### PR TITLE
Connectors batch get

### DIFF
--- a/connectors/src/api/get_connector.ts
+++ b/connectors/src/api/get_connector.ts
@@ -74,45 +74,45 @@ const _getConnector = async (
 
 export const getConnectorAPIHandler = withLogging(_getConnector);
 
-type GetConnectorsResponseBody = WithConnectorsAPIErrorReponse<{
-  connectors: ConnectorType[];
-}>;
+type GetConnectorsResponseBody = WithConnectorsAPIErrorReponse<ConnectorType[]>;
 
 const _getConnectors = async (
   req: Request<Record<string, string>, GetConnectorsResponseBody, undefined>,
   res: Response<GetConnectorsResponseBody>
 ) => {
   if (
-    typeof req.query.connector_provider !== "string" ||
-    !isConnectorProvider(req.query.connector_provider)
+    typeof req.query.provider !== "string" ||
+    !isConnectorProvider(req.query.provider)
   ) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
         type: "unknown_connector_provider",
-        message: `Unknown connector provider ${req.params.connector_provider}`,
+        message: `Unknown connector provider ${req.params.provider}`,
       },
     });
   }
 
-  if (!Array.isArray(req.query.connector_ids)) {
+  if (typeof req.query.connector_id === "string") {
+    req.query.connector_id = [req.query.connector_id];
+  }
+
+  if (!Array.isArray(req.query.connector_id)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: `Expecting connector_ids to be passed as query parameters`,
+        message: `Expecting connector_id to be passed as query parameters`,
       },
     });
   }
 
   const connectors = await ConnectorResource.fetchByIds(
-    req.query.connector_provider,
-    req.query.connector_ids as string[]
+    req.query.provider,
+    req.query.connector_id as string[]
   );
 
-  return res.status(200).json({
-    connectors: connectors.map((c) => c.toJSON()),
-  });
+  return res.status(200).json(connectors.map((c) => c.toJSON()));
 };
 
 export const getConnectorsAPIHandler = withLogging(_getConnectors);

--- a/connectors/src/api_server.ts
+++ b/connectors/src/api_server.ts
@@ -8,7 +8,10 @@ import { adminAPIHandler } from "@connectors/api/admin";
 import { patchConnectorConfigurationAPIHandler } from "@connectors/api/configuration";
 import { createConnectorAPIHandler } from "@connectors/api/create_connector";
 import { deleteConnectorAPIHandler } from "@connectors/api/delete_connector";
-import { getConnectorAPIHandler } from "@connectors/api/get_connector";
+import {
+  getConnectorAPIHandler,
+  getConnectorsAPIHandler,
+} from "@connectors/api/get_connector";
 import { getConnectorPermissionsAPIHandler } from "@connectors/api/get_connector_permissions";
 import { getContentNodesParentsAPIHandler } from "@connectors/api/get_content_node_parents";
 import { getContentNodesAPIHandler } from "@connectors/api/get_content_nodes";
@@ -95,6 +98,7 @@ export function startServer(port: number) {
   app.post("/connectors/resume/:connector_id", resumeConnectorAPIHandler);
   app.delete("/connectors/delete/:connector_id", deleteConnectorAPIHandler);
   app.get("/connectors/:connector_id", getConnectorAPIHandler);
+  app.get("/connectors", getConnectorsAPIHandler);
   app.post("/connectors/sync/:connector_id", syncConnectorAPIHandler);
   app.get(
     "/connectors/:connector_id/permissions",

--- a/connectors/src/connectors/interface.ts
+++ b/connectors/src/connectors/interface.ts
@@ -41,9 +41,6 @@ export abstract class BaseConnectorManager<T extends ConnectorConfiguration> {
     fromTs: number | null;
   }): Promise<Result<string, Error>>;
 
-  abstract retrieveConnector(): Promise<Result<ConnectorType, Error>>;
-  abstract retrieveBatchConnectors(): Promise<Result<ConnectorType[], Error>>;
-
   abstract retrievePermissions(params: {
     parentInternalId: string | null;
     filterPermission: ConnectorPermission | null;

--- a/connectors/src/connectors/interface.ts
+++ b/connectors/src/connectors/interface.ts
@@ -1,6 +1,5 @@
 import type {
   ConnectorPermission,
-  ConnectorType,
   ConnectorsAPIError,
   ContentNode,
   ContentNodesViewType,

--- a/connectors/src/connectors/interface.ts
+++ b/connectors/src/connectors/interface.ts
@@ -1,5 +1,6 @@
 import type {
   ConnectorPermission,
+  ConnectorType,
   ConnectorsAPIError,
   ContentNode,
   ContentNodesViewType,
@@ -39,6 +40,9 @@ export abstract class BaseConnectorManager<T extends ConnectorConfiguration> {
   abstract sync(params: {
     fromTs: number | null;
   }): Promise<Result<string, Error>>;
+
+  abstract retrieveConnector(): Promise<Result<ConnectorType, Error>>;
+  abstract retrieveBatchConnectors(): Promise<Result<ConnectorType[], Error>>;
 
   abstract retrievePermissions(params: {
     parentInternalId: string | null;

--- a/connectors/src/resources/connector_resource.ts
+++ b/connectors/src/resources/connector_resource.ts
@@ -142,11 +142,15 @@ export class ConnectorResource extends BaseResource<ConnectorModel> {
     return c;
   }
 
-  static async fetchByIds(type: ConnectorProvider, ids: ModelId[]) {
+  static async fetchByIds(type: ConnectorProvider, ids: (ModelId | string)[]) {
+    const parsedIds = ids.map((id) =>
+      typeof id === "string" ? parseInt(id, 10) : id
+    );
+
     const blobs = await ConnectorResource.model.findAll({
       where: {
         type,
-        id: ids,
+        id: parsedIds,
       },
     });
 

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -355,6 +355,25 @@ export class ConnectorsAPI {
     return this._resultFromResponse(res);
   }
 
+  async getConnectors(
+    provider: ConnectorProvider,
+    connectorIds: string[]
+  ): Promise<ConnectorsAPIResponse<ConnectorType[]>> {
+    const res = await this._fetchWithError(
+      `${CONNECTORS_API}/connectors?provider=${encodeURIComponent(
+        provider
+      )}&${connectorIds
+        .map((id) => `connector_id=${encodeURIComponent(id)}`)
+        .join("&")}`,
+      {
+        method: "GET",
+        headers: this.getDefaultHeaders(),
+      }
+    );
+
+    return this._resultFromResponse(res);
+  }
+
   async setConnectorConfig(
     connectorId: string,
     configKey: string,

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -359,6 +359,9 @@ export class ConnectorsAPI {
     provider: ConnectorProvider,
     connectorIds: string[]
   ): Promise<ConnectorsAPIResponse<ConnectorType[]>> {
+    if (connectorIds.length === 0) {
+      return new Ok([]);
+    }
     const res = await this._fetchWithError(
       `${CONNECTORS_API}/connectors?provider=${encodeURIComponent(
         provider


### PR DESCRIPTION
## Description

Introduces a batch GET endpoint in connectors so that we batch GET connectors from /public-urls to avoid sending hundreds of concurrent requests from front to connectors

Fixes: https://github.com/dust-tt/tasks/issues/805

## Risk

Low

## Deploy Plan

- deploy `connectors`
- deploy `front`