### PR TITLE
[front] fix: Limit tool description

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -752,8 +752,9 @@ function ActionEditor({
                 What's the data?
               </div>
               <div className="text-sm text-element-600">
-                Clarify the data's content and context to guide your Assistant
-                in determining when and how to utilize it.
+                Provide a brief description of the data content and context.
+                This helps the Assistant determine when and how to utilize this
+                information source effectively
               </div>
             </div>
           ) : (
@@ -767,11 +768,13 @@ function ActionEditor({
             }
             value={action.description}
             onChange={(v) => {
-              updateAction({
-                actionName: action.name,
-                actionDescription: v,
-                getNewActionConfig: (old) => old,
-              });
+              if (v.length < 800) {
+                updateAction({
+                  actionName: action.name,
+                  actionDescription: v,
+                  getNewActionConfig: (old) => old,
+                });
+              }
             }}
             error={!descriptionValid ? "Description cannot be empty" : null}
           />

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -417,6 +417,10 @@ export async function* runMultiActionsAgent(
 
       return;
     }
+
+    // Truncate the description to 1024 characters
+    specRes.value.description = specRes.value.description.slice(0, 1024);
+
     specifications.push(specRes.value);
   }
 


### PR DESCRIPTION
## Description

- Update descriptin to provide a "brief" description
- Block text area to 800 chars
- Hard cut at 1024 chars the description sent to the model

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy `front`
