### PR TITLE
fix: metabase deployment env var needs to be a string

### DIFF
--- a/k8s/deployments/metabase-deployment.yaml
+++ b/k8s/deployments/metabase-deployment.yaml
@@ -39,7 +39,7 @@ spec:
               value: https://metabase.dust.tt
 
             - name: MB_JDBC_DATA_WAREHOUSE_MAX_CONNECTION_POOL_SIZE
-              value: 30
+              value: "30"
 
           resources:
             requests:


### PR DESCRIPTION
## Description

Apply infra failing due to the integer env var
## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
