### PR TITLE
enh: refactor connectors management interface with classes

### DIFF
--- a/connectors/migrations/20240110_batch_resync_notion_connectors.ts
+++ b/connectors/migrations/20240110_batch_resync_notion_connectors.ts
@@ -1,129 +1,129 @@
-import type { ModelId, Result } from "@dust-tt/types";
-import parseArgs from "minimist";
-import readline from "readline";
+// import type { ModelId, Result } from "@dust-tt/types";
+// import parseArgs from "minimist";
+// import readline from "readline";
 
-import { SYNC_CONNECTOR_BY_TYPE } from "@connectors/connectors";
-import { sequelizeConnection } from "@connectors/resources/storage";
+// import { SYNC_CONNECTOR_BY_TYPE } from "@connectors/connectors";
+// import { sequelizeConnection } from "@connectors/resources/storage";
 
-const main = async () => {
-  const argv = parseArgs(process.argv.slice(2));
+// const main = async () => {
+//   const argv = parseArgs(process.argv.slice(2));
 
-  if (argv._.length < 3) {
-    throw new Error(
-      "Expects size, batchNumber, batchSize as argument, eg: `cli medium 0 10`"
-    );
-  }
+//   if (argv._.length < 3) {
+//     throw new Error(
+//       "Expects size, batchNumber, batchSize as argument, eg: `cli medium 0 10`"
+//     );
+//   }
 
-  const [size, batchNumberStr, batchSizeStr] = argv._;
+//   const [size, batchNumberStr, batchSizeStr] = argv._;
 
-  if (!size || !["small", "medium", "large"].includes(size)) {
-    throw new Error("size must be small, medium or large");
-  }
+//   if (!size || !["small", "medium", "large"].includes(size)) {
+//     throw new Error("size must be small, medium or large");
+//   }
 
-  if (!batchNumberStr || !batchSizeStr) {
-    throw new Error("batchNumber and batchSize are required");
-  }
+//   if (!batchNumberStr || !batchSizeStr) {
+//     throw new Error("batchNumber and batchSize are required");
+//   }
 
-  const batchNumber = parseInt(batchNumberStr, 10);
-  const batchSize = parseInt(batchSizeStr, 10);
+//   const batchNumber = parseInt(batchNumberStr, 10);
+//   const batchSize = parseInt(batchSizeStr, 10);
 
-  if (isNaN(batchNumber) || isNaN(batchSize)) {
-    throw new Error("batchNumber and batchSize must be numbers");
-  }
+//   if (isNaN(batchNumber) || isNaN(batchSize)) {
+//     throw new Error("batchNumber and batchSize must be numbers");
+//   }
 
-  if (batchNumber < 0) {
-    throw new Error("batchNumber must be positive");
-  }
+//   if (batchNumber < 0) {
+//     throw new Error("batchNumber must be positive");
+//   }
 
-  const queryRes = await sequelizeConnection.query(`
-    SELECT COUNT(*) c, "connectorId"
-    FROM notion_pages
-    WHERE "connectorId" IS NOT NULL
-    GROUP BY "connectorId"
-    ORDER BY "connectorId" ASC`);
+//   const queryRes = await sequelizeConnection.query(`
+//     SELECT COUNT(*) c, "connectorId"
+//     FROM notion_pages
+//     WHERE "connectorId" IS NOT NULL
+//     GROUP BY "connectorId"
+//     ORDER BY "connectorId" ASC`);
 
-  const connectorIdsWithCount = queryRes[0] as {
-    c: number;
-    connectorId: ModelId;
-  }[];
+//   const connectorIdsWithCount = queryRes[0] as {
+//     c: number;
+//     connectorId: ModelId;
+//   }[];
 
-  const filter = (c: number) => {
-    if (size === "small") {
-      return c <= 10_000;
-    }
+//   const filter = (c: number) => {
+//     if (size === "small") {
+//       return c <= 10_000;
+//     }
 
-    if (size === "medium") {
-      return c > 10_000 && c <= 60_000;
-    }
+//     if (size === "medium") {
+//       return c > 10_000 && c <= 60_000;
+//     }
 
-    if (size === "large") {
-      return c > 60_000;
-    }
-  };
+//     if (size === "large") {
+//       return c > 60_000;
+//     }
+//   };
 
-  const connectorIds = connectorIdsWithCount
-    .filter((c) => filter(c.c))
-    .map((c) => c.connectorId);
+//   const connectorIds = connectorIdsWithCount
+//     .filter((c) => filter(c.c))
+//     .map((c) => c.connectorId);
 
-  let connectorsToResync = [];
+//   let connectorsToResync = [];
 
-  if (batchSize !== -1) {
-    const start = batchNumber * batchSize;
-    const end = start + batchSize;
-    const batchesRemaining = Math.ceil((connectorIds.length - end) / batchSize);
-    console.log(
-      `Resyncing batch ${batchNumber} of size ${batchSize} (from ${start} to ${end}). ${batchesRemaining} batches remaining.`
-    );
-    connectorsToResync = connectorIds.slice(start, end);
-  } else {
-    console.log(`Resyncing ${connectorIds.length} connectors`);
-    connectorsToResync = connectorIds;
-  }
+//   if (batchSize !== -1) {
+//     const start = batchNumber * batchSize;
+//     const end = start + batchSize;
+//     const batchesRemaining = Math.ceil((connectorIds.length - end) / batchSize);
+//     console.log(
+//       `Resyncing batch ${batchNumber} of size ${batchSize} (from ${start} to ${end}). ${batchesRemaining} batches remaining.`
+//     );
+//     connectorsToResync = connectorIds.slice(start, end);
+//   } else {
+//     console.log(`Resyncing ${connectorIds.length} connectors`);
+//     connectorsToResync = connectorIds;
+//   }
 
-  console.log("Connectors to resync:", connectorsToResync);
+//   console.log("Connectors to resync:", connectorsToResync);
 
-  const answer: string = await new Promise((resolve) => {
-    const rl = readline.createInterface({
-      input: process.stdin,
-      output: process.stdout,
-    });
-    rl.question(
-      "Are you sure you want to trigger full sync" +
-        ` for ${connectorsToResync.length} Notion connectors ? (y/N) `,
-      (answer) => {
-        rl.close();
-        resolve(answer);
-      }
-    );
-  });
+//   const answer: string = await new Promise((resolve) => {
+//     const rl = readline.createInterface({
+//       input: process.stdin,
+//       output: process.stdout,
+//     });
+//     rl.question(
+//       "Are you sure you want to trigger full sync" +
+//         ` for ${connectorsToResync.length} Notion connectors ? (y/N) `,
+//       (answer) => {
+//         rl.close();
+//         resolve(answer);
+//       }
+//     );
+//   });
 
-  if (answer !== "y") {
-    console.log("Cancelled");
-    return;
-  }
+//   if (answer !== "y") {
+//     console.log("Cancelled");
+//     return;
+//   }
 
-  for (const connectorId of connectorsToResync) {
-    await throwOnError(SYNC_CONNECTOR_BY_TYPE["notion"](connectorId, null));
-  }
+//   for (const connectorId of connectorsToResync) {
+//     await throwOnError(SYNC_CONNECTOR_BY_TYPE["notion"](connectorId, null));
+//   }
 
-  return;
-};
+//   return;
+// };
 
-main()
-  .then(() => {
-    console.error("\x1b[32m%s\x1b[0m", `Done`);
-    process.exit(0);
-  })
-  .catch((err) => {
-    console.error("\x1b[31m%s\x1b[0m", `Error: ${err.message}`);
-    console.log(err);
-    process.exit(1);
-  });
+// main()
+//   .then(() => {
+//     console.error("\x1b[32m%s\x1b[0m", `Done`);
+//     process.exit(0);
+//   })
+//   .catch((err) => {
+//     console.error("\x1b[31m%s\x1b[0m", `Error: ${err.message}`);
+//     console.log(err);
+//     process.exit(1);
+//   });
 
-async function throwOnError<T>(p: Promise<Result<T, Error>>) {
-  const res = await p;
-  if (res.isErr()) {
-    throw res.error;
-  }
-  return res;
-}
+// async function throwOnError<T>(p: Promise<Result<T, Error>>) {
+//   const res = await p;
+//   if (res.isErr()) {
+//     throw res.error;
+//   }
+//   return res;
+// }

--- a/connectors/migrations/20240111_batch_resync_google_drive_connectors.ts
+++ b/connectors/migrations/20240111_batch_resync_google_drive_connectors.ts
@@ -1,110 +1,110 @@
-import type { ModelId, Result } from "@dust-tt/types";
-import parseArgs from "minimist";
-import readline from "readline";
+// import type { ModelId, Result } from "@dust-tt/types";
+// import parseArgs from "minimist";
+// import readline from "readline";
 
-import { SYNC_CONNECTOR_BY_TYPE } from "@connectors/connectors";
-import { sequelizeConnection } from "@connectors/resources/storage";
+// import { SYNC_CONNECTOR_BY_TYPE } from "@connectors/connectors";
+// import { sequelizeConnection } from "@connectors/resources/storage";
 
-const main = async () => {
-  const argv = parseArgs(process.argv.slice(2));
+// const main = async () => {
+//   const argv = parseArgs(process.argv.slice(2));
 
-  const { size, batchNumber, batchSize } = argv;
+//   const { size, batchNumber, batchSize } = argv;
 
-  if (!size || !["small", "large"].includes(size)) {
-    throw new Error("size must be small or large");
-  }
+//   if (!size || !["small", "large"].includes(size)) {
+//     throw new Error("size must be small or large");
+//   }
 
-  if (batchNumber === undefined || batchNumber < 0) {
-    throw new Error("batchNumber must be positive");
-  }
+//   if (batchNumber === undefined || batchNumber < 0) {
+//     throw new Error("batchNumber must be positive");
+//   }
 
-  const queryRes = await sequelizeConnection.query(`
-    SELECT COUNT(*) c, "connectorId"
-    FROM google_drive_files
-    WHERE "connectorId" IS NOT NULL
-    GROUP BY "connectorId"
-    ORDER BY "connectorId" ASC`);
+//   const queryRes = await sequelizeConnection.query(`
+//     SELECT COUNT(*) c, "connectorId"
+//     FROM google_drive_files
+//     WHERE "connectorId" IS NOT NULL
+//     GROUP BY "connectorId"
+//     ORDER BY "connectorId" ASC`);
 
-  const connectorIdsWithCount = queryRes[0] as {
-    c: number;
-    connectorId: ModelId;
-  }[];
+//   const connectorIdsWithCount = queryRes[0] as {
+//     c: number;
+//     connectorId: ModelId;
+//   }[];
 
-  const filter = (c: number) => {
-    if (size === "small") {
-      return c <= 10_000;
-    }
+//   const filter = (c: number) => {
+//     if (size === "small") {
+//       return c <= 10_000;
+//     }
 
-    if (size === "large") {
-      return c > 10_000;
-    }
-  };
+//     if (size === "large") {
+//       return c > 10_000;
+//     }
+//   };
 
-  const connectorIds = connectorIdsWithCount
-    .filter((c) => filter(c.c))
-    .map((c) => c.connectorId);
+//   const connectorIds = connectorIdsWithCount
+//     .filter((c) => filter(c.c))
+//     .map((c) => c.connectorId);
 
-  let connectorsToResync = [];
+//   let connectorsToResync = [];
 
-  if (batchSize) {
-    const start = batchNumber * batchSize;
-    const end = start + batchSize;
-    const batchesRemaining = Math.ceil((connectorIds.length - end) / batchSize);
-    console.log(
-      `Resyncing batch ${batchNumber} of size ${batchSize} (from ${start} to ${end}). ${batchesRemaining} batches remaining.`
-    );
-    connectorsToResync = connectorIds.slice(start, end);
-  } else {
-    console.log(`Resyncing ${connectorIds.length} connectors`);
-    connectorsToResync = connectorIds;
-  }
+//   if (batchSize) {
+//     const start = batchNumber * batchSize;
+//     const end = start + batchSize;
+//     const batchesRemaining = Math.ceil((connectorIds.length - end) / batchSize);
+//     console.log(
+//       `Resyncing batch ${batchNumber} of size ${batchSize} (from ${start} to ${end}). ${batchesRemaining} batches remaining.`
+//     );
+//     connectorsToResync = connectorIds.slice(start, end);
+//   } else {
+//     console.log(`Resyncing ${connectorIds.length} connectors`);
+//     connectorsToResync = connectorIds;
+//   }
 
-  console.log("Connectors to resync:", connectorsToResync);
+//   console.log("Connectors to resync:", connectorsToResync);
 
-  const answer: string = await new Promise((resolve) => {
-    const rl = readline.createInterface({
-      input: process.stdin,
-      output: process.stdout,
-    });
-    rl.question(
-      "Are you sure you want to trigger full sync" +
-        ` for ${connectorsToResync.length} Notion connectors ? (y/N) `,
-      (answer) => {
-        rl.close();
-        resolve(answer);
-      }
-    );
-  });
+//   const answer: string = await new Promise((resolve) => {
+//     const rl = readline.createInterface({
+//       input: process.stdin,
+//       output: process.stdout,
+//     });
+//     rl.question(
+//       "Are you sure you want to trigger full sync" +
+//         ` for ${connectorsToResync.length} Notion connectors ? (y/N) `,
+//       (answer) => {
+//         rl.close();
+//         resolve(answer);
+//       }
+//     );
+//   });
 
-  if (answer !== "y") {
-    console.log("Cancelled");
-    return;
-  }
+//   if (answer !== "y") {
+//     console.log("Cancelled");
+//     return;
+//   }
 
-  for (const connectorId of connectorsToResync) {
-    await throwOnError(
-      SYNC_CONNECTOR_BY_TYPE["google_drive"](connectorId, null)
-    );
-  }
+//   for (const connectorId of connectorsToResync) {
+//     await throwOnError(
+//       SYNC_CONNECTOR_BY_TYPE["google_drive"](connectorId, null)
+//     );
+//   }
 
-  return;
-};
+//   return;
+// };
 
-main()
-  .then(() => {
-    console.error("\x1b[32m%s\x1b[0m", `Done`);
-    process.exit(0);
-  })
-  .catch((err) => {
-    console.error("\x1b[31m%s\x1b[0m", `Error: ${err.message}`);
-    console.log(err);
-    process.exit(1);
-  });
+// main()
+//   .then(() => {
+//     console.error("\x1b[32m%s\x1b[0m", `Done`);
+//     process.exit(0);
+//   })
+//   .catch((err) => {
+//     console.error("\x1b[31m%s\x1b[0m", `Error: ${err.message}`);
+//     console.log(err);
+//     process.exit(1);
+//   });
 
-async function throwOnError<T>(p: Promise<Result<T, Error>>) {
-  const res = await p;
-  if (res.isErr()) {
-    throw res.error;
-  }
-  return res;
-}
+// async function throwOnError<T>(p: Promise<Result<T, Error>>) {
+//   const res = await p;
+//   if (res.isErr()) {
+//     throw res.error;
+//   }
+//   return res;
+// }

--- a/connectors/src/api/configuration.ts
+++ b/connectors/src/api/configuration.ts
@@ -11,7 +11,7 @@ import {
 } from "@dust-tt/types";
 import type { Request, Response } from "express";
 
-import { SET_CONNECTOR_CONFIGURATION_BY_TYPE } from "@connectors/connectors";
+import { getConnectorManager } from "@connectors/connectors";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 
@@ -53,9 +53,11 @@ const _patchConnectorConfiguration = async (
           status_code: 400,
         });
       }
-      const setConfiguration =
-        SET_CONNECTOR_CONFIGURATION_BY_TYPE[connector.type];
-      patchRes = await setConfiguration(connector.id, parseRes.value);
+
+      patchRes = await getConnectorManager({
+        connectorId: connector.id,
+        connectorProvider: "webcrawler",
+      }).configure({ configuration: parseRes.value });
       break;
     }
 

--- a/connectors/src/api/connector_config.ts
+++ b/connectors/src/api/connector_config.ts
@@ -4,10 +4,7 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 
-import {
-  GET_CONNECTOR_CONFIG_BY_TYPE,
-  SET_CONNECTOR_CONFIG_BY_TYPE,
-} from "@connectors/connectors";
+import { getConnectorManager } from "@connectors/connectors";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 
@@ -55,8 +52,11 @@ const _getConnectorConfig = async (
       status_code: 404,
     });
   }
-  const getter = GET_CONNECTOR_CONFIG_BY_TYPE[connector.type];
-  const configValueRes = await getter(connector.id, req.params.config_key);
+
+  const configValueRes = await getConnectorManager({
+    connectorId: connector.id,
+    connectorProvider: "webcrawler",
+  }).getConfigurationKey({ configKey: req.params.config_key });
   if (configValueRes.isErr()) {
     return apiError(
       req,
@@ -129,12 +129,14 @@ const _setConnectorConfig = async (
       status_code: 404,
     });
   }
-  const setter = SET_CONNECTOR_CONFIG_BY_TYPE[connector.type];
-  const setConfigRes = await setter(
-    connector.id,
-    req.params.config_key,
-    req.body.configValue
-  );
+
+  const setConfigRes = await getConnectorManager({
+    connectorId: connector.id,
+    connectorProvider: "webcrawler",
+  }).setConfigurationKey({
+    configKey: req.params.config_key,
+    configValue: req.body.configValue,
+  });
   if (setConfigRes.isErr()) {
     return apiError(
       req,

--- a/connectors/src/api/create_connector.ts
+++ b/connectors/src/api/create_connector.ts
@@ -15,7 +15,7 @@ import type { Request, Response } from "express";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
 
-import { CREATE_CONNECTOR_BY_TYPE } from "@connectors/connectors";
+import { createConnector } from "@connectors/connectors";
 import { errorFromAny } from "@connectors/lib/error";
 import logger from "@connectors/logger/logger";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
@@ -62,8 +62,6 @@ const _createConnectorAPIHandler = async (
     let connectorRes: Result<string, Error> | null = null;
     switch (req.params.connector_provider) {
       case "webcrawler": {
-        const connectorCreator =
-          CREATE_CONNECTOR_BY_TYPE[req.params.connector_provider];
         const configurationRes = ioTsParsePayload(
           configuration,
           WebCrawlerConfigurationTypeSchema
@@ -77,21 +75,22 @@ const _createConnectorAPIHandler = async (
             },
           });
         }
-        connectorRes = await connectorCreator(
-          {
-            workspaceAPIKey: workspaceAPIKey,
-            dataSourceName: dataSourceName,
-            workspaceId: workspaceId,
+        connectorRes = await createConnector({
+          connectorProvider: "webcrawler",
+          params: {
+            configuration: configurationRes.value,
+            dataSourceConfig: {
+              dataSourceName,
+              workspaceId,
+              workspaceAPIKey,
+            },
+            connectionId,
           },
-          connectionId,
-          configurationRes.value
-        );
+        });
         break;
       }
 
       case "slack": {
-        const connectorCreator =
-          CREATE_CONNECTOR_BY_TYPE[req.params.connector_provider];
         const configurationRes = ioTsParsePayload(
           configuration,
           SlackConfigurationTypeSchema
@@ -105,15 +104,18 @@ const _createConnectorAPIHandler = async (
             },
           });
         }
-        connectorRes = await connectorCreator(
-          {
-            workspaceAPIKey: workspaceAPIKey,
-            dataSourceName: dataSourceName,
-            workspaceId: workspaceId,
+        connectorRes = await createConnector({
+          connectorProvider: "slack",
+          params: {
+            configuration: configurationRes.value,
+            dataSourceConfig: {
+              dataSourceName,
+              workspaceId,
+              workspaceAPIKey,
+            },
+            connectionId,
           },
-          connectionId,
-          configurationRes.value
-        );
+        });
         break;
       }
 
@@ -123,17 +125,27 @@ const _createConnectorAPIHandler = async (
       case "google_drive":
       case "intercom":
       case "microsoft": {
-        const connectorCreator =
-          CREATE_CONNECTOR_BY_TYPE[req.params.connector_provider];
-        connectorRes = await connectorCreator(
-          {
-            workspaceAPIKey: workspaceAPIKey,
-            dataSourceName: dataSourceName,
-            workspaceId: workspaceId,
+        // const connectorCreator =
+        //   CREATE_CONNECTOR_BY_TYPE[req.params.connector_provider];
+        // connectorRes = await connectorCreator(
+        //   {
+        //     workspaceAPIKey: workspaceAPIKey,
+        //     dataSourceName: dataSourceName,
+        //     workspaceId: workspaceId,
+        //   },
+        // });
+        connectorRes = await createConnector({
+          connectorProvider: req.params.connector_provider,
+          params: {
+            dataSourceConfig: {
+              dataSourceName,
+              workspaceId,
+              workspaceAPIKey,
+            },
+            connectionId,
+            configuration: null,
           },
-          connectionId,
-          null
-        );
+        });
         break;
       }
       default:

--- a/connectors/src/api/create_connector.ts
+++ b/connectors/src/api/create_connector.ts
@@ -125,15 +125,6 @@ const _createConnectorAPIHandler = async (
       case "google_drive":
       case "intercom":
       case "microsoft": {
-        // const connectorCreator =
-        //   CREATE_CONNECTOR_BY_TYPE[req.params.connector_provider];
-        // connectorRes = await connectorCreator(
-        //   {
-        //     workspaceAPIKey: workspaceAPIKey,
-        //     dataSourceName: dataSourceName,
-        //     workspaceId: workspaceId,
-        //   },
-        // });
         connectorRes = await createConnector({
           connectorProvider: req.params.connector_provider,
           params: {

--- a/connectors/src/api/get_connector_permissions.ts
+++ b/connectors/src/api/get_connector_permissions.ts
@@ -5,7 +5,7 @@ import type {
 import type { ContentNode } from "@dust-tt/types";
 import type { Request, Response } from "express";
 
-import { RETRIEVE_CONNECTOR_PERMISSIONS_BY_TYPE } from "@connectors/connectors";
+import { getConnectorManager } from "@connectors/connectors";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 
@@ -73,11 +73,10 @@ const _getConnectorPermissions = async (
     });
   }
 
-  const connectorPermissionRetriever =
-    RETRIEVE_CONNECTOR_PERMISSIONS_BY_TYPE[connector.type];
-
-  const pRes = await connectorPermissionRetriever({
+  const pRes = await getConnectorManager({
+    connectorProvider: connector.type,
     connectorId: connector.id,
+  }).retrievePermissions({
     parentInternalId,
     filterPermission,
     viewType,

--- a/connectors/src/api/get_content_node_parents.ts
+++ b/connectors/src/api/get_content_node_parents.ts
@@ -5,7 +5,7 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 
-import { RETRIEVE_CONTENT_NODE_PARENTS_BY_TYPE } from "@connectors/connectors";
+import { getConnectorManager } from "@connectors/connectors";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import logger from "@connectors/logger/logger";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
@@ -61,10 +61,13 @@ const _getContentNodesParents = async (
 
   const { internalIds } = bodyValidation.right;
 
-  const parentsGetter = RETRIEVE_CONTENT_NODE_PARENTS_BY_TYPE[connector.type];
+  const connectorManager = getConnectorManager({
+    connectorProvider: connector.type,
+    connectorId: connector.id,
+  });
   const parentsResults = await concurrentExecutor(
     internalIds,
-    (internalId) => parentsGetter(connector.id, internalId),
+    (internalId) => connectorManager.retrieveContentNodeParents({ internalId }),
     { concurrency: 4 }
   );
   const nodes: { internalId: string; parents: string[] }[] = [];

--- a/connectors/src/api/get_content_nodes.ts
+++ b/connectors/src/api/get_content_nodes.ts
@@ -8,7 +8,7 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 
-import { BATCH_RETRIEVE_CONTENT_NODES_BY_TYPE } from "@connectors/connectors";
+import { getConnectorManager } from "@connectors/connectors";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 
@@ -58,11 +58,10 @@ const _getContentNodes = async (
   const { internalIds, viewType } = bodyValidation.right;
 
   const contentNodesRes: Result<ContentNode[], Error> =
-    await BATCH_RETRIEVE_CONTENT_NODES_BY_TYPE[connector.type](
-      connector.id,
-      internalIds,
-      viewType
-    );
+    await getConnectorManager({
+      connectorProvider: connector.type,
+      connectorId: connector.id,
+    }).retrieveBatchContentNodes({ internalIds, viewType });
 
   if (contentNodesRes.isErr()) {
     return apiError(req, res, {

--- a/connectors/src/api/pause_connector.ts
+++ b/connectors/src/api/pause_connector.ts
@@ -1,7 +1,7 @@
 import type { WithConnectorsAPIErrorReponse } from "@dust-tt/types";
 import type { Request, Response } from "express";
 
-import { PAUSE_CONNECTOR_BY_TYPE } from "@connectors/connectors";
+import { getConnectorManager } from "@connectors/connectors";
 import { errorFromAny } from "@connectors/lib/error";
 import logger from "@connectors/logger/logger";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
@@ -28,9 +28,11 @@ const _pauseConnectorAPIHandler = async (
         status_code: 404,
       });
     }
-    const connectorPauser = PAUSE_CONNECTOR_BY_TYPE[connector.type];
 
-    const pauseRes = await connectorPauser(connector.id);
+    const pauseRes = await getConnectorManager({
+      connectorProvider: connector.type,
+      connectorId: connector.id,
+    }).pause();
 
     if (pauseRes.isErr()) {
       return apiError(req, res, {

--- a/connectors/src/api/resume_connector.ts
+++ b/connectors/src/api/resume_connector.ts
@@ -1,7 +1,7 @@
 import type { WithConnectorsAPIErrorReponse } from "@dust-tt/types";
 import type { Request, Response } from "express";
 
-import { RESUME_CONNECTOR_BY_TYPE } from "@connectors/connectors";
+import { getConnectorManager } from "@connectors/connectors";
 import { errorFromAny } from "@connectors/lib/error";
 import logger from "@connectors/logger/logger";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
@@ -28,9 +28,11 @@ const _resumeConnectorAPIHandler = async (
         },
       });
     }
-    const connectorResumer = RESUME_CONNECTOR_BY_TYPE[connector.type];
 
-    const resumeRes = await connectorResumer(connector.id);
+    const resumeRes = await getConnectorManager({
+      connectorProvider: connector.type,
+      connectorId: connector.id,
+    }).resume();
 
     if (resumeRes.isErr()) {
       return apiError(req, res, {

--- a/connectors/src/api/set_connector_permissions.ts
+++ b/connectors/src/api/set_connector_permissions.ts
@@ -4,7 +4,7 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 
-import { SET_CONNECTOR_PERMISSIONS_BY_TYPE } from "@connectors/connectors";
+import { getConnectorManager } from "@connectors/connectors";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 
@@ -75,16 +75,15 @@ const _setConnectorPermissions = async (
     });
   }
 
-  const connectorPermissionSetter =
-    SET_CONNECTOR_PERMISSIONS_BY_TYPE[connector.type];
-
-  const pRes = await connectorPermissionSetter(
-    connector.id,
-    resources.reduce(
+  const pRes = await getConnectorManager({
+    connectorProvider: connector.type,
+    connectorId: connector.id,
+  }).setPermissions({
+    permissions: resources.reduce(
       (acc, r) => Object.assign(acc, { [r.internal_id]: r.permission }),
       {}
-    )
-  );
+    ),
+  });
 
   if (pRes.isErr()) {
     return apiError(req, res, {

--- a/connectors/src/api/stop_connector.ts
+++ b/connectors/src/api/stop_connector.ts
@@ -1,7 +1,7 @@
 import type { WithConnectorsAPIErrorReponse } from "@dust-tt/types";
 import type { Request, Response } from "express";
 
-import { STOP_CONNECTOR_BY_TYPE } from "@connectors/connectors";
+import { getConnectorManager } from "@connectors/connectors";
 import { errorFromAny } from "@connectors/lib/error";
 import logger from "@connectors/logger/logger";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
@@ -28,9 +28,11 @@ const _stopConnectorAPIHandler = async (
         status_code: 404,
       });
     }
-    const connectorStopper = STOP_CONNECTOR_BY_TYPE[connector.type];
 
-    const stopRes = await connectorStopper(connector.id);
+    const stopRes = await getConnectorManager({
+      connectorProvider: connector.type,
+      connectorId: connector.id,
+    }).stop();
 
     if (stopRes.isErr()) {
       return apiError(req, res, {

--- a/connectors/src/api/sync_connector.ts
+++ b/connectors/src/api/sync_connector.ts
@@ -1,7 +1,7 @@
 import type { WithConnectorsAPIErrorReponse } from "@dust-tt/types";
 import type { Request, Response } from "express";
 
-import { SYNC_CONNECTOR_BY_TYPE } from "@connectors/connectors";
+import { getConnectorManager } from "@connectors/connectors";
 import { withLogging } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 
@@ -32,10 +32,11 @@ const _syncConnectorAPIHandler = async (
     });
     return;
   }
-  const launchRes = await SYNC_CONNECTOR_BY_TYPE[connector.type](
-    connector.id,
-    null
-  );
+  const launchRes = await getConnectorManager({
+    connectorProvider: connector.type,
+    connectorId: connector.id,
+  }).sync({ fromTs: null });
+
   if (launchRes.isErr()) {
     res.status(500).send({
       error: {

--- a/connectors/src/api/unpause_connector.ts
+++ b/connectors/src/api/unpause_connector.ts
@@ -1,7 +1,7 @@
 import type { WithConnectorsAPIErrorReponse } from "@dust-tt/types";
 import type { Request, Response } from "express";
 
-import { UNPAUSE_CONNECTOR_BY_TYPE } from "@connectors/connectors";
+import { getConnectorManager } from "@connectors/connectors";
 import { errorFromAny } from "@connectors/lib/error";
 import logger from "@connectors/logger/logger";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
@@ -37,9 +37,11 @@ const _unpauseConnectorAPIHandler = async (
       );
       return res.sendStatus(204);
     }
-    const connectorUnpauser = UNPAUSE_CONNECTOR_BY_TYPE[connector.type];
 
-    const unpauseRes = await connectorUnpauser(connector.id);
+    const unpauseRes = await getConnectorManager({
+      connectorProvider: connector.type,
+      connectorId: connector.id,
+    }).unpause();
 
     if (unpauseRes.isErr()) {
       return apiError(req, res, {

--- a/connectors/src/api/update_connector.ts
+++ b/connectors/src/api/update_connector.ts
@@ -4,7 +4,7 @@ import type { Request, Response } from "express";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
 
-import { UPDATE_CONNECTOR_BY_TYPE } from "@connectors/connectors";
+import { getConnectorManager } from "@connectors/connectors";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 
@@ -55,8 +55,10 @@ const _postConnectorUpdateAPIHandler = async (
     });
   }
 
-  const connectorUpdater = UPDATE_CONNECTOR_BY_TYPE[connector.type];
-  const updateRes = await connectorUpdater(connector.id, {
+  const updateRes = await getConnectorManager({
+    connectorProvider: connector.type,
+    connectorId: connector.id,
+  }).update({
     connectionId: connectionId,
   });
 

--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -2,7 +2,7 @@ import type {
   ConnectorPermission,
   ConnectorsAPIError,
   ContentNode,
-  ModelId,
+  ContentNodesViewType,
   Result,
 } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
@@ -34,7 +34,7 @@ import {
   launchConfluenceSyncWorkflow,
   stopConfluenceSyncWorkflow,
 } from "@connectors/connectors/confluence/temporal/client";
-import type { ConnectorPermissionRetriever } from "@connectors/connectors/interface";
+import { BaseConnectorManager } from "@connectors/connectors/interface";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import {
   ConfluenceConfiguration,
@@ -49,7 +49,6 @@ import { getAccessTokenFromNango } from "@connectors/lib/nango_helpers";
 import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
-import type { NangoConnectionId } from "@connectors/types/nango_connection_id";
 
 const { getRequiredNangoConfluenceConnectorId } = confluenceConfig;
 
@@ -57,471 +56,509 @@ const logger = mainLogger.child({
   connector: "confluence",
 });
 
-export async function createConfluenceConnector(
-  dataSourceConfig: DataSourceConfig,
-  connectionId: NangoConnectionId
-): Promise<Result<string, Error>> {
-  const nangoConnectionId = connectionId;
-  const confluenceAccessToken = await getAccessTokenFromNango({
-    connectionId: nangoConnectionId,
-    integrationId: getRequiredNangoConfluenceConnectorId(),
-    useCache: false,
-  });
-
-  const confluenceCloudInformation = await getConfluenceCloudInformation(
-    confluenceAccessToken
-  );
-  if (!confluenceCloudInformation) {
-    return new Err(new Error("Confluence access token is invalid"));
-  }
-
-  const userAccountId = await getConfluenceUserAccountId(confluenceAccessToken);
-
-  const { id: cloudId, url: cloudUrl } = confluenceCloudInformation;
-  try {
-    const confluenceConfigurationBlob = {
-      cloudId,
-      url: cloudUrl,
-      userAccountId,
-    };
-
-    const connector = await ConnectorResource.makeNew(
-      "confluence",
-      {
-        connectionId: nangoConnectionId,
-        workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
-        workspaceId: dataSourceConfig.workspaceId,
-        dataSourceName: dataSourceConfig.dataSourceName,
-      },
-      confluenceConfigurationBlob
-    );
-
-    const workflowStarted = await launchConfluenceSyncWorkflow(
-      connector.id,
-      null
-    );
-    if (workflowStarted.isErr()) {
-      return new Err(workflowStarted.error);
-    }
-
-    await launchConfluencePersonalDataReportingSchedule();
-
-    return new Ok(connector.id.toString());
-  } catch (e) {
-    logger.error({ error: e }, "Error creating confluence connector.");
-    return new Err(e as Error);
-  }
-}
-
-export async function updateConfluenceConnector(
-  connectorId: ModelId,
-  {
+export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
+  static async create({
+    dataSourceConfig,
     connectionId,
   }: {
-    connectionId?: NangoConnectionId | null;
-  }
-): Promise<Result<string, ConnectorsAPIError>> {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    logger.error({ connectorId }, "Connector not found.");
-    return new Err({
-      message: "Connector not found",
-      type: "connector_not_found",
-    });
-  }
-
-  if (connectionId) {
-    const { connectionId: oldConnectionId } = connector;
-
-    const currentCloudInformation = await ConfluenceConfiguration.findOne({
-      attributes: ["cloudId"],
-      where: {
-        connectorId,
-      },
+    dataSourceConfig: DataSourceConfig;
+    connectionId: string;
+  }): Promise<Result<string, Error>> {
+    const nangoConnectionId = connectionId;
+    const confluenceAccessToken = await getAccessTokenFromNango({
+      connectionId: nangoConnectionId,
+      integrationId: getRequiredNangoConfluenceConnectorId(),
+      useCache: false,
     });
 
-    const newConnection = await nango_client().getConnection(
-      getRequiredNangoConfluenceConnectorId(),
-      connectionId,
-      false
+    const confluenceCloudInformation = await getConfluenceCloudInformation(
+      confluenceAccessToken
     );
+    if (!confluenceCloudInformation) {
+      return new Err(new Error("Confluence access token is invalid"));
+    }
 
-    const confluenceAccessToken = newConnection?.credentials?.access_token;
-    const newConfluenceCloudInformation = await getConfluenceCloudInformation(
+    const userAccountId = await getConfluenceUserAccountId(
       confluenceAccessToken
     );
 
-    // Change connection only if "cloudId" matches.
-    if (
-      newConfluenceCloudInformation &&
-      currentCloudInformation &&
-      newConfluenceCloudInformation.id === currentCloudInformation.cloudId
-    ) {
-      await connector.update({ connectionId });
+    const { id: cloudId, url: cloudUrl } = confluenceCloudInformation;
+    try {
+      const confluenceConfigurationBlob = {
+        cloudId,
+        url: cloudUrl,
+        userAccountId,
+      };
 
-      await nangoDeleteConnection(
-        oldConnectionId,
-        getRequiredNangoConfluenceConnectorId()
-      );
-    } else {
-      logger.info(
+      const connector = await ConnectorResource.makeNew(
+        "confluence",
         {
-          connectorId,
-          newCloudId: newConfluenceCloudInformation?.id,
-          previousCloudId: currentCloudInformation?.cloudId,
+          connectionId: nangoConnectionId,
+          workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
+          workspaceId: dataSourceConfig.workspaceId,
+          dataSourceName: dataSourceConfig.dataSourceName,
         },
-        "Cannot change the workspace of a Confluence connector"
+        confluenceConfigurationBlob
       );
 
-      // If the new connection does not grant us access to the same cloud id
-      // delete the Nango Connection.
-      await nangoDeleteConnection(
-        connectionId,
-        getRequiredNangoConfluenceConnectorId()
+      const workflowStarted = await launchConfluenceSyncWorkflow(
+        connector.id,
+        null
       );
+      if (workflowStarted.isErr()) {
+        return new Err(workflowStarted.error);
+      }
 
+      await launchConfluencePersonalDataReportingSchedule();
+
+      return new Ok(connector.id.toString());
+    } catch (e) {
+      logger.error({ error: e }, "Error creating confluence connector.");
+      return new Err(e as Error);
+    }
+  }
+
+  async update({
+    connectionId,
+  }: {
+    connectionId?: string | null;
+  }): Promise<Result<string, ConnectorsAPIError>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      logger.error({ connectorId: this.connectorId }, "Connector not found.");
       return new Err({
-        type: "connector_oauth_target_mismatch",
-        message: "Cannot change the workspace of a Confluence connector",
+        message: "Connector not found",
+        type: "connector_not_found",
       });
     }
+
+    if (connectionId) {
+      const { connectionId: oldConnectionId } = connector;
+
+      const currentCloudInformation = await ConfluenceConfiguration.findOne({
+        attributes: ["cloudId"],
+        where: {
+          connectorId: this.connectorId,
+        },
+      });
+
+      const newConnection = await nango_client().getConnection(
+        getRequiredNangoConfluenceConnectorId(),
+        connectionId,
+        false
+      );
+
+      const confluenceAccessToken = newConnection?.credentials?.access_token;
+      const newConfluenceCloudInformation = await getConfluenceCloudInformation(
+        confluenceAccessToken
+      );
+
+      // Change connection only if "cloudId" matches.
+      if (
+        newConfluenceCloudInformation &&
+        currentCloudInformation &&
+        newConfluenceCloudInformation.id === currentCloudInformation.cloudId
+      ) {
+        await connector.update({ connectionId });
+
+        await nangoDeleteConnection(
+          oldConnectionId,
+          getRequiredNangoConfluenceConnectorId()
+        );
+      } else {
+        logger.info(
+          {
+            connectorId: this.connectorId,
+            newCloudId: newConfluenceCloudInformation?.id,
+            previousCloudId: currentCloudInformation?.cloudId,
+          },
+          "Cannot change the workspace of a Confluence connector"
+        );
+
+        // If the new connection does not grant us access to the same cloud id
+        // delete the Nango Connection.
+        await nangoDeleteConnection(
+          connectionId,
+          getRequiredNangoConfluenceConnectorId()
+        );
+
+        return new Err({
+          type: "connector_oauth_target_mismatch",
+          message: "Cannot change the workspace of a Confluence connector",
+        });
+      }
+    }
+
+    return new Ok(connector.id.toString());
   }
 
-  return new Ok(connector.id.toString());
-}
+  async clean(): Promise<Result<undefined, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      logger.error(
+        { connectorId: this.connectorId },
+        "Confluence connector not found."
+      );
+      return new Err(new Error("Connector not found"));
+    }
 
-export async function stopConfluenceConnector(
-  connectorId: ModelId
-): Promise<Result<undefined, Error>> {
-  const res = await stopConfluenceSyncWorkflow(connectorId);
-  if (res.isErr()) {
-    return res;
+    const nangoRes = await nangoDeleteConnection(
+      connector.connectionId,
+      getRequiredNangoConfluenceConnectorId()
+    );
+    if (nangoRes.isErr()) {
+      throw nangoRes.error;
+    }
+
+    const res = await connector.delete();
+    if (res.isErr()) {
+      logger.error(
+        { connectorId: this.connectorId, error: res.error },
+        "Error cleaning up Confluence connector."
+      );
+      return res;
+    }
+
+    return new Ok(undefined);
   }
 
-  return new Ok(undefined);
-}
+  async stop(): Promise<Result<undefined, Error>> {
+    const res = await stopConfluenceSyncWorkflow(this.connectorId);
+    if (res.isErr()) {
+      return res;
+    }
 
-export async function resumeConfluenceConnector(
-  connectorId: ModelId
-): Promise<Result<undefined, Error>> {
-  try {
-    const connector = await ConnectorResource.fetchById(connectorId);
+    return new Ok(undefined);
+  }
+
+  async resume(): Promise<Result<undefined, Error>> {
+    try {
+      const connector = await ConnectorResource.fetchById(this.connectorId);
+      if (!connector) {
+        return new Err(
+          new Error(
+            `Confluence connector not found (connectorId: ${this.connectorId}`
+          )
+        );
+      }
+
+      const connectorState = await ConfluenceConfiguration.findOne({
+        where: {
+          connectorId: connector.id,
+        },
+      });
+      if (!connectorState) {
+        return new Err(new Error("Confluence configuration not found"));
+      }
+
+      await launchConfluenceSyncWorkflow(connector.id, null);
+
+      return new Ok(undefined);
+    } catch (err) {
+      return new Err(err as Error);
+    }
+  }
+
+  async sync({
+    fromTs,
+  }: {
+    fromTs: number | null;
+  }): Promise<Result<string, Error>> {
+    return launchConfluenceSyncWorkflow(this.connectorId, fromTs);
+  }
+
+  async retrievePermissions({
+    parentInternalId,
+    filterPermission,
+  }: {
+    parentInternalId: string | null;
+    filterPermission: ConnectorPermission | null;
+    viewType: ContentNodesViewType;
+  }): Promise<Result<ContentNode[], Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      logger.error({ connectorId: this.connectorId }, "Connector not found");
+      return new Err(new Error("Connector not found"));
+    }
+
+    const confluenceConfig = await ConfluenceConfiguration.findOne({
+      where: {
+        connectorId: this.connectorId,
+      },
+    });
+    if (!confluenceConfig) {
+      logger.error(
+        { connectorId: this.connectorId },
+        "Confluence configuration not found"
+      );
+      return new Err(new Error("Confluence configuration not found"));
+    }
+
+    // When the filter permission is set to 'read', the full hierarchy of spaces
+    // and pages that Dust can access is displayed to the user.
+    if (filterPermission === "read") {
+      const data = await retrieveHierarchyForParent(
+        connector,
+        confluenceConfig,
+        parentInternalId
+      );
+
+      if (data.isErr()) {
+        return new Err(data.error);
+      }
+
+      return new Ok(data.value);
+    } else {
+      // If the permission is not set to 'read', users are limited to selecting only
+      // spaces for synchronization with Dust.
+      const allSpaces = await retrieveAvailableSpaces(
+        connector,
+        confluenceConfig
+      );
+
+      return new Ok(allSpaces);
+    }
+  }
+
+  async setPermissions({
+    permissions,
+  }: {
+    permissions: Record<string, ConnectorPermission>;
+  }): Promise<Result<void, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
     if (!connector) {
       return new Err(
-        new Error(`Confluence connector not found (connectorId: ${connectorId}`)
+        new Error(`Connector not found with id ${this.connectorId}`)
       );
     }
 
+    let spaces: ConfluenceSpaceType[] = [];
+    // Fetch Confluence spaces only if the intention is to add new spaces to sync.
+    const shouldFetchConfluenceSpaces = Object.values(permissions).some(
+      (permission) => permission === "read"
+    );
+    if (shouldFetchConfluenceSpaces) {
+      spaces = await listConfluenceSpaces(connector);
+    }
+
+    const addedSpaceIds = [];
+    const removedSpaceIds = [];
+    for (const [internalId, permission] of Object.entries(permissions)) {
+      const confluenceId = getIdFromConfluenceInternalId(internalId);
+      if (permission === "none") {
+        await ConfluenceSpace.destroy({
+          where: {
+            connectorId: this.connectorId,
+            spaceId: confluenceId,
+          },
+        });
+
+        removedSpaceIds.push(confluenceId);
+      } else if (permission === "read") {
+        const confluenceSpace = spaces.find((s) => s.id === confluenceId);
+
+        await ConfluenceSpace.upsert({
+          connectorId: this.connectorId,
+          name: confluenceSpace?.name ?? confluenceId,
+          spaceId: confluenceId,
+          urlSuffix: confluenceSpace?._links.webui,
+        });
+
+        addedSpaceIds.push(confluenceId);
+      } else {
+        return new Err(
+          new Error(
+            `Invalid permission ${permission} for resource ${confluenceId}`
+          )
+        );
+      }
+    }
+
+    if (addedSpaceIds.length > 0) {
+      const addedSpacesResult = await launchConfluenceSyncWorkflow(
+        this.connectorId,
+        null,
+        addedSpaceIds
+      );
+      if (addedSpacesResult.isErr()) {
+        return new Err(addedSpacesResult.error);
+      }
+    }
+
+    if (removedSpaceIds.length > 0) {
+      const removedSpacesResult =
+        await launchConfluenceRemoveSpacesSyncWorkflow(
+          this.connectorId,
+          removedSpaceIds
+        );
+      if (removedSpacesResult.isErr()) {
+        return new Err(removedSpacesResult.error);
+      }
+    }
+
+    return new Ok(undefined);
+  }
+
+  async retrieveBatchContentNodes({
+    internalIds,
+  }: {
+    internalIds: string[];
+    viewType: ContentNodesViewType;
+  }): Promise<Result<ContentNode[], Error>> {
     const connectorState = await ConfluenceConfiguration.findOne({
       where: {
-        connectorId: connector.id,
+        connectorId: this.connectorId,
       },
     });
     if (!connectorState) {
       return new Err(new Error("Confluence configuration not found"));
     }
 
-    await launchConfluenceSyncWorkflow(connector.id, null);
+    const spaceIds: string[] = [];
+    const pageIds: string[] = [];
 
-    return new Ok(undefined);
-  } catch (err) {
-    return new Err(err as Error);
-  }
-}
+    internalIds.forEach((internalId) => {
+      if (isConfluenceInternalSpaceId(internalId)) {
+        spaceIds.push(getIdFromConfluenceInternalId(internalId));
+      } else if (isConfluenceInternalPageId(internalId)) {
+        pageIds.push(getIdFromConfluenceInternalId(internalId));
+      }
+    });
 
-export async function pauseConfluenceConnector(
-  connectorId: ModelId
-): Promise<Result<undefined, Error>> {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    logger.error({ connectorId }, "Connector not found.");
-    return new Err(new Error("Connector not found"));
-  }
-
-  await connector.markAsPaused();
-  const r = await stopConfluenceSyncWorkflow(connectorId);
-  if (r.isErr()) {
-    return r;
-  }
-
-  return new Ok(undefined);
-}
-
-export async function unpauseConfluenceConnector(
-  connectorId: ModelId
-): Promise<Result<undefined, Error>> {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    logger.error({ connectorId }, "Connector not found.");
-    return new Err(new Error("Connector not found"));
-  }
-
-  await connector.markAsUnpaused();
-  const r = await launchConfluenceSyncWorkflow(connectorId, null);
-  if (r.isErr()) {
-    return r;
-  }
-
-  return new Ok(undefined);
-}
-
-export async function cleanupConfluenceConnector(
-  connectorId: ModelId
-): Promise<Result<undefined, Error>> {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    logger.error({ connectorId }, "Confluence connector not found.");
-    return new Err(new Error("Connector not found"));
-  }
-
-  const nangoRes = await nangoDeleteConnection(
-    connector.connectionId,
-    getRequiredNangoConfluenceConnectorId()
-  );
-  if (nangoRes.isErr()) {
-    throw nangoRes.error;
-  }
-
-  const res = await connector.delete();
-  if (res.isErr()) {
-    logger.error(
-      { connectorId, error: res.error },
-      "Error cleaning up Confluence connector."
-    );
-    return res;
-  }
-
-  return new Ok(undefined);
-}
-
-export async function retrieveConfluenceConnectorPermissions({
-  connectorId,
-  parentInternalId,
-  filterPermission,
-}: Parameters<ConnectorPermissionRetriever>[0]): Promise<
-  Result<ContentNode[], Error>
-> {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    logger.error({ connectorId }, "Connector not found");
-    return new Err(new Error("Connector not found"));
-  }
-
-  const confluenceConfig = await ConfluenceConfiguration.findOne({
-    where: {
-      connectorId: connectorId,
-    },
-  });
-  if (!confluenceConfig) {
-    logger.error({ connectorId }, "Confluence configuration not found");
-    return new Err(new Error("Confluence configuration not found"));
-  }
-
-  // When the filter permission is set to 'read', the full hierarchy of spaces
-  // and pages that Dust can access is displayed to the user.
-  if (filterPermission === "read") {
-    const data = await retrieveHierarchyForParent(
-      connector,
-      confluenceConfig,
-      parentInternalId
-    );
-
-    if (data.isErr()) {
-      return new Err(data.error);
-    }
-
-    return new Ok(data.value);
-  } else {
-    // If the permission is not set to 'read', users are limited to selecting only
-    // spaces for synchronization with Dust.
-    const allSpaces = await retrieveAvailableSpaces(
-      connector,
-      confluenceConfig
-    );
-
-    return new Ok(allSpaces);
-  }
-}
-
-export async function setConfluenceConnectorPermissions(
-  connectorId: ModelId,
-  permissions: Record<string, ConnectorPermission>
-): Promise<Result<void, Error>> {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    return new Err(new Error(`Connector not found with id ${connectorId}`));
-  }
-
-  let spaces: ConfluenceSpaceType[] = [];
-  // Fetch Confluence spaces only if the intention is to add new spaces to sync.
-  const shouldFetchConfluenceSpaces = Object.values(permissions).some(
-    (permission) => permission === "read"
-  );
-  if (shouldFetchConfluenceSpaces) {
-    spaces = await listConfluenceSpaces(connector);
-  }
-
-  const addedSpaceIds = [];
-  const removedSpaceIds = [];
-  for (const [internalId, permission] of Object.entries(permissions)) {
-    const confluenceId = getIdFromConfluenceInternalId(internalId);
-    if (permission === "none") {
-      await ConfluenceSpace.destroy({
+    const [confluenceSpaces, confluencePages] = await Promise.all([
+      ConfluenceSpace.findAll({
         where: {
-          connectorId,
-          spaceId: confluenceId,
+          connectorId: this.connectorId,
+          spaceId: spaceIds,
+        },
+      }),
+      ConfluencePage.findAll({
+        where: {
+          connectorId: this.connectorId,
+          pageId: pageIds,
+        },
+      }),
+    ]);
+
+    const spaceContentNodes: ContentNode[] = confluenceSpaces.map((space) => {
+      return createContentNodeFromSpace(space, connectorState.url, "read", {
+        isExpandable: true,
+      });
+    });
+
+    const pageContentNodes: ContentNode[] = await concurrentExecutor(
+      confluencePages,
+      async (page) => {
+        let parentId: string;
+        let parentType: "page" | "space";
+
+        if (page.parentId) {
+          parentId = page.parentId;
+          parentType = "page";
+        } else {
+          parentId = page.spaceId;
+          parentType = "space";
+        }
+        const isExpandable = await checkPageHasChildren(
+          this.connectorId,
+          page.pageId
+        );
+
+        return createContentNodeFromPage(
+          { id: parentId, type: parentType },
+          connectorState.url,
+          page,
+          isExpandable
+        );
+      },
+      { concurrency: 8 }
+    );
+
+    const contentNodes = spaceContentNodes.concat(pageContentNodes);
+    return new Ok(contentNodes);
+  }
+
+  async retrieveContentNodeParents({
+    internalId,
+  }: {
+    internalId: string;
+    memoizationKey?: string;
+  }): Promise<Result<string[], Error>> {
+    const confluenceId = getIdFromConfluenceInternalId(internalId);
+
+    if (isConfluenceInternalPageId(internalId)) {
+      const currentPage = await ConfluencePage.findOne({
+        attributes: ["pageId", "parentId", "spaceId"],
+        where: {
+          connectorId: this.connectorId,
+          pageId: confluenceId,
         },
       });
 
-      removedSpaceIds.push(confluenceId);
-    } else if (permission === "read") {
-      const confluenceSpace = spaces.find((s) => s.id === confluenceId);
-
-      await ConfluenceSpace.upsert({
-        connectorId: connectorId,
-        name: confluenceSpace?.name ?? confluenceId,
-        spaceId: confluenceId,
-        urlSuffix: confluenceSpace?._links.webui,
-      });
-
-      addedSpaceIds.push(confluenceId);
-    } else {
-      return new Err(
-        new Error(
-          `Invalid permission ${permission} for resource ${confluenceId}`
-        )
-      );
-    }
-  }
-
-  if (addedSpaceIds.length > 0) {
-    const addedSpacesResult = await launchConfluenceSyncWorkflow(
-      connectorId,
-      null,
-      addedSpaceIds
-    );
-    if (addedSpacesResult.isErr()) {
-      return new Err(addedSpacesResult.error);
-    }
-  }
-
-  if (removedSpaceIds.length > 0) {
-    const removedSpacesResult = await launchConfluenceRemoveSpacesSyncWorkflow(
-      connectorId,
-      removedSpaceIds
-    );
-    if (removedSpacesResult.isErr()) {
-      return new Err(removedSpacesResult.error);
-    }
-  }
-
-  return new Ok(undefined);
-}
-
-export async function retrieveConfluenceContentNodes(
-  connectorId: ModelId,
-  internalIds: string[]
-): Promise<Result<ContentNode[], Error>> {
-  const connectorState = await ConfluenceConfiguration.findOne({
-    where: {
-      connectorId,
-    },
-  });
-  if (!connectorState) {
-    return new Err(new Error("Confluence configuration not found"));
-  }
-
-  const spaceIds: string[] = [];
-  const pageIds: string[] = [];
-
-  internalIds.forEach((internalId) => {
-    if (isConfluenceInternalSpaceId(internalId)) {
-      spaceIds.push(getIdFromConfluenceInternalId(internalId));
-    } else if (isConfluenceInternalPageId(internalId)) {
-      pageIds.push(getIdFromConfluenceInternalId(internalId));
-    }
-  });
-
-  const [confluenceSpaces, confluencePages] = await Promise.all([
-    ConfluenceSpace.findAll({
-      where: {
-        connectorId: connectorId,
-        spaceId: spaceIds,
-      },
-    }),
-    ConfluencePage.findAll({
-      where: {
-        connectorId: connectorId,
-        pageId: pageIds,
-      },
-    }),
-  ]);
-
-  const spaceContentNodes: ContentNode[] = confluenceSpaces.map((space) => {
-    return createContentNodeFromSpace(space, connectorState.url, "read", {
-      isExpandable: true,
-    });
-  });
-
-  const pageContentNodes: ContentNode[] = await concurrentExecutor(
-    confluencePages,
-    async (page) => {
-      let parentId: string;
-      let parentType: "page" | "space";
-
-      if (page.parentId) {
-        parentId = page.parentId;
-        parentType = "page";
-      } else {
-        parentId = page.spaceId;
-        parentType = "space";
+      if (!currentPage) {
+        return new Err(new Error("Confluence page not found."));
       }
-      const isExpandable = await checkPageHasChildren(connectorId, page.pageId);
 
-      return createContentNodeFromPage(
-        { id: parentId, type: parentType },
-        connectorState.url,
-        page,
-        isExpandable
+      // If the page does not have a parentId, return only the spaceId.
+      if (!currentPage.parentId) {
+        return new Ok([makeConfluenceInternalSpaceId(currentPage.spaceId)]);
+      }
+
+      const parentIds = await getConfluencePageParentIds(
+        this.connectorId,
+        currentPage
       );
-    },
-    { concurrency: 8 }
-  );
-
-  const contentNodes = spaceContentNodes.concat(pageContentNodes);
-  return new Ok(contentNodes);
-}
-
-export async function retrieveConfluenceContentNodeParents(
-  connectorId: ModelId,
-  internalId: string
-): Promise<Result<string[], Error>> {
-  const confluenceId = getIdFromConfluenceInternalId(internalId);
-
-  if (isConfluenceInternalPageId(internalId)) {
-    const currentPage = await ConfluencePage.findOne({
-      attributes: ["pageId", "parentId", "spaceId"],
-      where: {
-        connectorId,
-        pageId: confluenceId,
-      },
-    });
-
-    if (!currentPage) {
-      return new Err(new Error("Confluence page not found."));
+      return new Ok(parentIds);
     }
 
-    // If the page does not have a parentId, return only the spaceId.
-    if (!currentPage.parentId) {
-      return new Ok([makeConfluenceInternalSpaceId(currentPage.spaceId)]);
-    }
-
-    const parentIds = await getConfluencePageParentIds(
-      connectorId,
-      currentPage
-    );
-    return new Ok(parentIds);
+    return new Ok([]);
   }
 
-  return new Ok([]);
+  async pause(): Promise<Result<undefined, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      logger.error({ connectorId: this.connectorId }, "Connector not found.");
+      return new Err(new Error("Connector not found"));
+    }
+
+    await connector.markAsPaused();
+    const r = await stopConfluenceSyncWorkflow(this.connectorId);
+    if (r.isErr()) {
+      return r;
+    }
+
+    return new Ok(undefined);
+  }
+
+  async unpause(): Promise<Result<undefined, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      logger.error({ connectorId: this.connectorId }, "Connector not found.");
+      return new Err(new Error("Connector not found"));
+    }
+
+    await connector.markAsUnpaused();
+    const r = await launchConfluenceSyncWorkflow(this.connectorId, null);
+    if (r.isErr()) {
+      return r;
+    }
+
+    return new Ok(undefined);
+  }
+
+  async setConfigurationKey(): Promise<Result<void, Error>> {
+    throw new Error("Method not implemented.");
+  }
+
+  async getConfigurationKey(): Promise<Result<string | null, Error>> {
+    throw new Error("Method not implemented.");
+  }
+
+  async garbageCollect(): Promise<Result<string, Error>> {
+    throw new Error("Method not implemented.");
+  }
+
+  async configure(): Promise<Result<void, Error>> {
+    throw new Error("Method not implemented.");
+  }
 }

--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -273,7 +273,6 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
   }: {
     parentInternalId: string | null;
     filterPermission: ConnectorPermission | null;
-    viewType: ContentNodesViewType;
   }): Promise<Result<ContentNode[], Error>> {
     const connector = await ConnectorResource.fetchById(this.connectorId);
     if (!connector) {

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -1,9 +1,5 @@
-import type {
-  ConnectorsAPIError,
-  ContentNode,
-  ModelId,
-  Result,
-} from "@dust-tt/types";
+import type { ConnectorsAPIError, ContentNode, Result } from "@dust-tt/types";
+import type { ConnectorPermission, ContentNodesViewType } from "@dust-tt/types";
 import { assertNever, Err, Ok } from "@dust-tt/types";
 
 import type { GithubRepo } from "@connectors/connectors/github/lib/github_api";
@@ -15,10 +11,7 @@ import {
 import { getGithubCodeOrDirectoryParentIds } from "@connectors/connectors/github/lib/hierarchy";
 import { matchGithubInternalIdType } from "@connectors/connectors/github/lib/utils";
 import { launchGithubFullSyncWorkflow } from "@connectors/connectors/github/temporal/client";
-import type {
-  ConnectorConfigGetter,
-  ConnectorPermissionRetriever,
-} from "@connectors/connectors/interface";
+import { BaseConnectorManager } from "@connectors/connectors/interface";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import {
   GithubCodeDirectory,
@@ -37,748 +30,769 @@ type GithubInstallationId = string;
 
 const logger = mainLogger.child({ provider: "github" });
 
-export async function createGithubConnector(
-  dataSourceConfig: DataSourceConfig,
-  connectionId: GithubInstallationId
-): Promise<Result<string, Error>> {
-  const githubInstallationId = connectionId;
+export class GithubConnectorManager extends BaseConnectorManager<null> {
+  static async create({
+    dataSourceConfig,
+    connectionId,
+  }: {
+    dataSourceConfig: DataSourceConfig;
+    connectionId: GithubInstallationId;
+  }): Promise<Result<string, Error>> {
+    const githubInstallationId = connectionId;
 
-  if (!(await validateInstallationId(githubInstallationId))) {
-    return new Err(new Error("Github installation id is invalid"));
+    if (!(await validateInstallationId(githubInstallationId))) {
+      return new Err(new Error("Github installation id is invalid"));
+    }
+    try {
+      const githubConfigurationBlob = {
+        webhooksEnabledAt: new Date(),
+        codeSyncEnabled: false,
+      };
+
+      const connector = await ConnectorResource.makeNew(
+        "github",
+        {
+          connectionId: githubInstallationId,
+          workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
+          workspaceId: dataSourceConfig.workspaceId,
+          dataSourceName: dataSourceConfig.dataSourceName,
+        },
+        githubConfigurationBlob
+      );
+
+      await launchGithubFullSyncWorkflow({
+        connectorId: connector.id,
+        syncCodeOnly: false,
+      });
+      return new Ok(connector.id.toString());
+    } catch (err) {
+      logger.error({ error: err }, "Error creating github connector");
+
+      return new Err(err as Error);
+    }
   }
-  try {
-    const githubConfigurationBlob = {
-      webhooksEnabledAt: new Date(),
-      codeSyncEnabled: false,
-    };
 
-    const connector = await ConnectorResource.makeNew(
-      "github",
-      {
-        connectionId: githubInstallationId,
-        workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
-        workspaceId: dataSourceConfig.workspaceId,
-        dataSourceName: dataSourceConfig.dataSourceName,
-      },
-      githubConfigurationBlob
-    );
-
-    await launchGithubFullSyncWorkflow({
-      connectorId: connector.id,
-      syncCodeOnly: false,
-    });
-    return new Ok(connector.id.toString());
-  } catch (err) {
-    logger.error({ error: err }, "Error creating github connector");
-
-    return new Err(err as Error);
-  }
-}
-
-export async function updateGithubConnector(
-  connectorId: ModelId,
-  {
+  async update({
     connectionId,
   }: {
     connectionId?: string | null;
-  }
-): Promise<Result<string, ConnectorsAPIError>> {
-  const c = await ConnectorResource.fetchById(connectorId);
-  if (!c) {
-    logger.error({ connectorId }, "Connector not found");
-    return new Err({
-      message: "Connector not found",
-      type: "connector_not_found",
-    });
-  }
-
-  if (connectionId) {
-    const oldGithubInstallationId = c.connectionId;
-    const newGithubInstallationId = connectionId;
-
-    if (oldGithubInstallationId !== newGithubInstallationId) {
+  }): Promise<Result<string, ConnectorsAPIError>> {
+    const c = await ConnectorResource.fetchById(this.connectorId);
+    if (!c) {
+      logger.error({ connectorId: this.connectorId }, "Connector not found");
       return new Err({
-        type: "connector_oauth_target_mismatch",
-        message: "Cannot change the Installation Id of a Github Data Source",
+        message: "Connector not found",
+        type: "connector_not_found",
       });
     }
 
-    await c.update({ connectionId });
-  }
+    if (connectionId) {
+      const oldGithubInstallationId = c.connectionId;
+      const newGithubInstallationId = connectionId;
 
-  return new Ok(c.id.toString());
-}
-
-export async function stopGithubConnector(
-  connectorId: ModelId
-): Promise<Result<undefined, Error>> {
-  try {
-    const connector = await ConnectorResource.fetchById(connectorId);
-
-    if (!connector) {
-      return new Err(new Error("Connector not found"));
-    }
-
-    const connectorState = await GithubConnectorState.findOne({
-      where: {
-        connectorId: connector.id,
-      },
-    });
-
-    if (!connectorState) {
-      return new Err(new Error("Connector state not found"));
-    }
-
-    if (!connectorState.webhooksEnabledAt) {
-      return new Err(new Error("Connector is already stopped"));
-    }
-
-    await connectorState.update({
-      webhooksEnabledAt: null,
-    });
-
-    return new Ok(undefined);
-  } catch (err) {
-    return new Err(err as Error);
-  }
-}
-
-export async function pauseGithubConnector(
-  connectorId: ModelId
-): Promise<Result<undefined, Error>> {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    logger.error({ connectorId }, "Connector not found");
-    return new Err(new Error("Connector not found"));
-  }
-  await connector.markAsPaused();
-  await terminateAllWorkflowsForConnectorId(connectorId);
-  return new Ok(undefined);
-}
-
-export async function unpauseGithubConnector(
-  connectorId: ModelId
-): Promise<Result<undefined, Error>> {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    logger.error({ connectorId }, "Connector not found");
-    return new Err(new Error("Connector not found"));
-  }
-  await connector.markAsUnpaused();
-  await launchGithubFullSyncWorkflow({
-    connectorId,
-    syncCodeOnly: false,
-  });
-
-  return new Ok(undefined);
-}
-
-export async function resumeGithubConnector(
-  connectorId: ModelId
-): Promise<Result<undefined, Error>> {
-  try {
-    const connector = await ConnectorResource.fetchById(connectorId);
-
-    if (!connector) {
-      return new Err(new Error("Connector not found"));
-    }
-
-    const connectorState = await GithubConnectorState.findOne({
-      where: {
-        connectorId: connector.id,
-      },
-    });
-
-    if (!connectorState) {
-      return new Err(new Error("Connector state not found"));
-    }
-
-    if (connectorState.webhooksEnabledAt) {
-      return new Err(new Error("Connector is not stopped"));
-    }
-
-    await connectorState.update({
-      webhooksEnabledAt: new Date(),
-    });
-
-    await launchGithubFullSyncWorkflow({
-      connectorId: connector.id,
-      syncCodeOnly: false,
-    });
-
-    return new Ok(undefined);
-  } catch (err) {
-    return new Err(err as Error);
-  }
-}
-
-export async function fullResyncGithubConnector(
-  connectorId: ModelId,
-  fromTs: number | null
-): Promise<Result<string, Error>> {
-  if (fromTs) {
-    return new Err(
-      new Error("Github connector does not support partial resync")
-    );
-  }
-
-  try {
-    await launchGithubFullSyncWorkflow({
-      connectorId,
-      syncCodeOnly: false,
-    });
-    return new Ok(connectorId.toString());
-  } catch (err) {
-    return new Err(err as Error);
-  }
-}
-
-export async function cleanupGithubConnector(
-  connectorId: ModelId
-): Promise<Result<undefined, Error>> {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    logger.error({ connectorId }, "Connector not found");
-    return new Err(new Error("Connector not found"));
-  }
-
-  const res = await connector.delete();
-  if (res.isErr()) {
-    logger.error(
-      { connectorId, error: res.error },
-      "Error cleaning up Github connector."
-    );
-    return res;
-  }
-
-  return new Ok(undefined);
-}
-
-export async function retrieveGithubConnectorPermissions({
-  connectorId,
-  parentInternalId,
-}: Parameters<ConnectorPermissionRetriever>[0]): Promise<
-  Result<ContentNode[], Error>
-> {
-  const c = await ConnectorResource.fetchById(connectorId);
-  if (!c) {
-    logger.error({ connectorId }, "Connector not found");
-    return new Err(new Error("Connector not found"));
-  }
-
-  const githubInstallationId = c.connectionId;
-
-  if (!parentInternalId) {
-    // No parentInternalId: we return the repositories.
-
-    let nodes: ContentNode[] = [];
-    let pageNumber = 1; // 1-indexed
-    for (;;) {
-      const pageRes = await getReposPage(githubInstallationId, pageNumber);
-
-      if (pageRes.isErr()) {
-        return new Err(pageRes.error);
-      }
-
-      const page = pageRes.value;
-      pageNumber += 1;
-      if (page.length === 0) {
-        break;
-      }
-
-      nodes = nodes.concat(
-        page.map((repo) => ({
-          provider: c.type,
-          internalId: repo.id.toString(),
-          parentInternalId: null,
-          type: "folder",
-          title: repo.name,
-          sourceUrl: repo.url,
-          expandable: true,
-          permission: "read",
-          dustDocumentId: null,
-          lastUpdatedAt: null,
-        }))
-      );
-    }
-
-    nodes.sort((a, b) => {
-      return a.title.localeCompare(b.title);
-    });
-
-    return new Ok(nodes);
-  } else {
-    if (parentInternalId.startsWith("github-code-")) {
-      const [files, directories] = await Promise.all([
-        (async () => {
-          return GithubCodeFile.findAll({
-            where: {
-              connectorId: c.id,
-              parentInternalId,
-            },
-          });
-        })(),
-        (async () => {
-          return GithubCodeDirectory.findAll({
-            where: {
-              connectorId: c.id,
-              parentInternalId,
-            },
-          });
-        })(),
-      ]);
-
-      files.sort((a, b) => {
-        return a.fileName.localeCompare(b.fileName);
-      });
-      directories.sort((a, b) => {
-        return a.dirName.localeCompare(b.dirName);
-      });
-
-      const nodes: ContentNode[] = [];
-
-      directories.forEach((directory) => {
-        nodes.push({
-          provider: c.type,
-          internalId: directory.internalId,
-          parentInternalId,
-          type: "folder",
-          title: directory.dirName,
-          sourceUrl: directory.sourceUrl,
-          expandable: true,
-          permission: "read",
-          dustDocumentId: null,
-          lastUpdatedAt: directory.codeUpdatedAt.getTime(),
-        });
-      });
-
-      files.forEach((file) => {
-        nodes.push({
-          provider: c.type,
-          internalId: file.documentId,
-          parentInternalId,
-          type: "file",
-          title: file.fileName,
-          sourceUrl: file.sourceUrl,
-          expandable: false,
-          permission: "read",
-          dustDocumentId: file.documentId,
-          lastUpdatedAt: file.codeUpdatedAt.getTime(),
-        });
-      });
-
-      return new Ok(nodes);
-    } else {
-      // If parentInternalId is set and does not start with `github-code` it means that it is
-      // supposed to be the repoId. We support issues and discussions and also want to add the code
-      // repo resource if it exists (code sync enabled).
-      const repoId = parseInt(parentInternalId, 10);
-      if (isNaN(repoId)) {
-        return new Err(new Error(`Invalid repoId: ${parentInternalId}`));
-      }
-
-      const [latestDiscussion, latestIssue, repo, codeRepo] = await Promise.all(
-        [
-          (async () => {
-            return GithubDiscussion.findOne({
-              where: {
-                connectorId: c.id,
-                repoId: repoId.toString(),
-              },
-              limit: 1,
-              order: [["updatedAt", "DESC"]],
-            });
-          })(),
-          (async () => {
-            return GithubIssue.findOne({
-              where: {
-                connectorId: c.id,
-                repoId: repoId.toString(),
-              },
-              limit: 1,
-              order: [["updatedAt", "DESC"]],
-            });
-          })(),
-          getRepo(githubInstallationId, repoId),
-          (async () => {
-            return GithubCodeRepository.findOne({
-              where: {
-                connectorId: c.id,
-                repoId: repoId.toString(),
-              },
-            });
-          })(),
-        ]
-      );
-
-      const nodes: ContentNode[] = [];
-
-      if (latestIssue) {
-        nodes.push({
-          provider: c.type,
-          internalId: `${repoId}-issues`,
-          parentInternalId,
-          type: "database",
-          title: "Issues",
-          sourceUrl: repo.url + "/issues",
-          expandable: false,
-          permission: "read",
-          dustDocumentId: null,
-          lastUpdatedAt: latestIssue.updatedAt.getTime(),
+      if (oldGithubInstallationId !== newGithubInstallationId) {
+        return new Err({
+          type: "connector_oauth_target_mismatch",
+          message: "Cannot change the Installation Id of a Github Data Source",
         });
       }
 
-      if (latestDiscussion) {
-        nodes.push({
-          provider: c.type,
-          internalId: `${repoId}-discussions`,
-          parentInternalId,
-          type: "channel",
-          title: "Discussions",
-          sourceUrl: repo.url + "/discussions",
-          expandable: false,
-          permission: "read",
-          dustDocumentId: null,
-          lastUpdatedAt: latestDiscussion.updatedAt.getTime(),
-        });
+      await c.update({ connectionId });
+    }
+
+    return new Ok(c.id.toString());
+  }
+
+  async stop(): Promise<Result<undefined, Error>> {
+    try {
+      const connector = await ConnectorResource.fetchById(this.connectorId);
+
+      if (!connector) {
+        return new Err(new Error("Connector not found"));
       }
 
-      if (codeRepo) {
-        nodes.push({
-          provider: c.type,
-          internalId: `github-code-${repoId}`,
-          parentInternalId,
-          type: "folder",
-          title: "Code",
-          sourceUrl: repo.url,
-          expandable: true,
-          permission: "read",
-          dustDocumentId: null,
-          lastUpdatedAt: codeRepo.codeUpdatedAt.getTime(),
-        });
-      }
-
-      return new Ok(nodes);
-    }
-  }
-}
-
-export async function retrieveGithubReposContentNodes(
-  connectorId: ModelId,
-  internalIds: string[]
-): Promise<Result<ContentNode[], Error>> {
-  const c = await ConnectorResource.fetchById(connectorId);
-  if (!c) {
-    logger.error({ connectorId }, "Connector not found");
-    return new Err(new Error("Connector not found"));
-  }
-
-  const githubInstallationId = c.connectionId;
-  const allReposIdsToFetch: Set<number> = new Set();
-  const nodes: ContentNode[] = [];
-
-  // Users can select:
-  // A full repo (issues + discussions + code if enabled)
-  const fullRepoIds: number[] = [];
-
-  //  All issues of the repo, or all discussions of the repo
-  const allIssuesFromRepoIds: number[] = [];
-  const allDiscussionsFromRepoIds: number[] = [];
-
-  // The full code, or a specific folder or file in the code
-  const allCodeFromRepoIds: string[] = [];
-  const codeDirectoryIds: string[] = [];
-  const codeFileIds: string[] = [];
-
-  // We loop on all the internalIds we receive to know what is the related data type
-  internalIds.forEach((internalId) => {
-    const { type, repoId } = matchGithubInternalIdType(internalId);
-    allReposIdsToFetch.add(repoId);
-
-    switch (type) {
-      case "REPO_FULL":
-        fullRepoIds.push(repoId);
-        break;
-      case "REPO_ISSUES":
-        allIssuesFromRepoIds.push(repoId);
-        break;
-      case "REPO_DISCUSSIONS":
-        allDiscussionsFromRepoIds.push(repoId);
-        break;
-      case "REPO_CODE":
-        allCodeFromRepoIds.push(repoId.toString());
-        break;
-      case "REPO_CODE_DIR":
-        codeDirectoryIds.push(internalId);
-        break;
-      case "REPO_CODE_FILE":
-        codeFileIds.push(internalId);
-        break;
-      default:
-        assertNever(type);
-    }
-  });
-
-  // Repos are not stored in the DB, we have to fetch them from the API
-  const uniqueRepoIdsArray: number[] = Array.from(allReposIdsToFetch);
-  const uniqueRepos: Record<number, GithubRepo> = {};
-  await concurrentExecutor(
-    uniqueRepoIdsArray,
-    async (repoId) => {
-      const repoData = await getRepo(githubInstallationId, repoId);
-      uniqueRepos[repoId] = repoData;
-    },
-    { concurrency: 8 }
-  );
-
-  // Code Repositories, Directories and Files are stored in the DB
-  const [fullCodeInRepos, codeDirectories, codeFiles] = await Promise.all([
-    GithubCodeRepository.findAll({
-      where: {
-        connectorId: c.id,
-        repoId: allCodeFromRepoIds,
-      },
-    }),
-    GithubCodeDirectory.findAll({
-      where: {
-        connectorId: c.id,
-        internalId: codeDirectoryIds,
-      },
-    }),
-    GithubCodeFile.findAll({
-      where: {
-        connectorId: c.id,
-        documentId: codeFileIds,
-      },
-    }),
-  ]);
-
-  // Constructing Nodes for Full Repo
-  fullRepoIds.forEach((repoId) => {
-    const repo = uniqueRepos[repoId];
-    if (!repo) {
-      return;
-    }
-    nodes.push({
-      provider: c.type,
-      internalId: repoId.toString(),
-      parentInternalId: null,
-      type: "folder",
-      title: repo.name,
-      titleWithParentsContext: `[${repo.name}] - Full repository`,
-      sourceUrl: repo.url,
-      expandable: true,
-      permission: "read",
-      dustDocumentId: null,
-      lastUpdatedAt: null,
-    });
-  });
-
-  // Constructing Nodes for All Issues and All Discussions
-  allIssuesFromRepoIds.forEach((repoId) => {
-    const repo = uniqueRepos[repoId];
-    if (!repo) {
-      return;
-    }
-    nodes.push({
-      provider: c.type,
-      internalId: `${repoId}-issues`,
-      parentInternalId: repoId.toString(),
-      type: "database",
-      title: "Issues",
-      titleWithParentsContext: `[${repo.name}] Issues`,
-      sourceUrl: repo.url + "/issues",
-      expandable: false,
-      permission: "read",
-      dustDocumentId: null,
-      lastUpdatedAt: null,
-    });
-  });
-  allDiscussionsFromRepoIds.forEach((repoId) => {
-    const repo = uniqueRepos[repoId];
-    if (!repo) {
-      return;
-    }
-    nodes.push({
-      provider: c.type,
-      internalId: `${repoId}-discussions`,
-      parentInternalId: repoId.toString(),
-      type: "channel",
-      title: "Discussions",
-      titleWithParentsContext: `[${repo.name}] Discussions`,
-      sourceUrl: repo.url + "/discussions",
-      expandable: false,
-      permission: "read",
-      dustDocumentId: null,
-      lastUpdatedAt: null,
-    });
-  });
-
-  // Constructing Nodes for Code
-  fullCodeInRepos.forEach((codeRepo) => {
-    const repo = uniqueRepos[parseInt(codeRepo.repoId)];
-    nodes.push({
-      provider: c.type,
-      internalId: `github-code-${codeRepo.repoId}`,
-      parentInternalId: codeRepo.repoId,
-      type: "folder",
-      title: "Code",
-      titleWithParentsContext: repo ? `[${repo.name}] Code` : "Code",
-      sourceUrl: codeRepo.sourceUrl,
-      expandable: true,
-      permission: "read",
-      dustDocumentId: null,
-      lastUpdatedAt: codeRepo.codeUpdatedAt.getTime(),
-    });
-  });
-
-  // Constructing Nodes for Code Directories
-  codeDirectories.forEach((directory) => {
-    const repo = uniqueRepos[parseInt(directory.repoId)];
-    nodes.push({
-      provider: c.type,
-      internalId: directory.internalId,
-      parentInternalId: directory.parentInternalId,
-      type: "folder",
-      title: directory.dirName,
-      titleWithParentsContext: repo
-        ? `[${repo.name}] ${directory.dirName} (code)`
-        : directory.dirName,
-      sourceUrl: directory.sourceUrl,
-      expandable: true,
-      permission: "read",
-      dustDocumentId: null,
-      lastUpdatedAt: directory.codeUpdatedAt.getTime(),
-    });
-  });
-
-  // Constructing Nodes for Code Files
-  codeFiles.forEach((file) => {
-    const repo = uniqueRepos[parseInt(file.repoId)];
-    nodes.push({
-      provider: c.type,
-      internalId: file.documentId,
-      parentInternalId: file.parentInternalId,
-      type: "file",
-      title: file.fileName,
-      titleWithParentsContext: repo
-        ? `[${repo.name}] ${file.fileName} (code)`
-        : file.fileName,
-      sourceUrl: file.sourceUrl,
-      expandable: false,
-      permission: "read",
-      dustDocumentId: file.documentId,
-      lastUpdatedAt: file.codeUpdatedAt.getTime(),
-    });
-  });
-
-  return new Ok(nodes);
-}
-
-export const getGithubConfig: ConnectorConfigGetter = async function (
-  connectorId: ModelId,
-  configKey: string
-) {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    return new Err(
-      new Error(`Connector not found (connectorId: ${connectorId})`)
-    );
-  }
-
-  switch (configKey) {
-    case "codeSyncEnabled": {
       const connectorState = await GithubConnectorState.findOne({
         where: {
           connectorId: connector.id,
         },
       });
+
       if (!connectorState) {
-        return new Err(
-          new Error(`Connector state not found (connectorId: ${connector.id})`)
-        );
+        return new Err(new Error("Connector state not found"));
       }
 
-      return new Ok(connectorState.codeSyncEnabled.toString());
-    }
-    default:
-      return new Err(new Error(`Invalid config key ${configKey}`));
-  }
-};
-
-export async function setGithubConfig(
-  connectorId: ModelId,
-  configKey: string,
-  configValue: string
-) {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    return new Err(
-      new Error(`Connector not found (connectorId: ${connectorId})`)
-    );
-  }
-
-  switch (configKey) {
-    case "codeSyncEnabled": {
-      const connectorState = await GithubConnectorState.findOne({
-        where: {
-          connectorId: connector.id,
-        },
-      });
-      if (!connectorState) {
-        return new Err(
-          new Error(`Connector state not found (connectorId: ${connector.id})`)
-        );
+      if (!connectorState.webhooksEnabledAt) {
+        return new Err(new Error("Connector is already stopped"));
       }
 
       await connectorState.update({
-        codeSyncEnabled: configValue === "true",
+        webhooksEnabledAt: null,
       });
 
-      // launch full-resync workflow, code sync only (to be launched on enable and disable to sync
-      // or properly clean up the code).
-      await launchGithubFullSyncWorkflow({
-        connectorId: connector.id,
-        syncCodeOnly: true,
-      });
-
-      return new Ok(void 0);
-    }
-
-    default: {
-      return new Err(new Error(`Invalid config key ${configKey}`));
+      return new Ok(undefined);
+    } catch (err) {
+      return new Err(err as Error);
     }
   }
-}
 
-export async function retrieveGithubContentNodeParents(
-  connectorId: ModelId,
-  internalId: string
-): Promise<Result<string[], Error>> {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
+  async clean(): Promise<Result<undefined, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      logger.error({ connectorId: this.connectorId }, "Connector not found");
+      return new Err(new Error("Connector not found"));
+    }
+
+    const res = await connector.delete();
+    if (res.isErr()) {
+      logger.error(
+        { connectorId: this.connectorId, error: res.error },
+        "Error cleaning up Github connector."
+      );
+      return res;
+    }
+
+    return new Ok(undefined);
+  }
+
+  async resume(): Promise<Result<undefined, Error>> {
+    try {
+      const connector = await ConnectorResource.fetchById(this.connectorId);
+
+      if (!connector) {
+        return new Err(new Error("Connector not found"));
+      }
+
+      const connectorState = await GithubConnectorState.findOne({
+        where: {
+          connectorId: connector.id,
+        },
+      });
+
+      if (!connectorState) {
+        return new Err(new Error("Connector state not found"));
+      }
+
+      if (connectorState.webhooksEnabledAt) {
+        return new Err(new Error("Connector is not stopped"));
+      }
+
+      await connectorState.update({
+        webhooksEnabledAt: new Date(),
+      });
+
+      await launchGithubFullSyncWorkflow({
+        connectorId: connector.id,
+        syncCodeOnly: false,
+      });
+
+      return new Ok(undefined);
+    } catch (err) {
+      return new Err(err as Error);
+    }
+  }
+
+  async sync({
+    fromTs,
+  }: {
+    fromTs: number | null;
+  }): Promise<Result<string, Error>> {
+    if (fromTs) {
+      return new Err(
+        new Error("Github connector does not support partial resync")
+      );
+    }
+
+    try {
+      await launchGithubFullSyncWorkflow({
+        connectorId: this.connectorId,
+        syncCodeOnly: false,
+      });
+      return new Ok(this.connectorId.toString());
+    } catch (err) {
+      return new Err(err as Error);
+    }
+  }
+
+  async retrievePermissions({
+    parentInternalId,
+  }: {
+    parentInternalId: string | null;
+    filterPermission: ConnectorPermission | null;
+    viewType: ContentNodesViewType;
+  }): Promise<Result<ContentNode[], Error>> {
+    const c = await ConnectorResource.fetchById(this.connectorId);
+    if (!c) {
+      logger.error({ connectorId: this.connectorId }, "Connector not found");
+      return new Err(new Error("Connector not found"));
+    }
+
+    const githubInstallationId = c.connectionId;
+
+    if (!parentInternalId) {
+      // No parentInternalId: we return the repositories.
+
+      let nodes: ContentNode[] = [];
+      let pageNumber = 1; // 1-indexed
+      for (;;) {
+        const pageRes = await getReposPage(githubInstallationId, pageNumber);
+
+        if (pageRes.isErr()) {
+          return new Err(pageRes.error);
+        }
+
+        const page = pageRes.value;
+        pageNumber += 1;
+        if (page.length === 0) {
+          break;
+        }
+
+        nodes = nodes.concat(
+          page.map((repo) => ({
+            provider: c.type,
+            internalId: repo.id.toString(),
+            parentInternalId: null,
+            type: "folder",
+            title: repo.name,
+            sourceUrl: repo.url,
+            expandable: true,
+            permission: "read",
+            dustDocumentId: null,
+            lastUpdatedAt: null,
+          }))
+        );
+      }
+
+      nodes.sort((a, b) => {
+        return a.title.localeCompare(b.title);
+      });
+
+      return new Ok(nodes);
+    } else {
+      if (parentInternalId.startsWith("github-code-")) {
+        const [files, directories] = await Promise.all([
+          (async () => {
+            return GithubCodeFile.findAll({
+              where: {
+                connectorId: c.id,
+                parentInternalId,
+              },
+            });
+          })(),
+          (async () => {
+            return GithubCodeDirectory.findAll({
+              where: {
+                connectorId: c.id,
+                parentInternalId,
+              },
+            });
+          })(),
+        ]);
+
+        files.sort((a, b) => {
+          return a.fileName.localeCompare(b.fileName);
+        });
+        directories.sort((a, b) => {
+          return a.dirName.localeCompare(b.dirName);
+        });
+
+        const nodes: ContentNode[] = [];
+
+        directories.forEach((directory) => {
+          nodes.push({
+            provider: c.type,
+            internalId: directory.internalId,
+            parentInternalId,
+            type: "folder",
+            title: directory.dirName,
+            sourceUrl: directory.sourceUrl,
+            expandable: true,
+            permission: "read",
+            dustDocumentId: null,
+            lastUpdatedAt: directory.codeUpdatedAt.getTime(),
+          });
+        });
+
+        files.forEach((file) => {
+          nodes.push({
+            provider: c.type,
+            internalId: file.documentId,
+            parentInternalId,
+            type: "file",
+            title: file.fileName,
+            sourceUrl: file.sourceUrl,
+            expandable: false,
+            permission: "read",
+            dustDocumentId: file.documentId,
+            lastUpdatedAt: file.codeUpdatedAt.getTime(),
+          });
+        });
+
+        return new Ok(nodes);
+      } else {
+        // If parentInternalId is set and does not start with `github-code` it means that it is
+        // supposed to be the repoId. We support issues and discussions and also want to add the code
+        // repo resource if it exists (code sync enabled).
+        const repoId = parseInt(parentInternalId, 10);
+        if (isNaN(repoId)) {
+          return new Err(new Error(`Invalid repoId: ${parentInternalId}`));
+        }
+
+        const [latestDiscussion, latestIssue, repo, codeRepo] =
+          await Promise.all([
+            (async () => {
+              return GithubDiscussion.findOne({
+                where: {
+                  connectorId: c.id,
+                  repoId: repoId.toString(),
+                },
+                limit: 1,
+                order: [["updatedAt", "DESC"]],
+              });
+            })(),
+            (async () => {
+              return GithubIssue.findOne({
+                where: {
+                  connectorId: c.id,
+                  repoId: repoId.toString(),
+                },
+                limit: 1,
+                order: [["updatedAt", "DESC"]],
+              });
+            })(),
+            getRepo(githubInstallationId, repoId),
+            (async () => {
+              return GithubCodeRepository.findOne({
+                where: {
+                  connectorId: c.id,
+                  repoId: repoId.toString(),
+                },
+              });
+            })(),
+          ]);
+
+        const nodes: ContentNode[] = [];
+
+        if (latestIssue) {
+          nodes.push({
+            provider: c.type,
+            internalId: `${repoId}-issues`,
+            parentInternalId,
+            type: "database",
+            title: "Issues",
+            sourceUrl: repo.url + "/issues",
+            expandable: false,
+            permission: "read",
+            dustDocumentId: null,
+            lastUpdatedAt: latestIssue.updatedAt.getTime(),
+          });
+        }
+
+        if (latestDiscussion) {
+          nodes.push({
+            provider: c.type,
+            internalId: `${repoId}-discussions`,
+            parentInternalId,
+            type: "channel",
+            title: "Discussions",
+            sourceUrl: repo.url + "/discussions",
+            expandable: false,
+            permission: "read",
+            dustDocumentId: null,
+            lastUpdatedAt: latestDiscussion.updatedAt.getTime(),
+          });
+        }
+
+        if (codeRepo) {
+          nodes.push({
+            provider: c.type,
+            internalId: `github-code-${repoId}`,
+            parentInternalId,
+            type: "folder",
+            title: "Code",
+            sourceUrl: repo.url,
+            expandable: true,
+            permission: "read",
+            dustDocumentId: null,
+            lastUpdatedAt: codeRepo.codeUpdatedAt.getTime(),
+          });
+        }
+
+        return new Ok(nodes);
+      }
+    }
+  }
+
+  async retrieveBatchContentNodes({
+    internalIds,
+  }: {
+    internalIds: string[];
+    viewType: ContentNodesViewType;
+  }): Promise<Result<ContentNode[], Error>> {
+    const c = await ConnectorResource.fetchById(this.connectorId);
+    if (!c) {
+      logger.error({ connectorId: this.connectorId }, "Connector not found");
+      return new Err(new Error("Connector not found"));
+    }
+
+    const githubInstallationId = c.connectionId;
+    const allReposIdsToFetch: Set<number> = new Set();
+    const nodes: ContentNode[] = [];
+
+    // Users can select:
+    // A full repo (issues + discussions + code if enabled)
+    const fullRepoIds: number[] = [];
+
+    //  All issues of the repo, or all discussions of the repo
+    const allIssuesFromRepoIds: number[] = [];
+    const allDiscussionsFromRepoIds: number[] = [];
+
+    // The full code, or a specific folder or file in the code
+    const allCodeFromRepoIds: string[] = [];
+    const codeDirectoryIds: string[] = [];
+    const codeFileIds: string[] = [];
+
+    // We loop on all the internalIds we receive to know what is the related data type
+    internalIds.forEach((internalId) => {
+      const { type, repoId } = matchGithubInternalIdType(internalId);
+      allReposIdsToFetch.add(repoId);
+
+      switch (type) {
+        case "REPO_FULL":
+          fullRepoIds.push(repoId);
+          break;
+        case "REPO_ISSUES":
+          allIssuesFromRepoIds.push(repoId);
+          break;
+        case "REPO_DISCUSSIONS":
+          allDiscussionsFromRepoIds.push(repoId);
+          break;
+        case "REPO_CODE":
+          allCodeFromRepoIds.push(repoId.toString());
+          break;
+        case "REPO_CODE_DIR":
+          codeDirectoryIds.push(internalId);
+          break;
+        case "REPO_CODE_FILE":
+          codeFileIds.push(internalId);
+          break;
+        default:
+          assertNever(type);
+      }
+    });
+
+    // Repos are not stored in the DB, we have to fetch them from the API
+    const uniqueRepoIdsArray: number[] = Array.from(allReposIdsToFetch);
+    const uniqueRepos: Record<number, GithubRepo> = {};
+    await concurrentExecutor(
+      uniqueRepoIdsArray,
+      async (repoId) => {
+        const repoData = await getRepo(githubInstallationId, repoId);
+        uniqueRepos[repoId] = repoData;
+      },
+      { concurrency: 8 }
+    );
+
+    // Code Repositories, Directories and Files are stored in the DB
+    const [fullCodeInRepos, codeDirectories, codeFiles] = await Promise.all([
+      GithubCodeRepository.findAll({
+        where: {
+          connectorId: c.id,
+          repoId: allCodeFromRepoIds,
+        },
+      }),
+      GithubCodeDirectory.findAll({
+        where: {
+          connectorId: c.id,
+          internalId: codeDirectoryIds,
+        },
+      }),
+      GithubCodeFile.findAll({
+        where: {
+          connectorId: c.id,
+          documentId: codeFileIds,
+        },
+      }),
+    ]);
+
+    // Constructing Nodes for Full Repo
+    fullRepoIds.forEach((repoId) => {
+      const repo = uniqueRepos[repoId];
+      if (!repo) {
+        return;
+      }
+      nodes.push({
+        provider: c.type,
+        internalId: repoId.toString(),
+        parentInternalId: null,
+        type: "folder",
+        title: repo.name,
+        titleWithParentsContext: `[${repo.name}] - Full repository`,
+        sourceUrl: repo.url,
+        expandable: true,
+        permission: "read",
+        dustDocumentId: null,
+        lastUpdatedAt: null,
+      });
+    });
+
+    // Constructing Nodes for All Issues and All Discussions
+    allIssuesFromRepoIds.forEach((repoId) => {
+      const repo = uniqueRepos[repoId];
+      if (!repo) {
+        return;
+      }
+      nodes.push({
+        provider: c.type,
+        internalId: `${repoId}-issues`,
+        parentInternalId: repoId.toString(),
+        type: "database",
+        title: "Issues",
+        titleWithParentsContext: `[${repo.name}] Issues`,
+        sourceUrl: repo.url + "/issues",
+        expandable: false,
+        permission: "read",
+        dustDocumentId: null,
+        lastUpdatedAt: null,
+      });
+    });
+    allDiscussionsFromRepoIds.forEach((repoId) => {
+      const repo = uniqueRepos[repoId];
+      if (!repo) {
+        return;
+      }
+      nodes.push({
+        provider: c.type,
+        internalId: `${repoId}-discussions`,
+        parentInternalId: repoId.toString(),
+        type: "channel",
+        title: "Discussions",
+        titleWithParentsContext: `[${repo.name}] Discussions`,
+        sourceUrl: repo.url + "/discussions",
+        expandable: false,
+        permission: "read",
+        dustDocumentId: null,
+        lastUpdatedAt: null,
+      });
+    });
+
+    // Constructing Nodes for Code
+    fullCodeInRepos.forEach((codeRepo) => {
+      const repo = uniqueRepos[parseInt(codeRepo.repoId)];
+      nodes.push({
+        provider: c.type,
+        internalId: `github-code-${codeRepo.repoId}`,
+        parentInternalId: codeRepo.repoId,
+        type: "folder",
+        title: "Code",
+        titleWithParentsContext: repo ? `[${repo.name}] Code` : "Code",
+        sourceUrl: codeRepo.sourceUrl,
+        expandable: true,
+        permission: "read",
+        dustDocumentId: null,
+        lastUpdatedAt: codeRepo.codeUpdatedAt.getTime(),
+      });
+    });
+
+    // Constructing Nodes for Code Directories
+    codeDirectories.forEach((directory) => {
+      const repo = uniqueRepos[parseInt(directory.repoId)];
+      nodes.push({
+        provider: c.type,
+        internalId: directory.internalId,
+        parentInternalId: directory.parentInternalId,
+        type: "folder",
+        title: directory.dirName,
+        titleWithParentsContext: repo
+          ? `[${repo.name}] ${directory.dirName} (code)`
+          : directory.dirName,
+        sourceUrl: directory.sourceUrl,
+        expandable: true,
+        permission: "read",
+        dustDocumentId: null,
+        lastUpdatedAt: directory.codeUpdatedAt.getTime(),
+      });
+    });
+
+    // Constructing Nodes for Code Files
+    codeFiles.forEach((file) => {
+      const repo = uniqueRepos[parseInt(file.repoId)];
+      nodes.push({
+        provider: c.type,
+        internalId: file.documentId,
+        parentInternalId: file.parentInternalId,
+        type: "file",
+        title: file.fileName,
+        titleWithParentsContext: repo
+          ? `[${repo.name}] ${file.fileName} (code)`
+          : file.fileName,
+        sourceUrl: file.sourceUrl,
+        expandable: false,
+        permission: "read",
+        dustDocumentId: file.documentId,
+        lastUpdatedAt: file.codeUpdatedAt.getTime(),
+      });
+    });
+
+    return new Ok(nodes);
+  }
+
+  async retrieveContentNodeParents({
+    internalId,
+  }: {
+    internalId: string;
+    memoizationKey?: string;
+  }): Promise<Result<string[], Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      return new Err(
+        new Error(`Connector not found (connectorId: ${this.connectorId})`)
+      );
+    }
+
+    if (internalId.startsWith(`github-code-`)) {
+      const repoId = parseInt(internalId.split("-")[2] || "", 10);
+      if (internalId.split("-").length > 3) {
+        const parents = await getGithubCodeOrDirectoryParentIds(
+          connector.id,
+          internalId,
+          repoId
+        );
+        return new Ok(parents);
+      } else {
+        return new Ok([`${repoId}`]);
+      }
+    } else {
+      const repoId = parseInt(internalId.split("-")[0] || "", 10);
+      if (
+        internalId.endsWith("-issues") ||
+        internalId.endsWith("-discussions")
+      ) {
+        return new Ok([`${repoId}`]);
+      }
+      return new Ok([]);
+    }
+  }
+
+  async setConfigurationKey({
+    configKey,
+    configValue,
+  }: {
+    configKey: string;
+    configValue: string;
+  }): Promise<Result<void, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      return new Err(
+        new Error(`Connector not found (connectorId: ${this.connectorId})`)
+      );
+    }
+
+    switch (configKey) {
+      case "codeSyncEnabled": {
+        const connectorState = await GithubConnectorState.findOne({
+          where: {
+            connectorId: connector.id,
+          },
+        });
+        if (!connectorState) {
+          return new Err(
+            new Error(
+              `Connector state not found (connectorId: ${connector.id})`
+            )
+          );
+        }
+
+        await connectorState.update({
+          codeSyncEnabled: configValue === "true",
+        });
+
+        // launch full-resync workflow, code sync only (to be launched on enable and disable to sync
+        // or properly clean up the code).
+        await launchGithubFullSyncWorkflow({
+          connectorId: connector.id,
+          syncCodeOnly: true,
+        });
+
+        return new Ok(void 0);
+      }
+
+      default: {
+        return new Err(new Error(`Invalid config key ${configKey}`));
+      }
+    }
+  }
+
+  async getConfigurationKey({
+    configKey,
+  }: {
+    configKey: string;
+  }): Promise<Result<string | null, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      return new Err(
+        new Error(`Connector not found (connectorId: ${this.connectorId})`)
+      );
+    }
+
+    switch (configKey) {
+      case "codeSyncEnabled": {
+        const connectorState = await GithubConnectorState.findOne({
+          where: {
+            connectorId: connector.id,
+          },
+        });
+        if (!connectorState) {
+          return new Err(
+            new Error(
+              `Connector state not found (connectorId: ${connector.id})`
+            )
+          );
+        }
+
+        return new Ok(connectorState.codeSyncEnabled.toString());
+      }
+      default:
+        return new Err(new Error(`Invalid config key ${configKey}`));
+    }
+  }
+
+  async pause(): Promise<Result<undefined, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      logger.error({ connectorId: this.connectorId }, "Connector not found");
+      return new Err(new Error("Connector not found"));
+    }
+    await connector.markAsPaused();
+    await terminateAllWorkflowsForConnectorId(this.connectorId);
+    return new Ok(undefined);
+  }
+
+  async unpause(): Promise<Result<undefined, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      logger.error({ connectorId: this.connectorId }, "Connector not found");
+      return new Err(new Error("Connector not found"));
+    }
+    await connector.markAsUnpaused();
+    await launchGithubFullSyncWorkflow({
+      connectorId: this.connectorId,
+      syncCodeOnly: false,
+    });
+
+    return new Ok(undefined);
+  }
+
+  async setPermissions(): Promise<Result<void, Error>> {
     return new Err(
-      new Error(`Connector not found (connectorId: ${connectorId})`)
+      new Error(`Setting Github connector permissions is not implemented yet.`)
     );
   }
 
-  if (internalId.startsWith(`github-code-`)) {
-    const repoId = parseInt(internalId.split("-")[2] || "", 10);
-    if (internalId.split("-").length > 3) {
-      const parents = await getGithubCodeOrDirectoryParentIds(
-        connector.id,
-        internalId,
-        repoId
-      );
-      return new Ok(parents);
-    } else {
-      return new Ok([`${repoId}`]);
-    }
-  } else {
-    const repoId = parseInt(internalId.split("-")[0] || "", 10);
-    if (internalId.endsWith("-issues") || internalId.endsWith("-discussions")) {
-      return new Ok([`${repoId}`]);
-    }
-    return new Ok([]);
+  async garbageCollect(): Promise<Result<string, Error>> {
+    throw new Error("Method not implemented.");
+  }
+
+  async configure(): Promise<Result<void, Error>> {
+    throw new Error("Method not implemented.");
   }
 }

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -6,7 +6,7 @@ import {
   getLocalParents,
   isDriveObjectExpandable,
 } from "@connectors/connectors/google_drive/lib";
-import type { ConnectorPermissionRetriever } from "@connectors/connectors/interface";
+import { BaseConnectorManager } from "@connectors/connectors/interface";
 import { GoogleDriveSheet } from "@connectors/lib/models/google_drive";
 import {
   GoogleDriveConfig,
@@ -29,7 +29,6 @@ import type {
   ConnectorsAPIError,
   ContentNode,
   ContentNodesViewType,
-  ModelId,
   Result,
 } from "@dust-tt/types";
 import {
@@ -68,825 +67,904 @@ import { terminateAllWorkflowsForConnectorId } from "@connectors/lib/temporal";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { FILE_ATTRIBUTES_TO_FETCH } from "@connectors/types/google_drive";
 
-export async function createGoogleDriveConnector(
-  dataSourceConfig: DataSourceConfig,
-  nangoConnectionId: NangoConnectionId
-): Promise<Result<string, Error>> {
-  try {
-    const driveClient = await getDriveClient(nangoConnectionId);
-
-    // Sanity checks to confirm we have sufficient permissions.
-    const [sanityCheckAbout, sanityCheckFilesGet, sanityCheckFilesList] =
-      await Promise.all([
-        driveClient.about.get({ fields: "*" }),
-        driveClient.files.get({ fileId: "root" }),
-        driveClient.drives.list({
-          pageSize: 10,
-          fields: "nextPageToken, drives(id, name)",
-        }),
-      ]);
-
-    if (sanityCheckAbout.status !== 200) {
-      throw new Error(
-        `Could not get google drive info. Error message: ${
-          sanityCheckAbout.statusText || "unknown"
-        }`
-      );
-    }
-    if (sanityCheckFilesGet.status !== 200) {
-      throw new Error(
-        `Could not call google drive files get. Error message: ${
-          sanityCheckFilesGet.statusText || "unknown"
-        }`
-      );
-    }
-    if (sanityCheckFilesList.status !== 200) {
-      throw new Error(
-        `Could not call google drive files list. Error message: ${
-          sanityCheckFilesList.statusText || "unknown"
-        }`
-      );
-    }
-  } catch (err) {
-    logger.error(
-      {
-        err,
-      },
-      "Error creating Google Drive connector"
-    );
-    return new Err(new Error("Error creating Google Drive connector"));
-  }
-
-  const googleDriveConfigurationBlob = {
-    pdfEnabled: false,
-    largeFilesEnabled: false,
-  };
-
-  const connector = await ConnectorResource.makeNew(
-    "google_drive",
-    {
-      connectionId: nangoConnectionId,
-      workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
-      workspaceId: dataSourceConfig.workspaceId,
-      dataSourceName: dataSourceConfig.dataSourceName,
-    },
-    googleDriveConfigurationBlob
-  );
-
-  // We mark it artificially as sync succeeded as google drive is created empty.
-  await syncSucceeded(connector.id);
-
-  // We nonetheless launch the incremental sync.
-  const res = await launchGoogleDriveIncrementalSyncWorkflow(connector.id);
-  if (res.isErr()) {
-    return res;
-  }
-
-  return new Ok(connector.id.toString());
-}
-
-export async function updateGoogleDriveConnector(
-  connectorId: ModelId,
-  {
-    connectionId,
+export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
+  static async create({
+    dataSourceConfig,
+    connectionId: nangoConnectionId,
   }: {
-    connectionId?: NangoConnectionId | null;
-  }
-): Promise<Result<string, ConnectorsAPIError>> {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    logger.error({ connectorId }, "Connector not found");
-    return new Err({
-      message: "Connector not found",
-      type: "connector_not_found",
-    });
-  }
-
-  // Ideally we want to check that the Google Project ID is the same as the one from the connector
-  // I couln't find an easy way to access it from the googleapis library
-  // Workaround is checking the domain of the user who is updating the connector
-  if (connectionId) {
+    dataSourceConfig: DataSourceConfig;
+    connectionId: NangoConnectionId;
+  }): Promise<Result<string, Error>> {
     try {
-      const oldConnectionId = connector.connectionId;
-      const currentDriveClient = await getDriveClient(oldConnectionId);
-      const currentDriveUser = await currentDriveClient.about.get({
-        fields: "user",
-      });
-      const currentUserEmail = currentDriveUser.data?.user?.emailAddress || "";
-      const currentDriveUserDomain = currentUserEmail.split("@")[1];
+      const driveClient = await getDriveClient(nangoConnectionId);
 
-      const newDriveClient = await getDriveClient(connectionId);
-      const newDriveUser = await newDriveClient.about.get({
-        fields: "user",
-      });
-      const newDriveUserEmail = newDriveUser.data?.user?.emailAddress || "";
-      const newDriveUserDomain = newDriveUserEmail.split("@")[1];
+      // Sanity checks to confirm we have sufficient permissions.
+      const [sanityCheckAbout, sanityCheckFilesGet, sanityCheckFilesList] =
+        await Promise.all([
+          driveClient.about.get({ fields: "*" }),
+          driveClient.files.get({ fileId: "root" }),
+          driveClient.drives.list({
+            pageSize: 10,
+            fields: "nextPageToken, drives(id, name)",
+          }),
+        ]);
 
-      if (!currentDriveUserDomain || !newDriveUserDomain) {
-        return new Err({
-          type: "connector_update_error",
-          message: "Error retrieving google drive info to update connector",
-        });
+      if (sanityCheckAbout.status !== 200) {
+        throw new Error(
+          `Could not get google drive info. Error message: ${
+            sanityCheckAbout.statusText || "unknown"
+          }`
+        );
       }
-
-      if (currentDriveUserDomain !== newDriveUserDomain) {
-        return new Err({
-          type: "connector_oauth_target_mismatch",
-          message: "Cannot change domain of a Google Drive connector",
-        });
+      if (sanityCheckFilesGet.status !== 200) {
+        throw new Error(
+          `Could not call google drive files get. Error message: ${
+            sanityCheckFilesGet.statusText || "unknown"
+          }`
+        );
       }
-    } catch (e) {
-      logger.error(
-        {
-          error: e,
-        },
-        `Error checking Google domain of user who is updating the connector - lets update the connector regardless`
-      );
-    }
-
-    const oldConnectionId = connector.connectionId;
-    await connector.update({ connectionId });
-
-    nangoDeleteConnection(
-      oldConnectionId,
-      googleDriveConfig.getRequiredNangoGoogleDriveConnectorId()
-    ).catch((e) => {
-      logger.error(
-        { error: e, oldConnectionId },
-        "Error deleting old Nango connection"
-      );
-    });
-  }
-
-  return new Ok(connector.id.toString());
-}
-
-export async function cleanupGoogleDriveConnector(
-  connectorId: ModelId,
-  force = false
-): Promise<Result<undefined, Error>> {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    return new Err(
-      new Error(`Could not find connector with id ${connectorId}`)
-    );
-  }
-
-  const authClient = new google.auth.OAuth2(
-    googleDriveConfig.getRequiredGoogleDriveClientId(),
-    googleDriveConfig.getRequiredGoogleDriveClientSecret()
-  );
-
-  try {
-    const credentials = await getGoogleCredentials(connector.connectionId);
-
-    const revokeTokenRes = await authClient.revokeToken(
-      credentials.credentials.refresh_token
-    );
-
-    if (revokeTokenRes.status !== 200) {
-      logger.error(
-        {
-          error: revokeTokenRes.data,
-        },
-        "Could not revoke token"
-      );
-      if (!force) {
-        return new Err(new Error("Could not revoke token"));
+      if (sanityCheckFilesList.status !== 200) {
+        throw new Error(
+          `Could not call google drive files list. Error message: ${
+            sanityCheckFilesList.statusText || "unknown"
+          }`
+        );
       }
-    }
-  } catch (err) {
-    if (!force) {
-      throw err;
-    } else {
+    } catch (err) {
       logger.error(
         {
           err,
         },
-        "Error revoking token"
+        "Error creating Google Drive connector"
       );
+      return new Err(new Error("Error creating Google Drive connector"));
     }
-  }
 
-  const nangoRes = await nangoDeleteConnection(
-    connector.connectionId,
-    googleDriveConfig.getRequiredNangoGoogleDriveConnectorId()
-  );
-  if (nangoRes.isErr()) {
-    if (!force) {
-      return nangoRes;
-    } else {
-      logger.error(
-        {
-          err: nangoRes.error,
-        },
-        "Error deleting connection from Nango"
-      );
-    }
-  }
+    const googleDriveConfigurationBlob = {
+      pdfEnabled: false,
+      largeFilesEnabled: false,
+    };
 
-  const res = await connector.delete();
-  if (res.isErr()) {
-    logger.error(
-      { connectorId, error: res.error },
-      "Error cleaning up Google Drive connector."
+    const connector = await ConnectorResource.makeNew(
+      "google_drive",
+      {
+        connectionId: nangoConnectionId,
+        workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
+        workspaceId: dataSourceConfig.workspaceId,
+        dataSourceName: dataSourceConfig.dataSourceName,
+      },
+      googleDriveConfigurationBlob
     );
-    return res;
-  }
 
-  return new Ok(undefined);
-}
+    // We mark it artificially as sync succeeded as google drive is created empty.
+    await syncSucceeded(connector.id);
 
-export async function retrieveGoogleDriveConnectorPermissions({
-  connectorId,
-  parentInternalId,
-  filterPermission,
-  viewType,
-}: Parameters<ConnectorPermissionRetriever>[0]): Promise<
-  Result<ContentNode[], Error>
-> {
-  const c = await ConnectorResource.fetchById(connectorId);
-  const isTablesView = viewType === "tables";
-  if (!c) {
-    logger.error({ connectorId }, "Connector not found");
-    return new Err(new Error("Connector not found"));
-  }
-  const authCredentials = await getAuthObject(c.connectionId);
-  if (isTablesView && filterPermission !== "read") {
-    return new Err(
-      new Error("Tables view is only supported for read permissions")
-    );
-  }
-  if (filterPermission === "read") {
-    if (parentInternalId === null) {
-      // Return the list of folders explicitly selected by the user.
-      const folders = await GoogleDriveFolders.findAll({
-        where: {
-          connectorId: connectorId,
-        },
-      });
-
-      const folderAsContentNodes = await getFoldersAsContentNodes({
-        authCredentials,
-        folders,
-        viewType,
-      });
-
-      const nodes = removeNulls(folderAsContentNodes);
-
-      nodes.sort((a, b) => {
-        return a.title.localeCompare(b.title);
-      });
-
-      return new Ok(nodes);
-    } else {
-      // Return the list of all folders and files synced in a parent folder.
-      const where: WhereOptions<InferAttributes<GoogleDriveFiles>> = {
-        connectorId: connectorId,
-        parentId: parentInternalId,
-      };
-      if (isTablesView) {
-        // In tables view, we only show folders, spreadhsheets and sheets.
-        // We filter out folders that only contain Documents.
-        where.mimeType = [
-          "application/vnd.google-apps.folder",
-          "application/vnd.google-apps.spreadsheet",
-        ];
-      }
-      const folderOrFiles = await GoogleDriveFiles.findAll({
-        where,
-      });
-      let sheets: GoogleDriveSheet[] = [];
-      if (isTablesView) {
-        sheets = await GoogleDriveSheet.findAll({
-          where: {
-            connectorId: connectorId,
-            driveFileId: parentInternalId,
-          },
-        });
-      }
-
-      let nodes = await concurrentExecutor(
-        folderOrFiles,
-        async (f): Promise<ContentNode> => {
-          const type = getPermissionViewType(f);
-
-          return {
-            provider: c.type,
-            internalId: f.driveFileId,
-            parentInternalId: null,
-            type,
-            title: f.name || "",
-            dustDocumentId: getGoogleDriveEntityDocumentId(f),
-            lastUpdatedAt: f.lastUpsertedTs?.getTime() || null,
-            sourceUrl: null,
-            expandable: await isDriveObjectExpandable({
-              objectId: f.driveFileId,
-              mimeType: f.mimeType,
-              connectorId,
-              viewType,
-            }),
-            permission: "read",
-          };
-        },
-        { concurrency: 4 }
-      );
-
-      if (sheets.length) {
-        nodes = nodes.concat(
-          sheets.map((s) => {
-            return {
-              provider: c.type,
-              internalId: getGoogleSheetContentNodeInternalId(
-                s.driveFileId,
-                s.driveSheetId
-              ),
-              parentInternalId: s.driveFileId,
-              type: "database" as const,
-              title: s.name || "",
-              dustDocumentId: null,
-              lastUpdatedAt: s.updatedAt.getTime() || null,
-              sourceUrl: null,
-              expandable: false,
-              permission: "read",
-              dustTableId: getGoogleSheetTableId(s.driveFileId, s.driveSheetId),
-            };
-          })
-        );
-      }
-
-      // Sorting nodes, folders first then alphabetically.
-      nodes.sort((a, b) => {
-        if (a.type !== b.type) {
-          return a.type === "folder" ? -1 : 1;
-        }
-        return a.title.localeCompare(b.title);
-      });
-
-      return new Ok(nodes);
-    }
-  } else if (filterPermission === null) {
-    if (parentInternalId === null) {
-      // Return the list of remote shared drives.
-      const drives = await getDrives(c.id);
-
-      const nodes: ContentNode[] = await Promise.all(
-        drives.map(async (d): Promise<ContentNode> => {
-          const driveObject = await getGoogleDriveObject(authCredentials, d.id);
-          if (!driveObject) {
-            throw new Error(`Drive ${d.id} unexpectedly not found (got 404).`);
-          }
-          return {
-            provider: c.type,
-            internalId: driveObject.id,
-            parentInternalId: driveObject.parent,
-            type: "folder" as const,
-            title: driveObject.name,
-            sourceUrl: driveObject.webViewLink || null,
-            dustDocumentId: null,
-            lastUpdatedAt: driveObject.updatedAtMs || null,
-            expandable: await folderHasChildren(connectorId, driveObject.id),
-            permission: (await GoogleDriveFolders.findOne({
-              where: {
-                connectorId: connectorId,
-                folderId: driveObject.id,
-              },
-            }))
-              ? "read"
-              : "none",
-          };
-        })
-      );
-      // Adding a fake "Shared with me" node, to allow the user to see their shared files
-      // that are not living in a shared drive.
-      nodes.push({
-        provider: c.type,
-        internalId: GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID,
-        parentInternalId: null,
-        type: "folder" as const,
-        preventSelection: true,
-        title: "Shared with me",
-        sourceUrl: null,
-        dustDocumentId: null,
-        lastUpdatedAt: null,
-        expandable: true,
-        permission: "none",
-      });
-
-      nodes.sort((a, b) => {
-        return a.title.localeCompare(b.title);
-      });
-
-      return new Ok(nodes);
-    } else {
-      // Return the list of remote folders inside a parent folder.
-      const drive = await getDriveClient(authCredentials);
-      let nextPageToken: string | undefined = undefined;
-      let remoteFolders: drive_v3.Schema$File[] = [];
-      // Depending on the view the user is requesting, the way of querying changes.
-      // The "Shared with me" view requires to look for folders
-      // with the flag `sharedWithMe=true`, but there is no need to check for the parents.
-      let gdriveQuery = `mimeType='application/vnd.google-apps.folder'`;
-      if (parentInternalId === GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID) {
-        gdriveQuery += ` and sharedWithMe=true`;
-      } else {
-        gdriveQuery += ` and '${parentInternalId}' in parents`;
-      }
-      do {
-        const res: GaxiosResponse<drive_v3.Schema$FileList> =
-          await drive.files.list({
-            corpora: "allDrives",
-            pageSize: 200,
-            includeItemsFromAllDrives: true,
-            supportsAllDrives: true,
-            fields: `nextPageToken, files(${FILE_ATTRIBUTES_TO_FETCH.join(
-              ", "
-            )})`,
-            q: gdriveQuery,
-            pageToken: nextPageToken,
-          });
-
-        if (res.status !== 200) {
-          throw new Error(
-            `Error getting files. status_code: ${res.status}. status_text: ${res.statusText}`
-          );
-        }
-        if (!res.data.files) {
-          throw new Error("Files list is undefined");
-        }
-        remoteFolders = remoteFolders.concat(res.data.files);
-        nextPageToken = res.data.nextPageToken || undefined;
-      } while (nextPageToken);
-
-      const nodes: ContentNode[] = await Promise.all(
-        remoteFolders.map(async (rf): Promise<ContentNode> => {
-          const driveObject = await driveObjectToDustType(rf, authCredentials);
-
-          return {
-            provider: c.type,
-            internalId: driveObject.id,
-            parentInternalId: driveObject.parent,
-            type: "folder" as const,
-            title: driveObject.name,
-            sourceUrl: driveObject.webViewLink || null,
-            expandable: await folderHasChildren(connectorId, driveObject.id),
-            dustDocumentId: null,
-            lastUpdatedAt: driveObject.updatedAtMs || null,
-            permission: (await GoogleDriveFolders.findOne({
-              where: {
-                connectorId: connectorId,
-                folderId: driveObject.id,
-              },
-            }))
-              ? "read"
-              : "none",
-          };
-        })
-      );
-
-      nodes.sort((a, b) => {
-        return a.title.localeCompare(b.title);
-      });
-
-      return new Ok(nodes);
-    }
-  } else {
-    return new Err(new Error(`Invalid permission: ${filterPermission}`));
-  }
-}
-
-export async function setGoogleDriveConnectorPermissions(
-  connectorId: ModelId,
-  permissions: Record<string, ConnectorPermission>
-): Promise<Result<void, Error>> {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    return new Err(new Error(`Connector not found with id ${connectorId}`));
-  }
-
-  let shouldFullSync = false;
-  for (const [id, permission] of Object.entries(permissions)) {
-    shouldFullSync = true;
-    if (permission === "none") {
-      await GoogleDriveFolders.destroy({
-        where: {
-          connectorId: connectorId,
-          folderId: id,
-        },
-      });
-    } else if (permission === "read") {
-      await GoogleDriveFolders.upsert({
-        connectorId: connectorId,
-        folderId: id,
-      });
-    } else {
-      return new Err(
-        new Error(`Invalid permission ${permission} for node ${id}`)
-      );
-    }
-  }
-
-  if (shouldFullSync) {
-    const res = await launchGoogleDriveFullSyncWorkflow(connectorId, null);
+    // We nonetheless launch the incremental sync.
+    const res = await launchGoogleDriveIncrementalSyncWorkflow(connector.id);
     if (res.isErr()) {
       return res;
     }
-  }
-  const incrementalRes =
-    await launchGoogleDriveIncrementalSyncWorkflow(connectorId);
-  if (incrementalRes.isErr()) {
-    return incrementalRes;
+
+    return new Ok(connector.id.toString());
   }
 
-  return new Ok(undefined);
-}
+  async update({
+    connectionId,
+  }: {
+    connectionId?: string | null;
+  }): Promise<Result<string, ConnectorsAPIError>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      logger.error({ connectorId: this.connectorId }, "Connector not found");
+      return new Err({
+        message: "Connector not found",
+        type: "connector_not_found",
+      });
+    }
 
-export async function retrieveGoogleDriveContentNodes(
-  connectorId: ModelId,
-  internalIds: string[],
-  viewType: ContentNodesViewType
-): Promise<Result<ContentNode[], Error>> {
-  const driveFileIds = internalIds.filter(
-    (id) => !isGoogleSheetContentNodeInternalId(id)
-  );
-  const sheetIds = internalIds
-    .filter((id) => isGoogleSheetContentNodeInternalId(id))
-    .map(getGoogleIdsFromSheetContentNodeInternalId);
+    // Ideally we want to check that the Google Project ID is the same as the one from the connector
+    // I couln't find an easy way to access it from the googleapis library
+    // Workaround is checking the domain of the user who is updating the connector
+    if (connectionId) {
+      try {
+        const oldConnectionId = connector.connectionId;
+        const currentDriveClient = await getDriveClient(oldConnectionId);
+        const currentDriveUser = await currentDriveClient.about.get({
+          fields: "user",
+        });
+        const currentUserEmail =
+          currentDriveUser.data?.user?.emailAddress || "";
+        const currentDriveUserDomain = currentUserEmail.split("@")[1];
 
-  if (!!sheetIds.length && viewType !== "tables") {
-    return new Err(
-      new Error(
-        `Cannot retrieve Google Sheets Content Nodes in view type "${viewType}".`
-      )
-    );
-  }
+        const newDriveClient = await getDriveClient(connectionId);
+        const newDriveUser = await newDriveClient.about.get({
+          fields: "user",
+        });
+        const newDriveUserEmail = newDriveUser.data?.user?.emailAddress || "";
+        const newDriveUserDomain = newDriveUserEmail.split("@")[1];
 
-  const folderOrFiles = driveFileIds.length
-    ? await GoogleDriveFiles.findAll({
-        where: {
-          connectorId: connectorId,
-          driveFileId: driveFileIds,
-        },
-      })
-    : [];
+        if (!currentDriveUserDomain || !newDriveUserDomain) {
+          return new Err({
+            type: "connector_update_error",
+            message: "Error retrieving google drive info to update connector",
+          });
+        }
 
-  const drivesOrTopLevelFolders = driveFileIds.length
-    ? (
-        await GoogleDriveFolders.findAll({
-          where: {
-            connectorId: connectorId,
-            folderId: driveFileIds,
+        if (currentDriveUserDomain !== newDriveUserDomain) {
+          return new Err({
+            type: "connector_oauth_target_mismatch",
+            message: "Cannot change domain of a Google Drive connector",
+          });
+        }
+      } catch (e) {
+        logger.error(
+          {
+            error: e,
           },
-        })
-      ).filter(
-        // no need to add it if already in folderOrFiles
-        (f) => folderOrFiles.every((ff) => ff.driveFileId !== f.folderId)
-      )
-    : [];
-
-  const sheets = sheetIds.length
-    ? await GoogleDriveSheet.findAll({
-        where: {
-          connectorId: connectorId,
-          [Op.or]: sheetIds.map((s) => ({
-            [Op.and]: [
-              {
-                driveFileId: s.googleFileId,
-              },
-              {
-                driveSheetId: s.googleSheetId,
-              },
-            ],
-          })),
-        },
-      })
-    : [];
-
-  const folderOrFileNodes = await concurrentExecutor(
-    folderOrFiles,
-    async (f): Promise<ContentNode> => {
-      const type = getPermissionViewType(f);
-      let sourceUrl = null;
-
-      if (isGoogleDriveSpreadSheetFile(f)) {
-        sourceUrl = `https://docs.google.com/spreadsheets/d/${f.driveFileId}/edit`;
-      } else if (isGoogleDriveFolder(f)) {
-        sourceUrl = `https://drive.google.com/drive/folders/${f.driveFileId}`;
-      } else {
-        sourceUrl = `https://drive.google.com/file/d/${f.driveFileId}/view`;
+          `Error checking Google domain of user who is updating the connector - lets update the connector regardless`
+        );
       }
 
-      return {
-        provider: "google_drive",
-        internalId: f.driveFileId,
-        parentInternalId: null,
-        type,
-        title: f.name || "",
-        dustDocumentId: getGoogleDriveEntityDocumentId(f),
-        lastUpdatedAt: f.lastUpsertedTs?.getTime() || null,
-        sourceUrl,
-        expandable: await isDriveObjectExpandable({
-          objectId: f.driveFileId,
-          mimeType: f.mimeType,
-          connectorId,
-          viewType,
-        }),
-        permission: "read",
-      };
-    },
-    { concurrency: 4 }
-  );
+      const oldConnectionId = connector.connectionId;
+      await connector.update({ connectionId });
 
-  const drivesOrTopLevelFolderNodes = await (async () => {
-    if (drivesOrTopLevelFolders.length === 0) {
-      return [];
+      nangoDeleteConnection(
+        oldConnectionId,
+        googleDriveConfig.getRequiredNangoGoogleDriveConnectorId()
+      ).catch((e) => {
+        logger.error(
+          { error: e, oldConnectionId },
+          "Error deleting old Nango connection"
+        );
+      });
     }
-    const c = await ConnectorResource.fetchById(connectorId);
+
+    return new Ok(connector.id.toString());
+  }
+
+  async clean({
+    force,
+  }: {
+    force: boolean;
+  }): Promise<Result<undefined, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      return new Err(
+        new Error(`Could not find connector with id ${this.connectorId}`)
+      );
+    }
+
+    const authClient = new google.auth.OAuth2(
+      googleDriveConfig.getRequiredGoogleDriveClientId(),
+      googleDriveConfig.getRequiredGoogleDriveClientSecret()
+    );
+
+    try {
+      const credentials = await getGoogleCredentials(connector.connectionId);
+
+      const revokeTokenRes = await authClient.revokeToken(
+        credentials.credentials.refresh_token
+      );
+
+      if (revokeTokenRes.status !== 200) {
+        logger.error(
+          {
+            error: revokeTokenRes.data,
+          },
+          "Could not revoke token"
+        );
+        if (!force) {
+          return new Err(new Error("Could not revoke token"));
+        }
+      }
+    } catch (err) {
+      if (!force) {
+        throw err;
+      } else {
+        logger.error(
+          {
+            err,
+          },
+          "Error revoking token"
+        );
+      }
+    }
+
+    const nangoRes = await nangoDeleteConnection(
+      connector.connectionId,
+      googleDriveConfig.getRequiredNangoGoogleDriveConnectorId()
+    );
+    if (nangoRes.isErr()) {
+      if (!force) {
+        return nangoRes;
+      } else {
+        logger.error(
+          {
+            err: nangoRes.error,
+          },
+          "Error deleting connection from Nango"
+        );
+      }
+    }
+
+    const res = await connector.delete();
+    if (res.isErr()) {
+      logger.error(
+        { connectorId: this.connectorId, error: res.error },
+        "Error cleaning up Google Drive connector."
+      );
+      return res;
+    }
+
+    return new Ok(undefined);
+  }
+
+  async retrievePermissions({
+    parentInternalId,
+    filterPermission,
+    viewType,
+  }: {
+    parentInternalId: string | null;
+    filterPermission: ConnectorPermission | null;
+    viewType: ContentNodesViewType;
+  }): Promise<Result<ContentNode[], Error>> {
+    const c = await ConnectorResource.fetchById(this.connectorId);
+    const isTablesView = viewType === "tables";
     if (!c) {
-      logger.error({ connectorId }, "Connector not found");
-      throw new Error("Connector not found");
+      logger.error({ connectorId: this.connectorId }, "Connector not found");
+      return new Err(new Error("Connector not found"));
     }
     const authCredentials = await getAuthObject(c.connectionId);
-    return removeNulls(
-      await getFoldersAsContentNodes({
-        authCredentials,
-        folders: drivesOrTopLevelFolders,
-        viewType,
-      })
-    );
-  })();
+    if (isTablesView && filterPermission !== "read") {
+      return new Err(
+        new Error("Tables view is only supported for read permissions")
+      );
+    }
+    if (filterPermission === "read") {
+      if (parentInternalId === null) {
+        // Return the list of folders explicitly selected by the user.
+        const folders = await GoogleDriveFolders.findAll({
+          where: {
+            connectorId: this.connectorId,
+          },
+        });
 
-  const sheetNodes: ContentNode[] = sheets.map((s) => ({
-    provider: "google_drive",
-    internalId: getGoogleSheetContentNodeInternalId(
-      s.driveFileId,
-      s.driveSheetId
-    ),
-    parentInternalId: s.driveFileId,
-    type: "database",
-    title: s.name || "",
-    dustDocumentId: null,
-    lastUpdatedAt: s.updatedAt.getTime() || null,
-    sourceUrl: `https://docs.google.com/spreadsheets/d/${s.driveFileId}/edit#gid=${s.driveSheetId}`,
-    expandable: false,
-    permission: "read",
-  }));
+        const folderAsContentNodes = await getFoldersAsContentNodes({
+          authCredentials,
+          folders,
+          viewType,
+        });
 
-  // Return the nodes in the same order as the input internalIds.
-  const nodeByInternalId = new Map(
-    [...folderOrFileNodes, ...drivesOrTopLevelFolderNodes, ...sheetNodes].map(
-      (n) => [n.internalId, n]
-    )
-  );
-  return new Ok(
-    internalIds
-      .filter((id) => nodeByInternalId.has(id))
-      .map((id) => {
-        const node = nodeByInternalId.get(id);
-        if (!node) {
-          throw new Error(`Could not find node with internalId ${id}`);
+        const nodes = removeNulls(folderAsContentNodes);
+
+        nodes.sort((a, b) => {
+          return a.title.localeCompare(b.title);
+        });
+
+        return new Ok(nodes);
+      } else {
+        // Return the list of all folders and files synced in a parent folder.
+        const where: WhereOptions<InferAttributes<GoogleDriveFiles>> = {
+          connectorId: this.connectorId,
+          parentId: parentInternalId,
+        };
+        if (isTablesView) {
+          // In tables view, we only show folders, spreadhsheets and sheets.
+          // We filter out folders that only contain Documents.
+          where.mimeType = [
+            "application/vnd.google-apps.folder",
+            "application/vnd.google-apps.spreadsheet",
+          ];
         }
-        return node;
-      })
-  );
-}
+        const folderOrFiles = await GoogleDriveFiles.findAll({
+          where,
+        });
+        let sheets: GoogleDriveSheet[] = [];
+        if (isTablesView) {
+          sheets = await GoogleDriveSheet.findAll({
+            where: {
+              connectorId: this.connectorId,
+              driveFileId: parentInternalId,
+            },
+          });
+        }
 
-export async function retrieveGoogleDriveContentNodeParents(
-  connectorId: ModelId,
-  internalId: string,
-  memoizationKey?: string
-): Promise<Result<string[], Error>> {
-  const memo = memoizationKey || uuidv4();
-  try {
-    const parents = await getLocalParents(connectorId, internalId, memo);
-    return new Ok(parents);
-  } catch (err) {
-    return new Err(err as Error);
-  }
-}
+        let nodes = await concurrentExecutor(
+          folderOrFiles,
+          async (f): Promise<ContentNode> => {
+            const type = getPermissionViewType(f);
 
-export async function getGoogleDriveConfig(
-  connectorId: ModelId,
-  configKey: string
-) {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    return new Err(new Error(`Connector not found with id ${connectorId}`));
-  }
-  const config = await GoogleDriveConfig.findOne({
-    where: { connectorId: connectorId },
-  });
-  if (!config) {
-    return new Err(
-      new Error(`Google Drive config not found with connectorId ${connectorId}`)
-    );
-  }
-  switch (configKey) {
-    case "pdfEnabled": {
-      return new Ok(config.pdfEnabled ? "true" : "false");
+            return {
+              provider: c.type,
+              internalId: f.driveFileId,
+              parentInternalId: null,
+              type,
+              title: f.name || "",
+              dustDocumentId: getGoogleDriveEntityDocumentId(f),
+              lastUpdatedAt: f.lastUpsertedTs?.getTime() || null,
+              sourceUrl: null,
+              expandable: await isDriveObjectExpandable({
+                objectId: f.driveFileId,
+                mimeType: f.mimeType,
+                connectorId: this.connectorId,
+                viewType,
+              }),
+              permission: "read",
+            };
+          },
+          { concurrency: 4 }
+        );
+
+        if (sheets.length) {
+          nodes = nodes.concat(
+            sheets.map((s) => {
+              return {
+                provider: c.type,
+                internalId: getGoogleSheetContentNodeInternalId(
+                  s.driveFileId,
+                  s.driveSheetId
+                ),
+                parentInternalId: s.driveFileId,
+                type: "database" as const,
+                title: s.name || "",
+                dustDocumentId: null,
+                lastUpdatedAt: s.updatedAt.getTime() || null,
+                sourceUrl: null,
+                expandable: false,
+                permission: "read",
+                dustTableId: getGoogleSheetTableId(
+                  s.driveFileId,
+                  s.driveSheetId
+                ),
+              };
+            })
+          );
+        }
+
+        // Sorting nodes, folders first then alphabetically.
+        nodes.sort((a, b) => {
+          if (a.type !== b.type) {
+            return a.type === "folder" ? -1 : 1;
+          }
+          return a.title.localeCompare(b.title);
+        });
+
+        return new Ok(nodes);
+      }
+    } else if (filterPermission === null) {
+      if (parentInternalId === null) {
+        // Return the list of remote shared drives.
+        const drives = await getDrives(c.id);
+
+        const nodes: ContentNode[] = await Promise.all(
+          drives.map(async (d): Promise<ContentNode> => {
+            const driveObject = await getGoogleDriveObject(
+              authCredentials,
+              d.id
+            );
+            if (!driveObject) {
+              throw new Error(
+                `Drive ${d.id} unexpectedly not found (got 404).`
+              );
+            }
+            return {
+              provider: c.type,
+              internalId: driveObject.id,
+              parentInternalId: driveObject.parent,
+              type: "folder" as const,
+              title: driveObject.name,
+              sourceUrl: driveObject.webViewLink || null,
+              dustDocumentId: null,
+              lastUpdatedAt: driveObject.updatedAtMs || null,
+              expandable: await folderHasChildren(
+                this.connectorId,
+                driveObject.id
+              ),
+              permission: (await GoogleDriveFolders.findOne({
+                where: {
+                  connectorId: this.connectorId,
+                  folderId: driveObject.id,
+                },
+              }))
+                ? "read"
+                : "none",
+            };
+          })
+        );
+        // Adding a fake "Shared with me" node, to allow the user to see their shared files
+        // that are not living in a shared drive.
+        nodes.push({
+          provider: c.type,
+          internalId: GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID,
+          parentInternalId: null,
+          type: "folder" as const,
+          preventSelection: true,
+          title: "Shared with me",
+          sourceUrl: null,
+          dustDocumentId: null,
+          lastUpdatedAt: null,
+          expandable: true,
+          permission: "none",
+        });
+
+        nodes.sort((a, b) => {
+          return a.title.localeCompare(b.title);
+        });
+
+        return new Ok(nodes);
+      } else {
+        // Return the list of remote folders inside a parent folder.
+        const drive = await getDriveClient(authCredentials);
+        let nextPageToken: string | undefined = undefined;
+        let remoteFolders: drive_v3.Schema$File[] = [];
+        // Depending on the view the user is requesting, the way of querying changes.
+        // The "Shared with me" view requires to look for folders
+        // with the flag `sharedWithMe=true`, but there is no need to check for the parents.
+        let gdriveQuery = `mimeType='application/vnd.google-apps.folder'`;
+        if (parentInternalId === GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID) {
+          gdriveQuery += ` and sharedWithMe=true`;
+        } else {
+          gdriveQuery += ` and '${parentInternalId}' in parents`;
+        }
+        do {
+          const res: GaxiosResponse<drive_v3.Schema$FileList> =
+            await drive.files.list({
+              corpora: "allDrives",
+              pageSize: 200,
+              includeItemsFromAllDrives: true,
+              supportsAllDrives: true,
+              fields: `nextPageToken, files(${FILE_ATTRIBUTES_TO_FETCH.join(
+                ", "
+              )})`,
+              q: gdriveQuery,
+              pageToken: nextPageToken,
+            });
+
+          if (res.status !== 200) {
+            throw new Error(
+              `Error getting files. status_code: ${res.status}. status_text: ${res.statusText}`
+            );
+          }
+          if (!res.data.files) {
+            throw new Error("Files list is undefined");
+          }
+          remoteFolders = remoteFolders.concat(res.data.files);
+          nextPageToken = res.data.nextPageToken || undefined;
+        } while (nextPageToken);
+
+        const nodes: ContentNode[] = await Promise.all(
+          remoteFolders.map(async (rf): Promise<ContentNode> => {
+            const driveObject = await driveObjectToDustType(
+              rf,
+              authCredentials
+            );
+
+            return {
+              provider: c.type,
+              internalId: driveObject.id,
+              parentInternalId: driveObject.parent,
+              type: "folder" as const,
+              title: driveObject.name,
+              sourceUrl: driveObject.webViewLink || null,
+              expandable: await folderHasChildren(
+                this.connectorId,
+                driveObject.id
+              ),
+              dustDocumentId: null,
+              lastUpdatedAt: driveObject.updatedAtMs || null,
+              permission: (await GoogleDriveFolders.findOne({
+                where: {
+                  connectorId: this.connectorId,
+                  folderId: driveObject.id,
+                },
+              }))
+                ? "read"
+                : "none",
+            };
+          })
+        );
+
+        nodes.sort((a, b) => {
+          return a.title.localeCompare(b.title);
+        });
+
+        return new Ok(nodes);
+      }
+    } else {
+      return new Err(new Error(`Invalid permission: ${filterPermission}`));
     }
-    case "largeFilesEnabled": {
-      return new Ok(config.largeFilesEnabled ? "true" : "false");
+  }
+
+  async setPermissions({
+    permissions,
+  }: {
+    permissions: Record<string, ConnectorPermission>;
+  }): Promise<Result<void, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      return new Err(
+        new Error(`Connector not found with id ${this.connectorId}`)
+      );
     }
-    default:
-      return new Err(new Error(`Invalid config key ${configKey}`));
-  }
-}
 
-export async function setGoogleDriveConfig(
-  connectorId: ModelId,
-  configKey: string,
-  configValue: string
-) {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    return new Err(new Error(`Connector not found with id ${connectorId}`));
-  }
-  const config = await GoogleDriveConfig.findOne({
-    where: { connectorId: connectorId },
-  });
-  if (!config) {
-    return new Err(
-      new Error(`Google Drive config not found with connectorId ${connectorId}`)
-    );
-  }
+    let shouldFullSync = false;
+    for (const [id, permission] of Object.entries(permissions)) {
+      shouldFullSync = true;
+      if (permission === "none") {
+        await GoogleDriveFolders.destroy({
+          where: {
+            connectorId: this.connectorId,
+            folderId: id,
+          },
+        });
+      } else if (permission === "read") {
+        await GoogleDriveFolders.upsert({
+          connectorId: this.connectorId,
+          folderId: id,
+        });
+      } else {
+        return new Err(
+          new Error(`Invalid permission ${permission} for node ${id}`)
+        );
+      }
+    }
 
-  if (!["true", "false"].includes(configValue)) {
-    return new Err(
-      new Error(`Invalid config value ${configValue}, must be true or false`)
-    );
-  }
-
-  switch (configKey) {
-    case "pdfEnabled": {
-      await config.update({
-        pdfEnabled: configValue === "true",
-      });
-      const workflowRes = await launchGoogleDriveFullSyncWorkflow(
-        connectorId,
+    if (shouldFullSync) {
+      const res = await launchGoogleDriveFullSyncWorkflow(
+        this.connectorId,
         null
       );
-      if (workflowRes.isErr()) {
-        return workflowRes;
+      if (res.isErr()) {
+        return res;
       }
-      return new Ok(void 0);
+    }
+    const incrementalRes = await launchGoogleDriveIncrementalSyncWorkflow(
+      this.connectorId
+    );
+    if (incrementalRes.isErr()) {
+      return incrementalRes;
     }
 
-    case "largeFilesEnabled": {
-      await config.update({
-        largeFilesEnabled: configValue === "true",
-      });
-      const workflowRes = await launchGoogleDriveFullSyncWorkflow(
-        connectorId,
-        null
+    return new Ok(undefined);
+  }
+
+  async retrieveBatchContentNodes({
+    internalIds,
+    viewType,
+  }: {
+    internalIds: string[];
+    viewType: ContentNodesViewType;
+  }): Promise<Result<ContentNode[], Error>> {
+    const driveFileIds = internalIds.filter(
+      (id) => !isGoogleSheetContentNodeInternalId(id)
+    );
+    const sheetIds = internalIds
+      .filter((id) => isGoogleSheetContentNodeInternalId(id))
+      .map(getGoogleIdsFromSheetContentNodeInternalId);
+
+    if (!!sheetIds.length && viewType !== "tables") {
+      return new Err(
+        new Error(
+          `Cannot retrieve Google Sheets Content Nodes in view type "${viewType}".`
+        )
       );
-      if (workflowRes.isErr()) {
-        return workflowRes;
+    }
+
+    const folderOrFiles = driveFileIds.length
+      ? await GoogleDriveFiles.findAll({
+          where: {
+            connectorId: this.connectorId,
+            driveFileId: driveFileIds,
+          },
+        })
+      : [];
+
+    const drivesOrTopLevelFolders = driveFileIds.length
+      ? (
+          await GoogleDriveFolders.findAll({
+            where: {
+              connectorId: this.connectorId,
+              folderId: driveFileIds,
+            },
+          })
+        ).filter(
+          // no need to add it if already in folderOrFiles
+          (f) => folderOrFiles.every((ff) => ff.driveFileId !== f.folderId)
+        )
+      : [];
+
+    const sheets = sheetIds.length
+      ? await GoogleDriveSheet.findAll({
+          where: {
+            connectorId: this.connectorId,
+            [Op.or]: sheetIds.map((s) => ({
+              [Op.and]: [
+                {
+                  driveFileId: s.googleFileId,
+                },
+                {
+                  driveSheetId: s.googleSheetId,
+                },
+              ],
+            })),
+          },
+        })
+      : [];
+
+    const folderOrFileNodes = await concurrentExecutor(
+      folderOrFiles,
+      async (f): Promise<ContentNode> => {
+        const type = getPermissionViewType(f);
+        let sourceUrl = null;
+
+        if (isGoogleDriveSpreadSheetFile(f)) {
+          sourceUrl = `https://docs.google.com/spreadsheets/d/${f.driveFileId}/edit`;
+        } else if (isGoogleDriveFolder(f)) {
+          sourceUrl = `https://drive.google.com/drive/folders/${f.driveFileId}`;
+        } else {
+          sourceUrl = `https://drive.google.com/file/d/${f.driveFileId}/view`;
+        }
+
+        return {
+          provider: "google_drive",
+          internalId: f.driveFileId,
+          parentInternalId: null,
+          type,
+          title: f.name || "",
+          dustDocumentId: getGoogleDriveEntityDocumentId(f),
+          lastUpdatedAt: f.lastUpsertedTs?.getTime() || null,
+          sourceUrl,
+          expandable: await isDriveObjectExpandable({
+            objectId: f.driveFileId,
+            mimeType: f.mimeType,
+            connectorId: this.connectorId,
+            viewType,
+          }),
+          permission: "read",
+        };
+      },
+      { concurrency: 4 }
+    );
+
+    const drivesOrTopLevelFolderNodes = await (async () => {
+      if (drivesOrTopLevelFolders.length === 0) {
+        return [];
       }
-      return new Ok(void 0);
+      const c = await ConnectorResource.fetchById(this.connectorId);
+      if (!c) {
+        logger.error({ connectorId: this.connectorId }, "Connector not found");
+        throw new Error("Connector not found");
+      }
+      const authCredentials = await getAuthObject(c.connectionId);
+      return removeNulls(
+        await getFoldersAsContentNodes({
+          authCredentials,
+          folders: drivesOrTopLevelFolders,
+          viewType,
+        })
+      );
+    })();
+
+    const sheetNodes: ContentNode[] = sheets.map((s) => ({
+      provider: "google_drive",
+      internalId: getGoogleSheetContentNodeInternalId(
+        s.driveFileId,
+        s.driveSheetId
+      ),
+      parentInternalId: s.driveFileId,
+      type: "database",
+      title: s.name || "",
+      dustDocumentId: null,
+      lastUpdatedAt: s.updatedAt.getTime() || null,
+      sourceUrl: `https://docs.google.com/spreadsheets/d/${s.driveFileId}/edit#gid=${s.driveSheetId}`,
+      expandable: false,
+      permission: "read",
+    }));
+
+    // Return the nodes in the same order as the input internalIds.
+    const nodeByInternalId = new Map(
+      [...folderOrFileNodes, ...drivesOrTopLevelFolderNodes, ...sheetNodes].map(
+        (n) => [n.internalId, n]
+      )
+    );
+    return new Ok(
+      internalIds
+        .filter((id) => nodeByInternalId.has(id))
+        .map((id) => {
+          const node = nodeByInternalId.get(id);
+          if (!node) {
+            throw new Error(`Could not find node with internalId ${id}`);
+          }
+          return node;
+        })
+    );
+  }
+
+  async retrieveContentNodeParents({
+    internalId,
+    memoizationKey,
+  }: {
+    internalId: string;
+    memoizationKey?: string;
+  }): Promise<Result<string[], Error>> {
+    const memo = memoizationKey || uuidv4();
+    try {
+      const parents = await getLocalParents(this.connectorId, internalId, memo);
+      return new Ok(parents);
+    } catch (err) {
+      return new Err(err as Error);
+    }
+  }
+
+  async setConfigurationKey({
+    configKey,
+    configValue,
+  }: {
+    configKey: string;
+    configValue: string;
+  }): Promise<Result<void, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      return new Err(
+        new Error(`Connector not found with id ${this.connectorId}`)
+      );
+    }
+    const config = await GoogleDriveConfig.findOne({
+      where: { connectorId: this.connectorId },
+    });
+    if (!config) {
+      return new Err(
+        new Error(
+          `Google Drive config not found with connectorId ${this.connectorId}`
+        )
+      );
     }
 
-    default: {
-      return new Err(new Error(`Invalid config key ${configKey}`));
+    if (!["true", "false"].includes(configValue)) {
+      return new Err(
+        new Error(`Invalid config value ${configValue}, must be true or false`)
+      );
+    }
+
+    switch (configKey) {
+      case "pdfEnabled": {
+        await config.update({
+          pdfEnabled: configValue === "true",
+        });
+        const workflowRes = await launchGoogleDriveFullSyncWorkflow(
+          this.connectorId,
+          null
+        );
+        if (workflowRes.isErr()) {
+          return workflowRes;
+        }
+        return new Ok(void 0);
+      }
+
+      case "largeFilesEnabled": {
+        await config.update({
+          largeFilesEnabled: configValue === "true",
+        });
+        const workflowRes = await launchGoogleDriveFullSyncWorkflow(
+          this.connectorId,
+          null
+        );
+        if (workflowRes.isErr()) {
+          return workflowRes;
+        }
+        return new Ok(void 0);
+      }
+
+      default: {
+        return new Err(new Error(`Invalid config key ${configKey}`));
+      }
     }
   }
-}
 
-export async function googleDriveGarbageCollect(connectorId: ModelId) {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    return new Err(new Error(`Connector not found with id ${connectorId}`));
+  async getConfigurationKey({
+    configKey,
+  }: {
+    configKey: string;
+  }): Promise<Result<string | null, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      return new Err(
+        new Error(`Connector not found with id ${this.connectorId}`)
+      );
+    }
+    const config = await GoogleDriveConfig.findOne({
+      where: { connectorId: this.connectorId },
+    });
+    if (!config) {
+      return new Err(
+        new Error(
+          `Google Drive config not found with connectorId ${this.connectorId}`
+        )
+      );
+    }
+    switch (configKey) {
+      case "pdfEnabled": {
+        return new Ok(config.pdfEnabled ? "true" : "false");
+      }
+      case "largeFilesEnabled": {
+        return new Ok(config.largeFilesEnabled ? "true" : "false");
+      }
+      default:
+        return new Err(new Error(`Invalid config key ${configKey}`));
+    }
   }
 
-  return launchGoogleGarbageCollector(connectorId);
-}
+  async garbageCollect(): Promise<Result<string, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      return new Err(
+        new Error(`Connector not found with id ${this.connectorId}`)
+      );
+    }
 
-export async function pauseGoogleDriveConnector(connectorId: ModelId) {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    return new Err(new Error(`Connector not found with id ${connectorId}`));
+    return launchGoogleGarbageCollector(this.connectorId);
   }
-  await connector.markAsPaused();
-  await terminateAllWorkflowsForConnectorId(connectorId);
-  return new Ok(undefined);
-}
 
-export async function unpauseGoogleDriveConnector(connectorId: ModelId) {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    return new Err(new Error(`Connector not found with id ${connectorId}`));
+  async pause(): Promise<Result<undefined, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      return new Err(
+        new Error(`Connector not found with id ${this.connectorId}`)
+      );
+    }
+    await connector.markAsPaused();
+    await terminateAllWorkflowsForConnectorId(this.connectorId);
+    return new Ok(undefined);
   }
-  await connector.markAsUnpaused();
-  const r = await launchGoogleDriveFullSyncWorkflow(connectorId, null);
-  if (r.isErr()) {
-    return r;
+
+  async unpause(): Promise<Result<undefined, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      return new Err(
+        new Error(`Connector not found with id ${this.connectorId}`)
+      );
+    }
+    await connector.markAsUnpaused();
+    const r = await launchGoogleDriveFullSyncWorkflow(this.connectorId, null);
+    if (r.isErr()) {
+      return r;
+    }
+    const incrementalSync = await launchGoogleDriveIncrementalSyncWorkflow(
+      this.connectorId
+    );
+    if (incrementalSync.isErr()) {
+      return incrementalSync;
+    }
+    return new Ok(undefined);
   }
-  const incrementalSync =
-    await launchGoogleDriveIncrementalSyncWorkflow(connectorId);
-  if (incrementalSync.isErr()) {
-    return incrementalSync;
+
+  async stop(): Promise<Result<undefined, Error>> {
+    await terminateAllWorkflowsForConnectorId(this.connectorId);
+    return new Ok(undefined);
   }
-  return new Ok(undefined);
+
+  async resume(): Promise<Result<undefined, Error>> {
+    const res = await launchGoogleDriveIncrementalSyncWorkflow(
+      this.connectorId
+    );
+    if (res.isErr()) {
+      return res;
+    }
+
+    return new Ok(undefined);
+  }
+
+  async sync({
+    fromTs,
+  }: {
+    fromTs: number | null;
+  }): Promise<Result<string, Error>> {
+    return launchGoogleDriveFullSyncWorkflow(this.connectorId, fromTs);
+  }
+
+  async configure(): Promise<Result<void, Error>> {
+    throw new Error("Method not implemented.");
+  }
 }
 
 async function getFoldersAsContentNodes({

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -2,6 +2,7 @@ import type {
   ConnectorProvider,
   ModelId,
   Result,
+  SlackConfiguration,
   WebCrawlerConfiguration,
 } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
@@ -60,7 +61,7 @@ export function createConnector({
   params,
 }:
   | {
-      connectorProvider: Exclude<ConnectorProvider, "webcrawler">;
+      connectorProvider: Exclude<ConnectorProvider, "webcrawler" | "slack">;
       params: {
         dataSourceConfig: DataSourceConfig;
         connectionId: string;
@@ -73,6 +74,14 @@ export function createConnector({
         dataSourceConfig: DataSourceConfig;
         connectionId: string;
         configuration: WebCrawlerConfiguration;
+      };
+    }
+  | {
+      connectorProvider: "slack";
+      params: {
+        dataSourceConfig: DataSourceConfig;
+        connectionId: string;
+        configuration: SlackConfiguration;
       };
     }): Promise<Result<string, Error>> {
   switch (connectorProvider) {

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -1,445 +1,98 @@
 import type {
   ConnectorProvider,
   ModelId,
-  WebCrawlerConfigurationType,
+  Result,
+  WebCrawlerConfiguration,
 } from "@dust-tt/types";
-import { Err, Ok } from "@dust-tt/types";
+import { assertNever } from "@dust-tt/types";
 
-import {
-  cleanupConfluenceConnector,
-  createConfluenceConnector,
-  pauseConfluenceConnector,
-  resumeConfluenceConnector,
-  retrieveConfluenceConnectorPermissions,
-  retrieveConfluenceContentNodeParents,
-  retrieveConfluenceContentNodes,
-  setConfluenceConnectorPermissions,
-  stopConfluenceConnector,
-  unpauseConfluenceConnector,
-  updateConfluenceConnector,
-} from "@connectors/connectors/confluence";
-import { launchConfluenceSyncWorkflow } from "@connectors/connectors/confluence/temporal/client";
-import {
-  cleanupGithubConnector,
-  createGithubConnector,
-  fullResyncGithubConnector,
-  getGithubConfig,
-  pauseGithubConnector,
-  resumeGithubConnector,
-  retrieveGithubConnectorPermissions,
-  retrieveGithubContentNodeParents,
-  retrieveGithubReposContentNodes,
-  setGithubConfig,
-  stopGithubConnector,
-  unpauseGithubConnector,
-  updateGithubConnector,
-} from "@connectors/connectors/github";
-import {
-  cleanupGoogleDriveConnector,
-  createGoogleDriveConnector,
-  getGoogleDriveConfig,
-  googleDriveGarbageCollect,
-  pauseGoogleDriveConnector,
-  retrieveGoogleDriveConnectorPermissions,
-  retrieveGoogleDriveContentNodeParents,
-  retrieveGoogleDriveContentNodes,
-  setGoogleDriveConfig,
-  setGoogleDriveConnectorPermissions,
-  unpauseGoogleDriveConnector,
-  updateGoogleDriveConnector,
-} from "@connectors/connectors/google_drive";
-import {
-  launchGoogleDriveFullSyncWorkflow,
-  launchGoogleDriveIncrementalSyncWorkflow,
-} from "@connectors/connectors/google_drive/temporal/client";
-import {
-  cleanupIntercomConnector,
-  createIntercomConnector,
-  fullResyncIntercomSyncWorkflow,
-  getIntercomConfig,
-  pauseIntercomConnector,
-  resumeIntercomConnector,
-  retrieveIntercomConnectorPermissions,
-  retrieveIntercomContentNodeParents,
-  retrieveIntercomContentNodes,
-  setIntercomConfig,
-  setIntercomConnectorPermissions,
-  stopIntercomConnector,
-  unpauseIntercomConnector,
-  updateIntercomConnector,
-} from "@connectors/connectors/intercom";
-import type {
-  ConnectorBatchContentNodesRetriever,
-  ConnectorCleaner,
-  ConnectorConfigGetter,
-  ConnectorConfigSetter,
-  ConnectorGarbageCollector,
-  ConnectorPauser,
-  ConnectorPermissionRetriever,
-  ConnectorPermissionSetter,
-  ConnectorProviderCreateConnectorMapping,
-  ConnectorProviderUpdateConfigurationMapping,
-  ConnectorResumer,
-  ConnectorStopper,
-  ConnectorUnpauser,
-  ConnectorUpdater,
-  ContentNodeParentsRetriever,
-  SyncConnector,
-} from "@connectors/connectors/interface";
-import {
-  cleanupMicrosoftConnector,
-  createMicrosoftConnector,
-  fullResyncMicrosoftConnector,
-  getMicrosoftConfig,
-  pauseMicrosoftConnector,
-  resumeMicrosoftConnector,
-  retrieveMicrosoftConnectorPermissions,
-  retrieveMicrosoftContentNodeParents,
-  retrieveMicrosoftContentNodes,
-  setMicrosoftConfig,
-  setMicrosoftConnectorPermissions,
-  stopMicrosoftConnector,
-  unpauseMicrosoftConnector,
-  updateMicrosoftConnector,
-} from "@connectors/connectors/microsoft";
-import {
-  cleanupNotionConnector,
-  createNotionConnector,
-  fullResyncNotionConnector,
-  pauseNotionConnector,
-  resumeNotionConnector,
-  retrieveNotionConnectorPermissions,
-  retrieveNotionContentNodeParents,
-  retrieveNotionContentNodes,
-  stopNotionConnector,
-  unpauseNotionConnector,
-  updateNotionConnector,
-} from "@connectors/connectors/notion";
-import {
-  cleanupSlackConnector,
-  createSlackConnector,
-  getSlackConfig,
-  pauseSlackConnector,
-  retrieveSlackConnectorPermissions,
-  retrieveSlackContentNodes,
-  setSlackConfig,
-  setSlackConnectorPermissions,
-  unpauseSlackConnector,
-  updateSlackConnector,
-} from "@connectors/connectors/slack";
-import { launchSlackSyncWorkflow } from "@connectors/connectors/slack/temporal/client";
-import { terminateAllWorkflowsForConnectorId } from "@connectors/lib/temporal";
-import logger from "@connectors/logger/logger";
+import { ConfluenceConnectorManager } from "@connectors/connectors/confluence";
+import { GithubConnectorManager } from "@connectors/connectors/github";
+import { GoogleDriveConnectorManager } from "@connectors/connectors/google_drive";
+import { IntercomConnectorManager } from "@connectors/connectors/intercom";
+import { MicrosoftConnectorManager } from "@connectors/connectors/microsoft";
+import { NotionConnectorManager } from "@connectors/connectors/notion";
+import { SlackConnectorManager } from "@connectors/connectors/slack";
+import { WebcrawlerConnectorManager } from "@connectors/connectors/webcrawler";
+import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
-import {
-  cleanupWebcrawlerConnector,
-  createWebcrawlerConnector,
-  pauseWebcrawlerConnector,
-  retrieveWebcrawlerConnectorPermissions,
-  retrieveWebCrawlerContentNodeParents,
-  retrieveWebCrawlerContentNodes,
-  setWebcrawlerConfiguration,
-  stopWebcrawlerConnector,
-  unpauseWebcrawlerConnector,
-} from "./webcrawler";
-import { launchCrawlWebsiteWorkflow } from "./webcrawler/temporal/client";
+type ConnectorManager =
+  | NotionConnectorManager
+  | ConfluenceConnectorManager
+  | WebcrawlerConnectorManager
+  | MicrosoftConnectorManager
+  | SlackConnectorManager
+  | IntercomConnectorManager
+  | GithubConnectorManager
+  | GoogleDriveConnectorManager;
 
-export const CREATE_CONNECTOR_BY_TYPE: ConnectorProviderCreateConnectorMapping =
-  {
-    confluence: createConfluenceConnector,
-    github: createGithubConnector,
-    google_drive: createGoogleDriveConnector,
-    intercom: createIntercomConnector,
-    microsoft: createMicrosoftConnector,
-    notion: createNotionConnector,
-    slack: createSlackConnector,
-    webcrawler: createWebcrawlerConnector,
-  };
+export function getConnectorManager({
+  connectorProvider,
+  connectorId,
+}: {
+  connectorProvider: ConnectorProvider;
+  connectorId: ModelId;
+}): ConnectorManager {
+  switch (connectorProvider) {
+    case "confluence":
+      return new ConfluenceConnectorManager(connectorId);
+    case "github":
+      return new GithubConnectorManager(connectorId);
+    case "google_drive":
+      return new GoogleDriveConnectorManager(connectorId);
+    case "intercom":
+      return new IntercomConnectorManager(connectorId);
+    case "microsoft":
+      return new MicrosoftConnectorManager(connectorId);
+    case "notion":
+      return new NotionConnectorManager(connectorId);
+    case "slack":
+      return new SlackConnectorManager(connectorId);
+    case "webcrawler":
+      return new WebcrawlerConnectorManager(connectorId);
+    default:
+      assertNever(connectorProvider);
+  }
+}
 
-export const UPDATE_CONNECTOR_BY_TYPE: Record<
-  ConnectorProvider,
-  ConnectorUpdater
-> = {
-  confluence: updateConfluenceConnector,
-  slack: updateSlackConnector,
-  microsoft: updateMicrosoftConnector,
-  notion: updateNotionConnector,
-  github: updateGithubConnector,
-  google_drive: updateGoogleDriveConnector,
-  intercom: updateIntercomConnector,
-  webcrawler: () => {
-    throw new Error(`Not implemented`);
-  },
-};
-
-export const STOP_CONNECTOR_BY_TYPE: Record<
-  ConnectorProvider,
-  ConnectorStopper
-> = {
-  confluence: stopConfluenceConnector,
-  slack: async (connectorId: ModelId) => {
-    logger.info({ connectorId }, `Stopping Slack connector is a no-op.`);
-    return new Ok(undefined);
-  },
-  github: stopGithubConnector,
-  microsoft: stopMicrosoftConnector,
-  notion: stopNotionConnector,
-  google_drive: async (connectorId: ModelId) => {
-    await terminateAllWorkflowsForConnectorId(connectorId);
-    return new Ok(undefined);
-  },
-  intercom: stopIntercomConnector,
-  webcrawler: stopWebcrawlerConnector,
-};
-
-export const DELETE_CONNECTOR_BY_TYPE: Record<
-  ConnectorProvider,
-  ConnectorCleaner
-> = {
-  confluence: cleanupConfluenceConnector,
-  slack: cleanupSlackConnector,
-  microsoft: cleanupMicrosoftConnector,
-  notion: cleanupNotionConnector,
-  github: cleanupGithubConnector,
-  google_drive: cleanupGoogleDriveConnector,
-  intercom: cleanupIntercomConnector,
-  webcrawler: cleanupWebcrawlerConnector,
-};
-
-export const RESUME_CONNECTOR_BY_TYPE: Record<
-  ConnectorProvider,
-  ConnectorResumer
-> = {
-  confluence: resumeConfluenceConnector,
-  slack: async (connectorId: ModelId) => {
-    logger.info({ connectorId }, `Resuming Slack connector is a no-op.`);
-    return new Ok(undefined);
-  },
-  microsoft: resumeMicrosoftConnector,
-  notion: resumeNotionConnector,
-  github: resumeGithubConnector,
-  google_drive: async (connectorId: ModelId) => {
-    const res = await launchGoogleDriveIncrementalSyncWorkflow(connectorId);
-    if (res.isErr()) {
-      return res;
+export function createConnector({
+  connectorProvider,
+  params,
+}:
+  | {
+      connectorProvider: Exclude<ConnectorProvider, "webcrawler">;
+      params: {
+        dataSourceConfig: DataSourceConfig;
+        connectionId: string;
+        configuration: null;
+      };
     }
-
-    return new Ok(undefined);
-  },
-  intercom: resumeIntercomConnector,
-  webcrawler: (connectorId: ModelId) => {
-    throw new Error(`Not implemented ${connectorId}`);
-  },
-};
-
-export const SYNC_CONNECTOR_BY_TYPE: Record<ConnectorProvider, SyncConnector> =
-  {
-    confluence: launchConfluenceSyncWorkflow,
-    slack: launchSlackSyncWorkflow,
-    microsoft: fullResyncMicrosoftConnector,
-    notion: fullResyncNotionConnector,
-    github: fullResyncGithubConnector,
-    google_drive: launchGoogleDriveFullSyncWorkflow,
-    intercom: fullResyncIntercomSyncWorkflow,
-    webcrawler: launchCrawlWebsiteWorkflow,
-  };
-
-export const RETRIEVE_CONNECTOR_PERMISSIONS_BY_TYPE: Record<
-  ConnectorProvider,
-  ConnectorPermissionRetriever
-> = {
-  confluence: retrieveConfluenceConnectorPermissions,
-  slack: retrieveSlackConnectorPermissions,
-  github: retrieveGithubConnectorPermissions,
-  microsoft: retrieveMicrosoftConnectorPermissions,
-  notion: retrieveNotionConnectorPermissions,
-  google_drive: retrieveGoogleDriveConnectorPermissions,
-  intercom: retrieveIntercomConnectorPermissions,
-  webcrawler: retrieveWebcrawlerConnectorPermissions,
-};
-
-export const SET_CONNECTOR_PERMISSIONS_BY_TYPE: Record<
-  ConnectorProvider,
-  ConnectorPermissionSetter
-> = {
-  confluence: setConfluenceConnectorPermissions,
-  slack: setSlackConnectorPermissions,
-  microsoft: setMicrosoftConnectorPermissions,
-  notion: async () => {
-    return new Err(
-      new Error(`Setting Notion connector permissions is not implemented yet.`)
-    );
-  },
-  github: async () => {
-    return new Err(
-      new Error(`Setting Github connector permissions is not implemented yet.`)
-    );
-  },
-  google_drive: setGoogleDriveConnectorPermissions,
-  intercom: setIntercomConnectorPermissions,
-  webcrawler: async () => {
-    return new Err(
-      new Error(`Setting Webcrawler connector permissions is not applicable.`)
-    );
-  },
-};
-
-export const BATCH_RETRIEVE_CONTENT_NODES_BY_TYPE: Record<
-  ConnectorProvider,
-  ConnectorBatchContentNodesRetriever
-> = {
-  confluence: retrieveConfluenceContentNodes,
-  slack: retrieveSlackContentNodes,
-  microsoft: retrieveMicrosoftContentNodes,
-  notion: retrieveNotionContentNodes,
-  github: retrieveGithubReposContentNodes,
-  google_drive: retrieveGoogleDriveContentNodes,
-  intercom: retrieveIntercomContentNodes,
-  webcrawler: retrieveWebCrawlerContentNodes,
-};
-
-export const RETRIEVE_CONTENT_NODE_PARENTS_BY_TYPE: Record<
-  ConnectorProvider,
-  ContentNodeParentsRetriever
-> = {
-  confluence: retrieveConfluenceContentNodeParents,
-  microsoft: retrieveMicrosoftContentNodeParents,
-  notion: retrieveNotionContentNodeParents,
-  google_drive: retrieveGoogleDriveContentNodeParents,
-  slack: async () => new Ok([]), // Slack is flat
-  github: retrieveGithubContentNodeParents,
-  intercom: retrieveIntercomContentNodeParents,
-  webcrawler: retrieveWebCrawlerContentNodeParents,
-};
-
-// Old configuration interface that allows to set one config key at a time.
-export const SET_CONNECTOR_CONFIG_BY_TYPE: Record<
-  ConnectorProvider,
-  ConnectorConfigSetter
-> = {
-  confluence: () => {
-    throw new Error("Not implemented");
-  },
-  slack: setSlackConfig,
-  microsoft: setMicrosoftConfig,
-  notion: async () => {
-    throw new Error("Not implemented");
-  },
-  github: setGithubConfig,
-  google_drive: setGoogleDriveConfig,
-  intercom: setIntercomConfig,
-  webcrawler: async () => {
-    throw new Error("Not implemented");
-  },
-};
-
-// Old configuration interface that allows to get one config key at a time.
-export const GET_CONNECTOR_CONFIG_BY_TYPE: Record<
-  ConnectorProvider,
-  ConnectorConfigGetter
-> = {
-  confluence: () => {
-    throw new Error("Not implemented");
-  },
-  slack: getSlackConfig,
-  microsoft: getMicrosoftConfig,
-  notion: async () => {
-    throw new Error("Not implemented");
-  },
-  github: getGithubConfig,
-  google_drive: getGoogleDriveConfig,
-  intercom: getIntercomConfig,
-  webcrawler: () => {
-    throw new Error("Not implemented");
-  },
-};
-
-export const SET_CONNECTOR_CONFIGURATION_BY_TYPE: ConnectorProviderUpdateConfigurationMapping =
-  {
-    webcrawler: (
-      connectorId: ModelId,
-      configuration: WebCrawlerConfigurationType
-    ) => setWebcrawlerConfiguration(connectorId, configuration),
-    intercom: () => {
-      throw new Error("Not implemented");
-    },
-    slack: () => {
-      throw new Error("Not implemented");
-    },
-    microsoft: () => {
-      throw new Error("Not implemented");
-    },
-    notion: () => {
-      throw new Error("Not implemented");
-    },
-    github: () => {
-      throw new Error("Not implemented");
-    },
-    google_drive: () => {
-      throw new Error("Not implemented");
-    },
-    confluence: () => {
-      throw new Error("Not implemented");
-    },
-  };
-
-export const GARBAGE_COLLECT_BY_TYPE: Record<
-  ConnectorProvider,
-  ConnectorGarbageCollector
-> = {
-  confluence: () => {
-    throw new Error("Not implemented");
-  },
-  slack: () => {
-    throw new Error("Not implemented");
-  },
-  microsoft: async () => {
-    throw new Error("Not implemented");
-  },
-  notion: async () => {
-    throw new Error("Not implemented");
-  },
-  github: async () => {
-    throw new Error("Not implemented");
-  },
-  google_drive: googleDriveGarbageCollect,
-  intercom: async () => {
-    throw new Error("Not implemented");
-  },
-  webcrawler: () => {
-    throw new Error("Not implemented");
-  },
-};
-
-// If the connector has webhooks: stop processing them.
-// If the connector has long-running workflows: stop them.
-// Exclude the connector from the prod checks.
-export const PAUSE_CONNECTOR_BY_TYPE: Record<
-  ConnectorProvider,
-  ConnectorPauser
-> = {
-  confluence: pauseConfluenceConnector,
-  slack: pauseSlackConnector,
-  microsoft: pauseMicrosoftConnector,
-  notion: pauseNotionConnector,
-  github: pauseGithubConnector,
-  google_drive: pauseGoogleDriveConnector,
-  intercom: pauseIntercomConnector,
-  webcrawler: pauseWebcrawlerConnector,
-};
-
-// If the connector has webhooks: resume processing them, and trigger a full sync.
-// If the connector has long-running workflows: resume them. If they support "partial resync" do that, otherwise trigger a full sync.
-export const UNPAUSE_CONNECTOR_BY_TYPE: Record<
-  ConnectorProvider,
-  ConnectorUnpauser
-> = {
-  confluence: unpauseConfluenceConnector,
-  slack: unpauseSlackConnector,
-  microsoft: unpauseMicrosoftConnector,
-  notion: unpauseNotionConnector,
-  github: unpauseGithubConnector,
-  google_drive: unpauseGoogleDriveConnector,
-  intercom: unpauseIntercomConnector,
-  webcrawler: unpauseWebcrawlerConnector,
-};
+  | {
+      connectorProvider: "webcrawler";
+      params: {
+        dataSourceConfig: DataSourceConfig;
+        connectionId: string;
+        configuration: WebCrawlerConfiguration;
+      };
+    }): Promise<Result<string, Error>> {
+  switch (connectorProvider) {
+    case "confluence":
+      return ConfluenceConnectorManager.create(params);
+    case "github":
+      return GithubConnectorManager.create(params);
+    case "google_drive":
+      return GoogleDriveConnectorManager.create(params);
+    case "intercom":
+      return IntercomConnectorManager.create(params);
+    case "microsoft":
+      return MicrosoftConnectorManager.create(params);
+    case "notion":
+      return NotionConnectorManager.create(params);
+    case "slack":
+      return SlackConnectorManager.create(params);
+    case "webcrawler":
+      return WebcrawlerConnectorManager.create(params);
+    default:
+      assertNever(connectorProvider);
+  }
+}

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -2,9 +2,9 @@ import type {
   ConnectorPermission,
   ConnectorsAPIError,
   ContentNode,
-  ModelId,
   Result,
 } from "@dust-tt/types";
+import type { ContentNodesViewType } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 import { Op } from "sequelize";
 
@@ -38,10 +38,7 @@ import {
   launchIntercomSyncWorkflow,
   stopIntercomSyncWorkflow,
 } from "@connectors/connectors/intercom/temporal/client";
-import type {
-  ConnectorConfigGetter,
-  ConnectorPermissionRetriever,
-} from "@connectors/connectors/interface";
+import { BaseConnectorManager } from "@connectors/connectors/interface";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import {
   IntercomArticle,
@@ -55,843 +52,915 @@ import { getAccessTokenFromNango } from "@connectors/lib/nango_helpers";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
-import type { NangoConnectionId } from "@connectors/types/nango_connection_id";
 
 const { NANGO_INTERCOM_CONNECTOR_ID } = process.env;
 
-export async function createIntercomConnector(
-  dataSourceConfig: DataSourceConfig,
-  connectionId: NangoConnectionId
-): Promise<Result<string, Error>> {
-  const nangoConnectionId = connectionId;
-
-  if (!NANGO_INTERCOM_CONNECTOR_ID) {
-    throw new Error("NANGO_INTERCOM_CONNECTOR_ID not set");
-  }
-
-  let connector = null;
-
-  try {
-    const intercomWorkspace = await fetchIntercomWorkspace(nangoConnectionId);
-    if (!intercomWorkspace) {
-      return new Err(
-        new Error(
-          "Error retrieving intercom workspace, cannot create Connector."
-        )
-      );
-    }
-
-    const intercomConfigurationBlob = {
-      intercomWorkspaceId: intercomWorkspace.id,
-      name: intercomWorkspace.name,
-      conversationsSlidingWindow: 90,
-      region: intercomWorkspace.region,
-      syncAllConversations: "disabled" as const,
-      shouldSyncNotes: true,
-    };
-
-    connector = await ConnectorResource.makeNew(
-      "intercom",
-      {
-        connectionId: nangoConnectionId,
-        workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
-        workspaceId: dataSourceConfig.workspaceId,
-        dataSourceName: dataSourceConfig.dataSourceName,
-      },
-      intercomConfigurationBlob
-    );
-
-    const workflowStarted = await launchIntercomSyncWorkflow({
-      connectorId: connector.id,
-    });
-    if (workflowStarted.isErr()) {
-      await connector.delete();
-      logger.error(
-        {
-          workspaceId: dataSourceConfig.workspaceId,
-          error: workflowStarted.error,
-        },
-        "[Intercom] Error creating connector Could not launch sync workflow."
-      );
-      return new Err(workflowStarted.error);
-    }
-    return new Ok(connector.id.toString());
-  } catch (e) {
-    logger.error(
-      { workspaceId: dataSourceConfig.workspaceId, error: e },
-      "[Intercom] Unknown Error creating connector."
-    );
-    if (connector) {
-      await connector.delete();
-    }
-    return new Err(e as Error);
-  }
-}
-
-export async function updateIntercomConnector(
-  connectorId: ModelId,
-  {
+export class IntercomConnectorManager extends BaseConnectorManager<null> {
+  static async create({
+    dataSourceConfig,
     connectionId,
   }: {
-    connectionId?: NangoConnectionId | null;
-  }
-): Promise<Result<string, ConnectorsAPIError>> {
-  if (!NANGO_INTERCOM_CONNECTOR_ID) {
-    throw new Error("NANGO_INTERCOM_CONNECTOR_ID not set");
-  }
+    dataSourceConfig: DataSourceConfig;
+    connectionId: string;
+  }): Promise<Result<string, Error>> {
+    const nangoConnectionId = connectionId;
 
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    logger.error({ connectorId }, "[Intercom] Connector not found.");
-    return new Err({
-      message: "Connector not found",
-      type: "connector_not_found",
-    });
-  }
-
-  const intercomWorkspace = await IntercomWorkspace.findOne({
-    where: { connectorId: connector.id },
-  });
-
-  if (!intercomWorkspace) {
-    return new Err({
-      type: "connector_update_error",
-      message: "Error retrieving intercom workspace to update connector",
-    });
-  }
-
-  if (connectionId) {
-    const oldConnectionId = connector.connectionId;
-    const newConnectionId = connectionId;
-    const newIntercomWorkspace = await fetchIntercomWorkspace(newConnectionId);
-
-    if (!newIntercomWorkspace) {
-      return new Err({
-        type: "connector_update_error",
-        message: "Error retrieving nango connection info to update connector",
-      });
-    }
-    if (intercomWorkspace.intercomWorkspaceId !== newIntercomWorkspace.id) {
-      nangoDeleteConnection(newConnectionId, NANGO_INTERCOM_CONNECTOR_ID).catch(
-        (e) => {
-          logger.error(
-            { error: e, connectorId },
-            "Error deleting old Nango connection"
-          );
-        }
-      );
-      return new Err({
-        type: "connector_oauth_target_mismatch",
-        message: "Cannot change workspace of a Intercom connector",
-      });
+    if (!NANGO_INTERCOM_CONNECTOR_ID) {
+      throw new Error("NANGO_INTERCOM_CONNECTOR_ID not set");
     }
 
-    await connector.update({ connectionId: newConnectionId });
+    let connector = null;
 
-    await IntercomWorkspace.update(
-      {
-        intercomWorkspaceId: newIntercomWorkspace.id,
-        name: newIntercomWorkspace.name,
-        region: newIntercomWorkspace.region,
-      },
-      {
-        where: { connectorId: connector.id },
-      }
-    );
-    nangoDeleteConnection(oldConnectionId, NANGO_INTERCOM_CONNECTOR_ID).catch(
-      (e) => {
-        logger.error(
-          { error: e, connectorId, oldConnectionId },
-          "Error deleting old Nango connection"
-        );
-      }
-    );
-  }
-  return new Ok(connector.id.toString());
-}
-
-export async function cleanupIntercomConnector(
-  connectorId: ModelId
-): Promise<Result<undefined, Error>> {
-  if (!NANGO_INTERCOM_CONNECTOR_ID) {
-    throw new Error("INTERCOM_NANGO_CONNECTOR_ID not set");
-  }
-
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    logger.error({ connectorId }, "Intercom connector not found.");
-    return new Err(new Error("Connector not found"));
-  }
-
-  try {
-    const accessToken = await getAccessTokenFromNango({
-      connectionId: connector.connectionId,
-      integrationId: NANGO_INTERCOM_CONNECTOR_ID,
-      useCache: true,
-    });
-
-    const resp = await fetch(`https://api.intercom.io/auth/uninstall`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        Accept: `application/json`,
-        ContentType: `application/json`,
-      },
-    });
-
-    if (!resp.ok) {
-      throw new Error(resp.statusText);
-    } else {
-      logger.info({ connectorId }, "Uninstalled Intercom.");
-    }
-  } catch (e) {
-    // If we error we still continue the process, as it's likely the fact that the nango connection
-    // was already deleted or the intercom app was already uninstalled.
-    logger.error(
-      { connectorId, error: e },
-      "Error uninstalling Intercom, continuing..."
-    );
-  }
-
-  const nangoRes = await nangoDeleteConnection(
-    connector.connectionId,
-    NANGO_INTERCOM_CONNECTOR_ID
-  );
-  if (nangoRes.isErr()) {
-    logger.error(
-      {
-        error: nangoRes.error,
-        connectorId: connector.id,
-        connectionId: connector.connectionId,
-      },
-      "Error deleting old Nango connection (intercom uninstall webhook)"
-    );
-  }
-
-  const res = await connector.delete();
-  if (res.isErr()) {
-    logger.error(
-      { connectorId, error: res.error },
-      "Error cleaning up Intercom connector."
-    );
-    return res;
-  }
-
-  return new Ok(undefined);
-}
-
-export async function stopIntercomConnector(
-  connectorId: ModelId
-): Promise<Result<undefined, Error>> {
-  const res = await stopIntercomSyncWorkflow(connectorId);
-  if (res.isErr()) {
-    return res;
-  }
-
-  return new Ok(undefined);
-}
-
-export async function resumeIntercomConnector(
-  connectorId: ModelId
-): Promise<Result<undefined, Error>> {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    logger.error({ connectorId }, "[Intercom] Connector not found.");
-    return new Err(new Error("Connector not found"));
-  }
-
-  const dataSourceConfig = dataSourceConfigFromConnector(connector);
-  try {
-    await launchIntercomSyncWorkflow({
-      connectorId,
-    });
-  } catch (e) {
-    logger.error(
-      {
-        workspaceId: dataSourceConfig.workspaceId,
-        dataSourceName: dataSourceConfig.dataSourceName,
-        error: e,
-      },
-      "Error launching Intercom sync workflow."
-    );
-  }
-
-  return new Ok(undefined);
-}
-
-export async function fullResyncIntercomSyncWorkflow(
-  connectorId: ModelId
-): Promise<Result<string, Error>> {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    logger.error({ connectorId }, "Notion connector not found.");
-    return new Err(new Error("Connector not found"));
-  }
-
-  const helpCentersIds = await IntercomHelpCenter.findAll({
-    where: {
-      connectorId,
-    },
-    attributes: ["helpCenterId"],
-  });
-  const teamsIds = await IntercomTeam.findAll({
-    where: {
-      connectorId,
-    },
-    attributes: ["teamId"],
-  });
-
-  const toBeSignaledHelpCenterIds = helpCentersIds.map((hc) => hc.helpCenterId);
-  const toBeSignaledTeamIds = teamsIds.map((team) => team.teamId);
-
-  const sendSignalToWorkflowResult = await launchIntercomSyncWorkflow({
-    connectorId,
-    helpCenterIds: toBeSignaledHelpCenterIds,
-    teamIds: toBeSignaledTeamIds,
-    forceResync: true,
-  });
-  if (sendSignalToWorkflowResult.isErr()) {
-    return new Err(sendSignalToWorkflowResult.error);
-  }
-  return new Ok(connector.id.toString());
-}
-
-export async function retrieveIntercomConnectorPermissions({
-  connectorId,
-  parentInternalId,
-  filterPermission,
-}: Parameters<ConnectorPermissionRetriever>[0]): Promise<
-  Result<ContentNode[], Error>
-> {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    logger.error({ connectorId }, "[Intercom] Connector not found.");
-    return new Err(new Error("Connector not found"));
-  }
-
-  try {
-    const helpCenterNodes = await retrieveIntercomHelpCentersPermissions({
-      connectorId,
-      parentInternalId,
-      filterPermission,
-      viewType: "documents",
-    });
-    const convosNodes = await retrieveIntercomConversationsPermissions({
-      connectorId,
-      parentInternalId,
-      filterPermission,
-      viewType: "documents",
-    });
-    const nodes = [...helpCenterNodes, ...convosNodes];
-    return new Ok(nodes);
-  } catch (e) {
-    return new Err(e as Error);
-  }
-}
-
-export async function setIntercomConnectorPermissions(
-  connectorId: ModelId,
-  permissions: Record<string, ConnectorPermission>
-): Promise<Result<void, Error>> {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    logger.error({ connectorId }, "[Intercom] Connector not found.");
-    return new Err(new Error("Connector not found"));
-  }
-
-  const intercomWorkspace = await IntercomWorkspace.findOne({
-    where: {
-      connectorId,
-    },
-  });
-  if (!intercomWorkspace) {
-    logger.error(
-      { connectorId },
-      "[Intercom] IntercomWorkspace not found. Cannot set permissions."
-    );
-    return new Err(new Error("IntercomWorkspace not found"));
-  }
-
-  const connectionId = connector.connectionId;
-
-  const toBeSignaledHelpCenterIds = new Set<string>();
-  const toBeSignaledTeamIds = new Set<string>();
-  let toBeSignaledSelectAllConversations = false;
-
-  try {
-    for (const [id, permission] of Object.entries(permissions)) {
-      if (permission !== "none" && permission !== "read") {
+    try {
+      const intercomWorkspace = await fetchIntercomWorkspace(nangoConnectionId);
+      if (!intercomWorkspace) {
         return new Err(
           new Error(
-            `Invalid permission ${permission} for connector ${connectorId}`
+            "Error retrieving intercom workspace, cannot create Connector."
           )
         );
       }
 
-      const helpCenterId = getHelpCenterIdFromInternalId(connectorId, id);
-      const collectionId = getHelpCenterCollectionIdFromInternalId(
-        connectorId,
-        id
-      );
-      const isAllConversations = isInternalIdForAllConversations(
-        connectorId,
-        id
-      );
-      const teamId = getTeamIdFromInternalId(connectorId, id);
+      const intercomConfigurationBlob = {
+        intercomWorkspaceId: intercomWorkspace.id,
+        name: intercomWorkspace.name,
+        conversationsSlidingWindow: 90,
+        region: intercomWorkspace.region,
+        syncAllConversations: "disabled" as const,
+        shouldSyncNotes: true,
+      };
 
-      if (helpCenterId) {
-        toBeSignaledHelpCenterIds.add(helpCenterId);
-        if (permission === "none") {
-          await revokeSyncHelpCenter({
-            connectorId,
-            helpCenterId,
-          });
-        }
-        if (permission === "read") {
-          await allowSyncHelpCenter({
-            connectorId,
-            connectionId,
-            helpCenterId,
-            region: intercomWorkspace.region,
-            withChildren: true,
-          });
-        }
-      } else if (collectionId) {
-        if (permission === "none") {
-          const revokedCollection = await revokeSyncCollection({
-            connectorId,
-            collectionId,
-          });
-          if (revokedCollection) {
-            toBeSignaledHelpCenterIds.add(revokedCollection.helpCenterId);
-          }
-        }
-        if (permission === "read") {
-          const newCollection = await allowSyncCollection({
-            connectorId,
-            connectionId,
-            collectionId,
-            region: intercomWorkspace.region,
-          });
-          if (newCollection) {
-            toBeSignaledHelpCenterIds.add(newCollection.helpCenterId);
-          }
-        }
-      } else if (isAllConversations) {
-        if (permission === "none") {
-          await intercomWorkspace.update({
-            syncAllConversations: "scheduled_revoke",
-          });
-          toBeSignaledSelectAllConversations = true;
-        } else if (permission === "read") {
-          await intercomWorkspace.update({
-            syncAllConversations: "scheduled_activate",
-          });
-          toBeSignaledSelectAllConversations = true;
-        }
-      } else if (teamId) {
-        if (permission === "none") {
-          const revokedTeam = await revokeSyncTeam({
-            connectorId,
-            teamId,
-          });
-          if (revokedTeam) {
-            toBeSignaledTeamIds.add(revokedTeam.teamId);
-          }
-        }
-        if (permission === "read") {
-          const newTeam = await allowSyncTeam({
-            connectorId,
-            connectionId,
-            teamId,
-          });
-          if (newTeam) {
-            toBeSignaledTeamIds.add(newTeam.teamId);
-          }
-        }
+      connector = await ConnectorResource.makeNew(
+        "intercom",
+        {
+          connectionId: nangoConnectionId,
+          workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
+          workspaceId: dataSourceConfig.workspaceId,
+          dataSourceName: dataSourceConfig.dataSourceName,
+        },
+        intercomConfigurationBlob
+      );
+
+      const workflowStarted = await launchIntercomSyncWorkflow({
+        connectorId: connector.id,
+      });
+      if (workflowStarted.isErr()) {
+        await connector.delete();
+        logger.error(
+          {
+            workspaceId: dataSourceConfig.workspaceId,
+            error: workflowStarted.error,
+          },
+          "[Intercom] Error creating connector Could not launch sync workflow."
+        );
+        return new Err(workflowStarted.error);
       }
+      return new Ok(connector.id.toString());
+    } catch (e) {
+      logger.error(
+        { workspaceId: dataSourceConfig.workspaceId, error: e },
+        "[Intercom] Unknown Error creating connector."
+      );
+      if (connector) {
+        await connector.delete();
+      }
+      return new Err(e as Error);
+    }
+  }
+
+  async update({
+    connectionId,
+  }: {
+    connectionId?: string | null;
+  }): Promise<Result<string, ConnectorsAPIError>> {
+    if (!NANGO_INTERCOM_CONNECTOR_ID) {
+      throw new Error("NANGO_INTERCOM_CONNECTOR_ID not set");
     }
 
-    if (
-      toBeSignaledHelpCenterIds.size > 0 ||
-      toBeSignaledTeamIds.size > 0 ||
-      toBeSignaledSelectAllConversations
-    ) {
-      const sendSignalToWorkflowResult = await launchIntercomSyncWorkflow({
-        connectorId,
-        helpCenterIds: [...toBeSignaledHelpCenterIds],
-        teamIds: [...toBeSignaledTeamIds],
-        hasUpdatedSelectAllConversations: toBeSignaledSelectAllConversations,
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      logger.error(
+        { connectorId: this.connectorId },
+        "[Intercom] Connector not found."
+      );
+      return new Err({
+        message: "Connector not found",
+        type: "connector_not_found",
       });
-      if (sendSignalToWorkflowResult.isErr()) {
-        return new Err(sendSignalToWorkflowResult.error);
+    }
+
+    const intercomWorkspace = await IntercomWorkspace.findOne({
+      where: { connectorId: connector.id },
+    });
+
+    if (!intercomWorkspace) {
+      return new Err({
+        type: "connector_update_error",
+        message: "Error retrieving intercom workspace to update connector",
+      });
+    }
+
+    if (connectionId) {
+      const oldConnectionId = connector.connectionId;
+      const newConnectionId = connectionId;
+      const newIntercomWorkspace = await fetchIntercomWorkspace(
+        newConnectionId
+      );
+
+      if (!newIntercomWorkspace) {
+        return new Err({
+          type: "connector_update_error",
+          message: "Error retrieving nango connection info to update connector",
+        });
       }
+      if (intercomWorkspace.intercomWorkspaceId !== newIntercomWorkspace.id) {
+        nangoDeleteConnection(
+          newConnectionId,
+          NANGO_INTERCOM_CONNECTOR_ID
+        ).catch((e) => {
+          logger.error(
+            { error: e, connectorId: this.connectorId },
+            "Error deleting old Nango connection"
+          );
+        });
+        return new Err({
+          type: "connector_oauth_target_mismatch",
+          message: "Cannot change workspace of a Intercom connector",
+        });
+      }
+
+      await connector.update({ connectionId: newConnectionId });
+
+      await IntercomWorkspace.update(
+        {
+          intercomWorkspaceId: newIntercomWorkspace.id,
+          name: newIntercomWorkspace.name,
+          region: newIntercomWorkspace.region,
+        },
+        {
+          where: { connectorId: connector.id },
+        }
+      );
+      nangoDeleteConnection(oldConnectionId, NANGO_INTERCOM_CONNECTOR_ID).catch(
+        (e) => {
+          logger.error(
+            { error: e, connectorId: this.connectorId, oldConnectionId },
+            "Error deleting old Nango connection"
+          );
+        }
+      );
+    }
+    return new Ok(connector.id.toString());
+  }
+
+  async clean(): Promise<Result<undefined, Error>> {
+    if (!NANGO_INTERCOM_CONNECTOR_ID) {
+      throw new Error("INTERCOM_NANGO_CONNECTOR_ID not set");
+    }
+
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      logger.error(
+        { connectorId: this.connectorId },
+        "Intercom connector not found."
+      );
+      return new Err(new Error("Connector not found"));
+    }
+
+    try {
+      const accessToken = await getAccessTokenFromNango({
+        connectionId: connector.connectionId,
+        integrationId: NANGO_INTERCOM_CONNECTOR_ID,
+        useCache: true,
+      });
+
+      const resp = await fetch(`https://api.intercom.io/auth/uninstall`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          Accept: `application/json`,
+          ContentType: `application/json`,
+        },
+      });
+
+      if (!resp.ok) {
+        throw new Error(resp.statusText);
+      } else {
+        logger.info({ connectorId: this.connectorId }, "Uninstalled Intercom.");
+      }
+    } catch (e) {
+      // If we error we still continue the process, as it's likely the fact that the nango connection
+      // was already deleted or the intercom app was already uninstalled.
+      logger.error(
+        { connectorId: this.connectorId, error: e },
+        "Error uninstalling Intercom, continuing..."
+      );
+    }
+
+    const nangoRes = await nangoDeleteConnection(
+      connector.connectionId,
+      NANGO_INTERCOM_CONNECTOR_ID
+    );
+    if (nangoRes.isErr()) {
+      logger.error(
+        {
+          error: nangoRes.error,
+          connectorId: connector.id,
+          connectionId: connector.connectionId,
+        },
+        "Error deleting old Nango connection (intercom uninstall webhook)"
+      );
+    }
+
+    const res = await connector.delete();
+    if (res.isErr()) {
+      logger.error(
+        { connectorId: this.connectorId, error: res.error },
+        "Error cleaning up Intercom connector."
+      );
+      return res;
     }
 
     return new Ok(undefined);
-  } catch (e) {
-    logger.error(
-      {
-        connectorId: connectorId,
-        error: e,
-      },
-      "Error setting connector permissions."
-    );
-    return new Err(new Error("Error setting permissions"));
   }
-}
 
-export async function retrieveIntercomContentNodes(
-  connectorId: ModelId,
-  internalIds: string[]
-): Promise<Result<ContentNode[], Error>> {
-  const helpCenterIds: string[] = [];
-  const collectionIds: string[] = [];
-  const articleIds: string[] = [];
-  let isAllTeams = false;
-  const teamIds: string[] = [];
-
-  internalIds.forEach((internalId) => {
-    let objectId = getHelpCenterIdFromInternalId(connectorId, internalId);
-    if (objectId) {
-      helpCenterIds.push(objectId);
-      return;
+  async stop(): Promise<Result<undefined, Error>> {
+    const res = await stopIntercomSyncWorkflow(this.connectorId);
+    if (res.isErr()) {
+      return res;
     }
-    objectId = getHelpCenterCollectionIdFromInternalId(connectorId, internalId);
-    if (objectId) {
-      collectionIds.push(objectId);
-      return;
-    }
-    objectId = getHelpCenterArticleIdFromInternalId(connectorId, internalId);
-    if (objectId) {
-      articleIds.push(objectId);
-      return;
-    }
-    if (!isAllTeams && isInternalIdForAllTeams(connectorId, internalId)) {
-      isAllTeams = true;
-    }
-    objectId = getTeamIdFromInternalId(connectorId, internalId);
-    if (objectId) {
-      teamIds.push(objectId);
-    }
-  });
 
-  const [helpCenters, collections, articles, teams] = await Promise.all([
-    IntercomHelpCenter.findAll({
-      where: {
-        connectorId: connectorId,
-        helpCenterId: { [Op.in]: helpCenterIds },
-      },
-    }),
-    IntercomCollection.findAll({
-      where: {
-        connectorId: connectorId,
-        collectionId: { [Op.in]: collectionIds },
-      },
-    }),
-    IntercomArticle.findAll({
-      where: {
-        connectorId: connectorId,
-        articleId: { [Op.in]: articleIds },
-      },
-    }),
-    IntercomTeam.findAll({
-      where: {
-        connectorId: connectorId,
-        teamId: { [Op.in]: teamIds },
-      },
-    }),
-  ]);
-
-  const nodes: ContentNode[] = [];
-  for (const helpCenter of helpCenters) {
-    nodes.push({
-      provider: "intercom",
-      internalId: getHelpCenterInternalId(connectorId, helpCenter.helpCenterId),
-      parentInternalId: null,
-      type: "database",
-      title: helpCenter.name,
-      sourceUrl: null,
-      expandable: true,
-      permission: helpCenter.permission,
-      dustDocumentId: null,
-      lastUpdatedAt: null,
-    });
-  }
-  for (const collection of collections) {
-    nodes.push({
-      provider: "intercom",
-      internalId: getHelpCenterCollectionInternalId(
-        connectorId,
-        collection.collectionId
-      ),
-      parentInternalId: collection.parentId
-        ? getHelpCenterCollectionInternalId(connectorId, collection.parentId)
-        : null,
-      type: "folder",
-      title: collection.name,
-      sourceUrl: collection.url,
-      expandable: true,
-      permission: collection.permission,
-      dustDocumentId: null,
-      lastUpdatedAt: collection.lastUpsertedTs?.getTime() || null,
-    });
-  }
-  for (const article of articles) {
-    nodes.push({
-      provider: "intercom",
-      internalId: getHelpCenterArticleInternalId(
-        connectorId,
-        article.articleId
-      ),
-      parentInternalId: article.parentId
-        ? getHelpCenterCollectionInternalId(connectorId, article.parentId)
-        : null,
-      type: "file",
-      title: article.title,
-      sourceUrl: article.url,
-      expandable: false,
-      permission: article.permission,
-      dustDocumentId: null,
-      lastUpdatedAt: article.lastUpsertedTs?.getTime() || null,
-    });
-  }
-  if (isAllTeams) {
-    nodes.push({
-      provider: "intercom",
-      internalId: getTeamsInternalId(connectorId),
-      parentInternalId: null,
-      type: "channel",
-      title: "Conversations",
-      sourceUrl: null,
-      expandable: true,
-      permission: "none",
-      dustDocumentId: null,
-      lastUpdatedAt: null,
-    });
-  }
-  for (const team of teams) {
-    nodes.push({
-      provider: "intercom",
-      internalId: getTeamInternalId(connectorId, team.teamId),
-      parentInternalId: getTeamsInternalId(connectorId),
-      type: "channel",
-      title: team.name,
-      sourceUrl: null,
-      expandable: false,
-      permission: team.permission,
-      dustDocumentId: null,
-      lastUpdatedAt: null,
-    });
+    return new Ok(undefined);
   }
 
-  return new Ok(nodes);
-}
-
-export async function retrieveIntercomContentNodeParents(
-  connectorId: ModelId,
-  internalId: string
-): Promise<Result<string[], Error>> {
-  // No parent for Help Center & Team
-  const helpCenterId = getHelpCenterIdFromInternalId(connectorId, internalId);
-  if (helpCenterId) {
-    return new Ok([]);
-  }
-  const teamId = getTeamIdFromInternalId(connectorId, internalId);
-  if (teamId) {
-    return new Ok([getTeamsInternalId(connectorId)]);
-  }
-
-  const parents: string[] = [];
-  let collection = null;
-
-  const collectionId = getHelpCenterCollectionIdFromInternalId(
-    connectorId,
-    internalId
-  );
-  const articleId = getHelpCenterArticleIdFromInternalId(
-    connectorId,
-    internalId
-  );
-
-  if (collectionId) {
-    collection = await IntercomCollection.findOne({
-      where: {
-        connectorId,
-        collectionId,
-      },
-    });
-  } else if (articleId) {
-    const article = await IntercomArticle.findOne({
-      where: {
-        connectorId,
-        articleId,
-      },
-    });
-    if (article && article.parentType === "collection" && article.parentId) {
-      parents.push(
-        getHelpCenterCollectionInternalId(connectorId, article.parentId)
+  async resume(): Promise<Result<undefined, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      logger.error(
+        { connectorId: this.connectorId },
+        "[Intercom] Connector not found."
       );
+      return new Err(new Error("Connector not found"));
+    }
+
+    const dataSourceConfig = dataSourceConfigFromConnector(connector);
+    try {
+      await launchIntercomSyncWorkflow({
+        connectorId: this.connectorId,
+      });
+    } catch (e) {
+      logger.error(
+        {
+          workspaceId: dataSourceConfig.workspaceId,
+          dataSourceName: dataSourceConfig.dataSourceName,
+          error: e,
+        },
+        "Error launching Intercom sync workflow."
+      );
+    }
+
+    return new Ok(undefined);
+  }
+
+  async sync(): Promise<Result<string, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      logger.error(
+        { connectorId: this.connectorId },
+        "Notion connector not found."
+      );
+      return new Err(new Error("Connector not found"));
+    }
+
+    const helpCentersIds = await IntercomHelpCenter.findAll({
+      where: {
+        connectorId: this.connectorId,
+      },
+      attributes: ["helpCenterId"],
+    });
+    const teamsIds = await IntercomTeam.findAll({
+      where: {
+        connectorId: this.connectorId,
+      },
+      attributes: ["teamId"],
+    });
+
+    const toBeSignaledHelpCenterIds = helpCentersIds.map(
+      (hc) => hc.helpCenterId
+    );
+    const toBeSignaledTeamIds = teamsIds.map((team) => team.teamId);
+
+    const sendSignalToWorkflowResult = await launchIntercomSyncWorkflow({
+      connectorId: this.connectorId,
+      helpCenterIds: toBeSignaledHelpCenterIds,
+      teamIds: toBeSignaledTeamIds,
+      forceResync: true,
+    });
+    if (sendSignalToWorkflowResult.isErr()) {
+      return new Err(sendSignalToWorkflowResult.error);
+    }
+    return new Ok(connector.id.toString());
+  }
+
+  async retrievePermissions({
+    parentInternalId,
+    filterPermission,
+  }: {
+    parentInternalId: string | null;
+    filterPermission: ConnectorPermission | null;
+    viewType: ContentNodesViewType;
+  }): Promise<Result<ContentNode[], Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      logger.error(
+        { connectorId: this.connectorId },
+        "[Intercom] Connector not found."
+      );
+      return new Err(new Error("Connector not found"));
+    }
+
+    try {
+      const helpCenterNodes = await retrieveIntercomHelpCentersPermissions({
+        connectorId: this.connectorId,
+        parentInternalId,
+        filterPermission,
+        viewType: "documents",
+      });
+      const convosNodes = await retrieveIntercomConversationsPermissions({
+        connectorId: this.connectorId,
+        parentInternalId,
+        filterPermission,
+        viewType: "documents",
+      });
+      const nodes = [...helpCenterNodes, ...convosNodes];
+      return new Ok(nodes);
+    } catch (e) {
+      return new Err(e as Error);
+    }
+  }
+
+  async setPermissions({
+    permissions,
+  }: {
+    permissions: Record<string, ConnectorPermission>;
+  }): Promise<Result<void, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      logger.error(
+        { connectorId: this.connectorId },
+        "[Intercom] Connector not found."
+      );
+      return new Err(new Error("Connector not found"));
+    }
+
+    const intercomWorkspace = await IntercomWorkspace.findOne({
+      where: {
+        connectorId: this.connectorId,
+      },
+    });
+    if (!intercomWorkspace) {
+      logger.error(
+        { connectorId: this.connectorId },
+        "[Intercom] IntercomWorkspace not found. Cannot set permissions."
+      );
+      return new Err(new Error("IntercomWorkspace not found"));
+    }
+
+    const connectionId = connector.connectionId;
+
+    const toBeSignaledHelpCenterIds = new Set<string>();
+    const toBeSignaledTeamIds = new Set<string>();
+    let toBeSignaledSelectAllConversations = false;
+
+    try {
+      for (const [id, permission] of Object.entries(permissions)) {
+        if (permission !== "none" && permission !== "read") {
+          return new Err(
+            new Error(
+              `Invalid permission ${permission} for connector ${this.connectorId}`
+            )
+          );
+        }
+
+        const helpCenterId = getHelpCenterIdFromInternalId(
+          this.connectorId,
+          id
+        );
+        const collectionId = getHelpCenterCollectionIdFromInternalId(
+          this.connectorId,
+          id
+        );
+        const isAllConversations = isInternalIdForAllConversations(
+          this.connectorId,
+          id
+        );
+        const teamId = getTeamIdFromInternalId(this.connectorId, id);
+
+        if (helpCenterId) {
+          toBeSignaledHelpCenterIds.add(helpCenterId);
+          if (permission === "none") {
+            await revokeSyncHelpCenter({
+              connectorId: this.connectorId,
+              helpCenterId,
+            });
+          }
+          if (permission === "read") {
+            await allowSyncHelpCenter({
+              connectorId: this.connectorId,
+              connectionId,
+              helpCenterId,
+              region: intercomWorkspace.region,
+              withChildren: true,
+            });
+          }
+        } else if (collectionId) {
+          if (permission === "none") {
+            const revokedCollection = await revokeSyncCollection({
+              connectorId: this.connectorId,
+              collectionId,
+            });
+            if (revokedCollection) {
+              toBeSignaledHelpCenterIds.add(revokedCollection.helpCenterId);
+            }
+          }
+          if (permission === "read") {
+            const newCollection = await allowSyncCollection({
+              connectorId: this.connectorId,
+              connectionId,
+              collectionId,
+              region: intercomWorkspace.region,
+            });
+            if (newCollection) {
+              toBeSignaledHelpCenterIds.add(newCollection.helpCenterId);
+            }
+          }
+        } else if (isAllConversations) {
+          if (permission === "none") {
+            await intercomWorkspace.update({
+              syncAllConversations: "scheduled_revoke",
+            });
+            toBeSignaledSelectAllConversations = true;
+          } else if (permission === "read") {
+            await intercomWorkspace.update({
+              syncAllConversations: "scheduled_activate",
+            });
+            toBeSignaledSelectAllConversations = true;
+          }
+        } else if (teamId) {
+          if (permission === "none") {
+            const revokedTeam = await revokeSyncTeam({
+              connectorId: this.connectorId,
+              teamId,
+            });
+            if (revokedTeam) {
+              toBeSignaledTeamIds.add(revokedTeam.teamId);
+            }
+          }
+          if (permission === "read") {
+            const newTeam = await allowSyncTeam({
+              connectorId: this.connectorId,
+              connectionId,
+              teamId,
+            });
+            if (newTeam) {
+              toBeSignaledTeamIds.add(newTeam.teamId);
+            }
+          }
+        }
+      }
+
+      if (
+        toBeSignaledHelpCenterIds.size > 0 ||
+        toBeSignaledTeamIds.size > 0 ||
+        toBeSignaledSelectAllConversations
+      ) {
+        const sendSignalToWorkflowResult = await launchIntercomSyncWorkflow({
+          connectorId: this.connectorId,
+          helpCenterIds: [...toBeSignaledHelpCenterIds],
+          teamIds: [...toBeSignaledTeamIds],
+          hasUpdatedSelectAllConversations: toBeSignaledSelectAllConversations,
+        });
+        if (sendSignalToWorkflowResult.isErr()) {
+          return new Err(sendSignalToWorkflowResult.error);
+        }
+      }
+
+      return new Ok(undefined);
+    } catch (e) {
+      logger.error(
+        {
+          connectorId: this.connectorId,
+          error: e,
+        },
+        "Error setting connector permissions."
+      );
+      return new Err(new Error("Error setting permissions"));
+    }
+  }
+
+  async retrieveBatchContentNodes({
+    internalIds,
+  }: {
+    internalIds: string[];
+    viewType: ContentNodesViewType;
+  }): Promise<Result<ContentNode[], Error>> {
+    const helpCenterIds: string[] = [];
+    const collectionIds: string[] = [];
+    const articleIds: string[] = [];
+    let isAllTeams = false;
+    const teamIds: string[] = [];
+
+    internalIds.forEach((internalId) => {
+      let objectId = getHelpCenterIdFromInternalId(
+        this.connectorId,
+        internalId
+      );
+      if (objectId) {
+        helpCenterIds.push(objectId);
+        return;
+      }
+      objectId = getHelpCenterCollectionIdFromInternalId(
+        this.connectorId,
+        internalId
+      );
+      if (objectId) {
+        collectionIds.push(objectId);
+        return;
+      }
+      objectId = getHelpCenterArticleIdFromInternalId(
+        this.connectorId,
+        internalId
+      );
+      if (objectId) {
+        articleIds.push(objectId);
+        return;
+      }
+      if (
+        !isAllTeams &&
+        isInternalIdForAllTeams(this.connectorId, internalId)
+      ) {
+        isAllTeams = true;
+      }
+      objectId = getTeamIdFromInternalId(this.connectorId, internalId);
+      if (objectId) {
+        teamIds.push(objectId);
+      }
+    });
+
+    const [helpCenters, collections, articles, teams] = await Promise.all([
+      IntercomHelpCenter.findAll({
+        where: {
+          connectorId: this.connectorId,
+          helpCenterId: { [Op.in]: helpCenterIds },
+        },
+      }),
+      IntercomCollection.findAll({
+        where: {
+          connectorId: this.connectorId,
+          collectionId: { [Op.in]: collectionIds },
+        },
+      }),
+      IntercomArticle.findAll({
+        where: {
+          connectorId: this.connectorId,
+          articleId: { [Op.in]: articleIds },
+        },
+      }),
+      IntercomTeam.findAll({
+        where: {
+          connectorId: this.connectorId,
+          teamId: { [Op.in]: teamIds },
+        },
+      }),
+    ]);
+
+    const nodes: ContentNode[] = [];
+    for (const helpCenter of helpCenters) {
+      nodes.push({
+        provider: "intercom",
+        internalId: getHelpCenterInternalId(
+          this.connectorId,
+          helpCenter.helpCenterId
+        ),
+        parentInternalId: null,
+        type: "database",
+        title: helpCenter.name,
+        sourceUrl: null,
+        expandable: true,
+        permission: helpCenter.permission,
+        dustDocumentId: null,
+        lastUpdatedAt: null,
+      });
+    }
+    for (const collection of collections) {
+      nodes.push({
+        provider: "intercom",
+        internalId: getHelpCenterCollectionInternalId(
+          this.connectorId,
+          collection.collectionId
+        ),
+        parentInternalId: collection.parentId
+          ? getHelpCenterCollectionInternalId(
+              this.connectorId,
+              collection.parentId
+            )
+          : null,
+        type: "folder",
+        title: collection.name,
+        sourceUrl: collection.url,
+        expandable: true,
+        permission: collection.permission,
+        dustDocumentId: null,
+        lastUpdatedAt: collection.lastUpsertedTs?.getTime() || null,
+      });
+    }
+    for (const article of articles) {
+      nodes.push({
+        provider: "intercom",
+        internalId: getHelpCenterArticleInternalId(
+          this.connectorId,
+          article.articleId
+        ),
+        parentInternalId: article.parentId
+          ? getHelpCenterCollectionInternalId(
+              this.connectorId,
+              article.parentId
+            )
+          : null,
+        type: "file",
+        title: article.title,
+        sourceUrl: article.url,
+        expandable: false,
+        permission: article.permission,
+        dustDocumentId: null,
+        lastUpdatedAt: article.lastUpsertedTs?.getTime() || null,
+      });
+    }
+    if (isAllTeams) {
+      nodes.push({
+        provider: "intercom",
+        internalId: getTeamsInternalId(this.connectorId),
+        parentInternalId: null,
+        type: "channel",
+        title: "Conversations",
+        sourceUrl: null,
+        expandable: true,
+        permission: "none",
+        dustDocumentId: null,
+        lastUpdatedAt: null,
+      });
+    }
+    for (const team of teams) {
+      nodes.push({
+        provider: "intercom",
+        internalId: getTeamInternalId(this.connectorId, team.teamId),
+        parentInternalId: getTeamsInternalId(this.connectorId),
+        type: "channel",
+        title: team.name,
+        sourceUrl: null,
+        expandable: false,
+        permission: team.permission,
+        dustDocumentId: null,
+        lastUpdatedAt: null,
+      });
+    }
+
+    return new Ok(nodes);
+  }
+
+  async retrieveContentNodeParents({
+    internalId,
+  }: {
+    internalId: string;
+    memoizationKey?: string;
+  }): Promise<Result<string[], Error>> {
+    // No parent for Help Center & Team
+    const helpCenterId = getHelpCenterIdFromInternalId(
+      this.connectorId,
+      internalId
+    );
+    if (helpCenterId) {
+      return new Ok([]);
+    }
+    const teamId = getTeamIdFromInternalId(this.connectorId, internalId);
+    if (teamId) {
+      return new Ok([getTeamsInternalId(this.connectorId)]);
+    }
+
+    const parents: string[] = [];
+    let collection = null;
+
+    const collectionId = getHelpCenterCollectionIdFromInternalId(
+      this.connectorId,
+      internalId
+    );
+    const articleId = getHelpCenterArticleIdFromInternalId(
+      this.connectorId,
+      internalId
+    );
+
+    if (collectionId) {
       collection = await IntercomCollection.findOne({
         where: {
-          connectorId: connectorId,
-          collectionId: article.parentId,
+          connectorId: this.connectorId,
+          collectionId,
         },
       });
+    } else if (articleId) {
+      const article = await IntercomArticle.findOne({
+        where: {
+          connectorId: this.connectorId,
+          articleId,
+        },
+      });
+      if (article && article.parentType === "collection" && article.parentId) {
+        parents.push(
+          getHelpCenterCollectionInternalId(this.connectorId, article.parentId)
+        );
+        collection = await IntercomCollection.findOne({
+          where: {
+            connectorId: this.connectorId,
+            collectionId: article.parentId,
+          },
+        });
+      }
     }
-  }
 
-  if (collection && collection.parentId) {
-    parents.push(
-      getHelpCenterCollectionInternalId(connectorId, collection.parentId)
-    );
-    const parentCollection = await IntercomCollection.findOne({
-      where: {
-        connectorId: connectorId,
-        collectionId: collection.parentId,
-      },
-    });
-    if (parentCollection && parentCollection.parentId) {
+    if (collection && collection.parentId) {
       parents.push(
-        getHelpCenterCollectionInternalId(
-          connectorId,
-          parentCollection.parentId
-        )
+        getHelpCenterCollectionInternalId(this.connectorId, collection.parentId)
+      );
+      const parentCollection = await IntercomCollection.findOne({
+        where: {
+          connectorId: this.connectorId,
+          collectionId: collection.parentId,
+        },
+      });
+      if (parentCollection && parentCollection.parentId) {
+        parents.push(
+          getHelpCenterCollectionInternalId(
+            this.connectorId,
+            parentCollection.parentId
+          )
+        );
+      }
+      // we can stop here as Intercom has max 3 levels of collections
+    }
+
+    if (collection && collection.helpCenterId) {
+      parents.push(
+        getHelpCenterInternalId(this.connectorId, collection.helpCenterId)
       );
     }
-    // we can stop here as Intercom has max 3 levels of collections
+
+    return new Ok(parents);
   }
 
-  if (collection && collection.helpCenterId) {
-    parents.push(getHelpCenterInternalId(connectorId, collection.helpCenterId));
-  }
-
-  return new Ok(parents);
-}
-
-export async function pauseIntercomConnector(connectorId: ModelId) {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    logger.error({ connectorId }, "[Intercom] Connector not found.");
-    return new Err(new Error("Connector not found"));
-  }
-
-  await connector.markAsPaused();
-  const stopRes = await stopIntercomConnector(connectorId);
-  if (stopRes.isErr()) {
-    return stopRes;
-  }
-
-  return new Ok(undefined);
-}
-
-export async function unpauseIntercomConnector(connectorId: ModelId) {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    logger.error({ connectorId }, "[Intercom] Connector not found.");
-    return new Err(new Error("Connector not found"));
-  }
-
-  await connector.markAsUnpaused();
-  const teamsIds = await IntercomTeam.findAll({
-    where: {
-      connectorId,
-    },
-    attributes: ["teamId"],
-  });
-  const toBeSignaledTeamIds = teamsIds.map((team) => team.teamId);
-  const r = await launchIntercomSyncWorkflow({
-    connectorId,
-    teamIds: toBeSignaledTeamIds,
-  });
-  if (r.isErr()) {
-    return r;
-  }
-
-  return new Ok(undefined);
-}
-
-export const getIntercomConfig: ConnectorConfigGetter = async function (
-  connectorId: ModelId,
-  configKey: string
-) {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    return new Err(
-      new Error(`Connector not found (connectorId: ${connectorId})`)
-    );
-  }
-
-  switch (configKey) {
-    case "intercomConversationsNotesSyncEnabled": {
-      const connectorState = await IntercomWorkspace.findOne({
-        where: {
-          connectorId: connector.id,
-        },
-      });
-      if (!connectorState) {
-        return new Err(
-          new Error(`Connector state not found (connectorId: ${connector.id})`)
-        );
-      }
-
-      return new Ok(connectorState.shouldSyncNotes.toString());
-    }
-    default:
-      return new Err(new Error(`Invalid config key ${configKey}`));
-  }
-};
-
-export async function setIntercomConfig(
-  connectorId: ModelId,
-  configKey: string,
-  configValue: string
-) {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    return new Err(
-      new Error(`Connector not found (connectorId: ${connectorId})`)
-    );
-  }
-
-  switch (configKey) {
-    case "intercomConversationsNotesSyncEnabled": {
-      const connectorState = await IntercomWorkspace.findOne({
-        where: {
-          connectorId: connector.id,
-        },
-      });
-      if (!connectorState) {
-        return new Err(
-          new Error(`Connector state not found (connectorId: ${connector.id})`)
-        );
-      }
-
-      await connectorState.update({
-        shouldSyncNotes: configValue === "true",
-      });
-
-      const teamsIds = await IntercomTeam.findAll({
-        where: {
-          connectorId,
-        },
-        attributes: ["teamId"],
-      });
-      const toBeSignaledTeamIds = teamsIds.map((team) => team.teamId);
-      const r = await launchIntercomSyncWorkflow({
-        connectorId,
-        teamIds: toBeSignaledTeamIds,
-        forceResync: true,
-      });
-      if (r.isErr()) {
-        return r;
-      }
-
-      return new Ok(void 0);
+  async setConfigurationKey({
+    configKey,
+    configValue,
+  }: {
+    configKey: string;
+    configValue: string;
+  }): Promise<Result<void, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      return new Err(
+        new Error(`Connector not found (connectorId: ${this.connectorId})`)
+      );
     }
 
-    default: {
-      return new Err(new Error(`Invalid config key ${configKey}`));
+    switch (configKey) {
+      case "intercomConversationsNotesSyncEnabled": {
+        const connectorState = await IntercomWorkspace.findOne({
+          where: {
+            connectorId: connector.id,
+          },
+        });
+        if (!connectorState) {
+          return new Err(
+            new Error(
+              `Connector state not found (connectorId: ${connector.id})`
+            )
+          );
+        }
+
+        await connectorState.update({
+          shouldSyncNotes: configValue === "true",
+        });
+
+        const teamsIds = await IntercomTeam.findAll({
+          where: {
+            connectorId: this.connectorId,
+          },
+          attributes: ["teamId"],
+        });
+        const toBeSignaledTeamIds = teamsIds.map((team) => team.teamId);
+        const r = await launchIntercomSyncWorkflow({
+          connectorId: this.connectorId,
+          teamIds: toBeSignaledTeamIds,
+          forceResync: true,
+        });
+        if (r.isErr()) {
+          return r;
+        }
+
+        return new Ok(void 0);
+      }
+
+      default: {
+        return new Err(new Error(`Invalid config key ${configKey}`));
+      }
     }
+  }
+
+  async getConfigurationKey({
+    configKey,
+  }: {
+    configKey: string;
+  }): Promise<Result<string | null, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      return new Err(
+        new Error(`Connector not found (connectorId: ${this.connectorId})`)
+      );
+    }
+
+    switch (configKey) {
+      case "intercomConversationsNotesSyncEnabled": {
+        const connectorState = await IntercomWorkspace.findOne({
+          where: {
+            connectorId: connector.id,
+          },
+        });
+        if (!connectorState) {
+          return new Err(
+            new Error(
+              `Connector state not found (connectorId: ${connector.id})`
+            )
+          );
+        }
+
+        return new Ok(connectorState.shouldSyncNotes.toString());
+      }
+      default:
+        return new Err(new Error(`Invalid config key ${configKey}`));
+    }
+  }
+
+  async pause(): Promise<Result<undefined, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      logger.error(
+        { connectorId: this.connectorId },
+        "[Intercom] Connector not found."
+      );
+      return new Err(new Error("Connector not found"));
+    }
+
+    await connector.markAsPaused();
+    const stopRes = await this.stop();
+    if (stopRes.isErr()) {
+      return stopRes;
+    }
+
+    return new Ok(undefined);
+  }
+
+  async unpause(): Promise<Result<undefined, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      logger.error(
+        { connectorId: this.connectorId },
+        "[Intercom] Connector not found."
+      );
+      return new Err(new Error("Connector not found"));
+    }
+
+    await connector.markAsUnpaused();
+    const teamsIds = await IntercomTeam.findAll({
+      where: {
+        connectorId: this.connectorId,
+      },
+      attributes: ["teamId"],
+    });
+    const toBeSignaledTeamIds = teamsIds.map((team) => team.teamId);
+    const r = await launchIntercomSyncWorkflow({
+      connectorId: this.connectorId,
+      teamIds: toBeSignaledTeamIds,
+    });
+    if (r.isErr()) {
+      return r;
+    }
+
+    return new Ok(undefined);
+  }
+
+  async garbageCollect(): Promise<Result<string, Error>> {
+    throw new Error("Method not implemented.");
+  }
+
+  async configure(): Promise<Result<void, Error>> {
+    throw new Error("Method not implemented.");
   }
 }

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -163,9 +163,8 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
     if (connectionId) {
       const oldConnectionId = connector.connectionId;
       const newConnectionId = connectionId;
-      const newIntercomWorkspace = await fetchIntercomWorkspace(
-        newConnectionId
-      );
+      const newIntercomWorkspace =
+        await fetchIntercomWorkspace(newConnectionId);
 
       if (!newIntercomWorkspace) {
         return new Err({

--- a/connectors/src/connectors/intercom/lib/conversation_permissions.ts
+++ b/connectors/src/connectors/intercom/lib/conversation_permissions.ts
@@ -1,4 +1,9 @@
-import type { ContentNode, ModelId } from "@dust-tt/types";
+import type {
+  ConnectorPermission,
+  ContentNode,
+  ContentNodesViewType,
+  ModelId,
+} from "@dust-tt/types";
 
 import {
   fetchIntercomTeam,
@@ -8,7 +13,6 @@ import {
   getAllConversationsInternalId,
   getTeamInternalId,
 } from "@connectors/connectors/intercom/lib/utils";
-import type { ConnectorPermissionRetriever } from "@connectors/connectors/interface";
 import {
   IntercomTeam,
   IntercomWorkspace,
@@ -84,7 +88,12 @@ export async function retrieveIntercomConversationsPermissions({
   connectorId,
   parentInternalId,
   filterPermission,
-}: Parameters<ConnectorPermissionRetriever>[0]): Promise<ContentNode[]> {
+}: {
+  connectorId: ModelId;
+  parentInternalId: string | null;
+  filterPermission: ConnectorPermission | null;
+  viewType: ContentNodesViewType;
+}): Promise<ContentNode[]> {
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
     logger.error({ connectorId }, "[Intercom] Connector not found.");

--- a/connectors/src/connectors/intercom/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/intercom/lib/help_center_permissions.ts
@@ -1,4 +1,9 @@
-import type { ContentNode, ModelId } from "@dust-tt/types";
+import type {
+  ConnectorPermission,
+  ContentNode,
+  ContentNodesViewType,
+  ModelId,
+} from "@dust-tt/types";
 import { Op } from "sequelize";
 
 import {
@@ -15,7 +20,6 @@ import {
   getHelpCenterIdFromInternalId,
   getHelpCenterInternalId,
 } from "@connectors/connectors/intercom/lib/utils";
-import type { ConnectorPermissionRetriever } from "@connectors/connectors/interface";
 import {
   IntercomArticle,
   IntercomCollection,
@@ -346,7 +350,12 @@ export async function retrieveIntercomHelpCentersPermissions({
   connectorId,
   parentInternalId,
   filterPermission,
-}: Parameters<ConnectorPermissionRetriever>[0]): Promise<ContentNode[]> {
+}: {
+  connectorId: ModelId;
+  parentInternalId: string | null;
+  filterPermission: ConnectorPermission | null;
+  viewType: ContentNodesViewType;
+}): Promise<ContentNode[]> {
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
     logger.error({ connectorId }, "[Intercom] Connector not found.");

--- a/connectors/src/connectors/interface.ts
+++ b/connectors/src/connectors/interface.ts
@@ -1,7 +1,5 @@
 import type {
-  ConnectorConfigurations,
   ConnectorPermission,
-  ConnectorProvider,
   ConnectorsAPIError,
   ContentNode,
   ContentNodesViewType,
@@ -12,96 +10,72 @@ import type { ConnectorConfiguration } from "@dust-tt/types";
 
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
-export type ConnectorCreate<T extends ConnectorConfiguration> = (
-  DataSourceConfig: DataSourceConfig,
-  connectionid: string,
-  configuration: T
-) => Promise<Result<string, Error>>;
+export abstract class BaseConnectorManager<T extends ConnectorConfiguration> {
+  readonly connectorId: ModelId;
 
-export type ConnectorProviderCreateConnectorMapping = {
-  [K in ConnectorProvider]: ConnectorCreate<ConnectorConfigurations[K]>;
-};
-
-export type ConnectorUpdater = (
-  connectorId: ModelId,
-  params: {
-    connectionId?: string | null;
+  constructor(connectorId: ModelId) {
+    this.connectorId = connectorId;
   }
-) => Promise<Result<string, ConnectorsAPIError>>;
 
-export type ConnectorStopper = (
-  connectorId: ModelId
-) => Promise<Result<undefined, Error>>;
+  static async create(params: {
+    dataSourceConfig: DataSourceConfig;
+    connectionId: string;
+    configuration: ConnectorConfiguration;
+  }): Promise<Result<string, Error>> {
+    void params;
+    throw new Error("Method not implemented.");
+  }
 
-// Should cleanup any state/resources associated with the connector
-export type ConnectorCleaner = (
-  connectorId: ModelId,
-  force: boolean
-) => Promise<Result<undefined, Error>>;
+  abstract update(params: {
+    connectionId?: string | null;
+  }): Promise<Result<string, ConnectorsAPIError>>;
 
-export type ConnectorResumer = (
-  connectorId: ModelId
-) => Promise<Result<undefined, Error>>;
+  abstract clean(params: { force: boolean }): Promise<Result<undefined, Error>>;
 
-export type SyncConnector = (
-  connectorId: ModelId,
-  fromTs: number | null
-) => Promise<Result<string, Error>>;
+  abstract stop(): Promise<Result<undefined, Error>>;
 
-export type ConnectorPermissionRetriever = (params: {
-  connectorId: ModelId;
-  parentInternalId: string | null;
-  filterPermission: ConnectorPermission | null;
-  viewType: ContentNodesViewType;
-}) => Promise<Result<ContentNode[], Error>>;
+  abstract resume(): Promise<Result<undefined, Error>>;
 
-export type ConnectorPermissionSetter = (
-  connectorId: ModelId,
-  // internalId -> "read" | "write" | "read_write" | "none"
-  permissions: Record<string, ConnectorPermission>
-) => Promise<Result<void, Error>>;
+  abstract sync(params: {
+    fromTs: number | null;
+  }): Promise<Result<string, Error>>;
 
-export type ConnectorBatchContentNodesRetriever = (
-  connectorId: ModelId,
-  internalIds: string[],
-  viewType: ContentNodesViewType
-) => Promise<Result<ContentNode[], Error>>;
+  abstract retrievePermissions(params: {
+    parentInternalId: string | null;
+    filterPermission: ConnectorPermission | null;
+    viewType: ContentNodesViewType;
+  }): Promise<Result<ContentNode[], Error>>;
 
-export type ContentNodeParentsRetriever = (
-  connectorId: ModelId,
-  internalId: string,
-  memoizationKey?: string
-) => Promise<Result<string[], Error>>;
+  abstract setPermissions(params: {
+    permissions: Record<string, ConnectorPermission>;
+  }): Promise<Result<void, Error>>;
 
-export type ConnectorConfigSetter = (
-  connectorId: ModelId,
-  configKey: string,
-  configValue: string
-) => Promise<Result<void, Error>>;
+  abstract retrieveBatchContentNodes(params: {
+    internalIds: string[];
+    viewType: ContentNodesViewType;
+  }): Promise<Result<ContentNode[], Error>>;
 
-export type ConnectorConfigGetter = (
-  connectorId: ModelId,
-  configKey: string
-) => Promise<Result<string | null, Error>>;
+  abstract retrieveContentNodeParents(params: {
+    internalId: string;
+    memoizationKey?: string;
+  }): Promise<Result<string[], Error>>;
 
-export type ConnectorGarbageCollector = (
-  connectorId: ModelId
-) => Promise<Result<string, Error>>;
+  abstract setConfigurationKey(params: {
+    configKey: string;
+    configValue: string;
+  }): Promise<Result<void, Error>>;
 
-export type ConnectorPauser = (
-  connectorId: ModelId
-) => Promise<Result<undefined, Error>>;
-export type ConnectorUnpauser = (
-  connectorId: ModelId
-) => Promise<Result<undefined, Error>>;
+  abstract getConfigurationKey(params: {
+    configKey: string;
+  }): Promise<Result<string | null, Error>>;
 
-export type ConnectorConfigurationSetter<T extends ConnectorConfiguration> = (
-  connectorId: ModelId,
-  configuration: T
-) => Promise<Result<void, Error>>;
+  abstract garbageCollect(): Promise<Result<string, Error>>;
 
-export type ConnectorProviderUpdateConfigurationMapping = {
-  [K in keyof ConnectorConfigurations]: ConnectorConfigurationSetter<
-    ConnectorConfigurations[K]
-  >;
-};
+  abstract pause(): Promise<Result<undefined, Error>>;
+
+  abstract unpause(): Promise<Result<undefined, Error>>;
+
+  abstract configure(params: {
+    configuration: T;
+  }): Promise<Result<void, Error>>;
+}

--- a/connectors/src/connectors/interface.ts
+++ b/connectors/src/connectors/interface.ts
@@ -17,12 +17,12 @@ export abstract class BaseConnectorManager<T extends ConnectorConfiguration> {
     this.connectorId = connectorId;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   static async create(params: {
     dataSourceConfig: DataSourceConfig;
     connectionId: string;
     configuration: ConnectorConfiguration;
   }): Promise<Result<string, Error>> {
-    void params;
     throw new Error("Method not implemented.");
   }
 

--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -2,14 +2,14 @@ import type {
   ConnectorPermission,
   ConnectorsAPIError,
   ContentNode,
-  ModelId,
+  ContentNodesViewType,
   NangoConnectionId,
   Result,
 } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 import { Client } from "@microsoft/microsoft-graph-client";
 
-import type { ConnectorPermissionRetriever } from "@connectors/connectors/interface";
+import { BaseConnectorManager } from "@connectors/connectors/interface";
 import { microsoftConfig } from "@connectors/connectors/microsoft/lib/config";
 import {
   getChannelAsContentNode,
@@ -37,6 +37,298 @@ import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { MicrosoftRootResource } from "@connectors/resources/microsoft_resource";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
+export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
+  static async create({
+    dataSourceConfig,
+    connectionId,
+  }: {
+    dataSourceConfig: DataSourceConfig;
+    connectionId: string;
+  }): Promise<Result<string, Error>> {
+    const client = await getClient(connectionId);
+
+    try {
+      // Sanity checks - check connectivity and permissions. User should be able to access the sites and teams list.
+      await getSites(client);
+      await getTeams(client);
+    } catch (err) {
+      logger.error(
+        {
+          err,
+        },
+        "Error creating Microsoft connector"
+      );
+      return new Err(new Error("Error creating Microsoft connector"));
+    }
+
+    const connector = await ConnectorResource.makeNew(
+      "microsoft",
+      {
+        connectionId,
+        workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
+        workspaceId: dataSourceConfig.workspaceId,
+        dataSourceName: dataSourceConfig.dataSourceName,
+      },
+      {}
+    );
+
+    await syncSucceeded(connector.id);
+
+    return new Ok(connector.id.toString());
+  }
+
+  async update({
+    connectionId,
+  }: {
+    connectionId?: string | null;
+  }): Promise<Result<string, ConnectorsAPIError>> {
+    console.log("updateMicrosoftConnector", this.connectorId, connectionId);
+    throw Error("Not implemented");
+  }
+
+  async clean({
+    force,
+  }: {
+    force: boolean;
+  }): Promise<Result<undefined, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      return new Err(
+        new Error(`Could not find connector with id ${this.connectorId}`)
+      );
+    }
+
+    const nangoRes = await nangoDeleteConnection(
+      connector.connectionId,
+      microsoftConfig.getRequiredNangoMicrosoftConnectorId()
+    );
+    if (nangoRes.isErr()) {
+      if (!force) {
+        return nangoRes;
+      } else {
+        logger.error(
+          {
+            err: nangoRes.error,
+          },
+          "Error deleting connection from Nango"
+        );
+      }
+    }
+
+    const res = await connector.delete();
+    if (res.isErr()) {
+      logger.error(
+        { connectorId: this.connectorId, error: res.error },
+        "Error cleaning up Microsoft connector."
+      );
+      return res;
+    }
+
+    return new Ok(undefined);
+  }
+
+  async sync({
+    fromTs,
+  }: {
+    fromTs: number | null;
+  }): Promise<Result<string, Error>> {
+    console.log("fullResyncMicrosoftConnector", this.connectorId, fromTs);
+    return launchMicrosoftFullSyncWorkflow(this.connectorId, null);
+  }
+
+  async retrievePermissions({
+    parentInternalId,
+    filterPermission,
+  }: {
+    parentInternalId: string | null;
+    filterPermission: ConnectorPermission | null;
+    viewType: ContentNodesViewType;
+  }): Promise<Result<ContentNode[], Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      return new Err(
+        new Error(`Could not find connector with id ${this.connectorId}`)
+      );
+    }
+
+    const client = await getClient(connector.connectionId);
+    const nodes = [];
+
+    const selectedResources = (
+      await MicrosoftRootResource.listRootsByConnectorId(connector.id)
+    ).map((r) =>
+      microsoftInternalIdFromNodeData({
+        nodeType: r.nodeType,
+        itemApiPath: r.itemApiPath,
+      })
+    );
+
+    if (!parentInternalId) {
+      nodes.push(...getRootNodes());
+    } else {
+      const { nodeType } = microsoftNodeDataFromInternalId(parentInternalId);
+
+      switch (nodeType) {
+        case "sites-root":
+          nodes.push(
+            ...(await getSites(client)).map((n) => getSiteAsContentNode(n))
+          );
+          break;
+        case "teams-root":
+          nodes.push(
+            ...(await getTeams(client)).map((n) => getTeamAsContentNode(n))
+          );
+          break;
+        case "team":
+          nodes.push(
+            ...(await getChannels(client, parentInternalId)).map((n) =>
+              getChannelAsContentNode(n, parentInternalId)
+            )
+          );
+          break;
+        case "site":
+          nodes.push(
+            ...(await getDrives(client, parentInternalId)).map((n) =>
+              getDriveAsContentNode(n, parentInternalId)
+            )
+          );
+          break;
+        case "drive":
+        case "folder":
+          nodes.push(
+            ...(await getFolders(client, parentInternalId)).map((n) =>
+              getFolderAsContentNode(n, parentInternalId)
+            )
+          );
+          break;
+      }
+    }
+
+    const nodesWithPermissions = nodes.map((res) => ({
+      ...res,
+      permission: (selectedResources.includes(res.internalId)
+        ? "read"
+        : "none") as ConnectorPermission,
+    }));
+
+    if (filterPermission) {
+      return new Ok(
+        nodesWithPermissions.filter((n) => n.permission === filterPermission)
+      );
+    }
+
+    return new Ok(nodesWithPermissions);
+  }
+
+  async setPermissions({
+    permissions,
+  }: {
+    permissions: Record<string, ConnectorPermission>;
+  }): Promise<Result<void, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      return new Err(
+        new Error(`Could not find connector with id ${this.connectorId}`)
+      );
+    }
+
+    await MicrosoftRootResource.batchDelete({
+      resourceIds: Object.entries(permissions).map((internalId) => {
+        const { itemApiPath } = microsoftNodeDataFromInternalId(internalId[0]);
+        return itemApiPath;
+      }),
+      connectorId: connector.id,
+    });
+
+    await MicrosoftRootResource.batchMakeNew(
+      Object.entries(permissions)
+        .filter(([, permission]) => permission === "read")
+        .map(([id]) => {
+          return {
+            connectorId: connector.id,
+            ...microsoftNodeDataFromInternalId(id),
+          };
+        })
+    );
+
+    return new Ok(undefined);
+  }
+
+  async stop(): Promise<Result<undefined, Error>> {
+    console.log("stopMicrosoftConnector", this.connectorId);
+    return new Ok(undefined);
+  }
+
+  async resume(): Promise<Result<undefined, Error>> {
+    console.log("resumeMicrosoftConnector", this.connectorId);
+    throw Error("Not implemented");
+  }
+
+  async retrieveBatchContentNodes({
+    internalIds,
+  }: {
+    internalIds: string[];
+    viewType: ContentNodesViewType;
+  }): Promise<Result<ContentNode[], Error>> {
+    console.log("retrieveMicrosoftContentNodes", this.connectorId, internalIds);
+    throw Error("Not implemented");
+  }
+
+  async retrieveContentNodeParents({
+    internalId,
+    memoizationKey,
+  }: {
+    internalId: string;
+    memoizationKey?: string;
+  }): Promise<Result<string[], Error>> {
+    console.log(
+      "retrieveMicrosoftContentNodeParents",
+      this.connectorId,
+      internalId,
+      memoizationKey
+    );
+    throw Error("Not implemented");
+  }
+
+  async setConfigurationKey({
+    configKey,
+  }: {
+    configKey: string;
+    configValue: string;
+  }): Promise<Result<void, Error>> {
+    console.log("setMicrosoftConfig", this.connectorId, configKey);
+    throw Error("Not implemented");
+  }
+
+  async getConfigurationKey({
+    configKey,
+  }: {
+    configKey: string;
+  }): Promise<Result<string | null, Error>> {
+    console.log("getMicrosoftConfig", this.connectorId, configKey);
+    throw Error("Not implemented");
+  }
+
+  async pause(): Promise<Result<undefined, Error>> {
+    console.log("pauseMicrosoftConnector", this.connectorId);
+    throw Error("Not implemented");
+  }
+
+  async unpause(): Promise<Result<undefined, Error>> {
+    console.log("unpauseMicrosoftConnector", this.connectorId);
+    throw Error("Not implemented");
+  }
+
+  async garbageCollect(): Promise<Result<string, Error>> {
+    console.log("garbageCollectMicrosoftConnector", this.connectorId);
+    throw Error("Not implemented");
+  }
+
+  async configure(): Promise<Result<void, Error>> {
+    throw new Error("Method not implemented.");
+  }
+}
+
 export async function getClient(connectionId: NangoConnectionId) {
   const nangoConnectionId = connectionId;
 
@@ -49,282 +341,4 @@ export async function getClient(connectionId: NangoConnectionId) {
   return Client.init({
     authProvider: (done) => done(null, msAccessToken),
   });
-}
-
-export async function createMicrosoftConnector(
-  dataSourceConfig: DataSourceConfig,
-  connectionId: NangoConnectionId
-) {
-  const client = await getClient(connectionId);
-
-  try {
-    // Sanity checks - check connectivity and permissions. User should be able to access the sites and teams list.
-    await getSites(client);
-    await getTeams(client);
-  } catch (err) {
-    logger.error(
-      {
-        err,
-      },
-      "Error creating Microsoft connector"
-    );
-    return new Err(new Error("Error creating Microsoft connector"));
-  }
-
-  const connector = await ConnectorResource.makeNew(
-    "microsoft",
-    {
-      connectionId,
-      workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
-      workspaceId: dataSourceConfig.workspaceId,
-      dataSourceName: dataSourceConfig.dataSourceName,
-    },
-    {}
-  );
-
-  await syncSucceeded(connector.id);
-
-  return new Ok(connector.id.toString());
-}
-
-export async function updateMicrosoftConnector(
-  connectorId: ModelId,
-  {
-    connectionId,
-  }: {
-    connectionId?: string | null;
-  }
-): Promise<Result<string, ConnectorsAPIError>> {
-  console.log("updateMicrosoftConnector", connectorId, connectionId);
-  throw Error("Not implemented");
-}
-
-export async function stopMicrosoftConnector(
-  connectorId: ModelId
-): Promise<Result<undefined, Error>> {
-  console.log("stopMicrosoftConnector", connectorId);
-  return new Ok(undefined);
-}
-
-export async function cleanupMicrosoftConnector(
-  connectorId: ModelId,
-  force = false
-) {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    return new Err(
-      new Error(`Could not find connector with id ${connectorId}`)
-    );
-  }
-
-  const nangoRes = await nangoDeleteConnection(
-    connector.connectionId,
-    microsoftConfig.getRequiredNangoMicrosoftConnectorId()
-  );
-  if (nangoRes.isErr()) {
-    if (!force) {
-      return nangoRes;
-    } else {
-      logger.error(
-        {
-          err: nangoRes.error,
-        },
-        "Error deleting connection from Nango"
-      );
-    }
-  }
-
-  const res = await connector.delete();
-  if (res.isErr()) {
-    logger.error(
-      { connectorId, error: res.error },
-      "Error cleaning up Microsoft connector."
-    );
-    return res;
-  }
-
-  return new Ok(undefined);
-}
-
-export async function pauseMicrosoftConnector(
-  connectorId: ModelId
-): Promise<Result<undefined, Error>> {
-  console.log("pauseMicrosoftConnector", connectorId);
-  throw Error("Not implemented");
-}
-
-export async function unpauseMicrosoftConnector(
-  connectorId: ModelId
-): Promise<Result<undefined, Error>> {
-  console.log("unpauseMicrosoftConnector", connectorId);
-  throw Error("Not implemented");
-}
-
-export async function resumeMicrosoftConnector(
-  connectorId: ModelId
-): Promise<Result<undefined, Error>> {
-  console.log("resumeMicrosoftConnector", connectorId);
-  throw Error("Not implemented");
-}
-
-export async function fullResyncMicrosoftConnector(
-  connectorId: ModelId,
-  fromTs: number | null
-) {
-  console.log("fullResyncMicrosoftConnector", connectorId, fromTs);
-  return launchMicrosoftFullSyncWorkflow(connectorId, null);
-}
-
-export async function retrieveMicrosoftConnectorPermissions({
-  connectorId,
-  parentInternalId,
-  filterPermission,
-}: Parameters<ConnectorPermissionRetriever>[0]): Promise<
-  Result<ContentNode[], Error>
-> {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    return new Err(
-      new Error(`Could not find connector with id ${connectorId}`)
-    );
-  }
-
-  const client = await getClient(connector.connectionId);
-  const nodes = [];
-
-  const selectedResources = (
-    await MicrosoftRootResource.listRootsByConnectorId(connector.id)
-  ).map((r) =>
-    microsoftInternalIdFromNodeData({
-      nodeType: r.nodeType,
-      itemApiPath: r.itemApiPath,
-    })
-  );
-
-  if (!parentInternalId) {
-    nodes.push(...getRootNodes());
-  } else {
-    const { nodeType } = microsoftNodeDataFromInternalId(parentInternalId);
-
-    switch (nodeType) {
-      case "sites-root":
-        nodes.push(
-          ...(await getSites(client)).map((n) => getSiteAsContentNode(n))
-        );
-        break;
-      case "teams-root":
-        nodes.push(
-          ...(await getTeams(client)).map((n) => getTeamAsContentNode(n))
-        );
-        break;
-      case "team":
-        nodes.push(
-          ...(await getChannels(client, parentInternalId)).map((n) =>
-            getChannelAsContentNode(n, parentInternalId)
-          )
-        );
-        break;
-      case "site":
-        nodes.push(
-          ...(await getDrives(client, parentInternalId)).map((n) =>
-            getDriveAsContentNode(n, parentInternalId)
-          )
-        );
-        break;
-      case "drive":
-      case "folder":
-        nodes.push(
-          ...(await getFolders(client, parentInternalId)).map((n) =>
-            getFolderAsContentNode(n, parentInternalId)
-          )
-        );
-        break;
-    }
-  }
-
-  const nodesWithPermissions = nodes.map((res) => ({
-    ...res,
-    permission: (selectedResources.includes(res.internalId)
-      ? "read"
-      : "none") as ConnectorPermission,
-  }));
-
-  if (filterPermission) {
-    return new Ok(
-      nodesWithPermissions.filter((n) => n.permission === filterPermission)
-    );
-  }
-
-  return new Ok(nodesWithPermissions);
-}
-
-export async function setMicrosoftConnectorPermissions(
-  connectorId: ModelId,
-  permissions: Record<string, ConnectorPermission>
-): Promise<Result<void, Error>> {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    return new Err(
-      new Error(`Could not find connector with id ${connectorId}`)
-    );
-  }
-
-  await MicrosoftRootResource.batchDelete({
-    resourceIds: Object.entries(permissions).map((internalId) => {
-      const { itemApiPath } = microsoftNodeDataFromInternalId(internalId[0]);
-      return itemApiPath;
-    }),
-    connectorId: connector.id,
-  });
-
-  await MicrosoftRootResource.batchMakeNew(
-    Object.entries(permissions)
-      .filter(([, permission]) => permission === "read")
-      .map(([id]) => {
-        return {
-          connectorId: connector.id,
-          ...microsoftNodeDataFromInternalId(id),
-        };
-      })
-  );
-
-  return new Ok(undefined);
-}
-
-export async function getMicrosoftConfig(
-  connectorId: ModelId,
-  configKey: string
-): Promise<Result<string | null, Error>> {
-  console.log("getMicrosoftConfig", connectorId, configKey);
-  throw Error("Not implemented");
-}
-
-export async function setMicrosoftConfig(
-  connectorId: ModelId,
-  configKey: string,
-  configValue: string
-): Promise<Result<void, Error>> {
-  console.log("setMicrosoftConfig", connectorId, configKey, configValue);
-  throw Error("Not implemented");
-}
-
-export async function retrieveMicrosoftContentNodeParents(
-  connectorId: ModelId,
-  internalId: string,
-  memoizationKey?: string
-): Promise<Result<string[], Error>> {
-  console.log(
-    "retrieveMicrosoftContentNodeParents",
-    connectorId,
-    internalId,
-    memoizationKey
-  );
-  throw Error("Not implemented");
-}
-export function retrieveMicrosoftContentNodes(
-  connectorId: ModelId,
-  internalIds: string[]
-): Promise<Result<ContentNode[], Error>> {
-  console.log("retrieveMicrosoftContentNodes", connectorId, internalIds);
-  throw Error("Not implemented");
 }

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -1,7 +1,7 @@
 import type {
   ConnectorsAPIError,
   ContentNode,
-  ModelId,
+  ContentNodesViewType,
   Result,
 } from "@dust-tt/types";
 import { Err, getNotionDatabaseTableId, Ok } from "@dust-tt/types";
@@ -29,126 +29,53 @@ import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 import type { NangoConnectionId } from "@connectors/types/nango_connection_id";
 
-import type { ConnectorPermissionRetriever } from "../interface";
+import { BaseConnectorManager } from "../interface";
 import { getParents } from "./lib/parents";
 
 const { getRequiredNangoNotionConnectorId } = notionConfig;
 
 const logger = mainLogger.child({ provider: "notion" });
 
-export async function createNotionConnector(
-  dataSourceConfig: DataSourceConfig,
-  connectionId: NangoConnectionId
-): Promise<Result<string, Error>> {
-  const nangoConnectionId = connectionId;
-
-  const notionAccessToken = await getAccessTokenFromNango({
-    connectionId: nangoConnectionId,
-    integrationId: getRequiredNangoNotionConnectorId(),
-    useCache: false,
-  });
-
-  const isValidToken = await validateAccessToken(notionAccessToken);
-  if (!isValidToken) {
-    return new Err(new Error("Notion access token is invalid"));
-  }
-
-  let connector: ConnectorResource;
-  try {
-    connector = await ConnectorResource.makeNew(
-      "notion",
-      {
-        connectionId: nangoConnectionId,
-        workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
-        workspaceId: dataSourceConfig.workspaceId,
-        dataSourceName: dataSourceConfig.dataSourceName,
-      },
-      {}
-    );
-  } catch (e) {
-    logger.error({ error: e }, "Error creating notion connector.");
-    return new Err(e as Error);
-  }
-
-  try {
-    await launchNotionSyncWorkflow(connector.id);
-  } catch (e) {
-    logger.error(
-      {
-        workspaceId: dataSourceConfig.workspaceId,
-        dataSourceName: dataSourceConfig.dataSourceName,
-        error: e,
-      },
-      "Error launching notion sync workflow."
-    );
-    await connector.delete();
-    return new Err(e as Error);
-  }
-
-  return new Ok(connector.id.toString());
-}
-
-export async function updateNotionConnector(
-  connectorId: ModelId,
-  {
+export class NotionConnectorManager extends BaseConnectorManager<null> {
+  static async create({
+    dataSourceConfig,
     connectionId,
   }: {
-    connectionId?: NangoConnectionId | null;
-  }
-): Promise<Result<string, ConnectorsAPIError>> {
-  const c = await ConnectorResource.fetchById(connectorId);
-  if (!c) {
-    logger.error({ connectorId }, "Connector not found");
-    return new Err({
-      message: "Connector not found",
-      type: "connector_not_found",
-    });
-  }
+    dataSourceConfig: DataSourceConfig;
+    connectionId: NangoConnectionId;
+  }): Promise<Result<string, Error>> {
+    const nangoConnectionId = connectionId;
 
-  if (connectionId) {
-    const oldConnectionId = c.connectionId;
-    const connectionRes = await nango_client().getConnection(
-      getRequiredNangoNotionConnectorId(),
-      oldConnectionId,
-      false
-    );
-    const newConnectionRes = await nango_client().getConnection(
-      getRequiredNangoNotionConnectorId(),
-      connectionId,
-      false
-    );
-
-    const workspaceId = connectionRes?.credentials?.raw?.workspace_id || null;
-    const newWorkspaceId =
-      newConnectionRes?.credentials?.raw?.workspace_id || null;
-
-    if (!workspaceId || !newWorkspaceId) {
-      return new Err({
-        type: "connector_update_error",
-        message: "Error retrieving nango connection info to update connector",
-      });
-    }
-    if (workspaceId !== newWorkspaceId) {
-      return new Err({
-        type: "connector_oauth_target_mismatch",
-        message: "Cannot change workspace of a Notion connector",
-      });
-    }
-
-    await c.update({ connectionId });
-    nangoDeleteConnection(
-      oldConnectionId,
-      getRequiredNangoNotionConnectorId()
-    ).catch((e) => {
-      logger.error(
-        { error: e, oldConnectionId },
-        "Error deleting old Nango connection"
-      );
+    const notionAccessToken = await getAccessTokenFromNango({
+      connectionId: nangoConnectionId,
+      integrationId: getRequiredNangoNotionConnectorId(),
+      useCache: false,
     });
 
-    const dataSourceConfig = dataSourceConfigFromConnector(c);
+    const isValidToken = await validateAccessToken(notionAccessToken);
+    if (!isValidToken) {
+      return new Err(new Error("Notion access token is invalid"));
+    }
+
+    let connector: ConnectorResource;
     try {
-      await launchNotionSyncWorkflow(c.id);
+      connector = await ConnectorResource.makeNew(
+        "notion",
+        {
+          connectionId: nangoConnectionId,
+          workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
+          workspaceId: dataSourceConfig.workspaceId,
+          dataSourceName: dataSourceConfig.dataSourceName,
+        },
+        {}
+      );
+    } catch (e) {
+      logger.error({ error: e }, "Error creating notion connector.");
+      return new Err(e as Error);
+    }
+
+    try {
+      await launchNotionSyncWorkflow(connector.id);
     } catch (e) {
       logger.error(
         {
@@ -156,307 +83,467 @@ export async function updateNotionConnector(
           dataSourceName: dataSourceConfig.dataSourceName,
           error: e,
         },
-        "Error launching notion sync workflow post update."
+        "Error launching notion sync workflow."
       );
+      await connector.delete();
+      return new Err(e as Error);
+    }
+
+    return new Ok(connector.id.toString());
+  }
+
+  async update({
+    connectionId,
+  }: {
+    connectionId?: NangoConnectionId | null;
+  }): Promise<Result<string, ConnectorsAPIError>> {
+    const c = await ConnectorResource.fetchById(this.connectorId);
+    if (!c) {
+      logger.error({ connectorId: this.connectorId }, "Connector not found");
       return new Err({
-        type: "connector_update_error",
-        message: "Error restarting sync workflow after updating connector",
+        message: "Connector not found",
+        type: "connector_not_found",
       });
     }
+
+    if (connectionId) {
+      const oldConnectionId = c.connectionId;
+      const connectionRes = await nango_client().getConnection(
+        getRequiredNangoNotionConnectorId(),
+        oldConnectionId,
+        false
+      );
+      const newConnectionRes = await nango_client().getConnection(
+        getRequiredNangoNotionConnectorId(),
+        connectionId,
+        false
+      );
+
+      const workspaceId = connectionRes?.credentials?.raw?.workspace_id || null;
+      const newWorkspaceId =
+        newConnectionRes?.credentials?.raw?.workspace_id || null;
+
+      if (!workspaceId || !newWorkspaceId) {
+        return new Err({
+          type: "connector_update_error",
+          message: "Error retrieving nango connection info to update connector",
+        });
+      }
+      if (workspaceId !== newWorkspaceId) {
+        return new Err({
+          type: "connector_oauth_target_mismatch",
+          message: "Cannot change workspace of a Notion connector",
+        });
+      }
+
+      await c.update({ connectionId });
+      nangoDeleteConnection(
+        oldConnectionId,
+        getRequiredNangoNotionConnectorId()
+      ).catch((e) => {
+        logger.error(
+          { error: e, oldConnectionId },
+          "Error deleting old Nango connection"
+        );
+      });
+
+      const dataSourceConfig = dataSourceConfigFromConnector(c);
+      try {
+        await launchNotionSyncWorkflow(c.id);
+      } catch (e) {
+        logger.error(
+          {
+            workspaceId: dataSourceConfig.workspaceId,
+            dataSourceName: dataSourceConfig.dataSourceName,
+            error: e,
+          },
+          "Error launching notion sync workflow post update."
+        );
+        return new Err({
+          type: "connector_update_error",
+          message: "Error restarting sync workflow after updating connector",
+        });
+      }
+    }
+
+    return new Ok(c.id.toString());
   }
 
-  return new Ok(c.id.toString());
-}
+  async stop(): Promise<Result<undefined, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
 
-export async function stopNotionConnector(
-  connectorId: ModelId
-): Promise<Result<undefined, Error>> {
-  const connector = await ConnectorResource.fetchById(connectorId);
+    if (!connector) {
+      logger.error(
+        {
+          connectorId: this.connectorId,
+        },
+        "Notion connector not found."
+      );
 
-  if (!connector) {
-    logger.error(
-      {
-        connectorId,
-      },
-      "Notion connector not found."
-    );
+      return new Err(new Error("Connector not found"));
+    }
 
-    return new Err(new Error("Connector not found"));
+    try {
+      await stopNotionSyncWorkflow(connector.id);
+    } catch (e) {
+      logger.error(
+        {
+          connectorId: connector.id,
+          error: e,
+        },
+        "Error stopping notion sync workflow"
+      );
+
+      return new Err(e as Error);
+    }
+
+    return new Ok(undefined);
   }
 
-  try {
-    await stopNotionSyncWorkflow(connector.id);
-  } catch (e) {
-    logger.error(
-      {
-        connectorId: connector.id,
-        error: e,
-      },
-      "Error stopping notion sync workflow"
-    );
+  async resume(): Promise<Result<undefined, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
 
-    return new Err(e as Error);
+    if (!connector) {
+      logger.error(
+        {
+          connectorId: this.connectorId,
+        },
+        "Notion connector not found."
+      );
+      return new Err(new Error("Connector not found"));
+    }
+
+    const dataSourceConfig = dataSourceConfigFromConnector(connector);
+    try {
+      await launchNotionSyncWorkflow(
+        connector.id,
+        connector.lastSyncSuccessfulTime
+          ? connector.lastSyncStartTime?.getTime()
+          : null
+      );
+    } catch (e) {
+      logger.error(
+        {
+          workspaceId: dataSourceConfig.workspaceId,
+          dataSourceName: dataSourceConfig.dataSourceName,
+          error: e,
+        },
+        "Error launching notion sync workflow."
+      );
+    }
+
+    return new Ok(undefined);
   }
 
-  return new Ok(undefined);
-}
+  async clean(): Promise<Result<undefined, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      logger.error(
+        { connectorId: this.connectorId },
+        "Notion connector not found."
+      );
+      return new Err(new Error("Connector not found"));
+    }
 
-export async function pauseNotionConnector(
-  connectorId: ModelId
-): Promise<Result<undefined, Error>> {
-  const connector = await ConnectorResource.fetchById(connectorId);
+    await this.deleteNangoConnection(connector.connectionId);
 
-  if (!connector) {
-    logger.error(
-      {
-        connectorId,
-      },
-      "Notion connector not found."
-    );
+    const res = await connector.delete();
+    if (res.isErr()) {
+      logger.error(
+        { connectorId: this.connectorId, error: res.error },
+        "Error cleaning up Notion connector."
+      );
+      return res;
+    }
 
-    return new Err(new Error("Connector not found"));
+    return new Ok(undefined);
   }
 
-  await connector.markAsPaused();
-  const stopRes = await stopNotionConnector(connector.id);
-  if (stopRes.isErr()) {
-    return stopRes;
+  async pause(): Promise<Result<undefined, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+
+    if (!connector) {
+      logger.error(
+        {
+          connectorId: this.connectorId,
+        },
+        "Notion connector not found."
+      );
+
+      return new Err(new Error("Connector not found"));
+    }
+
+    await connector.markAsPaused();
+    const stopRes = await this.stop();
+    if (stopRes.isErr()) {
+      return stopRes;
+    }
+
+    return new Ok(undefined);
   }
 
-  return new Ok(undefined);
-}
+  async unpause(): Promise<Result<undefined, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
 
-export async function unpauseNotionConnector(
-  connectorId: ModelId
-): Promise<Result<undefined, Error>> {
-  const connector = await ConnectorResource.fetchById(connectorId);
+    if (!connector) {
+      logger.error(
+        {
+          connectorId: this.connectorId,
+        },
+        "Notion connector not found."
+      );
 
-  if (!connector) {
-    logger.error(
-      {
-        connectorId,
-      },
-      "Notion connector not found."
-    );
+      return new Err(new Error("Connector not found"));
+    }
 
-    return new Err(new Error("Connector not found"));
+    await connector.markAsUnpaused();
+    const r = await this.resume();
+    if (r.isErr()) {
+      return r;
+    }
+
+    return new Ok(undefined);
   }
 
-  await connector.markAsUnpaused();
-  const r = await resumeNotionConnector(connector.id);
-  if (r.isErr()) {
-    return r;
-  }
+  async sync({
+    fromTs,
+  }: {
+    fromTs: number | null;
+  }): Promise<Result<string, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      logger.error(
+        { connectorId: this.connectorId },
+        "Notion connector not found."
+      );
+      return new Err(new Error("Connector not found"));
+    }
 
-  return new Ok(undefined);
-}
-
-export async function resumeNotionConnector(
-  connectorId: ModelId
-): Promise<Result<undefined, Error>> {
-  const connector = await ConnectorResource.fetchById(connectorId);
-
-  if (!connector) {
-    logger.error(
-      {
-        connectorId: connectorId,
-      },
-      "Notion connector not found."
-    );
-    return new Err(new Error("Connector not found"));
-  }
-
-  const dataSourceConfig = dataSourceConfigFromConnector(connector);
-  try {
-    await launchNotionSyncWorkflow(
-      connector.id,
-      connector.lastSyncSuccessfulTime
-        ? connector.lastSyncStartTime?.getTime()
-        : null
-    );
-  } catch (e) {
-    logger.error(
-      {
-        workspaceId: dataSourceConfig.workspaceId,
-        dataSourceName: dataSourceConfig.dataSourceName,
-        error: e,
-      },
-      "Error launching notion sync workflow."
-    );
-  }
-
-  return new Ok(undefined);
-}
-
-export async function fullResyncNotionConnector(
-  connectorId: ModelId,
-  fromTs: number | null
-) {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    logger.error({ connectorId }, "Notion connector not found.");
-    return new Err(new Error("Connector not found"));
-  }
-
-  const notionConnectorState = await NotionConnectorState.findOne({
-    where: {
-      connectorId,
-    },
-  });
-
-  if (!notionConnectorState) {
-    logger.error({ connectorId }, "Notion connector state not found.");
-    return new Err(new Error("Connector state not found"));
-  }
-
-  try {
-    await stopNotionConnector(connector.id);
-  } catch (e) {
-    logger.error(
-      {
-        connectorId,
-        workspaceId: connector.workspaceId,
-        dataSourceName: connector.dataSourceName,
-        e,
-      },
-      "Error stopping notion sync workflow."
-    );
-
-    return new Err(e as Error);
-  }
-
-  notionConnectorState.fullResyncStartTime = new Date();
-  await notionConnectorState.save();
-
-  try {
-    await launchNotionSyncWorkflow(
-      connector.id,
-      fromTs,
-      true //forceResync
-    );
-  } catch (e) {
-    logger.error(
-      {
-        connectorId,
-        workspaceId: connector.workspaceId,
-        dataSourceName: connector.dataSourceName,
-        error: e,
-      },
-      "Error launching notion sync workflow."
-    );
-  }
-
-  return new Ok(connector.id.toString());
-}
-
-export async function cleanupNotionConnector(
-  connectorId: ModelId
-): Promise<Result<undefined, Error>> {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    logger.error({ connectorId }, "Notion connector not found.");
-    return new Err(new Error("Connector not found"));
-  }
-
-  await deleteNangoConnection(connector.connectionId);
-
-  const res = await connector.delete();
-  if (res.isErr()) {
-    logger.error(
-      { connectorId, error: res.error },
-      "Error cleaning up Notion connector."
-    );
-    return res;
-  }
-
-  return new Ok(undefined);
-}
-
-async function deleteNangoConnection(connectionId: NangoConnectionId) {
-  const nangoRes = await nangoDeleteConnection(
-    connectionId,
-    getRequiredNangoNotionConnectorId()
-  );
-  if (nangoRes.isErr()) {
-    logger.error(
-      { err: nangoRes.error },
-      "Error deleting connection from Nango"
-    );
-  }
-}
-
-export async function retrieveNotionConnectorPermissions({
-  connectorId,
-  parentInternalId,
-  viewType,
-}: Parameters<ConnectorPermissionRetriever>[0]): Promise<
-  Result<ContentNode[], Error>
-> {
-  const c = await ConnectorResource.fetchById(connectorId);
-  if (!c) {
-    logger.error({ connectorId }, "Connector not found");
-    return new Err(new Error("Connector not found"));
-  }
-
-  const parentId = parentInternalId || "workspace";
-
-  const [pages, dbs] = await Promise.all([
-    NotionPage.findAll({
+    const notionConnectorState = await NotionConnectorState.findOne({
       where: {
-        connectorId,
-        parentId,
+        connectorId: this.connectorId,
       },
-    }),
-    NotionDatabase.findAll({
-      where: {
-        connectorId,
-        parentId,
-      },
-    }),
-  ]);
+    });
 
-  const getPageNodes = async (page: NotionPage): Promise<ContentNode> => {
-    const [childPage, childDB] = await Promise.all([
-      NotionPage.findOne({
+    if (!notionConnectorState) {
+      logger.error(
+        { connectorId: this.connectorId },
+        "Notion connector state not found."
+      );
+      return new Err(new Error("Connector state not found"));
+    }
+
+    try {
+      await this.stop();
+    } catch (e) {
+      logger.error(
+        {
+          connectorId: this.connectorId,
+          workspaceId: connector.workspaceId,
+          dataSourceName: connector.dataSourceName,
+          e,
+        },
+        "Error stopping notion sync workflow."
+      );
+
+      return new Err(e as Error);
+    }
+
+    notionConnectorState.fullResyncStartTime = new Date();
+    await notionConnectorState.save();
+
+    try {
+      await launchNotionSyncWorkflow(
+        connector.id,
+        fromTs,
+        true //forceResync
+      );
+    } catch (e) {
+      logger.error(
+        {
+          connectorId: this.connectorId,
+          workspaceId: connector.workspaceId,
+          dataSourceName: connector.dataSourceName,
+          error: e,
+        },
+        "Error launching notion sync workflow."
+      );
+    }
+
+    return new Ok(connector.id.toString());
+  }
+
+  async retrievePermissions({
+    parentInternalId,
+    viewType,
+  }: {
+    parentInternalId: string | null;
+    viewType: ContentNodesViewType;
+  }): Promise<Result<ContentNode[], Error>> {
+    const c = await ConnectorResource.fetchById(this.connectorId);
+    if (!c) {
+      logger.error({ connectorId: this.connectorId }, "Connector not found");
+      return new Err(new Error("Connector not found"));
+    }
+
+    const parentId = parentInternalId || "workspace";
+
+    const [pages, dbs] = await Promise.all([
+      NotionPage.findAll({
         where: {
-          connectorId,
-          parentId: page.notionPageId,
+          connectorId: this.connectorId,
+          parentId,
         },
       }),
-      NotionDatabase.findOne({
+      NotionDatabase.findAll({
         where: {
-          connectorId,
-          parentId: page.notionPageId,
+          connectorId: this.connectorId,
+          parentId,
         },
       }),
     ]);
 
-    const expandable = childPage || childDB ? true : false;
+    const getPageNodes = async (page: NotionPage): Promise<ContentNode> => {
+      const [childPage, childDB] = await Promise.all([
+        NotionPage.findOne({
+          where: {
+            connectorId: this.connectorId,
+            parentId: page.notionPageId,
+          },
+        }),
+        NotionDatabase.findOne({
+          where: {
+            connectorId: this.connectorId,
+            parentId: page.notionPageId,
+          },
+        }),
+      ]);
 
-    return {
-      provider: c.type,
+      const expandable = childPage || childDB ? true : false;
+
+      return {
+        provider: c.type,
+        internalId: page.notionPageId,
+        parentInternalId:
+          !page.parentId || page.parentId === "workspace"
+            ? null
+            : page.parentId,
+        type: "file",
+        title: page.title || "",
+        sourceUrl: page.notionUrl || null,
+        expandable,
+        permission: "read",
+        dustDocumentId: `notion-${page.notionPageId}`,
+        lastUpdatedAt: page.lastUpsertedTs?.getTime() || null,
+      };
+    };
+
+    let pageNodes = await Promise.all(pages.map((p) => getPageNodes(p)));
+    // In structured data mode, we remove leaf node pages
+    if (viewType === "tables") {
+      pageNodes = pageNodes.filter((p) => p.expandable);
+    }
+
+    const getDbNodes = async (db: NotionDatabase): Promise<ContentNode> => {
+      return {
+        provider: c.type,
+        internalId: db.notionDatabaseId,
+        parentInternalId:
+          !db.parentId || db.parentId === "workspace" ? null : db.parentId,
+        type: "database",
+        title: db.title || "",
+        sourceUrl: db.notionUrl || null,
+        expandable: true,
+        permission: "read",
+        dustDocumentId: `notion-database-${db.notionDatabaseId}`,
+        lastUpdatedAt: db.structuredDataUpsertedTs?.getTime() ?? null,
+      };
+    };
+
+    const dbNodes = await Promise.all(dbs.map((db) => getDbNodes(db)));
+
+    const folderNodes: ContentNode[] = [];
+    if (!parentInternalId) {
+      const [orphanedPagesCount, orphanedDbsCount] = await Promise.all([
+        NotionPage.count({
+          where: {
+            connectorId: this.connectorId,
+            parentId: "unknown",
+          },
+        }),
+        NotionDatabase.count({
+          where: {
+            connectorId: this.connectorId,
+            parentId: "unknown",
+          },
+        }),
+      ]);
+
+      if (orphanedPagesCount + orphanedDbsCount > 0) {
+        // We also need to return a "fake" top-level folder call "Orphaned" to include resources
+        // we haven't been able to find a parent for.
+        folderNodes.push({
+          provider: c.type,
+          // Orphaned resources in the database will have "unknown" as their parentId.
+          internalId: "unknown",
+          parentInternalId: null,
+          type: "folder",
+          title: "Orphaned Resources",
+          sourceUrl: null,
+          expandable: true,
+          permission: "read",
+          dustDocumentId: null,
+          lastUpdatedAt: null,
+        });
+      }
+    }
+
+    const nodes = pageNodes.concat(dbNodes);
+
+    nodes.sort((a, b) => {
+      return a.title.localeCompare(b.title);
+    });
+
+    return new Ok(nodes.concat(folderNodes));
+  }
+
+  async retrieveBatchContentNodes({
+    internalIds,
+  }: {
+    internalIds: string[];
+  }): Promise<Result<ContentNode[], Error>> {
+    const [pages, dbs] = await Promise.all([
+      NotionPage.findAll({
+        where: {
+          connectorId: this.connectorId,
+          notionPageId: internalIds,
+        },
+      }),
+      NotionDatabase.findAll({
+        where: {
+          connectorId: this.connectorId,
+          notionDatabaseId: internalIds,
+        },
+      }),
+    ]);
+
+    const pageNodes: ContentNode[] = pages.map((page) => ({
+      provider: "notion",
       internalId: page.notionPageId,
       parentInternalId:
         !page.parentId || page.parentId === "workspace" ? null : page.parentId,
       type: "file",
       title: page.title || "",
       sourceUrl: page.notionUrl || null,
-      expandable,
+      expandable: false,
       permission: "read",
       dustDocumentId: `notion-${page.notionPageId}`,
       lastUpdatedAt: page.lastUpsertedTs?.getTime() || null,
-    };
-  };
+      dustTableId: null,
+    }));
 
-  let pageNodes = await Promise.all(pages.map((p) => getPageNodes(p)));
-  // In structured data mode, we remove leaf node pages
-  if (viewType === "tables") {
-    pageNodes = pageNodes.filter((p) => p.expandable);
-  }
-
-  const getDbNodes = async (db: NotionDatabase): Promise<ContentNode> => {
-    return {
-      provider: c.type,
+    const dbNodes: ContentNode[] = dbs.map((db) => ({
+      provider: "notion",
       internalId: db.notionDatabaseId,
       parentInternalId:
         !db.parentId || db.parentId === "workspace" ? null : db.parentId,
@@ -465,139 +552,81 @@ export async function retrieveNotionConnectorPermissions({
       sourceUrl: db.notionUrl || null,
       expandable: true,
       permission: "read",
-      dustDocumentId: `notion-database-${db.notionDatabaseId}`,
-      lastUpdatedAt: db.structuredDataUpsertedTs?.getTime() ?? null,
-    };
-  };
+      dustDocumentId: null,
+      lastUpdatedAt: null,
+      dustTableId: getNotionDatabaseTableId(db.notionDatabaseId),
+    }));
 
-  const dbNodes = await Promise.all(dbs.map((db) => getDbNodes(db)));
+    const contentNodes = pageNodes.concat(dbNodes);
 
-  const folderNodes: ContentNode[] = [];
-  if (!parentInternalId) {
-    const [orphanedPagesCount, orphanedDbsCount] = await Promise.all([
-      NotionPage.count({
-        where: {
-          connectorId,
-          parentId: "unknown",
-        },
-      }),
-      NotionDatabase.count({
-        where: {
-          connectorId,
-          parentId: "unknown",
-        },
-      }),
-    ]);
+    return new Ok(contentNodes);
+  }
 
-    if (orphanedPagesCount + orphanedDbsCount > 0) {
-      // We also need to return a "fake" top-level folder call "Orphaned" to include resources
-      // we haven't been able to find a parent for.
-      folderNodes.push({
-        provider: c.type,
-        // Orphaned resources in the database will have "unknown" as their parentId.
-        internalId: "unknown",
-        parentInternalId: null,
-        type: "folder",
-        title: "Orphaned Resources",
-        sourceUrl: null,
-        expandable: true,
-        permission: "read",
-        dustDocumentId: null,
-        lastUpdatedAt: null,
-      });
+  async retrieveContentNodeParents({
+    internalId,
+    memoizationKey,
+  }: {
+    internalId: string;
+    memoizationKey?: string;
+  }): Promise<Result<string[], Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      logger.error({ connectorId: this.connectorId }, "Connector not found");
+      return new Err(new Error("Connector not found"));
+    }
+
+    const memo = memoizationKey || uuidv4();
+
+    try {
+      const parents = await getParents(
+        this.connectorId,
+        internalId,
+        new Set<string>(),
+        memo
+      );
+
+      return new Ok(parents);
+    } catch (e) {
+      logger.error(
+        { connectorId: this.connectorId, internalId, memoizationKey, error: e },
+        "Error retrieving notion resource parents"
+      );
+      return new Err(e as Error);
     }
   }
 
-  const nodes = pageNodes.concat(dbNodes);
-
-  nodes.sort((a, b) => {
-    return a.title.localeCompare(b.title);
-  });
-
-  return new Ok(nodes.concat(folderNodes));
-}
-
-export async function retrieveNotionContentNodeParents(
-  connectorId: ModelId,
-  internalId: string,
-  memoizationKey?: string
-): Promise<Result<string[], Error>> {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    logger.error({ connectorId }, "Connector not found");
-    return new Err(new Error("Connector not found"));
+  async setPermissions(): Promise<Result<void, Error>> {
+    return new Err(
+      new Error(`Setting Notion connector permissions is not implemented yet.`)
+    );
   }
 
-  const memo = memoizationKey || uuidv4();
-
-  try {
-    const parents = await getParents(
-      connectorId,
-      internalId,
-      new Set<string>(),
-      memo
-    );
-
-    return new Ok(parents);
-  } catch (e) {
-    logger.error(
-      { connectorId, internalId, memoizationKey, error: e },
-      "Error retrieving notion resource parents"
-    );
-    return new Err(e as Error);
+  async setConfigurationKey(): Promise<Result<void, Error>> {
+    throw new Error("Method not implemented.");
   }
-}
 
-export async function retrieveNotionContentNodes(
-  connectorId: ModelId,
-  internalIds: string[]
-): Promise<Result<ContentNode[], Error>> {
-  const [pages, dbs] = await Promise.all([
-    NotionPage.findAll({
-      where: {
-        connectorId,
-        notionPageId: internalIds,
-      },
-    }),
-    NotionDatabase.findAll({
-      where: {
-        connectorId,
-        notionDatabaseId: internalIds,
-      },
-    }),
-  ]);
+  async getConfigurationKey(): Promise<Result<string | null, Error>> {
+    throw new Error("Method not implemented.");
+  }
 
-  const pageNodes: ContentNode[] = pages.map((page) => ({
-    provider: "notion",
-    internalId: page.notionPageId,
-    parentInternalId:
-      !page.parentId || page.parentId === "workspace" ? null : page.parentId,
-    type: "file",
-    title: page.title || "",
-    sourceUrl: page.notionUrl || null,
-    expandable: false,
-    permission: "read",
-    dustDocumentId: `notion-${page.notionPageId}`,
-    lastUpdatedAt: page.lastUpsertedTs?.getTime() || null,
-    dustTableId: null,
-  }));
+  async garbageCollect(): Promise<Result<string, Error>> {
+    throw new Error("Method not implemented.");
+  }
 
-  const dbNodes: ContentNode[] = dbs.map((db) => ({
-    provider: "notion",
-    internalId: db.notionDatabaseId,
-    parentInternalId:
-      !db.parentId || db.parentId === "workspace" ? null : db.parentId,
-    type: "database",
-    title: db.title || "",
-    sourceUrl: db.notionUrl || null,
-    expandable: true,
-    permission: "read",
-    dustDocumentId: null,
-    lastUpdatedAt: null,
-    dustTableId: getNotionDatabaseTableId(db.notionDatabaseId),
-  }));
+  async configure(): Promise<Result<void, Error>> {
+    throw new Error("Method not implemented.");
+  }
 
-  const contentNodes = pageNodes.concat(dbNodes);
-
-  return new Ok(contentNodes);
+  private async deleteNangoConnection(connectionId: NangoConnectionId) {
+    const nangoRes = await nangoDeleteConnection(
+      connectionId,
+      getRequiredNangoNotionConnectorId()
+    );
+    if (nangoRes.isErr()) {
+      logger.error(
+        { err: nangoRes.error },
+        "Error deleting connection from Nango"
+      );
+    }
+  }
 }

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -6,14 +6,12 @@ import type {
   Result,
   SlackConfigurationType,
 } from "@dust-tt/types";
+import type { ContentNodesViewType } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 import { WebClient } from "@slack/web-api";
 import PQueue from "p-queue";
 
-import type {
-  ConnectorConfigGetter,
-  ConnectorPermissionRetriever,
-} from "@connectors/connectors/interface";
+import { BaseConnectorManager } from "@connectors/connectors/interface";
 import { getChannels } from "@connectors/connectors/slack//temporal/activities";
 import { getBotEnabled } from "@connectors/connectors/slack/bot";
 import { joinChannel } from "@connectors/connectors/slack/lib/channels";
@@ -33,164 +31,701 @@ import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
 import type { DataSourceConfig } from "@connectors/types/data_source_config.js";
-import type { NangoConnectionId } from "@connectors/types/nango_connection_id";
 
 const { NANGO_SLACK_CONNECTOR_ID, SLACK_CLIENT_ID, SLACK_CLIENT_SECRET } =
   process.env;
 
-export async function createSlackConnector(
-  dataSourceConfig: DataSourceConfig,
-  connectionId: NangoConnectionId,
-  configuration: SlackConfigurationType
-): Promise<Result<string, Error>> {
-  const nangoConnectionId = connectionId;
+export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurationType> {
+  static async create({
+    dataSourceConfig,
+    connectionId,
+    configuration,
+  }: {
+    dataSourceConfig: DataSourceConfig;
+    connectionId: string;
+    configuration: SlackConfigurationType;
+  }): Promise<Result<string, Error>> {
+    const nangoConnectionId = connectionId;
 
-  const nango = nango_client();
-  if (!NANGO_SLACK_CONNECTOR_ID) {
-    throw new Error("NANGO_SLACK_CONNECTOR_ID is not defined");
-  }
-  const slackAccessToken = (await nango.getToken(
-    NANGO_SLACK_CONNECTOR_ID,
-    nangoConnectionId
-  )) as string;
-  const client = new WebClient(slackAccessToken);
-
-  const teamInfo = await client.team.info();
-  if (teamInfo.ok !== true) {
-    return new Err(
-      new Error(
-        `Could not get slack team info. Error message: ${
-          teamInfo.error || "unknown"
-        }`
-      )
-    );
-  }
-  if (!teamInfo.team?.id) {
-    return new Err(
-      new Error(
-        `Could not get slack team id. Error message: ${
-          teamInfo.error || "unknown"
-        }`
-      )
-    );
-  }
-
-  const connector = await ConnectorResource.makeNew(
-    "slack",
-    {
-      connectionId: nangoConnectionId,
-      workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
-      workspaceId: dataSourceConfig.workspaceId,
-      dataSourceName: dataSourceConfig.dataSourceName,
-    },
-    {
-      slackTeamId: teamInfo.team.id,
-      botEnabled: configuration.botEnabled,
-      autoReadChannelPattern: configuration.autoReadChannelPattern,
-      whitelistedDomains: configuration.whitelistedDomains,
+    const nango = nango_client();
+    if (!NANGO_SLACK_CONNECTOR_ID) {
+      throw new Error("NANGO_SLACK_CONNECTOR_ID is not defined");
     }
-  );
+    const slackAccessToken = (await nango.getToken(
+      NANGO_SLACK_CONNECTOR_ID,
+      nangoConnectionId
+    )) as string;
+    const client = new WebClient(slackAccessToken);
 
-  return new Ok(connector.id.toString());
-}
+    const teamInfo = await client.team.info();
+    if (teamInfo.ok !== true) {
+      return new Err(
+        new Error(
+          `Could not get slack team info. Error message: ${
+            teamInfo.error || "unknown"
+          }`
+        )
+      );
+    }
+    if (!teamInfo.team?.id) {
+      return new Err(
+        new Error(
+          `Could not get slack team id. Error message: ${
+            teamInfo.error || "unknown"
+          }`
+        )
+      );
+    }
+    const connector = await ConnectorResource.makeNew(
+      "slack",
+      {
+        connectionId: nangoConnectionId,
+        workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
+        workspaceId: dataSourceConfig.workspaceId,
+        dataSourceName: dataSourceConfig.dataSourceName,
+      },
+      {
+        slackTeamId: teamInfo.team.id,
+        botEnabled: configuration.botEnabled,
+        autoReadChannelPattern: configuration.autoReadChannelPattern,
+        whitelistedDomains: configuration.whitelistedDomains,
+      }
+    );
 
-export async function updateSlackConnector(
-  connectorId: ModelId,
-  {
+    return new Ok(connector.id.toString());
+  }
+
+  async update({
     connectionId,
   }: {
     connectionId?: string | null;
-  }
-): Promise<Result<string, ConnectorsAPIError>> {
-  if (!NANGO_SLACK_CONNECTOR_ID) {
-    throw new Error("NANGO_SLACK_CONNECTOR_ID not set");
-  }
+  }): Promise<Result<string, ConnectorsAPIError>> {
+    if (!NANGO_SLACK_CONNECTOR_ID) {
+      throw new Error("NANGO_SLACK_CONNECTOR_ID not set");
+    }
 
-  const c = await ConnectorResource.fetchById(connectorId);
-  if (!c) {
-    logger.error({ connectorId }, "Connector not found");
-    return new Err({
-      message: "Connector not found",
-      type: "connector_not_found",
-    });
-  }
-
-  const currentSlackConfig =
-    await SlackConfigurationResource.fetchByConnectorId(connectorId);
-  if (!currentSlackConfig) {
-    logger.error({ connectorId }, "Slack configuration not found");
-    return new Err({
-      message: "Slack configuration not found",
-      type: "connector_not_found",
-    });
-  }
-
-  const updateParams: Parameters<typeof c.update>[0] = {};
-
-  if (connectionId) {
-    const accessToken = await getSlackAccessToken(connectionId);
-    const slackClient = await getSlackClient(accessToken);
-    const teamInfoRes = await slackClient.team.info();
-    if (!teamInfoRes.ok || !teamInfoRes.team?.id) {
+    const c = await ConnectorResource.fetchById(this.connectorId);
+    if (!c) {
+      logger.error({ connectorId: this.connectorId }, "Connector not found");
       return new Err({
-        type: "internal_server_error",
-        message: "Can't get the Slack team information.",
+        message: "Connector not found",
+        type: "connector_not_found",
       });
     }
 
-    const newTeamId = teamInfoRes.team.id;
-    if (newTeamId !== currentSlackConfig.slackTeamId) {
-      const configurations =
-        await SlackConfigurationResource.listForTeamId(newTeamId);
+    const currentSlackConfig =
+      await SlackConfigurationResource.fetchByConnectorId(this.connectorId);
+    if (!currentSlackConfig) {
+      logger.error(
+        { connectorId: this.connectorId },
+        "Slack configuration not found"
+      );
+      return new Err({
+        message: "Slack configuration not found",
+        type: "connector_not_found",
+      });
+    }
 
-      // Revoke the token if no other slack connector is active on the same slackTeamId.
-      if (configurations.length == 0) {
-        logger.info(
-          {
-            connectorId: c.id,
-            slackTeamId: newTeamId,
-            nangoConnectionId: connectionId,
-          },
-          `Attempting Slack app deactivation [updateSlackConnector/team_id_mismatch]`
-        );
-        const uninstallRes = await uninstallSlack(connectionId);
+    const updateParams: Parameters<typeof c.update>[0] = {};
 
-        if (uninstallRes.isErr()) {
-          return new Err({
-            type: "internal_server_error",
-            message: "Failed to deactivate the mismatching Slack app",
-          });
-        }
-        logger.info(
-          {
-            connectorId: c.id,
-            slackTeamId: newTeamId,
-            nangoConnectionId: connectionId,
-          },
-          `Deactivated Slack app [updateSlackConnector/team_id_mismatch]`
-        );
-      } else {
-        logger.info(
-          {
-            slackTeamId: newTeamId,
-            activeConfigurations: configurations.length,
-          },
-          `Skipping deactivation of the Slack app [updateSlackConnector/team_id_mismatch]`
-        );
+    if (connectionId) {
+      const accessToken = await getSlackAccessToken(connectionId);
+      const slackClient = await getSlackClient(accessToken);
+      const teamInfoRes = await slackClient.team.info();
+      if (!teamInfoRes.ok || !teamInfoRes.team?.id) {
+        return new Err({
+          type: "internal_server_error",
+          message: "Can't get the Slack team information.",
+        });
       }
 
-      return new Err({
-        type: "connector_oauth_target_mismatch",
-        message: "Cannot change the Slack Team of a Data Source",
-      });
+      const newTeamId = teamInfoRes.team.id;
+      if (newTeamId !== currentSlackConfig.slackTeamId) {
+        const configurations = await SlackConfigurationResource.listForTeamId(
+          newTeamId
+        );
+
+        // Revoke the token if no other slack connector is active on the same slackTeamId.
+        if (configurations.length == 0) {
+          logger.info(
+            {
+              connectorId: c.id,
+              slackTeamId: newTeamId,
+              nangoConnectionId: connectionId,
+            },
+            `Attempting Slack app deactivation [updateSlackConnector/team_id_mismatch]`
+          );
+          const uninstallRes = await uninstallSlack(connectionId);
+
+          if (uninstallRes.isErr()) {
+            return new Err({
+              type: "internal_server_error",
+              message: "Failed to deactivate the mismatching Slack app",
+            });
+          }
+          logger.info(
+            {
+              connectorId: c.id,
+              slackTeamId: newTeamId,
+              nangoConnectionId: connectionId,
+            },
+            `Deactivated Slack app [updateSlackConnector/team_id_mismatch]`
+          );
+        } else {
+          logger.info(
+            {
+              slackTeamId: newTeamId,
+              activeConfigurations: configurations.length,
+            },
+            `Skipping deactivation of the Slack app [updateSlackConnector/team_id_mismatch]`
+          );
+        }
+
+        return new Err({
+          type: "connector_oauth_target_mismatch",
+          message: "Cannot change the Slack Team of a Data Source",
+        });
+      }
+
+      updateParams.connectionId = connectionId;
     }
 
-    updateParams.connectionId = connectionId;
+    await c.update(updateParams);
+
+    return new Ok(c.id.toString());
   }
 
-  await c.update(updateParams);
+  async clean({
+    force,
+  }: {
+    force: boolean;
+  }): Promise<Result<undefined, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      return new Err(
+        new Error(`Could not find connector with id ${this.connectorId}`)
+      );
+    }
 
-  return new Ok(c.id.toString());
+    const configuration = await SlackConfigurationResource.fetchByConnectorId(
+      this.connectorId
+    );
+    if (!configuration) {
+      return new Err(
+        new Error(
+          `Could not find configuration for connector id ${this.connectorId}`
+        )
+      );
+    }
+
+    const configurations = await SlackConfigurationResource.listForTeamId(
+      configuration.slackTeamId
+    );
+
+    // We deactivate our connections only if we are the only live slack connection for this team.
+    if (configurations.length == 1) {
+      logger.info(
+        {
+          connectorId: connector.id,
+          slackTeamId: configuration.slackTeamId,
+          nangoConnectionId: connector.connectionId,
+        },
+        `Attempting Slack app deactivation [cleanupSlackConnector]`
+      );
+
+      try {
+        const uninstallRes = await uninstallSlack(connector.connectionId);
+
+        if (uninstallRes.isErr() && !force) {
+          return uninstallRes;
+        }
+      } catch (e) {
+        if (!force) {
+          throw e;
+        }
+      }
+
+      logger.info(
+        {
+          connectorId: connector.id,
+          slackTeamId: configuration.slackTeamId,
+        },
+        `Deactivated Slack app [cleanupSlackConnector]`
+      );
+    } else {
+      logger.info(
+        {
+          connectorId: connector.id,
+          slackTeamId: configuration.slackTeamId,
+          activeConfigurations: configurations.length - 1,
+        },
+        `Skipping deactivation of the Slack app [cleanupSlackConnector]`
+      );
+    }
+
+    const res = await connector.delete();
+    if (res.isErr()) {
+      logger.error(
+        { connectorId: this.connectorId, error: res.error },
+        "Error cleaning up Slack connector."
+      );
+      return res;
+    }
+
+    return new Ok(undefined);
+  }
+
+  async sync({
+    fromTs,
+  }: {
+    fromTs: number | null;
+  }): Promise<Result<string, Error>> {
+    return launchSlackSyncWorkflow(this.connectorId, fromTs);
+  }
+
+  async retrievePermissions({
+    parentInternalId,
+    filterPermission,
+  }: {
+    parentInternalId: string | null;
+    filterPermission: ConnectorPermission | null;
+    viewType: ContentNodesViewType;
+  }): Promise<Result<ContentNode[], Error>> {
+    if (parentInternalId) {
+      return new Err(
+        new Error(
+          "Slack connector does not support permission retrieval with `parentInternalId`"
+        )
+      );
+    }
+
+    const c = await ConnectorResource.fetchById(this.connectorId);
+    if (!c) {
+      logger.error({ connectorId: this.connectorId }, "Connector not found");
+      return new Err(new Error("Connector not found"));
+    }
+    const slackConfig = await SlackConfigurationResource.fetchByConnectorId(
+      this.connectorId
+    );
+    if (!slackConfig) {
+      logger.error(
+        { connectorId: this.connectorId },
+        "Slack configuration not found"
+      );
+      return new Err(new Error("Slack configuration not found"));
+    }
+
+    let permissionToFilter: ConnectorPermission[] = [];
+
+    switch (filterPermission) {
+      case "read":
+        permissionToFilter = ["read", "read_write"];
+        break;
+      case "write":
+        permissionToFilter = ["write", "read_write"];
+        break;
+      case "read_write":
+        permissionToFilter = ["read_write"];
+        break;
+    }
+
+    const slackChannels: {
+      slackChannelId: string;
+      slackChannelName: string;
+      permission: ConnectorPermission;
+    }[] = [];
+
+    try {
+      const [remoteChannels, localChannels] = await Promise.all([
+        getChannels(c.id, false),
+        SlackChannel.findAll({
+          where: {
+            connectorId: this.connectorId,
+          },
+        }),
+      ]);
+
+      const localChannelsById = localChannels.reduce((acc, ch) => {
+        acc[ch.slackChannelId] = ch;
+        return acc;
+      }, {} as Record<string, SlackChannel>);
+
+      for (const remoteChannel of remoteChannels) {
+        if (!remoteChannel.id || !remoteChannel.name) {
+          continue;
+        }
+
+        const permissions =
+          localChannelsById[remoteChannel.id]?.permission ||
+          (remoteChannel.is_member ? "write" : "none");
+
+        if (
+          permissionToFilter.length === 0 ||
+          permissionToFilter.includes(permissions)
+        ) {
+          slackChannels.push({
+            slackChannelId: remoteChannel.id,
+            slackChannelName: remoteChannel.name,
+            permission: permissions,
+          });
+        }
+      }
+
+      const resources: ContentNode[] = slackChannels.map((ch) => ({
+        provider: "slack",
+        internalId: ch.slackChannelId,
+        parentInternalId: null,
+        type: "channel",
+        title: `#${ch.slackChannelName}`,
+        sourceUrl: `https://app.slack.com/client/${slackConfig.slackTeamId}/${ch.slackChannelId}`,
+        expandable: false,
+        permission: ch.permission,
+        dustDocumentId: null,
+        lastUpdatedAt: null,
+        dustTableId: null,
+      }));
+
+      resources.sort((a, b) => {
+        return a.title.localeCompare(b.title);
+      });
+
+      return new Ok(resources);
+    } catch (e) {
+      if (e instanceof ExternalOauthTokenError) {
+        logger.error({ connectorId: this.connectorId }, "Slack token invalid");
+        return new Err(
+          new Error("Slack token invalid. Please re-authorize Slack.")
+        );
+      }
+      throw e;
+    }
+  }
+
+  async setPermissions({
+    permissions,
+  }: {
+    permissions: Record<string, ConnectorPermission>;
+  }): Promise<Result<void, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      return new Err(
+        new Error(`Connector not found with id ${this.connectorId}`)
+      );
+    }
+
+    const configuration = await SlackConfigurationResource.fetchByConnectorId(
+      this.connectorId
+    );
+    if (!configuration) {
+      return new Err(
+        new Error(
+          `Could not find configuration for connector id ${this.connectorId}`
+        )
+      );
+    }
+
+    const channels = (
+      await SlackChannel.findAll({
+        where: {
+          connectorId: this.connectorId,
+          slackChannelId: Object.keys(permissions),
+        },
+      })
+    ).reduce(
+      (acc, c) => Object.assign(acc, { [c.slackChannelId]: c }),
+      {} as {
+        [key: string]: SlackChannel;
+      }
+    );
+
+    const q = new PQueue({ concurrency: 10 });
+    const promises: Promise<void>[] = [];
+
+    const slackChannelsToSync: string[] = [];
+    for (const [id, permission] of Object.entries(permissions)) {
+      let channel = channels[id];
+      const slackClient = await getSlackClient(connector.id);
+      if (!channel) {
+        const remoteChannel = await slackClient.conversations.info({
+          channel: id,
+        });
+        if (!remoteChannel.ok || !remoteChannel.channel?.name) {
+          logger.error(
+            {
+              connectorId: this.connectorId,
+              channelId: id,
+              error: remoteChannel.error,
+            },
+            "Could not get the Slack channel information"
+          );
+          return new Err(
+            new Error("Could not get the Slack channel information.")
+          );
+        }
+        const joinRes = await joinChannel(this.connectorId, id);
+        if (joinRes.isErr()) {
+          logger.error(
+            {
+              connectorId: this.connectorId,
+              channelId: id,
+              error: joinRes.error,
+            },
+            "Could not join the Slack channel"
+          );
+          return new Err(
+            new Error(
+              `Our Slack bot (@Dust) was not able to join the Slack channel #${remoteChannel.channel.name}. Please re-authorize Slack or invite @Dust from #${remoteChannel.channel.name} on Slack.`
+            )
+          );
+        }
+        const slackChannel = await SlackChannel.create({
+          connectorId: this.connectorId,
+          slackChannelId: id,
+          slackChannelName: remoteChannel.channel.name,
+          permission: "none",
+        });
+        channels[id] = slackChannel;
+        channel = slackChannel;
+      }
+
+      promises.push(
+        q.add(async () => {
+          if (!channel) {
+            return;
+          }
+          const oldPermission = channel.permission;
+          if (oldPermission === permission) {
+            return;
+          }
+          await channel.update({
+            permission: permission,
+          });
+
+          if (
+            !["read", "read_write"].includes(oldPermission) &&
+            ["read", "read_write"].includes(permission)
+          ) {
+            // handle read permission enabled
+            slackChannelsToSync.push(channel.slackChannelId);
+            const joinChannelRes = await joinChannel(
+              this.connectorId,
+              channel.slackChannelId
+            );
+            if (joinChannelRes.isErr()) {
+              logger.error(
+                {
+                  connectorId: this.connectorId,
+                  channelId: channel.slackChannelId,
+                  error: joinChannelRes.error,
+                },
+                "Could not join the Slack channel"
+              );
+              throw new Error(
+                `Our Slack bot (@Dust) was not able to join the Slack channel #${channel.slackChannelName}. Please re-authorize Slack or invite @Dust from #${channel.slackChannelName} on Slack.`
+              );
+            }
+          }
+        })
+      );
+    }
+
+    try {
+      await Promise.all(promises);
+      const workflowRes = await launchSlackSyncWorkflow(
+        this.connectorId,
+        null,
+        slackChannelsToSync
+      );
+
+      if (workflowRes.isErr()) {
+        return new Err(workflowRes.error);
+      }
+    } catch (e) {
+      return new Err(e as Error);
+    }
+
+    return new Ok(undefined);
+  }
+
+  async retrieveBatchContentNodes({
+    internalIds,
+  }: {
+    internalIds: string[];
+    viewType: ContentNodesViewType;
+  }): Promise<Result<ContentNode[], Error>> {
+    const slackConfig = await SlackConfigurationResource.fetchByConnectorId(
+      this.connectorId
+    );
+    if (!slackConfig) {
+      logger.error(
+        { connectorId: this.connectorId },
+        "Slack configuration not found"
+      );
+      return new Err(new Error("Slack configuration not found"));
+    }
+
+    const channels = await SlackChannel.findAll({
+      where: {
+        connectorId: this.connectorId,
+        slackChannelId: internalIds,
+      },
+    });
+
+    const contentNodes: ContentNode[] = channels.map((ch) => ({
+      provider: "slack",
+      internalId: ch.slackChannelId,
+      parentInternalId: null,
+      type: "channel",
+      title: `#${ch.slackChannelName}`,
+      sourceUrl: `https://app.slack.com/client/${slackConfig.slackTeamId}/${ch.slackChannelId}`,
+      expandable: false,
+      permission: ch.permission,
+      dustDocumentId: null,
+      lastUpdatedAt: null,
+      dustTableId: null,
+    }));
+
+    return new Ok(contentNodes);
+  }
+
+  async retrieveContentNodeParents(): Promise<Result<string[], Error>> {
+    // Slack is flat.
+    return new Ok([]);
+  }
+
+  async setConfigurationKey({
+    configKey,
+    configValue,
+  }: {
+    configKey: string;
+    configValue: string;
+  }): Promise<Result<void, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      return new Err(
+        new Error(`Connector not found with id ${this.connectorId}`)
+      );
+    }
+
+    switch (configKey) {
+      case "botEnabled": {
+        const slackConfig = await SlackConfigurationResource.fetchByConnectorId(
+          this.connectorId
+        );
+        if (!slackConfig) {
+          return new Err(
+            new Error(
+              `Slack configuration not found for connector ${this.connectorId}`
+            )
+          );
+        }
+        if (configValue === "true") {
+          return slackConfig.enableBot();
+        } else {
+          return slackConfig.disableBot();
+        }
+      }
+      case "autoReadChannelPattern": {
+        const slackConfig = await SlackConfigurationResource.fetchByConnectorId(
+          this.connectorId
+        );
+        if (!slackConfig) {
+          return new Err(
+            new Error(
+              `Slack configuration not found for connector ${this.connectorId}`
+            )
+          );
+        }
+        return slackConfig.setAutoReadChannelPattern(configValue || null);
+      }
+
+      default: {
+        return new Err(new Error(`Invalid config key ${configKey}`));
+      }
+    }
+  }
+
+  async getConfigurationKey({
+    configKey,
+  }: {
+    configKey: string;
+  }): Promise<Result<string | null, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      return new Err(
+        new Error(`Connector not found with id ${this.connectorId}`)
+      );
+    }
+
+    switch (configKey) {
+      case "botEnabled": {
+        const botEnabledRes = await getBotEnabled(this.connectorId);
+        if (botEnabledRes.isErr()) {
+          return botEnabledRes;
+        }
+        return new Ok(botEnabledRes.value.toString());
+      }
+      case "autoReadChannelPattern": {
+        const autoReadChannelPattern = await getAutoReadChannelPattern(
+          this.connectorId
+        );
+        return autoReadChannelPattern;
+      }
+      default:
+        return new Err(new Error(`Invalid config key ${configKey}`));
+    }
+  }
+
+  async pause(): Promise<Result<undefined, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      return new Err(
+        new Error(`Connector not found with id ${this.connectorId}`)
+      );
+    }
+    await connector.markAsPaused();
+    await terminateAllWorkflowsForConnectorId(this.connectorId);
+    return new Ok(undefined);
+  }
+
+  async unpause(): Promise<Result<undefined, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      return new Err(
+        new Error(`Connector not found with id ${this.connectorId}`)
+      );
+    }
+    await connector.markAsUnpaused();
+    const r = await launchSlackSyncWorkflow(this.connectorId, null);
+    if (r.isErr()) {
+      return r;
+    }
+    return new Ok(undefined);
+  }
+
+  async stop(): Promise<Result<undefined, Error>> {
+    logger.info(
+      { connectorId: this.connectorId },
+      `Stopping Slack connector is a no-op.`
+    );
+    return new Ok(undefined);
+  }
+
+  async resume(): Promise<Result<undefined, Error>> {
+    logger.info(
+      { connectorId: this.connectorId },
+      `Resuming Slack connector is a no-op.`
+    );
+    return new Ok(undefined);
+  }
+
+  async garbageCollect(): Promise<Result<string, Error>> {
+    throw new Error("Method not implemented.");
+  }
+
+  async configure(): Promise<Result<void, Error>> {
+    throw new Error("Method not implemented.");
+  }
 }
 
 export async function uninstallSlack(nangoConnectionId: string) {
@@ -253,373 +788,6 @@ export async function uninstallSlack(nangoConnectionId: string) {
   return new Ok(undefined);
 }
 
-export async function cleanupSlackConnector(
-  connectorId: ModelId,
-  force = false
-): Promise<Result<undefined, Error>> {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    return new Err(
-      new Error(`Could not find connector with id ${connectorId}`)
-    );
-  }
-
-  const configuration =
-    await SlackConfigurationResource.fetchByConnectorId(connectorId);
-  if (!configuration) {
-    return new Err(
-      new Error(`Could not find configuration for connector id ${connectorId}`)
-    );
-  }
-
-  const configurations = await SlackConfigurationResource.listForTeamId(
-    configuration.slackTeamId
-  );
-
-  // We deactivate our connections only if we are the only live slack connection for this team.
-  if (configurations.length == 1) {
-    logger.info(
-      {
-        connectorId: connector.id,
-        slackTeamId: configuration.slackTeamId,
-        nangoConnectionId: connector.connectionId,
-      },
-      `Attempting Slack app deactivation [cleanupSlackConnector]`
-    );
-
-    try {
-      const uninstallRes = await uninstallSlack(connector.connectionId);
-
-      if (uninstallRes.isErr() && !force) {
-        return uninstallRes;
-      }
-    } catch (e) {
-      if (!force) {
-        throw e;
-      }
-    }
-
-    logger.info(
-      {
-        connectorId: connector.id,
-        slackTeamId: configuration.slackTeamId,
-      },
-      `Deactivated Slack app [cleanupSlackConnector]`
-    );
-  } else {
-    logger.info(
-      {
-        connectorId: connector.id,
-        slackTeamId: configuration.slackTeamId,
-        activeConfigurations: configurations.length - 1,
-      },
-      `Skipping deactivation of the Slack app [cleanupSlackConnector]`
-    );
-  }
-
-  const res = await connector.delete();
-  if (res.isErr()) {
-    logger.error(
-      { connectorId, error: res.error },
-      "Error cleaning up Slack connector."
-    );
-    return res;
-  }
-
-  return new Ok(undefined);
-}
-
-export async function retrieveSlackConnectorPermissions({
-  connectorId,
-  parentInternalId,
-  filterPermission,
-}: Parameters<ConnectorPermissionRetriever>[0]): Promise<
-  Result<ContentNode[], Error>
-> {
-  if (parentInternalId) {
-    return new Err(
-      new Error(
-        "Slack connector does not support permission retrieval with `parentInternalId`"
-      )
-    );
-  }
-
-  const c = await ConnectorResource.fetchById(connectorId);
-  if (!c) {
-    logger.error({ connectorId }, "Connector not found");
-    return new Err(new Error("Connector not found"));
-  }
-  const slackConfig =
-    await SlackConfigurationResource.fetchByConnectorId(connectorId);
-  if (!slackConfig) {
-    logger.error({ connectorId }, "Slack configuration not found");
-    return new Err(new Error("Slack configuration not found"));
-  }
-
-  let permissionToFilter: ConnectorPermission[] = [];
-
-  switch (filterPermission) {
-    case "read":
-      permissionToFilter = ["read", "read_write"];
-      break;
-    case "write":
-      permissionToFilter = ["write", "read_write"];
-      break;
-    case "read_write":
-      permissionToFilter = ["read_write"];
-      break;
-  }
-
-  const slackChannels: {
-    slackChannelId: string;
-    slackChannelName: string;
-    permission: ConnectorPermission;
-  }[] = [];
-
-  try {
-    const [remoteChannels, localChannels] = await Promise.all([
-      getChannels(c.id, false),
-      SlackChannel.findAll({
-        where: {
-          connectorId: connectorId,
-        },
-      }),
-    ]);
-
-    const localChannelsById = localChannels.reduce(
-      (acc, ch) => {
-        acc[ch.slackChannelId] = ch;
-        return acc;
-      },
-      {} as Record<string, SlackChannel>
-    );
-
-    for (const remoteChannel of remoteChannels) {
-      if (!remoteChannel.id || !remoteChannel.name) {
-        continue;
-      }
-
-      const permissions =
-        localChannelsById[remoteChannel.id]?.permission ||
-        (remoteChannel.is_member ? "write" : "none");
-
-      if (
-        permissionToFilter.length === 0 ||
-        permissionToFilter.includes(permissions)
-      ) {
-        slackChannels.push({
-          slackChannelId: remoteChannel.id,
-          slackChannelName: remoteChannel.name,
-          permission: permissions,
-        });
-      }
-    }
-
-    const resources: ContentNode[] = slackChannels.map((ch) => ({
-      provider: "slack",
-      internalId: ch.slackChannelId,
-      parentInternalId: null,
-      type: "channel",
-      title: `#${ch.slackChannelName}`,
-      sourceUrl: `https://app.slack.com/client/${slackConfig.slackTeamId}/${ch.slackChannelId}`,
-      expandable: false,
-      permission: ch.permission,
-      dustDocumentId: null,
-      lastUpdatedAt: null,
-      dustTableId: null,
-    }));
-
-    resources.sort((a, b) => {
-      return a.title.localeCompare(b.title);
-    });
-
-    return new Ok(resources);
-  } catch (e) {
-    if (e instanceof ExternalOauthTokenError) {
-      logger.error({ connectorId }, "Slack token invalid");
-      return new Err(
-        new Error("Slack token invalid. Please re-authorize Slack.")
-      );
-    }
-    throw e;
-  }
-}
-
-export async function setSlackConnectorPermissions(
-  connectorId: ModelId,
-  permissions: Record<string, ConnectorPermission>
-): Promise<Result<void, Error>> {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    return new Err(new Error(`Connector not found with id ${connectorId}`));
-  }
-
-  const configuration =
-    await SlackConfigurationResource.fetchByConnectorId(connectorId);
-  if (!configuration) {
-    return new Err(
-      new Error(`Could not find configuration for connector id ${connectorId}`)
-    );
-  }
-
-  const channels = (
-    await SlackChannel.findAll({
-      where: {
-        connectorId: connectorId,
-        slackChannelId: Object.keys(permissions),
-      },
-    })
-  ).reduce(
-    (acc, c) => Object.assign(acc, { [c.slackChannelId]: c }),
-    {} as {
-      [key: string]: SlackChannel;
-    }
-  );
-
-  const q = new PQueue({ concurrency: 10 });
-  const promises: Promise<void>[] = [];
-
-  const slackChannelsToSync: string[] = [];
-  for (const [id, permission] of Object.entries(permissions)) {
-    let channel = channels[id];
-    const slackClient = await getSlackClient(connector.id);
-    if (!channel) {
-      const remoteChannel = await slackClient.conversations.info({
-        channel: id,
-      });
-      if (!remoteChannel.ok || !remoteChannel.channel?.name) {
-        logger.error(
-          {
-            connectorId,
-            channelId: id,
-            error: remoteChannel.error,
-          },
-          "Could not get the Slack channel information"
-        );
-        return new Err(
-          new Error("Could not get the Slack channel information.")
-        );
-      }
-      const joinRes = await joinChannel(connectorId, id);
-      if (joinRes.isErr()) {
-        logger.error(
-          {
-            connectorId,
-            channelId: id,
-            error: joinRes.error,
-          },
-          "Could not join the Slack channel"
-        );
-        return new Err(
-          new Error(
-            `Our Slack bot (@Dust) was not able to join the Slack channel #${remoteChannel.channel.name}. Please re-authorize Slack or invite @Dust from #${remoteChannel.channel.name} on Slack.`
-          )
-        );
-      }
-      const slackChannel = await SlackChannel.create({
-        connectorId: connectorId,
-        slackChannelId: id,
-        slackChannelName: remoteChannel.channel.name,
-        permission: "none",
-      });
-      channels[id] = slackChannel;
-      channel = slackChannel;
-    }
-
-    promises.push(
-      q.add(async () => {
-        if (!channel) {
-          return;
-        }
-        const oldPermission = channel.permission;
-        if (oldPermission === permission) {
-          return;
-        }
-        await channel.update({
-          permission: permission,
-        });
-
-        if (
-          !["read", "read_write"].includes(oldPermission) &&
-          ["read", "read_write"].includes(permission)
-        ) {
-          // handle read permission enabled
-          slackChannelsToSync.push(channel.slackChannelId);
-          const joinChannelRes = await joinChannel(
-            connectorId,
-            channel.slackChannelId
-          );
-          if (joinChannelRes.isErr()) {
-            logger.error(
-              {
-                connectorId,
-                channelId: channel.slackChannelId,
-                error: joinChannelRes.error,
-              },
-              "Could not join the Slack channel"
-            );
-            throw new Error(
-              `Our Slack bot (@Dust) was not able to join the Slack channel #${channel.slackChannelName}. Please re-authorize Slack or invite @Dust from #${channel.slackChannelName} on Slack.`
-            );
-          }
-        }
-      })
-    );
-  }
-
-  try {
-    await Promise.all(promises);
-    const workflowRes = await launchSlackSyncWorkflow(
-      connectorId,
-      null,
-      slackChannelsToSync
-    );
-
-    if (workflowRes.isErr()) {
-      return new Err(workflowRes.error);
-    }
-  } catch (e) {
-    return new Err(e as Error);
-  }
-
-  return new Ok(undefined);
-}
-
-export async function retrieveSlackContentNodes(
-  connectorId: ModelId,
-  internalIds: string[]
-): Promise<Result<ContentNode[], Error>> {
-  const slackConfig =
-    await SlackConfigurationResource.fetchByConnectorId(connectorId);
-  if (!slackConfig) {
-    logger.error({ connectorId }, "Slack configuration not found");
-    return new Err(new Error("Slack configuration not found"));
-  }
-
-  const channels = await SlackChannel.findAll({
-    where: {
-      connectorId: connectorId,
-      slackChannelId: internalIds,
-    },
-  });
-
-  const contentNodes: ContentNode[] = channels.map((ch) => ({
-    provider: "slack",
-    internalId: ch.slackChannelId,
-    parentInternalId: null,
-    type: "channel",
-    title: `#${ch.slackChannelName}`,
-    sourceUrl: `https://app.slack.com/client/${slackConfig.slackTeamId}/${ch.slackChannelId}`,
-    expandable: false,
-    permission: ch.permission,
-    dustDocumentId: null,
-    lastUpdatedAt: null,
-    dustTableId: null,
-  }));
-
-  return new Ok(contentNodes);
-}
-
 export async function getAutoReadChannelPattern(
   connectorId: ModelId
 ): Promise<Result<string | null, Error>> {
@@ -636,100 +804,4 @@ export async function getAutoReadChannelPattern(
     return new Ok(null);
   }
   return new Ok(slackConfiguration.autoReadChannelPattern);
-}
-
-export const getSlackConfig: ConnectorConfigGetter = async function (
-  connectorId: ModelId,
-  configKey: string
-) {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    return new Err(new Error(`Connector not found with id ${connectorId}`));
-  }
-
-  switch (configKey) {
-    case "botEnabled": {
-      const botEnabledRes = await getBotEnabled(connectorId);
-      if (botEnabledRes.isErr()) {
-        return botEnabledRes;
-      }
-      return new Ok(botEnabledRes.value.toString());
-    }
-    case "autoReadChannelPattern": {
-      const autoReadChannelPattern =
-        await getAutoReadChannelPattern(connectorId);
-      return autoReadChannelPattern;
-    }
-    default:
-      return new Err(new Error(`Invalid config key ${configKey}`));
-  }
-};
-
-export async function setSlackConfig(
-  connectorId: ModelId,
-  configKey: string,
-  configValue: string
-) {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    return new Err(new Error(`Connector not found with id ${connectorId}`));
-  }
-
-  switch (configKey) {
-    case "botEnabled": {
-      const slackConfig =
-        await SlackConfigurationResource.fetchByConnectorId(connectorId);
-      if (!slackConfig) {
-        return new Err(
-          new Error(
-            `Slack configuration not found for connector ${connectorId}`
-          )
-        );
-      }
-      if (configValue === "true") {
-        return slackConfig.enableBot();
-      } else {
-        return slackConfig.disableBot();
-      }
-    }
-    case "autoReadChannelPattern": {
-      const slackConfig =
-        await SlackConfigurationResource.fetchByConnectorId(connectorId);
-      if (!slackConfig) {
-        return new Err(
-          new Error(
-            `Slack configuration not found for connector ${connectorId}`
-          )
-        );
-      }
-      return slackConfig.setAutoReadChannelPattern(configValue || null);
-    }
-
-    default: {
-      return new Err(new Error(`Invalid config key ${configKey}`));
-    }
-  }
-}
-
-export async function pauseSlackConnector(connectorId: ModelId) {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    return new Err(new Error(`Connector not found with id ${connectorId}`));
-  }
-  await connector.markAsPaused();
-  await terminateAllWorkflowsForConnectorId(connectorId);
-  return new Ok(undefined);
-}
-
-export async function unpauseSlackConnector(connectorId: ModelId) {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    return new Err(new Error(`Connector not found with id ${connectorId}`));
-  }
-  await connector.markAsUnpaused();
-  const r = await launchSlackSyncWorkflow(connectorId, null);
-  if (r.isErr()) {
-    return r;
-  }
-  return new Ok(undefined);
 }

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -141,9 +141,8 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
 
       const newTeamId = teamInfoRes.team.id;
       if (newTeamId !== currentSlackConfig.slackTeamId) {
-        const configurations = await SlackConfigurationResource.listForTeamId(
-          newTeamId
-        );
+        const configurations =
+          await SlackConfigurationResource.listForTeamId(newTeamId);
 
         // Revoke the token if no other slack connector is active on the same slackTeamId.
         if (configurations.length == 0) {
@@ -345,10 +344,13 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
         }),
       ]);
 
-      const localChannelsById = localChannels.reduce((acc, ch) => {
-        acc[ch.slackChannelId] = ch;
-        return acc;
-      }, {} as Record<string, SlackChannel>);
+      const localChannelsById = localChannels.reduce(
+        (acc, ch) => {
+          acc[ch.slackChannelId] = ch;
+          return acc;
+        },
+        {} as Record<string, SlackChannel>
+      );
 
       for (const remoteChannel of remoteChannels) {
         if (!remoteChannel.id || !remoteChannel.name) {

--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -1,6 +1,8 @@
 import type {
+  ConnectorPermission,
+  ConnectorsAPIError,
   ContentNode,
-  ModelId,
+  ContentNodesViewType,
   Result,
   WebCrawlerConfigurationType,
 } from "@dust-tt/types";
@@ -27,427 +29,458 @@ import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { WebCrawlerConfigurationResource } from "@connectors/resources/webcrawler_resource";
 import type { DataSourceConfig } from "@connectors/types/data_source_config.js";
 
-import type { ConnectorPermissionRetriever } from "../interface";
+import { BaseConnectorManager } from "../interface";
 import {
   launchCrawlWebsiteWorkflow,
   stopCrawlWebsiteWorkflow,
 } from "./temporal/client";
 
-export async function createWebcrawlerConnector(
-  dataSourceConfig: DataSourceConfig,
-  connectionId: string,
-  configuration: WebCrawlerConfigurationType
-): Promise<Result<string, Error>> {
-  if (!configuration) {
-    throw new Error("Configuration is required");
-  }
-  const depth = configuration.depth;
-  if (!isDepthOption(depth)) {
-    return new Err(new Error("Invalid depth option"));
-  }
-  if (configuration.maxPageToCrawl > WEBCRAWLER_MAX_PAGES) {
-    return new Err(
-      new Error(`Maximum value for Max Page is ${WEBCRAWLER_MAX_PAGES}`)
+export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerConfigurationType> {
+  static async create({
+    dataSourceConfig,
+    configuration,
+  }: {
+    dataSourceConfig: DataSourceConfig;
+    connectionId: string;
+    configuration: WebCrawlerConfigurationType;
+  }): Promise<Result<string, Error>> {
+    if (!configuration) {
+      throw new Error("Configuration is required");
+    }
+    const depth = configuration.depth;
+    if (!isDepthOption(depth)) {
+      return new Err(new Error("Invalid depth option"));
+    }
+    if (configuration.maxPageToCrawl > WEBCRAWLER_MAX_PAGES) {
+      return new Err(
+        new Error(`Maximum value for Max Page is ${WEBCRAWLER_MAX_PAGES}`)
+      );
+    }
+    const url = configuration.url.trim();
+    const webCrawlerConfigurationBlob = {
+      url,
+      maxPageToCrawl: configuration.maxPageToCrawl,
+      crawlMode: configuration.crawlMode,
+      depth: depth,
+      crawlFrequency: configuration.crawlFrequency,
+      lastCrawledAt: null,
+      headers: configuration.headers,
+    };
+
+    const connector = await ConnectorResource.makeNew(
+      "webcrawler",
+      {
+        connectionId: configuration.url,
+        workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
+        workspaceId: dataSourceConfig.workspaceId,
+        dataSourceName: dataSourceConfig.dataSourceName,
+      },
+      webCrawlerConfigurationBlob
     );
-  }
-  const url = configuration.url.trim();
-  const webCrawlerConfigurationBlob = {
-    url,
-    maxPageToCrawl: configuration.maxPageToCrawl,
-    crawlMode: configuration.crawlMode,
-    depth: depth,
-    crawlFrequency: configuration.crawlFrequency,
-    lastCrawledAt: null,
-    headers: configuration.headers,
-  };
 
-  const connector = await ConnectorResource.makeNew(
-    "webcrawler",
-    {
-      connectionId: configuration.url,
-      workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
-      workspaceId: dataSourceConfig.workspaceId,
-      dataSourceName: dataSourceConfig.dataSourceName,
-    },
-    webCrawlerConfigurationBlob
-  );
+    const workflowRes = await launchCrawlWebsiteWorkflow(connector.id);
+    if (workflowRes.isErr()) {
+      return workflowRes;
+    }
+    logger.info(
+      { connectorId: connector.id },
+      `Launched crawl website workflow for connector`
+    );
 
-  const workflowRes = await launchCrawlWebsiteWorkflow(connector.id);
-  if (workflowRes.isErr()) {
-    return workflowRes;
-  }
-  logger.info(
-    { connectorId: connector.id },
-    `Launched crawl website workflow for connector`
-  );
-
-  return new Ok(connector.id.toString());
-}
-
-export async function retrieveWebcrawlerConnectorPermissions({
-  connectorId,
-  parentInternalId,
-}: Parameters<ConnectorPermissionRetriever>[0]): Promise<
-  Result<ContentNode[], Error>
-> {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    return new Err(new Error("Connector not found"));
+    return new Ok(connector.id.toString());
   }
 
-  const webCrawlerConfig =
-    await WebCrawlerConfigurationResource.fetchByConnectorId(connector.id);
+  async clean(): Promise<Result<undefined, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      throw new Error("Connector not found.");
+    }
 
-  if (!webCrawlerConfig) {
-    return new Err(new Error("Webcrawler configuration not found"));
+    const res = await connector.delete();
+    if (res.isErr()) {
+      logger.error(
+        { connectorId: this.connectorId, error: res.error },
+        "Error cleaning up Webcrawler connector."
+      );
+      return res;
+    }
+
+    return new Ok(undefined);
   }
-  let parentUrl: string | null = null;
-  if (parentInternalId) {
-    const parent = await WebCrawlerFolder.findOne({
+
+  async stop(): Promise<Result<undefined, Error>> {
+    const res = await stopCrawlWebsiteWorkflow(this.connectorId);
+    if (res.isErr()) {
+      return res;
+    }
+
+    return new Ok(undefined);
+  }
+
+  async sync(): Promise<Result<string, Error>> {
+    return launchCrawlWebsiteWorkflow(this.connectorId);
+  }
+
+  async retrievePermissions({
+    parentInternalId,
+  }: {
+    parentInternalId: string | null;
+    filterPermission: ConnectorPermission | null;
+    viewType: ContentNodesViewType;
+  }): Promise<Result<ContentNode[], Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      return new Err(new Error("Connector not found"));
+    }
+
+    const webCrawlerConfig =
+      await WebCrawlerConfigurationResource.fetchByConnectorId(connector.id);
+
+    if (!webCrawlerConfig) {
+      return new Err(new Error("Webcrawler configuration not found"));
+    }
+    let parentUrl: string | null = null;
+    if (parentInternalId) {
+      const parent = await WebCrawlerFolder.findOne({
+        where: {
+          connectorId: connector.id,
+          webcrawlerConfigurationId: webCrawlerConfig.id,
+          internalId: parentInternalId,
+        },
+      });
+      if (!parent) {
+        return new Err(new Error("Parent not found"));
+      }
+      parentUrl = parent.url;
+    }
+
+    const pages = await WebCrawlerPage.findAll({
       where: {
         connectorId: connector.id,
         webcrawlerConfigurationId: webCrawlerConfig.id,
-        internalId: parentInternalId,
+        parentUrl: parentUrl,
       },
     });
-    if (!parent) {
-      return new Err(new Error("Parent not found"));
-    }
-    parentUrl = parent.url;
-  }
 
-  const pages = await WebCrawlerPage.findAll({
-    where: {
-      connectorId: connector.id,
-      webcrawlerConfigurationId: webCrawlerConfig.id,
-      parentUrl: parentUrl,
-    },
-  });
+    const folders = await WebCrawlerFolder.findAll({
+      where: {
+        connectorId: connector.id,
+        webcrawlerConfigurationId: webCrawlerConfig.id,
+        parentUrl: parentUrl,
+      },
+    });
 
-  const folders = await WebCrawlerFolder.findAll({
-    where: {
-      connectorId: connector.id,
-      webcrawlerConfigurationId: webCrawlerConfig.id,
-      parentUrl: parentUrl,
-    },
-  });
+    const normalizedPagesSet = new Set(
+      pages.map((p) => normalizeFolderUrl(p.url))
+    );
+    // List of folders that are also pages
+    const excludedFoldersSet = new Set(
+      folders.map((f) => f.url).filter((f) => normalizedPagesSet.has(f))
+    );
 
-  const normalizedPagesSet = new Set(
-    pages.map((p) => normalizeFolderUrl(p.url))
-  );
-  // List of folders that are also pages
-  const excludedFoldersSet = new Set(
-    folders.map((f) => f.url).filter((f) => normalizedPagesSet.has(f))
-  );
-
-  return new Ok(
-    folders
-      // We don't want to show folders that are also pages.
-      .filter((f) => !excludedFoldersSet.has(f.url))
-      .map((folder): ContentNode => {
-        return {
-          provider: "webcrawler",
-          internalId: folder.internalId,
-          parentInternalId: folder.parentUrl
-            ? stableIdForUrl({
-                url: folder.parentUrl,
-                ressourceType: "folder",
-              })
-            : null,
-          title:
-            new URL(folder.url).pathname
-              .split("/")
-              .filter((x) => x)
-              .pop() || folder.url,
-          sourceUrl: null,
-          expandable: true,
-          permission: "read",
-          dustDocumentId: null,
-          type: "folder",
-          lastUpdatedAt: folder.updatedAt.getTime(),
-        };
-      })
-      .concat(
-        pages.map((page): ContentNode => {
-          const isFileAndFolder = excludedFoldersSet.has(
-            normalizeFolderUrl(page.url)
-          );
+    return new Ok(
+      folders
+        // We don't want to show folders that are also pages.
+        .filter((f) => !excludedFoldersSet.has(f.url))
+        .map((folder): ContentNode => {
           return {
             provider: "webcrawler",
-            internalId: isFileAndFolder
+            internalId: folder.internalId,
+            parentInternalId: folder.parentUrl
               ? stableIdForUrl({
-                  url: normalizeFolderUrl(page.url),
-                  ressourceType: "folder",
-                })
-              : page.documentId,
-            parentInternalId: page.parentUrl
-              ? stableIdForUrl({
-                  url: page.parentUrl,
+                  url: folder.parentUrl,
                   ressourceType: "folder",
                 })
               : null,
-            title: getDisplayNameForPage(page.url),
-            sourceUrl: page.url,
-            expandable: isFileAndFolder ? true : false,
+            title:
+              new URL(folder.url).pathname
+                .split("/")
+                .filter((x) => x)
+                .pop() || folder.url,
+            sourceUrl: null,
+            expandable: true,
             permission: "read",
-            dustDocumentId: page.documentId,
-            type: "file",
-            lastUpdatedAt: page.updatedAt.getTime(),
+            dustDocumentId: null,
+            type: "folder",
+            lastUpdatedAt: folder.updatedAt.getTime(),
           };
         })
-      )
-      .sort((a, b) => a.title.localeCompare(b.title))
-  );
-}
-
-export async function stopWebcrawlerConnector(
-  connectorId: ModelId
-): Promise<Result<undefined, Error>> {
-  const res = await stopCrawlWebsiteWorkflow(connectorId);
-  if (res.isErr()) {
-    return res;
-  }
-
-  return new Ok(undefined);
-}
-
-export async function pauseWebcrawlerConnector(
-  connectorId: ModelId
-): Promise<Result<undefined, Error>> {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    throw new Error("Connector not found.");
-  }
-  await connector.markAsPaused();
-  const stopRes = await stopCrawlWebsiteWorkflow(connectorId);
-  if (stopRes.isErr()) {
-    return stopRes;
-  }
-  return new Ok(undefined);
-}
-
-export async function unpauseWebcrawlerConnector(
-  connectorId: ModelId
-): Promise<Result<undefined, Error>> {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    throw new Error("Connector not found.");
-  }
-  await connector.markAsUnpaused();
-
-  const startRes = await launchCrawlWebsiteWorkflow(connectorId);
-  if (startRes.isErr()) {
-    return startRes;
-  }
-  return new Ok(undefined);
-}
-
-export async function cleanupWebcrawlerConnector(
-  connectorId: ModelId
-): Promise<Result<undefined, Error>> {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    throw new Error("Connector not found.");
-  }
-
-  const res = await connector.delete();
-  if (res.isErr()) {
-    logger.error(
-      { connectorId, error: res.error },
-      "Error cleaning up Webcrawler connector."
+        .concat(
+          pages.map((page): ContentNode => {
+            const isFileAndFolder = excludedFoldersSet.has(
+              normalizeFolderUrl(page.url)
+            );
+            return {
+              provider: "webcrawler",
+              internalId: isFileAndFolder
+                ? stableIdForUrl({
+                    url: normalizeFolderUrl(page.url),
+                    ressourceType: "folder",
+                  })
+                : page.documentId,
+              parentInternalId: page.parentUrl
+                ? stableIdForUrl({
+                    url: page.parentUrl,
+                    ressourceType: "folder",
+                  })
+                : null,
+              title: getDisplayNameForPage(page.url),
+              sourceUrl: page.url,
+              expandable: isFileAndFolder ? true : false,
+              permission: "read",
+              dustDocumentId: page.documentId,
+              type: "file",
+              lastUpdatedAt: page.updatedAt.getTime(),
+            };
+          })
+        )
+        .sort((a, b) => a.title.localeCompare(b.title))
     );
-    return res;
   }
 
-  return new Ok(undefined);
-}
+  async retrieveBatchContentNodes({
+    internalIds,
+  }: {
+    internalIds: string[];
+    viewType: ContentNodesViewType;
+  }): Promise<Result<ContentNode[], Error>> {
+    const nodes: ContentNode[] = [];
 
-export async function retrieveWebCrawlerContentNodes(
-  connectorId: ModelId,
-  internalIds: string[]
-): Promise<Result<ContentNode[], Error>> {
-  const nodes: ContentNode[] = [];
-
-  const [folders, pages] = await Promise.all([
-    WebCrawlerFolder.findAll({
-      where: {
-        connectorId: connectorId,
-        url: internalIds,
-      },
-    }),
-    WebCrawlerPage.findAll({
-      where: {
-        connectorId: connectorId,
-        documentId: internalIds,
-      },
-    }),
-  ]);
-
-  folders.forEach((folder) => {
-    nodes.push({
-      provider: "webcrawler",
-      internalId: folder.internalId,
-      parentInternalId: folder.parentUrl,
-      title: folder.url,
-      sourceUrl: folder.url,
-      expandable: true,
-      permission: "read",
-      dustDocumentId: null,
-      type: "folder",
-      lastUpdatedAt: folder.updatedAt.getTime(),
-    });
-  });
-  pages.forEach((page) => {
-    nodes.push({
-      provider: "webcrawler",
-      internalId: page.documentId,
-      parentInternalId: page.parentUrl,
-      title: page.title ?? page.url,
-      sourceUrl: page.url,
-      expandable: false,
-      permission: "read",
-      dustDocumentId: page.documentId,
-      type: "file",
-      lastUpdatedAt: page.updatedAt.getTime(),
-    });
-  });
-
-  return new Ok(nodes);
-}
-
-export async function retrieveWebCrawlerContentNodeParents(
-  connectorId: ModelId,
-  internalId: string
-): Promise<Result<string[], Error>> {
-  const parents: string[] = [];
-  let parentUrl: string | null = null;
-
-  // First we get the Page or Folder for which we want to retrieve the parents
-  const page = await WebCrawlerPage.findOne({
-    where: {
-      connectorId: connectorId,
-      documentId: internalId,
-    },
-  });
-  if (page && page.parentUrl) {
-    parentUrl = page.parentUrl;
-  } else {
-    const folder = await WebCrawlerFolder.findOne({
-      where: {
-        connectorId: connectorId,
-        internalId: internalId,
-      },
-    });
-    if (folder && folder.parentUrl) {
-      parentUrl = folder.parentUrl;
-    }
-  }
-
-  // If the Page or Folder has no parentUrl, we return an empty array
-  if (!parentUrl) {
-    return new Ok([]);
-  }
-
-  // Otherwise we loop on the parentUrl to retrieve all the parents
-  const visitedUrls = new Set<string>();
-  while (parentUrl) {
-    const parentFolder: WebCrawlerFolder | null =
-      await WebCrawlerFolder.findOne({
+    const [folders, pages] = await Promise.all([
+      WebCrawlerFolder.findAll({
         where: {
-          connectorId: connectorId,
-          url: parentUrl,
+          connectorId: this.connectorId,
+          url: internalIds,
+        },
+      }),
+      WebCrawlerPage.findAll({
+        where: {
+          connectorId: this.connectorId,
+          documentId: internalIds,
+        },
+      }),
+    ]);
+
+    folders.forEach((folder) => {
+      nodes.push({
+        provider: "webcrawler",
+        internalId: folder.internalId,
+        parentInternalId: folder.parentUrl,
+        title: folder.url,
+        sourceUrl: folder.url,
+        expandable: true,
+        permission: "read",
+        dustDocumentId: null,
+        type: "folder",
+        lastUpdatedAt: folder.updatedAt.getTime(),
+      });
+    });
+    pages.forEach((page) => {
+      nodes.push({
+        provider: "webcrawler",
+        internalId: page.documentId,
+        parentInternalId: page.parentUrl,
+        title: page.title ?? page.url,
+        sourceUrl: page.url,
+        expandable: false,
+        permission: "read",
+        dustDocumentId: page.documentId,
+        type: "file",
+        lastUpdatedAt: page.updatedAt.getTime(),
+      });
+    });
+
+    return new Ok(nodes);
+  }
+
+  async retrieveContentNodeParents({
+    internalId,
+  }: {
+    internalId: string;
+    memoizationKey?: string;
+  }): Promise<Result<string[], Error>> {
+    const parents: string[] = [];
+    let parentUrl: string | null = null;
+
+    // First we get the Page or Folder for which we want to retrieve the parents
+    const page = await WebCrawlerPage.findOne({
+      where: {
+        connectorId: this.connectorId,
+        documentId: internalId,
+      },
+    });
+    if (page && page.parentUrl) {
+      parentUrl = page.parentUrl;
+    } else {
+      const folder = await WebCrawlerFolder.findOne({
+        where: {
+          connectorId: this.connectorId,
+          internalId: internalId,
         },
       });
-
-    if (!parentFolder) {
-      parentUrl = null;
-      continue;
-    }
-
-    if (visitedUrls.has(parentFolder.url)) {
-      logger.error(
-        {
-          connectorId,
-          internalId,
-          parents,
-        },
-        "Found a cycle in the parents tree"
-      );
-      parentUrl = null;
-      continue;
-    }
-    parents.push(parentFolder.internalId);
-    visitedUrls.add(parentFolder.url);
-    parentUrl = parentFolder.parentUrl;
-  }
-
-  return new Ok(parents);
-}
-
-export async function setWebcrawlerConfiguration(
-  connectorId: ModelId,
-  configuration: WebCrawlerConfigurationType
-): Promise<Result<void, Error>> {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    return new Err(new Error("Connector not found"));
-  }
-  const depth = configuration.depth;
-  if (!isDepthOption(depth)) {
-    return new Err(
-      new Error(
-        `Invalid depth option. Expected one of: (${DepthOptions.join(",")})`
-      )
-    );
-  }
-
-  if (configuration.maxPageToCrawl > WEBCRAWLER_MAX_PAGES) {
-    return new Err(
-      new Error(`Maximum value for Max Page is ${WEBCRAWLER_MAX_PAGES}`)
-    );
-  }
-  const webcrawlerConfig =
-    await WebCrawlerConfigurationResource.fetchByConnectorId(connector.id);
-
-  if (!webcrawlerConfig) {
-    return new Err(
-      new Error(`Webcrawler configuration not found for ${connectorId}`)
-    );
-  }
-  await webcrawlerConfig.update({
-    url: configuration.url,
-    maxPageToCrawl: configuration.maxPageToCrawl,
-    crawlMode: configuration.crawlMode,
-    depth: depth,
-    crawlFrequency: configuration.crawlFrequency,
-  });
-  const existingHeaders = webcrawlerConfig.getCustomHeaders();
-  const headersForUpdate: Record<string, string> = {};
-  for (const [key, value] of Object.entries(configuration.headers)) {
-    if (value !== WebCrawlerHeaderRedactedValue) {
-      // If the value is not redacted, we use the new value.
-      headersForUpdate[key] = value;
-    } else {
-      // If the value is redacted, we use the existing value from
-      // the database.
-      const existingValue = existingHeaders[key];
-      if (existingValue) {
-        headersForUpdate[key] = existingValue;
+      if (folder && folder.parentUrl) {
+        parentUrl = folder.parentUrl;
       }
     }
+
+    // If the Page or Folder has no parentUrl, we return an empty array
+    if (!parentUrl) {
+      return new Ok([]);
+    }
+
+    // Otherwise we loop on the parentUrl to retrieve all the parents
+    const visitedUrls = new Set<string>();
+    while (parentUrl) {
+      const parentFolder: WebCrawlerFolder | null =
+        await WebCrawlerFolder.findOne({
+          where: {
+            connectorId: this.connectorId,
+            url: parentUrl,
+          },
+        });
+
+      if (!parentFolder) {
+        parentUrl = null;
+        continue;
+      }
+
+      if (visitedUrls.has(parentFolder.url)) {
+        logger.error(
+          {
+            connectorId: this.connectorId,
+            internalId,
+            parents,
+          },
+          "Found a cycle in the parents tree"
+        );
+        parentUrl = null;
+        continue;
+      }
+      parents.push(parentFolder.internalId);
+      visitedUrls.add(parentFolder.url);
+      parentUrl = parentFolder.parentUrl;
+    }
+
+    return new Ok(parents);
   }
 
-  await webcrawlerConfig.setCustomHeaders(headersForUpdate);
-
-  const stopRes = await stopCrawlWebsiteWorkflow(connector.id);
-  if (stopRes.isErr()) {
-    return new Err(stopRes.error);
+  async pause(): Promise<Result<undefined, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      throw new Error("Connector not found.");
+    }
+    await connector.markAsPaused();
+    const stopRes = await stopCrawlWebsiteWorkflow(this.connectorId);
+    if (stopRes.isErr()) {
+      return stopRes;
+    }
+    return new Ok(undefined);
   }
 
-  const startRes = await launchCrawlWebsiteWorkflow(connector.id);
-  if (startRes.isErr()) {
-    return new Err(startRes.error);
+  async unpause(): Promise<Result<undefined, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      throw new Error("Connector not found.");
+    }
+    await connector.markAsUnpaused();
+
+    const startRes = await launchCrawlWebsiteWorkflow(this.connectorId);
+    if (startRes.isErr()) {
+      return startRes;
+    }
+    return new Ok(undefined);
   }
 
-  return new Ok(undefined);
+  async configure({
+    configuration,
+  }: {
+    configuration: WebCrawlerConfigurationType;
+  }): Promise<Result<void, Error>> {
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      return new Err(new Error("Connector not found"));
+    }
+    const depth = configuration.depth;
+    if (!isDepthOption(depth)) {
+      return new Err(
+        new Error(
+          `Invalid depth option. Expected one of: (${DepthOptions.join(",")})`
+        )
+      );
+    }
+
+    if (configuration.maxPageToCrawl > WEBCRAWLER_MAX_PAGES) {
+      return new Err(
+        new Error(`Maximum value for Max Page is ${WEBCRAWLER_MAX_PAGES}`)
+      );
+    }
+    const webcrawlerConfig =
+      await WebCrawlerConfigurationResource.fetchByConnectorId(connector.id);
+
+    if (!webcrawlerConfig) {
+      return new Err(
+        new Error(`Webcrawler configuration not found for ${this.connectorId}`)
+      );
+    }
+    await webcrawlerConfig.update({
+      url: configuration.url,
+      maxPageToCrawl: configuration.maxPageToCrawl,
+      crawlMode: configuration.crawlMode,
+      depth: depth,
+      crawlFrequency: configuration.crawlFrequency,
+    });
+    const existingHeaders = webcrawlerConfig.getCustomHeaders();
+    const headersForUpdate: Record<string, string> = {};
+    for (const [key, value] of Object.entries(configuration.headers)) {
+      if (value !== WebCrawlerHeaderRedactedValue) {
+        // If the value is not redacted, we use the new value.
+        headersForUpdate[key] = value;
+      } else {
+        // If the value is redacted, we use the existing value from
+        // the database.
+        const existingValue = existingHeaders[key];
+        if (existingValue) {
+          headersForUpdate[key] = existingValue;
+        }
+      }
+    }
+
+    await webcrawlerConfig.setCustomHeaders(headersForUpdate);
+
+    const stopRes = await stopCrawlWebsiteWorkflow(connector.id);
+    if (stopRes.isErr()) {
+      return new Err(stopRes.error);
+    }
+
+    const startRes = await launchCrawlWebsiteWorkflow(connector.id);
+    if (startRes.isErr()) {
+      return new Err(startRes.error);
+    }
+
+    return new Ok(undefined);
+  }
+
+  async update(): Promise<Result<string, ConnectorsAPIError>> {
+    throw new Error("Method not implemented.");
+  }
+
+  async resume(): Promise<Result<undefined, Error>> {
+    throw new Error("Method not implemented.");
+  }
+
+  async setPermissions(): Promise<Result<void, Error>> {
+    throw new Error("Method not implemented.");
+  }
+
+  async setConfigurationKey(): Promise<Result<void, Error>> {
+    throw new Error("Method not implemented.");
+  }
+
+  async getConfigurationKey(): Promise<Result<string | null, Error>> {
+    throw new Error("Method not implemented.");
+  }
+
+  async garbageCollect(): Promise<Result<string, Error>> {
+    throw new Error("Method not implemented.");
+  }
 }


### PR DESCRIPTION
## Description

The `Record<ConnectorProvider, fn>` solution was a bit ugly and messy. I made a base class and one sub-class per connector to store the methods. This makes it simpler to see what needs to be implemented for each connector.


## Risk

Risk of breaking connectors, but should be a functional no-op

## Deploy Plan

N/A