### PR TITLE
fix: get/set connector config must use the right manager class

### DIFF
--- a/connectors/src/api/connector_config.ts
+++ b/connectors/src/api/connector_config.ts
@@ -55,7 +55,7 @@ const _getConnectorConfig = async (
 
   const configValueRes = await getConnectorManager({
     connectorId: connector.id,
-    connectorProvider: "webcrawler",
+    connectorProvider: connector.type,
   }).getConfigurationKey({ configKey: req.params.config_key });
   if (configValueRes.isErr()) {
     return apiError(
@@ -132,7 +132,7 @@ const _setConnectorConfig = async (
 
   const setConfigRes = await getConnectorManager({
     connectorId: connector.id,
-    connectorProvider: "webcrawler",
+    connectorProvider: connector.type,
   }).setConfigurationKey({
     configKey: req.params.config_key,
     configValue: req.body.configValue,


### PR DESCRIPTION
## Description

Right now, we simply fail with "not implemented" for every connector type

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
