### PR TITLE
Introduce withSessionAuthenticationForWorkspace.

### DIFF
--- a/front/lib/api/wrappers.ts
+++ b/front/lib/api/wrappers.ts
@@ -6,6 +6,13 @@ import { getSession } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
+/**
+ * This function is a wrapper for API routes that require session authentication.
+ *
+ * @param handler
+ * @param param1
+ * @returns
+ */
 export function withSessionAuthentication<T>(
   handler: (
     req: NextApiRequest,
@@ -37,6 +44,15 @@ export function withSessionAuthentication<T>(
     isStreaming
   );
 }
+
+/**
+ * This function is a wrapper for API routes that require session authentication for a workspace.
+ * It must be used on all routes that require workspace authentication (prefix: /w/[wId/]).
+ *
+ * @param handler
+ * @param opts
+ * @returns
+ */
 export function withSessionAuthenticationForWorkspace<T>(
   handler: (
     req: NextApiRequest,

--- a/front/lib/api/wrappers.ts
+++ b/front/lib/api/wrappers.ts
@@ -1,13 +1,16 @@
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { Authenticator } from "@app/lib/auth";
 import { getSession } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
 export function withSessionAuthentication<T>(
   handler: (
     req: NextApiRequest,
-    res: NextApiResponse<WithAPIErrorResponse<T>>
+    res: NextApiResponse<WithAPIErrorResponse<T>>,
+    session: SessionWithUser
   ) => Promise<void> | void,
   { isStreaming = false }: { isStreaming?: boolean } = {}
 ) {
@@ -29,10 +32,64 @@ export function withSessionAuthentication<T>(
         });
       }
 
-      // TODO(2024-07-09 Flav) Create `Authenticator` from session.
-
-      return handler(req, res);
+      return handler(req, res, session);
     },
     isStreaming
+  );
+}
+export function withSessionAuthenticationForWorkspace<T>(
+  handler: (
+    req: NextApiRequest,
+    res: NextApiResponse<WithAPIErrorResponse<T>>,
+    auth: Authenticator,
+    session: SessionWithUser
+  ) => Promise<void> | void,
+  opts: { isStreaming?: boolean } = {}
+) {
+  return withSessionAuthentication(
+    async (
+      req: NextApiRequest,
+      res: NextApiResponse<WithAPIErrorResponse<T>>,
+      session: SessionWithUser
+    ) => {
+      const { wId } = req.query;
+      if (typeof wId !== "string" || !wId) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "workspace_not_found",
+            message: "The workspace was not found.",
+          },
+        });
+      }
+
+      const auth = await Authenticator.fromSession(session, wId);
+
+      const owner = auth.workspace();
+      const plan = auth.plan();
+      if (!owner || !plan) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "workspace_not_found",
+            message: "The workspace was not found.",
+          },
+        });
+      }
+
+      const user = auth.user();
+      if (!user) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "workspace_user_not_found",
+            message: "Could not find the user of the current session.",
+          },
+        });
+      }
+
+      return handler(req, res, auth, session);
+    },
+    opts
   );
 }

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -459,6 +459,18 @@ export class Authenticator {
       : null;
   }
 
+  getNonNullableWorkspace(): WorkspaceType {
+    const workspace = this.workspace();
+
+    if (!workspace) {
+      throw new Error(
+        "Unexpected unauthenticated call to `getNonNullableWorkspace`."
+      );
+    }
+
+    return workspace;
+  }
+
   subscription(): SubscriptionType | null {
     return this._subscription;
   }

--- a/front/pages/api/w/[wId]/apps/[aId]/clone.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/clone.ts
@@ -6,6 +6,7 @@ import { getApp } from "@app/lib/api/app";
 import { getDatasets } from "@app/lib/api/datasets";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
 import { App, Clone, Dataset } from "@app/lib/models/apps";
 import { generateLegacyModelSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
@@ -18,7 +19,8 @@ export type PostAppResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<PostAppResponseBody>>,
-  auth: Authenticator
+  auth: Authenticator,
+  session: SessionWithUser
 ): Promise<void> {
   const app = await getApp(auth, req.query.aId as string);
 

--- a/front/pages/api/w/[wId]/apps/[aId]/clone.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/clone.ts
@@ -4,8 +4,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getApp } from "@app/lib/api/app";
 import { getDatasets } from "@app/lib/api/datasets";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import { Authenticator } from "@app/lib/auth";
 import { App, Clone, Dataset } from "@app/lib/models/apps";
 import { generateLegacyModelSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
@@ -17,25 +17,9 @@ export type PostAppResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<PostAppResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PostAppResponseBody>>,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "app_not_found",
-        message: "The app was not found.",
-      },
-    });
-  }
-
   const app = await getApp(auth, req.query.aId as string);
 
   if (!app) {
@@ -162,4 +146,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/apps/[aId]/datasets/[name]/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/datasets/[name]/index.ts
@@ -6,8 +6,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getApp } from "@app/lib/api/app";
 import { getDatasetHash } from "@app/lib/api/datasets";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { checkDatasetData } from "@app/lib/datasets";
 import { Dataset } from "@app/lib/models/apps";
 import logger from "@app/logger/logger";
