### PR TITLE
[fix] - fix(sparkle): `AssistantPreview` click

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.186",
+  "version": "0.2.188",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.186",
+      "version": "0.2.188",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.187",
+  "version": "0.2.188",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/AssistantPreview.tsx
+++ b/sparkle/src/components/AssistantPreview.tsx
@@ -50,8 +50,8 @@ const titleClassNames = {
     getWindowWidth() <= breakpoints.sm
       ? "s-text-sm"
       : getWindowWidth() <= breakpoints.md
-      ? "s-text-base"
-      : ""
+        ? "s-text-base"
+        : ""
   }`,
 };
 
@@ -62,8 +62,8 @@ const subtitleClassNames = {
     getWindowWidth() <= breakpoints.sm
       ? "s-text-xs"
       : getWindowWidth() <= breakpoints.md
-      ? "s-text-xs"
-      : "s-text-sm"
+        ? "s-text-xs"
+        : "s-text-sm"
   }`,
 };
 
@@ -161,7 +161,10 @@ const MinimalVariantContent = ({
       <div
         id="assistant-container"
         className="s-flex s-grow s-flex-col s-justify-start s-gap-2 s-overflow-hidden s-py-1"
-        onClick={onClick}
+        onClick={(e) => {
+          e.stopPropagation();
+          onClick?.();
+        }}
       >
         <div className="s-flex s-flex-row s-justify-between s-gap-2 s-overflow-hidden">
           <div


### PR DESCRIPTION
## Description

This PR aims at fixing the following behaviour: when using `AssistantPreview` in "minimal" variant, the `onClick` callback was executed twice. 

This was fixed by adding a `e.stopPropagation()` to avoid the callback from bubbling up.

Task: https://github.com/dust-tt/tasks/issues/1037

## Risk

Breaking the `AssistantPreview` click event.

## Deploy Plan

Deploy `sparkle`
