### PR TITLE
feat: allow tokenizing in batch

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1179,22 +1179,30 @@ async fn data_sources_tokenize(
                 let embedder_config = ds.embedder_config().clone();
                 let embedder =
                     provider(embedder_config.provider_id).embedder(embedder_config.model_id);
-                match embedder.tokenize(&payload.text).await {
+                match embedder.tokenize(vec![payload.text]).await {
                     Err(e) => error_response(
                         StatusCode::INTERNAL_SERVER_ERROR,
                         "internal_server_error",
                         "Failed to tokenize text",
                         Some(e),
                     ),
-                    Ok(tokens) => (
-                        StatusCode::OK,
-                        Json(APIResponse {
-                            error: None,
-                            response: Some(json!({
-                                "tokens": tokens,
-                            })),
-                        }),
-                    ),
+                    Ok(mut res) => match res.pop() {
+                        None => error_response(
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "internal_server_error",
+                            "Failed to tokenize text",
+                            None,
+                        ),
+                        Some(tokens) => (
+                            StatusCode::OK,
+                            Json(APIResponse {
+                                error: None,
+                                response: Some(json!({
+                                    "tokens": tokens,
+                                })),
+                            }),
+                        ),
+                    },
                 }
             }
         },
@@ -2407,22 +2415,30 @@ async fn tokenize(Json(payload): Json<TokenizePayload>) -> (StatusCode, Json<API
         None => (),
     }
 
-    match llm.tokenize(&payload.text).await {
+    match llm.tokenize(vec![payload.text]).await {
         Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
             "internal_server_error",
             "Failed to tokenize text",
             Some(e),
         ),
-        Ok(tokens) => (
-            StatusCode::OK,
-            Json(APIResponse {
-                error: None,
-                response: Some(json!({
-                    "tokens": tokens,
-                })),
-            }),
-        ),
+        Ok(mut res) => match res.pop() {
+            None => error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal_server_error",
+                "Failed to tokenize text",
+                None,
+            ),
+            Some(tokens) => (
+                StatusCode::OK,
+                Json(APIResponse {
+                    error: None,
+                    response: Some(json!({
+                        "tokens": tokens,
+                    })),
+                }),
+            ),
+        },
     }
 }
 

--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -2442,6 +2442,56 @@ async fn tokenize(Json(payload): Json<TokenizePayload>) -> (StatusCode, Json<API
     }
 }
 
