### PR TITLE
[front/migrations] - fix: correct table name in migration_34.sql

### DIFF
--- a/front/migrations/db/migration_34.sql
+++ b/front/migrations/db/migration_34.sql
@@ -1,2 +1,2 @@
 -- Migration created on Jul 04, 2024
-CREATE INDEX CONCURRENTLY "data_source_workspace_connector_provider" ON "data_source" ("workspaceId", "connectorProvider");
+CREATE INDEX CONCURRENTLY "data_source_workspace_connector_provider" ON "data_sources" ("workspaceId", "connectorProvider");


### PR DESCRIPTION
## Description

Fixed the SQL index creation statement to refer to the correct table name "data_sources" instead of "data_source"

## Risk

None

## Deploy Plan

None
