### PR TITLE
fix: suggestions may be undefined

### DIFF
--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -424,7 +424,7 @@ function Suggestions({
       }
       if (
         updatedSuggestions.value.status === "ok" &&
-        !updatedSuggestions.value.suggestions.length
+        !updatedSuggestions.value.suggestions?.length
       ) {
         setSuggestionsStatus("instructions_are_good");
         return;
@@ -616,7 +616,7 @@ function mergeSuggestions(
 ): string[] {
   if (dustAppSuggestions.status === "ok") {
     const visibleSuggestions = suggestions.slice(0, VISIBLE_SUGGESTIONS_NUMBER);
-    const bestRankedSuggestions = dustAppSuggestions.suggestions.slice(
+    const bestRankedSuggestions = (dustAppSuggestions.suggestions ?? []).slice(
       0,
       VISIBLE_SUGGESTIONS_NUMBER
     );

--- a/front/components/assistant_builder/NamingScreen.tsx
+++ b/front/components/assistant_builder/NamingScreen.tsx
@@ -239,7 +239,7 @@ export default function NamingScreen({
       if (descriptionSuggestions.isOk()) {
         const suggestion =
           descriptionSuggestions.value.status === "ok" &&
-          descriptionSuggestions.value.suggestions.length > 0
+          descriptionSuggestions.value.suggestions?.length
             ? descriptionSuggestions.value.suggestions[0]
             : null;
         if (suggestion) {
@@ -320,7 +320,7 @@ export default function NamingScreen({
               </div>
             </div>
             {nameSuggestions.status === "ok" &&
-              nameSuggestions.suggestions.length > 0 && (
+              nameSuggestions.suggestions?.length && (
                 <div className="flex items-center gap-2">
                   <div className="text-xs font-semibold text-element-800">
                     Suggestions:

--- a/types/src/front/api_handlers/internal/assistant.ts
+++ b/types/src/front/api_handlers/internal/assistant.ts
@@ -106,7 +106,7 @@ export type BuilderSuggestionsRequestType = t.TypeOf<
 export const BuilderSuggestionsResponseBodySchema = t.union([
   t.type({
     status: t.literal("ok"),
-    suggestions: t.array(t.string),
+    suggestions: t.union([t.array(t.string), t.null, t.undefined]),
   }),
   t.type({
     status: t.literal("unavailable"),


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/tasks/issues/1006

`suggestions` returned by the name/description/instruction suggestions dust app may be undefined as it is model-generated. The current io-ts schema does not take this into account.

## Risk

N/A

## Deploy Plan

N/A