### PR TITLE
Websearch citation v2

### DIFF
--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -108,7 +108,7 @@ function citeDirective() {
           const references = node.children[0]?.value
             .split(",")
             .map((s: string) => s.trim())
-            .filter((s: string) => s.length == 2 || s.length == 3)
+            .filter((s: string) => s.length == 2)
             .map((ref: string) => ({
               counter: counter(ref),
               ref,

--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -6,7 +6,10 @@ import {
   Tooltip,
   WrenchIcon,
 } from "@dust-tt/sparkle";
-import type { LightAgentConfigurationType } from "@dust-tt/types";
+import type {
+  LightAgentConfigurationType,
+  WebsearchResultType,
+} from "@dust-tt/types";
 import type { RetrievalDocumentType } from "@dust-tt/types";
 import mermaid from "mermaid";
 import dynamic from "next/dynamic";
@@ -105,7 +108,7 @@ function citeDirective() {
           const references = node.children[0]?.value
             .split(",")
             .map((s: string) => s.trim())
-            .filter((s: string) => s.length == 2)
+            .filter((s: string) => s.length == 2 || s.length == 3)
             .map((ref: string) => ({
               counter: counter(ref),
               ref,
@@ -154,9 +157,12 @@ function addClosingBackticks(str: string): string {
 
 type CitationsContextType = {
   references: {
-    [key: string]: RetrievalDocumentType;
+    [key: string]: RetrievalDocumentType | WebsearchResultType;
   };
-  updateActiveReferences: (doc: RetrievalDocumentType, index: number) => void;
+  updateActiveReferences: (
+    doc: RetrievalDocumentType | WebsearchResultType,
+    index: number
+  ) => void;
   setHoveredReference: (index: number | null) => void;
 };
 
@@ -331,7 +337,10 @@ function CiteBlock(props: ReactMarkdownProps) {
       <span className="inline-flex space-x-1">
         {refs.map((r, i) => {
           const document = references[r.ref];
-          const link = makeLinkForRetrievedDocument(document);
+          const link =
+            "link" in document
+              ? document.link
+              : makeLinkForRetrievedDocument(document);
 
           return (
             <sup key={`${r.ref}-${i}`}>

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -23,6 +23,8 @@ import type {
   LightAgentConfigurationType,
   RetrievalActionType,
   UserType,
+  WebsearchActionType,
+  WebsearchResultType,
   WorkspaceType,
 } from "@dust-tt/types";
 import type { RetrievalDocumentType } from "@dust-tt/types";
@@ -30,6 +32,7 @@ import type { AgentMessageType, MessageReactionType } from "@dust-tt/types";
 import {
   assertNever,
   isRetrievalActionType,
+  isWebsearchActionType,
   removeNulls,
 } from "@dust-tt/types";
 import Link from "next/link";
@@ -86,11 +89,11 @@ export function AgentMessage({
     useState<boolean>(false);
 
   const [references, setReferences] = useState<{
-    [key: string]: RetrievalDocumentType;
+    [key: string]: RetrievalDocumentType | WebsearchResultType;
   }>({});
 
   const [activeReferences, setActiveReferences] = useState<
-    { index: number; document: RetrievalDocumentType }[]
+    { index: number; document: RetrievalDocumentType | WebsearchResultType }[]
   >([]);
 
   const shouldStream = (() => {
@@ -386,7 +389,7 @@ export function AgentMessage({
         ];
 
   function updateActiveReferences(
-    document: RetrievalDocumentType,
+    document: RetrievalDocumentType | WebsearchResultType,
     index: number
   ) {
     const existingIndex = activeReferences.find((r) => r.index === index);
@@ -398,24 +401,39 @@ export function AgentMessage({
   const [lastHoveredReference, setLastHoveredReference] = useState<
     number | null
   >(null);
+
   useEffect(() => {
+    // Retrieval actions
     const retrievalActionsWithDocs = agentMessageToRender.actions
       .filter((a) => isRetrievalActionType(a) && a.documents)
       .sort((a, b) => a.id - b.id) as RetrievalActionType[];
-
     const allDocs = removeNulls(
       retrievalActionsWithDocs.map((a) => a.documents).flat()
     );
+    const allDocsReferences = allDocs.reduce((acc, d) => {
+      acc[d.reference] = d;
+      return acc;
+    }, {} as { [key: string]: RetrievalDocumentType });
 
-    setReferences(
-      allDocs.reduce(
-        (acc, d) => {
-          acc[d.reference] = d;
-          return acc;
-        },
-        {} as { [key: string]: RetrievalDocumentType }
+    // Websearch actions
+    const websearchActionsWithResults = agentMessageToRender.actions
+      .filter(
+        (a) =>
+          isWebsearchActionType(a) &&
+          a.output?.results &&
+          a.output.results.length > 0
       )
+      .sort((a, b) => a.id - b.id) as WebsearchActionType[];
+    const allWebResults = removeNulls(
+      websearchActionsWithResults.map((a) => a.output?.results).flat()
     );
+    const allWebReferences = allWebResults.reduce((acc, l) => {
+      acc[l.reference] = l;
+      return acc;
+    }, {} as { [key: string]: WebsearchResultType });
+
+    // Merge all references
+    setReferences({ ...allDocsReferences, ...allWebReferences });
   }, [
     agentMessageToRender.actions,
     agentMessageToRender.status,
@@ -473,7 +491,7 @@ export function AgentMessage({
     lastTokenClassification,
   }: {
     agentMessage: AgentMessageType;
-    references: { [key: string]: RetrievalDocumentType };
+    references: { [key: string]: RetrievalDocumentType | WebsearchResultType };
     streaming: boolean;
     lastTokenClassification: null | "tokens" | "chain_of_thought";
   }) {
@@ -594,7 +612,10 @@ function Citations({
   activeReferences,
   lastHoveredReference,
 }: {
-  activeReferences: { index: number; document: RetrievalDocumentType }[];
+  activeReferences: {
+    index: number;
+    document: RetrievalDocumentType | WebsearchResultType;
+  }[];
   lastHoveredReference: number | null;
 }) {
   activeReferences.sort((a, b) => a.index - b.index);
@@ -604,7 +625,16 @@ function Citations({
       // ref={citationContainer}
     >
       {activeReferences.map(({ document, index }) => {
-        const [documentCitation] = makeDocumentCitations([document]);
+        const [documentCitation] =
+          "link" in document
+            ? [
+                {
+                  href: document.link,
+                  title: document.title,
+                  type: "document" as const,
+                },
+              ]
+            : makeDocumentCitations([document]);
 
         return (
           <Citation

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -410,27 +410,28 @@ export function AgentMessage({
     const allDocs = removeNulls(
       retrievalActionsWithDocs.map((a) => a.documents).flat()
     );
-    const allDocsReferences = allDocs.reduce((acc, d) => {
-      acc[d.reference] = d;
-      return acc;
-    }, {} as { [key: string]: RetrievalDocumentType });
+    const allDocsReferences = allDocs.reduce(
+      (acc, d) => {
+        acc[d.reference] = d;
+        return acc;
+      },
+      {} as { [key: string]: RetrievalDocumentType }
+    );
 
     // Websearch actions
     const websearchActionsWithResults = agentMessageToRender.actions
-      .filter(
-        (a) =>
-          isWebsearchActionType(a) &&
-          a.output?.results &&
-          a.output.results.length > 0
-      )
+      .filter((a) => isWebsearchActionType(a) && a.output?.results?.length)
       .sort((a, b) => a.id - b.id) as WebsearchActionType[];
     const allWebResults = removeNulls(
       websearchActionsWithResults.map((a) => a.output?.results).flat()
     );
-    const allWebReferences = allWebResults.reduce((acc, l) => {
-      acc[l.reference] = l;
-      return acc;
-    }, {} as { [key: string]: WebsearchResultType });
+    const allWebReferences = allWebResults.reduce(
+      (acc, l) => {
+        acc[l.reference] = l;
+        return acc;
+      },
+      {} as { [key: string]: WebsearchResultType }
+    );
 
     // Merge all references
     setReferences({ ...allDocsReferences, ...allWebReferences });

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -934,19 +934,6 @@ export async function retrievalActionTypesFromAgentMessageIds(
 }
 
 /**
- * Retrieval meta-prompt
- */
-
-export function retrievalMetaPromptMutiActions() {
-  return (
-    "To cite documents retrieved with a 2-character REFERENCE, " +
-    "use the markdown directive :cite[REFERENCE] " +
-    "(eg :cite[xx] or :cite[xx,xx] but not :cite[xx][xx]). " +
-    "Ensure citations are placed as close as possible to the related information."
-  );
-}
-
-/**
  * Action execution.
  */
 

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -28,6 +28,7 @@ import { runActionStreamed } from "@app/lib/actions/server";
 import { DEFAULT_RETRIEVAL_ACTION_NAME } from "@app/lib/api/assistant/actions/names";
 import type { BaseActionRunParams } from "@app/lib/api/assistant/actions/types";
 import { BaseActionConfigurationServerRunner } from "@app/lib/api/assistant/actions/types";
+import { getRefs } from "@app/lib/api/assistant/citations";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { PRODUCTION_DUST_WORKSPACE_ID } from "@app/lib/development";
@@ -37,7 +38,6 @@ import {
   RetrievalDocumentChunk,
 } from "@app/lib/models/assistant/actions/retrieval";
 import { frontSequelize } from "@app/lib/resources/storage";
-import { rand } from "@app/lib/utils/seeded_random";
 import logger from "@app/logger/logger";
 
 import { getRunnerforActionConfiguration } from "./runners";
@@ -932,29 +932,3 @@ export async function retrievalActionTypesFromAgentMessageIds(
 
   return actions;
 }
-
-/**
- * Action execution.
- */
-
-let REFS: string[] | null = null;
-const getRand = rand("chawarma");
-
-const getRefs = () => {
-  if (REFS === null) {
-    REFS = "abcdefghijklmnopqrstuvwxyz0123456789"
-      .split("")
-      .map((c) => {
-        return "abcdefghijklmnopqrstuvwxyz0123456789".split("").map((n) => {
-          return `${c}${n}`;
-        });
-      })
-      .flat();
-    // randomize
-    REFS.sort(() => {
-      const r = getRand();
-      return r > 0.5 ? 1 : -1;
-    });
-  }
-  return REFS;
-};

--- a/front/lib/api/assistant/actions/websearch.ts
+++ b/front/lib/api/assistant/actions/websearch.ts
@@ -27,7 +27,7 @@ import { runActionStreamed } from "@app/lib/actions/server";
 import { DEFAULT_WEBSEARCH_ACTION_NAME } from "@app/lib/api/assistant/actions/names";
 import type { BaseActionRunParams } from "@app/lib/api/assistant/actions/types";
 import { BaseActionConfigurationServerRunner } from "@app/lib/api/assistant/actions/types";
-import { getRefsForActionInStep } from "@app/lib/api/assistant/citations";
+import { getRefs } from "@app/lib/api/assistant/citations";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentWebsearchAction } from "@app/lib/models/assistant/actions/websearch";
 import logger from "@app/logger/logger";
@@ -228,7 +228,7 @@ export class WebsearchConfigurationServerRunner extends BaseActionConfigurationS
       return;
     }
 
-    const { numResults /*, refsOffset*/ } =
+    const { numResults, refsOffset } =
       this.stepNumResultsAndRefsOffsetForAction({
         agentConfiguration,
         stepActionIndex,
@@ -379,10 +379,7 @@ export class WebsearchConfigurationServerRunner extends BaseActionConfigurationS
           const rawResults = outputValidation.right.results;
 
           if (rawResults) {
-            const refs = getRefsForActionInStep({
-              stepIndex: step,
-              actionIndex: stepActionIndex,
-            });
+            const refs = getRefs().slice(refsOffset, refsOffset + numResults);
 
             rawResults.forEach((result) => {
               formattedResults.push({

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -48,7 +48,7 @@ import { redisClient } from "@app/lib/redis";
 import logger from "@app/logger/logger";
 
 const CANCELLATION_CHECK_INTERVAL = 500;
-const MAX_ACTIONS_PER_STEP = 16;
+export const MAX_ACTIONS_PER_STEP = 16;
 
 // This interface is used to execute an agent. It is not in charge of creating the AgentMessage,
 // nor updating it (responsability of the caller based on the emitted events).

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -48,7 +48,7 @@ import { redisClient } from "@app/lib/redis";
 import logger from "@app/logger/logger";
 
 const CANCELLATION_CHECK_INTERVAL = 500;
-export const MAX_ACTIONS_PER_STEP = 16;
+const MAX_ACTIONS_PER_STEP = 16;
 
 // This interface is used to execute an agent. It is not in charge of creating the AgentMessage,
 // nor updating it (responsability of the caller based on the emitted events).

--- a/front/lib/api/assistant/citations.ts
+++ b/front/lib/api/assistant/citations.ts
@@ -1,35 +1,18 @@
-import _ from "lodash";
-
-import { MAX_ACTIONS_PER_STEP } from "@app/lib/api/assistant/agent";
 import { rand } from "@app/lib/utils/seeded_random";
 
-/**
- * REFS are 3-character references used to cite documents or web pages.
- * They are generated randomly and are unique.
- * With this configuration, we generate 52×9×52=24336 references.
- *
- * Since we have currently max 8 steps, and 16 actions per step,
- * we could have up to 190 refs per action.
- *
- * We currently limit to 64 refs per action.
- */
-const REFS_PER_ACTION = 64;
 let REFS: string[] | null = null;
 const getRand = rand("chawarma");
-export const getRefs = () => {
-  const c = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".split("");
-  const nb = "123456789".split("");
 
+export const getRefs = () => {
   if (REFS === null) {
-    REFS = c
-      .map((c1) => {
-        return nb.map((n) => {
-          return c.map((c2) => {
-            return `${c1}${n}${c2}`;
-          });
+    REFS = "abcdefghijklmnopqrstuvwxyz0123456789"
+      .split("")
+      .map((c) => {
+        return "abcdefghijklmnopqrstuvwxyz0123456789".split("").map((n) => {
+          return `${c}${n}`;
         });
       })
-      .flat(2);
+      .flat();
     // randomize
     REFS.sort(() => {
       const r = getRand();
@@ -40,31 +23,13 @@ export const getRefs = () => {
 };
 
 /**
- * Get the refs for a given action in a step.
- */
-export const getRefsForActionInStep = ({
-  stepIndex,
-  actionIndex,
-}: {
-  stepIndex: number;
-  actionIndex: number;
-}) => {
-  const allRefs = getRefs();
-  const startIndex =
-    stepIndex * MAX_ACTIONS_PER_STEP * REFS_PER_ACTION +
-    actionIndex * REFS_PER_ACTION;
-
-  return _.slice(allRefs, startIndex, startIndex + REFS_PER_ACTION);
-};
-
-/**
  * Prompt to remind agents how to cite documents or web pages.
  */
 export function citationMetaPrompt() {
   return (
-    "To cite documents or web pages retrieved with a 2-character or 3-character REFERENCE, " +
+    "To cite documents or web pages retrieved with a 2-character REFERENCE, " +
     "use the markdown directive :cite[REFERENCE] " +
-    "(eg :cite[xxx] or :cite[xxx,xxx] but not :cite[xxx][xxx]). " +
+    "(eg :cite[xx] or :cite[xx,xx] but not :cite[xx][xx]). " +
     "Ensure citations are placed as close as possible to the related information."
   );
 }

--- a/front/lib/api/assistant/citations.ts
+++ b/front/lib/api/assistant/citations.ts
@@ -1,0 +1,70 @@
+import _ from "lodash";
+
+import { MAX_ACTIONS_PER_STEP } from "@app/lib/api/assistant/agent";
+import { rand } from "@app/lib/utils/seeded_random";
+
+/**
+ * REFS are 3-character references used to cite documents or web pages.
+ * They are generated randomly and are unique.
+ * With this configuration, we generate 52×9×52=24336 references.
+ *
+ * Since we have currently max 8 steps, and 16 actions per step,
+ * we could have up to 190 refs per action.
+ *
+ * We currently limit to 64 refs per action.
+ */
+const REFS_PER_ACTION = 64;
+let REFS: string[] | null = null;
+const getRand = rand("chawarma");
+export const getRefs = () => {
+  const c = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".split("");
+  const nb = "123456789".split("");
+
+  if (REFS === null) {
+    REFS = c
+      .map((c1) => {
+        return nb.map((n) => {
+          return c.map((c2) => {
+            return `${c1}${n}${c2}`;
+          });
+        });
+      })
+      .flat(2);
+    // randomize
+    REFS.sort(() => {
+      const r = getRand();
+      return r > 0.5 ? 1 : -1;
+    });
+  }
+  return REFS;
+};
+
+/**
+ * Get the refs for a given action in a step.
+ */
+export const getRefsForActionInStep = ({
+  stepIndex,
+  actionIndex,
+}: {
+  stepIndex: number;
+  actionIndex: number;
+}) => {
+  const allRefs = getRefs();
+  const startIndex =
+    stepIndex * MAX_ACTIONS_PER_STEP * REFS_PER_ACTION +
+    actionIndex * REFS_PER_ACTION;
+
+  return _.slice(allRefs, startIndex, startIndex + REFS_PER_ACTION);
+};
+
+/**
+ * Prompt to remind agents how to cite documents or web pages.
+ */
+export function citationMetaPrompt() {
+  return (
+    "To cite documents or web pages retrieved with a 2-character or 3-character REFERENCE, " +
+    "use the markdown directive :cite[REFERENCE] " +
+    "(eg :cite[xxx] or :cite[xxx,xxx] but not :cite[xxx][xxx]). " +
+    "Ensure citations are placed as close as possible to the related information."
+  );
+}

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -17,12 +17,13 @@ import {
   isContentFragmentType,
   isRetrievalConfiguration,
   isUserMessageType,
+  isWebsearchConfiguration,
   Ok,
   removeNulls,
 } from "@dust-tt/types";
 import moment from "moment-timezone";
 
-import { retrievalMetaPromptMutiActions } from "@app/lib/api/assistant/actions/retrieval";
+import { citationMetaPrompt } from "@app/lib/api/assistant/citations";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import type { Authenticator } from "@app/lib/auth";
 import { getContentFragmentText } from "@app/lib/resources/content_fragment_resource";
@@ -370,11 +371,12 @@ export async function constructPromptMultiActions(
   // ADDITIONAL INSTRUCTIONS section
   let additionalInstructions = "";
 
-  const hasRetrievalAction = agentConfiguration.actions.some((action) =>
-    isRetrievalConfiguration(action)
+  const canCiteDocuments = agentConfiguration.actions.some(
+    (action) =>
+      isRetrievalConfiguration(action) || isWebsearchConfiguration(action)
   );
-  if (hasRetrievalAction) {
-    additionalInstructions += `${retrievalMetaPromptMutiActions()}\n`;
+  if (canCiteDocuments) {
+    additionalInstructions += `${citationMetaPrompt()}\n`;
   }
 
   const providerMetaPrompt = model.metaPrompt;

--- a/types/src/front/assistant/actions/websearch.ts
+++ b/types/src/front/assistant/actions/websearch.ts
@@ -13,12 +13,28 @@ export type WebsearchConfigurationType = {
   description: string | null;
 };
 
-export const WebsearchResultSchema = t.type({
+// Type fresh out from the Dust app
+const WebsearchAppResultSchema = t.type({
   title: t.string,
   snippet: t.string,
   link: t.string,
 });
-
+export const WebsearchAppActionOutputSchema = t.union([
+  t.type({
+    results: t.array(WebsearchAppResultSchema),
+  }),
+  t.type({
+    results: t.array(WebsearchAppResultSchema),
+    error: t.string,
+  }),
+]);
+// Type after processing in the run loop (to add references)
+const WebsearchResultSchema = t.type({
+  title: t.string,
+  snippet: t.string,
+  link: t.string,
+  reference: t.string,
+});
 export const WebsearchActionOutputSchema = t.union([
   t.type({
     results: t.array(WebsearchResultSchema),


### PR DESCRIPTION
## Description

Initially attempted here: https://github.com/dust-tt/dust/pull/5720, I closed the PR to reopen a more simple version (no change in the Dust app, less changes in the types and  and that should avoid collision of references. 

I added a new lib for references that creates a 3 char ref: one char, one number, one char again. 
That's 24336 refs. 

Since we have 8 steps max, with 16 actions max per step, that means this gives us 24336 / ( 8 * 16) ~= 190 refs per action. 


<kbd>
<img width="887" alt="Screenshot 2024-06-25 at 14 27 18" src="https://github.com/dust-tt/dust/assets/3803406/e49bde0c-3880-4a1f-b7e5-6c16353185a2">
</kbd>


## NEXT

If we go with that next steps are: 
- Use these refs also for retrieval.
- Edit https://github.com/dust-tt/dust/blob/main/connectors/src/connectors/slack/chat/citations.ts#L17 to also have websearch citations formatted on Slack. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 
