### PR TITLE
[front] - feature: implement user and agent usage reporting

### DIFF
--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -1,14 +1,19 @@
 import { format } from "date-fns/format";
-import { Op, QueryTypes } from "sequelize";
+import { Op, QueryTypes, Sequelize } from "sequelize";
 
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
-import { Conversation } from "@app/lib/models/assistant/conversation";
+import {
+  Conversation,
+  Message,
+  UserMessage,
+} from "@app/lib/models/assistant/conversation";
 import { DataSource } from "@app/lib/models/data_source";
-import type { Workspace } from "@app/lib/models/workspace";
+import { User } from "@app/lib/models/user";
+import { Workspace } from "@app/lib/models/workspace";
 
 import { frontSequelize } from "./resources/storage";
 
-export interface WorkpsaceUsageQueryResult {
+export interface WorkspaceUsageQueryResult {
   createdAt: string;
   conversationModelId: string;
   messageId: string;
@@ -23,12 +28,53 @@ export interface WorkpsaceUsageQueryResult {
   source: string;
 }
 
+interface MessageUsageQueryResult {
+  message_id: number;
+  created_at: Date;
+  assistant_id: string;
+  assistant_name: string;
+  workspace_id: number;
+  workspace_name: string;
+  conversation_id: number;
+  parent_message_id: number | null;
+  user_message_id: number | null;
+  user_id: number | null;
+  user_email: string | null;
+  source: string | null;
+}
+
+export type userUsage = {
+  userName: string;
+  userEmail: string;
+  messageCount: number;
+  lastMessageSent: string;
+  activeDaysCount: number;
+};
+
+type builderUsage = {
+  userEmail: string;
+  userFirstName: string;
+  userLastName: string;
+  agentsEditionsCount: number;
+  distinctAgentsEditionsCount: number;
+};
+
+interface AgentUsageQueryResult {
+  name: string;
+  description: string;
+  settings: "shared" | "private" | "company";
+  authorEmails: string[];
+  messages: number;
+  distinctUsersReached: number;
+  lastConfiguration: Date;
+}
+
 export async function unsafeGetUsageData(
   startDate: Date,
   endDate: Date,
   wId: string
 ): Promise<string> {
-  const results = await frontSequelize.query<WorkpsaceUsageQueryResult>(
+  const results = await frontSequelize.query<WorkspaceUsageQueryResult>(
     `
       SELECT
         TO_CHAR(m."createdAt"::timestamp, 'YYYY-MM-DD HH24:MI:SS') AS "createdAt",
@@ -98,6 +144,301 @@ export async function unsafeGetUsageData(
   }
   const csvHeader = Object.keys(results[0]).join(",") + "\n";
   const csvContent = results
+    .map((row) => Object.values(row).join(","))
+    .join("\n");
+
+  return csvHeader + csvContent;
+}
+
+export async function unsafeGetMessageUsageData(
+  startDate: Date,
+  endDate: Date,
+  workspaceId: string
+): Promise<string> {
+  const workspace = await Workspace.findOne({
+    where: { sId: workspaceId },
+  });
+  if (!workspace) {
+    throw new Error(`Workspace not found for sId: ${workspaceId}`);
+  }
+  const wId = workspace.id;
+  const results = await frontSequelize.query<MessageUsageQueryResult>(
+    `
+      SELECT
+        am."id" AS "message_id",
+        TO_CHAR(am."createdAt"::timestamp, 'YYYY-MM-DD HH24:MI:SS') AS "createdAt",
+        COALESCE(ac."sId", am."agentConfigurationId") AS "assistant_id",
+        COALESCE(ac."name", am."agentConfigurationId") AS "assistant_name",
+        w."id" AS "workspace_id",
+        w."name" AS "workspace_name",
+        c."id" AS "conversation_id",
+        m."parentId" AS "parent_message_id",
+        um."id" AS "user_message_id",
+        um."userId" AS "user_id",
+        um."userContextEmail" AS "user_email",
+        um."userContextOrigin" AS "source"
+      FROM
+        "agent_messages" am
+      JOIN
+        "messages" m ON am."id" = m."agentMessageId"
+      JOIN
+        "conversations" c ON m."conversationId" = c."id"
+      JOIN
+        "workspaces" w ON c."workspaceId" = w."id"
+      LEFT JOIN
+        "agent_configurations" ac ON am."agentConfigurationId" = ac."sId" AND am."agentConfigurationVersion" = ac."version"
+      LEFT JOIN 
+        "messages" m2 on m."parentId" = m2."id"
+      LEFT JOIN
+        "user_messages" um on m2."userMessageId" = um."id"
+      WHERE
+        am."status" = 'succeeded'
+        AND w."id" = wId
+        AND am."createdAt" BETWEEN :startDate AND :endDate
+    `,
+    {
+      replacements: {
+        wId,
+        startDate: format(startDate, "yyyy-MM-dd'T'00:00:00"), // Use first day of start month
+        endDate: format(endDate, "yyyy-MM-dd'T'23:59:59"), // Use last day of end month
+      },
+      type: QueryTypes.SELECT,
+    }
+  );
+  if (!results.length) {
+    return "No data available for the selected period.";
+  }
+  const csvHeader = Object.keys(results[0]).join(",") + "\n";
+  const csvContent = results
+    .map((row) => Object.values(row).join(","))
+    .join("\n");
+  return csvHeader + csvContent;
+}
+
+export async function getUserUsage(
+  workspaceId: string,
+  startDate: Date,
+  endDate: Date
+): Promise<string> {
+  const workspace = await Workspace.findOne({
+    where: { sId: workspaceId },
+  });
+  if (!workspace) {
+    throw new Error(`Workspace not found for sId: ${workspaceId}`);
+  }
+  const wId = workspace.id;
+  const userMessages = await Message.findAll({
+    attributes: [
+      "userMessage.userId",
+      "userMessage.userContextFullName",
+      "userMessage.userContextEmail",
+      [Sequelize.fn("COUNT", Sequelize.col("userMessage.id")), "count"],
+      [
+        Sequelize.cast(
+          Sequelize.fn("MAX", Sequelize.col("userMessage.createdAt")),
+          "DATE"
+        ),
+        "lastMessageSent",
+      ],
+      [
+        Sequelize.fn(
+          "COUNT",
+          Sequelize.fn(
+            "DISTINCT",
+            Sequelize.fn("DATE", Sequelize.col("userMessage.createdAt"))
+          )
+        ),
+        "activeDaysCount",
+      ],
+    ],
+    where: {
+      createdAt: {
+        [Op.gt]: startDate,
+        [Op.lt]: endDate,
+      },
+    },
+    include: [
+      {
+        model: UserMessage,
+        as: "userMessage",
+        required: true,
+        attributes: [],
+        where: {
+          userId: {
+            [Op.not]: null,
+          },
+        },
+      },
+      {
+        model: Conversation,
+        as: "conversation",
+        attributes: [],
+        required: true,
+        where: {
+          workspaceId: wId,
+        },
+      },
+    ],
+    group: [
+      "userMessage.userId",
+      "userMessage.userContextFullName",
+      "userMessage.userContextEmail",
+    ],
+    order: [["count", "DESC"]],
+    raw: true,
+  });
+  const userUsage: userUsage[] = userMessages.map((result) => {
+    return {
+      userName: (result as unknown as { userContextFullName: string })
+        .userContextFullName,
+      userEmail: (result as unknown as { userContextEmail: string })
+        .userContextEmail,
+      messageCount: (result as unknown as { count: number }).count,
+      lastMessageSent: (result as unknown as { lastMessageSent: string })
+        .lastMessageSent,
+      activeDaysCount: (result as unknown as { activeDaysCount: number })
+        .activeDaysCount,
+    };
+  });
+  if (!userUsage.length) {
+    return "No data available for the selected period.";
+  }
+  const csvHeader = Object.keys(userUsage[0]).join(",") + "\n";
+  const csvContent = userUsage
+    .map((row) => Object.values(row).join(","))
+    .join("\n");
+  return csvHeader + csvContent;
+}
+
+export async function getBuildersUsage(
+  workspaceId: string,
+  startDate: Date,
+  endDate: Date
+): Promise<string> {
+  const workspace = await Workspace.findOne({
+    where: { sId: workspaceId },
+  });
+  if (!workspace) {
+    throw new Error(`Workspace not found for sId: ${workspaceId}`);
+  }
+  const wId = workspace.id;
+  const agentConfigurations = await AgentConfiguration.findAll({
+    attributes: [
+      [
+        Sequelize.fn("COUNT", Sequelize.col("agent_configuration.sId")),
+        "agentsEditionsCount",
+      ],
+      "user.email",
+      "user.firstName",
+      "user.lastName",
+      [
+        Sequelize.fn(
+          "COUNT",
+          Sequelize.literal('DISTINCT "agent_configuration"."sId"')
+        ),
+        "distinctAgentsEditionsCount",
+      ],
+    ],
+    where: {
+      workspaceId: wId,
+      createdAt: {
+        [Op.gt]: startDate,
+        [Op.lt]: endDate,
+      },
+    },
+    include: [
+      {
+        model: User,
+        as: "user",
+        attributes: [],
+        required: true,
+      },
+    ],
+    raw: true,
+    group: ["authorId", "user.email", "user.firstName", "user.lastName"],
+  });
+  const buildersUsage: builderUsage[] = agentConfigurations.map((result) => {
+    return {
+      userFirstName: (result as unknown as { firstName: string }).firstName,
+      userLastName: (result as unknown as { lastName: string }).lastName,
+      userEmail: (result as unknown as { email: string }).email,
+      agentsEditionsCount: (
+        result as unknown as { agentsEditionsCount: number }
+      ).agentsEditionsCount,
+      distinctAgentsEditionsCount: (
+        result as unknown as { distinctAgentsEditionsCount: number }
+      ).distinctAgentsEditionsCount,
+    };
+  });
+  if (!buildersUsage.length) {
+    return "No data available for the selected period.";
+  }
+  const csvHeader = Object.keys(buildersUsage[0]).join(",") + "\n";
+  const csvContent = buildersUsage
+    .map((row) => Object.values(row).join(","))
+    .join("\n");
+  return csvHeader + csvContent;
+}
+
+export async function getAgentUsage(
+  workspaceId: string,
+  startDate: Date,
+  endDate: Date
+): Promise<string> {
+  const workspace = await Workspace.findOne({
+    where: { sId: workspaceId },
+  });
+  if (!workspace) {
+    throw new Error(`Workspace not found for sId: ${workspaceId}`);
+  }
+  const wId = workspace.id;
+  const mentions = await frontSequelize.query<AgentUsageQueryResult>(
+    `
+    SELECT
+      ac."name",
+      ac."description",
+      CASE
+        WHEN ac."scope" = 'published' THEN 'shared'
+        WHEN ac."scope" = 'private' THEN 'private'
+        ELSE 'company'
+      END AS "settings",
+      ARRAY_AGG(DISTINCT aut."email") AS "authorEmails",
+      COUNT(a."id") AS "messages",
+      COUNT(DISTINCT u."id") AS "distinctUsersReached",
+      MAX(CAST(ac."createdAt" AS DATE)) AS "lastConfiguration"
+    FROM
+      "mentions" a
+      JOIN "messages" m ON a."id" = m."agentMessageId"
+      JOIN "messages" parent ON m."parentId" = parent."id"
+      JOIN "user_messages" um ON um."id" = parent."userMessageId"
+      JOIN "users" u ON um."userId" = u."id"
+      JOIN "agent_configurations" ac ON a."agentConfigurationId" = ac."sId"
+      JOIN "users" aut ON ac."authorId" = aut."id"
+    WHERE
+      a."createdAt" BETWEEN :startDate AND :endDate
+      AND ac."workspaceId" = ${wId}
+      AND ac."status" = 'active'
+      AND ac."scope" != 'private'
+    GROUP BY
+      ac."name",
+      ac."description",
+      ac."scope"
+    ORDER BY
+      "Messages Last 30 Days" DESC;
+    `,
+    {
+      type: QueryTypes.SELECT,
+      replacements: {
+        startDate: format(startDate, "yyyy-MM-dd'T'00:00:00"), // Use first day of start month
+        endDate: format(endDate, "yyyy-MM-dd'T'23:59:59"), // Use last day of end month
+      },
+    }
+  );
+  if (!mentions.length) {
+    return "No data available for the selected period.";
+  }
+  const csvHeader = Object.keys(mentions[0]).join(",") + "\n";
+  const csvContent = mentions
     .map((row) => Object.values(row).join(","))
     .join("\n");
 

--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -208,7 +208,6 @@ export async function getMessageUsageData(
   if (!results.length) {
     return "No data available for the selected period.";
   }
-  console.log(">>>> getMessageUsageData", results.slice(0, 10));
   return generateCsvFromQueryResult(results);
 }
 
@@ -300,7 +299,6 @@ export async function getUserUsageData(
   if (!userUsage.length) {
     return "No data available for the selected period.";
   }
-  console.log(">>>>>> getUserUsageData", userUsage.slice(0, 10));
   return generateCsvFromQueryResult(userUsage);
 }
 
@@ -369,7 +367,6 @@ export async function getBuildersUsageData(
   if (!buildersUsage.length) {
     return "No data available for the selected period.";
   }
-  console.log(">>>>>> getBuildersUsageData", buildersUsage.slice(0, 10));
   return generateCsvFromQueryResult(buildersUsage);
 }
 
@@ -430,7 +427,6 @@ export async function getAgentUsageData(
   if (!mentions.length) {
     return "No data available for the selected period.";
   }
-  console.log(">>>> getAgentUsageData", mentions.slice(0, 10));
   return generateCsvFromQueryResult(mentions);
 }
 

--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -193,7 +193,7 @@ export async function getMessageUsageData(
         "user_messages" um on m2."userMessageId" = um."id"
       WHERE
         am."status" = 'succeeded'
-        AND w."id" = wId
+        AND w."id" = :wId
         AND am."createdAt" BETWEEN :startDate AND :endDate
     `,
     {
@@ -208,13 +208,14 @@ export async function getMessageUsageData(
   if (!results.length) {
     return "No data available for the selected period.";
   }
+  console.log(">>>> getMessageUsageData", results.slice(0, 10));
   return generateCsvFromQueryResult(results);
 }
 
-export async function getUserUsage(
-  workspaceId: string,
+export async function getUserUsageData(
   startDate: Date,
-  endDate: Date
+  endDate: Date,
+  workspaceId: string
 ): Promise<string> {
   const workspace = await Workspace.findOne({
     where: { sId: workspaceId },
@@ -299,13 +300,14 @@ export async function getUserUsage(
   if (!userUsage.length) {
     return "No data available for the selected period.";
   }
+  console.log(">>>>>> getUserUsageData", userUsage.slice(0, 10));
   return generateCsvFromQueryResult(userUsage);
 }
 
-export async function getBuildersUsage(
-  workspaceId: string,
+export async function getBuildersUsageData(
   startDate: Date,
-  endDate: Date
+  endDate: Date,
+  workspaceId: string
 ): Promise<string> {
   const workspace = await Workspace.findOne({
     where: { sId: workspaceId },
@@ -367,17 +369,14 @@ export async function getBuildersUsage(
   if (!buildersUsage.length) {
     return "No data available for the selected period.";
   }
-  const csvHeader = Object.keys(buildersUsage[0]).join(",") + "\n";
-  const csvContent = buildersUsage
-    .map((row) => Object.values(row).join(","))
-    .join("\n");
-  return csvHeader + csvContent;
+  console.log(">>>>>> getBuildersUsageData", buildersUsage.slice(0, 10));
+  return generateCsvFromQueryResult(buildersUsage);
 }
 
-export async function getAgentUsage(
-  workspaceId: string,
+export async function getAgentUsageData(
   startDate: Date,
-  endDate: Date
+  endDate: Date,
+  workspaceId: string
 ): Promise<string> {
   const workspace = await Workspace.findOne({
     where: { sId: workspaceId },
@@ -431,6 +430,7 @@ export async function getAgentUsage(
   if (!mentions.length) {
     return "No data available for the selected period.";
   }
+  console.log(">>>> getAgentUsageData", mentions.slice(0, 10));
   return generateCsvFromQueryResult(mentions);
 }
 
@@ -439,6 +439,7 @@ function generateCsvFromQueryResult(
     | userUsageQueryResult[]
     | AgentUsageQueryResult[]
     | MessageUsageQueryResult[]
+    | builderUsageQueryResult[]
 ) {
   const csvHeader = Object.keys(rows[0]).join(",") + "\n";
   const csvContent = rows.map((row) => Object.values(row).join(",")).join("\n");

--- a/front/pages/api/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/w/[wId]/workspace-usage.ts
@@ -6,13 +6,7 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
-import {
-  getAgentUsageData,
-  getBuildersUsageData,
-  getMessageUsageData,
-  getUserUsageData,
-  unsafeGetUsageData,
-} from "@app/lib/workspace_usage";
+import { unsafeGetUsageData } from "@app/lib/workspace_usage";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
 const MonthSchema = t.refinement(
@@ -111,10 +105,6 @@ async function handler(
       })();
 
       const csvData = await unsafeGetUsageData(startDate, endDate, owner.sId);
-      await getUserUsageData(startDate, endDate, owner.sId);
-      await getBuildersUsageData(startDate, endDate, owner.sId);
-      await getAgentUsageData(startDate, endDate, owner.sId);
-      await getMessageUsageData(startDate, endDate, owner.sId);
       res.setHeader("Content-Type", "text/csv");
       res.setHeader("Content-Disposition", `attachment; filename="usage.csv"`);
       res.status(200).send(csvData);

--- a/front/pages/api/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/w/[wId]/workspace-usage.ts
@@ -6,7 +6,13 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
-import { unsafeGetUsageData } from "@app/lib/workspace_usage";
+import {
+  getAgentUsageData,
+  getBuildersUsageData,
+  getMessageUsageData,
+  getUserUsageData,
+  unsafeGetUsageData,
+} from "@app/lib/workspace_usage";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
 const MonthSchema = t.refinement(
@@ -105,6 +111,10 @@ async function handler(
       })();
 
       const csvData = await unsafeGetUsageData(startDate, endDate, owner.sId);
+      await getUserUsageData(startDate, endDate, owner.sId);
+      await getBuildersUsageData(startDate, endDate, owner.sId);
+      await getAgentUsageData(startDate, endDate, owner.sId);
+      await getMessageUsageData(startDate, endDate, owner.sId);
       res.setHeader("Content-Type", "text/csv");
       res.setHeader("Content-Disposition", `attachment; filename="usage.csv"`);
       res.status(200).send(csvData);


### PR DESCRIPTION
## Description
This PR introduces new queries that will be added to the reporting for workspace analytics. 

The main changes include:
- Adding new SQL queries to fetch detailed usage data for users, agents, and messages within specified time periods.
- Implementing functions to generate CSV reports for message, user, builder, and agent usage data.

References:
- https://github.com/orgs/dust-tt/projects/3/views/1?pane=issue&itemId=67809458

## Risk
None for now as the new queries are not being used

## Deploy Plan
None