### PR TITLE
DustAPI: config based constructor

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -29,6 +29,7 @@ import {
   isBotAllowed,
   notifyIfSlackUserIsNotAllowed,
 } from "@connectors/connectors/slack/lib/workspace_limits";
+import { apiConfig } from "@connectors/lib/api/config";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import {
   SlackChannel,
@@ -245,6 +246,7 @@ async function botAnswerMessage(
   }
 
   const dustAPI = new DustAPI(
+    apiConfig.getDustAPIConfig(),
     {
       workspaceId: connector.workspaceId,
       apiKey: connector.workspaceAPIKey,

--- a/connectors/src/connectors/slack/lib/workspace_limits.ts
+++ b/connectors/src/connectors/slack/lib/workspace_limits.ts
@@ -6,6 +6,7 @@ import type {} from "@slack/web-api/dist/response/UsersInfoResponse";
 import { SlackExternalUserError } from "@connectors/connectors/slack/lib/errors";
 import type { SlackUserInfo } from "@connectors/connectors/slack/lib/slack_client";
 import { getSlackConversationInfo } from "@connectors/connectors/slack/lib/slack_client";
+import { apiConfig } from "@connectors/lib/api/config";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -18,6 +19,7 @@ async function getActiveMemberEmails(
 
   // List the emails of all active members in the workspace.
   const dustAPI = new DustAPI(
+    apiConfig.getDustAPIConfig(),
     {
       apiKey: ds.workspaceAPIKey,
       workspaceId: ds.workspaceId,
@@ -55,6 +57,7 @@ async function getVerifiedDomainsForWorkspace(
   const ds = dataSourceConfigFromConnector(connector);
 
   const dustAPI = new DustAPI(
+    apiConfig.getDustAPIConfig(),
     {
       apiKey: ds.workspaceAPIKey,
       workspaceId: ds.workspaceId,

--- a/connectors/src/lib/api/config.ts
+++ b/connectors/src/lib/api/config.ts
@@ -1,0 +1,11 @@
+import { EnvironmentConfig } from "@dust-tt/types";
+
+export const apiConfig = {
+  getDustAPIConfig: (): { url: string; nodeEnv: string } => {
+    return {
+      // Dust production API URL is hardcoded for now.
+      url: "https://dust.tt",
+      nodeEnv: EnvironmentConfig.getEnvVariable("NODE_ENV"),
+    };
+  },
+};

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -19,6 +19,7 @@ import { gfmFromMarkdown, gfmToMarkdown } from "mdast-util-gfm";
 import { toMarkdown } from "mdast-util-to-markdown";
 import { gfm } from "micromark-extension-gfm";
 
+import { apiConfig } from "@connectors/lib/api/config";
 import { withRetries } from "@connectors/lib/dust_front_api_helpers";
 import { DustConnectorWorkflowError } from "@connectors/lib/error";
 import logger from "@connectors/logger/logger";
@@ -349,6 +350,7 @@ export async function renderPrefixSection({
 
 async function tokenize(text: string, ds: DataSourceConfig) {
   const dustAPI = new DustAPI(
+    apiConfig.getDustAPIConfig(),
     {
       apiKey: ds.workspaceAPIKey,
       workspaceId: ds.workspaceId,

--- a/connectors/src/lib/workspace.ts
+++ b/connectors/src/lib/workspace.ts
@@ -1,6 +1,7 @@
 import type { WhitelistableFeature } from "@dust-tt/types";
 import { cacheWithRedis, DustAPI } from "@dust-tt/types";
 
+import { apiConfig } from "@connectors/lib/api/config";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -12,6 +13,7 @@ async function getEnabledFeatureFlags(
 
   // List the feature flags enabled for the workspace.
   const dustAPI = new DustAPI(
+    apiConfig.getDustAPIConfig(),
     {
       apiKey: ds.workspaceAPIKey,
       workspaceId: ds.workspaceId,

--- a/front/lib/actions/helpers.ts
+++ b/front/lib/actions/helpers.ts
@@ -11,6 +11,7 @@ import {
   ActionResponseBaseSchema,
   isActionResponseBase,
 } from "@app/lib/actions/types";
+import apiConfig from "@app/lib/api/config";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 
@@ -51,7 +52,11 @@ export async function callAction<V extends t.Mixed>({
 
   const prodCredentials = await prodAPICredentialsForOwner(owner);
 
-  const prodAPI = new DustAPI(prodCredentials, logger);
+  const prodAPI = new DustAPI(
+    apiConfig.getDustAPIConfig(),
+    prodCredentials,
+    logger
+  );
 
   const r = await prodAPI.runApp(app, config, [input]);
 

--- a/front/lib/actions/server.ts
+++ b/front/lib/actions/server.ts
@@ -4,6 +4,7 @@ import { DustProdActionRegistry } from "@dust-tt/types";
 import { DustAPI } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 
+import apiConfig from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import logger from "@app/logger/logger";
@@ -85,7 +86,11 @@ export async function runActionStreamed(
   const now = new Date();
 
   const prodCredentials = await prodAPICredentialsForOwner(owner);
-  const api = new DustAPI(prodCredentials, logger);
+  const api = new DustAPI(
+    apiConfig.getDustAPIConfig(),
+    prodCredentials,
+    logger
+  );
 
   const res = await api.runAppStreamed(action.app, config, inputs);
   if (res.isErr()) {
@@ -193,7 +198,11 @@ export async function runAction(
   const now = new Date();
 
   const prodCredentials = await prodAPICredentialsForOwner(owner);
-  const api = new DustAPI(prodCredentials, logger);
+  const api = new DustAPI(
+    apiConfig.getDustAPIConfig(),
+    prodCredentials,
+    logger
+  );
 
   const res = await api.runApp(action.app, config, inputs);
   if (res.isErr()) {

--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -19,7 +19,7 @@ import { Err, Ok } from "@dust-tt/types";
 import { getApp } from "@app/lib/api/app";
 import type { BaseActionRunParams } from "@app/lib/api/assistant/actions/types";
 import { BaseActionConfigurationServerRunner } from "@app/lib/api/assistant/actions/types";
-import config from "@app/lib/api/config"
+import config from "@app/lib/api/config";
 import { getDatasetSchema } from "@app/lib/api/datasets";
 import type { Authenticator } from "@app/lib/auth";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";

--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -19,6 +19,7 @@ import { Err, Ok } from "@dust-tt/types";
 import { getApp } from "@app/lib/api/app";
 import type { BaseActionRunParams } from "@app/lib/api/assistant/actions/types";
 import { BaseActionConfigurationServerRunner } from "@app/lib/api/assistant/actions/types";
+import config from "@app/lib/api/config"
 import { getDatasetSchema } from "@app/lib/api/datasets";
 import type { Authenticator } from "@app/lib/auth";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";
@@ -26,8 +27,6 @@ import { extractConfig } from "@app/lib/config";
 import { AgentDustAppRunAction } from "@app/lib/models/assistant/actions/dust_app_run";
 import { sanitizeJSONOutput } from "@app/lib/utils";
 import logger from "@app/logger/logger";
-
-import config from "../../config";
 
 interface DustAppRunActionBlob {
   id: ModelId; // AgentDustAppRun.

--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -27,6 +27,8 @@ import { AgentDustAppRunAction } from "@app/lib/models/assistant/actions/dust_ap
 import { sanitizeJSONOutput } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 
+import config from "../../config";
+
 interface DustAppRunActionBlob {
   id: ModelId; // AgentDustAppRun.
   agentMessageId: ModelId;
@@ -302,9 +304,14 @@ export class DustAppRunConfigurationServerRunner extends BaseActionConfiguration
     const prodCredentials = await prodAPICredentialsForOwner(owner, {
       useLocalInDev: true,
     });
-    const api = new DustAPI(prodCredentials, logger, {
-      useLocalInDev: true,
-    });
+    const api = new DustAPI(
+      config.getDustAPIConfig(),
+      prodCredentials,
+      logger,
+      {
+        useLocalInDev: true,
+      }
+    );
 
     // As we run the app (using a system API key here), we do force using the workspace credentials so
     // that the app executes in the exact same conditions in which they were developed.

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -40,6 +40,8 @@ import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import { GlobalAgentSettings } from "@app/lib/models/assistant/agent";
 import logger from "@app/logger/logger";
 
+import config from "../config";
+
 // Used when returning an agent with status 'disabled_by_admin'
 const dummyModelConfiguration = {
   providerId: GPT_3_5_TURBO_MODEL_CONFIG.providerId,
@@ -825,7 +827,7 @@ async function _getDustGlobalAgent(
   }
 
   const prodCredentials = await prodAPICredentialsForOwner(owner);
-  const api = new DustAPI(prodCredentials, logger);
+  const api = new DustAPI(config.getDustAPIConfig(), prodCredentials, logger);
 
   const dsRes = await api.getDataSources(prodCredentials.workspaceId);
   if (dsRes.isErr()) {
@@ -932,7 +934,7 @@ export async function getGlobalAgent(
 
   if (preFetchedDataSources === null) {
     const prodCredentials = await prodAPICredentialsForOwner(owner);
-    const api = new DustAPI(prodCredentials, logger);
+    const api = new DustAPI(config.getDustAPIConfig(), prodCredentials, logger);
 
     const dsRes = await api.getDataSources(prodCredentials.workspaceId);
     if (dsRes.isErr()) {
@@ -1072,7 +1074,7 @@ export async function getGlobalAgents(
   }
 
   const prodCredentials = await prodAPICredentialsForOwner(owner);
-  const api = new DustAPI(prodCredentials, logger);
+  const api = new DustAPI(config.getDustAPIConfig(), prodCredentials, logger);
 
   const dsRes = await api.getDataSources(prodCredentials.workspaceId);
   if (dsRes.isErr()) {

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -34,13 +34,13 @@ import {
   DEFAULT_RETRIEVAL_ACTION_NAME,
   DEFAULT_WEBSEARCH_ACTION_NAME,
 } from "@app/lib/api/assistant/actions/names";
+import config from "@app/lib/api/config"
 import { GLOBAL_AGENTS_SID } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import { GlobalAgentSettings } from "@app/lib/models/assistant/agent";
 import logger from "@app/logger/logger";
 
-import config from "../config";
 
 // Used when returning an agent with status 'disabled_by_admin'
 const dummyModelConfiguration = {

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -34,13 +34,12 @@ import {
   DEFAULT_RETRIEVAL_ACTION_NAME,
   DEFAULT_WEBSEARCH_ACTION_NAME,
 } from "@app/lib/api/assistant/actions/names";
-import config from "@app/lib/api/config"
+import config from "@app/lib/api/config";
 import { GLOBAL_AGENTS_SID } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import { GlobalAgentSettings } from "@app/lib/models/assistant/agent";
 import logger from "@app/logger/logger";
-
 
 // Used when returning an agent with status 'disabled_by_admin'
 const dummyModelConfiguration = {

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -47,24 +47,31 @@ const config = {
       EnvironmentConfig.getOptionalEnvVariable("CUSTOMERIO_ENABLED") === "true"
     );
   },
-  getOAuthAPIConfig: (): { url: string } => {
+  getCoreAPIConfig: (): { url: string } => {
     return {
-      url: EnvironmentConfig.getEnvVariable("OAUTH_API"),
+      url: EnvironmentConfig.getEnvVariable("CORE_API"),
     };
   },
-  getConnectorsAPIConfig(): { url: string; secret: string } {
+  getConnectorsAPIConfig: (): { url: string; secret: string } => {
     return {
       url: EnvironmentConfig.getEnvVariable("CONNECTORS_API"),
       secret: EnvironmentConfig.getEnvVariable("DUST_CONNECTORS_SECRET"),
     };
   },
+  getDustAPIConfig: (): { url: string; nodeEnv: string } => {
+    return {
+      // Dust production API URL is hardcoded for now.
+      url: "https://dust.tt",
+      nodeEnv: EnvironmentConfig.getEnvVariable("NODE_ENV"),
+    };
+  },
+  getOAuthAPIConfig: (): { url: string } => {
+    return {
+      url: EnvironmentConfig.getEnvVariable("OAUTH_API"),
+    };
+  },
   getOAuthGithubApp: (): string => {
     return EnvironmentConfig.getEnvVariable("OAUTH_GITHUB_APP");
-  },
-  getCoreAPIConfig: (): { url: string } => {
-    return {
-      url: EnvironmentConfig.getEnvVariable("CORE_API"),
-    };
   },
 };
 

--- a/front/lib/documents_post_process_hooks/hooks/document_tracker/lib.ts
+++ b/front/lib/documents_post_process_hooks/hooks/document_tracker/lib.ts
@@ -1,6 +1,7 @@
 import type { WorkspaceType } from "@dust-tt/types";
 import { DustAPI } from "@dust-tt/types";
 
+import config from "@app/lib/api/config";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import { TRACKABLE_CONNECTOR_TYPES } from "@app/lib/documents_post_process_hooks/hooks/document_tracker/consts";
 import logger from "@app/logger/logger";
@@ -13,7 +14,11 @@ export async function getTrackableDataSources(owner: WorkspaceType): Promise<
 > {
   const prodCredentials = await prodAPICredentialsForOwner(owner);
 
-  const prodAPI = new DustAPI(prodCredentials, logger);
+  const prodAPI = new DustAPI(
+    config.getDustAPIConfig(),
+    prodCredentials,
+    logger
+  );
 
   // Fetch data sources
   const dsRes = await prodAPI.getDataSources(prodAPI.workspaceId());

--- a/front/temporal/labs/activities.ts
+++ b/front/temporal/labs/activities.ts
@@ -9,6 +9,7 @@ import { Err } from "@dust-tt/types";
 import marked from "marked";
 import sanitizeHtml from "sanitize-html";
 
+import config from "@app/lib/api/config";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import { sendEmail } from "@app/lib/email";
@@ -220,9 +221,14 @@ export async function processTranscriptActivity(
     renderLightWorkspaceType({ workspace: owner }),
     { useLocalInDev: true }
   );
-  const dustAPI = new DustAPI(prodCredentials, localLogger, {
-    useLocalInDev: true,
-  });
+  const dustAPI = new DustAPI(
+    config.getDustAPIConfig(),
+    prodCredentials,
+    localLogger,
+    {
+      useLocalInDev: true,
+    }
+  );
 
   const { agentConfigurationId } = transcriptsConfiguration;
   if (!agentConfigurationId) {

--- a/types/src/front/lib/dust_api.ts
+++ b/types/src/front/lib/dust_api.ts
@@ -29,8 +29,6 @@ import { UserMessageErrorEvent } from "./api/assistant/conversation";
 import { GenerationTokensEvent } from "./api/assistant/generation";
 import { APIError, isAPIError } from "./error";
 
-const { DUST_PROD_API = "https://dust.tt", NODE_ENV } = process.env;
-
 export type DustAppType = {
   workspaceId: string;
   appId: string;
@@ -305,6 +303,8 @@ export async function processStreamedRunResponse(
 }
 
 export class DustAPI {
+  _url: string;
+  _nodeEnv: string;
   _credentials: DustAPICredentials;
   _useLocalInDev: boolean;
   _logger: LoggerInterface;
@@ -314,6 +314,10 @@ export class DustAPI {
    * @param credentials DustAPICrededentials
    */
   constructor(
+    config: {
+      url: string;
+      nodeEnv: string;
+    },
     credentials: DustAPICredentials,
     logger: LoggerInterface,
     {
@@ -324,6 +328,8 @@ export class DustAPI {
       urlOverride?: string;
     } = { useLocalInDev: false }
   ) {
+    this._url = config.url;
+    this._nodeEnv = config.nodeEnv;
     this._credentials = credentials;
     this._logger = logger;
     this._useLocalInDev = useLocalInDev;
@@ -338,9 +344,9 @@ export class DustAPI {
     if (this._urlOverride) {
       return this._urlOverride;
     }
-    return this._useLocalInDev && NODE_ENV === "development"
+    return this._useLocalInDev && this._nodeEnv === "development"
       ? "http://localhost:3000"
-      : DUST_PROD_API;
+      : this._url;
   }
 
   /**


### PR DESCRIPTION
## Description

Remove env getter from types and receive the config for CoreAPI from constructor + rely on the config pattern for that in front

I checked that NODE_ENV is defined in production on both connectors and front and tested both connectors and front flows locally.

## Risk

Critical path for all assistants and all connectors

## Deploy Plan

- deploy `front`
- deploy `connectors`