### PR TITLE
`oauth`: initial scaffolding

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -2676,6 +2676,8 @@ dependencies = [
  "bytes",
  "fallible-iterator 0.2.0",
  "postgres-protocol",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -921,6 +921,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.68",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.68",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1004,6 +1039,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0350b5cb0331628a5916d6c5c0b72e97393b8b6b03b47a9284f4e7f5a405ffd7"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d48cda787f839151732d396ac69e3473923d54312c070ee21e9effcaa8ca0b1d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1102,6 +1168,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shellexpand",
+ "sqids",
  "tera",
  "thiserror",
  "tokio",
@@ -1849,6 +1916,12 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -3532,6 +3605,18 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "sqids"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f328f10ae594f0da04e5b2f82c089232697312661bca22d5d015a680c84639d"
+dependencies = [
+ "derive_builder",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
 
 [[package]]
 name = "static_assertions"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -49,7 +49,7 @@ uuid = { version = "1.8", features = ["v4"] }
 parking_lot = "0.12"
 axum = "0.7.4"
 rusqlite = { version = "0.31", features = ["bundled"] }
-tokio-postgres = "0.7"
+tokio-postgres = { version = "0.7", features = ["with-serde_json-1"] }
 bb8 = "0.8"
 bb8-postgres = "0.8"
 urlencoding = "2.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -73,3 +73,4 @@ sentencepiece = { version = "0.11", features = ["static"] }
 reqwest = { version = "0.12", features = ["json"] }
 tracing-bunyan-formatter = "0.3.9"
 http = "1.1.0"
+sqids = "0.4.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -23,6 +23,10 @@ path = "bin/qdrant/create_collection.rs"
 name = "sqlite-worker"
 path = "bin/sqlite_worker.rs"
 
+[[bin]]
+name = "oauth"
+path = "bin/oauth.rs"
+
 [dependencies]
 anyhow = "1.0"
 serde = { version = "1.0", features = ["rc", "derive"] }

--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -176,7 +176,7 @@ impl APIState {
 /// Index
 
 async fn index() -> &'static str {
-    "Welcome to the Dust API!"
+    "dust_api server ready"
 }
 
 /// Create a new project (simply generates an id)
@@ -2471,8 +2471,8 @@ fn main() {
             databases_store,
             QdrantClients::build().await?,
         ));
-        let router = Router::new()
 
+        let router = Router::new()
         // Index
         .route("/", get(index))
         // Projects
@@ -2649,7 +2649,7 @@ fn main() {
             tx2.send(()).ok();
         });
 
-        info!(pid = std::process::id() as u64, "API server started");
+        info!(pid = std::process::id() as u64, "dust_api server started");
 
         let mut stream = signal(SignalKind::terminate()).unwrap();
         stream.recv().await;
@@ -2666,7 +2666,7 @@ fn main() {
         info!("[GRACEFUL] Awaiting stop loop...");
         state.stop_loop().await;
 
-        info!("[GRACEFUL] Exiting!");
+        info!("[GRACEFUL] Exiting");
 
         // sleep for 1 second to allow the logger to flush
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
@@ -2677,7 +2677,7 @@ fn main() {
     match r {
         Ok(_) => (),
         Err(e) => {
-            error!(error = %e, "API Server error");
+            error!(error = %e, "dust_api server error");
             std::process::exit(1);
         }
     }

--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -2442,7 +2442,7 @@ fn main() {
             .with(JsonStorageLayer)
             .with(
                 BunyanFormattingLayer::new("dust_api".into(), std::io::stdout)
-                    .skip_fields(vec!["file", "line", "target", "v", "pid"].into_iter())
+                    .skip_fields(vec!["file", "line", "target"].into_iter())
                     .unwrap(),
             )
             .with(tracing_subscriber::EnvFilter::new("info"))

--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -2442,7 +2442,7 @@ fn main() {
             .with(JsonStorageLayer)
             .with(
                 BunyanFormattingLayer::new("dust_api".into(), std::io::stdout)
-                    .skip_fields(vec!["file", "line", "target"].into_iter())
+                    .skip_fields(vec!["file", "line", "target", "v", "pid"].into_iter())
                     .unwrap(),
             )
             .with(tracing_subscriber::EnvFilter::new("info"))

--- a/core/bin/oauth.rs
+++ b/core/bin/oauth.rs
@@ -1,0 +1,173 @@
+use anyhow::anyhow;
+use axum::{
+    extract::State,
+    response::Json,
+    routing::{get, post},
+    Router,
+};
+use dust::{
+    oauth::{
+        connection::{Connection, ConnectionProvider},
+        store,
+    },
+    utils::{error_response, APIResponse, CoreRequestMakeSpan},
+};
+use hyper::StatusCode;
+use serde::Deserialize;
+use serde_json::json;
+use std::sync::Arc;
+use tokio::{
+    net::TcpListener,
+    signal::unix::{signal, SignalKind},
+};
+use tower_http::trace::{self, TraceLayer};
+use tracing::{error, info, Level};
+use tracing_bunyan_formatter::{BunyanFormattingLayer, JsonStorageLayer};
+use tracing_subscriber::prelude::*;
+
+struct OAuthState {
+    store: Box<dyn store::OAuthStore + Sync + Send>,
+}
+
+impl OAuthState {
+    fn new(store: Box<dyn store::OAuthStore + Sync + Send>) -> Self {
+        Self { store }
+    }
+}
+
+async fn index() -> &'static str {
+    "oauth server ready"
+}
+
+#[derive(Deserialize)]
+struct ConnectionCreatePayload {
+    provider: ConnectionProvider,
+}
+
+async fn connections_create(
+    State(state): State<Arc<OAuthState>>,
+    Json(payload): Json<ConnectionCreatePayload>,
+) -> (StatusCode, Json<APIResponse>) {
+    match Connection::create(state.store.clone(), payload.provider).await {
+        Err(e) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "internal_server_error",
+            "Failed to create connection",
+            Some(e),
+        ),
+        Ok(c) => (
+            StatusCode::OK,
+            Json(APIResponse {
+                error: None,
+                response: Some(json!({
+                    "connection": {
+                        "connection_id": c.connection_id(),
+                        "created": c.created(),
+                        "provider": c.provider(),
+                        "status": c.status(),
+                        "secret": c.secret(),
+                    },
+                })),
+            }),
+        ),
+    }
+}
+
+fn main() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let r = rt.block_on(async {
+        tracing_subscriber::registry()
+            .with(JsonStorageLayer)
+            .with(
+                BunyanFormattingLayer::new("oauth".into(), std::io::stdout)
+                    .skip_fields(vec!["file", "line", "target"].into_iter())
+                    .unwrap(),
+            )
+            .with(tracing_subscriber::EnvFilter::new("info"))
+            .init();
+
+        let store: Box<dyn store::OAuthStore + Sync + Send> =
+            match std::env::var("OAUTH_DATABASE_URI") {
+                Ok(db_uri) => {
+                    let s = store::PostgresOAuthStore::new(&db_uri).await?;
+                    s.init().await?;
+                    Box::new(s)
+                }
+                Err(_) => Err(anyhow!("OAUTH_DATABASE_URI not set."))?,
+            };
+
+        let state = Arc::new(OAuthState::new(store));
+
+        let app = Router::new()
+            // Index
+            .route("/", get(index))
+            // Connections
+            .route("/connections", post(connections_create))
+            // .route(
+            //     "/connections/:connection_id/:secret/finalize",
+            //     post(connections_finalize),
+            // )
+            // .route(
+            //     "/connections/:connection_id/:secret/access_token",
+            //     get(connections_access_token),
+            // )
+            // Extensions
+            .layer(
+                TraceLayer::new_for_http()
+                    .make_span_with(CoreRequestMakeSpan::new())
+                    .on_response(trace::DefaultOnResponse::new().level(Level::INFO)),
+            )
+            .with_state(state.clone());
+
+        let (tx1, rx1) = tokio::sync::oneshot::channel::<()>();
+        let (tx2, rx2) = tokio::sync::oneshot::channel::<()>();
+
+        let srv = axum::serve(
+            TcpListener::bind::<std::net::SocketAddr>("[::]:3006".parse().unwrap()).await?,
+            app.into_make_service(),
+        )
+        .with_graceful_shutdown(async {
+            rx1.await.ok();
+        });
+
+        tokio::spawn(async move {
+            if let Err(e) = srv.await {
+                error!(error = %e, "Server error");
+            }
+            info!("[GRACEFUL] Server stopped");
+            tx2.send(()).ok();
+        });
+
+        info!(pid = std::process::id() as u64, "oauth server started");
+
+        let mut stream = signal(SignalKind::terminate()).unwrap();
+        stream.recv().await;
+
+        // Gracefully shut down the server
+        info!("[GRACEFUL] SIGTERM received, stopping server...");
+        tx1.send(()).ok();
+
+        // Wait for the server to shutdown
+        info!("[GRACEFUL] Awaiting server shutdown...");
+        rx2.await.ok();
+
+        info!("[GRACEFUL] Exiting");
+
+        // sleep for 1 second to allow the logger to flush
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+        Ok::<(), anyhow::Error>(())
+    });
+
+    match r {
+        Ok(_) => (),
+        Err(e) => {
+            error!(error = %e, "oauth server error");
+            std::process::exit(1);
+        }
+    }
+}

--- a/core/bin/oauth.rs
+++ b/core/bin/oauth.rs
@@ -109,11 +109,11 @@ fn main() {
             // Connections
             .route("/connections", post(connections_create))
             // .route(
-            //     "/connections/:connection_id/:secret/finalize",
+            //     "/connections/:connection_id/finalize",
             //     post(connections_finalize),
             // )
             // .route(
-            //     "/connections/:connection_id/:secret/access_token",
+            //     "/connections/:connection_id/access_token",
             //     get(connections_access_token),
             // )
             // Extensions

--- a/core/bin/oauth.rs
+++ b/core/bin/oauth.rs
@@ -133,7 +133,7 @@ fn main() {
             .with(JsonStorageLayer)
             .with(
                 BunyanFormattingLayer::new("oauth".into(), std::io::stdout)
-                    .skip_fields(vec!["file", "line", "target"].into_iter())
+                    .skip_fields(vec!["file", "line", "target", "v", "pid"].into_iter())
                     .unwrap(),
             )
             .with(tracing_subscriber::EnvFilter::new("info"))

--- a/core/bin/oauth.rs
+++ b/core/bin/oauth.rs
@@ -66,7 +66,7 @@ async fn connections_create(
                         "created": c.created(),
                         "provider": c.provider(),
                         "status": c.status(),
-                        "secret": c.secret(),
+                        "metadata": c.metadata(),
                     },
                 })),
             }),

