### PR TITLE
Pre Process CSV to store both the content & schema, retrieve schema only for big files

### DIFF
--- a/front/lib/api/csv.ts
+++ b/front/lib/api/csv.ts
@@ -1,5 +1,65 @@
 import { parse } from "csv-parse";
 
+const POSSIBLE_VALUES_MAX_LEN = 32;
+const POSSIBLE_VALUES_MAX_COUNT = 16;
+
+interface ColumnTypeInfo {
+  type: "string" | "number" | "boolean" | "enum";
+  possibleValues: string[] | null;
+}
+
+export interface CSVRow {
+  [key: string]: string;
+}
+
+/**
+ * Detect the type of a column based on its values.
+ */
+function detectColumnType(columnValues: string[]): ColumnTypeInfo {
+  const uniqueValues = new Set(columnValues);
+
+  if (columnValues.every((value) => !isNaN(Number(value)))) {
+    return { type: "number", possibleValues: null };
+  }
+
+  if (
+    columnValues.every(
+      (value) =>
+        value.toLowerCase() === "true" || value.toLowerCase() === "false"
+    )
+  ) {
+    return { type: "boolean", possibleValues: null };
+  }
+
+  if (
+    uniqueValues.size <= POSSIBLE_VALUES_MAX_COUNT &&
+    Array.from(uniqueValues).every(
+      (value) => value.length <= POSSIBLE_VALUES_MAX_LEN
+    )
+  ) {
+    return { type: "enum", possibleValues: Array.from(uniqueValues) };
+  }
+
+  return { type: "string", possibleValues: null };
+}
+
+/**
+ * Analyze the columns of a CSV file and return the type of each column.
+ */
+export function analyzeCSVColumns(
+  csvData: CSVRow[]
+): Record<string, ColumnTypeInfo> {
+  const columnTypes: Record<string, ColumnTypeInfo> = {};
+  const columns = Object.keys(csvData[0]);
+
+  for (const column of columns) {
+    const columnValues = csvData.map((row) => row[column]);
+    columnTypes[column] = detectColumnType(columnValues);
+  }
+
+  return columnTypes;
+}
+
 export async function guessDelimiter(csv: string): Promise<string | undefined> {
   // Detect the delimiter: try to parse the first 2 lines with different delimiters,
   // keep the one that works for both lines and has the most columns.

--- a/front/lib/api/csv.ts
+++ b/front/lib/api/csv.ts
@@ -4,8 +4,8 @@ const POSSIBLE_VALUES_MAX_LEN = 32;
 const POSSIBLE_VALUES_MAX_COUNT = 16;
 
 interface ColumnTypeInfo {
-  type: "string" | "number" | "boolean" | "enum";
-  possibleValues: string[] | null;
+  type: "string" | "number" | "boolean";
+  possibleValues?: string[];
 }
 
 interface CSVRow {
@@ -43,24 +43,31 @@ function detectColumnType(columnValues: Iterable<string>): ColumnTypeInfo {
     }
   }
 
-  if (allNumbers) {
-    return { type: "number", possibleValues: null };
-  }
-
-  if (allBooleans) {
-    return { type: "boolean", possibleValues: null };
-  }
-
+  let possibleValues = null;
   if (
     uniqueValues.size <= POSSIBLE_VALUES_MAX_COUNT &&
     Array.from(uniqueValues).every(
       (value) => value.length <= POSSIBLE_VALUES_MAX_LEN
     )
   ) {
-    return { type: "enum", possibleValues: Array.from(uniqueValues) };
+    possibleValues = Array.from(uniqueValues);
   }
 
-  return { type: "string", possibleValues: null };
+  if (allNumbers) {
+    return possibleValues
+      ? { type: "number", possibleValues }
+      : { type: "number" };
+  }
+
+  if (allBooleans) {
+    return possibleValues
+      ? { type: "boolean", possibleValues }
+      : { type: "boolean" };
+  }
+
+  return possibleValues
+    ? { type: "string", possibleValues }
+    : { type: "string" };
 }
 
 /**

--- a/front/lib/api/csv.ts
+++ b/front/lib/api/csv.ts
@@ -73,9 +73,9 @@ function detectColumnType(columnValues: Iterable<string>): ColumnTypeInfo {
 /**
  * Analyze each column of a CSV row by row to determine column types incrementally.
  */
