### PR TITLE
[Sparkle] Popup display fix

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.177",
+  "version": "0.2.178",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.177",
+      "version": "0.2.178",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.177",
+  "version": "0.2.178",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/Popup.tsx
+++ b/sparkle/src/components/Popup.tsx
@@ -37,12 +37,13 @@ export function Popup({
       leave="s-transition-opacity s-duration-300"
       leaveFrom="s-opacity-100"
       leaveTo="s-opacity-0"
-      className={classNames(
-        "s-z-30 s-flex s-w-64 s-flex-col s-gap-3 s-rounded-xl s-border s-border-pink-100 s-bg-pink-50 s-p-4 s-shadow-xl",
-        className || ""
-      )}
     >
-      <div>
+      <div
+        className={classNames(
+          "s-z-30 s-flex s-w-64 s-flex-col s-gap-3 s-rounded-xl s-border s-border-pink-100 s-bg-pink-50 s-p-4 s-shadow-xl",
+          className || ""
+        )}
+      >
         <div className="s-flex">
           <Chip color="pink">{chipLabel}</Chip>
           {onClose && (


### PR DESCRIPTION
Description
---
Following #5955  a regression on popup display was introduced, see [here](https://dust4ai.slack.com/archives/C050A0S2Z7F/p1719908758185319) 
This removes the regression
![image](https://github.com/dust-tt/dust/assets/5437393/b24e9e37-f2dc-40b1-a2a1-79ce5d0e8d3d)

Risk & Deploy
---
na
