### PR TITLE
Flav/input bar upload image

### DIFF
--- a/front/components/assistant/conversation/ContentFragment.tsx
+++ b/front/components/assistant/conversation/ContentFragment.tsx
@@ -1,30 +1,45 @@
 import { Citation } from "@dust-tt/sparkle";
+import type { CitationType } from "@dust-tt/sparkle/dist/cjs/components/Citation";
 import type { ContentFragmentType } from "@dust-tt/types";
+import {
+  isSupportedImageContentFragmentType,
+  isSupportedTextContentFragmentType,
+} from "@dust-tt/types";
 
 export function ContentFragment({ message }: { message: ContentFragmentType }) {
-  let logoType: "document" | "slack" = "document";
+  let citationType: CitationType = "document";
 
   if (
     message.contentType === "slack_thread_content" ||
     message.contentType === "dust-application/slack"
   ) {
-    logoType = "slack";
-  } else if (
-    message.contentType.startsWith("text/") ||
-    message.contentType === "application/pdf" ||
-    message.contentType === "file_attachment"
-  ) {
-    logoType = "document";
-  } else {
-    throw new Error(`Unsupported ContentFragmentType '${message.contentType}'`);
+    citationType = "slack";
+  } else if (isSupportedTextContentFragmentType(message.contentType)) {
+    citationType = "document";
+  } else if (isSupportedImageContentFragmentType(message.contentType)) {
+    citationType = "image";
   }
+
   return (
     <Citation
       title={message.title}
       size="xs"
-      type={logoType}
+      type={citationType}
       href={message.sourceUrl || undefined}
+      imgSrc={getViewUrlForContentFragment(message)}
       avatarSrc={message.context.profilePictureUrl ?? undefined}
     />
   );
+}
+
+function getViewUrlForContentFragment(message: ContentFragmentType) {
+  if (!message.sourceUrl) {
+    return undefined;
+  }
+
+  if (isSupportedImageContentFragmentType(message.contentType)) {
+    return `${message.sourceUrl}&action=view`;
+  }
+
+  return undefined;
 }

--- a/front/hooks/useFileUploaderService.ts
+++ b/front/hooks/useFileUploaderService.ts
@@ -1,5 +1,8 @@
-import type { SupportedContentFragmentType } from "@dust-tt/types";
-import { isSupportedTextContentFragmentType } from "@dust-tt/types";
+import type { SupportedUploadableContentFragmentType } from "@dust-tt/types";
+import {
+  isSupportedImageContentFragmentType,
+  isSupportedUploadableContentFragmentType,
+} from "@dust-tt/types";
 import { useContext, useState } from "react";
 
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
@@ -14,7 +17,7 @@ interface FileContent {
   preview?: string;
   size: number;
   // TODO(2024-06-26 flav) Make this configurable.
-  contentType: SupportedContentFragmentType;
+  contentType: SupportedUploadableContentFragmentType;
 }
 
 type FileBlobUploadErrorCode =
@@ -33,8 +36,12 @@ class FileBlobUploadError extends Error {
   }
 }
 
