### PR TITLE
[front] - fix: adjust emoji selector dropdown orientation

### DIFF
--- a/front/components/assistant/conversation/messages/MessageActions.tsx
+++ b/front/components/assistant/conversation/messages/MessageActions.tsx
@@ -239,7 +239,7 @@ function EmojiSelector({
       </DropdownMenu.Button>
       <DropdownMenu.Items
         width={350}
-        origin="topRight"
+        origin="bottomRight"
         overflow="visible"
         variant="no-padding"
       >


### PR DESCRIPTION
## Description

Change the emoji selector dropdown to open towards the bottom right for better visibility and access.

See issue: https://github.com/dust-tt/dust/issues/6043

## Risk

None

## Deploy Plan

Deploy `front`
