### PR TITLE
fix: use DataTypes.INTEGER instead of DataTypes.NUMBER

### DIFF
--- a/front/lib/resources/storage/models/files.ts
+++ b/front/lib/resources/storage/models/files.ts
@@ -56,7 +56,7 @@ FileModel.init(
       allowNull: false,
     },
     fileSize: {
-      type: DataTypes.NUMBER,
+      type: DataTypes.INTEGER,
       allowNull: false,
     },
     sId: {


### PR DESCRIPTION
## Description

This is breaking `initdb` locally, as `DataTypes.NUMBER` resolves to column type "number" which isn't a thing.

As per the SQL migration file, this field is really an INTEGER, so it should be fine to simply change this to `DataTypes.INTEGER` in the model file

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

N/A (not a real migration)