### PR TITLE
chore: rename maxToolsUsePerRun to maxStepsPerRun

### DIFF
--- a/front/components/assistant/AssistantActions.tsx
+++ b/front/components/assistant/AssistantActions.tsx
@@ -198,7 +198,7 @@ export function RemoveAssistantFromWorkspaceDialog({
             model: agentConfiguration.model,
             actions: detailedConfiguration.actions,
             templateId: agentConfiguration.templateId,
-            maxToolsUsePerRun: agentConfiguration.maxToolsUsePerRun,
+            maxStepsPerRun: agentConfiguration.maxStepsPerRun,
           },
         };
 

--- a/front/components/assistant/AssistantActions.tsx
+++ b/front/components/assistant/AssistantActions.tsx
@@ -199,6 +199,8 @@ export function RemoveAssistantFromWorkspaceDialog({
             actions: detailedConfiguration.actions,
             templateId: agentConfiguration.templateId,
             maxStepsPerRun: agentConfiguration.maxStepsPerRun,
+            // TODO(@fontanierh): remove
+            maxToolsUsePerRun: agentConfiguration.maxStepsPerRun,
           },
         };
 

--- a/front/components/assistant/TryAssistant.tsx
+++ b/front/components/assistant/TryAssistant.tsx
@@ -92,7 +92,7 @@ export function usePreviewAssistant({
         scope: "private",
         generationSettings: builderState.generationSettings,
         actions: builderState.actions,
-        maxToolsUsePerRun: builderState.maxToolsUsePerRun,
+        maxStepsPerRun: builderState.maxStepsPerRun,
         templateId: builderState.templateId,
       },
       agentConfigurationId: null,
@@ -129,7 +129,7 @@ export function usePreviewAssistant({
     builderState.avatarUrl,
     builderState.generationSettings,
     builderState.actions,
-    builderState.maxToolsUsePerRun,
+    builderState.maxStepsPerRun,
     builderState.templateId,
     sendNotification,
   ]);

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -15,7 +15,7 @@ import {
   XMarkIcon,
 } from "@dust-tt/sparkle";
 import type { AppType, DataSourceType, WorkspaceType } from "@dust-tt/types";
-import { assertNever, MAX_TOOLS_USE_PER_RUN_LIMIT } from "@dust-tt/types";
+import { assertNever, MAX_STEPS_USE_PER_RUN_LIMIT } from "@dust-tt/types";
 import type { ReactNode } from "react";
 import React, { useCallback, useEffect, useState } from "react";
 
@@ -303,12 +303,12 @@ export default function ActionsScreen({
                   }}
                 />
                 <AdvancedSettings
-                  maxToolsUsePerRun={builderState.maxToolsUsePerRun}
-                  setMaxToolsUsePerRun={(maxToolsUsePerRun) => {
+                  maxStepsPerRun={builderState.maxStepsPerRun}
+                  setmaxStepsPerRun={(maxStepsPerRun) => {
                     setEdited(true);
                     setBuilderState((state) => ({
                       ...state,
-                      maxToolsUsePerRun,
+                      maxStepsPerRun,
                     }));
                   }}
                 />
@@ -800,11 +800,11 @@ function ActionEditor({
 }
 
 function AdvancedSettings({
-  maxToolsUsePerRun,
-  setMaxToolsUsePerRun,
+  maxStepsPerRun,
+  setmaxStepsPerRun,
 }: {
-  maxToolsUsePerRun: number | null;
-  setMaxToolsUsePerRun: (maxToolsUsePerRun: number | null) => void;
+  maxStepsPerRun: number | null;
+  setmaxStepsPerRun: (maxStepsPerRun: number | null) => void;
 }) {
   return (
     <DropdownMenu>
@@ -821,28 +821,28 @@ function AdvancedSettings({
           <div className="flex flex-col gap-2">
             <div className="flex flex-col items-start justify-start">
               <div className="w-full grow text-sm font-bold text-element-800">
-                Max tools per run
+                Max steps per run
               </div>
               <div className="w-full grow text-sm text-element-600">
-                up to {MAX_TOOLS_USE_PER_RUN_LIMIT}
+                up to {MAX_STEPS_USE_PER_RUN_LIMIT}
               </div>
             </div>
             <Input
-              value={maxToolsUsePerRun?.toString() ?? ""}
+              value={maxStepsPerRun?.toString() ?? ""}
               placeholder=""
-              name="maxToolsUsePerRun"
+              name="maxStepsPerRun"
               onChange={(v) => {
                 if (!v || v === "") {
-                  setMaxToolsUsePerRun(null);
+                  setmaxStepsPerRun(null);
                   return;
                 }
                 const value = parseInt(v);
                 if (
                   !isNaN(value) &&
                   value >= 0 &&
-                  value <= MAX_TOOLS_USE_PER_RUN_LIMIT
+                  value <= MAX_STEPS_USE_PER_RUN_LIMIT
                 ) {
-                  setMaxToolsUsePerRun(value);
+                  setmaxStepsPerRun(value);
                 }
               }}
             />

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -304,7 +304,7 @@ export default function ActionsScreen({
                 />
                 <AdvancedSettings
                   maxStepsPerRun={builderState.maxStepsPerRun}
-                  setmaxStepsPerRun={(maxStepsPerRun) => {
+                  setMaxStepsPerRun={(maxStepsPerRun) => {
                     setEdited(true);
                     setBuilderState((state) => ({
                       ...state,
@@ -801,10 +801,10 @@ function ActionEditor({
 
 function AdvancedSettings({
   maxStepsPerRun,
-  setmaxStepsPerRun,
+  setMaxStepsPerRun,
 }: {
   maxStepsPerRun: number | null;
-  setmaxStepsPerRun: (maxStepsPerRun: number | null) => void;
+  setMaxStepsPerRun: (maxStepsPerRun: number | null) => void;
 }) {
   return (
     <DropdownMenu>
@@ -833,7 +833,7 @@ function AdvancedSettings({
               name="maxStepsPerRun"
               onChange={(v) => {
                 if (!v || v === "") {
-                  setmaxStepsPerRun(null);
+                  setMaxStepsPerRun(null);
                   return;
                 }
                 const value = parseInt(v);
@@ -842,7 +842,7 @@ function AdvancedSettings({
                   value >= 0 &&
                   value <= MAX_STEPS_USE_PER_RUN_LIMIT
                 ) {
-                  setmaxStepsPerRun(value);
+                  setMaxStepsPerRun(value);
                 }
               }}
             />

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -112,9 +112,9 @@ export default function AssistantBuilder({
             ...getDefaultAssistantState().generationSettings,
           },
           actions: initialBuilderState.actions,
-          maxToolsUsePerRun:
-            initialBuilderState.maxToolsUsePerRun ??
-            getDefaultAssistantState().maxToolsUsePerRun,
+          maxStepsPerRun:
+            initialBuilderState.maxStepsPerRun ??
+            getDefaultAssistantState().maxStepsPerRun,
           templateId: initialBuilderState.templateId,
         }
       : {

--- a/front/components/assistant_builder/submitAssistantBuilderForm.ts
+++ b/front/components/assistant_builder/submitAssistantBuilderForm.ts
@@ -206,9 +206,9 @@ export async function submitAssistantBuilderForm({
           providerId: builderState.generationSettings.modelSettings.providerId,
           temperature: builderState.generationSettings.temperature,
         },
-        maxToolsUsePerRun: isLegacyAgent
+        maxStepsPerRun: isLegacyAgent
           ? undefined
-          : builderState.maxToolsUsePerRun ?? undefined,
+          : builderState.maxStepsPerRun ?? undefined,
         templateId: builderState.templateId,
       },
     };

--- a/front/components/assistant_builder/submitAssistantBuilderForm.ts
+++ b/front/components/assistant_builder/submitAssistantBuilderForm.ts
@@ -190,6 +190,9 @@ export async function submitAssistantBuilderForm({
   const actionParams: ActionsType = builderState.actions.flatMap(map);
 
   const isLegacyAgent = isLegacyAssistantBuilderConfiguration(builderState);
+  const maxStepsPerRun = isLegacyAgent
+    ? undefined
+    : builderState.maxStepsPerRun ?? undefined;
 
   const body: t.TypeOf<typeof PostOrPatchAgentConfigurationRequestBodySchema> =
     {
@@ -206,9 +209,9 @@ export async function submitAssistantBuilderForm({
           providerId: builderState.generationSettings.modelSettings.providerId,
           temperature: builderState.generationSettings.temperature,
         },
-        maxStepsPerRun: isLegacyAgent
-          ? undefined
-          : builderState.maxStepsPerRun ?? undefined,
+        maxStepsPerRun,
+        // TODO(@fontanierh): remove
+        maxToolsUsePerRun: maxStepsPerRun,
         templateId: builderState.templateId,
       },
     };

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -170,7 +170,7 @@ export type AssistantBuilderState = {
     temperature: number;
   };
   actions: Array<AssistantBuilderActionConfiguration>;
-  maxToolsUsePerRun: number | null;
+  maxStepsPerRun: number | null;
   templateId: string | null;
 };
 
@@ -185,7 +185,7 @@ export type AssistantBuilderInitialState = {
     temperature: number;
   } | null;
   actions: Array<AssistantBuilderActionConfiguration>;
-  maxToolsUsePerRun: number | null;
+  maxStepsPerRun: number | null;
   templateId: string | null;
 };
 
@@ -205,7 +205,7 @@ export function getDefaultAssistantState() {
       },
       temperature: 0.7,
     },
-    maxToolsUsePerRun: 3,
+    maxStepsPerRun: 3,
     templateId: null,
   } satisfies AssistantBuilderState;
 }

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -116,13 +116,13 @@ export async function* runMultiActionsAgentLoop(
   const now = Date.now();
 
   const isLegacyAgent = isLegacyAgentConfiguration(configuration);
-  const maxToolsUsePerRun = isLegacyAgent ? 1 : configuration.maxToolsUsePerRun;
+  const maxStepsPerRun = isLegacyAgent ? 1 : configuration.maxStepsPerRun;
 
   // Citations references offset kept up to date across steps.
   let citationsRefsOffset = 0;
 
   let processedContent = "";
-  for (let i = 0; i < maxToolsUsePerRun + 1; i++) {
+  for (let i = 0; i < maxStepsPerRun + 1; i++) {
     const localLogger = logger.child({
       workspaceId: conversation.owner.sId,
       conversationId: conversation.sId,
@@ -131,7 +131,7 @@ export async function* runMultiActionsAgentLoop(
 
     localLogger.info("Starting multi-action loop iteration");
 
-    const isLastGenerationIteration = i === maxToolsUsePerRun;
+    const isLastGenerationIteration = i === maxStepsPerRun;
 
     const actions =
       // If we already executed the maximum number of actions, we don't run any more.

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -22,7 +22,7 @@ import {
   assertNever,
   Err,
   isTimeFrame,
-  MAX_TOOLS_USE_PER_RUN_LIMIT,
+  MAX_STEPS_USE_PER_RUN_LIMIT,
   Ok,
 } from "@dust-tt/types";
 import * as _ from "lodash";
@@ -719,7 +719,7 @@ async function fetchWorkspaceAgentConfigurationsForView(
       status: agent.status,
       actions,
       versionAuthorId: agent.authorId,
-      maxToolsUsePerRun: agent.maxToolsUsePerRun,
+      maxStepsPerRun: agent.maxToolsUsePerRun,
       templateId: template?.sId ?? null,
     };
 
@@ -911,7 +911,7 @@ export async function createAgentConfiguration(
     name,
     description,
     instructions,
-    maxToolsUsePerRun,
+    maxStepsPerRun,
     pictureUrl,
     status,
     scope,
@@ -922,7 +922,7 @@ export async function createAgentConfiguration(
     name: string;
     description: string;
     instructions: string | null;
-    maxToolsUsePerRun: number;
+    maxStepsPerRun: number;
     pictureUrl: string;
     status: AgentStatus;
     scope: Exclude<AgentConfigurationScope, "global">;
@@ -941,11 +941,8 @@ export async function createAgentConfiguration(
     throw new Error("Unexpected `auth` without `user`.");
   }
 
-  if (
-    maxToolsUsePerRun < 0 ||
-    maxToolsUsePerRun > MAX_TOOLS_USE_PER_RUN_LIMIT
-  ) {
-    return new Err(new Error("maxToolsUsePerRun must be between 0 and 8."));
+  if (maxStepsPerRun < 0 || maxStepsPerRun > MAX_STEPS_USE_PER_RUN_LIMIT) {
+    return new Err(new Error("maxStepsPerRun must be between 0 and 8."));
   }
 
   const isValidPictureUrl =
@@ -1037,7 +1034,8 @@ export async function createAgentConfiguration(
             providerId: model.providerId,
             modelId: model.modelId,
             temperature: model.temperature,
-            maxToolsUsePerRun,
+            maxToolsUsePerRun: maxStepsPerRun,
+            maxStepsPerRun,
             pictureUrl,
             workspaceId: owner.id,
             authorId: user.id,
@@ -1071,7 +1069,7 @@ export async function createAgentConfiguration(
       },
       pictureUrl: agent.pictureUrl,
       status: agent.status,
-      maxToolsUsePerRun: agent.maxToolsUsePerRun,
+      maxStepsPerRun: agent.maxToolsUsePerRun,
       templateId: template?.sId ?? null,
     };
 

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -138,7 +138,7 @@ async function _getHelperGlobalAgent(
         description: null,
       },
     ],
-    maxToolsUsePerRun: 0,
+    maxStepsPerRun: 0,
     templateId: null,
   };
 }
@@ -168,7 +168,7 @@ async function _getGPT35TurboGlobalAgent({
       temperature: 0.7,
     },
     actions: [],
-    maxToolsUsePerRun: 0,
+    maxStepsPerRun: 0,
     templateId: null,
   };
 }
@@ -198,7 +198,7 @@ async function _getGPT4GlobalAgent({
       temperature: 0.7,
     },
     actions: [],
-    maxToolsUsePerRun: 0,
+    maxStepsPerRun: 0,
     templateId: null,
   };
 }
@@ -228,7 +228,7 @@ async function _getClaudeInstantGlobalAgent({
       temperature: 0.7,
     },
     actions: [],
-    maxToolsUsePerRun: 0,
+    maxStepsPerRun: 0,
     templateId: null,
   };
 }
@@ -265,7 +265,7 @@ async function _getClaude2GlobalAgent({
     },
 
     actions: [],
-    maxToolsUsePerRun: 0,
+    maxStepsPerRun: 0,
     templateId: null,
   };
 }
@@ -296,7 +296,7 @@ async function _getClaude3HaikuGlobalAgent({
       temperature: 0.7,
     },
     actions: [],
-    maxToolsUsePerRun: 0,
+    maxStepsPerRun: 0,
     templateId: null,
   };
 }
@@ -332,7 +332,7 @@ async function _getClaude3OpusGlobalAgent({
       temperature: 0.7,
     },
     actions: [],
-    maxToolsUsePerRun: 0,
+    maxStepsPerRun: 0,
     templateId: null,
   };
 }
@@ -369,7 +369,7 @@ async function _getClaude3GlobalAgent({
     },
 
     actions: [],
-    maxToolsUsePerRun: 0,
+    maxStepsPerRun: 0,
     templateId: null,
   };
 }
@@ -405,7 +405,7 @@ async function _getMistralLargeGlobalAgent({
       temperature: 0.7,
     },
     actions: [],
-    maxToolsUsePerRun: 0,
+    maxStepsPerRun: 0,
     templateId: null,
   };
 }
@@ -441,7 +441,7 @@ async function _getMistralMediumGlobalAgent({
       temperature: 0.7,
     },
     actions: [],
-    maxToolsUsePerRun: 0,
+    maxStepsPerRun: 0,
     templateId: null,
   };
 }
@@ -471,7 +471,7 @@ async function _getMistralSmallGlobalAgent({
       temperature: 0.7,
     },
     actions: [],
-    maxToolsUsePerRun: 0,
+    maxStepsPerRun: 0,
     templateId: null,
   };
 }
@@ -506,7 +506,7 @@ async function _getGeminiProGlobalAgent({
       temperature: 0.7,
     },
     actions: [],
-    maxToolsUsePerRun: 0,
+    maxStepsPerRun: 0,
     templateId: null,
   };
 }
@@ -576,7 +576,7 @@ async function _getManagedDataSourceAgent(
       userListStatus: "not-in-list",
       model,
       actions: [],
-      maxToolsUsePerRun: 0,
+      maxStepsPerRun: 0,
       templateId: null,
     };
   }
@@ -601,7 +601,7 @@ async function _getManagedDataSourceAgent(
       userListStatus: "not-in-list",
       model,
       actions: [],
-      maxToolsUsePerRun: 0,
+      maxStepsPerRun: 0,
       templateId: null,
     };
   }
@@ -639,7 +639,7 @@ async function _getManagedDataSourceAgent(
         description: `The user's ${connectorProvider} data source.`,
       },
     ],
-    maxToolsUsePerRun: 1,
+    maxStepsPerRun: 1,
     templateId: null,
   };
 }
@@ -819,7 +819,7 @@ async function _getDustGlobalAgent(
       userListStatus: "not-in-list",
       model,
       actions: [],
-      maxToolsUsePerRun: 0,
+      maxStepsPerRun: 0,
       templateId: null,
     };
   }
@@ -852,7 +852,7 @@ async function _getDustGlobalAgent(
       userListStatus: "not-in-list",
       model,
       actions: [],
-      maxToolsUsePerRun: 0,
+      maxStepsPerRun: 0,
       templateId: null,
     };
   }
@@ -907,7 +907,7 @@ async function _getDustGlobalAgent(
         description: null,
       },
     ],
-    maxToolsUsePerRun: 3,
+    maxStepsPerRun: 3,
     templateId: null,
   };
 }

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -51,6 +51,7 @@ export class AgentConfiguration extends Model<
   declare authorId: ForeignKey<User["id"]>;
 
   declare maxToolsUsePerRun: number;
+  declare maxStepsPerRun: number;
 
   declare templateId: ForeignKey<TemplateModel["id"]> | null;
 
@@ -121,6 +122,10 @@ AgentConfiguration.init(
     maxToolsUsePerRun: {
       type: DataTypes.INTEGER,
       allowNull: false,
+    },
+    maxStepsPerRun: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
     },
     pictureUrl: {
       type: DataTypes.TEXT,

--- a/front/migrations/20240715_backfill_max_steps_per_run.sql
+++ b/front/migrations/20240715_backfill_max_steps_per_run.sql
@@ -1,0 +1,6 @@
+UPDATE
+    agent_configurations
+SET
+    "maxStepsPerRun" = "maxToolsUsePerRun"
+WHERE
+    "maxStepsPerRun" IS NULL;

--- a/front/migrations/db/migration_41.sql
+++ b/front/migrations/db/migration_41.sql
@@ -1,0 +1,5 @@
+-- Migration created on Jul 15, 2024
+ALTER TABLE
+    "public"."agent_configurations"
+ADD
+    COLUMN "maxStepsPerRun" INTEGER;

--- a/front/migrations/db/migration_42.sql
+++ b/front/migrations/db/migration_42.sql
@@ -1,0 +1,6 @@
+ALTER TABLE
+    agent_configurations
+ALTER COLUMN
+    "maxStepsPerRun"
+SET
+    NOT NULL;

--- a/front/pages/api/v1/w/[wId]/swagger_schemas.ts
+++ b/front/pages/api/v1/w/[wId]/swagger_schemas.ts
@@ -146,7 +146,7 @@
  *               type: number
  *         actions:
  *           type: array
- *         maxToolsUsePerRun:
+ *         maxStepsPerRun:
  *           type: integer
  *         templateId:
  *           type: string

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
@@ -97,35 +97,33 @@ async function handler(
         });
       }
 
-      const maxToolsUsePerRun =
-        bodyValidation.right.assistant.maxToolsUsePerRun;
+      const maxStepsPerRun = bodyValidation.right.assistant.maxStepsPerRun;
 
       const isLegacyConfiguration =
         bodyValidation.right.assistant.actions.length === 1 &&
         !bodyValidation.right.assistant.actions[0].description;
 
-      if (isLegacyConfiguration && maxToolsUsePerRun !== undefined) {
+      if (isLegacyConfiguration && maxStepsPerRun !== undefined) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "app_auth_error",
-            message:
-              "maxToolsUsePerRun is only supported in multi-actions mode.",
+            message: "maxStepsPerRun is only supported in multi-actions mode.",
           },
         });
       }
-      if (!isLegacyConfiguration && maxToolsUsePerRun === undefined) {
+      if (!isLegacyConfiguration && maxStepsPerRun === undefined) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "app_auth_error",
-            message: "maxToolsUsePerRun is required in multi-actions mode.",
+            message: "maxStepsPerRun is required in multi-actions mode.",
           },
         });
       }
       const agentConfigurationRes = await createOrUpgradeAgentConfiguration({
         auth,
-        assistant: { ...bodyValidation.right.assistant, maxToolsUsePerRun },
+        assistant: { ...bodyValidation.right.assistant, maxStepsPerRun },
         agentConfigurationId: req.query.aId as string,
       });
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
@@ -97,7 +97,10 @@ async function handler(
         });
       }
 
