### PR TITLE
Flav/content block wrapper

### DIFF
--- a/front/components/actions/dust_app_run/DustAppRunActionDetails.tsx
+++ b/front/components/actions/dust_app_run/DustAppRunActionDetails.tsx
@@ -6,8 +6,8 @@ import { useMemo } from "react";
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
 import type { ActionDetailsComponentBaseProps } from "@app/components/actions/types";
 import { CodeBlock } from "@app/components/assistant/RenderMessageMarkdown";
-import type { GetContentToDownloadFunction } from "@app/components/misc/CodeBlockBanner";
-import { CodeBlockBanner } from "@app/components/misc/CodeBlockBanner";
+import type { GetContentToDownloadFunction } from "@app/components/misc/ContentBlockWrapper";
+import { ContentBlockWrapper } from "@app/components/misc/ContentBlockWrapper";
 
 export function DustAppRunActionDetails({
   action,
@@ -75,7 +75,7 @@ function DustAppRunOutputDetails({ action }: { action: DustAppRunActionType }) {
   }
 
   return (
-    <CodeBlockBanner
+    <ContentBlockWrapper
       content={stringifiedOutput}
       getContentToDownload={getContentToDownload}
     >
@@ -85,6 +85,6 @@ function DustAppRunOutputDetails({ action }: { action: DustAppRunActionType }) {
       >
         {stringifiedOutput}
       </CodeBlock>
-    </CodeBlockBanner>
+    </ContentBlockWrapper>
   );
 }

--- a/front/components/actions/process/ProcessActionDetails.tsx
+++ b/front/components/actions/process/ProcessActionDetails.tsx
@@ -6,8 +6,8 @@ import { useMemo } from "react";
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
 import type { ActionDetailsComponentBaseProps } from "@app/components/actions/types";
 import { CodeBlock } from "@app/components/assistant/RenderMessageMarkdown";
-import type { GetContentToDownloadFunction } from "@app/components/misc/CodeBlockBanner";
-import { CodeBlockBanner } from "@app/components/misc/CodeBlockBanner";
+import type { GetContentToDownloadFunction } from "@app/components/misc/ContentBlockWrapper";
+import { ContentBlockWrapper } from "@app/components/misc/ContentBlockWrapper";
 
 export function ProcessActionDetails({
   action,
@@ -106,7 +106,7 @@ function ProcessActionOutputDetails({ action }: { action: ProcessActionType }) {
   }
 
   return (
-    <CodeBlockBanner
+    <ContentBlockWrapper
       content={stringifiedOutput}
       getContentToDownload={getContentToDownload}
     >
@@ -116,6 +116,6 @@ function ProcessActionOutputDetails({ action }: { action: ProcessActionType }) {
       >
         {stringifiedOutput}
       </CodeBlock>
-    </CodeBlockBanner>
+    </ContentBlockWrapper>
   );
 }

--- a/front/components/actions/tables_query/TablesQueryActionDetails.tsx
+++ b/front/components/actions/tables_query/TablesQueryActionDetails.tsx
@@ -6,7 +6,7 @@ import { useCallback, useContext } from "react";
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
 import type { ActionDetailsComponentBaseProps } from "@app/components/actions/types";
 import { CodeBlock } from "@app/components/assistant/RenderMessageMarkdown";
-import { CodeBlockBanner } from "@app/components/misc/CodeBlockBanner";
+import { ContentBlockWrapper } from "@app/components/misc/ContentBlockWrapper";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 
 export function TablesQueryActionDetails({
@@ -51,14 +51,14 @@ function TablesQuery({ action }: { action: TablesQueryActionType }) {
   }
 
   return (
-    <CodeBlockBanner content={query}>
+    <ContentBlockWrapper content={query}>
       <CodeBlock
         className="language-sql max-h-60 overflow-y-auto"
         wrapLongLines={true}
       >
         {query}
       </CodeBlock>
-    </CodeBlockBanner>
+    </ContentBlockWrapper>
   );
 }
 

--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -4,7 +4,7 @@ import type { RetrievalDocumentType } from "@dust-tt/types";
 import mermaid from "mermaid";
 import dynamic from "next/dynamic";
 import type { ReactNode } from "react";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo } from "react";
 import type { Components } from "react-markdown";
 import ReactMarkdown from "react-markdown";
 import type { ReactMarkdownProps } from "react-markdown/lib/complex-types";
@@ -30,8 +30,8 @@ import {
   MermaidGraph,
   useMermaidDisplay,
 } from "@app/components/assistant/RenderMermaid";
-import type { GetContentToDownloadFunction } from "@app/components/misc/CodeBlockBanner";
-import { CodeBlockBanner } from "@app/components/misc/CodeBlockBanner";
+import type { GetContentToDownloadFunction } from "@app/components/misc/ContentBlockWrapper";
+import { ContentBlockWrapper } from "@app/components/misc/ContentBlockWrapper";
 import { classNames } from "@app/lib/utils";
 
 const SyntaxHighlighter = dynamic(
@@ -368,12 +368,12 @@ function TableBlock({ children }: { children: React.ReactNode }) {
   }, [children]);
 
   return (
-    <CodeBlockBanner
+    <ContentBlockWrapper
       className="border border-structure-200 dark:border-structure-200-dark"
       content={tableData}
     >
       <table className="w-full table-auto">{children}</table>
-    </CodeBlockBanner>
+    </ContentBlockWrapper>
   );
 }
 
@@ -503,7 +503,7 @@ function PreBlock({
       )}
     >
       <div className="relative">
-        <CodeBlockBanner
+        <ContentBlockWrapper
           content={{
             "text/plain": text,
           }}
@@ -541,7 +541,7 @@ function PreBlock({
           <div className="overflow-auto pt-8 text-sm">
             {validChildrenContent ? children : fallbackData || children}
           </div>
-        </CodeBlockBanner>
+        </ContentBlockWrapper>
       </div>
     </pre>
   );

--- a/front/components/misc/CodeBlockBanner.tsx
+++ b/front/components/misc/CodeBlockBanner.tsx
@@ -62,7 +62,7 @@ export function CodeBlockBanner({
 
   return (
     <div className="relative">
-      <div className="relative w-auto overflow-x-auto rounded-lg border border-structure-200 dark:border-structure-200-dark">
+      <div className="relative w-auto overflow-x-auto rounded-lg">
         <div className="w-full table-auto">{children}</div>
       </div>
 

--- a/front/components/misc/ContentBlockWrapper.tsx
+++ b/front/components/misc/ContentBlockWrapper.tsx
@@ -28,19 +28,19 @@ type ClipboardContent = {
   "text/html"?: string;
 };
 
-interface CodeBlockBannerProps {
+interface ContentBlockWrapperProps {
   children: React.ReactNode;
   className?: string;
-  content?: ClipboardContent;
+  content?: ClipboardContent | string;
   getContentToDownload?: GetContentToDownloadFunction;
 }
 
-export function CodeBlockBanner({
+export function ContentBlockWrapper({
   children,
   className,
   content,
   getContentToDownload,
-}: CodeBlockBannerProps) {
+}: ContentBlockWrapperProps) {
   const [isCopied, copyToClipboard] = useCopyToClipboard();
 
   const handleCopyToClipboard = useCallback(() => {
@@ -48,8 +48,11 @@ export function CodeBlockBanner({
       return;
     }
 
+    const rawContent: ClipboardContent =
+      typeof content === "string" ? { "text/plain": content } : content;
+
     const data = new ClipboardItem(
-      Object.entries(content).reduce(
+      Object.entries(rawContent).reduce(
         (acc, [type, data]) => {
           acc[type] = new Blob([data], { type });
           return acc;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR refactors `RenderMessageMarkdown` to use `ContentBlockWrapper` and extends support for CSV files. The aim is to provide an affordable solution for generating proper CSV files by allowing users to download them directly from the markdown block.

Additionally, `ContentBlockWrapper` has been enhanced to support multiple content types in the clipboard, offering greater flexibility.

<img width="877" alt="image" src="https://github.com/dust-tt/dust/assets/7428970/112ed9ea-6f97-42f3-86dc-889f17d7b508">

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
