### PR TITLE
Redirect newly created user to pending invitation if any.

### DIFF
--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -136,7 +136,9 @@ export async function updateOrCreateInvitation(
   );
 }
 
-export function getInvitationToken(invitation: MembershipInvitationType) {
+export function getMembershipInvitationToken(
+  invitation: MembershipInvitationType
+) {
   return sign(
     {
       membershipInvitationId: invitation.id,
@@ -146,7 +148,7 @@ export function getInvitationToken(invitation: MembershipInvitationType) {
   );
 }
 
-export function getInvitationUrl(
+export function getMembershipInvitationUrlForToken(
   owner: LightWorkspaceType,
   invitationToken: string
 ) {
@@ -158,8 +160,11 @@ export async function sendWorkspaceInvitationEmail(
   user: UserType,
   invitation: MembershipInvitationType
 ) {
-  const invitationToken = getInvitationToken(invitation);
-  const invitationUrl = getInvitationUrl(owner, invitationToken);
+  const invitationToken = getMembershipInvitationToken(invitation);
+  const invitationUrl = getMembershipInvitationUrlForToken(
+    owner,
+    invitationToken
+  );
 
   // Send invite email.
   const message = {

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -11,7 +11,6 @@ import type {
 import { Err, Ok, sanitizeString } from "@dust-tt/types";
 import sgMail from "@sendgrid/mail";
 import { sign } from "jsonwebtoken";
-import type { Light } from "react-syntax-highlighter";
 import { Op } from "sequelize";
 
 import config from "@app/lib/api/config";

--- a/front/lib/iam/invitations.ts
+++ b/front/lib/iam/invitations.ts
@@ -3,18 +3,15 @@ import type {
   MembershipInvitationType,
   Result,
   UserType,
-  WorkspaceType,
 } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 import { verify } from "jsonwebtoken";
-import { create, initial } from "lodash";
 
 import config from "@app/lib/api/config";
 import { AuthFlowError } from "@app/lib/iam/errors";
 import { MembershipInvitation, Workspace } from "@app/lib/models/workspace";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
-import status from "@app/pages/api/w/[wId]/apps/[aId]/runs/[runId]/status";
 
 export async function getPendingMembershipInvitationForToken(
   inviteToken: string | string[] | undefined

--- a/front/lib/models/workspace.ts
+++ b/front/lib/models/workspace.ts
@@ -224,6 +224,7 @@ MembershipInvitation.init(
     indexes: [
       { fields: ["workspaceId", "status"] },
       { unique: true, fields: ["sId"] },
+      { fields: ["email", "status"] },
     ],
   }
 );

--- a/front/lib/models/workspace.ts
+++ b/front/lib/models/workspace.ts
@@ -172,6 +172,8 @@ export class MembershipInvitation extends Model<
 
   declare workspaceId: ForeignKey<Workspace["id"]>;
   declare invitedUserId: ForeignKey<User["id"]> | null;
+
+  declare workspace: NonAttribute<Workspace>;
 }
 MembershipInvitation.init(
   {
@@ -229,6 +231,8 @@ Workspace.hasMany(MembershipInvitation, {
   foreignKey: { allowNull: false },
   onDelete: "CASCADE",
 });
+MembershipInvitation.belongsTo(Workspace);
+
 User.hasMany(MembershipInvitation, {
   foreignKey: "invitedUserId",
 });

--- a/front/migrations/db/migration_31.sql
+++ b/front/migrations/db/migration_31.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jul 03, 2024
+CREATE INDEX CONCURRENTLY "membership_invitations_email_status" ON "membership_invitations" ("email", "status");

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -7,7 +7,10 @@ import type {
 import { Err, Ok } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { getInvitationToken, getInvitationUrl } from "@app/lib/api/invitation";
+import {
+  getMembershipInvitationToken,
+  getMembershipInvitationUrlForToken,
+} from "@app/lib/api/invitation";
 import { deleteUser } from "@app/lib/api/user";
 import { evaluateWorkspaceSeatAvailability } from "@app/lib/api/workspace";
 import { getSession, subscriptionForWorkspace } from "@app/lib/auth";
@@ -369,8 +372,11 @@ async function handler(
         const { invitation: pendingInvitation, workspace } =
           pendingInvitationAndWorkspace;
 
-        const invitationToken = getInvitationToken(pendingInvitation);
-        const invitationUrl = getInvitationUrl(workspace, invitationToken);
+        const invitationToken = getMembershipInvitationToken(pendingInvitation);
+        const invitationUrl = getMembershipInvitationUrlForToken(
+          workspace,
+          invitationToken
+        );
 
         res.redirect(invitationUrl);
         return;

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -7,6 +7,7 @@ import type {
 import { Err, Ok } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { getInvitationToken, getInvitationUrl } from "@app/lib/api/invitation";
 import { deleteUser } from "@app/lib/api/user";
 import { evaluateWorkspaceSeatAvailability } from "@app/lib/api/workspace";
 import { getSession, subscriptionForWorkspace } from "@app/lib/auth";
@@ -14,6 +15,7 @@ import { AuthFlowError, SSOEnforcedError } from "@app/lib/iam/errors";
 import {
   getPendingMembershipInvitationForEmailAndWorkspace,
   getPendingMembershipInvitationForToken,
+  getPendingMembershipInvitationWithWorkspaceForEmail,
   markInvitationAsConsumed,
 } from "@app/lib/iam/invitations";
 import type { SessionWithUser } from "@app/lib/iam/provider";
@@ -358,6 +360,23 @@ async function handler(
 
     targetWorkspace = workspace;
   } else {
+    if (userCreated) {
+      // If user is newly created, check if there is a pending invitation for the user.
+      // If present, redirect to the workspace join page.
+      const pendingInvitationAndWorkspace =
+        await getPendingMembershipInvitationWithWorkspaceForEmail(user.email);
+      if (pendingInvitationAndWorkspace) {
+        const { invitation: pendingInvitation, workspace } =
+          pendingInvitationAndWorkspace;
+
+        const invitationToken = getInvitationToken(pendingInvitation);
+        const invitationUrl = getInvitationUrl(workspace, invitationToken);
+
+        res.redirect(invitationUrl);
+        return;
+      }
+    }
+
     const loginFctn = membershipInvite
       ? async () => handleMembershipInvite(user, membershipInvite)
       : async () => handleRegularSignupFlow(session, user, targetWorkspaceId);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We have identified issues for new users signing up via invitation. If they choose to sign up using email/password, the invitation token is lost, resulting in the creation of a new workspace, which is not the intended outcome. Currently, the only solution is to restart the process from the invitation email.

This PR makes a strong assumption: all newly created users with pending invitations likely intended to use the invitation to join the target workspace. Hence they will get redirected to the workspace join page.
 
## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Once the PR is merged we need to run:
```
psql $FRONT_DATABASE_URI -f ./migrations/db/migration_31.sql
```