-export async function analyzeCSVColumns(
+export function analyzeCSVColumns(
   rows: CSVRow[]
-): Promise<Record<string, ColumnTypeInfo>> {
+): Record<string, ColumnTypeInfo> {
   const columnSamples: Record<string, Set<string>> = {};
   const columnTypes: Record<string, ColumnTypeInfo> = {};
 

--- a/front/lib/api/files/preprocessing.ts
+++ b/front/lib/api/files/preprocessing.ts
@@ -203,12 +203,8 @@ const extractContentAndSchemaFromCSV: PreprocessingFunction = async (
           callback();
         },
         flush(callback: TransformCallback) {
-          analyzeCSVColumns(rows)
-            .then((columnTypes) => {
-              this.push(JSON.stringify(columnTypes, null, 2));
-              callback();
-            })
-            .catch((err) => callback(err));
+          this.push(JSON.stringify(analyzeCSVColumns(rows), null, 2));
+          callback();
         },
       });
     };

--- a/front/lib/api/files/preprocessing.ts
+++ b/front/lib/api/files/preprocessing.ts
@@ -39,8 +39,14 @@ const uploadToPublicBucket: PreprocessingFunction = async (
   auth: Authenticator,
   file: FileResource
 ) => {
-  const readStream = file.getReadStream(auth, "original");
-  const writeStream = file.getWriteStream(auth, "public");
+  const readStream = file.getReadStream({
+    auth,
+    version: "original",
+  });
+  const writeStream = file.getWriteStream({
+    auth,
+    version: "public",
+  });
   try {
     await pipeline(readStream, writeStream);
     return new Ok(undefined);
@@ -69,7 +75,10 @@ const resizeAndUploadToFileStorage: PreprocessingFunction = async (
   auth: Authenticator,
   file: FileResource
 ) => {
-  const readStream = file.getReadStream(auth, "original");
+  const readStream = file.getReadStream({
+    auth,
+    version: "original",
+  });
 
   // Resize the image, preserving the aspect ratio. Longest side is max 768px.
   const resizedImageStream = sharp().resize(768, 768, {
@@ -77,7 +86,10 @@ const resizeAndUploadToFileStorage: PreprocessingFunction = async (
     withoutEnlargement: true, // Avoid upscaling if image is smaller than 768px.
   });
 
-  const writeStream = file.getWriteStream(auth, "processed");
+  const writeStream = file.getWriteStream({
+    auth,
+    version: "processed",
+  });
 
   try {
     await pipeline(readStream, resizedImageStream, writeStream);
@@ -135,11 +147,17 @@ const extractTextFromPDF: PreprocessingFunction = async (
   file: FileResource
 ) => {
   try {
-    const readStream = file.getReadStream(auth, "original");
+    const readStream = file.getReadStream({
+      auth,
+      version: "original",
+    });
     // Load file in memory.
     const arrayBuffer = await buffer(readStream);
 
-    const writeStream = file.getWriteStream(auth, "processed");
+    const writeStream = file.getWriteStream({
+      auth,
+      version: "processed",
+    });
     const pdfTextStream = await createPdfTextStream(arrayBuffer);
 
     await pipeline(
@@ -195,9 +213,19 @@ const extractContentAndSchemaFromCSV: PreprocessingFunction = async (
   file: FileResource
 ): Promise<Result<undefined, Error>> => {
   try {
-    const readStream = file.getReadStream(auth, "original");
-    const processedWriteStream = file.getWriteStream(auth, "processed");
-    const schemaWriteStream = file.getWriteStream(auth, "snippet");
+    const readStream = file.getReadStream({
+      auth,
+      version: "original",
+    });
+    const processedWriteStream = file.getWriteStream({
+      auth,
+      version: "processed",
+    });
+    const schemaWriteStream = file.getWriteStream({
+      auth,
+      version: "snippet",
+      overrideContentType: "application/json",
+    });
 
     // Process the first stream for processed file
     const processedPipeline = pipeline(
@@ -242,8 +270,14 @@ const storeRawText: PreprocessingFunction = async (
   auth: Authenticator,
   file: FileResource
 ) => {
-  const readStream = file.getReadStream(auth, "original");
-  const writeStream = file.getWriteStream(auth, "processed");
+  const readStream = file.getReadStream({
+    auth,
+    version: "original",
+  });
+  const writeStream = file.getWriteStream({
+    auth,
+    version: "processed",
+  });
 
   try {
     await pipeline(readStream, writeStream);

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -415,9 +415,9 @@ export async function renderContentFragmentForModel(
   const { contentType, fileId, sId, title, textBytes } = message;
 
   try {
-    // If the content fragment is a file, we render it from the file and we have a logic
-    // to render a snippet version if it is a CSV file and the content is too large (CSV schema).
-    // If the content fragment is not a file (public API), we render the content always.
+    // Render content based on fragment type:
+    // - If the fragment is a file, render it from the file. For large CSV files, render a snippet version (CSV schema).
+    // - If the fragment is not a file (public API), always render the full content.
     if (fileId) {
       return await renderFromFileId(conversation.owner, {
         contentType,

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -25,6 +25,8 @@ import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import logger from "@app/logger/logger";
 
+const MAX_BYTE_SIZE_CSV_RENDER_FULL_CONTENT = 500 * 1024; // 500 KB
+
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unsafe-declaration-merging
@@ -305,6 +307,19 @@ export async function getProcessedFileContent(
   return getPrivateUploadBucket().fetchFileContent(fileCloudStoragePath);
 }
 
+export async function getSnippetFileContent(
+  workspace: WorkspaceType,
+  fileId: string
+): Promise<string> {
+  const fileCloudStoragePath = FileResource.getCloudStoragePathForId({
+    fileId,
+    workspaceId: workspace.sId,
+    version: "snippet",
+  });
+
+  return getPrivateUploadBucket().fetchFileContent(fileCloudStoragePath);
+}
+
 async function getSignedUrlForProcessedContent(
   workspace: WorkspaceType,
   fileId: string
@@ -326,12 +341,14 @@ async function renderFromFileId(
     fileId,
     model,
     title,
+    textBytes,
   }: {
     contentType: string;
     excludeImages: boolean;
     fileId: string;
     model: ModelConfigurationType;
     title: string;
+    textBytes: number | null;
   }
 ): Promise<Result<ContentFragmentMessageTypeModel, Error>> {
   if (isSupportedImageContentFragmentType(contentType)) {
@@ -363,7 +380,14 @@ async function renderFromFileId(
       ],
     });
   } else {
-    const content = await getProcessedFileContent(workspace, fileId);
+    const shouldRetrieveSnippetVersion =
+      contentType === "text/csv" &&
+      textBytes &&
+      textBytes > MAX_BYTE_SIZE_CSV_RENDER_FULL_CONTENT;
+
+    const content = shouldRetrieveSnippetVersion
+      ? await getSnippetFileContent(workspace, fileId)
+      : await getProcessedFileContent(workspace, fileId);
 
     return new Ok({
       role: "content_fragment",
@@ -388,9 +412,12 @@ export async function renderContentFragmentForModel(
     excludeImages: boolean;
   }
 ): Promise<Result<ContentFragmentMessageTypeModel, Error>> {
-  const { contentType, fileId, sId, title } = message;
+  const { contentType, fileId, sId, title, textBytes } = message;
 
   try {
+    // If the content fragment is a file, we render it from the file and we have a logic
+    // to render a snippet version if it is a CSV file and the content is too large (CSV schema).
+    // If the content fragment is not a file (public API), we render the content always.
     if (fileId) {
       return await renderFromFileId(conversation.owner, {
         contentType,
@@ -398,6 +425,7 @@ export async function renderContentFragmentForModel(
         fileId,
         model,
         title,
+        textBytes,
       });
     } else {
       const content = await getContentFragmentText({

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -256,14 +256,22 @@ export class FileResource extends BaseResource<FileModel> {
 
   // Stream logic.
 
-  getWriteStream(auth: Authenticator, version: FileVersion): Writable {
+  getWriteStream({
+    auth,
+    version,
+    overrideContentType,
+  }: {
+    auth: Authenticator;
+    version: FileVersion;
+    overrideContentType?: string;
+  }): Writable {
     if (version === "public") {
       return getPublicUploadBucket()
         .file(this.getCloudStoragePath(auth, version))
         .createWriteStream({
           resumable: false,
           gzip: true,
-          contentType: this.contentType,
+          contentType: overrideContentType ?? this.contentType,
         });
     } else {
       return getPrivateUploadBucket()
@@ -271,12 +279,18 @@ export class FileResource extends BaseResource<FileModel> {
         .createWriteStream({
           resumable: false,
           gzip: true,
-          contentType: this.contentType,
+          contentType: overrideContentType ?? this.contentType,
         });
     }
   }
 
-  getReadStream(auth: Authenticator, version: FileVersion): Readable {
+  getReadStream({
+    auth,
+    version,
+  }: {
+    auth: Authenticator;
+    version: FileVersion;
+  }): Readable {
     if (version === "public") {
       return getPublicUploadBucket()
         .file(this.getCloudStoragePath(auth, version))

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -121,6 +121,10 @@ export class FileResource extends BaseResource<FileModel> {
         await getPrivateUploadBucket()
           .file(this.getCloudStoragePath(auth, "snippet"))
           .delete({ ignoreNotFound: true });
+        // Delete the public file if it exists.
+        await getPublicUploadBucket()
+          .file(this.getCloudStoragePath(auth, "public"))
+          .delete({ ignoreNotFound: true });
       }
 
       await this.model.destroy({

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -29,7 +29,7 @@ import { FileModel } from "@app/lib/resources/storage/models/files";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 
-type FileVersion = "processed" | "original" | "public";
+type FileVersion = "processed" | "original" | "public" | "snippet";
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface FileResource extends ReadonlyAttributesType<FileModel> {}
@@ -116,6 +116,10 @@ export class FileResource extends BaseResource<FileModel> {
         // Delete the processed file if it exists.
         await getPrivateUploadBucket()
           .file(this.getCloudStoragePath(auth, "processed"))
+          .delete({ ignoreNotFound: true });
+        // Delete the snippet file if it exists.
+        await getPrivateUploadBucket()
+          .file(this.getCloudStoragePath(auth, "snippet"))
           .delete({ ignoreNotFound: true });
       }
 

--- a/front/pages/api/w/[wId]/files/[fileId].ts
+++ b/front/pages/api/w/[wId]/files/[fileId].ts
@@ -68,7 +68,10 @@ async function handler(
 
       // TODO(2024-07-01 flav) Expose the different versions of the file.
       if (action === "view") {
-        const readStream = file.getReadStream(auth, "original");
+        const readStream = file.getReadStream({
+          auth,
+          version: "original",
+        });
         readStream.on("error", () => {
           return apiError(req, res, {
             status_code: 404,
@@ -137,7 +140,10 @@ async function handler(
         const form = new IncomingForm({
           // Stream the uploaded document to the cloud storage.
           fileWriteStreamHandler: () => {
-            return file.getWriteStream(auth, "original");
+            return file.getWriteStream({
+              auth,
+              version: "original",
+            });
           },
 
           // Support only one file upload.


### PR DESCRIPTION
## Description

This PR adds a preprocessing function for CSVs. The processed content still contains the full content of the csv, and we've added a `snippet` file version that contains a json with the schema of the csv file. 

When we render a content fragment to the model, if it is a CSV > 500Kb, we will render the snippet instead of the full content. This is only for content fragment uploaded with the FileAPI meaning not available at the moment for the public API since FileAPI was not implemented yet in the public API. 

Schema looks like this: 

```json
{
  "message_id": {
    "type": "number"
  },
  "createdAt": {
    "type": "string"
  },
  "assistant_id": {
    "type": "string"
  },
  "assistant_name": {
    "type": "string"
  },
  "workspace_id": {
    "type": "number",
    "possibleValues": [
      "4525"
    ]
  },
  "workspace_name": {
    "type": "string",
    "possibleValues": [
      "Dust"
    ]
  },
  "conversation_id": {
    "type": "number"
  },
  "parent_message_id": {
    "type": "number"
  },
  "user_message_id": {
    "type": "number"
  },
  "user_id": {
    "type": "number"
  },
  "user_email": {
    "type": "string"
  },
  "source": {
    "type": "string",
    "possibleValues": [
      "slack",
      "web",
      "api"
    ]
  }
}
```

## Risk

Break CSV content fragment. 
Can be rolled back. 

## Deploy Plan

Deploy front.
