### PR TITLE
fix(slackbot): handle agent message success properly

### DIFF
--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -171,8 +171,8 @@ export async function streamConversationToSlack(
         break;
       }
 
-      case "agent_generation_success": {
-        fullAnswer = `${botIdentity}${event.text}`;
+      case "agent_message_success": {
+        fullAnswer = `${botIdentity}${event.message.content}`;
 
         const { formattedContent, footnotes } = annotateCitations(
           fullAnswer,

--- a/types/src/front/lib/dust_api.ts
+++ b/types/src/front/lib/dust_api.ts
@@ -24,6 +24,7 @@ import {
   AgentActionSuccessEvent,
   AgentErrorEvent,
   AgentGenerationSuccessEvent,
+  AgentMessageSuccessEvent,
 } from "./api/assistant/agent";
 import { UserMessageErrorEvent } from "./api/assistant/conversation";
 import { GenerationTokensEvent } from "./api/assistant/generation";
@@ -633,6 +634,7 @@ export class DustAPI {
       | AgentActionSuccessEvent
       | GenerationTokensEvent
       | AgentGenerationSuccessEvent
+      | AgentMessageSuccessEvent
     )[] = [];
 
     const parser = createParser((event) => {


### PR DESCRIPTION
## Description

Slackbot is handling `agent_generation_success`. This is not useful to handle, since the `agent_message_success` follows right after and contains all the contents generated for the agent message (processed)

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
