### PR TITLE
Add ZoomableImageCitationWrapper component + bump headless ui version

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.170",
+  "version": "0.2.171",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.170",
+      "version": "0.2.171",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
-        "@headlessui/react": "^1.7.17",
+        "@headlessui/react": "^2.1.0",
         "emoji-mart": "^5.5.2",
         "esbuild": "^0.20.0",
         "eslint-plugin-import": "^2.29.1",
@@ -2918,7 +2918,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.0.tgz",
       "integrity": "sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==",
-      "dev": true,
       "dependencies": {
         "@floating-ui/utils": "^0.1.3"
       }
@@ -2927,44 +2926,63 @@
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.3.tgz",
       "integrity": "sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==",
-      "dev": true,
       "dependencies": {
         "@floating-ui/core": "^1.4.2",
         "@floating-ui/utils": "^0.1.3"
       }
     },
-    "node_modules/@floating-ui/react-dom": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.2.tgz",
-      "integrity": "sha512-5qhlDvjaLmAst/rKb3VdlCinwTF4EYMiVxuuc/HVUjs46W0zgtbMmAZ1UTsDrRTxRmUEzl92mOtWbeeXL26lSQ==",
-      "dev": true,
+    "node_modules/@floating-ui/react": {
+      "version": "0.26.18",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.18.tgz",
+      "integrity": "sha512-enDDX09Jpi3kmhcXXpvs+fvRXOfBj1jUV2KF6uDMf5HjS+SOZJzNTFUW71lKbFcxz0BkmQqwbvqdmHIxMq/fyQ==",
       "dependencies": {
-        "@floating-ui/dom": "^1.5.1"
+        "@floating-ui/react-dom": "^2.1.0",
+        "@floating-ui/utils": "^0.2.3",
+        "tabbable": "^6.0.0"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
       }
     },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.1.tgz",
+      "integrity": "sha512-4h84MJt3CHrtG18mGsXuLCHMrug49d7DFkU0RMIyshRveBeyV2hmV/pDaF2Uxtu8kgq5r46llp5E5FQiR0K2Yg==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/react/node_modules/@floating-ui/utils": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.3.tgz",
+      "integrity": "sha512-XGndio0l5/Gvd6CLIABvsav9HHezgDFFhDfHk1bvLfr9ni8dojqLSvBbotJEjmIwNHL7vK4QzBJTdBRoB+c1ww=="
+    },
     "node_modules/@floating-ui/utils": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
