### PR TITLE
Lowercase tool renaming to avoid confusion

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -700,7 +700,7 @@ function ActionEditor({
                       value={action.name}
                       onChange={(v) => {
                         updateAction({
-                          actionName: v,
+                          actionName: v.toLowerCase(),
                           actionDescription: action.description,
                           getNewActionConfig: (old) => old,
                         });


### PR DESCRIPTION
## Description

Confusion on tool name renaming arises when starting the tool name with a capital letter because the save button becomes disabled. 
Making sure the name stays lowercase to avoid this

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
