### PR TITLE
[chore] - chore(front): bump headless

### DIFF
--- a/front/components/app/CopyRun.tsx
+++ b/front/components/app/CopyRun.tsx
@@ -11,6 +11,7 @@ import {
   Transition,
   TransitionChild,
 } from "@headlessui/react";
+import classNames from "classnames";
 import { Fragment, useMemo, useState } from "react";
 
 import { DisplayCurlRequest } from "@app/components/app/Deploy";
@@ -78,16 +79,15 @@ export default function CopyRun({
           className="relative z-30"
           onClose={() => setOpen(false)}
         >
-          <TransitionChild
-            as={Fragment}
-            enter="ease-out duration-300"
-            enterFrom="opacity-0"
-            enterTo="opacity-100"
-            leave="ease-in duration-200"
-            leaveFrom="opacity-100"
-            leaveTo="opacity-0"
-          >
-            <div className="fixed inset-0 bg-gray-800 bg-opacity-75 transition-opacity" />
+          <TransitionChild as={Fragment} appear={true}>
+            <div
+              className={classNames(
+                "fixed inset-0 bg-gray-800 bg-opacity-75 transition-opacity",
+                "duration-300 ease-out",
+                "data-[enter]:data-[closed]:opacity-0",
+                "data-[leave]:data-[closed]:opacity-0"
+              )}
+            />
           </TransitionChild>
 
           <div className="fixed inset-0 z-10 overflow-y-auto">

--- a/front/components/app/CopyRun.tsx
+++ b/front/components/app/CopyRun.tsx
@@ -4,7 +4,13 @@ import { Button, CubeIcon, Tooltip } from "@dust-tt/sparkle";
 import type { WorkspaceType } from "@dust-tt/types";
 import type { AppType, SpecificationType } from "@dust-tt/types";
 import type { RunType } from "@dust-tt/types";
-import { Dialog, Transition } from "@headlessui/react";
+import {
+  Dialog,
+  DialogPanel,
+  DialogTitle,
+  Transition,
+  TransitionChild,
+} from "@headlessui/react";
 import { Fragment, useMemo, useState } from "react";
 
 import { DisplayCurlRequest } from "@app/components/app/Deploy";
@@ -66,13 +72,13 @@ export default function CopyRun({
         />
       </Tooltip>
 
-      <Transition.Root show={open} as={Fragment}>
+      <Transition show={open} as={Fragment}>
         <Dialog
           as="div"
           className="relative z-30"
           onClose={() => setOpen(false)}
         >
-          <Transition.Child
+          <TransitionChild
             as={Fragment}
             enter="ease-out duration-300"
             enterFrom="opacity-0"
@@ -82,25 +88,25 @@ export default function CopyRun({
             leaveTo="opacity-0"
           >
             <div className="fixed inset-0 bg-gray-800 bg-opacity-75 transition-opacity" />
-          </Transition.Child>
+          </TransitionChild>
 
           <div className="fixed inset-0 z-10 overflow-y-auto">
             <div className="flex min-h-full items-end items-center justify-center p-4">
-              <Transition.Child
+              <TransitionChild
                 as={Fragment}
                 enter="ease-out duration-300"
                 leave="ease-in duration-200"
                 leaveTo="opacity-0"
               >
-                <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-4xl sm:p-6 lg:max-w-4xl">
+                <DialogPanel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-4xl sm:p-6 lg:max-w-4xl">
                   <div data-color-mode="light">
                     <div className="mt-3">
-                      <Dialog.Title
+                      <DialogTitle
                         as="h3"
                         className="text-lg font-medium leading-6 text-gray-900"
                       >
                         Run as API Endpoint
-                      </Dialog.Title>
+                      </DialogTitle>
                       <DisplayCurlRequest
                         app={app}
                         inputs={inputs}
@@ -120,12 +126,12 @@ export default function CopyRun({
                       />
                     </div>
                   </div>
-                </Dialog.Panel>
-              </Transition.Child>
+                </DialogPanel>
+              </TransitionChild>
             </div>
           </div>
         </Dialog>
-      </Transition.Root>
+      </Transition>
     </div>
   );
 }

--- a/front/components/app/DatasetPicker.tsx
+++ b/front/components/app/DatasetPicker.tsx
@@ -97,7 +97,7 @@ export default function DatasetPicker({
                     {({ focus }) => (
                       <span
                         className={classNames(
-                          active ? "bg-gray-50 text-gray-900" : "text-gray-700",
+                          focus ? "bg-gray-50 text-gray-900" : "text-gray-700",
                           "block cursor-pointer whitespace-nowrap px-4 py-2 text-sm"
                         )}
                         onClick={() => onDatasetUpdate(d.name)}

--- a/front/components/app/DatasetPicker.tsx
+++ b/front/components/app/DatasetPicker.tsx
@@ -1,7 +1,7 @@
 import { ChevronDownIcon } from "@dust-tt/sparkle";
 import type { WorkspaceType } from "@dust-tt/types";
 import type { AppType } from "@dust-tt/types";
-import { Menu } from "@headlessui/react";
+import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/react";
 import Link from "next/link";
 
 import { useDatasets } from "@app/lib/swr";
@@ -60,7 +60,7 @@ export default function DatasetPicker({
               {isDatasetsLoading ? "Loading..." : "Create dataset"}
             </Link>
           ) : readOnly ? null : (
-            <Menu.Button
+            <MenuButton
               className={classNames(
                 "inline-flex items-center rounded-md px-3 py-1 text-sm font-normal",
                 dataset ? "border px-1" : "border border-orange-400",
@@ -79,12 +79,12 @@ export default function DatasetPicker({
               ) : (
                 "Select dataset"
               )}
-            </Menu.Button>
+            </MenuButton>
           )}
         </div>
 
         {readOnly ? null : (
-          <Menu.Items
+          <MenuItems
             className={classNames(
               "absolute left-1 z-10 mt-1 origin-top-left rounded-md bg-white shadow-sm ring-1 ring-black ring-opacity-5 focus:outline-none",
               dataset ? "-left-8" : "left-1"
@@ -93,7 +93,7 @@ export default function DatasetPicker({
             <div className="py-1">
               {datasets.map((d) => {
                 return (
-                  <Menu.Item key={d.name}>
+                  <MenuItem key={d.name}>
                     {({ active }) => (
                       <span
                         className={classNames(
@@ -105,10 +105,10 @@ export default function DatasetPicker({
                         {d.name}
                       </span>
                     )}
-                  </Menu.Item>
+                  </MenuItem>
                 );
               })}
-              <Menu.Item key="__create_dataset">
+              <MenuItem key="__create_dataset">
                 {({ active }) => (
                   <Link href={`/w/${owner.sId}/a/${app.sId}/datasets/new`}>
                     <div
@@ -121,9 +121,9 @@ export default function DatasetPicker({
                     </div>
                   </Link>
                 )}
-              </Menu.Item>
+              </MenuItem>
             </div>
-          </Menu.Items>
+          </MenuItems>
         )}
       </Menu>
     </div>

--- a/front/components/app/DatasetPicker.tsx
+++ b/front/components/app/DatasetPicker.tsx
@@ -94,7 +94,7 @@ export default function DatasetPicker({
               {datasets.map((d) => {
                 return (
                   <MenuItem key={d.name}>
-                    {({ active }) => (
+                    {({ focus }) => (
                       <span
                         className={classNames(
                           active ? "bg-gray-50 text-gray-900" : "text-gray-700",
@@ -109,11 +109,11 @@ export default function DatasetPicker({
                 );
               })}
               <MenuItem key="__create_dataset">
-                {({ active }) => (
+                {({ focus }) => (
                   <Link href={`/w/${owner.sId}/a/${app.sId}/datasets/new`}>
                     <div
                       className={classNames(
-                        active ? "bg-gray-50 text-gray-500" : "text-gray-400",
+                        focus ? "bg-gray-50 text-gray-500" : "text-gray-400",
                         "block cursor-pointer whitespace-nowrap px-4 py-2 text-sm font-normal"
                       )}
                     >

--- a/front/components/app/Deploy.tsx
+++ b/front/components/app/Deploy.tsx
@@ -10,7 +10,13 @@ import {
 import type { WorkspaceType } from "@dust-tt/types";
 import type { AppType, SpecificationType } from "@dust-tt/types";
 import type { RunConfig, RunType } from "@dust-tt/types";
-import { Dialog, Transition } from "@headlessui/react";
+import {
+  Dialog,
+  DialogPanel,
+  DialogTitle,
+  Transition,
+  TransitionChild,
+} from "@headlessui/react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { Fragment, useState } from "react";
@@ -73,13 +79,13 @@ export default function Deploy({
         />
       </Tooltip>
 
-      <Transition.Root show={open} as={Fragment}>
+      <Transition show={open} as={Fragment}>
         <Dialog
           as="div"
           className="relative z-30"
           onClose={() => setOpen(false)}
         >
-          <Transition.Child
+          <TransitionChild
             as={Fragment}
             enter="ease-out duration-300"
             enterFrom="opacity-0"
@@ -89,25 +95,25 @@ export default function Deploy({
             leaveTo="opacity-0"
           >
             <div className="fixed inset-0 bg-gray-800 bg-opacity-75 transition-opacity" />
-          </Transition.Child>
+          </TransitionChild>
 
           <div className="fixed inset-0 z-10 overflow-y-auto">
             <div className="flex min-h-full items-end items-center justify-center p-4">
-              <Transition.Child
+              <TransitionChild
                 as={Fragment}
                 enter="ease-out duration-300"
                 leave="ease-in duration-200"
                 leaveTo="opacity-0"
               >
-                <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-4xl sm:p-6 lg:max-w-4xl">
+                <DialogPanel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-4xl sm:p-6 lg:max-w-4xl">
                   <div data-color-mode="light">
                     <div className="mt-3">
-                      <Dialog.Title
+                      <DialogTitle
                         as="h3"
                         className="text-lg font-medium leading-6 text-gray-900"
                       >
                         Run as API Endpoint
-                      </Dialog.Title>
+                      </DialogTitle>
                       <DisplayCurlRequest
                         app={app}
                         owner={owner}
@@ -126,12 +132,12 @@ export default function Deploy({
                       />
                     </div>
                   </div>
-                </Dialog.Panel>
-              </Transition.Child>
+                </DialogPanel>
+              </TransitionChild>
             </div>
           </div>
         </Dialog>
-      </Transition.Root>
+      </Transition>
     </div>
   );
 }

--- a/front/components/app/Deploy.tsx
+++ b/front/components/app/Deploy.tsx
@@ -85,55 +85,55 @@ export default function Deploy({
           className="relative z-30"
           onClose={() => setOpen(false)}
         >
-          <TransitionChild
-            as={Fragment}
-            enter="ease-out duration-300"
-            enterFrom="opacity-0"
-            enterTo="opacity-100"
-            leave="ease-in duration-200"
-            leaveFrom="opacity-100"
-            leaveTo="opacity-0"
-          >
-            <div className="fixed inset-0 bg-gray-800 bg-opacity-75 transition-opacity" />
+          <TransitionChild as={Fragment}>
+            <div
+              className={classNames(
+                "fixed inset-0 bg-gray-800 bg-opacity-75 transition-opacity",
+                "duration-300 ease-out",
+                "data-[enter]:data-[closed]:opacity-0",
+                "data-[leave]:data-[closed]:opacity-0"
+              )}
+            />
           </TransitionChild>
 
           <div className="fixed inset-0 z-10 overflow-y-auto">
-            <div className="flex min-h-full items-end items-center justify-center p-4">
-              <TransitionChild
-                as={Fragment}
-                enter="ease-out duration-300"
-                leave="ease-in duration-200"
-                leaveTo="opacity-0"
+            <div className="flex min-h-full items-center justify-center p-4">
+              <DialogPanel
+                className={classNames(
+                  "relative overflow-hidden rounded-lg bg-white p-4 sm:my-8 sm:w-full sm:max-w-4xl sm:p-6 lg:max-w-4xl",
+                  "duration-300",
+                  "data-[enter]:data-[closed]:opacity-0",
+                  "data-[leave]:data-[closed]:opacity-0"
+                )}
+                transition
               >
-                <DialogPanel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-4xl sm:p-6 lg:max-w-4xl">
-                  <div data-color-mode="light">
-                    <div className="mt-3">
-                      <DialogTitle
-                        as="h3"
-                        className="text-lg font-medium leading-6 text-gray-900"
-                      >
-                        Run as API Endpoint
-                      </DialogTitle>
-                      <DisplayCurlRequest
-                        app={app}
-                        owner={owner}
-                        run={run}
-                        url={url}
-                      />
-                    </div>
+                <div data-color-mode="light">
+                  <div className="mt-3">
+                    <DialogTitle
+                      as="h3"
+                      className="text-lg font-medium leading-6 text-gray-900"
+                    >
+                      Run as API Endpoint
+                    </DialogTitle>
+                    <DisplayCurlRequest
+                      app={app}
+                      owner={owner}
+                      run={run}
+                      url={url}
+                    />
                   </div>
-                  <div className="mt-5 flex flex-row items-center space-x-2 sm:mt-6">
-                    <div className="flex-1"></div>
-                    <div className="flex flex-initial">
-                      <Button
-                        variant="secondary"
-                        onClick={() => setOpen(false)}
-                        label="Close"
-                      />
-                    </div>
+                </div>
+                <div className="mt-5 flex flex-row items-center space-x-2 sm:mt-6">
+                  <div className="flex-1"></div>
+                  <div className="flex flex-initial">
+                    <Button
+                      variant="secondary"
+                      onClick={() => setOpen(false)}
+                      label="Close"
+                    />
                   </div>
-                </DialogPanel>
-              </TransitionChild>
+                </div>
+              </DialogPanel>
             </div>
           </div>
         </Dialog>

--- a/front/components/app/ModelPicker.tsx
+++ b/front/components/app/ModelPicker.tsx
@@ -1,6 +1,6 @@
 import { ChevronDownIcon } from "@dust-tt/sparkle";
 import type { WorkspaceType } from "@dust-tt/types";
-import { Menu, MenuButton, MenuItems, MenuItem } from "@headlessui/react";
+import { Menu, MenuButton, MenuItem,MenuItems } from "@headlessui/react";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 

--- a/front/components/app/ModelPicker.tsx
+++ b/front/components/app/ModelPicker.tsx
@@ -1,6 +1,6 @@
 import { ChevronDownIcon } from "@dust-tt/sparkle";
 import type { WorkspaceType } from "@dust-tt/types";
-import { Menu } from "@headlessui/react";
+import { Menu, MenuButton, MenuItems, MenuItem } from "@headlessui/react";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
@@ -119,7 +119,7 @@ export default function ModelPicker({
                   : ""}
               </div>
             ) : (
-              <Menu.Button
+              <MenuButton
                 className={classNames(
                   "inline-flex items-center rounded-md py-1 text-sm font-bold",
                   model.provider_id && model.provider_id.length > 0
@@ -139,12 +139,12 @@ export default function ModelPicker({
                 ) : (
                   "Select provider"
                 )}
-              </Menu.Button>
+              </MenuButton>
             )}
           </div>
 
           {readOnly ? null : (
-            <Menu.Items
+            <MenuItems
               className={classNames(
                 "absolute left-1 z-10 mt-1 origin-top-left rounded-md bg-white shadow-sm ring-1 ring-black ring-opacity-5 focus:outline-none",
                 model.provider_id && model.provider_id.length > 0
@@ -155,7 +155,7 @@ export default function ModelPicker({
               <div className="py-1">
                 {modelProviders.map((p) => {
                   return (
-                    <Menu.Item key={p.providerId}>
+                    <MenuItem key={p.providerId}>
                       {({ active }) => (
                         <span
                           className={classNames(
@@ -175,11 +175,11 @@ export default function ModelPicker({
                           {p.providerId}
                         </span>
                       )}
-                    </Menu.Item>
+                    </MenuItem>
                   );
                 })}
               </div>
-            </Menu.Items>
+            </MenuItems>
           )}
         </Menu>
       </div>
@@ -195,7 +195,7 @@ export default function ModelPicker({
           ) : (
             <Menu as="div" className="relative inline-block text-left">
               <div>
-                <Menu.Button
+                <MenuButton
                   className={classNames(
                     "inline-flex items-center rounded-md py-1 text-sm font-bold text-gray-700",
                     model.model_id && model.model_id.length > 0
@@ -215,10 +215,10 @@ export default function ModelPicker({
                   ) : (
                     "Select model"
                   )}
-                </Menu.Button>
+                </MenuButton>
               </div>
 
-              <Menu.Items
+              <MenuItems
                 className={classNames(
                   "absolute z-10 mt-1 w-max origin-top-left rounded-md bg-white shadow ring-1 ring-black ring-opacity-5 focus:outline-none",
                   model.model_id && model.model_id.length > 0
@@ -229,7 +229,7 @@ export default function ModelPicker({
                 <div className="py-1">
                   {(models || []).map((m) => {
                     return (
-                      <Menu.Item key={m.id}>
+                      <MenuItem key={m.id}>
                         {({ active }) => (
                           <span
                             className={classNames(
@@ -248,11 +248,11 @@ export default function ModelPicker({
                             {m.id}
                           </span>
                         )}
-                      </Menu.Item>
+                      </MenuItem>
                     );
                   })}
                 </div>
-              </Menu.Items>
+              </MenuItems>
             </Menu>
           )}
         </div>

--- a/front/components/app/ModelPicker.tsx
+++ b/front/components/app/ModelPicker.tsx
@@ -156,10 +156,10 @@ export default function ModelPicker({
                 {modelProviders.map((p) => {
                   return (
                     <MenuItem key={p.providerId}>
-                      {({ active }) => (
+                      {({ focus }) => (
                         <span
                           className={classNames(
-                            active
+                            focus
                               ? "bg-gray-50 text-gray-900"
                               : "text-gray-700",
                             "block cursor-pointer px-4 py-2 text-sm"
@@ -230,10 +230,10 @@ export default function ModelPicker({
                   {(models || []).map((m) => {
                     return (
                       <MenuItem key={m.id}>
-                        {({ active }) => (
+                        {({ focus }) => (
                           <span
                             className={classNames(
-                              active
+                              focus
                                 ? "bg-gray-50 text-gray-900"
                                 : "text-gray-700",
                               "block cursor-pointer px-4 py-2 text-sm"

--- a/front/components/app/ModelPicker.tsx
+++ b/front/components/app/ModelPicker.tsx
@@ -1,6 +1,6 @@
 import { ChevronDownIcon } from "@dust-tt/sparkle";
 import type { WorkspaceType } from "@dust-tt/types";
-import { Menu, MenuButton, MenuItem,MenuItems } from "@headlessui/react";
+import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/react";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 

--- a/front/components/app/NewBlock.tsx
+++ b/front/components/app/NewBlock.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@dust-tt/sparkle";
 import type { SpecificationType } from "@dust-tt/types";
 import type { BlockType } from "@dust-tt/types";
-import { Menu } from "@headlessui/react";
+import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/react";
 import { PlusIcon } from "@heroicons/react/20/solid";
 
 import { classNames } from "@app/lib/utils";
@@ -123,7 +123,7 @@ export default function NewBlock({
     <Menu as="div" className="relative inline-block">
       <div>
         {small ? (
-          <Menu.Button
+          <MenuButton
             className={classNames(
               "border-1 inline-flex items-center border-red-200 bg-transparent px-0 py-0 text-sm font-medium leading-6 text-gray-400",
               disabled ? "text-gray-300" : "hover:text-gray-700",
@@ -132,19 +132,19 @@ export default function NewBlock({
             disabled={disabled}
           >
             <PlusIcon className="h-4 w-4" />
-          </Menu.Button>
+          </MenuButton>
         ) : (
-          <Menu.Button as="div" disabled={disabled}>
+          <MenuButton as="div" disabled={disabled}>
             <Button
               variant="secondary"
               label="Add Block"
               icon={PlusIcon}
               disabled={disabled}
             />
-          </Menu.Button>
+          </MenuButton>
         )}
       </div>
-      <Menu.Items
+      <MenuItems
         className={classNames(
           "absolute z-10 my-2 block w-max rounded-md bg-white shadow ring-1 ring-black ring-opacity-5 focus:outline-none",
           small ? "-right-16" : "",
@@ -152,7 +152,7 @@ export default function NewBlock({
         )}
       >
         {blocks.map((block) => (
-          <Menu.Item
+          <MenuItem
             as="div"
             key={block.type}
             onClick={() => {
@@ -182,9 +182,9 @@ export default function NewBlock({
                 </div>
               </div>
             )}
-          </Menu.Item>
+          </MenuItem>
         ))}
-      </Menu.Items>
+      </MenuItems>
     </Menu>
   );
 }

--- a/front/components/app/blocks/Curl.tsx
+++ b/front/components/app/blocks/Curl.tsx
@@ -141,10 +141,10 @@ export default function Curl({
                     {availableMethods.map((method) => {
                       return (
                         <MenuItem key={method}>
-                          {({ active }) => (
+                          {({ focus }) => (
                             <span
                               className={classNames(
-                                active
+                                focus
                                   ? "bg-gray-50 text-gray-900"
                                   : "text-gray-700",
                                 "block cursor-pointer whitespace-nowrap px-4 py-1 text-sm"

--- a/front/components/app/blocks/Curl.tsx
+++ b/front/components/app/blocks/Curl.tsx
@@ -8,7 +8,7 @@ import type {
   SpecificationType,
 } from "@dust-tt/types";
 import type { BlockType, RunType } from "@dust-tt/types";
-import { Menu } from "@headlessui/react";
+import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/react";
 import dynamic from "next/dynamic";
 import { useEffect } from "react";
 
@@ -119,7 +119,7 @@ export default function Curl({
           <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
             <Menu as="div" className="relative inline-block text-left">
               <div>
-                <Menu.Button
+                <MenuButton
                   className={classNames(
                     "inline-flex items-center rounded-md border border-gray-300 bg-gray-50 px-1 py-1 text-sm font-normal",
                     "focus:outline-none focus:ring-0",
@@ -128,11 +128,11 @@ export default function Curl({
                 >
                   {block.spec.method}
                   <ChevronDownIcon className="mt-0.5 h-4 w-4 hover:text-gray-700" />
-                </Menu.Button>
+                </MenuButton>
               </div>
 
               {readOnly ? null : (
-                <Menu.Items
+                <MenuItems
                   className={classNames(
                     "absolute left-1 z-10 mt-1 origin-top-left rounded-md bg-white shadow ring-1 ring-black ring-opacity-5 focus:outline-none"
                   )}
@@ -140,7 +140,7 @@ export default function Curl({
                   <div className="py-1">
                     {availableMethods.map((method) => {
                       return (
-                        <Menu.Item key={method}>
+                        <MenuItem key={method}>
                           {({ active }) => (
                             <span
                               className={classNames(
@@ -154,11 +154,11 @@ export default function Curl({
                               {method}
                             </span>
                           )}
-                        </Menu.Item>
+                        </MenuItem>
                       );
                     })}
                   </div>
-                </Menu.Items>
+                </MenuItems>
               )}
             </Menu>
           </div>

--- a/front/components/app/blocks/Search.tsx
+++ b/front/components/app/blocks/Search.tsx
@@ -3,7 +3,7 @@ import type { SpecificationBlockType, SpecificationType } from "@dust-tt/types";
 import type { AppType } from "@dust-tt/types";
 import type { BlockType } from "@dust-tt/types";
 import type { RunType } from "@dust-tt/types";
-import { Menu } from "@headlessui/react";
+import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/react";
 import { ChevronDownIcon } from "@heroicons/react/20/solid";
 import Link from "next/link";
 
@@ -132,7 +132,7 @@ export default function Search({
 
           {!isProvidersLoading && !readOnly && searchProviders?.length > 0 && (
             <Menu as="div" className="relative inline-block text-left">
-              <Menu.Button
+              <MenuButton
                 className={classNames(
                   "inline-flex items-center rounded-md py-1 text-sm font-bold",
                   currentProvider?.providerId ? "px-0" : "border px-3",
@@ -150,9 +150,9 @@ export default function Search({
                 ) : (
                   "Select provider"
                 )}
-              </Menu.Button>
+              </MenuButton>
 
-              <Menu.Items
+              <MenuItems
                 className={classNames(
                   "absolute z-10 mt-1 w-max origin-top-left rounded-md bg-white shadow ring-1 ring-black ring-opacity-5 focus:outline-none",
                   currentProvider?.providerId ? "-left-4" : "left-1"
@@ -179,7 +179,7 @@ export default function Search({
                     );
                   })}
                 </div>
-              </Menu.Items>
+              </MenuItems>
             </Menu>
           )}
         </div>

--- a/front/components/app/blocks/Search.tsx
+++ b/front/components/app/blocks/Search.tsx
@@ -161,11 +161,11 @@ export default function Search({
                 <div className="py-1">
                   {(searchProviders || []).map((p) => {
                     return (
-                      <Menu.Item key={p.providerId}>
-                        {({ active }) => (
+                      <MenuItem key={p.providerId}>
+                        {({ focus }) => (
                           <span
                             className={classNames(
-                              active
+                              focus
                                 ? "bg-gray-50 text-gray-900"
                                 : "text-gray-700",
                               "block cursor-pointer px-4 py-2 text-sm"
@@ -175,7 +175,7 @@ export default function Search({
                             {p.providerId}
                           </span>
                         )}
-                      </Menu.Item>
+                      </MenuItem>
                     );
                   })}
                 </div>

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -247,7 +247,7 @@ export function ConversationContainer({
 
   return (
     <>
-      <Transition show={!!activeConversationId} as="div">
+      <Transition show={!!activeConversationId} as="div" appear={true}>
         {activeConversationId ? (
           <div
             className={classNames(
@@ -273,19 +273,19 @@ export function ConversationContainer({
         )}
       </Transition>
 
-      <Transition
-        as={Fragment}
-        show={!activeConversationId}
-        enter="transition-opacity duration-100 ease-out"
-        enterFrom="opacity-0 min-h-[20vh]"
-        enterTo="opacity-100"
-        leave="transition-opacity duration-100 ease-out"
-        leaveFrom="opacity-100"
-        leaveTo="opacity-0 min-h-[20vh]"
-      >
+      <Transition show={!activeConversationId}>
         <div
+          className={classNames(
+            "mb-2 flex h-fit min-h-[20vh] w-full max-w-4xl flex-col justify-end px-4 py-2",
+            "transition-opacity ease-out",
+            "data-[enter]:duration-100",
+            "data-[enter]:data-[closed]:min-h-[20vh] data-[enter]:data-[closed]:opacity-0",
+            "data-[enter]:data-[open]:opacity-100",
+            "data-[leave]:duration-100",
+            "data-[leave]:data-[open]:opacity-100",
+            "data-[leave]:data-[closed]:min-h-[20vh] data-[leave]:data-[closed]:opacity-0"
+          )}
           id="assistant-input-header"
-          className="mb-2 flex h-fit min-h-[20vh] w-full max-w-4xl flex-col justify-end px-4 py-2"
         >
           <Page.SectionHeader title={greeting} />
           <Page.SectionHeader title="Start a conversation" />
@@ -299,24 +299,27 @@ export function ConversationContainer({
         conversationId={activeConversationId}
       />
 
-      <Transition
-        as="div"
-        show={!activeConversationId}
-        enter="transition-opacity duration-100 ease-out"
-        enterFrom="opacity-0"
-        enterTo="opacity-100"
-        leave="transition-opacity duration-100 ease-out"
-        leaveFrom="opacity-100"
-        leaveTo="opacity-0"
-        className={"flex w-full justify-center"}
-      >
-        <AssistantBrowserContainer
-          onAgentConfigurationClick={setInputbarMention}
-          setAssistantToMention={(assistant) => {
-            assistantToMention.current = assistant;
-          }}
-          owner={owner}
-        />
+      <Transition as={Fragment} show={!activeConversationId}>
+        <div
+          className={classNames(
+            "flex w-full justify-center",
+            "transition-opacity ease-out",
+            "data-[enter]:duration-100",
+            "data-[enter]:data-[closed]:opacity-0",
+            "data-[enter]:data-[open]:opacity-100",
+            "data-[leave]:duration-100",
+            "data-[leave]:data-[open]:opacity-100",
+            "data-[leave]:data-[closed]:opacity-0"
+          )}
+        >
+          <AssistantBrowserContainer
+            onAgentConfigurationClick={setInputbarMention}
+            setAssistantToMention={(assistant) => {
+              assistantToMention.current = assistant;
+            }}
+            owner={owner}
+          />
+        </div>
       </Transition>
 
       {activeConversationId !== "new" && (

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -247,11 +247,16 @@ export function ConversationContainer({
 
   return (
     <>
-      <Transition show={!!activeConversationId} as="div" appear={true}>
+      <Transition
+        show={!!activeConversationId}
+        as="div"
+        appear={false}
+        className="flex w-full max-w-4xl flex-1 flex-col justify-start gap-2 pb-4 sm:px-4"
+      >
         {activeConversationId ? (
           <div
             className={classNames(
-              "h-full w-full max-w-4xl transition-all ease-out",
+              "transition-all ease-out",
               "data-[enter]:duration-300",
               "data-[enter]:data-[closed]:h-0 data-[enter]:data-[closed]:w-full data-[enter]:data-[closed]:flex-none",
               "data-[enter]:data-[open]:flex data-[enter]:data-[open]:w-full data-[enter]:data-[open]:flex-1",

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -39,6 +39,7 @@ import type { FetchConversationMessagesResponse } from "@app/lib/api/assistant/m
 import { getRandomGreetingForName } from "@app/lib/client/greetings";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { useConversationMessages } from "@app/lib/swr";
+import { classNames } from "@app/lib/utils";
 
 interface ConversationContainerProps {
   conversationId: string | null;
@@ -246,24 +247,27 @@ export function ConversationContainer({
 
   return (
     <>
-      <Transition
-        show={!!activeConversationId}
-        as={Fragment}
-        enter="transition-all duration-300 ease-out"
-        enterFrom="flex-none w-full h-0"
-        enterTo="flex flex-1 w-full"
-        leave="transition-all duration-0 ease-out"
-        leaveFrom="flex flex-1 w-full"
-        leaveTo="flex-none w-full h-0"
-      >
+      <Transition show={!!activeConversationId} as="div">
         {activeConversationId ? (
-          <ConversationViewer
-            owner={owner}
-            user={user}
-            conversationId={activeConversationId}
-            // TODO(2024-06-20 flav): Fix extra-rendering loop with sticky mentions.
-            onStickyMentionsChange={onStickyMentionsChange}
-          />
+          <div
+            className={classNames(
+              "h-full w-full max-w-4xl transition-all ease-out",
+              "data-[enter]:duration-300",
+              "data-[enter]:data-[closed]:h-0 data-[enter]:data-[closed]:w-full data-[enter]:data-[closed]:flex-none",
+              "data-[enter]:data-[open]:flex data-[enter]:data-[open]:w-full data-[enter]:data-[open]:flex-1",
+              "data-[leave]:duration-300",
+              "data-[leave]:data-[open]:flex data-[leave]:data-[open]:w-full data-[leave]:data-[open]:flex-1",
+              "data-[leave]:data-[closed]:h-0 data-[leave]:data-[closed]:w-full data-[leave]:data-[closed]:flex-none"
+            )}
+          >
+            <ConversationViewer
+              owner={owner}
+              user={user}
+              conversationId={activeConversationId}
+              // TODO(2024-06-20 flav): Fix extra-rendering loop with sticky mentions.
+              onStickyMentionsChange={onStickyMentionsChange}
+            />
+          </div>
         ) : (
           <div></div>
         )}

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -296,6 +296,7 @@ export function ConversationContainer({
       />
 
       <Transition
+        as="div"
         show={!activeConversationId}
         enter="transition-opacity duration-100 ease-out"
         enterFrom="opacity-0"

--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -335,11 +335,7 @@ function PickDataSource({
   );
 
   return (
-    <Transition
-      as="div"
-      show={show}
-      className="mx-auto max-w-6xl"
-    >
+    <Transition as="div" show={show} className="mx-auto max-w-6xl">
       <Page>
         <Page.Header
           title="Select Data Sources in"
@@ -404,11 +400,7 @@ function DataSourceResourceSelector({
   ];
 
   return (
-    <Transition
-      as="div"
-      show={!!dataSource}
-      className="mx-auto max-w-6xl pb-8"
-    >
+    <Transition as="div" show={!!dataSource} className="mx-auto max-w-6xl pb-8">
       <Page>
         <Page.Header
           title={`Select Data Sources in ${

--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -335,7 +335,11 @@ function PickDataSource({
   );
 
   return (
-    <Transition show={show} className="mx-auto max-w-6xl">
+    <Transition
+      as="div"
+      show={show}
+      className="mx-auto max-w-6xl"
+    >
       <Page>
         <Page.Header
           title="Select Data Sources in"
@@ -400,7 +404,11 @@ function DataSourceResourceSelector({
   ];
 
   return (
-    <Transition show={!!dataSource} className="mx-auto max-w-6xl pb-8">
+    <Transition
+      as="div"
+      show={!!dataSource}
+      className="mx-auto max-w-6xl pb-8"
+    >
       <Page>
         <Page.Header
           title={`Select Data Sources in ${
@@ -492,7 +500,7 @@ function FolderOrWebsiteResourceSelector({
   });
 
   return (
-    <Transition show={!!owner} className="mx-auto max-w-6xl pb-8">
+    <Transition as="div" show={!!owner} className="mx-auto max-w-6xl pb-8">
       <Page>
         <Page.Header
           title={type === "folder" ? "Select Folders" : "Select Websites"}

--- a/front/components/assistant_builder/AssistantBuilderDustAppModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDustAppModal.tsx
@@ -58,7 +58,7 @@ function PickDustApp({
     (app) => !app.description || app.description.length === 0
   );
   return (
-    <Transition show={show} className="mx-auto max-w-6xl">
+    <Transition as="div" show={show} className="mx-auto max-w-6xl">
       <Page>
         <Page.Header title="Select Dust App" icon={CloudArrowDownIcon} />
         {hasSomeUnselectableApps && (

--- a/front/components/assistant_builder/AssistantBuilderTablesModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderTablesModal.tsx
@@ -277,7 +277,7 @@ function PickDataSource({
   });
 
   return (
-    <Transition show={true} className="mx-auto max-w-6xl">
+    <Transition as="div" show={true} className="mx-auto max-w-6xl">
       <Page>
         <Page.Header title="Select a Table in" icon={ServerIcon} />
         <Searchbar
@@ -341,7 +341,7 @@ const PickTable = ({
   const isAllSelected = !!tables.length && !tablesToDisplay.length;
 
   return (
-    <Transition show={true} className="mx-auto max-w-6xl">
+    <Transition as="div" show={true} className="mx-auto max-w-6xl">
       <Page>
         <Page.Header title="Select a Table" icon={ServerIcon} />
         {isAllSelected && (
@@ -417,7 +417,7 @@ const PickTablesManaged = ({
   parentsById: Record<string, Set<string>>;
 }) => {
   return (
-    <Transition show={true} className="mx-auto max-w-6xl">
+    <Transition as="div" show={true} className="mx-auto max-w-6xl">
       <Page>
         <Page.Header title="Select a Table" icon={ServerIcon} />
         <DataSourceResourceSelectorTree

--- a/front/components/assistant_builder/DustAppSelectionSection.tsx
+++ b/front/components/assistant_builder/DustAppSelectionSection.tsx
@@ -24,6 +24,7 @@ export default function DustAppSelectionSection({
 }) {
   return (
     <Transition
+      as="div"
       show={show}
       enterFrom="opacity-0"
       enterTo="opacity-100"

--- a/front/components/assistant_builder/DustAppSelectionSection.tsx
+++ b/front/components/assistant_builder/DustAppSelectionSection.tsx
@@ -8,6 +8,7 @@ import { Transition } from "@headlessui/react";
 
 import type { AssistantBuilderDustAppConfiguration } from "@app/components/assistant_builder/types";
 import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
+import { classNames } from "@app/lib/utils";
 
 export default function DustAppSelectionSection({
   show,
@@ -26,13 +27,6 @@ export default function DustAppSelectionSection({
     <Transition
       as="div"
       show={show}
-      enterFrom="opacity-0"
-      enterTo="opacity-100"
-      leave="transition-all duration-300"
-      enter="transition-all duration-300"
-      leaveFrom="opacity-100"
-      leaveTo="opacity-0"
-      className="overflow-hidden pt-6"
       afterEnter={() => {
         window.scrollBy({
           left: 0,
@@ -41,7 +35,18 @@ export default function DustAppSelectionSection({
         });
       }}
     >
-      <div>
+      <div
+        className={classNames(
+          "overflow-hidden pt-6",
+          "transition-all",
+          "data-[enter]:duration-300",
+          "data-[leave]:duration-300",
+          "data-[enter]:data-[closed]:opacity-0",
+          "data-[enter]:data-[open]:opacity-100",
+          "data-[leave]:data-[open]:opacity-100",
+          "data-[leave]:data-[closed]:opacity-0"
+        )}
+      >
         {!dustAppConfiguration.app ? (
           <EmptyCallToAction
             label="Select Dust App"

--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -30,7 +30,7 @@ import { History } from "@tiptap/extension-history";
 import Text from "@tiptap/extension-text";
 import type { Editor, JSONContent } from "@tiptap/react";
 import { EditorContent, useEditor } from "@tiptap/react";
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { Fragment, useEffect, useMemo, useRef, useState } from "react";
 
 import type { AssistantBuilderState } from "@app/components/assistant_builder/types";
 import {
@@ -470,17 +470,19 @@ function Suggestions({
   };
 
   return (
-    <Transition
-      as="div"
-      show={suggestionsStatus !== "no_suggestions"}
-      enter="transition-[max-height] duration-1000"
-      enterFrom="max-h-0"
-      enterTo="max-h-full"
-      leave="transition-[max-height] duration-1000"
-      leaveFrom="max-h-full"
-      leaveTo="max-h-0"
-    >
-      <div className="relative flex flex-col">
+    <Transition as="div" show={suggestionsStatus !== "no_suggestions"}>
+      <div
+        className={classNames(
+          "relative flex flex-col",
+          "transition-[max-height]",
+          "data-[enter]:duration-1000",
+          "data-[enter]:data-[closed]:max-h-0",
+          "data-[enter]:data-[open]:max-h-full",
+          "data-[leave]:duration-1000",
+          "data-[leave]:data-[open]:max-h-full",
+          "data-[leave]:data-[closed]:max-h-0"
+        )}
+      >
         <div className="flex items-center gap-2 text-base font-bold text-element-800">
           <div>Tips</div>
           {suggestionsStatus === "loading" && <Spinner size="xs" />}
@@ -547,25 +549,27 @@ function AnimatedSuggestion({
   afterEnter?: () => void;
 }) {
   return (
-    <Transition
-      as="div"
-      appear={true}
-      enter="transition-all ease-out duration-300"
-      enterFrom="opacity-0 w-0"
-      enterTo="opacity-100 w-[320px]"
-      leave="ease-in duration-300"
-      leaveFrom="opacity-100 w-[320px]"
-      leaveTo="opacity-0 w-0"
-      afterEnter={afterEnter}
-    >
-      <ContentMessage
-        size="sm"
-        title=""
-        variant={variant}
-        className="h-fit w-[308px]"
+    <Transition as={Fragment} appear={true} afterEnter={afterEnter}>
+      <div
+        className={classNames(
+          "w-[320px] opacity-100 transition-all ease-out",
+          "data-[enter]:duration-300",
+          "data-[enter]:data-[closed]:w-0 data-[enter]:data-[closed]:opacity-0",
+          "data-[enter]:data-[open]:w-[320px] data-[enter]:data-[open]:opacity-100",
+          "data-[leave]:duration-300",
+          "data-[leave]:data-[open]:w-[320px] data-[leave]:data-[open]:opacity-100",
+          "data-[leave]:data-[closed]:w-0 data-[leave]:data-[closed]:opacity-0"
+        )}
       >
-        {suggestion}
-      </ContentMessage>
+        <ContentMessage
+          size="sm"
+          title=""
+          variant={variant}
+          className="h-fit w-[308px]"
+        >
+          {suggestion}
+        </ContentMessage>
+      </div>
     </Transition>
   );
 }

--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -471,6 +471,7 @@ function Suggestions({
 
   return (
     <Transition
+      as="div"
       show={suggestionsStatus !== "no_suggestions"}
       enter="transition-[max-height] duration-1000"
       enterFrom="max-h-0"
@@ -547,6 +548,7 @@ function AnimatedSuggestion({
 }) {
   return (
     <Transition
+      as="div"
       appear={true}
       enter="transition-all ease-out duration-300"
       enterFrom="opacity-0 w-0"

--- a/front/components/assistant_builder/TablesSelectionSection.tsx
+++ b/front/components/assistant_builder/TablesSelectionSection.tsx
@@ -26,6 +26,7 @@ export default function TablesSelectionSection({
 }) {
   return (
     <Transition
+      as="div"
       show={show}
       enterFrom="opacity-0"
       enterTo="opacity-100"

--- a/front/components/assistant_builder/TablesSelectionSection.tsx
+++ b/front/components/assistant_builder/TablesSelectionSection.tsx
@@ -10,6 +10,7 @@ import { Transition } from "@headlessui/react";
 import type { AssistantBuilderTableConfiguration } from "@app/components/assistant_builder/types";
 import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
 import { tableKey } from "@app/lib/client/tables_query";
+import { classNames } from "@app/lib/utils";
 
 export default function TablesSelectionSection({
   show,
@@ -28,13 +29,6 @@ export default function TablesSelectionSection({
     <Transition
       as="div"
       show={show}
-      enterFrom="opacity-0"
-      enterTo="opacity-100"
-      leave="transition-all duration-300"
-      enter="transition-all duration-300"
-      leaveFrom="opacity-100"
-      leaveTo="opacity-0"
-      className="overflow-hidden pt-6"
       afterEnter={() => {
         window.scrollBy({
           left: 0,
@@ -43,7 +37,18 @@ export default function TablesSelectionSection({
         });
       }}
     >
-      <div>
+      <div
+        className={classNames(
+          "overflow-hidden pt-6",
+          "transition-all",
+          "data-[enter]:duration-300",
+          "data-[leave]:duration-300",
+          "data-[enter]:data-[closed]:opacity-0",
+          "data-[enter]:data-[open]:opacity-100",
+          "data-[leave]:data-[open]:opacity-100",
+          "data-[leave]:data-[closed]:opacity-0"
+        )}
+      >
         <div className="flex flex-row items-start">
           <div className="flex-grow" />
           {Object.keys(tablesQueryConfiguration).length > 0 && (

--- a/front/components/data_source/DataSourcePicker.tsx
+++ b/front/components/data_source/DataSourcePicker.tsx
@@ -1,5 +1,5 @@
 import type { WorkspaceType } from "@dust-tt/types";
-import { Menu } from "@headlessui/react";
+import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/react";
 import { ChevronDownIcon } from "@heroicons/react/20/solid";
 import Link from "next/link";
 import { useEffect, useState } from "react";
@@ -80,7 +80,7 @@ export default function DataSourcePicker({
         ) : (
           <Menu as="div" className="relative inline-block text-left">
             <div>
-              <Menu.Button
+              <MenuButton
                 className={classNames(
                   "inline-flex items-center rounded-md py-1 text-sm font-normal text-gray-700",
                   name && name.length > 0 ? "px-0" : "border px-3",
@@ -113,11 +113,11 @@ export default function DataSourcePicker({
                     Create DataSource
                   </Link>
                 )}
-              </Menu.Button>
+              </MenuButton>
             </div>
 
             {(dataSources || []).length > 0 ? (
-              <Menu.Items
+              <MenuItems
                 className={classNames(
                   "absolute z-10 mt-1 w-max origin-top-left rounded-md bg-white shadow-sm ring-1 ring-black ring-opacity-5 focus:outline-none",
                   name && name.length > 0 ? "-left-4" : "left-1"
@@ -126,7 +126,7 @@ export default function DataSourcePicker({
                 <div className="py-1">
                   {(dataSources || []).map((ds) => {
                     return (
-                      <Menu.Item key={ds.name}>
+                      <MenuItem key={ds.name}>
                         {({ active }) => (
                           <span
                             className={classNames(
@@ -147,11 +147,11 @@ export default function DataSourcePicker({
                             {ds.name}
                           </span>
                         )}
-                      </Menu.Item>
+                      </MenuItem>
                     );
                   })}
                 </div>
-              </Menu.Items>
+              </MenuItems>
             ) : null}
           </Menu>
         )}

--- a/front/components/data_source/DataSourcePicker.tsx
+++ b/front/components/data_source/DataSourcePicker.tsx
@@ -127,10 +127,10 @@ export default function DataSourcePicker({
                   {(dataSources || []).map((ds) => {
                     return (
                       <MenuItem key={ds.name}>
-                        {({ active }) => (
+                        {({ focus }) => (
                           <span
                             className={classNames(
-                              active
+                              focus
                                 ? "bg-gray-50 text-gray-900"
                                 : "text-gray-700",
                               "block cursor-pointer px-4 py-2 text-sm"

--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -11,7 +11,7 @@ import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import Script from "next/script";
-import { useEffect, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
 import { useCookies } from "react-cookie";
 
 import RootLayout from "@app/components/app/RootLayout";
@@ -183,46 +183,46 @@ const CookieBanner = ({
   className?: string;
 }) => {
   return (
-    <Transition
-      as="div"
-      show={show}
-      enter="transition-opacity s-duration-300"
-      appear={true}
-      enterFrom="opacity-0"
-      enterTo="opacity-100"
-      leave="transition-opacity duration-300"
-      leaveFrom="opacity-100"
-      leaveTo="opacity-0"
-      className={classNames(
-        "z-30 flex w-64 flex-col gap-3 rounded-xl border border-structure-100 bg-white p-4 shadow-xl",
-        className || ""
-      )}
-    >
-      <div className="text-sm font-normal text-element-900">
-        We use{" "}
-        <A variant="primary">
-          <Link
-            href="https://dust-tt.notion.site/Cookie-Policy-ec63a7fb72104a7babff1bf413e2c1ec"
-            target="_blank"
-          >
-            cookies
-          </Link>
-        </A>{" "}
-        to improve your experience on our site.
-      </div>
-      <div className="flex gap-2">
-        <Button
-          variant="tertiary"
-          size="sm"
-          label="Reject"
-          onClick={onClickRefuse}
-        />
-        <Button
-          variant="primary"
-          size="sm"
-          label="Accept All"
-          onClick={onClickAccept}
-        />
+    <Transition show={show} appear={true}>
+      <div
+        className={classNames(
+          "transition ease-out",
+          "z-30 flex w-64 flex-col gap-3 rounded-xl border border-structure-100 bg-white p-4 shadow-xl",
+          className || "",
+          "data-[enter]:duration-300",
+          "data-[enter]:data-[closed]:opacity-0",
+          "data-[enter]:data-[open]:opacity-100",
+          "data-[leave]:duration-300",
+          "data-[leave]:data-[open]:opacity-100",
+          "data-[leave]:data-[closed]:opacity-0"
+        )}
+      >
+        <div className="text-sm font-normal text-element-900">
+          We use{" "}
+          <A variant="primary">
+            <Link
+              href="https://dust-tt.notion.site/Cookie-Policy-ec63a7fb72104a7babff1bf413e2c1ec"
+              target="_blank"
+            >
+              cookies
+            </Link>
+          </A>{" "}
+          to improve your experience on our site.
+        </div>
+        <div className="flex gap-2">
+          <Button
+            variant="tertiary"
+            size="sm"
+            label="Reject"
+            onClick={onClickRefuse}
+          />
+          <Button
+            variant="primary"
+            size="sm"
+            label="Accept All"
+            onClick={onClickAccept}
+          />
+        </div>
       </div>
     </Transition>
   );

--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -184,6 +184,7 @@ const CookieBanner = ({
 }) => {
   return (
     <Transition
+      as="div"
       show={show}
       enter="transition-opacity s-duration-300"
       appear={true}

--- a/front/components/navigation/Navigation.tsx
+++ b/front/components/navigation/Navigation.tsx
@@ -118,17 +118,19 @@ export function Navigation({
       </Transition>
 
       {/*Desktop sidebar*/}
-      <Transition
-        show={isNavigationBarOpen}
-        as={Fragment}
-        enter="transition-all duration-150 ease-out"
-        enterFrom="flex-none lg:w-0 h-full"
-        enterTo="flex flex-1 lg:w-80"
-        leave="transition-all duration-150 ease-out"
-        leaveFrom="flex flex-1 lg:w-80"
-        leaveTo="flex-none h-full lg:w-0"
-      >
-        <div className="hidden flex-1 lg:inset-y-0 lg:z-0 lg:flex lg:w-80 lg:flex-col">
+      <Transition show={isNavigationBarOpen}>
+        <div
+          className={classNames(
+            "hidden flex-1 lg:inset-y-0 lg:z-0 lg:flex lg:w-80 lg:flex-col",
+            "transition-all ease-out",
+            "data-[enter]:duration-150",
+            "data-[enter]:data-[closed]:h-full data-[enter]:data-[closed]:flex-none data-[enter]:data-[closed]:lg:w-0",
+            "data-[enter]:data-[open]:flex data-[enter]:data-[open]:flex-1 data-[enter]:data-[open]:lg:w-80",
+            "data-[leave]:h-full data-[leave]:duration-150",
+            "data-[leave]:data-[open]:flex data-[leave]:data-[open]:flex-1 data-[leave]:data-[open]:lg:w-80",
+            "data-[leave]:data-[closed]:h-full data-[leave]:data-[closed]:flex-none data-[leave]:data-[closed]:lg:w-0"
+          )}
+        >
           <NavigationSidebar
             owner={owner}
             subscription={subscription}

--- a/front/components/navigation/Navigation.tsx
+++ b/front/components/navigation/Navigation.tsx
@@ -58,61 +58,48 @@ export function Navigation({
           className="relative z-50 lg:hidden"
           onClose={setSidebarOpen}
         >
-          <TransitionChild
-            as={Fragment}
-            enter="transition-opacity ease-linear duration-300"
-            enterFrom="opacity-0"
-            enterTo="opacity-100"
-            leave="transition-opacity ease-linear duration-300"
-            leaveFrom="opacity-100"
-            leaveTo="opacity-0"
-          >
-            <div className="fixed inset-0 bg-gray-900/80" />
+          <TransitionChild as={Fragment} appear={false}>
+            <div
+              className={classNames(
+                "fixed inset-0 bg-gray-900/80",
+                "transition-opacity duration-300 ease-linear",
+                "data-[enter]:data-[closed]:opacity-0",
+                "data-[leave]:data-[closed]:opacity-0"
+              )}
+            />
           </TransitionChild>
 
           <div className="fixed inset-0 flex">
-            <TransitionChild
-              as={Fragment}
-              enter="transition ease-in-out duration-300 transform"
-              enterFrom="-translate-x-full"
-              enterTo="translate-x-0"
-              leave="transition ease-in-out duration-300 transform"
-              leaveFrom="translate-x-0"
-              leaveTo="-translate-x-full"
+            <DialogPanel
+              className={classNames(
+                "relative mr-16 flex w-full max-w-xs flex-1",
+                "transform transition duration-300 ease-in-out",
+                "data-[enter]:data-[closed]:-translate-x-full",
+                "data-[leave]:data-[closed]:-translate-x-full"
+              )}
+              transition
             >
-              <DialogPanel className="relative mr-16 flex w-full max-w-xs flex-1">
-                <TransitionChild
-                  as={Fragment}
-                  enter="ease-in-out duration-300"
-                  enterFrom="opacity-0"
-                  enterTo="opacity-100"
-                  leave="ease-in-out duration-300"
-                  leaveFrom="opacity-100"
-                  leaveTo="opacity-0"
+              <div className="absolute left-full top-0 flex w-16 justify-center pt-5">
+                <button
+                  type="button"
+                  className="-m-2.5 p-2.5"
+                  onClick={() => setSidebarOpen(false)}
                 >
-                  <div className="absolute left-full top-0 flex w-16 justify-center pt-5">
-                    <button
-                      type="button"
-                      className="-m-2.5 p-2.5"
-                      onClick={() => setSidebarOpen(false)}
-                    >
-                      <span className="sr-only">Close sidebar</span>
-                      <XMarkIcon
-                        className="h-6 w-6 text-white"
-                        aria-hidden="true"
-                      />
-                    </button>
-                  </div>
-                </TransitionChild>
-                <NavigationSidebar
-                  subscription={subscription}
-                  owner={owner}
-                  subNavigation={subNavigation}
-                >
-                  {navChildren && navChildren}
-                </NavigationSidebar>
-              </DialogPanel>
-            </TransitionChild>
+                  <span className="sr-only">Close sidebar</span>
+                  <XMarkIcon
+                    className="h-6 w-6 text-white"
+                    aria-hidden="true"
+                  />
+                </button>
+              </div>
+              <NavigationSidebar
+                subscription={subscription}
+                owner={owner}
+                subNavigation={subNavigation}
+              >
+                {navChildren && navChildren}
+              </NavigationSidebar>
+            </DialogPanel>
           </div>
         </Dialog>
       </Transition>

--- a/front/components/navigation/Navigation.tsx
+++ b/front/components/navigation/Navigation.tsx
@@ -1,6 +1,11 @@
 import { XMarkIcon } from "@dust-tt/sparkle";
 import type { SubscriptionType, WorkspaceType } from "@dust-tt/types";
-import { Dialog, Transition } from "@headlessui/react";
+import {
+  Dialog,
+  DialogPanel,
+  Transition,
+  TransitionChild,
+} from "@headlessui/react";
 import { Bars3Icon } from "@heroicons/react/20/solid";
 import React, { Fragment, useContext, useState } from "react";
 
@@ -47,13 +52,13 @@ export function Navigation({
           <Bars3Icon className="h-5 w-5" aria-hidden="true" />
         </button>
       </div>
-      <Transition.Root show={sidebarOpen} as={Fragment}>
+      <Transition show={sidebarOpen} as={Fragment}>
         <Dialog
           as="div"
           className="relative z-50 lg:hidden"
           onClose={setSidebarOpen}
         >
-          <Transition.Child
+          <TransitionChild
             as={Fragment}
             enter="transition-opacity ease-linear duration-300"
             enterFrom="opacity-0"
@@ -63,10 +68,10 @@ export function Navigation({
             leaveTo="opacity-0"
           >
             <div className="fixed inset-0 bg-gray-900/80" />
-          </Transition.Child>
+          </TransitionChild>
 
           <div className="fixed inset-0 flex">
-            <Transition.Child
+            <TransitionChild
               as={Fragment}
               enter="transition ease-in-out duration-300 transform"
               enterFrom="-translate-x-full"
@@ -75,8 +80,8 @@ export function Navigation({
               leaveFrom="translate-x-0"
               leaveTo="-translate-x-full"
             >
-              <Dialog.Panel className="relative mr-16 flex w-full max-w-xs flex-1">
-                <Transition.Child
+              <DialogPanel className="relative mr-16 flex w-full max-w-xs flex-1">
+                <TransitionChild
                   as={Fragment}
                   enter="ease-in-out duration-300"
                   enterFrom="opacity-0"
@@ -98,7 +103,7 @@ export function Navigation({
                       />
                     </button>
                   </div>
-                </Transition.Child>
+                </TransitionChild>
                 <NavigationSidebar
                   subscription={subscription}
                   owner={owner}
@@ -106,11 +111,11 @@ export function Navigation({
                 >
                   {navChildren && navChildren}
                 </NavigationSidebar>
-              </Dialog.Panel>
-            </Transition.Child>
+              </DialogPanel>
+            </TransitionChild>
           </div>
         </Dialog>
-      </Transition.Root>
+      </Transition>
 
       {/*Desktop sidebar*/}
       <Transition

--- a/front/components/providers/AnthropicSetup.tsx
+++ b/front/components/providers/AnthropicSetup.tsx
@@ -11,6 +11,7 @@ import { Fragment, useEffect, useState } from "react";
 import { useSWRConfig } from "swr";
 
 import { checkProvider } from "@app/lib/providers";
+import { classNames } from "@app/lib/utils";
 
 export default function AnthropicSetup({
   owner,
@@ -89,124 +90,118 @@ export default function AnthropicSetup({
   return (
     <Transition show={open} as={Fragment}>
       <Dialog as="div" className="relative z-30" onClose={() => setOpen(false)}>
-        <TransitionChild
-          as={Fragment}
-          enter="ease-out duration-300"
-          enterFrom="opacity-0"
-          enterTo="opacity-100"
-          leave="ease-in duration-200"
-          leaveFrom="opacity-100"
-          leaveTo="opacity-0"
-        >
-          <div className="fixed inset-0 bg-gray-800 bg-opacity-75 transition-opacity" />
+        <TransitionChild as={Fragment} appear={true}>
+          <div
+            className={classNames(
+              "fixed inset-0 bg-gray-800 bg-opacity-75 transition-opacity",
+              "duration-700 ease-out",
+              "data-[enter]:data-[closed]:opacity-0",
+              "data-[leave]:data-[closed]:opacity-0"
+            )}
+          />
         </TransitionChild>
 
         <div className="fixed inset-0 z-30 overflow-y-auto">
-          <div className="flex min-h-full items-end items-center justify-center p-4">
-            <TransitionChild
-              as={Fragment}
-              enter="ease-out duration-300"
-              leave="ease-in duration-200"
-              leaveTo="opacity-0"
+          <div className="flex min-h-full items-center justify-center p-4">
+            <DialogPanel
+              className={classNames(
+                "relative overflow-hidden rounded-lg bg-white p-4 sm:my-8 sm:w-full sm:max-w-sm sm:p-6 lg:max-w-lg",
+                "duration-300",
+                "data-[enter]:data-[closed]:opacity-0",
+                "data-[leave]:data-[closed]:opacity-0"
+              )}
+              transition
             >
-              <DialogPanel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6 lg:max-w-lg">
-                <div>
-                  <div className="mt-3">
-                    <DialogTitle
-                      as="h3"
-                      className="text-lg font-medium leading-6 text-gray-900"
+              <div className="mt-3">
+                <DialogTitle
+                  as="h3"
+                  className="text-lg font-medium leading-6 text-gray-900"
+                >
+                  Setup Anthropic
+                </DialogTitle>
+                <div className="mt-4">
+                  <p className="text-sm text-gray-500">
+                    To use Anthropic models you must provide your API key. It
+                    can be found{" "}
+                    <a
+                      className="font-bold text-action-600 hover:text-action-500"
+                      href="https://console.anthropic.com/account/keys"
+                      target="_blank"
                     >
-                      Setup Anthropic
-                    </DialogTitle>
-                    <div className="mt-4">
-                      <p className="text-sm text-gray-500">
-                        To use Anthropic models you must provide your API key.
-                        It can be found{" "}
-                        <a
-                          className="font-bold text-action-600 hover:text-action-500"
-                          href="https://console.anthropic.com/account/keys"
-                          target="_blank"
-                        >
-                          here
-                        </a>
-                        &nbsp;(you can create a new key specifically for Dust).
-                      </p>
-                      <p className="mt-2 text-sm text-gray-500">
-                        We'll never use your API key for anything other than to
-                        run your apps.
-                      </p>
-                    </div>
-                    <div className="mt-6">
-                      <input
-                        type="text"
-                        className="block w-full rounded-md border-gray-300 shadow-sm focus:border-action-500 focus:ring-action-500 sm:text-sm"
-                        placeholder="Anthropic API Key"
-                        value={apiKey}
-                        onChange={(e) => {
-                          setApiKey(e.target.value);
-                          setTestSuccessful(false);
-                        }}
-                      />
-                    </div>
+                      here
+                    </a>
+                    &nbsp;(you can create a new key specifically for Dust).
+                  </p>
+                  <p className="mt-2 text-sm text-gray-500">
+                    We'll never use your API key for anything other than to run
+                    your apps.
+                  </p>
+                </div>
+                <div className="mt-6">
+                  <input
+                    type="text"
+                    className="block w-full rounded-md border-gray-300 shadow-sm focus:border-action-500 focus:ring-action-500 sm:text-sm"
+                    placeholder="Anthropic API Key"
+                    value={apiKey}
+                    onChange={(e) => {
+                      setApiKey(e.target.value);
+                      setTestSuccessful(false);
+                    }}
+                  />
+                </div>
+              </div>
+              <div className="mt-2 px-2 text-sm">
+                {testError.length > 0 ? (
+                  <span className="text-red-500">Error: {testError}</span>
+                ) : testSuccessful ? (
+                  <span className="text-green-600">
+                    Test succeeded! You can enable Anthropic.
+                  </span>
+                ) : (
+                  <span>&nbsp;</span>
+                )}
+              </div>
+              <div className="mt-5 flex flex-row items-center justify-between space-x-2 sm:mt-6">
+                {enabled ? (
+                  <div
+                    className="cursor-pointer text-sm font-bold text-red-500"
+                    onClick={() => handleDisable()}
+                  >
+                    Disable
                   </div>
-                </div>
-                <div className="mt-1 px-2 text-sm">
-                  {testError.length > 0 ? (
-                    <span className="text-red-500">Error: {testError}</span>
-                  ) : testSuccessful ? (
-                    <span className="text-green-600">
-                      Test succeeded! You can enable Anthropic.
-                    </span>
-                  ) : (
-                    <span>&nbsp;</span>
-                  )}
-                </div>
-                <div className="mt-5 flex flex-row items-center space-x-2 sm:mt-6">
-                  {enabled ? (
-                    <div
-                      className="flex-initial cursor-pointer text-sm font-bold text-red-500"
-                      onClick={() => handleDisable()}
-                    >
-                      Disable
-                    </div>
-                  ) : (
-                    <></>
-                  )}
-                  <div className="flex-1"></div>
-                  <div className="flex flex-initial">
-                    {/* TODO: typescript */}
+                ) : (
+                  <div></div>
+                )}
+                <div className="flex space-x-2">
+                  <Button
+                    onClick={() => setOpen(false)}
+                    label="Cancel"
+                    variant="secondary"
+                  />
+                  {testSuccessful ? (
                     <Button
-                      onClick={() => setOpen(false)}
-                      label="Cancel"
-                      variant="secondary"
+                      onClick={() => handleEnable()}
+                      disabled={enableRunning}
+                      label={
+                        enabled
+                          ? enableRunning
+                            ? "Updating..."
+                            : "Update"
+                          : enableRunning
+                            ? "Enabling..."
+                            : "Enable"
+                      }
                     />
-                  </div>
-                  <div className="flex flex-initial">
-                    {testSuccessful ? (
-                      <Button
-                        onClick={() => handleEnable()}
-                        disabled={enableRunning}
-                        label={
-                          enabled
-                            ? enableRunning
-                              ? "Updating..."
-                              : "Update"
-                            : enableRunning
-                              ? "Enabling..."
-                              : "Enable"
-                        }
-                      />
-                    ) : (
-                      <Button
-                        disabled={apiKey.length == 0 || testRunning}
-                        onClick={() => runTest()}
-                        label={testRunning ? "Testing..." : "Test"}
-                      />
-                    )}
-                  </div>
+                  ) : (
+                    <Button
+                      disabled={apiKey.length == 0 || testRunning}
+                      onClick={() => runTest()}
+                      label={testRunning ? "Testing..." : "Test"}
+                    />
+                  )}
                 </div>
-              </DialogPanel>
-            </TransitionChild>
+              </div>
+            </DialogPanel>
           </div>
         </div>
       </Dialog>

--- a/front/components/providers/AnthropicSetup.tsx
+++ b/front/components/providers/AnthropicSetup.tsx
@@ -1,6 +1,12 @@
 import { Button } from "@dust-tt/sparkle";
 import type { WorkspaceType } from "@dust-tt/types";
-import { Dialog, Transition } from "@headlessui/react";
+import {
+  Dialog,
+  DialogPanel,
+  DialogTitle,
+  Transition,
+  TransitionChild,
+} from "@headlessui/react";
 import { Fragment, useEffect, useState } from "react";
 import { useSWRConfig } from "swr";
 
@@ -81,9 +87,9 @@ export default function AnthropicSetup({
   };
 
   return (
-    <Transition.Root show={open} as={Fragment}>
+    <Transition show={open} as={Fragment}>
       <Dialog as="div" className="relative z-30" onClose={() => setOpen(false)}>
-        <Transition.Child
+        <TransitionChild
           as={Fragment}
           enter="ease-out duration-300"
           enterFrom="opacity-0"
@@ -93,25 +99,25 @@ export default function AnthropicSetup({
           leaveTo="opacity-0"
         >
           <div className="fixed inset-0 bg-gray-800 bg-opacity-75 transition-opacity" />
-        </Transition.Child>
+        </TransitionChild>
 
         <div className="fixed inset-0 z-30 overflow-y-auto">
           <div className="flex min-h-full items-end items-center justify-center p-4">
-            <Transition.Child
+            <TransitionChild
               as={Fragment}
               enter="ease-out duration-300"
               leave="ease-in duration-200"
               leaveTo="opacity-0"
             >
-              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6 lg:max-w-lg">
+              <DialogPanel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6 lg:max-w-lg">
                 <div>
                   <div className="mt-3">
-                    <Dialog.Title
+                    <DialogTitle
                       as="h3"
                       className="text-lg font-medium leading-6 text-gray-900"
                     >
                       Setup Anthropic
-                    </Dialog.Title>
+                    </DialogTitle>
                     <div className="mt-4">
                       <p className="text-sm text-gray-500">
                         To use Anthropic models you must provide your API key.
@@ -199,11 +205,11 @@ export default function AnthropicSetup({
                     )}
                   </div>
                 </div>
-              </Dialog.Panel>
-            </Transition.Child>
+              </DialogPanel>
+            </TransitionChild>
           </div>
         </div>
       </Dialog>
-    </Transition.Root>
+    </Transition>
   );
 }

--- a/front/components/providers/AzureOpenAISetup.tsx
+++ b/front/components/providers/AzureOpenAISetup.tsx
@@ -1,6 +1,12 @@
 import { Button } from "@dust-tt/sparkle";
 import type { WorkspaceType } from "@dust-tt/types";
-import { Dialog, Transition } from "@headlessui/react";
+import {
+  Dialog,
+  DialogPanel,
+  DialogTitle,
+  Transition,
+  TransitionChild,
+} from "@headlessui/react";
 import { Fragment, useEffect, useState } from "react";
 import { useSWRConfig } from "swr";
 
@@ -87,9 +93,9 @@ export default function AzureOpenAISetup({
   };
 
   return (
-    <Transition.Root show={open} as={Fragment}>
+    <Transition show={open} as={Fragment}>
       <Dialog as="div" className="relative z-30" onClose={() => setOpen(false)}>
-        <Transition.Child
+        <TransitionChild
           as={Fragment}
           enter="ease-out duration-300"
           enterFrom="opacity-0"
@@ -99,25 +105,25 @@ export default function AzureOpenAISetup({
           leaveTo="opacity-0"
         >
           <div className="fixed inset-0 bg-gray-800 bg-opacity-75 transition-opacity" />
-        </Transition.Child>
+        </TransitionChild>
 
         <div className="fixed inset-0 z-30 overflow-y-auto">
           <div className="flex min-h-full items-end items-center justify-center p-4">
-            <Transition.Child
+            <TransitionChild
               as={Fragment}
               enter="ease-out duration-300"
               leave="ease-in duration-200"
               leaveTo="opacity-0"
             >
-              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6 lg:max-w-lg">
+              <DialogPanel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6 lg:max-w-lg">
                 <div>
                   <div className="mt-3">
-                    <Dialog.Title
+                    <DialogTitle
                       as="h3"
                       className="text-lg font-medium leading-6 text-gray-900"
                     >
                       Setup Azure OpenAI
-                    </Dialog.Title>
+                    </DialogTitle>
                     <div className="mt-4">
                       <p className="text-sm text-gray-500">
                         To use Azure OpenAI models you must provide your API key
@@ -210,11 +216,11 @@ export default function AzureOpenAISetup({
                     )}
                   </div>
                 </div>
-              </Dialog.Panel>
-            </Transition.Child>
+              </DialogPanel>
+            </TransitionChild>
           </div>
         </div>
       </Dialog>
-    </Transition.Root>
+    </Transition>
   );
 }

--- a/front/components/providers/AzureOpenAISetup.tsx
+++ b/front/components/providers/AzureOpenAISetup.tsx
@@ -7,6 +7,7 @@ import {
   Transition,
   TransitionChild,
 } from "@headlessui/react";
+import classNames from "classnames";
 import { Fragment, useEffect, useState } from "react";
 import { useSWRConfig } from "swr";
 
@@ -95,129 +96,123 @@ export default function AzureOpenAISetup({
   return (
     <Transition show={open} as={Fragment}>
       <Dialog as="div" className="relative z-30" onClose={() => setOpen(false)}>
-        <TransitionChild
-          as={Fragment}
-          enter="ease-out duration-300"
-          enterFrom="opacity-0"
-          enterTo="opacity-100"
-          leave="ease-in duration-200"
-          leaveFrom="opacity-100"
-          leaveTo="opacity-0"
-        >
-          <div className="fixed inset-0 bg-gray-800 bg-opacity-75 transition-opacity" />
+        <TransitionChild as={Fragment} appear={true}>
+          <div
+            className={classNames(
+              "fixed inset-0 bg-gray-800 bg-opacity-75 transition-opacity",
+              "duration-700 ease-out",
+              "data-[enter]:data-[closed]:opacity-0",
+              "data-[leave]:data-[closed]:opacity-0"
+            )}
+          />
         </TransitionChild>
 
         <div className="fixed inset-0 z-30 overflow-y-auto">
-          <div className="flex min-h-full items-end items-center justify-center p-4">
-            <TransitionChild
-              as={Fragment}
-              enter="ease-out duration-300"
-              leave="ease-in duration-200"
-              leaveTo="opacity-0"
+          <div className="flex min-h-full items-center justify-center p-4">
+            <DialogPanel
+              className={classNames(
+                "relative overflow-hidden rounded-lg bg-white p-4 sm:my-8 sm:w-full sm:max-w-sm sm:p-6 lg:max-w-lg",
+                "duration-300",
+                "data-[enter]:data-[closed]:opacity-0",
+                "data-[leave]:data-[closed]:opacity-0"
+              )}
+              transition
             >
-              <DialogPanel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6 lg:max-w-lg">
-                <div>
-                  <div className="mt-3">
-                    <DialogTitle
-                      as="h3"
-                      className="text-lg font-medium leading-6 text-gray-900"
-                    >
-                      Setup Azure OpenAI
-                    </DialogTitle>
-                    <div className="mt-4">
-                      <p className="text-sm text-gray-500">
-                        To use Azure OpenAI models you must provide your API key
-                        and Endpoint. They can be found in the left menu of your
-                        OpenAI Azure Resource portal (menu item `Keys and
-                        Endpoint`).
-                      </p>
-                      <p className="mt-2 text-sm text-gray-500">
-                        We'll never use your API key for anything other than to
-                        run your apps.
-                      </p>
-                    </div>
-                    <div className="mt-6">
-                      <input
-                        type="text"
-                        className="block w-full rounded-md border-gray-300 shadow-sm focus:border-violet-500 focus:ring-violet-500 sm:text-sm"
-                        placeholder="Azure OpenAI Endpoint"
-                        value={endpoint}
-                        onChange={(e) => {
-                          setEndpoint(e.target.value);
-                          setTestSuccessful(false);
-                        }}
-                      />
-                    </div>
-                    <div className="mt-6">
-                      <input
-                        type="text"
-                        className="block w-full rounded-md border-gray-300 shadow-sm focus:border-violet-500 focus:ring-violet-500 sm:text-sm"
-                        placeholder="Azure OpenAI API Key"
-                        value={apiKey}
-                        onChange={(e) => {
-                          setApiKey(e.target.value);
-                          setTestSuccessful(false);
-                        }}
-                      />
-                    </div>
+              <div className="mt-3">
+                <DialogTitle
+                  as="h3"
+                  className="text-lg font-medium leading-6 text-gray-900"
+                >
+                  Setup Azure OpenAI
+                </DialogTitle>
+                <div className="mt-4">
+                  <p className="text-sm text-gray-500">
+                    To use Azure OpenAI models you must provide your API key and
+                    Endpoint. They can be found in the left menu of your OpenAI
+                    Azure Resource portal (menu item `Keys and Endpoint`).
+                  </p>
+                  <p className="mt-2 text-sm text-gray-500">
+                    We'll never use your API key for anything other than to run
+                    your apps.
+                  </p>
+                </div>
+                <div className="mt-6">
+                  <input
+                    type="text"
+                    className="block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+                    placeholder="Azure OpenAI Endpoint"
+                    value={endpoint}
+                    onChange={(e) => {
+                      setEndpoint(e.target.value);
+                      setTestSuccessful(false);
+                    }}
+                  />
+                </div>
+                <div className="mt-6">
+                  <input
+                    type="text"
+                    className="block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+                    placeholder="Azure OpenAI API Key"
+                    value={apiKey}
+                    onChange={(e) => {
+                      setApiKey(e.target.value);
+                      setTestSuccessful(false);
+                    }}
+                  />
+                </div>
+              </div>
+              <div className="mt-2 px-2 text-sm">
+                {testError.length > 0 ? (
+                  <span className="text-red-500">Error: {testError}</span>
+                ) : testSuccessful ? (
+                  <span className="text-green-600">
+                    Test succeeded! You can enable Azure OpenAI.
+                  </span>
+                ) : (
+                  <span>&nbsp;</span>
+                )}
+              </div>
+              <div className="mt-5 flex flex-row items-center justify-between space-x-2 sm:mt-6">
+                {enabled ? (
+                  <div
+                    className="cursor-pointer text-sm font-bold text-red-500"
+                    onClick={() => handleDisable()}
+                  >
+                    Disable
                   </div>
-                </div>
-                <div className="mt-1 px-2 text-sm">
-                  {testError.length > 0 ? (
-                    <span className="text-red-500">Error: {testError}</span>
-                  ) : testSuccessful ? (
-                    <span className="text-green-600">
-                      Test succeeded! You can enable Azure OpenAI.
-                    </span>
-                  ) : (
-                    <span>&nbsp;</span>
-                  )}
-                </div>
-                <div className="mt-5 flex flex-row items-center space-x-2 sm:mt-6">
-                  {enabled ? (
-                    <div
-                      className="flex-initial cursor-pointer text-sm font-bold text-red-500"
-                      onClick={() => handleDisable()}
-                    >
-                      Disable
-                    </div>
-                  ) : (
-                    <></>
-                  )}
-                  <div className="flex-1"></div>
-                  <div className="flex flex-initial">
+                ) : (
+                  <div></div>
+                )}
+                <div className="flex space-x-2">
+                  <Button
+                    onClick={() => setOpen(false)}
+                    label="Cancel"
+                    variant="secondary"
+                  />
+                  {testSuccessful ? (
                     <Button
-                      onClick={() => setOpen(false)}
-                      label="Cancel"
-                      variant="secondary"
+                      onClick={() => handleEnable()}
+                      disabled={enableRunning}
+                      label={
+                        enabled
+                          ? enableRunning
+                            ? "Updating..."
+                            : "Update"
+                          : enableRunning
+                            ? "Enabling..."
+                            : "Enable"
+                      }
                     />
-                  </div>
-                  <div className="flex flex-initial">
-                    {testSuccessful ? (
-                      <Button
-                        onClick={() => handleEnable()}
-                        disabled={enableRunning}
-                        label={
-                          enabled
-                            ? enableRunning
-                              ? "Updating..."
-                              : "Update"
-                            : enableRunning
-                              ? "Enabling..."
-                              : "Enable"
-                        }
-                      />
-                    ) : (
-                      <Button
-                        disabled={apiKey.length == 0 || testRunning}
-                        onClick={() => runTest()}
-                        label={testRunning ? "Testing..." : "Test"}
-                      />
-                    )}
-                  </div>
+                  ) : (
+                    <Button
+                      disabled={apiKey.length == 0 || testRunning}
+                      onClick={() => runTest()}
+                      label={testRunning ? "Testing..." : "Test"}
+                    />
+                  )}
                 </div>
-              </DialogPanel>
-            </TransitionChild>
+              </div>
+            </DialogPanel>
           </div>
         </div>
       </Dialog>

--- a/front/components/providers/BrowserlessAPISetup.tsx
+++ b/front/components/providers/BrowserlessAPISetup.tsx
@@ -7,6 +7,7 @@ import {
   Transition,
   TransitionChild,
 } from "@headlessui/react";
+import classNames from "classnames";
 import { Fragment, useEffect, useState } from "react";
 import { useSWRConfig } from "swr";
 
@@ -89,129 +90,124 @@ export default function BrowserlessAPISetup({
   return (
     <Transition show={open} as={Fragment}>
       <Dialog as="div" className="relative z-30" onClose={() => setOpen(false)}>
-        <TransitionChild
-          as={Fragment}
-          enter="ease-out duration-300"
-          enterFrom="opacity-0"
-          enterTo="opacity-100"
-          leave="ease-in duration-200"
-          leaveFrom="opacity-100"
-          leaveTo="opacity-0"
-        >
-          <div className="fixed inset-0 bg-gray-800 bg-opacity-75 transition-opacity" />
+        <TransitionChild as={Fragment} appear={true}>
+          <div
+            className={classNames(
+              "fixed inset-0 bg-gray-800 bg-opacity-75 transition-opacity",
+              "duration-700 ease-out",
+              "data-[enter]:data-[closed]:opacity-0",
+              "data-[leave]:data-[closed]:opacity-0"
+            )}
+          />
         </TransitionChild>
 
         <div className="fixed inset-0 z-30 overflow-y-auto">
-          <div className="flex min-h-full items-end items-center justify-center p-4">
-            <TransitionChild
-              as={Fragment}
-              enter="ease-out duration-300"
-              leave="ease-in duration-200"
-              leaveTo="opacity-0"
+          <div className="flex min-h-full items-center justify-center p-4">
+            <DialogPanel
+              className={classNames(
+                "relative overflow-hidden rounded-lg bg-white p-4 sm:my-8 sm:w-full sm:max-w-sm sm:p-6 lg:max-w-lg",
+                "duration-300",
+                "data-[enter]:data-[closed]:opacity-0",
+                "data-[leave]:data-[closed]:opacity-0"
+              )}
+              transition
             >
-              <DialogPanel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6 lg:max-w-lg">
-                <div>
-                  <div className="mt-3">
-                    <DialogTitle
-                      as="h3"
-                      className="text-lg font-medium leading-6 text-gray-900"
+              <div className="mt-3">
+                <DialogTitle
+                  as="h3"
+                  className="text-lg font-medium leading-6 text-gray-900"
+                >
+                  Setup Browserless API
+                </DialogTitle>
+                <div className="mt-4">
+                  <p className="text-sm text-gray-500">
+                    Browserless lets you use headless browsers to scrape web
+                    content. To use Browserless, you must provide your API key.
+                    It can be found{" "}
+                    <a
+                      className="font-bold text-action-600 hover:text-action-500"
+                      href="https://cloud.browserless.io/account/"
+                      target="_blank"
                     >
-                      Setup Browserless API
-                    </DialogTitle>
-                    <div className="mt-4">
-                      <p className="text-sm text-gray-500">
-                        Browserless lets you use headless browsers to scrape web
-                        content. To use Browserless, you must provide your API
-                        key. It can be found{" "}
-                        <a
-                          className="font-bold text-action-600 hover:text-action-500"
-                          href="https://cloud.browserless.io/account/"
-                          target="_blank"
-                        >
-                          here
-                        </a>
-                        .
-                      </p>
-                      <p className="mt-2 text-sm text-gray-500">
-                        Note that it generally takes{" "}
-                        <span className="font-bold">5 mins</span> for the API
-                        key to become active (an email is sent when it's ready).
-                      </p>
-                      <p className="mt-2 text-sm text-gray-500">
-                        We'll never use your API key for anything other than to
-                        run your apps.
-                      </p>
-                    </div>
-                    <div className="mt-6">
-                      <input
-                        type="text"
-                        className="block w-full rounded-md border-gray-300 shadow-sm focus:border-action-500 focus:ring-action-500 sm:text-sm"
-                        placeholder="Browserless API Key"
-                        value={apiKey}
-                        onChange={(e) => {
-                          setApiKey(e.target.value);
-                          setTestSuccessful(false);
-                        }}
-                      />
-                    </div>
+                      here
+                    </a>
+                    .
+                  </p>
+                  <p className="mt-2 text-sm text-gray-500">
+                    Note that it generally takes{" "}
+                    <span className="font-bold">5 mins</span> for the API key to
+                    become active (an email is sent when it's ready).
+                  </p>
+                  <p className="mt-2 text-sm text-gray-500">
+                    We'll never use your API key for anything other than to run
+                    your apps.
+                  </p>
+                </div>
+                <div className="mt-6">
+                  <input
+                    type="text"
+                    className="block w-full rounded-md border-gray-300 shadow-sm focus:border-action-500 focus:ring-action-500 sm:text-sm"
+                    placeholder="Browserless API Key"
+                    value={apiKey}
+                    onChange={(e) => {
+                      setApiKey(e.target.value);
+                      setTestSuccessful(false);
+                    }}
+                  />
+                </div>
+              </div>
+              <div className="mt-2 px-2 text-sm">
+                {testError.length > 0 ? (
+                  <span className="text-red-500">Error: {testError}</span>
+                ) : testSuccessful ? (
+                  <span className="text-green-600">
+                    Test succeeded! You can enable the Browserless API.
+                  </span>
+                ) : (
+                  <span>&nbsp;</span>
+                )}
+              </div>
+              <div className="mt-5 flex flex-row items-center justify-between space-x-2 sm:mt-6">
+                {enabled ? (
+                  <div
+                    className="cursor-pointer text-sm font-bold text-red-500"
+                    onClick={() => handleDisable()}
+                  >
+                    Disable
                   </div>
-                </div>
-                <div className="mt-1 px-2 text-sm">
-                  {testError.length > 0 ? (
-                    <span className="text-red-500">Error: {testError}</span>
-                  ) : testSuccessful ? (
-                    <span className="text-green-600">
-                      Test succeeded! You can enable the Browserless API.
-                    </span>
-                  ) : (
-                    <span>&nbsp;</span>
-                  )}
-                </div>
-                <div className="mt-5 flex flex-row items-center space-x-2 sm:mt-6">
-                  {enabled ? (
-                    <div
-                      className="flex-initial cursor-pointer text-sm font-bold text-red-500"
-                      onClick={() => handleDisable()}
-                    >
-                      Disable
-                    </div>
-                  ) : (
-                    <></>
-                  )}
-                  <div className="flex-1"></div>
-                  <div className="flex flex-initial">
+                ) : (
+                  <div></div>
+                )}
+                <div className="flex space-x-2">
+                  <Button
+                    onClick={() => setOpen(false)}
+                    label="Cancel"
+                    variant="secondary"
+                  />
+                  {testSuccessful ? (
                     <Button
-                      onClick={() => setOpen(false)}
-                      label="Cancel"
-                      variant="secondary"
+                      onClick={() => handleEnable()}
+                      disabled={enableRunning}
+                      label={
+                        enabled
+                          ? enableRunning
+                            ? "Updating..."
+                            : "Update"
+                          : enableRunning
+                            ? "Enabling..."
+                            : "Enable"
+                      }
                     />
-                  </div>
-                  <div className="flex flex-initial">
-                    {testSuccessful ? (
-                      <Button
-                        onClick={() => handleEnable()}
-                        disabled={enableRunning}
-                        label={
-                          enabled
-                            ? enableRunning
-                              ? "Updating..."
-                              : "Update"
-                            : enableRunning
-                              ? "Enabling..."
-                              : "Enable"
-                        }
-                      />
-                    ) : (
-                      <Button
-                        disabled={apiKey.length == 0 || testRunning}
-                        onClick={() => runTest()}
-                        label={testRunning ? "Testing..." : "Test"}
-                      />
-                    )}
-                  </div>
+                  ) : (
+                    <Button
+                      disabled={apiKey.length == 0 || testRunning}
+                      onClick={() => runTest()}
+                      label={testRunning ? "Testing..." : "Test"}
+                    />
+                  )}
                 </div>
-              </DialogPanel>
-            </TransitionChild>
+              </div>
+            </DialogPanel>
           </div>
         </div>
       </Dialog>

--- a/front/components/providers/BrowserlessAPISetup.tsx
+++ b/front/components/providers/BrowserlessAPISetup.tsx
@@ -1,6 +1,12 @@
 import { Button } from "@dust-tt/sparkle";
 import type { WorkspaceType } from "@dust-tt/types";
-import { Dialog, Transition } from "@headlessui/react";
+import {
+  Dialog,
+  DialogPanel,
+  DialogTitle,
+  Transition,
+  TransitionChild,
+} from "@headlessui/react";
 import { Fragment, useEffect, useState } from "react";
 import { useSWRConfig } from "swr";
 
@@ -81,9 +87,9 @@ export default function BrowserlessAPISetup({
   };
 
   return (
-    <Transition.Root show={open} as={Fragment}>
+    <Transition show={open} as={Fragment}>
       <Dialog as="div" className="relative z-30" onClose={() => setOpen(false)}>
-        <Transition.Child
+        <TransitionChild
           as={Fragment}
           enter="ease-out duration-300"
           enterFrom="opacity-0"
@@ -93,25 +99,25 @@ export default function BrowserlessAPISetup({
           leaveTo="opacity-0"
         >
           <div className="fixed inset-0 bg-gray-800 bg-opacity-75 transition-opacity" />
-        </Transition.Child>
+        </TransitionChild>
 
         <div className="fixed inset-0 z-30 overflow-y-auto">
           <div className="flex min-h-full items-end items-center justify-center p-4">
-            <Transition.Child
+            <TransitionChild
               as={Fragment}
               enter="ease-out duration-300"
               leave="ease-in duration-200"
               leaveTo="opacity-0"
             >
-              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6 lg:max-w-lg">
+              <DialogPanel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6 lg:max-w-lg">
                 <div>
                   <div className="mt-3">
-                    <Dialog.Title
+                    <DialogTitle
                       as="h3"
                       className="text-lg font-medium leading-6 text-gray-900"
                     >
                       Setup Browserless API
-                    </Dialog.Title>
+                    </DialogTitle>
                     <div className="mt-4">
                       <p className="text-sm text-gray-500">
                         Browserless lets you use headless browsers to scrape web
@@ -204,11 +210,11 @@ export default function BrowserlessAPISetup({
                     )}
                   </div>
                 </div>
-              </Dialog.Panel>
-            </Transition.Child>
+              </DialogPanel>
+            </TransitionChild>
           </div>
         </div>
       </Dialog>
-    </Transition.Root>
+    </Transition>
   );
 }

--- a/front/components/providers/GoogleAiStudioSetup.tsx
+++ b/front/components/providers/GoogleAiStudioSetup.tsx
@@ -7,6 +7,7 @@ import {
   Transition,
   TransitionChild,
 } from "@headlessui/react";
+import classNames from "classnames";
 import { Fragment, useEffect, useState } from "react";
 import { useSWRConfig } from "swr";
 
@@ -89,123 +90,118 @@ export default function GoogleAiStudioSetup({
   return (
     <Transition show={open} as={Fragment}>
       <Dialog as="div" className="relative z-30" onClose={() => setOpen(false)}>
-        <TransitionChild
-          as={Fragment}
-          enter="ease-out duration-300"
-          enterFrom="opacity-0"
-          enterTo="opacity-100"
-          leave="ease-in duration-200"
-          leaveFrom="opacity-100"
-          leaveTo="opacity-0"
-        >
-          <div className="fixed inset-0 bg-gray-800 bg-opacity-75 transition-opacity" />
+        <TransitionChild as={Fragment} appear={true}>
+          <div
+            className={classNames(
+              "fixed inset-0 bg-gray-800 bg-opacity-75 transition-opacity",
+              "duration-700 ease-out",
+              "data-[enter]:data-[closed]:opacity-0",
+              "data-[leave]:data-[closed]:opacity-0"
+            )}
+          />
         </TransitionChild>
 
         <div className="fixed inset-0 z-30 overflow-y-auto">
-          <div className="flex min-h-full items-end items-center justify-center p-4">
-            <TransitionChild
-              as={Fragment}
-              enter="ease-out duration-300"
-              leave="ease-in duration-200"
-              leaveTo="opacity-0"
+          <div className="flex min-h-full items-center justify-center p-4">
+            <DialogPanel
+              className={classNames(
+                "relative overflow-hidden rounded-lg bg-white p-4 sm:my-8 sm:w-full sm:max-w-sm sm:p-6 lg:max-w-lg",
+                "duration-300",
+                "data-[enter]:data-[closed]:opacity-0",
+                "data-[leave]:data-[closed]:opacity-0"
+              )}
+              transition
             >
-              <DialogPanel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6 lg:max-w-lg">
-                <div>
-                  <div className="mt-3">
-                    <DialogTitle
-                      as="h3"
-                      className="text-lg font-medium leading-6 text-gray-900"
+              <div className="mt-3">
+                <DialogTitle
+                  as="h3"
+                  className="text-lg font-medium leading-6 text-gray-900"
+                >
+                  Setup Google AI Studio
+                </DialogTitle>
+                <div className="mt-4">
+                  <p className="text-sm text-gray-500">
+                    To use Google AI Studio models you must provide your API
+                    key. It can be found{" "}
+                    <a
+                      className="font-bold text-action-600 hover:text-action-500"
+                      href="https://aistudio.google.com/app/apikey"
+                      target="_blank"
                     >
-                      Setup Google AI Studio
-                    </DialogTitle>
-                    <div className="mt-4">
-                      <p className="text-sm text-gray-500">
-                        To use Google AI Studio models you must provide your API
-                        key. It can be found{" "}
-                        <a
-                          className="font-bold text-action-600 hover:text-action-500"
-                          href="https://aistudio.google.com/app/apikey"
-                          target="_blank"
-                        >
-                          here
-                        </a>
-                        &nbsp;(you can create a new key specifically for Dust).
-                      </p>
-                      <p className="mt-2 text-sm text-gray-500">
-                        We'll never use your API key for anything other than to
-                        run your apps.
-                      </p>
-                    </div>
-                    <div className="mt-6">
-                      <input
-                        type="text"
-                        className="block w-full rounded-md border-gray-300 shadow-sm focus:border-action-500 focus:ring-action-500 sm:text-sm"
-                        placeholder="Google AI Studio API Key"
-                        value={apiKey}
-                        onChange={(e) => {
-                          setApiKey(e.target.value);
-                          setTestSuccessful(false);
-                        }}
-                      />
-                    </div>
+                      here
+                    </a>
+                    &nbsp;(you can create a new key specifically for Dust).
+                  </p>
+                  <p className="mt-2 text-sm text-gray-500">
+                    We'll never use your API key for anything other than to run
+                    your apps.
+                  </p>
+                </div>
+                <div className="mt-6">
+                  <input
+                    type="text"
+                    className="block w-full rounded-md border-gray-300 shadow-sm focus:border-action-500 focus:ring-action-500 sm:text-sm"
+                    placeholder="Google AI Studio API Key"
+                    value={apiKey}
+                    onChange={(e) => {
+                      setApiKey(e.target.value);
+                      setTestSuccessful(false);
+                    }}
+                  />
+                </div>
+              </div>
+              <div className="mt-2 px-2 text-sm">
+                {testError.length > 0 ? (
+                  <span className="text-red-500">Error: {testError}</span>
+                ) : testSuccessful ? (
+                  <span className="text-green-600">
+                    Test succeeded! You can enable Google AI Studio.
+                  </span>
+                ) : (
+                  <span>&nbsp;</span>
+                )}
+              </div>
+              <div className="mt-5 flex flex-row items-center justify-between space-x-2 sm:mt-6">
+                {enabled ? (
+                  <div
+                    className="cursor-pointer text-sm font-bold text-red-500"
+                    onClick={() => handleDisable()}
+                  >
+                    Disable
                   </div>
-                </div>
-                <div className="mt-1 px-2 text-sm">
-                  {testError.length > 0 ? (
-                    <span className="text-red-500">Error: {testError}</span>
-                  ) : testSuccessful ? (
-                    <span className="text-green-600">
-                      Test succeeded! You can enable Google AI Studio.
-                    </span>
-                  ) : (
-                    <span>&nbsp;</span>
-                  )}
-                </div>
-                <div className="mt-5 flex flex-row items-center space-x-2 sm:mt-6">
-                  {enabled ? (
-                    <div
-                      className="flex-initial cursor-pointer text-sm font-bold text-red-500"
-                      onClick={() => handleDisable()}
-                    >
-                      Disable
-                    </div>
-                  ) : (
-                    <></>
-                  )}
-                  <div className="flex-1"></div>
-                  <div className="flex flex-initial">
+                ) : (
+                  <div></div>
+                )}
+                <div className="flex space-x-2">
+                  <Button
+                    onClick={() => setOpen(false)}
+                    label="Cancel"
+                    variant="secondary"
+                  />
+                  {testSuccessful ? (
                     <Button
-                      onClick={() => setOpen(false)}
-                      label="Cancel"
-                      variant="secondary"
+                      onClick={() => handleEnable()}
+                      disabled={enableRunning}
+                      label={
+                        enabled
+                          ? enableRunning
+                            ? "Updating..."
+                            : "Update"
+                          : enableRunning
+                            ? "Enabling..."
+                            : "Enable"
+                      }
                     />
-                  </div>
-                  <div className="flex flex-initial">
-                    {testSuccessful ? (
-                      <Button
-                        onClick={() => handleEnable()}
-                        disabled={enableRunning}
-                        label={
-                          enabled
-                            ? enableRunning
-                              ? "Updating..."
-                              : "Update"
-                            : enableRunning
-                              ? "Enabling..."
-                              : "Enable"
-                        }
-                      />
-                    ) : (
-                      <Button
-                        disabled={apiKey.length == 0 || testRunning}
-                        onClick={() => runTest()}
-                        label={testRunning ? "Testing..." : "Test"}
-                      />
-                    )}
-                  </div>
+                  ) : (
+                    <Button
+                      disabled={apiKey.length == 0 || testRunning}
+                      onClick={() => runTest()}
+                      label={testRunning ? "Testing..." : "Test"}
+                    />
+                  )}
                 </div>
-              </DialogPanel>
-            </TransitionChild>
+              </div>
+            </DialogPanel>
           </div>
         </div>
       </Dialog>

--- a/front/components/providers/GoogleAiStudioSetup.tsx
+++ b/front/components/providers/GoogleAiStudioSetup.tsx
@@ -1,6 +1,12 @@
 import { Button } from "@dust-tt/sparkle";
 import type { WorkspaceType } from "@dust-tt/types";
-import { Dialog, Transition } from "@headlessui/react";
+import {
+  Dialog,
+  DialogPanel,
+  DialogTitle,
+  Transition,
+  TransitionChild,
+} from "@headlessui/react";
 import { Fragment, useEffect, useState } from "react";
 import { useSWRConfig } from "swr";
 
@@ -81,9 +87,9 @@ export default function GoogleAiStudioSetup({
   };
 
   return (
-    <Transition.Root show={open} as={Fragment}>
+    <Transition show={open} as={Fragment}>
       <Dialog as="div" className="relative z-30" onClose={() => setOpen(false)}>
-        <Transition.Child
+        <TransitionChild
           as={Fragment}
           enter="ease-out duration-300"
           enterFrom="opacity-0"
@@ -93,25 +99,25 @@ export default function GoogleAiStudioSetup({
           leaveTo="opacity-0"
         >
           <div className="fixed inset-0 bg-gray-800 bg-opacity-75 transition-opacity" />
-        </Transition.Child>
+        </TransitionChild>
 
         <div className="fixed inset-0 z-30 overflow-y-auto">
           <div className="flex min-h-full items-end items-center justify-center p-4">
-            <Transition.Child
+            <TransitionChild
               as={Fragment}
               enter="ease-out duration-300"
               leave="ease-in duration-200"
               leaveTo="opacity-0"
             >
-              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6 lg:max-w-lg">
+              <DialogPanel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6 lg:max-w-lg">
                 <div>
                   <div className="mt-3">
-                    <Dialog.Title
+                    <DialogTitle
                       as="h3"
                       className="text-lg font-medium leading-6 text-gray-900"
                     >
                       Setup Google AI Studio
-                    </Dialog.Title>
+                    </DialogTitle>
                     <div className="mt-4">
                       <p className="text-sm text-gray-500">
                         To use Google AI Studio models you must provide your API
@@ -198,11 +204,11 @@ export default function GoogleAiStudioSetup({
                     )}
                   </div>
                 </div>
-              </Dialog.Panel>
-            </Transition.Child>
+              </DialogPanel>
+            </TransitionChild>
           </div>
         </div>
       </Dialog>
-    </Transition.Root>
+    </Transition>
   );
 }

--- a/front/components/providers/MistralAISetup.tsx
+++ b/front/components/providers/MistralAISetup.tsx
@@ -1,6 +1,12 @@
 import { Button } from "@dust-tt/sparkle";
 import type { WorkspaceType } from "@dust-tt/types";
-import { Dialog, Transition } from "@headlessui/react";
+import {
+  Dialog,
+  DialogPanel,
+  DialogTitle,
+  Transition,
+  TransitionChild,
+} from "@headlessui/react";
 import { Fragment, useEffect, useState } from "react";
 import { useSWRConfig } from "swr";
 
@@ -79,9 +85,9 @@ export default function MistralAISetup({
   };
 
   return (
-    <Transition.Root show={open} as={Fragment}>
+    <Transition show={open} as={Fragment}>
       <Dialog as="div" className="relative z-30" onClose={() => setOpen(false)}>
-        <Transition.Child
+        <TransitionChild
           as={Fragment}
           enter="ease-out duration-300"
           enterFrom="opacity-0"
@@ -91,25 +97,25 @@ export default function MistralAISetup({
           leaveTo="opacity-0"
         >
           <div className="fixed inset-0 bg-gray-800 bg-opacity-75 transition-opacity" />
-        </Transition.Child>
+        </TransitionChild>
 
         <div className="fixed inset-0 z-30 overflow-y-auto">
           <div className="flex min-h-full items-end items-center justify-center p-4">
-            <Transition.Child
+            <TransitionChild
               as={Fragment}
               enter="ease-out duration-300"
               leave="ease-in duration-200"
               leaveTo="opacity-0"
             >
-              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6 lg:max-w-lg">
+              <DialogPanel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6 lg:max-w-lg">
                 <div>
                   <div className="mt-3">
-                    <Dialog.Title
+                    <DialogTitle
                       as="h3"
                       className="text-lg font-medium leading-6 text-gray-900"
                     >
                       Setup Mistral AI
-                    </Dialog.Title>
+                    </DialogTitle>
                     <div className="mt-4">
                       <p className="text-sm text-gray-500">
                         To use Mistral AI models you must provide your API key.
@@ -196,11 +202,11 @@ export default function MistralAISetup({
                     )}
                   </div>
                 </div>
-              </Dialog.Panel>
-            </Transition.Child>
+              </DialogPanel>
+            </TransitionChild>
           </div>
         </div>
       </Dialog>
-    </Transition.Root>
+    </Transition>
   );
 }

--- a/front/components/providers/MistralAISetup.tsx
+++ b/front/components/providers/MistralAISetup.tsx
@@ -7,6 +7,7 @@ import {
   Transition,
   TransitionChild,
 } from "@headlessui/react";
+import classNames from "classnames";
 import { Fragment, useEffect, useState } from "react";
 import { useSWRConfig } from "swr";
 
@@ -87,123 +88,116 @@ export default function MistralAISetup({
   return (
     <Transition show={open} as={Fragment}>
       <Dialog as="div" className="relative z-30" onClose={() => setOpen(false)}>
-        <TransitionChild
-          as={Fragment}
-          enter="ease-out duration-300"
-          enterFrom="opacity-0"
-          enterTo="opacity-100"
-          leave="ease-in duration-200"
-          leaveFrom="opacity-100"
-          leaveTo="opacity-0"
-        >
-          <div className="fixed inset-0 bg-gray-800 bg-opacity-75 transition-opacity" />
+        <TransitionChild as={Fragment} appear={true}>
+          <div
+            className={classNames(
+              "fixed inset-0 bg-gray-800 bg-opacity-75 transition-opacity",
+              "duration-700 ease-out",
+              "data-[enter]:data-[closed]:opacity-0",
+              "data-[leave]:data-[closed]:opacity-0"
+            )}
+          />
         </TransitionChild>
 
         <div className="fixed inset-0 z-30 overflow-y-auto">
-          <div className="flex min-h-full items-end items-center justify-center p-4">
-            <TransitionChild
-              as={Fragment}
-              enter="ease-out duration-300"
-              leave="ease-in duration-200"
-              leaveTo="opacity-0"
+          <div className="flex min-h-full items-center justify-center p-4">
+            <DialogPanel
+              className={classNames(
+                "relative overflow-hidden rounded-lg bg-white p-4 sm:my-8 sm:w-full sm:max-w-sm sm:p-6 lg:max-w-lg",
+                "duration-300",
+                "data-[enter]:data-[closed]:opacity-0",
+                "data-[leave]:data-[closed]:opacity-0"
+              )}
+              transition
             >
-              <DialogPanel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6 lg:max-w-lg">
-                <div>
-                  <div className="mt-3">
-                    <DialogTitle
-                      as="h3"
-                      className="text-lg font-medium leading-6 text-gray-900"
+              <div className="mt-3">
+                <DialogTitle
+                  as="h3"
+                  className="text-lg font-medium leading-6 text-gray-900"
+                >
+                  Setup Mistral AI
+                </DialogTitle>
+                <div className="mt-4">
+                  <p className="text-sm text-gray-500">
+                    To use Mistral AI models you must provide your API key. It
+                    can be found{" "}
+                    <a
+                      className="font-bold text-action-600 hover:text-action-500"
+                      href="https://console.mistral.ai/user/api-keys/"
+                      target="_blank"
                     >
-                      Setup Mistral AI
-                    </DialogTitle>
-                    <div className="mt-4">
-                      <p className="text-sm text-gray-500">
-                        To use Mistral AI models you must provide your API key.
-                        It can be found{" "}
-                        <a
-                          className="font-bold text-action-600 hover:text-action-500"
-                          href="https://console.mistral.ai/user/api-keys/"
-                          target="_blank"
-                        >
-                          here
-                        </a>
-                        &nbsp;(you can create a new key specifically for Dust).
-                      </p>
-                      <p className="mt-2 text-sm text-gray-500">
-                        We'll never use your API key for anything other than to
-                        run your apps.
-                      </p>
-                    </div>
-                    <div className="mt-6">
-                      <input
-                        type="text"
-                        className="block w-full rounded-md border-gray-300 shadow-sm focus:border-action-500 focus:ring-action-500 sm:text-sm"
-                        placeholder="Mistral AI API Key"
-                        value={apiKey}
-                        onChange={(e) => {
-                          setApiKey(e.target.value);
-                          setTestSuccessful(false);
-                        }}
-                      />
-                    </div>
+                      here
+                    </a>
+                    &nbsp;(you can create a new key specifically for Dust).
+                  </p>
+                  <p className="mt-2 text-sm text-gray-500">
+                    We'll never use your API key for anything other than to run
+                    your apps.
+                  </p>
+                </div>
+                <div className="mt-6">
+                  <input
+                    type="text"
+                    className="block w-full rounded-md border-gray-300 shadow-sm focus:border-action-500 focus:ring-action-500 sm:text-sm"
+                    placeholder="Mistral AI API Key"
+                    value={apiKey}
+                    onChange={(e) => {
+                      setApiKey(e.target.value);
+                      setTestSuccessful(false);
+                    }}
+                  />
+                </div>
+              </div>
+              <div className="mt-1 px-2 text-sm">
+                {testError.length > 0 ? (
+                  <span className="text-red-500">Error: {testError}</span>
+                ) : testSuccessful ? (
+                  <span className="text-green-600">
+                    Test succeeded! You can enable Mistral AI.
+                  </span>
+                ) : (
+                  <span>&nbsp;</span>
+                )}
+              </div>
+              <div className="mt-5 flex flex-row items-center justify-between space-x-2 sm:mt-6">
+                {enabled && (
+                  <div
+                    className="cursor-pointer text-sm font-bold text-red-500"
+                    onClick={() => handleDisable()}
+                  >
+                    Disable
                   </div>
-                </div>
-                <div className="mt-1 px-2 text-sm">
-                  {testError.length > 0 ? (
-                    <span className="text-red-500">Error: {testError}</span>
-                  ) : testSuccessful ? (
-                    <span className="text-green-600">
-                      Test succeeded! You can enable Mistral AI.
-                    </span>
-                  ) : (
-                    <span>&nbsp;</span>
-                  )}
-                </div>
-                <div className="mt-5 flex flex-row items-center space-x-2 sm:mt-6">
-                  {enabled ? (
-                    <div
-                      className="flex-initial cursor-pointer text-sm font-bold text-red-500"
-                      onClick={() => handleDisable()}
-                    >
-                      Disable
-                    </div>
-                  ) : (
-                    <></>
-                  )}
-                  <div className="flex-1"></div>
-                  <div className="flex flex-initial">
+                )}
+                <div className="flex space-x-2">
+                  <Button
+                    onClick={() => setOpen(false)}
+                    label="Cancel"
+                    variant="secondary"
+                  />
+                  {testSuccessful ? (
                     <Button
-                      onClick={() => setOpen(false)}
-                      label="Cancel"
-                      variant="secondary"
+                      onClick={() => handleEnable()}
+                      disabled={enableRunning}
+                      label={
+                        enabled
+                          ? enableRunning
+                            ? "Updating..."
+                            : "Update"
+                          : enableRunning
+                            ? "Enabling..."
+                            : "Enable"
+                      }
                     />
-                  </div>
-                  <div className="flex flex-initial">
-                    {testSuccessful ? (
-                      <Button
-                        onClick={() => handleEnable()}
-                        disabled={enableRunning}
-                        label={
-                          enabled
-                            ? enableRunning
-                              ? "Updating..."
-                              : "Update"
-                            : enableRunning
-                              ? "Enabling..."
-                              : "Enable"
-                        }
-                      />
-                    ) : (
-                      <Button
-                        disabled={apiKey.length == 0 || testRunning}
-                        onClick={() => runTest()}
-                        label={testRunning ? "Testing..." : "Test"}
-                      />
-                    )}
-                  </div>
+                  ) : (
+                    <Button
+                      disabled={apiKey.length == 0 || testRunning}
+                      onClick={() => runTest()}
+                      label={testRunning ? "Testing..." : "Test"}
+                    />
+                  )}
                 </div>
-              </DialogPanel>
-            </TransitionChild>
+              </div>
+            </DialogPanel>
           </div>
         </div>
       </Dialog>

--- a/front/components/providers/OpenAISetup.tsx
+++ b/front/components/providers/OpenAISetup.tsx
@@ -7,6 +7,7 @@ import {
   Transition,
   TransitionChild,
 } from "@headlessui/react";
+import classNames from "classnames";
 import { Fragment, useEffect, useState } from "react";
 import { useSWRConfig } from "swr";
 
@@ -87,123 +88,118 @@ export default function OpenAISetup({
   return (
     <Transition show={open} as={Fragment}>
       <Dialog as="div" className="relative z-30" onClose={() => setOpen(false)}>
-        <TransitionChild
-          as={Fragment}
-          enter="ease-out duration-300"
-          enterFrom="opacity-0"
-          enterTo="opacity-100"
-          leave="ease-in duration-200"
-          leaveFrom="opacity-100"
-          leaveTo="opacity-0"
-        >
-          <div className="fixed inset-0 bg-gray-800 bg-opacity-75 transition-opacity" />
+        <TransitionChild as={Fragment} appear={true}>
+          <div
+            className={classNames(
+              "fixed inset-0 bg-gray-800 bg-opacity-75 transition-opacity",
+              "duration-700 ease-out",
+              "data-[enter]:data-[closed]:opacity-0",
+              "data-[leave]:data-[closed]:opacity-0"
+            )}
+          />
         </TransitionChild>
 
         <div className="fixed inset-0 z-30 overflow-y-auto">
-          <div className="flex min-h-full items-end items-center justify-center p-4">
-            <TransitionChild
-              as={Fragment}
-              enter="ease-out duration-300"
-              leave="ease-in duration-200"
-              leaveTo="opacity-0"
+          <div className="flex min-h-full items-center justify-center p-4">
+            <DialogPanel
+              className={classNames(
+                "relative overflow-hidden rounded-lg bg-white p-4 sm:my-8 sm:w-full sm:max-w-sm sm:p-6 lg:max-w-lg",
+                "duration-300",
+                "data-[enter]:data-[closed]:opacity-0",
+                "data-[leave]:data-[closed]:opacity-0"
+              )}
+              transition
             >
-              <DialogPanel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6 lg:max-w-lg">
-                <div>
-                  <div className="mt-3">
-                    <DialogTitle
-                      as="h3"
-                      className="text-lg font-medium leading-6 text-gray-900"
+              <div className="mt-3">
+                <DialogTitle
+                  as="h3"
+                  className="text-lg font-medium leading-6 text-gray-900"
+                >
+                  Setup OpenAI
+                </DialogTitle>
+                <div className="mt-4">
+                  <p className="text-sm text-gray-500">
+                    To use OpenAI models you must provide your API key. It can
+                    be found{" "}
+                    <a
+                      className="font-bold text-action-600 hover:text-action-500"
+                      href="https://platform.openai.com/account/api-keys"
+                      target="_blank"
                     >
-                      Setup OpenAI
-                    </DialogTitle>
-                    <div className="mt-4">
-                      <p className="text-sm text-gray-500">
-                        To use OpenAI models you must provide your API key. It
-                        can be found{" "}
-                        <a
-                          className="font-bold text-action-600 hover:text-action-500"
-                          href="https://platform.openai.com/account/api-keys"
-                          target="_blank"
-                        >
-                          here
-                        </a>
-                        &nbsp;(you can create a new key specifically for Dust).
-                      </p>
-                      <p className="mt-2 text-sm text-gray-500">
-                        We'll never use your API key for anything other than to
-                        run your apps.
-                      </p>
-                    </div>
-                    <div className="mt-6">
-                      <input
-                        type="text"
-                        className="block w-full rounded-md border-gray-300 shadow-sm focus:border-action-500 focus:ring-action-500 sm:text-sm"
-                        placeholder="OpenAI API Key"
-                        value={apiKey}
-                        onChange={(e) => {
-                          setApiKey(e.target.value);
-                          setTestSuccessful(false);
-                        }}
-                      />
-                    </div>
+                      here
+                    </a>
+                    &nbsp;(you can create a new key specifically for Dust).
+                  </p>
+                  <p className="mt-2 text-sm text-gray-500">
+                    We'll never use your API key for anything other than to run
+                    your apps.
+                  </p>
+                </div>
+                <div className="mt-6">
+                  <input
+                    type="text"
+                    className="block w-full rounded-md border-gray-300 shadow-sm focus:border-action-500 focus:ring-action-500 sm:text-sm"
+                    placeholder="OpenAI API Key"
+                    value={apiKey}
+                    onChange={(e) => {
+                      setApiKey(e.target.value);
+                      setTestSuccessful(false);
+                    }}
+                  />
+                </div>
+              </div>
+              <div className="mt-2 px-2 text-sm">
+                {testError.length > 0 ? (
+                  <span className="text-red-500">Error: {testError}</span>
+                ) : testSuccessful ? (
+                  <span className="text-green-600">
+                    Test succeeded! You can enable OpenAI.
+                  </span>
+                ) : (
+                  <span>&nbsp;</span>
+                )}
+              </div>
+              <div className="mt-5 flex flex-row items-center justify-between space-x-2 sm:mt-6">
+                {enabled ? (
+                  <div
+                    className="cursor-pointer text-sm font-bold text-red-500"
+                    onClick={() => handleDisable()}
+                  >
+                    Disable
                   </div>
-                </div>
-                <div className="mt-1 px-2 text-sm">
-                  {testError.length > 0 ? (
-                    <span className="text-red-500">Error: {testError}</span>
-                  ) : testSuccessful ? (
-                    <span className="text-green-600">
-                      Test succeeded! You can enable OpenAI.
-                    </span>
-                  ) : (
-                    <span>&nbsp;</span>
-                  )}
-                </div>
-                <div className="mt-5 flex flex-row items-center space-x-2 sm:mt-6">
-                  {enabled ? (
-                    <div
-                      className="flex-initial cursor-pointer text-sm font-bold text-red-500"
-                      onClick={() => handleDisable()}
-                    >
-                      Disable
-                    </div>
-                  ) : (
-                    <></>
-                  )}
-                  <div className="flex-1"></div>
-                  <div className="flex flex-initial">
+                ) : (
+                  <div></div>
+                )}
+                <div className="flex space-x-2">
+                  <Button
+                    onClick={() => setOpen(false)}
+                    label="Cancel"
+                    variant="secondary"
+                  />
+                  {testSuccessful ? (
                     <Button
-                      onClick={() => setOpen(false)}
-                      label="Cancel"
-                      variant="secondary"
+                      onClick={() => handleEnable()}
+                      disabled={enableRunning}
+                      label={
+                        enabled
+                          ? enableRunning
+                            ? "Updating..."
+                            : "Update"
+                          : enableRunning
+                            ? "Enabling..."
+                            : "Enable"
+                      }
                     />
-                  </div>
-                  <div className="flex flex-initial">
-                    {testSuccessful ? (
-                      <Button
-                        onClick={() => handleEnable()}
-                        disabled={enableRunning}
-                        label={
-                          enabled
-                            ? enableRunning
-                              ? "Updating..."
-                              : "Update"
-                            : enableRunning
-                              ? "Enabling..."
-                              : "Enable"
-                        }
-                      />
-                    ) : (
-                      <Button
-                        disabled={apiKey.length == 0 || testRunning}
-                        onClick={() => runTest()}
-                        label={testRunning ? "Testing..." : "Test"}
-                      />
-                    )}
-                  </div>
+                  ) : (
+                    <Button
+                      disabled={apiKey.length == 0 || testRunning}
+                      onClick={() => runTest()}
+                      label={testRunning ? "Testing..." : "Test"}
+                    />
+                  )}
                 </div>
-              </DialogPanel>
-            </TransitionChild>
+              </div>
+            </DialogPanel>
           </div>
         </div>
       </Dialog>

--- a/front/components/providers/OpenAISetup.tsx
+++ b/front/components/providers/OpenAISetup.tsx
@@ -1,6 +1,12 @@
 import { Button } from "@dust-tt/sparkle";
 import type { WorkspaceType } from "@dust-tt/types";
-import { Dialog, Transition } from "@headlessui/react";
+import {
+  Dialog,
+  DialogPanel,
+  DialogTitle,
+  Transition,
+  TransitionChild,
+} from "@headlessui/react";
 import { Fragment, useEffect, useState } from "react";
 import { useSWRConfig } from "swr";
 
@@ -79,9 +85,9 @@ export default function OpenAISetup({
   };
 
   return (
-    <Transition.Root show={open} as={Fragment}>
+    <Transition show={open} as={Fragment}>
       <Dialog as="div" className="relative z-30" onClose={() => setOpen(false)}>
-        <Transition.Child
+        <TransitionChild
           as={Fragment}
           enter="ease-out duration-300"
           enterFrom="opacity-0"
@@ -91,25 +97,25 @@ export default function OpenAISetup({
           leaveTo="opacity-0"
         >
           <div className="fixed inset-0 bg-gray-800 bg-opacity-75 transition-opacity" />
-        </Transition.Child>
+        </TransitionChild>
 
         <div className="fixed inset-0 z-30 overflow-y-auto">
           <div className="flex min-h-full items-end items-center justify-center p-4">
-            <Transition.Child
+            <TransitionChild
               as={Fragment}
               enter="ease-out duration-300"
               leave="ease-in duration-200"
               leaveTo="opacity-0"
             >
-              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6 lg:max-w-lg">
+              <DialogPanel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6 lg:max-w-lg">
                 <div>
                   <div className="mt-3">
-                    <Dialog.Title
+                    <DialogTitle
                       as="h3"
                       className="text-lg font-medium leading-6 text-gray-900"
                     >
                       Setup OpenAI
-                    </Dialog.Title>
+                    </DialogTitle>
                     <div className="mt-4">
                       <p className="text-sm text-gray-500">
                         To use OpenAI models you must provide your API key. It
@@ -196,11 +202,11 @@ export default function OpenAISetup({
                     )}
                   </div>
                 </div>
-              </Dialog.Panel>
-            </Transition.Child>
+              </DialogPanel>
+            </TransitionChild>
           </div>
         </div>
       </Dialog>
-    </Transition.Root>
+    </Transition>
   );
 }

--- a/front/components/providers/SerpAPISetup.tsx
+++ b/front/components/providers/SerpAPISetup.tsx
@@ -1,6 +1,12 @@
 import { Button } from "@dust-tt/sparkle";
 import type { WorkspaceType } from "@dust-tt/types";
-import { Dialog, Transition } from "@headlessui/react";
+import {
+  Dialog,
+  DialogPanel,
+  DialogTitle,
+  Transition,
+  TransitionChild,
+} from "@headlessui/react";
 import { Fragment, useEffect, useState } from "react";
 import { useSWRConfig } from "swr";
 
@@ -79,9 +85,9 @@ export default function SerpAPISetup({
   };
 
   return (
-    <Transition.Root show={open} as={Fragment}>
+    <Transition show={open} as={Fragment}>
       <Dialog as="div" className="relative z-30" onClose={() => setOpen(false)}>
-        <Transition.Child
+        <TransitionChild
           as={Fragment}
           enter="ease-out duration-300"
           enterFrom="opacity-0"
@@ -91,25 +97,25 @@ export default function SerpAPISetup({
           leaveTo="opacity-0"
         >
           <div className="fixed inset-0 bg-gray-800 bg-opacity-75 transition-opacity" />
-        </Transition.Child>
+        </TransitionChild>
 
         <div className="fixed inset-0 z-30 overflow-y-auto">
           <div className="flex min-h-full items-end items-center justify-center p-4">
-            <Transition.Child
+            <TransitionChild
               as={Fragment}
               enter="ease-out duration-300"
               leave="ease-in duration-200"
               leaveTo="opacity-0"
             >
-              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6 lg:max-w-lg">
+              <DialogPanel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6 lg:max-w-lg">
                 <div>
                   <div className="mt-3">
-                    <Dialog.Title
+                    <DialogTitle
                       as="h3"
                       className="text-lg font-medium leading-6 text-gray-900"
                     >
                       Setup SerpAPI Search
-                    </Dialog.Title>
+                    </DialogTitle>
                     <div className="mt-4">
                       <p className="text-sm text-gray-500">
                         SerpAPI lets you search Google (and other search
@@ -196,11 +202,11 @@ export default function SerpAPISetup({
                     )}
                   </div>
                 </div>
-              </Dialog.Panel>
-            </Transition.Child>
+              </DialogPanel>
+            </TransitionChild>
           </div>
         </div>
       </Dialog>
-    </Transition.Root>
+    </Transition>
   );
 }

--- a/front/components/providers/SerpAPISetup.tsx
+++ b/front/components/providers/SerpAPISetup.tsx
@@ -7,6 +7,7 @@ import {
   Transition,
   TransitionChild,
 } from "@headlessui/react";
+import classNames from "classnames";
 import { Fragment, useEffect, useState } from "react";
 import { useSWRConfig } from "swr";
 
@@ -87,123 +88,118 @@ export default function SerpAPISetup({
   return (
     <Transition show={open} as={Fragment}>
       <Dialog as="div" className="relative z-30" onClose={() => setOpen(false)}>
-        <TransitionChild
-          as={Fragment}
-          enter="ease-out duration-300"
-          enterFrom="opacity-0"
-          enterTo="opacity-100"
-          leave="ease-in duration-200"
-          leaveFrom="opacity-100"
-          leaveTo="opacity-0"
-        >
-          <div className="fixed inset-0 bg-gray-800 bg-opacity-75 transition-opacity" />
+        <TransitionChild as={Fragment} appear={true}>
+          <div
+            className={classNames(
+              "fixed inset-0 bg-gray-800 bg-opacity-75 transition-opacity",
+              "duration-700 ease-out",
+              "data-[enter]:data-[closed]:opacity-0",
+              "data-[leave]:data-[closed]:opacity-0"
+            )}
+          />
         </TransitionChild>
 
         <div className="fixed inset-0 z-30 overflow-y-auto">
-          <div className="flex min-h-full items-end items-center justify-center p-4">
-            <TransitionChild
-              as={Fragment}
-              enter="ease-out duration-300"
-              leave="ease-in duration-200"
-              leaveTo="opacity-0"
+          <div className="flex min-h-full items-center justify-center p-4">
+            <DialogPanel
+              className={classNames(
+                "relative overflow-hidden rounded-lg bg-white p-4 sm:my-8 sm:w-full sm:max-w-sm sm:p-6 lg:max-w-lg",
+                "duration-300",
+                "data-[enter]:data-[closed]:opacity-0",
+                "data-[leave]:data-[closed]:opacity-0"
+              )}
+              transition
             >
-              <DialogPanel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6 lg:max-w-lg">
-                <div>
-                  <div className="mt-3">
-                    <DialogTitle
-                      as="h3"
-                      className="text-lg font-medium leading-6 text-gray-900"
+              <div className="mt-3">
+                <DialogTitle
+                  as="h3"
+                  className="text-lg font-medium leading-6 text-gray-900"
+                >
+                  Setup SerpAPI Search
+                </DialogTitle>
+                <div className="mt-4">
+                  <p className="text-sm text-gray-500">
+                    SerpAPI lets you search Google (and other search engines).
+                    To use SerpAPI you must provide your API key. It can be
+                    found{" "}
+                    <a
+                      className="font-bold text-action-600 hover:text-action-500"
+                      href="https://serpapi.com/manage-api-key"
+                      target="_blank"
                     >
-                      Setup SerpAPI Search
-                    </DialogTitle>
-                    <div className="mt-4">
-                      <p className="text-sm text-gray-500">
-                        SerpAPI lets you search Google (and other search
-                        engines). To use SerpAPI you must provide your API key.
-                        It can be found{" "}
-                        <a
-                          className="font-bold text-action-600 hover:text-action-500"
-                          href="https://serpapi.com/manage-api-key"
-                          target="_blank"
-                        >
-                          here
-                        </a>
-                      </p>
-                      <p className="mt-2 text-sm text-gray-500">
-                        We'll never use your API key for anything other than to
-                        run your apps.
-                      </p>
-                    </div>
-                    <div className="mt-6">
-                      <input
-                        type="text"
-                        className="block w-full rounded-md border-gray-300 shadow-sm focus:border-action-500 focus:ring-action-500 sm:text-sm"
-                        placeholder="SerpAPI API Key"
-                        value={apiKey}
-                        onChange={(e) => {
-                          setApiKey(e.target.value);
-                          setTestSuccessful(false);
-                        }}
-                      />
-                    </div>
+                      here
+                    </a>
+                  </p>
+                  <p className="mt-2 text-sm text-gray-500">
+                    We'll never use your API key for anything other than to run
+                    your apps.
+                  </p>
+                </div>
+                <div className="mt-6">
+                  <input
+                    type="text"
+                    className="block w-full rounded-md border-gray-300 shadow-sm focus:border-action-500 focus:ring-action-500 sm:text-sm"
+                    placeholder="SerpAPI API Key"
+                    value={apiKey}
+                    onChange={(e) => {
+                      setApiKey(e.target.value);
+                      setTestSuccessful(false);
+                    }}
+                  />
+                </div>
+              </div>
+              <div className="mt-2 px-2 text-sm">
+                {testError.length > 0 ? (
+                  <span className="text-red-500">Error: {testError}</span>
+                ) : testSuccessful ? (
+                  <span className="text-green-600">
+                    Test succeeded! You can enable SerpAPI Search.
+                  </span>
+                ) : (
+                  <span>&nbsp;</span>
+                )}
+              </div>
+              <div className="mt-5 flex flex-row items-center justify-between space-x-2 sm:mt-6">
+                {enabled ? (
+                  <div
+                    className="flex-initial cursor-pointer text-sm font-bold text-red-500"
+                    onClick={() => handleDisable()}
+                  >
+                    Disable
                   </div>
-                </div>
-                <div className="mt-1 px-2 text-sm">
-                  {testError.length > 0 ? (
-                    <span className="text-red-500">Error: {testError}</span>
-                  ) : testSuccessful ? (
-                    <span className="text-green-600">
-                      Test succeeded! You can enable SerpAPI Search.
-                    </span>
-                  ) : (
-                    <span>&nbsp;</span>
-                  )}
-                </div>
-                <div className="mt-5 flex flex-row items-center space-x-2 sm:mt-6">
-                  {enabled ? (
-                    <div
-                      className="flex-initial cursor-pointer text-sm font-bold text-red-500"
-                      onClick={() => handleDisable()}
-                    >
-                      Disable
-                    </div>
-                  ) : (
-                    <></>
-                  )}
-                  <div className="flex-1"></div>
-                  <div className="flex flex-initial">
+                ) : (
+                  <div></div>
+                )}
+                <div className="flex space-x-2">
+                  <Button
+                    onClick={() => setOpen(false)}
+                    label="Cancel"
+                    variant="secondary"
+                  />
+                  {testSuccessful ? (
                     <Button
-                      onClick={() => setOpen(false)}
-                      label="Cancel"
-                      variant="secondary"
+                      onClick={() => handleEnable()}
+                      disabled={enableRunning}
+                      label={
+                        enabled
+                          ? enableRunning
+                            ? "Updating..."
+                            : "Update"
+                          : enableRunning
+                            ? "Enabling..."
+                            : "Enable"
+                      }
                     />
-                  </div>
-                  <div className="flex flex-initial">
-                    {testSuccessful ? (
-                      <Button
-                        onClick={() => handleEnable()}
-                        disabled={enableRunning}
-                        label={
-                          enabled
-                            ? enableRunning
-                              ? "Updating..."
-                              : "Update"
-                            : enableRunning
-                              ? "Enabling..."
-                              : "Enable"
-                        }
-                      />
-                    ) : (
-                      <Button
-                        disabled={apiKey.length == 0 || testRunning}
-                        onClick={() => runTest()}
-                        label={testRunning ? "Testing..." : "Test"}
-                      />
-                    )}
-                  </div>
+                  ) : (
+                    <Button
+                      disabled={apiKey.length == 0 || testRunning}
+                      onClick={() => runTest()}
+                      label={testRunning ? "Testing..." : "Test"}
+                    />
+                  )}
                 </div>
-              </DialogPanel>
-            </TransitionChild>
+              </div>
+            </DialogPanel>
           </div>
         </div>
       </Dialog>

--- a/front/components/providers/SerperSetup.tsx
+++ b/front/components/providers/SerperSetup.tsx
@@ -1,6 +1,12 @@
 import { Button } from "@dust-tt/sparkle";
 import type { WorkspaceType } from "@dust-tt/types";
-import { Dialog, Transition } from "@headlessui/react";
+import {
+  Dialog,
+  DialogPanel,
+  DialogTitle,
+  Transition,
+  TransitionChild,
+} from "@headlessui/react";
 import { Fragment, useEffect, useState } from "react";
 import { useSWRConfig } from "swr";
 
@@ -79,9 +85,9 @@ export default function SerperSetup({
   };
 
   return (
-    <Transition.Root show={open} as={Fragment}>
+    <Transition show={open} as={Fragment}>
       <Dialog as="div" className="relative z-30" onClose={() => setOpen(false)}>
-        <Transition.Child
+        <TransitionChild
           as={Fragment}
           enter="ease-out duration-300"
           enterFrom="opacity-0"
@@ -91,25 +97,25 @@ export default function SerperSetup({
           leaveTo="opacity-0"
         >
           <div className="fixed inset-0 bg-gray-800 bg-opacity-75 transition-opacity" />
-        </Transition.Child>
+        </TransitionChild>
 
         <div className="fixed inset-0 z-30 overflow-y-auto">
           <div className="flex min-h-full items-end items-center justify-center p-4">
-            <Transition.Child
+            <TransitionChild
               as={Fragment}
               enter="ease-out duration-300"
               leave="ease-in duration-200"
               leaveTo="opacity-0"
             >
-              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6 lg:max-w-lg">
+              <DialogPanel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6 lg:max-w-lg">
                 <div>
                   <div className="mt-3">
-                    <Dialog.Title
+                    <DialogTitle
                       as="h3"
                       className="text-lg font-medium leading-6 text-gray-900"
                     >
                       Setup Serper Search
-                    </Dialog.Title>
+                    </DialogTitle>
                     <div className="mt-4">
                       <p className="text-sm text-gray-500">
                         Serper lets you search Google (and other search
@@ -196,11 +202,11 @@ export default function SerperSetup({
                     )}
                   </div>
                 </div>
-              </Dialog.Panel>
-            </Transition.Child>
+              </DialogPanel>
+            </TransitionChild>
           </div>
         </div>
       </Dialog>
-    </Transition.Root>
+    </Transition>
   );
 }

--- a/front/components/providers/SerperSetup.tsx
+++ b/front/components/providers/SerperSetup.tsx
@@ -7,6 +7,7 @@ import {
   Transition,
   TransitionChild,
 } from "@headlessui/react";
+import classNames from "classnames";
 import { Fragment, useEffect, useState } from "react";
 import { useSWRConfig } from "swr";
 
@@ -87,123 +88,117 @@ export default function SerperSetup({
   return (
     <Transition show={open} as={Fragment}>
       <Dialog as="div" className="relative z-30" onClose={() => setOpen(false)}>
-        <TransitionChild
-          as={Fragment}
-          enter="ease-out duration-300"
-          enterFrom="opacity-0"
-          enterTo="opacity-100"
-          leave="ease-in duration-200"
-          leaveFrom="opacity-100"
-          leaveTo="opacity-0"
-        >
-          <div className="fixed inset-0 bg-gray-800 bg-opacity-75 transition-opacity" />
+        <TransitionChild as={Fragment} appear={true}>
+          <div
+            className={classNames(
+              "fixed inset-0 bg-gray-800 bg-opacity-75 transition-opacity",
+              "duration-700 ease-out",
+              "data-[enter]:data-[closed]:opacity-0",
+              "data-[leave]:data-[closed]:opacity-0"
+            )}
+          />
         </TransitionChild>
 
         <div className="fixed inset-0 z-30 overflow-y-auto">
-          <div className="flex min-h-full items-end items-center justify-center p-4">
-            <TransitionChild
-              as={Fragment}
-              enter="ease-out duration-300"
-              leave="ease-in duration-200"
-              leaveTo="opacity-0"
+          <div className="flex min-h-full items-center justify-center p-4">
+            <DialogPanel
+              className={classNames(
+                "relative overflow-hidden rounded-lg bg-white p-4 sm:my-8 sm:w-full sm:max-w-sm sm:p-6 lg:max-w-lg",
+                "duration-300",
+                "data-[enter]:data-[closed]:opacity-0",
+                "data-[leave]:data-[closed]:opacity-0"
+              )}
+              transition
             >
-              <DialogPanel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6 lg:max-w-lg">
-                <div>
-                  <div className="mt-3">
-                    <DialogTitle
-                      as="h3"
-                      className="text-lg font-medium leading-6 text-gray-900"
+              <div className="mt-3">
+                <DialogTitle
+                  as="h3"
+                  className="text-lg font-medium leading-6 text-gray-900"
+                >
+                  Setup Serper Search
+                </DialogTitle>
+                <div className="mt-4">
+                  <p className="text-sm text-gray-500">
+                    Serper lets you search Google (and other search engines). To
+                    use Serper you must provide your API key. It can be found{" "}
+                    <a
+                      className="font-bold text-action-600 hover:text-action-500"
+                      href="https://serper.dev/api-key"
+                      target="_blank"
                     >
-                      Setup Serper Search
-                    </DialogTitle>
-                    <div className="mt-4">
-                      <p className="text-sm text-gray-500">
-                        Serper lets you search Google (and other search
-                        engines). To use Serper you must provide your API key.
-                        It can be found{" "}
-                        <a
-                          className="font-bold text-action-600 hover:text-action-500"
-                          href="https://serper.dev/api-key"
-                          target="_blank"
-                        >
-                          here
-                        </a>
-                      </p>
-                      <p className="mt-2 text-sm text-gray-500">
-                        We'll never use your API key for anything other than to
-                        run your apps.
-                      </p>
-                    </div>
-                    <div className="mt-6">
-                      <input
-                        type="text"
-                        className="block w-full rounded-md border-gray-300 shadow-sm focus:border-action-500 focus:ring-action-500 sm:text-sm"
-                        placeholder="Serper API Key"
-                        value={apiKey}
-                        onChange={(e) => {
-                          setApiKey(e.target.value);
-                          setTestSuccessful(false);
-                        }}
-                      />
-                    </div>
+                      here
+                    </a>
+                  </p>
+                  <p className="mt-2 text-sm text-gray-500">
+                    We'll never use your API key for anything other than to run
+                    your apps.
+                  </p>
+                </div>
+                <div className="mt-6">
+                  <input
+                    type="text"
+                    className="block w-full rounded-md border-gray-300 shadow-sm focus:border-action-500 focus:ring-action-500 sm:text-sm"
+                    placeholder="Serper API Key"
+                    value={apiKey}
+                    onChange={(e) => {
+                      setApiKey(e.target.value);
+                      setTestSuccessful(false);
+                    }}
+                  />
+                </div>
+              </div>
+              <div className="mt-1 px-2 text-sm">
+                {testError.length > 0 ? (
+                  <span className="text-red-500">Error: {testError}</span>
+                ) : testSuccessful ? (
+                  <span className="text-green-600">
+                    Test succeeded! You can enable Serper Search.
+                  </span>
+                ) : (
+                  <span>&nbsp;</span>
+                )}
+              </div>
+              <div className="mt-5 flex flex-row items-center justify-between space-x-2 sm:mt-6">
+                {enabled ? (
+                  <div
+                    className="cursor-pointer text-sm font-bold text-red-500"
+                    onClick={() => handleDisable()}
+                  >
+                    Disable
                   </div>
-                </div>
-                <div className="mt-1 px-2 text-sm">
-                  {testError.length > 0 ? (
-                    <span className="text-red-500">Error: {testError}</span>
-                  ) : testSuccessful ? (
-                    <span className="text-green-600">
-                      Test succeeded! You can enable Serper Search.
-                    </span>
-                  ) : (
-                    <span>&nbsp;</span>
-                  )}
-                </div>
-                <div className="mt-5 flex flex-row items-center space-x-2 sm:mt-6">
-                  {enabled ? (
-                    <div
-                      className="flex-initial cursor-pointer text-sm font-bold text-red-500"
-                      onClick={() => handleDisable()}
-                    >
-                      Disable
-                    </div>
-                  ) : (
-                    <></>
-                  )}
-                  <div className="flex-1"></div>
-                  <div className="flex flex-initial">
+                ) : (
+                  <></>
+                )}
+                <div className="flex space-x-2">
+                  <Button
+                    onClick={() => setOpen(false)}
+                    label="Cancel"
+                    variant="secondary"
+                  />
+                  {testSuccessful ? (
                     <Button
-                      onClick={() => setOpen(false)}
-                      label="Cancel"
-                      variant="secondary"
+                      onClick={() => handleEnable()}
+                      disabled={enableRunning}
+                      label={
+                        enabled
+                          ? enableRunning
+                            ? "Updating..."
+                            : "Update"
+                          : enableRunning
+                            ? "Enabling..."
+                            : "Enable"
+                      }
                     />
-                  </div>
-                  <div className="flex flex-initial">
-                    {testSuccessful ? (
-                      <Button
-                        onClick={() => handleEnable()}
-                        disabled={enableRunning}
-                        label={
-                          enabled
-                            ? enableRunning
-                              ? "Updating..."
-                              : "Update"
-                            : enableRunning
-                              ? "Enabling..."
-                              : "Enable"
-                        }
-                      />
-                    ) : (
-                      <Button
-                        disabled={apiKey.length == 0 || testRunning}
-                        onClick={() => runTest()}
-                        label={testRunning ? "Testing..." : "Test"}
-                      />
-                    )}
-                  </div>
+                  ) : (
+                    <Button
+                      disabled={apiKey.length == 0 || testRunning}
+                      onClick={() => runTest()}
+                      label={testRunning ? "Testing..." : "Test"}
+                    />
+                  )}
                 </div>
-              </DialogPanel>
-            </TransitionChild>
+              </div>
+            </DialogPanel>
           </div>
         </div>
       </Dialog>

--- a/front/components/sparkle/Notification.tsx
+++ b/front/components/sparkle/Notification.tsx
@@ -82,6 +82,7 @@ export function Notification({ title, description, type }: NotificationType) {
   }, []);
   return (
     <Transition
+      as="div"
       show={showNotification}
       appear={true}
       enter="transition ease-in-out duration-300 transform"

--- a/front/components/sparkle/Notification.tsx
+++ b/front/components/sparkle/Notification.tsx
@@ -1,7 +1,9 @@
 import { Notification as SparkleNotification } from "@dust-tt/sparkle";
 import { Transition } from "@headlessui/react";
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
+
+import { classNames } from "@app/lib/utils";
 
 export type NotificationType = {
   title?: string;
@@ -74,30 +76,36 @@ export function NotificationsList({
 }
 
 export function Notification({ title, description, type }: NotificationType) {
-  const [showNotification, setShowNotification] = React.useState(true);
+  const [showNotification, setShowNotification] = useState(true);
+
   useEffect(() => {
-    setTimeout(() => {
+    const timer = setTimeout(() => {
       setShowNotification(false);
     }, NOTIFICATION_DELAY);
+
+    return () => clearTimeout(timer);
   }, []);
+
   return (
-    <Transition
-      as="div"
-      show={showNotification}
-      appear={true}
-      enter="transition ease-in-out duration-300 transform"
-      enterFrom="translate-y-16 opacity-0"
-      enterTo="translate-y-0 opacity-100"
-      leave="transition ease-in-out duration-300 transform"
-      leaveFrom="translate-y-0 opacity-100"
-      leaveTo="translate-y-16 opacity-0"
-    >
-      <SparkleNotification
-        variant={type}
-        description={description}
-        title={title}
-        onClick={() => setShowNotification(false)}
-      />
+    <Transition show={showNotification} appear={true}>
+      <div
+        className={classNames(
+          "transform transition ease-in-out",
+          "data-[enter]:duration-300",
+          "data-[enter]:data-[closed]:translate-y-16 data-[enter]:data-[closed]:opacity-0",
+          "data-[enter]:data-[open]:translate-y-0 data-[enter]:data-[open]:opacity-100",
+          "data-[leave]:duration-300",
+          "data-[leave]:data-[open]:translate-y-0 data-[leave]:data-[open]:opacity-100",
+          "data-[leave]:data-[closed]:translate-y-16 data-[leave]:data-[closed]:opacity-0"
+        )}
+      >
+        <SparkleNotification
+          variant={type}
+          description={description}
+          title={title}
+          onClick={() => setShowNotification(false)}
+        />
+      </div>
     </Transition>
   );
 }

--- a/front/components/tables/TablePicker.tsx
+++ b/front/components/tables/TablePicker.tsx
@@ -1,6 +1,6 @@
 import type { WorkspaceType } from "@dust-tt/types";
 import type { CoreAPITable } from "@dust-tt/types";
-import { Menu } from "@headlessui/react";
+import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/react";
 import { ChevronDownIcon } from "@heroicons/react/20/solid";
 
 import { useTables } from "@app/lib/swr";
@@ -48,7 +48,7 @@ export default function TablePicker({
         ) : (
           <Menu as="div" className="relative inline-block text-left">
             <div>
-              <Menu.Button
+              <MenuButton
                 className={classNames(
                   "inline-flex items-center rounded-md py-1 text-sm font-normal text-gray-700",
                   currentTable ? "px-0" : "border px-3",
@@ -70,11 +70,11 @@ export default function TablePicker({
                 ) : (
                   "No Tables"
                 )}
-              </Menu.Button>
+              </MenuButton>
             </div>
 
             {(tables || []).length > 0 ? (
-              <Menu.Items
+              <MenuItems
                 className={classNames(
                   "absolute z-10 mt-1 w-max origin-top-left rounded-md bg-white shadow-sm ring-1 ring-black ring-opacity-5 focus:outline-none",
                   currentTable ? "-left-4" : "left-1"
@@ -83,7 +83,7 @@ export default function TablePicker({
                 <div className="py-1">
                   {(tables || []).map((t) => {
                     return (
-                      <Menu.Item key={t.table_id}>
+                      <MenuItem key={t.table_id}>
                         {({ active }) => (
                           <span
                             className={classNames(
@@ -97,11 +97,11 @@ export default function TablePicker({
                             {t.name}
                           </span>
                         )}
-                      </Menu.Item>
+                      </MenuItem>
                     );
                   })}
                 </div>
-              </Menu.Items>
+              </MenuItems>
             ) : null}
           </Menu>
         )}

--- a/front/components/tables/TablePicker.tsx
+++ b/front/components/tables/TablePicker.tsx
@@ -84,10 +84,10 @@ export default function TablePicker({
                   {(tables || []).map((t) => {
                     return (
                       <MenuItem key={t.table_id}>
-                        {({ active }) => (
+                        {({ focus }) => (
                           <span
                             className={classNames(
-                              active
+                              focus
                                 ? "bg-gray-50 text-gray-900"
                                 : "text-gray-700",
                               "block cursor-pointer px-4 py-2 text-sm"

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -13,7 +13,7 @@
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
-        "@headlessui/react": "^1.7.7",
+        "@headlessui/react": "^2.1.0",
         "@heroicons/react": "^2.0.11",
         "@hookform/resolvers": "^3.3.4",
         "@nangohq/frontend": "^0.16.1",
@@ -10744,24 +10744,6 @@
         "react": "^18.2.0"
       }
     },
-    "node_modules/@dust-tt/sparkle/node_modules/@headlessui/react": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.1.0.tgz",
-      "integrity": "sha512-/MizQk2xqR5ELkmCI1xWy3VgJULvR8gcAXtZhcK7sY53TNRCPeMdeODEXKSv9LPSSRlEAyzW1+NGJiaXq6dLRw==",
-      "dependencies": {
-        "@floating-ui/react": "^0.26.16",
-        "@react-aria/focus": "^3.17.1",
-        "@react-aria/interactions": "^3.21.3",
-        "@tanstack/react-virtual": "3.5.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": "^18",
-        "react-dom": "^18"
-      }
-    },
     "node_modules/@dust-tt/sparkle/node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -12200,17 +12182,21 @@
       }
     },
     "node_modules/@headlessui/react": {
-      "version": "1.7.17",
-      "license": "MIT",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.1.1.tgz",
+      "integrity": "sha512-808gVNUbRDbDR3GMNPHy+ON0uvR8b9H7IA+Q2UbhOsNCIjgwuwb2Iuv8VPT/1AW0UzLX8g10tN6LhF15GaUJCQ==",
       "dependencies": {
-        "client-only": "^0.0.1"
+        "@floating-ui/react": "^0.26.16",
+        "@react-aria/focus": "^3.17.1",
+        "@react-aria/interactions": "^3.21.3",
+        "@tanstack/react-virtual": "3.5.0"
       },
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "react": "^16 || ^17 || ^18",
-        "react-dom": "^16 || ^17 || ^18"
+        "react": "^18",
+        "react-dom": "^18"
       }
     },
     "node_modules/@heroicons/react": {

--- a/front/package.json
+++ b/front/package.json
@@ -25,7 +25,7 @@
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",
-    "@headlessui/react": "^1.7.7",
+    "@headlessui/react": "^2.1.0",
     "@heroicons/react": "^2.0.11",
     "@hookform/resolvers": "^3.3.4",
     "@nangohq/frontend": "^0.16.1",

--- a/sparkle/src/components/Collapsible.tsx
+++ b/sparkle/src/components/Collapsible.tsx
@@ -151,6 +151,7 @@ export interface CollapsiblePanelProps {
 
 Collapsible.Panel = ({ children }: CollapsiblePanelProps) => (
   <Transition
+    as="div"
     enter="s-transition s-duration-300 s-ease-out"
     enterFrom="s-transform s-scale-95 s-opacity-0"
     enterTo="s-transform s-scale-100 s-opacity-100"

--- a/sparkle/src/components/Dialog.tsx
+++ b/sparkle/src/components/Dialog.tsx
@@ -1,4 +1,4 @@
-import { Dialog as HeadlessDialog, Transition } from "@headlessui/react";
+import { Dialog as HeadlessDialog, DialogPanel, DialogTitle,Transition, TransitionChild } from "@headlessui/react";
 import React, { Fragment, useRef } from "react";
 
 import { ConfettiBackground, Spinner } from "@sparkle/index";
@@ -36,7 +36,7 @@ export function Dialog({
   return (
     <Transition show={isOpen} as={Fragment} appear={true}>
       <HeadlessDialog as="div" className="s-relative s-z-50" onClose={onCancel}>
-        <Transition.Child
+        <TransitionChild
           as={Fragment}
           enter="s-ease-out s-duration-150"
           enterFrom="s-opacity-0"
@@ -46,11 +46,11 @@ export function Dialog({
           leaveTo="s-opacity-0"
         >
           <div className="s-fixed s-inset-0 s-bg-structure-50/80 s-backdrop-blur-sm s-transition-opacity" />
-        </Transition.Child>
+        </TransitionChild>
 
         <div className="s-fixed s-inset-0 s-z-50">
           <div className="s-flex s-min-h-full s-items-center s-justify-center">
-            <Transition.Child
+            <TransitionChild
               as={Fragment}
               enter="s-ease-out s-duration-300"
               enterFrom="s-opacity-0 s-translate-y-4 s-scale-95"
@@ -59,7 +59,7 @@ export function Dialog({
               leaveFrom="s-opacity-100 s-translate-y-0 s-scale-100"
               leaveTo="s-opacity-0 s-translate-y-4 s-scale-95"
             >
-              <HeadlessDialog.Panel
+              <DialogPanel
                 className={classNames(
                   "s-relative s-rounded-xl s-border s-border-structure-100 s-bg-structure-0 s-p-4 s-shadow-xl s-transition-all",
                   "s-w-full sm:s-w-[448px]",
@@ -67,9 +67,9 @@ export function Dialog({
                 )}
                 ref={referentRef}
               >
-                <HeadlessDialog.Title className="s-text-element-950 s-truncate s-text-lg s-font-medium">
+                <DialogTitle className="s-text-element-950 s-truncate s-text-lg s-font-medium">
                   {title}
-                </HeadlessDialog.Title>
+                </DialogTitle>
                 <div className="s-z-10 s-text-base s-text-element-700">
                   {children}
                 </div>
@@ -100,8 +100,8 @@ export function Dialog({
                     />
                   </div>
                 )}
-              </HeadlessDialog.Panel>
-            </Transition.Child>
+              </DialogPanel>
+            </TransitionChild>
           </div>
         </div>
       </HeadlessDialog>

--- a/sparkle/src/components/DropdownMenu.tsx
+++ b/sparkle/src/components/DropdownMenu.tsx
@@ -1,4 +1,4 @@
-import { Menu, Transition } from "@headlessui/react";
+import { Menu, MenuButton, MenuItem, MenuItems, Transition } from "@headlessui/react";
 import React, {
   ComponentType,
   Fragment,
@@ -143,7 +143,7 @@ DropdownMenu.Button = function ({
 
   if (children) {
     return (
-      <Menu.Button
+      <MenuButton
         as="div"
         disabled={disabled}
         ref={buttonRef}
@@ -162,7 +162,7 @@ DropdownMenu.Button = function ({
         ) : (
           children
         )}
-      </Menu.Button>
+      </MenuButton>
     );
   }
 
@@ -177,7 +177,7 @@ DropdownMenu.Button = function ({
     <>
       {tooltip ? (
         <Tooltip label={tooltip} position={tooltipPosition}>
-          <Menu.Button
+          <MenuButton
             disabled={disabled}
             ref={buttonRef}
             className={classNames(
@@ -193,10 +193,10 @@ DropdownMenu.Button = function ({
               size={size === "sm" ? "xs" : "sm"}
               className={finalChevronClasses}
             />
-          </Menu.Button>
+          </MenuButton>
         </Tooltip>
       ) : (
-        <Menu.Button
+        <MenuButton
           disabled={disabled}
           ref={buttonRef}
           className={classNames(
@@ -221,7 +221,7 @@ DropdownMenu.Button = function ({
             size={size === "sm" ? "xs" : "sm"}
             className={finalChevronClasses}
           />
-        </Menu.Button>
+        </MenuButton>
       )}
     </>
   );
@@ -256,7 +256,7 @@ DropdownMenu.Item = function ({
 }: DropdownItemProps) {
   return (
     // need to use as="div" -- otherwise we get a "forwardRef" error in the console
-    <Menu.Item disabled={disabled} as="div">
+    <MenuItem disabled={disabled} as="div">
       {hasChildren ? (
         <DropdownMenu className="s-w-full s-gap-x-2 s-py-2">
           <DropdownMenu.Button
@@ -279,7 +279,7 @@ DropdownMenu.Item = function ({
           selected={selected}
         />
       )}
-    </Menu.Item>
+    </MenuItem>
   );
 };
 
@@ -290,7 +290,7 @@ interface DropdownSectionHeaderProps {
 DropdownMenu.SectionHeader = function ({ label }: DropdownSectionHeaderProps) {
   return (
     // need to use as="div" -- otherwise we get a "forwardRef" error in the console
-    <Menu.Item as="div">
+    <MenuItem as="div">
       <div
         className={classNames(
           "s-w-full",
@@ -300,7 +300,7 @@ DropdownMenu.SectionHeader = function ({ label }: DropdownSectionHeaderProps) {
       >
         {label}
       </div>
-    </Menu.Item>
+    </MenuItem>
   );
 };
 
@@ -428,7 +428,7 @@ DropdownMenu.Items = function ({
       leaveFrom="s-transform s-opacity-100 s-scale-100 s-translate-y-0"
       leaveTo={getOriginTransClass(origin)}
     >
-      <Menu.Items
+      <MenuItems
         onKeyDown={onKeyDown}
         className={classNames(
           "s-absolute s-z-10",
@@ -447,7 +447,7 @@ DropdownMenu.Items = function ({
           <StandardItem.List>{children}</StandardItem.List>
         </div>
         {bottomBar}
-      </Menu.Items>
+      </MenuItems>
     </Transition>
   );
 };

--- a/sparkle/src/components/Modal.tsx
+++ b/sparkle/src/components/Modal.tsx
@@ -1,4 +1,4 @@
-import { Dialog, Transition } from "@headlessui/react";
+import { Dialog, DialogPanel, Transition, TransitionChild } from "@headlessui/react";
 import React, { Fragment } from "react";
 
 import { classNames } from "@sparkle/lib/utils";
@@ -131,7 +131,7 @@ export function Modal({
         onClose={onClose}
       >
         {/* Smoke screen and transition */}
-        <Transition.Child
+        <TransitionChild
           as={Fragment}
           enter="s-ease-out s-duration-150"
           enterFrom="s-opacity-0"
@@ -141,11 +141,11 @@ export function Modal({
           leaveTo="s-opacity-0"
         >
           <div className="s-fixed s-inset-0 s-bg-structure-50/80 s-backdrop-blur-sm s-transition-opacity" />
-        </Transition.Child>
+        </TransitionChild>
 
         {/* Panel and transition */}
         <div className={classNames(containerClasses, variantSize[variant])}>
-          <Transition.Child
+          <TransitionChild
             as={Fragment}
             enter="s-ease-out s-duration-300"
             enterFrom={transitionEnterFrom}
@@ -154,7 +154,7 @@ export function Modal({
             leaveFrom={transitionLeaveFrom}
             leaveTo={transitionLeaveTo}
           >
-            <Dialog.Panel
+            <DialogPanel
               className={classNames(
                 "s-absolute s-transform s-bg-structure-0 s-px-3 s-transition-all sm:s-px-4",
                 panelClasses,
@@ -175,8 +175,8 @@ export function Modal({
               >
                 {children}
               </div>
-            </Dialog.Panel>
-          </Transition.Child>
+            </DialogPanel>
+          </TransitionChild>
         </div>
       </Dialog>
     </Transition>

--- a/sparkle/src/components/Popup.tsx
+++ b/sparkle/src/components/Popup.tsx
@@ -29,6 +29,7 @@ export function Popup({
 }: PopupProps) {
   return (
     <Transition
+      as="div"
       show={show}
       enter="s-transition-opacity s-duration-300"
       appear={true}


### PR DESCRIPTION
## Description
This PR updates the Headless UI library from version 1.7.7 to 2.1.0 in `front`. 

The update involves changes to the usage of `Transition`, `Dialog`, and `Menu` components across various parts of the application. Key modifications include:

1. `Transition` component:
   - Replaced Transition.Root with Transition
   - Replaced Transition.Child with TransitionChild
   - Added `as` prop to Transition components where necessary

2. `Dialog` component:
   - Replaced Dialog.Panel with DialogPanel
   - Replaced Dialog.Title with DialogTitle

3. `Menu` component:
   - Replaced Menu.Button with MenuButton
   - Replaced Menu.Item with MenuItem
   - Replaced Menu.Items with MenuItems

4. Updated transition classes:
   - Replaced enter/leave classes with data attributes for transitions

These changes have been applied across multiple files in the project, including components like CopyRun, Deploy, Navigation, and various modal components.

**References:**
-  [Headless v2 release note](https://github.com/tailwindlabs/headlessui/releases/tag/%40headlessui%2Freact%40v2.0.0)

## Risk
The update to Headless UI v2 introduces changes to the API and behavior of some components. While efforts have been made to update all usages, there is a risk of:

1. Missed component updates in less frequently used parts of the application
2. Subtle changes in component behavior that may affect user experience
3. Potential performance impacts due to changes in the library's internals

However, the changes are mostly straightforward replacements, and the risk is mitigated by the extensive testing done across the application.

## Deploy Plan
1. Deploy and test on `front-edge`
2. Deploy `front` package
3. Monitor closely for any visual or functional regressions in areas using Headless UI components, particularly modals, dropdowns, and transitions