-      "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==",
-      "dev": true
+      "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A=="
     },
     "node_modules/@headlessui/react": {
-      "version": "1.7.17",
-      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.17.tgz",
-      "integrity": "sha512-4am+tzvkqDSSgiwrsEpGWqgGo9dz8qU5M3znCkC4PgkpY4HcCZzEDEvozltGGGHIKl9jbXbZPSH5TWn4sWJdow==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.1.0.tgz",
+      "integrity": "sha512-/MizQk2xqR5ELkmCI1xWy3VgJULvR8gcAXtZhcK7sY53TNRCPeMdeODEXKSv9LPSSRlEAyzW1+NGJiaXq6dLRw==",
       "dependencies": {
-        "client-only": "^0.0.1"
+        "@floating-ui/react": "^0.26.16",
+        "@react-aria/focus": "^3.17.1",
+        "@react-aria/interactions": "^3.21.3",
+        "@tanstack/react-virtual": "3.5.0"
       },
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "react": "^16 || ^17 || ^18",
-        "react-dom": "^16 || ^17 || ^18"
+        "react": "^18",
+        "react-dom": "^18"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -4111,6 +4129,83 @@
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10"
+      }
+    },
+    "node_modules/@react-aria/focus": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.17.1.tgz",
+      "integrity": "sha512-FLTySoSNqX++u0nWZJPPN5etXY0WBxaIe/YuL/GTEeuqUIuC/2bJSaw5hlsM6T2yjy6Y/VAxBcKSdAFUlU6njQ==",
+      "dependencies": {
+        "@react-aria/interactions": "^3.21.3",
+        "@react-aria/utils": "^3.24.1",
+        "@react-types/shared": "^3.23.1",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-aria/interactions": {
+      "version": "3.21.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.21.3.tgz",
+      "integrity": "sha512-BWIuf4qCs5FreDJ9AguawLVS0lV9UU+sK4CCnbCNNmYqOWY+1+gRXCsnOM32K+oMESBxilAjdHW5n1hsMqYMpA==",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.4",
+        "@react-aria/utils": "^3.24.1",
+        "@react-types/shared": "^3.23.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-aria/ssr": {
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.4.tgz",
+      "integrity": "sha512-4jmAigVq409qcJvQyuorsmBR4+9r3+JEC60wC+Y0MZV0HCtTmm8D9guYXlJMdx0SSkgj0hHAyFm/HvPNFofCoQ==",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-aria/utils": {
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.24.1.tgz",
+      "integrity": "sha512-O3s9qhPMd6n42x9sKeJ3lhu5V1Tlnzhu6Yk8QOvDuXf7UGuUjXf9mzfHJt1dYzID4l9Fwm8toczBzPM9t0jc8Q==",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.4",
+        "@react-stately/utils": "^3.10.1",
+        "@react-types/shared": "^3.23.1",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-stately/utils": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.1.tgz",
+      "integrity": "sha512-VS/EHRyicef25zDZcM/ClpzYMC5i2YGN6uegOeQawmgfGjb02yaCX0F0zR69Pod9m2Hr3wunTbtpgVXvYbZItg==",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-types/shared": {
+      "version": "3.23.1",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.23.1.tgz",
+      "integrity": "sha512-5d+3HbFDxGZjhbMBeFHRQhexMFt4pUce3okyRtUVKbbedQFUrtXSBg9VszgF2RTeQDKDkMCIQDtz5ccP/Lk1gw==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
     },
     "node_modules/@rollup/plugin-commonjs": {
@@ -9620,6 +9715,14 @@
       "integrity": "sha512-9F4ys4C74eSTEUNndnER3VJ15oru2NumfQxS8geE+f3eB5xvfxpWyqE5XlVnxb/R14uoXi6SLbBwwiDSkv+XEw==",
       "dev": true
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.11.tgz",
+      "integrity": "sha512-YNlnKRWF2sVojTpIyzwou9XoTNbzbzONwRhOoniEioF1AtaitTvVZblaQRrAzChWQ1bLYyYSWzM18y4WwgzJ+A==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@swc/types": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.5.tgz",
@@ -9636,6 +9739,31 @@
       },
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.5.0.tgz",
+      "integrity": "sha512-rtvo7KwuIvqK9zb0VZ5IL7fiJAEnG+0EiFZz8FUOs+2mhGqdGmjKIaT1XU7Zq0eFqL0jonLlhbayJI/J2SA/Bw==",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.5.0.tgz",
+      "integrity": "sha512-KnPRCkQTyqhanNC0K63GBG3wA8I+D1fQuVnAvcBF8f13akOKeQp1gSbu6f77zCxhEk727iV5oQnbHLYzHrECLg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -12284,11 +12412,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/client-only": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
-      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
-    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -12370,6 +12493,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -24735,6 +24866,11 @@
       "integrity": "sha512-AsS729u2RHUfEra9xJrE39peJcc2stq2+poBXX8bcM08Y6g9j/i/PUzwNQqkaJde7Ntg1TO7bSREbR5sdosQ+g==",
       "dev": true
     },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
+    },
     "node_modules/tailwind-scrollbar-hide": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/tailwind-scrollbar-hide/-/tailwind-scrollbar-hide-1.1.7.tgz",