-      const maxStepsPerRun = bodyValidation.right.assistant.maxStepsPerRun;
+      // TODO(@fontanierh): remove
+      const maxStepsPerRun =
+        bodyValidation.right.assistant.maxStepsPerRun ??
+        bodyValidation.right.assistant.maxToolsUsePerRun;
 
       const isLegacyConfiguration =
         bodyValidation.right.assistant.actions.length === 1 &&

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
@@ -117,6 +117,8 @@ async function handler(
         auth,
         assistant: {
           ...assistant,
+          // TODO(@fontanierh): remove
+          maxToolsUsePerRun: assistant.maxStepsPerRun,
           scope: bodyValidation.right.scope,
           status: assistant.status as AgentStatus,
           templateId: assistant.templateId,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -189,7 +189,10 @@ async function handler(
         });
       }
 
-      const maxStepsPerRun = bodyValidation.right.assistant.maxStepsPerRun;
+      const maxStepsPerRun =
+        bodyValidation.right.assistant.maxStepsPerRun ??
+        // TODO(@fontanierh): remove
+        bodyValidation.right.assistant.maxToolsUsePerRun;
 
       const isLegacyConfiguration =
         bodyValidation.right.assistant.actions.length === 1 &&

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -189,35 +189,33 @@ async function handler(
         });
       }
 