@@ -19,25 +19,9 @@ export type GetDatasetResponseBody = { dataset: DatasetType };
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetDatasetResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetDatasetResponseBody>>,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "app_not_found",
-        message: "The app was not found.",
-      },
-    });
-  }
-
   const app = await getApp(auth, req.query.aId as string);
   if (!app) {
     return apiError(req, res, {
@@ -48,6 +32,8 @@ async function handler(
       },
     });
   }
+
+  const owner = auth.getNonNullableWorkspace();
 
   const [dataset] = await Promise.all([
     Dataset.findOne({
@@ -203,4 +189,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/apps/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/index.ts
@@ -2,8 +2,8 @@ import type { AppType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { Op } from "sequelize";
 
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { App } from "@app/lib/models/apps";
 import { apiError } from "@app/logger/withlogging";
 
@@ -13,24 +13,10 @@ export type GetOrPostAppResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetOrPostAppResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetOrPostAppResponseBody>>,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "app_not_found",
-        message: "The app was not found.",
-      },
-    });
-  }
+  const owner = auth.getNonNullableWorkspace();
 
   const app = await App.findOne({
     where: auth.isUser()
@@ -159,4 +145,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]/index.ts
@@ -3,8 +3,8 @@ import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getApp } from "@app/lib/api/app";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 
@@ -20,14 +20,9 @@ export type GetRunBlockResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetRunBlockResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetRunBlockResponseBody>>,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
   const app = await getApp(auth, req.query.aId as string);
 
   if (!app) {
@@ -86,4 +81,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/status.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/status.ts
@@ -3,8 +3,8 @@ import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getApp } from "@app/lib/api/app";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 
@@ -14,14 +14,9 @@ export type GetRunStatusResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetRunStatusResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetRunStatusResponseBody>>,
+  auth: Authenticator
 ) {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
   const app = await getApp(auth, req.query.aId as string);
   if (!app) {
     return apiError(req, res, {
@@ -75,4 +70,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/apps/[aId]/state.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/state.ts
@@ -2,8 +2,8 @@ import type { AppType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { Op } from "sequelize";
 
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { App } from "@app/lib/models/apps";
 import { apiError } from "@app/logger/withlogging";
 
@@ -13,24 +13,10 @@ export type PostStateResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<PostStateResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PostStateResponseBody>>,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "app_not_found",
-        message: "The app you're trying to modify was not found.",
-      },
-    });
-  }
+  const owner = auth.getNonNullableWorkspace();
 
   const app = await App.findOne({
     where: auth.isUser()
@@ -139,4 +125,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
@@ -6,8 +6,8 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { DataSource } from "@app/lib/models/data_source";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -24,23 +24,10 @@ async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
     WithAPIErrorResponse<PatchLinkedSlackChannelsResponseBody | void>
-  >
+  >,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you're trying to modify was not found.",
-      },
-    });
-  }
+  const owner = auth.getNonNullableWorkspace();
 
   if (!auth.isBuilder()) {
     return apiError(req, res, {
@@ -144,4 +131,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
@@ -6,8 +6,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import { setAgentUserListStatus } from "@app/lib/api/assistant/user_relation";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import { createOrUpgradeAgentConfiguration } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 
@@ -25,23 +25,9 @@ export type PostAgentScopeRequestBody = t.TypeOf<
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<void>>
+  res: NextApiResponse<WithAPIErrorResponse<void>>,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you're trying to modify was not found.",
-      },
-    });
-  }
   if (!auth.isUser()) {
     return apiError(req, res, {
       status_code: 404,
@@ -52,6 +38,7 @@ async function handler(
       },
     });
   }
