### PR TITLE
Fix X CTA on zoomable citation

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.175",
+  "version": "0.2.176",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.175",
+      "version": "0.2.176",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.175",
+  "version": "0.2.176",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/ZoomableImageCitationWrapper.tsx
+++ b/sparkle/src/components/ZoomableImageCitationWrapper.tsx
@@ -32,16 +32,16 @@ export function ZoomableImageCitationWrapper({
       <Dialog
         open={isZoomed}
         onClose={handleZoomToggle}
-        className="s-relative s-z-50 s-transition s-duration-300 s-ease-out data-[closed]:s-opacity-0"
+        className="s-relative s-z-50"
       >
-        <div className="s-fixed s-inset-8 s-flex s-w-screen s-items-center s-justify-center s-p-4">
+        <div className="s-fixed s-inset-0 s-flex s-w-screen s-items-center s-justify-center s-bg-black/70 s-p-4 s-transition-opacity">
           <Dialog.Panel className="s-max-w-lg s-space-y-4">
             <Dialog.Title>
               <div className="s-flex s-justify-end">
                 <IconButton
                   icon={XCircle}
                   onClick={handleZoomToggle}
-                  variant="tertiary"
+                  variant="white"
                 />
               </div>
             </Dialog.Title>

--- a/sparkle/src/components/ZoomableImageCitationWrapper.tsx
+++ b/sparkle/src/components/ZoomableImageCitationWrapper.tsx
@@ -41,7 +41,7 @@ export function ZoomableImageCitationWrapper({
                 <IconButton
                   icon={XCircle}
                   onClick={handleZoomToggle}
-                  variant="white"
+                  variant="tertiary"
                 />
               </div>
             </Dialog.Title>


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This https://github.com/dust-tt/dust/pull/5961 introduced a regression on `ZoomableImageCitationWrapper` when downgrading Headless UI. The backdrop was removed leading to the CTA not clearly visible.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