@@ -25276,8 +25412,7 @@
     "node_modules/tslib": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-      "dev": true
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -79,7 +79,7 @@
   "dependencies": {
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",
-    "@headlessui/react": "^1.7.17",
+    "@headlessui/react": "^2.1.0",
     "emoji-mart": "^5.5.2",
     "esbuild": "^0.20.0",
     "eslint-plugin-import": "^2.29.1",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.170",
+  "version": "0.2.171",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/_index.ts
+++ b/sparkle/src/_index.ts
@@ -52,6 +52,9 @@ export { Chip };
 import { Citation } from "./components/Citation";
 export { Citation };
 
+import { ZoomableImageCitationWrapper } from "./components/ZoomableImageCitationWrapper";
+export { ZoomableImageCitationWrapper };
+
 import { DropdownMenu } from "./components/DropdownMenu";
 export { DropdownMenu };
 

--- a/sparkle/src/components/ZoomableImageCitationWrapper.tsx
+++ b/sparkle/src/components/ZoomableImageCitationWrapper.tsx
@@ -6,6 +6,7 @@ import {
 } from "@headlessui/react";
 import React, { useState } from "react";
 
+import { XCircle } from "@sparkle/icons/solid";
 import { Citation, IconButton, XMarkIcon } from "@sparkle/index";
 
 interface ZoomableImageCitationWrapperProps {
@@ -39,12 +40,16 @@ export function ZoomableImageCitationWrapper({
         onClose={handleZoomToggle}
         className="s-relative s-z-50 s-transition s-duration-300 s-ease-out data-[closed]:s-opacity-0"
       >
-        <DialogBackdrop className="s-fixed s-inset-0 s-bg-black/30" />
+        <DialogBackdrop className="s-fixed s-inset-0 s-bg-black/70" />
         <div className="s-fixed s-inset-8 s-flex s-w-screen s-items-center s-justify-center s-p-4">
           <DialogPanel className="s-max-w-lg s-space-y-4">
             <DialogTitle>
               <div className="s-flex s-justify-end">
-                <IconButton icon={XMarkIcon} onClick={handleZoomToggle} />
+                <IconButton
+                  icon={XCircle}
+                  onClick={handleZoomToggle}
+                  variant="white"
+                />
               </div>
             </DialogTitle>
             <img src={imgSrc} alt={alt} />

--- a/sparkle/src/components/ZoomableImageCitationWrapper.tsx
+++ b/sparkle/src/components/ZoomableImageCitationWrapper.tsx
@@ -7,7 +7,7 @@ import {
 import React, { useState } from "react";
 
 import { XCircle } from "@sparkle/icons/solid";
-import { Citation, IconButton, XMarkIcon } from "@sparkle/index";
+import { Citation, IconButton } from "@sparkle/index";
 
 interface ZoomableImageCitationWrapperProps {
   alt: string;

--- a/sparkle/src/components/ZoomableImageCitationWrapper.tsx
+++ b/sparkle/src/components/ZoomableImageCitationWrapper.tsx
@@ -1,0 +1,56 @@
+import {
+  Dialog,
+  DialogBackdrop,
+  DialogPanel,
+  DialogTitle,
+} from "@headlessui/react";
+import React, { useState } from "react";
+
+import { Citation, IconButton, XMarkIcon } from "@sparkle/index";
+
+interface ZoomableImageCitationWrapperProps {
+  alt: string;
+  imgSrc: string;
+  title: string;
+  size: "xs" | "sm";
+}
+
+export function ZoomableImageCitationWrapper({
+  alt,
+  imgSrc,
+  title,
+  size = "sm",
+}: ZoomableImageCitationWrapperProps) {
+  const [isZoomed, setIsZoomed] = useState(false);
+
+  const handleZoomToggle = () => {
+    setIsZoomed(!isZoomed);
+  };
+
+  return (
+    <>
+      <div onClick={handleZoomToggle} className="s-min-h-76 s-group s-h-full">
+        <Citation title={title} size={size} type="image" imgSrc={imgSrc} />
+      </div>
+
+      <Dialog
+        transition
+        open={isZoomed}
+        onClose={handleZoomToggle}
+        className="s-relative s-z-50 s-transition s-duration-300 s-ease-out data-[closed]:s-opacity-0"
+      >
+        <DialogBackdrop className="s-fixed s-inset-0 s-bg-black/30" />
+        <div className="s-fixed s-inset-8 s-flex s-w-screen s-items-center s-justify-center s-p-4">
+          <DialogPanel className="s-max-w-lg s-space-y-4">
+            <DialogTitle>
+              <div className="s-flex s-justify-end">
+                <IconButton icon={XMarkIcon} onClick={handleZoomToggle} />
+              </div>
+            </DialogTitle>
+            <img src={imgSrc} alt={alt} />
+          </DialogPanel>
+        </div>
+      </Dialog>
+    </>
+  );
+}

--- a/sparkle/src/stories/Citation.stories.tsx
+++ b/sparkle/src/stories/Citation.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta } from "@storybook/react";
 import React from "react";
 
+import { ZoomableCitationWrapper } from "@sparkle/components/ZoomableCitationWrapper";
+
 import { Citation } from "../index_with_tw_base";
 
 const meta = {
@@ -187,6 +189,15 @@ export const CitationsExample = () => (
         href="https://www.google.com"
         description="Write a 120 character description of the citation here to be displayed in the citation list."
         isBlinking={false}
+      />
+    </div>
+    <h2>With zoom effect</h2>
+    <div className="s-flex s-gap-2">
+      <ZoomableCitationWrapper
+        title="With imgSrc"
+        // size="xs"
+        imgSrc="https://dust.tt/static/droidavatar/Droid_Black_4.jpg"
+        alt="A nice image."
       />
     </div>
   </div>

--- a/sparkle/src/stories/Citation.stories.tsx
+++ b/sparkle/src/stories/Citation.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta } from "@storybook/react";
 import React from "react";
 
-import { ZoomableCitationWrapper } from "@sparkle/components/ZoomableCitationWrapper";
+import { ZoomableImageCitationWrapper } from "@sparkle/components/ZoomableImageCitationWrapper";
 
 import { Citation } from "../index_with_tw_base";
 
@@ -193,7 +193,7 @@ export const CitationsExample = () => (
     </div>
     <h2>With zoom effect</h2>
     <div className="s-flex s-gap-2">
-      <ZoomableCitationWrapper
+      <ZoomableImageCitationWrapper
         title="With imgSrc"
         // size="xs"
         imgSrc="https://dust.tt/static/droidavatar/Droid_Black_4.jpg"


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This fixes https://github.com/dust-tt/dust/issues/5854.

This PR adds a `ZoomableImageCitationWrapper` component to wrap a `Citation` component and add a zoom effect when clicked. This is required as part of the vision initiative.

It looks like this:

![zoomableImage](https://github.com/dust-tt/dust/assets/7428970/157015c0-a8d1-4c36-9db7-6c745d8d01ab)


I bumped headless UI to the latest version and made sure that it was not breaking anything on our side.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
