### PR TITLE
front: fix folders UX

### DIFF
--- a/front/components/data_source/DataSourceSyncChip.tsx
+++ b/front/components/data_source/DataSourceSyncChip.tsx
@@ -1,4 +1,4 @@
-import { Chip } from "@dust-tt/sparkle";
+import { Chip, Tooltip } from "@dust-tt/sparkle";
 import type { ConnectorType } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
 
@@ -46,29 +46,36 @@ export default function ConnectorSyncingChip({
     switch (connector.errorType) {
       case "oauth_token_revoked":
         return (
-          <Chip color="warning">
-            Our access to your account has been revoked. Re-authorize to keep
-            the connection up-to-date.
-          </Chip>
+          <Tooltip
+            label={
+              "Our access to your account has been revoked. Re-authorize to keep the connection up-to-date."
+            }
+          >
+            <Chip color="warning">Re-authorization required</Chip>
+          </Tooltip>
         );
       case "third_party_internal_error":
         return (
-          <Chip color="warning">
-            We have encountered an error with{" "}
-            {CONNECTOR_CONFIGURATIONS[connector.type].name}. We sent you an
-            email to resolve the issue.
-          </Chip>
+          <Tooltip
+            label={
+              `We have encountered an error with ${CONNECTOR_CONFIGURATIONS[connector.type].name}. ` +
+              "We sent you an email to resolve the issue."
+            }
+          >
+            <Chip color="warning">Synchronization failed</Chip>
+          </Tooltip>
         );
       case "webcrawling_error":
         return (
-          <>
-            <Chip color="warning">Synchronization failed.</Chip>
-            <div className="text-sm">
-              We were unable to extract data from your site's pages using our
-              webcrawler. This problem commonly occurs with JavaScript-based
-              websites, as our current crawler cannot process JavaScript.
-            </div>
-          </>
+          <Tooltip
+            label={
+              "We were unable to extract data from your site's pages using our webcrawler." +
+              "This problem commonly occurs with JavaScript-based websites," +
+              " as our current crawler cannot process JavaScript."
+            }
+          >
+            <Chip color="warning">Synchronization failed</Chip>
+          </Tooltip>
         );
       default:
         assertNever(connector.errorType);

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/csv.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/csv.ts
@@ -80,7 +80,7 @@ async function handler(
   const owner = auth.workspace();
   const plan = auth.plan();
   const isSystemKey = keyRes.value.isSystem;
-  if (!owner || !plan || !auth.isBuilder()) {
+  if (!owner || !plan || !auth.isBuilder() || !isSystemKey) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/csv.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/csv.ts
@@ -80,7 +80,7 @@ async function handler(
   const owner = auth.workspace();
   const plan = auth.plan();
   const isSystemKey = keyRes.value.isSystem;
-  if (!owner || !plan || !auth.isBuilder() || !isSystemKey) {
+  if (!owner || !plan || !auth.isBuilder()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
@@ -4,7 +4,7 @@ import {
   Page,
   PlusIcon,
   Popup,
-  RobotIcon,
+  RobotStrokeIcon,
 } from "@dust-tt/sparkle";
 import { GlobeAltIcon } from "@dust-tt/sparkle";
 import type { PlanType, SubscriptionType } from "@dust-tt/types";
@@ -212,6 +212,14 @@ export default function DataSourcesView({
                   }/builder/data-sources/${encodeURIComponent(ds.name)}`
                 );
               }}
+              subElement={
+                <div className="flex items-center gap-1 pl-2 pt-1 text-xs text-element-700">
+                  <span>Added by: {ds.editedByUser?.fullName}</span>
+                  <span className="px-1 text-element-500">|</span>
+                  <span>{dataSourcesUsage[ds.id] ?? 0}</span>
+                  <RobotStrokeIcon />
+                </div>
+              }
               action={
                 <ConnectorSyncingChip
                   initialState={ds.connector}
@@ -220,15 +228,6 @@ export default function DataSourcesView({
                 />
               }
             >
-              <ContextItem.Description>
-                <div className="mt-1 flex items-center gap-1 text-xs text-element-700">
-                  <span>Added by: {ds.editedByUser?.fullName} | </span>
-                  <span className="underline">
-                    {dataSourcesUsage[ds.id] ?? 0}
-                  </span>
-                  <RobotIcon />
-                </div>
-              </ContextItem.Description>
             </ContextItem>
           ))}
         </ContextItem.List>

--- a/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
@@ -227,8 +227,7 @@ export default function DataSourcesView({
                   dataSourceName={ds.connector.dataSourceName}
                 />
               }
-            >
-            </ContextItem>
+            ></ContextItem>
           ))}
         </ContextItem.List>
       </Page.Vertical>

--- a/front/pages/w/[wId]/builder/data-sources/static.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/static.tsx
@@ -174,16 +174,11 @@ export default function DataSourcesView({
                   <RobotIcon />
                 </div>
               }
-              action={
-                <IconButton
-                  icon={MoreIcon}
-                  onClick={() => {
-                    void router.push(
-                      `/w/${owner.sId}/builder/data-sources/${ds.name}`
-                    );
-                  }}
-                />
-              }
+              onClick={() => {
+                void router.push(
+                  `/w/${owner.sId}/builder/data-sources/${ds.name}`
+                );
+              }}
             >
               <ContextItem.Description>
                 <div className="text-sm text-element-700">{ds.description}</div>

--- a/front/pages/w/[wId]/builder/data-sources/static.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/static.tsx
@@ -2,12 +2,10 @@ import {
   ContextItem,
   DocumentPileIcon,
   FolderOpenIcon,
-  IconButton,
-  MoreIcon,
   Page,
   PlusIcon,
   Popup,
-  RobotIcon,
+  RobotStrokeIcon,
 } from "@dust-tt/sparkle";
 import type { DataSourceType, WorkspaceType } from "@dust-tt/types";
 import type { PlanType, SubscriptionType } from "@dust-tt/types";
@@ -166,12 +164,11 @@ export default function DataSourcesView({
                 />
               }
               subElement={
-                <div className="flex items-center gap-1 text-xs text-element-700">
-                  <span>Added by: {ds.editedByUser?.fullName} | </span>
-                  <span className="underline">
-                    {dataSourcesUsage[ds.id] ?? 0}
-                  </span>
-                  <RobotIcon />
+                <div className="flex items-center gap-1 pl-2 pt-1 text-xs text-element-700">
+                  <span>Added by: {ds.editedByUser?.fullName}</span>
+                  <span className="px-1 text-element-500">|</span>
+                  <span>{dataSourcesUsage[ds.id] ?? 0}</span>
+                  <RobotStrokeIcon />
                 </div>
               }
               onClick={() => {


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/1027

Make the whole folder context item clickable instead of only the MoreIcon. This is more intuitive and aligns with websites.

## Risk

N/A

## Deploy Plan

- deploy `front`