### PR TITLE
Fix websearch errors

### DIFF
--- a/types/src/front/assistant/actions/websearch.ts
+++ b/types/src/front/assistant/actions/websearch.ts
@@ -25,6 +25,7 @@ export const WebsearchAppActionOutputSchema = t.union([
   }),
   t.type({
     error: t.string,
+    results: t.array(WebsearchAppResultSchema),
   }),
 ]);
 // Type after processing in the run loop (to add references)

--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -139,7 +139,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "098b515f8e",
       appHash:
-        "74ece03e8c502d4ae1681847df945248b43b63a0eaa811daed50a3bc81615ac4",
+        "1945bd13cadf24ac757efb8af15cd26ed3a08462e9e9231bc700d57df3776ccb",
     },
     config: { SEARCH: { provider_id: "serpapi", use_cache: false } },
   },

--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -139,7 +139,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "098b515f8e",
       appHash:
-        "1945bd13cadf24ac757efb8af15cd26ed3a08462e9e9231bc700d57df3776ccb",
+        "514d54c0967638656b437417228efec26de465796b5ab67ae0480d6976250768",
     },
     config: { SEARCH: { provider_id: "serpapi", use_cache: false } },
   },


### PR DESCRIPTION
## Description

We got many errors from the websearch action: [Logs](https://app.datadoghq.eu/logs?query=%22Error%20running%20websearch%20action%22%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1719479796274&to_ts=1720084596274&live=true).

Digging into the logs I realized sometimes the snippet was missing: 
<kbd>
<img width="664" alt="Screenshot 2024-07-04 at 11 17 30" src="https://github.com/dust-tt/dust/assets/3803406/77bc9f54-1463-4a9f-b5ad-aca563c4a08c">
</kbd>

This PR edits the Dust app to filter out those results. 
It also fixed the type `WebsearchAppActionOutputSchema` according to what's really in the db ([MB query](https://metabase.dust.tt/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiJTRUxFQ1QgKiBGUk9NIGFnZW50X3dlYnNlYXJjaF9hY3Rpb25zXG5XSEVSRSBvdXRwdXQtPj4nZXJyb3InIElTIE5PVCBOVUxMXG5MSU1JVCAxMDA7IiwidGVtcGxhdGUtdGFncyI6e319LCJkYXRhYmFzZSI6NH0sImRpc3BsYXkiOiJ0YWJsZSIsInBhcmFtZXRlcnMiOltdLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7fX0=)).


### Changes in the Dust app

Before: 
<kbd>
<img width="794" alt="Screenshot 2024-07-04 at 11 00 52" src="https://github.com/dust-tt/dust/assets/3803406/16d5d125-128a-4f7e-abcc-e2fe5efb91e1">
</kbd>

After: 
<kbd>
<img width="785" alt="Screenshot 2024-07-04 at 11 19 12" src="https://github.com/dust-tt/dust/assets/3803406/0a57c2ff-6c0e-45d6-b2ad-b17854bb9353">
</kbd>

## Risk

Not super risky, but can be rolled back if needed. 

## Deploy Plan
Deploy front. 