### PR TITLE
enh: consume pending invitation in ent signup flow

### DIFF
--- a/front/lib/iam/invitations.ts
+++ b/front/lib/iam/invitations.ts
@@ -56,6 +56,19 @@ export async function getPendingMembershipInvitationForToken(
   return new Ok(null);
 }
 
+export async function getPendingMembershipInvitationForEmailAndWorkspace(
+  email: string,
+  workspaceId: number
+): Promise<MembershipInvitation | null> {
+  return MembershipInvitation.findOne({
+    where: {
+      inviteEmail: email,
+      workspaceId,
+      status: "pending",
+    },
+  });
+}
+
 export async function markInvitationAsConsumed(
   membershipInvite: MembershipInvitation,
   user: UserType


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/1003

When users are invited by email with a specific role into a workspace that has SSO enforced, they are redirected into the enterprise signup flow, which doesn't consume pending membership invitations.
The issue is that the initial role set in the invitation is not honored, which  causes users to always have the default "user" role despite the choice of the admin.

## Risk

Critical path (incl security)

## Deploy Plan

N/A