### PR TITLE
fix(intercom): all convs root node id syncAllConversation activated

### DIFF
--- a/connectors/src/connectors/intercom/lib/conversation_permissions.ts
+++ b/connectors/src/connectors/intercom/lib/conversation_permissions.ts
@@ -138,8 +138,13 @@ export async function retrieveIntercomConversationsPermissions({
   // If Root level we display the fake parent "Conversations"
   // If isReadPermissionsOnly = true, we retrieve the list of Teams from DB that have permission = "read"
   // If isReadPermissionsOnly = false, we retrieve the list of Teams from Intercom
+
   if (isReadPermissionsOnly) {
-    if (isRootLevel && teamsWithReadPermission.length > 0) {
+    if (
+      isRootLevel &&
+      (teamsWithReadPermission.length > 0 ||
+        intercomWorkspace.syncAllConversations === "activated")
+    ) {
       nodes.push(rootConversationNode);
     }
     if (parentInternalId === allConvosInternalId) {


### PR DESCRIPTION
## Description

In intercom connector's retrieve permissions, we are not returning the conversations root node if no team has explicit read permission, even if the intercom workspace has `syncAllConversations='activated'`.
This commit changes the condition to include the root node in such cases.

## Risk

N/A

## Deploy Plan

Simple deploy