### PR TITLE
Limit the number of slack blocks

### DIFF
--- a/connectors/src/connectors/slack/chat/blocks.ts
+++ b/connectors/src/connectors/slack/chat/blocks.ts
@@ -85,7 +85,10 @@ function makeContextSectionBlocks(
     blocks.push(makeConversationLinkContextBlock(conversationUrl));
   }
 
-  return blocks.length ? [makeDividerBlock(), ...blocks] : [];
+  const resultBlocks = blocks.length ? [makeDividerBlock(), ...blocks] : [];
+
+  // Slack limits the number of blocks to 10.
+  return resultBlocks.slice(0, 10);
 }
 
 export type SlackMessageUpdate =


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See [logs](https://app.datadoghq.eu/logs?query=%22Unexpected%20exception%20answering%20to%20Slack%20Chat%20Bot%20message%22%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAZCnDZU89eeqUwAAAAAAAAAYAAAAAEFaQ25EWnN3QUFBaVB1SW9XNkZMV3dBTQAAACQAAAAAMDE5MGE3MGQtYmE1NS00NWFhLWFiNmMtMDcwYzUwMmM1Yjkz&fromUser=true&messageDisplay=inline&refresh_mode=sliding&source=monitor_notif&storage=hot&stream_sort=desc&viz=stream&from_ts=1720789179000&to_ts=1720789779000&live=false).

This PR ensures that we don't send more than 10 context blocks (:cite blocks) to Slack. Their API seems to enforce a limit of 10.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
