### PR TITLE
[connector] fix: force delete of slack connector

### DIFF
--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -251,7 +251,7 @@ export async function uninstallSlack(nangoConnectionId: string) {
 
 export async function cleanupSlackConnector(
   connectorId: ModelId,
-  force: boolean
+  force = false
 ): Promise<Result<undefined, Error>> {
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -250,7 +250,8 @@ export async function uninstallSlack(nangoConnectionId: string) {
 }
 
 export async function cleanupSlackConnector(
-  connectorId: ModelId
+  connectorId: ModelId,
+  force: boolean
 ): Promise<Result<undefined, Error>> {
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
@@ -282,9 +283,16 @@ export async function cleanupSlackConnector(
       `Attempting Slack app deactivation [cleanupSlackConnector]`
     );
 
-    const uninstallRes = await uninstallSlack(connector.connectionId);
-    if (uninstallRes.isErr()) {
-      return uninstallRes;
+    try {
+      const uninstallRes = await uninstallSlack(connector.connectionId);
+
+      if (uninstallRes.isErr() && !force) {
+        return uninstallRes;
+      }
+    } catch (e) {
+      if (!force) {
+        throw e;
+      }
     }
 
     logger.info(


### PR DESCRIPTION
## Description

Catch error in uninstall if if force is set. Bypass error like invalid nango connection.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy `connector`