### PR TITLE
oauth: redis lock for finalize/refresh

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -831,6 +831,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,6 +1178,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.5",
  "ring 0.17.8",
+ "rslock",
  "rusqlite",
  "rustc-hash",
  "sentencepiece",
@@ -2947,6 +2962,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "redis"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c580d9cbbe1d1b479e8d67cf9daf6a62c957e6846048408b80b43ac3f6af84cd"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "combine",
+ "futures-util",
+ "itoa",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "sha1_smol",
+ "socket2 0.4.10",
+ "tokio",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3139,6 +3175,19 @@ dependencies = [
  "spin 0.9.8",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rslock"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ccef14203800d37582083dfa94c8f60a84bb55ce517c837308a94070b66cc0c"
+dependencies = [
+ "futures",
+ "rand",
+ "redis",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -3490,6 +3539,12 @@ dependencies = [
  "thiserror",
  "v8",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -84,3 +84,4 @@ http = "1.1.0"
 sqids = "0.4.1"
 ring = "0.17.8"
 jsonwebtoken = "9.3.0"
+rslock = { version = "0.4.0", default-features = false, features = ["tokio-comp"] }


### PR DESCRIPTION
## Description

Introduce a redis lock to enforce a distributed critical section for connections finalization and refresh
Proposes semantics for retrieving the access token:
- Refresh only if the access_token expired (We don't need a buffer here IMHO)
- When refreshing and finalizing reload the connection since we locked and proceed with the critical section if applicable

Fixes: https://github.com/dust-tt/dust/issues/6138

## Risk

N/A

## Deploy Plan

N/A