### PR TITLE
core: improve logging

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1084,6 +1084,7 @@ dependencies = [
  "eventsource-client",
  "fancy-regex",
  "futures",
+ "http 1.1.0",
  "hyper 1.4.0",
  "itertools 0.10.5",
  "lazy_static",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -72,3 +72,4 @@ thiserror = "1.0.57"
 sentencepiece = { version = "0.11", features = ["static"] }
 reqwest = { version = "0.12", features = ["json"] }
 tracing-bunyan-formatter = "0.3.9"
+http = "1.1.0"

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -5,6 +5,7 @@ use hyper::StatusCode;
 use serde::Serialize;
 use serde_json::Value;
 use std::io::Write;
+use tower_http::trace::MakeSpan;
 use uuid::Uuid;
 
 #[derive(Debug)]
@@ -134,4 +135,32 @@ pub fn error_response(
             response: None,
         }),
     )
+}
+
+/// Core requests span creation.
+#[derive(Debug, Clone)]
+pub struct CoreRequestMakeSpan {}
+
+impl CoreRequestMakeSpan {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Default for CoreRequestMakeSpan {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<B> MakeSpan<B> for CoreRequestMakeSpan {
+    fn make_span(&mut self, request: &http::Request<B>) -> tracing::Span {
+        tracing::span!(
+            tracing::Level::INFO,
+            "core request",
+            method = %request.method(),
+            uri = %request.uri(),
+            request_span_id = new_id()[0..12].to_string(),
+        )
+    }
 }


### PR DESCRIPTION
## Description

Introduce a `request_span_id` that can be used to correlate all logs in `core` associated with a given request.
Cleans-up the log objects with unused fields (target, file, line).

```
[2024-07-10T10:18:24.263Z]  INFO: dust_api/1052699 on spolu-box: API server started
[2024-07-10T10:18:29.012Z]  INFO: dust_api/1052699 on spolu-box: [CORE REQUEST - START] (method=GET,request_span_id=2258b13e)
    uri: /projects/3/data_sources/load-test/documents?limit=10&offset=0
[2024-07-10T10:18:29.028Z]  INFO: dust_api/1052699 on spolu-box: [CORE REQUEST - EVENT] finished processing request (latency="15 ms",method=GET,request_span_id=2258b13e,status=200)
    uri: /projects/3/data_sources/load-test/documents?limit=10&offset=0
[2024-07-10T10:18:29.028Z]  INFO: dust_api/1052699 on spolu-box: [CORE REQUEST - END] (elapsed_milliseconds=15,method=GET,request_span_id=2258b13e)
    uri: /projects/3/data_sources/load-test/documents?limit=10&offset=0
[2024-07-10T10:18:32.027Z]  INFO: dust_api/1052699 on spolu-box: [CORE REQUEST - START] (method=GET,request_span_id=1f9c4ba8)
    uri: /projects/3/data_sources/load-test/documents?limit=10&offset=0
[2024-07-10T10:18:32.043Z]  INFO: dust_api/1052699 on spolu-box: [CORE REQUEST - EVENT] finished processing request (latency="15 ms",method=GET,request_span_id=1f9c4ba8,status=200)
    uri: /projects/3/data_sources/load-test/documents?limit=10&offset=0
[2024-07-10T10:18:32.043Z]  INFO: dust_api/1052699 on spolu-box: [CORE REQUEST - END] (elapsed_milliseconds=15,method=GET,request_span_id=1f9c4ba8)
    uri: /projects/3/data_sources/load-test/documents?limit=10&offset=0
[2024-07-10T10:19:06.111Z]  INFO: dust_api/1052699 on spolu-box: [CORE REQUEST - START] (method=GET,request_span_id=89b9a9e2)
    uri: /projects/3/data_sources/load-test/documents?limit=10&offset=0
[2024-07-10T10:19:06.116Z]  INFO: dust_api/1052699 on spolu-box: [CORE REQUEST - EVENT] finished processing request (latency="4 ms",method=GET,request_span_id=89b9a9e2,status=200)
    uri: /projects/3/data_sources/load-test/documents?limit=10&offset=0
[2024-07-10T10:19:06.116Z]  INFO: dust_api/1052699 on spolu-box: [CORE REQUEST - END] (elapsed_milliseconds=4,method=GET,request_span_id=89b9a9e2)
    uri: /projects/3/data_sources/load-test/documents?limit=10&offset=0
```

## Risk

N/A

## Deploy Plan

- deploy `core`