### PR TITLE
oauth: use config and constructor for URL

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -44,6 +44,11 @@ const config = {
       EnvironmentConfig.getOptionalEnvVariable("CUSTOMERIO_ENABLED") === "true"
     );
   },
+  getOAuthAPIConfig: (): { url: string } => {
+    return {
+      url: EnvironmentConfig.getEnvVariable("OAUTH_API"),
+    };
+  },
   getOAuthGithubApp: (): string => {
     return EnvironmentConfig.getEnvVariable("OAUTH_GITHUB_APP");
   },

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -134,7 +134,7 @@ export async function createConnectionAndGetRedirectURL(
   provider: OAuthProvider,
   useCase: OAuthUseCase
 ): Promise<Result<string, OAuthError>> {
-  const api = new OAuthAPI(logger);
+  const api = new OAuthAPI(config.getOAuthAPIConfig(), logger);
 
   const cRes = await api.createConnection({
     provider,
@@ -189,7 +189,7 @@ export async function finalizeConnection(
     });
   }
 
-  const api = new OAuthAPI(logger);
+  const api = new OAuthAPI(config.getOAuthAPIConfig(), logger);
 
   const cRes = await api.finalizeConnection({ provider, connectionId, code });
   logger.error(

--- a/types/src/core/oauth_api.ts
+++ b/types/src/core/oauth_api.ts
@@ -17,8 +17,6 @@ export function isOAuthProvider(obj: unknown): obj is OAuthProvider {
   return OAUTH_PROVIDERS.includes(obj as OAuthProvider);
 }
 
-const { OAUTH_API = "http://127.0.0.1:3006" } = process.env;
-
 export type OAuthAPIError = {
   message: string;
   code: string;
@@ -47,13 +45,15 @@ export type OAuthConnectionType = {
 
 export class OAuthAPI {
   _logger: LoggerInterface;
+  _url: string;
 
-  constructor(logger: LoggerInterface) {
+  constructor(config: { url: string }, logger: LoggerInterface) {
+    this._url = config.url;
     this._logger = logger;
   }
 
   apiUrl() {
-    return OAUTH_API;
+    return this._url;
   }
 
   async createConnection({
@@ -63,7 +63,7 @@ export class OAuthAPI {
     provider: OAuthProvider;
     metadata: Record<string, unknown> | null;
   }): Promise<OAuthAPIResponse<{ connection: OAuthConnectionType }>> {
-    const response = await this._fetchWithError(`${OAUTH_API}/connections`, {
+    const response = await this._fetchWithError(`${this._url}/connections`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -86,7 +86,7 @@ export class OAuthAPI {
     code: string;
   }): Promise<OAuthAPIResponse<{ connection: OAuthConnectionType }>> {
     const response = await this._fetchWithError(
-      `${OAUTH_API}/connections/${connectionId}/finalize`,
+      `${this._url}/connections/${connectionId}/finalize`,
       {
         method: "POST",
         headers: {


### PR DESCRIPTION
## Description

Remove env getter from types and receive the config for OAuthAPI from constructor + rely on the config pattern for that in front

## Risk

N/A

## Deploy Plan

N/A