### PR TITLE
Fix Agent messages citation blinking

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -385,6 +385,8 @@ export function AgentMessage({
           },
         ];
 
+  // References logic.
+
   function updateActiveReferences(
     document: RetrievalDocumentType | WebsearchResultType,
     index: number
@@ -398,6 +400,16 @@ export function AgentMessage({
   const [lastHoveredReference, setLastHoveredReference] = useState<
     number | null
   >(null);
+
+  useEffect(() => {
+    let timer: NodeJS.Timeout;
+    if (lastHoveredReference !== null) {
+      timer = setTimeout(() => {
+        setLastHoveredReference(null);
+      }, 1000); // Reset after 1 second.
+    }
+    return () => clearTimeout(timer);
+  }, [lastHoveredReference]);
 
   useEffect(() => {
     // Retrieval actions


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes https://github.com/dust-tt/tasks/issues/1022.

Hovering over a reference in an `AgentMessage` inconsistently triggers the blinking state of the `Citation` component. It works only once because the last hovered citation is never reset. This PR introduces a 1-second timeout to reset the state. Why 1 second? Simply because the citation animation lasts for 500ms.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
