### PR TITLE
Flav/create authentification wrapper

### DIFF
--- a/front/lib/api/wrappers.ts
+++ b/front/lib/api/wrappers.ts
@@ -1,0 +1,36 @@
+import type { WithAPIErrorResponse } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getSession } from "@app/lib/auth";
+import { apiError, withLogging } from "@app/logger/withlogging";
+
+export function withSessionAuthentication<T>(
+  handler: (
+    req: NextApiRequest,
+    res: NextApiResponse<WithAPIErrorResponse<T>>
+  ) => Promise<void> | void
+) {
+  return withLogging(
+    async (
+      req: NextApiRequest,
+      res: NextApiResponse<WithAPIErrorResponse<T>>
+    ) => {
+      const session = await getSession(req, res);
+
+      if (!session) {
+        return apiError(req, res, {
+          status_code: 401,
+          api_error: {
+            type: "not_authenticated",
+            message:
+              "The user does not have an active session or is not authenticated",
+          },
+        });
+      }
+
+      // TODO(2024-07-09 Flav) Create `Authenticator` from session.
+
+      return handler(req, res);
+    }
+  );
+}

--- a/front/lib/api/wrappers.ts
+++ b/front/lib/api/wrappers.ts
@@ -8,7 +8,8 @@ export function withSessionAuthentication<T>(
   handler: (
     req: NextApiRequest,
     res: NextApiResponse<WithAPIErrorResponse<T>>
-  ) => Promise<void> | void
+  ) => Promise<void> | void,
+  { isStreaming = false }: { isStreaming?: boolean } = {}
 ) {
   return withLogging(
     async (
@@ -31,6 +32,7 @@ export function withSessionAuthentication<T>(
       // TODO(2024-07-09 Flav) Create `Authenticator` from session.
 
       return handler(req, res);
-    }
+    },
+    isStreaming
   );
 }

--- a/front/lib/iam/session.ts
+++ b/front/lib/iam/session.ts
@@ -1,13 +1,7 @@
-import type {
-  RoleType,
-  UserTypeWithWorkspaces,
-  WithAPIErrorResponse,
-} from "@dust-tt/types";
+import type { RoleType, UserTypeWithWorkspaces } from "@dust-tt/types";
 import type {
   GetServerSidePropsContext,
   GetServerSidePropsResult,
-  NextApiRequest,
-  NextApiResponse,
   PreviewData,
 } from "next";
 import type { ParsedUrlQuery } from "querystring";
