### PR TITLE
Fix OpenAI max_tokens + stop parameters

### DIFF
--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -613,15 +613,10 @@ pub async fn streamed_completion(
 
     let mut body = json!({
         "prompt": prompt,
-        "max_tokens": max_tokens,
         "temperature": temperature,
         "n": n,
         "logprobs": logprobs,
         "echo": echo,
-        "stop": match stop.len() {
-            0 => None,
-            _ => Some(stop),
-        },
         "frequency_penalty": frequency_penalty,
         "presence_penalty": presence_penalty,
         "top_p": top_p,
@@ -632,6 +627,12 @@ pub async fn streamed_completion(
     }
     if model_id.is_some() {
         body["model"] = json!(model_id);
+    }
+    if let Some(mt) = max_tokens {
+        body["max_tokens"] = mt.into();
+    }
+    if !stop.is_empty() {
+        body["stop"] = json!(stop);
     }
 
     // println!("BODY: {}", body.to_string());
@@ -894,14 +895,9 @@ pub async fn completion(
 
     let mut body = json!({
         "prompt": prompt,
-        "max_tokens": max_tokens,
         "temperature": temperature,
         "n": n,
         "logprobs": logprobs,
-        "stop": match stop.len() {
-            0 => None,
-            _ => Some(stop),
-        },
         "frequency_penalty": frequency_penalty,
         "presence_penalty": presence_penalty,
         "top_p": top_p,
@@ -912,6 +908,13 @@ pub async fn completion(
     if model_id.is_some() {
         body["model"] = json!(model_id);
     }
+    if let Some(mt) = max_tokens {
+        body["max_tokens"] = mt.into();
+    }
+    if !stop.is_empty() {
+        body["stop"] = json!(stop);
+    }
+
     match model_id {
         None => (),
         Some(model_id) => {
@@ -1039,11 +1042,6 @@ pub async fn streamed_chat_completion(
         "temperature": temperature,
         "top_p": top_p,
         "n": n,
-        "stop": match stop.len() {
-            0 => None,
-            _ => Some(stop),
-        },
-        "max_tokens": max_tokens,
         "presence_penalty": presence_penalty,
         "frequency_penalty": frequency_penalty,
         "stream": true,
@@ -1055,6 +1053,13 @@ pub async fn streamed_chat_completion(
     if model_id.is_some() {
         body["model"] = json!(model_id);
     }
+    if let Some(mt) = max_tokens {
+        body["max_tokens"] = mt.into();
+    }
+    if !stop.is_empty() {
+        body["stop"] = json!(stop);
+    }
+
     if tools.len() > 0 {
         body["tools"] = json!(tools);
     }
@@ -1430,11 +1435,6 @@ pub async fn chat_completion(
         "temperature": temperature,
         "top_p": top_p,
         "n": n,
-        "stop": match stop.len() {
-            0 => None,
-            _ => Some(stop),
-        },
-        "max_tokens": max_tokens,
         "presence_penalty": presence_penalty,
         "frequency_penalty": frequency_penalty,
     });
@@ -1444,6 +1444,13 @@ pub async fn chat_completion(
     if model_id.is_some() {
         body["model"] = json!(model_id);
     }
+    if let Some(mt) = max_tokens {
+        body["max_tokens"] = mt.into();
+    }
+    if !stop.is_empty() {
+        body["stop"] = json!(stop);
+    }
+
     if response_format.is_some() {
         body["response_format"] = json!({
             "type": response_format.unwrap(),


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
While testing vision, it looks like OpenAI enforces stricter type checking on `max_tokens` and `stop`. This PR fixes it.

```
ERROR: Error running assistant: Error querying `openai:gpt-4o`: error=[model_error(retryable=, request_id=req_662f77bf5b85f3059114da915bdc4699false)] OpenAIError: [invalid_request_error] [{'type': 'int_type', 'loc': ('body', 'max_tokens'), 'msg': 'Input should be a valid integer', 'input': None}, {'type': 'string_type', 'loc': ('body', 'stop', 'str'), 'msg': 'Input should be a valid string', 'input': None}, {'type': 'list_type', 'loc': ('body', 'stop', 'list[str]'), 'msg': 'Input should be a valid list', 'input': None}, {'type': 'list_type', 'loc': ('body', 'stop', 'list[list[int]]'), 'msg': 'Input should be a valid list', 'input': None}] (code: multi_actions_error)
```

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
