### PR TITLE
[Help Drawer] Fix react warning caused by drawer

### DIFF
--- a/front/components/assistant/HelpDrawer.tsx
+++ b/front/components/assistant/HelpDrawer.tsx
@@ -20,7 +20,6 @@ import type { ComponentType } from "react";
 import { useCallback, useContext } from "react";
 
 import { AssistantInputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
-import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { createConversationWithMessage } from "@app/components/assistant/conversation/lib";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { GLOBAL_AGENTS_SID } from "@app/lib/assistant";
@@ -85,8 +84,6 @@ export function HelpDrawer({
 }) {
   const router = useRouter();
   const sendNotification = useContext(SendNotificationsContext);
-  const { setSelectedAssistant } = useContext(InputBarContext);
-  setSelectedAssistant(null);
 
   const { submit: handleHelpSubmit } = useSubmitFunction(
     useCallback(


### PR DESCRIPTION
Description
---
Help Drawer caused an error in react, due to it resetting selectedAssistant for legacy reasons (of 2 weeks ago)
![Screenshot from 2024-06-25 21-59-30](https://github.com/dust-tt/dust/assets/5437393/338f4e51-c7d5-4b00-9d58-7cd6c44520c2)

Since selectedAssistant isn't used anymore in the main conversation, the setSelectedAssistant can be removed from HelpDrawer

Risk
---
na