+
   const assistant = await getAgentConfiguration(auth, req.query.aId as string);
   if (
     !assistant ||
@@ -161,4 +148,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -27,8 +27,8 @@ import {
   unsafeHardDeleteAgentConfiguration,
 } from "@app/lib/api/assistant/configuration";
 import { getAgentsRecentAuthors } from "@app/lib/api/assistant/recent_authors";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { safeRedisClient } from "@app/lib/redis";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { apiError } from "@app/logger/withlogging";
@@ -48,23 +48,10 @@ async function handler(
       | PostAgentConfigurationResponseBody
       | void
     >
-  >
+  >,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you're trying to modify was not found.",
-      },
-    });
-  }
+  const owner = auth.getNonNullableWorkspace();
 
   switch (req.method) {
     case "GET":
@@ -256,7 +243,7 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);
 
 /**
  * Create Or Upgrade Agent Configuration If an agentConfigurationId is provided, it will create a

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/name_available.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/name_available.ts
@@ -5,8 +5,8 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { agentNameIsAvailable } from "@app/lib/api/assistant/configuration";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
 export type GetAgentNameIsAvailableResponseBody = {
@@ -21,24 +21,9 @@ async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
     WithAPIErrorResponse<GetAgentNameIsAvailableResponseBody | void>
-  >
+  >,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you're trying to access to was not found.",
-      },
-    });
-  }
-
   switch (req.method) {
     case "GET":
       if (!auth.isUser()) {
@@ -82,4 +67,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/builder/process/generate_schema.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/process/generate_schema.ts
@@ -14,8 +14,8 @@ import { DustProdActionRegistry } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { runAction } from "@app/lib/actions/server";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
 async function handler(
@@ -24,25 +24,10 @@ async function handler(
     WithAPIErrorResponse<{
       schema: ProcessSchemaPropertyType[];
     }>
-  >
+  >,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner || !auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "app_auth_error",
-        message:
-          "Workspace not found or user not authenticated to this workspace.",
-      },
-    });
-  }
+  const owner = auth.getNonNullableWorkspace();
 
   switch (req.method) {
     case "POST":
@@ -144,4 +129,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/builder/templates/[tId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/templates/[tId]/index.ts
@@ -1,8 +1,7 @@
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import { TemplateResource } from "@app/lib/resources/template_resource";
 import { apiError } from "@app/logger/withlogging";
 
@@ -14,23 +13,6 @@ async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<FetchAssistantTemplateResponse>>
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-  const owner = auth.workspace();
-  if (!owner || !auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "app_auth_error",
-        message:
-          "Workspace not found or user not authenticated to this workspace.",
-      },
-    });
-  }
-
   switch (req.method) {
     case "GET":
       const { tId: templateId } = req.query;
@@ -68,4 +50,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/builder/templates/index.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/templates/index.ts
@@ -1,8 +1,7 @@
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import { TemplateResource } from "@app/lib/resources/template_resource";
 import { apiError } from "@app/logger/withlogging";
 
@@ -18,23 +17,6 @@ async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<FetchAssistantTemplatesResponse>>
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-  const owner = auth.workspace();
-  if (!owner || !auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "app_auth_error",
-        message:
-          "Workspace not found or user not authenticated to this workspace.",
-      },
-    });
-  }
-
   switch (req.method) {
     case "GET":
       const templates = await TemplateResource.listAll({
@@ -56,4 +38,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
@@ -6,8 +6,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
 import { cancelMessageGenerationEvent } from "@app/lib/api/assistant/pubsub";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
 export type PostMessageEventResponseBody = {
@@ -20,35 +20,9 @@ const PostMessageEventBodySchema = t.type({
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<PostMessageEventResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PostMessageEventResponseBody>>,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you're trying to modify was not found.",
-      },
-    });
-  }
-
-  if (!auth.user()) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_user_not_found",
-        message: "Could not find the user of the current session.",
-      },
-    });
-  }
-
   if (!auth.isUser()) {
     return apiError(req, res, {
       status_code: 403,
@@ -112,4 +86,6 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler, { isStreaming: true });
+export default withSessionAuthenticationForWorkspace(handler, {
+  isStreaming: true,
+});

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/content_fragment/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/content_fragment/index.ts
@@ -9,8 +9,8 @@ import {
   getConversation,
   postNewContentFragment,
 } from "@app/lib/api/assistant/conversation";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
 export type PostContentFragmentRequestBody = t.TypeOf<
@@ -21,25 +21,9 @@ async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
     WithAPIErrorResponse<{ contentFragment: ContentFragmentType }>
-  >
+  >,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you're trying to modify was not found.",
-      },
-    });
-  }
-
   const user = auth.user();
   if (!user || !auth.isUser()) {
     return apiError(req, res, {
@@ -130,4 +114,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -3,41 +3,15 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
 import { getConversationEvents } from "@app/lib/api/assistant/pubsub";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<void>>
+  res: NextApiResponse<WithAPIErrorResponse<void>>,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you're trying to modify was not found.",
-      },
-    });
-  }
-
-  if (!auth.user()) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_user_not_found",
-        message: "Could not find the user of the current session.",
-      },
-    });
-  }
-
   if (!auth.isUser()) {
     return apiError(req, res, {
       status_code: 403,
@@ -118,4 +92,6 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler, { isStreaming: true });
+export default withSessionAuthenticationForWorkspace(handler, {
+  isStreaming: true,
+});

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -12,8 +12,8 @@ import {
   getConversationWithoutContent,
   updateConversation,
 } from "@app/lib/api/assistant/conversation";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
 export const PatchConversationsRequestBodySchema = t.type({
@@ -34,35 +34,9 @@ async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
     WithAPIErrorResponse<GetConversationsResponseBody | void>
-  >
+  >,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you're trying to modify was not found.",
-      },
-    });
-  }
-
-  if (!auth.user()) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_user_not_found",
-        message: "Could not find the user of the current session.",
-      },
-    });
-  }
-
   if (!auth.isUser()) {
     return apiError(req, res, {
       status_code: 403,
@@ -73,6 +47,7 @@ async function handler(
       },
     });
   }
+
   if (!(typeof req.query.cId === "string")) {
     return apiError(req, res, {
       status_code: 400,
@@ -144,4 +119,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
@@ -7,8 +7,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
 import { editUserMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
 export const PostEditRequestBodySchema = t.type({
@@ -18,25 +18,9 @@ export const PostEditRequestBodySchema = t.type({
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<{ message: UserMessageType }>>
+  res: NextApiResponse<WithAPIErrorResponse<{ message: UserMessageType }>>,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you're trying to modify was not found.",
-      },
-    });
-  }
-
   const user = auth.user();
   if (!user) {
     return apiError(req, res, {
@@ -146,4 +130,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
@@ -6,41 +6,15 @@ import {
   getConversationWithoutContent,
 } from "@app/lib/api/assistant/conversation";
 import { getMessagesEvents } from "@app/lib/api/assistant/pubsub";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<void>>
+  res: NextApiResponse<WithAPIErrorResponse<void>>,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you're trying to modify was not found.",
-      },
-    });
-  }
-
-  if (!auth.user()) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_user_not_found",
-        message: "Could not find the user of the current session.",
-      },
-    });
-  }
-
   if (!auth.isUser()) {
     return apiError(req, res, {
       status_code: 403,
@@ -158,4 +132,6 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler, { isStreaming: true });
+export default withSessionAuthenticationForWorkspace(handler, {
+  isStreaming: true,
+});

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/raw_content_fragment/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/raw_content_fragment/index.ts
@@ -4,8 +4,8 @@ import { IncomingForm } from "formidable";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { fileAttachmentLocation } from "@app/lib/resources/content_fragment_resource";
 import { apiError } from "@app/logger/withlogging";
@@ -25,24 +25,10 @@ type Action = (typeof validActions)[number];
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<{ sourceUrl: string }>>
+  res: NextApiResponse<WithAPIErrorResponse<{ sourceUrl: string }>>,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you're trying to modify was not found.",
-      },
-    });
-  }
+  const owner = auth.getNonNullableWorkspace();
 
   const user = auth.user();
   if (!user) {
@@ -214,4 +200,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
@@ -9,8 +9,8 @@ import {
   createMessageReaction,
   deleteMessageReaction,
 } from "@app/lib/api/assistant/reaction";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
 export const MessageReactionRequestBodySchema = t.type({
@@ -23,25 +23,9 @@ async function handler(
     WithAPIErrorResponse<
       { reactions: MessageReactionType[] } | { success: boolean }
     >
-  >
+  >,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you're trying to modify was not found.",
-      },
-    });
-  }
-
   const user = auth.user();
   if (!user) {
     return apiError(req, res, {
@@ -170,4 +154,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
@@ -7,8 +7,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
 import { retryAgentMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
 export const PostRetryRequestBodySchema = t.union([
@@ -20,36 +20,9 @@ export const PostRetryRequestBodySchema = t.union([
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<{ message: AgentMessageType }>>
+  res: NextApiResponse<WithAPIErrorResponse<{ message: AgentMessageType }>>,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you're trying to modify was not found.",
-      },
-    });
-  }
-
-  const user = auth.user();
-  if (!user) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_user_not_found",
-        message: "Could not find the user of the current session.",
-      },
-    });
-  }
-
   if (!auth.isUser()) {
     return apiError(req, res, {
       status_code: 403,
@@ -145,4 +118,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -9,8 +9,8 @@ import type { FetchConversationMessagesResponse } from "@app/lib/api/assistant/m
 import { fetchConversationMessages } from "@app/lib/api/assistant/messages";
 import { postUserMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
 import { getPaginationParams } from "@app/lib/api/pagination";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
 async function handler(
@@ -19,25 +19,9 @@ async function handler(
     WithAPIErrorResponse<
       { message: UserMessageType } | FetchConversationMessagesResponse
     >
-  >
+  >,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you're trying to modify was not found.",
-      },
-    });
-  }
-
   const user = auth.user();
   if (!user) {
     return apiError(req, res, {
@@ -180,4 +164,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/participants.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/participants.ts
@@ -7,8 +7,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
 import { fetchConversationParticipants } from "@app/lib/api/assistant/participants";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
 export type FetchConversationParticipantsResponse = {
@@ -21,36 +21,9 @@ async function handler(
     WithAPIErrorResponse<
       { message: UserMessageType } | FetchConversationParticipantsResponse
     >
-  >
+  >,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you're trying to modify was not found.",
-      },
-    });
-  }
-
-  const user = auth.user();
-  if (!user) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_user_not_found",
-        message: "Could not find the user of the current session.",
-      },
-    });
-  }
-
   if (!auth.isUser()) {
     return apiError(req, res, {
       status_code: 403,
@@ -117,4 +90,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/reactions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/reactions.ts
@@ -6,44 +6,17 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
 import { getMessageReactions } from "@app/lib/api/assistant/reaction";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
     WithAPIErrorResponse<{ reactions: ConversationMessageReactions }>
-  >
+  >,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you're trying to modify was not found.",
-      },
-    });
-  }
-
-  const user = auth.user();
-  if (!user) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_user_not_found",
-        message: "Could not find the user of the current session.",
-      },
-    });
-  }
-
   if (!auth.isUser()) {
     return apiError(req, res, {
       status_code: 403,
@@ -96,4 +69,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -17,8 +17,8 @@ import {
   postNewContentFragment,
 } from "@app/lib/api/assistant/conversation";
 import { postUserMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
 export type GetConversationsResponseBody = {
@@ -36,35 +36,9 @@ async function handler(
     WithAPIErrorResponse<
       GetConversationsResponseBody | PostConversationsResponseBody | void
     >
-  >
+  >,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you're trying to modify was not found.",
-      },
-    });
-  }
-
-  if (!auth.user()) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_user_not_found",
-        message: "Could not find the user of the current session.",
-      },
-    });
-  }
-
   const user = auth.user();
   if (!user) {
     return apiError(req, res, {
@@ -223,4 +197,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/global_agents/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/global_agents/[aId]/index.ts
@@ -5,8 +5,8 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { upsertGlobalAgentSettings } from "@app/lib/api/assistant/global_agents";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
 type PatchGlobalAgentSettingResponseBody = {
@@ -20,24 +20,9 @@ async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
     WithAPIErrorResponse<PatchGlobalAgentSettingResponseBody | void>
-  >
+  >,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you're trying to modify was not found.",
-      },
-    });
-  }
-
   if (!auth.isBuilder()) {
     return apiError(req, res, {
       status_code: 404,
@@ -94,4 +79,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/data_sources/[name]/configuration.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/configuration.ts
@@ -8,8 +8,8 @@ import {
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 
@@ -21,25 +21,9 @@ async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
     WithAPIErrorResponse<PostDataSourceConfigurationResBody | void>
-  >
+  >,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you requested was not found.",
-      },
-    });
-  }
-
   if (!auth.isBuilder()) {
     return apiError(req, res, {
       status_code: 403,
@@ -184,4 +168,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/data_sources/[name]/connector.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/connector.ts
@@ -3,8 +3,8 @@ import { ConnectorsAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 
@@ -14,16 +14,10 @@ export type GetConnectorResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetConnectorResponseBody | void>>
+  res: NextApiResponse<WithAPIErrorResponse<GetConnectorResponseBody | void>>,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner || !auth.isUser()) {
+  if (!auth.isUser()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -94,4 +88,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -14,8 +14,8 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { validateUrl } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -34,18 +34,12 @@ export type GetDocumentResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetDocumentResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetDocumentResponseBody>>,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
   const plan = auth.plan();
 
-  if (!owner || !plan || !auth.isUser()) {
+  if (!plan || !auth.isUser()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -328,4 +322,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/data_sources/[name]/documents/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/documents/index.ts
@@ -13,6 +13,7 @@ export type GetDocumentsResponseBody = {
   total: number;
 };
 
+// TODO(2024-07-09 flav) Create a dedicated endpoint on Poke.
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<GetDocumentsResponseBody>>

--- a/front/pages/api/w/[wId]/data_sources/[name]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/index.ts
@@ -6,8 +6,8 @@ import {
   getDataSource,
   MANAGED_DS_DELETABLE_AS_BUILDER,
 } from "@app/lib/api/data_sources";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { DataSource } from "@app/lib/models/data_source";
 import { apiError } from "@app/logger/withlogging";
 
@@ -19,16 +19,10 @@ async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
     WithAPIErrorResponse<GetOrPostDataSourceResponseBody | void>
-  >
+  >,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner || !auth.isUser()) {
+  if (!auth.isUser()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -213,4 +207,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/config/[key]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/config/[key]/index.ts
@@ -6,8 +6,8 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 
@@ -23,16 +23,10 @@ async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
     WithAPIErrorResponse<GetOrPostManagedDataSourceConfigResponseBody | void>
-  >
+  >,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner || !auth.isUser()) {
+  if (!auth.isUser()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -182,4 +176,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/content_nodes.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/content_nodes.ts
@@ -6,8 +6,8 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 
@@ -21,16 +21,10 @@ export type GetContentNodeResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetContentNodeResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetContentNodeResponseBody>>,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner || !auth.isUser()) {
+  if (!auth.isUser()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -121,4 +115,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
@@ -11,8 +11,8 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 
@@ -45,17 +45,10 @@ async function handler(
       | GetDataSourcePermissionsResponseBody
       | SetDataSourcePermissionsResponseBody
     >
-  >
+  >,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-
-  if (!owner || !auth.isUser()) {
+  if (!auth.isUser()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -287,4 +280,4 @@ export async function getManagedDataSourcePermissionsHandler(
   return;
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/slack/channels_linked_with_agent.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/slack/channels_linked_with_agent.ts
@@ -3,8 +3,8 @@ import { ConnectorsAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 
@@ -20,25 +20,9 @@ async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
     WithAPIErrorResponse<GetSlackChannelsLinkedWithAgentResponseBody>
-  >
+  >,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "data_source_not_found",
-        message: "The data source you requested was not found.",
-      },
-    });
-  }
-
   const dataSource = await getDataSource(auth, req.query.name as string);
   if (!dataSource) {
     return apiError(req, res, {
@@ -121,4 +105,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/data_sources/[name]/search.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/search.ts
@@ -5,8 +5,8 @@ import type { JSONSchemaType } from "ajv";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { parse_payload } from "@app/lib/http_utils";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -47,16 +47,10 @@ export type DatasourceSearchResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<DatasourceSearchResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<DatasourceSearchResponseBody>>,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner || !auth.isUser()) {
+  if (!auth.isUser()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -82,7 +76,7 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);
 
 export async function handleSearchDataSource({
   req,

--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/index.ts
@@ -3,8 +3,8 @@ import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 
@@ -14,16 +14,10 @@ export type ListTablesResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<ListTablesResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<ListTablesResponseBody>>,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner || !auth.isBuilder()) {
+  if (!auth.isBuilder()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -33,16 +27,7 @@ async function handler(
     });
   }
 
-  const plan = auth.plan();
-  if (!owner || !plan) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you requested was not found.",
-      },
-    });
-  }
+  const owner = auth.getNonNullableWorkspace();
 
   if (!req.query.name || typeof req.query.name !== "string") {
     return apiError(req, res, {
@@ -105,4 +90,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -9,8 +9,8 @@ import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource, getDataSources } from "@app/lib/api/data_sources";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { DataSource } from "@app/lib/models/data_source";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import logger from "@app/logger/logger";
@@ -30,18 +30,13 @@ async function handler(
     WithAPIErrorResponse<
       GetDataSourcesResponseBody | PostDataSourceResponseBody
     >
-  >
+  >,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
+  const owner = auth.getNonNullableWorkspace();
   const user = auth.user();
   const plan = auth.plan();
-  if (!owner || !plan || !user || !auth.isUser()) {
+  if (!plan || !user || !auth.isUser()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -218,4 +213,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -19,12 +19,9 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import {
-  Authenticator,
-  getOrCreateSystemApiKey,
-  getSession,
-} from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { getOrCreateSystemApiKey } from "@app/lib/auth";
 import { DataSource } from "@app/lib/models/data_source";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { isDisposableEmailDomain } from "@app/lib/utils/disposable_email_domains";
@@ -49,15 +46,11 @@ export type PostManagedDataSourceResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<PostManagedDataSourceResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PostManagedDataSourceResponseBody>>,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
+  const owner = auth.getNonNullableWorkspace();
 
-  const owner = auth.workspace();
   const plan = auth.plan();
   const user = auth.user();
   if (
@@ -433,4 +426,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/dust_app_secrets/[name]/destroy.ts
+++ b/front/pages/api/w/[wId]/dust_app_secrets/[name]/destroy.ts
@@ -3,8 +3,8 @@ import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDustAppSecret } from "@app/lib/api/dust_app_secrets";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
 export type PostDustAppSecretsResponseBody = {
@@ -13,26 +13,9 @@ export type PostDustAppSecretsResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<PostDustAppSecretsResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PostDustAppSecretsResponseBody>>,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner) {
-    apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "Workspace not found.",
-      },
-    });
-    return;
-  }
-
   if (!auth.isBuilder()) {
     apiError(req, res, {
       status_code: 403,
@@ -76,4 +59,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/dust_app_secrets/index.ts
+++ b/front/pages/api/w/[wId]/dust_app_secrets/index.ts
@@ -6,8 +6,8 @@ import {
   getDustAppSecret,
   getDustAppSecrets,
 } from "@app/lib/api/dust_app_secrets";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { DustAppSecret } from "@app/lib/models/workspace";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -26,17 +26,13 @@ async function handler(
     WithAPIErrorResponse<
       GetDustAppSecretsResponseBody | PostDustAppSecretsResponseBody
     >
-  >
+  >,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
+  const owner = auth.getNonNullableWorkspace();
 
-  const owner = auth.workspace();
   const user = auth.user();
-  if (!owner || !user) {
+  if (!user) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -123,4 +119,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/files/[fileId].ts
+++ b/front/pages/api/w/[wId]/files/[fileId].ts
@@ -6,8 +6,8 @@ import { IncomingForm } from "formidable";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { maybeApplyPreProcessing } from "@app/lib/api/files/preprocessing";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { apiError } from "@app/logger/withlogging";
 
@@ -24,36 +24,9 @@ type Action = (typeof validActions)[number];
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<FileUploadedRequestResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<FileUploadedRequestResponseBody>>,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you're trying to modify was not found.",
-      },
-    });
-  }
-
-  const user = auth.user();
-  if (!user) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_user_not_found",
-        message: "Could not find the user of the current session.",
-      },
-    });
-  }
-
   if (!auth.isUser()) {
     return apiError(req, res, {
       status_code: 403,
@@ -248,4 +221,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/files/index.ts
+++ b/front/pages/api/w/[wId]/files/index.ts
@@ -12,33 +12,17 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<FileUploadRequestResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<FileUploadRequestResponseBody>>,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you're trying to modify was not found.",
-      },
-    });
-  }
-
   const user = auth.user();
   if (!user) {
     return apiError(req, res, {
@@ -60,6 +44,8 @@ async function handler(
       },
     });
   }
+
+  const owner = auth.getNonNullableWorkspace();
 
   switch (req.method) {
     case "POST": {
@@ -139,4 +125,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/invitations/[iId]/index.ts
+++ b/front/pages/api/w/[wId]/invitations/[iId]/index.ts
@@ -12,8 +12,8 @@ import {
   getInvitation,
   updateInvitationStatusAndRole,
 } from "@app/lib/api/invitation";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
 export type PostMemberInvitationsResponseBody = {
@@ -27,25 +27,9 @@ export const PostMemberInvitationBodySchema = t.type({
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<PostMemberInvitationsResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PostMemberInvitationsResponseBody>>,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace was not found.",
-      },
-    });
-  }
-
   if (!auth.isAdmin()) {
     return apiError(req, res, {
       status_code: 403,
@@ -116,4 +100,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/keys/index.ts
+++ b/front/pages/api/w/[wId]/keys/index.ts
@@ -3,8 +3,8 @@ import { isLeft } from "fp-ts/Either";
 import * as t from "io-ts";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { KeyResource } from "@app/lib/resources/key_resource";
 import { apiError } from "@app/logger/withlogging";
 
@@ -24,25 +24,17 @@ async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
     WithAPIErrorResponse<GetKeysResponseBody | PostKeysResponseBody>
-  >
+  >,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
   const user = auth.user();
-  if (!owner) {
-    res.status(404).end();
-    return;
-  }
 
   if (!auth.isBuilder()) {
     res.status(403).end();
     return;
   }
+
+  const owner = auth.getNonNullableWorkspace();
 
   switch (req.method) {
     case "GET":
@@ -86,4 +78,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/labs/transcripts/default.ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/default.ts
@@ -3,8 +3,8 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { GetLabsTranscriptsConfigurationResponseBody } from "@app/pages/api/w/[wId]/labs/transcripts";
@@ -20,26 +20,10 @@ async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
     WithAPIErrorResponse<GetLabsTranscriptsConfigurationResponseBody>
-  >
+  >,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  const userId = auth.user()?.id;
-
-  if (!owner || !userId) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace or user was not found.",
-      },
-    });
-  }
+  const owner = auth.getNonNullableWorkspace();
 
   if (!owner.flags.includes("labs_transcripts")) {
     return apiError(req, res, {
@@ -105,4 +89,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/labs/transcripts/index.ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/index.ts
@@ -4,8 +4,8 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
 import { apiError } from "@app/logger/withlogging";
 
@@ -27,18 +27,12 @@ async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
     WithAPIErrorResponse<GetLabsTranscriptsConfigurationResponseBody>
-  >
+  >,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
   const userId = auth.user()?.id;
 
-  if (!owner || !userId) {
+  if (!userId) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -47,6 +41,8 @@ async function handler(
       },
     });
   }
+
+  const owner = auth.getNonNullableWorkspace();
 
   if (!owner.flags.includes("labs_transcripts")) {
     return apiError(req, res, {
@@ -134,4 +130,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/members/index.ts
+++ b/front/pages/api/w/[wId]/members/index.ts
@@ -5,8 +5,8 @@ import type {
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getMembers } from "@app/lib/api/workspace";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
 export type GetMembersResponseBody = {
@@ -15,25 +15,9 @@ export type GetMembersResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetMembersResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetMembersResponseBody>>,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace was not found.",
-      },
-    });
-  }
-
   if (!auth.isAdmin()) {
     return apiError(req, res, {
       status_code: 403,
@@ -63,4 +47,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/members/me/agent_list_status.ts
+++ b/front/pages/api/w/[wId]/members/me/agent_list_status.ts
@@ -6,8 +6,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import { setAgentUserListStatus } from "@app/lib/api/assistant/user_relation";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
 export type PostAgentListStatusResponseBody = {
@@ -26,36 +26,9 @@ export type PostAgentListStatusRequestBody = t.TypeOf<
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<PostAgentListStatusResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PostAgentListStatusResponseBody>>,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace was not found.",
-      },
-    });
-  }
-
-  const user = auth.user();
-  if (!user) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_user_not_found",
-        message: "The user requested was not found.",
-      },
-    });
-  }
-
   if (!auth.isUser()) {
     return apiError(req, res, {
       status_code: 403,
@@ -125,4 +98,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/providers/[pId]/check.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/check.ts
@@ -1,8 +1,8 @@
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
 export type GetProvidersCheckResponseBody =
@@ -11,25 +11,9 @@ export type GetProvidersCheckResponseBody =
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetProvidersCheckResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetProvidersCheckResponseBody>>,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "provider_not_found",
-        message: "The provider you're trying to update was not found.",
-      },
-    });
-  }
-
   if (!auth.isBuilder()) {
     return apiError(req, res, {
       status_code: 403,
@@ -271,4 +255,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/providers/index.ts
+++ b/front/pages/api/w/[wId]/providers/index.ts
@@ -2,8 +2,8 @@ import type { ProviderType, WithAPIErrorResponse } from "@dust-tt/types";
 import { redactString } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { Provider } from "@app/lib/models/apps";
 import { apiError } from "@app/logger/withlogging";
 
@@ -22,25 +22,9 @@ function redactConfig(config: string) {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetProvidersResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetProvidersResponseBody>>,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you're trying to access was not found.",
-      },
-    });
-  }
-
   if (!auth.isBuilder()) {
     return apiError(req, res, {
       status_code: 403,
@@ -51,6 +35,8 @@ async function handler(
       },
     });
   }
+
+  const owner = auth.getNonNullableWorkspace();
 
   switch (req.method) {
     case "GET":
@@ -82,4 +68,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/subscriptions/index.ts
+++ b/front/pages/api/w/[wId]/subscriptions/index.ts
@@ -9,8 +9,8 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import {
   cancelSubscriptionImmediately,
   skipSubscriptionFreeTrial,
@@ -51,26 +51,9 @@ async function handler(
       | PostSubscriptionResponseBody
       | PatchSubscriptionResponseBody
     >
-  >
+  >,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  const plan = auth.plan();
-  if (!owner || !plan) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace was not found.",
-      },
-    });
-  }
-
   if (!auth.isAdmin()) {
     return apiError(req, res, {
       status_code: 403,
@@ -227,4 +210,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/w/[wId]/workspace-usage.ts
@@ -6,8 +6,8 @@ import * as reporter from "io-ts-reporters";
 import JSZip from "jszip";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import {
   getAssistantsUsageData,
   getBuildersUsageData,
@@ -63,25 +63,9 @@ const GetUsageQueryParamsSchema = t.union([
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse
+  res: NextApiResponse,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth = await Authenticator.fromSession(
-    session,
-    req.query.wId as string
-  );
-
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace was not found.",
-      },
-    });
-  }
-
   if (!auth.isAdmin()) {
     return apiError(req, res, {
       status_code: 403,
@@ -159,7 +143,7 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);
 
 function resolveDates(query: t.TypeOf<typeof GetUsageQueryParamsSchema>) {
   switch (query.mode) {

--- a/front/pages/api/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/w/[wId]/workspace-usage.ts
@@ -77,6 +77,8 @@ async function handler(
     });
   }
 
+  const owner = auth.getNonNullableWorkspace();
+
   switch (req.method) {
     case "GET":
       const queryValidation = GetUsageQueryParamsSchema.decode(req.query);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR is a continuation of https://github.com/dust-tt/dust/pull/6143. It introduces the `withSessionAuthenticationForWorkspace` wrapper, which secures all API endpoints under the `w/[wId]/` prefix. The aim is to standardize and ensure a valid `Authenticator` object, allowing for future enhancements. Currently, this function does not enforce any roles, this responsibility remains within each endpoint for now. We plan to move this logic to the wrapper in a subsequent pull request, as this one is already quite large. We will also refactor Poke's logic.

The existing `Authenticator` implementation depends on functions to retrieve values, making type overriding tricky. As a solution, we are introducing a new function, `getNonNullableWorkspace`, which consistently returns a `WorkspaceType` or throws an error.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
The primary risks are around security. All endpoints should now be more secure, as we previously had inconsistent checks in place. There is a possibility of encountering unexpected 404 errors. Safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
