### PR TITLE
enh: hide assistant menu in preview modal

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -67,6 +67,7 @@ interface AgentMessageProps {
   conversationId: string;
   reactions: MessageReactionType[];
   hideReactions?: boolean;
+  isInModal: boolean;
   size: MessageSizeType;
 }
 
@@ -83,6 +84,7 @@ export function AgentMessage({
   conversationId,
   reactions,
   hideReactions,
+  isInModal,
   size,
 }: AgentMessageProps) {
   const [streamedAgentMessage, setStreamedAgentMessage] =
@@ -452,15 +454,17 @@ export function AgentMessage({
       enableEmojis={!hideReactions}
       renderName={() => {
         return (
-          <div className="flex flex-row gap-2">
+          <div className="flex flex-row items-center gap-2">
             <div className="text-base font-medium">
               {AssitantDetailViewLink(agentConfiguration)}
             </div>
-            <AssistantDetailsDropdownMenu
-              agentConfigurationId={agentConfiguration.sId}
-              owner={owner}
-              showAddRemoveToList
-            />
+            {!isInModal && (
+              <AssistantDetailsDropdownMenu
+                agentConfigurationId={agentConfiguration.sId}
+                owner={owner}
+                showAddRemoveToList
+              />
+            )}
           </div>
         );
       }}

--- a/front/components/assistant/conversation/messages/MessageItem.tsx
+++ b/front/components/assistant/conversation/messages/MessageItem.tsx
@@ -74,6 +74,7 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
               conversationId={conversationId}
               reactions={messageReactions}
               hideReactions={hideReactions}
+              isInModal={isInModal}
               size={isInModal ? "compact" : "normal"}
             />
           </div>


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/tasks/issues/1020

- remove menu icon from assistant message when in preview modal
- properly align menu icon when not in preview modal

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
