### PR TITLE
Add documentation-ack to danger check for public api changes

### DIFF
--- a/front/dangerfile.ts
+++ b/front/dangerfile.ts
@@ -1,12 +1,15 @@
 import { danger, fail, warn } from "danger";
 
+const migrationAckLabel = "migration-ack";
+const documentationAckLabel = "documentation-ack";
+
 function failMigrationAck() {
   fail(
     "Files in `**/models/` have been modified. " +
       `Addition and deletion should be in 2 separate PRs:\n` +
       ` 1. Addition: migrate and deploy\n` +
       ` 2. Deletion: deploy and migrate\n\n` +
-      `Please add the \`migration-ack\` label to acknowledge ` +
+      `Please add the \`${migrationAckLabel}\` label to acknowledge ` +
       `that a migration will be needed once merged into 'main'.`
   );
 }
@@ -15,12 +18,41 @@ function warnMigrationAck(migrationAckLabel: string) {
   warn(
     "Files in `**/lib/models/` have been modified and the PR has the `" +
       migrationAckLabel +
-      "` label. Don't forget to run the migration from the `-edge` infrastructure."
+      "` label. Don't forget to run the migration from prodbox."
+  );
+}
+
+function checkDocumentationLabel() {
+  const hasDocumentationAckLabel = danger.github.issue.labels.some(
+    (label) => label.name === documentationAckLabel
+  );
+
+  if (!hasDocumentationAckLabel) {
+    failDocumentationAck();
+  } else {
+    warnDocumentationAck(documentationAckLabel);
+  }
+}
+
+function failDocumentationAck() {
+  fail(
+    "Files in `**/api/v1/` have been modified. " +
+      `Please add the \`${documentationAckLabel}\` label to acknowlegde that if anything changes 
+      in a public endpoint, you need to edit the JSDoc comment 
+      above the handler definition and/or the swagger_schemas.ts file and regenerate the documentation using \`npm run docs\``
+  );
+}
+
+function warnDocumentationAck(documentationAckLabel: string) {
+  warn(
+    "Files in `**/api/v1/` have been modified and the PR has the `" +
+      documentationAckLabel +
+      "` label. \n" +
+      "Don't forget to run `npm run docs` and use the `Deploy OpenAPI Docs` Github action to update https://docs.dust.tt/reference."
   );
 }
 
 function checkMigrationLabel() {
-  const migrationAckLabel = "migration-ack";
   const hasMigrationAckLabel = danger.github.issue.labels.some(
     (label) => label.name === migrationAckLabel
   );
@@ -46,7 +78,7 @@ function checkDeployPlanSection() {
   }
 }
 
-function checkModifiedModelFiles() {
+function checkModifiedFiles() {
   const modifiedModelFiles = danger.git.modified_files.filter((path) => {
     return (
       path.startsWith("front/lib/models/") ||
@@ -60,6 +92,14 @@ function checkModifiedModelFiles() {
     checkMigrationLabel();
     checkDeployPlanSection();
   }
+
+  const modifiedPublicApiFiles = danger.git.modified_files.filter((path) => {
+    return path.startsWith("front/pages/api/v1/");
+  });
+
+  if (modifiedPublicApiFiles.length > 0) {
+    checkDocumentationLabel();
+  }
 }
 
-checkModifiedModelFiles();
+checkModifiedFiles();

--- a/front/dangerfile.ts
+++ b/front/dangerfile.ts
@@ -3,6 +3,10 @@ import { danger, fail, warn } from "danger";
 const migrationAckLabel = "migration-ack";
 const documentationAckLabel = "documentation-ack";
 
+const hasLabel = (label: string) => {
+  return danger.github.issue.labels.some((l) => l.name === label);
+}
+
 function failMigrationAck() {
   fail(
     "Files in `**/models/` have been modified. " +
@@ -23,11 +27,7 @@ function warnMigrationAck(migrationAckLabel: string) {
 }
 
 function checkDocumentationLabel() {
-  const hasDocumentationAckLabel = danger.github.issue.labels.some(
-    (label) => label.name === documentationAckLabel
-  );
-
-  if (!hasDocumentationAckLabel) {
+  if (!hasLabel(documentationAckLabel)) {
     failDocumentationAck();
   } else {
     warnDocumentationAck(documentationAckLabel);
@@ -53,11 +53,7 @@ function warnDocumentationAck(documentationAckLabel: string) {
 }
 
 function checkMigrationLabel() {
-  const hasMigrationAckLabel = danger.github.issue.labels.some(
-    (label) => label.name === migrationAckLabel
-  );
-
-  if (!hasMigrationAckLabel) {
+  if (!hasLabel(migrationAckLabel)) {
     failMigrationAck();
   } else {
     warnMigrationAck(migrationAckLabel);

--- a/front/dangerfile.ts
+++ b/front/dangerfile.ts
@@ -5,7 +5,7 @@ const documentationAckLabel = "documentation-ack";
 
 const hasLabel = (label: string) => {
   return danger.github.issue.labels.some((l) => l.name === label);
-}
+};
 
 function failMigrationAck() {
   fail(
@@ -24,6 +24,14 @@ function warnMigrationAck(migrationAckLabel: string) {
       migrationAckLabel +
       "` label. Don't forget to run the migration from prodbox."
   );
+}
+
+function checkMigrationLabel() {
+  if (!hasLabel(migrationAckLabel)) {
+    failMigrationAck();
+  } else {
+    warnMigrationAck(migrationAckLabel);
+  }
 }
 
 function checkDocumentationLabel() {
@@ -50,28 +58,6 @@ function warnDocumentationAck(documentationAckLabel: string) {
       "` label. \n" +
       "Don't forget to run `npm run docs` and use the `Deploy OpenAPI Docs` Github action to update https://docs.dust.tt/reference."
   );
-}
-
-function checkMigrationLabel() {
-  if (!hasLabel(migrationAckLabel)) {
-    failMigrationAck();
-  } else {
-    warnMigrationAck(migrationAckLabel);
-  }
-}
-
-function checkDeployPlanSection() {
-  const PRDescription = danger.github.pr.body;
-
-  const deployPlanSectionRegex =
-    /## Deploy Plan.*?\r\n([\s\S]*?)(?=<!--|\n##|$)/;
-
-  const match = PRDescription.match(deployPlanSectionRegex);
-  if (!match || match[1].trim().length < 20) {
-    fail(
-      "Please include a detailed Deploy Plan section in your PR description."
-    );
-  }
 }
 
 function checkModifiedFiles() {

--- a/front/dangerfile.ts
+++ b/front/dangerfile.ts
@@ -34,6 +34,20 @@ function checkMigrationLabel() {
   }
 }
 
+function checkDeployPlanSection() {
+  const PRDescription = danger.github.pr.body;
+
+  const deployPlanSectionRegex =
+    /## Deploy Plan.*?\r\n([\s\S]*?)(?=<!--|\n##|$)/;
+
+  const match = PRDescription.match(deployPlanSectionRegex);
+  if (!match || match[1].trim().length < 20) {
+    fail(
+      "Please include a detailed Deploy Plan section in your PR description."
+    );
+  }
+}
+
 function checkDocumentationLabel() {
   if (!hasLabel(documentationAckLabel)) {
     failDocumentationAck();


### PR DESCRIPTION
## Description

This PR adds a `documentation-ack` label check when public API files change. 
This introduces a new way to deploy by making sure our documentation is always up to date without currently having the possibility to full-auto it.


## Risk

Could break all danger checks if something's wrong

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
