### PR TITLE
[front] - chore(front): increase caching agent popularity

### DIFF
--- a/front/lib/api/assistant/agent_usage.ts
+++ b/front/lib/api/assistant/agent_usage.ts
@@ -14,8 +14,8 @@ import { redisClient } from "@app/lib/redis";
 // Ranking of agents is done over a 30 days period.
 const rankingTimeframeSec = 60 * 60 * 24 * 30; // 30 days
 
-// Computing agent mention count over a 2h period
-const popularityComputationTimeframeSec = 2 * 60 * 60;
+// Computing agent mention count over a 3h period
+const popularityComputationTimeframeSec = 3 * 60 * 60;
 
 const TTL_KEY_NOT_EXIST = -2;
 const TTL_KEY_NOT_SET = -1;


### PR DESCRIPTION
## Description

This PR increases the caching duration for agent popularity computation.

This change aims to reduce the frequency of popularity computations, potentially improving performance and reducing database load.

## Risk

Low. The change only affects the caching duration of agent popularity data.

## Deploy Plan

Deploy `front`
