### PR TITLE
[chore] - chore(UX): impacted assistant datasource

### DIFF
--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -1,11 +1,11 @@
-import type { ConnectorProvider } from "@dust-tt/types";
+import type { ConnectorProvider, ModelId } from "@dust-tt/types";
 import { Sequelize } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
 import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
 import { DataSource } from "@app/lib/models/data_source";
 
-export type DataSourcesUsageByAgent = Record<number, number>;
+export type DataSourcesUsageByAgent = Record<ModelId, number>;
 
 export async function getDataSourcesUsageByAgents({
   auth,

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -1,0 +1,75 @@
+import type { ConnectorProvider } from "@dust-tt/types";
+
+import type { Authenticator } from "@app/lib/auth";
+import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
+import { DataSource } from "@app/lib/models/data_source";
+import { User } from "@app/lib/models/user";
+import { Workspace } from "@app/lib/models/workspace";
+
+export type AgentEnabledDataSource = {
+  workspaceId: number;
+  dataSourceId: number;
+  dataSourceName: string;
+  dataSourceDescription: string | null;
+  connectorProvider: ConnectorProvider | null;
+  connectorId: string | null;
+  createdAt: number;
+  createdBy: string;
+};
+
+export async function getAgentEnabledDataSources({
+  auth,
+  providerFilter,
+}: {
+  auth: Authenticator;
+  providerFilter?: ConnectorProvider;
+}): Promise<AgentEnabledDataSource[]> {
+  const owner = auth.workspace();
+
+  // This condition is critical it checks that we can identify the workspace and that the current
+  // auth is a user for this workspace. Checking `auth.isUser()` is critical as it would otherwise
+  // be possible to access data sources without being authenticated.
+  if (!owner || !auth.isUser()) {
+    return [];
+  }
+  const workspace = await Workspace.findOne({
+    where: { sId: owner.sId },
+  });
+  if (!workspace) {
+    throw new Error(`Workspace not found for sId: ${owner.sId}`);
+  }
+  const wId = workspace.id;
+
+  const filters = providerFilter
+    ? {
+        workspaceId: wId,
+        connectorProvider: providerFilter,
+      }
+    : { workspaceId: wId };
+
+  const dataSourceConfigurations = await AgentDataSourceConfiguration.findAll({
+    include: [
+      {
+        model: DataSource,
+        as: "dataSource",
+        where: filters,
+        include: [
+          {
+            model: User,
+            as: "editedByUser",
+          },
+        ],
+      },
+    ],
+  });
+  return dataSourceConfigurations.map((dsConfig) => ({
+    workspaceId: wId,
+    dataSourceId: dsConfig.dataSource.id,
+    dataSourceName: dsConfig.dataSource.name,
+    connectorProvider: dsConfig.dataSource.connectorProvider,
+    connectorId: dsConfig.dataSource.connectorId,
+    createdAt: dsConfig.createdAt.getTime(),
+    createdBy: dsConfig.dataSource.editedByUser.name,
+    dataSourceDescription: dsConfig.dataSource.description,
+  }));
+}

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -52,6 +52,6 @@ export async function getAgentEnabledDataSources({
     ],
   });
   return dataSourceConfigurations.map((dsConfig) => ({
-    dataSourceId: dsConfig.dataSource.id
+    dataSourceId: dsConfig.dataSource.id,
   }));
 }

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -17,7 +17,7 @@ export async function getAgentEnabledDataSources({
   providerFilter,
 }: {
   auth: Authenticator;
-  providerFilter?: ConnectorProvider;
+  providerFilter: ConnectorProvider | null;
 }): Promise<AgentEnabledDataSource[]> {
   const owner = auth.workspace();
 
@@ -35,19 +35,15 @@ export async function getAgentEnabledDataSources({
   }
   const wId = workspace.id;
 
-  const filters = providerFilter
-    ? {
-        workspaceId: wId,
-        connectorProvider: providerFilter,
-      }
-    : { workspaceId: wId };
-
   const dataSourceConfigurations = await AgentDataSourceConfiguration.findAll({
     include: [
       {
         model: DataSource,
         as: "dataSource",
-        where: filters,
+        where: {
+          workspaceId: wId,
+          connectorProvider: providerFilter,
+        },
         include: [
           {
             model: User,
@@ -58,7 +54,7 @@ export async function getAgentEnabledDataSources({
     ],
   });
   return dataSourceConfigurations.map((dsConfig) => ({
-    dataSourceId: dsConfig.id,
+    dataSourceId: dsConfig.dataSource.id,
     retrievalConfigurationId: dsConfig.retrievalConfigurationId,
     processConfigurationId: dsConfig.processConfigurationId,
   }));

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -20,7 +20,7 @@ export async function getDataSourcesUsageByAgents({
   // auth is a user for this workspace. Checking `auth.isUser()` is critical as it would otherwise
   // be possible to access data sources without being authenticated.
   if (!owner || !auth.isUser()) {
-    return [];
+    return {};
   }
 
   const agentDataSourceConfigurations =
@@ -42,10 +42,13 @@ export async function getDataSourcesUsageByAgents({
       group: ["dataSource.id"],
       raw: true,
     });
-  return agentDataSourceConfigurations.reduce((acc, dsConfig) => {
-    acc[dsConfig.dataSourceId] = (
-      dsConfig as unknown as { count: number }
-    ).count;
-    return acc;
-  }, {} as DataSourcesUsageByAgent);
+  return agentDataSourceConfigurations.reduce<DataSourcesUsageByAgent>(
+    (acc, dsConfig) => {
+      acc[dsConfig.dataSourceId] = (
+        dsConfig as unknown as { count: number }
+      ).count;
+      return acc;
+    },
+    {}
+  );
 }

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -7,14 +7,9 @@ import { User } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
 
 export type AgentEnabledDataSource = {
-  workspaceId: number;
   dataSourceId: number;
-  dataSourceName: string;
-  dataSourceDescription: string | null;
-  connectorProvider: ConnectorProvider | null;
-  connectorId: string | null;
-  createdAt: number;
-  createdBy: string;
+  retrievalConfigurationId: number | null;
+  processConfigurationId: number | null;
 };
 
 export async function getAgentEnabledDataSources({
@@ -63,13 +58,8 @@ export async function getAgentEnabledDataSources({
     ],
   });
   return dataSourceConfigurations.map((dsConfig) => ({
-    workspaceId: wId,
-    dataSourceId: dsConfig.dataSource.id,
-    dataSourceName: dsConfig.dataSource.name,
-    connectorProvider: dsConfig.dataSource.connectorProvider,
-    connectorId: dsConfig.dataSource.connectorId,
-    createdAt: dsConfig.createdAt.getTime(),
-    createdBy: dsConfig.dataSource.editedByUser.name,
-    dataSourceDescription: dsConfig.dataSource.description,
+    dataSourceId: dsConfig.id,
+    retrievalConfigurationId: dsConfig.retrievalConfigurationId,
+    processConfigurationId: dsConfig.processConfigurationId,
   }));
 }

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -8,8 +8,6 @@ import { Workspace } from "@app/lib/models/workspace";
 
 export type AgentEnabledDataSource = {
   dataSourceId: number;
-  retrievalConfigurationId: number | null;
-  processConfigurationId: number | null;
 };
 
 export async function getAgentEnabledDataSources({
@@ -54,8 +52,6 @@ export async function getAgentEnabledDataSources({
     ],
   });
   return dataSourceConfigurations.map((dsConfig) => ({
-    dataSourceId: dsConfig.dataSource.id,
-    retrievalConfigurationId: dsConfig.retrievalConfigurationId,
-    processConfigurationId: dsConfig.processConfigurationId,
+    dataSourceId: dsConfig.dataSource.id
   }));
 }

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -26,7 +26,7 @@ export async function getDataSourcesUsageByAgents({
   const agentDataSourceConfigurations =
     await AgentDataSourceConfiguration.findAll({
       attributes: [
-        "dataSource.id",
+        [Sequelize.col("dataSource.id"), "dataSourceId"],
         [Sequelize.fn("COUNT", Sequelize.col("dataSource.id")), "count"],
       ],
       include: [
@@ -43,7 +43,9 @@ export async function getDataSourcesUsageByAgents({
       raw: true,
     });
   return agentDataSourceConfigurations.reduce((acc, dsConfig) => {
-    acc[dsConfig.id] = (dsConfig as unknown as { count: number }).count;
+    acc[dsConfig.dataSourceId] = (
+      dsConfig as unknown as { count: number }
+    ).count;
     return acc;
   }, {} as DataSourcesUsageByAgent);
 }

--- a/front/lib/models/data_source.ts
+++ b/front/lib/models/data_source.ts
@@ -87,7 +87,7 @@ DataSource.init(
     sequelize: frontSequelize,
     indexes: [
       { fields: ["workspaceId", "name"], unique: true },
-      { fields: ["connectorProvider"] },
+      { fields: ["workspaceId", "connectorProvider"] },
     ],
   }
 );

--- a/front/lib/models/data_source.ts
+++ b/front/lib/models/data_source.ts
@@ -85,7 +85,10 @@ DataSource.init(
   {
     modelName: "data_source",
     sequelize: frontSequelize,
-    indexes: [{ fields: ["workspaceId", "name"], unique: true }],
+    indexes: [
+      { fields: ["workspaceId", "name"], unique: true },
+      { fields: ["connectorProvider"] },
+    ],
   }
 );
 Workspace.hasMany(DataSource, {

--- a/front/migrations/db/migration_34.sql
+++ b/front/migrations/db/migration_34.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jul 04, 2024
+CREATE INDEX CONCURRENTLY "data_source_workspace_connector_provider" ON "data_source" ("workspaceId", "connectorProvider");

--- a/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
@@ -58,7 +58,10 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   const readOnly = !auth.isBuilder();
 
   const allDataSources = await getDataSources(auth, { includeEditedBy: true });
-  const agentEnabledDataSources = await getAgentEnabledDataSources({ auth });
+  const agentEnabledDataSources = await getAgentEnabledDataSources({
+    auth,
+    providerFilter: "webcrawler",
+  });
 
   const connectorsAPI = new ConnectorsAPI(logger);
   const dataSources = await Promise.all(

--- a/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
@@ -1,11 +1,10 @@
 import {
-  Button,
-  Cog6ToothIcon,
   ContextItem,
   FolderOpenIcon,
   Page,
   PlusIcon,
   Popup,
+  RobotIcon,
 } from "@dust-tt/sparkle";
 import { GlobeAltIcon } from "@dust-tt/sparkle";
 import type { PlanType, SubscriptionType } from "@dust-tt/types";
@@ -15,14 +14,17 @@ import type {
   WorkspaceType,
 } from "@dust-tt/types";
 import { ConnectorsAPI } from "@dust-tt/types";
+import _ from "lodash";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import ConnectorSyncingChip from "@app/components/data_source/DataSourceSyncChip";
 import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
 import { subNavigationBuild } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
+import type { AgentEnabledDataSource } from "@app/lib/api/agent_data_sources";
+import { getAgentEnabledDataSources } from "@app/lib/api/agent_data_sources";
 import { getDataSources } from "@app/lib/api/data_sources";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
@@ -41,6 +43,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   readOnly: boolean;
   dataSources: DataSourceWithConnector[];
   gaTrackingId: string;
+  agentEnabledDataSources: AgentEnabledDataSource[];
 }>(async (context, auth) => {
   const owner = auth.workspace();
   const plan = auth.plan();
@@ -54,7 +57,9 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
 
   const readOnly = !auth.isBuilder();
 
-  const allDataSources = await getDataSources(auth);
+  const allDataSources = await getDataSources(auth, { includeEditedBy: true });
+  const agentEnabledDataSources = await getAgentEnabledDataSources({ auth });
+
   const connectorsAPI = new ConnectorsAPI(logger);
   const dataSources = await Promise.all(
     allDataSources
@@ -82,6 +87,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       readOnly,
       dataSources,
       gaTrackingId: GA_TRACKING_ID,
+      agentEnabledDataSources,
     },
   };
 });
@@ -93,6 +99,7 @@ export default function DataSourcesView({
   readOnly,
   dataSources,
   gaTrackingId,
+  agentEnabledDataSources,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
   const [showDatasourceLimitPopup, setShowDatasourceLimitPopup] =
@@ -112,6 +119,10 @@ export default function DataSourcesView({
       void router.push(`/w/${owner.sId}/builder/data-sources/new-public-url`);
     }
   });
+
+  const agentCountPerDataSource = useMemo(() => {
+    return _.countBy(agentEnabledDataSources, "dataSourceId");
+  }, [agentEnabledDataSources]);
 
   return (
     <AppLayout
@@ -169,7 +180,6 @@ export default function DataSourcesView({
             icon={PlusIcon}
           />
         )}
-
         <ContextItem.List>
           {dataSources.map((ds) => (
             <ContextItem
@@ -186,30 +196,28 @@ export default function DataSourcesView({
                   }
                 />
               }
+              onClick={() => {
+                void router.push(
+                  `/w/${
+                    owner.sId
+                  }/builder/data-sources/${encodeURIComponent(ds.name)}`
+                );
+              }}
               action={
-                <Button.List>
-                  <Button
-                    variant="secondary"
-                    icon={Cog6ToothIcon}
-                    onClick={() => {
-                      void router.push(
-                        `/w/${
-                          owner.sId
-                        }/builder/data-sources/${encodeURIComponent(ds.name)}`
-                      );
-                    }}
-                    label="Manage"
-                  />
-                </Button.List>
+                <ConnectorSyncingChip
+                  initialState={ds.connector}
+                  workspaceId={ds.connector.workspaceId}
+                  dataSourceName={ds.connector.dataSourceName}
+                />
               }
             >
               <ContextItem.Description>
-                <div className="pt-1">
-                  <ConnectorSyncingChip
-                    initialState={ds.connector}
-                    workspaceId={ds.connector.workspaceId}
-                    dataSourceName={ds.connector.dataSourceName}
-                  />
+                <div className="mt-1 flex items-center gap-1 text-xs text-element-700">
+                  <span>Added by: {ds.editedByUser?.fullName} | </span>
+                  <span className="underline">
+                    {agentCountPerDataSource[ds.id] ?? 0}
+                  </span>
+                  <RobotIcon />
                 </div>
               </ContextItem.Description>
             </ContextItem>

--- a/front/pages/w/[wId]/builder/data-sources/static.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/static.tsx
@@ -48,9 +48,12 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
 
   const readOnly = !auth.isBuilder();
 
+  const agentEnabledDataSources = await getAgentEnabledDataSources({
+    auth,
+    providerFilter: null,
+  });
   const allDataSources = await getDataSources(auth, { includeEditedBy: true });
   const dataSources = allDataSources.filter((ds) => !ds.connectorId);
-  const agentEnabledDataSources = await getAgentEnabledDataSources({ auth });
   return {
     props: {
       owner,
@@ -90,7 +93,6 @@ export default function DataSourcesView({
       void router.push(`/w/${owner.sId}/builder/data-sources/new`);
     }
   });
-
   const agentCountPerDataSource = useMemo(() => {
     return _.countBy(agentEnabledDataSources, "dataSourceId");
   }, [agentEnabledDataSources]);


### PR DESCRIPTION
## Description

This PR aims at displaying how many assistants use a given data source (website or folder).

This is based on the following task: https://github.com/dust-tt/tasks/issues/849

See screenshots below:

<img width="1020" alt="Screenshot 2024-07-02 at 15 26 22" src="https://github.com/dust-tt/dust/assets/32683010/7faf74c1-0a04-47b7-88d5-ee2f6259789d">

<img width="1020" alt="Screenshot 2024-07-02 at 15 25 59" src="https://github.com/dust-tt/dust/assets/32683010/bbaed1e2-4262-4227-82c7-2d7848d4c944">

## Risk 

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
