### PR TITLE
fix: increase startToCloseTimeout of google drive incremental sync

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -26,7 +26,7 @@ const {
 
 // Hotfix: increase timeout on incrementalSync to avoid restarting ongoing activities
 const { incrementalSync } = proxyActivities<typeof activities>({
-  startToCloseTimeout: "60 minutes",
+  startToCloseTimeout: "120 minutes",
   heartbeatTimeout: "5 minutes",
 });
 


### PR DESCRIPTION
## Description

Double Google drive incremental sync start to close timeout.
We are seeing some timeouts.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
