### PR TITLE
[front] - fix: standardize `contentType` for file attachments in API

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1896,3 +1896,22 @@ async function isMessagesLimitReached({
     limitType: isLimitReached ? "plan_message_limit_exceeded" : null,
   };
 }
+
+export function normalizeContentFragmentType({
+  contentType,
+  url,
+}: {
+  contentType: SupportedContentFragmentType;
+  url?: string;
+}) {
+  // hack: for users creating content_fragments through our public API
+  if (contentType === "file_attachment") {
+    logger.info(
+      {
+        url,
+      },
+      "ContentFragment of type 'file_attachment' being created"
+    );
+  }
+  return contentType;
+}

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1912,6 +1912,7 @@ export function normalizeContentFragmentType({
       },
       "ContentFragment of type 'file_attachment' being created"
     );
+    return "text/plain";
   }
   return contentType;
 }

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -7,6 +7,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
   getConversation,
+  normalizeContentFragmentType,
   postNewContentFragment,
 } from "@app/lib/api/assistant/conversation";
 import { Authenticator, getAPIKey } from "@app/lib/auth";
@@ -166,15 +167,16 @@ async function handler(
           },
         });
       }
-
+      const normalizedContentType = normalizeContentFragmentType({
+        contentType,
+        url: req.url,
+      });
       const contentFragment = await postNewContentFragment(auth, {
         conversation,
         title,
         content,
         url,
-        // hack: for users creating content_fragments through our public API
-        contentType:
-          contentType === "file_attachment" ? "text/plain" : contentType,
+        contentType: normalizedContentType,
         context: {
           username: context?.username || null,
           fullName: context?.fullName || null,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -15,6 +15,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import {
   createConversation,
   getConversation,
+  normalizeContentFragmentType,
   postNewContentFragment,
 } from "@app/lib/api/assistant/conversation";
 import { postUserMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
@@ -205,11 +206,10 @@ async function handler(
       let newMessage: UserMessageType | null = null;
 
       if (contentFragment) {
-        // hack: for users creating content_fragments through our public API
-        const contentType =
-          contentFragment.contentType === "file_attachment"
-            ? "text/plain"
-            : contentFragment.contentType;
+        const contentType = normalizeContentFragmentType({
+          contentType: contentFragment.contentType,
+          url: req.url,
+        });
         const cf = await postNewContentFragment(auth, {
           conversation,
           title: contentFragment.title,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -205,12 +205,17 @@ async function handler(
       let newMessage: UserMessageType | null = null;
 
       if (contentFragment) {
+        // hack: for users creating content_fragments through our public API
+        const contentType =
+          contentFragment.contentType === "file_attachment"
+            ? "text/plain"
+            : contentFragment.contentType;
         const cf = await postNewContentFragment(auth, {
           conversation,
           title: contentFragment.title,
           content: contentFragment.content,
           url: contentFragment.url,
-          contentType: contentFragment.contentType,
+          contentType,
           context: {
             username: contentFragment.context?.username || null,
             fullName: contentFragment.context?.fullName || null,


### PR DESCRIPTION
## Description

This PR aims at standardizing `contentFragment.contentType` values when fragments are being created through the public API. We for now enforce its value to `text/plain` if the legacy value (`file_attachment`) is being passed.

## Risk

None

## Deploy Plan

Deploy `front`