### PR TITLE
[Sparkle Tooltip] When copying stuff, do not copy tooltip text with it

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.172",
+  "version": "0.2.173",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.172",
+      "version": "0.2.173",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.172",
+  "version": "0.2.173",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/Tooltip.tsx
+++ b/sparkle/src/components/Tooltip.tsx
@@ -15,6 +15,9 @@ export function Tooltip({
   position = "above",
   contentChildren,
 }: TooltipProps) {
+  // used to disable the tooltip when copying
+  const [isCopying, setIsCopying] = useState(false);
+
   const [isHovered, setIsHovered] = useState(false);
   const [timerId, setTimerId] = useState<number | null>(null);
   const [isTouchDevice, setIsTouchDevice] = useState(false);
@@ -61,11 +64,21 @@ export function Tooltip({
   const labelLength = label?.length || 0;
   const labelClasses = labelLength > 80 ? "s-w-[38em]" : "s-whitespace-nowrap";
 
+  // do not show the tooltip while we're copying the content
+  // otherwise the tooltip text is copied also
+  if (isCopying) {
+    return <>{children}</>;
+  }
+
   return (
     <div
       onMouseEnter={handleMouseOver}
       onMouseLeave={handleMouseLeave}
       className="s-relative s-inline-block"
+      onCopyCapture={() => {
+        setIsCopying(true);
+        setTimeout(() => setIsCopying(false), 200);
+      }}
     >
       {children}
       <div


### PR DESCRIPTION
Description
---

Fixes https://github.com/dust-tt/dust/issues/5699 and relatedly https://github.com/dust-tt/tasks/issues/882

Before:
![Screencast from 2024-06-26 15-20-16](https://github.com/dust-tt/dust/assets/5437393/abd6c62f-994f-4052-a64f-1611e783b8ac)


After:
![Screencast from 2024-06-26 15-22-50](https://github.com/dust-tt/dust/assets/5437393/8df94763-3dda-42a9-951e-a0f6f28ece4c)

Risk & deploy
---
na
