### PR TITLE
feat: renderConversationForModel using agent message raw contents

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -240,6 +240,10 @@ export async function* runMultiActionsAgentLoop(
             step: i,
             content: event.content,
           });
+          agentMessage.rawContents.push({
+            step: i,
+            content: event.content,
+          });
           break;
 
         // Generation events

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -64,6 +64,7 @@ import {
   batchRenderUserMessages,
 } from "@app/lib/api/assistant/messages";
 import type { Authenticator } from "@app/lib/auth";
+import { AgentMessageContent } from "@app/lib/models/assistant/agent_message_content";
 import {
   AgentMessage,
   Conversation,
@@ -305,6 +306,13 @@ export async function getConversation(
         model: AgentMessage,
         as: "agentMessage",
         required: false,
+        include: [
+          {
+            model: AgentMessageContent,
+            as: "agentMessageContents",
+            required: false,
+          },
+        ],
       },
       // We skip ContentFragmentResource here for efficiency reasons (retrieving contentFragments
       // along with messages in one query). Only once we move to a MessageResource will we be able
@@ -813,6 +821,7 @@ export async function* postUserMessage(
                   actions: [],
                   content: null,
                   chainOfThoughts: [],
+                  rawContents: [],
                   error: null,
                   configuration,
                   rank: messageRow.rank,
@@ -1289,6 +1298,7 @@ export async function* editUserMessage(
                 actions: [],
                 content: null,
                 chainOfThoughts: [],
+                rawContents: [],
                 error: null,
                 configuration,
                 rank: messageRow.rank,
@@ -1505,6 +1515,7 @@ export async function* retryAgentMessage(
         actions: [],
         content: null,
         chainOfThoughts: [],
+        rawContents: [],
         error: null,
         configuration: message.configuration,
         rank: m.rank,

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -143,22 +143,18 @@ export async function renderConversationForModelMultiActions({
             continue;
           }
 
-          if (step.actions.length) {
-            messages.push({
-              role: "assistant",
-              function_calls: step.actions.map((s) => s.call),
-              content: step.contents.join("\n"),
-            } satisfies AssistantFunctionCallMessageTypeModel);
+          messages.push({
+            role: "assistant",
+            function_calls: step.actions.length
+              ? step.actions.map((s) => s.call)
+              : undefined,
+            content: step.contents.join("\n"),
+          } as typeof step.actions.length extends 0
+            ? AssistantContentMessageTypeModel
+            : AssistantFunctionCallMessageTypeModel);
 
-            for (const { result } of step.actions) {
-              messages.push(result);
-            }
-          } else if (step.contents.length) {
-            messages.push({
-              role: "assistant",
-              name: m.configuration.name,
-              content: step.contents.join("\n"),
-            } satisfies AssistantContentMessageTypeModel);
+          for (const { result } of step.actions) {
+            messages.push(result);
           }
         }
       }

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -22,6 +22,7 @@ import { websearchActionTypesFromAgentMessageIds } from "@app/lib/api/assistant/
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import type { PaginationParams } from "@app/lib/api/pagination";
 import type { Authenticator } from "@app/lib/auth";
+import { AgentMessageContent } from "@app/lib/models/assistant/agent_message_content";
 import {
   AgentMessage,
   Conversation,
@@ -223,6 +224,11 @@ export async function batchRenderAgentMessages(
       actions: actions,
       content: agentMessage.content,
       chainOfThoughts: agentMessage.chainOfThoughts,
+      rawContents:
+        agentMessage.agentMessageContents?.map((rc) => ({
+          step: rc.step,
+          content: rc.content,
+        })) ?? [],
       error,
       // TODO(2024-03-21 flav) Dry the agent configuration object for rendering.
       configuration: agentConfiguration,
@@ -328,6 +334,13 @@ async function fetchMessagesForPage(
         model: AgentMessage,
         as: "agentMessage",
         required: false,
+        include: [
+          {
+            model: AgentMessageContent,
+            as: "agentMessageContents",
+            required: false,
+          },
+        ],
       },
       // We skip ContentFragmentResource here for efficiency reasons (retrieving contentFragments
       // along with messages in one query). Only once we move to a MessageResource will we be able

--- a/types/src/front/assistant/conversation.ts
+++ b/types/src/front/assistant/conversation.ts
@@ -123,6 +123,10 @@ export type AgentMessageType = {
   actions: AgentActionType[];
   content: string | null;
   chainOfThoughts: string[];
+  rawContents: Array<{
+    step: number;
+    content: string;
+  }>;
   error: {
     code: string;
     message: string;


### PR DESCRIPTION




## Description
This PR implements the use of raw contents in rendering conversations for the model. The key changes include:

1. Adding `rawContents` to the `AgentMessageType`, storing an array of content with associated steps.
2. Adjusting the data fetching process to include the new `AgentMessageContent` model.
3. Modifying the `renderConversationForModelMultiActions` function to use these raw contents when generating the conversation for the model.

These changes allow for a more accurate representation of the assistant's thought process by preserving the raw content generated at each step. 

## Risk
Changes how agent messages are rendered to the model, but we maintain backwards compatibility with legacy messages.
Could impact latency due to the additional joins.

## Deploy Plan

N/A
