### PR TITLE
Assistant Builder suggest emoji from instructions

### DIFF
--- a/front/components/assistant/TryAssistant.tsx
+++ b/front/components/assistant/TryAssistant.tsx
@@ -20,6 +20,7 @@ import {
   createConversationWithMessage,
   submitMessage,
 } from "@app/components/assistant/conversation/lib";
+import { getDefaultAvatarUrlForPreview } from "@app/components/assistant_builder/avatar_picker/utils";
 import { submitAssistantBuilderForm } from "@app/components/assistant_builder/submitAssistantBuilderForm";
 import type { AssistantBuilderState } from "@app/components/assistant_builder/types";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
@@ -80,13 +81,14 @@ export function usePreviewAssistant({
       // No changes since the last submission
       return;
     }
+
     const aRes = await submitAssistantBuilderForm({
       owner,
       builderState: {
         handle: builderState.handle,
         description: "Draft Assistant",
         instructions: builderState.instructions,
-        avatarUrl: builderState.avatarUrl,
+        avatarUrl: builderState.avatarUrl ?? getDefaultAvatarUrlForPreview(),
         scope: "private",
         generationSettings: builderState.generationSettings,
         actions: builderState.actions,

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -40,10 +40,6 @@ import NamingScreen, {
   validateHandle,
 } from "@app/components/assistant_builder/NamingScreen";
 import { PrevNextButtons } from "@app/components/assistant_builder/PrevNextButtons";
-import {
-  DROID_AVATAR_URLS,
-  SPIRIT_AVATAR_URLS,
-} from "@app/components/assistant_builder/shared";
 import { submitAssistantBuilderForm } from "@app/components/assistant_builder/submitAssistantBuilderForm";
 import type {
   AssistantBuilderPendingAction,
@@ -186,18 +182,6 @@ export default function AssistantBuilder({
       ? closeRightPanel()
       : openRightPanelTab(template === null ? "Preview" : "Template");
   };
-
-  useEffect(() => {
-    const availableUrls = [...DROID_AVATAR_URLS, ...SPIRIT_AVATAR_URLS];
-    // Only set a random avatar if one isn't already set
-    if (!builderState.avatarUrl) {
-      setBuilderState((state) => ({
-        ...state,
-        avatarUrl:
-          availableUrls[Math.floor(Math.random() * availableUrls.length)],
-      }));
-    }
-  }, [builderState.avatarUrl]);
 
   const formValidation = useCallback(async () => {
     let valid = true;

--- a/front/components/assistant_builder/avatar_picker/AssistantBuilderAvatarPicker.tsx
+++ b/front/components/assistant_builder/avatar_picker/AssistantBuilderAvatarPicker.tsx
@@ -17,7 +17,7 @@ import type { AvatarPickerTabElement } from "@app/components/assistant_builder/a
 type AvatarUrlTabId = "droids" | "spirits";
 type TabId = AvatarUrlTabId | "emojis" | "upload";
 
-const DEFAULT_TAB: TabId = "droids";
+const DEFAULT_TAB: TabId = "emojis";
 
 interface TabConfig {
   label: string;

--- a/front/components/assistant_builder/avatar_picker/utils.ts
+++ b/front/components/assistant_builder/avatar_picker/utils.ts
@@ -41,3 +41,18 @@ export function buildSelectedEmojiType(
 
   return null;
 }
+
+export function getDefaultAvatarUrlForPreview(): string | null {
+  const emoji = buildSelectedEmojiType("🤖");
+  if (!emoji) {
+    return null;
+  }
+  return makeUrlForEmojiAndBackgroud(
+    {
+      id: emoji.id,
+      unified: emoji.unified,
+      native: emoji.native,
+    },
+    `bg-blue-200`
+  );
+}

--- a/front/components/assistant_builder/avatar_picker/utils.ts
+++ b/front/components/assistant_builder/avatar_picker/utils.ts
@@ -1,4 +1,6 @@
 import { avatarUtils } from "@dust-tt/sparkle";
+import type { EmojiMartData as EmojiData } from "@emoji-mart/data";
+import data from "@emoji-mart/data";
 
 import type { SelectedEmojiType } from "@app/components/assistant_builder/avatar_picker/types";
 import { EMOJI_AVATAR_BASE_URL } from "@app/components/assistant_builder/shared";
@@ -18,4 +20,24 @@ export function makeUrlForEmojiAndBackgroud(
   const url = `${EMOJI_AVATAR_BASE_URL}${avatarUrlSuffix}`;
 
   return url;
+}
+
+export function buildSelectedEmojiType(
+  emojiString: string
+): SelectedEmojiType | null {
+  const emojiData: EmojiData = data as EmojiData;
+
+  const emoji = Object.values(emojiData.emojis).find(
+    (e) => e.skins[0].native === emojiString
+  );
+
+  if (emoji) {
+    return {
+      id: emoji.id,
+      native: emoji.skins[0].native,
+      unified: emoji.skins[0].unified,
+    };
+  }
+
+  return null;
 }

--- a/types/src/front/api_handlers/internal/assistant.ts
+++ b/types/src/front/api_handlers/internal/assistant.ts
@@ -39,6 +39,10 @@ export const InternalPostBuilderSuggestionsRequestBodySchema = t.union([
     inputs: t.type({ instructions: t.string, description: t.string }),
   }),
   t.type({
+    type: t.literal("emoji"),
+    inputs: t.type({ instructions: t.string }),
+  }),
+  t.type({
     type: t.literal("instructions"),
     inputs: t.type({
       current_instructions: t.string,
@@ -71,6 +75,13 @@ export const BuilderSuggestionsResponseBodySchema = t.union([
 
 export type BuilderSuggestionsType = t.TypeOf<
   typeof BuilderSuggestionsResponseBodySchema
+>;
+
+export const BuilderEmojiSuggestionsResponseBodySchema = t.type({
+  suggestions: t.array(t.type({ emoji: t.string, backgroundColor: t.string })),
+});
+export type BuilderEmojiSuggestionsType = t.TypeOf<
+  typeof BuilderEmojiSuggestionsResponseBodySchema
 >;
 
 export const InternalPostBuilderProcessActionGenerateSchemaRequestBodySchema =

--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -188,6 +188,21 @@ export const DustProdActionRegistry = createActionRegistry({
       },
     },
   },
+  "assistant-builder-emoji-suggestions": {
+    app: {
+      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
+      appId: "b69YdlJ3PJ",
+      appHash:
+        "68bb3c2bb8bec11abedf110f3cf7ccf86a7685e827c1e3657abc720550002bf3",
+    },
+    config: {
+      CREATE_SUGGESTIONS: {
+        // `provider_id` and `model_id` must be set by caller.
+        function_call: "send_suggestions",
+        use_cache: false,
+      },
+    },
+  },
   "assistant-builder-description-suggestions": {
     app: {
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,


### PR DESCRIPTION
## Description

### TODO

Task: https://github.com/dust-tt/tasks/issues/950
New Assistant Icon is by default an Emoji Icon and it is suggested by the DUST based on Instructions.

### How

I plugged on the assistant builder suggestions logic to keep consistency. 

I created a new `assistant-builder-emoji-suggestions` app that suggest an emoji and a background color. We run it once when we land on the naming screen. If we find an emoji we set it, otherwise we keep the default fallback on droids & spirits.
We don't re-run it if the instructions are changed again (validated with Ed).  

=> No screenshots cause not really anything to screenshot, but you can check it on FrontEdge

## Risk

Break avatars? 

## Deploy Plan

Deploy front. 
