### PR TITLE
[front] enh: Allow to reinvite revoked members

### DIFF
--- a/front/components/members/InvitationModal.tsx
+++ b/front/components/members/InvitationModal.tsx
@@ -102,36 +102,17 @@ export function InviteEmailModal({
             m.workspaces[0].role !== "none"
         )
       ),
-      revoked: members.filter((m) =>
-        inviteEmailsList.find(
-          (e) => m.email === e && m.workspaces[0].role === "none"
-        )
-      ),
       notInWorkspace: inviteEmailsList.filter(
-        (e) => !members.find((m) => m.email === e)
+        (e) =>
+          !members.find((m) => m.email === e) ||
+          members.find((m) => m.email === e)?.workspaces[0].role === "none"
       ),
     };
 
-    const { notInWorkspace, activeDifferentRole, revoked } = invitesByCase;
+    const { notInWorkspace, activeDifferentRole } = invitesByCase;
 
     const ReinviteUsersMessage = (
       <div className="mt-6 flex flex-col gap-6 px-2">
-        {revoked.length > 0 && (
-          <div>
-            <div>
-              The user(s) below were previously revoked from your workspace.
-              Reinstating them will also immediately reinstate their
-              conversation history on Dust.
-            </div>
-            <div className="mt-2 flex max-h-48 flex-col gap-1 overflow-y-auto rounded border p-2 text-xs">
-              {revoked.map((user) => (
-                <div
-                  key={user.email}
-                >{`- ${user.fullName} (${user.email})`}</div>
-              ))}
-            </div>
-          </div>
-        )}
         {activeDifferentRole.length > 0 && (
           <div>
             <div>
@@ -154,8 +135,7 @@ export function InviteEmailModal({
         <div>Do you want to proceed?</div>
       </div>
     );
-    const hasExistingMembers =
-      activeDifferentRole.length > 0 || revoked.length > 0;
+    const hasExistingMembers = activeDifferentRole.length > 0;
 
     const shouldProceedWithInvites =
       !hasExistingMembers ||
@@ -177,7 +157,7 @@ export function InviteEmailModal({
 
       if (hasExistingMembers) {
         await handleMembersRoleChange({
-          members: [...activeDifferentRole, ...revoked],
+          members: [...activeDifferentRole],
           role: invitationRole,
           sendNotification,
         });

--- a/front/components/members/InvitationModal.tsx
+++ b/front/components/members/InvitationModal.tsx
@@ -157,7 +157,7 @@ export function InviteEmailModal({
 
       if (hasExistingMembers) {
         await handleMembersRoleChange({
-          members: [...activeDifferentRole],
+          members: activeDifferentRole,
           role: invitationRole,
           sendNotification,
         });

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -21,6 +21,9 @@ import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { generateModelSId, isEmailValid } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 
+// Make token expire after 7 days
+const INVITATION_EXPIRATION_TIME = 60 * 60 * 24 * 7;
+
 sgMail.setApiKey(config.getSendgridApiKey());
 
 function typeFromModel(
@@ -136,11 +139,10 @@ export async function sendWorkspaceInvitationEmail(
   user: UserType,
   invitation: MembershipInvitationType
 ) {
-  // Make token expire after 7 days
   const invitationToken = sign(
     {
       membershipInvitationId: invitation.id,
-      exp: Math.floor(Date.now() / 1000) + 60 * 24 * 7,
+      exp: Math.floor(Date.now() / 1000) + INVITATION_EXPIRATION_TIME,
     },
     config.getDustInviteTokenSecret()
   );

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -136,8 +136,12 @@ export async function sendWorkspaceInvitationEmail(
   user: UserType,
   invitation: MembershipInvitationType
 ) {
+  // Make token expire after 7 days
   const invitationToken = sign(
-    { membershipInvitationId: invitation.id },
+    {
+      membershipInvitationId: invitation.id,
+      exp: Math.floor(Date.now() / 1000) + 60 * 24 * 7,
+    },
     config.getDustInviteTokenSecret()
   );
 

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -21,8 +21,8 @@ import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { generateModelSId, isEmailValid } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 
-// Make token expire after 7 days
-const INVITATION_EXPIRATION_TIME = 60 * 60 * 24 * 7;
+// Make token expires after 7 days
+const INVITATION_EXPIRATION_TIME_SEC = 60 * 60 * 24 * 7;
 
 sgMail.setApiKey(config.getSendgridApiKey());
 
@@ -142,7 +142,7 @@ export async function sendWorkspaceInvitationEmail(
   const invitationToken = sign(
     {
       membershipInvitationId: invitation.id,
-      exp: Math.floor(Date.now() / 1000) + INVITATION_EXPIRATION_TIME,
+      exp: Math.floor(Date.now() / 1000) + INVITATION_EXPIRATION_TIME_SEC,
     },
     config.getDustInviteTokenSecret()
   );

--- a/front/lib/iam/invitations.ts
+++ b/front/lib/iam/invitations.ts
@@ -2,11 +2,10 @@ import type { Result, UserType } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 import { verify } from "jsonwebtoken";
 
+import config from "@app/lib/api/config";
 import { AuthFlowError } from "@app/lib/iam/errors";
 import { MembershipInvitation } from "@app/lib/models/workspace";
 import logger from "@app/logger/logger";
-
-const { DUST_INVITE_TOKEN_SECRET = "" } = process.env;
 
 export async function getPendingMembershipInvitationForToken(
   inviteToken: string | string[] | undefined
@@ -14,7 +13,7 @@ export async function getPendingMembershipInvitationForToken(
   if (inviteToken && typeof inviteToken === "string") {
     let decodedToken: { membershipInvitationId: number } | null = null;
     try {
-      decodedToken = verify(inviteToken, DUST_INVITE_TOKEN_SECRET) as {
+      decodedToken = verify(inviteToken, config.getDustInviteTokenSecret()) as {
         membershipInvitationId: number;
       };
     } catch (e) {

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -81,12 +81,12 @@ async function handleMembershipInvite(
   });
 
   if (m?.isRevoked()) {
-    return new Err(
-      new AuthFlowError(
-        "revoked",
-        "Your access to the workspace has expired, please contact the workspace admin to update your role."
-      )
-    );
+    await MembershipResource.updateMembershipRole({
+      user,
+      workspace: renderLightWorkspaceType({ workspace }),
+      newRole: membershipInvite.initialRole,
+      allowTerminated: true,
+    });
   }
 
   if (!m) {


### PR DESCRIPTION
## Description

- Allow to use invite token on login if member was revoked, create a new membership
- Add expiration on invite token
- Update invitation flow in admin

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy `front`