### PR TITLE
[Microsoft] Initial connector create/delete/add-remove-data ux flow

### DIFF
--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -281,10 +281,6 @@ export async function setMicrosoftConnectorPermissions(
 
   await MicrosoftRootResource.batchMakeNew(
     Object.entries(permissions)
-      .map(([nodeId, permission]) => {
-        console.log(nodeId, permission);
-        return [nodeId, permission] as [string, ConnectorPermission];
-      })
       .filter(([, permission]) => permission === "read")
       .map(([id]) => {
         const [nodeType, nodeId] = splitId(id);

--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -174,6 +174,14 @@ export async function fullResyncMicrosoftConnector(
   return launchMicrosoftFullSyncWorkflow(connectorId);
 }
 
+function getIdFromResource(r: MicrosoftRootResource) {
+  if (!r.nodeId) {
+    return r.nodeType;
+  }
+
+  return `${r.nodeType}/${r.nodeId}`;
+}
+
 export async function retrieveMicrosoftConnectorPermissions({
   connectorId,
   parentInternalId,
@@ -193,7 +201,7 @@ export async function retrieveMicrosoftConnectorPermissions({
 
   const selectedResources = (
     await MicrosoftRootResource.listRootsByConnectorId(connector.id)
-  ).map((r) => r.nodeType + "/" + r.nodeId);
+  ).map((r) => getIdFromResource(r));
 
   if (!parentInternalId) {
     nodes.push(...getRootNodes());

--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -263,8 +263,20 @@ export async function setMicrosoftConnectorPermissions(
     );
   }
 
+  await MicrosoftRootResource.batchDelete({
+    resourceIds: Object.entries(permissions).map(([nodeId]) => {
+      const [, ...rest] = nodeId.split("/");
+      return rest.join("/");
+    }),
+    connectorId: connector.id,
+  });
+
   await MicrosoftRootResource.batchMakeNew(
     Object.entries(permissions)
+      .map(([nodeId, permission]) => {
+        console.log(nodeId, permission);
+        return [nodeId, permission] as [string, ConnectorPermission];
+      })
       .filter(([, permission]) => permission === "read")
       .map(([id]) => {
         const [nodeType, nodeId] = splitId(id);
@@ -273,15 +285,6 @@ export async function setMicrosoftConnectorPermissions(
           nodeId,
           nodeType,
         };
-      })
-  );
-
-  await MicrosoftRootResource.batchDelete(
-    Object.entries(permissions)
-      .filter(([, permission]) => permission === "none")
-      .map(([nodeId]) => {
-        const [, ...rest] = nodeId.split("/");
-        return rest.join("/");
       })
   );
 

--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -102,10 +102,10 @@ export async function stopMicrosoftConnector(
   connectorId: ModelId
 ): Promise<Result<undefined, Error>> {
   console.log("stopMicrosoftConnector", connectorId);
-  throw Error("Not implemented");
+  return new Ok(undefined);
 }
 
-export async function deleteMicrosoftConnector(
+export async function cleanupMicrosoftConnector(
   connectorId: ModelId,
   force = false
 ) {
@@ -172,13 +172,6 @@ export async function fullResyncMicrosoftConnector(
 ) {
   console.log("fullResyncMicrosoftConnector", connectorId, fromTs);
   return launchMicrosoftFullSyncWorkflow(connectorId);
-}
-
-export async function cleanupMicrosoftConnector(
-  connectorId: ModelId
-): Promise<Result<undefined, Error>> {
-  console.log("cleanupMicrosoftConnector", connectorId);
-  throw Error("Not implemented");
 }
 
 export async function retrieveMicrosoftConnectorPermissions({

--- a/connectors/src/resources/microsoft_resource.ts
+++ b/connectors/src/resources/microsoft_resource.ts
@@ -121,10 +121,19 @@ export class MicrosoftRootResource extends BaseResource<MicrosoftRootModel> {
     return resources.map((resource) => new this(this.model, resource.get()));
   }
 
-  static async batchDelete(resourceIds: string[], transaction?: Transaction) {
+  static async batchDelete({
+    resourceIds,
+    connectorId,
+    transaction,
+  }: {
+    resourceIds: string[];
+    connectorId: ModelId;
+    transaction?: Transaction;
+  }) {
     return MicrosoftRootModel.destroy({
       where: {
         nodeId: resourceIds,
+        connectorId,
       },
       transaction,
     });


### PR DESCRIPTION
## Description

This PR:
- provides basic version of cleanupMSConnector so we can easily create/delete connector (copied from deleteConnector)
- allows managing permissions: deletes then write, rather than the reverse, that yielded a validation constraint error in case the same resource was selected
- adds connectorId to batchDelete in order to ensure resources deleted are only pertaining to a given connector


## Risk
na (gated)

## Deploy Plan
connectors
