### PR TITLE
chore: cleanup agent message model and events

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -1,14 +1,12 @@
 import type {
+  AgentMessageSuccessEvent,
   ConversationType,
   LightAgentConfigurationType,
   ModelId,
   Result,
   UserMessageType,
 } from "@dust-tt/types";
-import type {
-  AgentGenerationSuccessEvent,
-  PublicPostContentFragmentRequestBodySchema,
-} from "@dust-tt/types";
+import type { PublicPostContentFragmentRequestBodySchema } from "@dust-tt/types";
 import { Err, Ok, sectionFullText } from "@dust-tt/types";
 import { DustAPI } from "@dust-tt/types";
 import type { WebClient } from "@slack/web-api";
@@ -56,7 +54,7 @@ export async function botAnswerMessageWithErrorHandling(
   slackBotId: string | null,
   slackMessageTs: string,
   slackThreadTs: string | null
-): Promise<Result<AgentGenerationSuccessEvent | undefined, Error>> {
+): Promise<Result<AgentMessageSuccessEvent | undefined, Error>> {
   const slackConfig =
     await SlackConfigurationResource.fetchByActiveBot(slackTeamId);
   if (!slackConfig) {
@@ -153,7 +151,7 @@ async function botAnswerMessage(
   slackThreadTs: string | null,
   connector: ConnectorResource,
   slackConfig: SlackConfigurationResource
-): Promise<Result<AgentGenerationSuccessEvent | undefined, Error>> {
+): Promise<Result<AgentMessageSuccessEvent | undefined, Error>> {
   let lastSlackChatBotMessage: SlackChatBotMessage | null = null;
   if (slackThreadTs) {
     lastSlackChatBotMessage = await SlackChatBotMessage.findOne({

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -18,7 +18,6 @@ import type {
   AgentChainOfThoughtEvent,
   AgentErrorEvent,
   AgentGenerationCancelledEvent,
-  AgentGenerationSuccessEvent,
   AgentMessageSuccessEvent,
   GenerationTokensEvent,
   LightAgentConfigurationType,
@@ -164,7 +163,6 @@ export function AgentMessage({
         | AgentActionSpecificEvent
         | AgentActionSuccessEvent
         | GenerationTokensEvent
-        | AgentGenerationSuccessEvent
         | AgentGenerationCancelledEvent
         | AgentMessageSuccessEvent
         | AgentChainOfThoughtEvent;
@@ -215,10 +213,6 @@ export function AgentMessage({
         setStreamedAgentMessage((m) => {
           return { ...m, status: "cancelled" };
         });
-        break;
-      case "agent_generation_success":
-        // There is no point in handling this event here, since it is always immediately
-        // followed by an "agent_message_success" event (which includes all content / CoT we need).
         break;
       case "agent_message_success": {
         setStreamedAgentMessage((m) => {

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -9,7 +9,6 @@ import type {
   AgentContentEvent,
   AgentErrorEvent,
   AgentGenerationCancelledEvent,
-  AgentGenerationSuccessEvent,
   AgentMessageSuccessEvent,
   AgentMessageType,
   ConversationType,
@@ -66,7 +65,6 @@ export async function* runAgent(
   | AgentActionSpecificEvent
   | AgentActionSuccessEvent
   | GenerationTokensEvent
-  | AgentGenerationSuccessEvent
   | AgentGenerationCancelledEvent
   | AgentMessageSuccessEvent
   | AgentChainOfThoughtEvent,
@@ -112,7 +110,6 @@ export async function* runMultiActionsAgentLoop(
   | AgentActionSpecificEvent
   | AgentActionSuccessEvent
   | GenerationTokensEvent
-  | AgentGenerationSuccessEvent
   | AgentGenerationCancelledEvent
   | AgentMessageSuccessEvent
   | AgentChainOfThoughtEvent
@@ -273,15 +270,6 @@ export async function* runMultiActionsAgentLoop(
             };
             agentMessage.chainOfThoughts.push(event.chainOfThought);
           }
-          yield {
-            type: "agent_generation_success",
-            created: event.created,
-            configurationId: configuration.sId,
-            messageId: agentMessage.sId,
-            text: event.text,
-            runId: event.runId,
-          } satisfies AgentGenerationSuccessEvent;
-
           agentMessage.content = processedContent;
           agentMessage.status = "succeeded";
           yield {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2,7 +2,6 @@ import type {
   AgentActionsEvent,
   AgentActionSpecificEvent,
   AgentActionSuccessEvent,
-  AgentChainOfThoughtEvent,
   AgentDisabledErrorEvent,
   AgentErrorEvent,
   AgentGenerationCancelledEvent,
@@ -609,8 +608,7 @@ export async function* postUserMessage(
   | GenerationTokensEvent
   | AgentGenerationCancelledEvent
   | AgentMessageSuccessEvent
-  | ConversationTitleEvent
-  | AgentChainOfThoughtEvent,
+  | ConversationTitleEvent,
   void
 > {
   const user = auth.user();
@@ -819,7 +817,7 @@ export async function* postUserMessage(
                   status: "created",
                   actions: [],
                   content: null,
-                  chainOfThoughts: [],
+                  chainOfThought: null,
                   rawContents: [],
                   error: null,
                   configuration,
@@ -1020,8 +1018,7 @@ export async function* editUserMessage(
   | AgentActionSuccessEvent
   | GenerationTokensEvent
   | AgentGenerationCancelledEvent
-  | AgentMessageSuccessEvent
-  | AgentChainOfThoughtEvent,
+  | AgentMessageSuccessEvent,
   void
 > {
   const user = auth.user();
@@ -1295,7 +1292,7 @@ export async function* editUserMessage(
                 status: "created",
                 actions: [],
                 content: null,
-                chainOfThoughts: [],
+                chainOfThought: null,
                 rawContents: [],
                 error: null,
                 configuration,
@@ -1433,8 +1430,7 @@ export async function* retryAgentMessage(
   | AgentActionSuccessEvent
   | GenerationTokensEvent
   | AgentGenerationCancelledEvent
-  | AgentMessageSuccessEvent
-  | AgentChainOfThoughtEvent,
+  | AgentMessageSuccessEvent,
   void
 > {
   class AgentMessageError extends Error {}
@@ -1511,7 +1507,7 @@ export async function* retryAgentMessage(
         status: "created",
         actions: [],
         content: null,
-        chainOfThoughts: [],
+        chainOfThought: null,
         rawContents: [],
         error: null,
         configuration: message.configuration,
@@ -1690,8 +1686,7 @@ async function* streamRunAgentEvents(
     | GenerationTokensEvent
     | AgentGenerationSuccessEvent
     | AgentGenerationCancelledEvent
-    | AgentMessageSuccessEvent
-    | AgentChainOfThoughtEvent,
+    | AgentMessageSuccessEvent,
     void
   >,
   agentMessage: AgentMessageType,
@@ -1702,8 +1697,7 @@ async function* streamRunAgentEvents(
   | AgentActionSuccessEvent
   | GenerationTokensEvent
   | AgentGenerationCancelledEvent
-  | AgentMessageSuccessEvent
-  | AgentChainOfThoughtEvent,
+  | AgentMessageSuccessEvent,
   void
 > {
   const runIds = [];
@@ -1787,10 +1781,6 @@ async function* streamRunAgentEvents(
         } else {
           assertNever(event.classification);
         }
-        break;
-
-      case "agent_chain_of_thought":
-        yield event;
         break;
 
       default:

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -244,7 +244,7 @@ export async function batchRenderAgentMessages(
         status: agentMessage.status,
         actions: actions,
         content: parsedContent.content,
-        chainOfThoughts: removeNulls([parsedContent.chainOfThought]),
+        chainOfThought: parsedContent.chainOfThought,
         rawContents:
           agentMessage.agentMessageContents?.map((rc) => ({
             step: rc.step,

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -15,7 +15,6 @@ import type {
   AgentActionSuccessEvent,
   AgentErrorEvent,
   AgentGenerationCancelledEvent,
-  AgentGenerationSuccessEvent,
   AgentMessageSuccessEvent,
 } from "@dust-tt/types";
 import type {
@@ -116,7 +115,6 @@ async function handleUserMessageEvents(
     | AgentActionSpecificEvent
     | AgentActionSuccessEvent
     | GenerationTokensEvent
-    | AgentGenerationSuccessEvent
     | AgentGenerationCancelledEvent
     | AgentMessageSuccessEvent
     | ConversationTitleEvent
@@ -185,7 +183,6 @@ async function handleUserMessageEvents(
             case "agent_error":
             case "agent_action_success":
             case "generation_tokens":
-            case "agent_generation_success":
             case "agent_generation_cancelled":
             case "agent_chain_of_thought":
             case "agent_message_success": {
@@ -338,7 +335,6 @@ export async function retryAgentMessageWithPubSub(
               case "agent_error":
               case "agent_action_success":
               case "generation_tokens":
-              case "agent_generation_success":
               case "agent_generation_cancelled":
               case "agent_chain_of_thought":
               case "agent_message_success": {
@@ -476,8 +472,7 @@ export async function* getMessagesEvents(
       | AgentActionSpecificEvent
       | AgentActionSuccessEvent
       | AgentGenerationCancelledEvent
-      | GenerationTokensEvent
-      | AgentGenerationSuccessEvent;
+      | GenerationTokensEvent;
   },
   void
 > {

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -1,5 +1,4 @@
 import type {
-  AgentChainOfThoughtEvent,
   AgentDisabledErrorEvent,
   AgentMessageType,
   ConversationType,
@@ -117,8 +116,7 @@ async function handleUserMessageEvents(
     | GenerationTokensEvent
     | AgentGenerationCancelledEvent
     | AgentMessageSuccessEvent
-    | ConversationTitleEvent
-    | AgentChainOfThoughtEvent,
+    | ConversationTitleEvent,
     void
   >,
   resolveAfterFullGeneration = false
@@ -184,7 +182,6 @@ async function handleUserMessageEvents(
             case "agent_action_success":
             case "generation_tokens":
             case "agent_generation_cancelled":
-            case "agent_chain_of_thought":
             case "agent_message_success": {
               const pubsubChannel = getMessageChannelId(event.messageId);
               await redis.xAdd(pubsubChannel, "*", {
@@ -336,7 +333,6 @@ export async function retryAgentMessageWithPubSub(
               case "agent_action_success":
               case "generation_tokens":
               case "agent_generation_cancelled":
-              case "agent_chain_of_thought":
               case "agent_message_success": {
                 const pubsubChannel = getMessageChannelId(event.messageId);
                 await redis.xAdd(pubsubChannel, "*", {

--- a/front/lib/models/assistant/agent_message_content.ts
+++ b/front/lib/models/assistant/agent_message_content.ts
@@ -9,11 +9,6 @@ import { DataTypes, Model } from "sequelize";
 import { AgentMessage } from "@app/lib/models/assistant/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
 
-// Captures content that is emitted by an assistant before using a tool.
-// This content is not part of the final message sent to the user and is not
-// stored in the AgentMessage table.
-// TODO(fontanierh): Also store the final generation in this table.
-// Ultimately, this table should model the `content` field of the model provider messages.
 export class AgentMessageContent extends Model<
   InferAttributes<AgentMessageContent>,
   InferCreationAttributes<AgentMessageContent>

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -251,8 +251,6 @@ export class AgentMessage extends Model<
   declare runIds: string[] | null;
   declare status: CreationOptional<AgentMessageStatus>;
 
-  declare content: string | null;
-  declare chainOfThoughts: CreationOptional<string[]>;
   declare errorCode: string | null;
   declare errorMessage: string | null;
 
@@ -289,15 +287,6 @@ AgentMessage.init(
       type: DataTypes.STRING,
       allowNull: false,
       defaultValue: "created",
-    },
-    content: {
-      type: DataTypes.TEXT,
-      allowNull: true,
-    },
-    chainOfThoughts: {
-      type: DataTypes.ARRAY(DataTypes.TEXT),
-      allowNull: false,
-      defaultValue: [],
     },
     errorCode: {
       type: DataTypes.STRING,

--- a/front/migrations/db/migration_39.sql
+++ b/front/migrations/db/migration_39.sql
@@ -1,0 +1,6 @@
+-- Migration created on Jul 10, 2024
+ALTER TABLE
+    "public"."agent_messages" DROP COLUMN "content";
+
+ALTER TABLE
+    "public"."agent_messages" DROP COLUMN "chainOfThoughts";

--- a/front/migrations/db/migration_39.sql
+++ b/front/migrations/db/migration_39.sql
@@ -1,6 +1,5 @@
 -- Migration created on Jul 10, 2024
 ALTER TABLE
-    "public"."agent_messages" DROP COLUMN "content";
-
-ALTER TABLE
-    "public"."agent_messages" DROP COLUMN "chainOfThoughts";
+    "public"."agent_messages"
+ALTER COLUMN
+    "chainOfThoughts" DROP NOT NULL;

--- a/front/migrations/db/migration_40.sql
+++ b/front/migrations/db/migration_40.sql
@@ -1,0 +1,6 @@
+-- Migration created on Jul 10, 2024
+ALTER TABLE
+    "public"."agent_messages" DROP COLUMN "content";
+
+ALTER TABLE
+    "public"."agent_messages" DROP COLUMN "chainOfThoughts";

--- a/types/src/front/assistant/conversation.ts
+++ b/types/src/front/assistant/conversation.ts
@@ -122,7 +122,7 @@ export type AgentMessageType = {
   status: AgentMessageStatus;
   actions: AgentActionType[];
   content: string | null;
-  chainOfThoughts: string[];
+  chainOfThought: string | null;
   rawContents: Array<{
     step: number;
     content: string;

--- a/types/src/front/lib/api/assistant/agent.ts
+++ b/types/src/front/lib/api/assistant/agent.ts
@@ -130,9 +130,6 @@ export type AgentChainOfThoughtEvent = {
   chainOfThought: string;
 };
 
-// Content that is emitted right before a Tool Use
-// and therefore not part of the "final" generation.
-// TODO(fontanierh): Also store the final generation in this table.
 export type AgentContentEvent = {
   type: "agent_message_content";
   created: number;


### PR DESCRIPTION
## Description

- remove `agent_messages.content` and `agent_messages.chainOfThoughts` columns (replaced by the raw contents in `AgentMessageContent`)
- "agent_generation_success" and "agent_chain_of_thought" aren't useful for the client / API so we will no longer yield them all the way up ("agent_chain_of_thought" doesn't get out of multi actions loop and "agent_generation_success" doesn't get out of "streamRunAgentEvents")

## Risk

Critical path + migration

## Deploy Plan

1. deploy first migration (39) to allow null values in the chainOfThoughts column
2. deploy code (remove all uses of the `content` and `chainOfThoughts`, stop populating them)
3. apply second migration (40) to drop the 2 columns