### PR TITLE
Amplitude tracking of assistant builder usage.

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -67,6 +67,7 @@ import {
 } from "@app/components/sparkle/AppLayoutTitle";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
+import { ClientSideTracking } from "@app/lib/tracking/client";
 
 export default function AssistantBuilder({
   owner,
@@ -339,6 +340,37 @@ export default function AssistantBuilder({
       })),
     [screen]
   );
+
+  useEffect(() => {
+    void ClientSideTracking.trackAssistantBuilderOpened({
+      isNew: !agentConfigurationId,
+      templateName: defaultTemplate?.handle,
+      assistantName: builderState.handle || undefined,
+      workspaceId: owner.sId,
+    });
+  }, [
+    agentConfigurationId,
+    builderState.handle,
+    defaultTemplate?.handle,
+    owner.sId,
+  ]);
+
+  useEffect(() => {
+    void ClientSideTracking.trackAssistantBuilderStepViewed({
+      step: screen,
+      isNew: !agentConfigurationId,
+      templateName: defaultTemplate?.handle,
+      assistantName: builderState.handle || undefined,
+      workspaceId: owner.sId,
+    });
+  }, [
+    agentConfigurationId,
+    builderState.handle,
+    defaultTemplate?.handle,
+    owner.sId,
+    screen,
+  ]);
+
   const modalTitle = agentConfigurationId
     ? `Edit @${builderState.handle}`
     : "New Assistant";

--- a/front/lib/tracking/amplitude/client/generated/index.ts
+++ b/front/lib/tracking/amplitude/client/generated/index.ts
@@ -70,6 +70,24 @@ export interface IdentifyProperties {
   SignupDate?: string;
 }
 
+export interface AssistantBuilderOpenedProperties {
+  assistantName: string;
+  isNew: boolean;
+  templateName?: string;
+}
+
+export interface AssistantBuilderStepViewedProperties {
+  /**
+   * | Rule | Value |
+   * |---|---|
+   * | Enum Values | instructions, actions, naming |
+   */
+  assistantBuilderStep: "instructions" | "actions" | "naming";
+  assistantName: string;
+  isNew: boolean;
+  templateName?: string;
+}
+
 export interface ClickedEnterpriseContactUsProperties {
   email: string;
 }
@@ -117,6 +135,22 @@ export class Identify implements BaseEvent {
   event_type = amplitude.Types.SpecialEventType.IDENTIFY;
 
   constructor(public event_properties?: IdentifyProperties) {
+    this.event_properties = event_properties;
+  }
+}
+
+export class AssistantBuilderOpened implements BaseEvent {
+  event_type = "AssistantBuilderOpened";
+
+  constructor(public event_properties: AssistantBuilderOpenedProperties) {
+    this.event_properties = event_properties;
+  }
+}
+
+export class AssistantBuilderStepViewed implements BaseEvent {
+  event_type = "AssistantBuilderStepViewed";
+
+  constructor(public event_properties: AssistantBuilderStepViewedProperties) {
     this.event_properties = event_properties;
   }
 }
@@ -284,6 +318,40 @@ export class Ampli {
     }
 
     return this.amplitude!.track(event, undefined, options);
