### PR TITLE
Preview is only accessible when there are instructions OR tools

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -167,12 +167,8 @@ export default function AssistantBuilder({
     });
 
   // We deactivate the Preview button if the BuilderState is empty (= no instructions, no tools)
-  // Needs the regex cause tiptap always keeps a node, which is a \n when empty.
   const isBuilderStateEmpty =
-    builderState.actions.length === 0 &&
-    (builderState.instructions === null ||
-      !builderState.instructions.length ||
-      !builderState.instructions.replace(/\s/g, ""));
+    !builderState.instructions?.trim() && !builderState.actions.length;
 
   const [isPreviewButtonAnimating, setIsPreviewButtonAnimating] =
     useState(false);


### PR DESCRIPTION
## Description

Task: https://github.com/dust-tt/tasks/issues/1010

Ed's instructions: 
- Preview Button is "disabled" until intructions and or tools are not null
- when the button goes from disabled to able, a small "breathing" animation runs (breathing animation exists in the code today)

=> I reused the existing animation, IMHO result is not super pretty but can be polished later with Ed if needed. 

## Risk

/
## Deploy Plan

Deploy front. 
