### PR TITLE
Save Confluence page's labels in Core

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -60,6 +60,15 @@ const ConfluencePageWithBodyCodec = t.intersection([
         value: t.string,
       }),
     }),
+    labels: t.type({
+      results: t.array(
+        t.type({
+          id: t.string,
+          name: t.string,
+          prefix: t.string,
+        })
+      ),
+    }),
   }),
 ]);
 export type ConfluencePageWithBodyType = t.TypeOf<
@@ -396,6 +405,7 @@ export class ConfluenceClient {
   async getPageById(pageId: string) {
     const params = new URLSearchParams({
       "body-format": "storage", // Returns HTML.
+      "include-labels": "true", // Include labels.
     });
 
     return this.request(

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -312,7 +312,9 @@ export async function confluenceCheckAndUpsertPageActivity({
     }
 
     // Limit to 10 custom tags.
-    const customTags = page.labels.results.slice(0, 10).map((l) => l.id);
+    const customTags = page.labels.results
+      .slice(0, 10)
+      .map((l) => `labels:${l.id}`);
 
     const tags = [
       `createdAt:${pageCreatedAt.getTime()}`,

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -302,12 +302,25 @@ export async function confluenceCheckAndUpsertPageActivity({
       baseUrl: confluenceConfig.url,
       suffix: page._links.tinyui,
     });
+
+    // We log the number of labels to help define the importance of labels in the future.
+    if (page.labels.results.length > 0) {
+      localLogger.info(
+        { labelsCount: page.labels.results.length },
+        "Confluence page has labels."
+      );
+    }
+
+    // Limit to 10 custom tags.
+    const customTags = page.labels.results.slice(0, 10).map((l) => l.id);
+
     const tags = [
       `createdAt:${pageCreatedAt.getTime()}`,
       `space:${spaceName}`,
       `title:${page.title}`,
       `updatedAt:${lastPageVersionCreatedAt.getTime()}`,
       `version:${page.version.number}`,
+      ...customTags,
     ];
 
     await upsertToDatasource({


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See https://github.com/dust-tt/dust/issues/5817.

This PR stores Confluence page labels in core. This is an interim step that allows us to query these labels in the data source block of the Dust app. Currently, we are only taking the first 10 labels, sorted alphabetically. Future enhancements are being tracked [here](https://github.com/dust-tt/tasks/issues/923).

Successfully tested using a data source block.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
