### PR TITLE
Fix raw model assistants authors

### DIFF
--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -61,6 +61,28 @@ export enum GLOBAL_AGENTS_SID {
   GEMINI_PRO = "gemini-pro",
 }
 
+export function getGlobalAgentAuthorName(agentId: string): string {
+  switch (agentId) {
+    case GLOBAL_AGENTS_SID.GPT35_TURBO:
+    case GLOBAL_AGENTS_SID.GPT4:
+      return "OpenAI";
+    case GLOBAL_AGENTS_SID.CLAUDE_INSTANT:
+    case GLOBAL_AGENTS_SID.CLAUDE_3_OPUS:
+    case GLOBAL_AGENTS_SID.CLAUDE_3_SONNET:
+    case GLOBAL_AGENTS_SID.CLAUDE_3_HAIKU:
+    case GLOBAL_AGENTS_SID.CLAUDE_2:
+      return "Anthropic";
+    case GLOBAL_AGENTS_SID.MISTRAL_LARGE:
+    case GLOBAL_AGENTS_SID.MISTRAL_MEDIUM:
+    case GLOBAL_AGENTS_SID.MISTRAL_SMALL:
+      return "Mistral";
+    case GLOBAL_AGENTS_SID.GEMINI_PRO:
+      return "Google";
+    default:
+      return "Dust";
+  }
+}
+
 const CUSTOM_ORDER: string[] = [
   GLOBAL_AGENTS_SID.DUST,
   GLOBAL_AGENTS_SID.GPT4,


### PR DESCRIPTION
## Description

Task: https://github.com/dust-tt/tasks/issues/961
Fixes the author name of the global agents. 

I did not want to touch the type `AgentConfigurationType` for this so I added a function with a switch. It's located right below where we define the list of global agent to ensure the chances it's updated when needed, yet in any case we have the default behavior set to Dust as we had before so not the biggest deal. 

## Risk

Low, default is always set to "Dust" as before. 

## Deploy Plan

Deploy front. 
