### PR TITLE
Visualization generation

### DIFF
--- a/front/components/actions/visualization/VisualizationActionDetails.tsx
+++ b/front/components/actions/visualization/VisualizationActionDetails.tsx
@@ -18,7 +18,7 @@ export function VisualizationActionDetails({
       <div className="flex flex-col gap-4 pl-6 pt-4">
         <div className="flex flex-col gap-1">
           <div className="text-sm font-normal text-slate-500">
-            <ReadOnlyTextArea content={action.output?.code ?? ""} />
+            <ReadOnlyTextArea content={action.output?.generation ?? ""} />
           </div>
         </div>
       </div>

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -94,10 +94,10 @@ export function AgentMessage({
     ) as VisualizationActionType[];
 
   const [streamedVisualizations, setStreamedVisualizations] = useState<
-    { index: number; visualization: string }[]
+    { actionId: number; visualization: string }[]
   >(
     defaultVisualizations.map((v) => ({
-      index: v.id,
+      actionId: v.id,
       visualization: v?.output?.generation ?? "",
     }))
   );
@@ -283,12 +283,12 @@ export function AgentMessage({
         setStreamedVisualizations((m) => {
           const actionId = event.actionId;
           const tokens = event.text;
-          const index = m.findIndex((v) => v.index === actionId);
+          const index = m.findIndex((v) => v.actionId === actionId);
           if (index === -1) {
-            return [...m, { index: actionId, visualization: tokens }];
+            return [...m, { actionId, visualization: tokens }];
           } else {
             return m.map((v) => {
-              if (v.index === actionId) {
+              if (v.actionId === actionId) {
                 return { ...v, visualization: v.visualization + tokens };
               }
               return v;
@@ -533,7 +533,7 @@ export function AgentMessage({
     references: { [key: string]: RetrievalDocumentType | WebsearchResultType };
     streaming: boolean;
     lastTokenClassification: null | "tokens" | "chain_of_thought";
-    streamedVisualizations: { index: number; visualization: string }[];
+    streamedVisualizations: { actionId: number; visualization: string }[];
   }) {
     if (agentMessage.status === "failed") {
       return (
@@ -574,9 +574,10 @@ export function AgentMessage({
           </div>
         ) : null}
 
-        {streamedVisualizations.map(({ index, visualization }) => {
+        {/* This is where we will we plug Aric's work to render the graph in an iframe. */}
+        {streamedVisualizations.map(({ actionId, visualization }) => {
           return (
-            <div key={index}>
+            <div key={actionId}>
               <div className="flex flex-row gap-2">
                 <Icon size="sm" visual={BracesIcon} />
                 <div className="font-semibold">Visualization</div>

--- a/front/lib/api/assistant/actions/visualization.ts
+++ b/front/lib/api/assistant/actions/visualization.ts
@@ -208,7 +208,7 @@ export class VisualizationConfigurationServerRunner extends BaseActionConfigurat
       model: agentModelConfig,
       prompt: "", // There is no prompt for title generation.
       allowedTokenCount: agentModelConfig.contextSize - MIN_GENERATION_TOKENS,
-      excludeActions: true,
+      excludeActions: false,
       excludeImages: true,
     });
 

--- a/front/lib/api/assistant/actions/visualization.ts
+++ b/front/lib/api/assistant/actions/visualization.ts
@@ -8,6 +8,7 @@ import type {
   VisualizationActionType,
   VisualizationConfigurationType,
   VisualizationErrorEvent,
+  VisualizationGenerationTokensEvent,
   VisualizationParamsEvent,
   VisualizationSuccessEvent,
 } from "@dust-tt/types";
@@ -24,6 +25,8 @@ import { runActionStreamed } from "@app/lib/actions/server";
 import { DEFAULT_VISUALIZATION_ACTION_NAME } from "@app/lib/api/assistant/actions/names";
 import type { BaseActionRunParams } from "@app/lib/api/assistant/actions/types";
 import { BaseActionConfigurationServerRunner } from "@app/lib/api/assistant/actions/types";
+import { renderConversationForModelMultiActions } from "@app/lib/api/assistant/generation";
+import { getSupportedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentVisualizationAction } from "@app/lib/models/assistant/actions/visualization";
 import logger from "@app/logger/logger";
@@ -31,7 +34,6 @@ import logger from "@app/logger/logger";
 interface VisualizationActionBlob {
   id: ModelId; // VisualizationAction
   agentMessageId: ModelId;
-  query: string;
   output: VisualizationActionOutputType | null;
   functionCallId: string | null;
   functionCallName: string | null;
@@ -40,7 +42,6 @@ interface VisualizationActionBlob {
 
 export class VisualizationAction extends BaseAction {
   readonly agentMessageId: ModelId;
-  readonly query: string;
   readonly output: VisualizationActionOutputType | null;
   readonly functionCallId: string | null;
   readonly functionCallName: string | null;
@@ -51,18 +52,20 @@ export class VisualizationAction extends BaseAction {
     super(blob.id, "visualization_action");
 
     this.agentMessageId = blob.agentMessageId;
-    this.query = blob.query;
     this.output = blob.output;
     this.functionCallId = blob.functionCallId;
     this.functionCallName = blob.functionCallName;
     this.step = blob.step;
   }
 
+  // Visualization is not a function call, it is pure generation cause we need streaming.
+  // We fake a function call for the multi-actions model because
+  // we cannot render two agent messages in a row.
   renderForFunctionCall(): FunctionCallType {
     return {
       id: this.functionCallId ?? `call_${this.id.toString()}`,
       name: this.functionCallName ?? DEFAULT_VISUALIZATION_ACTION_NAME,
-      arguments: JSON.stringify({ query: this.query }),
+      arguments: JSON.stringify({}),
     };
   }
 
@@ -71,7 +74,7 @@ export class VisualizationAction extends BaseAction {
     if (this.output === null) {
       content += "The visualization failed.\n";
     } else {
-      content += `${JSON.stringify(this.output, null, 2)}\n`;
+      content += this.output?.generation ?? "";
     }
 
     return {
@@ -136,7 +139,8 @@ export class VisualizationConfigurationServerRunner extends BaseActionConfigurat
   ): AsyncGenerator<
     | VisualizationParamsEvent
     | VisualizationSuccessEvent
-    | VisualizationErrorEvent,
+    | VisualizationErrorEvent
+    | VisualizationGenerationTokensEvent,
     void
   > {
     const owner = auth.workspace();
@@ -189,13 +193,38 @@ export class VisualizationConfigurationServerRunner extends BaseActionConfigurat
       action: new VisualizationAction({
         id: action.id,
         agentMessageId: action.agentMessageId,
-        query,
         output: null,
         functionCallId: action.functionCallId,
         functionCallName: action.functionCallName,
         step: action.step,
       }),
     };
+
+    // Turn the conversation into a digest that can be presented to the model.
+    const MIN_GENERATION_TOKENS = 2048;
+    const agentModelConfig = getSupportedModelConfig(agentConfiguration.model);
+    const modelConversationRes = await renderConversationForModelMultiActions({
+      conversation,
+      model: agentModelConfig,
+      prompt: "", // There is no prompt for title generation.
+      allowedTokenCount: agentModelConfig.contextSize - MIN_GENERATION_TOKENS,
+      excludeActions: true,
+      excludeImages: true,
+    });
+
+    if (modelConversationRes.isErr()) {
+      yield {
+        type: "visualization_error",
+        created: Date.now(),
+        configurationId: agentConfiguration.sId,
+        messageId: agentMessage.sId,
+        error: {
+          code: "conversation_rendering_error",
+          message: modelConversationRes.error.message,
+        },
+      };
+      return;
+    }
 
     // Configure the Vizualization Dust App to the assistant model configuration.
     const config = cloneBaseConfig(
@@ -213,7 +242,7 @@ export class VisualizationConfigurationServerRunner extends BaseActionConfigurat
       config,
       [
         {
-          query,
+          conversation: modelConversationRes.value.modelConversation,
         },
       ],
       {
@@ -241,6 +270,16 @@ export class VisualizationConfigurationServerRunner extends BaseActionConfigurat
     let output: VisualizationActionOutputType | null = null;
 
     for await (const event of eventStream) {
+      if (event.type === "tokens") {
+        yield {
+          type: "visualization_generation_tokens",
+          created: Date.now(),
+          configurationId: agentConfiguration.sId,
+          messageId: agentMessage.sId,
+          actionId: action.id,
+          text: event.content.tokens.text,
+        };
+      }
       if (event.type === "error") {
         logger.error(
           {
@@ -286,7 +325,7 @@ export class VisualizationConfigurationServerRunner extends BaseActionConfigurat
           return;
         }
 
-        if (event.content.block_name === "FINAL" && e.value) {
+        if (event.content.block_name === "OUTPUT" && e.value) {
           const outputValidation = VisualizationActionOutputSchema.decode(
             e.value
           );
@@ -349,7 +388,6 @@ export async function visualizationActionTypesFromAgentMessageIds(
     return new VisualizationAction({
       id: action.id,
       agentMessageId: action.agentMessageId,
-      query: action.query,
       output: action.output,
       functionCallId: action.functionCallId,
       functionCallName: action.functionCallName,

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -20,6 +20,7 @@ import type {
   LightAgentConfigurationType,
   ModelConfigurationType,
   UserMessageType,
+  VisualizationGenerationTokensEvent,
 } from "@dust-tt/types";
 import {
   assertNever,
@@ -117,6 +118,7 @@ export async function* runMultiActionsAgentLoop(
   | AgentGenerationCancelledEvent
   | AgentMessageSuccessEvent
   | AgentChainOfThoughtEvent
+  | VisualizationGenerationTokensEvent
 > {
   const now = Date.now();
 
@@ -244,6 +246,7 @@ export async function* runMultiActionsAgentLoop(
 
         // Generation events
         case "generation_tokens":
+        case "visualization_generation_tokens":
           yield event;
           break;
         case "generation_cancel":
@@ -327,6 +330,7 @@ export async function* runMultiActionsAgent(
   | AgentActionsEvent
   | AgentChainOfThoughtEvent
   | AgentContentEvent
+  | VisualizationGenerationTokensEvent
 > {
   const model = SUPPORTED_MODEL_CONFIGS.find(
     (m) =>
@@ -1185,7 +1189,9 @@ async function* runAction(
           // the agentMessage object, updating this object will update the conversation as well.
           agentMessage.actions.push(event.action);
           break;
-
+        case "visualization_generation_tokens":
+          yield event;
+          break;
         default:
           assertNever(event);
       }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1770,6 +1770,9 @@ async function* streamRunAgentEvents(
       case "visualization_params":
         yield event;
         break;
+      case "visualization_generation_tokens":
+        yield event;
+        break;
       case "generation_tokens":
         if (event.classification === "tokens") {
           content += event.text;

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1768,8 +1768,6 @@ async function* streamRunAgentEvents(
       case "websearch_params":
       case "browse_params":
       case "visualization_params":
-        yield event;
-        break;
       case "visualization_generation_tokens":
         yield event;
         break;

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -18,6 +18,8 @@ import {
   isRetrievalConfiguration,
   isTextContent,
   isUserMessageType,
+  isVisualizationActionType,
+  isVisualizationConfiguration,
   isWebsearchConfiguration,
   Ok,
   removeNulls,
@@ -388,6 +390,13 @@ export async function constructPromptMultiActions(
   );
   if (canCiteDocuments) {
     additionalInstructions += `${citationMetaPrompt()}\n`;
+  }
+
+  const needVisualizationMetaPrompt = agentConfiguration.actions.some(
+    (action) => isVisualizationConfiguration(action)
+  );
+  if (needVisualizationMetaPrompt) {
+    additionalInstructions += `The React code generated in a <visualization> tag in the tool call is interpreted to render the graph. No need to repeat it.\n`;
   }
 
   const providerMetaPrompt = model.metaPrompt;

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -18,7 +18,6 @@ import {
   isRetrievalConfiguration,
   isTextContent,
   isUserMessageType,
-  isVisualizationActionType,
   isVisualizationConfiguration,
   isWebsearchConfiguration,
   Ok,
@@ -396,7 +395,7 @@ export async function constructPromptMultiActions(
     (action) => isVisualizationConfiguration(action)
   );
   if (needVisualizationMetaPrompt) {
-    additionalInstructions += `The React code generated in a <visualization> tag in the tool call is interpreted to render the graph. No need to repeat it.\n`;
+    additionalInstructions += `Graphs are generated with the visualization tool. The tool is rendering the graph to the user. Don't repeat its code.\n`;
   }
 
   const providerMetaPrompt = model.metaPrompt;

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -181,6 +181,7 @@ async function handleUserMessageEvents(
             case "websearch_params":
             case "browse_params":
             case "visualization_params":
+            case "visualization_generation_tokens":
             case "agent_error":
             case "agent_action_success":
             case "generation_tokens":
@@ -323,6 +324,7 @@ export async function retryAgentMessageWithPubSub(
               case "websearch_params":
               case "browse_params":
               case "visualization_params":
+              case "visualization_generation_tokens":
               case "agent_error":
               case "agent_action_success":
               case "generation_tokens":

--- a/types/src/front/assistant/actions/visualization.ts
+++ b/types/src/front/assistant/actions/visualization.ts
@@ -14,13 +14,12 @@ export type VisualizationConfigurationType = {
 
 // Dust App output
 export type VisualizationActionOutputType = {
-  code: string;
+  generation: string;
 };
 
 // Action execution
 export interface VisualizationActionType extends BaseAction {
   agentMessageId: ModelId;
-  query: string;
   output: VisualizationActionOutputType | null;
   functionCallId: string | null;
   functionCallName: string | null;
@@ -29,5 +28,5 @@ export interface VisualizationActionType extends BaseAction {
 }
 
 export const VisualizationActionOutputSchema = t.type({
-  code: t.string,
+  generation: t.string,
 });

--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -238,13 +238,13 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "tWcuYDj1OE",
       appHash:
-        "7cd6f307204d785f788e2ce9248672f1c72a6c77fda44c818c99d10b07d1fc7c",
+        "92bd9196b55883814347f8aef8042ea860c4a03b41b06e3a841777caace5b7f7",
     },
     config: {
       MODEL: {
         // `provider_id` and `model_id` must be set by caller.
-        function_call: "visualize",
         use_cache: false,
+        use_stream: true,
       },
     },
   },

--- a/types/src/front/lib/api/assistant/actions/visualization.ts
+++ b/types/src/front/lib/api/assistant/actions/visualization.ts
@@ -31,3 +31,12 @@ export type VisualizationSuccessEvent = {
   messageId: string;
   action: VisualizationActionType;
 };
+
+export type VisualizationGenerationTokensEvent = {
+  type: "visualization_generation_tokens";
+  created: number;
+  configurationId: string;
+  messageId: string;
+  actionId: number;
+  text: string;
+};

--- a/types/src/front/lib/api/assistant/agent.ts
+++ b/types/src/front/lib/api/assistant/agent.ts
@@ -15,7 +15,10 @@ import {
   TablesQueryOutputEvent,
   TablesQueryParamsEvent,
 } from "../../../../front/lib/api/assistant/actions/tables_query";
-import { VisualizationParamsEvent } from "../../../../front/lib/api/assistant/actions/visualization";
+import {
+  VisualizationGenerationTokensEvent,
+  VisualizationParamsEvent,
+} from "../../../../front/lib/api/assistant/actions/visualization";
 import {
   AgentActionConfigurationType,
   AgentActionSpecification,
@@ -67,7 +70,8 @@ export type AgentActionSpecificEvent =
   | ProcessParamsEvent
   | WebsearchParamsEvent
   | BrowseParamsEvent
-  | VisualizationParamsEvent;
+  | VisualizationParamsEvent
+  | VisualizationGenerationTokensEvent;
 
 // Event sent once the action is completed, we're moving to generating a message if applicable.
 export type AgentActionSuccessEvent = {


### PR DESCRIPTION
## Description

This PRs changes the way we process the visualization action. Since we want to stream its token, we switch from a tool call to a generation: 
- We now send the conversation to the action (as opposed to a query param). 
- The answer is generated with the code inside a `<visualization>` tag.
- This is streamed in the UI.

We currently stream the results in between the Assistant Thoughts and the Agent message. Design is not final, currently we render the code in a code block but obv goal is render the iframe (Aric's work).

This action is under a feature flag. 

Next steps: 
- Cleanup the configuration model (remove query column now unused & replace JSONB output for a "generation" text column. 
- Use the TokenEmitter to ensure we don't stream the potential content generated from the model outside of the <visualization> tags. 
- Present the structure of the file if any content fragment attached to the convo https://github.com/dust-tt/dust/issues/5780

## Risk

Action is under feature flag so not a big risk. Can be rolled back if needed. 

## Deploy Plan

Deploy front; 
