### PR TITLE
Visualization Action run

### DIFF
--- a/front/components/actions/code_interpreter/CodeInterpreterActionDetails.tsx
+++ b/front/components/actions/code_interpreter/CodeInterpreterActionDetails.tsx
@@ -1,0 +1,29 @@
+import { CommandLineIcon } from "@dust-tt/sparkle";
+import type { CodeInterpreterActionType } from "@dust-tt/types";
+
+import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
+import type { ActionDetailsComponentBaseProps } from "@app/components/actions/types";
+import { ReadOnlyTextArea } from "@app/components/assistant/ReadOnlyTextArea";
+
+export function CodeInterpreterActionDetails({
+  action,
+  defaultOpen,
+}: ActionDetailsComponentBaseProps<CodeInterpreterActionType>) {
+  return (
+    <ActionDetailsWrapper
+      actionName="Code Interpreter"
+      defaultOpen={defaultOpen}
+      visual={CommandLineIcon}
+    >
+      <div className="flex flex-col gap-4 pl-6 pt-4">
+        <div className="flex flex-col gap-1">
+          <div className="text-sm font-normal text-slate-500">
+            <ReadOnlyTextArea
+              content={action.output?.code ?? "// No code was generated"}
+            />
+          </div>
+        </div>
+      </div>
+    </ActionDetailsWrapper>
+  );
+}

--- a/front/components/actions/types.ts
+++ b/front/components/actions/types.ts
@@ -1,6 +1,7 @@
 import type { AgentActionType } from "@dust-tt/types";
 
 import { BrowseActionDetails } from "@app/components/actions/browse/BrowseActionDetails";
+import { CodeInterpreterActionDetails } from "@app/components/actions/code_interpreter/CodeInterpreterActionDetails";
 import { DustAppRunActionDetails } from "@app/components/actions/dust_app_run/DustAppRunActionDetails";
 import { ProcessActionDetails } from "@app/components/actions/process/ProcessActionDetails";
 import { RetrievalActionDetails } from "@app/components/actions/retrieval/RetrievalActionDetails";
@@ -49,6 +50,10 @@ const actionsSpecification: ActionSpecifications = {
   browse_action: {
     detailsComponent: BrowseActionDetails,
     runningLabel: "Browsing page",
+  },
+  code_interpreter_action: {
+    detailsComponent: CodeInterpreterActionDetails,
+    runningLabel: "Analyzing request",
   },
 };
 

--- a/front/components/actions/types.ts
+++ b/front/components/actions/types.ts
@@ -1,11 +1,11 @@
 import type { AgentActionType } from "@dust-tt/types";
 
 import { BrowseActionDetails } from "@app/components/actions/browse/BrowseActionDetails";
-import { CodeInterpreterActionDetails } from "@app/components/actions/code_interpreter/CodeInterpreterActionDetails";
 import { DustAppRunActionDetails } from "@app/components/actions/dust_app_run/DustAppRunActionDetails";
 import { ProcessActionDetails } from "@app/components/actions/process/ProcessActionDetails";
 import { RetrievalActionDetails } from "@app/components/actions/retrieval/RetrievalActionDetails";
 import { TablesQueryActionDetails } from "@app/components/actions/tables_query/TablesQueryActionDetails";
+import { VisualizationActionDetails } from "@app/components/actions/visualization/VisualizationActionDetails";
 import { WebsearchActionDetails } from "@app/components/actions/websearch/WebsearchActionDetails";
 
 export interface ActionDetailsComponentBaseProps<
@@ -51,8 +51,8 @@ const actionsSpecification: ActionSpecifications = {
     detailsComponent: BrowseActionDetails,
     runningLabel: "Browsing page",
   },
-  code_interpreter_action: {
-    detailsComponent: CodeInterpreterActionDetails,
+  visualization_action: {
+    detailsComponent: VisualizationActionDetails,
     runningLabel: "Analyzing request",
   },
 };

--- a/front/components/actions/visualization/VisualizationActionDetails.tsx
+++ b/front/components/actions/visualization/VisualizationActionDetails.tsx
@@ -1,26 +1,24 @@
 import { CommandLineIcon } from "@dust-tt/sparkle";
-import type { CodeInterpreterActionType } from "@dust-tt/types";
+import type { VisualizationActionType } from "@dust-tt/types";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
 import type { ActionDetailsComponentBaseProps } from "@app/components/actions/types";
 import { ReadOnlyTextArea } from "@app/components/assistant/ReadOnlyTextArea";
 
