### PR TITLE
fix: slackbot isn't getting the agent message success event

### DIFF
--- a/connectors/src/connectors/slack/chat/citations.ts
+++ b/connectors/src/connectors/slack/chat/citations.ts
@@ -17,7 +17,7 @@ export type SlackMessageFootnotes = SlackMessageFootnote[];
 
 export function annotateCitations(
   content: string,
-  action: AgentActionType | null
+  actions: AgentActionType[]
 ): { formattedContent: string; footnotes: SlackMessageFootnotes } {
   const references: {
     [key: string]: {
@@ -27,29 +27,31 @@ export function annotateCitations(
     };
   } = {};
 
-  if (action && isRetrievalActionType(action) && action.documents) {
-    action.documents.forEach((d) => {
-      references[d.reference] = {
-        reference: d.reference,
-        link: d.sourceUrl
-          ? d.sourceUrl
-          : makeDustAppUrl(
-              `/w/${d.dataSourceWorkspaceId}/builder/data-sources/${
-                d.dataSourceId
-              }/upsert?documentId=${encodeURIComponent(d.documentId)}`
-            ),
-        title: getTitleFromRetrievedDocument(d),
-      };
-    });
-  }
-  if (action && isWebsearchActionType(action) && action.output) {
-    action.output.results.forEach((r) => {
-      references[r.reference] = {
-        reference: r.reference,
-        link: r.link,
-        title: r.title,
-      };
-    });
+  for (const action of actions) {
+    if (action && isRetrievalActionType(action) && action.documents) {
+      action.documents.forEach((d) => {
+        references[d.reference] = {
+          reference: d.reference,
+          link: d.sourceUrl
+            ? d.sourceUrl
+            : makeDustAppUrl(
+                `/w/${d.dataSourceWorkspaceId}/builder/data-sources/${
+                  d.dataSourceId
+                }/upsert?documentId=${encodeURIComponent(d.documentId)}`
+              ),
+          title: getTitleFromRetrievedDocument(d),
+        };
+      });
+    }
+    if (action && isWebsearchActionType(action) && action.output) {
+      action.output.results.forEach((r) => {
+        references[r.reference] = {
+          reference: r.reference,
+          link: r.link,
+          title: r.title,
+        };
+      });
+    }
   }
 
   if (references) {

--- a/types/src/front/lib/dust_api.ts
+++ b/types/src/front/lib/dust_api.ts
@@ -23,7 +23,6 @@ import { WhitelistableFeature } from "../feature_flags";
 import {
   AgentActionSuccessEvent,
   AgentErrorEvent,
-  AgentGenerationSuccessEvent,
   AgentMessageSuccessEvent,
 } from "./api/assistant/agent";
 import { UserMessageErrorEvent } from "./api/assistant/conversation";
@@ -633,7 +632,6 @@ export class DustAPI {
       | AgentErrorEvent
       | AgentActionSuccessEvent
       | GenerationTokensEvent
-      | AgentGenerationSuccessEvent
       | AgentMessageSuccessEvent
     )[] = [];
 
@@ -659,8 +657,8 @@ export class DustAPI {
                 pendingEvents.push(data as GenerationTokensEvent);
                 break;
               }
-              case "agent_generation_success": {
-                pendingEvents.push(data as AgentGenerationSuccessEvent);
+              case "agent_message_success": {
+                pendingEvents.push(data as AgentMessageSuccessEvent);
                 break;
               }
             }


### PR DESCRIPTION
## Description

https://github.com/dust-tt/tasks/issues/1042

This does 2 things:
- add support for multi-actions to slackbot (wrt references)
- fix a bug where the slackbot would always send an error message at the end because the `agent_message_success` event was not being properly streamed

## Risk

N/A

## Deploy Plan

N/A