### PR TITLE
API tab per defaut when viewing runs with a wIdTarget

### DIFF
--- a/front/pages/w/[wId]/a/[aId]/runs/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/runs/index.tsx
@@ -88,7 +88,7 @@ export default function RunsView({
   wIdTarget,
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
-  const [runType, setRunType] = useState("local" as RunRunType);
+  const [runType, setRunType] = useState(wIdTarget ? "deploy" : "local" as RunRunType);
   const [limit] = useState(10);
   const [offset, setOffset] = useState(0);
 

--- a/front/pages/w/[wId]/a/[aId]/runs/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/runs/index.tsx
@@ -88,7 +88,9 @@ export default function RunsView({
   wIdTarget,
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
-  const [runType, setRunType] = useState(wIdTarget ? "deploy" : "local" as RunRunType);
+  const [runType, setRunType] = useState(
+    wIdTarget ? "deploy" : ("local" as RunRunType)
+  );
   const [limit] = useState(10);
   const [offset, setOffset] = useState(0);
 

--- a/front/pages/w/[wId]/a/[aId]/runs/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/runs/index.tsx
@@ -89,7 +89,7 @@ export default function RunsView({
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [runType, setRunType] = useState(
-    wIdTarget ? "deploy" : ("local" as RunRunType)
+    (wIdTarget ? "deploy" : "local") as RunRunType
   );
   const [limit] = useState(10);
   const [offset, setOffset] = useState(0);


### PR DESCRIPTION
## Description

When viewing runs with a wIdTarget (usually with shortcut from Poké), save a click and select the API tab per default. 

## Risk

/

## Deploy Plan

Deploy front. 