### PR TITLE
[chore] - chore(front): update suggest assistants UI

### DIFF
--- a/front/components/assistant/conversation/AgentSuggestion.tsx
+++ b/front/components/assistant/conversation/AgentSuggestion.tsx
@@ -29,7 +29,7 @@ export function AgentSuggestion({
   });
   const sendNotification = useContext(SendNotificationsContext);
 
-  const [loading, setLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
 
   const { submit: handleSelectSuggestion } = useSubmitFunction(
     async (agent: LightAgentConfigurationType) => {
@@ -55,7 +55,6 @@ export function AgentSuggestion({
 
       if (!mRes.ok) {
         const data = await mRes.json();
-        window.alert(`Error adding mention to message: ${data.error.message}`);
         sendNotification({
           type: "error",
           title: "Invite sent",
@@ -83,10 +82,10 @@ export function AgentSuggestion({
           owner={owner}
           assistants={agents.slice(3)}
           onItemClick={async (agent) => {
-            if (!loading) {
-              setLoading(true);
+            if (!isLoading) {
+              setIsLoading(true);
               await handleSelectSuggestion(agent);
-              setLoading(false);
+              setIsLoading(false);
             }
           }}
           pickerButton={

--- a/front/components/assistant/conversation/AgentSuggestion.tsx
+++ b/front/components/assistant/conversation/AgentSuggestion.tsx
@@ -82,7 +82,7 @@ export function AgentSuggestion({
     <div className="pt-4">
       <div className="flex items-center gap-2">
         <span className="text-xs font-bold text-element-600">
-          Which Assistant would you like to talk with?
+          Which Assistant would you like to chat with?
         </span>
         <AssistantPicker
           owner={owner}

--- a/front/components/assistant/conversation/AgentSuggestion.tsx
+++ b/front/components/assistant/conversation/AgentSuggestion.tsx
@@ -64,13 +64,12 @@ export function AgentSuggestion({
     }
   );
 
-  const agents = useMemo(
-    () =>
-      agentConfigurations.sort((a, b) => {
-        return sortAgents(a, b);
-      }),
-    [agentConfigurations]
-  );
+  const [topAgents, otherAgents] = useMemo(() => {
+    const agents = agentConfigurations.sort((a, b) => {
+      return sortAgents(a, b);
+    });
+    return [agents.slice(0, 3), agents.slice(3)];
+  }, [agentConfigurations]);
 
   return (
     <div className="pt-4">
@@ -80,7 +79,7 @@ export function AgentSuggestion({
         </span>
         <AssistantPicker
           owner={owner}
-          assistants={agents.slice(3)}
+          assistants={otherAgents}
           onItemClick={async (agent) => {
             if (!isLoading) {
               setIsLoading(true);
@@ -100,13 +99,13 @@ export function AgentSuggestion({
         />
       </div>
 
-      {agents.length === 0 ? (
+      {agentConfigurations.length === 0 ? (
         <div className="flex h-full min-h-28 w-full items-center justify-center">
           <Spinner />
         </div>
       ) : (
         <div className="mt-3 grid gap-2 md:grid-cols-3">
-          {agents.slice(0, 3).map((agent, id) => (
+          {topAgents.map((agent, id) => (
             <AssistantPreview
               key={`${agent.sId}-${id}`}
               variant="minimal"

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -151,27 +151,6 @@ const ConversationViewer = React.forwardRef<
     }
   }, [isInModal, latestPage]);
 
-  // Compute the latest mentions ordered by the most recents first.
-  const latestMentions = useMemo(() => {
-    const recentMentions = latestPage?.messages.reduce((acc, message) => {
-      if (isUserMessageType(message)) {
-        for (const mention of message.mentions) {
-          if (isAgentMention(mention)) {
-            acc.add(mention.configurationId);
-          }
-        }
-      }
-
-      return acc;
-    }, new Set<string>());
-
-    if (!recentMentions) {
-      return [];
-    }
-
-    return [...recentMentions].reverse();
-  }, [latestPage]);
-
   // Keep a reference to the previous oldest message to maintain user position
   // after fetching more data. This is a best effort approach to keep the user
   // roughly at the same place they were before the new data is loaded.
@@ -406,7 +385,6 @@ const ConversationViewer = React.forwardRef<
               prevFirstMessageRef={prevFirstMessageRef}
               user={user}
               latestPage={latestPage}
-              latestMentions={latestMentions}
             />
           );
         })}

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -14,7 +14,6 @@ interface UserMessageProps {
   conversationId: string;
   hideReactions?: boolean;
   isLastMessage: boolean;
-  latestMentions: string[];
   message: UserMessageType;
   owner: WorkspaceType;
   reactions: MessageReactionType[];
@@ -27,7 +26,6 @@ export function UserMessage({
   conversationId,
   hideReactions,
   isLastMessage,
-  latestMentions,
   message,
   owner,
   reactions,
@@ -60,7 +58,6 @@ export function UserMessage({
         {message.mentions.length === 0 && isLastMessage && (
           <AgentSuggestion
             conversationId={conversationId}
-            latestMentions={latestMentions}
             owner={owner}
             userMessage={message}
           />

--- a/front/components/assistant/conversation/messages/MessageGroup.tsx
+++ b/front/components/assistant/conversation/messages/MessageGroup.tsx
@@ -21,7 +21,6 @@ interface MessageGroupProps {
   prevFirstMessageRef: React.RefObject<HTMLDivElement>;
   user: UserType;
   latestPage?: FetchConversationMessagesResponse;
-  latestMentions: string[];
 }
 
 // arbitrary offset to scroll the last MessageGroup to
@@ -42,7 +41,6 @@ export default function MessageGroup({
   prevFirstMessageRef,
   user,
   latestPage,
-  latestMentions,
 }: MessageGroupProps) {
   const lastMessageGroupRef = useRef<HTMLDivElement>(null);
 
@@ -82,7 +80,6 @@ export default function MessageGroup({
               }
               user={user}
               isLastMessage={latestPage?.messages.at(-1)?.sId === message.sId}
-              latestMentions={latestMentions}
             />
           );
         });

--- a/front/components/assistant/conversation/messages/MessageItem.tsx
+++ b/front/components/assistant/conversation/messages/MessageItem.tsx
@@ -14,7 +14,6 @@ interface MessageItemProps {
   hideReactions: boolean;
   isInModal: boolean;
   isLastMessage: boolean;
-  latestMentions: string[];
   message: MessageWithContentFragmentsType;
   owner: WorkspaceType;
   reactions: ConversationMessageReactions;
@@ -28,7 +27,6 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
       hideReactions,
       isInModal,
       isLastMessage,
-      latestMentions,
       message,
       owner,
       reactions,
@@ -53,7 +51,6 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
               conversationId={conversationId}
               hideReactions={hideReactions}
               isLastMessage={isLastMessage}
-              latestMentions={latestMentions}
               message={message}
               owner={owner}
               reactions={messageReactions}


### PR DESCRIPTION
## Description

✨ This PR aims at updating the assistants suggestion UI to display 3 assistants along with their descriptions and add a dropdown button to select any other assistant. The 3 displayed assistants are: Dust and the top 2 most used assistants in the workspace.

✂️  As we do not need the latest mentions anymore (previously used to suggest the latest mentioned assistants) we don't need to compute them and hence pass them all the way down to the `UserMessage`. 

**References**:
- https://github.com/dust-tt/tasks/issues/1016

## Risk

Moderated

## Deploy Plan

Deploy `front`
