### PR TITLE
feat: tables query execution error

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -2274,6 +2274,12 @@ async fn databases_query_run(
                             "The query returned too many rows",
                             None,
                         ),
+                        Err(QueryDatabaseError::ExecutionError(s)) => error_response(
+                            StatusCode::BAD_REQUEST,
+                            "query_execution_error",
+                            &s,
+                            None,
+                        ),
                         Err(e) => error_response(
                             StatusCode::INTERNAL_SERVER_ERROR,
                             "internal_server_error",

--- a/core/bin/sqlite_worker.rs
+++ b/core/bin/sqlite_worker.rs
@@ -9,7 +9,7 @@ use datadog_formatting_layer::DatadogFormattingLayer;
 use dust::{
     databases::database::Table,
     databases_store::{self, store::DatabasesStore},
-    sqlite_workers::sqlite_database::{QueryError, SqliteDatabase},
+    sqlite_workers::sqlite_database::{SqliteDatabase, SqliteDatabaseError},
     utils::{error_response, APIResponse},
 };
 use hyper::StatusCode;
@@ -220,7 +220,13 @@ async fn databases_query(
             }),
         ),
         Err(e) => match e {
-            QueryError::ExceededMaxRows(max) => error_response(
+            SqliteDatabaseError::QueryExecutionError(e) => error_response(
+                StatusCode::BAD_REQUEST,
+                "query_execution_error",
+                e.to_string().as_str(),
+                Some(e.into()),
+            ),
+            SqliteDatabaseError::ExceededMaxRows(max) => error_response(
                 StatusCode::BAD_REQUEST,
                 "too_many_result_rows",
                 &format!("Result contains too many rows (max: {})", max),

--- a/core/src/databases/database.rs
+++ b/core/src/databases/database.rs
@@ -38,16 +38,18 @@ pub enum QueryDatabaseError {
     GenericError(#[from] anyhow::Error),
     #[error("Too many result rows")]
     TooManyResultRows,
+    #[error("Query execution error: {0}")]
+    ExecutionError(String),
 }
 
 impl From<SqliteWorkerError> for QueryDatabaseError {
     fn from(e: SqliteWorkerError) -> Self {
         match &e {
-            SqliteWorkerError::ServerError(_, code, _) => match code.as_str() {
-                "too_many_result_rows" => QueryDatabaseError::TooManyResultRows,
-                _ => QueryDatabaseError::GenericError(e.into()),
-            },
-            _ => e.into(),
+            SqliteWorkerError::TooManyResultRows => QueryDatabaseError::TooManyResultRows,
+            SqliteWorkerError::QueryExecutionError(msg) => {
+                QueryDatabaseError::ExecutionError(msg.clone())
+            }
+            _ => QueryDatabaseError::GenericError(e.into()),
         }
     }
 }

--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -124,7 +124,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "b4f205e453",
       appHash:
-        "186056690b9ddd79075fe0ac46a8150e4815589d93c6d1da3b28d2522a4871c0",
+        "cd60b80149bf36069cde1d88623493197db0449522d5ec7bed31266a34724a75",
     },
     config: {
       MODEL: {


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/dust/issues/5875

- improve the error handling of tables query in core, better separating different error classes
- distinguish errors that originate from a wrong query vs other type of errors (i.e "query execution error")
- query execution errors now cause the API to 400 instead of 500
- query execution errors now don't cause the block to fail. Instead, the block returns an error, so ultimately the assistant will be able to understand that the query failed (and might decide to retry it)
- the tables query dust app has been updated to handle this new `error` field

## Risk

N/A

## Deploy Plan

ideally we deploy front first so that the handling of the new field is live before it can happen.
But overall not such a big deal since the dust app would have failed anyway and it's unlikely to happen in such a short time frame.