### PR TITLE
[front] fix: Use dedicated function to add mention instead of using stickyMentions

### DIFF
--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -195,22 +195,14 @@ export function ConversationContainer({
     )
   );
 
+  const addMentionRef = useRef<(mention: AgentMention) => void>(() => {});
+
   const setInputbarMention = useCallback(
     (agent: LightAgentConfigurationType) => {
-      setStickyMentions((prev) => {
-        const alreadyInStickyMention = prev.find(
-          (m) => m.configurationId === agent.sId
-        );
-
-        if (alreadyInStickyMention) {
-          return prev;
-        }
-
-        return [...prev, { configurationId: agent.sId }];
-      });
+      addMentionRef.current({ configurationId: agent.sId });
       setAnimate(true);
     },
-    [setStickyMentions, setAnimate]
+    [setAnimate]
   );
 
   useEffect(() => {
@@ -291,6 +283,7 @@ export function ConversationContainer({
       <FixedAssistantInputBar
         owner={owner}
         onSubmit={activeConversationId ? handleSubmit : handleMessageSubmit}
+        addMentionRef={addMentionRef}
         stickyMentions={stickyMentions}
         conversationId={activeConversationId}
       />

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -195,14 +195,14 @@ export function ConversationContainer({
     )
   );
 
-  const addMentionRef = useRef<(mention: AgentMention) => void>(() => {});
+  const { setSelectedAssistant } = useContext(InputBarContext);
 
   const setInputbarMention = useCallback(
     (agent: LightAgentConfigurationType) => {
-      addMentionRef.current({ configurationId: agent.sId });
+      setSelectedAssistant({ configurationId: agent.sId });
       setAnimate(true);
     },
-    [setAnimate]
+    [setAnimate, setSelectedAssistant]
   );
 
   useEffect(() => {
@@ -283,7 +283,6 @@ export function ConversationContainer({
       <FixedAssistantInputBar
         owner={owner}
         onSubmit={activeConversationId ? handleSubmit : handleMessageSubmit}
-        addMentionRef={addMentionRef}
         stickyMentions={stickyMentions}
         conversationId={activeConversationId}
       />

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -53,6 +53,7 @@ export function AssistantInputBar({
   onSubmit,
   conversationId,
   stickyMentions,
+  addMentionRef,
   additionalAgentConfiguration,
   actions = DEFAULT_INPUT_BAR_ACTIONS,
   disableAutoFocus = false,
@@ -67,6 +68,7 @@ export function AssistantInputBar({
   ) => void;
   conversationId: string | null;
   stickyMentions?: AgentMention[];
+  addMentionRef?: React.MutableRefObject<(mention: AgentMention) => void>;
   additionalAgentConfiguration?: LightAgentConfigurationType;
   actions?: InputBarContainerProps["actions"];
   disableAutoFocus: boolean;
@@ -258,6 +260,7 @@ export function AssistantInputBar({
                 selectedAssistant={selectedAssistant}
                 onEnterKeyDown={handleSubmit}
                 stickyMentions={stickyMentions}
+                addMentionRef={addMentionRef}
                 fileUploaderService={fileUploaderService}
                 disableSendButton={fileUploaderService.isProcessingFiles}
               />
@@ -273,6 +276,7 @@ export function FixedAssistantInputBar({
   owner,
   onSubmit,
   stickyMentions,
+  addMentionRef,
   conversationId,
   additionalAgentConfiguration,
   actions = DEFAULT_INPUT_BAR_ACTIONS,
@@ -285,6 +289,7 @@ export function FixedAssistantInputBar({
     contentFragments: UploadedContentFragment[]
   ) => void;
   stickyMentions?: AgentMention[];
+  addMentionRef?: React.MutableRefObject<(mention: AgentMention) => void>;
   conversationId: string | null;
   additionalAgentConfiguration?: LightAgentConfigurationType;
   actions?: InputBarContainerProps["actions"];
@@ -297,6 +302,7 @@ export function FixedAssistantInputBar({
         onSubmit={onSubmit}
         conversationId={conversationId}
         stickyMentions={stickyMentions}
+        addMentionRef={addMentionRef}
         additionalAgentConfiguration={additionalAgentConfiguration}
         actions={actions}
         disableAutoFocus={disableAutoFocus}

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -53,7 +53,6 @@ export function AssistantInputBar({
   onSubmit,
   conversationId,
   stickyMentions,
-  addMentionRef,
   additionalAgentConfiguration,
   actions = DEFAULT_INPUT_BAR_ACTIONS,
   disableAutoFocus = false,
@@ -68,7 +67,6 @@ export function AssistantInputBar({
   ) => void;
   conversationId: string | null;
   stickyMentions?: AgentMention[];
-  addMentionRef?: React.MutableRefObject<(mention: AgentMention) => void>;
   additionalAgentConfiguration?: LightAgentConfigurationType;
   actions?: InputBarContainerProps["actions"];
   disableAutoFocus: boolean;
@@ -260,7 +258,6 @@ export function AssistantInputBar({
                 selectedAssistant={selectedAssistant}
                 onEnterKeyDown={handleSubmit}
                 stickyMentions={stickyMentions}
-                addMentionRef={addMentionRef}
                 fileUploaderService={fileUploaderService}
                 disableSendButton={fileUploaderService.isProcessingFiles}
               />
@@ -276,7 +273,6 @@ export function FixedAssistantInputBar({
   owner,
   onSubmit,
   stickyMentions,
-  addMentionRef,
   conversationId,
   additionalAgentConfiguration,
   actions = DEFAULT_INPUT_BAR_ACTIONS,
@@ -289,7 +285,6 @@ export function FixedAssistantInputBar({
     contentFragments: UploadedContentFragment[]
   ) => void;
   stickyMentions?: AgentMention[];
-  addMentionRef?: React.MutableRefObject<(mention: AgentMention) => void>;
   conversationId: string | null;
   additionalAgentConfiguration?: LightAgentConfigurationType;
   actions?: InputBarContainerProps["actions"];
@@ -302,7 +297,6 @@ export function FixedAssistantInputBar({
         onSubmit={onSubmit}
         conversationId={conversationId}
         stickyMentions={stickyMentions}
-        addMentionRef={addMentionRef}
         additionalAgentConfiguration={additionalAgentConfiguration}
         actions={actions}
         disableAutoFocus={disableAutoFocus}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -35,7 +35,8 @@ export interface InputBarContainerProps {
   onEnterKeyDown: CustomEditorProps["onEnterKeyDown"];
   owner: WorkspaceType;
   selectedAssistant: AgentMention | null;
-  stickyMentions: AgentMention[] | undefined;
+  stickyMentions?: AgentMention[];
+  addMentionRef?: React.MutableRefObject<(mention: AgentMention) => void>;
   actions: InputBarAction[];
   disableAutoFocus: boolean;
   disableSendButton: boolean;
@@ -49,6 +50,7 @@ const InputBarContainer = ({
   owner,
   selectedAssistant,
   stickyMentions,
+  addMentionRef,
   actions,
   disableAutoFocus,
   disableSendButton,
@@ -91,6 +93,27 @@ const InputBarContainer = ({
     selectedAssistant,
     disableAutoFocus
   );
+
+  useEffect(() => {
+    if (addMentionRef) {
+      addMentionRef.current = (agentMention: AgentMention) => {
+        const { configurationId } = agentMention;
+        const agentConfiguration = agentConfigurations.find(
+          (agent) => agent.sId === configurationId
+        );
+        if (agentConfiguration) {
+          const { mentions } = editorService.getTextAndMentions();
+          const mentionIds = mentions.map((mention) => mention.id);
+          if (!mentionIds.includes(agentConfiguration.sId)) {
+            editorService.insertMention({
+              id: agentConfiguration.sId,
+              label: agentConfiguration.name,
+            });
+          }
+        }
+      };
+    }
+  }, [addMentionRef, agentConfigurations, editorService]);
 
   // TODO: Reset after loading.
   const fileInputRef = useRef<HTMLInputElement>(null);

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -36,7 +36,6 @@ export interface InputBarContainerProps {
   owner: WorkspaceType;
   selectedAssistant: AgentMention | null;
   stickyMentions?: AgentMention[];
-  addMentionRef?: React.MutableRefObject<(mention: AgentMention) => void>;
   actions: InputBarAction[];
   disableAutoFocus: boolean;
   disableSendButton: boolean;
@@ -50,7 +49,6 @@ const InputBarContainer = ({
   owner,
   selectedAssistant,
   stickyMentions,
-  addMentionRef,
   actions,
   disableAutoFocus,
   disableSendButton,
@@ -93,27 +91,6 @@ const InputBarContainer = ({
     selectedAssistant,
     disableAutoFocus
   );
-
-  useEffect(() => {
-    if (addMentionRef) {
-      addMentionRef.current = (agentMention: AgentMention) => {
-        const { configurationId } = agentMention;
-        const agentConfiguration = agentConfigurations.find(
-          (agent) => agent.sId === configurationId
-        );
-        if (agentConfiguration) {
-          const { mentions } = editorService.getTextAndMentions();
-          const mentionIds = mentions.map((mention) => mention.id);
-          if (!mentionIds.includes(agentConfiguration.sId)) {
-            editorService.insertMention({
-              id: agentConfiguration.sId,
-              label: agentConfiguration.name,
-            });
-          }
-        }
-      };
-    }
-  }, [addMentionRef, agentConfigurations, editorService]);
 
   // TODO: Reset after loading.
   const fileInputRef = useRef<HTMLInputElement>(null);


### PR DESCRIPTION
fixes : [#963](https://github.com/dust-tt/tasks/issues/963)
## Description

In the new conversation screen, clicking on a agent should just add an agent to the current text input, not change sticky mentions. Sticky mentions are used to persist and prefill mentions across messages.

## Risk

UI only

## Deploy Plan

deploy `front`
