### PR TITLE
Fix new conversation view

### DIFF
--- a/front/pages/w/[wId]/assistant/[cId]/index.tsx
+++ b/front/pages/w/[wId]/assistant/[cId]/index.tsx
@@ -8,6 +8,7 @@ import React from "react";
 import { ConversationContainer } from "@app/components/assistant/conversation/ConversationContainer";
 import type { ConversationLayoutProps } from "@app/components/assistant/conversation/ConversationLayout";
 import ConversationLayout from "@app/components/assistant/conversation/ConversationLayout";
+import { CONVERSATION_PARENT_SCROLL_DIV_ID } from "@app/components/assistant/conversation/lib";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 
 const { URL = "", GA_TRACKING_ID = "" } = process.env;
@@ -80,6 +81,15 @@ export default function AssistantConversation({
     } else if (!conversationId && !initialConversationId) {
       // Force re-render by setting a new key with a random number.
       setConversationKey(`new_${Math.random() * 1000}`);
+
+      // Scroll to the top of the conversation container when clicking on "new".
+      const mainTag = document.getElementById(
+        CONVERSATION_PARENT_SCROLL_DIV_ID["page"]
+      );
+
+      if (mainTag) {
+        mainTag.scrollTo(0, 0);
+      }
     }
   }, [router.query, setConversationKey, initialConversationId]);
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes the current issue that when clicking on "New conversation" brings you in the middle of the assistant list. This comes from the fact that we do shallow browsing. With this PR we reset the scroll when browsing to new.

**Before:**

![NewConversationBug](https://github.com/dust-tt/dust/assets/7428970/b9baadd7-569b-42ce-977e-f472a1a52564)

**After:**

![NewConversationFixed](https://github.com/dust-tt/dust/assets/7428970/54886c20-5765-44fb-862a-9403f9a947d0)

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
