### PR TITLE
enh(tables query): pass conversation history to action instead of model-generated query

### DIFF
--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -129,19 +129,7 @@ async function tablesQueryActionSpecification({
   return {
     name,
     description,
-    inputs: [
-      {
-        name: "question",
-        description:
-          "The natural language question to answer based on the user" +
-          " request and conversation context. The question should include" +
-          " all the context required to be understood without reference to the conversation." +
-          " If the user has multiple unanswered questions, make sure to include all of them." +
-          " If the user asked to correct a previous attempt in a specific way," +
-          " take it into account when generating the question.",
-        type: "string" as const,
-      },
-    ],
+    inputs: [],
   };
 }
 
@@ -159,8 +147,8 @@ export class TablesQueryConfigurationServerRunner extends BaseActionConfiguratio
     }
 
     let actionDescription =
-      "Query data tables specificied by the user by executing a generated SQL query from a" +
-      " natural language question.";
+      "Query data tables specificied by the user by executing a generated SQL query. " +
+      "The function does not require any inputs, the SQL query will be inferred from the conversation history.";
     if (description) {
       actionDescription += `\nDescription of the data tables:\n${description}`;
     }
@@ -199,22 +187,6 @@ export class TablesQueryConfigurationServerRunner extends BaseActionConfiguratio
     }
 
     const { actionConfiguration } = this;
-
-    if (!rawInputs.question || typeof rawInputs.question !== "string") {
-      yield {
-        type: "tables_query_error",
-        created: Date.now(),
-        configurationId: agentConfiguration.sId,
-        messageId: agentMessage.sId,
-        error: {
-          code: "tables_query_parameters_generation_error",
-          message: `Error generating parameters for tables query: failed to generate a valid question.`,
-        },
-      };
-      return;
-    }
-
-    const question = rawInputs.question as string;
 
     let output: Record<string, string | boolean | number> = {};
 
@@ -335,8 +307,7 @@ export class TablesQueryConfigurationServerRunner extends BaseActionConfiguratio
       config,
       [
         {
-          question,
-          conversation: renderedConversation.modelConversation,
+          conversation: renderedConversation.modelConversation.messages,
           instructions: agentConfiguration.instructions,
         },
       ],

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -30,7 +30,9 @@ import { AgentTablesQueryAction } from "@app/lib/models/assistant/actions/tables
 import { sanitizeJSONOutput } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 
-const TABLES_QUERY_MIN_TOKEN = 64_000;
+// Need a model with at least 32k to run tables query.
+const TABLES_QUERY_MIN_TOKEN = 28_000;
+const RENDERED_CONVERSATION_MIN_TOKEN = 4_000;
 
 interface TablesQueryActionBlob {
   id: ModelId; // AgentTablesQueryAction.
@@ -235,7 +237,7 @@ export class TablesQueryConfigurationServerRunner extends BaseActionConfiguratio
 
     const allowedTokenCount =
       supportedModel.contextSize - TABLES_QUERY_MIN_TOKEN;
-    if (allowedTokenCount < 4096) {
+    if (allowedTokenCount < RENDERED_CONVERSATION_MIN_TOKEN) {
       yield {
         type: "tables_query_error",
         created: Date.now(),

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -221,17 +221,6 @@ export class TablesQueryConfigurationServerRunner extends BaseActionConfiguratio
     // Render conversation for the action.
     const supportedModel = getSupportedModelConfig(agentConfiguration.model);
     if (!supportedModel) {
-      yield {
-        type: "tables_query_error",
-        created: Date.now(),
-        configurationId: agentConfiguration.sId,
-        messageId: agentMessage.sId,
-        error: {
-          code: "tables_query_error",
-          message: `Error running TablesQuery app: model not supported.`,
-        },
-      };
-
       throw new Error("Unreachable: Supported model not found.");
     }
 
@@ -248,10 +237,7 @@ export class TablesQueryConfigurationServerRunner extends BaseActionConfiguratio
           message: `Error running TablesQuery app: model context too small.`,
         },
       };
-
-      throw new Error(
-        `Unreachable: Model context too small. (model=${supportedModel.modelId}, provider=${supportedModel.providerId}, contextSize=${supportedModel.contextSize})`
-      );
+      return;
     }
 
     const renderedConversationRes =

--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -124,7 +124,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "b4f205e453",
       appHash:
-        "cd60b80149bf36069cde1d88623493197db0449522d5ec7bed31266a34724a75",
+        "4bcaad425dc8030fbe5944928f7f8942e22bce94062dada80b3e1a282887503a",
     },
     config: {
       MODEL: {


### PR DESCRIPTION
## Description

fixes: https://github.com/dust-tt/dust/issues/5870


Right now, the tables query dust app receives a model-generated natural language query, which is low throughput, expensive and lossy.
In order to:
- improve performance
- reduce cost
- improve reliability
- improve ability for the user to steer the SQL query

This commit changes action so it receives the conversation history (with enough space to add the DB schema, tables head and generated query) instead of a model-generated question.


## Risk

Risk of breaking tables query (tested though)

## Deploy Plan

N/A