### PR TITLE
[chore] - chore(front): landing assistants loading

### DIFF
--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -211,9 +211,11 @@ export function AssistantDetails({
               {agentConfiguration.lastAuthors.join(", ")}
             </div>
           )}
-          <div>
-            {editedSentence + ", "} {usageSentence}
-          </div>
+          {usageSentence ? (
+            <div>{[editedSentence, usageSentence].join(", ")}</div>
+          ) : (
+            <div className="justify-self-end">{editedSentence}</div>
+          )}
         </div>
       )}
       <Page.Separator />

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -212,7 +212,7 @@ export function AssistantDetails({
             </div>
           )}
           {usageSentence ? (
-            <div>{[editedSentence, usageSentence].join(", ")}</div>
+            <div>{editedSentence + ", "}{usageSentence}</div>
           ) : (
             <div className="justify-self-end">{editedSentence}</div>
           )}

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -212,7 +212,10 @@ export function AssistantDetails({
             </div>
           )}
           {usageSentence ? (
-            <div>{editedSentence + ", "}{usageSentence}</div>
+            <div>
+              {editedSentence + ", "}
+              {usageSentence}
+            </div>
           ) : (
             <div className="justify-self-end">{editedSentence}</div>
           )}

--- a/front/lib/api/assistant/agent_usage.ts
+++ b/front/lib/api/assistant/agent_usage.ts
@@ -65,14 +65,8 @@ export async function getAgentsUsage({
       agentMessageCountTTL === TTL_KEY_NOT_EXIST ||
       agentMessageCountTTL === TTL_KEY_NOT_SET
     ) {
-      void (async () => {
-        const agentMessageCounts = await agentMentionsCount(owner.id);
-        void safeRedisClient((redis) =>
-          storeCountsInRedis(workspaceId, agentMessageCounts, redis)
-        );
-      })();
+      await launchMentionsCountWorkflow({ workspaceId });
       return [];
-
       // agent mention count is stale
     } else if (agentMessageCountTTL < MENTION_COUNT_UPDATE_PERIOD_SEC) {
       await launchMentionsCountWorkflow({ workspaceId });

--- a/front/lib/api/assistant/agent_usage.ts
+++ b/front/lib/api/assistant/agent_usage.ts
@@ -1,4 +1,4 @@
-import type { AgentConfigurationType, AgentUsageType } from "@dust-tt/types";
+import type { AgentConfigurationType } from "@dust-tt/types";
 import { literal, Op, Sequelize } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
@@ -20,7 +20,7 @@ const MENTION_COUNT_UPDATE_PERIOD_SEC = 4 * 60 * 60;
 const TTL_KEY_NOT_EXIST = -2;
 const TTL_KEY_NOT_SET = -1;
 
-type agentUsage = {
+type AgentUsageCount = {
   agentId: string;
   messageCount: number;
   timePeriodSec: number;
@@ -46,7 +46,7 @@ export async function getAgentsUsage({
   workspaceId: string;
   providedRedis?: Awaited<ReturnType<typeof redisClient>>;
   limit?: number;
-}): Promise<agentUsage[]> {
+}): Promise<AgentUsageCount[]> {
   const owner = await Workspace.findOne({ where: { sId: workspaceId } });
   if (!owner) {
     throw new Error(`Workspace ${workspaceId} not found`);
@@ -65,8 +65,14 @@ export async function getAgentsUsage({
       agentMessageCountTTL === TTL_KEY_NOT_EXIST ||
       agentMessageCountTTL === TTL_KEY_NOT_SET
     ) {
-      const agentMessageCounts = await agentMentionsCount(owner.id);
-      await storeCountsInRedis(workspaceId, agentMessageCounts, redis);
+      void (async () => {
+        const agentMessageCounts = await agentMentionsCount(owner.id);
+        void safeRedisClient((redis) =>
+          storeCountsInRedis(workspaceId, agentMessageCounts, redis)
+        );
+      })();
+      return [];
+
       // agent mention count is stale
     } else if (agentMessageCountTTL < MENTION_COUNT_UPDATE_PERIOD_SEC) {
       await launchMentionsCountWorkflow({ workspaceId });
@@ -100,7 +106,7 @@ export async function getAgentUsage(
     agentConfiguration: AgentConfigurationType;
     providedRedis?: Awaited<ReturnType<typeof redisClient>>;
   }
-): Promise<AgentUsageType> {
+): Promise<AgentUsageCount | null> {
   const owner = auth.workspace();
   if (!owner) {
     throw new Error("Unexpected unauthenticated call");
@@ -121,11 +127,13 @@ export async function getAgentUsage(
       agentMessageCountKey,
       agentConfigurationId
     );
-    const messageCount = agentUsage ? parseInt(agentUsage, 10) : 0;
-    return {
-      messageCount,
-      timePeriodSec: rankingTimeframeSec,
-    };
+    return agentUsage
+      ? {
+          agentId: agentConfigurationId,
+          messageCount: parseInt(agentUsage, 10),
+          timePeriodSec: rankingTimeframeSec,
+        }
+      : null;
   } finally {
     if (redis && !providedRedis) {
       await redis.quit();

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage.ts
@@ -8,7 +8,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
 export type GetAgentUsageResponseBody = {
-  agentUsage: AgentUsageType;
+  agentUsage: AgentUsageType | null;
 };
 
 async function handler(

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -118,13 +118,17 @@ async function handler(
           });
         });
         const usageMap = _.keyBy(mentionCounts, "agentId");
-        agentConfigurations = agentConfigurations.map((agentConfiguration) => ({
-          ...agentConfiguration,
-          usage: {
-            messageCount: usageMap[agentConfiguration.sId]?.messageCount || 0,
-            timePeriodSec: usageMap[agentConfiguration.sId]?.timePeriodSec || 0,
-          },
-        }));
+        agentConfigurations = agentConfigurations.map((agentConfiguration) =>
+          usageMap[agentConfiguration.sId]
+            ? {
+                ...agentConfiguration,
+                usage: {
+                  messageCount: usageMap[agentConfiguration.sId].messageCount,
+                  timePeriodSec: usageMap[agentConfiguration.sId].timePeriodSec,
+                },
+              }
+            : agentConfiguration
+        );
       }
       if (withAuthors === "true") {
         const recentAuthors = await getAgentsRecentAuthors({

--- a/front/start_worker.ts
+++ b/front/start_worker.ts
@@ -5,11 +5,11 @@ import { runPokeWorker } from "@app/poke/temporal/worker";
 import { runPostUpsertHooksWorker } from "@app/temporal/documents_post_process_hooks/worker";
 import { runHardDeleteWorker } from "@app/temporal/hard_delete/worker";
 import { runLabsWorker } from "@app/temporal/labs/worker";
+import { runMentionsCountWorker } from "@app/temporal/mentions_count_queue/worker";
 import { runProductionChecksWorker } from "@app/temporal/production_checks/worker";
 import { runScrubWorkspaceQueueWorker } from "@app/temporal/scrub_workspace/worker";
 import { runUpsertQueueWorker } from "@app/temporal/upsert_queue/worker";
 import { runUpdateWorkspaceUsageWorker } from "@app/temporal/usage_queue/worker";
-import { runMentionsCountWorker } from "@app/temporal/mentions_count_queue/worker";
 
 setupGlobalErrorHandler(logger);
 

--- a/front/temporal/mentions_count_queue/client.ts
+++ b/front/temporal/mentions_count_queue/client.ts
@@ -1,12 +1,12 @@
 import type { Result } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
+import { WorkflowNotFoundError } from "@temporalio/client";
 
 import { getTemporalClient } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 
 import { QUEUE_NAME } from "./config";
 import { mentionsCountWorkflow } from "./workflows";
-import { WorkflowNotFoundError } from "@temporalio/client";
 
 export async function launchMentionsCountWorkflow({
   workspaceId,


### PR DESCRIPTION
## Description

This PR aims at handling the *rare* case in which a user ends up in the landing page while agents do not have usage computed.

It introduces the following changes:
- Redis hashset are unset or expired we run the usage query in the background and return an empty list
- In this case the "Most popular" tab will be hidden and the usage won't be visible in the `AssistantDetails` drawer.

## Risk

Unexpected behaviours in the landing page

## Deploy Plan

- Deploy `front-edge`
- Deploy `front`
