### PR TITLE
End message stream once message generation is done.

### DIFF
--- a/front/lib/api/assistant/agent_usage.ts
+++ b/front/lib/api/assistant/agent_usage.ts
@@ -1,4 +1,5 @@
 import type { AgentConfigurationType } from "@dust-tt/types";
+import type { RedisClientType } from "redis";
 import { literal, Op, Sequelize } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
@@ -47,7 +48,7 @@ export async function getAgentsUsage({
   limit,
 }: {
   workspaceId: string;
-  providedRedis?: Awaited<ReturnType<typeof redisClient>>;
+  providedRedis?: RedisClientType;
   limit?: number;
 }): Promise<AgentUsageCount[]> {
   const owner = await Workspace.findOne({ where: { sId: workspaceId } });
@@ -55,7 +56,7 @@ export async function getAgentsUsage({
     throw new Error(`Workspace ${workspaceId} not found`);
   }
 
-  let redis: Awaited<ReturnType<typeof redisClient>> | null = null;
+  let redis: RedisClientType | null = null;
 
   const agentMessageCountKey = _getUsageKey(workspaceId);
 
@@ -104,7 +105,7 @@ export async function getAgentUsage(
   }: {
     workspaceId: string;
     agentConfiguration: AgentConfigurationType;
-    providedRedis?: Awaited<ReturnType<typeof redisClient>>;
+    providedRedis?: RedisClientType;
   }
 ): Promise<AgentUsageCount | null> {
   const owner = auth.workspace();
@@ -115,7 +116,7 @@ export async function getAgentUsage(
     throw new Error("Provided workspace and owner workspace do not match.");
   }
 
-  let redis: Awaited<ReturnType<typeof redisClient>> | null = null;
+  let redis: RedisClientType | null = null;
   const { sId: agentConfigurationId } = agentConfiguration;
 
   const agentMessageCountKey = _getUsageKey(workspaceId);
@@ -201,7 +202,7 @@ export async function agentMentionsCount(
 export async function storeCountsInRedis(
   workspaceId: string,
   agentMessageCounts: mentionCount[],
-  redis: Awaited<ReturnType<typeof redisClient>>
+  redis: RedisClientType
 ) {
   const transaction = redis.multi();
   const agentMessageCountKey = _getUsageKey(workspaceId);
@@ -224,7 +225,7 @@ export async function signalAgentUsage({
   agentConfigurationId: string;
   workspaceId: string;
 }) {
-  let redis: Awaited<ReturnType<typeof redisClient>> | null = null;
+  let redis: RedisClientType | null = null;
 
   try {
     redis = await redisClient();

--- a/front/lib/redis.ts
+++ b/front/lib/redis.ts
@@ -1,11 +1,12 @@
+import type { RedisClientType } from "redis";
 import { createClient } from "redis";
 
-export async function redisClient() {
+export async function redisClient(): Promise<RedisClientType> {
   const { REDIS_URI } = process.env;
   if (!REDIS_URI) {
     throw new Error("REDIS_URI is not defined");
   }
-  const client = createClient({
+  const client: RedisClientType = createClient({
     url: REDIS_URI,
   });
   client.on("error", (err) => console.log("Redis Client Error", err));
@@ -16,7 +17,7 @@ export async function redisClient() {
 }
 
 export async function safeRedisClient<T>(
-  fn: (client: Awaited<ReturnType<typeof redisClient>>) => PromiseLike<T>
+  fn: (client: RedisClientType) => PromiseLike<T>
 ): Promise<T> {
   const client = await redisClient();
   try {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We have noticed an unusually high number of connections on our Redis instances, even though we only have a few pods running. Ideally, each Node.js process should be limited to a single Redis connection. However, this isn't applicable in our case since we use Redis streaming with the `xAdd` and `xRead` commands. The `xRead` command, used with the `BLOCK` parameter, waits for one minute and resolves if no events are received within that time. While this `xRead` operation isn't blocking Redis, it does consume a connection.

Currently, our implementation keeps the connection open for agent message events for one minute, even after the message is either completed or failed. This PR takes an initial, draft approach to reducing the number of connections, aiming to see how many we can cut down. Our [statistics](https://dust.tt/w/0ec9852c2f/assistant/kjc7Wa14a4) show that we don't process many agent messages per second, suggesting a significant potential reduction in our current connection usage.

A bigger refactor is planned for later. First, we want to identify issues before implementing a more robust solution. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Worst case, it breaks the agent message streaming, safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