-const COMBINED_MAX_FILES_SIZE = 500_000;
-const MAX_FILE_SIZE = 100_000_000;
+// TODO: This feels weird.
+const COMBINED_MAX_TEXT_FILES_SIZE = 500_000;
+const MAX_TEXT_FILE_SIZE = 100_000_000;
+
+const MAX_IMAGE_FILE_SIZE = 3 * 1024 * 1024; // 3MB in bytes.
+const COMBINED_MAX_IMAGE_FILES_SIZE = 20 * 1024 * 1024; // 15MB in bytes.
 
 export function useFileUploaderService() {
   const [fileBlobs, setFileBlobs] = useState<FileContent[]>([]);
@@ -49,17 +56,44 @@ export function useFileUploaderService() {
 
     setIsProcessingFiles(true);
 
-    // TODO(2024-06-26 flav): Handle image's sizes differently.
-    const totalSize = [...fileBlobs, ...selectedFiles].reduce(
-      (sum, content) => sum + content.size,
-      0
+    const { totalTextualSize, totalImageSize } = [
+      ...fileBlobs,
+      ...selectedFiles,
+    ].reduce(
+      (acc, content) => {
+        if (
+          isSupportedImageContentFragmentType(
+            content instanceof File ? content.type : content.contentType
+          )
+        ) {
+          acc.totalImageSize += content.size;
+        } else {
+          acc.totalTextualSize += content.size;
+        }
+        return acc;
+      },
+      {
+        totalTextualSize: 0,
+        totalImageSize: 0,
+      }
     );
-    if (totalSize > COMBINED_MAX_FILES_SIZE) {
+
+    if (totalTextualSize > COMBINED_MAX_TEXT_FILES_SIZE) {
       sendNotification({
         type: "error",
         title: "Files too large.",
         description:
-          "The combined extracted text from the files you selected results in more than 500,000 characters. This will overflow the assistant context. Please consider uploading smaller files.",
+          "Combined text exceeds 500,000 characters, overflowing assistant context. Please upload smaller files.",
+      });
+      return;
+    }
+
+    if (totalImageSize > COMBINED_MAX_IMAGE_FILES_SIZE) {
+      sendNotification({
+        type: "error",
+        title: "Files too large.",
+        description:
+          "The total size of the image files you selected exceeds 20MB. Please upload smaller images or reduce the number of images.",
       });
       return;
     }
@@ -68,23 +102,32 @@ export function useFileUploaderService() {
       const previewPromises: Promise<FileContent>[] = selectedFiles.map(
         async (file) => {
           const contentType = getMimeTypeFromFile(file);
-          if (!isSupportedTextContentFragmentType(contentType)) {
+          if (!isSupportedUploadableContentFragmentType(contentType)) {
             return Promise.reject(
               new FileBlobUploadError("file_type_not_supported", file)
             );
           }
 
-          if (file.size > MAX_FILE_SIZE) {
+          if (isSupportedImageContentFragmentType(contentType)) {
+            if (file.size > MAX_IMAGE_FILE_SIZE) {
+              return Promise.reject(
+                new FileBlobUploadError("file_too_large", file)
+              );
+            }
+
+            const base64Text = await getPreview(file);
+
+            // No content for image-like files.
+            return createFileBlob(file, "", contentType, base64Text);
+          }
+
+          if (file.size > MAX_TEXT_FILE_SIZE) {
             return Promise.reject(
               new FileBlobUploadError("file_too_large", file)
             );
           }
 
-          if (contentType.startsWith("image/")) {
-            const base64Text = await getPreview(file);
-
-            return createFileBlob(file, base64Text, contentType, base64Text);
-          } else if (contentType === "application/pdf") {
+          if (contentType === "application/pdf") {
             const text = await getTextFromPDF(file);
 
             return createFileBlob(file, text, contentType);
@@ -188,7 +231,7 @@ export type FileUploaderService = ReturnType<typeof useFileUploaderService>;
 const createFileBlob = (
   file: File,
   content: string,
-  contentType: SupportedContentFragmentType,
+  contentType: SupportedUploadableContentFragmentType,
   preview?: string
 ): FileContent => ({
   id: file.name,

--- a/front/hooks/useFileUploaderService.ts
+++ b/front/hooks/useFileUploaderService.ts
@@ -36,9 +36,8 @@ class FileBlobUploadError extends Error {
   }
 }
 
-// TODO: This feels weird.
-const COMBINED_MAX_TEXT_FILES_SIZE = 500_000;
-const MAX_TEXT_FILE_SIZE = 100_000_000;
+const COMBINED_MAX_TEXT_FILES_SIZE = 30 * 1024 * 1024; // 30MB in bytes.
+const MAX_TEXT_FILE_SIZE = 30 * 1024 * 1024; // 30MB in bytes.
 
 const MAX_IMAGE_FILE_SIZE = 3 * 1024 * 1024; // 3MB in bytes.
 const COMBINED_MAX_IMAGE_FILES_SIZE = 20 * 1024 * 1024; // 15MB in bytes.

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -30,7 +30,10 @@ import type {
   UserMessageWithRankType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { isSupportedTextContentFragmentType } from "@dust-tt/types";
+import {
+  isSupportedTextContentFragmentType,
+  isSupportedUploadableContentFragmentType,
+} from "@dust-tt/types";
 import {
   assertNever,
   getSmallWhitelistedModel,
@@ -1631,7 +1634,7 @@ export async function postNewContentFragment(
 
   const messageId = generateModelSId();
 
-  const sourceUrl = isSupportedTextContentFragmentType(contentType)
+  const sourceUrl = isSupportedUploadableContentFragmentType(contentType)
     ? fileAttachmentLocation({
         workspaceId: owner.sId,
         conversationId: conversation.sId,
@@ -1639,6 +1642,8 @@ export async function postNewContentFragment(
         contentFormat: "raw",
       }).downloadUrl
     : url;
+
+  // TODO(2024-06-27 flav) Consider resizing images.
 
   const textBytes = await storeContentFragmentText({
     workspaceId: owner.sId,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -30,10 +30,7 @@ import type {
   UserMessageWithRankType,
   WorkspaceType,
 } from "@dust-tt/types";
-import {
-  isSupportedTextContentFragmentType,
-  isSupportedUploadableContentFragmentType,
-} from "@dust-tt/types";
+import { isSupportedUploadableContentFragmentType } from "@dust-tt/types";
 import {
   assertNever,
   getSmallWhitelistedModel,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/raw_content_fragment/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/raw_content_fragment/index.ts
@@ -17,6 +17,11 @@ export const config = {
 
 const privateUploadGcs = getPrivateUploadBucket();
 
+const validFormats = ["raw", "text"] as const;
+const validActions = ["view", "download"] as const;
+type ContentFormat = (typeof validFormats)[number];
+type Action = (typeof validActions)[number];
+
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorReponse<{ sourceUrl: string }>>
@@ -105,20 +110,37 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      let contentFormat: "raw" | "text" = "raw";
-      if (
-        typeof req.query.format === "string" &&
-        ["raw", "text"].includes(req.query.format)
-      ) {
-        contentFormat = req.query.format as "raw" | "text";
-      }
+      const contentFormat: ContentFormat = validFormats.includes(
+        req.query.format as ContentFormat
+      )
+        ? (req.query.format as ContentFormat)
+        : "raw";
+
+      const action: Action = validActions.includes(req.query.action as Action)
+        ? (req.query.action as Action)
+        : "download";
 
       const { filePath } = fileAttachmentLocation({
         workspaceId: owner.sId,
         conversationId,
         messageId,
-        contentFormat,
+        contentFormat: action === "view" ? "raw" : contentFormat, // Always use raw format for view.
       });
+
+      if (action === "view") {
+        const stream = privateUploadGcs.file(filePath).createReadStream();
+        stream.on("error", () => {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "message_not_found",
+              message: "File not found.",
+            },
+          });
+        });
+        stream.pipe(res);
+        return;
+      }
 
       // redirect to a signed URL
       const [url] = await privateUploadGcs.file(filePath).getSignedUrl({

--- a/types/src/front/content_fragment.ts
+++ b/types/src/front/content_fragment.ts
@@ -12,7 +12,7 @@ export type ContentFragmentContextType = {
 
 // TODO (26/06/2024 jules): remove "slack_thread_content" and "file_attachment"
 // after backfilling data
-export const supportedTextContentFragment = [
+const supportedTextContentFragmentType = [
   "text/plain",
   "text/csv",
   "text/tsv",
@@ -24,19 +24,33 @@ export const supportedTextContentFragment = [
 ] as const;
 
 export type SupportedTextContentFragmentType =
-  (typeof supportedTextContentFragment)[number];
+  (typeof supportedTextContentFragmentType)[number];
 
-export const supportedContentFragment = [
-  ...supportedTextContentFragment,
+const supportedImagesContentFragmentType = ["image/jpeg", "image/png"] as const;
+
+export type SupportedImagesContentFragmentType =
+  (typeof supportedImagesContentFragmentType)[number];
+
+// Content fragment types that users are allowed to upload.
+const supportedUploadableContentFragmentType = [
+  ...supportedTextContentFragmentType,
+  ...supportedImagesContentFragmentType,
+] as const;
+
+export type SupportedUploadableContentFragmentType =
+  (typeof supportedUploadableContentFragmentType)[number];
+
+export const supportedContentFragmentType = [
+  ...supportedUploadableContentFragmentType,
   "slack_thread_content",
   "dust-application/slack",
 ] as const;
 
 export type SupportedContentFragmentType =
-  (typeof supportedContentFragment)[number];
+  (typeof supportedContentFragmentType)[number];
 
 export function getSupportedContentFragmentTypeCodec(): t.Mixed {
-  const [first, second, ...rest] = supportedContentFragment;
+  const [first, second, ...rest] = supportedContentFragmentType;
   return t.union([
     t.literal(first),
     t.literal(second),
@@ -77,7 +91,9 @@ export function isSupportedContentFragmentType(
 ): format is SupportedContentFragmentType {
   return (
     typeof format === "string" &&
-    supportedContentFragment.includes(format as SupportedContentFragmentType)
+    supportedContentFragmentType.includes(
+      format as SupportedContentFragmentType
+    )
   );
 }
 
@@ -86,8 +102,22 @@ export function isSupportedTextContentFragmentType(
 ): format is SupportedTextContentFragmentType {
   return (
     typeof format === "string" &&
-    supportedTextContentFragment.includes(
+    supportedTextContentFragmentType.includes(
       format as SupportedTextContentFragmentType
     )
+  );
+}
+
+export function isSupportedUploadableContentFragmentType(
+  format: string
+): format is SupportedUploadableContentFragmentType {
+  return supportedUploadableContentFragmentType.includes(
+    format as SupportedUploadableContentFragmentType
+  );
+}
+
+export function isSupportedImageContentFragmentType(format: string) {
+  return supportedImagesContentFragmentType.includes(
+    format as SupportedImagesContentFragmentType
   );
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR implements the remaining logic necessary to support image uploads. The feature is still restricted by the accept attribute on the file input, except for the public API part.

**Key changes include:**
- Enhancing the existing `/raw_content_fragment` endpoint to proxy to GCS content, which is essential for displaying images in the app.
- Extending content fragment types to differentiate between uploadable and non-uploadable content.
- Display images in message citations.
- Revising upload limits, as they no longer apply to images. By default, images are larger than extracted content, and we will resize them in a follow-up PR before this feature goes General Availability (GA).

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
