### PR TITLE
[ms-connector] Get nodes from id

### DIFF
--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -13,16 +13,20 @@ import { BaseConnectorManager } from "@connectors/connectors/interface";
 import { microsoftConfig } from "@connectors/connectors/microsoft/lib/config";
 import {
   getChannelAsContentNode,
+  getContentNode,
   getDriveAsContentNode,
   getFolderAsContentNode,
   getRootNodes,
   getSiteAsContentNode,
+  getSitesRootAsContentNode,
   getTeamAsContentNode,
+  getTeamsRootAsContentNode,
 } from "@connectors/connectors/microsoft/lib/content_nodes";
 import {
   getChannels,
   getDrives,
   getFolders,
+  getItem,
   getSites,
   getTeams,
   microsoftInternalIdFromNodeData,
@@ -40,6 +44,7 @@ import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import {
   MicrosoftConfigurationResource,
+  MicrosoftNodeResource,
   MicrosoftRootResource,
 } from "@connectors/resources/microsoft_resource";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
@@ -181,7 +186,17 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
     );
 
     if (!parentInternalId) {
-      nodes.push(...getRootNodes());
+      if (filterPermission === null) {
+        nodes.push(...getRootNodes());
+      } else if (filterPermission === "read") {
+        nodes.push(
+          ...(await Promise.all(
+            selectedResources.map((internalId) =>
+              getContentNode(client, internalId)
+            )
+          ))
+        );
+      }
     } else {
       const { nodeType } = microsoftNodeDataFromInternalId(parentInternalId);
 

--- a/front/components/assistant_builder/AssistantBuilderTablesModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderTablesModal.tsx
@@ -31,7 +31,11 @@ import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import { useDataSourceNodes, useTables } from "@app/lib/swr";
 import { compareForFuzzySort, subFilter } from "@app/lib/utils";
 
-const STRUCTURED_DATA_SOURCES: ConnectorProvider[] = ["google_drive", "notion"];
+const STRUCTURED_DATA_SOURCES: ConnectorProvider[] = [
+  "google_drive",
+  "notion",
+  "microsoft",
+];
 
 export default function AssistantBuilderTablesModal({
   isOpen,
@@ -322,6 +326,9 @@ const PickTable = ({
     workspaceId: owner.sId,
     dataSourceName: dataSource.name,
   });
+
+  console.log("tables", tables);
+
   const [query, setQuery] = useState<string>("");
 
   const tablesToDisplay = tables.filter(

--- a/front/components/assistant_builder/AssistantBuilderTablesModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderTablesModal.tsx
@@ -327,8 +327,6 @@ const PickTable = ({
     dataSourceName: dataSource.name,
   });
 
-  console.log("tables", tables);
-
   const [query, setQuery] = useState<string>("");
 
   const tablesToDisplay = tables.filter(


### PR DESCRIPTION
## Description

When getting read permissions we need to load as root the configured root (on which we have read permisisons)
To do that we need to get content nodes from internal ids -> code added in content_ndoes
Still one issue : when getting a drive, I was not able to get the parent (site) id ..

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
