### PR TITLE
Fix column type on AgentVisualizationAction

### DIFF
--- a/front/lib/models/assistant/actions/visualization.ts
+++ b/front/lib/models/assistant/actions/visualization.ts
@@ -124,7 +124,7 @@ AgentVisualizationAction.init(
       allowNull: false,
     },
     generation: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     functionCallId: {


### PR DESCRIPTION
## Description

Fixes the column type of the `generation` column in `AgentVisualizationAction`.
The type is already TEXT on db (see migration_36), so no migration required. 

## Risk

/

## Deploy Plan

Deploy front. 
No migration needed. 
