### PR TITLE
Cleanup Visu model

### DIFF
--- a/front/components/actions/visualization/VisualizationActionDetails.tsx
+++ b/front/components/actions/visualization/VisualizationActionDetails.tsx
@@ -18,7 +18,7 @@ export function VisualizationActionDetails({
       <div className="flex flex-col gap-4 pl-6 pt-4">
         <div className="flex flex-col gap-1">
           <div className="text-sm font-normal text-slate-500">
-            <ReadOnlyTextArea content={action.output?.generation ?? ""} />
+            <ReadOnlyTextArea content={action.generation ?? ""} />
           </div>
         </div>
       </div>

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -98,7 +98,7 @@ export function AgentMessage({
   >(
     defaultVisualizations.map((v) => ({
       actionId: v.id,
-      visualization: v?.output?.generation ?? "",
+      visualization: v.generation ?? "",
     }))
   );
 
@@ -564,7 +564,7 @@ export function AgentMessage({
               </div>
               <div>
                 <RenderMessageMarkdown
-                  content={"```js" + visualization + "```"}
+                  content={"```js" + visualization + "\n```"}
                   isStreaming={true}
                 />
               </div>

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -452,7 +452,7 @@ export async function constructPromptMultiActions(
     (action) => isVisualizationConfiguration(action)
   );
   if (needVisualizationMetaPrompt) {
-    additionalInstructions += `Graphs are generated with the visualization tool. The tool is rendering the graph to the user. Don't repeat its code.\n`;
+    additionalInstructions += `If mermaid is asked for a graph you can proceed. Otherwise to generate graphs only call the visualization tool. It takes care of writing and rendering the graph above your message.\n`;
   }
 
   const providerMetaPrompt = model.metaPrompt;

--- a/front/lib/models/assistant/actions/visualization.ts
+++ b/front/lib/models/assistant/actions/visualization.ts
@@ -1,4 +1,3 @@
-import type { VisualizationActionOutputType } from "@dust-tt/types";
 import type {
   CreationOptional,
   ForeignKey,
@@ -91,9 +90,7 @@ export class AgentVisualizationAction extends Model<
 
   declare visualizationConfigurationId: string;
 
-  declare query: string;
-
-  declare output: VisualizationActionOutputType | null;
+  declare generation: string | null;
   declare functionCallId: string | null;
   declare functionCallName: string | null;
 
@@ -126,16 +123,10 @@ AgentVisualizationAction.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
-
-    query: {
-      type: DataTypes.TEXT,
-      allowNull: false,
-    },
-    output: {
-      type: DataTypes.JSONB,
+    generation: {
+      type: DataTypes.STRING,
       allowNull: true,
     },
-
     functionCallId: {
       type: DataTypes.STRING,
       allowNull: true,

--- a/front/migrations/db/migration_36.sql
+++ b/front/migrations/db/migration_36.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jul 04, 2024
+ALTER TABLE "public"."agent_visualization_actions" ADD COLUMN "generation" TEXT;

--- a/front/migrations/db/migration_37.sql
+++ b/front/migrations/db/migration_37.sql
@@ -1,0 +1,3 @@
+-- Migration created on Jul 04, 2024
+ALTER TABLE "public"."agent_visualization_actions" DROP COLUMN "query";
+ALTER TABLE "public"."agent_visualization_actions" DROP COLUMN "output";

--- a/types/src/front/assistant/actions/visualization.ts
+++ b/types/src/front/assistant/actions/visualization.ts
@@ -12,15 +12,10 @@ export type VisualizationConfigurationType = {
   description: string | null;
 };
 
-// Dust App output
-export type VisualizationActionOutputType = {
-  generation: string;
-};
-
 // Action execution
 export interface VisualizationActionType extends BaseAction {
   agentMessageId: ModelId;
-  output: VisualizationActionOutputType | null;
+  generation: string | null;
   functionCallId: string | null;
   functionCallName: string | null;
   step: number;


### PR DESCRIPTION
## Description

Cleanup of the visualization action model. 
- We remove the column `query` that is not used anymore, since we feed the action with the conversation instead of via a built query. 
- We remove the column `output` that was a JSONB and replace it with a text `generation` column. Since the action is not using a tool call but is a generation, we are good with a string output. 

## Risk

Shouldn't be too risky because the action is not used yet. 

## Deploy Plan

- Deploy Probox
- Run `psql $FRONT_DATABASE_URI -f ./migrations/db/migration_36.sql` to create the new `generation` column that is required from the code. 
- Deploy front. 
- Run `psql $FRONT_DATABASE_URI -f ./migrations/db/migration_35.sql` to remove the  `query` & `output` columns.

I'm able to have this deploy plan only because this action is currently behind a feature flag activated to no workspace.  

