### PR TITLE
fix: tables query dust app

### DIFF
--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -124,7 +124,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "b4f205e453",
       appHash:
-        "e8a7693b41b53d2f22379720d173783d669d4a8fb79c8bd302df28a3488f27af",
+        "3a2dfb3cea868dfc0c1c04ea1dbaeb82af2fc047151e6381355d718b0388fb47",
     },
     config: {
       MODEL: {


### PR DESCRIPTION
## Description

We now enforce proper function calls.
I updated the tables query dust app to inject an agent message with `function_calls` before the dust-injected `function` mesages.
I also added proper `function_call_id` in both function_calls and functions


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