@@ -24,11 +18,7 @@ import {
 import { Workspace } from "@app/lib/models/workspace";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import logger from "@app/logger/logger";
-import {
-  apiError,
-  withGetServerSidePropsLogging,
-  withLogging,
-} from "@app/logger/withlogging";
+import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
 /**
  * Retrieves the user for a given session
@@ -280,36 +270,3 @@ export const withSuperUserAuthRequirements =
     requireUserPrivilege: "superuser",
     requireCanUseProduct: false,
   });
-
-// API routes handlers.
-
-export function withAuthentication<T>(
-  handler: (
-    req: NextApiRequest,
-    res: NextApiResponse<WithAPIErrorResponse<T>>
-  ) => Promise<void> | void
-) {
-  return withLogging(
-    async (
-      req: NextApiRequest,
-      res: NextApiResponse<WithAPIErrorResponse<T>>
-    ) => {
-      const session = await getSession(req, res);
-
-      if (!session) {
-        return apiError(req, res, {
-          status_code: 401,
-          api_error: {
-            type: "not_authenticated",
-            message:
-              "The user does not have an active session or is not authenticated",
-          },
-        });
-      }
-
-      // TODO(2024-07-09 Flav) Create `Authenticator` from session.
-
-      return handler(req, res);
-    }
-  );
-}

--- a/front/logger/withlogging.ts
+++ b/front/logger/withlogging.ts
@@ -1,6 +1,6 @@
 import type {
   APIErrorWithStatusCode,
-  WithAPIErrorReponse,
+  WithAPIErrorResponse,
 } from "@dust-tt/types";
 import tracer from "dd-trace";
 import StatsD from "hot-shots";
@@ -19,13 +19,13 @@ export const statsDClient = new StatsD();
 export function withLogging<T>(
   handler: (
     req: NextApiRequest,
-    res: NextApiResponse<WithAPIErrorReponse<T>>
+    res: NextApiResponse<WithAPIErrorResponse<T>>
   ) => Promise<void>,
   streaming = false
 ) {
   return async (
     req: NextApiRequest,
-    res: NextApiResponse<WithAPIErrorReponse<T>>
+    res: NextApiResponse<WithAPIErrorResponse<T>>
   ): Promise<void> => {
     const ddtraceSpan = tracer.scope().active();
     if (ddtraceSpan) {
@@ -114,7 +114,7 @@ export function withLogging<T>(
 
 export function apiError<T>(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<T>>,
+  res: NextApiResponse<WithAPIErrorResponse<T>>,
   apiError: APIErrorWithStatusCode,
   error?: Error
 ): void {

--- a/front/pages/api/create-new-workspace.ts
+++ b/front/pages/api/create-new-workspace.ts
@@ -2,9 +2,12 @@ import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getSession } from "@app/lib/auth";
-import { getUserFromSession } from "@app/lib/iam/session";
+import {
+  getUserFromSession,
+  withSessionAuthentication,
+} from "@app/lib/iam/session";
 import { createWorkspace } from "@app/lib/iam/workspaces";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 import { createAndLogMembership } from "@app/pages/api/login";
 
 async function handler(
@@ -59,4 +62,4 @@ async function handler(
   res.status(200).json({ sId: workspace.sId });
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/create-new-workspace.ts
+++ b/front/pages/api/create-new-workspace.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getSession } from "@app/lib/auth";
@@ -9,7 +9,7 @@ import { createAndLogMembership } from "@app/pages/api/login";
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<{ sId: string }>>
+  res: NextApiResponse<WithAPIErrorResponse<{ sId: string }>>
 ): Promise<void> {
   const session = await getSession(req, res);
   if (!session) {

--- a/front/pages/api/create-new-workspace.ts
+++ b/front/pages/api/create-new-workspace.ts
@@ -1,11 +1,9 @@
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { getSession } from "@app/lib/auth";
-import {
-  getUserFromSession,
-  withSessionAuthentication,
-} from "@app/lib/iam/session";
+import { getUserFromSession } from "@app/lib/iam/session";
 import { createWorkspace } from "@app/lib/iam/workspaces";
 import { apiError } from "@app/logger/withlogging";
 import { createAndLogMembership } from "@app/pages/api/login";

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -2,7 +2,7 @@ import type {
   ActiveRoleType,
   Result,
   UserType,
-  WithAPIErrorReponse,
+  WithAPIErrorResponse,
 } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -300,7 +300,7 @@ async function handleRegularSignupFlow(
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<void>>
+  res: NextApiResponse<WithAPIErrorResponse<void>>
 ): Promise<void> {
   const session = await getSession(req, res);
   if (!session) {

--- a/front/pages/api/poke/admin.ts
+++ b/front/pages/api/poke/admin.ts
@@ -5,8 +5,9 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
+import { withAuthentication } from "@app/lib/iam/session";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 async function handler(
   req: NextApiRequest,
@@ -65,4 +66,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withAuthentication(handler);

--- a/front/pages/api/poke/admin.ts
+++ b/front/pages/api/poke/admin.ts
@@ -4,8 +4,8 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { withAuthentication } from "@app/lib/iam/session";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 
@@ -66,4 +66,4 @@ async function handler(
   }
 }
 
-export default withAuthentication(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/poke/admin.ts
+++ b/front/pages/api/poke/admin.ts
@@ -1,4 +1,4 @@
-import type { AdminResponseType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { AdminResponseType, WithAPIErrorResponse } from "@dust-tt/types";
 import { AdminCommandSchema, ConnectorsAPI } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
@@ -10,7 +10,7 @@ import { apiError, withLogging } from "@app/logger/withlogging";
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<AdminResponseType>>
+  res: NextApiResponse<WithAPIErrorResponse<AdminResponseType>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(session, null);

--- a/front/pages/api/poke/plans.ts
+++ b/front/pages/api/poke/plans.ts
@@ -5,9 +5,10 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
+import { withAuthentication } from "@app/lib/iam/session";
 import { Plan } from "@app/lib/models/plan";
 import { renderPlanFromModel } from "@app/lib/plans/subscription";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export const PlanTypeSchema = t.type({
   code: t.string,
@@ -132,4 +133,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withAuthentication(handler);

--- a/front/pages/api/poke/plans.ts
+++ b/front/pages/api/poke/plans.ts
@@ -1,4 +1,4 @@
-import type { PlanType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { PlanType, WithAPIErrorResponse } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -53,7 +53,7 @@ export type GetPokePlansResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<GetPokePlansResponseBody | UpsertPokePlanResponseBody>
+    WithAPIErrorResponse<GetPokePlansResponseBody | UpsertPokePlanResponseBody>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/poke/plans.ts
+++ b/front/pages/api/poke/plans.ts
@@ -4,8 +4,8 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { withAuthentication } from "@app/lib/iam/session";
 import { Plan } from "@app/lib/models/plan";
 import { renderPlanFromModel } from "@app/lib/plans/subscription";
 import { apiError } from "@app/logger/withlogging";
@@ -133,4 +133,4 @@ async function handler(
   }
 }
 
-export default withAuthentication(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/poke/templates/[tId].ts
+++ b/front/pages/api/poke/templates/[tId].ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import {
   CreateTemplateFormSchema,
   isTemplateTagCodeArray,
@@ -23,7 +23,7 @@ interface PokeCreateTemplateResponseBody {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<
+    WithAPIErrorResponse<
       PokeCreateTemplateResponseBody | PokeFetchAssistantTemplateResponse
     >
   >

--- a/front/pages/api/poke/templates/[tId].ts
+++ b/front/pages/api/poke/templates/[tId].ts
@@ -9,8 +9,9 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { USED_MODEL_CONFIGS } from "@app/components/providers/types";
 import { Authenticator, getSession } from "@app/lib/auth";
+import { withAuthentication } from "@app/lib/iam/session";
 import { TemplateResource } from "@app/lib/resources/template_resource";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type PokeFetchAssistantTemplateResponse = ReturnType<
   TemplateResource["toJSON"]
@@ -176,4 +177,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withAuthentication(handler);

--- a/front/pages/api/poke/templates/[tId].ts
+++ b/front/pages/api/poke/templates/[tId].ts
@@ -8,8 +8,8 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { USED_MODEL_CONFIGS } from "@app/components/providers/types";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { withAuthentication } from "@app/lib/iam/session";
 import { TemplateResource } from "@app/lib/resources/template_resource";
 import { apiError } from "@app/logger/withlogging";
 
@@ -177,4 +177,4 @@ async function handler(
   }
 }
 
-export default withAuthentication(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/poke/templates/index.ts
+++ b/front/pages/api/poke/templates/index.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import {
   CreateTemplateFormSchema,
   isTemplateTagCodeArray,
@@ -25,7 +25,7 @@ interface PokeFetchAssistantTemplatesResponse {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<
+    WithAPIErrorResponse<
       CreateTemplateResponseBody | PokeFetchAssistantTemplatesResponse
     >
   >

--- a/front/pages/api/poke/templates/index.ts
+++ b/front/pages/api/poke/templates/index.ts
@@ -8,8 +8,8 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { USED_MODEL_CONFIGS } from "@app/components/providers/types";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { withAuthentication } from "@app/lib/iam/session";
 import { generateLegacyModelSId } from "@app/lib/resources/string_ids";
 import { TemplateResource } from "@app/lib/resources/template_resource";
 import { apiError } from "@app/logger/withlogging";
@@ -125,4 +125,4 @@ async function handler(
   }
 }
 
-export default withAuthentication(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/poke/templates/index.ts
+++ b/front/pages/api/poke/templates/index.ts
@@ -9,9 +9,10 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { USED_MODEL_CONFIGS } from "@app/components/providers/types";
 import { Authenticator, getSession } from "@app/lib/auth";
+import { withAuthentication } from "@app/lib/iam/session";
 import { generateLegacyModelSId } from "@app/lib/resources/string_ids";
 import { TemplateResource } from "@app/lib/resources/template_resource";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 import type { AssistantTemplateListType } from "@app/pages/api/w/[wId]/assistant/builder/templates";
 
 export interface CreateTemplateResponseBody {
@@ -124,4 +125,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withAuthentication(handler);

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/index.ts
@@ -5,8 +5,8 @@ import {
   archiveAgentConfiguration,
   getAgentConfiguration,
 } from "@app/lib/api/assistant/configuration";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { withAuthentication } from "@app/lib/iam/session";
 import { apiError } from "@app/logger/withlogging";
 
 export type DeleteAgentConfigurationResponseBody = {
@@ -77,4 +77,4 @@ async function handler(
   }
 }
 
-export default withAuthentication(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/index.ts
@@ -6,7 +6,8 @@ import {
   getAgentConfiguration,
 } from "@app/lib/api/assistant/configuration";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { withAuthentication } from "@app/lib/iam/session";
+import { apiError } from "@app/logger/withlogging";
 
 export type DeleteAgentConfigurationResponseBody = {
   success: true;
@@ -76,4 +77,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withAuthentication(handler);

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/index.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
@@ -15,7 +15,7 @@ export type DeleteAgentConfigurationResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<DeleteAgentConfigurationResponseBody>
+    WithAPIErrorResponse<DeleteAgentConfigurationResponseBody>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/restore.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/restore.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
@@ -15,7 +15,7 @@ export type RestoreAgentConfigurationResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<RestoreAgentConfigurationResponseBody>
+    WithAPIErrorResponse<RestoreAgentConfigurationResponseBody>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/restore.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/restore.ts
@@ -5,8 +5,8 @@ import {
   getAgentConfiguration,
   restoreAgentConfiguration,
 } from "@app/lib/api/assistant/configuration";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { withAuthentication } from "@app/lib/iam/session";
 import { apiError } from "@app/logger/withlogging";
 
 export type RestoreAgentConfigurationResponseBody = {
@@ -90,4 +90,4 @@ async function handler(
   }
 }
 
-export default withAuthentication(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/restore.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/restore.ts
@@ -6,7 +6,8 @@ import {
   restoreAgentConfiguration,
 } from "@app/lib/api/assistant/configuration";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { withAuthentication } from "@app/lib/iam/session";
+import { apiError } from "@app/logger/withlogging";
 
 export type RestoreAgentConfigurationResponseBody = {
   success: true;
@@ -89,4 +90,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withAuthentication(handler);

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/index.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -16,7 +16,7 @@ const GetAgentConfigurationsQuerySchema = t.type({
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<GetAgentConfigurationsResponseBody | void>
+    WithAPIErrorResponse<GetAgentConfigurationsResponseBody | void>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/index.ts
@@ -6,7 +6,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { withAuthentication } from "@app/lib/iam/session";
+import { apiError } from "@app/logger/withlogging";
 import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 
 const GetAgentConfigurationsQuerySchema = t.type({
@@ -85,4 +86,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withAuthentication(handler);

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/index.ts
@@ -5,8 +5,8 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { withAuthentication } from "@app/lib/iam/session";
 import { apiError } from "@app/logger/withlogging";
 import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 
@@ -86,4 +86,4 @@ async function handler(
   }
 }
 
-export default withAuthentication(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/index.ts
@@ -1,4 +1,4 @@
-import type { ConversationType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { ConversationType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
@@ -11,7 +11,7 @@ export type GetConversationResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<GetConversationResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetConversationResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/index.ts
@@ -3,7 +3,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { withAuthentication } from "@app/lib/iam/session";
+import { apiError } from "@app/logger/withlogging";
 
 export type GetConversationResponseBody = {
   conversation: ConversationType;
@@ -67,4 +68,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withAuthentication(handler);

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/index.ts
@@ -2,8 +2,8 @@ import type { ConversationType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { withAuthentication } from "@app/lib/iam/session";
 import { apiError } from "@app/logger/withlogging";
 
 export type GetConversationResponseBody = {
@@ -68,4 +68,4 @@ async function handler(
   }
 }
 
-export default withAuthentication(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/config.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/config.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { ConnectorsAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -14,7 +14,7 @@ export type SetConfigResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<SetConfigResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<SetConfigResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/config.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/config.ts
@@ -3,9 +3,10 @@ import { ConnectorsAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
+import { withAuthentication } from "@app/lib/iam/session";
 import { DataSource } from "@app/lib/models/data_source";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type SetConfigResponseBody = {
   configKey: string;
@@ -115,4 +116,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withAuthentication(handler);

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/config.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/config.ts
@@ -2,8 +2,8 @@ import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { ConnectorsAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { withAuthentication } from "@app/lib/iam/session";
 import { DataSource } from "@app/lib/models/data_source";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -116,4 +116,4 @@ async function handler(
   }
 }
 
-export default withAuthentication(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/index.ts
@@ -3,7 +3,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { deleteDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { withAuthentication } from "@app/lib/iam/session";
+import { apiError } from "@app/logger/withlogging";
 
 export type DeleteDataSourceResponseBody = {
   success: true;
@@ -64,4 +65,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withAuthentication(handler);

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/index.ts
@@ -2,8 +2,8 @@ import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { deleteDataSource } from "@app/lib/api/data_sources";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { withAuthentication } from "@app/lib/iam/session";
 import { apiError } from "@app/logger/withlogging";
 
 export type DeleteDataSourceResponseBody = {
@@ -65,4 +65,4 @@ async function handler(
   }
 }
 
-export default withAuthentication(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/index.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { deleteDataSource } from "@app/lib/api/data_sources";
@@ -11,7 +11,7 @@ export type DeleteDataSourceResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<DeleteDataSourceResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<DeleteDataSourceResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/managed/permissions.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/managed/permissions.ts
@@ -2,8 +2,8 @@ import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { withAuthentication } from "@app/lib/iam/session";
 import { apiError } from "@app/logger/withlogging";
 import type { GetDataSourcePermissionsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/permissions";
 import { getManagedDataSourcePermissionsHandler } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/permissions";
@@ -74,4 +74,4 @@ async function handler(
   }
 }
 
-export default withAuthentication(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/managed/permissions.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/managed/permissions.ts
@@ -3,7 +3,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { withAuthentication } from "@app/lib/iam/session";
+import { apiError } from "@app/logger/withlogging";
 import type { GetDataSourcePermissionsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/permissions";
 import { getManagedDataSourcePermissionsHandler } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/permissions";
 
@@ -73,4 +74,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withAuthentication(handler);

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/managed/permissions.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/managed/permissions.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
@@ -10,7 +10,7 @@ import { getManagedDataSourcePermissionsHandler } from "@app/pages/api/w/[wId]/d
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<GetDataSourcePermissionsResponseBody>
+    WithAPIErrorResponse<GetDataSourcePermissionsResponseBody>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/search.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/search.ts
@@ -2,7 +2,8 @@ import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { withAuthentication } from "@app/lib/iam/session";
+import { apiError } from "@app/logger/withlogging";
 import type { DatasourceSearchResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/search";
 import { handleSearchDataSource } from "@app/pages/api/w/[wId]/data_sources/[name]/search";
 
@@ -42,4 +43,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withAuthentication(handler);

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/search.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/search.ts
@@ -1,8 +1,8 @@
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { withAuthentication } from "@app/lib/iam/session";
 import { apiError } from "@app/logger/withlogging";
 import type { DatasourceSearchResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/search";
 import { handleSearchDataSource } from "@app/pages/api/w/[wId]/data_sources/[name]/search";
@@ -43,4 +43,4 @@ async function handler(
   }
 }
 
-export default withAuthentication(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/search.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/search.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
@@ -8,7 +8,7 @@ import { handleSearchDataSource } from "@app/pages/api/w/[wId]/data_sources/[nam
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<DatasourceSearchResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<DatasourceSearchResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(

--- a/front/pages/api/poke/workspaces/[wId]/downgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/downgrade.ts
@@ -2,8 +2,9 @@ import type { LightWorkspaceType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
+import { withAuthentication } from "@app/lib/iam/session";
 import { internalSubscribeWorkspaceToFreeNoPlan } from "@app/lib/plans/subscription";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 import { launchScheduleWorkspaceScrubWorkflow } from "@app/temporal/scrub_workspace/client";
 
 export type DowngradeWorkspaceResponseBody = {
@@ -64,4 +65,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withAuthentication(handler);

--- a/front/pages/api/poke/workspaces/[wId]/downgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/downgrade.ts
@@ -1,8 +1,8 @@
 import type { LightWorkspaceType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { withAuthentication } from "@app/lib/iam/session";
 import { internalSubscribeWorkspaceToFreeNoPlan } from "@app/lib/plans/subscription";
 import { apiError } from "@app/logger/withlogging";
 import { launchScheduleWorkspaceScrubWorkflow } from "@app/temporal/scrub_workspace/client";
@@ -65,4 +65,4 @@ async function handler(
   }
 }
 
-export default withAuthentication(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/poke/workspaces/[wId]/downgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/downgrade.ts
@@ -1,4 +1,4 @@
-import type { LightWorkspaceType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { LightWorkspaceType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
@@ -12,7 +12,7 @@ export type DowngradeWorkspaceResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<DowngradeWorkspaceResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<DowngradeWorkspaceResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(

--- a/front/pages/api/poke/workspaces/[wId]/features.ts
+++ b/front/pages/api/poke/workspaces/[wId]/features.ts
@@ -5,8 +5,8 @@ import type {
 import { isWhitelistableFeature } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { withAuthentication } from "@app/lib/iam/session";
 import { FeatureFlag } from "@app/lib/models/feature_flag";
 import { apiError } from "@app/logger/withlogging";
 
@@ -138,4 +138,4 @@ async function handler(
   }
 }
 
-export default withAuthentication(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/poke/workspaces/[wId]/features.ts
+++ b/front/pages/api/poke/workspaces/[wId]/features.ts
@@ -1,4 +1,7 @@
-import type { WhitelistableFeature, WithAPIErrorReponse } from "@dust-tt/types";
+import type {
+  WhitelistableFeature,
+  WithAPIErrorResponse,
+} from "@dust-tt/types";
 import { isWhitelistableFeature } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -17,7 +20,7 @@ export type CreateOrDeleteFeatureFlagResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<
+    WithAPIErrorResponse<
       CreateOrDeleteFeatureFlagResponseBody | GetPokeFeaturesResponseBody
     >
   >

--- a/front/pages/api/poke/workspaces/[wId]/features.ts
+++ b/front/pages/api/poke/workspaces/[wId]/features.ts
@@ -6,8 +6,9 @@ import { isWhitelistableFeature } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
+import { withAuthentication } from "@app/lib/iam/session";
 import { FeatureFlag } from "@app/lib/models/feature_flag";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type GetPokeFeaturesResponseBody = {
   features: WhitelistableFeature[];
@@ -137,4 +138,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withAuthentication(handler);

--- a/front/pages/api/poke/workspaces/[wId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/index.ts
@@ -6,7 +6,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { setInternalWorkspaceSegmentation } from "@app/lib/api/workspace";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { withAuthentication } from "@app/lib/iam/session";
+import { apiError } from "@app/logger/withlogging";
 import { launchDeleteWorkspaceWorkflow } from "@app/poke/temporal/client";
 
 export const WorkspaceTypeSchema = t.type({
@@ -86,4 +87,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withAuthentication(handler);

--- a/front/pages/api/poke/workspaces/[wId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/index.ts
@@ -5,8 +5,8 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { setInternalWorkspaceSegmentation } from "@app/lib/api/workspace";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { withAuthentication } from "@app/lib/iam/session";
 import { apiError } from "@app/logger/withlogging";
 import { launchDeleteWorkspaceWorkflow } from "@app/poke/temporal/client";
 
@@ -87,4 +87,4 @@ async function handler(
   }
 }
 
-export default withAuthentication(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/poke/workspaces/[wId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/index.ts
@@ -1,4 +1,4 @@
-import type { LightWorkspaceType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { LightWorkspaceType, WithAPIErrorResponse } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -24,7 +24,7 @@ export type DeleteWorkspaceResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<
+    WithAPIErrorResponse<
       SegmentWorkspaceResponseBody | DeleteWorkspaceResponseBody
     >
   >

--- a/front/pages/api/poke/workspaces/[wId]/invitations.ts
+++ b/front/pages/api/poke/workspaces/[wId]/invitations.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { ActiveRoleSchema } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -22,7 +22,7 @@ type PokePostInvitationResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<PokePostInvitationResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PokePostInvitationResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/poke/workspaces/[wId]/invitations.ts
+++ b/front/pages/api/poke/workspaces/[wId]/invitations.ts
@@ -7,7 +7,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { handleMembershipInvitations } from "@app/lib/api/invitation";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { withAuthentication } from "@app/lib/iam/session";
+import { apiError } from "@app/logger/withlogging";
 
 const PokePostInvitationRequestBodySchema = t.type({
   email: t.string,
@@ -120,4 +121,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withAuthentication(handler);

--- a/front/pages/api/poke/workspaces/[wId]/invitations.ts
+++ b/front/pages/api/poke/workspaces/[wId]/invitations.ts
@@ -6,8 +6,8 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { handleMembershipInvitations } from "@app/lib/api/invitation";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { withAuthentication } from "@app/lib/iam/session";
 import { apiError } from "@app/logger/withlogging";
 
 const PokePostInvitationRequestBodySchema = t.type({
@@ -121,4 +121,4 @@ async function handler(
   }
 }
 
-export default withAuthentication(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/poke/workspaces/[wId]/revoke.ts
+++ b/front/pages/api/poke/workspaces/[wId]/revoke.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -14,7 +14,7 @@ export type RevokeUserResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<RevokeUserResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<RevokeUserResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(

--- a/front/pages/api/poke/workspaces/[wId]/revoke.ts
+++ b/front/pages/api/poke/workspaces/[wId]/revoke.ts
@@ -4,8 +4,9 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getUserForWorkspace } from "@app/lib/api/user";
 import { Authenticator, getSession } from "@app/lib/auth";
+import { withAuthentication } from "@app/lib/iam/session";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 import { launchUpdateUsageWorkflow } from "@app/temporal/usage_queue/client";
 
 export type RevokeUserResponseBody = {
@@ -94,4 +95,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withAuthentication(handler);

--- a/front/pages/api/poke/workspaces/[wId]/revoke.ts
+++ b/front/pages/api/poke/workspaces/[wId]/revoke.ts
@@ -3,8 +3,8 @@ import { assertNever } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getUserForWorkspace } from "@app/lib/api/user";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { withAuthentication } from "@app/lib/iam/session";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { apiError } from "@app/logger/withlogging";
 import { launchUpdateUsageWorkflow } from "@app/temporal/usage_queue/client";
@@ -95,4 +95,4 @@ async function handler(
   }
 }
 
-export default withAuthentication(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/poke/workspaces/[wId]/upgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade.ts
@@ -1,4 +1,4 @@
-import type { LightWorkspaceType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { LightWorkspaceType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
@@ -11,7 +11,7 @@ export type UpgradeWorkspaceResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<UpgradeWorkspaceResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<UpgradeWorkspaceResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(

--- a/front/pages/api/poke/workspaces/[wId]/upgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade.ts
@@ -2,8 +2,9 @@ import type { LightWorkspaceType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
+import { withAuthentication } from "@app/lib/iam/session";
 import { pokeUpgradeWorkspaceToPlan } from "@app/lib/plans/subscription";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type UpgradeWorkspaceResponseBody = {
   workspace: LightWorkspaceType;
@@ -68,4 +69,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withAuthentication(handler);

--- a/front/pages/api/poke/workspaces/[wId]/upgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade.ts
@@ -1,8 +1,8 @@
 import type { LightWorkspaceType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { withAuthentication } from "@app/lib/iam/session";
 import { pokeUpgradeWorkspaceToPlan } from "@app/lib/plans/subscription";
 import { apiError } from "@app/logger/withlogging";
 
@@ -69,4 +69,4 @@ async function handler(
   }
 }
 
-export default withAuthentication(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
@@ -5,6 +5,7 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
+import { withAuthentication } from "@app/lib/iam/session";
 import {
   assertStripeSubscriptionIsValid,
   getStripeSubscription,
@@ -14,7 +15,7 @@ import {
   getSubscriptionForStripeId,
   pokeUpgradeWorkspaceToEnterprise,
 } from "@app/lib/plans/subscription";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export interface UpgradeEnterpriseSuccessResponseBody {
   success: boolean;
@@ -161,4 +162,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withAuthentication(handler);

--- a/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
@@ -4,8 +4,8 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { withAuthentication } from "@app/lib/iam/session";
 import {
   assertStripeSubscriptionIsValid,
   getStripeSubscription,
@@ -162,4 +162,4 @@ async function handler(
   }
 }
 
-export default withAuthentication(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { EnterpriseUpgradeFormSchema } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
@@ -23,7 +23,7 @@ export interface UpgradeEnterpriseSuccessResponseBody {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<UpgradeEnterpriseSuccessResponseBody>
+    WithAPIErrorResponse<UpgradeEnterpriseSuccessResponseBody>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -5,13 +5,14 @@ import { Op } from "sequelize";
 
 import { renderUserType } from "@app/lib/api/user";
 import { Authenticator, getSession } from "@app/lib/auth";
+import { withAuthentication } from "@app/lib/iam/session";
 import { Plan, Subscription } from "@app/lib/models/plan";
 import { User } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
 import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { isEmailValid } from "@app/lib/utils";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type GetWorkspacesResponseBody = {
   workspaces: LightWorkspaceType[];
@@ -195,4 +196,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withAuthentication(handler);

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -4,8 +4,8 @@ import type { FindOptions, WhereOptions } from "sequelize";
 import { Op } from "sequelize";
 
 import { renderUserType } from "@app/lib/api/user";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { withAuthentication } from "@app/lib/iam/session";
 import { Plan, Subscription } from "@app/lib/models/plan";
 import { User } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
@@ -196,4 +196,4 @@ async function handler(
   }
 }
 
-export default withAuthentication(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -1,4 +1,4 @@
-import type { LightWorkspaceType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { LightWorkspaceType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 import type { FindOptions, WhereOptions } from "sequelize";
 import { Op } from "sequelize";
@@ -19,7 +19,7 @@ export type GetWorkspacesResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<GetWorkspacesResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetWorkspacesResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(session, null);

--- a/front/pages/api/stripe/portal.ts
+++ b/front/pages/api/stripe/portal.ts
@@ -4,8 +4,8 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { withAuthentication } from "@app/lib/iam/session";
 import { createCustomerPortalSession } from "@app/lib/plans/stripe";
 import { apiError } from "@app/logger/withlogging";
 
@@ -88,4 +88,4 @@ async function handler(
   }
 }
 
-export default withAuthentication(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/stripe/portal.ts
+++ b/front/pages/api/stripe/portal.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -16,7 +16,7 @@ type PostStripePortalResponseBody = {
 };
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<PostStripePortalResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PostStripePortalResponseBody>>
 ): Promise<void> {
   const bodyValidation = PostStripePortalRequestBody.decode(req.body);
   if (isLeft(bodyValidation)) {

--- a/front/pages/api/stripe/portal.ts
+++ b/front/pages/api/stripe/portal.ts
@@ -5,8 +5,9 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
+import { withAuthentication } from "@app/lib/iam/session";
 import { createCustomerPortalSession } from "@app/lib/plans/stripe";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 const PostStripePortalRequestBody = t.type({
   workspaceId: t.string,
@@ -87,4 +88,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withAuthentication(handler);

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { assertNever, ConnectorsAPI, removeNulls } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { pipeline, Writable } from "stream";
@@ -47,7 +47,7 @@ export const config = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<GetResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetResponseBody>>
 ): Promise<void> {
   const stripe = new Stripe(STRIPE_SECRET_KEY, {
     apiVersion: "2023-10-16",
@@ -666,7 +666,7 @@ async function handler(
 
 function _returnStripeApiError(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<GetResponseBody>>,
+  res: NextApiResponse<WithAPIErrorResponse<GetResponseBody>>,
   event: string,
   message: string
 ) {

--- a/front/pages/api/user/index.ts
+++ b/front/pages/api/user/index.ts
@@ -8,11 +8,12 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { updateUserFullName } from "@app/lib/api/user";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { getSession } from "@app/lib/auth";
 import { getUserFromSession } from "@app/lib/iam/session";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type PostUserMetadataResponseBody = {
   success: boolean;
@@ -103,4 +104,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/user/index.ts
+++ b/front/pages/api/user/index.ts
@@ -1,6 +1,6 @@
 import type {
   UserTypeWithWorkspaces,
-  WithAPIErrorReponse,
+  WithAPIErrorResponse,
 } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -30,7 +30,7 @@ export type GetUserResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<PostUserMetadataResponseBody | GetUserResponseBody>
+    WithAPIErrorResponse<PostUserMetadataResponseBody | GetUserResponseBody>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/user/metadata/[key]/index.ts
+++ b/front/pages/api/user/metadata/[key]/index.ts
@@ -2,9 +2,10 @@ import type { UserMetadataType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getUserMetadata, setUserMetadata } from "@app/lib/api/user";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { getSession } from "@app/lib/auth";
 import { getUserFromSession } from "@app/lib/iam/session";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type PostUserMetadataResponseBody = {
   metadata: UserMetadataType;
@@ -89,4 +90,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/user/metadata/[key]/index.ts
+++ b/front/pages/api/user/metadata/[key]/index.ts
@@ -1,4 +1,4 @@
-import type { UserMetadataType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { UserMetadataType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getUserMetadata, setUserMetadata } from "@app/lib/api/user";
@@ -16,7 +16,7 @@ export type GetUserMetadataResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<
+    WithAPIErrorResponse<
       PostUserMetadataResponseBody | GetUserMetadataResponseBody
     >
   >

--- a/front/pages/api/v1/w/[wId]/apps/[aId]/runs/[runId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/[aId]/runs/[runId]/index.ts
@@ -1,4 +1,4 @@
-import type { RunType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { RunType, WithAPIErrorResponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -107,7 +107,7 @@ export type GetRunResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<GetRunResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetRunResponseBody>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
@@ -4,7 +4,7 @@ import type {
   ModelIdType,
   ModelProviderIdType,
   TraceType,
-  WithAPIErrorReponse,
+  WithAPIErrorResponse,
 } from "@dust-tt/types";
 import type { RunType } from "@dust-tt/types";
 import {
@@ -147,7 +147,7 @@ function extractUsageFromExecutions(
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<PostRunResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PostRunResponseBody>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/apps/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/index.ts
@@ -1,4 +1,4 @@
-import type { AppType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { AppType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getApps } from "@app/lib/api/app";
@@ -47,7 +47,7 @@ export type GetAppsResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<GetAppsResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetAppsResponseBody>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
@@ -44,7 +44,7 @@ import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<GetAgentConfigurationsResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetAgentConfigurationsResponseBody>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -1,4 +1,4 @@
-import type { ContentFragmentType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { ContentFragmentType, WithAPIErrorResponse } from "@dust-tt/types";
 import { PublicPostContentFragmentRequestBodySchema } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import type * as t from "io-ts";
@@ -103,7 +103,7 @@ export type PostContentFragmentRequestBody = t.TypeOf<
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<PostContentFragmentsResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PostContentFragmentsResponseBody>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
@@ -50,7 +50,7 @@ import { apiError, withLogging } from "@app/logger/withlogging";
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<void>>
+  res: NextApiResponse<WithAPIErrorResponse<void>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -1,4 +1,4 @@
-import type { ConversationType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { ConversationType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
@@ -48,7 +48,7 @@ import { apiError, withLogging } from "@app/logger/withlogging";
  */
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<{ conversation: ConversationType }>>
+  res: NextApiResponse<WithAPIErrorResponse<{ conversation: ConversationType }>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
@@ -72,7 +72,7 @@ import { apiError, withLogging } from "@app/logger/withlogging";
  */
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<void>>
+  res: NextApiResponse<WithAPIErrorResponse<void>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -1,7 +1,7 @@
 import type {
   AgentMessageType,
   UserMessageType,
-  WithAPIErrorReponse,
+  WithAPIErrorResponse,
 } from "@dust-tt/types";
 import {
   isEmptyString,
@@ -118,7 +118,7 @@ export type PostMessagesResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<PostMessagesResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PostMessagesResponseBody>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -2,7 +2,7 @@ import type {
   ContentFragmentType,
   ConversationType,
   UserMessageType,
-  WithAPIErrorReponse,
+  WithAPIErrorResponse,
 } from "@dust-tt/types";
 import {
   isEmptyString,
@@ -154,7 +154,7 @@ export type PostConversationsResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<PostConversationsResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PostConversationsResponseBody>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -2,7 +2,7 @@ import type {
   CoreAPILightDocument,
   DataSourceType,
   DocumentType,
-  WithAPIErrorReponse,
+  WithAPIErrorResponse,
 } from "@dust-tt/types";
 import {
   PostDataSourceDocumentRequestBodySchema,
@@ -200,7 +200,7 @@ export type UpsertDocumentResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<
+    WithAPIErrorResponse<
       | GetDocumentResponseBody
       | DeleteDocumentResponseBody
       | UpsertDocumentResponseBody

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/parents.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/parents.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -72,7 +72,7 @@ export type PostParentsResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<PostParentsResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PostParentsResponseBody>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/index.ts
@@ -1,4 +1,4 @@
-import type { DocumentType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { DocumentType, WithAPIErrorResponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -60,7 +60,7 @@ export type GetDocumentsResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<GetDocumentsResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetDocumentsResponseBody>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/search.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/search.ts
@@ -1,4 +1,4 @@
-import type { DocumentType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { DocumentType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { CredentialsType } from "@dust-tt/types";
 import {
   credentialsFromProviders,
@@ -185,7 +185,7 @@ type DatasourceSearchResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<DatasourceSearchResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<DatasourceSearchResponseBody>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
@@ -1,4 +1,4 @@
-import type { CoreAPITableSchema, WithAPIErrorReponse } from "@dust-tt/types";
+import type { CoreAPITableSchema, WithAPIErrorResponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -98,7 +98,7 @@ export type GetTableResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<GetTableResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetTableResponseBody>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/[rId].ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/[rId].ts
@@ -1,4 +1,4 @@
-import type { CoreAPIRow, WithAPIErrorReponse } from "@dust-tt/types";
+import type { CoreAPIRow, WithAPIErrorResponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -105,7 +105,7 @@ type GetTableRowsResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<GetTableRowsResponseBody | { success: boolean }>
+    WithAPIErrorResponse<GetTableRowsResponseBody | { success: boolean }>
   >
 ): Promise<void> {
   const keyRes = await getAPIKey(req);

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/index.ts
@@ -1,7 +1,7 @@
 import type {
   CoreAPIRow,
   CoreAPITableSchema,
-  WithAPIErrorReponse,
+  WithAPIErrorResponse,
 } from "@dust-tt/types";
 import { CoreAPI, isSlugified } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
@@ -183,7 +183,9 @@ type ListTableRowsResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<UpsertTableRowsResponseBody | ListTableRowsResponseBody>
+    WithAPIErrorResponse<
+      UpsertTableRowsResponseBody | ListTableRowsResponseBody
+    >
   >
 ): Promise<void> {
   const keyRes = await getAPIKey(req);

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/index.ts
@@ -1,4 +1,4 @@
-import type { CoreAPITableSchema, WithAPIErrorReponse } from "@dust-tt/types";
+import type { CoreAPITableSchema, WithAPIErrorResponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -113,7 +113,7 @@ type UpsertTableResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<ListTablesResponseBody | UpsertTableResponseBody>
+    WithAPIErrorResponse<ListTablesResponseBody | UpsertTableResponseBody>
   >
 ): Promise<void> {
   const keyRes = await getAPIKey(req);

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tokenize.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tokenize.ts
@@ -1,4 +1,4 @@
-import type { CoreAPITokenType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { CoreAPITokenType, WithAPIErrorResponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -69,7 +69,7 @@ type PostDatasourceTokenizeResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<PostDatasourceTokenizeResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PostDatasourceTokenizeResponseBody>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/index.ts
@@ -1,4 +1,4 @@
-import type { DataSourceType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { DataSourceType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSources } from "@app/lib/api/data_sources";
@@ -41,7 +41,7 @@ export type GetDataSourcesResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<GetDataSourcesResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetDataSourcesResponseBody>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/feature_flags.ts
+++ b/front/pages/api/v1/w/[wId]/feature_flags.ts
@@ -1,4 +1,7 @@
-import type { WhitelistableFeature, WithAPIErrorReponse } from "@dust-tt/types";
+import type {
+  WhitelistableFeature,
+  WithAPIErrorResponse,
+} from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getAPIKey } from "@app/lib/auth";
@@ -45,7 +48,7 @@ export type WorkspaceFeatureFlagsResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<WorkspaceFeatureFlagsResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<WorkspaceFeatureFlagsResponseBody>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/members/emails.ts
+++ b/front/pages/api/v1/w/[wId]/members/emails.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getMembers } from "@app/lib/api/workspace";
@@ -52,7 +52,7 @@ export type ListMemberEmailsResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<ListMemberEmailsResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<ListMemberEmailsResponseBody>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/verified_domains.ts
+++ b/front/pages/api/v1/w/[wId]/verified_domains.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse, WorkspaceDomain } from "@dust-tt/types";
+import type { WithAPIErrorResponse, WorkspaceDomain } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getWorkspaceVerifiedDomain } from "@app/lib/api/workspace";
@@ -41,7 +41,7 @@ export type ListMemberEmailsResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<ListMemberEmailsResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<ListMemberEmailsResponseBody>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/w/[wId]/apps/[aId]/clone.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/clone.ts
@@ -4,11 +4,12 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getApp } from "@app/lib/api/app";
 import { getDatasets } from "@app/lib/api/datasets";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { App, Clone, Dataset } from "@app/lib/models/apps";
 import { generateLegacyModelSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type PostAppResponseBody = {
   app: AppType;
@@ -161,4 +162,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/apps/[aId]/clone.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/clone.ts
@@ -1,4 +1,4 @@
-import type { AppType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { AppType, WithAPIErrorResponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -16,7 +16,7 @@ export type PostAppResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<PostAppResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PostAppResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/apps/[aId]/datasets/[name]/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/datasets/[name]/index.ts
@@ -6,11 +6,12 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getApp } from "@app/lib/api/app";
 import { getDatasetHash } from "@app/lib/api/datasets";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { checkDatasetData } from "@app/lib/datasets";
 import { Dataset } from "@app/lib/models/apps";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 import { PostDatasetRequestBodySchema } from "..";
 
@@ -202,4 +203,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/apps/[aId]/datasets/[name]/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/datasets/[name]/index.ts
@@ -1,4 +1,4 @@
-import type { DatasetType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { DatasetType, WithAPIErrorResponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
@@ -18,7 +18,7 @@ export type GetDatasetResponseBody = { dataset: DatasetType };
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<GetDatasetResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetDatasetResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/apps/[aId]/datasets/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/datasets/index.ts
@@ -1,4 +1,4 @@
-import type { DatasetType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { DatasetType, WithAPIErrorResponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -44,7 +44,7 @@ export const PostDatasetRequestBodySchema = t.type({
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<GetDatasetsResponseBody | PostDatasetResponseBody>
+    WithAPIErrorResponse<GetDatasetsResponseBody | PostDatasetResponseBody>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/apps/[aId]/datasets/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/datasets/index.ts
@@ -7,11 +7,12 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getApp } from "@app/lib/api/app";
 import { getDatasets } from "@app/lib/api/datasets";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { checkDatasetData } from "@app/lib/datasets";
 import { Dataset } from "@app/lib/models/apps";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type GetDatasetsResponseBody = {
   datasets: DatasetType[];
@@ -208,4 +209,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/apps/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/index.ts
@@ -1,4 +1,4 @@
-import type { AppType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { AppType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { Op } from "sequelize";
 
@@ -12,7 +12,7 @@ export type GetOrPostAppResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<GetOrPostAppResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetOrPostAppResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/apps/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/index.ts
@@ -2,9 +2,10 @@ import type { AppType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { Op } from "sequelize";
 
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { App } from "@app/lib/models/apps";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type GetOrPostAppResponseBody = {
   app: AppType;
@@ -158,4 +159,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]/index.ts
@@ -3,9 +3,10 @@ import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getApp } from "@app/lib/api/app";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export const config = {
   api: {
@@ -85,4 +86,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]/index.ts
@@ -1,4 +1,4 @@
-import type { BlockType, RunType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { BlockType, RunType, WithAPIErrorResponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -19,7 +19,7 @@ export type GetRunBlockResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<GetRunBlockResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetRunBlockResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/status.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/status.ts
@@ -3,9 +3,10 @@ import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getApp } from "@app/lib/api/app";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type GetRunStatusResponseBody = {
   run: RunType | null;
@@ -74,4 +75,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/status.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/status.ts
@@ -1,4 +1,4 @@
-import type { RunType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { RunType, WithAPIErrorResponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -13,7 +13,7 @@ export type GetRunStatusResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<GetRunStatusResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetRunStatusResponseBody>>
 ) {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/runs/index.ts
@@ -1,4 +1,4 @@
-import type { RunType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { RunType, WithAPIErrorResponse } from "@dust-tt/types";
 import { credentialsFromProviders } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -24,7 +24,7 @@ export type PostRunsResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<GetRunsResponseBody | PostRunsResponseBody>
+    WithAPIErrorResponse<GetRunsResponseBody | PostRunsResponseBody>
   >
 ) {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/runs/index.ts
@@ -5,12 +5,13 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getApp } from "@app/lib/api/app";
 import { getDustAppSecrets } from "@app/lib/api/dust_app_secrets";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { App, Provider } from "@app/lib/models/apps";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { dumpSpecification } from "@app/lib/specification";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type GetRunsResponseBody = {
   runs: RunType[];
@@ -275,4 +276,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/apps/[aId]/state.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/state.ts
@@ -1,4 +1,4 @@
-import type { AppType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { AppType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { Op } from "sequelize";
 
@@ -12,7 +12,7 @@ export type PostStateResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<PostStateResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PostStateResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/apps/[aId]/state.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/state.ts
@@ -2,9 +2,10 @@ import type { AppType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { Op } from "sequelize";
 
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { App } from "@app/lib/models/apps";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type PostStateResponseBody = {
   app: AppType;
@@ -138,4 +139,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/apps/index.ts
+++ b/front/pages/api/w/[wId]/apps/index.ts
@@ -2,11 +2,12 @@ import type { AppType, WithAPIErrorResponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { App } from "@app/lib/models/apps";
 import { generateLegacyModelSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type PostAppResponseBody = {
   app: AppType;
@@ -112,4 +113,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/apps/index.ts
+++ b/front/pages/api/w/[wId]/apps/index.ts
@@ -1,4 +1,4 @@
-import type { AppType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { AppType, WithAPIErrorResponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -14,7 +14,7 @@ export type PostAppResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<PostAppResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PostAppResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
@@ -1,6 +1,6 @@
 import type {
   AgentConfigurationType,
-  WithAPIErrorReponse,
+  WithAPIErrorResponse,
 } from "@dust-tt/types";
 import { PostOrPatchAgentConfigurationRequestBodySchema } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
@@ -26,7 +26,7 @@ export type DeleteAgentConfigurationResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<
+    WithAPIErrorResponse<
       | GetAgentConfigurationResponseBody
       | DeleteAgentConfigurationResponseBody
       | void

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
@@ -12,8 +12,9 @@ import {
   getAgentConfiguration,
 } from "@app/lib/api/assistant/configuration";
 import { getAgentRecentAuthors } from "@app/lib/api/assistant/recent_authors";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 import { createOrUpgradeAgentConfiguration } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 
 export type GetAgentConfigurationResponseBody = {
@@ -194,4 +195,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
@@ -6,10 +6,11 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { DataSource } from "@app/lib/models/data_source";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type PatchLinkedSlackChannelsResponseBody = {
   success: true;
@@ -143,4 +144,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { ConnectorsAPI } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -22,7 +22,7 @@ export const PatchLinkedSlackChannelsRequestBodySchema = t.type({
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<PatchLinkedSlackChannelsResponseBody | void>
+    WithAPIErrorResponse<PatchLinkedSlackChannelsResponseBody | void>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
@@ -6,8 +6,9 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import { setAgentUserListStatus } from "@app/lib/api/assistant/user_relation";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 import { createOrUpgradeAgentConfiguration } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 
 export const PostAgentScopeRequestBodySchema = t.type({
@@ -160,4 +161,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
@@ -1,4 +1,4 @@
-import type { AgentStatus, WithAPIErrorReponse } from "@dust-tt/types";
+import type { AgentStatus, WithAPIErrorResponse } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -24,7 +24,7 @@ export type PostAgentScopeRequestBody = t.TypeOf<
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<void>>
+  res: NextApiResponse<WithAPIErrorResponse<void>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage.ts
@@ -1,4 +1,4 @@
-import type { AgentUsageType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { AgentUsageType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getAgentUsage } from "@app/lib/api/assistant/agent_usage";
@@ -12,7 +12,7 @@ export type GetAgentUsageResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<GetAgentUsageResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetAgentUsageResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage.ts
@@ -3,8 +3,9 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getAgentUsage } from "@app/lib/api/assistant/agent_usage";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type GetAgentUsageResponseBody = {
   agentUsage: AgentUsageType;
@@ -73,4 +74,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/avatar.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/avatar.ts
@@ -1,8 +1,8 @@
 import { IncomingForm } from "formidable";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { getPublicUploadBucket } from "@app/lib/file_storage";
-import { withLogging } from "@app/logger/withlogging";
 
 export const config = {
   api: {
@@ -55,4 +55,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -27,10 +27,11 @@ import {
   unsafeHardDeleteAgentConfiguration,
 } from "@app/lib/api/assistant/configuration";
 import { getAgentsRecentAuthors } from "@app/lib/api/assistant/recent_authors";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { safeRedisClient } from "@app/lib/redis";
 import { ServerSideTracking } from "@app/lib/tracking/server";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type GetAgentConfigurationsResponseBody = {
   agentConfigurations: LightAgentConfigurationType[];
@@ -255,7 +256,7 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);
 
 /**
  * Create Or Upgrade Agent Configuration If an agentConfigurationId is provided, it will create a

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -3,7 +3,7 @@ import type {
   AgentConfigurationType,
   LightAgentConfigurationType,
   Result,
-  WithAPIErrorReponse,
+  WithAPIErrorResponse,
 } from "@dust-tt/types";
 import {
   assertNever,
@@ -42,7 +42,7 @@ export type PostAgentConfigurationResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<
+    WithAPIErrorResponse<
       | GetAgentConfigurationsResponseBody
       | PostAgentConfigurationResponseBody
       | void

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/name_available.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/name_available.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -19,7 +19,7 @@ export const GetAgentConfigurationNameIsAvailable = t.type({
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<GetAgentNameIsAvailableResponseBody | void>
+    WithAPIErrorResponse<GetAgentNameIsAvailableResponseBody | void>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/name_available.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/name_available.ts
@@ -5,8 +5,9 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { agentNameIsAvailable } from "@app/lib/api/assistant/configuration";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type GetAgentNameIsAvailableResponseBody = {
   available: boolean;
@@ -81,4 +82,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/assistant/builder/process/generate_schema.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/process/generate_schema.ts
@@ -1,6 +1,6 @@
 import type {
   ProcessSchemaPropertyType,
-  WithAPIErrorReponse,
+  WithAPIErrorResponse,
 } from "@dust-tt/types";
 import {
   cloneBaseConfig,
@@ -20,7 +20,7 @@ import { apiError, withLogging } from "@app/logger/withlogging";
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<{
+    WithAPIErrorResponse<{
       schema: ProcessSchemaPropertyType[];
     }>
   >

--- a/front/pages/api/w/[wId]/assistant/builder/process/generate_schema.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/process/generate_schema.ts
@@ -14,8 +14,9 @@ import { DustProdActionRegistry } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { runAction } from "@app/lib/actions/server";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 async function handler(
   req: NextApiRequest,
@@ -143,4 +144,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/assistant/builder/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/suggestions.ts
@@ -20,8 +20,9 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { runAction } from "@app/lib/actions/server";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 async function handler(
   req: NextApiRequest,
@@ -148,4 +149,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/assistant/builder/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/suggestions.ts
@@ -2,7 +2,7 @@ import type {
   BuilderEmojiSuggestionsType,
   BuilderSuggestionsType,
   ModelConfigurationType,
-  WithAPIErrorReponse,
+  WithAPIErrorResponse,
 } from "@dust-tt/types";
 import {
   assertNever,
@@ -26,7 +26,7 @@ import { apiError, withLogging } from "@app/logger/withlogging";
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<BuilderSuggestionsType | BuilderEmojiSuggestionsType>
+    WithAPIErrorResponse<BuilderSuggestionsType | BuilderEmojiSuggestionsType>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/assistant/builder/templates/[tId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/templates/[tId]/index.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
@@ -11,7 +11,7 @@ export type FetchAssistantTemplateResponse = ReturnType<
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<FetchAssistantTemplateResponse>>
+  res: NextApiResponse<WithAPIErrorResponse<FetchAssistantTemplateResponse>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/assistant/builder/templates/[tId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/templates/[tId]/index.ts
@@ -1,9 +1,10 @@
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { TemplateResource } from "@app/lib/resources/template_resource";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type FetchAssistantTemplateResponse = ReturnType<
   TemplateResource["toJSON"]
@@ -67,4 +68,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/assistant/builder/templates/index.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/templates/index.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
@@ -15,7 +15,7 @@ export interface FetchAssistantTemplatesResponse {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<FetchAssistantTemplatesResponse>>
+  res: NextApiResponse<WithAPIErrorResponse<FetchAssistantTemplatesResponse>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/assistant/builder/templates/index.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/templates/index.ts
@@ -1,9 +1,10 @@
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { TemplateResource } from "@app/lib/resources/template_resource";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type AssistantTemplateListType = ReturnType<
   TemplateResource["toListJSON"]
@@ -55,4 +56,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
@@ -6,8 +6,9 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
 import { cancelMessageGenerationEvent } from "@app/lib/api/assistant/pubsub";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type PostMessageEventResponseBody = {
   success: true;
@@ -111,4 +112,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler, true);
+export default withSessionAuthentication(handler, true);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
@@ -112,4 +112,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler, true);
+export default withSessionAuthentication(handler, { isStreaming: true });

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -19,7 +19,7 @@ const PostMessageEventBodySchema = t.type({
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<PostMessageEventResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PostMessageEventResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/content_fragment/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/content_fragment/index.ts
@@ -1,4 +1,4 @@
-import type { ContentFragmentType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { ContentFragmentType, WithAPIErrorResponse } from "@dust-tt/types";
 import { InternalPostContentFragmentRequestBodySchema } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import type * as t from "io-ts";
@@ -19,7 +19,7 @@ export type PostContentFragmentRequestBody = t.TypeOf<
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<{ contentFragment: ContentFragmentType }>
+    WithAPIErrorResponse<{ contentFragment: ContentFragmentType }>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/content_fragment/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/content_fragment/index.ts
@@ -9,8 +9,9 @@ import {
   getConversation,
   postNewContentFragment,
 } from "@app/lib/api/assistant/conversation";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type PostContentFragmentRequestBody = t.TypeOf<
   typeof InternalPostContentFragmentRequestBodySchema
@@ -129,4 +130,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -3,8 +3,9 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
 import { getConversationEvents } from "@app/lib/api/assistant/pubsub";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 async function handler(
   req: NextApiRequest,
@@ -117,4 +118,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler, true);
+export default withSessionAuthentication(handler, true);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -118,4 +118,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler, true);
+export default withSessionAuthentication(handler, { isStreaming: true });

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
@@ -8,7 +8,7 @@ import { apiError, withLogging } from "@app/logger/withlogging";
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<void>>
+  res: NextApiResponse<WithAPIErrorResponse<void>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -1,6 +1,6 @@
 import type {
   ConversationWithoutContentType,
-  WithAPIErrorReponse,
+  WithAPIErrorResponse,
 } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -31,7 +31,9 @@ export type GetConversationsResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<GetConversationsResponseBody | void>>
+  res: NextApiResponse<
+    WithAPIErrorResponse<GetConversationsResponseBody | void>
+  >
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -12,8 +12,9 @@ import {
   getConversationWithoutContent,
   updateConversation,
 } from "@app/lib/api/assistant/conversation";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export const PatchConversationsRequestBodySchema = t.type({
   title: t.union([t.string, t.null]),
@@ -143,4 +144,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
@@ -1,4 +1,4 @@
-import type { UserMessageType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { UserMessageType, WithAPIErrorResponse } from "@dust-tt/types";
 import { isUserMessageType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -17,7 +17,7 @@ export const PostEditRequestBodySchema = t.type({
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<{ message: UserMessageType }>>
+  res: NextApiResponse<WithAPIErrorResponse<{ message: UserMessageType }>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
@@ -7,8 +7,9 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
 import { editUserMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export const PostEditRequestBodySchema = t.type({
   content: t.string,
@@ -145,4 +146,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
@@ -11,7 +11,7 @@ import { apiError, withLogging } from "@app/logger/withlogging";
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<void>>
+  res: NextApiResponse<WithAPIErrorResponse<void>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
@@ -6,8 +6,9 @@ import {
   getConversationWithoutContent,
 } from "@app/lib/api/assistant/conversation";
 import { getMessagesEvents } from "@app/lib/api/assistant/pubsub";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 async function handler(
   req: NextApiRequest,
@@ -157,4 +158,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler, true);
+export default withSessionAuthentication(handler, true);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
@@ -158,4 +158,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler, true);
+export default withSessionAuthentication(handler, { isStreaming: true });

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/raw_content_fragment/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/raw_content_fragment/index.ts
@@ -4,10 +4,11 @@ import { IncomingForm } from "formidable";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { fileAttachmentLocation } from "@app/lib/resources/content_fragment_resource";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export const config = {
   api: {
@@ -213,4 +214,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/raw_content_fragment/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/raw_content_fragment/index.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { isContentFragmentType } from "@dust-tt/types";
 import { IncomingForm } from "formidable";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -24,7 +24,7 @@ type Action = (typeof validActions)[number];
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<{ sourceUrl: string }>>
+  res: NextApiResponse<WithAPIErrorResponse<{ sourceUrl: string }>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
@@ -1,4 +1,4 @@
-import type { MessageReactionType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { MessageReactionType, WithAPIErrorResponse } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -19,7 +19,7 @@ export const MessageReactionRequestBodySchema = t.type({
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<
+    WithAPIErrorResponse<
       { reactions: MessageReactionType[] } | { success: boolean }
     >
   >

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
@@ -9,8 +9,9 @@ import {
   createMessageReaction,
   deleteMessageReaction,
 } from "@app/lib/api/assistant/reaction";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export const MessageReactionRequestBodySchema = t.type({
   reaction: t.string,
@@ -169,4 +170,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
@@ -7,8 +7,9 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
 import { retryAgentMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export const PostRetryRequestBodySchema = t.union([
   t.null,
@@ -144,4 +145,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
@@ -1,4 +1,4 @@
-import type { AgentMessageType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { AgentMessageType, WithAPIErrorResponse } from "@dust-tt/types";
 import { isAgentMessageType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -19,7 +19,7 @@ export const PostRetryRequestBodySchema = t.union([
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<{ message: AgentMessageType }>>
+  res: NextApiResponse<WithAPIErrorResponse<{ message: AgentMessageType }>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -1,4 +1,4 @@
-import type { UserMessageType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { UserMessageType, WithAPIErrorResponse } from "@dust-tt/types";
 import { InternalPostMessagesRequestBodySchema } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
@@ -15,7 +15,7 @@ import { apiError, withLogging } from "@app/logger/withlogging";
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<
+    WithAPIErrorResponse<
       { message: UserMessageType } | FetchConversationMessagesResponse
     >
   >

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -9,8 +9,9 @@ import type { FetchConversationMessagesResponse } from "@app/lib/api/assistant/m
 import { fetchConversationMessages } from "@app/lib/api/assistant/messages";
 import { postUserMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
 import { getPaginationParams } from "@app/lib/api/pagination";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 async function handler(
   req: NextApiRequest,
@@ -179,4 +180,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/participants.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/participants.ts
@@ -1,7 +1,7 @@
 import type {
   ConversationParticipantsType,
   UserMessageType,
-  WithAPIErrorReponse,
+  WithAPIErrorResponse,
 } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -17,7 +17,7 @@ export type FetchConversationParticipantsResponse = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<
+    WithAPIErrorResponse<
       { message: UserMessageType } | FetchConversationParticipantsResponse
     >
   >

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/participants.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/participants.ts
@@ -7,8 +7,9 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
 import { fetchConversationParticipants } from "@app/lib/api/assistant/participants";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type FetchConversationParticipantsResponse = {
   participants: ConversationParticipantsType;
@@ -116,4 +117,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/reactions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/reactions.ts
@@ -6,8 +6,9 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
 import { getMessageReactions } from "@app/lib/api/assistant/reaction";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 async function handler(
   req: NextApiRequest,
@@ -95,4 +96,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/reactions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/reactions.ts
@@ -1,6 +1,6 @@
 import type {
   ConversationMessageReactions,
-  WithAPIErrorReponse,
+  WithAPIErrorResponse,
 } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -12,7 +12,7 @@ import { apiError, withLogging } from "@app/logger/withlogging";
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<{ reactions: ConversationMessageReactions }>
+    WithAPIErrorResponse<{ reactions: ConversationMessageReactions }>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -17,8 +17,9 @@ import {
   postNewContentFragment,
 } from "@app/lib/api/assistant/conversation";
 import { postUserMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type GetConversationsResponseBody = {
   conversations: ConversationWithoutContentType[];
@@ -222,4 +223,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -3,7 +3,7 @@ import type {
   ConversationType,
   ConversationWithoutContentType,
   UserMessageType,
-  WithAPIErrorReponse,
+  WithAPIErrorResponse,
 } from "@dust-tt/types";
 import { InternalPostConversationsRequestBodySchema } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
@@ -32,7 +32,7 @@ export type PostConversationsResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<
+    WithAPIErrorResponse<
       GetConversationsResponseBody | PostConversationsResponseBody | void
     >
   >

--- a/front/pages/api/w/[wId]/assistant/global_agents/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/global_agents/[aId]/index.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -18,7 +18,7 @@ const PatchGlobalAgentSettingsRequestBodySchema = t.type({
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<PatchGlobalAgentSettingResponseBody | void>
+    WithAPIErrorResponse<PatchGlobalAgentSettingResponseBody | void>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/assistant/global_agents/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/global_agents/[aId]/index.ts
@@ -5,8 +5,9 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { upsertGlobalAgentSettings } from "@app/lib/api/assistant/global_agents";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 type PatchGlobalAgentSettingResponseBody = {
   success: boolean;
@@ -93,4 +94,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/data_sources/[name]/configuration.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/configuration.ts
@@ -1,4 +1,4 @@
-import type { ConnectorType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { ConnectorType, WithAPIErrorResponse } from "@dust-tt/types";
 import {
   assertNever,
   ConnectorsAPI,
@@ -19,7 +19,7 @@ export type PostDataSourceConfigurationResBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<PostDataSourceConfigurationResBody | void>
+    WithAPIErrorResponse<PostDataSourceConfigurationResBody | void>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/data_sources/[name]/configuration.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/configuration.ts
@@ -8,9 +8,10 @@ import {
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type PostDataSourceConfigurationResBody = {
   connector: ConnectorType;
@@ -183,4 +184,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/data_sources/[name]/connector.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/connector.ts
@@ -3,9 +3,10 @@ import { ConnectorsAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type GetConnectorResponseBody = {
   connector: ConnectorType;
@@ -93,4 +94,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/data_sources/[name]/connector.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/connector.ts
@@ -1,4 +1,4 @@
-import type { ConnectorType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { ConnectorType, WithAPIErrorResponse } from "@dust-tt/types";
 import { ConnectorsAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -13,7 +13,7 @@ export type GetConnectorResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<GetConnectorResponseBody | void>>
+  res: NextApiResponse<WithAPIErrorResponse<GetConnectorResponseBody | void>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -14,10 +14,11 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { validateUrl } from "@app/lib/utils";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export const config = {
   api: {
@@ -327,4 +328,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -1,4 +1,7 @@
-import type { CoreAPILightDocument, WithAPIErrorReponse } from "@dust-tt/types";
+import type {
+  CoreAPILightDocument,
+  WithAPIErrorResponse,
+} from "@dust-tt/types";
 import type { DocumentType } from "@dust-tt/types";
 import {
   PostDataSourceDocumentRequestBodySchema,
@@ -30,7 +33,7 @@ export type GetDocumentResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<GetDocumentResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetDocumentResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/data_sources/[name]/documents/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/documents/index.ts
@@ -3,9 +3,10 @@ import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type GetDocumentsResponseBody = {
   documents: Array<DocumentType>;
@@ -93,4 +94,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/data_sources/[name]/documents/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/documents/index.ts
@@ -1,4 +1,4 @@
-import type { DocumentType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { DocumentType, WithAPIErrorResponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -14,7 +14,7 @@ export type GetDocumentsResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<GetDocumentsResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetDocumentsResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth =

--- a/front/pages/api/w/[wId]/data_sources/[name]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/index.ts
@@ -1,4 +1,4 @@
-import type { DataSourceType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { DataSourceType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
@@ -17,7 +17,7 @@ export type GetOrPostDataSourceResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<GetOrPostDataSourceResponseBody | void>
+    WithAPIErrorResponse<GetOrPostDataSourceResponseBody | void>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/data_sources/[name]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/index.ts
@@ -6,9 +6,10 @@ import {
   getDataSource,
   MANAGED_DS_DELETABLE_AS_BUILDER,
 } from "@app/lib/api/data_sources";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { DataSource } from "@app/lib/models/data_source";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type GetOrPostDataSourceResponseBody = {
   dataSource: DataSourceType;
@@ -212,4 +213,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/config/[key]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/config/[key]/index.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { ConnectorsAPI } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -21,7 +21,7 @@ export type GetOrPostManagedDataSourceConfigResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<GetOrPostManagedDataSourceConfigResponseBody | void>
+    WithAPIErrorResponse<GetOrPostManagedDataSourceConfigResponseBody | void>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/config/[key]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/config/[key]/index.ts
@@ -6,9 +6,10 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export const PostManagedDataSourceConfigRequestBodySchema = t.type({
   configValue: t.string,
@@ -181,4 +182,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/content-nodes/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/content-nodes/index.ts
@@ -6,9 +6,10 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 const GetContentNodesRequestBody = t.type({
   internalIds: t.array(t.string),
@@ -159,4 +160,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/content-nodes/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/content-nodes/index.ts
@@ -1,4 +1,4 @@
-import type { ContentNode, WithAPIErrorReponse } from "@dust-tt/types";
+import type { ContentNode, WithAPIErrorResponse } from "@dust-tt/types";
 import { ConnectorsAPI } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -20,7 +20,7 @@ export type GetContentNodesResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<GetContentNodesResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetContentNodesResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/content_nodes.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/content_nodes.ts
@@ -1,4 +1,4 @@
-import type { ContentNode, WithAPIErrorReponse } from "@dust-tt/types";
+import type { ContentNode, WithAPIErrorResponse } from "@dust-tt/types";
 import { ConnectorsAPI } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -20,7 +20,7 @@ export type GetContentNodeResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<GetContentNodeResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetContentNodeResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/content_nodes.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/content_nodes.ts
@@ -6,9 +6,10 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 const GetContentNodeRequestBodySchema = t.type({
   internalIds: t.array(t.string),
@@ -120,4 +121,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/parents.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/parents.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { ConnectorsAPI } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -20,7 +20,7 @@ export type GetContentNodeParentsResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<GetContentNodeParentsResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetContentNodeParentsResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/parents.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/parents.ts
@@ -6,9 +6,10 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 const GetContentNodeParentsRequestBodySchema = t.type({
   internalIds: t.array(t.string),
@@ -134,4 +135,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
@@ -2,7 +2,7 @@ import type {
   ConnectorPermission,
   ContentNode,
   DataSourceType,
-  WithAPIErrorReponse,
+  WithAPIErrorResponse,
 } from "@dust-tt/types";
 import { assertNever, ConnectorsAPI } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
@@ -40,7 +40,7 @@ export type SetDataSourcePermissionsResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<
+    WithAPIErrorResponse<
       | GetDataSourcePermissionsResponseBody
       | SetDataSourcePermissionsResponseBody
     >
@@ -186,7 +186,7 @@ export async function getManagedDataSourcePermissionsHandler(
   dataSource: DataSourceType & { connectorId: string },
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<GetDataSourcePermissionsResponseBody>
+    WithAPIErrorResponse<GetDataSourcePermissionsResponseBody>
   >
 ) {
   let parentId: string | undefined = undefined;

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
@@ -11,9 +11,10 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 const SetConnectorPermissionsRequestBodySchema = t.type({
   resources: t.array(
@@ -286,4 +287,4 @@ export async function getManagedDataSourcePermissionsHandler(
   return;
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/slack/channels_linked_with_agent.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/slack/channels_linked_with_agent.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { ConnectorsAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -18,7 +18,7 @@ export type GetSlackChannelsLinkedWithAgentResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<GetSlackChannelsLinkedWithAgentResponseBody>
+    WithAPIErrorResponse<GetSlackChannelsLinkedWithAgentResponseBody>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/slack/channels_linked_with_agent.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/slack/channels_linked_with_agent.ts
@@ -3,9 +3,10 @@ import { ConnectorsAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type GetSlackChannelsLinkedWithAgentResponseBody = {
   slackChannels: {
@@ -120,4 +121,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/update.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/update.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import {
   ConnectorsAPI,
   sendUserOperationMessage,
@@ -25,7 +25,7 @@ export type GetDataSourceUpdateResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<GetDataSourceUpdateResponseBody | void>
+    WithAPIErrorResponse<GetDataSourceUpdateResponseBody | void>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/update.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/update.ts
@@ -12,11 +12,12 @@ import {
   getDataSource,
   updateDataSourceEditedBy,
 } from "@app/lib/api/data_sources";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { isDisposableEmailDomain } from "@app/lib/utils/disposable_email_domains";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type GetDataSourceUpdateResponseBody = {
   connectorId: string;
@@ -151,4 +152,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/data_sources/[name]/search.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/search.ts
@@ -5,10 +5,11 @@ import type { JSONSchemaType } from "ajv";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { parse_payload } from "@app/lib/http_utils";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type DatasourceSearchQuery = {
   query: string;
@@ -81,7 +82,7 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);
 
 export async function handleSearchDataSource({
   req,

--- a/front/pages/api/w/[wId]/data_sources/[name]/search.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/search.ts
@@ -1,4 +1,4 @@
-import type { DocumentType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { DocumentType, WithAPIErrorResponse } from "@dust-tt/types";
 import { dustManagedCredentials } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { JSONSchemaType } from "ajv";
@@ -46,7 +46,7 @@ export type DatasourceSearchResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<DatasourceSearchResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<DatasourceSearchResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(
@@ -89,7 +89,7 @@ export async function handleSearchDataSource({
   auth,
 }: {
   req: NextApiRequest;
-  res: NextApiResponse<WithAPIErrorReponse<DatasourceSearchResponseBody>>;
+  res: NextApiResponse<WithAPIErrorResponse<DatasourceSearchResponseBody>>;
   auth: Authenticator;
 }) {
   const dataSource = await getDataSource(auth, req.query.name as string);

--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
@@ -9,9 +9,10 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
 import { deleteTable } from "@app/lib/api/tables";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type GetTableResponseBody = {
   table: CoreAPITable;
@@ -140,7 +141,7 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);
 
 export async function handleDeleteTableByIdRequest(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
@@ -1,7 +1,7 @@
 import type {
   CoreAPITable,
   DataSourceType,
-  WithAPIErrorReponse,
+  WithAPIErrorResponse,
   WorkspaceType,
 } from "@dust-tt/types";
 import { assertNever, CoreAPI } from "@dust-tt/types";
@@ -19,7 +19,7 @@ export type GetTableResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<GetTableResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetTableResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
@@ -6,10 +6,11 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
 import { upsertTableFromCsv } from "@app/lib/api/tables";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { generateLegacyModelSId } from "@app/lib/resources/string_ids";
 import { enqueueUpsertTable } from "@app/lib/upsert_queue";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export const config = {
   api: {
@@ -94,7 +95,7 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);
 
 export async function handlePostTableCsvUpsertRequest(
   auth: Authenticator,

--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/index.ts
@@ -1,4 +1,4 @@
-import type { CoreAPITable, WithAPIErrorReponse } from "@dust-tt/types";
+import type { CoreAPITable, WithAPIErrorResponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -13,7 +13,7 @@ export type ListTablesResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<ListTablesResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<ListTablesResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/index.ts
@@ -3,9 +3,10 @@ import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type ListTablesResponseBody = {
   tables: CoreAPITable[];
@@ -104,4 +105,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -1,4 +1,4 @@
-import type { DataSourceType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { DataSourceType, WithAPIErrorResponse } from "@dust-tt/types";
 import {
   DEFAULT_QDRANT_CLUSTER,
   dustManagedCredentials,
@@ -26,7 +26,9 @@ export type PostDataSourceResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<GetDataSourcesResponseBody | PostDataSourceResponseBody>
+    WithAPIErrorResponse<
+      GetDataSourcesResponseBody | PostDataSourceResponseBody
+    >
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -9,11 +9,12 @@ import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource, getDataSources } from "@app/lib/api/data_sources";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { DataSource } from "@app/lib/models/data_source";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type GetDataSourcesResponseBody = {
   dataSources: Array<DataSourceType>;
@@ -217,4 +218,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -1,4 +1,4 @@
-import type { DataSourceType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { DataSourceType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { ConnectorType } from "@dust-tt/types";
 import {
   assertNever,
@@ -48,7 +48,7 @@ export type PostManagedDataSourceResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<PostManagedDataSourceResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PostManagedDataSourceResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -19,6 +19,7 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import {
   Authenticator,
   getOrCreateSystemApiKey,
@@ -28,7 +29,7 @@ import { DataSource } from "@app/lib/models/data_source";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { isDisposableEmailDomain } from "@app/lib/utils/disposable_email_domains";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export const PostManagedDataSourceRequestBodySchema = t.type({
   provider: t.string,
@@ -432,4 +433,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/dust_app_secrets/[name]/destroy.ts
+++ b/front/pages/api/w/[wId]/dust_app_secrets/[name]/destroy.ts
@@ -3,8 +3,9 @@ import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDustAppSecret } from "@app/lib/api/dust_app_secrets";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type PostDustAppSecretsResponseBody = {
   secret: DustAppSecretType;
@@ -75,4 +76,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/dust_app_secrets/[name]/destroy.ts
+++ b/front/pages/api/w/[wId]/dust_app_secrets/[name]/destroy.ts
@@ -1,5 +1,5 @@
 import type { DustAppSecretType } from "@dust-tt/types";
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDustAppSecret } from "@app/lib/api/dust_app_secrets";
@@ -12,7 +12,7 @@ export type PostDustAppSecretsResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<PostDustAppSecretsResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PostDustAppSecretsResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/dust_app_secrets/index.ts
+++ b/front/pages/api/w/[wId]/dust_app_secrets/index.ts
@@ -1,4 +1,4 @@
-import type { DustAppSecretType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { DustAppSecretType, WithAPIErrorResponse } from "@dust-tt/types";
 import { encrypt, rateLimiter } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -22,7 +22,7 @@ export type PostDustAppSecretsResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<
+    WithAPIErrorResponse<
       GetDustAppSecretsResponseBody | PostDustAppSecretsResponseBody
     >
   >

--- a/front/pages/api/w/[wId]/dust_app_secrets/index.ts
+++ b/front/pages/api/w/[wId]/dust_app_secrets/index.ts
@@ -6,10 +6,11 @@ import {
   getDustAppSecret,
   getDustAppSecrets,
 } from "@app/lib/api/dust_app_secrets";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { DustAppSecret } from "@app/lib/models/workspace";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type GetDustAppSecretsResponseBody = {
   secrets: DustAppSecretType[];
@@ -122,4 +123,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/enterprise-connection.ts
+++ b/front/pages/api/w/[wId]/enterprise-connection.ts
@@ -1,5 +1,5 @@
 import type {
-  WithAPIErrorReponse,
+  WithAPIErrorResponse,
   WorkspaceEnterpriseConnection,
 } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
@@ -30,7 +30,9 @@ const PostCreateEnterpriseConnectionRequestBodySchema = t.type({
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<GetEnterpriseConnectionResponseBody>>
+  res: NextApiResponse<
+    WithAPIErrorResponse<GetEnterpriseConnectionResponseBody>
+  >
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/enterprise-connection.ts
+++ b/front/pages/api/w/[wId]/enterprise-connection.ts
@@ -12,10 +12,11 @@ import {
   deleteEnterpriseConnection,
   getEnterpriseConnectionForWorkspace,
 } from "@app/lib/api/enterprise_connection";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { Workspace, WorkspaceHasDomain } from "@app/lib/models/workspace";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type GetEnterpriseConnectionResponseBody = {
   connection: WorkspaceEnterpriseConnection;
@@ -170,4 +171,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/files/[fileId].ts
+++ b/front/pages/api/w/[wId]/files/[fileId].ts
@@ -1,6 +1,6 @@
 import type {
   FileUploadedRequestResponseBody,
-  WithAPIErrorReponse,
+  WithAPIErrorResponse,
 } from "@dust-tt/types";
 import { IncomingForm } from "formidable";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -23,7 +23,7 @@ type Action = (typeof validActions)[number];
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<FileUploadedRequestResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<FileUploadedRequestResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/files/[fileId].ts
+++ b/front/pages/api/w/[wId]/files/[fileId].ts
@@ -6,9 +6,10 @@ import { IncomingForm } from "formidable";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { maybeApplyPreProcessing } from "@app/lib/api/files/preprocessing";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 const UPLOAD_DELAY_AFTER_CREATION_MS = 1000 * 60 * 1; // 1 minute.
 
@@ -247,4 +248,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/files/index.ts
+++ b/front/pages/api/w/[wId]/files/index.ts
@@ -1,6 +1,6 @@
 import type {
   FileUploadRequestResponseBody,
-  WithAPIErrorReponse,
+  WithAPIErrorResponse,
 } from "@dust-tt/types";
 import {
   ensureFileSize,
@@ -19,7 +19,7 @@ import { apiError, withLogging } from "@app/logger/withlogging";
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<FileUploadRequestResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<FileUploadRequestResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/files/index.ts
+++ b/front/pages/api/w/[wId]/files/index.ts
@@ -12,10 +12,11 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 async function handler(
   req: NextApiRequest,
@@ -138,4 +139,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/index.ts
+++ b/front/pages/api/w/[wId]/index.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse, WorkspaceType } from "@dust-tt/types";
+import type { WithAPIErrorResponse, WorkspaceType } from "@dust-tt/types";
 import { EmbeddingProviderCodec, ModelProviderIdCodec } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -40,7 +40,7 @@ const PostWorkspaceRequestBodySchema = t.union([
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<PostWorkspaceResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PostWorkspaceResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/index.ts
+++ b/front/pages/api/w/[wId]/index.ts
@@ -5,9 +5,10 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { Workspace, WorkspaceHasDomain } from "@app/lib/models/workspace";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type PostWorkspaceResponseBody = {
   workspace: WorkspaceType;
@@ -158,4 +159,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/invitations/[iId]/index.ts
+++ b/front/pages/api/w/[wId]/invitations/[iId]/index.ts
@@ -12,8 +12,9 @@ import {
   getInvitation,
   updateInvitationStatusAndRole,
 } from "@app/lib/api/invitation";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type PostMemberInvitationsResponseBody = {
   invitation: MembershipInvitationType;
@@ -115,4 +116,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/invitations/[iId]/index.ts
+++ b/front/pages/api/w/[wId]/invitations/[iId]/index.ts
@@ -1,6 +1,6 @@
 import type {
   MembershipInvitationType,
-  WithAPIErrorReponse,
+  WithAPIErrorResponse,
 } from "@dust-tt/types";
 import { ActiveRoleSchema } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
@@ -26,7 +26,7 @@ export const PostMemberInvitationBodySchema = t.type({
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<PostMemberInvitationsResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PostMemberInvitationsResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/invitations/index.ts
+++ b/front/pages/api/w/[wId]/invitations/index.ts
@@ -1,6 +1,6 @@
 import type {
   MembershipInvitationType,
-  WithAPIErrorReponse,
+  WithAPIErrorResponse,
 } from "@dust-tt/types";
 import { ActiveRoleSchema } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
@@ -37,7 +37,7 @@ export type PostInvitationResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<
+    WithAPIErrorResponse<
       GetWorkspaceInvitationsResponseBody | PostInvitationResponseBody
     >
   >

--- a/front/pages/api/w/[wId]/invitations/index.ts
+++ b/front/pages/api/w/[wId]/invitations/index.ts
@@ -10,8 +10,9 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { handleMembershipInvitations } from "@app/lib/api/invitation";
 import { getPendingInvitations } from "@app/lib/api/invitation";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type GetWorkspaceInvitationsResponseBody = {
   invitations: MembershipInvitationType[];
@@ -139,4 +140,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/keys/[id]/disable.ts
+++ b/front/pages/api/w/[wId]/keys/[id]/disable.ts
@@ -1,9 +1,10 @@
 import type { KeyType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { KeyResource } from "@app/lib/resources/key_resource";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type PostKeysResponseBody = {
   key: KeyType;
@@ -87,4 +88,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/keys/[id]/disable.ts
+++ b/front/pages/api/w/[wId]/keys/[id]/disable.ts
@@ -1,4 +1,4 @@
-import type { KeyType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { KeyType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
@@ -11,7 +11,7 @@ export type PostKeysResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<PostKeysResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PostKeysResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/keys/index.ts
+++ b/front/pages/api/w/[wId]/keys/index.ts
@@ -3,9 +3,10 @@ import { isLeft } from "fp-ts/Either";
 import * as t from "io-ts";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { KeyResource } from "@app/lib/resources/key_resource";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type GetKeysResponseBody = {
   keys: KeyType[];
@@ -85,4 +86,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/keys/index.ts
+++ b/front/pages/api/w/[wId]/keys/index.ts
@@ -1,4 +1,4 @@
-import type { KeyType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { KeyType, WithAPIErrorResponse } from "@dust-tt/types";
 import { isLeft } from "fp-ts/Either";
 import * as t from "io-ts";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -22,7 +22,7 @@ const CreateKeyPostBodySchema = t.type({
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<GetKeysResponseBody | PostKeysResponseBody>
+    WithAPIErrorResponse<GetKeysResponseBody | PostKeysResponseBody>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -27,7 +27,7 @@ export type PatchTranscriptsConfiguration = t.TypeOf<
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<GetLabsTranscriptsConfigurationResponseBody>
+    WithAPIErrorResponse<GetLabsTranscriptsConfigurationResponseBody>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
@@ -4,9 +4,10 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 import {
   launchRetrieveTranscriptsWorkflow,
   stopRetrieveTranscriptsWorkflow,
@@ -151,4 +152,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/labs/transcripts/default.ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/default.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -18,7 +18,7 @@ export const GetDefaultTranscriptsConfigurationBodySchema = t.type({
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<GetLabsTranscriptsConfigurationResponseBody>
+    WithAPIErrorResponse<GetLabsTranscriptsConfigurationResponseBody>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/labs/transcripts/default.ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/default.ts
@@ -3,9 +3,10 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 import type { GetLabsTranscriptsConfigurationResponseBody } from "@app/pages/api/w/[wId]/labs/transcripts";
 import { acceptableTranscriptProvidersCodec } from "@app/pages/api/w/[wId]/labs/transcripts";
 
@@ -104,4 +105,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/labs/transcripts/index.ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/index.ts
@@ -4,9 +4,10 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type GetLabsTranscriptsConfigurationResponseBody = {
   configuration: LabsTranscriptsConfigurationResource | null;
@@ -133,4 +134,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/labs/transcripts/index.ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/index.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -25,7 +25,7 @@ export const PostLabsTranscriptsConfigurationBodySchema = t.type({
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<GetLabsTranscriptsConfigurationResponseBody>
+    WithAPIErrorResponse<GetLabsTranscriptsConfigurationResponseBody>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/members/[uId]/index.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/index.ts
@@ -6,9 +6,10 @@ import { assertNever, isMembershipRoleType } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getUserForWorkspace } from "@app/lib/api/user";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 import { launchUpdateUsageWorkflow } from "@app/temporal/usage_queue/client";
 
 export type PostMemberResponseBody = {
@@ -170,4 +171,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/members/[uId]/index.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/index.ts
@@ -1,6 +1,6 @@
 import type {
   UserTypeWithWorkspaces,
-  WithAPIErrorReponse,
+  WithAPIErrorResponse,
 } from "@dust-tt/types";
 import { assertNever, isMembershipRoleType } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -17,7 +17,7 @@ export type PostMemberResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<PostMemberResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PostMemberResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/members/index.ts
+++ b/front/pages/api/w/[wId]/members/index.ts
@@ -5,8 +5,9 @@ import type {
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getMembers } from "@app/lib/api/workspace";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type GetMembersResponseBody = {
   members: UserTypeWithWorkspaces[];
@@ -62,4 +63,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/members/index.ts
+++ b/front/pages/api/w/[wId]/members/index.ts
@@ -1,6 +1,6 @@
 import type {
   UserTypeWithWorkspaces,
-  WithAPIErrorReponse,
+  WithAPIErrorResponse,
 } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -14,7 +14,7 @@ export type GetMembersResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<GetMembersResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetMembersResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/members/me/agent_list_status.ts
+++ b/front/pages/api/w/[wId]/members/me/agent_list_status.ts
@@ -6,8 +6,9 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import { setAgentUserListStatus } from "@app/lib/api/assistant/user_relation";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type PostAgentListStatusResponseBody = {
   agentId: string;
@@ -124,4 +125,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/members/me/agent_list_status.ts
+++ b/front/pages/api/w/[wId]/members/me/agent_list_status.ts
@@ -1,4 +1,4 @@
-import type { AgentUserListStatus, WithAPIErrorReponse } from "@dust-tt/types";
+import type { AgentUserListStatus, WithAPIErrorResponse } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -25,7 +25,7 @@ export type PostAgentListStatusRequestBody = t.TypeOf<
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<PostAgentListStatusResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PostAgentListStatusResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/providers/[pId]/check.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/check.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
@@ -10,7 +10,7 @@ export type GetProvidersCheckResponseBody =
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<GetProvidersCheckResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetProvidersCheckResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/providers/[pId]/check.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/check.ts
@@ -1,8 +1,9 @@
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type GetProvidersCheckResponseBody =
   | { ok: true }
@@ -270,4 +271,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/providers/[pId]/index.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/index.ts
@@ -1,4 +1,4 @@
-import type { ProviderType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { ProviderType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
@@ -18,7 +18,7 @@ export type DeleteProviderResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<PostProviderResponseBody | DeleteProviderResponseBody>
+    WithAPIErrorResponse<PostProviderResponseBody | DeleteProviderResponseBody>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/providers/[pId]/index.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/index.ts
@@ -1,9 +1,10 @@
 import type { ProviderType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { Provider } from "@app/lib/models/apps";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type PostProviderResponseBody = {
   provider: ProviderType;
@@ -144,4 +145,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/providers/[pId]/models.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/models.ts
@@ -1,9 +1,10 @@
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { Provider } from "@app/lib/models/apps";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type GetProviderModelsResponseBody = {
   models: Array<{ id: string }>;
@@ -288,4 +289,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/providers/[pId]/models.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/models.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
@@ -15,7 +15,7 @@ export type GetProviderModelsErrorResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<
+    WithAPIErrorResponse<
       GetProviderModelsResponseBody | GetProviderModelsErrorResponseBody
     >
   >

--- a/front/pages/api/w/[wId]/providers/index.ts
+++ b/front/pages/api/w/[wId]/providers/index.ts
@@ -2,9 +2,10 @@ import type { ProviderType, WithAPIErrorResponse } from "@dust-tt/types";
 import { redactString } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { Provider } from "@app/lib/models/apps";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type GetProvidersResponseBody = {
   providers: ProviderType[];
@@ -81,4 +82,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/providers/index.ts
+++ b/front/pages/api/w/[wId]/providers/index.ts
@@ -1,4 +1,4 @@
-import type { ProviderType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { ProviderType, WithAPIErrorResponse } from "@dust-tt/types";
 import { redactString } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -21,7 +21,7 @@ function redactConfig(config: string) {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<GetProvidersResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetProvidersResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/subscriptions/index.ts
+++ b/front/pages/api/w/[wId]/subscriptions/index.ts
@@ -1,7 +1,7 @@
 import type {
   PlanType,
   SubscriptionType,
-  WithAPIErrorReponse,
+  WithAPIErrorResponse,
 } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
@@ -45,7 +45,7 @@ export const PatchSubscriptionRequestBody = t.type({
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorReponse<
+    WithAPIErrorResponse<
       | GetSubscriptionsResponseBody
       | PostSubscriptionResponseBody
       | PatchSubscriptionResponseBody

--- a/front/pages/api/w/[wId]/subscriptions/index.ts
+++ b/front/pages/api/w/[wId]/subscriptions/index.ts
@@ -9,6 +9,7 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import {
   cancelSubscriptionImmediately,
@@ -19,7 +20,7 @@ import {
   getSubscriptions,
 } from "@app/lib/plans/subscription";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type PostSubscriptionResponseBody = {
   plan: PlanType;
@@ -226,4 +227,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);

--- a/front/pages/api/w/[wId]/workspace-analytics.ts
+++ b/front/pages/api/w/[wId]/workspace-analytics.ts
@@ -2,9 +2,10 @@ import type { APIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { QueryTypes } from "sequelize";
 
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { frontSequelize } from "@app/lib/resources/storage";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type GetWorkspaceAnalyticsResponse = {
   memberCount: number;
@@ -71,7 +72,7 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);
 
 interface MemberCountQueryResult {
   member_count: number;

--- a/front/pages/api/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/w/[wId]/workspace-usage.ts
@@ -6,6 +6,7 @@ import * as reporter from "io-ts-reporters";
 import JSZip from "jszip";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import {
   getAssistantsUsageData,
@@ -13,7 +14,7 @@ import {
   getMessageUsageData,
   getUserUsageData,
 } from "@app/lib/workspace_usage";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 const MonthSchema = t.refinement(
   t.string,
@@ -158,7 +159,7 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withSessionAuthentication(handler);
 
 function resolveDates(query: t.TypeOf<typeof GetUsageQueryParamsSchema>) {
   switch (query.mode) {

--- a/types/src/front/lib/error.ts
+++ b/types/src/front/lib/error.ts
@@ -127,4 +127,4 @@ export function isAPIErrorResponse(obj: unknown): obj is APIErrorResponse {
   );
 }
 
-export type WithAPIErrorReponse<T> = T | APIErrorResponse;
+export type WithAPIErrorResponse<T> = T | APIErrorResponse;

--- a/types/src/front/lib/error.ts
+++ b/types/src/front/lib/error.ts
@@ -6,6 +6,7 @@ export type InternalErrorWithStatusCode = {
 };
 
 export type APIErrorType =
+  | "not_authenticated"
   | "missing_authorization_header_error"
   | "malformed_authorization_header_error"
   | "invalid_api_key_error"


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See https://github.com/dust-tt/dust/issues/5979 and thread [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1720454887190259).

This PR introduces a wrapper for our NextJS endpoints on our private API. Currently, this wrapper ensures that the user has a valid session when querying our private API endpoints. The aim is to return a proper 401 status, allowing us to handle the error downstream and improve error handling on the SWR side.

At the moment, this wrapper is focused solely on our private API since the public API relies on a system key. It also includes logging logic. In the future, the wrapper will be augmented to verify the existence of a workspace and its valid subscription, which will be reflected in the types as well.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
