### PR TITLE
Move PRODUCTION_DUST_APPS_WORKSPACE_ID and PRODUCTION_DUST_WORKSPACE_ID to env vars

### DIFF
--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -23,6 +23,7 @@ import {
   PROCESS_ACTION_TOP_K,
   renderSchemaPropertiesAsJSONSchema,
 } from "@dust-tt/types";
+import { EnvironmentConfig } from "@dust-tt/types";
 
 import { runActionStreamed } from "@app/lib/actions/server";
 import { DEFAULT_PROCESS_ACTION_NAME } from "@app/lib/api/assistant/actions/names";
@@ -36,7 +37,6 @@ import { BaseActionConfigurationServerRunner } from "@app/lib/api/assistant/acti
 import { constructPromptMultiActions } from "@app/lib/api/assistant/generation";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
-import { PRODUCTION_DUST_WORKSPACE_ID } from "@app/lib/development";
 import { AgentProcessAction } from "@app/lib/models/assistant/actions/process";
 import logger from "@app/logger/logger";
 
@@ -255,7 +255,7 @@ export class ProcessConfigurationServerRunner extends BaseActionConfigurationSer
     config.DATASOURCE.data_sources = actionConfiguration.dataSources.map(
       (d) => ({
         workspace_id: isDevelopment()
-          ? PRODUCTION_DUST_WORKSPACE_ID
+          ? EnvironmentConfig.getEnvVariable("PRODUCTION_DUST_WORKSPACE_ID")
           : d.workspaceId,
         data_source_id: d.dataSourceId,
       })

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -23,6 +23,7 @@ import {
   isDevelopment,
 } from "@dust-tt/types";
 import { Ok } from "@dust-tt/types";
+import { EnvironmentConfig } from "@dust-tt/types";
 
 import { runActionStreamed } from "@app/lib/actions/server";
 import { DEFAULT_RETRIEVAL_ACTION_NAME } from "@app/lib/api/assistant/actions/names";
@@ -31,7 +32,6 @@ import { BaseActionConfigurationServerRunner } from "@app/lib/api/assistant/acti
 import { getRefs } from "@app/lib/api/assistant/citations";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
-import { PRODUCTION_DUST_WORKSPACE_ID } from "@app/lib/development";
 import {
   AgentRetrievalAction,
   RetrievalDocument,
@@ -465,7 +465,7 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
     config.DATASOURCE.data_sources = actionConfiguration.dataSources.map(
       (d) => ({
         workspace_id: isDevelopment()
-          ? PRODUCTION_DUST_WORKSPACE_ID
+          ? EnvironmentConfig.getEnvVariable("PRODUCTION_DUST_WORKSPACE_ID")
           : d.workspaceId,
         data_source_id: d.dataSourceId,
       })

--- a/front/lib/development.ts
+++ b/front/lib/development.ts
@@ -5,7 +5,9 @@ import { EnvironmentConfig } from "@dust-tt/types";
 export function isDevelopmentOrDustWorkspace(owner: WorkspaceType) {
   return (
     isDevelopment() ||
-    owner.sId === EnvironmentConfig.getEnvVariable("PRODUCTION_DUST_WORKSPACE_ID") ||
-    owner.sId === EnvironmentConfig.getEnvVariable("PRODUCTION_DUST_APPS_WORKSPACE_ID")
+    owner.sId ===
+      EnvironmentConfig.getEnvVariable("PRODUCTION_DUST_WORKSPACE_ID") ||
+    owner.sId ===
+      EnvironmentConfig.getEnvVariable("PRODUCTION_DUST_APPS_WORKSPACE_ID")
   );
 }

--- a/front/lib/development.ts
+++ b/front/lib/development.ts
@@ -1,13 +1,11 @@
 import type { WorkspaceType } from "@dust-tt/types";
 import { isDevelopment } from "@dust-tt/types";
-
-export const PRODUCTION_DUST_WORKSPACE_ID = "0ec9852c2f";
-const PRODUCTION_DUST_APPS_WORKSPACE_ID = "78bda07b39";
+import { EnvironmentConfig } from "@dust-tt/types";
 
 export function isDevelopmentOrDustWorkspace(owner: WorkspaceType) {
   return (
     isDevelopment() ||
-    owner.sId === PRODUCTION_DUST_WORKSPACE_ID ||
-    owner.sId === PRODUCTION_DUST_APPS_WORKSPACE_ID
+    owner.sId === EnvironmentConfig.getEnvVariable("PRODUCTION_DUST_WORKSPACE_ID") ||
+    owner.sId === EnvironmentConfig.getEnvVariable("PRODUCTION_DUST_APPS_WORKSPACE_ID")
   );
 }

--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -1,6 +1,6 @@
 import { DustAppType } from "../../../front/lib/dust_api";
-
-const PRODUCTION_DUST_APPS_WORKSPACE_ID = "78bda07b39";
+import { EnvironmentConfig } from "../../../shared/utils/config";
+const PRODUCTION_DUST_APPS_WORKSPACE_ID = EnvironmentConfig.getEnvVariable("PRODUCTION_DUST_APPS_WORKSPACE_ID");
 
 export type Action = {
   app: DustAppType;


### PR DESCRIPTION
## Description

Move PRODUCTION_DUST_APPS_WORKSPACE_ID and PRODUCTION_DUST_WORKSPACE_ID to env vars

## Risk

Multi tools might break if this doesn't work

## Deploy Plan

Already pushed the secrets to kube, will try on front-edge first.
