### PR TITLE
enh: skip archived resources in notion sync

### DIFF
--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -236,6 +236,9 @@ export async function getPagesAndDatabasesEditedSince(
   for (const pageOrDb of resultsPage.results) {
     if (pageOrDb.object === "page") {
       if (isFullPage(pageOrDb)) {
+        if (pageOrDb.archived) {
+          continue;
+        }
         const lastEditedTime = new Date(pageOrDb.last_edited_time).getTime();
 
         // skip pages that have a `lastEditedTime` in the future
@@ -274,6 +277,9 @@ export async function getPagesAndDatabasesEditedSince(
         continue;
       }
       if (isFullDatabase(pageOrDb)) {
+        if (pageOrDb.archived) {
+          continue;
+        }
         const lastEditedTime = new Date(pageOrDb.last_edited_time).getTime();
 
         // skip databases that have a `lastEditedTime` in the future


### PR DESCRIPTION
## Description

Sometimes, notion will return archived pages / DBs. We should not return those from `getPagesAndDatabasesEditedSince` so they can be deleted as expected by the GC process.

fixes https://github.com/dust-tt/tasks/issues/947


## Risk

N/A

## Deploy Plan

N/A