### PR TITLE
[MS connector] Use provider configuration from connector

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -30,8 +30,8 @@ import type { MicrosoftNodeModel } from "@connectors/lib/models/microsoft";
 import logger from "@connectors/logger/logger";
 import type { WithCreationAttributes } from "@connectors/resources/connector/strategy";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
+import type { MicrosoftConfigurationResource } from "@connectors/resources/microsoft_resource";
 import {
-  MicrosoftConfigurationResource,
   MicrosoftNodeResource,
   MicrosoftRootResource,
 } from "@connectors/resources/microsoft_resource";
@@ -170,7 +170,7 @@ export async function syncFiles({
   }
 
   const providerConfig =
-    await MicrosoftConfigurationResource.fetchByConnectorId(connectorId);
+    connector.providerConfiguration as MicrosoftConfigurationResource;
 
   if (!providerConfig) {
     throw new Error(`Configuration for connector ${connectorId} not found`);

--- a/connectors/src/resources/connector_resource.ts
+++ b/connectors/src/resources/connector_resource.ts
@@ -207,6 +207,10 @@ export class ConnectorResource extends BaseResource<ConnectorModel> {
     return this.errorType === "third_party_internal_error";
   }
 
+  get providerConfiguration(): ConnectorProviderConfigurationResource | null {
+    return this.configuration;
+  }
+
   toJSON(): ConnectorType {
     return {
       id: this.id.toString(),


### PR DESCRIPTION
Description
---
Instead of fetching config, use the one already fetched by connector

Note: did not find an easy way to type, so went with an `as`. Open to alternate solutions if this seems too liberal
