### PR TITLE
Rename Gdrive full sync queue.

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/config.ts
+++ b/connectors/src/connectors/google_drive/temporal/config.ts
@@ -1,3 +1,3 @@
 export const WORKFLOW_VERSION = 5;
-export const GDRIVE_FULL_SYNC_QUEUE_NAME = `google-queue-v${WORKFLOW_VERSION}`;
+export const GDRIVE_FULL_SYNC_QUEUE_NAME = `google-queue-fullsync-v${WORKFLOW_VERSION}`;
 export const GDRIVE_INCREMENTAL_SYNC_QUEUE_NAME = `google-queue-incremental-v${WORKFLOW_VERSION}`;


### PR DESCRIPTION
## Description

When moving Gdrive sync on two different queues (`fullSync` and `incrementalSync`), we could not rename the full sync queue easily because of an ongoing long full sync.


Task is [here](https://github.com/dust-tt/tasks/issues/929).

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- Deploy connectors
- Check that no workflow is on the old queue. If there is one, re-trigger it via the connectors CLI.

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
