### PR TITLE
enh(sparkle): tooltip should be outside of Citation card

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.188",
+  "version": "0.2.189",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.188",
+      "version": "0.2.189",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
@@ -49,7 +49,6 @@
         "autoprefixer": "^10.4.14",
         "babel-loader": "^9.1.3",
         "babel-preset-react-app": "^10.0.1",
-        "copyfiles": "^2.4.1",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-simple-import-sort": "^12.1.0",
@@ -65,9 +64,7 @@
         "sass-loader": "^13.3.2",
         "storybook": "^7.4.6",
         "tailwindcss": "^3.2.4",
-        "tsc-alias": "^1.8.10",
         "typescript": "^5.4.5",
-        "typescript-transform-paths": "^3.4.7",
         "uuid": "^9.0.1"
       },
       "peerDependencies": {
@@ -12769,58 +12766,6 @@
         "url": "https://github.com/sponsors/mesqueeb"
       }
     },
-    "node_modules/copyfiles": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.4.1.tgz",
-      "integrity": "sha512-fereAvAvxDrQDOXybk3Qu3dPbOoKoysFMWtkY3mv5BsL8//OSZVL5DCLYqgRfY5cWirgRzlC+WSrxp6Bo3eNZg==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.0.5",
-        "minimatch": "^3.0.3",
-        "mkdirp": "^1.0.4",
-        "noms": "0.0.0",
-        "through2": "^2.0.1",
-        "untildify": "^4.0.0",
-        "yargs": "^16.1.0"
-      },
-      "bin": {
-        "copyfiles": "copyfiles",
-        "copyup": "copyfiles"
-      }
-    },
-    "node_modules/copyfiles/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/copyfiles/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/core-js-compat": {
       "version": "3.31.1",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.31.1.tgz",
@@ -20481,19 +20426,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "node_modules/mylas": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/mylas/-/mylas-2.1.13.tgz",
-      "integrity": "sha512-+MrqnJRtxdF+xngFfUUkIMQrUUL0KsxbADUkn23Z/4ibGg192Q+z+CQyiYwvWTsYjJygmMR8+w3ZDa98Zh6ESg==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/raouldeheer"
-      }
-    },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -20651,40 +20583,6 @@
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
       "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
