### PR TITLE
connectors: better configuration rendering (toJSON) typing

### DIFF
--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -4,6 +4,7 @@ import type {
   ContentNode,
   ModelId,
   Result,
+  SlackConfigurationType,
 } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 import { WebClient } from "@slack/web-api";
@@ -39,7 +40,8 @@ const { NANGO_SLACK_CONNECTOR_ID, SLACK_CLIENT_ID, SLACK_CLIENT_SECRET } =
 
 export async function createSlackConnector(
   dataSourceConfig: DataSourceConfig,
-  connectionId: NangoConnectionId
+  connectionId: NangoConnectionId,
+  configuration: SlackConfigurationType
 ): Promise<Result<string, Error>> {
   const nangoConnectionId = connectionId;
 
@@ -83,7 +85,9 @@ export async function createSlackConnector(
     },
     {
       slackTeamId: teamInfo.team.id,
-      botEnabled: true,
+      botEnabled: configuration.botEnabled,
+      autoReadChannelPattern: configuration.autoReadChannelPattern,
+      whitelistedDomains: configuration.whitelistedDomains,
     }
   );
 

--- a/connectors/src/resources/connector/confluence.ts
+++ b/connectors/src/resources/connector/confluence.ts
@@ -7,6 +7,7 @@ import {
   ConfluenceSpace,
 } from "@connectors/lib/models/confluence";
 import type {
+  ConnectorProviderConfigurationType,
   ConnectorProviderModelResourceMapping,
   ConnectorProviderStrategy,
   WithCreationAttributes,
@@ -62,5 +63,9 @@ export class ConfluenceConnectorStrategy
     Record<ModelId, ConnectorProviderModelResourceMapping["confluence"]>
   > {
     return {};
+  }
+
+  configurationJSON(): ConnectorProviderConfigurationType {
+    return null;
   }
 }

--- a/connectors/src/resources/connector/github.ts
+++ b/connectors/src/resources/connector/github.ts
@@ -6,6 +6,7 @@ import {
   GithubIssue,
 } from "@connectors/lib/models/github";
 import type {
+  ConnectorProviderConfigurationType,
   ConnectorProviderModelResourceMapping,
   ConnectorProviderStrategy,
   WithCreationAttributes,
@@ -49,5 +50,9 @@ export class GithubConnectorStrategy
     Record<ModelId, ConnectorProviderModelResourceMapping["github"]>
   > {
     return {};
+  }
+
+  configurationJSON(): ConnectorProviderConfigurationType {
+    return null;
   }
 }

--- a/connectors/src/resources/connector/google_drive.ts
+++ b/connectors/src/resources/connector/google_drive.ts
@@ -11,6 +11,7 @@ import {
   GoogleDriveSyncToken,
 } from "@connectors/lib/models/google_drive";
 import type {
+  ConnectorProviderConfigurationType,
   ConnectorProviderModelResourceMapping,
   ConnectorProviderStrategy,
   WithCreationAttributes,
@@ -76,5 +77,9 @@ export class GoogleDriveConnectorStrategy
     Record<ModelId, ConnectorProviderModelResourceMapping["google_drive"]>
   > {
     return {};
+  }
+
+  configurationJSON(): ConnectorProviderConfigurationType {
+    return null;
   }
 }

--- a/connectors/src/resources/connector/intercom.ts
+++ b/connectors/src/resources/connector/intercom.ts
@@ -10,6 +10,7 @@ import {
   IntercomWorkspace,
 } from "@connectors/lib/models/intercom";
 import type {
+  ConnectorProviderConfigurationType,
   ConnectorProviderModelResourceMapping,
   ConnectorProviderStrategy,
   WithCreationAttributes,
@@ -82,5 +83,9 @@ export class IntercomConnectorStrategy
     Record<ModelId, ConnectorProviderModelResourceMapping["intercom"]>
   > {
     return {};
+  }
+
+  configurationJSON(): ConnectorProviderConfigurationType {
+    return null;
   }
 }

--- a/connectors/src/resources/connector/microsoft.ts
+++ b/connectors/src/resources/connector/microsoft.ts
@@ -3,6 +3,7 @@ import type { Transaction } from "sequelize";
 
 import type { MicrosoftConfigurationModel } from "@connectors/lib/models/microsoft";
 import type {
+  ConnectorProviderConfigurationType,
   ConnectorProviderModelResourceMapping,
   ConnectorProviderStrategy,
   WithCreationAttributes,
@@ -48,5 +49,9 @@ export class MicrosoftConnectorStrategy
     Record<ModelId, ConnectorProviderModelResourceMapping["microsoft"]>
   > {
     return MicrosoftConfigurationResource.fetchByConnectorIds(connectorIds);
+  }
+
+  configurationJSON(): ConnectorProviderConfigurationType {
+    return null;
   }
 }

