### PR TITLE
Preserve maxToolsUsePerRun when duplicating an assistant

### DIFF
--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -222,7 +222,7 @@ export default function CreateAssistant({
                 },
                 temperature: agentConfiguration.model.temperature,
               },
-              maxToolsUsePerRun: null,
+              maxToolsUsePerRun: agentConfiguration.maxToolsUsePerRun ?? null,
               templateId: templateId,
             }
           : null

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -196,6 +196,7 @@ export interface TemplateAgentConfigurationType {
   actions: AgentActionConfigurationType[];
   instructions: string | null;
   isTemplate: true;
+  maxToolsUsePerRun?: number;
 }
 
 export const MAX_TOOLS_USE_PER_RUN_LIMIT = 8;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes https://github.com/dust-tt/tasks/issues/1048.

It preserves the `maxToolsUserPerRun` when duplicating an assistant.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
