### PR TITLE
[assistant] - refactor: remove "magic" from search order

### DIFF
--- a/front/components/assistant/SearchOrderDropdown.tsx
+++ b/front/components/assistant/SearchOrderDropdown.tsx
@@ -1,6 +1,6 @@
 import { Button, DropdownMenu } from "@dust-tt/sparkle";
 
-export const SearchOrder = ["name", "usage", "magic"] as const;
+export const SearchOrder = ["name", "usage"] as const;
 export type SearchOrderType = (typeof SearchOrder)[number];
 
 // Headless UI does not inherently handle Portal-based rendering,

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -32,7 +32,6 @@ import { assistantUsageMessage } from "@app/components/assistant/Usage";
 import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
 import { subNavigationBuild } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
-import { compareAgentsForSort } from "@app/lib/assistant";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useAgentConfigurations } from "@app/lib/swr";
 import { classNames, subFilter } from "@app/lib/utils";
@@ -198,17 +197,13 @@ export default function WorkspaceAssistants({
       });
       break;
     }
-    case "magic": {
-      filteredAgents.sort(compareAgentsForSort);
-      break;
-    }
     default:
       assertNever(orderBy);
   }
 
   useEffect(() => {
     if (tabScope === "global") {
-      setOrderBy("magic");
+      setOrderBy("usage");
     }
   }, [tabScope]);
 

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -203,7 +203,7 @@ export default function WorkspaceAssistants({
 
   useEffect(() => {
     if (tabScope === "global") {
-      setOrderBy("usage");
+      setOrderBy("name");
     }
   }, [tabScope]);
 


### PR DESCRIPTION
## Description

This PR removes the assistants "magic" ordering.

## Risk

None

## Deploy Plan

Deploy `front`
