### PR TITLE
[Gdrive] Full re-sync of PPTX and DOCX for all Gdrives

### DIFF
--- a/connectors/migrations/20240702_gdrive_fullsync_pptx_docx.ts
+++ b/connectors/migrations/20240702_gdrive_fullsync_pptx_docx.ts
@@ -13,15 +13,19 @@ export async function main() {
       pausedAt: null,
     },
   });
-  const additionalFilter =
-    " and (mimeType = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' or mimeType = 'application/vnd.openxmlformats-officedocument.presentationml.presentation' or mimeType = 'application/vnd.google-apps.folder')";
+  const mimeTypeFilter = [
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    "application/vnd.google-apps.folder",
+  ];
+
   for (const connector of connectors) {
     try {
       if (LIVE) {
         await launchGoogleDriveFullSyncWorkflow(
           connector.id,
           null,
-          additionalFilter
+          mimeTypeFilter
         );
       }
     } catch (e) {

--- a/connectors/migrations/20240702_gdrive_fullsync_pptx_docx.ts
+++ b/connectors/migrations/20240702_gdrive_fullsync_pptx_docx.ts
@@ -1,0 +1,36 @@
+import { launchGoogleDriveFullSyncWorkflow } from "@connectors/connectors/google_drive/temporal/client";
+import logger from "@connectors/logger/logger";
+import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
+
+const { LIVE } = process.env;
+
+// Syncing all pptx and docx files for all existing Google Drive connectors.
+export async function main() {
+  const connectors = await ConnectorModel.findAll({
+    where: {
+      type: "google_drive",
+      errorType: null,
+      pausedAt: null,
+    },
+  });
+  const additionalFilter =
+    " and (mimeType = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' or mimeType = 'application/vnd.openxmlformats-officedocument.presentationml.presentation' or mimeType = 'application/vnd.google-apps.folder')";
+  for (const connector of connectors) {
+    try {
+      if (LIVE) {
+        await launchGoogleDriveFullSyncWorkflow(
+          connector.id,
+          null,
+          additionalFilter
+        );
+      }
+    } catch (e) {
+      logger.error(
+        { connectorId: connector.id, error: e },
+        "Failed to launch workflow - skipping"
+      );
+    }
+  }
+}
+
+main().catch(console.error);

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -202,13 +202,12 @@ export async function syncFiles(
 
   const drive = await getDriveClient(authCredentials);
   const mimeTypesSearchString = mimeTypesToSync
+    .filter(
+      (mimeType) =>
+        mimeTypeFilter === undefined || mimeTypeFilter.includes(mimeType)
+    )
     .map((mimeType) => `mimeType='${mimeType}'`)
     .join(" or ");
-
-  const mimeTypeFilterString =
-    mimeTypeFilter && mimeTypeFilter.length > 0
-      ? `and (${mimeTypeFilter.map((mimeType) => `mimeType='${mimeType}'`).join(" or ")})`
-      : ``;
 
   const res = await drive.files.list({
     corpora: "allDrives",
@@ -216,7 +215,7 @@ export async function syncFiles(
     includeItemsFromAllDrives: true,
     supportsAllDrives: true,
     fields: `nextPageToken, files(${FILE_ATTRIBUTES_TO_FETCH.join(",")})`,
-    q: `'${driveFolder.id}' in parents and (${mimeTypesSearchString}) and trashed=false ${mimeTypeFilterString}`,
+    q: `'${driveFolder.id}' in parents and (${mimeTypesSearchString}) and trashed=false`,
     pageToken: nextPageToken,
   });
   if (res.status !== 200) {

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -138,7 +138,7 @@ export async function syncFiles(
   driveFolderId: string,
   startSyncTs: number,
   nextPageToken?: string,
-  additionalFilter: string | undefined = undefined
+  mimeTypeFilter?: string[]
 ): Promise<{
   nextPageToken: string | null;
   count: number;
@@ -205,13 +205,18 @@ export async function syncFiles(
     .map((mimeType) => `mimeType='${mimeType}'`)
     .join(" or ");
 
+  const mimeTypeFilterString =
+    mimeTypeFilter && mimeTypeFilter.length > 0
+      ? `and (${mimeTypeFilter.map((mimeType) => `mimeType='${mimeType}'`).join(" or ")})`
+      : ``;
+
   const res = await drive.files.list({
     corpora: "allDrives",
     pageSize: 200,
     includeItemsFromAllDrives: true,
     supportsAllDrives: true,
     fields: `nextPageToken, files(${FILE_ATTRIBUTES_TO_FETCH.join(",")})`,
-    q: `'${driveFolder.id}' in parents and (${mimeTypesSearchString}) and trashed=false ${additionalFilter ?? ""}`,
+    q: `'${driveFolder.id}' in parents and (${mimeTypesSearchString}) and trashed=false ${mimeTypeFilterString}`,
     pageToken: nextPageToken,
   });
   if (res.status !== 200) {

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -135,10 +135,10 @@ export async function getDrivesToSync(
 
 export async function syncFiles(
   connectorId: ModelId,
-  dataSourceConfig: DataSourceConfig,
   driveFolderId: string,
   startSyncTs: number,
-  nextPageToken?: string
+  nextPageToken?: string,
+  additionalFilter: string | undefined = undefined
 ): Promise<{
   nextPageToken: string | null;
   count: number;
@@ -153,6 +153,8 @@ export async function syncFiles(
       connectorId: connectorId,
     },
   });
+
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
 
   logger.info(
     {
@@ -209,7 +211,7 @@ export async function syncFiles(
     includeItemsFromAllDrives: true,
     supportsAllDrives: true,
     fields: `nextPageToken, files(${FILE_ATTRIBUTES_TO_FETCH.join(",")})`,
-    q: `'${driveFolder.id}' in parents and (${mimeTypesSearchString}) and trashed=false`,
+    q: `'${driveFolder.id}' in parents and (${mimeTypesSearchString}) and trashed=false ${additionalFilter ?? ""}`,
     pageToken: nextPageToken,
   });
   if (res.status !== 200) {

--- a/connectors/src/connectors/google_drive/temporal/client.ts
+++ b/connectors/src/connectors/google_drive/temporal/client.ts
@@ -23,7 +23,8 @@ const logger = mainLogger.child({ provider: "google" });
 
 export async function launchGoogleDriveFullSyncWorkflow(
   connectorId: ModelId,
-  fromTs: number | null
+  fromTs: number | null,
+  additionalFilter?: string
 ): Promise<Result<string, Error>> {
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
@@ -44,7 +45,16 @@ export async function launchGoogleDriveFullSyncWorkflow(
   try {
     await terminateWorkflow(workflowId);
     await client.workflow.start(googleDriveFullSync, {
-      args: [connectorId, dataSourceConfig],
+      args: [
+        {
+          connectorId: connectorId,
+          garbageCollect: true,
+          startSyncTs: undefined,
+          foldersToBrowse: undefined,
+          totalCount: 0,
+          additionalFilter: additionalFilter,
+        },
+      ],
       taskQueue: GDRIVE_FULL_SYNC_QUEUE_NAME,
       workflowId: workflowId,
       searchAttributes: {

--- a/connectors/src/connectors/google_drive/temporal/client.ts
+++ b/connectors/src/connectors/google_drive/temporal/client.ts
@@ -24,7 +24,7 @@ const logger = mainLogger.child({ provider: "google" });
 export async function launchGoogleDriveFullSyncWorkflow(
   connectorId: ModelId,
   fromTs: number | null,
-  additionalFilter?: string
+  mimeTypeFilter?: string[]
 ): Promise<Result<string, Error>> {
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
@@ -52,7 +52,7 @@ export async function launchGoogleDriveFullSyncWorkflow(
           startSyncTs: undefined,
           foldersToBrowse: undefined,
           totalCount: 0,
-          additionalFilter: additionalFilter,
+          mimeTypeFilter: mimeTypeFilter,
         },
       ],
       taskQueue: GDRIVE_FULL_SYNC_QUEUE_NAME,

--- a/connectors/src/connectors/google_drive/temporal/config.ts
+++ b/connectors/src/connectors/google_drive/temporal/config.ts
@@ -1,3 +1,4 @@
-export const WORKFLOW_VERSION = 5;
-export const GDRIVE_FULL_SYNC_QUEUE_NAME = `google-queue-fullsync-v${WORKFLOW_VERSION}`;
-export const GDRIVE_INCREMENTAL_SYNC_QUEUE_NAME = `google-queue-incremental-v${WORKFLOW_VERSION}`;
+const GDRIVE_FULL_SYNC_QUEUE_VERSION = 6;
+const GDRIVE_INCREMENTAL_SYNC_QUEUE_VERSION = 5;
+export const GDRIVE_FULL_SYNC_QUEUE_NAME = `google-queue-fullsync-v${GDRIVE_FULL_SYNC_QUEUE_VERSION}`;
+export const GDRIVE_INCREMENTAL_SYNC_QUEUE_NAME = `google-queue-incremental-v${GDRIVE_INCREMENTAL_SYNC_QUEUE_VERSION}`;

--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -41,14 +41,21 @@ const { reportInitialSyncProgress, syncSucceeded } = proxyActivities<
   startToCloseTimeout: "10 minutes",
 });
 
-export async function googleDriveFullSync(
-  connectorId: ModelId,
-  dataSourceConfig: DataSourceConfig,
+export async function googleDriveFullSync({
+  connectorId,
   garbageCollect = true,
-  foldersToBrowse: string[] | undefined = undefined,
+  foldersToBrowse = undefined,
   totalCount = 0,
-  startSyncTs: number | undefined = undefined
-) {
+  startSyncTs = undefined,
+  additionalFilter,
+}: {
+  connectorId: ModelId;
+  garbageCollect: boolean;
+  foldersToBrowse: string[] | undefined;
+  totalCount: number;
+  startSyncTs: number | undefined;
+  additionalFilter: string | undefined;
+}) {
   // Running the incremental sync workflow before the full sync to populate the
   // Google Drive sync tokens.
   await populateSyncTokens(connectorId);
@@ -69,10 +76,10 @@ export async function googleDriveFullSync(
     do {
       const res = await syncFiles(
         connectorId,
-        dataSourceConfig,
         folder,
         startSyncTs,
-        nextPageToken
+        nextPageToken,
+        additionalFilter
       );
       nextPageToken = res.nextPageToken ? res.nextPageToken : undefined;
       totalCount += res.count;
@@ -85,14 +92,14 @@ export async function googleDriveFullSync(
     } while (nextPageToken);
     await markFolderAsVisited(connectorId, folder);
     if (workflowInfo().historyLength > 4000) {
-      await continueAsNew<typeof googleDriveFullSync>(
+      await continueAsNew<typeof googleDriveFullSync>({
         connectorId,
-        dataSourceConfig,
         garbageCollect,
         foldersToBrowse,
         totalCount,
-        startSyncTs
-      );
+        startSyncTs,
+        additionalFilter,
+      });
     }
   }
   await syncSucceeded(connectorId);

--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -47,14 +47,14 @@ export async function googleDriveFullSync({
   foldersToBrowse = undefined,
   totalCount = 0,
   startSyncTs = undefined,
-  additionalFilter,
+  mimeTypeFilter,
 }: {
   connectorId: ModelId;
   garbageCollect: boolean;
   foldersToBrowse: string[] | undefined;
   totalCount: number;
   startSyncTs: number | undefined;
-  additionalFilter: string | undefined;
+  mimeTypeFilter?: string[];
 }) {
   // Running the incremental sync workflow before the full sync to populate the
   // Google Drive sync tokens.
@@ -79,7 +79,7 @@ export async function googleDriveFullSync({
         folder,
         startSyncTs,
         nextPageToken,
-        additionalFilter
+        mimeTypeFilter
       );
       nextPageToken = res.nextPageToken ? res.nextPageToken : undefined;
       totalCount += res.count;
@@ -98,7 +98,7 @@ export async function googleDriveFullSync({
         foldersToBrowse,
         totalCount,
         startSyncTs,
-        additionalFilter,
+        mimeTypeFilter,
       });
     }
   }


### PR DESCRIPTION
## Description

Since we communicated to the users that we support PPTX and DOCX on Google Drive in our latest product update email , I am adding a migration script to sync all PPTX and DOCX for all existing Gdrive connectors.

This required a little change in the full sync workflow to support filtering for these files only.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

No risk, if a full sync workflow for a given connectors is started while on of these is running, the already running one will be killed and the new one would sync everything, including PPTX and DOCX.
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- Deploy connectors
- Start the migration

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
