### PR TITLE
[fix] - fix(front): allow null for defaultEmbeddingProvider

### DIFF
--- a/front/pages/api/w/[wId]/index.ts
+++ b/front/pages/api/w/[wId]/index.ts
@@ -28,7 +28,7 @@ const WorkspaceAllowedDomainUpdateBodySchema = t.type({
 
 const WorkspaceProvidersUpdateBodySchema = t.type({
   whiteListedProviders: t.array(ModelProviderIdCodec),
-  defaultEmbeddingProvider: EmbeddingProviderCodec,
+  defaultEmbeddingProvider: t.union([EmbeddingProviderCodec, t.null]),
 });
 
 const PostWorkspaceRequestBodySchema = t.union([


### PR DESCRIPTION
 ## Description

This PR aims at fixing the `ProviderManagementModal`.

Currently, as one cannot set the "Embedding Provider" (disabled dropdown) the `defaultEmbeddingProvider` value is `null` which is not accepted by the `/api/w/[wId]`.

The `WorkspaceProvidersUpdateBodySchema` has been updated to accept this value. We want to keep this behaviour as having `null` as default value allows us to control the default embedding provider.


**References**
- https://github.com/dust-tt/dust/issues/6115

## Risk

Very limited  

## Deploy Plan

Deploy `front`