### PR TITLE
Refactor file upload for content fragment

### DIFF
--- a/front/components/assistant/conversation/ContentFragment.tsx
+++ b/front/components/assistant/conversation/ContentFragment.tsx
@@ -38,7 +38,7 @@ function getViewUrlForContentFragment(message: ContentFragmentType) {
   }
 
   if (isSupportedImageContentFragmentType(message.contentType)) {
-    return `${message.sourceUrl}&action=view`;
+    return `${message.sourceUrl}?action=view`;
   }
 
   return undefined;

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -28,7 +28,6 @@ import ConversationViewer from "@app/components/assistant/conversation/Conversat
 import { HelpAndQuickGuideWrapper } from "@app/components/assistant/conversation/HelpAndQuickGuideWrapper";
 import { FixedAssistantInputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
-import type { ContentFragmentInput } from "@app/components/assistant/conversation/lib";
 import {
   createConversationWithMessage,
   createPlaceholderUserMessage,

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -81,7 +81,7 @@ export function ConversationContainer({
   const handleSubmit = async (
     input: string,
     mentions: MentionType[],
-    contentFragments: ContentFragmentInput[]
+    contentFragments: UploadedContentFragment[]
   ) => {
     if (!activeConversationId) {
       return null;

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -156,6 +156,7 @@ export function AssistantInputBar({
           content: cf.content,
           file: cf.file,
           contentType: cf.contentType,
+          url: cf.url,
         };
       })
     );
@@ -163,7 +164,7 @@ export function AssistantInputBar({
     fileUploaderService.resetUpload();
   };
 
-  const fileUploaderService = useFileUploaderService();
+  const fileUploaderService = useFileUploaderService({ owner });
 
   const [isProcessing, setIsProcessing] = useState<boolean>(false);
 

--- a/front/components/assistant/conversation/input_bar/InputBarCitations.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarCitations.tsx
@@ -26,6 +26,8 @@ export function InputBarCitations({
           onClose={() => {
             fileUploaderService.removeFile(blob.id);
           }}
+          // TODO(2026-06-28 flav) Find a better way to display the file while being uploaded.
+          isBlinking={blob.isUploading}
         />
       );
     }

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -27,7 +27,14 @@ export const INPUT_BAR_ACTIONS = ["attachment", "quick-actions"] as const;
 
 export type InputBarAction = (typeof INPUT_BAR_ACTIONS)[number];
 
-const supportedFileExtensions = [".txt", ".csv", ".md", ".pdf"];
+const acceptedFileTypes = [
+  ".txt",
+  ".csv",
+  ".md",
+  ".pdf",
+  "image/jpeg",
+  "image/png",
+];
 
 export interface InputBarContainerProps {
   allAssistants: LightAgentConfigurationType[];
@@ -129,7 +136,7 @@ const InputBarContainer = ({
           {actions.includes("attachment") && (
             <>
               <input
-                accept={supportedFileExtensions.join(",")}
+                accept={acceptedFileTypes.join(",")}
                 onChange={async (e) => {
                   await fileUploaderService.handleFileChange(e);
                   editorService.focusEnd();

--- a/front/hooks/useFileUploaderService.ts
+++ b/front/hooks/useFileUploaderService.ts
@@ -11,7 +11,6 @@ import { useContext, useState } from "react";
 
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { extractTextFromPDF } from "@app/lib/client/handle_file_upload";
-// TODO(2024-06-28 flav) Rename file.
 import { getMimeTypeFromFile } from "@app/lib/file";
 
 interface FileContent {

--- a/front/hooks/useFileUploaderService.ts
+++ b/front/hooks/useFileUploaderService.ts
@@ -195,7 +195,9 @@ export function useFileUploaderService({
               b.internalId = fileId;
               b.isUploading = false;
               b.url = downloadUrl;
-              b.preview = `${downloadUrl}?action=view`;
+              b.preview = b.contentType.startsWith("image/")
+                ? `${downloadUrl}?action=view`
+                : undefined;
             }
 
             return b;

--- a/front/hooks/useFileUploaderService.ts
+++ b/front/hooks/useFileUploaderService.ts
@@ -255,12 +255,25 @@ export function useFileUploaderService({
   };
 
   const removeFile = (fileId: string) => {
-    // TODO(2024-06-28 flav) Delete on the remote if the file is removed.
-    setFileBlobs((prevFiles) => prevFiles.filter((file) => file.id !== fileId));
+    const fileBlob = fileBlobs.find((f) => f.id === fileId);
 
-    const allFilesReady = fileBlobs.every((f) => !!f.url);
-    if (allFilesReady && isProcessingFiles) {
-      setIsProcessingFiles(false);
+    if (fileBlob) {
+      setFileBlobs((prevFiles) =>
+        prevFiles.filter((f) => f.internalId !== fileBlob?.internalId)
+      );
+
+      // Intentionally not awaiting the fetch call to allow it to run asynchronously.
+      void fetch(`/api/w/${owner.sId}/files/${fileBlob.internalId}`, {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+
+      const allFilesReady = fileBlobs.every((f) => !!f.url);
+      if (allFilesReady && isProcessingFiles) {
+        setIsProcessingFiles(false);
+      }
     }
   };
 

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -62,8 +62,8 @@ import {
   batchRenderContentFragment,
   batchRenderUserMessages,
 } from "@app/lib/api/assistant/messages";
+import { isFileUrlInWorkspace } from "@app/lib/api/files";
 import type { Authenticator } from "@app/lib/auth";
-import { isFileUrlInWorkspace } from "@app/lib/files";
 import {
   AgentMessage,
   Conversation,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1638,7 +1638,7 @@ export async function postNewContentFragment(
     // Use the provided URL if it is an internal file path.
     sourceUrl = url;
   } else if (isSupportedUploadableContentFragmentType(contentType)) {
-    // For supported content types, create a file path and use its download URL.
+    // Deprecated, for supported content types, create a file path and use its download URL.
     sourceUrl = fileAttachmentLocation({
       workspaceId: owner.sId,
       conversationId: conversation.sId,

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -19,6 +19,9 @@ const config = {
   getDustInviteTokenSecret: (): string => {
     return EnvironmentConfig.getEnvVariable("DUST_INVITE_TOKEN_SECRET");
   },
+  getFileIdSecret: (): string => {
+    return EnvironmentConfig.getEnvVariable("DUST_FILE_TOKEN_SECRET");
+  },
   getSendgridApiKey: (): string => {
     return EnvironmentConfig.getEnvVariable("SENDGRID_API_KEY");
   },

--- a/front/lib/api/files.ts
+++ b/front/lib/api/files.ts
@@ -11,8 +11,6 @@ import config from "@app/lib/api/config";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { generateModelSId } from "@app/lib/utils";
 
-// TODO(2024-06-28 flav) Rename this file.
-
 const FILE_ID_PREFIX = "file_";
 
 type FileId = `${typeof FILE_ID_PREFIX}${string}`;

--- a/front/lib/file.ts
+++ b/front/lib/file.ts
@@ -1,3 +1,5 @@
+// These are the front-end helpers.
+
 function isMarkdownFile(file: File): boolean {
   if (file.type === "") {
     const fileExtension = file.name.split(".").at(-1)?.toLowerCase();

--- a/front/lib/file_storage/index.ts
+++ b/front/lib/file_storage/index.ts
@@ -35,6 +35,9 @@ class FileStorage {
       gcsFile.createWriteStream({
         metadata: {
           contentType: file.mimetype,
+          metadata: {
+            fileName: file.originalFilename,
+          },
         },
       })
     );
@@ -58,13 +61,19 @@ class FileStorage {
 
   async uploadStream(
     filePath: string,
-    contentType: string | null,
-    fileStream: Readable
+    fileStream: Readable,
+    metadata: {
+      contentType: string | null;
+      fileName?: string;
+    }
   ) {
     const gcsFile = this.file(filePath);
     const writeStream = gcsFile.createWriteStream({
       metadata: {
-        contentType: contentType,
+        contentType: metadata.contentType,
+        metadata: {
+          fileName: metadata.fileName,
+        },
       },
     });
 

--- a/front/lib/file_storage/index.ts
+++ b/front/lib/file_storage/index.ts
@@ -1,5 +1,3 @@
-import type { Result } from "@dust-tt/types";
-import { Err, Ok } from "@dust-tt/types";
 import type { Bucket } from "@google-cloud/storage";
 import { Storage } from "@google-cloud/storage";
 import type formidable from "formidable";

--- a/front/lib/files.ts
+++ b/front/lib/files.ts
@@ -17,7 +17,7 @@ const FILE_ID_PREFIX = "file_";
 
 type FileId = `${typeof FILE_ID_PREFIX}${string}`;
 
-export function makeFileId(): FileId {
+export function makeDustFileId(): FileId {
   const fileId = generateModelSId();
   return `${FILE_ID_PREFIX}${fileId}`;
 }
@@ -82,8 +82,6 @@ interface FileTokenPayload {
   workspaceId: string;
 }
 
-type DecodedFileTokenPayload = FileTokenPayload & { iat: number };
-
 export function encodeFilePayload(
   owner: LightWorkspaceType,
   payload: Omit<FileTokenPayload, "workspaceId">
@@ -98,12 +96,12 @@ export function encodeFilePayload(
   );
 }
 
-export function decodeFileToken(token: string): DecodedFileTokenPayload | null {
+export function decodeFileToken(token: string): FileTokenPayload | null {
   try {
     const decoded = jwt.verify(
       token,
       config.getFileIdSecret()
-    ) as DecodedFileTokenPayload;
+    ) as FileTokenPayload;
 
     return decoded;
   } catch (err) {
@@ -127,7 +125,7 @@ export function isSupportedTextMimeType(file: formidable.File): boolean {
 
 export async function uploadToFileStorage(
   owner: LightWorkspaceType,
-  fileTokenPayload: DecodedFileTokenPayload,
+  fileTokenPayload: FileTokenPayload,
   file: formidable.File
 ) {
   const filePath = makeStorageFilePathForWorkspaceId(
@@ -156,7 +154,7 @@ export function isSupportedImageMimeType(file: formidable.File): boolean {
 
 export async function resizeAndUploadToFileStorage(
   owner: LightWorkspaceType,
-  fileTokenPayload: DecodedFileTokenPayload,
+  fileTokenPayload: FileTokenPayload,
   file: formidable.File
 ) {
   const filePath = makeStorageFilePathForWorkspaceId(

--- a/front/lib/files.ts
+++ b/front/lib/files.ts
@@ -71,6 +71,24 @@ export async function getSignedUrlForFile(
   return null;
 }
 
+export async function getFileNameFromFileMetadata(
+  filePath: string
+): Promise<string | null> {
+  const metadata = await getPrivateUploadBucket().file(filePath).getMetadata();
+
+  const [m] = metadata;
+
+  if (
+    typeof m.metadata === "object" &&
+    m.metadata !== null &&
+    typeof m.metadata.fileName === "string"
+  ) {
+    return m.metadata.fileName;
+  }
+
+  return null;
+}
+
 /**
  * File id logic.
  */
@@ -168,11 +186,10 @@ export async function resizeAndUploadToFileStorage(
     withoutEnlargement: true, // Avoid upscaling if image is smaller than 768px.
   });
 
-  await getPrivateUploadBucket().uploadStream(
-    filePath,
-    file.mimetype,
-    resizedImageStream
-  );
+  await getPrivateUploadBucket().uploadStream(filePath, resizedImageStream, {
+    contentType: file.mimetype,
+    fileName: file.originalFilename ?? file.newFilename,
+  });
 
   return filePath;
 }

--- a/front/lib/files.ts
+++ b/front/lib/files.ts
@@ -1,0 +1,180 @@
+import type { LightWorkspaceType } from "@dust-tt/types";
+import {
+  isSupportedImageContentFragmentType,
+  isSupportedTextContentFragmentType,
+} from "@dust-tt/types";
+import type formidable from "formidable";
+import jwt from "jsonwebtoken";
+import sharp from "sharp";
+
+import config from "@app/lib/api/config";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { generateModelSId } from "@app/lib/utils";
+
+// TODO(2024-06-28 flav) Rename this file.
+
+const FILE_ID_PREFIX = "file_";
+
+type FileId = `${typeof FILE_ID_PREFIX}${string}`;
+
+export function makeFileId(): FileId {
+  const fileId = generateModelSId();
+  return `${FILE_ID_PREFIX}${fileId}`;
+}
+
+export function isDustFileId(fileId: string): fileId is FileId {
+  return fileId.startsWith(FILE_ID_PREFIX);
+}
+
+export function makeStorageFilePathForWorkspaceId(
+  owner: LightWorkspaceType,
+  fileId: FileId
+) {
+  return `files/w/${owner.sId}/${fileId}`;
+}
+
+function getBasePathForWorkspacesFiles(owner: LightWorkspaceType) {
+  return `${config.getAppUrl()}/api/w/${owner.sId}/files/`;
+}
+
+export function isFileUrlInWorkspace(
+  owner: LightWorkspaceType,
+  fileUrl: string
+) {
+  const workspaceBasePath = getBasePathForWorkspacesFiles(owner);
+
+  return fileUrl.startsWith(workspaceBasePath);
+}
+
+export function getDownloadUrlForFileId(
+  owner: LightWorkspaceType,
+  fileId: FileId
+) {
+  return `${getBasePathForWorkspacesFiles(owner)}${fileId}`;
+}
+
+export async function getSignedUrlForFile(
+  owner: LightWorkspaceType,
+  url: string | null
+): Promise<string | null> {
+  if (!url) {
+    return null;
+  }
+
+  const fileId = url.replace(getBasePathForWorkspacesFiles(owner), "");
+  if (isDustFileId(fileId)) {
+    const filePath = makeStorageFilePathForWorkspaceId(owner, fileId);
+
+    return getPrivateUploadBucket().getSignedUrl(filePath);
+  }
+
+  return null;
+}
+
+/**
+ * File id logic.
+ */
+
+interface FileTokenPayload {
+  fileId: FileId;
+  fileName: string;
+  fileSize: number;
+  workspaceId: string;
+}
+
+type DecodedFileTokenPayload = FileTokenPayload & { iat: number };
+
+export function encodeFilePayload(
+  owner: LightWorkspaceType,
+  payload: Omit<FileTokenPayload, "workspaceId">
+) {
+  return jwt.sign(
+    {
+      workspaceId: owner.sId,
+      ...payload,
+    },
+    config.getFileIdSecret(),
+    { expiresIn: "30s" } // Token expiration set to 30 seconds.
+  );
+}
+
+export function decodeFileToken(token: string): DecodedFileTokenPayload | null {
+  try {
+    const decoded = jwt.verify(
+      token,
+      config.getFileIdSecret()
+    ) as DecodedFileTokenPayload;
+
+    return decoded;
+  } catch (err) {
+    return null;
+  }
+}
+
+/**
+ * Text files handling.
+ */
+
+export function isSupportedTextMimeType(file: formidable.File): boolean {
+  const { mimetype } = file;
+
+  if (!mimetype || !isSupportedTextContentFragmentType(mimetype)) {
+    return false;
+  }
+
+  return true;
+}
+
+export async function uploadToFileStorage(
+  owner: LightWorkspaceType,
+  fileTokenPayload: DecodedFileTokenPayload,
+  file: formidable.File
+) {
+  const filePath = makeStorageFilePathForWorkspaceId(
+    owner,
+    fileTokenPayload.fileId
+  );
+
+  await getPrivateUploadBucket().uploadFileToBucket(file, filePath);
+
+  return filePath;
+}
+
+/**
+ * Image files handling.
+ */
+
+export function isSupportedImageMimeType(file: formidable.File): boolean {
+  const { mimetype } = file;
+
+  if (!mimetype || !isSupportedImageContentFragmentType(mimetype)) {
+    return false;
+  }
+
+  return true;
+}
+
+export async function resizeAndUploadToFileStorage(
+  owner: LightWorkspaceType,
+  fileTokenPayload: DecodedFileTokenPayload,
+  file: formidable.File
+) {
+  const filePath = makeStorageFilePathForWorkspaceId(
+    owner,
+    fileTokenPayload.fileId
+  );
+
+  // Resize the image, preserving the aspect ratio. Longest side is max 768px.
+  const resizedImageStream = sharp(file.filepath).resize(768, 768, {
+    fit: sharp.fit.inside, // Ensure longest side is 768px.
+    withoutEnlargement: true, // Avoid upscaling if image is smaller than 768px.
+  });
+
+  await getPrivateUploadBucket().uploadStream(
+    filePath,
+    file.mimetype,
+    resizedImageStream
+  );
+
+  return filePath;
+}

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -15,9 +15,9 @@ import type {
 } from "sequelize";
 
 import appConfig from "@app/lib/api/config";
+import { getSignedUrlForFile } from "@app/lib/api/files";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
-import { getSignedUrlForFile } from "@app/lib/files";
 import { Message } from "@app/lib/models/assistant/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -105,6 +105,7 @@
         "remark-gfm": "^3.0.1",
         "sanitize-html": "^2.13.0",
         "sequelize": "^6.31.0",
+        "sharp": "^0.33.4",
         "showdown": "^2.1.0",
         "slick-carousel": "^1.8.1",
         "sqlite3": "^5.1.4",
@@ -11427,6 +11428,15 @@
       "resolved": "../types",
       "link": true
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.2.0.tgz",
+      "integrity": "sha512-bV21/9LQmcQeCPEg3BDFtvwL6cwiTMksYNWQQ4KOxCZikEGalWtenoZ0wCiukJINlGCIi2KXx01g4FoH/LxpzQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emoji-mart/data": {
       "version": "1.1.2",
       "license": "MIT"
@@ -12256,6 +12266,437 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA=="
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.4.tgz",
+      "integrity": "sha512-p0suNqXufJs9t3RqLBO6vvrgr5OhgbWp76s5gTRvdmxmuv9E1rcaqGUsl3l4mKVmXPkTkTErXediAui4x+8PSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "glibc": ">=2.26",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.2"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.4.tgz",
+      "integrity": "sha512-0l7yRObwtTi82Z6ebVI2PnHT8EB2NxBgpK2MiKJZJ7cz32R4lxd001ecMhzzsZig3Yv9oclvqqdV93jo9hy+Dw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "glibc": ">=2.26",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.2"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.2.tgz",
+      "integrity": "sha512-tcK/41Rq8IKlSaKRCCAuuY3lDJjQnYIW1UXU1kxcEKrfL8WR7N6+rzNoOxoQRJWTAECuKwgAHnPvqXGN8XfkHA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "macos": ">=11",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.2.tgz",
+      "integrity": "sha512-Ofw+7oaWa0HiiMiKWqqaZbaYV3/UGL2wAPeLuJTx+9cXpCRdvQhCLG0IH8YGwM0yGWGLpsF4Su9vM1o6aer+Fw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "macos": ">=10.13",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.2.tgz",
+      "integrity": "sha512-iLWCvrKgeFoglQxdEwzu1eQV04o8YeYGFXtfWU26Zr2wWT3q3MTzC+QTCO3ZQfWd3doKHT4Pm2kRmLbupT+sZw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "glibc": ">=2.28",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.2.tgz",
+      "integrity": "sha512-x7kCt3N00ofFmmkkdshwj3vGPCnmiDh7Gwnd4nUwZln2YjqPxV1NlTyZOvoDWdKQVDL911487HOueBvrpflagw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "glibc": ">=2.26",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.2.tgz",
+      "integrity": "sha512-cmhQ1J4qVhfmS6szYW7RT+gLJq9dH2i4maq+qyXayUSn9/3iY2ZeWpbAgSpSVbV2E1JUL2Gg7pwnYQ1h8rQIog==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "glibc": ">=2.28",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.2.tgz",
+      "integrity": "sha512-E441q4Qdb+7yuyiADVi5J+44x8ctlrqn8XgkDTwr4qPJzWkaHwD489iZ4nGDgcuya4iMN3ULV6NwbhRZJ9Z7SQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "glibc": ">=2.26",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.2.tgz",
+      "integrity": "sha512-3CAkndNpYUrlDqkCM5qhksfE+qSIREVpyoeHIU6jd48SJZViAmznoQQLAv4hVXF7xyUB9zf+G++e2v1ABjCbEQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "musl": ">=1.2.2",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.2.tgz",
+      "integrity": "sha512-VI94Q6khIHqHWNOh6LLdm9s2Ry4zdjWJwH56WoiJU7NTeDwyApdZZ8c+SADC8OH98KWNQXnE01UdJ9CSfZvwZw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "musl": ">=1.2.2",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.4.tgz",
+      "integrity": "sha512-RUgBD1c0+gCYZGCCe6mMdTiOFS0Zc/XrN0fYd6hISIKcDUbAW5NtSQW9g/powkrXYm6Vzwd6y+fqmExDuCdHNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "glibc": ">=2.28",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.4.tgz",
+      "integrity": "sha512-2800clwVg1ZQtxwSoTlHvtm9ObgAax7V6MTAB/hDT945Tfyy3hVkmiHpeLPCKYqYR1Gcmv1uDZ3a4OFwkdBL7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "glibc": ">=2.26",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.4.tgz",
+      "integrity": "sha512-h3RAL3siQoyzSoH36tUeS0PDmb5wINKGYzcLB5C6DIiAn2F3udeFAum+gj8IbA/82+8RGCTn7XW8WTFnqag4tQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "glibc": ">=2.31",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.4.tgz",
+      "integrity": "sha512-GoR++s0XW9DGVi8SUGQ/U4AeIzLdNjHka6jidVwapQ/JebGVQIpi52OdyxCNVRE++n1FCLzjDovJNozif7w/Aw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "glibc": ">=2.26",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.4.tgz",
+      "integrity": "sha512-nhr1yC3BlVrKDTl6cO12gTpXMl4ITBUZieehFvMntlCXFzH2bvKG76tBL2Y/OqhupZt81pR7R+Q5YhJxW0rGgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "musl": ">=1.2.2",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.4.tgz",
+      "integrity": "sha512-uCPTku0zwqDmZEOi4ILyGdmW76tH7dm8kKlOIV1XC5cLyJ71ENAAqarOHQh0RLfpIpbV5KOpXzdU6XkJtS0daw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "musl": ">=1.2.2",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.2"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.4.tgz",
+      "integrity": "sha512-Bmmauh4sXUsUqkleQahpdNXKvo+wa1V9KhT2pDA4VJGKwnKMJXiSTGphn0gnJrlooda0QxCtXc6RX1XAU6hMnQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.4.tgz",
+      "integrity": "sha512-99SJ91XzUhYHbx7uhK3+9Lf7+LjwMGQZMDlO/E/YVJ7Nc3lyDFZPGhjwiYdctoH2BOzW9+TnfqcaMKt0jHLdqw==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.4.tgz",
+      "integrity": "sha512-3QLocdTRVIrFNye5YocZl+KKpYKP+fksi1QhmOArgx7GyhIbQp/WrJRu176jm8IxromS7RIkzMiMINVdBtC8Aw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -18572,6 +19013,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "license": "MIT",
@@ -18585,6 +19038,15 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/color-support": {
       "version": "1.1.3",
@@ -19763,8 +20225,9 @@
       }
     },
     "node_modules/detect-libc": {
-      "version": "2.0.2",
-      "license": "Apache-2.0",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
       "engines": {
         "node": ">=8"
       }
@@ -31831,6 +32294,45 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/sharp": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.4.tgz",
+      "integrity": "sha512-7i/dt5kGl7qR4gwPRD2biwD2/SvBn3O04J77XKFgL2OnZtQw+AG9wnuS/csmu80nPRHLYE9E41fyEiG8nhH6/Q==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.0"
+      },
+      "engines": {
+        "libvips": ">=8.15.2",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.4",
+        "@img/sharp-darwin-x64": "0.33.4",
+        "@img/sharp-libvips-darwin-arm64": "1.0.2",
+        "@img/sharp-libvips-darwin-x64": "1.0.2",
+        "@img/sharp-libvips-linux-arm": "1.0.2",
+        "@img/sharp-libvips-linux-arm64": "1.0.2",
+        "@img/sharp-libvips-linux-s390x": "1.0.2",
+        "@img/sharp-libvips-linux-x64": "1.0.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.2",
+        "@img/sharp-linux-arm": "0.33.4",
+        "@img/sharp-linux-arm64": "0.33.4",
+        "@img/sharp-linux-s390x": "0.33.4",
+        "@img/sharp-linux-x64": "0.33.4",
+        "@img/sharp-linuxmusl-arm64": "0.33.4",
+        "@img/sharp-linuxmusl-x64": "0.33.4",
+        "@img/sharp-wasm32": "0.33.4",
+        "@img/sharp-win32-ia32": "0.33.4",
+        "@img/sharp-win32-x64": "0.33.4"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "license": "MIT",
@@ -31914,6 +32416,19 @@
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
       }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",

--- a/front/package.json
+++ b/front/package.json
@@ -117,6 +117,7 @@
     "remark-gfm": "^3.0.1",
     "sanitize-html": "^2.13.0",
     "sequelize": "^6.31.0",
+    "sharp": "^0.33.4",
     "showdown": "^2.1.0",
     "slick-carousel": "^1.8.1",
     "sqlite3": "^5.1.4",

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/raw_content_fragment/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/raw_content_fragment/index.ts
@@ -11,9 +11,7 @@ import { apiError, withLogging } from "@app/logger/withlogging";
 const privateUploadGcs = getPrivateUploadBucket();
 
 const validFormats = ["raw", "text"] as const;
-const validActions = ["view", "download"] as const;
 type ContentFormat = (typeof validFormats)[number];
-type Action = (typeof validActions)[number];
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/files/[fileId].ts
+++ b/front/pages/api/w/[wId]/files/[fileId].ts
@@ -117,6 +117,15 @@ async function handler(
       return;
     }
 
+    case "DELETE": {
+      const filePath = makeStorageFilePathForWorkspaceId(owner, fileId);
+
+      await getPrivateUploadBucket().delete(filePath);
+
+      res.status(204).end();
+      return;
+    }
+
     case "POST": {
       if (typeof token !== "string") {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/files/[fileId].ts
+++ b/front/pages/api/w/[wId]/files/[fileId].ts
@@ -2,8 +2,6 @@ import type { WithAPIErrorReponse } from "@dust-tt/types";
 import { IncomingForm } from "formidable";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { Authenticator, getSession } from "@app/lib/auth";
-import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import {
   decodeFileToken,
   getDownloadUrlForFileId,
@@ -14,7 +12,9 @@ import {
   makeStorageFilePathForWorkspaceId,
   resizeAndUploadToFileStorage,
   uploadToFileStorage,
-} from "@app/lib/files";
+} from "@app/lib/api/files";
+import { Authenticator, getSession } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
 export const config = {

--- a/front/pages/api/w/[wId]/files/[fileId].ts
+++ b/front/pages/api/w/[wId]/files/[fileId].ts
@@ -18,7 +18,7 @@ import { apiError, withLogging } from "@app/logger/withlogging";
 
 export const config = {
   api: {
-    bodyParser: false, // Disabling Next.js's body parser as formidable has its own
+    bodyParser: false, // Disabling Next.js's body parser as formidable has its own.
   },
 };
 
@@ -160,7 +160,7 @@ async function handler(
         if (isSupportedImageMimeType(file)) {
           await resizeAndUploadToFileStorage(owner, fileTokenPayload, file);
         } else if (isSupportedTextMimeType(file)) {
-          // TODO: Move logic to extract text from PDF here.
+          // TODO:(2026-06-28 flav) Move logic to extract text from PDF here.
           await uploadToFileStorage(owner, fileTokenPayload, file);
         } else {
           return apiError(req, res, {

--- a/front/pages/api/w/[wId]/files/[fileId].ts
+++ b/front/pages/api/w/[wId]/files/[fileId].ts
@@ -7,6 +7,7 @@ import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import {
   decodeFileToken,
   getDownloadUrlForFileId,
+  getFileNameFromFileMetadata,
   isDustFileId,
   isSupportedImageMimeType,
   isSupportedTextMimeType,
@@ -103,12 +104,13 @@ async function handler(
         return;
       }
 
+      const fileName = await getFileNameFromFileMetadata(filePath);
+
       // Redirect to a signed URL.
       const url = await getPrivateUploadBucket().getSignedUrl(filePath, {
         // Since we redirect, the use is immediate so expiry can be short.
         expirationDelay: 10 * 1000,
-        // TODO:(2024-06-26 flav) Improve file name + extension.
-        promptSaveAs: `dust_${fileId}`,
+        promptSaveAs: fileName ?? `dust_${fileId}`,
       });
 
       res.redirect(url);

--- a/front/pages/api/w/[wId]/files/[fileId].ts
+++ b/front/pages/api/w/[wId]/files/[fileId].ts
@@ -1,0 +1,206 @@
+import type { WithAPIErrorReponse } from "@dust-tt/types";
+import { IncomingForm } from "formidable";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { Authenticator, getSession } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import {
+  decodeFileToken,
+  getDownloadUrlForFileId,
+  isDustFileId,
+  isSupportedImageMimeType,
+  isSupportedTextMimeType,
+  makeStorageFilePathForWorkspaceId,
+  resizeAndUploadToFileStorage,
+  uploadToFileStorage,
+} from "@app/lib/files";
+import { apiError, withLogging } from "@app/logger/withlogging";
+
+export const config = {
+  api: {
+    bodyParser: false, // Disabling Next.js's body parser as formidable has its own
+  },
+};
+
+const validActions = ["view", "download"] as const;
+type Action = (typeof validActions)[number];
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorReponse<{ downloadUrl: string }>>
+): Promise<void> {
+  const session = await getSession(req, res);
+  const auth = await Authenticator.fromSession(
+    session,
+    req.query.wId as string
+  );
+
+  const owner = auth.workspace();
+  if (!owner) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace you're trying to modify was not found.",
+      },
+    });
+  }
+
+  const user = auth.user();
+  if (!user) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_user_not_found",
+        message: "Could not find the user of the current session.",
+      },
+    });
+  }
+
+  if (!auth.isUser()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users of the current workspace can update chat sessions.",
+      },
+    });
+  }
+
+  const { fileId, token } = req.query;
+  if (typeof fileId !== "string" || !isDustFileId(fileId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing fileId query parameter.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const action: Action = validActions.includes(req.query.action as Action)
+        ? (req.query.action as Action)
+        : "download";
+
+      const filePath = makeStorageFilePathForWorkspaceId(owner, fileId);
+
+      if (action === "view") {
+        const stream = await getPrivateUploadBucket().fetchWithStream(filePath);
+        stream.on("error", () => {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "message_not_found",
+              message: "File not found.",
+            },
+          });
+        });
+
+        stream.pipe(res);
+        return;
+      }
+
+      // Redirect to a signed URL.
+      const url = await getPrivateUploadBucket().getSignedUrl(filePath, {
+        // Since we redirect, the use is immediate so expiry can be short.
+        expirationDelay: 10 * 1000,
+        // TODO:(2024-06-26 flav) Improve file name + extension.
+        promptSaveAs: `dust_${fileId}`,
+      });
+
+      res.redirect(url);
+      return;
+    }
+
+    case "POST": {
+      if (typeof token !== "string") {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Invalid token.",
+          },
+        });
+      }
+
+      // Ensure that the file token is valid.
+      const fileTokenPayload = decodeFileToken(token);
+
+      if (!fileTokenPayload || fileTokenPayload.fileId !== fileId) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Invalid file id.",
+          },
+        });
+      }
+
+      try {
+        const form = new IncomingForm();
+        const [, files] = await form.parse(req);
+
+        const maybeFiles = files.file;
+
+        if (!maybeFiles || maybeFiles.length === 0) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: "No file uploaded",
+            },
+          });
+        }
+
+        const [file] = maybeFiles;
+
+        if (isSupportedImageMimeType(file)) {
+          await resizeAndUploadToFileStorage(owner, fileTokenPayload, file);
+        } else if (isSupportedTextMimeType(file)) {
+          // TODO: Move logic to extract text from PDF here.
+          await uploadToFileStorage(owner, fileTokenPayload, file);
+        } else {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: "File type not supported.",
+            },
+          });
+        }
+
+        res
+          .status(200)
+          .json({ downloadUrl: getDownloadUrlForFileId(owner, fileId) });
+        return;
+      } catch (error) {
+        return apiError(
+          req,
+          res,
+          {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: "Error uploading file.",
+            },
+          },
+          error instanceof Error ? error : new Error(JSON.stringify(error))
+        );
+      }
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);

--- a/front/pages/api/w/[wId]/files/index.ts
+++ b/front/pages/api/w/[wId]/files/index.ts
@@ -9,7 +9,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import config from "@app/lib/api/config";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { encodeFilePayload, makeFileId } from "@app/lib/files";
+import { encodeFilePayload, makeDustFileId } from "@app/lib/files";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
 async function handler(
@@ -71,7 +71,7 @@ async function handler(
 
       const { fileName, fileSize } = bodyValidation.right;
 
-      const fileId = makeFileId();
+      const fileId = makeDustFileId();
       const fileToken = encodeFilePayload(owner, {
         fileId,
         fileName,

--- a/front/pages/api/w/[wId]/files/index.ts
+++ b/front/pages/api/w/[wId]/files/index.ts
@@ -1,0 +1,98 @@
+import type {
+  FileUploadRequestResponseBody,
+  WithAPIErrorReponse,
+} from "@dust-tt/types";
+import { FileUploadUrlRequestSchema } from "@dust-tt/types";
+import { isLeft } from "fp-ts/lib/Either";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import config from "@app/lib/api/config";
+import { Authenticator, getSession } from "@app/lib/auth";
+import { encodeFilePayload, makeFileId } from "@app/lib/files";
+import { apiError, withLogging } from "@app/logger/withlogging";
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorReponse<FileUploadRequestResponseBody>>
+): Promise<void> {
+  const session = await getSession(req, res);
+  const auth = await Authenticator.fromSession(
+    session,
+    req.query.wId as string
+  );
+
+  const owner = auth.workspace();
+  if (!owner) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace you're trying to modify was not found.",
+      },
+    });
+  }
+
+  const user = auth.user();
+  if (!user) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_user_not_found",
+        message: "Could not find the user of the current session.",
+      },
+    });
+  }
+
+  if (!auth.isUser()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users of the current workspace can update chat sessions.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST": {
+      const bodyValidation = FileUploadUrlRequestSchema.decode(req.body);
+      if (isLeft(bodyValidation)) {
+        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `The request body is invalid: ${pathError}`,
+          },
+        });
+      }
+
+      const { fileName, fileSize } = bodyValidation.right;
+
+      const fileId = makeFileId();
+      const fileToken = encodeFilePayload(owner, {
+        fileId,
+        fileName,
+        fileSize,
+      });
+
+      const uploadUrl = `${config.getAppUrl()}/api/w/${owner.sId}/files/${fileId}?token=${fileToken}`;
+
+      res.status(200).json({ fileId, uploadUrl });
+      return;
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);

--- a/front/pages/api/w/[wId]/files/index.ts
+++ b/front/pages/api/w/[wId]/files/index.ts
@@ -11,8 +11,8 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import config from "@app/lib/api/config";
+import { encodeFilePayload, makeDustFileId } from "@app/lib/api/files";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { encodeFilePayload, makeDustFileId } from "@app/lib/files";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
 async function handler(

--- a/types/src/front/content_fragment.ts
+++ b/types/src/front/content_fragment.ts
@@ -78,6 +78,7 @@ export type UploadedContentFragment = {
   content: string;
   file: File;
   contentType: SupportedContentFragmentType;
+  url: string | null;
 };
 
 export function isContentFragmentType(

--- a/types/src/front/files.ts
+++ b/types/src/front/files.ts
@@ -1,8 +1,14 @@
 import * as t from "io-ts";
 
+import {
+  isSupportedImageContentFragmentType,
+  isSupportedTextContentFragmentType,
+} from "./content_fragment";
+
 // File upload form validation.
 
 export const FileUploadUrlRequestSchema = t.type({
+  contentType: t.string,
   fileName: t.string,
   fileSize: t.number,
 });
@@ -14,4 +20,21 @@ export type FileUploadUrlRequestType = t.TypeOf<
 export interface FileUploadRequestResponseBody {
   fileId: string;
   uploadUrl: string;
+}
+
+export const MAX_TEXT_FILE_SIZE = 30 * 1024 * 1024; // 30MB in bytes.
+
+export const MAX_IMAGE_FILE_SIZE = 3 * 1024 * 1024; // 3MB in bytes.
+
+// TODO: (2024-06-28 flav) Rename all occurrences of content fragment from the file logic.
+export function getMaximumFileSizeForContentType(
+  fileContentType: string
+): number {
+  if (isSupportedImageContentFragmentType(fileContentType)) {
+    return MAX_IMAGE_FILE_SIZE;
+  } else if (isSupportedTextContentFragmentType(fileContentType)) {
+    return MAX_TEXT_FILE_SIZE;
+  }
+
+  return 0;
 }

--- a/types/src/front/files.ts
+++ b/types/src/front/files.ts
@@ -5,8 +5,6 @@ import * as t from "io-ts";
 export const FileUploadUrlRequestSchema = t.type({
   fileName: t.string,
   fileSize: t.number,
-  // TODO(2024-06-28 flav) Refine based on accepted content types.
-  contentType: t.string,
 });
 
 export type FileUploadUrlRequestType = t.TypeOf<

--- a/types/src/front/files.ts
+++ b/types/src/front/files.ts
@@ -1,0 +1,19 @@
+import * as t from "io-ts";
+
+// File upload form validation.
+
+export const FileUploadUrlRequestSchema = t.type({
+  fileName: t.string,
+  fileSize: t.number,
+  // TODO(2024-06-28 flav) Refine based on accepted content types.
+  contentType: t.string,
+});
+
+export type FileUploadUrlRequestType = t.TypeOf<
+  typeof FileUploadUrlRequestSchema
+>;
+
+export interface FileUploadRequestResponseBody {
+  fileId: string;
+  uploadUrl: string;
+}

--- a/types/src/front/lib/error.ts
+++ b/types/src/front/lib/error.ts
@@ -78,7 +78,10 @@ export type APIErrorType =
   // Labs:
   | "transcripts_configuration_not_found"
   | "transcripts_configuration_default_not_allowed"
-  | "transcripts_configuration_already_exists";
+  | "transcripts_configuration_already_exists"
+  // Files:
+  | "file_too_large"
+  | "file_type_not_supported";
 
 export type APIError = {
   type: APIErrorType;

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -36,6 +36,7 @@ export * from "./front/dataset";
 export * from "./front/document";
 export * from "./front/dust_app_secret";
 export * from "./front/feature_flags";
+export * from "./front/files";
 export * from "./front/key";
 export * from "./front/lib/actions/registry";
 export * from "./front/lib/actions/types";


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

### Summary

While working on vision, we identified a race condition in the process of uploading content fragment files. Currently, we create the conversation/post the message with the content fragment before uploading the associated file, which causes issues. As we plan to use URLs for vision and need to resize images (increasing upload time), the existing logic needs an refactoring.

### Key Changes

This PR revamps the current logic, separating files from content fragments. While files will still be used within content fragments, they can now exist independently. The goal is to achieve this separation without storing every file in a database. The main changes include:

1. **New Endpoint  `/files`**: This endpoint must be called first, allowing the client to obtain a file ID. The endpoint returns the file ID and a signed (using JWT) upload URL valid for 30 seconds.
2. **New Endpoint `/files/:fileId`**: This endpoint supports both file upload and retrieval. For uploads, the client must provide the token to verify that the file ID was generated by our system. While it currently doesn't process textual files, it does resize images. Once the file is uploaded, the endpoint returns a download URL, which can be used in the `url` field of a content fragment.

The `useFileUploaderService` has been adjusted to accommodate these changes. Previously, no special handling was done until files were submitted. With the new approach, files are uploaded to our cloud storage as soon as they are uploaded to the system, unblocking the send button only after the upload and resizing are complete. This avoids impacting the chat experience.

### Impact on Production

- All files must now be uploaded using the new architecture to be used in content fragments.
- Text extraction remains on the front-end for now but will soon be moved to the new pattern.
- Legacy logic for uploading raw files post-content fragment creation is removed.

### Trade-offs and Future Considerations

This solution has some trade-offs, such as the inability to recompute file IDs and the loss of the current GCS structure of conversation/message/content. There is also the potential for "ghost" files to remain in the system if they are added to the input bar but never sent. However, these drawbacks are acceptable given the increased flexibility needed for future file handling enhancements.

### Note on Public API

These changes do not yet apply to the public API but will be rolled out once vision becomes generally available.

### Image Resizing

Based on experiments with vision, we plan to resize the largest side of images down to 768px.

### Follow up work
- [x] Implement file deletion when files are being removed from the input bar 

### Demos

![ImageUpload](https://github.com/dust-tt/dust/assets/7428970/656aa0f9-220c-48eb-961c-c7331e5047d3)

![PDFUpload](https://github.com/dust-tt/dust/assets/7428970/2bae63c0-e1a6-418a-a359-ed5b3fafc435)

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Worst case, file upload is broken.

⚠️ Rolling back is not fully safe, as it will disrupt the file downloads for files created while this code was in production.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
