### PR TITLE
Ignore GH issue not found

### DIFF
--- a/connectors/src/connectors/github/lib/github_api.ts
+++ b/connectors/src/connectors/github/lib/github_api.ts
@@ -240,8 +240,12 @@ export async function getIssue(
       isPullRequest: !!issue.pull_request,
     };
   } catch (err) {
-    // Handle excessive redirection during issue retrieval by safely ignoring the issue.
-    if (isGithubRequestRedirectCountExceededError(err)) {
+    // Handle excessive redirection or issue not found errors during issue retrieval
+    // by safely ignoring the issue and logging the error.
+    if (
+      isGithubRequestRedirectCountExceededError(err) ||
+      isGithubRequestErrorNotFound(err)
+    ) {
       logger.info({ ...loggerArgs, err: err.message }, "Failed to get issue.");
 
       return null;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See logs [here](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAZC1PNHfUWMVNAAAAAAAAAAYAAAAAEFaQzFQT0NhQUFDRWNlMlpwaDlnSEFBUwAAACQAAAAAMDE5MGI1M2MtZmUxMC00NDk3LTk5YzUtMzQzZmFmYzhkZjY0&fromUser=true&messageDisplay=inline&refresh_mode=sliding&source=monitor_notif&storage=hot&stream_sort=desc&viz=stream&from_ts=1721012742032&to_ts=1721027142032&live=true).

This PR modifies the GitHub retrieval issue code to handle "not found" errors, which are often due to a revoked token. However, since most calls are still succeeding, we can assume it's a race condition between listing and retrieving. For what it's worth, most other API calls will still trigger the `external_token_revoked` error if they encounter a 404. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
