### PR TITLE
Disable name/description edition

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -669,10 +669,15 @@ function ActionEditor({
     "RETRIEVAL_SEARCH",
   ].includes(action.type as any);
 
-  const shouldDisplayAdvancedSettings = action.type !== "DUST_APP_RUN";
-  const shouldDisplayDescription = !["DUST_APP_RUN", "PROCESS"].includes(
-    action.type
-  );
+  const shouldDisplayAdvancedSettings = ![
+    "DUST_APP_RUN",
+    "WEB_NAVIGATION",
+  ].includes(action.type);
+  const shouldDisplayDescription = ![
+    "DUST_APP_RUN",
+    "PROCESS",
+    "WEB_NAVIGATION",
+  ].includes(action.type);
 
   return (
     <>

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -704,7 +704,6 @@ function ActionEditor({
                     <Input
                       name="actionName"
                       placeholder="My tool name…"
-                      disabled={action.noConfigurationRequired}
                       value={action.name}
                       onChange={(v) => {
                         updateAction({
@@ -762,29 +761,20 @@ function ActionEditor({
               What is this tool about?
             </div>
           )}
-          {action.noConfigurationRequired ? (
-            <div className="text-sm">{action.description}</div>
-          ) : (
-            <TextArea
-              className="cursor-not-allowed text-gray-500"
-              placeholder={
-                isDataSourceAction
-                  ? "This data contains…"
-                  : "This tool is about…"
-              }
-              value={action.description}
-              onChange={(v) => {
-                if (!action.noConfigurationRequired) {
-                  updateAction({
-                    actionName: action.name,
-                    actionDescription: v,
-                    getNewActionConfig: (old) => old,
-                  });
-                }
-              }}
-              error={!descriptionValid ? "Description cannot be empty" : null}
-            />
-          )}
+          <TextArea
+            placeholder={
+              isDataSourceAction ? "This data contains…" : "This tool is about…"
+            }
+            value={action.description}
+            onChange={(v) => {
+              updateAction({
+                actionName: action.name,
+                actionDescription: v,
+                getNewActionConfig: (old) => old,
+              });
+            }}
+            error={!descriptionValid ? "Description cannot be empty" : null}
+          />
         </div>
       )}
     </>

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -704,6 +704,7 @@ function ActionEditor({
                     <Input
                       name="actionName"
                       placeholder="My tool name…"
+                      disabled={action.noConfigurationRequired}
                       value={action.name}
                       onChange={(v) => {
                         updateAction({
@@ -761,20 +762,29 @@ function ActionEditor({
               What is this tool about?
             </div>
           )}
-          <TextArea
-            placeholder={
-              isDataSourceAction ? "This data contains…" : "This tool is about…"
-            }
-            value={action.description}
-            onChange={(v) => {
-              updateAction({
-                actionName: action.name,
-                actionDescription: v,
-                getNewActionConfig: (old) => old,
-              });
-            }}
-            error={!descriptionValid ? "Description cannot be empty" : null}
-          />
+          {action.noConfigurationRequired ? (
+            <div className="text-sm">{action.description}</div>
+          ) : (
+            <TextArea
+              className="cursor-not-allowed text-gray-500"
+              placeholder={
+                isDataSourceAction
+                  ? "This data contains…"
+                  : "This tool is about…"
+              }
+              value={action.description}
+              onChange={(v) => {
+                if (!action.noConfigurationRequired) {
+                  updateAction({
+                    actionName: action.name,
+                    actionDescription: v,
+                    getNewActionConfig: (old) => old,
+                  });
+                }
+              }}
+              error={!descriptionValid ? "Description cannot be empty" : null}
+            />
+          )}
         </div>
       )}
     </>


### PR DESCRIPTION
fixes https://github.com/dust-tt/tasks/issues/969

## Description

Actions that can't be configured cannot be renamed or have description changed 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy `front`
