### PR TITLE
[Microsoft] Update name, mimetype and parent during fullsync

### DIFF
--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -25,7 +25,7 @@ import {
   getFolders,
   getSites,
   getTeams,
-  internalId,
+  internalIdFromTypeAndPath,
   typeAndPathFromInternalId,
 } from "@connectors/connectors/microsoft/lib/graph_api";
 import {
@@ -174,7 +174,7 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
     const selectedResources = (
       await MicrosoftRootResource.listRootsByConnectorId(connector.id)
     ).map((r) =>
-      internalId({
+      internalIdFromTypeAndPath({
         nodeType: r.nodeType,
         itemAPIPath: r.itemAPIPath,
       })
@@ -251,10 +251,8 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
 
     await MicrosoftRootResource.batchDelete({
       resourceIds: Object.entries(permissions).map((internalId) => {
-        const { itemAPIPath: itemApiPath } = typeAndPathFromInternalId(
-          internalId[0]
-        );
-        return itemApiPath;
+        const { itemAPIPath } = typeAndPathFromInternalId(internalId[0]);
+        return itemAPIPath;
       }),
       connectorId: connector.id,
     });

--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -25,8 +25,8 @@ import {
   getFolders,
   getSites,
   getTeams,
-  microsoftInternalIdFromNodeData,
-  microsoftNodeDataFromInternalId,
+  internalId,
+  typeAndPathFromInternalId,
 } from "@connectors/connectors/microsoft/lib/graph_api";
 import {
   launchMicrosoftFullSyncWorkflow,
@@ -174,16 +174,16 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
     const selectedResources = (
       await MicrosoftRootResource.listRootsByConnectorId(connector.id)
     ).map((r) =>
-      microsoftInternalIdFromNodeData({
+      internalId({
         nodeType: r.nodeType,
-        itemApiPath: r.itemApiPath,
+        itemAPIPath: r.itemAPIPath,
       })
     );
 
     if (!parentInternalId) {
       nodes.push(...getRootNodes());
     } else {
-      const { nodeType } = microsoftNodeDataFromInternalId(parentInternalId);
+      const { nodeType } = typeAndPathFromInternalId(parentInternalId);
 
       switch (nodeType) {
         case "sites-root":
@@ -251,7 +251,9 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
 
     await MicrosoftRootResource.batchDelete({
       resourceIds: Object.entries(permissions).map((internalId) => {
-        const { itemApiPath } = microsoftNodeDataFromInternalId(internalId[0]);
+        const { itemAPIPath: itemApiPath } = typeAndPathFromInternalId(
+          internalId[0]
+        );
         return itemApiPath;
       }),
       connectorId: connector.id,
@@ -263,7 +265,7 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
         .map(([id]) => {
           return {
             connectorId: connector.id,
-            ...microsoftNodeDataFromInternalId(id),
+            ...typeAndPathFromInternalId(id),
           };
         })
     );

--- a/connectors/src/connectors/microsoft/lib/content_nodes.ts
+++ b/connectors/src/connectors/microsoft/lib/content_nodes.ts
@@ -4,7 +4,7 @@ import {
   getDriveAPIPath,
   getDriveItemAPIPath,
   getSiteAPIPath,
-  internalId,
+  internalIdFromTypeAndPath,
   typeAndPathFromInternalId,
 } from "@connectors/connectors/microsoft/lib/graph_api";
 
@@ -15,7 +15,7 @@ export function getRootNodes(): ContentNode[] {
 export function getSitesRootAsContentNode(): ContentNode {
   return {
     provider: "microsoft",
-    internalId: internalId({
+    internalId: internalIdFromTypeAndPath({
       itemAPIPath: "",
       nodeType: "sites-root",
     }),
@@ -33,7 +33,7 @@ export function getSitesRootAsContentNode(): ContentNode {
 export function getTeamsRootAsContentNode(): ContentNode {
   return {
     provider: "microsoft",
-    internalId: internalId({
+    internalId: internalIdFromTypeAndPath({
       itemAPIPath: "",
       nodeType: "teams-root",
     }),
@@ -50,7 +50,7 @@ export function getTeamsRootAsContentNode(): ContentNode {
 export function getTeamAsContentNode(team: microsoftgraph.Team): ContentNode {
   return {
     provider: "microsoft",
-    internalId: internalId({
+    internalId: internalIdFromTypeAndPath({
       itemAPIPath: `/teams/${team.id}`,
       nodeType: "team",
     }),
@@ -72,7 +72,7 @@ export function getSiteAsContentNode(site: microsoftgraph.Site): ContentNode {
   }
   return {
     provider: "microsoft",
-    internalId: internalId({
+    internalId: internalIdFromTypeAndPath({
       itemAPIPath: getSiteAPIPath(site),
       nodeType: "site",
     }),
@@ -102,7 +102,7 @@ export function getChannelAsContentNode(
 
   return {
     provider: "microsoft",
-    internalId: internalId({
+    internalId: internalIdFromTypeAndPath({
       itemAPIPath: `/teams/${parentInternalId}/channels/${channel.id}`,
       nodeType: "channel",
     }),
@@ -127,7 +127,7 @@ export function getDriveAsContentNode(
   }
   return {
     provider: "microsoft",
-    internalId: internalId({
+    internalId: internalIdFromTypeAndPath({
       itemAPIPath: getDriveAPIPath(drive),
       nodeType: "drive",
     }),
@@ -147,7 +147,7 @@ export function getFolderAsContentNode(
 ): ContentNode {
   return {
     provider: "microsoft",
-    internalId: internalId({
+    internalId: internalIdFromTypeAndPath({
       itemAPIPath: getDriveItemAPIPath(folder),
       nodeType: "folder",
     }),

--- a/connectors/src/connectors/microsoft/lib/content_nodes.ts
+++ b/connectors/src/connectors/microsoft/lib/content_nodes.ts
@@ -4,8 +4,8 @@ import {
   getDriveAPIPath,
   getDriveItemAPIPath,
   getSiteAPIPath,
-  microsoftInternalIdFromNodeData,
-  microsoftNodeDataFromInternalId,
+  internalId,
+  typeAndPathFromInternalId,
 } from "@connectors/connectors/microsoft/lib/graph_api";
 
 export function getRootNodes(): ContentNode[] {
@@ -15,8 +15,8 @@ export function getRootNodes(): ContentNode[] {
 export function getSitesRootAsContentNode(): ContentNode {
   return {
     provider: "microsoft",
-    internalId: microsoftInternalIdFromNodeData({
-      itemApiPath: "",
+    internalId: internalId({
+      itemAPIPath: "",
       nodeType: "sites-root",
     }),
     parentInternalId: null,
@@ -33,8 +33,8 @@ export function getSitesRootAsContentNode(): ContentNode {
 export function getTeamsRootAsContentNode(): ContentNode {
   return {
     provider: "microsoft",
-    internalId: microsoftInternalIdFromNodeData({
-      itemApiPath: "",
+    internalId: internalId({
+      itemAPIPath: "",
       nodeType: "teams-root",
     }),
     parentInternalId: null,
@@ -50,8 +50,8 @@ export function getTeamsRootAsContentNode(): ContentNode {
 export function getTeamAsContentNode(team: microsoftgraph.Team): ContentNode {
   return {
     provider: "microsoft",
-    internalId: microsoftInternalIdFromNodeData({
-      itemApiPath: `/teams/${team.id}`,
+    internalId: internalId({
+      itemAPIPath: `/teams/${team.id}`,
       nodeType: "team",
     }),
     parentInternalId: null,
@@ -72,8 +72,8 @@ export function getSiteAsContentNode(site: microsoftgraph.Site): ContentNode {
   }
   return {
     provider: "microsoft",
-    internalId: microsoftInternalIdFromNodeData({
-      itemApiPath: getSiteAPIPath(site),
+    internalId: internalId({
+      itemAPIPath: getSiteAPIPath(site),
       nodeType: "site",
     }),
     parentInternalId: null,
@@ -95,15 +95,15 @@ export function getChannelAsContentNode(
     // Unexpected, unreachable
     throw new Error("Channel id is required");
   }
-  const { nodeType } = microsoftNodeDataFromInternalId(parentInternalId);
+  const { nodeType } = typeAndPathFromInternalId(parentInternalId);
   if (nodeType !== "team") {
     throw new Error(`Invalid parent nodeType: ${nodeType}`);
   }
 
   return {
     provider: "microsoft",
-    internalId: microsoftInternalIdFromNodeData({
-      itemApiPath: `/teams/${parentInternalId}/channels/${channel.id}`,
+    internalId: internalId({
+      itemAPIPath: `/teams/${parentInternalId}/channels/${channel.id}`,
       nodeType: "channel",
     }),
     parentInternalId,
@@ -127,8 +127,8 @@ export function getDriveAsContentNode(
   }
   return {
     provider: "microsoft",
-    internalId: microsoftInternalIdFromNodeData({
-      itemApiPath: getDriveAPIPath(drive),
+    internalId: internalId({
+      itemAPIPath: getDriveAPIPath(drive),
       nodeType: "drive",
     }),
     parentInternalId,
@@ -147,8 +147,8 @@ export function getFolderAsContentNode(
 ): ContentNode {
   return {
     provider: "microsoft",
-    internalId: microsoftInternalIdFromNodeData({
-      itemApiPath: getDriveItemAPIPath(folder),
+    internalId: internalId({
+      itemAPIPath: getDriveItemAPIPath(folder),
       nodeType: "folder",
     }),
     parentInternalId,

--- a/connectors/src/connectors/microsoft/lib/graph_api.ts
+++ b/connectors/src/connectors/microsoft/lib/graph_api.ts
@@ -175,7 +175,7 @@ export function itemToMicrosoftNode<T extends keyof MicrosoftEntityMapping>(
       return {
         nodeType,
         name: item.name ?? null,
-        internalId: internalId({
+        internalId: internalIdFromTypeAndPath({
           nodeType,
           itemAPIPath: getDriveItemAPIPath(item),
         }),
@@ -188,7 +188,7 @@ export function itemToMicrosoftNode<T extends keyof MicrosoftEntityMapping>(
       return {
         nodeType,
         name: item.name ?? null,
-        internalId: internalId({
+        internalId: internalIdFromTypeAndPath({
           nodeType,
           itemAPIPath: getDriveItemAPIPath(item),
         }),
@@ -201,7 +201,7 @@ export function itemToMicrosoftNode<T extends keyof MicrosoftEntityMapping>(
       return {
         nodeType,
         name: item.name ?? null,
-        internalId: internalId({
+        internalId: internalIdFromTypeAndPath({
           nodeType,
           itemAPIPath: getDriveAPIPath(item),
         }),
@@ -214,7 +214,10 @@ export function itemToMicrosoftNode<T extends keyof MicrosoftEntityMapping>(
       return {
         nodeType,
         name: item.name ?? null,
-        internalId: internalId({ nodeType, itemAPIPath: getSiteAPIPath(item) }),
+        internalId: internalIdFromTypeAndPath({
+          nodeType,
+          itemAPIPath: getSiteAPIPath(item),
+        }),
         mimeType: null,
         parentInternalId: null,
       };
@@ -230,13 +233,13 @@ export function itemToMicrosoftNode<T extends keyof MicrosoftEntityMapping>(
   }
 }
 
-export function internalId({
+export function internalIdFromTypeAndPath({
   nodeType,
   itemAPIPath,
 }: {
   nodeType: MicrosoftNodeType;
   itemAPIPath: string;
-}) {
+}): string {
   let stringId = "";
   if (nodeType === "sites-root" || nodeType === "teams-root") {
     stringId = nodeType;

--- a/connectors/src/connectors/microsoft/lib/graph_api.ts
+++ b/connectors/src/connectors/microsoft/lib/graph_api.ts
@@ -1,10 +1,10 @@
+import { assertNever } from "@dust-tt/types";
 import type { Client } from "@microsoft/microsoft-graph-client";
-import * as MicrosoftGraph from "@microsoft/microsoft-graph-types";
+import type * as MicrosoftGraph from "@microsoft/microsoft-graph-types";
 
 import type { MicrosoftNodeType } from "@connectors/connectors/microsoft/lib/types";
+import type { MicrosoftNode } from "@connectors/connectors/microsoft/lib/types";
 import { isValidNodeType } from "@connectors/connectors/microsoft/lib/types";
-import { MicrosoftNode } from "@connectors/connectors/microsoft/lib/types";
-import { assertNever } from "@dust-tt/types";
 
 export async function getSites(client: Client): Promise<MicrosoftGraph.Site[]> {
   const res = await client.api("/sites?search=*").get();
@@ -164,7 +164,7 @@ export function itemToMicrosoftNode<T extends keyof MicrosoftEntityMapping>(
 ): MicrosoftNode & { nodeType: T } {
   switch (nodeType) {
     case "folder": {
-      const item: MicrosoftGraph.DriveItem = itemRaw as any;
+      const item = itemRaw as MicrosoftGraph.DriveItem;
       return {
         nodeType,
         name: item.name ?? null,
@@ -173,7 +173,7 @@ export function itemToMicrosoftNode<T extends keyof MicrosoftEntityMapping>(
       };
     }
     case "file": {
-      const item: MicrosoftGraph.DriveItem = itemRaw as any;
+      const item = itemRaw as MicrosoftGraph.DriveItem;
       return {
         nodeType,
         name: item.name ?? null,
@@ -181,14 +181,15 @@ export function itemToMicrosoftNode<T extends keyof MicrosoftEntityMapping>(
         mimeType: item.file?.mimeType ?? null,
       };
     }
-    case "drive":
-      const item: MicrosoftGraph.Drive = itemRaw as any;
+    case "drive": {
+      const item = itemRaw as MicrosoftGraph.Drive;
       return {
         nodeType,
         name: item.name ?? null,
         itemAPIPath: getDriveAPIPath(item),
         mimeType: null,
       };
+    }
     case "site":
     case "team":
     case "channel":

--- a/connectors/src/connectors/microsoft/lib/graph_api.ts
+++ b/connectors/src/connectors/microsoft/lib/graph_api.ts
@@ -158,31 +158,34 @@ export type MicrosoftEntityMapping = {
   [K in keyof MicrosoftEntity]: MicrosoftEntity[K];
 };
 
-type test = MicrosoftEntityMapping["folder"];
-
 export function itemToMicrosoftNode<T extends keyof MicrosoftEntityMapping>(
   nodeType: T,
-  item: MicrosoftEntityMapping[T]
+  itemRaw: MicrosoftEntityMapping[T]
 ): MicrosoftNode & { nodeType: T } {
   switch (nodeType) {
-    case "folder":
+    case "folder": {
+      const item: MicrosoftGraph.DriveItem = itemRaw as any;
       return {
         nodeType,
-        name: item.name,
-        itemAPIPath: item.id,
-        mimeType: "application/vnd.google-apps.folder",
+        name: item.name ?? null,
+        itemAPIPath: getDriveItemAPIPath(item),
+        mimeType: null,
       };
-    case "file":
+    }
+    case "file": {
+      const item: MicrosoftGraph.DriveItem = itemRaw as any;
       return {
         nodeType,
-        name: item.name,
+        name: item.name ?? null,
         itemAPIPath: getDriveItemAPIPath(item),
         mimeType: item.file?.mimeType ?? null,
       };
+    }
     case "drive":
+      const item: MicrosoftGraph.Drive = itemRaw as any;
       return {
         nodeType,
-        name: item.name,
+        name: item.name ?? null,
         itemAPIPath: getDriveAPIPath(item),
         mimeType: null,
       };

--- a/connectors/src/connectors/microsoft/lib/graph_api.ts
+++ b/connectors/src/connectors/microsoft/lib/graph_api.ts
@@ -158,10 +158,17 @@ export type MicrosoftEntityMapping = {
   [K in keyof MicrosoftEntity]: MicrosoftEntity[K];
 };
 
+/**
+ * Converts a Microsoft entity to a MicrosoftNode depending on the nodeType
+ * Note: parentItemAPIPath is not set in the returned object, the parent logic
+ * is not explicit in the Microsoft Graph API and is handled on our side
+ * @param nodeType
+ * @param itemRaw
+ */
 export function itemToMicrosoftNode<T extends keyof MicrosoftEntityMapping>(
   nodeType: T,
   itemRaw: MicrosoftEntityMapping[T]
-): MicrosoftNode & { nodeType: T } {
+): MicrosoftNode {
   switch (nodeType) {
     case "folder": {
       const item = itemRaw as MicrosoftGraph.DriveItem;

--- a/connectors/src/connectors/microsoft/lib/graph_api.ts
+++ b/connectors/src/connectors/microsoft/lib/graph_api.ts
@@ -209,29 +209,27 @@ export function itemToMicrosoftNode<T extends keyof MicrosoftEntityMapping>(
   }
 }
 
-export type MicrosoftNodeData = {
+export function internalId({
+  nodeType,
+  itemAPIPath,
+}: {
   nodeType: MicrosoftNodeType;
   itemAPIPath: string;
-};
-
-export function internalId(nodeData: MicrosoftNodeData) {
+}) {
   let stringId = "";
-  if (
-    nodeData.nodeType === "sites-root" ||
-    nodeData.nodeType === "teams-root"
-  ) {
-    stringId = nodeData.nodeType;
+  if (nodeType === "sites-root" || nodeType === "teams-root") {
+    stringId = nodeType;
   } else {
-    const { nodeType, itemAPIPath } = nodeData;
     stringId = `${nodeType}/${itemAPIPath}`;
   }
   // encode to base64url so the internal id is URL-friendly
   return "microsoft-" + Buffer.from(stringId).toString("base64url");
 }
 
-export function typeAndPathFromInternalId(
-  internalId: string
-): MicrosoftNodeData {
+export function typeAndPathFromInternalId(internalId: string): {
+  nodeType: MicrosoftNodeType;
+  itemAPIPath: string;
+} {
   if (!internalId.startsWith("microsoft-")) {
     throw new Error(`Invalid internal id: ${internalId}`);
   }

--- a/connectors/src/connectors/microsoft/lib/graph_api.ts
+++ b/connectors/src/connectors/microsoft/lib/graph_api.ts
@@ -175,7 +175,11 @@ export function itemToMicrosoftNode<T extends keyof MicrosoftEntityMapping>(
       return {
         nodeType,
         name: item.name ?? null,
-        itemAPIPath: getDriveItemAPIPath(item),
+        internalId: internalId({
+          nodeType,
+          itemAPIPath: getDriveItemAPIPath(item),
+        }),
+        parentInternalId: null,
         mimeType: null,
       };
     }
@@ -184,7 +188,11 @@ export function itemToMicrosoftNode<T extends keyof MicrosoftEntityMapping>(
       return {
         nodeType,
         name: item.name ?? null,
-        itemAPIPath: getDriveItemAPIPath(item),
+        internalId: internalId({
+          nodeType,
+          itemAPIPath: getDriveItemAPIPath(item),
+        }),
+        parentInternalId: null,
         mimeType: item.file?.mimeType ?? null,
       };
     }
@@ -193,11 +201,24 @@ export function itemToMicrosoftNode<T extends keyof MicrosoftEntityMapping>(
       return {
         nodeType,
         name: item.name ?? null,
-        itemAPIPath: getDriveAPIPath(item),
+        internalId: internalId({
+          nodeType,
+          itemAPIPath: getDriveAPIPath(item),
+        }),
+        parentInternalId: null,
         mimeType: null,
       };
     }
-    case "site":
+    case "site": {
+      const item = itemRaw as MicrosoftGraph.Site;
+      return {
+        nodeType,
+        name: item.name ?? null,
+        internalId: internalId({ nodeType, itemAPIPath: getSiteAPIPath(item) }),
+        mimeType: null,
+        parentInternalId: null,
+      };
+    }
     case "team":
     case "channel":
     case "message":

--- a/connectors/src/connectors/microsoft/lib/types.ts
+++ b/connectors/src/connectors/microsoft/lib/types.ts
@@ -18,3 +18,10 @@ export function isValidNodeType(
 ): nodeType is MicrosoftNodeType {
   return MICROSOFT_NODE_TYPES.includes(nodeType as MicrosoftNodeType);
 }
+
+export type MicrosoftNode = {
+  nodeType: MicrosoftNodeType;
+  name: string | null;
+  itemAPIPath: string;
+  mimeType: string | null;
+};

--- a/connectors/src/connectors/microsoft/lib/types.ts
+++ b/connectors/src/connectors/microsoft/lib/types.ts
@@ -1,3 +1,5 @@
+import { internalId } from "@connectors/connectors/microsoft/lib/graph_api";
+
 export const MICROSOFT_NODE_TYPES = [
   "sites-root",
   "teams-root",

--- a/connectors/src/connectors/microsoft/lib/types.ts
+++ b/connectors/src/connectors/microsoft/lib/types.ts
@@ -1,5 +1,3 @@
-import { internalId } from "@connectors/connectors/microsoft/lib/graph_api";
-
 export const MICROSOFT_NODE_TYPES = [
   "sites-root",
   "teams-root",
@@ -25,5 +23,6 @@ export type MicrosoftNode = {
   nodeType: MicrosoftNodeType;
   name: string | null;
   itemAPIPath: string;
+  parentItemAPIPath?: string;
   mimeType: string | null;
 };

--- a/connectors/src/connectors/microsoft/lib/types.ts
+++ b/connectors/src/connectors/microsoft/lib/types.ts
@@ -22,7 +22,7 @@ export function isValidNodeType(
 export type MicrosoftNode = {
   nodeType: MicrosoftNodeType;
   name: string | null;
-  itemAPIPath: string;
-  parentItemAPIPath?: string;
+  internalId: string;
+  parentInternalId: string | null;
   mimeType: string | null;
 };

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -181,22 +181,6 @@ export async function syncFiles({
   );
   const client = await getClient(connector.connectionId);
 
-  const { itemAPIPath, nodeType } = typeAndPathFromInternalId(parentInternalId);
-
-  // TODO(pr) type this
-  const item = await getItem(client, itemAPIPath);
-
-  if (!item) {
-    throw new Error(`Item not found: ${itemAPIPath}`);
-  }
-
-  parent.update({
-    name: item.name,
-    mimeType: item.folder
-      ? "application/vnd.google-apps.folder"
-      : item.file?.mimeType,
-  });
-
   // TODO(pr): handle pagination
   const children = await getFilesAndFolders(client, parent.internalId);
 

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -13,7 +13,6 @@ import {
   getSites,
   internalId,
   itemToMicrosoftNode,
-  typeAndPathFromInternalId,
 } from "@connectors/connectors/microsoft/lib/graph_api";
 import type { MicrosoftNode } from "@connectors/connectors/microsoft/lib/types";
 import { getMimeTypesToSync } from "@connectors/connectors/microsoft/temporal/mime_types";

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -203,6 +203,7 @@ export async function syncFiles({
         dataSourceConfig,
         providerConfig,
         file: child,
+        parentInternalId,
         startSyncTs,
       });
     },
@@ -245,6 +246,7 @@ export async function syncOneFile({
   dataSourceConfig,
   providerConfig,
   file,
+  parentInternalId,
   startSyncTs,
   isBatchSync = false,
 }: {
@@ -252,6 +254,7 @@ export async function syncOneFile({
   dataSourceConfig: DataSourceConfig;
   providerConfig: MicrosoftConfigurationResource;
   file: microsoftgraph.DriveItem;
+  parentInternalId: string;
   startSyncTs: number;
   isBatchSync?: boolean;
 }) {
@@ -266,10 +269,8 @@ export async function syncOneFile({
     throw new Error(`Item is not a file: ${JSON.stringify(file)}`);
   }
 
-  const itemApiPath = getDriveItemAPIPath(file);
-
   const documentId = internalId({
-    itemAPIPath: itemApiPath,
+    itemAPIPath: getDriveItemAPIPath(file),
     nodeType: "file",
   });
 
@@ -461,6 +462,7 @@ export async function syncOneFile({
     lastSeenTs: new Date(),
     nodeType: "file",
     name: file.name ?? "",
+    parentInternalId,
     mimeType: file.file.mimeType ?? "",
     lastUpsertedTs:
       isInSizeRange && upsertTimestampMs ? new Date(upsertTimestampMs) : null,

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -11,7 +11,7 @@ import {
   getItem,
   getSiteAPIPath,
   getSites,
-  internalId,
+  internalIdFromTypeAndPath,
   itemToMicrosoftNode,
 } from "@connectors/connectors/microsoft/lib/graph_api";
 import type { MicrosoftNode } from "@connectors/connectors/microsoft/lib/types";
@@ -85,7 +85,7 @@ export async function getSiteNodesToSync(
       async (sitePath) => {
         const msDrives = await getDrives(
           client,
-          internalId({ nodeType: "site", itemAPIPath: sitePath })
+          internalIdFromTypeAndPath({ nodeType: "site", itemAPIPath: sitePath })
         );
         return msDrives.map((drive) => itemToMicrosoftNode("drive", drive));
       },
@@ -269,7 +269,7 @@ export async function syncOneFile({
     throw new Error(`Item is not a file: ${JSON.stringify(file)}`);
   }
 
-  const documentId = internalId({
+  const documentId = internalIdFromTypeAndPath({
     itemAPIPath: getDriveItemAPIPath(file),
     nodeType: "file",
   });

--- a/connectors/src/connectors/microsoft/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/microsoft/temporal/spreadsheets.ts
@@ -8,7 +8,7 @@ import {
   getWorksheetAPIPath,
   getWorksheetContent,
   getWorksheets,
-  internalId,
+  internalIdFromTypeAndPath,
 } from "@connectors/connectors/microsoft/lib/graph_api";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { upsertTableFromCsv } from "@connectors/lib/data_sources";
@@ -193,7 +193,7 @@ export async function syncSpreadSheet({
 
   const itemApiPath = getDriveItemAPIPath(file);
 
-  const documentId = internalId({
+  const documentId = internalIdFromTypeAndPath({
     itemAPIPath: itemApiPath,
     nodeType: "file",
   });
@@ -208,7 +208,7 @@ export async function syncSpreadSheet({
   const successfulSheetIdImports: string[] = [];
   for (const worksheet of worksheets) {
     if (worksheet.id) {
-      const internalWorkSheetId = internalId({
+      const internalWorkSheetId = internalIdFromTypeAndPath({
         nodeType: "worksheet",
         itemAPIPath: getWorksheetAPIPath(worksheet, documentId),
       });

--- a/connectors/src/connectors/microsoft/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/microsoft/temporal/spreadsheets.ts
@@ -8,7 +8,7 @@ import {
   getWorksheetAPIPath,
   getWorksheetContent,
   getWorksheets,
-  microsoftInternalIdFromNodeData,
+  internalId,
 } from "@connectors/connectors/microsoft/lib/graph_api";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { upsertTableFromCsv } from "@connectors/lib/data_sources";
@@ -193,8 +193,8 @@ export async function syncSpreadSheet({
 
   const itemApiPath = getDriveItemAPIPath(file);
 
-  const documentId = microsoftInternalIdFromNodeData({
-    itemApiPath,
+  const documentId = internalId({
+    itemAPIPath: itemApiPath,
     nodeType: "file",
   });
 
@@ -208,9 +208,9 @@ export async function syncSpreadSheet({
   const successfulSheetIdImports: string[] = [];
   for (const worksheet of worksheets) {
     if (worksheet.id) {
-      const internalWorkSheetId = microsoftInternalIdFromNodeData({
+      const internalWorkSheetId = internalId({
         nodeType: "worksheet",
-        itemApiPath: getWorksheetAPIPath(worksheet, documentId),
+        itemAPIPath: getWorksheetAPIPath(worksheet, documentId),
       });
       const isImported = await processSheet(
         client,

--- a/connectors/src/lib/models/microsoft.ts
+++ b/connectors/src/lib/models/microsoft.ts
@@ -111,7 +111,7 @@ MicrosoftRootModel.init(
     sequelize: sequelizeConnection,
     modelName: "microsoft_roots",
     indexes: [
-      { fields: ["connectorId", "itemApiPath"], unique: true },
+      { fields: ["connectorId", "itemAPIPath"], unique: true },
       { fields: ["connectorId", "nodeType"], unique: false },
     ],
   }

--- a/connectors/src/lib/models/microsoft.ts
+++ b/connectors/src/lib/models/microsoft.ts
@@ -6,7 +6,7 @@ import type {
 } from "sequelize";
 import { DataTypes, Model } from "sequelize";
 
-import type { MicrosoftNodeType } from "@connectors/connectors/microsoft/lib/node_types";
+import type { MicrosoftNodeType } from "@connectors/connectors/microsoft/lib/types";
 import { sequelizeConnection } from "@connectors/resources/storage";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 

--- a/connectors/src/lib/models/microsoft.ts
+++ b/connectors/src/lib/models/microsoft.ts
@@ -74,7 +74,7 @@ export class MicrosoftRootModel extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
-  declare itemApiPath: string;
+  declare itemAPIPath: string;
   declare nodeType: MicrosoftNodeType;
 }
 MicrosoftRootModel.init(
@@ -98,7 +98,7 @@ MicrosoftRootModel.init(
       type: DataTypes.INTEGER,
       allowNull: false,
     },
-    itemApiPath: {
+    itemAPIPath: {
       type: DataTypes.STRING,
       allowNull: false,
     },
@@ -213,7 +213,7 @@ export class MicrosoftDeltaModel extends Model<
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
-  declare rootId: ForeignKey<MicrosoftRootModel["itemApiPath"]>;
+  declare rootId: ForeignKey<MicrosoftRootModel["itemAPIPath"]>;
   declare deltaToken: string;
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
 }

--- a/connectors/src/resources/microsoft_resource.ts
+++ b/connectors/src/resources/microsoft_resource.ts
@@ -6,6 +6,8 @@ import {
   internalId as internalIdFromNode,
   typeAndPathFromInternalId,
 } from "@connectors/connectors/microsoft/lib/graph_api";
+import type { MicrosoftNode } from "@connectors/connectors/microsoft/lib/types";
+import { concurrentExecutor } from "@connectors/lib/async_utils";
 import {
   MicrosoftConfigurationModel,
   MicrosoftDeltaModel,
@@ -15,8 +17,6 @@ import {
 import { BaseResource } from "@connectors/resources/base_resource";
 import type { WithCreationAttributes } from "@connectors/resources/connector/strategy";
 import type { ReadonlyAttributesType } from "@connectors/resources/storage/types";
-import { MicrosoftNode } from "@connectors/connectors/microsoft/lib/types";
-import { concurrentExecutor } from "@connectors/lib/async_utils";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.

--- a/connectors/src/resources/microsoft_resource.ts
+++ b/connectors/src/resources/microsoft_resource.ts
@@ -2,10 +2,7 @@ import type { ModelId, Result } from "@dust-tt/types";
 import { Ok } from "@dust-tt/types";
 import type { Attributes, ModelStatic, Transaction } from "sequelize";
 
-import {
-  internalId as internalIdFromNode,
-  typeAndPathFromInternalId,
-} from "@connectors/connectors/microsoft/lib/graph_api";
+import { internalId as internalIdFromNode } from "@connectors/connectors/microsoft/lib/graph_api";
 import type { MicrosoftNode } from "@connectors/connectors/microsoft/lib/types";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import {


### PR DESCRIPTION
## Description
This PR completes the fullsync by ensuring names, parent ids and mimetypes are properly synced

While doing so, it performs a few refactorings & renamings, among which:
- introducing `fetchByInternalIds` (plural) and `batchUpdateOrCreate` in microsoft
- introduces `MicrosoftNode` as intermediate type between microsoft's graph_api & microsoft resource, and `itemToMicrosoftNode()` to convert --- correct typing in progress
- removes the former `MicrosoftNodeData`


## Risk

na (gated)

## Deploy Plan
connectors