--- a/connectors/src/resources/connector/notion.ts
+++ b/connectors/src/resources/connector/notion.ts
@@ -9,6 +9,7 @@ import {
   NotionPage,
 } from "@connectors/lib/models/notion";
 import type {
+  ConnectorProviderConfigurationType,
   ConnectorProviderModelResourceMapping,
   ConnectorProviderStrategy,
   WithCreationAttributes,
@@ -73,5 +74,9 @@ export class NotionConnectorStrategy
     Record<ModelId, ConnectorProviderModelResourceMapping["notion"]>
   > {
     return {};
+  }
+
+  configurationJSON(): ConnectorProviderConfigurationType {
+    return null;
   }
 }

--- a/connectors/src/resources/connector/slack.ts
+++ b/connectors/src/resources/connector/slack.ts
@@ -3,6 +3,7 @@ import type { Transaction } from "sequelize";
 
 import type { SlackConfigurationModel } from "@connectors/lib/models/slack";
 import type {
+  ConnectorProviderConfigurationType,
   ConnectorProviderModelResourceMapping,
   ConnectorProviderStrategy,
   WithCreationAttributes,
@@ -47,5 +48,11 @@ export class SlackConnectorStrategy
     connectorIds: ModelId[]
   ): Promise<Record<ModelId, ConnectorProviderModelResourceMapping["slack"]>> {
     return SlackConfigurationResource.fetchByConnectorIds(connectorIds);
+  }
+
+  configurationJSON(
+    configuration: SlackConfigurationResource
+  ): ConnectorProviderConfigurationType {
+    return configuration.toJSON();
   }
 }

--- a/connectors/src/resources/connector/strategy.ts
+++ b/connectors/src/resources/connector/strategy.ts
@@ -1,4 +1,9 @@
-import type { ConnectorProvider, ModelId } from "@dust-tt/types";
+import type {
+  ConnectorProvider,
+  ModelId,
+  SlackConfigurationType,
+  WebCrawlerConfigurationType,
+} from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
 import type { CreationAttributes, Model, Transaction } from "sequelize";
 
@@ -23,6 +28,9 @@ import type { ConnectorResource } from "@connectors/resources/connector_resource
 import type { BaseResource } from "../base_resource";
 
 export type WithCreationAttributes<T extends Model> = CreationAttributes<T>;
