### PR TITLE
[Conversation UX] Remove tooltip on assistant mention

### DIFF
--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -5,10 +5,7 @@ import {
   SparklesIcon,
   WrenchIcon,
 } from "@dust-tt/sparkle";
-import type {
-  LightAgentConfigurationType,
-  WebsearchResultType,
-} from "@dust-tt/types";
+import type { WebsearchResultType } from "@dust-tt/types";
 import type { RetrievalDocumentType } from "@dust-tt/types";
 import mermaid from "mermaid";
 import dynamic from "next/dynamic";
@@ -174,12 +171,10 @@ export const CitationsContext = React.createContext<CitationsContextType>({
 export function RenderMessageMarkdown({
   content,
   isStreaming,
-  agentConfigurations,
   citationsContext,
 }: {
   content: string;
   isStreaming: boolean;
-  agentConfigurations?: LightAgentConfigurationType[];
   citationsContext?: CitationsContextType;
 }) {
   // Memoize markdown components to avoid unnecessary re-renders that disrupt text selection

--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -3,7 +3,6 @@ import {
   ClipboardIcon,
   IconButton,
   SparklesIcon,
-  Tooltip,
   WrenchIcon,
 } from "@dust-tt/sparkle";
 import type {
@@ -237,15 +236,7 @@ export function RenderMessageMarkdown({
       // @ts-expect-error - `mention` is a custom tag, currently refused by
       // react-markdown types although the functionality is supported
       mention: ({ agentName, agentSId }) => {
-        const agentConfiguration = agentConfigurations?.find(
-          (agentConfiguration) => agentConfiguration.sId === agentSId
-        );
-        return (
-          <MentionBlock
-            agentConfiguration={agentConfiguration}
-            agentName={agentName}
-          />
-        );
+        return <MentionBlock agentName={agentName} />;
       },
     }),
     [agentConfigurations, isStreaming]
@@ -281,25 +272,10 @@ export function RenderMessageMarkdown({
   );
 }
 
-function MentionBlock({
-  agentName,
-  agentConfiguration,
-}: {
-  agentName: string;
-  agentConfiguration?: LightAgentConfigurationType;
-}) {
-  const statusText =
-    !agentConfiguration || agentConfiguration?.status === "archived"
-      ? "(This assistant was deleted)"
-      : agentConfiguration?.status === "active"
-        ? ""
-        : "(This assistant is either deactivated or being tested)";
-  const tooltipLabel = agentConfiguration?.description || "" + " " + statusText;
+function MentionBlock({ agentName }: { agentName: string }) {
   return (
     <span className="inline-block cursor-default font-medium text-brand">
-      <Tooltip label={tooltipLabel} position="below">
-        @{agentName}
-      </Tooltip>
+      @{agentName}
     </span>
   );
 }

--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -235,11 +235,11 @@ export function RenderMessageMarkdown({
       ),
       // @ts-expect-error - `mention` is a custom tag, currently refused by
       // react-markdown types although the functionality is supported
-      mention: ({ agentName, agentSId }) => {
+      mention: ({ agentName }) => {
         return <MentionBlock agentName={agentName} />;
       },
     }),
-    [agentConfigurations, isStreaming]
+    [isStreaming]
   );
 
   const markdownPlugins = useMemo(

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -9,7 +9,6 @@ import { AgentSuggestion } from "@app/components/assistant/conversation/AgentSug
 import type { MessageSizeType } from "@app/components/assistant/conversation/ConversationMessage";
 import { ConversationMessage } from "@app/components/assistant/conversation/ConversationMessage";
 import { RenderMessageMarkdown } from "@app/components/assistant/RenderMessageMarkdown";
-import { useAgentConfigurations } from "@app/lib/swr";
 
 interface UserMessageProps {
   conversationId: string;
@@ -36,11 +35,6 @@ export function UserMessage({
   contentFragments,
   size,
 }: UserMessageProps) {
-  const { agentConfigurations } = useAgentConfigurations({
-    workspaceId: owner.sId,
-    agentsGetView: { conversationId },
-  });
-
   return (
     <ConversationMessage
       owner={owner}
@@ -61,7 +55,6 @@ export function UserMessage({
           <RenderMessageMarkdown
             content={message.content}
             isStreaming={false}
-            agentConfigurations={agentConfigurations}
           />
         </div>
         {message.mentions.length === 0 && isLastMessage && (


### PR DESCRIPTION
Description
---

Fixes https://github.com/dust-tt/dust/issues/5699 and relatedly https://github.com/dust-tt/tasks/issues/882

The tooltip was being copied with the rest of the content

Before:
![Screencast from 2024-06-26 15-20-16](https://github.com/dust-tt/dust/assets/5437393/abd6c62f-994f-4052-a64f-1611e783b8ac)


After:
![Screencast from 2024-06-26 15-22-50](https://github.com/dust-tt/dust/assets/5437393/8df94763-3dda-42a9-951e-a0f6f28ece4c)

Risk & deploy
---
na