### PR TITLE
[front] fix: parse sourcemaps only for sparkle

### DIFF
--- a/front/next.config.js
+++ b/front/next.config.js
@@ -1,3 +1,5 @@
+const path = require("path");
+
 module.exports = {
   transpilePackages: ["@uiw/react-textarea-code-editor"],
   // As of Next 14.2.3 swc minification creates a bug in the generated client side files.
@@ -68,6 +70,7 @@ module.exports = {
       test: /\.js$/,
       use: ["source-map-loader"],
       enforce: "pre",
+      include: [path.resolve(__dirname, "node_modules/@dust-tt/sparkle")],
     });
     return config;
   },


### PR DESCRIPTION
## Description

execute plugin only for sparkle, avoid errors on other modules


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
