### PR TITLE
Improve Redis isolated pool eviction

### DIFF
--- a/front/lib/api/redis.ts
+++ b/front/lib/api/redis.ts
@@ -15,9 +15,10 @@ export async function getRedisClient(): Promise<RedisClientType> {
     client = createClient({
       url: REDIS_URI,
       isolationPoolOptions: {
-        acquireTimeoutMillis: 10000, // 10 seconds.
-        // We support up to 200 concurrent connections for streaming.
-        max: 200,
+        acquireTimeoutMillis: 10000, // Max time to wait for a connection: 10 seconds.
+        max: 200, // Maximum number of concurrent connections for streaming.
+        evictionRunIntervalMillis: 15000, // Check for idle connections every 15 seconds.
+        idleTimeoutMillis: 30000, // Connections idle for more than 30 seconds will be eligible for eviction.
       },
     });
     client.on("error", (err) => logger.info({ err }, "Redis Client Error"));


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of https://github.com/dust-tt/dust/pull/6187.

The PR above had the desired effect, capping the maximum number of connections per pod. We observed that, by default, connections are not evicted from the isolated connection pool, which is evident when we see the number of connections decreasing upon deployment.

<img width="452" alt="image" src="https://github.com/user-attachments/assets/230588df-2fc6-4bb4-9b84-97b39d04986b">

Looking closer at the Redis isolated pool’s implementation, eviction is not enabled by default ([doc](https://www.npmjs.com/package/generic-pool)), meaning all connections remain open for the pod's lifetime. This PR sets the `evictionRunIntervalMillis` to 15 seconds and the `idleTimeoutMillis` to 30 seconds, ensuring that an idle connection will be considered for eviction after 30 seconds, with the eviction process running every 15 seconds.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
