### PR TITLE
[MS Connector] API pagination

### DIFF
--- a/connectors/src/connectors/microsoft/lib/graph_api.ts
+++ b/connectors/src/connectors/microsoft/lib/graph_api.ts
@@ -6,15 +6,27 @@ import type { MicrosoftNodeType } from "@connectors/connectors/microsoft/lib/typ
 import type { MicrosoftNode } from "@connectors/connectors/microsoft/lib/types";
 import { isValidNodeType } from "@connectors/connectors/microsoft/lib/types";
 
-export async function getSites(client: Client): Promise<MicrosoftGraph.Site[]> {
-  const res = await client.api("/sites?search=*").get();
-  return res.value;
+export async function getSites(
+  client: Client,
+  nextLink?: string
+): Promise<{ results: MicrosoftGraph.Site[]; nextLink?: string }> {
+  const res = nextLink
+    ? await client.api(nextLink).get()
+    : await client.api("/sites?search=*").get();
+  if ("@odata.nextLink" in res) {
+    return {
+      results: res.value,
+      nextLink: res["@odata.nextLink"],
+    };
+  }
+  return { results: res.value };
 }
 
 export async function getDrives(
   client: Client,
-  parentInternalId: string
-): Promise<MicrosoftGraph.Drive[]> {
+  parentInternalId: string,
+  nextLink?: string
+): Promise<{ results: MicrosoftGraph.Drive[]; nextLink?: string }> {
   const { nodeType, itemAPIPath: parentResourcePath } =
     typeAndPathFromInternalId(parentInternalId);
 
@@ -24,17 +36,25 @@ export async function getDrives(
     );
   }
 
-  const res = await client
-    .api(`${parentResourcePath}/drives`)
-    .select("id,name")
-    .get();
-  return res.value;
+  const res = nextLink
+    ? await client.api(nextLink).get()
+    : await client.api(`${parentResourcePath}/drives`).get();
+
+  if ("@odata.nextLink" in res) {
+    return {
+      results: res.value,
+      nextLink: res["@odata.nextLink"],
+    };
+  }
+
+  return { results: res.value };
 }
 
 export async function getFilesAndFolders(
   client: Client,
-  parentInternalId: string
-): Promise<MicrosoftGraph.DriveItem[]> {
+  parentInternalId: string,
+  nextLink?: string
+): Promise<{ results: MicrosoftGraph.DriveItem[]; nextLink?: string }> {
   const { nodeType, itemAPIPath: parentResourcePath } =
     typeAndPathFromInternalId(parentInternalId);
 
@@ -48,22 +68,28 @@ export async function getFilesAndFolders(
       ? `${parentResourcePath}/root/children`
       : `${parentResourcePath}/children`;
 
-  const res = await client.api(endpoint).get();
-  return res.value;
-}
+  const res = nextLink
+    ? await client.api(nextLink).get()
+    : await client.api(endpoint).get();
 
-export async function getFolders(
-  client: Client,
-  parentInternalId: string
-): Promise<MicrosoftGraph.DriveItem[]> {
-  const res = await getFilesAndFolders(client, parentInternalId);
-  return res.filter((item) => item.folder);
+  if ("@odata.nextLink" in res) {
+    return {
+      results: res.value,
+      nextLink: res["@odata.nextLink"],
+    };
+  }
+
+  return { results: res.value };
 }
 
 export async function getWorksheets(
   client: Client,
-  internalId: string
-): Promise<MicrosoftGraph.WorkbookWorksheet[]> {
+  internalId: string,
+  nextLink?: string
+): Promise<{
+  results: MicrosoftGraph.WorkbookWorksheet[];
+  nextLink?: string;
+}> {
   const { nodeType, itemAPIPath: itemApiPath } =
     typeAndPathFromInternalId(internalId);
 
@@ -73,8 +99,18 @@ export async function getWorksheets(
     );
   }
 
-  const res = await client.api(`${itemApiPath}/workbook/worksheets`).get();
-  return res.value;
+  const res = nextLink
+    ? await client.api(nextLink).get()
+    : await client.api(`${itemApiPath}/workbook/worksheets`).get();
+
+  if ("@odata.nextLink" in res) {
+    return {
+      results: res.value,
+      nextLink: res["@odata.nextLink"],
+    };
+  }
+
+  return { results: res.value };
 }
 
 export async function getWorksheetContent(
@@ -93,18 +129,29 @@ export async function getWorksheetContent(
   return res;
 }
 
-export async function getTeams(client: Client): Promise<MicrosoftGraph.Team[]> {
-  const res = await client
-    .api("/me/joinedTeams")
-    .select("id,displayName")
-    .get();
-  return res.value;
+export async function getTeams(
+  client: Client,
+  nextLink?: string
+): Promise<{ results: MicrosoftGraph.Team[]; nextLink?: string }> {
+  const res = nextLink
+    ? await client.api(nextLink).get()
+    : await client.api("/me/joinedTeams").get();
+
+  if ("@odata.nextLink" in res) {
+    return {
+      results: res.value,
+      nextLink: res["@odata.nextLink"],
+    };
+  }
+
+  return { results: res.value };
 }
 
 export async function getChannels(
   client: Client,
-  parentInternalId: string
-): Promise<MicrosoftGraph.Channel[]> {
+  parentInternalId: string,
+  nextLink?: string
+): Promise<{ results: MicrosoftGraph.Channel[]; nextLink?: string }> {
   const { nodeType, itemAPIPath: parentResourcePath } =
     typeAndPathFromInternalId(parentInternalId);
 
@@ -114,17 +161,25 @@ export async function getChannels(
     );
   }
 
-  const res = await client
-    .api(`${parentResourcePath}/channels`)
-    .select("id,displayName")
-    .get();
-  return res.value;
+  const res = nextLink
+    ? await client.api(nextLink).get()
+    : await client.api(`${parentResourcePath}/channels`).get();
+
+  if ("@odata.nextLink" in res) {
+    return {
+      results: res.value,
+      nextLink: res["@odata.nextLink"],
+    };
+  }
+
+  return { results: res.value };
 }
 
 export async function getMessages(
   client: Client,
-  parentInternalId: string
-): Promise<MicrosoftGraph.ChatMessage[]> {
+  parentInternalId: string,
+  nextLink?: string
+): Promise<{ results: MicrosoftGraph.ChatMessage[]; nextLink?: string }> {
   const { nodeType, itemAPIPath: parentResourcePath } =
     typeAndPathFromInternalId(parentInternalId);
 
@@ -134,8 +189,38 @@ export async function getMessages(
     );
   }
 
-  const res = await client.api(`${parentResourcePath}/messages`).get();
-  return res.value;
+  const res = nextLink
+    ? await client.api(nextLink).get()
+    : await client.api(parentResourcePath).get();
+
+  if ("@odata.nextLink" in res) {
+    return {
+      results: res.value,
+      nextLink: res["@odata.nextLink"],
+    };
+  }
+
+  return { results: res.value };
+}
+/**
+ * Given a getter function with a single nextLink optional parameter, this function
+ * fetches all items by following nextLinks
+ */
+export async function getAllPaginatedEntities<T extends MicrosoftGraph.Entity>(
+  getEntitiesFn: (
+    nextLink?: string
+  ) => Promise<{ results: T[]; nextLink?: string }>
+): Promise<T[]> {
+  let nextLink: string | undefined = undefined;
+  let allItems: T[] = [];
+
+  do {
+    const { results, nextLink: newNextLink } = await getEntitiesFn(nextLink);
+    allItems = allItems.concat(results);
+    nextLink = newNextLink;
+  } while (nextLink);
+
+  return allItems;
 }
 
 export async function getItem(client: Client, itemApiPath: string) {

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -215,7 +215,7 @@ export async function syncFiles({
   const results = await concurrentExecutor(
     childrenToSync,
     async (child) =>
-      await syncOneFile({
+      syncOneFile({
         connectorId,
         dataSourceConfig,
         providerConfig,
@@ -343,7 +343,7 @@ export async function syncOneFile({
     file.file?.mimeType ===
     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
   ) {
-    return syncSpreadSheet({ connectorId, file });
+    return (await syncSpreadSheet({ connectorId, file })).isSupported;
   }
   if (!file.file?.mimeType || !mimeTypesToSync.includes(file.file.mimeType)) {
     localLogger.info("Type not supported, skipping file.");

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -214,7 +214,7 @@ export async function syncFiles({
   // sync files
   const results = await concurrentExecutor(
     childrenToSync,
-    async (child) => {
+    async (child) =>
       await syncOneFile({
         connectorId,
         dataSourceConfig,
@@ -222,8 +222,7 @@ export async function syncFiles({
         file: child,
         parentInternalId,
         startSyncTs,
-      });
-    },
+      }),
     { concurrency: FILES_SYNC_CONCURRENCY }
   );
 

--- a/connectors/src/connectors/microsoft/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/microsoft/temporal/spreadsheets.ts
@@ -4,6 +4,7 @@ import { stringify } from "csv-stringify/sync";
 
 import { getClient } from "@connectors/connectors/microsoft";
 import {
+  getAllPaginatedEntities,
   getDriveItemAPIPath,
   getWorksheetAPIPath,
   getWorksheetContent,
@@ -198,7 +199,9 @@ export async function syncSpreadSheet({
     nodeType: "file",
   });
 
-  const worksheets = await getWorksheets(client, documentId);
+  const worksheets = await getAllPaginatedEntities((nextLink) =>
+    getWorksheets(client, documentId, nextLink)
+  );
 
   const spreadsheet = await upsertSpreadsheetInDb(connector, documentId, file);
 


### PR DESCRIPTION
Description
---
Fixes #6198

Previous code was returning only first page of results. This PR:
- adds code in `graph_api.ts` to handle cases when results exceed page size;
- handles those situations for callers of `graph_api.ts` functions
  - for cases when we just list nodes (folders, sites...) => traverse all pagination directly;
  - for cases when we process node content, process page by page

Risks & deploy
---
na (gated)
