### PR TITLE
Use new AssistantPreview with desc & replace usage of TemplateItem

### DIFF
--- a/front/components/assistant/AssistantBrowser.tsx
+++ b/front/components/assistant/AssistantBrowser.tsx
@@ -171,30 +171,18 @@ export function AssistantBrowser({
 
       {displayedTab && (
         <div className="grid w-full grid-cols-1 gap-2 px-4 md:grid-cols-3">
-          {agentsByTab[displayedTab].map((agent) => {
-            return (
-              <div
-                key={agent.sId}
-                className="rounded-xl border border-structure-100"
-              >
-                <div
-                  onClick={(e) => {
-                    e.preventDefault();
-                    handleAssistantClick(agent);
-                  }}
-                >
-                  <AssistantPreview
-                    title={agent.name}
-                    pictureUrl={agent.pictureUrl}
-                    subtitle={agent.lastAuthors?.join(", ") ?? ""}
-                    description={agent.description}
-                    variant="minimal"
-                    onActionClick={() => setAssistantIdToShow(agent.sId)}
-                  />
-                </div>
-              </div>
-            );
-          })}
+          {agentsByTab[displayedTab].map((agent) => (
+            <AssistantPreview
+              key={agent.sId}
+              title={agent.name}
+              pictureUrl={agent.pictureUrl}
+              subtitle={agent.lastAuthors?.join(", ") ?? ""}
+              description={agent.description}
+              variant="minimal"
+              onClick={() => handleAssistantClick(agent)}
+              onActionClick={() => setAssistantIdToShow(agent.sId)}
+            />
+          ))}
         </div>
       )}
     </>

--- a/front/components/assistant/AssistantBrowser.tsx
+++ b/front/components/assistant/AssistantBrowser.tsx
@@ -187,7 +187,7 @@ export function AssistantBrowser({
                     title={agent.name}
                     pictureUrl={agent.pictureUrl}
                     subtitle={agent.lastAuthors?.join(", ") ?? ""}
-                    description=""
+                    description={agent.description}
                     variant="minimal"
                     onActionClick={() => setAssistantIdToShow(agent.sId)}
                   />

--- a/front/components/assistant_builder/TemplateGrid.tsx
+++ b/front/components/assistant_builder/TemplateGrid.tsx
@@ -1,4 +1,4 @@
-import { TemplateItem } from "@dust-tt/sparkle";
+import { AssistantPreview } from "@dust-tt/sparkle";
 import { useRouter } from "next/router";
 
 import type { AssistantTemplateListType } from "@app/pages/api/w/[wId]/assistant/builder/templates";
@@ -21,13 +21,13 @@ export function TemplateGrid({ templates }: TemplateGridProps) {
   };
 
   const items = templates.map((t) => (
-    <TemplateItem
+    <AssistantPreview
       key={t.sId}
+      title={t.handle}
+      pictureUrl={t.pictureUrl}
       description={t.description ?? ""}
-      id={t.sId}
-      name={`@${t.handle}`}
-      visual={t.pictureUrl}
-      href={makeTemplateModalHref(t.sId)}
+      variant="list"
+      onClick={() => router.push(makeTemplateModalHref(t.sId))}
     />
   ));
 

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,7 @@
         "@amplitude/analytics-browser": "^2.5.2",
         "@amplitude/analytics-node": "^1.3.5",
         "@auth0/nextjs-auth0": "^3.5.0",
-        "@dust-tt/sparkle": "^0.2.178",
+        "@dust-tt/sparkle": "^0.2.179",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -10733,9 +10733,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.178",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.178.tgz",
-      "integrity": "sha512-Ik4LH+2/Zc6aHSWyQgSULdwRv0uT+N1kw+ILOM8W9Ti65MEQgNogF/yRF/fC4TisurWBbBPOuxfFrBHNHaka8g==",
+      "version": "0.2.181",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.181.tgz",
+      "integrity": "sha512-e/YmKZXMxjBCWh/k8pBgepA2cV51y6ZqT10YZN/kMoxNCE+HO25LYK8AsLyuN/F13LMVAK7uZG4SdIWQtXNQAw==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
     "@amplitude/analytics-browser": "^2.5.2",
     "@amplitude/analytics-node": "^1.3.5",
     "@auth0/nextjs-auth0": "^3.5.0",
-    "@dust-tt/sparkle": "^0.2.178",
+    "@dust-tt/sparkle": "^0.2.179",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",

--- a/front/pages/poke/templates/[tId].tsx
+++ b/front/pages/poke/templates/[tId].tsx
@@ -1,9 +1,9 @@
 import {
+  AssistantPreview,
   ColorPicker,
   DropdownMenu,
   EmojiPicker,
   Markdown,
-  TemplateItem,
 } from "@dust-tt/sparkle";
 import type {
   CreateTemplateFormType,
@@ -438,12 +438,12 @@ function PreviewDialog({ form }: { form: any }) {
         <PokeDialogHeader>
           <PokeDialogTitle>Preview</PokeDialogTitle>
         </PokeDialogHeader>
-        <TemplateItem
-          name={form.getValues("handle")}
-          id="1"
+        <AssistantPreview
+          title={form.getValues("handle")}
+          pictureUrl={avatarVisual}
           description={form.getValues("description") ?? ""}
-          visual={avatarVisual}
-          href={""}
+          variant="list"
+          onClick={() => console.log("clicked")}
         />
       </PokeDialogContent>
     </PokeDialog>


### PR DESCRIPTION
## Description

Following up from : https://github.com/dust-tt/dust/pull/6003
@Duncid has edited our Sparkle component `<AssistantDetail>` so it can take a description, and asked me to: 
- Use it and display the description on the new chat page. 
- Use it to replace any usage of `<TemplateItem>` that will be removed from Sparkle.  

<kbd>
<img width="990" alt="Screenshot 2024-07-04 at 12 52 24" src="https://github.com/dust-tt/dust/assets/3803406/0052eb0d-29ed-43db-9c72-14da0a99d033">
</kbd>

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
