### PR TITLE
Start a conversation from assistant drawer

### DIFF
--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -36,7 +36,7 @@ import {
 import { useCallback, useContext, useEffect, useState } from "react";
 import type { KeyedMutator } from "swr";
 
-import { AssistantEditionMenu } from "@app/components/assistant/AssistantEditionMenu";
+import { AssistantDetailsDropdownMenu } from "@app/components/assistant/AssistantDetailsDropdownMenu";
 import AssistantListActions from "@app/components/assistant/AssistantListActions";
 import { ReadOnlyTextArea } from "@app/components/assistant/ReadOnlyTextArea";
 import { SharingDropdown } from "@app/components/assistant/Sharing";
@@ -175,7 +175,7 @@ export function AssistantDetails({
         </div>
         {agentConfiguration.status === "active" && (
           <div>
-            <AssistantEditionMenu
+            <AssistantDetailsDropdownMenu
               agentConfigurationId={agentConfiguration.sId}
               owner={owner}
               variant="button"

--- a/front/components/assistant/AssistantDetailsDropdownMenu.tsx
+++ b/front/components/assistant/AssistantDetailsDropdownMenu.tsx
@@ -141,7 +141,7 @@ export function AssistantDetailsDropdownMenu({
         <DropdownMenu.Items width={220}>
           <DropdownMenu.Item
             label="Start conversation"
-            href={`/w/${owner.sId}/assistant/new?mention=${agentConfiguration.sId}`}
+            href={`/w/${owner.sId}/assistant/new?assistant=${agentConfiguration.sId}`}
             icon={ChatBubbleBottomCenterTextIcon}
           />
           {!isGlobalAgent && (

--- a/front/components/assistant/AssistantDetailsDropdownMenu.tsx
+++ b/front/components/assistant/AssistantDetailsDropdownMenu.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  ChatBubbleBottomCenterTextIcon,
   ClipboardIcon,
   DropdownMenu,
   Icon,
@@ -22,7 +23,7 @@ import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { updateAgentUserListStatus } from "@app/lib/client/dust_api";
 import { useAgentConfiguration, useUser } from "@app/lib/swr";
 
-interface AssistantEditionMenuProps {
+interface AssistantDetailsDropdownMenuProps {
   agentConfigurationId: string;
   owner: WorkspaceType;
   variant?: "button" | "plain";
@@ -30,7 +31,7 @@ interface AssistantEditionMenuProps {
   showAddRemoveToList?: boolean;
 }
 
-export function AssistantEditionMenu({
+export function AssistantDetailsDropdownMenu({
   // The `agentConfiguration` cannot be used directly as it isn't dynamically
   // updated upon user list mutations. This limitation stems from its
   // propagation method from <ConversationMessage>.
@@ -39,7 +40,7 @@ export function AssistantEditionMenu({
   variant = "plain",
   onAgentDeletion,
   showAddRemoveToList = false,
-}: AssistantEditionMenuProps) {
+}: AssistantDetailsDropdownMenuProps) {
   const [isUpdatingList, setIsUpdatingList] = useState(false);
   const sendNotification = useContext(SendNotificationsContext);
   const { user } = useUser();
@@ -56,15 +57,13 @@ export function AssistantEditionMenu({
     return <></>;
   }
 
-  if (
-    agentConfiguration.scope === "global" ||
-    agentConfiguration.status === "archived"
-  ) {
+  if (agentConfiguration.status === "archived") {
     return <></>;
   }
 
   const isAgentWorkspace = agentConfiguration.scope === "workspace";
   const isAgentPublished = agentConfiguration.scope === "published";
+  const isGlobalAgent = agentConfiguration.scope === "global";
 
   const isInList = agentConfiguration.userListStatus === "in-list";
   const canDelete = onAgentDeletion && (isBuilder(owner) || !isAgentWorkspace);
@@ -140,50 +139,58 @@ export function AssistantEditionMenu({
       <DropdownMenu className="text-element-700">
         <DropdownMenu.Button>{dropdownButton}</DropdownMenu.Button>
         <DropdownMenu.Items width={220}>
-          {showAddRemoveToList && (
-            <DropdownMenu.SectionHeader label="Edition" />
-          )}
-          {/* Should use the router to have a better navigation experience */}
-          {(isBuilder(owner) || !isAgentWorkspace) && (
-            <DropdownMenu.Item
-              label="Edit"
-              href={`/w/${owner.sId}/builder/assistants/${
-                agentConfiguration.sId
-              }?flow=${
-                isAgentWorkspace
-                  ? "workspace_assistants"
-                  : "personal_assistants"
-              }`}
-              icon={PencilSquareIcon}
-            />
-          )}
           <DropdownMenu.Item
-            label="Duplicate (New)"
-            href={`/w/${owner.sId}/builder/assistants/new?flow=personal_assistants&duplicate=${agentConfiguration.sId}`}
-            icon={ClipboardIcon}
+            label="Start conversation"
+            href={`/w/${owner.sId}/assistant/new?mention=${agentConfiguration.sId}`}
+            icon={ChatBubbleBottomCenterTextIcon}
           />
-          {canDelete && (
-            <DropdownMenu.Item
-              label="Delete"
-              icon={TrashIcon}
-              variant="warning"
-              onClick={() => setShowDeletionModal(agentConfiguration)}
-            />
-          )}
-
-          {isAgentPublished && showAddRemoveToList && (
+          {!isGlobalAgent && (
             <>
-              <DropdownMenu.SectionHeader label="MY ASSISTANTS" />
+              <DropdownMenu.SectionHeader label="Edition" />
+
+              {/* Should use the router to have a better navigation experience */}
+              {(isBuilder(owner) || !isAgentWorkspace) && (
+                <DropdownMenu.Item
+                  label="Edit"
+                  href={`/w/${owner.sId}/builder/assistants/${
+                    agentConfiguration.sId
+                  }?flow=${
+                    isAgentWorkspace
+                      ? "workspace_assistants"
+                      : "personal_assistants"
+                  }`}
+                  icon={PencilSquareIcon}
+                />
+              )}
               <DropdownMenu.Item
-                label={isInList ? "Remove from my list" : "Add to my list"}
-                disabled={isUpdatingList}
-                onClick={() => {
-                  void updateAgentUserList(
-                    isInList ? "not-in-list" : "in-list"
-                  );
-                }}
-                icon={isInList ? ListRemoveIcon : ListAddIcon}
+                label="Duplicate (New)"
+                href={`/w/${owner.sId}/builder/assistants/new?flow=personal_assistants&duplicate=${agentConfiguration.sId}`}
+                icon={ClipboardIcon}
               />
+              {canDelete && (
+                <DropdownMenu.Item
+                  label="Delete"
+                  icon={TrashIcon}
+                  variant="warning"
+                  onClick={() => setShowDeletionModal(agentConfiguration)}
+                />
+              )}
+
+              {isAgentPublished && showAddRemoveToList && (
+                <>
+                  <DropdownMenu.SectionHeader label="MY ASSISTANTS" />
+                  <DropdownMenu.Item
+                    label={isInList ? "Remove from my list" : "Add to my list"}
+                    disabled={isUpdatingList}
+                    onClick={() => {
+                      void updateAgentUserList(
+                        isInList ? "not-in-list" : "in-list"
+                      );
+                    }}
+                    icon={isInList ? ListRemoveIcon : ListAddIcon}
+                  />
+                </>
+              )}
             </>
           )}
         </DropdownMenu.Items>

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -40,7 +40,7 @@ import { useRouter } from "next/router";
 import { useCallback, useContext, useEffect, useRef, useState } from "react";
 
 import { makeDocumentCitations } from "@app/components/actions/retrieval/utils";
-import { AssistantEditionMenu } from "@app/components/assistant/AssistantEditionMenu";
+import { AssistantDetailsDropdownMenu } from "@app/components/assistant/AssistantDetailsDropdownMenu";
 import { AgentMessageActions } from "@app/components/assistant/conversation/actions/AgentMessageActions";
 import type { MessageSizeType } from "@app/components/assistant/conversation/ConversationMessage";
 import { ConversationMessage } from "@app/components/assistant/conversation/ConversationMessage";
@@ -461,7 +461,7 @@ export function AgentMessage({
             <div className="text-base font-medium">
               {AssitantDetailViewLink(agentConfiguration)}
             </div>
-            <AssistantEditionMenu
+            <AssistantDetailsDropdownMenu
               agentConfigurationId={agentConfiguration.sId}
               owner={owner}
               showAddRemoveToList

--- a/front/components/assistant/conversation/AssistantBrowserContainer.tsx
+++ b/front/components/assistant/conversation/AssistantBrowserContainer.tsx
@@ -10,7 +10,7 @@ import { useProgressiveAgentConfigurations } from "@app/lib/swr";
 import { classNames } from "@app/lib/utils";
 
 interface AssistantBrowserContainerProps {
-  onAgentConfigurationClick: (agentSid: string) => void;
+  onAgentConfigurationClick: (agentId: string) => void;
   owner: WorkspaceType;
   setAssistantToMention: (agent: LightAgentConfigurationType) => void;
 }

--- a/front/components/assistant/conversation/AssistantBrowserContainer.tsx
+++ b/front/components/assistant/conversation/AssistantBrowserContainer.tsx
@@ -10,7 +10,7 @@ import { useProgressiveAgentConfigurations } from "@app/lib/swr";
 import { classNames } from "@app/lib/utils";
 
 interface AssistantBrowserContainerProps {
-  onAgentConfigurationClick: (agent: LightAgentConfigurationType) => void;
+  onAgentConfigurationClick: (agentSid: string) => void;
   owner: WorkspaceType;
   setAssistantToMention: (agent: LightAgentConfigurationType) => void;
 }
@@ -44,7 +44,7 @@ export function AssistantBrowserContainer({
       // is a clic on a visible assistant we still want this condition to
       // trigger.
       if (scrollDistance > -2) {
-        return onAgentConfigurationClick(agent);
+        return onAgentConfigurationClick(agent.sId);
       }
 
       // Otherwise, scroll to the input bar and set the ref (mention will be set via intersection observer).

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -27,6 +27,7 @@ import { AssistantBrowserContainer } from "@app/components/assistant/conversatio
 import ConversationViewer from "@app/components/assistant/conversation/ConversationViewer";
 import { HelpAndQuickGuideWrapper } from "@app/components/assistant/conversation/HelpAndQuickGuideWrapper";
 import { FixedAssistantInputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
+import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import type { ContentFragmentInput } from "@app/components/assistant/conversation/lib";
 import {
   createConversationWithMessage,
@@ -44,8 +45,7 @@ interface ConversationContainerProps {
   owner: WorkspaceType;
   subscription: SubscriptionType;
   user: UserType;
-  setInputbarMention: (mention: string) => void;
-  setAnimate: (animate: boolean) => void;
+  agentIdToMention: string | null;
 }
 
 export function ConversationContainer({
@@ -53,13 +53,15 @@ export function ConversationContainer({
   owner,
   subscription,
   user,
-  setInputbarMention,
-  setAnimate,
+  agentIdToMention,
 }: ConversationContainerProps) {
   const [activeConversationId, setActiveConversationId] =
     useState(conversationId);
   const [planLimitReached, setPlanLimitReached] = useState(false);
   const [stickyMentions, setStickyMentions] = useState<AgentMention[]>([]);
+
+  const { animate, setAnimate, setSelectedAssistant } =
+    useContext(InputBarContext);
 
   const assistantToMention = useRef<LightAgentConfigurationType | null>(null);
 
@@ -71,6 +73,26 @@ export function ConversationContainer({
     conversationId: activeConversationId,
     workspaceId: owner.sId,
     limit: 50,
+  });
+
+  const setInputbarMention = useCallback(
+    (agentId: string) => {
+      setSelectedAssistant({ configurationId: agentId });
+      setAnimate(true);
+    },
+    [setAnimate, setSelectedAssistant]
+  );
+
+  useEffect(() => {
+    if (agentIdToMention) {
+      setInputbarMention(agentIdToMention);
+    }
+  }, [agentIdToMention, setInputbarMention]);
+
+  useEffect(() => {
+    if (animate) {
+      setTimeout(() => setAnimate(false), 500);
+    }
   });
 
   const handleSubmit = async (

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -27,7 +27,6 @@ import { AssistantBrowserContainer } from "@app/components/assistant/conversatio
 import ConversationViewer from "@app/components/assistant/conversation/ConversationViewer";
 import { HelpAndQuickGuideWrapper } from "@app/components/assistant/conversation/HelpAndQuickGuideWrapper";
 import { FixedAssistantInputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
-import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import type { ContentFragmentInput } from "@app/components/assistant/conversation/lib";
 import {
   createConversationWithMessage,
@@ -45,6 +44,8 @@ interface ConversationContainerProps {
   owner: WorkspaceType;
   subscription: SubscriptionType;
   user: UserType;
+  setInputbarMention: (mention: string) => void;
+  setAnimate: (animate: boolean) => void;
 }
 
 export function ConversationContainer({
@@ -52,13 +53,13 @@ export function ConversationContainer({
   owner,
   subscription,
   user,
+  setInputbarMention,
+  setAnimate,
 }: ConversationContainerProps) {
   const [activeConversationId, setActiveConversationId] =
     useState(conversationId);
   const [planLimitReached, setPlanLimitReached] = useState(false);
   const [stickyMentions, setStickyMentions] = useState<AgentMention[]>([]);
-
-  const { animate, setAnimate } = useContext(InputBarContext);
 
   const assistantToMention = useRef<LightAgentConfigurationType | null>(null);
 
@@ -71,39 +72,6 @@ export function ConversationContainer({
     workspaceId: owner.sId,
     limit: 50,
   });
-
-  const { setSelectedAssistant } = useContext(InputBarContext);
-
-  const setInputbarMention = useCallback(
-    (agentSid: string) => {
-      setSelectedAssistant({ configurationId: agentSid });
-      setAnimate(true);
-    },
-    [setAnimate, setSelectedAssistant]
-  );
-
-  useEffect(() => {
-    if (animate) {
-      setTimeout(() => setAnimate(false), 500);
-    }
-  });
-
-  useEffect(() => {
-    const handleRouteChange = () => {
-      const assistantSId = router.query.mention ?? null;
-      if (assistantSId && typeof assistantSId === "string") {
-        setInputbarMention(assistantSId);
-      }
-    };
-
-    // Initial check in case the component mounts with the query already set.
-    handleRouteChange();
-
-    router.events.on("routeChangeComplete", handleRouteChange);
-    return () => {
-      router.events.off("routeChangeComplete", handleRouteChange);
-    };
-  }, [router.query, router.events, setInputbarMention]);
 
   const handleSubmit = async (
     input: string,

--- a/front/pages/w/[wId]/assistant/[cId]/index.tsx
+++ b/front/pages/w/[wId]/assistant/[cId]/index.tsx
@@ -2,13 +2,12 @@ import type { UserType } from "@dust-tt/types";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import type { ReactElement } from "react";
-import { useCallback, useContext, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import React from "react";
 
 import { ConversationContainer } from "@app/components/assistant/conversation/ConversationContainer";
 import type { ConversationLayoutProps } from "@app/components/assistant/conversation/ConversationLayout";
 import ConversationLayout from "@app/components/assistant/conversation/ConversationLayout";
-import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { CONVERSATION_PARENT_SCROLL_DIV_ID } from "@app/components/assistant/conversation/lib";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 

--- a/front/pages/w/[wId]/assistant/[cId]/index.tsx
+++ b/front/pages/w/[wId]/assistant/[cId]/index.tsx
@@ -93,23 +93,13 @@ export default function AssistantConversation({
       }
     }
 
-    const handleRouteChange = () => {
-      const agentId = router.query.assistant ?? null;
-      if (agentId && typeof agentId === "string") {
-        setAgentIdToMention(agentId);
-      } else {
-        setAgentIdToMention(null);
-      }
-    };
-
-    // Initial check in case the component mounts with the query already set.
-    handleRouteChange();
-
-    router.events.on("routeChangeComplete", handleRouteChange);
-    return () => {
-      router.events.off("routeChangeComplete", handleRouteChange);
-    };
-  }, [router.query, router.events, setConversationKey, initialConversationId]);
+    const agentId = router.query.assistant ?? null;
+    if (agentId && typeof agentId === "string") {
+      setAgentIdToMention(agentId);
+    } else {
+      setAgentIdToMention(null);
+    }
+  }, [router.query, setConversationKey, initialConversationId]);
 
   useEffect(() => {
     function handleNewConvoShortcut(event: KeyboardEvent) {

--- a/front/pages/w/[wId]/assistant/[cId]/index.tsx
+++ b/front/pages/w/[wId]/assistant/[cId]/index.tsx
@@ -66,23 +66,8 @@ export default function AssistantConversation({
   user,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [conversationKey, setConversationKey] = useState<string | null>(null);
+  const [agentIdToMention, setAgentIdToMention] = useState<string | null>(null);
   const router = useRouter();
-  const { animate, setAnimate, setSelectedAssistant } =
-    useContext(InputBarContext);
-
-  const setInputbarMention = useCallback(
-    (agentSid: string) => {
-      setSelectedAssistant({ configurationId: agentSid });
-      setAnimate(true);
-    },
-    [setAnimate, setSelectedAssistant]
-  );
-
-  useEffect(() => {
-    if (animate) {
-      setTimeout(() => setAnimate(false), 500);
-    }
-  });
 
   // This useEffect handles whether to change the key of the ConversationContainer
   // or not. Altering the key forces a re-render of the component. A random number
@@ -110,9 +95,11 @@ export default function AssistantConversation({
     }
 
     const handleRouteChange = () => {
-      const assistantId = router.query.assistant ?? null;
-      if (assistantId && typeof assistantId === "string") {
-        setInputbarMention(assistantId);
+      const agentId = router.query.assistant ?? null;
+      if (agentId && typeof agentId === "string") {
+        setAgentIdToMention(agentId);
+      } else {
+        setAgentIdToMention(null);
       }
     };
 
@@ -123,13 +110,7 @@ export default function AssistantConversation({
     return () => {
       router.events.off("routeChangeComplete", handleRouteChange);
     };
-  }, [
-    router.query,
-    router.events,
-    setConversationKey,
-    initialConversationId,
-    setInputbarMention,
-  ]);
+  }, [router.query, router.events, setConversationKey, initialConversationId]);
 
   useEffect(() => {
     function handleNewConvoShortcut(event: KeyboardEvent) {
@@ -154,8 +135,7 @@ export default function AssistantConversation({
       owner={owner}
       subscription={subscription}
       user={user}
-      setInputbarMention={setInputbarMention}
-      setAnimate={setAnimate}
+      agentIdToMention={agentIdToMention}
     />
   );
 }


### PR DESCRIPTION
## Description

Task: https://github.com/dust-tt/tasks/issues/962

This adds a button "Start Conversation" from the AssistantDetails dropdown menu. 
We display this button for all agents that are not archived. 
To mention we had a query param : `http://localhost:3000/w/[wId]/assistant/new?assistant=[agentSid]`

Review with hidden whitespaces advised: https://github.com/dust-tt/dust/pull/5939/files?diff=split&w=1

<kbd>
<img width="456" alt="Screenshot 2024-06-28 at 11 33 01" src="https://github.com/dust-tt/dust/assets/3803406/327c8af6-d0ae-489e-9bff-040f5c581afb">

</kbd>

## Risk

Low, can be rolled back. 

## Deploy Plan

Deploy front. 
