### PR TITLE
Same UX for all lists of assistant on manage page

### DIFF
--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -1,5 +1,4 @@
 import {
-  AssistantPreview,
   Avatar,
   Button,
   Cog6ToothIcon,
@@ -319,23 +318,6 @@ function AgentViewForScope({
   setShowDisabledFreeWorkspacePopup: (s: string | null) => void;
 }) {
   const router = useRouter();
-  if (scopeView === "published") {
-    return (
-      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-        {agents.map((a) => (
-          <AssistantPreview
-            key={a.sId}
-            title={a.name}
-            pictureUrl={a.pictureUrl}
-            subtitle={a.lastAuthors?.join(", ") ?? ""}
-            description={a.description}
-            variant="list"
-            onClick={() => setShowDetails(a)}
-          />
-        ))}
-      </div>
-    );
-  }
 
   return (
     <ContextItem.List>


### PR DESCRIPTION
## Description

Task: https://github.com/dust-tt/tasks/issues/988

=> On the [builder/assistants page](https://dust.tt/w/0ec9852c2f/builder/assistants), we were using a different list component for the "shared" assistant. Ed asked that we use the same component for all tabs. 

## Risk

/

## Deploy Plan

Deploy front. 
