### PR TITLE
enh: add an error log when a model hallucinates an action

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -660,6 +660,16 @@ export async function* runMultiActionsAgent(
     const action = agentActions.find((ac) => ac.name === a.name);
 
     if (!action) {
+      logger.error(
+        {
+          workspaceId: conversation.owner.sId,
+          conversationId: conversation.sId,
+          configurationId: agentConfiguration.sId,
+          messageId: agentMessage.sId,
+          actionName: a.name,
+        },
+        "Model attempted to run an action that is not part of the agent configuration."
+      );
       yield {
         type: "agent_error",
         created: Date.now(),

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -677,7 +677,7 @@ export async function* runMultiActionsAgent(
         messageId: agentMessage.sId,
         error: {
           code: "action_not_found",
-          message: `Action ${a.name} not found`,
+          message: `The assistant attempted to run an invalid action (${a.name}). This model error can be safely retried.`,
         },
       } satisfies AgentErrorEvent;
       return;


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/tasks/issues/940

When the model tries to run an action that is not part of the assistant's configuration (either fully hallucinated or stolen from another agent in the conversation), we now log a distinct error and we return a clearer message to the user.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
