### PR TITLE
[front] fix: Reset input value once file is added

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -132,6 +132,9 @@ const InputBarContainer = ({
                 accept={supportedFileExtensions.join(",")}
                 onChange={async (e) => {
                   await fileUploaderService.handleFileChange(e);
+                  if (fileInputRef.current) {
+                    fileInputRef.current.value = "";
+                  }
                   editorService.focusEnd();
                 }}
                 ref={fileInputRef}

--- a/front/hooks/useFileUploaderService.ts
+++ b/front/hooks/useFileUploaderService.ts
@@ -49,9 +49,10 @@ export function useFileUploaderService() {
   const sendNotification = useContext(SendNotificationsContext);
 
   const handleFileChange = async (e: React.ChangeEvent) => {
+    const filenames = fileBlobs.map((b) => b.filename);
     const selectedFiles = Array.from(
       (e?.target as HTMLInputElement).files ?? []
-    );
+    ).filter((f) => !filenames.includes(f.name));
 
     setIsProcessingFiles(true);
 


### PR DESCRIPTION
fixes https://github.com/dust-tt/dust/issues/5937 

## Description

just reset input value so that reuploading the same file again trigger the handleChange again

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy `front`
