### PR TITLE
[front] enh: bump sparkle version - Remove unused empty space in pagination

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,7 @@
         "@amplitude/analytics-browser": "^2.5.2",
         "@amplitude/analytics-node": "^1.3.5",
         "@auth0/nextjs-auth0": "^3.5.0",
-        "@dust-tt/sparkle": "^0.2.171",
+        "@dust-tt/sparkle": "^0.2.173",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -10724,9 +10724,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.171",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.171.tgz",
-      "integrity": "sha512-HCIn9G4I8j0NCSmMutAwBN2hlRmgTRrMwdlYcswI760K1GUImUy2id9huueF237ZSX2fSpthQRCkWOK3eWrCvQ==",
+      "version": "0.2.173",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.173.tgz",
+      "integrity": "sha512-8nxDLs+c26oHHove/PmtiDhkFAbYEHWY/q/bhO5yYrCY7vYkwr84IIXTnCV5KX72I7R1kCsVjnTa0j2mYkKUNw==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
     "@amplitude/analytics-browser": "^2.5.2",
     "@amplitude/analytics-node": "^1.3.5",
     "@auth0/nextjs-auth0": "^3.5.0",
-    "@dust-tt/sparkle": "^0.2.171",
+    "@dust-tt/sparkle": "^0.2.173",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",


### PR DESCRIPTION
## Description

fixes: https://github.com/dust-tt/tasks/issues/942

If the total number of items can fit in less rows that the max allow, reduce the number of rows.



## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy `front`
