### PR TITLE
Rework content fragment rendering for model

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -173,8 +173,12 @@ export async function renderConversationForModelMultiActions({
     Promise.all(
       messages.map((m) => {
         let text = `${m.role} ${"name" in m ? m.name : ""} ${getTextContentFromMessage(m)}`;
-        if (isContentFragmentMessageTypeModel(m)) {
-          // We want to account for the upcoming </attachment> tag, which will be added in the merging loop.
+        if (
+          isContentFragmentMessageTypeModel(m) &&
+          m.content.every((c) => isTextContent(c))
+        ) {
+          // Account for the upcoming </attachment> tag for textual attachments,
+          // as it will be appended during the merging process.
           text += closingAttachmentTag;
         }
 

--- a/types/src/front/lib/api/assistant/generation.ts
+++ b/types/src/front/lib/api/assistant/generation.ts
@@ -12,7 +12,7 @@ export interface ModelConversationType {
   messages: ModelMessageType[];
 }
 
-export interface ImageContentFragmentContent {
+export interface ImageContent {
   type: "image_url";
   image_url: {
     url: string;
@@ -24,22 +24,22 @@ interface TextContent {
   text: string;
 }
 
-export function isTextContent(
-  content: TextContent | ImageContentFragmentContent
-): content is TextContent {
+type Content = TextContent | ImageContent;
+
+export function isTextContent(content: Content): content is TextContent {
   return content.type === "text";
 }
 
 export interface ContentFragmentMessageTypeModel {
   role: "content_fragment";
   name: string;
-  content: (TextContent | ImageContentFragmentContent)[];
+  content: Content[];
 }
 
 export interface UserMessageTypeModel {
   role: "user";
   name: string;
-  content: (ImageContentFragmentContent | TextContent)[];
+  content: Content[];
 }
 
 export interface FunctionCallType {

--- a/types/src/front/lib/api/assistant/generation.ts
+++ b/types/src/front/lib/api/assistant/generation.ts
@@ -2,51 +2,70 @@
  * Model rendering of conversations.
  */
 
-export type ModelMessageType = {
+export interface ModelMessageType {
   role: "action" | "agent" | "user" | "content_fragment";
   name: string;
   content: string;
-};
+}
 
-export type ModelConversationType = {
+export interface ModelConversationType {
   messages: ModelMessageType[];
-};
+}
 
-export type ContentFragmentMessageTypeModel = {
+export interface ImageContentFragmentContent {
+  type: "image_url";
+  image_url: {
+    url: string;
+  };
+}
+
+interface TextContent {
+  type: "text";
+  text: string;
+}
+
+export function isTextContent(
+  content: TextContent | ImageContentFragmentContent
+): content is TextContent {
+  return content.type === "text";
+}
+
+export interface ContentFragmentMessageTypeModel {
   role: "content_fragment";
   name: string;
-  content: string;
-};
+  content: (TextContent | ImageContentFragmentContent)[];
+}
 
-export type UserMessageTypeModel = {
+export interface UserMessageTypeModel {
   role: "user";
   name: string;
-  content: string;
-};
+  content: (ImageContentFragmentContent | TextContent)[];
+}
 
-export type FunctionCallType = {
+export interface FunctionCallType {
   id: string;
   name: string;
   arguments: string;
-};
+}
 
-export type AssistantFunctionCallMessageTypeModel = {
+export interface AssistantFunctionCallMessageTypeModel {
   role: "assistant";
   content?: string;
   function_calls: FunctionCallType[];
-};
-export type AssistantContentMessageTypeModel = {
+}
+
+export interface AssistantContentMessageTypeModel {
   role: "assistant";
   name: string;
   content: string;
-};
+}
 
-export type FunctionMessageTypeModel = {
+export interface FunctionMessageTypeModel {
   role: "function";
   name: string;
   function_call_id: string;
   content: string;
-};
+}
 
 export type ModelMessageTypeMultiActions =
   | ContentFragmentMessageTypeModel
@@ -54,6 +73,12 @@ export type ModelMessageTypeMultiActions =
   | AssistantFunctionCallMessageTypeModel
   | AssistantContentMessageTypeModel
   | FunctionMessageTypeModel;
+
+export function isContentFragmentMessageTypeModel(
+  contentFragment: ModelMessageTypeMultiActions
+): contentFragment is ContentFragmentMessageTypeModel {
+  return contentFragment.role === "content_fragment";
+}
 
 export type ModelConversationTypeMultiActions = {
   messages: ModelMessageTypeMultiActions[];


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
After the recent refactoring (see https://github.com/dust-tt/dust/pull/5835) of the supported types for chat, this PR revisits the existing logic of `renderConversationForModelMultiActions` to leverage the new additions.

### Key points to note:
- All user messages will be sent as either `content: [{type: "text", text: string}]` or as `content: [{type: "image_url", ...}]`.
- Content fragments are now grouped within the user message content array, formatted as follows:
  ```json
  [
    {
      "value": {
        "conversation": {
          "messages": [
            {
              "role": "user",
              "name": "<name>",
              "content": [
                {
                  "type": "text",
                  "text": "<attachment type=\"application/pdf\" title=\"c0d5b319-43bf-49dd-93d5-f3a1557876ce.pdf\">blob</attachment>\n"
                },
                { "type": "text", "text": "@gpt4 what's this?" }
              ]
            }
          ]
        },
        "specifications": [],
        "prompt": "<prompt>"
      },
      "error": null,
      "meta": null
    }
  ]
  ```

These changes are necessary to support vision capabilities. This PR also introduces the required types for image content fragments.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
There is a risk associated with these changes, but it is safe to rollback if needed.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
