### PR TITLE
Chore/delete data source warning

### DIFF
--- a/front/components/data_source/DeleteDataSourceDialog.tsx
+++ b/front/components/data_source/DeleteDataSourceDialog.tsx
@@ -1,0 +1,102 @@
+import { Button } from "@dust-tt/sparkle";
+import { Dialog, Transition } from "@headlessui/react";
+import { TrashIcon } from "@heroicons/react/24/outline";
+import { Fragment, useState } from "react";
+
+interface DeleteDataSourceDialogProps {
+  handleDelete: () => void;
+  dataSourceUsage: number;
+  isOpen: boolean;
+  setIsOpen: (isOpen: boolean) => void;
+}
+
+export function DeleteDataSourceDialog({
+  handleDelete,
+  dataSourceUsage,
+  isOpen,
+  setIsOpen,
+}: DeleteDataSourceDialogProps) {
+  const [isSavingOrDeleting, setIsSavingOrDeleting] = useState(false);
+
+  const onDelete = async () => {
+    setIsSavingOrDeleting(true);
+    await handleDelete();
+    setIsSavingOrDeleting(false);
+    setIsOpen(false);
+  };
+
+  return (
+    <>
+      <Transition appear show={isOpen} as={Fragment}>
+        <Dialog
+          as="div"
+          className="relative z-30"
+          onClose={() => {
+            setIsOpen(false);
+          }}
+        >
+          <Transition.Child
+            as={Fragment}
+            enter="ease-out duration-300"
+            enterFrom="opacity-0"
+            enterTo="opacity-100"
+            leave="ease-in duration-200"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+          >
+            <div className="fixed inset-0 bg-black bg-opacity-25" />
+          </Transition.Child>
+
+          <div className="fixed inset-0 overflow-y-auto">
+            <div className="flex min-h-full items-center justify-center p-4 text-center">
+              <Transition.Child
+                as={Fragment}
+                enter="ease-out duration-300"
+                enterFrom="opacity-0 scale-95"
+                enterTo="opacity-100 scale-100"
+                leave="ease-in duration-200"
+                leaveFrom="opacity-100 scale-100"
+                leaveTo="opacity-0 scale-95"
+              >
+                <Dialog.Panel className="w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all">
+                  <Dialog.Title
+                    as="h3"
+                    className="text-lg font-medium leading-6 text-gray-900"
+                  >
+                    Removing Data Source
+                  </Dialog.Title>
+                  <div className="mt-2">
+                    <p className="text-sm text-gray-500">
+                      {dataSourceUsage} assistants currently use this Data
+                      Source. Are you sure you want to remove?
+                    </p>
+                  </div>
+
+                  <div className="mt-4 flex justify-between">
+                    <Button
+                      variant="tertiary"
+                      size="sm"
+                      label="Cancel"
+                      disabled={isSavingOrDeleting}
+                      onClick={() => {
+                        setIsOpen(false);
+                      }}
+                    />
+                    <Button
+                      variant="primaryWarning"
+                      size="sm"
+                      label="Remove"
+                      disabled={isSavingOrDeleting}
+                      icon={TrashIcon}
+                      onClick={onDelete}
+                    />
+                  </div>
+                </Dialog.Panel>
+              </Transition.Child>
+            </div>
+          </div>
+        </Dialog>
+      </Transition>
+    </>
+  );
+}

