### PR TITLE
Enable CPU profiling for Gdrive workers

### DIFF
--- a/k8s/deployments/connectors-worker-google-drive-deployment.yaml
+++ b/k8s/deployments/connectors-worker-google-drive-deployment.yaml
@@ -32,6 +32,8 @@ spec:
           env:
             - name: DD_PROFILING_ENABLED
               value: "true"
+            - name: DD_PROFILING_EXPERIMENTAL_CPU_ENABLED
+              value: "true"
             - name: DD_AGENT_HOST
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
## Description

Enable CPU profiling for Gdrive workers.
The goal is to debug PPTXtext CPU consumption.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