+
+// ConnectorProvider to Configuration Model mapping used to define the type of the
+// ConfigurationResource.
 
 export interface ConnectorProviderModelM {
   confluence: ConfluenceConfiguration;
@@ -53,6 +61,27 @@ export type ConnectorProviderModelResourceMapping = {
 export type ConnectorProviderConfigurationResource =
   ConnectorProviderModelResourceMapping[keyof ConnectorProviderModelResourceMapping];
 
+// ConnectorProvider to ConfigurationType mapping used to define the type of the toJSON method of
+// the ConnectorProviderStrategy.
+
+export interface ConnectorProviderConfigurationTypeM {
+  confluence: null;
+  github: null;
+  google_drive: null;
+  intercom: null;
+  microsoft: null;
+  notion: null;
+  slack: SlackConfigurationType;
+  webcrawler: WebCrawlerConfigurationType;
+}
+
+export type ConnectorProviderConfigurationTypeMapping = {
+  [K in keyof ConnectorProviderConfigurationTypeM]: ConnectorProviderConfigurationTypeM[K];
+};
+
+export type ConnectorProviderConfigurationType =
+  ConnectorProviderConfigurationTypeMapping[keyof ConnectorProviderConfigurationTypeMapping];
+
 export interface ConnectorProviderStrategy<T extends ConnectorProvider> {
   delete(connector: ConnectorResource, transaction: Transaction): Promise<void>;
 
@@ -65,6 +94,10 @@ export interface ConnectorProviderStrategy<T extends ConnectorProvider> {
   fetchConfigurationsbyConnectorIds(connectorIds: ModelId[]): Promise<{
     [connectorId: ModelId]: ConnectorProviderConfigurationResource;
   }>;
+
+  configurationJSON(
+    configuration: ConnectorProviderModelResourceMapping[T]
+  ): ConnectorProviderConfigurationType;
 }
 
 export function getConnectorProviderStrategy(

--- a/connectors/src/resources/connector/webcrawler.ts
+++ b/connectors/src/resources/connector/webcrawler.ts
@@ -3,6 +3,7 @@ import type { Transaction } from "sequelize";
 
 import type { WebCrawlerConfigurationModel } from "@connectors/lib/models/webcrawler";
 import type {
+  ConnectorProviderConfigurationType,
   ConnectorProviderModelResourceMapping,
   ConnectorProviderStrategy,
   WithCreationAttributes,
@@ -50,5 +51,11 @@ export class WebCrawlerStrategy
     Record<ModelId, ConnectorProviderModelResourceMapping["webcrawler"]>
   > {
     return WebCrawlerConfigurationResource.fetchByConnectorIds(connectorIds);
+  }
+
+  configurationJSON(
+    configuration: WebCrawlerConfigurationResource
+  ): ConnectorProviderConfigurationType {
+    return configuration.toJSON();
   }
 }

--- a/connectors/src/resources/connector_resource.ts
+++ b/connectors/src/resources/connector_resource.ts
@@ -1,5 +1,4 @@
 import type {
-  ConnectorConfiguration,
   ConnectorProvider,
   ConnectorType,
   ModelId,
@@ -216,9 +215,9 @@ export class ConnectorResource extends BaseResource<ConnectorModel> {
       firstSuccessfulSyncTime: this.firstSuccessfulSyncTime?.getTime(),
       firstSyncProgress: this.firstSyncProgress,
       errorType: this.errorType ?? undefined,
-      // TODO remove `as` once we have a shared interface for configuration resources.
-      configuration: (this.configuration?.toJSON() ??
-        null) as ConnectorConfiguration,
+      configuration: this.configuration
+        ? this.strategy.configurationJSON(this.configuration)
+        : null,
       pausedAt: this.pausedAt,
       updatedAt: this.updatedAt.getTime(),
     };

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -194,9 +194,8 @@ async function handler(
           dataSourceDescription = configurationRes.value.url;
           break;
         case "slack":
-          // We accept not receiving a configuration for slack
-          // When creating a Slack data source we don't receive a configuration but pass the default
-          // one as we create the connector.
+          // When creating a Slack data source we don't receive a configuration but pass a default
+          // value for it as we create the connector.
           configuration = {
             botEnabled: true,
             whitelistedDomains: undefined,

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -94,8 +94,8 @@ async function handler(
         });
       }
 
-      const { connectionId, provider, name, configuration } =
-        bodyValidation.right;
+      let { configuration } = bodyValidation.right;
+      const { connectionId, provider, name } = bodyValidation.right;
 
       if (!isConnectorProvider(provider)) {
         return apiError(req, res, {
@@ -193,6 +193,17 @@ async function handler(
           }
           dataSourceDescription = configurationRes.value.url;
           break;
+        case "slack":
+          // We accept not receiving a configuration for slack
+          // When creating a Slack data source we don't receive a configuration but pass the default
+          // one as we create the connector.
+          configuration = {
+            botEnabled: true,
+            whitelistedDomains: undefined,
+            autoReadChannelPattern: undefined,
+          };
+          break;
+
         default:
           dataSourceDescription = suffix
             ? `Managed Data Source for ${provider} (${suffix})`

--- a/types/src/connectors/api_handlers/connector_configuration.ts
+++ b/types/src/connectors/api_handlers/connector_configuration.ts
@@ -1,9 +1,11 @@
 import * as t from "io-ts";
 
-import { WebCrawlerConfigurationTypeSchema } from "../webcrawler";
+import { SlackConfigurationTypeSchema } from "../../connectors/slack";
+import { WebCrawlerConfigurationTypeSchema } from "../../connectors/webcrawler";
 
 export const ConnectorConfigurationTypeSchema = t.union([
   WebCrawlerConfigurationTypeSchema,
+  SlackConfigurationTypeSchema,
   t.null,
 ]);
 

--- a/types/src/connectors/configuration.ts
+++ b/types/src/connectors/configuration.ts
@@ -1,13 +1,15 @@
+import { SlackConfigurationType } from "../connectors//slack";
 import { WebCrawlerConfigurationType } from "../connectors/webcrawler";
 
-export type ConnectorConfiguration = WebCrawlerConfigurationType | null;
+export type ConnectorConfiguration =
+  | WebCrawlerConfigurationType
+  | SlackConfigurationType
+  | null;
 
 export type ConnectorConfigurations = {
   webcrawler: WebCrawlerConfigurationType;
   notion: null;
-  // Slack technically has a configuration as per file `src/connectors/slack.ts` but we don't set it
-  // here because we don't expect a configuration at connector creation time for now.
-  slack: null;
+  slack: SlackConfigurationType;
   google_drive: null;
   github: null;
   confluence: null;


### PR DESCRIPTION
## Description

- Adds better support for typing of the ConfigurationResource toJSON throught the strategy `configurationJSON` helper
- Make SlackConfigurationType the official configuration of slack
- Use a default value in /managed in front to please the new requirement for a slack configuration at creation.

## Risk

N/A

## Deploy Plan

- deploy `front` (first)
- deploy `connectors`