-      const maxToolsUsePerRun =
-        bodyValidation.right.assistant.maxToolsUsePerRun;
+      const maxStepsPerRun = bodyValidation.right.assistant.maxStepsPerRun;
 
       const isLegacyConfiguration =
         bodyValidation.right.assistant.actions.length === 1 &&
         !bodyValidation.right.assistant.actions[0].description;
 
-      if (isLegacyConfiguration && maxToolsUsePerRun !== undefined) {
+      if (isLegacyConfiguration && maxStepsPerRun !== undefined) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "app_auth_error",
-            message:
-              "maxToolsUsePerRun is only supported in multi-actions mode.",
+            message: "maxStepsPerRun is only supported in multi-actions mode.",
           },
         });
       }
-      if (!isLegacyConfiguration && maxToolsUsePerRun === undefined) {
+      if (!isLegacyConfiguration && maxStepsPerRun === undefined) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "app_auth_error",
-            message: "maxToolsUsePerRun is required in multi-actions mode.",
+            message: "maxStepsPerRun is required in multi-actions mode.",
           },
         });
       }
       const agentConfigurationRes = await createOrUpgradeAgentConfiguration({
         auth,
-        assistant: { ...bodyValidation.right.assistant, maxToolsUsePerRun },
+        assistant: { ...bodyValidation.right.assistant, maxStepsPerRun },
       });
 
       if (agentConfigurationRes.isErr()) {
@@ -267,7 +265,7 @@ export async function createOrUpgradeAgentConfiguration({
 }): Promise<Result<AgentConfigurationType, Error>> {
   const { actions } = assistant;
 
-  const maxToolsUsePerRun = assistant.maxToolsUsePerRun ?? actions.length;
+  const maxStepsPerRun = assistant.maxStepsPerRun ?? actions.length;
 
   // Tools mode:
   // Enforce that every action has a name and a description and that every name is unique.
@@ -309,7 +307,7 @@ export async function createOrUpgradeAgentConfiguration({
     name: assistant.name,
     description: assistant.description,
     instructions: assistant.instructions ?? null,
-    maxToolsUsePerRun,
+    maxStepsPerRun,
     pictureUrl: assistant.pictureUrl,
     status: assistant.status,
     scope: assistant.scope,

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -175,7 +175,7 @@ export default function EditAssistant({
           temperature: agentConfiguration.model.temperature,
         },
         actions,
-        maxToolsUsePerRun: agentConfiguration.maxToolsUsePerRun,
+        maxStepsPerRun: agentConfiguration.maxStepsPerRun,
         templateId: agentConfiguration.templateId,
       }}
       agentConfigurationId={agentConfiguration.sId}

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -222,7 +222,7 @@ export default function CreateAssistant({
                 },
                 temperature: agentConfiguration.model.temperature,
               },
-              maxToolsUsePerRun: agentConfiguration.maxToolsUsePerRun ?? null,
+              maxStepsPerRun: agentConfiguration.maxStepsPerRun ?? null,
               templateId: templateId,
             }
           : null

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -2322,7 +2322,7 @@
           "actions": {
             "type": "array"
           },
-          "maxToolsUsePerRun": {
+          "maxStepsPerRun": {
             "type": "integer"
           },
           "templateId": {

--- a/types/src/front/api_handlers/internal/agent_configuration.ts
+++ b/types/src/front/api_handlers/internal/agent_configuration.ts
@@ -201,6 +201,7 @@ export const PostOrPatchAgentConfigurationRequestBodySchema = t.type({
     model: t.intersection([ModelConfigurationSchema, IsSupportedModelSchema]),
     actions: t.array(ActionConfigurationSchema),
     templateId: t.union([t.string, t.null, t.undefined]),
+    maxToolsUsePerRun: t.union([t.number, t.undefined]),
     maxStepsPerRun: t.union([t.number, t.undefined]),
   }),
 });

--- a/types/src/front/api_handlers/internal/agent_configuration.ts
+++ b/types/src/front/api_handlers/internal/agent_configuration.ts
@@ -201,7 +201,7 @@ export const PostOrPatchAgentConfigurationRequestBodySchema = t.type({
     model: t.intersection([ModelConfigurationSchema, IsSupportedModelSchema]),
     actions: t.array(ActionConfigurationSchema),
     templateId: t.union([t.string, t.null, t.undefined]),
-    maxToolsUsePerRun: t.union([t.number, t.undefined]),
+    maxStepsPerRun: t.union([t.number, t.undefined]),
   }),
 });
 

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -175,7 +175,7 @@ export type LightAgentConfigurationType = {
   lastAuthors?: AgentRecentAuthors;
   usage?: AgentUsageType;
 
-  maxToolsUsePerRun: number;
+  maxStepsPerRun: number;
 
   templateId: string | null;
 };
@@ -196,7 +196,7 @@ export interface TemplateAgentConfigurationType {
   actions: AgentActionConfigurationType[];
   instructions: string | null;
   isTemplate: true;
-  maxToolsUsePerRun?: number;
+  maxStepsPerRun?: number;
 }
 
-export const MAX_TOOLS_USE_PER_RUN_LIMIT = 8;
+export const MAX_STEPS_USE_PER_RUN_LIMIT = 8;


### PR DESCRIPTION
## Description

`maxToolsUsePerRun` limits the number of steps an assistant run and not the total number of tools (so the name is wrong).

This is step 1 out of 2 to rename the column: I'm introducing a new column `maxStepsPerRun` + a backfill migration for it.

Next PR will be removing `maxToolsUsePerRun`

## Risk

As always such migrations are risky. 
The change has been properly tested.

## Deploy Plan

1. run the first migration (`migration_41` to add the new field as nullable)
2. deploy the code
3. run the backfill script
4. run `migration_42` (make the field no nullable)
5. [NEXT PR] remove all usage of `maxToolsUsePerRun` in the code
6. [NEXT PR] drop the `maxToolsUsePerRun` column