### PR TITLE
[UX] In the Assistant Detail view, Instructions are in a block

### DIFF
--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -37,8 +37,8 @@ import { useCallback, useContext, useEffect, useState } from "react";
 import type { KeyedMutator } from "swr";
 
 import { AssistantEditionMenu } from "@app/components/assistant/AssistantEditionMenu";
-import { InstructionsReadOnlyTextArea } from "@app/components/assistant/AssistantInstructionReadOnlyTextArea";
 import AssistantListActions from "@app/components/assistant/AssistantListActions";
+import { ReadOnlyTextArea } from "@app/components/assistant/ReadOnlyTextArea";
 import { SharingDropdown } from "@app/components/assistant/Sharing";
 import { assistantUsageMessage } from "@app/components/assistant/Usage";
 import { PermissionTreeChildren } from "@app/components/ConnectorPermissionsTree";
@@ -225,9 +225,7 @@ export function AssistantDetails({
     agentConfiguration.instructions ? (
       <div className="flex flex-col gap-2">
         <div className="text-lg font-bold text-element-800">Instructions</div>
-        <InstructionsReadOnlyTextArea
-          instructions={agentConfiguration.instructions}
-        />
+        <ReadOnlyTextArea content={agentConfiguration.instructions} />
       </div>
     ) : (
       "This assistant has no instructions."

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -34,7 +34,6 @@ import {
   isWebsearchConfiguration,
 } from "@dust-tt/types";
 import { useCallback, useContext, useEffect, useState } from "react";
-import ReactMarkdown from "react-markdown";
 import type { KeyedMutator } from "swr";
 
 import { AssistantEditionMenu } from "@app/components/assistant/AssistantEditionMenu";

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -38,6 +38,7 @@ import ReactMarkdown from "react-markdown";
 import type { KeyedMutator } from "swr";
 
 import { AssistantEditionMenu } from "@app/components/assistant/AssistantEditionMenu";
+import { InstructionsReadOnlyTextArea } from "@app/components/assistant/AssistantInstructionReadOnlyTextArea";
 import AssistantListActions from "@app/components/assistant/AssistantListActions";
 import { SharingDropdown } from "@app/components/assistant/Sharing";
 import { assistantUsageMessage } from "@app/components/assistant/Usage";
@@ -225,7 +226,9 @@ export function AssistantDetails({
     agentConfiguration.instructions ? (
       <div className="flex flex-col gap-2">
         <div className="text-lg font-bold text-element-800">Instructions</div>
-        <ReactMarkdown>{agentConfiguration.instructions}</ReactMarkdown>
+        <InstructionsReadOnlyTextArea
+          instructions={agentConfiguration.instructions}
+        />
       </div>
     ) : (
       "This assistant has no instructions."

--- a/front/components/assistant/AssistantInstructionReadOnlyTextArea.tsx
+++ b/front/components/assistant/AssistantInstructionReadOnlyTextArea.tsx
@@ -1,0 +1,18 @@
+import { classNames } from "@app/lib/utils";
+
+export const InstructionsReadOnlyTextArea = ({
+  instructions,
+}: {
+  instructions: string | null;
+}) => {
+  return (
+    <textarea
+      disabled
+      className={classNames(
+        "block h-full min-h-60 w-full min-w-0 rounded-xl text-sm",
+        "resize-none border-structure-200 bg-structure-50"
+      )}
+      defaultValue={instructions ?? ""}
+    />
+  );
+};

--- a/front/components/assistant/ReadOnlyTextArea.tsx
+++ b/front/components/assistant/ReadOnlyTextArea.tsx
@@ -1,10 +1,6 @@
 import { classNames } from "@app/lib/utils";
 
-export const InstructionsReadOnlyTextArea = ({
-  instructions,
-}: {
-  instructions: string | null;
-}) => {
+export const ReadOnlyTextArea = ({ content }: { content: string | null }) => {
   return (
     <textarea
       disabled
@@ -12,7 +8,7 @@ export const InstructionsReadOnlyTextArea = ({
         "block h-full min-h-60 w-full min-w-0 rounded-xl text-sm",
         "resize-none border-structure-200 bg-structure-50"
       )}
-      defaultValue={instructions ?? ""}
+      defaultValue={content ?? ""}
     />
   );
 };

--- a/front/components/assistant_builder/AssistantTemplateModal.tsx
+++ b/front/components/assistant_builder/AssistantTemplateModal.tsx
@@ -9,10 +9,9 @@ import {
 import type { WorkspaceType } from "@dust-tt/types";
 import Link from "next/link";
 
-import { InstructionsReadOnlyTextArea } from "@app/components/assistant/AssistantInstructionReadOnlyTextArea";
+import { ReadOnlyTextArea } from "@app/components/assistant/ReadOnlyTextArea";
 import type { BuilderFlow } from "@app/components/assistant_builder/types";
 import { useAssistantTemplate } from "@app/lib/swr";
-import { classNames } from "@app/lib/utils";
 
 interface AssistantTemplateModalProps {
   flow: BuilderFlow;
@@ -85,7 +84,7 @@ function InstructionsSection({
   return (
     <>
       <Page.SectionHeader title="Instructions" />
-      <InstructionsReadOnlyTextArea instructions={instructions} />
+      <ReadOnlyTextArea content={instructions} />
     </>
   );
 }

--- a/front/components/assistant_builder/AssistantTemplateModal.tsx
+++ b/front/components/assistant_builder/AssistantTemplateModal.tsx
@@ -9,6 +9,7 @@ import {
 import type { WorkspaceType } from "@dust-tt/types";
 import Link from "next/link";
 
+import { InstructionsReadOnlyTextArea } from "@app/components/assistant/AssistantInstructionReadOnlyTextArea";
 import type { BuilderFlow } from "@app/components/assistant_builder/types";
 import { useAssistantTemplate } from "@app/lib/swr";
 import { classNames } from "@app/lib/utils";
@@ -84,14 +85,7 @@ function InstructionsSection({
   return (
     <>
       <Page.SectionHeader title="Instructions" />
-      <textarea
-        disabled
-        className={classNames(
-          "block h-full min-h-60 w-full min-w-0 rounded-xl text-sm",
-          "resize-none border-structure-200 bg-structure-50"
-        )}
-        defaultValue={instructions ?? ""}
-      />
+      <InstructionsReadOnlyTextArea instructions={instructions} />
     </>
   );
 }


### PR DESCRIPTION
## Description

Olympus Task: https://github.com/dust-tt/tasks/issues/960

Use the same design for instructions in the assistantDetail modal as we use for the template modal. 

<kbd>
<img width="451" alt="Screenshot 2024-06-26 at 14 53 51" src="https://github.com/dust-tt/dust/assets/3803406/140c97ac-89f4-4655-89a8-4aa8ec729ec5">
</kbd>


## Risk

Low, can be rolled back. 

## Deploy Plan

Deploy front. 