--- a/front/components/data_source/DeleteDataSourceDialog.tsx
+++ b/front/components/data_source/DeleteDataSourceDialog.tsx
@@ -72,7 +72,7 @@ export function DeleteDataSourceDialog({
                     </p>
                   </div>
 
-                  <div className="mt-4 flex justify-between">
+                  <div className="mt-4 flex justify-end gap-2">
                     <Button
                       variant="tertiary"
                       size="sm"

--- a/front/components/data_source/WebsiteConfiguration.tsx
+++ b/front/components/data_source/WebsiteConfiguration.tsx
@@ -30,6 +30,7 @@ import { useRouter } from "next/router";
 import { useCallback, useEffect, useState } from "react";
 import { useSWRConfig } from "swr";
 
+import { DeleteDataSourceDialog } from "@app/components/data_source/DeleteDataSourceDialog";
 import { subNavigationBuild } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleSaveCancelTitle } from "@app/components/sparkle/AppLayoutTitle";
@@ -43,6 +44,7 @@ export default function WebsiteConfiguration({
   dataSource,
   gaTrackingId,
   webCrawlerConfiguration,
+  dataSourceUsage,
 }: {
   owner: WorkspaceType;
   subscription: SubscriptionType;
@@ -50,9 +52,11 @@ export default function WebsiteConfiguration({
   webCrawlerConfiguration: WebCrawlerConfigurationType | null;
   dataSource: DataSourceType | null;
   gaTrackingId: string;
+  dataSourceUsage?: number;
 }) {
   const [isSaving, setIsSaving] = useState(false);
   const [isSubmitted, setIsSubmitted] = useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   const [dataSourceUrl, setDataSourceUrl] = useState(
     webCrawlerConfiguration?.url || ""
@@ -519,43 +523,21 @@ export default function WebsiteConfiguration({
             ></Button>
           </div>
           {webCrawlerConfiguration && (
-            <div className="flex">
-              <DropdownMenu>
-                <DropdownMenu.Button>
-                  <Button
-                    variant="secondaryWarning"
-                    icon={TrashIcon}
-                    label={"Delete this Website"}
-                  />
-                </DropdownMenu.Button>
-                <DropdownMenu.Items width={280}>
-                  <div className="flex flex-col gap-y-4 px-4 py-4">
-                    <div className="flex flex-col gap-y-2">
-                      <div className="grow text-sm font-medium text-element-800">
-                        Are you sure you want to delete?
-                      </div>
-
-                      <div className="text-sm font-normal text-element-700">
-                        This will delete the Website for everyone.
-                      </div>
-                    </div>
-                    <div className="flex justify-center">
-                      <Button
-                        variant="primaryWarning"
-                        size="sm"
-                        label={"Delete for Everyone"}
-                        disabled={false}
-                        icon={TrashIcon}
-                        onClick={async () => {
-                          // setIsSavingOrDeleting(true);
-                          await handleDelete();
-                          // setIsSavingOrDeleting(false);
-                        }}
-                      />
-                    </div>
-                  </div>
-                </DropdownMenu.Items>
-              </DropdownMenu>
+            <div className="flex py-16">
+              <Button
+                variant="secondaryWarning"
+                icon={TrashIcon}
+                label={"Delete this website"}
+                onClick={() => {
+                  setIsDeleteModalOpen(true);
+                }}
+              />
+              <DeleteDataSourceDialog
+                handleDelete={handleDelete}
+                isOpen={isDeleteModalOpen}
+                setIsOpen={setIsDeleteModalOpen}
+                dataSourceUsage={dataSourceUsage ?? 0}
+              />
             </div>
           )}
         </Page.Layout>

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -1,4 +1,8 @@
-import type { ConnectorProvider, ModelId } from "@dust-tt/types";
+import type {
+  ConnectorProvider,
+  DataSourceType,
+  ModelId,
+} from "@dust-tt/types";
 import { Sequelize } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
@@ -76,10 +80,10 @@ export async function getDataSourcesUsageByAgents({
 
 export async function getDataSourceUsage({
   auth,
-  dataSourceId,
+  dataSource,
 }: {
   auth: Authenticator;
-  dataSourceId: number;
+  dataSource: DataSourceType;
 }): Promise<number> {
   const owner = auth.workspace();
 
@@ -92,7 +96,7 @@ export async function getDataSourceUsage({
 
   return AgentDataSourceConfiguration.count({
     where: {
-      dataSourceId: dataSourceId,
+      dataSourceId: dataSource.id,
     },
     include: [
       {

--- a/front/pages/w/[wId]/builder/data-sources/[name]/edit-public-url.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/edit-public-url.tsx
@@ -8,6 +8,7 @@ import { ConnectorsAPI } from "@dust-tt/types";
 import type { InferGetServerSidePropsType } from "next";
 
 import WebsiteConfiguration from "@app/components/data_source/WebsiteConfiguration";
+import { getDataSourceUsage } from "@app/lib/api/agent_data_sources";
 import { getDataSource, getDataSources } from "@app/lib/api/data_sources";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import logger from "@app/logger/logger";
@@ -21,6 +22,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   dataSource: DataSourceType;
   webCrawlerConfiguration: WebCrawlerConfigurationType;
   gaTrackingId: string;
+  dataSourceUsage: number;
 }>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
@@ -57,6 +59,11 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     throw new Error(connectorRes.error.message);
   }
 
+  const dataSourceUsage = await getDataSourceUsage({
+    auth,
+    dataSourceId: dataSource.id,
+  });
+
   return {
     props: {
       owner,
@@ -66,6 +73,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       webCrawlerConfiguration: connectorRes.value
         .configuration as WebCrawlerConfigurationType,
       gaTrackingId: GA_TRACKING_ID,
+      dataSourceUsage,
     },
   };
 });
@@ -77,6 +85,7 @@ export default function DataSourceNew({
   dataSource,
   gaTrackingId,
   webCrawlerConfiguration,
+  dataSourceUsage,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   return (
     <WebsiteConfiguration
@@ -86,6 +95,7 @@ export default function DataSourceNew({
       gaTrackingId={gaTrackingId}
       webCrawlerConfiguration={webCrawlerConfiguration}
       dataSource={dataSource}
+      dataSourceUsage={dataSourceUsage}
     />
   );
 }

--- a/front/pages/w/[wId]/builder/data-sources/[name]/edit-public-url.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/edit-public-url.tsx
@@ -61,7 +61,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
 
   const dataSourceUsage = await getDataSourceUsage({
     auth,
-    dataSourceId: dataSource.id,
+    dataSource,
   });
 
   return {

--- a/front/pages/w/[wId]/builder/data-sources/[name]/settings.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/settings.tsx
@@ -52,7 +52,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   }
   const dataSourceUsage = await getDataSourceUsage({
     auth,
-    dataSourceId: dataSource.id,
+    dataSource,
   });
   return {
     props: {

--- a/front/pages/w/[wId]/builder/data-sources/[name]/settings.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/settings.tsx
@@ -1,4 +1,4 @@
-import { Button, DropdownMenu, TrashIcon } from "@dust-tt/sparkle";
+import { Button, TrashIcon } from "@dust-tt/sparkle";
 import type {
   APIError,
   DataSourceType,
@@ -12,9 +12,11 @@ import { useRouter } from "next/router";
 import { useCallback, useEffect, useState } from "react";
 import { useSWRConfig } from "swr";
 
+import { DeleteDataSourceDialog } from "@app/components/data_source/DeleteDataSourceDialog";
 import { subNavigationBuild } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleSaveCancelTitle } from "@app/components/sparkle/AppLayoutTitle";
+import { getDataSourceUsage } from "@app/lib/api/agent_data_sources";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { classNames } from "@app/lib/utils";
@@ -27,6 +29,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   dataSource: DataSourceType;
   fetchConnectorError?: boolean;
   gaTrackingId: string;
+  dataSourceUsage: number;
 }>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
@@ -47,13 +50,17 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       notFound: true,
     };
   }
-
+  const dataSourceUsage = await getDataSourceUsage({
+    auth,
+    dataSourceId: dataSource.id,
+  });
   return {
     props: {
       owner,
       subscription,
       dataSource,
       gaTrackingId: GA_TRACKING_ID,
+      dataSourceUsage,
     },
   };
 });
@@ -63,6 +70,7 @@ export default function DataSourceSettings({
   subscription,
   dataSource,
   gaTrackingId,
+  dataSourceUsage,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
 
@@ -105,6 +113,7 @@ export default function DataSourceSettings({
         assistantDefaultSelected: boolean;
       }) => handleUpdate(settings)}
       gaTrackingId={gaTrackingId}
+      dataSourceUsage={dataSourceUsage}
     />
   );
 }
@@ -115,6 +124,7 @@ function StandardDataSourceSettings({
   dataSource,
   handleUpdate,
   gaTrackingId,
+  dataSourceUsage,
 }: {
   owner: WorkspaceType;
   subscription: SubscriptionType;
@@ -124,12 +134,14 @@ function StandardDataSourceSettings({
     assistantDefaultSelected: boolean;
   }) => Promise<void>;
   gaTrackingId: string;
+  dataSourceUsage: number;
 }) {
   const { mutate } = useSWRConfig();
 
   const [dataSourceDescription, setDataSourceDescription] = useState(
     dataSource.description || ""
   );
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [isSavingOrDeleting, setIsSavingOrDeleting] = useState(false);
   const [isEdited, setIsEdited] = useState(false);
 
@@ -267,45 +279,20 @@ function StandardDataSourceSettings({
           </div>
 
           <div className="flex py-16">
-            <div className="flex">
-              <DropdownMenu>
-                <DropdownMenu.Button>
-                  <Button
-                    variant="secondaryWarning"
-                    icon={TrashIcon}
-                    label={"Delete this Folder"}
-                  />
-                </DropdownMenu.Button>
-                <DropdownMenu.Items width={280}>
-                  <div className="flex flex-col gap-y-4 px-4 py-4">
-                    <div className="flex flex-col gap-y-2">
-                      <div className="grow text-sm font-medium text-element-800">
-                        Are you sure you want to delete?
-                      </div>
-
-                      <div className="text-sm font-normal text-element-700">
-                        This will delete the Folder and all associated Documents
-                        for everyone.
-                      </div>
-                    </div>
-                    <div className="flex justify-center">
-                      <Button
-                        variant="primaryWarning"
-                        size="sm"
-                        label={"Delete for Everyone"}
-                        disabled={isSavingOrDeleting}
-                        icon={TrashIcon}
-                        onClick={async () => {
-                          setIsSavingOrDeleting(true);
-                          await handleDelete();
-                          setIsSavingOrDeleting(false);
-                        }}
-                      />
-                    </div>
-                  </div>
-                </DropdownMenu.Items>
-              </DropdownMenu>
-            </div>
+            <Button
+              variant="secondaryWarning"
+              icon={TrashIcon}
+              label={"Delete this Folder"}
+              onClick={() => {
+                setIsDeleteModalOpen(true);
+              }}
+            />
+            <DeleteDataSourceDialog
+              handleDelete={handleDelete}
+              isOpen={isDeleteModalOpen}
+              setIsOpen={setIsDeleteModalOpen}
+              dataSourceUsage={dataSourceUsage}
+            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Description

This PR implements a new warning dialog when deleting a data source, showing how many assistants are currently using it. The main changes include:

1. A new `DeleteDataSourceDialog` component that displays the number of assistants using the data source and asks for confirmation before deletion.
2. Implementation of `getDataSourceUsage` function to retrieve the number of assistants using a specific data source.
3. Updates to the WebsiteConfiguration and StandardDataSourceSettings components to use the new delete dialog.
4. Refactoring of the delete button UI for consistency across different data source types (websites and folders).

Reference:
- Task: https://github.com/dust-tt/tasks/issues/849#issuecomment-2199750709

## Risk

There's a small risk of:
- Unexpected behavior if the data source usage calculation is incorrect.
- Performance impact due to the additional API call when loading data source settings.

## Deploy Plan

- Deploy `front-edge`
- Deploy `front`