+#[derive(serde::Deserialize)]
+struct TokenizeBatchPayload {
+    texts: Vec<String>,
+    provider_id: ProviderID,
+    model_id: String,
+    credentials: Option<run::Credentials>,
+}
+
+async fn tokenize_batch(
+    Json(payload): Json<TokenizeBatchPayload>,
+) -> (StatusCode, Json<APIResponse>) {
+    let mut llm = provider(payload.provider_id).llm(payload.model_id);
+
+    // If we received credentials we initialize the llm with them.
+    match payload.credentials {
+        Some(c) => {
+            match llm.initialize(c.clone()).await {
+                Err(e) => {
+                    return error_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "internal_server_error",
+                        "Failed to initialize LLM",
+                        Some(e),
+                    );
+                }
+                Ok(()) => (),
+            };
+        }
+        None => (),
+    }
+
+    match llm.tokenize(payload.texts).await {
+        Err(e) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "internal_server_error",
+            "Failed to tokenize text",
+            Some(e),
+        ),
+        Ok(res) => (
+            StatusCode::OK,
+            Json(APIResponse {
+                error: None,
+                response: Some(json!({
+                    "tokens": res,
+                })),
+            }),
+        ),
+    }
+}
+
 fn main() {
     JSExecutor::init();
 
@@ -2625,6 +2675,7 @@ fn main() {
         .route("/sqlite_workers", delete(sqlite_workers_delete))
         // Misc
         .route("/tokenize", post(tokenize))
+        .route("/tokenize/batch", post(tokenize_batch))
 
         // Extensions
         .layer(DefaultBodyLimit::disable())

--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -1,9 +1,14 @@
+use crate::providers::chat_messages::{
+    AssistantChatMessage, ChatMessage, ContentBlock, MixedContent,
+};
 use crate::providers::embedder::{Embedder, EmbedderVector};
+use crate::providers::llm::{ChatFunction, ChatFunctionCall};
 use crate::providers::llm::{
     ChatMessageRole, LLMChatGeneration, LLMGeneration, LLMTokenUsage, Tokens, LLM,
 };
 use crate::providers::provider::{ModelError, ModelErrorRetryOptions, Provider, ProviderID};
 use crate::providers::tiktoken::tiktoken::anthropic_base_singleton;
+use crate::providers::tiktoken::tiktoken::{batch_tokenize_async, decode_async, encode_async};
 use crate::run::Credentials;
 use crate::utils;
 use crate::utils::ParseError;
@@ -21,10 +26,6 @@ use std::io::prelude::*;
 use std::str::FromStr;
 use std::time::Duration;
 use tokio::sync::mpsc::UnboundedSender;
-
-use super::chat_messages::{AssistantChatMessage, ChatMessage, ContentBlock, MixedContent};
-use super::llm::{ChatFunction, ChatFunctionCall};
-use super::tiktoken::tiktoken::{batch_tokenize_async, decode_async, encode_async};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]

--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -24,7 +24,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use super::chat_messages::{AssistantChatMessage, ChatMessage, ContentBlock, MixedContent};
 use super::llm::{ChatFunction, ChatFunctionCall};
-use super::tiktoken::tiktoken::{decode_async, encode_async, tokenize_async};
+use super::tiktoken::tiktoken::{batch_tokenize_async, decode_async, encode_async};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
@@ -1524,8 +1524,8 @@ impl LLM for AnthropicLLM {
         decode_async(anthropic_base_singleton(), tokens).await
     }
 
-    async fn tokenize(&self, text: &str) -> Result<Vec<(usize, String)>> {
-        tokenize_async(anthropic_base_singleton(), text).await
+    async fn tokenize(&self, texts: Vec<String>) -> Result<Vec<Vec<(usize, String)>>> {
+        batch_tokenize_async(anthropic_base_singleton(), texts).await
     }
 
     async fn chat(
@@ -1692,8 +1692,8 @@ impl Embedder for AnthropicEmbedder {
         decode_async(anthropic_base_singleton(), tokens).await
     }
 
-    async fn tokenize(&self, text: &str) -> Result<Vec<(usize, String)>> {
-        tokenize_async(anthropic_base_singleton(), text).await
+    async fn tokenize(&self, texts: Vec<String>) -> Result<Vec<Vec<(usize, String)>>> {
+        batch_tokenize_async(anthropic_base_singleton(), texts).await
     }
 
     async fn embed(&self, _text: Vec<&str>, _extras: Option<Value>) -> Result<Vec<EmbedderVector>> {

--- a/core/src/providers/azure_openai.rs
+++ b/core/src/providers/azure_openai.rs
@@ -11,7 +11,7 @@ use crate::providers::provider::{Provider, ProviderID};
 use crate::providers::tiktoken::tiktoken::{
     cl100k_base_singleton, p50k_base_singleton, r50k_base_singleton, CoreBPE,
 };
-use crate::providers::tiktoken::tiktoken::{decode_async, encode_async, tokenize_async};
+use crate::providers::tiktoken::tiktoken::{decode_async, encode_async};
 use crate::run::Credentials;
 use crate::utils;
 use anyhow::{anyhow, Result};
@@ -28,6 +28,7 @@ use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedSender;
 
 use super::chat_messages::ChatMessage;
+use super::tiktoken::tiktoken::batch_tokenize_async;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 struct AzureOpenAIScaleSettings {
@@ -238,8 +239,8 @@ impl LLM for AzureOpenAILLM {
         decode_async(self.tokenizer(), tokens).await
     }
 
-    async fn tokenize(&self, text: &str) -> Result<Vec<(usize, String)>> {
-        tokenize_async(self.tokenizer(), text).await
+    async fn tokenize(&self, texts: Vec<String>) -> Result<Vec<Vec<(usize, String)>>> {
+        batch_tokenize_async(self.tokenizer(), texts).await
     }
 
     async fn generate(
@@ -687,8 +688,8 @@ impl Embedder for AzureOpenAIEmbedder {
         decode_async(self.tokenizer(), tokens).await
     }
 
-    async fn tokenize(&self, text: &str) -> Result<Vec<(usize, String)>> {
-        tokenize_async(self.tokenizer(), text).await
+    async fn tokenize(&self, texts: Vec<String>) -> Result<Vec<Vec<(usize, String)>>> {
+        batch_tokenize_async(self.tokenizer(), texts).await
     }
 
     async fn embed(&self, text: Vec<&str>, extras: Option<Value>) -> Result<Vec<EmbedderVector>> {

--- a/core/src/providers/azure_openai.rs
+++ b/core/src/providers/azure_openai.rs
@@ -1,4 +1,5 @@
 use crate::providers::chat_messages::AssistantChatMessage;
+use crate::providers::chat_messages::ChatMessage;
 use crate::providers::embedder::{Embedder, EmbedderVector};
 use crate::providers::llm::ChatFunction;
 use crate::providers::llm::Tokens;
@@ -8,10 +9,10 @@ use crate::providers::openai::{
     to_openai_messages, OpenAILLM, OpenAITool, OpenAIToolChoice,
 };
 use crate::providers::provider::{Provider, ProviderID};
+use crate::providers::tiktoken::tiktoken::{batch_tokenize_async, decode_async, encode_async};
 use crate::providers::tiktoken::tiktoken::{
     cl100k_base_singleton, p50k_base_singleton, r50k_base_singleton, CoreBPE,
 };
-use crate::providers::tiktoken::tiktoken::{decode_async, encode_async};
 use crate::run::Credentials;
 use crate::utils;
 use anyhow::{anyhow, Result};
@@ -26,9 +27,6 @@ use std::io::prelude::*;
 use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedSender;
-
-use super::chat_messages::ChatMessage;
-use super::tiktoken::tiktoken::batch_tokenize_async;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 struct AzureOpenAIScaleSettings {

--- a/core/src/providers/embedder.rs
+++ b/core/src/providers/embedder.rs
@@ -29,7 +29,7 @@ pub trait Embedder {
 
     async fn encode(&self, text: &str) -> Result<Vec<usize>>;
     async fn decode(&self, tokens: Vec<usize>) -> Result<String>;
-    async fn tokenize(&self, text: &str) -> Result<Vec<(usize, String)>>;
+    async fn tokenize(&self, texts: Vec<String>) -> Result<Vec<Vec<(usize, String)>>>;
 
     async fn embed(&self, text: Vec<&str>, extras: Option<Value>) -> Result<Vec<EmbedderVector>>;
 }

--- a/core/src/providers/google_ai_studio.rs
+++ b/core/src/providers/google_ai_studio.rs
@@ -30,7 +30,7 @@ use super::{
     },
     provider::{Provider, ProviderID},
     tiktoken::tiktoken::{
-        cl100k_base_singleton, decode_async, encode_async, tokenize_async, CoreBPE,
+        batch_tokenize_async, cl100k_base_singleton, decode_async, encode_async, CoreBPE,
     },
 };
 
@@ -391,8 +391,8 @@ impl LLM for GoogleAiStudioLLM {
         decode_async(self.tokenizer(), tokens).await
     }
 
-    async fn tokenize(&self, text: &str) -> Result<Vec<(usize, String)>> {
-        tokenize_async(self.tokenizer(), text).await
+    async fn tokenize(&self, texts: Vec<String>) -> Result<Vec<Vec<(usize, String)>>> {
+        batch_tokenize_async(self.tokenizer(), texts).await
     }
 
     async fn generate(

--- a/core/src/providers/llm.rs
+++ b/core/src/providers/llm.rs
@@ -107,7 +107,7 @@ pub trait LLM {
 
     async fn encode(&self, text: &str) -> Result<Vec<usize>>;
     async fn decode(&self, tokens: Vec<usize>) -> Result<String>;
-    async fn tokenize(&self, text: &str) -> Result<Vec<(usize, String)>>;
+    async fn tokenize(&self, texts: Vec<String>) -> Result<Vec<Vec<(usize, String)>>>;
 
     async fn generate(
         &self,

--- a/core/src/providers/llm.rs
+++ b/core/src/providers/llm.rs
@@ -1,5 +1,6 @@
 use crate::cached_request::CachedRequest;
 use crate::project::Project;
+use crate::providers::chat_messages::{AssistantChatMessage, ChatMessage};
 use crate::providers::provider::{provider, with_retryable_back_off, ProviderID};
 use crate::run::Credentials;
 use crate::stores::store::Store;
@@ -12,8 +13,6 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::{error, info};
-
-use super::chat_messages::{AssistantChatMessage, ChatMessage};
 
 #[derive(Debug, Serialize, PartialEq, Clone, Deserialize)]
 pub struct Tokens {

--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -1,16 +1,18 @@
-use super::chat_messages::{AssistantChatMessage, ChatMessage, ContentBlock, MixedContent};
-use super::llm::{ChatFunction, ChatFunctionCall};
-use super::sentencepiece::sentencepiece::{
+use crate::providers::chat_messages::{
+    AssistantChatMessage, ChatMessage, ContentBlock, MixedContent,
+};
+use crate::providers::embedder::{Embedder, EmbedderVector};
+use crate::providers::llm::{ChatFunction, ChatFunctionCall};
+use crate::providers::llm::{
+    ChatMessageRole, LLMChatGeneration, LLMGeneration, LLMTokenUsage, LLM,
+};
+use crate::providers::provider::{ModelError, ModelErrorRetryOptions, Provider, ProviderID};
+use crate::providers::sentencepiece::sentencepiece::{
     batch_tokenize_async, decode_async, encode_async,
     mistral_instruct_tokenizer_240216_model_v2_base_singleton,
     mistral_instruct_tokenizer_240216_model_v3_base_singleton,
     mistral_tokenizer_model_v1_base_singleton,
 };
-use crate::providers::embedder::{Embedder, EmbedderVector};
-use crate::providers::llm::{
-    ChatMessageRole, LLMChatGeneration, LLMGeneration, LLMTokenUsage, LLM,
-};
-use crate::providers::provider::{ModelError, ModelErrorRetryOptions, Provider, ProviderID};
 use crate::run::Credentials;
 use crate::utils::{self, now, ParseError};
 use anyhow::{anyhow, Result};

--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -1,9 +1,10 @@
 use super::chat_messages::{AssistantChatMessage, ChatMessage, ContentBlock, MixedContent};
 use super::llm::{ChatFunction, ChatFunctionCall};
 use super::sentencepiece::sentencepiece::{
-    decode_async, encode_async, mistral_instruct_tokenizer_240216_model_v2_base_singleton,
+    batch_tokenize_async, decode_async, encode_async,
+    mistral_instruct_tokenizer_240216_model_v2_base_singleton,
     mistral_instruct_tokenizer_240216_model_v3_base_singleton,
-    mistral_tokenizer_model_v1_base_singleton, tokenize_async,
+    mistral_tokenizer_model_v1_base_singleton,
 };
 use crate::providers::embedder::{Embedder, EmbedderVector};
 use crate::providers::llm::{
@@ -912,8 +913,8 @@ impl LLM for MistralAILLM {
         decode_async(self.tokenizer(), tokens).await
     }
 
-    async fn tokenize(&self, text: &str) -> Result<Vec<(usize, String)>> {
-        tokenize_async(self.tokenizer(), text).await
+    async fn tokenize(&self, texts: Vec<String>) -> Result<Vec<Vec<(usize, String)>>> {
+        batch_tokenize_async(self.tokenizer(), texts).await
     }
 
     async fn chat(
@@ -1145,8 +1146,8 @@ impl Embedder for MistralEmbedder {
         decode_async(self.tokenizer(), tokens).await
     }
 
-    async fn tokenize(&self, text: &str) -> Result<Vec<(usize, String)>> {
-        tokenize_async(self.tokenizer(), text).await
+    async fn tokenize(&self, texts: Vec<String>) -> Result<Vec<Vec<(usize, String)>>> {
+        batch_tokenize_async(self.tokenizer(), texts).await
     }
 
     async fn embed(&self, text: Vec<&str>, _extras: Option<Value>) -> Result<Vec<EmbedderVector>> {

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -8,7 +8,7 @@ use crate::providers::provider::{ModelError, ModelErrorRetryOptions, Provider, P
 use crate::providers::tiktoken::tiktoken::{
     cl100k_base_singleton, p50k_base_singleton, r50k_base_singleton, CoreBPE,
 };
-use crate::providers::tiktoken::tiktoken::{decode_async, encode_async, tokenize_async};
+use crate::providers::tiktoken::tiktoken::{decode_async, encode_async};
 use crate::run::Credentials;
 use crate::utils;
 use crate::utils::ParseError;
@@ -33,6 +33,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use tokio::time::timeout;
 
 use super::chat_messages::{AssistantChatMessage, ChatMessage, ContentBlock, MixedContent};
+use super::tiktoken::tiktoken::batch_tokenize_async;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Usage {
@@ -1754,8 +1755,8 @@ impl LLM for OpenAILLM {
         decode_async(self.tokenizer(), tokens).await
     }
 
-    async fn tokenize(&self, text: &str) -> Result<Vec<(usize, String)>> {
-        tokenize_async(self.tokenizer(), text).await
+    async fn tokenize(&self, texts: Vec<String>) -> Result<Vec<Vec<(usize, String)>>> {
+        batch_tokenize_async(self.tokenizer(), texts).await
     }
 
     async fn generate(
@@ -2193,8 +2194,8 @@ impl Embedder for OpenAIEmbedder {
         decode_async(self.tokenizer(), tokens).await
     }
 
-    async fn tokenize(&self, text: &str) -> Result<Vec<(usize, String)>> {
-        tokenize_async(self.tokenizer(), text).await
+    async fn tokenize(&self, texts: Vec<String>) -> Result<Vec<Vec<(usize, String)>>> {
+        batch_tokenize_async(self.tokenizer(), texts).await
     }
 
     async fn embed(&self, text: Vec<&str>, extras: Option<Value>) -> Result<Vec<EmbedderVector>> {

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -1,3 +1,6 @@
+use crate::providers::chat_messages::{
+    AssistantChatMessage, ChatMessage, ContentBlock, MixedContent,
+};
 use crate::providers::embedder::{Embedder, EmbedderVector};
 use crate::providers::llm::Tokens;
 use crate::providers::llm::{ChatFunction, ChatFunctionCall};
@@ -6,7 +9,7 @@ use crate::providers::llm::{
 };
 use crate::providers::provider::{ModelError, ModelErrorRetryOptions, Provider, ProviderID};
 use crate::providers::tiktoken::tiktoken::{
-    cl100k_base_singleton, p50k_base_singleton, r50k_base_singleton, CoreBPE,
+    batch_tokenize_async, cl100k_base_singleton, p50k_base_singleton, r50k_base_singleton, CoreBPE,
 };
 use crate::providers::tiktoken::tiktoken::{decode_async, encode_async};
 use crate::run::Credentials;
@@ -31,9 +34,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::time::timeout;
-
-use super::chat_messages::{AssistantChatMessage, ChatMessage, ContentBlock, MixedContent};
-use super::tiktoken::tiktoken::batch_tokenize_async;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Usage {

--- a/front/lib/tokenization.ts
+++ b/front/lib/tokenization.ts
@@ -5,14 +5,14 @@ import logger from "@app/logger/logger";
 
 import config from "./api/config";
 
-export async function tokenCountForText(
-  text: string,
+export async function tokenCountForTexts(
+  texts: string[],
   model: { providerId: string; modelId: string }
-): Promise<Result<number, Error>> {
+): Promise<Result<Array<number>, Error>> {
   try {
     const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-    const res = await coreAPI.tokenize({
-      text,
+    const res = await coreAPI.tokenizeBatch({
+      texts,
       providerId: model.providerId,
       modelId: model.modelId,
     });
@@ -22,7 +22,7 @@ export async function tokenCountForText(
       );
     }
 
-    return new Ok(res.value.tokens.length);
+    return new Ok(res.value.tokens.map((t) => t.length));
   } catch (err) {
     return new Err(new Error(`Error tokenizing model message: ${err}`));
   }

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -940,6 +940,32 @@ export class CoreAPI {
     return this._resultFromResponse(response);
   }
 
+  async tokenizeBatch({
+    texts,
+    modelId,
+    providerId,
+  }: {
+    texts: string[];
+    modelId: string;
+    providerId: string;
+  }): Promise<CoreAPIResponse<{ tokens: CoreAPITokenType[][] }>> {
+    const credentials = dustManagedCredentials();
+    const response = await this._fetchWithError(`${this._url}/tokenize/batch`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        texts,
+        model_id: modelId,
+        provider_id: providerId,
+        credentials,
+      }),
+    });
+
+    return this._resultFromResponse(response);
+  }
+
   async dataSourceTokenize({
     text,
     projectId,


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/dust/issues/5934

In order to count tokens, we rely on a `core` endpoint that calls our tokenizers (in a Tokio `spawn_blocking` green thread).
When rendering the conversation for the model, we need to tokenize all the messages, and we currently do so with a `Promise.all` and n calls to the core API. This is inefficient as we're doing a lot of HTTP calls and using a lot of `spawn_blocking` threads (which is inefficient as the thread pool is large).

This commit:
- adds a new "batch tokenize" endpoint to core that uses `Rayon` to tokenize in parallel
- replaces the `Promise.all` in front with a call to this new endpoint

## Risk

critical path, but well tested
## Deploy Plan

Deploy core first, then front-edge (to test end to end one last time), then front