### PR TITLE
Moving docx2text and pptx2text to a shared workerpool

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -60,6 +60,7 @@
         "tsconfig-paths-webpack-plugin": "^4.1.0",
         "turndown": "^7.1.2",
         "uuid": "^9.0.0",
+        "workerpool": "^9.1.3",
         "yargs": "^17.7.2"
       },
       "devDependencies": {
@@ -12161,6 +12162,11 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/workerpool": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.1.3.tgz",
+      "integrity": "sha512-LhUrk4tbxJRDQmRrrFWA9EnboXI79fe0ZNTy3u8m+dqPN1EkVSIsQYAB8OF/fkyhG8Rtup+c/bzj/+bzbG8fqg=="
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/connectors/package.json
+++ b/connectors/package.json
@@ -66,6 +66,7 @@
     "tsconfig-paths-webpack-plugin": "^4.1.0",
     "turndown": "^7.1.2",
     "uuid": "^9.0.0",
+    "workerpool": "^9.1.3",
     "yargs": "^17.7.2"
   },
   "devDependencies": {

--- a/connectors/src/connectors/google_drive/temporal/file.ts
+++ b/connectors/src/connectors/google_drive/temporal/file.ts
@@ -25,7 +25,7 @@ import {
   sectionLength,
   upsertToDatasource,
 } from "@connectors/lib/data_sources";
-import { docx2text } from "@connectors/lib/docx2text.";
+import { docx2text } from "@connectors/lib/docx2text";
 import { dpdf2text } from "@connectors/lib/dpdf2text";
 import {
   GoogleDriveConfig,

--- a/connectors/src/lib/docx2text.ts
+++ b/connectors/src/lib/docx2text.ts
@@ -2,7 +2,9 @@ import tracer from "dd-trace";
 import mammoth from "mammoth";
 import turndown from "turndown";
 
-export async function docx2text(fileContent: Buffer, filename: string) {
+import { getWorkerPool } from "@connectors/lib/workerpool";
+
+async function _docx2text(fileContent: Buffer, filename: string) {
   return tracer.trace(
     `gdrive`,
     {
@@ -22,4 +24,8 @@ export async function docx2text(fileContent: Buffer, filename: string) {
       return result;
     }
   );
+}
+
+export async function docx2text(fileContent: Buffer, filename: string) {
+  return getWorkerPool().exec(_docx2text, [fileContent, filename]);
 }

--- a/connectors/src/lib/pptx2text.ts
+++ b/connectors/src/lib/pptx2text.ts
@@ -2,13 +2,15 @@ import tracer from "dd-trace";
 import JSZip from "jszip";
 import turndown from "turndown";
 
+import { getWorkerPool } from "@connectors/lib/workerpool";
+
 type PPTXDocument = {
   pages: {
     content: string;
   }[];
 };
 
-export async function PPTX2Text(
+async function _PPTX2Text(
   fileBuffer: Buffer,
   filename?: string
 ): Promise<PPTXDocument> {
@@ -69,4 +71,11 @@ export async function PPTX2Text(
       return document;
     }
   );
+}
+
+export async function PPTX2Text(
+  fileBuffer: Buffer,
+  filename?: string
+): Promise<PPTXDocument> {
+  return getWorkerPool().exec(_PPTX2Text, [fileBuffer, filename]);
 }

--- a/connectors/src/lib/workerpool.ts
+++ b/connectors/src/lib/workerpool.ts
@@ -1,0 +1,9 @@
+import workerpool from "workerpool";
+
+let POOL: ReturnType<typeof workerpool.pool> | null = null;
+export function getWorkerPool() {
+  if (!POOL) {
+    POOL = workerpool.pool({ maxWorkers: 3 });
+  }
+  return POOL;
+}

--- a/k8s/deployments/connectors-worker-google-drive-deployment.yaml
+++ b/k8s/deployments/connectors-worker-google-drive-deployment.yaml
@@ -47,12 +47,12 @@ spec:
 
           resources:
             requests:
-              cpu: 2000m
+              cpu: 3000m
               memory: 4Gi
               ephemeral-storage: 4Gi
 
             limits:
-              cpu: 2000m
+              cpu: 3000m
               memory: 4Gi
               ephemeral-storage: 4Gi
 


### PR DESCRIPTION
## Description

Moving docx2text and pptx2text to a shared workerpool to avoid blocking the nodejs thread.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
