### PR TITLE
[front] - fix: adjust website config modal title based on edit state 

### DIFF
--- a/front/components/data_source/WebsiteConfiguration.tsx
+++ b/front/components/data_source/WebsiteConfiguration.tsx
@@ -267,7 +267,7 @@ export default function WebsiteConfiguration({
       })}
       titleChildren={
         <AppLayoutSimpleSaveCancelTitle
-          title="Add a Website"
+          title={webCrawlerConfiguration ? "Edit Website" : "Add a Website"}
           onSave={() => {
             setIsSubmitted(true);
             if (!isSaving) {


### PR DESCRIPTION
## Description

Modify the title to display "Edit Website" when modifying an existing configuration, else "Add a Website" for new entries

## Risk

None

## Deploy Plan

Deploy `front`