### PR TITLE
[front] fix: fix body height

### DIFF
--- a/front/components/sparkle/AppLayout.tsx
+++ b/front/components/sparkle/AppLayout.tsx
@@ -188,7 +188,7 @@ export default function AppLayout({
 
             <div
               className={classNames(
-                "flex h-full w-full flex-col",
+                "flex h-[calc(100%-5rem)] w-full flex-col",
                 isWideMode ? "items-center" : "max-w-4xl px-6"
               )}
             >


### PR DESCRIPTION
fixes [#5878](https://github.com/dust-tt/dust/issues/5878)

## Description

Remove the height of the sticky header/topbar (h-16 = 4rem + mb-4 = 1rem) for the body

## Risk

layout only

## Deploy Plan

deploy `front`
