### PR TITLE
Revert "Moving docx2text and pptx2text to a shared workerpool"

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -60,7 +60,6 @@
         "tsconfig-paths-webpack-plugin": "^4.1.0",
         "turndown": "^7.1.2",
         "uuid": "^9.0.0",
-        "workerpool": "^9.1.3",
         "yargs": "^17.7.2"
       },
       "devDependencies": {
@@ -12162,11 +12161,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/workerpool": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.1.3.tgz",
-      "integrity": "sha512-LhUrk4tbxJRDQmRrrFWA9EnboXI79fe0ZNTy3u8m+dqPN1EkVSIsQYAB8OF/fkyhG8Rtup+c/bzj/+bzbG8fqg=="
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/connectors/package.json
+++ b/connectors/package.json
@@ -66,7 +66,6 @@
     "tsconfig-paths-webpack-plugin": "^4.1.0",
     "turndown": "^7.1.2",
     "uuid": "^9.0.0",
-    "workerpool": "^9.1.3",
     "yargs": "^17.7.2"
   },
   "devDependencies": {

--- a/connectors/src/connectors/google_drive/temporal/file.ts
+++ b/connectors/src/connectors/google_drive/temporal/file.ts
@@ -29,7 +29,7 @@ import {
   sectionLength,
   upsertToDatasource,
 } from "@connectors/lib/data_sources";
-import { docx2text } from "@connectors/lib/docx2text";
+import { docx2text } from "@connectors/lib/docx2text.";
 import { dpdf2text } from "@connectors/lib/dpdf2text";
 import {
   GoogleDriveConfig,

--- a/connectors/src/lib/docx2text..ts
+++ b/connectors/src/lib/docx2text..ts
@@ -2,9 +2,7 @@ import tracer from "dd-trace";
 import mammoth from "mammoth";
 import turndown from "turndown";
 
-import { getWorkerPool } from "@connectors/lib/workerpool";
-
-async function _docx2text(fileContent: Buffer, filename: string) {
+export async function docx2text(fileContent: Buffer, filename: string) {
   return tracer.trace(
     `gdrive`,
     {
@@ -24,8 +22,4 @@ async function _docx2text(fileContent: Buffer, filename: string) {
       return result;
     }
   );
-}
-
-export async function docx2text(fileContent: Buffer, filename: string) {
-  return getWorkerPool().exec(_docx2text, [fileContent, filename]);
 }

--- a/connectors/src/lib/pptx2text.ts
+++ b/connectors/src/lib/pptx2text.ts
@@ -2,15 +2,13 @@ import tracer from "dd-trace";
 import JSZip from "jszip";
 import turndown from "turndown";
 
-import { getWorkerPool } from "@connectors/lib/workerpool";
-
 type PPTXDocument = {
   pages: {
     content: string;
   }[];
 };
 
-async function _PPTX2Text(
+export async function PPTX2Text(
   fileBuffer: Buffer,
   filename?: string
 ): Promise<PPTXDocument> {
@@ -71,11 +69,4 @@ async function _PPTX2Text(
       return document;
     }
   );
-}
-
-export async function PPTX2Text(
-  fileBuffer: Buffer,
-  filename?: string
-): Promise<PPTXDocument> {
-  return getWorkerPool().exec(_PPTX2Text, [fileBuffer, filename]);
 }

--- a/connectors/src/lib/workerpool.ts
+++ b/connectors/src/lib/workerpool.ts
@@ -1,9 +1,0 @@
-import workerpool from "workerpool";
-
-let POOL: ReturnType<typeof workerpool.pool> | null = null;
-export function getWorkerPool() {
-  if (!POOL) {
-    POOL = workerpool.pool({ maxWorkers: 3 });
-  }
-  return POOL;
-}

--- a/k8s/deployments/connectors-worker-google-drive-deployment.yaml
+++ b/k8s/deployments/connectors-worker-google-drive-deployment.yaml
@@ -47,12 +47,12 @@ spec:
 
           resources:
             requests:
-              cpu: 3000m
+              cpu: 2000m
               memory: 4Gi
               ephemeral-storage: 4Gi
 
             limits:
-              cpu: 3000m
+              cpu: 2000m
               memory: 4Gi
               ephemeral-storage: 4Gi
 


### PR DESCRIPTION
Reverts dust-tt/dust#6087

This PR introduces a regression as none of the modules (`dd-tracer`, `turndown`) are actually loaded in the worker code. Logs [here](https://app.datadoghq.eu/logs?query=%22Error%20while%20converting%20docx%20document%20to%20text%22%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAZB-pz9ley50HgAAAAAAAAAYAAAAAEFaQi1wMEZJQUFDaWR5Ynd0WEUycUFBeQAAACQAAAAAMDE5MDdlZTMtZjAxZi00YmY0LTljNjMtMmQxN2UyMDNhNjY3&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1720110982496&to_ts=1720112033979&live=false).

I can easily reproduce locally:
```
[10:25:04.085] WARN (16411): Error while converting docx document to text
    provider: "google_drive"
    workspaceId: "a171d1f222"
    dataSourceName: "managed-google_drive"
    connectorId: 73
    documentId: "gdrive-1SI2LsaCq6QeOExQ-ubsMdRvz79hUE2vO"
    fileId: "1SI2LsaCq6QeOExQ-ubsMdRvz79hUE2vO"
    title: "sample4.docx"
    mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
    error: {
      "type": "Error",
      "message": "import_dd_trace is not defined",
      "stack":
          ReferenceError: import_dd_trace is not defined
              at _docx2text (eval at run (/Users/flaviendavid/Documents/workspace/dust/connectors/node_modules/workerpool/src/worker.js:98:11), <anonymous>:3:57)
              at Function.eval (eval at run (/Users/flaviendavid/Documents/workspace/dust/connectors/node_modules/workerpool/src/worker.js:98:11), <anonymous>:3:457)
              at Function.run (/Users/flaviendavid/Documents/workspace/dust/connectors/node_modules/workerpool/src/worker.js:99:12)
              at MessagePort.<anonymous> (/Users/flaviendavid/Documents/workspace/dust/connectors/node_modules/workerpool/src/worker.js:150:27)
              at [nodejs.internal.kHybridDispatch] (node:internal/event_target:825:20)
              at MessagePort.<anonymous> (node:internal/per_context/messageport:23:28)
    }
```