### PR TITLE
fix(intercom): return conversations root content node

### DIFF
--- a/connectors/src/connectors/intercom/lib/utils.ts
+++ b/connectors/src/connectors/intercom/lib/utils.ts
@@ -76,12 +76,6 @@ export function isInternalIdForAllConversations(
 ): boolean {
   return internalId === `intercom-conversations-all-${connectorId}`;
 }
-export function isInternalIdForAllTeams(
-  connectorId: ModelId,
-  internalId: string
-): boolean {
-  return internalId === `intercom-teams-${connectorId}`;
-}
 export function getTeamIdFromInternalId(
   connectorId: ModelId,
   internalId: string


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/tasks/issues/1021

In intercom's `retrieveContentNodes`, we are not properly returning the root conversations node in cases where `syncAllConversations` is activated.

## Risk

N/A

## Deploy Plan

N/A