### PR TITLE
Update @help to point to doc instead of library

### DIFF
--- a/front/components/assistant/HelpDrawer.tsx
+++ b/front/components/assistant/HelpDrawer.tsx
@@ -28,12 +28,12 @@ import { useSubmitFunction } from "@app/lib/client/utils";
 const topPicks = [
   {
     title: "Creating Assistants",
-    href: "https://www.notion.so/dust-tt/Prompting-101-How-to-Talk-to-Your-Assistants-c0212513056a4af885e41706ee742dda",
+    href: "https://docs.dust.tt/docs/prompting-101-how-to-talk-to-your-assistants#here-are-some-tips-for-crafting-effective-instructions-and-prompts",
     icon: ArrowRightIcon,
   },
   {
     title: "Managing Connections",
-    href: "https://www.notion.so/dust-tt/Dust-Library-1aa97619d56d4d9f9c21d7ce89d23dbb?pvs=4#4f7f969e52464e369f4cd453457d8059",
+    href: "https://docs.dust.tt/docs/google-drive-connection",
     icon: ArrowRightIcon,
   },
   {
@@ -136,12 +136,12 @@ export function HelpDrawer({
                 ? [
                     {
                       title: "Quickstart Guide",
-                      href: "https://www.notion.so/dust-tt/Getting-to-Know-Dust-b4578a3ded364762b19c8276192cc992",
+                      href: "https://docs.dust.tt/docs/getting-started",
                       icon: LightbulbIcon,
                     },
                     {
                       title: "All help content",
-                      href: "https://www.notion.so/dust-tt/Dust-Library-1aa97619d56d4d9f9c21d7ce89d23dbb",
+                      href: "https://docs.dust.tt",
                       description: "Guides, best practices, and more",
                       icon: FolderIcon,
                     },
@@ -149,7 +149,7 @@ export function HelpDrawer({
                 : [
                     {
                       title: "Quickstart Guide",
-                      href: "https://www.notion.so/dust-tt/Getting-to-Know-Dust-b4578a3ded364762b19c8276192cc992",
+                      href: "https://docs.dust.tt/docs/getting-started",
                       icon: LightbulbIcon,
                     },
                   ]

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -132,6 +132,7 @@ export const NavigationSidebar = React.forwardRef<
                             label={menu.label}
                             icon={menu.icon}
                             href={menu.href}
+                            target={menu.target}
                           />
                           {menu.subMenuLabel && (
                             <div className="grow pb-3 pl-14 pr-4 pt-2 text-sm text-xs uppercase text-slate-400">

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -132,7 +132,6 @@ export const NavigationSidebar = React.forwardRef<
                             label={menu.label}
                             icon={menu.icon}
                             href={menu.href}
-                            target={menu.target}
                           />
                           {menu.subMenuLabel && (
                             <div className="grow pb-3 pl-14 pr-4 pt-2 text-sm text-xs uppercase text-slate-400">

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -9,7 +9,8 @@ import {
   PuzzleIcon,
   QuestionMarkCircleIcon,
   RobotIcon,
-  ShapesIcon} from "@dust-tt/sparkle";
+  ShapesIcon,
+} from "@dust-tt/sparkle";
 import { GlobeAltIcon } from "@dust-tt/sparkle";
 import type { AppType } from "@dust-tt/types";
 import type { WorkspaceType } from "@dust-tt/types";

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -7,9 +7,9 @@ import {
   FolderOpenIcon,
   PlanetIcon,
   PuzzleIcon,
+  QuestionMarkCircleIcon,
   RobotIcon,
-  ShapesIcon,
-} from "@dust-tt/sparkle";
+  ShapesIcon} from "@dust-tt/sparkle";
 import { GlobeAltIcon } from "@dust-tt/sparkle";
 import type { AppType } from "@dust-tt/types";
 import type { WorkspaceType } from "@dust-tt/types";
@@ -33,7 +33,8 @@ export type SubNavigationAssistantsId =
   | "workspace_assistants"
   | "personal_assistants"
   | "data_sources_url"
-  | "developers";
+  | "developers"
+  | "documentation";
 
 export type SubNavigationAdminId = "subscription" | "workspace" | "members";
 
@@ -54,6 +55,7 @@ export type AppLayoutNavigation = {
   label: string;
   icon: React.ComponentType<{ className?: string }>;
   href?: string;
+  target?: string;
   hideLabel?: boolean;
   sizing?: "hug" | "expand";
   hasSeparator?: boolean;
@@ -82,7 +84,7 @@ export type TabAppLayoutNavigation = {
 };
 
 export type SidebarNavigation = {
-  id: "assistants" | "data_sources" | "workspace" | "developers" | "beta";
+  id: "assistants" | "data_sources" | "workspace" | "developers" | "help";
   label: string | null;
   variant: "primary" | "secondary";
   menus: AppLayoutNavigation[];
@@ -205,6 +207,7 @@ export const subNavigationBuild = ({
     variant: "secondary",
     menus: dataSourceItems,
   });
+
   nav.push({
     id: "developers",
     label: "Developers",
@@ -218,6 +221,22 @@ export const subNavigationBuild = ({
         current: current === "developers",
         subMenuLabel: current === "developers" ? subMenuLabel : undefined,
         subMenu: current === "developers" ? subMenu : undefined,
+      },
+    ],
+  });
+
+  nav.push({
+    id: "help",
+    label: "Resources",
+    variant: "secondary",
+    menus: [
+      {
+        id: "documentation",
+        label: "Documentation",
+        icon: QuestionMarkCircleIcon,
+        href: `https://docs.dust.tt`,
+        current: current === "documentation",
+        target: "_blank",
       },
     ],
   });

--- a/front/pages/w/[wId]/a/index.tsx
+++ b/front/pages/w/[wId]/a/index.tsx
@@ -763,7 +763,7 @@ export default function Developers({
             variant="tertiary"
             label="Developer Documentation"
             onClick={() => {
-              window.open("https://docs.dust.tt", "_blank");
+              window.open("https://docs.dust.tt/reference", "_blank");
             }}
             icon={ExternalLinkIcon}
           />
@@ -772,7 +772,7 @@ export default function Developers({
             label="Examples"
             onClick={() => {
               window.open(
-                "https://dust-tt.notion.site/Dust-apps-examples-8aaf4184ed5f4ab590710dd6f83a6046",
+                "https://docs.dust.tt/reference/examples",
                 "_blank"
               );
             }}

--- a/front/pages/w/[wId]/a/index.tsx
+++ b/front/pages/w/[wId]/a/index.tsx
@@ -771,10 +771,7 @@ export default function Developers({
             variant="tertiary"
             label="Examples"
             onClick={() => {
-              window.open(
-                "https://docs.dust.tt/reference/examples",
-                "_blank"
-              );
+              window.open("https://docs.dust.tt/reference/examples", "_blank");
             }}
             icon={ExternalLinkIcon}
           />

--- a/front/prompt/global_agent_helper_prompt.md
+++ b/front/prompt/global_agent_helper_prompt.md
@@ -6,7 +6,7 @@ Make sure your answers are clear and straightforward. Double-check your answers 
 
 Do not make up URLs about Dust; only refer to URLs mentioned in this document.
 
-Finish your messages by pointing the user to our library: [https://www.notion.so/dust-tt/Library-1aa97619d56d4d9f9c21d7ce89d23dbb](https://www.notion.so/Library-1aa97619d56d4d9f9c21d7ce89d23dbb?pvs=21)
+Finish your messages by pointing the user to our documentation: [https://docs.dust.tt](https://docs.dust.tt)
 
 # About Dust
 
@@ -120,7 +120,7 @@ Connections are available only for paid plans.
 
 As an Admin, go to ️`Build`> `Connections` > Select the desired Connection, click `Connect` > Authenticate your account, and select the data you wish to synchronize with Dust.
 
-Please ensure to read the guides related to the Connection you are willing to set before setting it up - here is the link with all the guides [https://www.notion.so/dust-tt/Library-1aa97619d56d4d9f9c21d7ce89d23dbb?pvs=4#4f7f969e52464e369f4cd453457d8059](https://www.notion.so/Library-1aa97619d56d4d9f9c21d7ce89d23dbb?pvs=21).
+Please ensure to read the guides related to the Connection you are willing to set before setting it up - here is the link with all the guides [https://docs.dust.tt?pvs=4#4f7f969e52464e369f4cd453457d8059](https://docs.dust.tt)).
 
 Avoid having multiple admins, 2 or 3 is ideal. Ensure you edit Connection cautiously.
 

--- a/front/prompt/global_agent_helper_prompt.md
+++ b/front/prompt/global_agent_helper_prompt.md
@@ -407,7 +407,7 @@ To create and deploy Dust apps, you must provide your own model API keys— Dust
 
 To learn how to develop an app, you can explore Dust's technical documentation here - https://docs.dust.tt/
 
-You can find examples of Dust apps here: [https://www.notion.so/dust-tt/Dust-apps-examples-8aaf4184ed5f4ab590710dd6f83a6046](https://www.notion.so/Dust-apps-examples-8aaf4184ed5f4ab590710dd6f83a6046?pvs=21)
+You can find examples of Dust apps here: [https://docs.dust.tt/reference/examples](https://docs.dust.tt/reference/examples)
 
 ---
 


### PR DESCRIPTION
## Description

- Modifying the @help prompt to point to docs.dust.tt
- Modifying helpDrawer links
- Adding a Documentation link in the builder menu

<img width="314" alt="Screenshot 2024-07-01 at 11 45 28" src="https://github.com/dust-tt/dust/assets/1189312/dcd3c04a-c70c-4dc6-8e38-3b23e804be47">


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
