### PR TITLE
[Microsoft] Store resourcePath and standardize internalIds

### DIFF
--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -197,8 +197,7 @@ export async function retrieveMicrosoftConnectorPermissions({
   ).map((r) =>
     microsoftInternalIdFromNodeData({
       nodeType: r.nodeType,
-      nodeId: r.nodeId,
-      resourcePath: r.resourcePath,
+      itemApiPath: r.itemApiPath,
     })
   );
 
@@ -272,8 +271,8 @@ export async function setMicrosoftConnectorPermissions(
 
   await MicrosoftRootResource.batchDelete({
     resourceIds: Object.entries(permissions).map((internalId) => {
-      const { nodeId } = microsoftNodeDataFromInternalId(internalId[0]);
-      return nodeId;
+      const { itemApiPath } = microsoftNodeDataFromInternalId(internalId[0]);
+      return itemApiPath;
     }),
     connectorId: connector.id,
   });

--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -18,7 +18,6 @@ import {
   getRootNodes,
   getSiteAsContentNode,
   getTeamAsContentNode,
-  splitId,
 } from "@connectors/connectors/microsoft/lib/content_nodes";
 import {
   getChannels,
@@ -26,6 +25,8 @@ import {
   getFolders,
   getSites,
   getTeams,
+  microsoftInternalIdFromNodeData,
+  microsoftNodeDataFromInternalId,
 } from "@connectors/connectors/microsoft/lib/graph_api";
 import { launchMicrosoftFullSyncWorkflow } from "@connectors/connectors/microsoft/temporal/client";
 import { nangoDeleteConnection } from "@connectors/lib/nango_client";
@@ -174,14 +175,6 @@ export async function fullResyncMicrosoftConnector(
   return launchMicrosoftFullSyncWorkflow(connectorId, null);
 }
 
-function getIdFromResource(r: MicrosoftRootResource) {
-  if (!r.nodeId) {
-    return r.nodeType;
-  }
-
-  return `${r.nodeType}/${r.nodeId}`;
-}
-
 export async function retrieveMicrosoftConnectorPermissions({
   connectorId,
   parentInternalId,
@@ -201,12 +194,18 @@ export async function retrieveMicrosoftConnectorPermissions({
 
   const selectedResources = (
     await MicrosoftRootResource.listRootsByConnectorId(connector.id)
-  ).map((r) => getIdFromResource(r));
+  ).map((r) =>
+    microsoftInternalIdFromNodeData({
+      nodeType: r.nodeType,
+      nodeId: r.nodeId,
+      resourcePath: r.resourcePath,
+    })
+  );
 
   if (!parentInternalId) {
     nodes.push(...getRootNodes());
   } else {
-    const [nodeType, nodeId] = splitId(parentInternalId);
+    const { nodeType } = microsoftNodeDataFromInternalId(parentInternalId);
 
     switch (nodeType) {
       case "sites-root":
@@ -221,14 +220,14 @@ export async function retrieveMicrosoftConnectorPermissions({
         break;
       case "team":
         nodes.push(
-          ...(await getChannels(client, nodeId)).map((n) =>
+          ...(await getChannels(client, parentInternalId)).map((n) =>
             getChannelAsContentNode(n, parentInternalId)
           )
         );
         break;
       case "site":
         nodes.push(
-          ...(await getDrives(client, nodeId)).map((n) =>
+          ...(await getDrives(client, parentInternalId)).map((n) =>
             getDriveAsContentNode(n, parentInternalId)
           )
         );
@@ -236,7 +235,7 @@ export async function retrieveMicrosoftConnectorPermissions({
       case "drive":
       case "folder":
         nodes.push(
-          ...(await getFolders(client, nodeId)).map((n) =>
+          ...(await getFolders(client, parentInternalId)).map((n) =>
             getFolderAsContentNode(n, parentInternalId)
           )
         );
@@ -272,9 +271,9 @@ export async function setMicrosoftConnectorPermissions(
   }
 
   await MicrosoftRootResource.batchDelete({
-    resourceIds: Object.entries(permissions).map(([nodeId]) => {
-      const [, ...rest] = nodeId.split("/");
-      return rest.join("/");
+    resourceIds: Object.entries(permissions).map((internalId) => {
+      const { nodeId } = microsoftNodeDataFromInternalId(internalId[0]);
+      return nodeId;
     }),
     connectorId: connector.id,
   });
@@ -283,11 +282,9 @@ export async function setMicrosoftConnectorPermissions(
     Object.entries(permissions)
       .filter(([, permission]) => permission === "read")
       .map(([id]) => {
-        const [nodeType, nodeId] = splitId(id);
         return {
           connectorId: connector.id,
-          nodeId,
-          nodeType,
+          ...microsoftNodeDataFromInternalId(id),
         };
       })
   );

--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -36,7 +36,7 @@ import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { MicrosoftRootResource } from "@connectors/resources/microsoft_resource";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
-async function getClient(connectionId: NangoConnectionId) {
+export async function getClient(connectionId: NangoConnectionId) {
   const nangoConnectionId = connectionId;
 
   const msAccessToken = await getAccessTokenFromNango({

--- a/connectors/src/connectors/microsoft/lib/content_nodes.ts
+++ b/connectors/src/connectors/microsoft/lib/content_nodes.ts
@@ -47,9 +47,8 @@ export function getTeamAsContentNode(team: microsoftgraph.Team): ContentNode {
   return {
     provider: "microsoft",
     internalId: microsoftInternalIdFromNodeData({
-      resourcePath: `/teams/${team.id}`,
+      itemApiPath: `/teams/${team.id}`,
       nodeType: "team",
-      nodeId: team.id,
     }),
     parentInternalId: null,
     type: "folder",
@@ -70,9 +69,8 @@ export function getSiteAsContentNode(site: microsoftgraph.Site): ContentNode {
   return {
     provider: "microsoft",
     internalId: microsoftInternalIdFromNodeData({
-      resourcePath: `/sites/${site.id}`,
+      itemApiPath: `/sites/${site.id}`,
       nodeType: "site",
-      nodeId: site.id,
     }),
     parentInternalId: null,
     type: "folder",
@@ -93,7 +91,7 @@ export function getChannelAsContentNode(
     // Unexpected, unreachable
     throw new Error("Channel id is required");
   }
-  const { nodeType, nodeId: teamId } =
+  const { nodeType, itemApiPath: parentItemApiPath } =
     microsoftNodeDataFromInternalId(parentInternalId);
   if (nodeType !== "team") {
     throw new Error(`Invalid parent nodeType: ${nodeType}`);
@@ -102,9 +100,8 @@ export function getChannelAsContentNode(
   return {
     provider: "microsoft",
     internalId: microsoftInternalIdFromNodeData({
-      resourcePath: `/teams/${teamId}/channels/${channel.id}`,
+      itemApiPath: `${parentItemApiPath}/channels/${channel.id}`,
       nodeType: "channel",
-      nodeId: channel.id,
     }),
     parentInternalId,
     type: "channel",
@@ -128,9 +125,8 @@ export function getDriveAsContentNode(
   return {
     provider: "microsoft",
     internalId: microsoftInternalIdFromNodeData({
-      resourcePath: `/drives/${drive.id}`,
+      itemApiPath: `/drives/${drive.id}`,
       nodeType: "drive",
-      nodeId: drive.id,
     }),
     parentInternalId,
     type: "folder",
@@ -150,11 +146,8 @@ export function getFolderAsContentNode(
     // Unexpected, unreachable
     throw new Error("Folder id is required");
   }
-  const {
-    nodeType,
-    nodeId,
-    resourcePath: parentResourcePath,
-  } = microsoftNodeDataFromInternalId(parentInternalId);
+  const { nodeType, itemApiPath: parentItemApiPath } =
+    microsoftNodeDataFromInternalId(parentInternalId);
 
   if (nodeType !== "drive" && nodeType !== "folder") {
     throw new Error(`Invalid parent nodeType: ${nodeType}`);
@@ -162,16 +155,15 @@ export function getFolderAsContentNode(
 
   const resourcePath =
     nodeType === "drive"
-      ? `/drives/${nodeId}/items/${folder.id}`
+      ? `${parentItemApiPath}/items/${folder.id}`
       : // replace items/${parentFolderId} with items/${folder.id} in parentResourcePath
-        parentResourcePath.replace(/items\/[^/]+$/, `items/${folder.id}`);
+        parentItemApiPath.replace(/items\/[^/]+$/, `items/${folder.id}`);
 
   return {
     provider: "microsoft",
     internalId: microsoftInternalIdFromNodeData({
-      resourcePath,
+      itemApiPath: resourcePath,
       nodeType: "folder",
-      nodeId: folder.id,
     }),
     parentInternalId,
     type: "folder",

--- a/connectors/src/connectors/microsoft/lib/content_nodes.ts
+++ b/connectors/src/connectors/microsoft/lib/content_nodes.ts
@@ -1,17 +1,9 @@
 import type { ContentNode } from "@dust-tt/types";
 
-import type { MicrosoftNodeType } from "@connectors/connectors/microsoft/lib/node_types";
-import { isValidNodeType } from "@connectors/connectors/microsoft/lib/node_types";
-
-export function splitId(internalId: string): [MicrosoftNodeType, string] {
-  const [resourceType, ...rest] = internalId.split("/");
-
-  if (!resourceType || !isValidNodeType(resourceType)) {
-    throw new Error(`Invalid internalId: ${internalId}`);
-  }
-
-  return [resourceType, rest.join("/")];
-}
+import {
+  microsoftInternalIdFromNodeData,
+  microsoftNodeDataFromInternalId,
+} from "@connectors/connectors/microsoft/lib/graph_api";
 
 export function getRootNodes(): ContentNode[] {
   return [getSitesRootAsContentNode(), getTeamsRootAsContentNode()];
@@ -20,7 +12,7 @@ export function getRootNodes(): ContentNode[] {
 export function getSitesRootAsContentNode(): ContentNode {
   return {
     provider: "microsoft",
-    internalId: "sites-root",
+    internalId: "microsoft/sites-root",
     parentInternalId: null,
     type: "folder",
     title: "Sites",
@@ -35,7 +27,7 @@ export function getSitesRootAsContentNode(): ContentNode {
 export function getTeamsRootAsContentNode(): ContentNode {
   return {
     provider: "microsoft",
-    internalId: "teams-root",
+    internalId: "microsoft/teams-root",
     parentInternalId: null,
     type: "folder",
     title: "Teams",
@@ -47,9 +39,18 @@ export function getTeamsRootAsContentNode(): ContentNode {
   };
 }
 export function getTeamAsContentNode(team: microsoftgraph.Team): ContentNode {
+  if (!team.id) {
+    // Unexpected, unreachable
+    throw new Error("Team id is required");
+  }
+
   return {
     provider: "microsoft",
-    internalId: `team/${team.id}`,
+    internalId: microsoftInternalIdFromNodeData({
+      resourcePath: `/teams/${team.id}`,
+      nodeType: "team",
+      nodeId: team.id,
+    }),
     parentInternalId: null,
     type: "folder",
     title: team.displayName || "unnamed",
@@ -62,9 +63,17 @@ export function getTeamAsContentNode(team: microsoftgraph.Team): ContentNode {
 }
 
 export function getSiteAsContentNode(site: microsoftgraph.Site): ContentNode {
+  if (!site.id) {
+    // Unexpected, unreachable
+    throw new Error("Site id is required");
+  }
   return {
     provider: "microsoft",
-    internalId: `site/${site.id}`,
+    internalId: microsoftInternalIdFromNodeData({
+      resourcePath: `/sites/${site.id}`,
+      nodeType: "site",
+      nodeId: site.id,
+    }),
     parentInternalId: null,
     type: "folder",
     title: site.displayName || site.name || "unnamed",
@@ -80,9 +89,23 @@ export function getChannelAsContentNode(
   channel: microsoftgraph.Channel,
   parentInternalId: string
 ): ContentNode {
+  if (!channel.id) {
+    // Unexpected, unreachable
+    throw new Error("Channel id is required");
+  }
+  const { nodeType, nodeId: teamId } =
+    microsoftNodeDataFromInternalId(parentInternalId);
+  if (nodeType !== "team") {
+    throw new Error(`Invalid parent nodeType: ${nodeType}`);
+  }
+
   return {
     provider: "microsoft",
-    internalId: `channel/${channel.id}`,
+    internalId: microsoftInternalIdFromNodeData({
+      resourcePath: `/teams/${teamId}/channels/${channel.id}`,
+      nodeType: "channel",
+      nodeId: channel.id,
+    }),
     parentInternalId,
     type: "channel",
     title: channel.displayName || "unnamed",
@@ -98,9 +121,17 @@ export function getDriveAsContentNode(
   drive: microsoftgraph.Drive,
   parentInternalId: string
 ): ContentNode {
+  if (!drive.id) {
+    // Unexpected, unreachable
+    throw new Error("Drive id is required");
+  }
   return {
     provider: "microsoft",
-    internalId: `drive/${drive.id}`,
+    internalId: microsoftInternalIdFromNodeData({
+      resourcePath: `/drives/${drive.id}`,
+      nodeType: "drive",
+      nodeId: drive.id,
+    }),
     parentInternalId,
     type: "folder",
     title: drive.name || "unnamed",
@@ -115,12 +146,33 @@ export function getFolderAsContentNode(
   folder: microsoftgraph.DriveItem,
   parentInternalId: string
 ): ContentNode {
-  const [, parentId] = splitId(parentInternalId);
-  const [driveId] = parentId.split("/");
+  if (!folder.id) {
+    // Unexpected, unreachable
+    throw new Error("Folder id is required");
+  }
+  const {
+    nodeType,
+    nodeId,
+    resourcePath: parentResourcePath,
+  } = microsoftNodeDataFromInternalId(parentInternalId);
+
+  if (nodeType !== "drive" && nodeType !== "folder") {
+    throw new Error(`Invalid parent nodeType: ${nodeType}`);
+  }
+
+  const resourcePath =
+    nodeType === "drive"
+      ? `/drives/${nodeId}/items/${folder.id}`
+      : // replace items/${parentFolderId} with items/${folder.id} in parentResourcePath
+        parentResourcePath.replace(/items\/[^/]+$/, `items/${folder.id}`);
 
   return {
     provider: "microsoft",
-    internalId: `folder/${driveId}/${folder.id}`,
+    internalId: microsoftInternalIdFromNodeData({
+      resourcePath,
+      nodeType: "folder",
+      nodeId: folder.id,
+    }),
     parentInternalId,
     type: "folder",
     title: folder.name || "unnamed",

--- a/connectors/src/connectors/microsoft/lib/graph_api.ts
+++ b/connectors/src/connectors/microsoft/lib/graph_api.ts
@@ -1,6 +1,9 @@
 import type { Client } from "@microsoft/microsoft-graph-client";
 import type * as MicrosoftGraph from "@microsoft/microsoft-graph-types";
 
+import type { MicrosoftNodeType } from "@connectors/connectors/microsoft/lib/node_types";
+import { isValidNodeType } from "@connectors/connectors/microsoft/lib/node_types";
+
 export async function getSites(client: Client): Promise<MicrosoftGraph.Site[]> {
   const res = await client
     .api("/sites?search=*")
@@ -11,10 +14,19 @@ export async function getSites(client: Client): Promise<MicrosoftGraph.Site[]> {
 
 export async function getDrives(
   client: Client,
-  siteId: string
+  parentInternalId: string
 ): Promise<MicrosoftGraph.Drive[]> {
+  const { nodeType, resourcePath: parentResourcePath } =
+    microsoftNodeDataFromInternalId(parentInternalId);
+
+  if (nodeType !== "site") {
+    throw new Error(
+      `Invalid node type: ${nodeType} for getDrives, expected site`
+    );
+  }
+
   const res = await client
-    .api(`/sites/${siteId}/drives`)
+    .api(`${parentResourcePath}/drives`)
     .select("id,name")
     .get();
   return res.value;
@@ -22,13 +34,22 @@ export async function getDrives(
 
 export async function getFilesAndFolders(
   client: Client,
-  parentId: string
+  parentInternalId: string
 ): Promise<MicrosoftGraph.DriveItem[]> {
-  const [driveId, folderId] = parentId.split("/");
+  const { nodeType, resourcePath: parentResourcePath } =
+    microsoftNodeDataFromInternalId(parentInternalId);
 
-  const parent = folderId ? `items/${folderId}` : "root";
+  if (nodeType !== "drive" && nodeType !== "folder") {
+    throw new Error(
+      `Invalid node type: ${nodeType} for getFilesAndFolders, expected drive or folder`
+    );
+  }
+  const endpoint =
+    nodeType === "drive"
+      ? `${parentResourcePath}/root/children`
+      : `${parentResourcePath}/children`;
   const res = await client
-    .api(`/drives/${driveId}/${parent}/children`)
+    .api(endpoint)
     .select("id,name,createdDateTime,file,folder")
     .get();
   return res.value;
@@ -36,9 +57,9 @@ export async function getFilesAndFolders(
 
 export async function getFolders(
   client: Client,
-  parentId: string
+  parentInternalId: string
 ): Promise<MicrosoftGraph.DriveItem[]> {
-  const res = await getFilesAndFolders(client, parentId);
+  const res = await getFilesAndFolders(client, parentInternalId);
   return res.filter((item) => item.folder);
 }
 
@@ -52,10 +73,19 @@ export async function getTeams(client: Client): Promise<MicrosoftGraph.Team[]> {
 
 export async function getChannels(
   client: Client,
-  teamId: string
+  parentInternalId: string
 ): Promise<MicrosoftGraph.Channel[]> {
+  const { nodeType, resourcePath: parentResourcePath } =
+    microsoftNodeDataFromInternalId(parentInternalId);
+
+  if (nodeType !== "team") {
+    throw new Error(
+      `Invalid node type: ${nodeType} for getChannels, expected team`
+    );
+  }
+
   const res = await client
-    .api(`/teams/${teamId}/channels`)
+    .api(`${parentResourcePath}/channels`)
     .select("id,displayName")
     .get();
   return res.value;
@@ -63,11 +93,53 @@ export async function getChannels(
 
 export async function getMessages(
   client: Client,
-  teamId: string,
-  channelId: string
+  parentInternalId: string
 ): Promise<MicrosoftGraph.Message[]> {
-  const res = await client
-    .api(`/teams/${teamId}/channels/${channelId}/messages`)
-    .get();
+  const { nodeType, resourcePath: parentResourcePath } =
+    microsoftNodeDataFromInternalId(parentInternalId);
+
+  if (nodeType !== "channel") {
+    throw new Error(
+      `Invalid node type: ${nodeType} for getMessages, expected channel`
+    );
+  }
+
+  const res = await client.api(`${parentResourcePath}/messages`).get();
   return res.value;
+}
+
+export type MicrosoftNodeData = {
+  nodeType: MicrosoftNodeType;
+  nodeId: string;
+  resourcePath: string;
+};
+
+export function microsoftInternalIdFromNodeData(nodeData: MicrosoftNodeData) {
+  if (nodeData.nodeType === "sites-root") {
+    return `microsoft/sites-root`;
+  }
+  if (nodeData.nodeType === "teams-root") {
+    return `microsoft/teams-root`;
+  }
+  const { nodeType, nodeId, resourcePath } = nodeData;
+  return `microsoft/${nodeType}/${nodeId}/${resourcePath}`;
+}
+
+export function microsoftNodeDataFromInternalId(
+  internalId: string
+): MicrosoftNodeData {
+  if (internalId === "microsoft/sites-root") {
+    return { nodeType: "sites-root", nodeId: "", resourcePath: "" };
+  }
+
+  if (internalId === "microsoft/teams-root") {
+    return { nodeType: "teams-root", nodeId: "", resourcePath: "" };
+  }
+
+  const [, nodeType, nodeId, ...resourcePathArr] = internalId.split("/");
+  if (!nodeId || !nodeType || !isValidNodeType(nodeType)) {
+    throw new Error(`Invalid internal id: ${internalId}`);
+  }
+
+  return { nodeType, nodeId, resourcePath: resourcePathArr.join("/") };
 }

--- a/connectors/src/connectors/microsoft/lib/graph_api.ts
+++ b/connectors/src/connectors/microsoft/lib/graph_api.ts
@@ -16,7 +16,7 @@ export async function getDrives(
   client: Client,
   parentInternalId: string
 ): Promise<MicrosoftGraph.Drive[]> {
-  const { nodeType, resourcePath: parentResourcePath } =
+  const { nodeType, itemApiPath: parentResourcePath } =
     microsoftNodeDataFromInternalId(parentInternalId);
 
   if (nodeType !== "site") {
@@ -36,7 +36,7 @@ export async function getFilesAndFolders(
   client: Client,
   parentInternalId: string
 ): Promise<MicrosoftGraph.DriveItem[]> {
-  const { nodeType, resourcePath: parentResourcePath } =
+  const { nodeType, itemApiPath: parentResourcePath } =
     microsoftNodeDataFromInternalId(parentInternalId);
 
   if (nodeType !== "drive" && nodeType !== "folder") {
@@ -75,7 +75,7 @@ export async function getChannels(
   client: Client,
   parentInternalId: string
 ): Promise<MicrosoftGraph.Channel[]> {
-  const { nodeType, resourcePath: parentResourcePath } =
+  const { nodeType, itemApiPath: parentResourcePath } =
     microsoftNodeDataFromInternalId(parentInternalId);
 
   if (nodeType !== "team") {
@@ -95,7 +95,7 @@ export async function getMessages(
   client: Client,
   parentInternalId: string
 ): Promise<MicrosoftGraph.Message[]> {
-  const { nodeType, resourcePath: parentResourcePath } =
+  const { nodeType, itemApiPath: parentResourcePath } =
     microsoftNodeDataFromInternalId(parentInternalId);
 
   if (nodeType !== "channel") {
@@ -110,8 +110,7 @@ export async function getMessages(
 
 export type MicrosoftNodeData = {
   nodeType: MicrosoftNodeType;
-  nodeId: string;
-  resourcePath: string;
+  itemApiPath: string;
 };
 
 export function microsoftInternalIdFromNodeData(nodeData: MicrosoftNodeData) {
@@ -121,25 +120,25 @@ export function microsoftInternalIdFromNodeData(nodeData: MicrosoftNodeData) {
   if (nodeData.nodeType === "teams-root") {
     return `microsoft/teams-root`;
   }
-  const { nodeType, nodeId, resourcePath } = nodeData;
-  return `microsoft/${nodeType}/${nodeId}/${resourcePath}`;
+  const { nodeType, itemApiPath } = nodeData;
+  return `microsoft/${nodeType}/${itemApiPath}`;
 }
 
 export function microsoftNodeDataFromInternalId(
   internalId: string
 ): MicrosoftNodeData {
   if (internalId === "microsoft/sites-root") {
-    return { nodeType: "sites-root", nodeId: "", resourcePath: "" };
+    return { nodeType: "sites-root", itemApiPath: "" };
   }
 
   if (internalId === "microsoft/teams-root") {
-    return { nodeType: "teams-root", nodeId: "", resourcePath: "" };
+    return { nodeType: "teams-root", itemApiPath: "" };
   }
 
-  const [, nodeType, nodeId, ...resourcePathArr] = internalId.split("/");
-  if (!nodeId || !nodeType || !isValidNodeType(nodeType)) {
+  const [, nodeType, ...resourcePathArr] = internalId.split("/");
+  if (!nodeType || !isValidNodeType(nodeType)) {
     throw new Error(`Invalid internal id: ${internalId}`);
   }
 
-  return { nodeType, nodeId, resourcePath: resourcePathArr.join("/") };
+  return { nodeType, itemApiPath: resourcePathArr.join("/") };
 }

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -1,11 +1,11 @@
 import type { ModelId } from "@dust-tt/types";
 
-import logger from "@connectors/logger/logger";
-import type { DataSourceConfig } from "@connectors/types/data_source_config";
-import { MicrosoftRootResource } from "@connectors/resources/microsoft_resource";
-import { getMessages } from "@connectors/connectors/microsoft/lib/graph_api";
-import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { getClient } from "@connectors/connectors/microsoft";
+import { getMessages } from "@connectors/connectors/microsoft/lib/graph_api";
+import logger from "@connectors/logger/logger";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import { MicrosoftRootResource } from "@connectors/resources/microsoft_resource";
+import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
 export async function fullSyncActivity({
   connectorId,
@@ -31,12 +31,17 @@ export async function fullSyncActivity({
   );
 
   const channel = teamResources[0];
+
+  if (!channel) {
+    throw new Error(`No channel found for connector ${connectorId}`);
+  }
+
   // get a message
-  // const message = getMessages(client, channel);
+  const message = getMessages(client, channel.resourcePath);
 
   logger.info(
     `To implement: full sync for connector ${connectorId} with config ${JSON.stringify(
       dataSourceConfig
-    )}`
+    )}\nExample message: ${JSON.stringify(message)}`
   );
 }

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -2,6 +2,10 @@ import type { ModelId } from "@dust-tt/types";
 
 import logger from "@connectors/logger/logger";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
+import { MicrosoftRootResource } from "@connectors/resources/microsoft_resource";
+import { getMessages } from "@connectors/connectors/microsoft/lib/graph_api";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import { getClient } from "@connectors/connectors/microsoft";
 
 export async function fullSyncActivity({
   connectorId,
@@ -10,6 +14,26 @@ export async function fullSyncActivity({
   connectorId: ModelId;
   dataSourceConfig: DataSourceConfig;
 }): Promise<void> {
+  const connector = await ConnectorResource.fetchById(connectorId);
+
+  if (!connector) {
+    throw new Error(`Connector with id ${connectorId} not found`);
+  }
+
+  const resources = await MicrosoftRootResource.listRootsByConnectorId(
+    connectorId
+  );
+
+  const client = await getClient(connector.connectionId);
+
+  const teamResources = resources.filter((resource) =>
+    ["channel"].includes(resource.nodeType)
+  );
+
+  const channel = teamResources[0];
+  // get a message
+  // const message = getMessages(client, channel);
+
   logger.info(
     `To implement: full sync for connector ${connectorId} with config ${JSON.stringify(
       dataSourceConfig

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -36,7 +36,7 @@ export async function fullSyncActivity({
   }
 
   // get a message
-  const message = getMessages(client, channel.resourcePath);
+  const message = getMessages(client, channel.itemApiPath);
 
   logger.info(
     `To implement: full sync for connector ${connectorId} with config ${JSON.stringify(

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -20,9 +20,8 @@ export async function fullSyncActivity({
     throw new Error(`Connector with id ${connectorId} not found`);
   }
 
-  const resources = await MicrosoftRootResource.listRootsByConnectorId(
-    connectorId
-  );
+  const resources =
+    await MicrosoftRootResource.listRootsByConnectorId(connectorId);
 
   const client = await getClient(connector.connectionId);
 

--- a/connectors/src/lib/models/microsoft.ts
+++ b/connectors/src/lib/models/microsoft.ts
@@ -51,10 +51,9 @@ MicrosoftConfigurationModel.init(
 ConnectorModel.hasMany(MicrosoftConfigurationModel);
 
 // MicrosoftRoot stores the drive/folders/channels selected by the user to sync.
-// In order to be able to uniquely identify each node, we store the GET API path
-// to the resource in the resourcePath field (e.g. /drives/{drive-id}), except for the toplevel
+// In order to be able to uniquely identify each node, we store the GET path
+// to the item in the itemApiPath field (e.g. /drives/{drive-id}), except for the toplevel
 // sites-root and teams-root, which are stored as "sites-root" and "teams-root" respectively.
-
 export class MicrosoftRootModel extends Model<
   InferAttributes<MicrosoftRootModel>,
   InferCreationAttributes<MicrosoftRootModel>
@@ -63,9 +62,8 @@ export class MicrosoftRootModel extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
-  declare resourcePath: string;
+  declare itemApiPath: string;
   declare nodeType: MicrosoftNodeType;
-  declare nodeId: string;
 }
 MicrosoftRootModel.init(
   {
@@ -88,15 +86,11 @@ MicrosoftRootModel.init(
       type: DataTypes.INTEGER,
       allowNull: false,
     },
-    resourcePath: {
+    itemApiPath: {
       type: DataTypes.STRING,
       allowNull: false,
     },
     nodeType: {
-      type: DataTypes.STRING,
-      allowNull: false,
-    },
-    nodeId: {
       type: DataTypes.STRING,
       allowNull: false,
     },
@@ -105,7 +99,7 @@ MicrosoftRootModel.init(
     sequelize: sequelizeConnection,
     modelName: "microsoft_roots",
     indexes: [
-      { fields: ["connectorId", "nodeId"], unique: true },
+      { fields: ["connectorId", "itemApiPath"], unique: true },
       { fields: ["connectorId", "nodeType"], unique: false },
     ],
   }
@@ -126,7 +120,6 @@ export class MicrosoftNodeModel extends Model<
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
   declare internalId: string;
   declare nodeType: MicrosoftNodeType;
-  declare nodeId: string;
   declare name: string;
   declare mimeType: string;
   declare parentInternalId: string | null;
@@ -172,10 +165,6 @@ MicrosoftNodeModel.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
-    nodeId: {
-      type: DataTypes.STRING,
-      allowNull: false,
-    },
     name: {
       type: DataTypes.TEXT,
       allowNull: false,
@@ -195,7 +184,7 @@ MicrosoftNodeModel.init(
     sequelize: sequelizeConnection,
     modelName: "microsoft_nodes",
     indexes: [
-      { fields: ["connectorId", "nodeId"], unique: true },
+      { fields: ["connectorId", "internalId"], unique: true },
       { fields: ["connectorId", "nodeType"], unique: false },
       { fields: ["connectorId", "parentInternalId"], concurrently: true },
     ],
@@ -213,7 +202,7 @@ export class MicrosoftDeltaModel extends Model<
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
-  declare rootId: ForeignKey<MicrosoftRootModel["nodeId"]>;
+  declare rootId: ForeignKey<MicrosoftRootModel["itemApiPath"]>;
   declare deltaToken: string;
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
 }

--- a/connectors/src/lib/models/microsoft.ts
+++ b/connectors/src/lib/models/microsoft.ts
@@ -51,6 +51,10 @@ MicrosoftConfigurationModel.init(
 ConnectorModel.hasMany(MicrosoftConfigurationModel);
 
 // MicrosoftRoot stores the drive/folders/channels selected by the user to sync.
+// In order to be able to uniquely identify each node, we store the GET API path
+// to the resource in the resourcePath field (e.g. /drives/{drive-id}), except for the toplevel
+// sites-root and teams-root, which are stored as "sites-root" and "teams-root" respectively.
+
 export class MicrosoftRootModel extends Model<
   InferAttributes<MicrosoftRootModel>,
   InferCreationAttributes<MicrosoftRootModel>
@@ -59,6 +63,7 @@ export class MicrosoftRootModel extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
+  declare resourcePath: string;
   declare nodeType: MicrosoftNodeType;
   declare nodeId: string;
 }
@@ -81,6 +86,10 @@ MicrosoftRootModel.init(
     },
     connectorId: {
       type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    resourcePath: {
+      type: DataTypes.STRING,
       allowNull: false,
     },
     nodeType: {
@@ -115,12 +124,12 @@ export class MicrosoftNodeModel extends Model<
   declare lastUpsertedTs: Date | null;
   declare skipReason: string | null;
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
-  declare dustFileId: string;
+  declare internalId: string;
   declare nodeType: MicrosoftNodeType;
   declare nodeId: string;
   declare name: string;
   declare mimeType: string;
-  declare parentId: string | null;
+  declare parentInternalId: string | null;
 }
 MicrosoftNodeModel.init(
   {
@@ -155,7 +164,7 @@ MicrosoftNodeModel.init(
       type: DataTypes.INTEGER,
       allowNull: false,
     },
-    dustFileId: {
+    internalId: {
       type: DataTypes.STRING,
       allowNull: false,
     },
@@ -177,7 +186,7 @@ MicrosoftNodeModel.init(
       allowNull: false,
       defaultValue: "",
     },
-    parentId: {
+    parentInternalId: {
       type: DataTypes.STRING,
       allowNull: true,
     },
@@ -188,7 +197,7 @@ MicrosoftNodeModel.init(
     indexes: [
       { fields: ["connectorId", "nodeId"], unique: true },
       { fields: ["connectorId", "nodeType"], unique: false },
-      { fields: ["connectorId", "parentId"], concurrently: true },
+      { fields: ["connectorId", "parentInternalId"], concurrently: true },
     ],
   }
 );

--- a/connectors/src/resources/microsoft_resource.ts
+++ b/connectors/src/resources/microsoft_resource.ts
@@ -165,7 +165,7 @@ export class MicrosoftRootResource extends BaseResource<MicrosoftRootModel> {
   }) {
     return MicrosoftRootModel.destroy({
       where: {
-        nodeId: resourceIds,
+        itemApiPath: resourceIds,
         connectorId,
       },
       transaction,
@@ -199,7 +199,7 @@ export class MicrosoftRootResource extends BaseResource<MicrosoftRootModel> {
     return {
       id: this.id,
       nodeType: this.nodeType,
-      nodeId: this.nodeId,
+      itemApiPath: this.itemApiPath,
       connectorId: this.connectorId,
     };
   }


### PR DESCRIPTION
## Description
This PR
- stores the path of a resource, so that given a row from MicrosoftRootModel we have the data to query it via microsoft's graph api;
- standardize internal ids: 
  - add a provider suffix like for other connectors
   - ensure that we can compute internal id from row, and vice versa that given solely the internal id we can also query the api

For review: best  to start by L111 of `graph_api.ts` introducing MicrosoftNodeData <-> InternalId conversion functions

Also starts the code of the full-sync activity (still a no-op at the time)

## Risk & deploy
na (gated)
