### PR TITLE
 feat: store raw agent message contents

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -38,6 +38,7 @@ import {
   AgentUserRelation,
   GlobalAgentSettings,
 } from "@app/lib/models/assistant/agent";
+import { AgentMessageContent } from "@app/lib/models/assistant/agent_message_content";
 import {
   AgentMessage,
   Conversation,
@@ -137,6 +138,7 @@ async function main() {
   await AgentWebsearchAction.sync({ alter: true });
   await AgentBrowseAction.sync({ alter: true });
   await AgentVisualizationAction.sync({ alter: true });
+  await AgentMessageContent.sync({ alter: true });
 
   await RetrievalDocument.sync({ alter: true });
   await RetrievalDocumentChunk.sync({ alter: true });

--- a/front/lib/models/assistant/agent_message_content.ts
+++ b/front/lib/models/assistant/agent_message_content.ts
@@ -1,0 +1,89 @@
+import type {
+  CreationOptional,
+  ForeignKey,
+  InferAttributes,
+  InferCreationAttributes,
+} from "sequelize";
+import { DataTypes, Model } from "sequelize";
+
+import { AgentMessage } from "@app/lib/models/assistant/conversation";
+import { frontSequelize } from "@app/lib/resources/storage";
+
+// Captures content that is emitted by an assistant before using a tool.
+// This content is not part of the final message sent to the user and is not
+// stored in the AgentMessage table.
+// TODO(fontanierh): Also store the final generation in this table.
+// Ultimately, this table should model the `content` field of the model provider messages.
+export class AgentMessageContent extends Model<
+  InferAttributes<AgentMessageContent>,
+  InferCreationAttributes<AgentMessageContent>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare agentMessageId: ForeignKey<AgentMessage["id"]>;
+  declare step: number;
+
+  declare content: string;
+}
+
+AgentMessageContent.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    agentMessageId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    step: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    content: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize: frontSequelize,
+    modelName: "agent_message_content",
+    indexes: [
+      {
+        fields: ["agentMessageId", "step"],
+        unique: true,
+      },
+    ],
+  }
+);
+
+AgentMessageContent.belongsTo(AgentMessage, {
+  as: "agentMessage",
+  foreignKey: {
+    name: "agentMessageId",
+    allowNull: false,
+  },
+  onDelete: "CASCADE",
+});
+
+AgentMessage.hasMany(AgentMessageContent, {
+  as: "agentMessageContents",
+  foreignKey: {
+    name: "agentMessageId",
+    allowNull: false,
+  },
+  onDelete: "CASCADE",
+});

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -14,6 +14,7 @@ import type {
 } from "sequelize";
 import { DataTypes, Model } from "sequelize";
 
+import type { AgentMessageContent } from "@app/lib/models/assistant/agent_message_content";
 import { User } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
 import { frontSequelize } from "@app/lib/resources/storage";
@@ -259,6 +260,8 @@ export class AgentMessage extends Model<
   // needs both sId and version to uniquely identify the agent configuration
   declare agentConfigurationId: string;
   declare agentConfigurationVersion: number;
+
+  declare agentMessageContents?: NonAttribute<AgentMessageContent[]>;
 }
 
 AgentMessage.init(

--- a/front/migrations/db/migration_31.sql
+++ b/front/migrations/db/migration_31.sql
@@ -1,3 +1,2 @@
 -- Migration created on Jul 03, 2024
 CREATE INDEX CONCURRENTLY "membership_invitations_invite_email_status" ON "membership_invitations" ("inviteEmail", "status");
-

--- a/front/migrations/db/migration_33.sql
+++ b/front/migrations/db/migration_33.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS "agent_message_contents" (
+    "id" SERIAL PRIMARY KEY,
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "agentMessageId" INTEGER NOT NULL REFERENCES "agent_messages" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    "step" INTEGER NOT NULL,
+    "content" TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "agent_message_contents_unique_agent_message_step" ON "agent_message_contents" ("agentMessageId", "step");

--- a/types/src/front/lib/api/assistant/agent.ts
+++ b/types/src/front/lib/api/assistant/agent.ts
@@ -125,3 +125,14 @@ export type AgentChainOfThoughtEvent = {
   message: AgentMessageType;
   chainOfThought: string;
 };
+
+// Content that is emitted right before a Tool Use
+// and therefore not part of the "final" generation.
+// TODO(fontanierh): Also store the final generation in this table.
+export type AgentContentEvent = {
+  type: "agent_message_content";
+  created: number;
+  configurationId: string;
+  messageId: string;
+  content: string;
+};


### PR DESCRIPTION
## Description
This PR introduces a new `AgentMessageContent` model to store all raw tokens emitted by the model. This change will allow for a more accurate representation of the assistant's thought process and improves the rendering of agent messages (for the model and ultimately for the user). Currently, this has no impact on user experience, and it is simply shadow writing all contents to the new table.

Next changes:
1. change how we render conversations for the model to use these raw contents instead of the processed ones
2. introduce (potentially via token emitter) a way to transform an array of contents into `{content: string, chainOfThougthts}`
3. change event emitting logit to stop emitting CoT events for tokens that were emitted before a tool + remove hacks in agentmessage.tsx that work around this + change conversation rendering to user to use (and parse) raw contents instead of pre-parsed contents
4. once everything is confirmed to work well, drop agentMessage.content and agentMessage.chainOfThoughts

## Risk
This change introduces a new database table and modifies the core conversation flow. While the risk is moderate, it's mitigated by the fact that existing functionality should remain unchanged.

## Deploy Plan
1. Apply the new database migration
5. Deploy the code changes
6. Monitor for any unexpected behavior in agent message generation and rendering
