### PR TITLE
[front] - fix(front): ensure content_fragment content type

### DIFF
--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -172,7 +172,9 @@ async function handler(
         title,
         content,
         url,
-        contentType,
+        // hack: for users creating content_fragments through our public API
+        contentType:
+          contentType === "file_attachment" ? "text/plain" : contentType,
         context: {
           username: context?.username || null,
           fullName: context?.fullName || null,


### PR DESCRIPTION
## Description

This PR aims at adding workaround for users using the public API to create content fragment. We now default to "text/plain" if the provided `contentType` is "file_attachment"

## Risk

Not risky

## Deploy Plan

Deploy `front`