-export function CodeInterpreterActionDetails({
+export function VisualizationActionDetails({
   action,
   defaultOpen,
-}: ActionDetailsComponentBaseProps<CodeInterpreterActionType>) {
+}: ActionDetailsComponentBaseProps<VisualizationActionType>) {
   return (
     <ActionDetailsWrapper
-      actionName="Code Interpreter"
+      actionName="Visualization"
       defaultOpen={defaultOpen}
       visual={CommandLineIcon}
     >
       <div className="flex flex-col gap-4 pl-6 pt-4">
         <div className="flex flex-col gap-1">
           <div className="text-sm font-normal text-slate-500">
-            <ReadOnlyTextArea
-              content={action.output?.code ?? "// No code was generated"}
-            />
+            <ReadOnlyTextArea content={action.output?.code ?? ""} />
           </div>
         </div>
       </div>

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -2,6 +2,7 @@ import {
   Avatar,
   BracesIcon,
   CommandLineIcon,
+  CommandLineStrokeIcon,
   ContentMessage,
   ElementModal,
   ExternalLinkIcon,
@@ -27,6 +28,7 @@ import type {
 import {
   assertNever,
   isBrowseConfiguration,
+  isCodeInterpreterConfiguration,
   isDustAppRunConfiguration,
   isProcessConfiguration,
   isRetrievalConfiguration,
@@ -286,6 +288,18 @@ export function AssistantDetails({
             </div>
           ) : isBrowseConfiguration(action) ? (
             false
+          ) : isCodeInterpreterConfiguration(action) ? (
+            <div className="flex flex-col gap-2" key={`action-${index}`}>
+              <div className="text-lg font-bold text-element-800">
+                Code Interpreter
+              </div>
+              <div className="flex items-center gap-2">
+                <Icon visual={CommandLineStrokeIcon} size="xs" />
+                <div>
+                  Assistant can generate and execute some code to answer
+                </div>
+              </div>
+            </div>
           ) : (
             assertNever(action)
           )

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -2,7 +2,6 @@ import {
   Avatar,
   BracesIcon,
   CommandLineIcon,
-  CommandLineStrokeIcon,
   ContentMessage,
   ElementModal,
   ExternalLinkIcon,
@@ -11,6 +10,7 @@ import {
   Page,
   PlanetIcon,
   ServerIcon,
+  ShapesIcon,
   Spinner,
   Tree,
 } from "@dust-tt/sparkle";
@@ -28,11 +28,11 @@ import type {
 import {
   assertNever,
   isBrowseConfiguration,
-  isCodeInterpreterConfiguration,
   isDustAppRunConfiguration,
   isProcessConfiguration,
   isRetrievalConfiguration,
   isTablesQueryConfiguration,
+  isVisualizationConfiguration,
   isWebsearchConfiguration,
 } from "@dust-tt/types";
 import { useCallback, useContext, useEffect, useState } from "react";
@@ -288,15 +288,15 @@ export function AssistantDetails({
             </div>
           ) : isBrowseConfiguration(action) ? (
             false
-          ) : isCodeInterpreterConfiguration(action) ? (
+          ) : isVisualizationConfiguration(action) ? (
             <div className="flex flex-col gap-2" key={`action-${index}`}>
               <div className="text-lg font-bold text-element-800">
-                Code Interpreter
+                Visualization
               </div>
               <div className="flex items-center gap-2">
-                <Icon visual={CommandLineStrokeIcon} size="xs" />
+                <Icon visual={ShapesIcon} size="xs" />
                 <div>
-                  Assistant can generate and execute some code to answer
+                  Assistant can generate graphs to visually represent your data.
                 </div>
               </div>
             </div>

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -178,6 +178,7 @@ export function AgentMessage({
       case "process_params":
       case "websearch_params":
       case "browse_params":
+      case "code_interpreter_params":
         setStreamedAgentMessage((m) => {
           return updateMessageWithAction(m, event.action);
         });

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -178,7 +178,7 @@ export function AgentMessage({
       case "process_params":
       case "websearch_params":
       case "browse_params":
-      case "code_interpreter_params":
+      case "visualization_params":
         setStreamedAgentMessage((m) => {
           return updateMessageWithAction(m, event.action);
         });

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -12,11 +12,11 @@ import {
   ConnectorsAPI,
   CoreAPI,
   isBrowseConfiguration,
-  isCodeInterpreterConfiguration,
   isDustAppRunConfiguration,
   isProcessConfiguration,
   isRetrievalConfiguration,
   isTablesQueryConfiguration,
+  isVisualizationConfiguration,
   isWebsearchConfiguration,
   slugify,
 } from "@dust-tt/types";
@@ -212,7 +212,7 @@ export async function buildInitialActions({
     } else if (isBrowseConfiguration(action)) {
       // Ignore browse actions
       continue;
-    } else if (isCodeInterpreterConfiguration(action)) {
+    } else if (isVisualizationConfiguration(action)) {
       // @todo[daph] this is the builder work, in the next PR.
       continue;
     } else {

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -12,6 +12,7 @@ import {
   ConnectorsAPI,
   CoreAPI,
   isBrowseConfiguration,
+  isCodeInterpreterConfiguration,
   isDustAppRunConfiguration,
   isProcessConfiguration,
   isRetrievalConfiguration,
@@ -210,6 +211,9 @@ export async function buildInitialActions({
       continue;
     } else if (isBrowseConfiguration(action)) {
       // Ignore browse actions
+      continue;
+    } else if (isCodeInterpreterConfiguration(action)) {
+      // @todo[daph] this is the builder work, in the next PR.
       continue;
     } else {
       assertNever(action);

--- a/front/lib/api/assistant/actions/code_interpreter.ts
+++ b/front/lib/api/assistant/actions/code_interpreter.ts
@@ -1,0 +1,360 @@
+import type {
+  AgentActionSpecification,
+  CodeInterpreterActionOutputType,
+  CodeInterpreterActionType,
+  CodeInterpreterConfigurationType,
+  CodeInterpreterErrorEvent,
+  CodeInterpreterParamsEvent,
+  CodeInterpreterSuccessEvent,
+  FunctionCallType,
+  FunctionMessageTypeModel,
+  ModelId,
+  Result,
+} from "@dust-tt/types";
+import {
+  BaseAction,
+  cloneBaseConfig,
+  CodeInterpreterActionOutputSchema,
+  DustProdActionRegistry,
+  Ok,
+} from "@dust-tt/types";
+import { isLeft } from "fp-ts/lib/Either";
+
+import { runActionStreamed } from "@app/lib/actions/server";
+import { DEFAULT_CODE_INTERPRETER_ACTION_NAME } from "@app/lib/api/assistant/actions/names";
+import type { BaseActionRunParams } from "@app/lib/api/assistant/actions/types";
+import { BaseActionConfigurationServerRunner } from "@app/lib/api/assistant/actions/types";
+import type { Authenticator } from "@app/lib/auth";
+import { AgentCodeInterpreterAction } from "@app/lib/models/assistant/actions/code_interpreter";
+import logger from "@app/logger/logger";
+
+interface CodeInterpreterActionBlob {
+  id: ModelId; // CodeInterpreterAction
+  agentMessageId: ModelId;
+  query: string;
+  output: CodeInterpreterActionOutputType | null;
+  functionCallId: string | null;
+  functionCallName: string | null;
+  step: number;
+}
+
+export class CodeInterpreterAction extends BaseAction {
+  readonly agentMessageId: ModelId;
+  readonly query: string;
+  readonly output: CodeInterpreterActionOutputType | null;
+  readonly functionCallId: string | null;
+  readonly functionCallName: string | null;
+  readonly step: number;
+  readonly type = "code_interpreter_action";
+
+  constructor(blob: CodeInterpreterActionBlob) {
+    super(blob.id, "code_interpreter_action");
+
+    this.agentMessageId = blob.agentMessageId;
+    this.query = blob.query;
+    this.output = blob.output;
+    this.functionCallId = blob.functionCallId;
+    this.functionCallName = blob.functionCallName;
+    this.step = blob.step;
+  }
+
+  renderForFunctionCall(): FunctionCallType {
+    return {
+      id: this.functionCallId ?? `call_${this.id.toString()}`,
+      name: this.functionCallName ?? DEFAULT_CODE_INTERPRETER_ACTION_NAME,
+      arguments: JSON.stringify({ query: this.query }),
+    };
+  }
+
+  renderForMultiActionsModel(): FunctionMessageTypeModel {
+    let content = "CODE INTERPRETER OUTPUT:\n";
+    if (this.output === null) {
+      content += "The interpreter failed.\n";
+    } else {
+      content += `${JSON.stringify(this.output, null, 2)}\n`;
+    }
+
+    return {
+      role: "function" as const,
+      name: this.functionCallName ?? DEFAULT_CODE_INTERPRETER_ACTION_NAME,
+      function_call_id: this.functionCallId ?? `call_${this.id.toString()}`,
+      content,
+    };
+  }
+}
+
+/**
+ * Params generation.
+ */
+
+export class CodeInterpreterConfigurationServerRunner extends BaseActionConfigurationServerRunner<CodeInterpreterConfigurationType> {
+  async buildSpecification(
+    auth: Authenticator,
+    { name, description }: { name: string; description: string | null }
+  ): Promise<Result<AgentActionSpecification, Error>> {
+    const owner = auth.workspace();
+    if (!owner) {
+      throw new Error(
+        "Unexpected unauthenticated call to `runCodeInterpreterAction`"
+      );
+    }
+
+    return new Ok({
+      name,
+      description:
+        description ||
+        "Generate code snippets to solve specified tasks or questions.",
+      inputs: [
+        {
+          name: "query",
+          description: "The query for which the code will be generated.",
+          type: "string",
+        },
+      ],
+    });
+  }
+
+  // CodeInterpreter does not use citations.
+  getCitationsCount(): number {
+    return 0;
+  }
+
+  // Create the CodeInterpreterAction object in the database and yield an event for the generation of
+  // the params. We store the action here as the params have been generated, if an error occurs
+  // later on, the action won't have outputs but the error will be stored on the parent agent
+  // message.
+  async *run(
+    auth: Authenticator,
+    {
+      agentConfiguration,
+      conversation,
+      agentMessage,
+      rawInputs,
+      functionCallId,
+      step,
+    }: BaseActionRunParams
+  ): AsyncGenerator<
+    | CodeInterpreterParamsEvent
+    | CodeInterpreterSuccessEvent
+    | CodeInterpreterErrorEvent,
+    void
+  > {
+    const owner = auth.workspace();
+    if (!owner) {
+      throw new Error(
+        "Unexpected unauthenticated call to `run` for websearch action"
+      );
+    }
+
+    const { actionConfiguration } = this;
+
+    const query = rawInputs.query;
+
+    if (!query || typeof query !== "string" || query.length === 0) {
+      yield {
+        type: "code_interpreter_error",
+        created: Date.now(),
+        configurationId: agentConfiguration.sId,
+        messageId: agentMessage.sId,
+        error: {
+          code: "code_interpreter_parameters_generation_error",
+          message:
+            "The query parameter is required and must be a non-empty string.",
+        },
+      };
+      return;
+    }
+
+    // Create the CodeInterpreterAction object in the database and yield an event for the generation of
+    // the params. We store the action here as the params have been generated, if an error occurs
+    // later on, the action won't have outputs but the error will be stored on the parent agent
+    // message.
+    const action = await AgentCodeInterpreterAction.create({
+      codeInterpreterConfigurationId: actionConfiguration.sId,
+      query,
+      output: null,
+      functionCallId,
+      functionCallName: actionConfiguration.name,
+      agentMessageId: agentMessage.agentMessageId,
+      step,
+    });
+
+    const now = Date.now();
+
+    yield {
+      type: "code_interpreter_params",
+      created: Date.now(),
+      configurationId: actionConfiguration.sId,
+      messageId: agentMessage.sId,
+      action: new CodeInterpreterAction({
+        id: action.id,
+        agentMessageId: action.agentMessageId,
+        query,
+        output: null,
+        functionCallId: action.functionCallId,
+        functionCallName: action.functionCallName,
+        step: action.step,
+      }),
+    };
+
+    // Configure the Code Interpreter Dust App to the assistant model configuration.
+    const config = cloneBaseConfig(
+      DustProdActionRegistry["assistant-v2-code-interpreter"].config
+    );
+    const model = agentConfiguration.model;
+    config.MODEL.provider_id = model.providerId;
+    config.MODEL.model_id = model.modelId;
+    config.MODEL.temperature = model.temperature;
+
+    // Execute the Code Interpreter Dust app.
+    const codeInterpreterRes = await runActionStreamed(
+      auth,
+      "assistant-v2-code-interpreter",
+      config,
+      [
+        {
+          query,
+          runtimeEnvironment: actionConfiguration.runtimeEnvironment,
+        },
+      ],
+      {
+        conversationId: conversation.sId,
+        workspaceId: conversation.owner.sId,
+        agentMessageId: agentMessage.sId,
+      }
+    );
+
+    if (codeInterpreterRes.isErr()) {
+      yield {
+        type: "code_interpreter_error",
+        created: Date.now(),
+        configurationId: agentConfiguration.sId,
+        messageId: agentMessage.sId,
+        error: {
+          code: "code_interpeter_execution_error",
+          message: codeInterpreterRes.error.message,
+        },
+      };
+      return;
+    }
+
+    const { eventStream, dustRunId } = codeInterpreterRes.value;
+    let output: CodeInterpreterActionOutputType | null = null;
+
+    for await (const event of eventStream) {
+      if (event.type === "error") {
+        logger.error(
+          {
+            workspaceId: owner.id,
+            conversationId: conversation.id,
+            error: event.content.message,
+          },
+          "Error running code_interpreter action"
+        );
+        yield {
+          type: "code_interpreter_error",
+          created: Date.now(),
+          configurationId: agentConfiguration.sId,
+          messageId: agentMessage.sId,
+          error: {
+            code: "code_interpreter_execution_error",
+            message: event.content.message,
+          },
+        };
+        return;
+      }
+      if (event.type === "block_execution") {
+        const e = event.content.execution[0][0];
+        if (e.error) {
+          logger.error(
+            {
+              workspaceId: owner.id,
+              conversationId: conversation.id,
+              error: e.error,
+            },
+            "Error running code_interpreter action"
+          );
+          yield {
+            type: "code_interpreter_error",
+            created: Date.now(),
+            configurationId: agentConfiguration.sId,
+            messageId: agentMessage.sId,
+            error: {
+              code: "code_interpreter_execution_error",
+              message: e.error,
+            },
+          };
+          return;
+        }
+
+        if (event.content.block_name === "CODE_INTERPRETER_FINAL" && e.value) {
+          const outputValidation = CodeInterpreterActionOutputSchema.decode(
+            e.value
+          );
+          if (isLeft(outputValidation)) {
+            logger.error(
+              {
+                workspaceId: owner.id,
+                conversationId: conversation.id,
+                error: outputValidation.left,
+              },
+              "Error running code interpreter action"
+            );
+            yield {
+              type: "code_interpreter_error",
+              created: Date.now(),
+              configurationId: agentConfiguration.sId,
+              messageId: agentMessage.sId,
+              error: {
+                code: "code_interpreter_execution_error",
+                message: `Invalid output from code interpreter action: ${outputValidation.left}`,
+              },
+            };
+            return;
+          }
+          output = outputValidation.right;
+        }
+      }
+    }
+
+    logger.info(
+      {
+        workspaceId: conversation.owner.sId,
+        conversationId: conversation.sId,
+        elapsed: Date.now() - now,
+      },
+      "[ASSISTANT_TRACE] Code Interpreter action execution"
+    );
+
+    await action.update({ runId: await dustRunId, output });
+  }
+}
+
+/**
+ * Action rendering.
+ */
+
+// Internal interface for the retrieval and rendering of a actions from AgentMessage ModelIds. This
+// should not be used outside of api/assistant. We allow a ModelId interface here because for
+// optimization purposes to avoid duplicating DB requests while having clear action specific code.
+export async function codeInterpreterActionTypesFromAgentMessageIds(
+  agentMessageIds: ModelId[]
+): Promise<CodeInterpreterActionType[]> {
+  const models = await AgentCodeInterpreterAction.findAll({
+    where: {
+      agentMessageId: agentMessageIds,
+    },
+  });
+
+  return models.map((action) => {
+    return new CodeInterpreterAction({
+      id: action.id,
+      agentMessageId: action.agentMessageId,
+      query: action.query,
+      output: action.output,
+      functionCallId: action.functionCallId,
+      functionCallName: action.functionCallName,
+      step: action.step,
+    });
+  });
+}

--- a/front/lib/api/assistant/actions/names.ts
+++ b/front/lib/api/assistant/actions/names.ts
@@ -8,4 +8,4 @@ export const DEFAULT_RETRIEVAL_NO_QUERY_ACTION_NAME =
   "most_recent_in_data_sources";
 export const DEFAULT_WEBSEARCH_ACTION_NAME = "web_search";
 export const DEFAULT_TABLES_QUERY_ACTION_NAME = "query_tables";
-export const DEFAULT_CODE_INTERPRETER_ACTION_NAME = "code_interpreter";
+export const DEFAULT_VISUALIZATION_ACTION_NAME = "visualization";

--- a/front/lib/api/assistant/actions/names.ts
+++ b/front/lib/api/assistant/actions/names.ts
@@ -8,3 +8,4 @@ export const DEFAULT_RETRIEVAL_NO_QUERY_ACTION_NAME =
   "most_recent_in_data_sources";
 export const DEFAULT_WEBSEARCH_ACTION_NAME = "web_search";
 export const DEFAULT_TABLES_QUERY_ACTION_NAME = "query_tables";
+export const DEFAULT_CODE_INTERPRETER_ACTION_NAME = "code_interpreter";

--- a/front/lib/api/assistant/actions/runners.ts
+++ b/front/lib/api/assistant/actions/runners.ts
@@ -1,6 +1,7 @@
 import type {
   AgentAction,
   BrowseConfigurationType,
+  CodeInterpreterConfigurationType,
   DustAppRunConfigurationType,
   ProcessConfigurationType,
   RetrievalConfigurationType,
@@ -9,6 +10,7 @@ import type {
 } from "@dust-tt/types";
 
 import { BrowseConfigurationServerRunner } from "@app/lib/api/assistant/actions/browse";
+import { CodeInterpreterConfigurationServerRunner } from "@app/lib/api/assistant/actions/code_interpreter";
 import { DustAppRunConfigurationServerRunner } from "@app/lib/api/assistant/actions/dust_app_run";
 import { ProcessConfigurationServerRunner } from "@app/lib/api/assistant/actions/process";
 import { RetrievalConfigurationServerRunner } from "@app/lib/api/assistant/actions/retrieval";
@@ -27,6 +29,7 @@ interface ActionToConfigTypeMap {
   tables_query_configuration: TablesQueryConfigurationType;
   websearch_configuration: WebsearchConfigurationType;
   browse_configuration: BrowseConfigurationType;
+  code_interpreter_configuration: CodeInterpreterConfigurationType;
 }
 
 interface ActionTypeToClassMap {
@@ -36,6 +39,7 @@ interface ActionTypeToClassMap {
   tables_query_configuration: TablesQueryConfigurationServerRunner;
   websearch_configuration: WebsearchConfigurationServerRunner;
   browse_configuration: BrowseConfigurationServerRunner;
+  code_interpreter_configuration: CodeInterpreterConfigurationServerRunner;
 }
 
 // Ensure all AgentAction keys are present in ActionToConfigTypeMap.
@@ -78,6 +82,7 @@ export const ACTION_TYPE_TO_CONFIGURATION_SERVER_RUNNER: {
   websearch_configuration: WebsearchConfigurationServerRunner,
   browse_configuration: BrowseConfigurationServerRunner,
   retrieval_configuration: RetrievalConfigurationServerRunner,
+  code_interpreter_configuration: CodeInterpreterConfigurationServerRunner,
 } as const;
 
 export function getRunnerforActionConfiguration<K extends keyof CombinedMap>(

--- a/front/lib/api/assistant/actions/runners.ts
+++ b/front/lib/api/assistant/actions/runners.ts
@@ -1,16 +1,15 @@
 import type {
   AgentAction,
   BrowseConfigurationType,
-  CodeInterpreterConfigurationType,
   DustAppRunConfigurationType,
   ProcessConfigurationType,
   RetrievalConfigurationType,
   TablesQueryConfigurationType,
+  VisualizationConfigurationType,
   WebsearchConfigurationType,
 } from "@dust-tt/types";
 
 import { BrowseConfigurationServerRunner } from "@app/lib/api/assistant/actions/browse";
-import { CodeInterpreterConfigurationServerRunner } from "@app/lib/api/assistant/actions/code_interpreter";
 import { DustAppRunConfigurationServerRunner } from "@app/lib/api/assistant/actions/dust_app_run";
 import { ProcessConfigurationServerRunner } from "@app/lib/api/assistant/actions/process";
 import { RetrievalConfigurationServerRunner } from "@app/lib/api/assistant/actions/retrieval";
@@ -20,6 +19,7 @@ import type {
   BaseActionConfigurationServerRunnerConstructor,
   BaseActionConfigurationStaticMethods,
 } from "@app/lib/api/assistant/actions/types";
+import { VisualizationConfigurationServerRunner } from "@app/lib/api/assistant/actions/visualization";
 import { WebsearchConfigurationServerRunner } from "@app/lib/api/assistant/actions/websearch";
 
 interface ActionToConfigTypeMap {
@@ -29,7 +29,7 @@ interface ActionToConfigTypeMap {
   tables_query_configuration: TablesQueryConfigurationType;
   websearch_configuration: WebsearchConfigurationType;
   browse_configuration: BrowseConfigurationType;
-  code_interpreter_configuration: CodeInterpreterConfigurationType;
+  visualization_configuration: VisualizationConfigurationType;
 }
 
 interface ActionTypeToClassMap {
@@ -39,7 +39,7 @@ interface ActionTypeToClassMap {
   tables_query_configuration: TablesQueryConfigurationServerRunner;
   websearch_configuration: WebsearchConfigurationServerRunner;
   browse_configuration: BrowseConfigurationServerRunner;
-  code_interpreter_configuration: CodeInterpreterConfigurationServerRunner;
+  visualization_configuration: VisualizationConfigurationServerRunner;
 }
 
 // Ensure all AgentAction keys are present in ActionToConfigTypeMap.
@@ -82,7 +82,7 @@ export const ACTION_TYPE_TO_CONFIGURATION_SERVER_RUNNER: {
   websearch_configuration: WebsearchConfigurationServerRunner,
   browse_configuration: BrowseConfigurationServerRunner,
   retrieval_configuration: RetrievalConfigurationServerRunner,
-  code_interpreter_configuration: CodeInterpreterConfigurationServerRunner,
+  visualization_configuration: VisualizationConfigurationServerRunner,
 } as const;
 
 export function getRunnerforActionConfiguration<K extends keyof CombinedMap>(

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -25,11 +25,11 @@ import {
   cloneBaseConfig,
   DustProdActionRegistry,
   isBrowseConfiguration,
-  isCodeInterpreterConfiguration,
   isDustAppRunConfiguration,
   isProcessConfiguration,
   isRetrievalConfiguration,
   isTablesQueryConfiguration,
+  isVisualizationConfiguration,
   isWebsearchConfiguration,
   removeNulls,
   SUPPORTED_MODEL_CONFIGS,
@@ -1106,7 +1106,7 @@ async function* runAction(
           assertNever(event);
       }
     }
-  } else if (isCodeInterpreterConfiguration(actionConfiguration)) {
+  } else if (isVisualizationConfiguration(actionConfiguration)) {
     const eventStream = getRunnerforActionConfiguration(
       actionConfiguration
     ).run(auth, {
@@ -1120,10 +1120,10 @@ async function* runAction(
 
     for await (const event of eventStream) {
       switch (event.type) {
-        case "code_interpreter_params":
+        case "visualization_params":
           yield event;
           break;
-        case "code_interpreter_error":
+        case "visualization_error":
           yield {
             type: "agent_error",
             created: event.created,
@@ -1135,7 +1135,7 @@ async function* runAction(
             },
           };
           return;
-        case "code_interpreter_success":
+        case "visualization_success":
           yield {
             type: "agent_action_success",
             created: event.created,

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -8,6 +8,7 @@ import type {
   AgentStatus,
   AgentUserListStatus,
   AppType,
+  CodeInterpreterRuntimeEnvironmentType,
   DataSourceConfiguration,
   LightAgentConfigurationType,
   ModelId,
@@ -31,6 +32,7 @@ import { Op, Sequelize, UniqueConstraintError } from "sequelize";
 
 import {
   DEFAULT_BROWSE_ACTION_NAME,
+  DEFAULT_CODE_INTERPRETER_ACTION_NAME,
   DEFAULT_PROCESS_ACTION_NAME,
   DEFAULT_RETRIEVAL_ACTION_NAME,
   DEFAULT_TABLES_QUERY_ACTION_NAME,
@@ -47,6 +49,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { getPublicUploadBucket } from "@app/lib/file_storage";
 import { App } from "@app/lib/models/apps";
 import { AgentBrowseConfiguration } from "@app/lib/models/assistant/actions/browse";
+import { AgentCodeInterpreterConfiguration } from "@app/lib/models/assistant/actions/code_interpreter";
 import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
 import { AgentDustAppRunConfiguration } from "@app/lib/models/assistant/actions/dust_app_run";
 import { AgentProcessConfiguration } from "@app/lib/models/assistant/actions/process";
@@ -382,6 +385,7 @@ async function fetchWorkspaceAgentConfigurationsForView(
     processConfigs,
     websearchConfigs,
     browseConfigs,
+    codeInterpreterConfigs,
     agentUserRelations,
   ] = await Promise.all([
     variant === "full"
@@ -422,6 +426,15 @@ async function fetchWorkspaceAgentConfigurationsForView(
           },
         }).then(groupByAgentConfigurationId)
       : Promise.resolve({} as Record<number, AgentBrowseConfiguration[]>),
+    variant === "full"
+      ? AgentCodeInterpreterConfiguration.findAll({
+          where: {
+            agentConfigurationId: { [Op.in]: configurationIds },
+          },
+        }).then(groupByAgentConfigurationId)
+      : Promise.resolve(
+          {} as Record<number, AgentCodeInterpreterConfiguration[]>
+        ),
     user && configurationIds.length > 0
       ? AgentUserRelation.findAll({
           where: {
@@ -617,6 +630,20 @@ async function fetchWorkspaceAgentConfigurationsForView(
           type: "browse_configuration",
           name: browseConfig.name || DEFAULT_BROWSE_ACTION_NAME,
           description: browseConfig.description,
+        });
+      }
+
+      const codeInterpreterConfigurations =
+        codeInterpreterConfigs[agent.id] ?? [];
+      for (const codeInterpreterConfig of codeInterpreterConfigurations) {
+        actions.push({
+          id: codeInterpreterConfig.id,
+          sId: codeInterpreterConfig.sId,
+          type: "code_interpreter_configuration",
+          name:
+            codeInterpreterConfig.name || DEFAULT_CODE_INTERPRETER_ACTION_NAME,
+          description: codeInterpreterConfig.description,
+          runtimeEnvironment: codeInterpreterConfig.runtypeEnvironment, // todo daph rename column
         });
       }
 
@@ -1167,6 +1194,10 @@ export async function createAgentActionConfiguration(
     | {
         type: "browse_configuration";
       }
+    | {
+        type: "code_interpreter_configuration";
+        runtimeEnvironment: string;
+      }
   ) & {
     name: string | null;
     description: string | null;
@@ -1344,6 +1375,26 @@ export async function createAgentActionConfiguration(
         sId: browseConfig.sId,
         type: "browse_configuration",
         name: action.name || DEFAULT_BROWSE_ACTION_NAME,
+        description: action.description,
+      });
+    }
+    case "code_interpreter_configuration": {
+      const codeInterpreterConfig =
+        await AgentCodeInterpreterConfiguration.create({
+          sId: generateModelSId(),
+          agentConfigurationId: agentConfiguration.id,
+          runtypeEnvironment:
+            action.runtimeEnvironment as CodeInterpreterRuntimeEnvironmentType,
+          name: action.name,
+          description: action.description,
+        });
+
+      return new Ok({
+        id: codeInterpreterConfig.id,
+        sId: codeInterpreterConfig.sId,
+        type: "code_interpreter_configuration",
+        runtimeEnvironment: codeInterpreterConfig.runtypeEnvironment,
+        name: action.name || DEFAULT_CODE_INTERPRETER_ACTION_NAME,
         description: action.description,
       });
     }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1792,6 +1792,7 @@ async function* streamRunAgentEvents(
       case "process_params":
       case "websearch_params":
       case "browse_params":
+      case "code_interpreter_params":
         yield event;
         break;
       case "generation_tokens":

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1792,7 +1792,7 @@ async function* streamRunAgentEvents(
       case "process_params":
       case "websearch_params":
       case "browse_params":
-      case "code_interpreter_params":
+      case "visualization_params":
         yield event;
         break;
       case "generation_tokens":

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -15,6 +15,7 @@ import type { WhereOptions } from "sequelize";
 import { Op, Sequelize } from "sequelize";
 
 import { browseActionTypesFromAgentMessageIds } from "@app/lib/api/assistant/actions/browse";
+import { codeInterpreterActionTypesFromAgentMessageIds } from "@app/lib/api/assistant/actions/code_interpreter";
 import { dustAppRunTypesFromAgentMessageIds } from "@app/lib/api/assistant/actions/dust_app_run";
 import { tableQueryTypesFromAgentMessageIds } from "@app/lib/api/assistant/actions/tables_query";
 import { websearchActionTypesFromAgentMessageIds } from "@app/lib/api/assistant/actions/websearch";
@@ -134,6 +135,7 @@ export async function batchRenderAgentMessages(
     agentProcessActions,
     agentWebsearchActions,
     agentBrowseActions,
+    agentCodeInterpreterActions,
   ] = await Promise.all([
     (async () => {
       const agentConfigurationIds: string[] = agentMessages.reduce(
@@ -161,6 +163,8 @@ export async function batchRenderAgentMessages(
     (async () => processActionTypesFromAgentMessageIds(agentMessageIds))(),
     (async () => websearchActionTypesFromAgentMessageIds(agentMessageIds))(),
     (async () => browseActionTypesFromAgentMessageIds(agentMessageIds))(),
+    (async () =>
+      codeInterpreterActionTypesFromAgentMessageIds(agentMessageIds))(),
   ]);
 
   return agentMessages.map((message) => {
@@ -178,6 +182,7 @@ export async function batchRenderAgentMessages(
       agentProcessActions,
       agentWebsearchActions,
       agentBrowseActions,
+      agentCodeInterpreterActions,
     ]
       .flat()
       .filter((a) => a.agentMessageId === agentMessage.id)

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -15,9 +15,9 @@ import type { WhereOptions } from "sequelize";
 import { Op, Sequelize } from "sequelize";
 
 import { browseActionTypesFromAgentMessageIds } from "@app/lib/api/assistant/actions/browse";
-import { codeInterpreterActionTypesFromAgentMessageIds } from "@app/lib/api/assistant/actions/code_interpreter";
 import { dustAppRunTypesFromAgentMessageIds } from "@app/lib/api/assistant/actions/dust_app_run";
 import { tableQueryTypesFromAgentMessageIds } from "@app/lib/api/assistant/actions/tables_query";
+import { visualizationActionTypesFromAgentMessageIds } from "@app/lib/api/assistant/actions/visualization";
 import { websearchActionTypesFromAgentMessageIds } from "@app/lib/api/assistant/actions/websearch";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import type { PaginationParams } from "@app/lib/api/pagination";
@@ -135,7 +135,7 @@ export async function batchRenderAgentMessages(
     agentProcessActions,
     agentWebsearchActions,
     agentBrowseActions,
-    agentCodeInterpreterActions,
+    agentVisualizationActions,
   ] = await Promise.all([
     (async () => {
       const agentConfigurationIds: string[] = agentMessages.reduce(
@@ -164,7 +164,7 @@ export async function batchRenderAgentMessages(
     (async () => websearchActionTypesFromAgentMessageIds(agentMessageIds))(),
     (async () => browseActionTypesFromAgentMessageIds(agentMessageIds))(),
     (async () =>
-      codeInterpreterActionTypesFromAgentMessageIds(agentMessageIds))(),
+      visualizationActionTypesFromAgentMessageIds(agentMessageIds))(),
   ]);
 
   return agentMessages.map((message) => {
@@ -182,7 +182,7 @@ export async function batchRenderAgentMessages(
       agentProcessActions,
       agentWebsearchActions,
       agentBrowseActions,
-      agentCodeInterpreterActions,
+      agentVisualizationActions,
     ]
       .flat()
       .filter((a) => a.agentMessageId === agentMessage.id)

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -180,6 +180,7 @@ async function handleUserMessageEvents(
             case "process_params":
             case "websearch_params":
             case "browse_params":
+            case "code_interpreter_params":
             case "agent_error":
             case "agent_action_success":
             case "generation_tokens":
@@ -321,6 +322,7 @@ export async function retryAgentMessageWithPubSub(
               case "process_params":
               case "websearch_params":
               case "browse_params":
+              case "code_interpreter_params":
               case "agent_error":
               case "agent_action_success":
               case "generation_tokens":

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -180,7 +180,7 @@ async function handleUserMessageEvents(
             case "process_params":
             case "websearch_params":
             case "browse_params":
-            case "code_interpreter_params":
+            case "visualization_params":
             case "agent_error":
             case "agent_action_success":
             case "generation_tokens":
@@ -322,7 +322,7 @@ export async function retryAgentMessageWithPubSub(
               case "process_params":
               case "websearch_params":
               case "browse_params":
-              case "code_interpreter_params":
+              case "visualization_params":
               case "agent_error":
               case "agent_action_success":
               case "generation_tokens":

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -453,6 +453,24 @@ export async function createOrUpgradeAgentConfiguration({
         return res;
       }
       actionConfigs.push(res.value);
+    } else if (action.type === "code_interpreter_configuration") {
+      const res = await createAgentActionConfiguration(
+        auth,
+        {
+          type: "code_interpreter_configuration",
+          runtimeEnvironment: action.runtimeEnvironment,
+          name: action.name ?? null,
+          description: action.description ?? null,
+        },
+        agentConfigurationRes.value
+      );
+      if (res.isErr()) {
+        // If we fail to create an action, we should delete the agent configuration
+        // we just created and re-throw the error.
+        await unsafeHardDeleteAgentConfiguration(agentConfigurationRes.value);
+        return res;
+      }
+      actionConfigs.push(res.value);
     } else {
       assertNever(action);
     }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -453,12 +453,11 @@ export async function createOrUpgradeAgentConfiguration({
         return res;
       }
       actionConfigs.push(res.value);
-    } else if (action.type === "code_interpreter_configuration") {
+    } else if (action.type === "visualization_configuration") {
       const res = await createAgentActionConfiguration(
         auth,
         {
-          type: "code_interpreter_configuration",
-          runtimeEnvironment: action.runtimeEnvironment,
+          type: "visualization_configuration",
           name: action.name ?? null,
           description: action.description ?? null,
         },

--- a/types/src/front/api_handlers/internal/agent_configuration.ts
+++ b/types/src/front/api_handlers/internal/agent_configuration.ts
@@ -101,6 +101,15 @@ const BrowseActionConfigurationSchema = t.type({
   type: t.literal("browse_configuration"),
 });
 
+const CodeInterpreterConfigurationSchema = t.type({
+  type: t.literal("code_interpreter_configuration"),
+  runtimeEnvironment: t.union([
+    t.literal("javascript"),
+    t.literal("javascript_with_react"),
+    t.literal("python"),
+  ]),
+});
+
 const ProcessActionConfigurationSchema = t.type({
   type: t.literal("process_configuration"),
   dataSources: t.array(
@@ -158,6 +167,7 @@ const ActionConfigurationSchema = t.intersection([
     ProcessActionConfigurationSchema,
     WebsearchActionConfigurationSchema,
     BrowseActionConfigurationSchema,
+    CodeInterpreterConfigurationSchema,
   ]),
   t.partial(multiActionsCommonFields),
 ]);

--- a/types/src/front/api_handlers/internal/agent_configuration.ts
+++ b/types/src/front/api_handlers/internal/agent_configuration.ts
@@ -101,13 +101,8 @@ const BrowseActionConfigurationSchema = t.type({
   type: t.literal("browse_configuration"),
 });
 
-const CodeInterpreterConfigurationSchema = t.type({
-  type: t.literal("code_interpreter_configuration"),
-  runtimeEnvironment: t.union([
-    t.literal("javascript"),
-    t.literal("javascript_with_react"),
-    t.literal("python"),
-  ]),
+const VisualizationConfigurationSchema = t.type({
+  type: t.literal("visualization_configuration"),
 });
 
 const ProcessActionConfigurationSchema = t.type({
@@ -167,7 +162,7 @@ const ActionConfigurationSchema = t.intersection([
     ProcessActionConfigurationSchema,
     WebsearchActionConfigurationSchema,
     BrowseActionConfigurationSchema,
-    CodeInterpreterConfigurationSchema,
+    VisualizationConfigurationSchema,
   ]),
   t.partial(multiActionsCommonFields),
 ]);

--- a/types/src/front/assistant/actions/guards.ts
+++ b/types/src/front/assistant/actions/guards.ts
@@ -1,4 +1,8 @@
 import {
+  CodeInterpreterActionType,
+  CodeInterpreterConfigurationType,
+} from "../../../front/assistant/actions/code_interpreter";
+import {
   DustAppRunActionType,
   DustAppRunConfigurationType,
 } from "../../../front/assistant/actions/dust_app_run";
@@ -16,7 +20,6 @@ import {
 } from "../../../front/assistant/actions/tables_query";
 import { AgentActionType } from "../../../front/assistant/conversation";
 import { BaseAction } from "../../../front/lib/api/assistant/actions/index";
-import { AgentActionConfigurationType } from "../agent";
 import { BrowseActionType, BrowseConfigurationType } from "./browse";
 import { WebsearchActionType, WebsearchConfigurationType } from "./websearch";
 
@@ -128,13 +131,19 @@ export function isBrowseActionType(
   return arg.type === "browse_action";
 }
 
-export function isAgentActionConfigurationType(
+export function isCodeInterpreterConfiguration(
   arg: unknown
-): arg is AgentActionConfigurationType {
+): arg is CodeInterpreterConfigurationType {
   return (
-    isTablesQueryConfiguration(arg) ||
-    isDustAppRunConfiguration(arg) ||
-    isRetrievalConfiguration(arg) ||
-    isProcessConfiguration(arg)
+    !!arg &&
+    typeof arg === "object" &&
+    "type" in arg &&
+    arg.type === "code_interpreter_configuration"
   );
+}
+
+export function isCodeInterpreterActionType(
+  arg: AgentActionType
+): arg is CodeInterpreterActionType {
+  return arg.type === "code_interpreter_action";
 }

--- a/types/src/front/assistant/actions/guards.ts
+++ b/types/src/front/assistant/actions/guards.ts
@@ -1,8 +1,4 @@
 import {
-  CodeInterpreterActionType,
-  CodeInterpreterConfigurationType,
-} from "../../../front/assistant/actions/code_interpreter";
-import {
   DustAppRunActionType,
   DustAppRunConfigurationType,
 } from "../../../front/assistant/actions/dust_app_run";
@@ -18,6 +14,10 @@ import {
   TablesQueryActionType,
   TablesQueryConfigurationType,
 } from "../../../front/assistant/actions/tables_query";
+import {
+  VisualizationActionType,
+  VisualizationConfigurationType,
+} from "../../../front/assistant/actions/visualization";
 import { AgentActionType } from "../../../front/assistant/conversation";
 import { BaseAction } from "../../../front/lib/api/assistant/actions/index";
 import { BrowseActionType, BrowseConfigurationType } from "./browse";
@@ -131,19 +131,19 @@ export function isBrowseActionType(
   return arg.type === "browse_action";
 }
 
-export function isCodeInterpreterConfiguration(
+export function isVisualizationConfiguration(
   arg: unknown
-): arg is CodeInterpreterConfigurationType {
+): arg is VisualizationConfigurationType {
   return (
     !!arg &&
     typeof arg === "object" &&
     "type" in arg &&
-    arg.type === "code_interpreter_configuration"
+    arg.type === "visualization_configuration"
   );
 }
 
-export function isCodeInterpreterActionType(
+export function isVisualizationActionType(
   arg: AgentActionType
-): arg is CodeInterpreterActionType {
-  return arg.type === "code_interpreter_action";
+): arg is VisualizationActionType {
+  return arg.type === "visualization_action";
 }

--- a/types/src/front/assistant/actions/visualization.ts
+++ b/types/src/front/assistant/actions/visualization.ts
@@ -1,3 +1,5 @@
+import * as t from "io-ts";
+
 import { ModelId } from "../../../shared/model_id";
 import { BaseAction } from "../../lib/api/assistant/actions";
 
@@ -25,3 +27,7 @@ export interface VisualizationActionType extends BaseAction {
   step: number;
   type: "visualization_action";
 }
+
+export const VisualizationActionOutputSchema = t.type({
+  code: t.string,
+});

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -5,6 +5,7 @@ import { TablesQueryConfigurationType } from "../../front/assistant/actions/tabl
 import { ModelIdType, ModelProviderIdType } from "../../front/lib/assistant";
 import { ModelId } from "../../shared/model_id";
 import { BrowseConfigurationType } from "./actions/browse";
+import { CodeInterpreterConfigurationType } from "./actions/code_interpreter";
 import { WebsearchConfigurationType } from "./actions/websearch";
 
 /**
@@ -20,7 +21,8 @@ export type AgentActionConfigurationType =
   | DustAppRunConfigurationType
   | ProcessConfigurationType
   | WebsearchConfigurationType
-  | BrowseConfigurationType;
+  | BrowseConfigurationType
+  | CodeInterpreterConfigurationType;
 
 export type AgentAction = AgentActionConfigurationType["type"];
 

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -5,7 +5,7 @@ import { TablesQueryConfigurationType } from "../../front/assistant/actions/tabl
 import { ModelIdType, ModelProviderIdType } from "../../front/lib/assistant";
 import { ModelId } from "../../shared/model_id";
 import { BrowseConfigurationType } from "./actions/browse";
-import { CodeInterpreterConfigurationType } from "./actions/code_interpreter";
+import { VisualizationConfigurationType } from "./actions/visualization";
 import { WebsearchConfigurationType } from "./actions/websearch";
 
 /**
@@ -22,7 +22,7 @@ export type AgentActionConfigurationType =
   | ProcessConfigurationType
   | WebsearchConfigurationType
   | BrowseConfigurationType
-  | CodeInterpreterConfigurationType;
+  | VisualizationConfigurationType;
 
 export type AgentAction = AgentActionConfigurationType["type"];
 

--- a/types/src/front/assistant/conversation.ts
+++ b/types/src/front/assistant/conversation.ts
@@ -1,8 +1,8 @@
-import { CodeInterpreterActionType } from "../../front/assistant/actions/code_interpreter";
 import { DustAppRunActionType } from "../../front/assistant/actions/dust_app_run";
 import { ProcessActionType } from "../../front/assistant/actions/process";
 import { RetrievalActionType } from "../../front/assistant/actions/retrieval";
 import { TablesQueryActionType } from "../../front/assistant/actions/tables_query";
+import { VisualizationActionType } from "../../front/assistant/actions/visualization";
 import { LightAgentConfigurationType } from "../../front/assistant/agent";
 import { UserType, WorkspaceType } from "../../front/user";
 import { ModelId } from "../../shared/model_id";
@@ -94,7 +94,7 @@ export type AgentActionType =
   | ProcessActionType
   | WebsearchActionType
   | BrowseActionType
-  | CodeInterpreterActionType;
+  | VisualizationActionType;
 
 export type AgentMessageStatus =
   | "created"

--- a/types/src/front/assistant/conversation.ts
+++ b/types/src/front/assistant/conversation.ts
@@ -1,3 +1,4 @@
+import { CodeInterpreterActionType } from "../../front/assistant/actions/code_interpreter";
 import { DustAppRunActionType } from "../../front/assistant/actions/dust_app_run";
 import { ProcessActionType } from "../../front/assistant/actions/process";
 import { RetrievalActionType } from "../../front/assistant/actions/retrieval";
@@ -92,7 +93,8 @@ export type AgentActionType =
   | TablesQueryActionType
   | ProcessActionType
   | WebsearchActionType
-  | BrowseActionType;
+  | BrowseActionType
+  | CodeInterpreterActionType;
 
 export type AgentMessageStatus =
   | "created"

--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -218,17 +218,17 @@ export const DustProdActionRegistry = createActionRegistry({
       },
     },
   },
-  "assistant-v2-code-interpreter": {
+  "assistant-v2-visualization": {
     app: {
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "tWcuYDj1OE",
       appHash:
-        "9a9adcfb020630171034d95679a484d8d5a7656968af7a26c9434968da083acc",
+        "7cd6f307204d785f788e2ce9248672f1c72a6c77fda44c818c99d10b07d1fc7c",
     },
     config: {
       MODEL: {
         // `provider_id` and `model_id` must be set by caller.
-        function_call: "generate_code",
+        function_call: "visualize",
         use_cache: false,
       },
     },

--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -218,6 +218,21 @@ export const DustProdActionRegistry = createActionRegistry({
       },
     },
   },
+  "assistant-v2-code-interpreter": {
+    app: {
+      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
+      appId: "tWcuYDj1OE",
+      appHash:
+        "9a9adcfb020630171034d95679a484d8d5a7656968af7a26c9434968da083acc",
+    },
+    config: {
+      MODEL: {
+        // `provider_id` and `model_id` must be set by caller.
+        function_call: "generate_code",
+        use_cache: false,
+      },
+    },
+  },
 });
 
 export type DustRegistryActionName = keyof typeof DustProdActionRegistry;

--- a/types/src/front/lib/api/assistant/agent.ts
+++ b/types/src/front/lib/api/assistant/agent.ts
@@ -6,7 +6,6 @@ import {
   AgentActionType,
   AgentMessageType,
 } from "../../../../front/assistant/conversation";
-import { CodeInterpreterParamsEvent } from "../../../../front/lib/api/assistant/actions/code_interpreter";
 import {
   DustAppRunBlockEvent,
   DustAppRunParamsEvent,
@@ -16,6 +15,7 @@ import {
   TablesQueryOutputEvent,
   TablesQueryParamsEvent,
 } from "../../../../front/lib/api/assistant/actions/tables_query";
+import { VisualizationParamsEvent } from "../../../../front/lib/api/assistant/actions/visualization";
 import {
   AgentActionConfigurationType,
   AgentActionSpecification,
@@ -67,7 +67,7 @@ export type AgentActionSpecificEvent =
   | ProcessParamsEvent
   | WebsearchParamsEvent
   | BrowseParamsEvent
-  | CodeInterpreterParamsEvent;
+  | VisualizationParamsEvent;
 
 // Event sent once the action is completed, we're moving to generating a message if applicable.
 export type AgentActionSuccessEvent = {

--- a/types/src/front/lib/api/assistant/agent.ts
+++ b/types/src/front/lib/api/assistant/agent.ts
@@ -6,6 +6,7 @@ import {
   AgentActionType,
   AgentMessageType,
 } from "../../../../front/assistant/conversation";
+import { CodeInterpreterParamsEvent } from "../../../../front/lib/api/assistant/actions/code_interpreter";
 import {
   DustAppRunBlockEvent,
   DustAppRunParamsEvent,
@@ -65,7 +66,8 @@ export type AgentActionSpecificEvent =
   | TablesQueryOutputEvent
   | ProcessParamsEvent
   | WebsearchParamsEvent
-  | BrowseParamsEvent;
+  | BrowseParamsEvent
+  | CodeInterpreterParamsEvent;
 
 // Event sent once the action is completed, we're moving to generating a message if applicable.
 export type AgentActionSuccessEvent = {


### PR DESCRIPTION
## Description

This PR implements all the logic necessary to run a visualization action: backend run logic & render in the convo. 
I prepared a very simple Dust app using Aric's prompt from his PR. 

We'll need to iterate on all the params and output logic of the app and of the action, and a lot of UI, but most of this code shouldn't change. 

For now the action calls the Dust app that generates the code and we do nothing with it, it is only displayed on the "Inspect tools" button. 

I have the code to display the action in the builder ready to push in a PR, it's not a lot of code but there's already 600 lines in this one (sometimes it's hard to split cause the types are shared everywhere). 

This makes no change for the user (nothing in the Builder yet to add this new action, and anyway it will be hidden behind a feature flag).

<kbd>
<img width="868" alt="Screenshot 2024-06-27 at 17 37 51" src="https://github.com/dust-tt/dust/assets/3803406/5e0dbdf8-5112-4203-941a-2c8d5e324e74">
</kbd>


## Risk

This should not break anything since the new action is not used, but in case it is safe to roll it back. 

## Deploy Plan

Deploy front. 
(changes on the model file is just a type)