--- a/core/bin/oauth.rs
+++ b/core/bin/oauth.rs
@@ -133,7 +133,7 @@ fn main() {
             .with(JsonStorageLayer)
             .with(
                 BunyanFormattingLayer::new("oauth".into(), std::io::stdout)
-                    .skip_fields(vec!["file", "line", "target", "v", "pid"].into_iter())
+                    .skip_fields(vec!["file", "line", "target"].into_iter())
                     .unwrap(),
             )
             .with(tracing_subscriber::EnvFilter::new("info"))

--- a/core/bin/oauth.rs
+++ b/core/bin/oauth.rs
@@ -42,13 +42,14 @@ async fn index() -> &'static str {
 #[derive(Deserialize)]
 struct ConnectionCreatePayload {
     provider: ConnectionProvider,
+    metadata: serde_json::Value,
 }
 
 async fn connections_create(
     State(state): State<Arc<OAuthState>>,
     Json(payload): Json<ConnectionCreatePayload>,
 ) -> (StatusCode, Json<APIResponse>) {
-    match Connection::create(state.store.clone(), payload.provider).await {
+    match Connection::create(state.store.clone(), payload.provider, payload.metadata).await {
         Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
             "internal_server_error",

--- a/core/bin/sqlite_worker.rs
+++ b/core/bin/sqlite_worker.rs
@@ -286,7 +286,7 @@ fn main() {
             .with(JsonStorageLayer)
             .with(
                 BunyanFormattingLayer::new("sqlite_worker".into(), std::io::stdout)
-                    .skip_fields(vec!["file", "line", "target", "v", "pid"].into_iter())
+                    .skip_fields(vec!["file", "line", "target"].into_iter())
                     .unwrap(),
             )
             .with(tracing_subscriber::EnvFilter::new("info"))

--- a/core/bin/sqlite_worker.rs
+++ b/core/bin/sqlite_worker.rs
@@ -286,7 +286,7 @@ fn main() {
             .with(JsonStorageLayer)
             .with(
                 BunyanFormattingLayer::new("sqlite_worker".into(), std::io::stdout)
-                    .skip_fields(vec!["file", "line", "target"].into_iter())
+                    .skip_fields(vec!["file", "line", "target", "v", "pid"].into_iter())
                     .unwrap(),
             )
             .with(tracing_subscriber::EnvFilter::new("info"))

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -80,3 +80,8 @@ pub mod databases_store {
 
 pub mod cached_request;
 pub mod consts;
+
+pub mod oauth {
+    pub mod connection;
+    pub mod store;
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -84,4 +84,7 @@ pub mod consts;
 pub mod oauth {
     pub mod connection;
     pub mod store;
+    pub mod providers {
+        pub mod github;
+    }
 }

--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -1,8 +1,11 @@
 use crate::oauth::{providers::github::GithubConnectionProvider, store::OAuthStore};
 use crate::utils;
+use crate::utils::ParseError;
 use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -13,6 +16,22 @@ pub enum ConnectionProvider {
     Intercom,
     Notion,
     Slack,
+}
+
+impl fmt::Display for ConnectionProvider {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", serde_json::to_string(&self).unwrap())
+    }
+}
+
+impl FromStr for ConnectionProvider {
+    type Err = ParseError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match serde_json::from_str(s) {
+            Ok(v) => Ok(v),
+            Err(_) => Err(ParseError::new()),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Deserialize)]
@@ -55,6 +74,22 @@ pub fn provider(t: ConnectionProvider) -> Box<dyn Provider + Sync + Send> {
 pub enum ConnectionStatus {
     Pending,
     Finalized,
+}
+
+impl fmt::Display for ConnectionStatus {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", serde_json::to_string(&self).unwrap())
+    }
+}
+
+impl FromStr for ConnectionStatus {
+    type Err = ParseError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match serde_json::from_str(s) {
+            Ok(v) => Ok(v),
+            Err(_) => Err(ParseError::new()),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Clone)]

--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -1,0 +1,85 @@
+use crate::oauth::store::OAuthStore;
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConnectionProvider {
+    Notion,
+    Slack,
+    GoogleDrive,
+    Intercom,
+    Confluence,
+    Github,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConnectionStatus {
+    Pending,
+    Finalized,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct Connection {
+    connection_id: String,
+    created: u64,
+    provider: ConnectionProvider,
+    status: ConnectionStatus,
+    secret: String,
+    authorization_code: Option<String>,
+    access_token: Option<String>,
+    access_token_expiry: Option<u64>,
+    refresh_token: Option<String>,
+    raw_json: Option<serde_json::Value>,
+}
+
+impl Connection {
+    pub fn new(
+        connection_id: String,
+        created: u64,
+        provider: ConnectionProvider,
+        status: ConnectionStatus,
+        secret: String,
+    ) -> Self {
+        Connection {
+            connection_id,
+            created,
+            provider,
+            status,
+            secret,
+            authorization_code: None,
+            access_token: None,
+            access_token_expiry: None,
+            refresh_token: None,
+            raw_json: None,
+        }
+    }
+
+    pub fn connection_id(&self) -> String {
+        self.connection_id.clone()
+    }
+
+    pub fn created(&self) -> u64 {
+        self.created
+    }
+
+    pub fn provider(&self) -> ConnectionProvider {
+        self.provider
+    }
+
+    pub fn status(&self) -> ConnectionStatus {
+        self.status
+    }
+
+    pub fn secret(&self) -> String {
+        self.secret.clone()
+    }
+
+    pub async fn create(
+        store: Box<dyn OAuthStore + Sync + Send>,
+        provider: ConnectionProvider,
+    ) -> Result<Self> {
+        store.create_connection(provider).await
+    }
+}

--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -81,6 +81,10 @@ impl Connection {
         self.status
     }
 
+    pub fn metadata(&self) -> &serde_json::Value {
+        &self.metadata
+    }
+
     pub async fn create(
         store: Box<dyn OAuthStore + Sync + Send>,
         provider: ConnectionProvider,

--- a/core/src/oauth/providers/github.rs
+++ b/core/src/oauth/providers/github.rs
@@ -1,0 +1,28 @@
+use crate::oauth::connection::{
+    Connection, ConnectionProvider, FinalizeResult, Provider, RefreshResult,
+};
+use anyhow::Result;
+use async_trait::async_trait;
+
+pub struct GithubConnectionProvider {}
+
+impl GithubConnectionProvider {
+    pub fn new() -> Self {
+        GithubConnectionProvider {}
+    }
+}
+
+#[async_trait]
+impl Provider for GithubConnectionProvider {
+    fn id(&self) -> ConnectionProvider {
+        ConnectionProvider::Github
+    }
+
+    async fn finalize(&self, connection: &Connection, code: &str) -> Result<FinalizeResult> {
+        unimplemented!();
+    }
+
+    async fn refresh(&self, connection: &Connection) -> Result<RefreshResult> {
+        unimplemented!();
+    }
+}

--- a/core/src/oauth/store.rs
+++ b/core/src/oauth/store.rs
@@ -64,8 +64,8 @@ impl OAuthStore for PostgresOAuthStore {
         // Create connection
         let stmt = c
             .prepare(
-                "INSERT INTO connections (id, created, provider, status, secret)
-                   VALUES (DEFAULT, $1, $2, $3, $4, $5) RETURNING id",
+                "INSERT INTO connections (id, created, provider, secret, status, metadata)
+                   VALUES (DEFAULT, $1, $2, $3, $4, $5::jsonb) RETURNING id",
             )
             .await?;
         let row_id: i64 = c
@@ -74,9 +74,9 @@ impl OAuthStore for PostgresOAuthStore {
                 &[
                     &(created as i64),
                     &serde_json::to_string(&provider)?,
-                    &serde_json::to_string(&status)?,
                     &secret,
-                    &serde_json::to_string(&metadata)?,
+                    &serde_json::to_string(&status)?,
+                    &metadata,
                 ],
             )
             .await?
@@ -103,8 +103,9 @@ pub const POSTGRES_TABLES: [&'static str; 1] = ["-- connections
        id                   BIGSERIAL PRIMARY KEY,
        created              BIGINT NOT NULL,
        provider             TEXT NOT NULL,
-       status               TEXT NOT NULL,
        secret               TEXT NOT NULL,
+       status               TEXT NOT NULL,
+       metadata             JSONB,
        authorization_code   TEXT,
        access_token         TEXT,
        access_token_expiry  BIGINT,

--- a/core/src/oauth/store.rs
+++ b/core/src/oauth/store.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use crate::oauth::connection::{Connection, ConnectionProvider, ConnectionStatus};
 use crate::utils;
 use anyhow::Result;
@@ -78,9 +80,9 @@ impl OAuthStore for PostgresOAuthStore {
                 &stmt,
                 &[
                     &(created as i64),
-                    &serde_json::to_string(&provider)?,
+                    &provider.to_string(),
                     &secret,
-                    &serde_json::to_string(&status)?,
+                    &status.to_string(),
                     &metadata,
                 ],
             )
@@ -120,12 +122,12 @@ impl OAuthStore for PostgresOAuthStore {
                         refresh_token, raw_json
                    FROM connections
                    WHERE id = $1 AND provider = $2 AND secret = $3",
-                &[&row_id, &serde_json::to_string(&provider)?, &secret],
+                &[&row_id, &provider.to_string(), &secret],
             )
             .await?;
 
         let created: i64 = r.get(0);
-        let status: ConnectionStatus = serde_json::from_str(r.get(1))?;
+        let status: ConnectionStatus = ConnectionStatus::from_str(r.get(1))?;
         let metadata: serde_json::Value = r.get(2);
         let authorization_code: Option<String> = r.get(3);
         let access_token: Option<String> = r.get(4);

--- a/core/src/oauth/store.rs
+++ b/core/src/oauth/store.rs
@@ -1,0 +1,106 @@
+use crate::oauth::connection::{Connection, ConnectionProvider, ConnectionStatus};
+use crate::utils;
+use anyhow::Result;
+use async_trait::async_trait;
+use bb8::Pool;
+use bb8_postgres::PostgresConnectionManager;
+use tokio_postgres::NoTls;
+
+#[async_trait]
+pub trait OAuthStore {
+    async fn create_connection(&self, provider: ConnectionProvider) -> Result<Connection>;
+
+    fn clone_box(&self) -> Box<dyn OAuthStore + Sync + Send>;
+}
+
+impl Clone for Box<dyn OAuthStore + Sync + Send> {
+    fn clone(&self) -> Self {
+        self.clone_box()
+    }
+}
+
+#[derive(Clone)]
+pub struct PostgresOAuthStore {
+    pool: Pool<PostgresConnectionManager<NoTls>>,
+}
+
+impl PostgresOAuthStore {
+    pub async fn new(db_uri: &str) -> Result<Self> {
+        let manager = PostgresConnectionManager::new_from_stringlike(db_uri, NoTls)?;
+        let pool = Pool::builder().max_size(16).build(manager).await?;
+        Ok(Self { pool })
+    }
+
+    pub async fn init(&self) -> Result<()> {
+        let conn = self.pool.get().await?;
+        for table in POSTGRES_TABLES {
+            conn.execute(table, &[]).await?;
+        }
+        for index in SQL_INDEXES {
+            conn.execute(index, &[]).await?;
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl OAuthStore for PostgresOAuthStore {
+    async fn create_connection(&self, provider: ConnectionProvider) -> Result<Connection> {
+        let pool = self.pool.clone();
+        let c = pool.get().await?;
+
+        let created = utils::now();
+        let status = ConnectionStatus::Pending;
+        let secret = utils::new_id();
+
+        // Create connection
+        let stmt = c
+            .prepare(
+                "INSERT INTO connections (id, created, provider, status, secret)
+                   VALUES (DEFAULT, $1, $2, $3, $4) RETURNING id",
+            )
+            .await?;
+        let row_id: i64 = c
+            .query_one(
+                &stmt,
+                &[
+                    &(created as i64),
+                    &serde_json::to_string(&provider)?,
+                    &serde_json::to_string(&status)?,
+                    &secret,
+                ],
+            )
+            .await?
+            .get(0);
+
+        let connection_id = utils::make_id("con", row_id as u64)?;
+
+        Ok(Connection::new(
+            connection_id,
+            created,
+            provider,
+            status,
+            secret,
+        ))
+    }
+
+    fn clone_box(&self) -> Box<dyn OAuthStore + Sync + Send> {
+        Box::new(self.clone())
+    }
+}
+
+pub const POSTGRES_TABLES: [&'static str; 1] = ["-- connections
+    CREATE TABLE IF NOT EXISTS connections (
+       id                   BIGSERIAL PRIMARY KEY,
+       created              BIGINT NOT NULL,
+       provider             TEXT NOT NULL,
+       status               TEXT NOT NULL,
+       secret               TEXT NOT NULL,
+       authorization_code   TEXT,
+       access_token         TEXT,
+       access_token_expiry  BIGINT,
+       refresh_token        TEXT,
+       raw_json             JSONB
+    );"];
+
+pub const SQL_INDEXES: [&'static str; 0] = [];

--- a/core/src/oauth/store.rs
+++ b/core/src/oauth/store.rs
@@ -119,7 +119,7 @@ impl OAuthStore for PostgresOAuthStore {
                         authorization_code, access_token, access_token_expiry,
                         refresh_token, raw_json
                    FROM connections
-                   WHERE row_id = $1 AND provider = $2 AND secret = $3",
+                   WHERE id = $1 AND provider = $2 AND secret = $3",
                 &[&row_id, &serde_json::to_string(&provider)?, &secret],
             )
             .await?;

--- a/core/src/providers/provider.rs
+++ b/core/src/providers/provider.rs
@@ -1,6 +1,7 @@
 use crate::providers::anthropic::AnthropicProvider;
 use crate::providers::azure_openai::AzureOpenAIProvider;
 use crate::providers::embedder::Embedder;
+use crate::providers::google_ai_studio::GoogleAiStudioProvider;
 use crate::providers::llm::LLM;
 use crate::providers::mistral::MistralProvider;
 use crate::providers::openai::OpenAIProvider;
@@ -13,8 +14,6 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
 use std::time::Duration;
-
-use super::google_ai_studio::GoogleAiStudioProvider;
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, ValueEnum, Deserialize)]
 #[serde(rename_all = "lowercase")]

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -172,15 +172,15 @@ const RESOURCE_S_ID_MIN_LENGTH: u8 = 10;
 const SHARD_KEY: u64 = 1;
 const REGION: u64 = 1;
 
-pub fn make_id(prefix: &str, id: usize) -> Result<String> {
+pub fn make_id(prefix: &str, id: u64) -> Result<String> {
     let sqids = Sqids::builder()
         .min_length(RESOURCE_S_ID_MIN_LENGTH)
         .build()?;
-    let id = sqids.encode(&[REGION, SHARD_KEY, id as u64])?;
+    let id = sqids.encode(&[REGION, SHARD_KEY, id])?;
     Ok(format!("{}_{}", prefix, id))
 }
 
-pub fn parse_id(id: &str) -> Result<(String, u64, u64, usize)> {
+pub fn parse_id(id: &str) -> Result<(String, u64, u64, u64)> {
     let sqids = Sqids::builder()
         .min_length(RESOURCE_S_ID_MIN_LENGTH)
         .build()?;
@@ -196,10 +196,5 @@ pub fn parse_id(id: &str) -> Result<(String, u64, u64, usize)> {
         return Err(anyhow::anyhow!("Invalid id decoding failed: {}", id));
     }
 
-    Ok((
-        prefix.to_string(),
-        decoded[0],
-        decoded[1],
-        decoded[2] as usize,
-    ))
+    Ok((prefix.to_string(), decoded[0], decoded[1], decoded[2]))
 }

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -4,6 +4,7 @@ use axum::Json;
 use hyper::StatusCode;
 use serde::Serialize;
 use serde_json::Value;
+use sqids::Sqids;
 use std::io::Write;
 use tower_http::trace::MakeSpan;
 use uuid::Uuid;
@@ -163,4 +164,42 @@ impl<B> MakeSpan<B> for CoreRequestMakeSpan {
             request_span_id = new_id()[0..12].to_string(),
         )
     }
+}
+
+// sqids
+// Aligned with front. Main difference is that we don't have workspace ids in our core ids.
+const RESOURCE_S_ID_MIN_LENGTH: u8 = 10;
+const SHARD_KEY: u64 = 1;
+const REGION: u64 = 1;
+
+pub fn make_id(prefix: &str, id: usize) -> Result<String> {
+    let sqids = Sqids::builder()
+        .min_length(RESOURCE_S_ID_MIN_LENGTH)
+        .build()?;
+    let id = sqids.encode(&[REGION, SHARD_KEY, id as u64])?;
+    Ok(format!("{}_{}", prefix, id))
+}
+
+pub fn parse_id(id: &str) -> Result<(String, u64, u64, usize)> {
+    let sqids = Sqids::builder()
+        .min_length(RESOURCE_S_ID_MIN_LENGTH)
+        .build()?;
+    let parts = id.split('_').collect::<Vec<&str>>();
+    if parts.len() != 2 {
+        return Err(anyhow::anyhow!("Invalid id format: {}", id));
+    }
+
+    let prefix = parts[0];
+    let decoded = sqids.decode(parts[1]);
+
+    if decoded.len() != 3 {
+        return Err(anyhow::anyhow!("Invalid id decoding failed: {}", id));
+    }
+
+    Ok((
+        prefix.to_string(),
+        decoded[0],
+        decoded[1],
+        decoded[2] as usize,
+    ))
 }

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -180,7 +180,7 @@ pub fn make_id(prefix: &str, id: u64) -> Result<String> {
     Ok(format!("{}_{}", prefix, id))
 }
 
-pub fn parse_id(id: &str) -> Result<(String, u64, u64, u64)> {
+pub fn parse_id(id: &str) -> Result<(String, u64)> {
     let sqids = Sqids::builder()
         .min_length(RESOURCE_S_ID_MIN_LENGTH)
         .build()?;
@@ -196,5 +196,5 @@ pub fn parse_id(id: &str) -> Result<(String, u64, u64, u64)> {
         return Err(anyhow::anyhow!("Invalid id decoding failed: {}", id));
     }
 
-    Ok((prefix.to_string(), decoded[0], decoded[1], decoded[2]))
+    Ok((prefix.to_string(), decoded[2]))
 }

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -44,6 +44,9 @@ const config = {
       EnvironmentConfig.getOptionalEnvVariable("CUSTOMERIO_ENABLED") === "true"
     );
   },
+  getOAuthGithubApp: (): string => {
+    return EnvironmentConfig.getEnvVariable("OAUTH_GITHUB_APP");
+  },
 };
 
 export default config;

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -192,7 +192,7 @@ export async function finalizeConnection(
 
   const api = new OAuthAPI(logger);
 
-  const cRes = await api.finalizeConnection({ connectionId, code });
+  const cRes = await api.finalizeConnection({ provider, connectionId, code });
   logger.error(
     {
       provider,

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -1,0 +1,10 @@
+import type { OAuthProvider } from "@dust-tt/types";
+
+import type { Authenticator } from "@app/lib/auth";
+
+export async function createConnectionAndGetRedirectURL(
+  auth: Authenticator,
+  provider: OAuthProvider
+): Promise<string> {
+  return "";
+}

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -1,10 +1,56 @@
+import type { OAuthAPIError, Result } from "@dust-tt/types";
 import type { OAuthProvider } from "@dust-tt/types";
+import { Err, OAuthAPI, Ok } from "@dust-tt/types";
 
 import type { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
+
+const { OAUTH_GITHUB_APP = "" } = process.env;
+
+export const OAUTH_USE_CASES = ["connection"] as const;
+
+export type OAuthUseCase = (typeof OAUTH_USE_CASES)[number];
+
+export function isOAuthUseCase(obj: unknown): obj is OAuthUseCase {
+  return OAUTH_USE_CASES.includes(obj as OAuthUseCase);
+}
+
+export type OAuthError = {
+  code: "connection_creation_failed";
+  message: string;
+  oAuthAPIError?: OAuthAPIError;
+};
 
 export async function createConnectionAndGetRedirectURL(
   auth: Authenticator,
-  provider: OAuthProvider
-): Promise<string> {
-  return "";
+  provider: OAuthProvider,
+  useCase: OAuthUseCase
+): Promise<Result<string, OAuthError>> {
+  const api = new OAuthAPI(logger);
+
+  const cRes = await api.createConnection(provider, {
+    use_case: useCase,
+    workspace_id: auth.getNonNullableWorkspace().sId,
+    user_id: auth.getNonNullableUser().sId,
+  });
+  if (cRes.isErr()) {
+    return new Err({
+      code: "connection_creation_failed",
+      message: "Failed to create new OAuth connection",
+      oAuthAPIError: cRes.error,
+    });
+  }
+
+  const connection = cRes.value.connection;
+
+  switch (provider) {
+    case "github":
+      return new Ok(
+        // Only the `installations/new` URL supports state passing.
+        `https://github.com/apps/${OAUTH_GITHUB_APP}/installations/new` +
+          `?state=${connection.connection_id}`
+      );
+    default:
+      throw new Error(`Unsupported provider: ${provider}`);
+  }
 }

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -7,10 +7,9 @@ import type { OAuthProvider } from "@dust-tt/types";
 import { Err, OAuthAPI, Ok } from "@dust-tt/types";
 import type { ParsedUrlQuery } from "querystring";
 
+import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
-
-const { OAUTH_GITHUB_APP = "" } = process.env;
 
 export const OAUTH_USE_CASES = ["connection"] as const;
 
@@ -51,7 +50,7 @@ const PROVIDER_STRATEGIES: Record<
     redirectUrl: (connection) => {
       // Only the `installations/new` URL supports state passing.
       return new Ok(
-        `https://github.com/apps/${OAUTH_GITHUB_APP}/installations/new` +
+        `https://github.com/apps/${config.getOAuthGithubApp()}/installations/new` +
           `?state=${connection.connection_id}`
       );
     },

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -1,6 +1,11 @@
-import type { OAuthAPIError, Result } from "@dust-tt/types";
+import type {
+  OAuthAPIError,
+  OAuthConnectionType,
+  Result,
+} from "@dust-tt/types";
 import type { OAuthProvider } from "@dust-tt/types";
 import { Err, OAuthAPI, Ok } from "@dust-tt/types";
+import type { ParsedUrlQuery } from "querystring";
 
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
@@ -16,9 +21,113 @@ export function isOAuthUseCase(obj: unknown): obj is OAuthUseCase {
 }
 
 export type OAuthError = {
-  code: "connection_creation_failed";
+  code:
+    | "connection_creation_failed"
+    | "connection_not_implemented"
+    | "connection_finalization_failed";
   message: string;
   oAuthAPIError?: OAuthAPIError;
+};
+
+function getStringFromQuery(query: ParsedUrlQuery, key: string): string | null {
+  const value = query[key];
+  if (typeof value != "string") {
+    return null;
+  }
+  return value;
+}
+
+const PROVIDER_STRATEGIES: Record<
+  OAuthProvider,
+  {
+    redirectUrl: (
+      connection: OAuthConnectionType
+    ) => Result<string, OAuthError>;
+    codeFromQuery: (query: ParsedUrlQuery) => string | null;
+    connectionIdFromQuery: (query: ParsedUrlQuery) => string | null;
+  }
+> = {
+  github: {
+    redirectUrl: (connection) => {
+      // Only the `installations/new` URL supports state passing.
+      return new Ok(
+        `https://github.com/apps/${OAUTH_GITHUB_APP}/installations/new` +
+          `?state=${connection.connection_id}`
+      );
+    },
+    // {
+    //   installation_id: '52689080',
+    //   setup_action: 'update',
+    //   state: 'con_...-...',
+    //   provider: 'github'
+    // }
+    codeFromQuery: (query) => {
+      return getStringFromQuery(query, "installation_id");
+    },
+    connectionIdFromQuery: (query) => {
+      return getStringFromQuery(query, "state");
+    },
+  },
+  google_drive: {
+    redirectUrl: () => {
+      return new Err({
+        code: "connection_not_implemented",
+        message: "Google Drive OAuth is not implemented",
+      });
+    },
+    codeFromQuery: () => null,
+    connectionIdFromQuery: () => null,
+  },
+  notion: {
+    redirectUrl: () => {
+      return new Err({
+        code: "connection_not_implemented",
+        message: "Notion OAuth is not implemented",
+      });
+    },
+    codeFromQuery: () => null,
+    connectionIdFromQuery: () => null,
+  },
+  slack: {
+    redirectUrl: () => {
+      return new Err({
+        code: "connection_not_implemented",
+        message: "Slack OAuth is not implemented",
+      });
+    },
+    codeFromQuery: () => null,
+    connectionIdFromQuery: () => null,
+  },
+  confluence: {
+    redirectUrl: () => {
+      return new Err({
+        code: "connection_not_implemented",
+        message: "Confluence OAuth is not implemented",
+      });
+    },
+    codeFromQuery: () => null,
+    connectionIdFromQuery: () => null,
+  },
+  intercom: {
+    redirectUrl: () => {
+      return new Err({
+        code: "connection_not_implemented",
+        message: "Intercom OAuth is not implemented",
+      });
+    },
+    codeFromQuery: () => null,
+    connectionIdFromQuery: () => null,
+  },
+  microsoft: {
+    redirectUrl: () => {
+      return new Err({
+        code: "connection_not_implemented",
+        message: "Microsoft OAuth is not implemented",
+      });
+    },
+    codeFromQuery: () => null,
+    connectionIdFromQuery: () => null,
+  },
 };
 
 export async function createConnectionAndGetRedirectURL(
@@ -28,12 +137,16 @@ export async function createConnectionAndGetRedirectURL(
 ): Promise<Result<string, OAuthError>> {
   const api = new OAuthAPI(logger);
 
-  const cRes = await api.createConnection(provider, {
-    use_case: useCase,
-    workspace_id: auth.getNonNullableWorkspace().sId,
-    user_id: auth.getNonNullableUser().sId,
+  const cRes = await api.createConnection({
+    provider,
+    metadata: {
+      use_case: useCase,
+      workspace_id: auth.getNonNullableWorkspace().sId,
+      user_id: auth.getNonNullableUser().sId,
+    },
   });
   if (cRes.isErr()) {
+    logger.error({ provider, useCase }, "OAuth: Failed to create connection");
     return new Err({
       code: "connection_creation_failed",
       message: "Failed to create new OAuth connection",
@@ -43,14 +156,58 @@ export async function createConnectionAndGetRedirectURL(
 
   const connection = cRes.value.connection;
 
-  switch (provider) {
-    case "github":
-      return new Ok(
-        // Only the `installations/new` URL supports state passing.
-        `https://github.com/apps/${OAUTH_GITHUB_APP}/installations/new` +
-          `?state=${connection.connection_id}`
-      );
-    default:
-      throw new Error(`Unsupported provider: ${provider}`);
+  return PROVIDER_STRATEGIES[provider].redirectUrl(connection);
+}
+
+export async function finalizeConnection(
+  provider: OAuthProvider,
+  query: ParsedUrlQuery
+): Promise<Result<OAuthConnectionType, OAuthError>> {
+  const code = PROVIDER_STRATEGIES[provider].codeFromQuery(query);
+
+  if (!code) {
+    logger.error(
+      { provider, step: "code_extraction" },
+      "OAuth: Failed to finalize connection"
+    );
+    return new Err({
+      code: "connection_finalization_failed",
+      message: `Failed to finalize ${provider} connection: authorization code not found in query`,
+    });
   }
+
+  const connectionId =
+    PROVIDER_STRATEGIES[provider].connectionIdFromQuery(query);
+
+  if (!connectionId) {
+    logger.error(
+      { provider, step: "connection_extraction" },
+      "OAuth: Failed to finalize connection"
+    );
+    return new Err({
+      code: "connection_finalization_failed",
+      message: `Failed to finalize ${provider} connection: connection not found in query`,
+    });
+  }
+
+  const api = new OAuthAPI(logger);
+
+  const cRes = await api.finalizeConnection({ connectionId, code });
+  logger.error(
+    {
+      provider,
+      connectionId,
+      step: "connection_finalization",
+    },
+    "OAuth: Failed to finalize connection"
+  );
+  if (cRes.isErr()) {
+    return new Err({
+      code: "connection_finalization_failed",
+      message: `Failed to finalize ${provider} connection: ${cRes.error.message}`,
+      oAuthAPIError: cRes.error,
+    });
+  }
+
+  return new Ok(cRes.value.connection);
 }

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -492,6 +492,18 @@ export class Authenticator {
     return this._user ? renderUserType(this._user) : null;
   }
 
+  getNonNullableUser(): UserType {
+    const user = this.user();
+
+    if (!user) {
+      throw new Error(
+        "Unexpected unauthenticated call to `getNonNullableUser`."
+      );
+    }
+
+    return user;
+  }
+
   isDustSuperUser(): boolean {
     if (!this._user) {
       return false;

--- a/front/lib/oauth.ts
+++ b/front/lib/oauth.ts
@@ -1,0 +1,40 @@
+import type { OAuthProvider } from "@dust-tt/types";
+
+export async function auth(
+  dustClientFacingUrl: string,
+  provider: OAuthProvider
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const oauthPopup = window.open(
+      `${dustClientFacingUrl}/oauth/${provider}/redirect`
+    );
+    let authComplete = false;
+
+    const popupMessageEventListener = (event: MessageEvent) => {
+      if (event.origin !== window.location.origin) {
+        return;
+      }
+
+      if (event.data.type === "connection_finalized") {
+        authComplete = true;
+        resolve(event.data.connection_id);
+        window.removeEventListener("message", popupMessageEventListener);
+        oauthPopup?.close();
+      }
+    };
+
+    window.addEventListener("message", popupMessageEventListener);
+
+    const checkPopupStatus = setInterval(() => {
+      if (oauthPopup && oauthPopup.closed) {
+        window.removeEventListener("message", popupMessageEventListener);
+        clearInterval(checkPopupStatus);
+        setTimeout(() => {
+          if (!authComplete) {
+            reject(new Error("User closed the window before auth completed"));
+          }
+        }, 100);
+      }
+    }, 100);
+  });
+}

--- a/front/lib/oauth.ts
+++ b/front/lib/oauth.ts
@@ -1,12 +1,21 @@
-import type { OAuthProvider } from "@dust-tt/types";
+import type { OAuthProvider, WorkspaceType } from "@dust-tt/types";
 
-export async function auth(
-  dustClientFacingUrl: string,
-  provider: OAuthProvider
-): Promise<string> {
+import type { OAuthUseCase } from "@app/lib/api/oauth";
+
+export async function auth({
+  owner,
+  provider,
+  useCase,
+  dustClientFacingUrl,
+}: {
+  owner: WorkspaceType;
+  provider: OAuthProvider;
+  useCase: OAuthUseCase;
+  dustClientFacingUrl: string;
+}): Promise<string> {
   return new Promise((resolve, reject) => {
     const oauthPopup = window.open(
-      `${dustClientFacingUrl}/oauth/${provider}/redirect`
+      `${dustClientFacingUrl}/w/${owner.sId}/oauth/${provider}/redirect?useCase=${useCase}`
     );
     let authComplete = false;
 
@@ -17,7 +26,7 @@ export async function auth(
 
       if (event.data.type === "connection_finalized") {
         authComplete = true;
-        resolve(event.data.connection_id);
+        resolve(event.data.connectionId);
         window.removeEventListener("message", popupMessageEventListener);
         oauthPopup?.close();
       }

--- a/front/pages/oauth/[provider]/finalize.tsx
+++ b/front/pages/oauth/[provider]/finalize.tsx
@@ -1,0 +1,55 @@
+import { isOAuthProvider } from "@dust-tt/types";
+import type { InferGetServerSidePropsType } from "next";
+import { useEffect } from "react";
+
+import { finalizeConnection } from "@app/lib/api/oauth";
+import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";
+
+// This endpoint is authenticated but cannot be workspace specific as it is hard-coded at each
+// provider as our callback URI.
+export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
+  requireUserPrivilege: "user",
+})<{
+  connectionId: string;
+}>(async (context) => {
+  const provider = context.query.provider as string;
+  if (!isOAuthProvider(provider)) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const cRes = await finalizeConnection(provider, context.query);
+  if (!cRes.isOk()) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      connectionId: cRes.value.connection_id,
+    },
+  };
+});
+
+export default function Finalize({
+  connectionId,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  useEffect(() => {
+    // When the component mounts and connectionId is available, send a message `connection_finalized
+    // `to the window that opened this one.
+    if (connectionId) {
+      window.opener &&
+        window.opener.postMessage(
+          {
+            type: "connection_finalized",
+            connectionId: connectionId,
+          },
+          window.location.origin
+        );
+    }
+  }, [connectionId]);
+
+  return null; // Render nothing.
+}

--- a/front/pages/oauth/[provider]/redirect.tsx
+++ b/front/pages/oauth/[provider]/redirect.tsx
@@ -1,0 +1,39 @@
+import { isOAuthAPIError } from "@dust-tt/types";
+
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+import { createConnectionAndGetRedirectURL } from "@app/lib/oauth";
+
+export const getServerSideProps = withDefaultUserAuthRequirements<object>(
+  async (context, auth) => {
+    if (!auth.workspace() || !auth.user()) {
+      return {
+        notFound: true,
+      };
+    }
+
+    const provider = context.query.provider as string;
+    if (!isOAuthAPIError(provider)) {
+      return {
+        notFound: true,
+      };
+    }
+
+    const url = await createConnectionAndGetRedirectURL(auth, provider);
+    // Optionally retrieve connectionId to update an existing connection.
+    // const connectionId = (context.query.connectionId as string) || null;
+
+    // Create a new connection
+    // Generate URL for redirect
+
+    return {
+      redirect: {
+        destination: `/w/${context.query.wId}/assistant/new`,
+        permanent: false,
+      },
+    };
+  }
+);
+
+export default function Redirect() {
+  return <></>;
+}

--- a/front/pages/w/[wId]/oauth/[provider]/setup.tsx
+++ b/front/pages/w/[wId]/oauth/[provider]/setup.tsx
@@ -14,7 +14,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<object>(
       };
     }
 
-    console.log("context.query", context.query);
     const provider = context.query.provider as string;
     if (!isOAuthProvider(provider)) {
       return {

--- a/init_dev_container.sh
+++ b/init_dev_container.sh
@@ -5,6 +5,7 @@ psql "postgres://dev:dev@localhost:5432/" -c "CREATE DATABASE dust_api;";
 psql "postgres://dev:dev@localhost:5432/" -c "CREATE DATABASE dust_databases_store;";
 psql "postgres://dev:dev@localhost:5432/" -c "CREATE DATABASE dust_front;";
 psql "postgres://dev:dev@localhost:5432/" -c "CREATE DATABASE dust_connectors;";
+psql "postgres://dev:dev@localhost:5432/" -c "CREATE DATABASE dust_oauth;";
 
 ## Initilizing Qdrant collections
 cd core/

--- a/types/src/core/oauth_api.ts
+++ b/types/src/core/oauth_api.ts
@@ -86,7 +86,7 @@ export class OAuthAPI {
     code: string;
   }): Promise<OAuthAPIResponse<{ connection: OAuthConnectionType }>> {
     const response = await this._fetchWithError(
-      `${OAUTH_API}/connections/${connectionId}`,
+      `${OAUTH_API}/connections/${connectionId}/finalize`,
       {
         method: "POST",
         headers: {

--- a/types/src/core/oauth_api.ts
+++ b/types/src/core/oauth_api.ts
@@ -77,9 +77,11 @@ export class OAuthAPI {
   }
 
   async finalizeConnection({
+    provider,
     connectionId,
     code,
   }: {
+    provider: OAuthProvider;
     connectionId: string;
     code: string;
   }): Promise<OAuthAPIResponse<{ connection: OAuthConnectionType }>> {
@@ -91,6 +93,7 @@ export class OAuthAPI {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
+          provider,
           code,
         }),
       }

--- a/types/src/core/oauth_api.ts
+++ b/types/src/core/oauth_api.ts
@@ -56,10 +56,13 @@ export class OAuthAPI {
     return OAUTH_API;
   }
 
-  async createConnection(
-    provider: OAuthProvider,
-    metadata: Record<string, unknown> | null = null
-  ): Promise<OAuthAPIResponse<{ connection: OAuthConnectionType }>> {
+  async createConnection({
+    provider,
+    metadata,
+  }: {
+    provider: OAuthProvider;
+    metadata: Record<string, unknown> | null;
+  }): Promise<OAuthAPIResponse<{ connection: OAuthConnectionType }>> {
     const response = await this._fetchWithError(`${OAUTH_API}/connections`, {
       method: "POST",
       headers: {
@@ -70,6 +73,28 @@ export class OAuthAPI {
         metadata,
       }),
     });
+    return this._resultFromResponse(response);
+  }
+
+  async finalizeConnection({
+    connectionId,
+    code,
+  }: {
+    connectionId: string;
+    code: string;
+  }): Promise<OAuthAPIResponse<{ connection: OAuthConnectionType }>> {
+    const response = await this._fetchWithError(
+      `${OAUTH_API}/connections/${connectionId}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          code,
+        }),
+      }
+    );
     return this._resultFromResponse(response);
   }
 

--- a/types/src/core/oauth_api.ts
+++ b/types/src/core/oauth_api.ts
@@ -57,7 +57,8 @@ export class OAuthAPI {
   }
 
   async createConnection(
-    provider: OAuthProvider
+    provider: OAuthProvider,
+    metadata: Record<string, unknown> | null = null
   ): Promise<OAuthAPIResponse<{ connection: OAuthConnectionType }>> {
     const response = await this._fetchWithError(`${OAUTH_API}/connections`, {
       method: "POST",
@@ -66,6 +67,7 @@ export class OAuthAPI {
       },
       body: JSON.stringify({
         provider,
+        metadata,
       }),
     });
     return this._resultFromResponse(response);

--- a/types/src/core/oauth_api.ts
+++ b/types/src/core/oauth_api.ts
@@ -1,0 +1,208 @@
+import { LoggerInterface } from "../shared/logger";
+import { Err, Ok, Result } from "../shared/result";
+
+export const OAUTH_PROVIDERS = [
+  "confluence",
+  "github",
+  "google_drive",
+  "intercom",
+  "notion",
+  "slack",
+  "microsoft",
+] as const;
+
+export type OAuthProvider = (typeof OAUTH_PROVIDERS)[number];
+
+export function isOAuthProvider(obj: unknown): obj is OAuthProvider {
+  return OAUTH_PROVIDERS.includes(obj as OAuthProvider);
+}
+
+const { OAUTH_API = "http://127.0.0.1:3006" } = process.env;
+
+export type OAuthAPIError = {
+  message: string;
+  code: string;
+};
+
+export function isOAuthAPIError(obj: unknown): obj is OAuthAPIError {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    "message" in obj &&
+    typeof obj.message === "string" &&
+    "code" in obj &&
+    typeof obj.code === "string"
+  );
+}
+
+export type OAuthAPIResponse<T> = Result<T, OAuthAPIError>;
+
+export type OAuthConnectionType = {
+  connection_id: string;
+  created: number;
+  provider: OAuthProvider;
+  status: "pending" | "finalized";
+  secret: string;
+};
+
+export class OAuthAPI {
+  _logger: LoggerInterface;
+
+  constructor(logger: LoggerInterface) {
+    this._logger = logger;
+  }
+
+  apiUrl() {
+    return OAUTH_API;
+  }
+
+  async createConnection(
+    provider: OAuthProvider
+  ): Promise<OAuthAPIResponse<{ connection: OAuthConnectionType }>> {
+    const response = await this._fetchWithError(`${OAUTH_API}/connections`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        provider,
+      }),
+    });
+    return this._resultFromResponse(response);
+  }
+
+  private async _fetchWithError(
+    url: string,
+    init?: RequestInit
+  ): Promise<Result<{ response: Response; duration: number }, OAuthAPIError>> {
+    const now = Date.now();
+    try {
+      const res = await fetch(url, init);
+      return new Ok({ response: res, duration: Date.now() - now });
+    } catch (e) {
+      const duration = Date.now() - now;
+      const err: OAuthAPIError = {
+        code: "unexpected_network_error",
+        message: `Unexpected network error from OAuthAPI: ${e}`,
+      };
+      this._logger.error(
+        {
+          url,
+          duration,
+          oAuthError: err,
+          error: e,
+        },
+        "OAuthAPI error"
+      );
+      return new Err(err);
+    }
+  }
+
+  private async _resultFromResponse<T>(
+    res: Result<
+      {
+        response: Response;
+        duration: number;
+      },
+      OAuthAPIError
+    >
+  ): Promise<OAuthAPIResponse<T>> {
+    if (res.isErr()) {
+      return res;
+    }
+
+    // We get the text and attempt to parse so that we can log the raw text in case of error (the
+    // body is already consumed by response.json() if used otherwise).
+    const text = await res.value.response.text();
+
+    let json = null;
+    try {
+      json = JSON.parse(text);
+    } catch (e) {
+      const err: OAuthAPIError = {
+        code: "unexpected_response_format",
+        message: `Unexpected response format from OAuthAPI: ${e}`,
+      };
+
+      this._logger.error(
+        {
+          oAuthError: err,
+          parseError: e,
+          rawText: text,
+          status: res.value.response.status,
+          url: res.value.response.url,
+          duration: res.value.duration,
+        },
+        "OAuthAPI error"
+      );
+      return new Err(err);
+    }
+
+    if (!res.value.response.ok) {
+      const err = json?.error;
+      if (isOAuthAPIError(err)) {
+        this._logger.error(
+          {
+            oAuthError: err,
+            status: res.value.response.status,
+            url: res.value.response.url,
+            duration: res.value.duration,
+          },
+          "OAuthAPI error"
+        );
+        return new Err(err);
+      } else {
+        const err: OAuthAPIError = {
+          code: "unexpected_error_format",
+          message: "Unexpected error format from OAuthAPI",
+        };
+        this._logger.error(
+          {
+            oAuthError: err,
+            json,
+            status: res.value.response.status,
+            url: res.value.response.url,
+            duration: res.value.duration,
+          },
+          "OAuthAPI error"
+        );
+        return new Err(err);
+      }
+    } else {
+      const err = json?.error;
+      const res = json?.response;
+
+      if (err && isOAuthAPIError(err)) {
+        this._logger.error(
+          {
+            oauthError: err,
+            json,
+            status: res.value.response.status,
+            url: res.value.response.url,
+            duration: res.value.duration,
+          },
+          "OAuthAPI error"
+        );
+        return new Err(err);
+      } else if (res) {
+        return new Ok(res);
+      } else {
+        const err: OAuthAPIError = {
+          code: "unexpected_response_format",
+          message: "Unexpected response format from OAuthAPI",
+        };
+        this._logger.error(
+          {
+            oAuthError: err,
+            json,
+            status: res.value.response.status,
+            url: res.value.response.url,
+            duration: res.value.duration,
+          },
+          "OAuthAPI error"
+        );
+        return new Err(err);
+      }
+    }
+  }
+}

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -12,6 +12,7 @@ export * from "./connectors/notion";
 export * from "./connectors/slack";
 export * from "./connectors/webcrawler";
 export * from "./core/data_source";
+export * from "./core/oauth_api";
 export * from "./front/api_handlers/internal/agent_configuration";
 export * from "./front/api_handlers/internal/assistant";
 export * from "./front/api_handlers/public/assistant";


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/dust/issues/6122

Scaffolding of the new `oauth` "core/front" service

### `types`

- `OAuthAPI` standard client library to interact with the `oauth` service
  - `createConnection` creates a new pending `OAuthConnectionType`
  - `finalizeConnection` finalizes the connection based on the received authorization `code`

### `front`

- `lib/api/oauth.ts` exposes:
  - `createConnectionAndGetRedirectURL` used by the `setup` front endpoint (egress setup redirect)
  - `finalizeConnection` used by the `finalize` endpoint (ingress return of the user)
  - very pragmatic / succinct strategies per provider to generate URLs and extract `connectionId` and `code` from return URLs. See  `PROVIDER_STRATEGIES`.

- `pages/w/[wId]/oauth/[provider]/setup.tsx` page to redirect users for setup (authenticated with Authenticator)
- `pages/oauth/[provider]/finalize.tsx` return page authenticated (but no Authenticator as URL must be fixed)

### `core/oauth`

- new `oauth` binary that exposes the Connection creation and finalization endpoint
- `oauth/store.rs` interface to the new DB
- `oauth/connection.rs` generic implementation, will enforce distributed locking for refresh
- `oauth/providers/...` provider specific strategies to finalize and refresh tokens
- As discussed `Connection.connection_id` is generated from the `row_id` and the `secret` of the Connection which is entirely abstracted by the `store` and helper functions in `connection.rs`

Not implemented yet:
- token refresh
- per provider finalization
- salting of DB

Right now it's possible to run an end-to-end "setup" flow with Github on a new `dust-data-sources-test` app:
- (i) visit `http://localhost:3000/w/UriWRtz9C3/oauth/github/setup?useCase=connection`
- (ii) gets redirected to Github + setup there
- (iii) gets redirect back to `front` on `http://localhost:3000/oauth/github/finalize?installation_id=52689080&setup_action=update&state=con_Td1Rn5QaMW-29b3168580746bd5f61c432c1c331c21e8be3b6ac078fb8c2135e3a367b57089` which calls into `oauth` to finalize and go all the way the GithubConnectionProvider dummy implementation:
```
Finalize for "github"/con_Bfj3oHJlRZ-eb8b9e42e66c498da062d16db349d33a4198026b4bd8e01281ea98b72f6761f2
```

Next steps (while entirely in development, without deploying anything)
- Implement salting of DB
- Implement `connection.rs` generic logic 
- Implement refresh of tokens
- Implement GithubConnectionProvider all the way to and end-to-end functioning system
- Implement Notion and Confluence end-to-end

Will start tracking the env-variable we will have to rely on in https://www.notion.so/dust-tt/Remove-Nango-72fdcee1b51a49d3bcb4dd5a2fb93bf0?pvs=4#528cf403fd5f44b9b2b10aac172d49cc

## Risk

None. Service is not built, front endpoints are not tied to anything and will just error safely in prod. `oauth` is not deployed.

## Deploy Plan

- N/A