### PR TITLE
[Doc] Add responses models to most endpoints + add a shared reference files for documentation models

### DIFF
--- a/front/pages/api/v1/w/[wId]/apps/[aId]/runs/[runId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/[aId]/runs/[runId]/index.ts
@@ -25,11 +25,13 @@ export type GetRunResponseBody = {
  *     description: Retrieve a run for an app in the workspace identified by {wId}.
  *     tags:
  *       - Apps
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *       - in: path
  *         name: wId
  *         required: true
- *         description: ID of the workspace
+ *         description: Unique string identifier for the workspace
  *         schema:
  *           type: string
  *       - in: path
@@ -42,12 +44,6 @@ export type GetRunResponseBody = {
  *         name: runId
  *         required: true
  *         description: ID of the run
- *         schema:
- *           type: string
- *       - in: header
- *         name: Authorization
- *         required: true
- *         description: Bearer token for authentication
  *         schema:
  *           type: string
  *     responses:

--- a/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
@@ -75,23 +75,19 @@ function extractUsageFromExecutions(
  *     description: Create a run for an app in the workspace identified by {wId}.
  *     tags:
  *       - Apps
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *       - in: path
  *         name: wId
  *         required: true
- *         description: ID of the workspace
+ *         description: Unique string identifier for the workspace
  *         schema:
  *           type: string
  *       - in: path
  *         name: appId
  *         required: true
  *         description: ID of the app
- *         schema:
- *           type: string
- *       - in: header
- *         name: Authorization
- *         required: true
- *         description: Bearer token for authentication
  *         schema:
  *           type: string
  *     requestBody:
@@ -133,6 +129,10 @@ function extractUsageFromExecutions(
  *     responses:
  *       200:
  *         description: App run
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Workspace'
  *       400:
  *         description: Bad Request. Missing or invalid parameters.
  *       401:

--- a/front/pages/api/v1/w/[wId]/apps/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/index.ts
@@ -17,22 +17,24 @@ export type GetAppsResponseBody = {
  *     description: Get all apps of a workspace.
  *     tags:
  *       - Apps
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *       - in: path
  *         name: wId
  *         required: true
- *         description: ID of the workspace
- *         schema:
- *           type: string
- *       - in: header
- *         name: Authorization
- *         required: true
- *         description: Bearer token for authentication
+ *         description: Unique string identifier for the workspace
  *         schema:
  *           type: string
  *     responses:
  *       200:
  *         description: Apps of the workspace
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Workspace'
  *       400:
  *         description: Bad Request. Missing or invalid parameters.
  *       401:

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
@@ -105,7 +105,6 @@ import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/
  *         description: Method not supported. Only GET is expected.
  */
 
-
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<GetAgentConfigurationsResponseBody>>

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
@@ -30,6 +30,69 @@ import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/
  *     responses:
  *       200:
  *         description: Agent configurations for the workspace
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: integer
+ *                   sId:
+ *                     type: string
+ *                   version:
+ *                     type: integer
+ *                   versionCreatedAt:
+ *                     type: string
+ *                     nullable: true
+ *                   versionAuthorId:
+ *                     type: string
+ *                     nullable: true
+ *                   name:
+ *                     type: string
+ *                   description:
+ *                     type: string
+ *                   instructions:
+ *                     type: string
+ *                   pictureUrl:
+ *                     type: string
+ *                   status:
+ *                     type: string
+ *                   userListStatus:
+ *                     type: string
+ *                   scope:
+ *                     type: string
+ *                   model:
+ *                     type: object
+ *                     properties:
+ *                       providerId:
+ *                         type: string
+ *                       modelId:
+ *                         type: string
+ *                       temperature:
+ *                         type: number
+ *                   actions:
+ *                     type: array
+ *                     items:
+ *                       type: object
+ *                       properties:
+ *                         id:
+ *                           type: integer
+ *                         sId:
+ *                           type: string
+ *                         type:
+ *                           type: string
+ *                         name:
+ *                           type: string
+ *                         description:
+ *                           type: string
+ *                           nullable: true
+ *                   maxToolsUsePerRun:
+ *                     type: integer
+ *                   templateId:
+ *                     type: string
+ *                     nullable: true
  *       400:
  *         description: Bad Request. Missing or invalid parameters.
  *       401:
@@ -41,6 +104,7 @@ import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/
  *       405:
  *         description: Method not supported. Only GET is expected.
  */
+
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
@@ -44,7 +44,6 @@ import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/
  *         description: Method not supported. Only GET is expected.
  */
 
-
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<GetAgentConfigurationsResponseBody>>

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
@@ -21,12 +21,8 @@ import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/
  *         description: ID of the workspace
  *         schema:
  *           type: string
- *       - in: header
- *         name: Authorization
- *         required: true
- *         description: Bearer token for authentication
- *         schema:
- *           type: string
+ *     security:
+ *       - BearerAuth: []
  *     responses:
  *       200:
  *         description: Agent configurations for the workspace
@@ -35,64 +31,7 @@ import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/
  *             schema:
  *               type: array
  *               items:
- *                 type: object
- *                 properties:
- *                   id:
- *                     type: integer
- *                   sId:
- *                     type: string
- *                   version:
- *                     type: integer
- *                   versionCreatedAt:
- *                     type: string
- *                     nullable: true
- *                   versionAuthorId:
- *                     type: string
- *                     nullable: true
- *                   name:
- *                     type: string
- *                   description:
- *                     type: string
- *                   instructions:
- *                     type: string
- *                   pictureUrl:
- *                     type: string
- *                   status:
- *                     type: string
- *                   userListStatus:
- *                     type: string
- *                   scope:
- *                     type: string
- *                   model:
- *                     type: object
- *                     properties:
- *                       providerId:
- *                         type: string
- *                       modelId:
- *                         type: string
- *                       temperature:
- *                         type: number
- *                   actions:
- *                     type: array
- *                     items:
- *                       type: object
- *                       properties:
- *                         id:
- *                           type: integer
- *                         sId:
- *                           type: string
- *                         type:
- *                           type: string
- *                         name:
- *                           type: string
- *                         description:
- *                           type: string
- *                           nullable: true
- *                   maxToolsUsePerRun:
- *                     type: integer
- *                   templateId:
- *                     type: string
- *                     nullable: true
+ *                 $ref: '#/components/schemas/AgentConfiguration'
  *       400:
  *         description: Bad Request. Missing or invalid parameters.
  *       401:
@@ -104,6 +43,7 @@ import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/
  *       405:
  *         description: Method not supported. Only GET is expected.
  */
+
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -42,57 +42,21 @@ export type PostContentFragmentRequestBody = t.TypeOf<
  *         description: ID of the conversation
  *         schema:
  *           type: string
- *       - in: header
- *         name: Authorization
- *         required: true
- *         description: Bearer token for authentication
- *         schema:
- *           type: string
+ *     security:
+ *       - BearerAuth: []
  *     requestBody:
  *       required: true
  *       content:
  *         application/json:
  *           schema:
- *             type: object
- *             properties:
- *               title:
- *                 type: string
- *                 description: The title of the content fragment
- *                 example: My content fragment
- *               content:
- *                 type: string
- *                 description: The content of the content fragment
- *                 example: This is my content fragment
- *               url:
- *                 type: string
- *                 description: The URL of the content fragment
- *                 example: https://example.com/content
- *               contentType:
- *                 type: string
- *                 description: The content type of the content fragment
- *                 example: text/plain
- *               context:
- *                 type: object
- *                 properties:
- *                   username:
- *                     type: string
- *                     description: The username of the user who created the content fragment
- *                     example: johndoe
- *                   fullName:
- *                     type: string
- *                     description: The full name of the user who created the content fragment
- *                     example: John Doe
- *                   email:
- *                     type: string
- *                     description: The email of the user who created the content fragment
- *                     example: johndoe@example.com
- *                   profilePictureUrl:
- *                     type: string
- *                     description: The profile picture URL of the user who created the content fragment
- *                     example: https://example.com/profile_picture.jpg
+ *             $ref: '#/components/schemas/ContentFragment'
  *     responses:
  *       200:
  *         description: Content fragment created successfully.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ContentFragment'
  *       400:
  *         description: Bad Request. Missing or invalid parameters.
  *       401:
@@ -100,6 +64,7 @@ export type PostContentFragmentRequestBody = t.TypeOf<
  *       500:
  *         description: Internal Server Error.
  */
+
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -65,7 +65,6 @@ export type PostContentFragmentRequestBody = t.TypeOf<
  *         description: Internal Server Error.
  */
 
-
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<PostContentFragmentsResponseBody>>

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -11,7 +11,7 @@ import { apiError, withLogging } from "@app/logger/withlogging";
  * /api/v1/w/{wId}/assistant/conversations/{cId}/events:
  *   get:
  *     summary: Get the events for a conversation
- *     description: Get the events for a conversation in the workspace identified by {wId}.
+ *     description: Get the events for a conversation in the workspace identified by {wId}. This is a STREAMING ENDPOINT and trying it from the documentation will likely not work.
  *     tags:
  *       - Conversations
  *     parameters:
@@ -31,13 +31,7 @@ import { apiError, withLogging } from "@app/logger/withlogging";
  *       - BearerAuth: []
  *     responses:
  *       200:
- *         description: Events for the conversation
- *         content:
- *           application/json:
- *             schema:
- *               type: array
- *               items:
- *                 $ref: '#/components/schemas/Conversation'
+ *         description: Events for the conversation, view the "Events" page from this documentation for more information.
  *       400:
  *         description: Bad Request. Missing or invalid parameters.
  *       401:

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -27,26 +27,29 @@ import { apiError, withLogging } from "@app/logger/withlogging";
  *         description: ID of the conversation
  *         schema:
  *           type: string
- *       - in: header
- *         name: Authorization
- *         required: true
- *         description: Bearer token for authentication
- *         schema:
- *           type: string
+ *     security:
+ *       - BearerAuth: []
  *     responses:
  *       200:
  *         description: Events for the conversation
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Conversation'
  *       400:
  *         description: Bad Request. Missing or invalid parameters.
  *       401:
  *         description: Unauthorized. Invalid or missing authentication token.
- *       500:
- *         description: Internal Server Error.
  *       404:
  *         description: Conversation not found.
  *       405:
  *         description: Method not supported. Only GET is expected.
+ *       500:
+ *         description: Internal Server Error.
  */
+
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -50,7 +50,6 @@ import { apiError, withLogging } from "@app/logger/withlogging";
  *         description: Internal Server Error.
  */
 
-
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<void>>

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -11,7 +11,7 @@ import { apiError, withLogging } from "@app/logger/withlogging";
  * /api/v1/w/{wId}/assistant/conversations/{cId}/events:
  *   get:
  *     summary: Get the events for a conversation
- *     description: Get the events for a conversation in the workspace identified by {wId}. This is a STREAMING ENDPOINT and trying it from the documentation will likely not work.
+ *     description: Get the events for a conversation in the workspace identified by {wId}.
  *     tags:
  *       - Conversations
  *     parameters:

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -14,7 +14,7 @@ import { apiError, withLogging } from "@app/logger/withlogging";
  *     tags:
  *       - Conversations
  *     security:
- *       - ApiKeyAuth: []
+ *       - BearerAuth: []
  *     parameters:
  *       - in: path
  *         name: wId

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -13,6 +13,8 @@ import { apiError, withLogging } from "@app/logger/withlogging";
  *     description: Get a conversation in the workspace identified by {wId}.
  *     tags:
  *       - Conversations
+ *     security:
+ *       - ApiKeyAuth: []
  *     parameters:
  *       - in: path
  *         name: wId
@@ -26,26 +28,25 @@ import { apiError, withLogging } from "@app/logger/withlogging";
  *         description: ID of the conversation
  *         schema:
  *           type: string
- *       - in: header
- *         name: Authorization
- *         required: true
- *         description: Bearer token for authentication
- *         schema:
- *           type: string
  *     responses:
  *       200:
  *         description: Conversation retrieved successfully.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Conversation'
  *       400:
  *         description: Bad Request. Missing or invalid parameters.
  *       401:
  *         description: Unauthorized. Invalid or missing authentication token.
- *       500:
- *         description: Internal Server Error.
  *       404:
  *         description: Conversation not found.
  *       405:
  *         description: Method not supported. Only GET is expected.
+ *       500:
+ *         description: Internal Server Error.
  */
+
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<{ conversation: ConversationType }>>

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
@@ -41,12 +41,8 @@ import { apiError, withLogging } from "@app/logger/withlogging";
  *         description: ID of the last event received
  *         schema:
  *           type: string
- *       - in: header
- *         name: Authorization
- *         required: true
- *         description: Bearer token for authentication
- *         schema:
- *           type: string
+ *     security:
+ *       - BearerAuth: []
  *     responses:
  *       200:
  *         description: The events
@@ -67,9 +63,17 @@ import { apiError, withLogging } from "@app/logger/withlogging";
  *                         type: string
  *                         description: Type of the event
  *                       data:
- *                         type: object
- *                         description: Data of the event
+ *                         $ref: '#/components/schemas/Message'
+ *       400:
+ *         description: Bad Request
+ *       401:
+ *         description: Unauthorized
+ *       404:
+ *         description: Not Found
+ *       500:
+ *         description: Internal Server Error
  */
+
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<void>>

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -65,7 +65,6 @@ export type PostMessagesResponseBody = {
  *         description: Internal Server Error.
  */
 
-
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<PostMessagesResponseBody>>

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -42,72 +42,21 @@ export type PostMessagesResponseBody = {
  *         description: ID of the conversation
  *         schema:
  *           type: string
- *       - in: header
- *         name: Authorization
- *         required: true
- *         description: Bearer token for authentication
- *         schema:
- *           type: string
+ *     security:
+ *       - BearerAuth: []
  *     requestBody:
  *       required: true
  *       content:
  *         application/json:
  *           schema:
- *             type: object
- *             properties:
- *               content:
- *                 type: string
- *                 description: The content of the message
- *                 example: This is my message
- *               mentions:
- *                 type: array
- *                 items:
- *                   type: object
- *                   description: The mentions of the message, where configurationId is the ID of the assistant mentioned.
- *                   properties:
- *                     configurationId:
- *                       type: string
- *                       example: [{ "configurationId":"dust" }]
- *               context:
- *                 type: object
- *                 properties:
- *                   timezone:
- *                     type: string
- *                     description: The timezone of the user who created the message
- *                     example: Europe/Paris
- *                   username:
- *                     type: string
- *                     description: The username of the user who created the message
- *                     example: johndoe
- *                   fullName:
- *                     type: string
- *                     description: The full name of the user who created the message
- *                     example: John Doe
- *                     nullable: true
- *                   email:
- *                     type: string
- *                     description: The email of the user who created the message
- *                     example: johndoe@example.com
- *                     nullable: true
- *                   profilePictureUrl:
- *                     type: string
- *                     nullable: true
- *                     description: The profile picture URL of the user who created the message
- *                     example: https://example.com/profile_picture.jpg
- *                   origin:
- *                     type: string
- *                     nullable: true
- *                     description: The origin of the message
- *                     enum:
- *                       - api
- *                       - web
- *                       - slack
- *                       - 'null'
- *                     default: api
- *                     example: api
+ *             $ref: '#/components/schemas/Message'
  *     responses:
  *       200:
  *         description: Message created successfully.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Message'
  *       400:
  *         description: Bad Request. Missing or invalid parameters.
  *       401:
@@ -115,6 +64,7 @@ export type PostMessagesResponseBody = {
  *       500:
  *         description: Internal Server Error.
  */
+
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -43,12 +43,8 @@ export type PostConversationsResponseBody = {
  *         description: ID of the workspace
  *         schema:
  *           type: string
- *       - in: header
- *         name: Authorization
- *         required: true
- *         description: Bearer token for authentication
- *         schema:
- *           type: string
+ *     security:
+ *       - ApiKeyAuth: []
  *     requestBody:
  *       required: true
  *       content:
@@ -71,44 +67,9 @@ export type PostConversationsResponseBody = {
  *                       properties:
  *                         configurationId:
  *                           type: string
- *                           example: [{ "configurationId":"dust" }]
+ *                           example: dust
  *                   context:
- *                     type: object
- *                     properties:
- *                       timezone:
- *                         type: string
- *                         description: The timezone of the user who created the message
- *                         example: Europe/Paris
- *                       username:
- *                         type: string
- *                         description: The username of the user who created the message
- *                         example: johndoe
- *                       fullName:
- *                         type: string
- *                         description: The full name of the user who created the message
- *                         example: John Doe
- *                         nullable: true
- *                       email:
- *                         type: string
- *                         description: The email of the user who created the message
- *                         example: johndoe@example.com
- *                         nullable: true
- *                       profilePictureUrl:
- *                         type: string
- *                         nullable: true
- *                         description: The profile picture URL of the user who created the message
- *                         example: https://example.com/profile_picture.jpg
- *                       origin:
- *                         type: string
- *                         nullable: true
- *                         description: The origin of the message
- *                         enum:
- *                           - api
- *                           - web
- *                           - slack
- *                           - 'null'
- *                         default: api
- *                         example: api
+ *                     $ref: '#/components/schemas/Context'
  *               contentFragment:
  *                 type: object
  *                 properties:
@@ -129,24 +90,7 @@ export type PostConversationsResponseBody = {
  *                     description: The content type of the content fragment
  *                     example: text/plain
  *                   context:
- *                     type: object
- *                     properties:
- *                       username:
- *                         type: string
- *                         description: The username of the user who created the content fragment
- *                         example: johndoe
- *                       fullName:
- *                         type: string
- *                         description: The full name of the user who created the content fragment
- *                         example: John Doe
- *                       email:
- *                         type: string
- *                         description: The email of the user who created the content fragment
- *                         example: johndoe@example.com
- *                       profilePictureUrl:
- *                         type: string
- *                         description: The profile picture URL of the user who created the content fragment
- *                         example: https://example.com/profile_picture.jpg
+ *                     $ref: '#/components/schemas/Context'
  *               blocking:
  *                 type: boolean
  *                 description: Whether to wait for the agent to generate the initial message
@@ -179,35 +123,8 @@ export type PostConversationsResponseBody = {
  *         description: Unauthorized
  *       500:
  *         description: Internal Server Error
- * components:
- *   schemas:
- *     Message:
- *       type: object
- *       properties:
- *         id:
- *           type: number
- *         created:
- *           type: number
- *         sId:
- *           type: string
- *         type:
- *           type: string
- *         visibility:
- *           type: string
- *         version:
- *           type: number
- *         user:
- *           type: object
- *           nullable: true
- *         mentions:
- *           type: array
- *         content:
- *           type: string
- *         context:
- *           type: object
- *         rank:
- *           type: number
  */
+
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -172,12 +172,7 @@ export type PostConversationsResponseBody = {
  *         content:
  *           application/json:
  *             schema:
- *               type: object
- *               properties:
- *                 conversation:
- *                   type: object
- *                 message:
- *                   $ref: '#/components/schemas/Message'
+ *               $ref: '#/components/schemas/Conversation'
  *       400:
  *         description: Bad Request
  *       401:

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -44,7 +44,7 @@ export type PostConversationsResponseBody = {
  *         schema:
  *           type: string
  *     security:
- *       - ApiKeyAuth: []
+ *       - BearerAuth: []
  *     requestBody:
  *       required: true
  *       content:

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -125,7 +125,6 @@ export type PostConversationsResponseBody = {
  *         description: Internal Server Error
  */
 
-
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<PostConversationsResponseBody>>

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -53,44 +53,9 @@ export type PostConversationsResponseBody = {
  *             type: object
  *             properties:
  *               message:
- *                 type: object
- *                 properties:
- *                   content:
- *                     type: string
- *                     description: The content of the message
- *                     example: This is my message
- *                   mentions:
- *                     type: array
- *                     items:
- *                       type: object
- *                       description: The mentions of the message, where configurationId is the ID of the assistant mentioned.
- *                       properties:
- *                         configurationId:
- *                           type: string
- *                           example: dust
- *                   context:
- *                     $ref: '#/components/schemas/Context'
+ *                 $ref: '#/components/schemas/Message'
  *               contentFragment:
- *                 type: object
- *                 properties:
- *                   title:
- *                     type: string
- *                     description: The title of the content fragment
- *                     example: My content fragment
- *                   content:
- *                     type: string
- *                     description: The content of the content fragment
- *                     example: This is my content fragment
- *                   url:
- *                     type: string
- *                     description: The URL of the content fragment
- *                     example: https://example.com/content
- *                   contentType:
- *                     type: string
- *                     description: The content type of the content fragment
- *                     example: text/plain
- *                   context:
- *                     $ref: '#/components/schemas/Context'
+ *                 $ref: '#/components/schemas/ContentFragment'
  *               blocking:
  *                 type: boolean
  *                 description: Whether to wait for the agent to generate the initial message

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -76,12 +76,8 @@ export type UpsertDocumentResponseBody = {
  *         description: ID of the document
  *         schema:
  *           type: string
- *       - in: header
- *         name: Authorization
- *         required: true
- *         description: Bearer token for authentication
- *         schema:
- *           type: string
+ *     security:
+ *       - BearerAuth: []
  *     responses:
  *       200:
  *         description: The document
@@ -119,12 +115,8 @@ export type UpsertDocumentResponseBody = {
  *         description: ID of the document
  *         schema:
  *           type: string
- *       - in: header
- *         name: Authorization
- *         required: true
- *         description: Bearer token for authentication
- *         schema:
- *           type: string
+ *     security:
+ *       - BearerAuth: []
  *     requestBody:
  *       required: true
  *       content:
@@ -178,12 +170,8 @@ export type UpsertDocumentResponseBody = {
  *         description: ID of the document
  *         schema:
  *           type: string
- *       - in: header
- *         name: Authorization
- *         required: true
- *         description: Bearer token for authentication
- *         schema:
- *           type: string
+ *     security:
+ *       - BearerAuth: []
  *     responses:
  *       200:
  *         description: The document

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/parents.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/parents.ts
@@ -23,7 +23,7 @@ export type PostParentsResponseBody = {
  *       - in: path
  *         name: wId
  *         required: true
- *         description: ID of the workspace
+ *         description: Unique string identifier for the workspace
  *         schema:
  *           type: string
  *       - in: path
@@ -38,12 +38,8 @@ export type PostParentsResponseBody = {
  *         description: ID of the document
  *         schema:
  *           type: string
- *       - in: header
- *         name: Authorization
- *         required: true
- *         description: Bearer token for authentication
- *         schema:
- *           type: string
+ *     security:
+ *       - BearerAuth: []
  *     requestBody:
  *       required: true
  *       content:
@@ -55,6 +51,7 @@ export type PostParentsResponseBody = {
  *                 type: array
  *                 items:
  *                   type: string
+ *                 description: Array of parent document IDs
  *     responses:
  *       200:
  *         description: The parents were updated

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/index.ts
@@ -20,6 +20,8 @@ export type GetDocumentsResponseBody = {
  *     description: Get documents in the data source identified by {name} in the workspace identified by {wId}.
  *     tags:
  *       - Datasources
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *       - in: path
  *         name: wId
@@ -43,15 +45,15 @@ export type GetDocumentsResponseBody = {
  *         description: Offset the returned documents
  *         schema:
  *           type: integer
- *       - in: header
- *         name: Authorization
- *         required: true
- *         description: Bearer token for authentication
- *         schema:
- *           type: string
  *     responses:
  *       200:
  *         description: The documents
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Datasource'
  *       404:
  *         description: The data source was not found
  *       405:

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/search.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/search.ts
@@ -57,6 +57,8 @@ type DatasourceSearchResponseBody = {
  *     description: Search the data source identified by {name} in the workspace identified by {wId}.
  *     tags:
  *       - Datasources
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *       - in: path
  *         name: wId
@@ -128,12 +130,6 @@ type DatasourceSearchResponseBody = {
  *         name: parents_not
  *         required: false
  *         description: The parents to filter by
- *         schema:
- *           type: string
- *       - in: header
- *         name: Authorization
- *         required: true
- *         description: Bearer token for authentication
  *         schema:
  *           type: string
  *     responses:

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
@@ -25,11 +25,13 @@ export type GetTableResponseBody = {
  *     description: Get a table in the data source identified by {name} in the workspace identified by {wId}.
  *     tags:
  *       - Datasources
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *       - in: path
  *         name: wId
  *         required: true
- *         description: ID of the workspace
+ *         description: Unique string identifier for the workspace
  *         schema:
  *           type: string
  *       - in: path
@@ -44,15 +46,13 @@ export type GetTableResponseBody = {
  *         description: ID of the table
  *         schema:
  *           type: string
- *       - in: header
- *         name: Authorization
- *         required: true
- *         description: Bearer token for authentication
- *         schema:
- *           type: string
  *     responses:
  *       200:
  *         description: The table
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Datasource'
  *       404:
  *         description: The table was not found
  *       405:
@@ -62,11 +62,13 @@ export type GetTableResponseBody = {
  *     description: Delete a table in the data source identified by {name} in the workspace identified by {wId}.
  *     tags:
  *       - Datasources
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *       - in: path
  *         name: wId
  *         required: true
- *         description: ID of the workspace
+ *         description: Unique string identifier for the workspace
  *         schema:
  *           type: string
  *       - in: path
@@ -79,12 +81,6 @@ export type GetTableResponseBody = {
  *         name: tId
  *         required: true
  *         description: ID of the table
- *         schema:
- *           type: string
- *       - in: header
- *         name: Authorization
- *         required: true
- *         description: Bearer token for authentication
  *         schema:
  *           type: string
  *     responses:

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/[rId].ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/[rId].ts
@@ -19,11 +19,13 @@ type GetTableRowsResponseBody = {
  *     description: Get a row in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.
  *     tags:
  *       - Datasources
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *       - in: path
  *         name: wId
  *         required: true
- *         description: ID of the workspace
+ *         description: Unique string identifier for the workspace
  *         schema:
  *           type: string
  *       - in: path
@@ -44,15 +46,13 @@ type GetTableRowsResponseBody = {
  *         description: ID of the row
  *         schema:
  *           type: string
- *       - in: header
- *         name: Authorization
- *         required: true
- *         description: Bearer token for authentication
- *         schema:
- *           type: string
  *     responses:
  *       200:
  *         description: The row
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Datasource'
  *       404:
  *         description: The row was not found
  *       405:
@@ -62,11 +62,13 @@ type GetTableRowsResponseBody = {
  *     description: Delete a row in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.
  *     tags:
  *       - Datasources
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *       - in: path
  *         name: wId
  *         required: true
- *         description: ID of the workspace
+ *         description: Unique string identifier for the workspace
  *         schema:
  *           type: string
  *       - in: path
@@ -85,12 +87,6 @@ type GetTableRowsResponseBody = {
  *         name: rId
  *         required: true
  *         description: ID of the row
- *         schema:
- *           type: string
- *       - in: header
- *         name: Authorization
- *         required: true
- *         description: Bearer token for authentication
  *         schema:
  *           type: string
  *     responses:

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/index.ts
@@ -64,11 +64,13 @@ type ListTableRowsResponseBody = {
  *    description: List rows in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.
  *    tags:
  *      - Datasources
+ *    security:
+ *      - BearerAuth: []
  *    parameters:
  *      - in: path
  *        name: wId
  *        required: true
- *        description: ID of the workspace
+ *        description: Unique string identifier for the workspace
  *        schema:
  *          type: string
  *      - in: path
@@ -93,15 +95,15 @@ type ListTableRowsResponseBody = {
  *        description: Offset the returned rows
  *        schema:
  *          type: integer
- *      - in: header
- *        name: Authorization
- *        required: true
- *        description: Bearer token for authentication
- *        schema:
- *          type: string
  *    responses:
  *      200:
  *        description: The rows
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: array
+ *              items:
+ *                $ref: '#/components/schemas/Datasource'
  *      405:
  *        description: Method not supported
  *  post:
@@ -109,11 +111,13 @@ type ListTableRowsResponseBody = {
  *    description: Upsert rows in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.
  *    tags:
  *      - Datasources
+ *    security:
+ *      - BearerAuth: []
  *    parameters:
  *      - in: path
  *        name: wId
  *        required: true
- *        description: ID of the workspace
+ *        description: Unique string identifier for the workspace
  *        schema:
  *          type: string
  *      - in: path
@@ -126,12 +130,6 @@ type ListTableRowsResponseBody = {
  *        name: tId
  *        required: true
  *        description: ID of the table
- *        schema:
- *          type: string
- *      - in: header
- *        name: Authorization
- *        required: true
- *        description: Bearer token for authentication
  *        schema:
  *          type: string
  *    requestBody:
@@ -148,6 +146,7 @@ type ListTableRowsResponseBody = {
  *                  properties:
  *                    row_id:
  *                      type: string
+ *                      description: Unique identifier for the row
  *                    value:
  *                      type: object
  *                      additionalProperties:
@@ -165,9 +164,14 @@ type ListTableRowsResponseBody = {
  *                                type: number
  *              truncate:
  *                type: boolean
+ *                description: Whether to truncate existing rows
  *    responses:
  *      200:
  *        description: The table
+ *        content:
+ *          application/json:
+ *            schema:
+ *              $ref: '#/components/schemas/Datasource'
  *      400:
  *        description: Bad Request. Missing or invalid parameters.
  *      401:

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/csv.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/csv.ts
@@ -20,11 +20,13 @@ export const config = {
  *     description: Upsert CSV data to a table in the data source identified by {name} in the workspace identified by {wId}.
  *     tags:
  *       - Datasources
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *       - in: path
  *         name: wId
  *         required: true
- *         description: ID of the workspace
+ *         description: Unique string identifier for the workspace
  *         schema:
  *           type: string
  *       - in: path
@@ -38,12 +40,6 @@ export const config = {
  *         description: ID of the table
  *         schema:
  *           type: string
- *       - in: header
- *         name: Authorization
- *         required: true
- *         description: Bearer token for authentication
- *         schema:
- *           type: string
  *     requestBody:
  *       required: true
  *       content:
@@ -54,9 +50,14 @@ export const config = {
  *               file:
  *                 type: string
  *                 format: binary
+ *                 description: CSV file to be uploaded
  *     responses:
  *       200:
  *         description: The table
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Datasource'
  *       404:
  *         description: The table was not found
  *       405:

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/index.ts
@@ -43,50 +43,48 @@ type UpsertTableResponseBody = {
  *     description: Get tables in the data source identified by {name} in the workspace identified by {wId}.
  *     tags:
  *       - Datasources
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *       - in: path
  *         name: wId
  *         required: true
- *         description: ID of the workspace
+ *         description: Unique string identifier for the workspace
  *         schema:
  *           type: string
  *       - in: path
  *         name: name
  *         required: true
  *         description: Name of the data source
- *         schema:
- *           type: string
- *       - in: header
- *         name: Authorization
- *         required: true
- *         description: Bearer token for authentication
  *         schema:
  *           type: string
  *     responses:
  *       200:
  *         description: The tables
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Datasource'
  *   post:
  *     summary: Upsert a table
  *     description: Upsert a table in the data source identified by {name} in the workspace identified by {wId}.
  *     tags:
  *       - Datasources
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *       - in: path
  *         name: wId
  *         required: true
- *         description: ID of the workspace
+ *         description: Unique string identifier for the workspace
  *         schema:
  *           type: string
  *       - in: path
  *         name: name
  *         required: true
  *         description: Name of the data source
- *         schema:
- *           type: string
- *       - in: header
- *         name: Authorization
- *         required: true
- *         description: Bearer token for authentication
  *         schema:
  *           type: string
  *     requestBody:
@@ -98,18 +96,26 @@ type UpsertTableResponseBody = {
  *             properties:
  *               name:
  *                 type: string
+ *                 description: Name of the table
  *               table_id:
  *                 type: string
+ *                 description: Unique identifier for the table
  *               description:
  *                 type: string
+ *                 description: Description of the table
  *     responses:
  *       200:
  *         description: The table
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Datasource'
  *       400:
  *         description: Invalid request
  *       405:
  *         description: Method not supported
  */
+
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tokenize.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tokenize.ts
@@ -43,12 +43,8 @@ type PostDatasourceTokenizeResponseBody = {
  *         description: Name of the data source
  *         schema:
  *           type: string
- *       - in: header
- *         name: Authorization
- *         required: true
- *         description: Bearer token for authentication
- *         schema:
- *           type: string
+ *     security:
+ *       - BearerAuth: []
  *     requestBody:
  *       required: true
  *       content:

--- a/front/pages/api/v1/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/index.ts
@@ -24,20 +24,26 @@ export type GetDataSourcesResponseBody = {
  *         description: ID of the workspace
  *         schema:
  *           type: string
- *       - in: header
- *         name: Authorization
- *         required: true
- *         description: Bearer token for authentication
- *         schema:
- *           type: string
+ *     security:
+ *       - BearerAuth: []
  *     responses:
  *       200:
  *         description: The data sources
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 # Note: The schema doesn't provide a specific DataSource type,
+ *                 # so we're keeping this generic. You may want to define a
+ *                 # DataSource schema if there's a specific structure.
  *       404:
  *         description: The workspace was not found
  *       405:
  *         description: Method not supported
  */
+
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/v1/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/index.ts
@@ -34,15 +34,13 @@ export type GetDataSourcesResponseBody = {
  *             schema:
  *               type: array
  *               items:
- *                 type: object
- *                 # Note: The schema doesn't provide a specific DataSource type,
- *                 # so we're keeping this generic. You may want to define a
- *                 # DataSource schema if there's a specific structure.
+ *                 $ref: '#/components/schemas/Datasource'
  *       404:
  *         description: The workspace was not found
  *       405:
  *         description: Method not supported
  */
+
 
 
 async function handler(

--- a/front/pages/api/v1/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/index.ts
@@ -41,8 +41,6 @@ export type GetDataSourcesResponseBody = {
  *         description: Method not supported
  */
 
-
-
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<GetDataSourcesResponseBody>>

--- a/front/pages/api/v1/w/[wId]/feature_flags.ts
+++ b/front/pages/api/v1/w/[wId]/feature_flags.ts
@@ -19,17 +19,13 @@ export type WorkspaceFeatureFlagsResponseBody = {
  *     description: Get the feature flags for the workspace identified by {wId}.
  *     tags:
  *       - Workspace
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *       - in: path
  *         name: wId
  *         required: true
- *         description: ID of the workspace
- *         schema:
- *           type: string
- *       - in: header
- *         name: Authorization
- *         required: true
- *         description: Bearer token for authentication
+ *         description: Unique string identifier for the workspace
  *         schema:
  *           type: string
  *     responses:
@@ -44,6 +40,7 @@ export type WorkspaceFeatureFlagsResponseBody = {
  *                   type: array
  *                   items:
  *                     type: string
+ *                     description: Feature flags enabled for the workspace
  */
 
 async function handler(

--- a/front/pages/api/v1/w/[wId]/members/emails.ts
+++ b/front/pages/api/v1/w/[wId]/members/emails.ts
@@ -21,7 +21,7 @@ export type ListMemberEmailsResponseBody = {
  *       - in: path
  *         name: wId
  *         required: true
- *         description: ID of the workspace
+ *         description: Unique string identifier for the workspace
  *         schema:
  *           type: string
  *       - in: query
@@ -30,12 +30,8 @@ export type ListMemberEmailsResponseBody = {
  *         description: Whether to list only active members
  *         schema:
  *           type: boolean
- *       - in: header
- *         name: Authorization
- *         required: true
- *         description: Bearer token for authentication
- *         schema:
- *           type: string
+ *     security:
+ *       - BearerAuth: []
  *     responses:
  *       200:
  *         description: The emails
@@ -48,6 +44,7 @@ export type ListMemberEmailsResponseBody = {
  *                   type: array
  *                   items:
  *                     type: string
+ *                     description: Email address of a workspace member
  */
 
 async function handler(

--- a/front/pages/api/v1/w/[wId]/swagger_schemas.ts
+++ b/front/pages/api/v1/w/[wId]/swagger_schemas.ts
@@ -1,0 +1,10 @@
+/**
+ * @swagger
+ * components:
+ *   securitySchemes:
+ *     ApiKeyAuth:
+ *       type: apiKey
+ *       in: header
+ *       name: Authorization
+ *       description: API key authentication. Prefix the key with 'Bearer '
+ */

--- a/front/pages/api/v1/w/[wId]/swagger_schemas.ts
+++ b/front/pages/api/v1/w/[wId]/swagger_schemas.ts
@@ -13,24 +13,32 @@
  *       properties:
  *         sId:
  *           type: string
+ *           description: Unique string identifier for the user
  *         id:
  *           type: integer
  *         createdAt:
  *           type: integer
  *         username:
  *           type: string
+ *           description: User's chosen username
  *         email:
  *           type: string
+ *           description: User's email address
  *         firstName:
  *           type: string
+ *           description: User's first name
  *         lastName:
  *           type: string
+ *           description: User's last name
  *         fullName:
  *           type: string
+ *           description: User's full name
  *         provider:
  *           type: string
+ *           description: Authentication provider used by the user
  *         image:
  *           type: string
+ *           description: URL of the user's profile image
  *     Workspace:
  *       type: object
  *       properties:
@@ -38,41 +46,54 @@
  *           type: integer
  *         sId:
  *           type: string
+ *           description: Unique string identifier for the workspace
  *         name:
  *           type: string
+ *           description: Name of the workspace
  *         role:
  *           type: string
+ *           description: User's role in the workspace
  *         segmentation:
  *           type: string
  *           nullable: true
+ *           description: Segmentation information for the workspace
  *         flags:
  *           type: array
  *           items:
  *             type: string
+ *             description: Feature flags enabled for the workspace
  *         ssoEnforced:
  *           type: boolean
  *         whiteListedProviders:
  *           type: array
  *           items:
  *             type: string
+ *             description: List of allowed authentication providers
  *         defaultEmbeddingProvider:
  *           type: string
  *           nullable: true
+ *           description: Default provider for embeddings in the workspace
  *     Context:
  *       type: object
  *       properties:
  *         username:
  *           type: string
+ *           description: Username in the current context
  *         timezone:
  *           type: string
+ *           description: User's timezone
  *         fullName:
  *           type: string
+ *           description: User's full name in the current context
  *         email:
  *           type: string
+ *           description: User's email in the current context
  *         profilePictureUrl:
  *           type: string
+ *           description: URL of the user's profile picture
  *         origin:
  *           type: string
+ *           description: Origin of the context (e.g., 'slack', 'web')
  *     AgentConfiguration:
  *       type: object
  *       properties:
@@ -80,36 +101,48 @@
  *           type: integer
  *         sId:
  *           type: string
+ *           description: Unique string identifier for the agent configuration
  *         version:
  *           type: integer
  *         versionCreatedAt:
  *           type: string
  *           nullable: true
+ *           description: Timestamp of when the version was created
  *         versionAuthorId:
  *           type: string
  *           nullable: true
+ *           description: ID of the user who created this version
  *         name:
  *           type: string
+ *           description: Name of the agent configuration
  *         description:
  *           type: string
+ *           description: Description of the agent configuration
  *         instructions:
  *           type: string
  *           nullable: true
+ *           description: Instructions for the agent
  *         pictureUrl:
  *           type: string
+ *           description: URL of the agent's picture
  *         status:
  *           type: string
+ *           description: Current status of the agent configuration
  *         scope:
  *           type: string
+ *           description: Scope of the agent configuration
  *         userListStatus:
  *           type: string
+ *           description: Status of the user list for this configuration
  *         model:
  *           type: object
  *           properties:
  *             providerId:
  *               type: string
+ *               description: ID of the model provider
  *             modelId:
  *               type: string
+ *               description: ID of the specific model
  *             temperature:
  *               type: number
  *         actions:
@@ -119,6 +152,7 @@
  *         templateId:
  *           type: string
  *           nullable: true
+ *           description: ID of the template used for this configuration
  *     Conversation:
  *       type: object
  *       properties:
@@ -131,12 +165,15 @@
  *               type: integer
  *             sId:
  *               type: string
+ *               description: Unique string identifier for the conversation
  *             owner:
  *               $ref: '#/components/schemas/Workspace'
  *             title:
  *               type: string
+ *               description: Title of the conversation
  *             visibility:
  *               type: string
+ *               description: Visibility setting of the conversation
  *             content:
  *               type: array
  *               items:
@@ -148,10 +185,13 @@
  *                       type: integer
  *                     sId:
  *                       type: string
+ *                       description: Unique string identifier for the message
  *                     type:
  *                       type: string
+ *                       description: Type of the message
  *                     visibility:
  *                       type: string
+ *                       description: Visibility setting of the message
  *                     version:
  *                       type: integer
  *                     created:
@@ -161,25 +201,26 @@
  *                     mentions:
  *                       type: array
  *                       items:
- *                         type: object
- *                         properties:
- *                           configurationId:
- *                             type: string
+ *                         $ref: '#/components/schemas/Mention'
  *                     content:
  *                       type: string
+ *                       description: Content of the message
  *                     context:
  *                       $ref: '#/components/schemas/Context'
  *                     agentMessageId:
  *                       type: integer
  *                     parentMessageId:
  *                       type: string
+ *                       description: ID of the parent message
  *                     status:
  *                       type: string
+ *                       description: Status of the message
  *                     actions:
  *                       type: array
  *                     chainOfThought:
  *                       type: string
  *                       nullable: true
+ *                       description: Chain of thought for the message
  *                     rawContents:
  *                       type: array
  *                       items:
@@ -189,9 +230,52 @@
  *                             type: integer
  *                           content:
  *                             type: string
+ *                             description: Content for each step
  *                     error:
  *                       type: string
  *                       nullable: true
+ *                       description: Error message, if any
  *                     configuration:
  *                       $ref: '#/components/schemas/AgentConfiguration'
+ *     Mention:
+ *       type: object
+ *       properties:
+ *         configurationId:
+ *           type: string
+ *           description: ID of the mentioned agent configuration
+ *           example: dust
+ *     Message:
+ *       type: object
+ *       properties:
+ *         content:
+ *           type: string
+ *           description: The content of the message
+ *           example: This is my message
+ *         mentions:
+ *           type: array
+ *           items:
+ *             $ref: '#/components/schemas/Mention'
+ *         context:
+ *           $ref: '#/components/schemas/Context'
+ *     ContentFragment:
+ *       type: object
+ *       properties:
+ *         title:
+ *           type: string
+ *           description: The title of the content fragment
+ *           example: My content fragment
+ *         content:
+ *           type: string
+ *           description: The content of the content fragment
+ *           example: This is my content fragment
+ *         url:
+ *           type: string
+ *           description: The URL of the content fragment
+ *           example: https://example.com/content
+ *         contentType:
+ *           type: string
+ *           description: The content type of the content fragment
+ *           example: text/plain
+ *         context:
+ *           $ref: '#/components/schemas/Context'
  */

--- a/front/pages/api/v1/w/[wId]/swagger_schemas.ts
+++ b/front/pages/api/v1/w/[wId]/swagger_schemas.ts
@@ -7,4 +7,183 @@
  *       in: header
  *       name: Authorization
  *       description: API key authentication. Prefix the key with 'Bearer '
+ *   schemas:
+ *     Conversation:
+ *       type: object
+ *       properties:
+ *         conversation:
+ *           type: object
+ *           properties:
+ *             id:
+ *               type: integer
+ *             created:
+ *               type: integer
+ *             sId:
+ *               type: string
+ *             owner:
+ *               type: object
+ *               properties:
+ *                 id:
+ *                   type: integer
+ *                 sId:
+ *                   type: string
+ *                 name:
+ *                   type: string
+ *                 role:
+ *                   type: string
+ *                 segmentation:
+ *                   type: string
+ *                   nullable: true
+ *                 flags:
+ *                   type: array
+ *                   items:
+ *                     type: string
+ *                 ssoEnforced:
+ *                   type: boolean
+ *                 whiteListedProviders:
+ *                   type: array
+ *                   items:
+ *                     type: string
+ *                 defaultEmbeddingProvider:
+ *                   type: string
+ *                   nullable: true
+ *             title:
+ *               type: string
+ *             visibility:
+ *               type: string
+ *             content:
+ *               type: array
+ *               items:
+ *                 type: array
+ *                 items:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: integer
+ *                     sId:
+ *                       type: string
+ *                     type:
+ *                       type: string
+ *                     visibility:
+ *                       type: string
+ *                     version:
+ *                       type: integer
+ *                     created:
+ *                       type: integer
+ *                     user:
+ *                       type: object
+ *                       properties:
+ *                         sId:
+ *                           type: string
+ *                         id:
+ *                           type: integer
+ *                         createdAt:
+ *                           type: integer
+ *                         username:
+ *                           type: string
+ *                         email:
+ *                           type: string
+ *                         firstName:
+ *                           type: string
+ *                         lastName:
+ *                           type: string
+ *                         fullName:
+ *                           type: string
+ *                         provider:
+ *                           type: string
+ *                         image:
+ *                           type: string
+ *                     mentions:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           configurationId:
+ *                             type: string
+ *                     content:
+ *                       type: string
+ *                     context:
+ *                       type: object
+ *                       properties:
+ *                         username:
+ *                           type: string
+ *                         timezone:
+ *                           type: string
+ *                         fullName:
+ *                           type: string
+ *                         email:
+ *                           type: string
+ *                         profilePictureUrl:
+ *                           type: string
+ *                         origin:
+ *                           type: string
+ *                     agentMessageId:
+ *                       type: integer
+ *                     parentMessageId:
+ *                       type: string
+ *                     status:
+ *                       type: string
+ *                     actions:
+ *                       type: array
+ *                     chainOfThought:
+ *                       type: string
+ *                       nullable: true
+ *                     rawContents:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           step:
+ *                             type: integer
+ *                           content:
+ *                             type: string
+ *                     error:
+ *                       type: string
+ *                       nullable: true
+ *                     configuration:
+ *                       type: object
+ *                       properties:
+ *                         id:
+ *                           type: integer
+ *                         sId:
+ *                           type: string
+ *                         version:
+ *                           type: integer
+ *                         versionCreatedAt:
+ *                           type: string
+ *                           nullable: true
+ *                         versionAuthorId:
+ *                           type: string
+ *                           nullable: true
+ *                         name:
+ *                           type: string
+ *                         description:
+ *                           type: string
+ *                         instructions:
+ *                           type: string
+ *                           nullable: true
+ *                         pictureUrl:
+ *                           type: string
+ *                         status:
+ *                           type: string
+ *                         scope:
+ *                           type: string
+ *                         userListStatus:
+ *                           type: string
+ *                         model:
+ *                           type: object
+ *                           properties:
+ *                             providerId:
+ *                               type: string
+ *                             modelId:
+ *                               type: string
+ *                             temperature:
+ *                               type: number
+ *                         actions:
+ *                           type: array
+ *                         maxToolsUsePerRun:
+ *                           type: integer
+ *                         templateId:
+ *                           type: string
+ *                           nullable: true
  */

--- a/front/pages/api/v1/w/[wId]/swagger_schemas.ts
+++ b/front/pages/api/v1/w/[wId]/swagger_schemas.ts
@@ -2,11 +2,10 @@
  * @swagger
  * components:
  *   securitySchemes:
- *     ApiKeyAuth:
- *       type: apiKey
- *       in: header
- *       name: Authorization
- *       description: API key authentication. Prefix the key with 'Bearer '
+ *     BearerAuth:
+ *       type: http
+ *       scheme: bearer
+ *       description: Your DUST API key prefixed by `Bearer sk-...`
  *   schemas:
  *     User:
  *       type: object

--- a/front/pages/api/v1/w/[wId]/swagger_schemas.ts
+++ b/front/pages/api/v1/w/[wId]/swagger_schemas.ts
@@ -277,4 +277,31 @@
  *           example: text/plain
  *         context:
  *           $ref: '#/components/schemas/Context'
+ *     Datasource:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: integer
+ *           description: Unique identifier for the datasource
+ *         createdAt:
+ *           type: integer
+ *           description: Timestamp of when the datasource was created
+ *         name:
+ *           type: string
+ *           description: Name of the datasource
+ *         description:
+ *           type: string
+ *           description: Description of the datasource
+ *         dustAPIProjectId:
+ *           type: string
+ *           description: ID of the associated Dust API project
+ *         connectorId:
+ *           type: string
+ *           description: ID of the connector used for this datasource
+ *         connectorProvider:
+ *           type: string
+ *           description: Provider of the connector (e.g., 'webcrawler')
+ *         assistantDefaultSelected:
+ *           type: boolean
+ *           description: Whether this datasource is selected by default for assistants
  */

--- a/front/pages/api/v1/w/[wId]/swagger_schemas.ts
+++ b/front/pages/api/v1/w/[wId]/swagger_schemas.ts
@@ -8,6 +8,117 @@
  *       name: Authorization
  *       description: API key authentication. Prefix the key with 'Bearer '
  *   schemas:
+ *     User:
+ *       type: object
+ *       properties:
+ *         sId:
+ *           type: string
+ *         id:
+ *           type: integer
+ *         createdAt:
+ *           type: integer
+ *         username:
+ *           type: string
+ *         email:
+ *           type: string
+ *         firstName:
+ *           type: string
+ *         lastName:
+ *           type: string
+ *         fullName:
+ *           type: string
+ *         provider:
+ *           type: string
+ *         image:
+ *           type: string
+ *     Workspace:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: integer
+ *         sId:
+ *           type: string
+ *         name:
+ *           type: string
+ *         role:
+ *           type: string
+ *         segmentation:
+ *           type: string
+ *           nullable: true
+ *         flags:
+ *           type: array
+ *           items:
+ *             type: string
+ *         ssoEnforced:
+ *           type: boolean
+ *         whiteListedProviders:
+ *           type: array
+ *           items:
+ *             type: string
+ *         defaultEmbeddingProvider:
+ *           type: string
+ *           nullable: true
+ *     Context:
+ *       type: object
+ *       properties:
+ *         username:
+ *           type: string
+ *         timezone:
+ *           type: string
+ *         fullName:
+ *           type: string
+ *         email:
+ *           type: string
+ *         profilePictureUrl:
+ *           type: string
+ *         origin:
+ *           type: string
+ *     AgentConfiguration:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: integer
+ *         sId:
+ *           type: string
+ *         version:
+ *           type: integer
+ *         versionCreatedAt:
+ *           type: string
+ *           nullable: true
+ *         versionAuthorId:
+ *           type: string
+ *           nullable: true
+ *         name:
+ *           type: string
+ *         description:
+ *           type: string
+ *         instructions:
+ *           type: string
+ *           nullable: true
+ *         pictureUrl:
+ *           type: string
+ *         status:
+ *           type: string
+ *         scope:
+ *           type: string
+ *         userListStatus:
+ *           type: string
+ *         model:
+ *           type: object
+ *           properties:
+ *             providerId:
+ *               type: string
+ *             modelId:
+ *               type: string
+ *             temperature:
+ *               type: number
+ *         actions:
+ *           type: array
+ *         maxToolsUsePerRun:
+ *           type: integer
+ *         templateId:
+ *           type: string
+ *           nullable: true
  *     Conversation:
  *       type: object
  *       properties:
@@ -21,32 +132,7 @@
  *             sId:
  *               type: string
  *             owner:
- *               type: object
- *               properties:
- *                 id:
- *                   type: integer
- *                 sId:
- *                   type: string
- *                 name:
- *                   type: string
- *                 role:
- *                   type: string
- *                 segmentation:
- *                   type: string
- *                   nullable: true
- *                 flags:
- *                   type: array
- *                   items:
- *                     type: string
- *                 ssoEnforced:
- *                   type: boolean
- *                 whiteListedProviders:
- *                   type: array
- *                   items:
- *                     type: string
- *                 defaultEmbeddingProvider:
- *                   type: string
- *                   nullable: true
+ *               $ref: '#/components/schemas/Workspace'
  *             title:
  *               type: string
  *             visibility:
@@ -71,28 +157,7 @@
  *                     created:
  *                       type: integer
  *                     user:
- *                       type: object
- *                       properties:
- *                         sId:
- *                           type: string
- *                         id:
- *                           type: integer
- *                         createdAt:
- *                           type: integer
- *                         username:
- *                           type: string
- *                         email:
- *                           type: string
- *                         firstName:
- *                           type: string
- *                         lastName:
- *                           type: string
- *                         fullName:
- *                           type: string
- *                         provider:
- *                           type: string
- *                         image:
- *                           type: string
+ *                       $ref: '#/components/schemas/User'
  *                     mentions:
  *                       type: array
  *                       items:
@@ -103,20 +168,7 @@
  *                     content:
  *                       type: string
  *                     context:
- *                       type: object
- *                       properties:
- *                         username:
- *                           type: string
- *                         timezone:
- *                           type: string
- *                         fullName:
- *                           type: string
- *                         email:
- *                           type: string
- *                         profilePictureUrl:
- *                           type: string
- *                         origin:
- *                           type: string
+ *                       $ref: '#/components/schemas/Context'
  *                     agentMessageId:
  *                       type: integer
  *                     parentMessageId:
@@ -141,49 +193,5 @@
  *                       type: string
  *                       nullable: true
  *                     configuration:
- *                       type: object
- *                       properties:
- *                         id:
- *                           type: integer
- *                         sId:
- *                           type: string
- *                         version:
- *                           type: integer
- *                         versionCreatedAt:
- *                           type: string
- *                           nullable: true
- *                         versionAuthorId:
- *                           type: string
- *                           nullable: true
- *                         name:
- *                           type: string
- *                         description:
- *                           type: string
- *                         instructions:
- *                           type: string
- *                           nullable: true
- *                         pictureUrl:
- *                           type: string
- *                         status:
- *                           type: string
- *                         scope:
- *                           type: string
- *                         userListStatus:
- *                           type: string
- *                         model:
- *                           type: object
- *                           properties:
- *                             providerId:
- *                               type: string
- *                             modelId:
- *                               type: string
- *                             temperature:
- *                               type: number
- *                         actions:
- *                           type: array
- *                         maxToolsUsePerRun:
- *                           type: integer
- *                         templateId:
- *                           type: string
- *                           nullable: true
+ *                       $ref: '#/components/schemas/AgentConfiguration'
  */

--- a/front/pages/api/v1/w/[wId]/swagger_schemas.ts
+++ b/front/pages/api/v1/w/[wId]/swagger_schemas.ts
@@ -5,7 +5,7 @@
  *     BearerAuth:
  *       type: http
  *       scheme: bearer
- *       description: Your DUST API key prefixed by `Bearer sk-...`
+ *       description: Your DUST API key is a Bearer token.
  *   schemas:
  *     User:
  *       type: object

--- a/front/pages/api/v1/w/[wId]/usage.ts
+++ b/front/pages/api/v1/w/[wId]/usage.ts
@@ -30,11 +30,13 @@ const GetWorkspaceUsageSchema = t.intersection([
  *     description: Get usage data for the workspace identified by {wId}.
  *     tags:
  *       - Workspace
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *       - in: path
  *         name: wId
  *         required: true
- *         description: ID of the workspace
+ *         description: Unique string identifier for the workspace
  *         schema:
  *           type: string
  *       - in: query
@@ -51,15 +53,13 @@ const GetWorkspaceUsageSchema = t.intersection([
  *         schema:
  *           type: string
  *           format: date
- *       - in: header
- *         name: Authorization
- *         required: true
- *         description: Bearer token for authentication
- *         schema:
- *           type: string
  *     responses:
  *       200:
  *         description: The usage data
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Workspace'
  *       404:
  *         description: The workspace was not found
  *       405:

--- a/front/pages/api/v1/w/[wId]/verified_domains.ts
+++ b/front/pages/api/v1/w/[wId]/verified_domains.ts
@@ -17,22 +17,22 @@ export type ListMemberEmailsResponseBody = {
  *     description: Get the verified domain for the workspace identified by {wId}.
  *     tags:
  *       - Workspace
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *       - in: path
  *         name: wId
  *         required: true
- *         description: ID of the workspace
- *         schema:
- *           type: string
- *       - in: header
- *         name: Authorization
- *         required: true
- *         description: Bearer token for authentication
+ *         description: Unique string identifier for the workspace
  *         schema:
  *           type: string
  *     responses:
  *       200:
  *         description: The verified domain
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Workspace'
  *       404:
  *         description: The workspace was not found
  *       405:

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -15,7 +15,9 @@
       "get": {
         "summary": "Get an app run",
         "description": "Retrieve a run for an app in the workspace identified by {wId}.",
-        "tags": ["Apps"],
+        "tags": [
+          "Apps"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -131,7 +133,9 @@
       "post": {
         "summary": "Create an app run",
         "description": "Create a run for an app in the workspace identified by {wId}.",
-        "tags": ["Apps"],
+        "tags": [
+          "Apps"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -242,7 +246,9 @@
       "get": {
         "summary": "List apps",
         "description": "Get all apps of a workspace.",
-        "tags": ["Apps"],
+        "tags": [
+          "Apps"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -295,7 +301,9 @@
       "get": {
         "summary": "List assistants",
         "description": "Get the agent configurations for the workspace identified by {wId}.",
-        "tags": ["Workspace"],
+        "tags": [
+          "Workspace"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -348,7 +356,9 @@
       "post": {
         "summary": "Create a content fragment",
         "description": "Create a new content fragment in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -410,8 +420,10 @@
     "/api/v1/w/{wId}/assistant/conversations/{cId}/events": {
       "get": {
         "summary": "Get the events for a conversation",
-        "description": "Get the events for a conversation in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "description": "Get the events for a conversation in the workspace identified by {wId}. This is a STREAMING ENDPOINT and trying it from the documentation will likely not work.",
+        "tags": [
+          "Conversations"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -439,17 +451,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Events for the conversation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Conversation"
-                  }
-                }
-              }
-            }
+            "description": "Events for the conversation, view the \"Events\" page from this documentation for more information."
           },
           "400": {
             "description": "Bad Request. Missing or invalid parameters."
@@ -473,7 +475,9 @@
       "get": {
         "summary": "Get a conversation",
         "description": "Get a conversation in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -532,7 +536,9 @@
       "get": {
         "summary": "Get events for a message",
         "description": "Get events for a message in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -626,7 +632,9 @@
       "post": {
         "summary": "Create a message",
         "description": "Create a message in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -689,7 +697,9 @@
       "post": {
         "summary": "Create a new conversation",
         "description": "Create a new conversation in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -734,7 +744,11 @@
                   "visibility": {
                     "type": "string",
                     "description": "The visibility of the conversation",
-                    "enum": ["public", "private", "unlisted"],
+                    "enum": [
+                      "public",
+                      "private",
+                      "unlisted"
+                    ],
                     "default": "public",
                     "example": "private"
                   }
@@ -770,7 +784,9 @@
       "get": {
         "summary": "Retrieve a document from a data source",
         "description": "Retrieve a document from a data source in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -829,7 +845,9 @@
       "post": {
         "summary": "Upsert a document in a data source",
         "description": "Upsert a document in a data source in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -912,7 +930,9 @@
       "delete": {
         "summary": "Delete a document from a data source",
         "description": "Delete a document from a data source in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -970,7 +990,9 @@
       "post": {
         "summary": "Update the parents of a document",
         "description": "Update the parents of a document in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1050,7 +1072,9 @@
       "get": {
         "summary": "Get documents",
         "description": "Get documents in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -1119,7 +1143,9 @@
       "get": {
         "summary": "Search the data source",
         "description": "Search the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -1307,7 +1333,9 @@
       "get": {
         "summary": "Get a table",
         "description": "Get a table in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -1364,7 +1392,9 @@
       "delete": {
         "summary": "Delete a table",
         "description": "Delete a table in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -1416,7 +1446,9 @@
       "get": {
         "summary": "Get a row",
         "description": "Get a row in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -1482,7 +1514,9 @@
       "delete": {
         "summary": "Delete a row",
         "description": "Delete a row in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -1543,7 +1577,9 @@
       "get": {
         "summary": "List rows",
         "description": "List rows in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -1616,7 +1652,9 @@
       "post": {
         "summary": "Upsert rows",
         "description": "Upsert rows in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -1685,7 +1723,9 @@
                                 "properties": {
                                   "type": {
                                     "type": "string",
-                                    "enum": ["datetime"]
+                                    "enum": [
+                                      "datetime"
+                                    ]
                                   },
                                   "epoch": {
                                     "type": "number"
@@ -1740,7 +1780,9 @@
       "post": {
         "summary": "Upsert CSV to table",
         "description": "Upsert CSV data to a table in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -1815,7 +1857,9 @@
       "get": {
         "summary": "Get tables",
         "description": "Get tables in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -1860,7 +1904,9 @@
       "post": {
         "summary": "Upsert a table",
         "description": "Upsert a table in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -1934,7 +1980,9 @@
       "post": {
         "summary": "Tokenize text",
         "description": "Tokenize text for the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1992,7 +2040,9 @@
       "get": {
         "summary": "Get data sources",
         "description": "Get data sources in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2036,7 +2086,9 @@
       "get": {
         "summary": "List feature flags",
         "description": "Get the feature flags for the workspace identified by {wId}.",
-        "tags": ["Workspace"],
+        "tags": [
+          "Workspace"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -2080,7 +2132,9 @@
       "get": {
         "summary": "List member emails",
         "description": "List the emails of all members in the workspace identified by {wId}.",
-        "tags": ["Workspace"],
+        "tags": [
+          "Workspace"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2133,7 +2187,9 @@
       "get": {
         "summary": "Get workspace usage data",
         "description": "Get usage data for the workspace identified by {wId}.",
-        "tags": ["Workspace"],
+        "tags": [
+          "Workspace"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -2194,7 +2250,9 @@
       "get": {
         "summary": "Get verified domains",
         "description": "Get the verified domain for the workspace identified by {wId}.",
-        "tags": ["Workspace"],
+        "tags": [
+          "Workspace"
+        ],
         "security": [
           {
             "BearerAuth": []

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -15,7 +15,9 @@
       "get": {
         "summary": "Get an app run",
         "description": "Retrieve a run for an app in the workspace identified by {wId}.",
-        "tags": ["Apps"],
+        "tags": [
+          "Apps"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -135,7 +137,9 @@
       "post": {
         "summary": "Create an app run",
         "description": "Create a run for an app in the workspace identified by {wId}.",
-        "tags": ["Apps"],
+        "tags": [
+          "Apps"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -243,7 +247,9 @@
       "get": {
         "summary": "List apps",
         "description": "Get all apps of a workspace.",
-        "tags": ["Apps"],
+        "tags": [
+          "Apps"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -290,7 +296,9 @@
       "get": {
         "summary": "List assistants",
         "description": "Get the agent configurations for the workspace identified by {wId}.",
-        "tags": ["Workspace"],
+        "tags": [
+          "Workspace"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -432,7 +440,9 @@
       "post": {
         "summary": "Create a content fragment",
         "description": "Create a new content fragment in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -539,7 +549,9 @@
       "get": {
         "summary": "Get the events for a conversation",
         "description": "Get the events for a conversation in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -595,7 +607,9 @@
       "get": {
         "summary": "Get a conversation",
         "description": "Get a conversation in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "security": [
           {
             "ApiKeyAuth": []
@@ -654,7 +668,9 @@
       "get": {
         "summary": "Get events for a message",
         "description": "Get events for a message in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -741,7 +757,9 @@
       "post": {
         "summary": "Create a message",
         "description": "Create a message in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -835,7 +853,12 @@
                         "type": "string",
                         "nullable": true,
                         "description": "The origin of the message",
-                        "enum": ["api", "web", "slack", "null"],
+                        "enum": [
+                          "api",
+                          "web",
+                          "slack",
+                          "null"
+                        ],
                         "default": "api",
                         "example": "api"
                       }
@@ -866,7 +889,9 @@
       "post": {
         "summary": "Create a new conversation",
         "description": "Create a new conversation in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -876,15 +901,11 @@
             "schema": {
               "type": "string"
             }
-          },
+          }
+        ],
+        "security": [
           {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "description": "Bearer token for authentication",
-            "schema": {
-              "type": "string"
-            }
+            "ApiKeyAuth": []
           }
         ],
         "requestBody": {
@@ -910,55 +931,13 @@
                           "properties": {
                             "configurationId": {
                               "type": "string",
-                              "example": [
-                                {
-                                  "configurationId": "dust"
-                                }
-                              ]
+                              "example": "dust"
                             }
                           }
                         }
                       },
                       "context": {
-                        "type": "object",
-                        "properties": {
-                          "timezone": {
-                            "type": "string",
-                            "description": "The timezone of the user who created the message",
-                            "example": "Europe/Paris"
-                          },
-                          "username": {
-                            "type": "string",
-                            "description": "The username of the user who created the message",
-                            "example": "johndoe"
-                          },
-                          "fullName": {
-                            "type": "string",
-                            "description": "The full name of the user who created the message",
-                            "example": "John Doe",
-                            "nullable": true
-                          },
-                          "email": {
-                            "type": "string",
-                            "description": "The email of the user who created the message",
-                            "example": "johndoe@example.com",
-                            "nullable": true
-                          },
-                          "profilePictureUrl": {
-                            "type": "string",
-                            "nullable": true,
-                            "description": "The profile picture URL of the user who created the message",
-                            "example": "https://example.com/profile_picture.jpg"
-                          },
-                          "origin": {
-                            "type": "string",
-                            "nullable": true,
-                            "description": "The origin of the message",
-                            "enum": ["api", "web", "slack", "null"],
-                            "default": "api",
-                            "example": "api"
-                          }
-                        }
+                        "$ref": "#/components/schemas/Context"
                       }
                     }
                   },
@@ -986,29 +965,7 @@
                         "example": "text/plain"
                       },
                       "context": {
-                        "type": "object",
-                        "properties": {
-                          "username": {
-                            "type": "string",
-                            "description": "The username of the user who created the content fragment",
-                            "example": "johndoe"
-                          },
-                          "fullName": {
-                            "type": "string",
-                            "description": "The full name of the user who created the content fragment",
-                            "example": "John Doe"
-                          },
-                          "email": {
-                            "type": "string",
-                            "description": "The email of the user who created the content fragment",
-                            "example": "johndoe@example.com"
-                          },
-                          "profilePictureUrl": {
-                            "type": "string",
-                            "description": "The profile picture URL of the user who created the content fragment",
-                            "example": "https://example.com/profile_picture.jpg"
-                          }
-                        }
+                        "$ref": "#/components/schemas/Context"
                       }
                     }
                   },
@@ -1027,7 +984,11 @@
                   "visibility": {
                     "type": "string",
                     "description": "The visibility of the conversation",
-                    "enum": ["public", "private", "unlisted"],
+                    "enum": [
+                      "public",
+                      "private",
+                      "unlisted"
+                    ],
                     "default": "public",
                     "example": "private"
                   }
@@ -1063,7 +1024,9 @@
       "get": {
         "summary": "Retrieve a document from a data source",
         "description": "Retrieve a document from a data source in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1126,7 +1089,9 @@
       "post": {
         "summary": "Upsert a document in a data source",
         "description": "Upsert a document in a data source in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1213,7 +1178,9 @@
       "delete": {
         "summary": "Delete a document from a data source",
         "description": "Delete a document from a data source in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1275,7 +1242,9 @@
       "post": {
         "summary": "Update the parents of a document",
         "description": "Update the parents of a document in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1358,7 +1327,9 @@
       "get": {
         "summary": "Get documents",
         "description": "Get documents in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1421,7 +1392,9 @@
       "get": {
         "summary": "Search the data source",
         "description": "Search the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1613,7 +1586,9 @@
       "get": {
         "summary": "Get a table",
         "description": "Get a table in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1667,7 +1642,9 @@
       "delete": {
         "summary": "Delete a table",
         "description": "Delete a table in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1723,7 +1700,9 @@
       "get": {
         "summary": "Get a row",
         "description": "Get a row in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1786,7 +1765,9 @@
       "delete": {
         "summary": "Delete a row",
         "description": "Delete a row in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1851,7 +1832,9 @@
       "get": {
         "summary": "List rows",
         "description": "List rows in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1918,7 +1901,9 @@
       "post": {
         "summary": "Upsert rows",
         "description": "Upsert rows in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1990,7 +1975,9 @@
                                 "properties": {
                                   "type": {
                                     "type": "string",
-                                    "enum": ["datetime"]
+                                    "enum": [
+                                      "datetime"
+                                    ]
                                   },
                                   "epoch": {
                                     "type": "number"
@@ -2037,7 +2024,9 @@
       "post": {
         "summary": "Upsert CSV to table",
         "description": "Upsert CSV data to a table in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2108,7 +2097,9 @@
       "get": {
         "summary": "Get tables",
         "description": "Get tables in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2147,7 +2138,9 @@
       "post": {
         "summary": "Upsert a table",
         "description": "Upsert a table in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2215,7 +2208,9 @@
       "post": {
         "summary": "Tokenize text",
         "description": "Tokenize text for the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2277,7 +2272,9 @@
       "get": {
         "summary": "Get data sources",
         "description": "Get data sources in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2315,7 +2312,9 @@
       "get": {
         "summary": "List feature flags",
         "description": "Get the feature flags for the workspace identified by {wId}.",
-        "tags": ["Workspace"],
+        "tags": [
+          "Workspace"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2362,7 +2361,9 @@
       "get": {
         "summary": "List member emails",
         "description": "List the emails of all members in the workspace identified by {wId}.",
-        "tags": ["Workspace"],
+        "tags": [
+          "Workspace"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2418,7 +2419,9 @@
       "get": {
         "summary": "Get workspace usage data",
         "description": "Get usage data for the workspace identified by {wId}.",
-        "tags": ["Workspace"],
+        "tags": [
+          "Workspace"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2476,7 +2479,9 @@
       "get": {
         "summary": "Get verified domains",
         "description": "Get the verified domain for the workspace identified by {wId}.",
-        "tags": ["Workspace"],
+        "tags": [
+          "Workspace"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2512,43 +2517,178 @@
     }
   },
   "components": {
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "Authorization",
+        "description": "API key authentication. Prefix the key with 'Bearer '"
+      }
+    },
     "schemas": {
-      "Message": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "sId": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "createdAt": {
+            "type": "integer"
+          },
+          "username": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "fullName": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "image": {
+            "type": "string"
+          }
+        }
+      },
+      "Workspace": {
         "type": "object",
         "properties": {
           "id": {
-            "type": "number"
-          },
-          "created": {
-            "type": "number"
+            "type": "integer"
           },
           "sId": {
             "type": "string"
           },
-          "type": {
+          "name": {
             "type": "string"
           },
-          "visibility": {
+          "role": {
+            "type": "string"
+          },
+          "segmentation": {
+            "type": "string",
+            "nullable": true
+          },
+          "flags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "ssoEnforced": {
+            "type": "boolean"
+          },
+          "whiteListedProviders": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "defaultEmbeddingProvider": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "Context": {
+        "type": "object",
+        "properties": {
+          "username": {
+            "type": "string"
+          },
+          "timezone": {
+            "type": "string"
+          },
+          "fullName": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "profilePictureUrl": {
+            "type": "string"
+          },
+          "origin": {
+            "type": "string"
+          }
+        }
+      },
+      "AgentConfiguration": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "sId": {
             "type": "string"
           },
           "version": {
-            "type": "number"
+            "type": "integer"
           },
-          "user": {
-            "type": "object",
+          "versionCreatedAt": {
+            "type": "string",
             "nullable": true
           },
-          "mentions": {
-            "type": "array"
+          "versionAuthorId": {
+            "type": "string",
+            "nullable": true
           },
-          "content": {
+          "name": {
             "type": "string"
           },
-          "context": {
-            "type": "object"
+          "description": {
+            "type": "string"
           },
-          "rank": {
-            "type": "number"
+          "instructions": {
+            "type": "string",
+            "nullable": true
+          },
+          "pictureUrl": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "scope": {
+            "type": "string"
+          },
+          "userListStatus": {
+            "type": "string"
+          },
+          "model": {
+            "type": "object",
+            "properties": {
+              "providerId": {
+                "type": "string"
+              },
+              "modelId": {
+                "type": "string"
+              },
+              "temperature": {
+                "type": "number"
+              }
+            }
+          },
+          "actions": {
+            "type": "array"
+          },
+          "maxToolsUsePerRun": {
+            "type": "integer"
+          },
+          "templateId": {
+            "type": "string",
+            "nullable": true
           }
         }
       },
@@ -2568,44 +2708,7 @@
                 "type": "string"
               },
               "owner": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "integer"
-                  },
-                  "sId": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "role": {
-                    "type": "string"
-                  },
-                  "segmentation": {
-                    "type": "string",
-                    "nullable": true
-                  },
-                  "flags": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "ssoEnforced": {
-                    "type": "boolean"
-                  },
-                  "whiteListedProviders": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "defaultEmbeddingProvider": {
-                    "type": "string",
-                    "nullable": true
-                  }
-                }
+                "$ref": "#/components/schemas/Workspace"
               },
               "title": {
                 "type": "string"
@@ -2639,39 +2742,7 @@
                         "type": "integer"
                       },
                       "user": {
-                        "type": "object",
-                        "properties": {
-                          "sId": {
-                            "type": "string"
-                          },
-                          "id": {
-                            "type": "integer"
-                          },
-                          "createdAt": {
-                            "type": "integer"
-                          },
-                          "username": {
-                            "type": "string"
-                          },
-                          "email": {
-                            "type": "string"
-                          },
-                          "firstName": {
-                            "type": "string"
-                          },
-                          "lastName": {
-                            "type": "string"
-                          },
-                          "fullName": {
-                            "type": "string"
-                          },
-                          "provider": {
-                            "type": "string"
-                          },
-                          "image": {
-                            "type": "string"
-                          }
-                        }
+                        "$ref": "#/components/schemas/User"
                       },
                       "mentions": {
                         "type": "array",
@@ -2688,27 +2759,7 @@
                         "type": "string"
                       },
                       "context": {
-                        "type": "object",
-                        "properties": {
-                          "username": {
-                            "type": "string"
-                          },
-                          "timezone": {
-                            "type": "string"
-                          },
-                          "fullName": {
-                            "type": "string"
-                          },
-                          "email": {
-                            "type": "string"
-                          },
-                          "profilePictureUrl": {
-                            "type": "string"
-                          },
-                          "origin": {
-                            "type": "string"
-                          }
-                        }
+                        "$ref": "#/components/schemas/Context"
                       },
                       "agentMessageId": {
                         "type": "integer"
@@ -2745,72 +2796,7 @@
                         "nullable": true
                       },
                       "configuration": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "integer"
-                          },
-                          "sId": {
-                            "type": "string"
-                          },
-                          "version": {
-                            "type": "integer"
-                          },
-                          "versionCreatedAt": {
-                            "type": "string",
-                            "nullable": true
-                          },
-                          "versionAuthorId": {
-                            "type": "string",
-                            "nullable": true
-                          },
-                          "name": {
-                            "type": "string"
-                          },
-                          "description": {
-                            "type": "string"
-                          },
-                          "instructions": {
-                            "type": "string",
-                            "nullable": true
-                          },
-                          "pictureUrl": {
-                            "type": "string"
-                          },
-                          "status": {
-                            "type": "string"
-                          },
-                          "scope": {
-                            "type": "string"
-                          },
-                          "userListStatus": {
-                            "type": "string"
-                          },
-                          "model": {
-                            "type": "object",
-                            "properties": {
-                              "providerId": {
-                                "type": "string"
-                              },
-                              "modelId": {
-                                "type": "string"
-                              },
-                              "temperature": {
-                                "type": "number"
-                              }
-                            }
-                          },
-                          "actions": {
-                            "type": "array"
-                          },
-                          "maxToolsUsePerRun": {
-                            "type": "integer"
-                          },
-                          "templateId": {
-                            "type": "string",
-                            "nullable": true
-                          }
-                        }
+                        "$ref": "#/components/schemas/AgentConfiguration"
                       }
                     }
                   }
@@ -2819,14 +2805,6 @@
             }
           }
         }
-      }
-    },
-    "securitySchemes": {
-      "ApiKeyAuth": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "Authorization",
-        "description": "API key authentication. Prefix the key with 'Bearer '"
       }
     }
   },

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -308,15 +308,11 @@
             "schema": {
               "type": "string"
             }
-          },
+          }
+        ],
+        "security": [
           {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "description": "Bearer token for authentication",
-            "schema": {
-              "type": "string"
-            }
+            "BearerAuth": []
           }
         ],
         "responses": {
@@ -327,92 +323,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "integer"
-                      },
-                      "sId": {
-                        "type": "string"
-                      },
-                      "version": {
-                        "type": "integer"
-                      },
-                      "versionCreatedAt": {
-                        "type": "string",
-                        "nullable": true
-                      },
-                      "versionAuthorId": {
-                        "type": "string",
-                        "nullable": true
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "description": {
-                        "type": "string"
-                      },
-                      "instructions": {
-                        "type": "string"
-                      },
-                      "pictureUrl": {
-                        "type": "string"
-                      },
-                      "status": {
-                        "type": "string"
-                      },
-                      "userListStatus": {
-                        "type": "string"
-                      },
-                      "scope": {
-                        "type": "string"
-                      },
-                      "model": {
-                        "type": "object",
-                        "properties": {
-                          "providerId": {
-                            "type": "string"
-                          },
-                          "modelId": {
-                            "type": "string"
-                          },
-                          "temperature": {
-                            "type": "number"
-                          }
-                        }
-                      },
-                      "actions": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "integer"
-                            },
-                            "sId": {
-                              "type": "string"
-                            },
-                            "type": {
-                              "type": "string"
-                            },
-                            "name": {
-                              "type": "string"
-                            },
-                            "description": {
-                              "type": "string",
-                              "nullable": true
-                            }
-                          }
-                        }
-                      },
-                      "maxToolsUsePerRun": {
-                        "type": "integer"
-                      },
-                      "templateId": {
-                        "type": "string",
-                        "nullable": true
-                      }
-                    }
+                    "$ref": "#/components/schemas/AgentConfiguration"
                   }
                 }
               }
@@ -461,15 +372,11 @@
             "schema": {
               "type": "string"
             }
-          },
+          }
+        ],
+        "security": [
           {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "description": "Bearer token for authentication",
-            "schema": {
-              "type": "string"
-            }
+            "BearerAuth": []
           }
         ],
         "requestBody": {
@@ -477,61 +384,21 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "title": {
-                    "type": "string",
-                    "description": "The title of the content fragment",
-                    "example": "My content fragment"
-                  },
-                  "content": {
-                    "type": "string",
-                    "description": "The content of the content fragment",
-                    "example": "This is my content fragment"
-                  },
-                  "url": {
-                    "type": "string",
-                    "description": "The URL of the content fragment",
-                    "example": "https://example.com/content"
-                  },
-                  "contentType": {
-                    "type": "string",
-                    "description": "The content type of the content fragment",
-                    "example": "text/plain"
-                  },
-                  "context": {
-                    "type": "object",
-                    "properties": {
-                      "username": {
-                        "type": "string",
-                        "description": "The username of the user who created the content fragment",
-                        "example": "johndoe"
-                      },
-                      "fullName": {
-                        "type": "string",
-                        "description": "The full name of the user who created the content fragment",
-                        "example": "John Doe"
-                      },
-                      "email": {
-                        "type": "string",
-                        "description": "The email of the user who created the content fragment",
-                        "example": "johndoe@example.com"
-                      },
-                      "profilePictureUrl": {
-                        "type": "string",
-                        "description": "The profile picture URL of the user who created the content fragment",
-                        "example": "https://example.com/profile_picture.jpg"
-                      }
-                    }
-                  }
-                }
+                "$ref": "#/components/schemas/ContentFragment"
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "Content fragment created successfully."
+            "description": "Content fragment created successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentFragment"
+                }
+              }
+            }
           },
           "400": {
             "description": "Bad Request. Missing or invalid parameters."
@@ -570,20 +437,26 @@
             "schema": {
               "type": "string"
             }
-          },
+          }
+        ],
+        "security": [
           {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "description": "Bearer token for authentication",
-            "schema": {
-              "type": "string"
-            }
+            "BearerAuth": []
           }
         ],
         "responses": {
           "200": {
-            "description": "Events for the conversation"
+            "description": "Events for the conversation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Conversation"
+                  }
+                }
+              }
+            }
           },
           "400": {
             "description": "Bad Request. Missing or invalid parameters."
@@ -706,15 +579,11 @@
             "schema": {
               "type": "string"
             }
-          },
+          }
+        ],
+        "security": [
           {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "description": "Bearer token for authentication",
-            "schema": {
-              "type": "string"
-            }
+            "BearerAuth": []
           }
         ],
         "responses": {
@@ -739,8 +608,7 @@
                             "description": "Type of the event"
                           },
                           "data": {
-                            "type": "object",
-                            "description": "Data of the event"
+                            "$ref": "#/components/schemas/Message"
                           }
                         }
                       }
@@ -749,6 +617,18 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "500": {
+            "description": "Internal Server Error"
           }
         }
       }
@@ -778,15 +658,11 @@
             "schema": {
               "type": "string"
             }
-          },
+          }
+        ],
+        "security": [
           {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "description": "Bearer token for authentication",
-            "schema": {
-              "type": "string"
-            }
+            "BearerAuth": []
           }
         ],
         "requestBody": {
@@ -794,84 +670,21 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "content": {
-                    "type": "string",
-                    "description": "The content of the message",
-                    "example": "This is my message"
-                  },
-                  "mentions": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "description": "The mentions of the message, where configurationId is the ID of the assistant mentioned.",
-                      "properties": {
-                        "configurationId": {
-                          "type": "string",
-                          "example": [
-                            {
-                              "configurationId": "dust"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  },
-                  "context": {
-                    "type": "object",
-                    "properties": {
-                      "timezone": {
-                        "type": "string",
-                        "description": "The timezone of the user who created the message",
-                        "example": "Europe/Paris"
-                      },
-                      "username": {
-                        "type": "string",
-                        "description": "The username of the user who created the message",
-                        "example": "johndoe"
-                      },
-                      "fullName": {
-                        "type": "string",
-                        "description": "The full name of the user who created the message",
-                        "example": "John Doe",
-                        "nullable": true
-                      },
-                      "email": {
-                        "type": "string",
-                        "description": "The email of the user who created the message",
-                        "example": "johndoe@example.com",
-                        "nullable": true
-                      },
-                      "profilePictureUrl": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "The profile picture URL of the user who created the message",
-                        "example": "https://example.com/profile_picture.jpg"
-                      },
-                      "origin": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "The origin of the message",
-                        "enum": [
-                          "api",
-                          "web",
-                          "slack",
-                          "null"
-                        ],
-                        "default": "api",
-                        "example": "api"
-                      }
-                    }
-                  }
-                }
+                "$ref": "#/components/schemas/Message"
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "Message created successfully."
+            "description": "Message created successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Message"
+                }
+              }
+            }
           },
           "400": {
             "description": "Bad Request. Missing or invalid parameters."
@@ -916,58 +729,10 @@
                 "type": "object",
                 "properties": {
                   "message": {
-                    "type": "object",
-                    "properties": {
-                      "content": {
-                        "type": "string",
-                        "description": "The content of the message",
-                        "example": "This is my message"
-                      },
-                      "mentions": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "description": "The mentions of the message, where configurationId is the ID of the assistant mentioned.",
-                          "properties": {
-                            "configurationId": {
-                              "type": "string",
-                              "example": "dust"
-                            }
-                          }
-                        }
-                      },
-                      "context": {
-                        "$ref": "#/components/schemas/Context"
-                      }
-                    }
+                    "$ref": "#/components/schemas/Message"
                   },
                   "contentFragment": {
-                    "type": "object",
-                    "properties": {
-                      "title": {
-                        "type": "string",
-                        "description": "The title of the content fragment",
-                        "example": "My content fragment"
-                      },
-                      "content": {
-                        "type": "string",
-                        "description": "The content of the content fragment",
-                        "example": "This is my content fragment"
-                      },
-                      "url": {
-                        "type": "string",
-                        "description": "The URL of the content fragment",
-                        "example": "https://example.com/content"
-                      },
-                      "contentType": {
-                        "type": "string",
-                        "description": "The content type of the content fragment",
-                        "example": "text/plain"
-                      },
-                      "context": {
-                        "$ref": "#/components/schemas/Context"
-                      }
-                    }
+                    "$ref": "#/components/schemas/ContentFragment"
                   },
                   "blocking": {
                     "type": "boolean",
@@ -2521,7 +2286,7 @@
       "BearerAuth": {
         "type": "http",
         "scheme": "bearer",
-        "description": "Your DUST API key prefixed by `Bearer sk-...`"
+        "description": "Your DUST API key is a Bearer token."
       }
     },
     "schemas": {

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -15,9 +15,7 @@
       "get": {
         "summary": "Get an app run",
         "description": "Retrieve a run for an app in the workspace identified by {wId}.",
-        "tags": [
-          "Apps"
-        ],
+        "tags": ["Apps"],
         "parameters": [
           {
             "in": "path",
@@ -137,9 +135,7 @@
       "post": {
         "summary": "Create an app run",
         "description": "Create a run for an app in the workspace identified by {wId}.",
-        "tags": [
-          "Apps"
-        ],
+        "tags": ["Apps"],
         "parameters": [
           {
             "in": "path",
@@ -247,9 +243,7 @@
       "get": {
         "summary": "List apps",
         "description": "Get all apps of a workspace.",
-        "tags": [
-          "Apps"
-        ],
+        "tags": ["Apps"],
         "parameters": [
           {
             "in": "path",
@@ -296,9 +290,7 @@
       "get": {
         "summary": "List assistants",
         "description": "Get the agent configurations for the workspace identified by {wId}.",
-        "tags": [
-          "Workspace"
-        ],
+        "tags": ["Workspace"],
         "parameters": [
           {
             "in": "path",
@@ -440,9 +432,7 @@
       "post": {
         "summary": "Create a content fragment",
         "description": "Create a new content fragment in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "parameters": [
           {
             "in": "path",
@@ -549,9 +539,7 @@
       "get": {
         "summary": "Get the events for a conversation",
         "description": "Get the events for a conversation in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "parameters": [
           {
             "in": "path",
@@ -607,9 +595,7 @@
       "get": {
         "summary": "Get a conversation",
         "description": "Get a conversation in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "security": [
           {
             "ApiKeyAuth": []
@@ -668,9 +654,7 @@
       "get": {
         "summary": "Get events for a message",
         "description": "Get events for a message in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "parameters": [
           {
             "in": "path",
@@ -757,9 +741,7 @@
       "post": {
         "summary": "Create a message",
         "description": "Create a message in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "parameters": [
           {
             "in": "path",
@@ -853,12 +835,7 @@
                         "type": "string",
                         "nullable": true,
                         "description": "The origin of the message",
-                        "enum": [
-                          "api",
-                          "web",
-                          "slack",
-                          "null"
-                        ],
+                        "enum": ["api", "web", "slack", "null"],
                         "default": "api",
                         "example": "api"
                       }
@@ -889,9 +866,7 @@
       "post": {
         "summary": "Create a new conversation",
         "description": "Create a new conversation in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "parameters": [
           {
             "in": "path",
@@ -984,11 +959,7 @@
                   "visibility": {
                     "type": "string",
                     "description": "The visibility of the conversation",
-                    "enum": [
-                      "public",
-                      "private",
-                      "unlisted"
-                    ],
+                    "enum": ["public", "private", "unlisted"],
                     "default": "public",
                     "example": "private"
                   }
@@ -1024,9 +995,7 @@
       "get": {
         "summary": "Retrieve a document from a data source",
         "description": "Retrieve a document from a data source in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -1089,9 +1058,7 @@
       "post": {
         "summary": "Upsert a document in a data source",
         "description": "Upsert a document in a data source in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -1178,9 +1145,7 @@
       "delete": {
         "summary": "Delete a document from a data source",
         "description": "Delete a document from a data source in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -1242,9 +1207,7 @@
       "post": {
         "summary": "Update the parents of a document",
         "description": "Update the parents of a document in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -1327,9 +1290,7 @@
       "get": {
         "summary": "Get documents",
         "description": "Get documents in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -1392,9 +1353,7 @@
       "get": {
         "summary": "Search the data source",
         "description": "Search the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -1586,9 +1545,7 @@
       "get": {
         "summary": "Get a table",
         "description": "Get a table in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -1642,9 +1599,7 @@
       "delete": {
         "summary": "Delete a table",
         "description": "Delete a table in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -1700,9 +1655,7 @@
       "get": {
         "summary": "Get a row",
         "description": "Get a row in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -1765,9 +1718,7 @@
       "delete": {
         "summary": "Delete a row",
         "description": "Delete a row in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -1832,9 +1783,7 @@
       "get": {
         "summary": "List rows",
         "description": "List rows in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -1901,9 +1850,7 @@
       "post": {
         "summary": "Upsert rows",
         "description": "Upsert rows in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -1975,9 +1922,7 @@
                                 "properties": {
                                   "type": {
                                     "type": "string",
-                                    "enum": [
-                                      "datetime"
-                                    ]
+                                    "enum": ["datetime"]
                                   },
                                   "epoch": {
                                     "type": "number"
@@ -2024,9 +1969,7 @@
       "post": {
         "summary": "Upsert CSV to table",
         "description": "Upsert CSV data to a table in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -2097,9 +2040,7 @@
       "get": {
         "summary": "Get tables",
         "description": "Get tables in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -2138,9 +2079,7 @@
       "post": {
         "summary": "Upsert a table",
         "description": "Upsert a table in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -2208,9 +2147,7 @@
       "post": {
         "summary": "Tokenize text",
         "description": "Tokenize text for the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -2272,9 +2209,7 @@
       "get": {
         "summary": "Get data sources",
         "description": "Get data sources in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -2312,9 +2247,7 @@
       "get": {
         "summary": "List feature flags",
         "description": "Get the feature flags for the workspace identified by {wId}.",
-        "tags": [
-          "Workspace"
-        ],
+        "tags": ["Workspace"],
         "parameters": [
           {
             "in": "path",
@@ -2361,9 +2294,7 @@
       "get": {
         "summary": "List member emails",
         "description": "List the emails of all members in the workspace identified by {wId}.",
-        "tags": [
-          "Workspace"
-        ],
+        "tags": ["Workspace"],
         "parameters": [
           {
             "in": "path",
@@ -2419,9 +2350,7 @@
       "get": {
         "summary": "Get workspace usage data",
         "description": "Get usage data for the workspace identified by {wId}.",
-        "tags": [
-          "Workspace"
-        ],
+        "tags": ["Workspace"],
         "parameters": [
           {
             "in": "path",
@@ -2479,9 +2408,7 @@
       "get": {
         "summary": "Get verified domains",
         "description": "Get the verified domain for the workspace identified by {wId}.",
-        "tags": [
-          "Workspace"
-        ],
+        "tags": ["Workspace"],
         "parameters": [
           {
             "in": "path",
@@ -2530,7 +2457,8 @@
         "type": "object",
         "properties": {
           "sId": {
-            "type": "string"
+            "type": "string",
+            "description": "Unique string identifier for the user"
           },
           "id": {
             "type": "integer"
@@ -2539,25 +2467,32 @@
             "type": "integer"
           },
           "username": {
-            "type": "string"
+            "type": "string",
+            "description": "User's chosen username"
           },
           "email": {
-            "type": "string"
+            "type": "string",
+            "description": "User's email address"
           },
           "firstName": {
-            "type": "string"
+            "type": "string",
+            "description": "User's first name"
           },
           "lastName": {
-            "type": "string"
+            "type": "string",
+            "description": "User's last name"
           },
           "fullName": {
-            "type": "string"
+            "type": "string",
+            "description": "User's full name"
           },
           "provider": {
-            "type": "string"
+            "type": "string",
+            "description": "Authentication provider used by the user"
           },
           "image": {
-            "type": "string"
+            "type": "string",
+            "description": "URL of the user's profile image"
           }
         }
       },
@@ -2568,22 +2503,27 @@
             "type": "integer"
           },
           "sId": {
-            "type": "string"
+            "type": "string",
+            "description": "Unique string identifier for the workspace"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "Name of the workspace"
           },
           "role": {
-            "type": "string"
+            "type": "string",
+            "description": "User's role in the workspace"
           },
           "segmentation": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Segmentation information for the workspace"
           },
           "flags": {
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "description": "Feature flags enabled for the workspace"
             }
           },
           "ssoEnforced": {
@@ -2592,12 +2532,14 @@
           "whiteListedProviders": {
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "description": "List of allowed authentication providers"
             }
           },
           "defaultEmbeddingProvider": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Default provider for embeddings in the workspace"
           }
         }
       },
@@ -2605,22 +2547,28 @@
         "type": "object",
         "properties": {
           "username": {
-            "type": "string"
+            "type": "string",
+            "description": "Username in the current context"
           },
           "timezone": {
-            "type": "string"
+            "type": "string",
+            "description": "User's timezone"
           },
           "fullName": {
-            "type": "string"
+            "type": "string",
+            "description": "User's full name in the current context"
           },
           "email": {
-            "type": "string"
+            "type": "string",
+            "description": "User's email in the current context"
           },
           "profilePictureUrl": {
-            "type": "string"
+            "type": "string",
+            "description": "URL of the user's profile picture"
           },
           "origin": {
-            "type": "string"
+            "type": "string",
+            "description": "Origin of the context (e.g., 'slack', 'web')"
           }
         }
       },
@@ -2631,49 +2579,61 @@
             "type": "integer"
           },
           "sId": {
-            "type": "string"
+            "type": "string",
+            "description": "Unique string identifier for the agent configuration"
           },
           "version": {
             "type": "integer"
           },
           "versionCreatedAt": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Timestamp of when the version was created"
           },
           "versionAuthorId": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "ID of the user who created this version"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "Name of the agent configuration"
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Description of the agent configuration"
           },
           "instructions": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Instructions for the agent"
           },
           "pictureUrl": {
-            "type": "string"
+            "type": "string",
+            "description": "URL of the agent's picture"
           },
           "status": {
-            "type": "string"
+            "type": "string",
+            "description": "Current status of the agent configuration"
           },
           "scope": {
-            "type": "string"
+            "type": "string",
+            "description": "Scope of the agent configuration"
           },
           "userListStatus": {
-            "type": "string"
+            "type": "string",
+            "description": "Status of the user list for this configuration"
           },
           "model": {
             "type": "object",
             "properties": {
               "providerId": {
-                "type": "string"
+                "type": "string",
+                "description": "ID of the model provider"
               },
               "modelId": {
-                "type": "string"
+                "type": "string",
+                "description": "ID of the specific model"
               },
               "temperature": {
                 "type": "number"
@@ -2688,7 +2648,8 @@
           },
           "templateId": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "ID of the template used for this configuration"
           }
         }
       },
@@ -2705,16 +2666,19 @@
                 "type": "integer"
               },
               "sId": {
-                "type": "string"
+                "type": "string",
+                "description": "Unique string identifier for the conversation"
               },
               "owner": {
                 "$ref": "#/components/schemas/Workspace"
               },
               "title": {
-                "type": "string"
+                "type": "string",
+                "description": "Title of the conversation"
               },
               "visibility": {
-                "type": "string"
+                "type": "string",
+                "description": "Visibility setting of the conversation"
               },
               "content": {
                 "type": "array",
@@ -2727,13 +2691,16 @@
                         "type": "integer"
                       },
                       "sId": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Unique string identifier for the message"
                       },
                       "type": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Type of the message"
                       },
                       "visibility": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Visibility setting of the message"
                       },
                       "version": {
                         "type": "integer"
@@ -2747,16 +2714,12 @@
                       "mentions": {
                         "type": "array",
                         "items": {
-                          "type": "object",
-                          "properties": {
-                            "configurationId": {
-                              "type": "string"
-                            }
-                          }
+                          "$ref": "#/components/schemas/Mention"
                         }
                       },
                       "content": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Content of the message"
                       },
                       "context": {
                         "$ref": "#/components/schemas/Context"
@@ -2765,17 +2728,20 @@
                         "type": "integer"
                       },
                       "parentMessageId": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "ID of the parent message"
                       },
                       "status": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Status of the message"
                       },
                       "actions": {
                         "type": "array"
                       },
                       "chainOfThought": {
                         "type": "string",
-                        "nullable": true
+                        "nullable": true,
+                        "description": "Chain of thought for the message"
                       },
                       "rawContents": {
                         "type": "array",
@@ -2786,14 +2752,16 @@
                               "type": "integer"
                             },
                             "content": {
-                              "type": "string"
+                              "type": "string",
+                              "description": "Content for each step"
                             }
                           }
                         }
                       },
                       "error": {
                         "type": "string",
-                        "nullable": true
+                        "nullable": true,
+                        "description": "Error message, if any"
                       },
                       "configuration": {
                         "$ref": "#/components/schemas/AgentConfiguration"
@@ -2803,6 +2771,63 @@
                 }
               }
             }
+          }
+        }
+      },
+      "Mention": {
+        "type": "object",
+        "properties": {
+          "configurationId": {
+            "type": "string",
+            "description": "ID of the mentioned agent configuration",
+            "example": "dust"
+          }
+        }
+      },
+      "Message": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "string",
+            "description": "The content of the message",
+            "example": "This is my message"
+          },
+          "mentions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Mention"
+            }
+          },
+          "context": {
+            "$ref": "#/components/schemas/Context"
+          }
+        }
+      },
+      "ContentFragment": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "The title of the content fragment",
+            "example": "My content fragment"
+          },
+          "content": {
+            "type": "string",
+            "description": "The content of the content fragment",
+            "example": "This is my content fragment"
+          },
+          "url": {
+            "type": "string",
+            "description": "The URL of the content fragment",
+            "example": "https://example.com/content"
+          },
+          "contentType": {
+            "type": "string",
+            "description": "The content type of the content fragment",
+            "example": "text/plain"
+          },
+          "context": {
+            "$ref": "#/components/schemas/Context"
           }
         }
       }

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -612,7 +612,7 @@
         ],
         "security": [
           {
-            "ApiKeyAuth": []
+            "BearerAuth": []
           }
         ],
         "parameters": [
@@ -905,7 +905,7 @@
         ],
         "security": [
           {
-            "ApiKeyAuth": []
+            "BearerAuth": []
           }
         ],
         "requestBody": {

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -2049,20 +2049,26 @@
             "schema": {
               "type": "string"
             }
-          },
+          }
+        ],
+        "security": [
           {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "description": "Bearer token for authentication",
-            "schema": {
-              "type": "string"
-            }
+            "BearerAuth": []
           }
         ],
         "responses": {
           "200": {
-            "description": "The data sources"
+            "description": "The data sources",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  }
+                }
+              }
+            }
           },
           "404": {
             "description": "The workspace was not found"

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -15,7 +15,9 @@
       "get": {
         "summary": "Get an app run",
         "description": "Retrieve a run for an app in the workspace identified by {wId}.",
-        "tags": ["Apps"],
+        "tags": [
+          "Apps"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -135,7 +137,9 @@
       "post": {
         "summary": "Create an app run",
         "description": "Create a run for an app in the workspace identified by {wId}.",
-        "tags": ["Apps"],
+        "tags": [
+          "Apps"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -243,7 +247,9 @@
       "get": {
         "summary": "List apps",
         "description": "Get all apps of a workspace.",
-        "tags": ["Apps"],
+        "tags": [
+          "Apps"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -290,7 +296,9 @@
       "get": {
         "summary": "List assistants",
         "description": "Get the agent configurations for the workspace identified by {wId}.",
-        "tags": ["Workspace"],
+        "tags": [
+          "Workspace"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -432,7 +440,9 @@
       "post": {
         "summary": "Create a content fragment",
         "description": "Create a new content fragment in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -539,7 +549,9 @@
       "get": {
         "summary": "Get the events for a conversation",
         "description": "Get the events for a conversation in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -595,7 +607,9 @@
       "get": {
         "summary": "Get a conversation",
         "description": "Get a conversation in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "security": [
           {
             "ApiKeyAuth": []
@@ -654,7 +668,9 @@
       "get": {
         "summary": "Get events for a message",
         "description": "Get events for a message in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -741,7 +757,9 @@
       "post": {
         "summary": "Create a message",
         "description": "Create a message in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -835,7 +853,12 @@
                         "type": "string",
                         "nullable": true,
                         "description": "The origin of the message",
-                        "enum": ["api", "web", "slack", "null"],
+                        "enum": [
+                          "api",
+                          "web",
+                          "slack",
+                          "null"
+                        ],
                         "default": "api",
                         "example": "api"
                       }
@@ -866,7 +889,9 @@
       "post": {
         "summary": "Create a new conversation",
         "description": "Create a new conversation in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -959,7 +984,11 @@
                   "visibility": {
                     "type": "string",
                     "description": "The visibility of the conversation",
-                    "enum": ["public", "private", "unlisted"],
+                    "enum": [
+                      "public",
+                      "private",
+                      "unlisted"
+                    ],
                     "default": "public",
                     "example": "private"
                   }
@@ -995,7 +1024,9 @@
       "get": {
         "summary": "Retrieve a document from a data source",
         "description": "Retrieve a document from a data source in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1058,7 +1089,9 @@
       "post": {
         "summary": "Upsert a document in a data source",
         "description": "Upsert a document in a data source in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1145,7 +1178,9 @@
       "delete": {
         "summary": "Delete a document from a data source",
         "description": "Delete a document from a data source in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1207,7 +1242,9 @@
       "post": {
         "summary": "Update the parents of a document",
         "description": "Update the parents of a document in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1290,7 +1327,9 @@
       "get": {
         "summary": "Get documents",
         "description": "Get documents in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1353,7 +1392,9 @@
       "get": {
         "summary": "Search the data source",
         "description": "Search the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1545,7 +1586,9 @@
       "get": {
         "summary": "Get a table",
         "description": "Get a table in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1599,7 +1642,9 @@
       "delete": {
         "summary": "Delete a table",
         "description": "Delete a table in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1655,7 +1700,9 @@
       "get": {
         "summary": "Get a row",
         "description": "Get a row in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1718,7 +1765,9 @@
       "delete": {
         "summary": "Delete a row",
         "description": "Delete a row in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1783,7 +1832,9 @@
       "get": {
         "summary": "List rows",
         "description": "List rows in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1850,7 +1901,9 @@
       "post": {
         "summary": "Upsert rows",
         "description": "Upsert rows in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1922,7 +1975,9 @@
                                 "properties": {
                                   "type": {
                                     "type": "string",
-                                    "enum": ["datetime"]
+                                    "enum": [
+                                      "datetime"
+                                    ]
                                   },
                                   "epoch": {
                                     "type": "number"
@@ -1969,7 +2024,9 @@
       "post": {
         "summary": "Upsert CSV to table",
         "description": "Upsert CSV data to a table in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2040,7 +2097,9 @@
       "get": {
         "summary": "Get tables",
         "description": "Get tables in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2079,7 +2138,9 @@
       "post": {
         "summary": "Upsert a table",
         "description": "Upsert a table in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2147,7 +2208,9 @@
       "post": {
         "summary": "Tokenize text",
         "description": "Tokenize text for the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2209,7 +2272,9 @@
       "get": {
         "summary": "Get data sources",
         "description": "Get data sources in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2247,7 +2312,9 @@
       "get": {
         "summary": "List feature flags",
         "description": "Get the feature flags for the workspace identified by {wId}.",
-        "tags": ["Workspace"],
+        "tags": [
+          "Workspace"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2294,7 +2361,9 @@
       "get": {
         "summary": "List member emails",
         "description": "List the emails of all members in the workspace identified by {wId}.",
-        "tags": ["Workspace"],
+        "tags": [
+          "Workspace"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2350,7 +2419,9 @@
       "get": {
         "summary": "Get workspace usage data",
         "description": "Get usage data for the workspace identified by {wId}.",
-        "tags": ["Workspace"],
+        "tags": [
+          "Workspace"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2408,7 +2479,9 @@
       "get": {
         "summary": "Get verified domains",
         "description": "Get the verified domain for the workspace identified by {wId}.",
-        "tags": ["Workspace"],
+        "tags": [
+          "Workspace"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2445,11 +2518,10 @@
   },
   "components": {
     "securitySchemes": {
-      "ApiKeyAuth": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "Authorization",
-        "description": "API key authentication. Prefix the key with 'Bearer '"
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Your DUST API key prefixed by `Bearer sk-...`"
       }
     },
     "schemas": {

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -15,9 +15,7 @@
       "get": {
         "summary": "Get an app run",
         "description": "Retrieve a run for an app in the workspace identified by {wId}.",
-        "tags": [
-          "Apps"
-        ],
+        "tags": ["Apps"],
         "security": [
           {
             "BearerAuth": []
@@ -133,9 +131,7 @@
       "post": {
         "summary": "Create an app run",
         "description": "Create a run for an app in the workspace identified by {wId}.",
-        "tags": [
-          "Apps"
-        ],
+        "tags": ["Apps"],
         "security": [
           {
             "BearerAuth": []
@@ -246,9 +242,7 @@
       "get": {
         "summary": "List apps",
         "description": "Get all apps of a workspace.",
-        "tags": [
-          "Apps"
-        ],
+        "tags": ["Apps"],
         "security": [
           {
             "BearerAuth": []
@@ -301,9 +295,7 @@
       "get": {
         "summary": "List assistants",
         "description": "Get the agent configurations for the workspace identified by {wId}.",
-        "tags": [
-          "Workspace"
-        ],
+        "tags": ["Workspace"],
         "parameters": [
           {
             "in": "path",
@@ -356,9 +348,7 @@
       "post": {
         "summary": "Create a content fragment",
         "description": "Create a new content fragment in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "parameters": [
           {
             "in": "path",
@@ -420,10 +410,8 @@
     "/api/v1/w/{wId}/assistant/conversations/{cId}/events": {
       "get": {
         "summary": "Get the events for a conversation",
-        "description": "Get the events for a conversation in the workspace identified by {wId}. This is a STREAMING ENDPOINT and trying it from the documentation will likely not work.",
-        "tags": [
-          "Conversations"
-        ],
+        "description": "Get the events for a conversation in the workspace identified by {wId}.",
+        "tags": ["Conversations"],
         "parameters": [
           {
             "in": "path",
@@ -475,9 +463,7 @@
       "get": {
         "summary": "Get a conversation",
         "description": "Get a conversation in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "security": [
           {
             "BearerAuth": []
@@ -536,9 +522,7 @@
       "get": {
         "summary": "Get events for a message",
         "description": "Get events for a message in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "parameters": [
           {
             "in": "path",
@@ -632,9 +616,7 @@
       "post": {
         "summary": "Create a message",
         "description": "Create a message in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "parameters": [
           {
             "in": "path",
@@ -697,9 +679,7 @@
       "post": {
         "summary": "Create a new conversation",
         "description": "Create a new conversation in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "parameters": [
           {
             "in": "path",
@@ -744,11 +724,7 @@
                   "visibility": {
                     "type": "string",
                     "description": "The visibility of the conversation",
-                    "enum": [
-                      "public",
-                      "private",
-                      "unlisted"
-                    ],
+                    "enum": ["public", "private", "unlisted"],
                     "default": "public",
                     "example": "private"
                   }
@@ -784,9 +760,7 @@
       "get": {
         "summary": "Retrieve a document from a data source",
         "description": "Retrieve a document from a data source in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -845,9 +819,7 @@
       "post": {
         "summary": "Upsert a document in a data source",
         "description": "Upsert a document in a data source in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -930,9 +902,7 @@
       "delete": {
         "summary": "Delete a document from a data source",
         "description": "Delete a document from a data source in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -990,9 +960,7 @@
       "post": {
         "summary": "Update the parents of a document",
         "description": "Update the parents of a document in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -1072,9 +1040,7 @@
       "get": {
         "summary": "Get documents",
         "description": "Get documents in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "security": [
           {
             "BearerAuth": []
@@ -1143,9 +1109,7 @@
       "get": {
         "summary": "Search the data source",
         "description": "Search the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "security": [
           {
             "BearerAuth": []
@@ -1333,9 +1297,7 @@
       "get": {
         "summary": "Get a table",
         "description": "Get a table in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "security": [
           {
             "BearerAuth": []
@@ -1392,9 +1354,7 @@
       "delete": {
         "summary": "Delete a table",
         "description": "Delete a table in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "security": [
           {
             "BearerAuth": []
@@ -1446,9 +1406,7 @@
       "get": {
         "summary": "Get a row",
         "description": "Get a row in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "security": [
           {
             "BearerAuth": []
@@ -1514,9 +1472,7 @@
       "delete": {
         "summary": "Delete a row",
         "description": "Delete a row in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "security": [
           {
             "BearerAuth": []
@@ -1577,9 +1533,7 @@
       "get": {
         "summary": "List rows",
         "description": "List rows in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "security": [
           {
             "BearerAuth": []
@@ -1652,9 +1606,7 @@
       "post": {
         "summary": "Upsert rows",
         "description": "Upsert rows in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "security": [
           {
             "BearerAuth": []
@@ -1723,9 +1675,7 @@
                                 "properties": {
                                   "type": {
                                     "type": "string",
-                                    "enum": [
-                                      "datetime"
-                                    ]
+                                    "enum": ["datetime"]
                                   },
                                   "epoch": {
                                     "type": "number"
@@ -1780,9 +1730,7 @@
       "post": {
         "summary": "Upsert CSV to table",
         "description": "Upsert CSV data to a table in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "security": [
           {
             "BearerAuth": []
@@ -1857,9 +1805,7 @@
       "get": {
         "summary": "Get tables",
         "description": "Get tables in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "security": [
           {
             "BearerAuth": []
@@ -1904,9 +1850,7 @@
       "post": {
         "summary": "Upsert a table",
         "description": "Upsert a table in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "security": [
           {
             "BearerAuth": []
@@ -1980,9 +1924,7 @@
       "post": {
         "summary": "Tokenize text",
         "description": "Tokenize text for the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -2040,9 +1982,7 @@
       "get": {
         "summary": "Get data sources",
         "description": "Get data sources in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -2086,9 +2026,7 @@
       "get": {
         "summary": "List feature flags",
         "description": "Get the feature flags for the workspace identified by {wId}.",
-        "tags": [
-          "Workspace"
-        ],
+        "tags": ["Workspace"],
         "security": [
           {
             "BearerAuth": []
@@ -2132,9 +2070,7 @@
       "get": {
         "summary": "List member emails",
         "description": "List the emails of all members in the workspace identified by {wId}.",
-        "tags": [
-          "Workspace"
-        ],
+        "tags": ["Workspace"],
         "parameters": [
           {
             "in": "path",
@@ -2187,9 +2123,7 @@
       "get": {
         "summary": "Get workspace usage data",
         "description": "Get usage data for the workspace identified by {wId}.",
-        "tags": [
-          "Workspace"
-        ],
+        "tags": ["Workspace"],
         "security": [
           {
             "BearerAuth": []
@@ -2250,9 +2184,7 @@
       "get": {
         "summary": "Get verified domains",
         "description": "Get the verified domain for the workspace identified by {wId}.",
-        "tags": [
-          "Workspace"
-        ],
+        "tags": ["Workspace"],
         "security": [
           {
             "BearerAuth": []

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -15,7 +15,9 @@
       "get": {
         "summary": "Get an app run",
         "description": "Retrieve a run for an app in the workspace identified by {wId}.",
-        "tags": ["Apps"],
+        "tags": [
+          "Apps"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -135,7 +137,9 @@
       "post": {
         "summary": "Create an app run",
         "description": "Create a run for an app in the workspace identified by {wId}.",
-        "tags": ["Apps"],
+        "tags": [
+          "Apps"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -243,7 +247,9 @@
       "get": {
         "summary": "List apps",
         "description": "Get all apps of a workspace.",
-        "tags": ["Apps"],
+        "tags": [
+          "Apps"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -290,7 +296,9 @@
       "get": {
         "summary": "List assistants",
         "description": "Get the agent configurations for the workspace identified by {wId}.",
-        "tags": ["Workspace"],
+        "tags": [
+          "Workspace"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -313,7 +321,102 @@
         ],
         "responses": {
           "200": {
-            "description": "Agent configurations for the workspace"
+            "description": "Agent configurations for the workspace",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "integer"
+                      },
+                      "sId": {
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "integer"
+                      },
+                      "versionCreatedAt": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "versionAuthorId": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "instructions": {
+                        "type": "string"
+                      },
+                      "pictureUrl": {
+                        "type": "string"
+                      },
+                      "status": {
+                        "type": "string"
+                      },
+                      "userListStatus": {
+                        "type": "string"
+                      },
+                      "scope": {
+                        "type": "string"
+                      },
+                      "model": {
+                        "type": "object",
+                        "properties": {
+                          "providerId": {
+                            "type": "string"
+                          },
+                          "modelId": {
+                            "type": "string"
+                          },
+                          "temperature": {
+                            "type": "number"
+                          }
+                        }
+                      },
+                      "actions": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer"
+                            },
+                            "sId": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "description": {
+                              "type": "string",
+                              "nullable": true
+                            }
+                          }
+                        }
+                      },
+                      "maxToolsUsePerRun": {
+                        "type": "integer"
+                      },
+                      "templateId": {
+                        "type": "string",
+                        "nullable": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
           },
           "400": {
             "description": "Bad Request. Missing or invalid parameters."
@@ -337,7 +440,9 @@
       "post": {
         "summary": "Create a content fragment",
         "description": "Create a new content fragment in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -444,7 +549,9 @@
       "get": {
         "summary": "Get the events for a conversation",
         "description": "Get the events for a conversation in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -500,7 +607,9 @@
       "get": {
         "summary": "Get a conversation",
         "description": "Get a conversation in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -556,7 +665,9 @@
       "get": {
         "summary": "Get events for a message",
         "description": "Get events for a message in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -643,7 +754,9 @@
       "post": {
         "summary": "Create a message",
         "description": "Create a message in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -737,7 +850,12 @@
                         "type": "string",
                         "nullable": true,
                         "description": "The origin of the message",
-                        "enum": ["api", "web", "slack", "null"],
+                        "enum": [
+                          "api",
+                          "web",
+                          "slack",
+                          "null"
+                        ],
                         "default": "api",
                         "example": "api"
                       }
@@ -768,7 +886,9 @@
       "post": {
         "summary": "Create a new conversation",
         "description": "Create a new conversation in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -856,7 +976,12 @@
                             "type": "string",
                             "nullable": true,
                             "description": "The origin of the message",
-                            "enum": ["api", "web", "slack", "null"],
+                            "enum": [
+                              "api",
+                              "web",
+                              "slack",
+                              "null"
+                            ],
                             "default": "api",
                             "example": "api"
                           }
@@ -929,7 +1054,11 @@
                   "visibility": {
                     "type": "string",
                     "description": "The visibility of the conversation",
-                    "enum": ["public", "private", "unlisted"],
+                    "enum": [
+                      "public",
+                      "private",
+                      "unlisted"
+                    ],
                     "default": "public",
                     "example": "private"
                   }
@@ -973,7 +1102,9 @@
       "get": {
         "summary": "Retrieve a document from a data source",
         "description": "Retrieve a document from a data source in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1036,7 +1167,9 @@
       "post": {
         "summary": "Upsert a document in a data source",
         "description": "Upsert a document in a data source in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1123,7 +1256,9 @@
       "delete": {
         "summary": "Delete a document from a data source",
         "description": "Delete a document from a data source in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1185,7 +1320,9 @@
       "post": {
         "summary": "Update the parents of a document",
         "description": "Update the parents of a document in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1268,7 +1405,9 @@
       "get": {
         "summary": "Get documents",
         "description": "Get documents in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1331,7 +1470,9 @@
       "get": {
         "summary": "Search the data source",
         "description": "Search the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1523,7 +1664,9 @@
       "get": {
         "summary": "Get a table",
         "description": "Get a table in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1577,7 +1720,9 @@
       "delete": {
         "summary": "Delete a table",
         "description": "Delete a table in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1633,7 +1778,9 @@
       "get": {
         "summary": "Get a row",
         "description": "Get a row in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1696,7 +1843,9 @@
       "delete": {
         "summary": "Delete a row",
         "description": "Delete a row in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1761,7 +1910,9 @@
       "get": {
         "summary": "List rows",
         "description": "List rows in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1828,7 +1979,9 @@
       "post": {
         "summary": "Upsert rows",
         "description": "Upsert rows in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1900,7 +2053,9 @@
                                 "properties": {
                                   "type": {
                                     "type": "string",
-                                    "enum": ["datetime"]
+                                    "enum": [
+                                      "datetime"
+                                    ]
                                   },
                                   "epoch": {
                                     "type": "number"
@@ -1947,7 +2102,9 @@
       "post": {
         "summary": "Upsert CSV to table",
         "description": "Upsert CSV data to a table in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2018,7 +2175,9 @@
       "get": {
         "summary": "Get tables",
         "description": "Get tables in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2057,7 +2216,9 @@
       "post": {
         "summary": "Upsert a table",
         "description": "Upsert a table in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2125,7 +2286,9 @@
       "post": {
         "summary": "Tokenize text",
         "description": "Tokenize text for the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2187,7 +2350,9 @@
       "get": {
         "summary": "Get data sources",
         "description": "Get data sources in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2225,7 +2390,9 @@
       "get": {
         "summary": "List feature flags",
         "description": "Get the feature flags for the workspace identified by {wId}.",
-        "tags": ["Workspace"],
+        "tags": [
+          "Workspace"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2272,7 +2439,9 @@
       "get": {
         "summary": "List member emails",
         "description": "List the emails of all members in the workspace identified by {wId}.",
-        "tags": ["Workspace"],
+        "tags": [
+          "Workspace"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2328,7 +2497,9 @@
       "get": {
         "summary": "Get workspace usage data",
         "description": "Get usage data for the workspace identified by {wId}.",
-        "tags": ["Workspace"],
+        "tags": [
+          "Workspace"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2386,7 +2557,9 @@
       "get": {
         "summary": "Get verified domains",
         "description": "Get the verified domain for the workspace identified by {wId}.",
-        "tags": ["Workspace"],
+        "tags": [
+          "Workspace"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2461,6 +2634,14 @@
             "type": "number"
           }
         }
+      }
+    },
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "Authorization",
+        "description": "API key authentication. Prefix the key with 'Bearer '"
       }
     }
   },

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -15,15 +15,18 @@
       "get": {
         "summary": "Get an app run",
         "description": "Retrieve a run for an app in the workspace identified by {wId}.",
-        "tags": [
-          "Apps"
+        "tags": ["Apps"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
         ],
         "parameters": [
           {
             "in": "path",
             "name": "wId",
             "required": true,
-            "description": "ID of the workspace",
+            "description": "Unique string identifier for the workspace",
             "schema": {
               "type": "string"
             }
@@ -42,15 +45,6 @@
             "name": "runId",
             "required": true,
             "description": "ID of the run",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "description": "Bearer token for authentication",
             "schema": {
               "type": "string"
             }
@@ -137,15 +131,18 @@
       "post": {
         "summary": "Create an app run",
         "description": "Create a run for an app in the workspace identified by {wId}.",
-        "tags": [
-          "Apps"
+        "tags": ["Apps"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
         ],
         "parameters": [
           {
             "in": "path",
             "name": "wId",
             "required": true,
-            "description": "ID of the workspace",
+            "description": "Unique string identifier for the workspace",
             "schema": {
               "type": "string"
             }
@@ -155,15 +152,6 @@
             "name": "appId",
             "required": true,
             "description": "ID of the app",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "description": "Bearer token for authentication",
             "schema": {
               "type": "string"
             }
@@ -223,7 +211,14 @@
         },
         "responses": {
           "200": {
-            "description": "App run"
+            "description": "App run",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Workspace"
+                }
+              }
+            }
           },
           "400": {
             "description": "Bad Request. Missing or invalid parameters."
@@ -247,24 +242,18 @@
       "get": {
         "summary": "List apps",
         "description": "Get all apps of a workspace.",
-        "tags": [
-          "Apps"
+        "tags": ["Apps"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
         ],
         "parameters": [
           {
             "in": "path",
             "name": "wId",
             "required": true,
-            "description": "ID of the workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "description": "Bearer token for authentication",
+            "description": "Unique string identifier for the workspace",
             "schema": {
               "type": "string"
             }
@@ -272,7 +261,17 @@
         ],
         "responses": {
           "200": {
-            "description": "Apps of the workspace"
+            "description": "Apps of the workspace",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Workspace"
+                  }
+                }
+              }
+            }
           },
           "400": {
             "description": "Bad Request. Missing or invalid parameters."
@@ -296,9 +295,7 @@
       "get": {
         "summary": "List assistants",
         "description": "Get the agent configurations for the workspace identified by {wId}.",
-        "tags": [
-          "Workspace"
-        ],
+        "tags": ["Workspace"],
         "parameters": [
           {
             "in": "path",
@@ -351,9 +348,7 @@
       "post": {
         "summary": "Create a content fragment",
         "description": "Create a new content fragment in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "parameters": [
           {
             "in": "path",
@@ -416,9 +411,7 @@
       "get": {
         "summary": "Get the events for a conversation",
         "description": "Get the events for a conversation in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "parameters": [
           {
             "in": "path",
@@ -480,9 +473,7 @@
       "get": {
         "summary": "Get a conversation",
         "description": "Get a conversation in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "security": [
           {
             "BearerAuth": []
@@ -541,9 +532,7 @@
       "get": {
         "summary": "Get events for a message",
         "description": "Get events for a message in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "parameters": [
           {
             "in": "path",
@@ -637,9 +626,7 @@
       "post": {
         "summary": "Create a message",
         "description": "Create a message in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "parameters": [
           {
             "in": "path",
@@ -702,9 +689,7 @@
       "post": {
         "summary": "Create a new conversation",
         "description": "Create a new conversation in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "parameters": [
           {
             "in": "path",
@@ -749,11 +734,7 @@
                   "visibility": {
                     "type": "string",
                     "description": "The visibility of the conversation",
-                    "enum": [
-                      "public",
-                      "private",
-                      "unlisted"
-                    ],
+                    "enum": ["public", "private", "unlisted"],
                     "default": "public",
                     "example": "private"
                   }
@@ -789,9 +770,7 @@
       "get": {
         "summary": "Retrieve a document from a data source",
         "description": "Retrieve a document from a data source in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -819,15 +798,11 @@
             "schema": {
               "type": "string"
             }
-          },
+          }
+        ],
+        "security": [
           {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "description": "Bearer token for authentication",
-            "schema": {
-              "type": "string"
-            }
+            "BearerAuth": []
           }
         ],
         "responses": {
@@ -854,9 +829,7 @@
       "post": {
         "summary": "Upsert a document in a data source",
         "description": "Upsert a document in a data source in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -884,15 +857,11 @@
             "schema": {
               "type": "string"
             }
-          },
+          }
+        ],
+        "security": [
           {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "description": "Bearer token for authentication",
-            "schema": {
-              "type": "string"
-            }
+            "BearerAuth": []
           }
         ],
         "requestBody": {
@@ -943,9 +912,7 @@
       "delete": {
         "summary": "Delete a document from a data source",
         "description": "Delete a document from a data source in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -973,15 +940,11 @@
             "schema": {
               "type": "string"
             }
-          },
+          }
+        ],
+        "security": [
           {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "description": "Bearer token for authentication",
-            "schema": {
-              "type": "string"
-            }
+            "BearerAuth": []
           }
         ],
         "responses": {
@@ -1007,15 +970,13 @@
       "post": {
         "summary": "Update the parents of a document",
         "description": "Update the parents of a document in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
             "name": "wId",
             "required": true,
-            "description": "ID of the workspace",
+            "description": "Unique string identifier for the workspace",
             "schema": {
               "type": "string"
             }
@@ -1037,15 +998,11 @@
             "schema": {
               "type": "string"
             }
-          },
+          }
+        ],
+        "security": [
           {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "description": "Bearer token for authentication",
-            "schema": {
-              "type": "string"
-            }
+            "BearerAuth": []
           }
         ],
         "requestBody": {
@@ -1059,7 +1016,8 @@
                     "type": "array",
                     "items": {
                       "type": "string"
-                    }
+                    },
+                    "description": "Array of parent document IDs"
                   }
                 }
               }
@@ -1092,8 +1050,11 @@
       "get": {
         "summary": "Get documents",
         "description": "Get documents in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
+        "tags": ["Datasources"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
         ],
         "parameters": [
           {
@@ -1129,20 +1090,21 @@
             "schema": {
               "type": "integer"
             }
-          },
-          {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "description": "Bearer token for authentication",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
           "200": {
-            "description": "The documents"
+            "description": "The documents",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Datasource"
+                  }
+                }
+              }
+            }
           },
           "404": {
             "description": "The data source was not found"
@@ -1157,8 +1119,11 @@
       "get": {
         "summary": "Search the data source",
         "description": "Search the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
+        "tags": ["Datasources"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
         ],
         "parameters": [
           {
@@ -1268,15 +1233,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "description": "Bearer token for authentication",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -1351,15 +1307,18 @@
       "get": {
         "summary": "Get a table",
         "description": "Get a table in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
+        "tags": ["Datasources"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
         ],
         "parameters": [
           {
             "in": "path",
             "name": "wId",
             "required": true,
-            "description": "ID of the workspace",
+            "description": "Unique string identifier for the workspace",
             "schema": {
               "type": "string"
             }
@@ -1381,20 +1340,18 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "description": "Bearer token for authentication",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
           "200": {
-            "description": "The table"
+            "description": "The table",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Datasource"
+                }
+              }
+            }
           },
           "404": {
             "description": "The table was not found"
@@ -1407,15 +1364,18 @@
       "delete": {
         "summary": "Delete a table",
         "description": "Delete a table in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
+        "tags": ["Datasources"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
         ],
         "parameters": [
           {
             "in": "path",
             "name": "wId",
             "required": true,
-            "description": "ID of the workspace",
+            "description": "Unique string identifier for the workspace",
             "schema": {
               "type": "string"
             }
@@ -1434,15 +1394,6 @@
             "name": "tId",
             "required": true,
             "description": "ID of the table",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "description": "Bearer token for authentication",
             "schema": {
               "type": "string"
             }
@@ -1465,15 +1416,18 @@
       "get": {
         "summary": "Get a row",
         "description": "Get a row in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
+        "tags": ["Datasources"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
         ],
         "parameters": [
           {
             "in": "path",
             "name": "wId",
             "required": true,
-            "description": "ID of the workspace",
+            "description": "Unique string identifier for the workspace",
             "schema": {
               "type": "string"
             }
@@ -1504,20 +1458,18 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "description": "Bearer token for authentication",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
           "200": {
-            "description": "The row"
+            "description": "The row",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Datasource"
+                }
+              }
+            }
           },
           "404": {
             "description": "The row was not found"
@@ -1530,15 +1482,18 @@
       "delete": {
         "summary": "Delete a row",
         "description": "Delete a row in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
+        "tags": ["Datasources"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
         ],
         "parameters": [
           {
             "in": "path",
             "name": "wId",
             "required": true,
-            "description": "ID of the workspace",
+            "description": "Unique string identifier for the workspace",
             "schema": {
               "type": "string"
             }
@@ -1566,15 +1521,6 @@
             "name": "rId",
             "required": true,
             "description": "ID of the row",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "description": "Bearer token for authentication",
             "schema": {
               "type": "string"
             }
@@ -1597,15 +1543,18 @@
       "get": {
         "summary": "List rows",
         "description": "List rows in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
+        "tags": ["Datasources"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
         ],
         "parameters": [
           {
             "in": "path",
             "name": "wId",
             "required": true,
-            "description": "ID of the workspace",
+            "description": "Unique string identifier for the workspace",
             "schema": {
               "type": "string"
             }
@@ -1643,20 +1592,21 @@
             "schema": {
               "type": "integer"
             }
-          },
-          {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "description": "Bearer token for authentication",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
           "200": {
-            "description": "The rows"
+            "description": "The rows",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Datasource"
+                  }
+                }
+              }
+            }
           },
           "405": {
             "description": "Method not supported"
@@ -1666,15 +1616,18 @@
       "post": {
         "summary": "Upsert rows",
         "description": "Upsert rows in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
+        "tags": ["Datasources"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
         ],
         "parameters": [
           {
             "in": "path",
             "name": "wId",
             "required": true,
-            "description": "ID of the workspace",
+            "description": "Unique string identifier for the workspace",
             "schema": {
               "type": "string"
             }
@@ -1696,15 +1649,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "description": "Bearer token for authentication",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "requestBody": {
@@ -1720,7 +1664,8 @@
                       "type": "object",
                       "properties": {
                         "row_id": {
-                          "type": "string"
+                          "type": "string",
+                          "description": "Unique identifier for the row"
                         },
                         "value": {
                           "type": "object",
@@ -1740,9 +1685,7 @@
                                 "properties": {
                                   "type": {
                                     "type": "string",
-                                    "enum": [
-                                      "datetime"
-                                    ]
+                                    "enum": ["datetime"]
                                   },
                                   "epoch": {
                                     "type": "number"
@@ -1756,7 +1699,8 @@
                     }
                   },
                   "truncate": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Whether to truncate existing rows"
                   }
                 }
               }
@@ -1765,7 +1709,14 @@
         },
         "responses": {
           "200": {
-            "description": "The table"
+            "description": "The table",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Datasource"
+                }
+              }
+            }
           },
           "400": {
             "description": "Bad Request. Missing or invalid parameters."
@@ -1789,15 +1740,18 @@
       "post": {
         "summary": "Upsert CSV to table",
         "description": "Upsert CSV data to a table in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
+        "tags": ["Datasources"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
         ],
         "parameters": [
           {
             "in": "path",
             "name": "wId",
             "required": true,
-            "description": "ID of the workspace",
+            "description": "Unique string identifier for the workspace",
             "schema": {
               "type": "string"
             }
@@ -1818,15 +1772,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "description": "Bearer token for authentication",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "requestBody": {
@@ -1838,7 +1783,8 @@
                 "properties": {
                   "file": {
                     "type": "string",
-                    "format": "binary"
+                    "format": "binary",
+                    "description": "CSV file to be uploaded"
                   }
                 }
               }
@@ -1847,7 +1793,14 @@
         },
         "responses": {
           "200": {
-            "description": "The table"
+            "description": "The table",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Datasource"
+                }
+              }
+            }
           },
           "404": {
             "description": "The table was not found"
@@ -1862,15 +1815,18 @@
       "get": {
         "summary": "Get tables",
         "description": "Get tables in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
+        "tags": ["Datasources"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
         ],
         "parameters": [
           {
             "in": "path",
             "name": "wId",
             "required": true,
-            "description": "ID of the workspace",
+            "description": "Unique string identifier for the workspace",
             "schema": {
               "type": "string"
             }
@@ -1880,15 +1836,6 @@
             "name": "name",
             "required": true,
             "description": "Name of the data source",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "description": "Bearer token for authentication",
             "schema": {
               "type": "string"
             }
@@ -1896,22 +1843,35 @@
         ],
         "responses": {
           "200": {
-            "description": "The tables"
+            "description": "The tables",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Datasource"
+                  }
+                }
+              }
+            }
           }
         }
       },
       "post": {
         "summary": "Upsert a table",
         "description": "Upsert a table in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
+        "tags": ["Datasources"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
         ],
         "parameters": [
           {
             "in": "path",
             "name": "wId",
             "required": true,
-            "description": "ID of the workspace",
+            "description": "Unique string identifier for the workspace",
             "schema": {
               "type": "string"
             }
@@ -1921,15 +1881,6 @@
             "name": "name",
             "required": true,
             "description": "Name of the data source",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "description": "Bearer token for authentication",
             "schema": {
               "type": "string"
             }
@@ -1943,13 +1894,16 @@
                 "type": "object",
                 "properties": {
                   "name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Name of the table"
                   },
                   "table_id": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Unique identifier for the table"
                   },
                   "description": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Description of the table"
                   }
                 }
               }
@@ -1958,7 +1912,14 @@
         },
         "responses": {
           "200": {
-            "description": "The table"
+            "description": "The table",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Datasource"
+                }
+              }
+            }
           },
           "400": {
             "description": "Invalid request"
@@ -1973,9 +1934,7 @@
       "post": {
         "summary": "Tokenize text",
         "description": "Tokenize text for the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -1994,15 +1953,11 @@
             "schema": {
               "type": "string"
             }
-          },
+          }
+        ],
+        "security": [
           {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "description": "Bearer token for authentication",
-            "schema": {
-              "type": "string"
-            }
+            "BearerAuth": []
           }
         ],
         "requestBody": {
@@ -2037,9 +1992,7 @@
       "get": {
         "summary": "Get data sources",
         "description": "Get data sources in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -2083,24 +2036,18 @@
       "get": {
         "summary": "List feature flags",
         "description": "Get the feature flags for the workspace identified by {wId}.",
-        "tags": [
-          "Workspace"
+        "tags": ["Workspace"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
         ],
         "parameters": [
           {
             "in": "path",
             "name": "wId",
             "required": true,
-            "description": "ID of the workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "description": "Bearer token for authentication",
+            "description": "Unique string identifier for the workspace",
             "schema": {
               "type": "string"
             }
@@ -2117,7 +2064,8 @@
                     "feature_flags": {
                       "type": "array",
                       "items": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Feature flags enabled for the workspace"
                       }
                     }
                   }
@@ -2132,15 +2080,13 @@
       "get": {
         "summary": "List member emails",
         "description": "List the emails of all members in the workspace identified by {wId}.",
-        "tags": [
-          "Workspace"
-        ],
+        "tags": ["Workspace"],
         "parameters": [
           {
             "in": "path",
             "name": "wId",
             "required": true,
-            "description": "ID of the workspace",
+            "description": "Unique string identifier for the workspace",
             "schema": {
               "type": "string"
             }
@@ -2153,15 +2099,11 @@
             "schema": {
               "type": "boolean"
             }
-          },
+          }
+        ],
+        "security": [
           {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "description": "Bearer token for authentication",
-            "schema": {
-              "type": "string"
-            }
+            "BearerAuth": []
           }
         ],
         "responses": {
@@ -2175,7 +2117,8 @@
                     "emails": {
                       "type": "array",
                       "items": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Email address of a workspace member"
                       }
                     }
                   }
@@ -2190,15 +2133,18 @@
       "get": {
         "summary": "Get workspace usage data",
         "description": "Get usage data for the workspace identified by {wId}.",
-        "tags": [
-          "Workspace"
+        "tags": ["Workspace"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
         ],
         "parameters": [
           {
             "in": "path",
             "name": "wId",
             "required": true,
-            "description": "ID of the workspace",
+            "description": "Unique string identifier for the workspace",
             "schema": {
               "type": "string"
             }
@@ -2222,20 +2168,18 @@
               "type": "string",
               "format": "date"
             }
-          },
-          {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "description": "Bearer token for authentication",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
           "200": {
-            "description": "The usage data"
+            "description": "The usage data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Workspace"
+                }
+              }
+            }
           },
           "404": {
             "description": "The workspace was not found"
@@ -2250,24 +2194,18 @@
       "get": {
         "summary": "Get verified domains",
         "description": "Get the verified domain for the workspace identified by {wId}.",
-        "tags": [
-          "Workspace"
+        "tags": ["Workspace"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
         ],
         "parameters": [
           {
             "in": "path",
             "name": "wId",
             "required": true,
-            "description": "ID of the workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "description": "Bearer token for authentication",
+            "description": "Unique string identifier for the workspace",
             "schema": {
               "type": "string"
             }
@@ -2275,7 +2213,14 @@
         ],
         "responses": {
           "200": {
-            "description": "The verified domain"
+            "description": "The verified domain",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Workspace"
+                }
+              }
+            }
           },
           "404": {
             "description": "The workspace was not found"

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -2064,7 +2064,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "type": "object"
+                    "$ref": "#/components/schemas/Datasource"
                   }
                 }
               }
@@ -2671,6 +2671,43 @@
           },
           "context": {
             "$ref": "#/components/schemas/Context"
+          }
+        }
+      },
+      "Datasource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Unique identifier for the datasource"
+          },
+          "createdAt": {
+            "type": "integer",
+            "description": "Timestamp of when the datasource was created"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the datasource"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the datasource"
+          },
+          "dustAPIProjectId": {
+            "type": "string",
+            "description": "ID of the associated Dust API project"
+          },
+          "connectorId": {
+            "type": "string",
+            "description": "ID of the connector used for this datasource"
+          },
+          "connectorProvider": {
+            "type": "string",
+            "description": "Provider of the connector (e.g., 'webcrawler')"
+          },
+          "assistantDefaultSelected": {
+            "type": "boolean",
+            "description": "Whether this datasource is selected by default for assistants"
           }
         }
       }

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -15,9 +15,7 @@
       "get": {
         "summary": "Get an app run",
         "description": "Retrieve a run for an app in the workspace identified by {wId}.",
-        "tags": [
-          "Apps"
-        ],
+        "tags": ["Apps"],
         "parameters": [
           {
             "in": "path",
@@ -137,9 +135,7 @@
       "post": {
         "summary": "Create an app run",
         "description": "Create a run for an app in the workspace identified by {wId}.",
-        "tags": [
-          "Apps"
-        ],
+        "tags": ["Apps"],
         "parameters": [
           {
             "in": "path",
@@ -247,9 +243,7 @@
       "get": {
         "summary": "List apps",
         "description": "Get all apps of a workspace.",
-        "tags": [
-          "Apps"
-        ],
+        "tags": ["Apps"],
         "parameters": [
           {
             "in": "path",
@@ -296,9 +290,7 @@
       "get": {
         "summary": "List assistants",
         "description": "Get the agent configurations for the workspace identified by {wId}.",
-        "tags": [
-          "Workspace"
-        ],
+        "tags": ["Workspace"],
         "parameters": [
           {
             "in": "path",
@@ -440,9 +432,7 @@
       "post": {
         "summary": "Create a content fragment",
         "description": "Create a new content fragment in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "parameters": [
           {
             "in": "path",
@@ -549,9 +539,7 @@
       "get": {
         "summary": "Get the events for a conversation",
         "description": "Get the events for a conversation in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "parameters": [
           {
             "in": "path",
@@ -607,8 +595,11 @@
       "get": {
         "summary": "Get a conversation",
         "description": "Get a conversation in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
+        "tags": ["Conversations"],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
         ],
         "parameters": [
           {
@@ -628,20 +619,18 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "description": "Bearer token for authentication",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
           "200": {
-            "description": "Conversation retrieved successfully."
+            "description": "Conversation retrieved successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Conversation"
+                }
+              }
+            }
           },
           "400": {
             "description": "Bad Request. Missing or invalid parameters."
@@ -665,9 +654,7 @@
       "get": {
         "summary": "Get events for a message",
         "description": "Get events for a message in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "parameters": [
           {
             "in": "path",
@@ -754,9 +741,7 @@
       "post": {
         "summary": "Create a message",
         "description": "Create a message in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "parameters": [
           {
             "in": "path",
@@ -850,12 +835,7 @@
                         "type": "string",
                         "nullable": true,
                         "description": "The origin of the message",
-                        "enum": [
-                          "api",
-                          "web",
-                          "slack",
-                          "null"
-                        ],
+                        "enum": ["api", "web", "slack", "null"],
                         "default": "api",
                         "example": "api"
                       }
@@ -886,9 +866,7 @@
       "post": {
         "summary": "Create a new conversation",
         "description": "Create a new conversation in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "parameters": [
           {
             "in": "path",
@@ -976,12 +954,7 @@
                             "type": "string",
                             "nullable": true,
                             "description": "The origin of the message",
-                            "enum": [
-                              "api",
-                              "web",
-                              "slack",
-                              "null"
-                            ],
+                            "enum": ["api", "web", "slack", "null"],
                             "default": "api",
                             "example": "api"
                           }
@@ -1054,11 +1027,7 @@
                   "visibility": {
                     "type": "string",
                     "description": "The visibility of the conversation",
-                    "enum": [
-                      "public",
-                      "private",
-                      "unlisted"
-                    ],
+                    "enum": ["public", "private", "unlisted"],
                     "default": "public",
                     "example": "private"
                   }
@@ -1073,15 +1042,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "conversation": {
-                      "type": "object"
-                    },
-                    "message": {
-                      "$ref": "#/components/schemas/Message"
-                    }
-                  }
+                  "$ref": "#/components/schemas/Conversation"
                 }
               }
             }
@@ -1102,9 +1063,7 @@
       "get": {
         "summary": "Retrieve a document from a data source",
         "description": "Retrieve a document from a data source in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -1167,9 +1126,7 @@
       "post": {
         "summary": "Upsert a document in a data source",
         "description": "Upsert a document in a data source in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -1256,9 +1213,7 @@
       "delete": {
         "summary": "Delete a document from a data source",
         "description": "Delete a document from a data source in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -1320,9 +1275,7 @@
       "post": {
         "summary": "Update the parents of a document",
         "description": "Update the parents of a document in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -1405,9 +1358,7 @@
       "get": {
         "summary": "Get documents",
         "description": "Get documents in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -1470,9 +1421,7 @@
       "get": {
         "summary": "Search the data source",
         "description": "Search the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -1664,9 +1613,7 @@
       "get": {
         "summary": "Get a table",
         "description": "Get a table in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -1720,9 +1667,7 @@
       "delete": {
         "summary": "Delete a table",
         "description": "Delete a table in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -1778,9 +1723,7 @@
       "get": {
         "summary": "Get a row",
         "description": "Get a row in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -1843,9 +1786,7 @@
       "delete": {
         "summary": "Delete a row",
         "description": "Delete a row in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -1910,9 +1851,7 @@
       "get": {
         "summary": "List rows",
         "description": "List rows in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -1979,9 +1918,7 @@
       "post": {
         "summary": "Upsert rows",
         "description": "Upsert rows in the table identified by {tId} in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -2053,9 +1990,7 @@
                                 "properties": {
                                   "type": {
                                     "type": "string",
-                                    "enum": [
-                                      "datetime"
-                                    ]
+                                    "enum": ["datetime"]
                                   },
                                   "epoch": {
                                     "type": "number"
@@ -2102,9 +2037,7 @@
       "post": {
         "summary": "Upsert CSV to table",
         "description": "Upsert CSV data to a table in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -2175,9 +2108,7 @@
       "get": {
         "summary": "Get tables",
         "description": "Get tables in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -2216,9 +2147,7 @@
       "post": {
         "summary": "Upsert a table",
         "description": "Upsert a table in the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -2286,9 +2215,7 @@
       "post": {
         "summary": "Tokenize text",
         "description": "Tokenize text for the data source identified by {name} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -2350,9 +2277,7 @@
       "get": {
         "summary": "Get data sources",
         "description": "Get data sources in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -2390,9 +2315,7 @@
       "get": {
         "summary": "List feature flags",
         "description": "Get the feature flags for the workspace identified by {wId}.",
-        "tags": [
-          "Workspace"
-        ],
+        "tags": ["Workspace"],
         "parameters": [
           {
             "in": "path",
@@ -2439,9 +2362,7 @@
       "get": {
         "summary": "List member emails",
         "description": "List the emails of all members in the workspace identified by {wId}.",
-        "tags": [
-          "Workspace"
-        ],
+        "tags": ["Workspace"],
         "parameters": [
           {
             "in": "path",
@@ -2497,9 +2418,7 @@
       "get": {
         "summary": "Get workspace usage data",
         "description": "Get usage data for the workspace identified by {wId}.",
-        "tags": [
-          "Workspace"
-        ],
+        "tags": ["Workspace"],
         "parameters": [
           {
             "in": "path",
@@ -2557,9 +2476,7 @@
       "get": {
         "summary": "Get verified domains",
         "description": "Get the verified domain for the workspace identified by {wId}.",
-        "tags": [
-          "Workspace"
-        ],
+        "tags": ["Workspace"],
         "parameters": [
           {
             "in": "path",
@@ -2632,6 +2549,274 @@
           },
           "rank": {
             "type": "number"
+          }
+        }
+      },
+      "Conversation": {
+        "type": "object",
+        "properties": {
+          "conversation": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer"
+              },
+              "created": {
+                "type": "integer"
+              },
+              "sId": {
+                "type": "string"
+              },
+              "owner": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer"
+                  },
+                  "sId": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "role": {
+                    "type": "string"
+                  },
+                  "segmentation": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "flags": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "ssoEnforced": {
+                    "type": "boolean"
+                  },
+                  "whiteListedProviders": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "defaultEmbeddingProvider": {
+                    "type": "string",
+                    "nullable": true
+                  }
+                }
+              },
+              "title": {
+                "type": "string"
+              },
+              "visibility": {
+                "type": "string"
+              },
+              "content": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "integer"
+                      },
+                      "sId": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      },
+                      "visibility": {
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "integer"
+                      },
+                      "created": {
+                        "type": "integer"
+                      },
+                      "user": {
+                        "type": "object",
+                        "properties": {
+                          "sId": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "integer"
+                          },
+                          "createdAt": {
+                            "type": "integer"
+                          },
+                          "username": {
+                            "type": "string"
+                          },
+                          "email": {
+                            "type": "string"
+                          },
+                          "firstName": {
+                            "type": "string"
+                          },
+                          "lastName": {
+                            "type": "string"
+                          },
+                          "fullName": {
+                            "type": "string"
+                          },
+                          "provider": {
+                            "type": "string"
+                          },
+                          "image": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "mentions": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "configurationId": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "content": {
+                        "type": "string"
+                      },
+                      "context": {
+                        "type": "object",
+                        "properties": {
+                          "username": {
+                            "type": "string"
+                          },
+                          "timezone": {
+                            "type": "string"
+                          },
+                          "fullName": {
+                            "type": "string"
+                          },
+                          "email": {
+                            "type": "string"
+                          },
+                          "profilePictureUrl": {
+                            "type": "string"
+                          },
+                          "origin": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "agentMessageId": {
+                        "type": "integer"
+                      },
+                      "parentMessageId": {
+                        "type": "string"
+                      },
+                      "status": {
+                        "type": "string"
+                      },
+                      "actions": {
+                        "type": "array"
+                      },
+                      "chainOfThought": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "rawContents": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "step": {
+                              "type": "integer"
+                            },
+                            "content": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "error": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "configuration": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer"
+                          },
+                          "sId": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "integer"
+                          },
+                          "versionCreatedAt": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "versionAuthorId": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "instructions": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "pictureUrl": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string"
+                          },
+                          "scope": {
+                            "type": "string"
+                          },
+                          "userListStatus": {
+                            "type": "string"
+                          },
+                          "model": {
+                            "type": "object",
+                            "properties": {
+                              "providerId": {
+                                "type": "string"
+                              },
+                              "modelId": {
+                                "type": "string"
+                              },
+                              "temperature": {
+                                "type": "number"
+                              }
+                            }
+                          },
+                          "actions": {
+                            "type": "array"
+                          },
+                          "maxToolsUsePerRun": {
+                            "type": "integer"
+                          },
+                          "templateId": {
+                            "type": "string",
+                            "nullable": true
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
## Description

- Add swagger_schema.ts containing detailed schemas for shared doc resources (conversation, message, contentFragment, etc...) 
- Move all authorization to Bearer token security : makes the doc a lot more usable for users that can keep their auth while navigating the endpoints
- Add response formats to most endpoints

<img width="1146" alt="Screenshot 2024-07-11 at 15 44 31" src="https://github.com/dust-tt/dust/assets/1189312/4ecd79b1-4811-45c5-9794-fd6f020d5850">


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Already live on [docs.dust.tt/reference](https://docs.dust.tt/reference/post_api-v1-w-wid-assistant-conversations-cid-content-fragments)