### PR TITLE
Add Front /healthz endpoint + update config

### DIFF
--- a/front/pages/api/healthz.ts
+++ b/front/pages/api/healthz.ts
@@ -1,0 +1,8 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  res.status(200).send("ok");
+}

--- a/k8s/deployments/front-deployment.yaml
+++ b/k8s/deployments/front-deployment.yaml
@@ -25,7 +25,7 @@ spec:
             - containerPort: 3000
           readinessProbe:
             httpGet:
-              path: /
+              path: /api/healthz
               port: 3000
             initialDelaySeconds: 5
             periodSeconds: 5

--- a/k8s/deployments/front-edge-deployment.yaml
+++ b/k8s/deployments/front-edge-deployment.yaml
@@ -23,6 +23,12 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 3000
+          readinessProbe:
+            httpGet:
+              path: /api/healthz
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 5
 
           envFrom:
             - configMapRef:


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR introduces a dedicated `/healthz` endpoint to the Front's API. Currently, readiness probes are conducted on the `/` endpoint, which defaults to our homepage and typically takes around 2 seconds to respond.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
First deploy this new endpoint, then apply infra.
