### PR TITLE
Fix websites data source name

### DIFF
--- a/front/components/data_source/WebsiteConfiguration.tsx
+++ b/front/components/data_source/WebsiteConfiguration.tsx
@@ -111,10 +111,10 @@ export default function WebsiteConfiguration({
   };
 
   useEffect(() => {
-    if (isUrlValid(dataSourceUrl) && !dataSourceName.length) {
+    if (isUrlValid(dataSourceUrl)) {
       setDataSourceName(urlToDataSourceName(dataSourceUrl));
     }
-  }, [dataSourceUrl, dataSourceName.length]);
+  }, [dataSourceUrl]);
 
   const validateForm = useCallback(() => {
     let urlError = null;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes https://github.com/dust-tt/tasks/issues/1045.

A regression was introduced in https://github.com/dust-tt/dust/pull/5282, causing the data source name for websites to stop updating once the URL was considered valid. For example, with http://docs.dust.tt, the useEffect stops updating the name at http://docs.du.

We have agreed that updating the URL should ALWAYS update the data source name, even if the user has already changed it.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
