### PR TITLE
[front] - fix: correct table reference in getAssistantsUsageData query

### DIFF
--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -407,7 +407,7 @@ export async function getAssistantsUsageData(
       COUNT(DISTINCT u."id") AS "distinctUsersReached",
       MAX(CAST(ac."createdAt" AS DATE)) AS "lastEdit"
     FROM
-      "mentions" a
+      "agent_messages" a
       JOIN "messages" m ON a."id" = m."agentMessageId"
       JOIN "messages" parent ON m."parentId" = parent."id"
       JOIN "user_messages" um ON um."id" = parent."userMessageId"


### PR DESCRIPTION
## Description

We identified a wrong table reference in the `getAssistantsUsageData` SQL query (cc @thib-martin)

 The changes introduced by this PR are the following:
- Replace the "mentions" table with "agent_messages" to accurately fetch assistants usage data

## Risk

Minor risks

## Deploy Plan

Deploy `front`
