### PR TITLE
Add forceUpsert in Confluence Signal

### DIFF
--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -264,7 +264,7 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
   }: {
     fromTs: number | null;
   }): Promise<Result<string, Error>> {
-    return launchConfluenceSyncWorkflow(this.connectorId, fromTs);
+    return launchConfluenceSyncWorkflow(this.connectorId, fromTs, [], true);
   }
 
   async retrievePermissions({

--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -264,7 +264,19 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
   }: {
     fromTs: number | null;
   }): Promise<Result<string, Error>> {
-    return launchConfluenceSyncWorkflow(this.connectorId, fromTs, [], true);
+    const spaces = await ConfluenceSpace.findAll({
+      attributes: ["spaceId"],
+      where: {
+        connectorId: this.connectorId,
+      },
+    });
+
+    return launchConfluenceSyncWorkflow(
+      this.connectorId,
+      fromTs,
+      spaces.map((s) => s.spaceId),
+      true
+    );
   }
 
   async retrievePermissions({

--- a/connectors/src/connectors/confluence/temporal/client.ts
+++ b/connectors/src/connectors/confluence/temporal/client.ts
@@ -44,6 +44,7 @@ export async function launchConfluenceSyncWorkflow(
 
   const signalArgs: SpaceUpdatesSignal[] = spaceIds.map((sId) => ({
     action: "added",
+    forceUpsert,
     spaceId: sId,
   }));
 
@@ -55,7 +56,6 @@ export async function launchConfluenceSyncWorkflow(
       args: [
         {
           connectorId: connector.id,
-          forceUpsert,
         },
       ],
       taskQueue: QUEUE_NAME,
@@ -92,6 +92,7 @@ export async function launchConfluenceRemoveSpacesSyncWorkflow(
   const signalArgs: SpaceUpdatesSignal[] = spaceIds.map((sId) => ({
     action: "removed",
     spaceId: sId,
+    forceUpsert: false,
   }));
 
   const workflowId = makeConfluenceRemoveSpacesWorkflowId(connector.id);

--- a/connectors/src/connectors/confluence/temporal/signals.ts
+++ b/connectors/src/connectors/confluence/temporal/signals.ts
@@ -1,8 +1,9 @@
 import { defineSignal } from "@temporalio/workflow";
 
 export interface SpaceUpdatesSignal {
-  spaceId: string;
   action: "added" | "removed";
+  forceUpsert: boolean;
+  spaceId: string;
 }
 
 export const spaceUpdatesSignal =


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR relocates the `forceUpsert` logic for Confluence spaces within the signal, allowing us to maintain active workflows. This change may introduce non-determinism errors, so I will restart all Confluence workflows.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
Restart all Confluence workflows once deployed.
