### PR TITLE
CSV ContentFragment are presented as a snippet when too big

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -462,17 +462,9 @@ const conversation = async (command: string, args: parseArgs.ParsedArgs) => {
       });
 
       if (response.isErr()) {
-        logger.error(response.error.message);
+        console.log(response.error.message);
       } else {
-        logger.info(
-          {
-            model,
-            prompt,
-          },
-          "Called renderConversationForModel with params:"
-        );
         const result = response.value;
-
         if (!verbose) {
           // For convenience we shorten the content when role = "tool"
           result.modelConversation.messages =
@@ -487,7 +479,11 @@ const conversation = async (command: string, args: parseArgs.ParsedArgs) => {
             });
         }
 
-        logger.info(result, "Result from renderConversationForModel:");
+        console.log(
+          "Result from renderConversationForModel:",
+          JSON.stringify(result, null, 2)
+        );
+        // console.dir(result, { depth: null, colors: true });
       }
       return;
     }

--- a/types/src/front/lib/api/assistant/generation.ts
+++ b/types/src/front/lib/api/assistant/generation.ts
@@ -24,7 +24,7 @@ interface TextContent {
   text: string;
 }
 
-type Content = TextContent | ImageContent;
+export type Content = TextContent | ImageContent;
 
 export function isTextContent(content: Content): content is TextContent {
   return content.type === "text";


### PR DESCRIPTION
## Description

Task: https://github.com/dust-tt/dust/issues/5779

We want to allow uploading CSV as a first step (no postprocessing other than validating it).
Then we want to update renderConversationForModel to properly render the ContentFragment given their type and size:

Small CSV -> header + embed content
Large CSV -> header + a few lines
Other file types -> do not change current behavior.

When truncated the content fragments looks like this: 

```
1723831,2024-06-10 07:00:18,a6c6f70d41,soupinou-archive-highlights,4525,Dust,614658,3472177,1712352,,unknown,slack\n1733359,2024-06-10 14:15:31,50cb634d5f,signupRadar,4525,Dust,617609,3491463,1721857,,unknown,slack\n1729955,2024-06-10 12:17:20,gemini-pro,gemini-pro,4525,Dust,616565,3484543,1718453,41217,soupinou@dust.tt,web\n... (truncated)</attachment>"
```


## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
