### PR TITLE
 Fix Scrolling Behavior for Shift+Enter in TipTap Editor

### DIFF
--- a/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
@@ -8,6 +8,7 @@ import { useEffect, useMemo } from "react";
 import { MentionStorage } from "@app/components/assistant/conversation/input_bar/editor/MentionStorage";
 import type { EditorSuggestions } from "@app/components/assistant/conversation/input_bar/editor/suggestion";
 import { makeGetAssistantSuggestions } from "@app/components/assistant/conversation/input_bar/editor/suggestion";
+import { ParagraphExtension } from "@app/components/text_editor/extensions";
 
 export interface EditorMention {
   id: string;
@@ -167,7 +168,10 @@ const useCustomEditor = ({
     extensions: [
       StarterKit.configure({
         heading: false,
+        // Disable the paragraph extension to handle Enter key press manually.
+        paragraph: false,
       }),
+      ParagraphExtension,
       MentionStorage,
       Mention.configure({
         HTMLAttributes: {
@@ -224,11 +228,11 @@ const useCustomEditor = ({
             clearEditor
           );
 
-          // Return true to indicate that this key event has been handled
+          // Return true to indicate that this key event has been handled.
           return true;
         }
 
-        // Return false to let other keydown handlers or TipTap's default behavior process the event
+        // Return false to let other keydown handlers or TipTap's default behavior process the event.
         return false;
       },
     },

--- a/front/components/text_editor/extensions.ts
+++ b/front/components/text_editor/extensions.ts
@@ -4,7 +4,6 @@ export const ParagraphExtension = Paragraph.extend({
   addKeyboardShortcuts() {
     return {
       "Shift-Enter": () => this.editor.commands.splitBlock(),
-      Enter: () => false,
     };
   },
 });

--- a/front/components/text_editor/extensions.ts
+++ b/front/components/text_editor/extensions.ts
@@ -3,7 +3,8 @@ import Paragraph from "@tiptap/extension-paragraph";
 export const ParagraphExtension = Paragraph.extend({
   addKeyboardShortcuts() {
     return {
-      "Shift-Enter": () => this.editor.commands.enter(),
+      "Shift-Enter": () => this.editor.commands.splitBlock(),
+      Enter: () => false,
     };
   },
 });


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
When users press Shift+Enter to create a new line in our TipTap-based editor, the view doesn't automatically scroll to display the newly created line. Instead, the view only scrolls when an alphanumeric character is typed. This results in a suboptimal user experience, particularly with longer content, as users might not see the cursor or the text they're typing if it's outside the visible area.

This PR uses our existing custom paragraph extension to map Shift+Enter to paragraph creation. We don't need to explicitly disable the Enter shortcut as it's already overridden in our custom handler. Our `handleKeyDown` function takes care of the Enter key press, preventing the default behavior and managing submission.

**Before:**

![InputBarScrollBefore](https://github.com/dust-tt/dust/assets/7428970/79acdad3-522e-4cb4-bf8b-5561c649f8c5)

**After:**

![InputBarScrollAfter](https://github.com/dust-tt/dust/assets/7428970/06a228ad-b711-48dc-aea0-3821e387755d)

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Worst case it breaks the input bar. Safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