+  }
+
+  /**
+   * AssistantBuilderOpened
+   *
+   * [View in Tracking Plan](https://data.amplitude.com/dust-tt/dust-prod/events/main/latest/AssistantBuilderOpened)
+   *
+   * Event has no description in tracking plan.
+   *
+   * @param properties The event's properties (e.g. assistantName)
+   * @param options Amplitude event options.
+   */
+  assistantBuilderOpened(
+    properties: AssistantBuilderOpenedProperties,
+    options?: EventOptions,
+  ) {
+    return this.track(new AssistantBuilderOpened(properties), options);
+  }
+
+  /**
+   * AssistantBuilderStepViewed
+   *
+   * [View in Tracking Plan](https://data.amplitude.com/dust-tt/dust-prod/events/main/latest/AssistantBuilderStepViewed)
+   *
+   * Event has no description in tracking plan.
+   *
+   * @param properties The event's properties (e.g. assistantBuilderStep)
+   * @param options Amplitude event options.
+   */
+  assistantBuilderStepViewed(
+    properties: AssistantBuilderStepViewedProperties,
+    options?: EventOptions,
+  ) {
+    return this.track(new AssistantBuilderStepViewed(properties), options);
   }
 
   /**

--- a/front/lib/tracking/amplitude/client/index.ts
+++ b/front/lib/tracking/amplitude/client/index.ts
@@ -1,8 +1,13 @@
 import type { LightWorkspaceType } from "@dust-tt/types";
 
-import type { Ampli } from "@app/lib/tracking/amplitude/client/generated";
+import type {
+  Ampli,
+  AssistantBuilderStepViewedProperties,
+} from "@app/lib/tracking/amplitude/client/generated";
 import {
   ampli,
+  AssistantBuilderOpened,
+  AssistantBuilderStepViewed,
   MultiFilesUploadUsed,
   PageViewed,
 } from "@app/lib/tracking/amplitude/client/generated";
@@ -144,5 +149,66 @@ export class AmplitudeClientSideTracking {
   static async flush() {
     const client = getBrowserClient();
     return client.flush().promise;
+  }
+
+  static trackAssistantBuilderOpened({
+    isNew,
+    assistantName,
+    templateName,
+    workspaceId,
+  }: {
+    isNew: boolean;
+    templateName?: string;
+    assistantName?: string;
+    workspaceId: string;
+  }) {
+    const client = getBrowserClient();
+    const event = new AssistantBuilderOpened({
+      isNew,
+      templateName,
+      assistantName: assistantName || "",
+    });
+    client.track({
+      ...event,
+      groups: workspaceId
+        ? {
+            [GROUP_TYPE]: workspaceId,
+          }
+        : undefined,
+    });
+
+    return AmplitudeClientSideTracking.flush();
+  }
+
+  static trackAssistantBuilderStepViewed({
+    step,
+    isNew,
+    assistantName,
+    templateName,
+    workspaceId,
+  }: {
+    step: AssistantBuilderStepViewedProperties["assistantBuilderStep"];
+    isNew: boolean;
+    templateName?: string;
+    assistantName?: string;
+    workspaceId: string;
+  }) {
+    const client = getBrowserClient();
+    const event = new AssistantBuilderStepViewed({
+      assistantBuilderStep: step,
+      isNew,
+      templateName,
+      assistantName: assistantName || "",
+    });
+    client.track({
+      ...event,
+      groups: workspaceId
+        ? {
+            [GROUP_TYPE]: workspaceId,
+          }
+        : undefined,
+    });
+
+    return AmplitudeClientSideTracking.flush();
   }
 }

--- a/front/lib/tracking/client.ts
+++ b/front/lib/tracking/client.ts
@@ -1,5 +1,6 @@
 import type { LightWorkspaceType } from "@dust-tt/types";
 
+import type { BuilderScreen } from "@app/components/assistant_builder/types";
 import { AmplitudeClientSideTracking } from "@app/lib/tracking/amplitude/client";
 
 export class ClientSideTracking {
@@ -73,6 +74,47 @@ export class ClientSideTracking {
       trialing,
       workspaceId,
       workspaceName,
+    });
+  }
+
+  static trackAssistantBuilderOpened({
+    isNew,
+    assistantName,
+    templateName,
+    workspaceId,
+  }: {
+    isNew: boolean;
+    assistantName?: string;
+    templateName?: string;
+    workspaceId: string;
+  }) {
+    return AmplitudeClientSideTracking.trackAssistantBuilderOpened({
+      isNew,
+      templateName,
+      assistantName,
+      workspaceId,
+    });
+  }
+
+  static trackAssistantBuilderStepViewed({
+    step,
+    isNew,
+    assistantName,
+    templateName,
+    workspaceId,
+  }: {
+    step: BuilderScreen;
+    isNew: boolean;
+    templateName?: string;
+    assistantName?: string;
+    workspaceId: string;
+  }) {
+    return AmplitudeClientSideTracking.trackAssistantBuilderStepViewed({
+      step,
+      isNew,
+      assistantName,
+      templateName,
+      workspaceId,
     });
   }
 }


### PR DESCRIPTION
## Description

We are adding tracking of assistant builder usage on Amplitude.
This PR is adding 2 events:
- `AssistantBuilderOpened`
- `AssistantBuilderStepViewed`

Task is [here](https://github.com/dust-tt/dust/issues/5490).


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
