### PR TITLE
[front] - feature: categorize models in advanced settings

### DIFF
--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -248,12 +248,12 @@ const InstructionsCharacterCount = ({
 };
 
 interface ModelItemProps {
-  modelConfig: ModelConfigurationType;
+  modelConfigs: ModelConfigurationType[];
   onClick: (modelSettings: SupportedModel) => void;
 }
 
-function ModelItem({ modelConfig, onClick }: ModelItemProps) {
-  const handleClick = () => {
+function ModelsItem({ modelConfigs, onClick }: ModelItemProps) {
+  const handleClick = (modelConfig: ModelConfigurationType) => {
     onClick({
       modelId: modelConfig.modelId,
       providerId: modelConfig.providerId,
@@ -261,13 +261,17 @@ function ModelItem({ modelConfig, onClick }: ModelItemProps) {
   };
 
   return (
-    <DropdownMenu.Item
-      key={modelConfig.modelId}
-      icon={MODEL_PROVIDER_LOGOS[modelConfig.providerId]}
-      description={modelConfig.shortDescription}
-      label={modelConfig.displayName}
-      onClick={handleClick}
-    />
+    <>
+      {modelConfigs.map((modelConfig) => (
+        <DropdownMenu.Item
+          key={modelConfig.modelId}
+          icon={MODEL_PROVIDER_LOGOS[modelConfig.providerId]}
+          description={modelConfig.shortDescription}
+          label={modelConfig.displayName}
+          onClick={() => handleClick(modelConfig)}
+        />
+      ))}
+    </>
   );
 }
 
@@ -348,33 +352,27 @@ function AdvancedSettings({
                   <span className="text-sm uppercase text-element-700">
                     Best performing models
                   </span>
-                  {bestPerformingModelConfig.map((modelConfig) => (
-                    <ModelItem
-                      key={modelConfig.modelId}
-                      modelConfig={modelConfig}
-                      onClick={(modelSettings) => {
-                        setGenerationSettings({
-                          ...generationSettings,
-                          modelSettings,
-                        });
-                      }}
-                    />
-                  ))}
+                  <ModelsItem
+                    modelConfigs={bestPerformingModelConfig}
+                    onClick={(modelSettings) => {
+                      setGenerationSettings({
+                        ...generationSettings,
+                        modelSettings,
+                      });
+                    }}
+                  />
                   <span className="text-sm uppercase text-element-700">
                     Other models
                   </span>
-                  {otherModelsConfig.map((modelConfig) => (
-                    <ModelItem
-                      key={modelConfig.modelId}
-                      modelConfig={modelConfig}
-                      onClick={(modelSettings) => {
-                        setGenerationSettings({
-                          ...generationSettings,
-                          modelSettings,
-                        });
-                      }}
-                    />
-                  ))}
+                  <ModelsItem
+                    modelConfigs={otherModelsConfig}
+                    onClick={(modelSettings) => {
+                      setGenerationSettings({
+                        ...generationSettings,
+                        modelSettings,
+                      });
+                    }}
+                  />
                 </div>
               </DropdownMenu.Items>
             </DropdownMenu>

--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -247,12 +247,12 @@ const InstructionsCharacterCount = ({
   );
 };
 
-interface ModelsItemProps {
+interface ModelListProps {
   modelConfigs: ModelConfigurationType[];
   onClick: (modelSettings: SupportedModel) => void;
 }
 
-function ModelsItem({ modelConfigs, onClick }: ModelsItemProps) {
+function ModelList({ modelConfigs, onClick }: ModelListProps) {
   const handleClick = (modelConfig: ModelConfigurationType) => {
     onClick({
       modelId: modelConfig.modelId,
@@ -352,7 +352,7 @@ function AdvancedSettings({
                   <span className="text-sm uppercase text-element-700">
                     Best performing models
                   </span>
-                  <ModelsItem
+                  <ModelList
                     modelConfigs={bestPerformingModelConfig}
                     onClick={(modelSettings) => {
                       setGenerationSettings({
@@ -364,7 +364,7 @@ function AdvancedSettings({
                   <span className="text-sm uppercase text-element-700">
                     Other models
                   </span>
-                  <ModelsItem
+                  <ModelList
                     modelConfigs={otherModelsConfig}
                     onClick={(modelSettings) => {
                       setGenerationSettings({

--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -247,12 +247,12 @@ const InstructionsCharacterCount = ({
   );
 };
 
-interface ModelItemProps {
+interface ModelsItemProps {
   modelConfigs: ModelConfigurationType[];
   onClick: (modelSettings: SupportedModel) => void;
 }
 
-function ModelsItem({ modelConfigs, onClick }: ModelItemProps) {
+function ModelsItem({ modelConfigs, onClick }: ModelsItemProps) {
   const handleClick = (modelConfig: ModelConfigurationType) => {
     onClick({
       modelId: modelConfig.modelId,

--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -14,11 +14,12 @@ import type {
   PlanType,
   Result,
   SupportedModel,
-  WorkspaceType} from "@dust-tt/types";
+  WorkspaceType,
+} from "@dust-tt/types";
 import {
   CLAUDE_3_5_SONNET_20240620_MODEL_ID,
   GPT_4O_MODEL_ID,
-  MISTRAL_LARGE_MODEL_ID
+  MISTRAL_LARGE_MODEL_ID,
 } from "@dust-tt/types";
 import { isProviderWhitelisted } from "@dust-tt/types";
 import {

--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -10,10 +10,15 @@ import type {
   APIError,
   AssistantCreativityLevel,
   BuilderSuggestionsType,
+  ModelIdType,
   PlanType,
   Result,
   SupportedModel,
-  WorkspaceType,
+  WorkspaceType} from "@dust-tt/types";
+import {
+  CLAUDE_3_5_SONNET_20240620_MODEL_ID,
+  GPT_4O_MODEL_ID,
+  MISTRAL_LARGE_MODEL_ID
 } from "@dust-tt/types";
 import { isProviderWhitelisted } from "@dust-tt/types";
 import {
@@ -56,6 +61,16 @@ export const CREATIVITY_LEVELS = Object.entries(
     ASSISTANT_CREATIVITY_LEVEL_DISPLAY_NAMES[k as AssistantCreativityLevel],
   value: v,
 }));
+
+const BEST_PERFORMING_MODELS_ID: ModelIdType[] = [
+  GPT_4O_MODEL_ID,
+  CLAUDE_3_5_SONNET_20240620_MODEL_ID,
+  MISTRAL_LARGE_MODEL_ID,
+] as const;
+
+function isBestPerformingModel(modelId: ModelIdType) {
+  return BEST_PERFORMING_MODELS_ID.includes(modelId);
+}
 
 const getCreativityLevelFromTemperature = (temperature: number) => {
   const closest = CREATIVITY_LEVELS.reduce((prev, curr) =>
@@ -250,6 +265,13 @@ function AdvancedSettings({
     // unreachable
     alert("Unsupported model");
   }
+
+  const bestPerformingModelConfig = USED_MODEL_CONFIGS.filter((m) =>
+    isBestPerformingModel(m.modelId)
+  );
+  const otherModelsConfig = USED_MODEL_CONFIGS.filter(
+    (m) => !isBestPerformingModel(m.modelId)
+  );
   return (
     <DropdownMenu>
       <DropdownMenu.Button>
@@ -282,28 +304,60 @@ function AdvancedSettings({
               </DropdownMenu.Button>
               <DropdownMenu.Items origin="topRight" width={250}>
                 <div className="z-[120]">
-                  {USED_MODEL_CONFIGS.filter(
-                    (m) =>
-                      !(m.largeModel && !isUpgraded(plan)) &&
-                      isProviderWhitelisted(owner, m.providerId)
-                  ).map((modelConfig) => (
-                    <DropdownMenu.Item
-                      key={modelConfig.modelId}
-                      icon={MODEL_PROVIDER_LOGOS[modelConfig.providerId]}
-                      description={modelConfig.shortDescription}
-                      label={modelConfig.displayName}
-                      onClick={() => {
-                        setGenerationSettings({
-                          ...generationSettings,
-                          modelSettings: {
-                            modelId: modelConfig.modelId,
-                            providerId: modelConfig.providerId,
-                            // safe because the SupportedModel is derived from the SUPPORTED_MODEL_CONFIGS array
-                          } as SupportedModel,
-                        });
-                      }}
-                    />
-                  ))}
+                  <span className="text-sm uppercase text-element-700">
+                    Best performing models
+                  </span>
+                  {bestPerformingModelConfig
+                    .filter(
+                      (m) =>
+                        !(m.largeModel && !isUpgraded(plan)) &&
+                        isProviderWhitelisted(owner, m.providerId)
+                    )
+                    .map((modelConfig) => (
+                      <DropdownMenu.Item
+                        key={modelConfig.modelId}
+                        icon={MODEL_PROVIDER_LOGOS[modelConfig.providerId]}
+                        description={modelConfig.shortDescription}
+                        label={modelConfig.displayName}
+                        onClick={() => {
+                          setGenerationSettings({
+                            ...generationSettings,
+                            modelSettings: {
+                              modelId: modelConfig.modelId,
+                              providerId: modelConfig.providerId,
+                              // safe because the SupportedModel is derived from the SUPPORTED_MODEL_CONFIGS array
+                            } as SupportedModel,
+                          });
+                        }}
+                      />
+                    ))}
+                  <span className="text-sm uppercase text-element-700">
+                    Other models
+                  </span>
+                  {otherModelsConfig
+                    .filter(
+                      (m) =>
+                        !(m.largeModel && !isUpgraded(plan)) &&
+                        isProviderWhitelisted(owner, m.providerId)
+                    )
+                    .map((modelConfig) => (
+                      <DropdownMenu.Item
+                        key={modelConfig.modelId}
+                        icon={MODEL_PROVIDER_LOGOS[modelConfig.providerId]}
+                        description={modelConfig.shortDescription}
+                        label={modelConfig.displayName}
+                        onClick={() => {
+                          setGenerationSettings({
+                            ...generationSettings,
+                            modelSettings: {
+                              modelId: modelConfig.modelId,
+                              providerId: modelConfig.providerId,
+                              // safe because the SupportedModel is derived from the SUPPORTED_MODEL_CONFIGS array
+                            } as SupportedModel,
+                          });
+                        }}
+                      />
+                    ))}
                 </div>
               </DropdownMenu.Items>
             </DropdownMenu>

--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -160,13 +160,13 @@ const OPEN_AI_TOOL_USE_META_PROMPT =
 export const GPT_4_TURBO_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
   modelId: GPT_4_TURBO_MODEL_ID,
-  displayName: "GPT-4 Turbo",
+  displayName: "GPT 4 Turbo",
   contextSize: 128_000,
   recommendedTopK: 32,
   recommendedExhaustiveTopK: 128, // 65_536
   largeModel: true,
-  description: "OpenAI's GPT-4 Turbo model for complex tasks (128k context).",
-  shortDescription: "OpenAI's most capable model.",
+  description: "OpenAI's GPT 4 Turbo model for complex tasks (128k context).",
+  shortDescription: "OpenAI's second best model.",
   isLegacy: false,
   toolUseMetaPrompt: OPEN_AI_TOOL_USE_META_PROMPT,
   supportsVision: true,
@@ -174,12 +174,12 @@ export const GPT_4_TURBO_MODEL_CONFIG: ModelConfigurationType = {
 export const GPT_4O_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
   modelId: GPT_4O_MODEL_ID,
-  displayName: "GPT-4o",
+  displayName: "GPT 4o",
   contextSize: 128_000,
   recommendedTopK: 32,
   recommendedExhaustiveTopK: 128, // 65_536
   largeModel: true,
-  description: "OpenAI's GPT-4o model (128k context).",
+  description: "OpenAI's GPT 4o model (128k context).",
   shortDescription: "OpenAI's most advanced model.",
   isLegacy: false,
   toolUseMetaPrompt: OPEN_AI_TOOL_USE_META_PROMPT,
@@ -188,7 +188,7 @@ export const GPT_4O_MODEL_CONFIG: ModelConfigurationType = {
 export const GPT_3_5_TURBO_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
   modelId: GPT_3_5_TURBO_MODEL_ID,
-  displayName: "GPT-3.5 Turbo",
+  displayName: "GPT 3.5 Turbo",
   contextSize: 16_384,
   recommendedTopK: 16,
   recommendedExhaustiveTopK: 24, // 12_288


### PR DESCRIPTION
## Description

This PR introduces the following changes: 
 - Refactor the model selection dropdown to separate best-performing models from the rest
 - Changed display names to remove hyphens for model names in model configuration constants (e.g., "GPT-4 Turbo" to "GPT 4 Turbo")
 - Updated the 'shortDescription' field to reflect the model's standing in the lineup (e.g., "most capable" to "second best" for GPT-4 Turbo)

Task: https://github.com/dust-tt/tasks/issues/1012

## Risk

None

## Deploy Plan

Deploy `front`