### PR TITLE
Enable Slack channels search when adding channels.

### DIFF
--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -122,6 +122,9 @@ export default function ConnectorPermissionsModal({
             />
             <div className="mx-2 mb-16 w-full">
               <PermissionTree
+                isSearchEnabled={
+                  CONNECTOR_CONFIGURATIONS[connector.type].isSearchEnabled
+                }
                 owner={owner}
                 dataSource={dataSource}
                 canUpdatePermissions={canUpdatePermissions}

--- a/front/components/ConnectorPermissionsTree.tsx
+++ b/front/components/ConnectorPermissionsTree.tsx
@@ -2,6 +2,7 @@ import {
   BracesIcon,
   ExternalLinkIcon,
   IconButton,
+  Input,
   Tooltip,
   Tree,
 } from "@dust-tt/sparkle";
@@ -57,6 +58,7 @@ export function PermissionTreeChildren({
   showExpand,
   displayDocumentSource,
   useConnectorPermissionsHook,
+  isSearchEnabled,
 }: {
   owner: WorkspaceType;
   dataSource: DataSourceType;
@@ -74,7 +76,9 @@ export function PermissionTreeChildren({
   showExpand?: boolean;
   displayDocumentSource: (documentId: string) => void;
   useConnectorPermissionsHook: typeof useConnectorPermissions;
+  isSearchEnabled: boolean;
 }) {
+  const [search, setSearch] = useState("");
   const { resources, isResourcesLoading, isResourcesError } =
     useConnectorPermissionsHook({
       owner,
@@ -104,104 +108,129 @@ export function PermissionTreeChildren({
     );
   }
 
+  const resourcesFiltered = resources.filter(
+    (r) => search.trim().length === 0 || r.title.includes(search)
+  );
+
   return (
-    <Tree isLoading={isResourcesLoading}>
-      {resources.map((r, i) => {
-        return (
-          <Tree.Item
-            key={r.internalId}
-            type={r.expandable ? "node" : "leaf"}
-            label={r.title}
-            variant={r.type}
-            className="whitespace-nowrap"
-            checkbox={
-              r.preventSelection !== true &&
-              canUpdatePermissions &&
-              onPermissionUpdate
-                ? {
-                    disabled: parentIsSelected,
-                    checked:
-                      parentIsSelected ||
-                      (localStateByInternalId[r.internalId] ??
-                        ["read", "read_write"].includes(r.permission)),
-                    onChange: (checked) => {
-                      setLocalStateByInternalId((prev) => ({
-                        ...prev,
-                        [r.internalId]: checked,
-                      }));
-                      onPermissionUpdate({
-                        internalId: r.internalId,
-                        permission: checked
-                          ? selectedPermission
-                          : unselectedPermission,
-                      });
-                    },
+    <>
+      {isSearchEnabled && (
+        <div className="flex w-full flex-row">
+          <div className="w-5"></div>
+
+          <div className="mr-8 flex-grow p-1">
+            <Input
+              placeholder="Search..."
+              value={search}
+              onChange={setSearch}
+              size="sm"
+              name="search"
+            />
+          </div>
+        </div>
+      )}
+      <Tree isLoading={isResourcesLoading}>
+        {resourcesFiltered.map((r, i) => {
+          return (
+            <Tree.Item
+              key={r.internalId}
+              type={r.expandable ? "node" : "leaf"}
+              label={r.title}
+              variant={r.type}
+              className="whitespace-nowrap"
+              checkbox={
+                r.preventSelection !== true &&
+                canUpdatePermissions &&
+                onPermissionUpdate
+                  ? {
+                      disabled: parentIsSelected,
+                      checked:
+                        parentIsSelected ||
+                        (localStateByInternalId[r.internalId] ??
+                          ["read", "read_write"].includes(r.permission)),
+                      onChange: (checked) => {
+                        setLocalStateByInternalId((prev) => ({
+                          ...prev,
+                          [r.internalId]: checked,
+                        }));
+                        onPermissionUpdate({
+                          internalId: r.internalId,
+                          permission: checked
+                            ? selectedPermission
+                            : unselectedPermission,
+                        });
+                      },
+                    }
+                  : undefined
+              }
+              actions={
+                <div className="mr-8 flex flex-row gap-2">
+                  {r.lastUpdatedAt ? (
+                    <Tooltip
+                      contentChildren={
+                        <span>
+                          {new Date(r.lastUpdatedAt).toLocaleString()}
+                        </span>
+                      }
+                      position={i === 0 ? "below" : "above"}
+                    >
+                      <span className="text-xs text-gray-500">
+                        {timeAgoFrom(r.lastUpdatedAt)} ago
+                      </span>
+                    </Tooltip>
+                  ) : null}
+                  <IconButton
+                    size="xs"
+                    icon={ExternalLinkIcon}
+                    onClick={() => {
+                      if (r.sourceUrl) {
+                        window.open(r.sourceUrl, "_blank");
+                      }
+                    }}
+                    className={classNames(
+                      r.sourceUrl ? "" : "pointer-events-none opacity-0"
+                    )}
+                    disabled={!r.sourceUrl}
+                  />
+                  <IconButton
+                    size="xs"
+                    icon={BracesIcon}
+                    onClick={() => {
+                      if (r.dustDocumentId) {
+                        displayDocumentSource(r.dustDocumentId);
+                      }
+                    }}
+                    className={classNames(
+                      r.dustDocumentId ? "" : "pointer-events-none opacity-0"
+                    )}
+                    disabled={!r.dustDocumentId}
+                  />
+                </div>
+              }
+              renderTreeItems={() => (
+                <PermissionTreeChildren
+                  owner={owner}
+                  dataSource={dataSource}
+                  parentId={r.internalId}
+                  permissionFilter={permissionFilter}
+                  canUpdatePermissions={canUpdatePermissions}
+                  onPermissionUpdate={onPermissionUpdate}
+                  showExpand={showExpand}
+                  parentIsSelected={
+                    (parentIsSelected ||
+                      localStateByInternalId[r.internalId]) ??
+                    ["read", "read_write"].includes(r.permission)
                   }
-                : undefined
-            }
-            actions={
-              <div className="mr-8 flex flex-row gap-2">
-                {r.lastUpdatedAt ? (
-                  <Tooltip
-                    contentChildren={
-                      <span>{new Date(r.lastUpdatedAt).toLocaleString()}</span>
-                    }
-                    position={i === 0 ? "below" : "above"}
-                  >
-                    <span className="text-xs text-gray-500">
-                      {timeAgoFrom(r.lastUpdatedAt)} ago
-                    </span>
-                  </Tooltip>
-                ) : null}
-                <IconButton
-                  size="xs"
-                  icon={ExternalLinkIcon}
-                  onClick={() => {
-                    if (r.sourceUrl) {
-                      window.open(r.sourceUrl, "_blank");
-                    }
-                  }}
-                  className={classNames(
-                    r.sourceUrl ? "" : "pointer-events-none opacity-0"
-                  )}
-                  disabled={!r.sourceUrl}
+                  displayDocumentSource={displayDocumentSource}
+                  useConnectorPermissionsHook={useConnectorPermissionsHook}
+                  isSearchEnabled={isSearchEnabled}
                 />
-                <IconButton
-                  size="xs"
-                  icon={BracesIcon}
-                  onClick={() => {
-                    if (r.dustDocumentId) {
-                      displayDocumentSource(r.dustDocumentId);
-                    }
-                  }}
-                  className={classNames(
-                    r.dustDocumentId ? "" : "pointer-events-none opacity-0"
-                  )}
-                  disabled={!r.dustDocumentId}
-                />
-              </div>
-            }
-            renderTreeItems={() => (
-              <PermissionTreeChildren
-                owner={owner}
-                dataSource={dataSource}
-                parentId={r.internalId}
-                permissionFilter={permissionFilter}
-                canUpdatePermissions={canUpdatePermissions}
-                onPermissionUpdate={onPermissionUpdate}
-                showExpand={showExpand}
-                parentIsSelected={
-                  (parentIsSelected || localStateByInternalId[r.internalId]) ??
-                  ["read", "read_write"].includes(r.permission)
-                }
-                displayDocumentSource={displayDocumentSource}
-                useConnectorPermissionsHook={useConnectorPermissionsHook}
-              />
-            )}
-          />
-        );
-      })}
-    </Tree>
+              )}
+            />
+          );
+        })}
+      </Tree>
+    </>
   );
 }
 
@@ -212,6 +241,7 @@ export function PermissionTree({
   canUpdatePermissions,
   onPermissionUpdate,
   showExpand,
+  isSearchEnabled,
 }: {
   owner: WorkspaceType;
   dataSource: DataSourceType;
@@ -225,6 +255,7 @@ export function PermissionTree({
     permission: ConnectorPermission;
   }) => void;
   showExpand?: boolean;
+  isSearchEnabled: boolean;
 }) {
   const [documentToDisplay, setDocumentToDisplay] = useState<string | null>(
     null
@@ -243,6 +274,7 @@ export function PermissionTree({
           }
         }}
       />
+
       <div className="overflow-x-auto">
         <PermissionTreeChildren
           owner={owner}
@@ -257,6 +289,7 @@ export function PermissionTree({
             setDocumentToDisplay(documentId);
           }}
           useConnectorPermissionsHook={useConnectorPermissions}
+          isSearchEnabled={isSearchEnabled}
         />
       </div>
     </>

--- a/front/components/ConnectorPermissionsTree.tsx
+++ b/front/components/ConnectorPermissionsTree.tsx
@@ -223,7 +223,8 @@ export function PermissionTreeChildren({
                   }
                   displayDocumentSource={displayDocumentSource}
                   useConnectorPermissionsHook={useConnectorPermissionsHook}
-                  isSearchEnabled={isSearchEnabled}
+                  // Disable search for children
+                  isSearchEnabled={false}
                 />
               )}
             />

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -385,6 +385,7 @@ function DataSourcesSection({
                     setDocumentToDisplay(documentId);
                   }}
                   useConnectorPermissionsHook={useConnectorPermissions}
+                  isSearchEnabled={false}
                 />
               )}
               {ds && !isAllSelected && (
@@ -475,6 +476,7 @@ function DataSourceSelectedNodes({
               setDocumentToDisplay(documentId);
             }}
             useConnectorPermissionsHook={useConnectorPermissions}
+            isSearchEnabled={false}
           />
         </Tree.Item>
       ))}

--- a/front/components/assistant_builder/DataSourceSelectionSection.tsx
+++ b/front/components/assistant_builder/DataSourceSelectionSection.tsx
@@ -110,6 +110,7 @@ export default function DataSourceSelectionSection({
                         setDocumentToDisplay(documentId);
                       }}
                       useConnectorPermissionsHook={useConnectorPermissions}
+                      isSearchEnabled={false}
                     />
                   )}
                   {dsConfig.selectedResources.map((node) => {
@@ -167,6 +168,7 @@ export default function DataSourceSelectionSection({
                             setDocumentToDisplay(documentId);
                           }}
                           useConnectorPermissionsHook={useConnectorPermissions}
+                          isSearchEnabled={false}
                         />
                       </Tree.Item>
                     );

--- a/front/components/poke/PokeConnectorPermissionsTree.tsx
+++ b/front/components/poke/PokeConnectorPermissionsTree.tsx
@@ -44,6 +44,7 @@ export function PokePermissionTree({
           parentIsSelected={false}
           displayDocumentSource={displayDocumentSource}
           useConnectorPermissionsHook={usePokeConnectorPermissions}
+          isSearchEnabled={false}
         />
       </div>
     </>

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -23,6 +23,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     limitations: string | null;
     guideLink: string | null;
     isNested: boolean;
+    isSearchEnabled: boolean;
   }
 > = {
   confluence: {
@@ -37,6 +38,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     guideLink: null,
     logoComponent: ConfluenceLogo,
     isNested: true,
+    isSearchEnabled: false,
   },
   notion: {
     name: "Notion",
@@ -49,6 +51,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     guideLink: null,
     logoComponent: NotionLogo,
     isNested: true,
+    isSearchEnabled: false,
   },
   google_drive: {
     name: "Google Drive™",
@@ -62,6 +65,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     guideLink: null,
     logoComponent: DriveLogo,
     isNested: true,
+    isSearchEnabled: false,
   },
   slack: {
     name: "Slack",
@@ -74,6 +78,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     guideLink: null,
     logoComponent: SlackLogo,
     isNested: false,
+    isSearchEnabled: true,
   },
   github: {
     name: "GitHub",
@@ -87,6 +92,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     guideLink: null,
     logoComponent: GithubLogo,
     isNested: true,
+    isSearchEnabled: false,
   },
   intercom: {
     name: "Intercom",
@@ -101,6 +107,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
       "https://dust-tt.notion.site/Intercom-connection-on-Dust-193f0670d39a44de85cd472c6035ea84",
     logoComponent: IntercomLogo,
     isNested: true,
+    isSearchEnabled: false,
   },
   microsoft: {
     name: "Microsoft",
@@ -115,6 +122,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     guideLink: "https://dust-tt.notion.site/",
     logoComponent: MicrosoftLogo,
     isNested: true,
+    isSearchEnabled: false,
   },
   webcrawler: {
     name: "Web Crawler",
@@ -126,5 +134,6 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     guideLink: null,
     logoComponent: GlobeAltIcon,
     isNested: true,
+    isSearchEnabled: false,
   },
 };

--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -1377,6 +1377,7 @@ function ManagedDataSourceView({
 
           <div className="pb-8">
             <PermissionTree
+              isSearchEnabled={false}
               owner={owner}
               dataSource={dataSource}
               permissionFilter="read"


### PR DESCRIPTION
## Description

This PR enables text filtering of Slack channels when adding Slack channel to synchronize.
The text filtering is done client side, and is only enabled for Slack because it is a "one level only" data sources, which plays well with client side search (vs Google Drive, for which a client side search would never work).

This has been asked by a customer.

# Screenshot

![Screenshot 2024-06-28 at 16 54 45](https://github.com/dust-tt/dust/assets/358965/da1f6c95-df97-4297-bf38-be63eb273854)


cc @Duncid 




<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
