### PR TITLE
[front/migrations] - feature: backfill content type

### DIFF
--- a/front/migrations/20240626_backfill_content_fragment_content_type.sql
+++ b/front/migrations/20240626_backfill_content_fragment_content_type.sql
@@ -11,3 +11,4 @@ SET "contentType" = CASE
 UPDATE content_fragments
 WHERE "contentType" = 'slack_thread_content'
 SET "contentType" = 'dust-application/slack';
+COMMIT;

--- a/front/migrations/20240626_backfill_content_fragment_content_type.sql
+++ b/front/migrations/20240626_backfill_content_fragment_content_type.sql
@@ -1,0 +1,13 @@
+BEGIN;
+UPDATE content_fragments
+WHERE "contentType" = 'file_attachment'
+SET "contentType" = CASE
+	WHEN title LIKE '%.csv' THEN 'text/csv'
+	WHEN title LIKE '%.md' THEN 'text/markdown'
+	WHEN title LIKE '%.pdf' THEN 'application/pdf'
+	WHEN title LIKE '%.PDF' THEN 'application/pdf'
+	ELSE 'text/plain' END;
+
+UPDATE content_fragments
+WHERE "contentType" = 'slack_thread_content'
+SET "contentType" = 'dust-application/slack';


### PR DESCRIPTION
## Description

Backfill `content_fragments` table with new `contentType`.

 - Update `contentType` field based on file extensions in `title` for `file_attachment` types
 - Set `contentType` for `slack_thread_content` to custom 'dust-application/slack' type

Notes:
<details>
  <summary>Extension count query</summary>

```
SELECT
  CASE
    WHEN title LIKE '%.csv' THEN 'text/csv'
    WHEN title LIKE '%.md' THEN 'text/markdown'
    WHEN title LIKE '%.pdf' THEN 'application/pdf'
    WHEN title LIKE '%.PDF' THEN 'application/pdf'
    WHEN title LIKE '%.txt' THEN 'text/plain'
    ELSE 'others'
  END AS new_content_type,
  COUNT(*) as row_count
FROM content_fragments
WHERE "contentType" = 'file_attachment'
GROUP BY new_content_type;
```
</details>


## Risk

Risky as it requires to directly manipulate prod data

## Deploy Plan

- [x] Limit the query to Dust workspace first 
- [x] Apply the changes to all workspaces