-      "dev": true
-    },
-    "node_modules/noms": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
-      "integrity": "sha512-lNDU9VJaOPxUmXcLb+HQFeUgQQPtMI24Gt6hgfuMHRJgMRHMF/qZ4HJD3GDru4sSw9IQl2jPjAYnQrdIeLbwow==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "readable-stream": "~1.0.31"
-      }
-    },
-    "node_modules/noms/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true
-    },
-    "node_modules/noms/node_modules/readable-stream": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
-      "dev": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/noms/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
       "dev": true
     },
     "node_modules/normalize-package-data": {
@@ -21263,18 +21161,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/plimit-lit": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/plimit-lit/-/plimit-lit-1.6.1.tgz",
-      "integrity": "sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==",
-      "dev": true,
-      "dependencies": {
-        "queue-lit": "^1.5.1"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/polished": {
@@ -22453,15 +22339,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/queue-lit": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/queue-lit/-/queue-lit-1.5.2.tgz",
-      "integrity": "sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/queue-microtask": {
@@ -25557,23 +25434,6 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true
     },
-    "node_modules/tsc-alias": {
-      "version": "1.8.10",
-      "resolved": "https://registry.npmjs.org/tsc-alias/-/tsc-alias-1.8.10.tgz",
-      "integrity": "sha512-Ibv4KAWfFkFdKJxnWfVtdOmB0Zi1RJVxcbPGiCDsFpCQSsmpWyuzHG3rQyI5YkobWwxFPEyQfu1hdo4qLG2zPw==",
-      "dev": true,
-      "dependencies": {
-        "chokidar": "^3.5.3",
-        "commander": "^9.0.0",
-        "globby": "^11.0.4",
-        "mylas": "^2.1.9",
-        "normalize-path": "^3.0.0",
-        "plimit-lit": "^1.2.6"
-      },
-      "bin": {
-        "tsc-alias": "dist/bin/index.js"
-      }
-    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -25749,18 +25609,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/typescript-transform-paths": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/typescript-transform-paths/-/typescript-transform-paths-3.4.7.tgz",
-      "integrity": "sha512-1Us1kdkdfKd2unbkBAOV2HHRmbRBYpSuk9nJ7cLD2hP4QmfToiM/VpxNlhJc1eezVwVqSKSBjNSzZsK/fWR/9A==",
-      "dev": true,
-      "dependencies": {
-        "minimatch": "^3.0.4"
-      },
-      "peerDependencies": {
-        "typescript": ">=3.6.5"
       }
     },
     "node_modules/uglify-js": {

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.188",
+  "version": "0.2.189",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/Citation.tsx
+++ b/sparkle/src/components/Citation.tsx
@@ -126,16 +126,15 @@ export function Citation({
           </div>
         )}
       </div>
-      <Tooltip label={title} position="above">
-        <div
-          className={classNames(
-            "s-line-clamp-1 s-text-sm s-text-element-800",
-            size === "sm" ? "s-font-bold" : "s-font-semibold"
-          )}
-        >
-          {title}
-        </div>
-      </Tooltip>
+      <div
+        className={classNames(
+          "s-line-clamp-1 s-text-sm s-text-element-800",
+          size === "sm" ? "s-font-bold" : "s-font-semibold"
+        )}
+      >
+        {title}
+      </div>
+
       {description && (
         <div className="s-line-clamp-2 s-text-xs s-font-normal s-text-element-700">
           {description}
@@ -145,24 +144,26 @@ export function Citation({
   );
 
   return (
-    <CardButton
-      variant="secondary"
-      size="sm"
-      className={classNames(
-        "s-relative s-flex s-w-48 s-flex-none s-flex-col s-gap-1",
-        sizing === "fluid" ? typeSizing[sizing] : typeSizing[sizing][size],
-        size === "sm" ? "sm:s-w-64" : "",
-        isBlinking ? "s-animate-[bgblink_500ms_3]" : "",
-        type === "image" ? "s-min-h-20" : ""
-      )}
-      {...(href && { href, target: "_blank", rel: "noopener noreferrer" })}
-    >
-      {isLoading && (
-        <div className="s-absolute s-inset-0 s-flex s-items-center s-justify-center">
-          <Spinner size="xs" variant="color" />
-        </div>
-      )}
-      <div className={isLoading ? "s-opacity-50" : ""}>{cardContent}</div>
-    </CardButton>
+    <Tooltip label={title} position="above">
+      <CardButton
+        variant="secondary"
+        size="sm"
+        className={classNames(
+          "s-relative s-flex s-w-48 s-flex-none s-flex-col s-gap-1",
+          sizing === "fluid" ? typeSizing[sizing] : typeSizing[sizing][size],
+          size === "sm" ? "sm:s-w-64" : "",
+          isBlinking ? "s-animate-[bgblink_500ms_3]" : "",
+          type === "image" ? "s-min-h-20" : ""
+        )}
+        {...(href && { href, target: "_blank", rel: "noopener noreferrer" })}
+      >
+        {isLoading && (
+          <div className="s-absolute s-inset-0 s-flex s-items-center s-justify-center">
+            <Spinner size="xs" variant="color" />
+          </div>
+        )}
+        <div className={isLoading ? "s-opacity-50" : ""}>{cardContent}</div>
+      </CardButton>
+    </Tooltip>
   );
 }


### PR DESCRIPTION
## Description

https://github.com/dust-tt/dust/issues/6120

Sparkle citations tooltips are cropped inside the Citations card. This fixes the issue by wrapping the card in the tooltip instead of simply wrapping the title, as suggested by @Duncid .

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
