### PR TITLE
front: more environment clean-up

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -1,8 +1,8 @@
 import { EnvironmentConfig } from "@dust-tt/types";
 
 const config = {
-  getAppUrl: (): string => {
-    return EnvironmentConfig.getEnvVariable("URL");
+  getClientFacingUrl: (): string => {
+    return EnvironmentConfig.getEnvVariable("DUST_CLIENT_FACING_URL");
   },
   getAuth0TenantUrl: (): string => {
     return EnvironmentConfig.getEnvVariable("AUTH0_TENANT_DOMAIN_URL");
@@ -26,6 +26,12 @@ const config = {
     return EnvironmentConfig.getEnvVariable(
       "SENDGRID_INVITATION_EMAIL_TEMPLATE_ID"
     );
+  },
+  getStripeSecretKey: (): string => {
+    return EnvironmentConfig.getEnvVariable("STRIPE_SECRET_KEY");
+  },
+  getStripeSecretWebhookKey: (): string => {
+    return EnvironmentConfig.getEnvVariable("STRIPE_SECRET_WEBHOOK_KEY");
   },
   getDustDataSourcesBucket: (): string => {
     return EnvironmentConfig.getEnvVariable("DUST_DATA_SOURCES_BUCKET");
@@ -70,8 +76,12 @@ const config = {
       url: EnvironmentConfig.getEnvVariable("OAUTH_API"),
     };
   },
+  // OAuth
   getOAuthGithubApp: (): string => {
     return EnvironmentConfig.getEnvVariable("OAUTH_GITHUB_APP");
+  },
+  getOAuthNotionClientId: (): string => {
+    return EnvironmentConfig.getEnvVariable("OAUTH_NOTION_CLIENT_ID");
   },
 };
 

--- a/front/lib/api/enterprise_connection.ts
+++ b/front/lib/api/enterprise_connection.ts
@@ -24,7 +24,7 @@ function makeEnterpriseConnectionName(workspaceId: string) {
 }
 
 export function makeEnterpriseConnectionInitiateLoginUrl(workspaceId: string) {
-  return `${config.getAppUrl()}/api/auth/login?connection=${makeEnterpriseConnectionName(
+  return `${config.getClientFacingUrl()}/api/auth/login?connection=${makeEnterpriseConnectionName(
     workspaceId
   )}`;
 }

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -152,7 +152,7 @@ export function getMembershipInvitationUrlForToken(
   owner: LightWorkspaceType,
   invitationToken: string
 ) {
-  return `${config.getAppUrl()}/w/${owner.sId}/join/?t=${invitationToken}`;
+  return `${config.getClientFacingUrl()}/w/${owner.sId}/join/?t=${invitationToken}`;
 }
 
 export async function sendWorkspaceInvitationEmail(

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -78,11 +78,14 @@ const PROVIDER_STRATEGIES: Record<
     connectionIdFromQuery: () => null,
   },
   notion: {
-    redirectUrl: () => {
-      return new Err({
-        code: "connection_not_implemented",
-        message: "Notion OAuth is not implemented",
-      });
+    redirectUrl: (connection) => {
+      return new Ok(
+        `https://api.notion.com/v1/oauth/authorize?owner=user` +
+          `response_type=code` +
+          `&client_id=${config.getOAuthNotionClientId()}` +
+          `&redirect_uri=${encodeURIComponent(config.getClientFacingUrl() + "/oauth/notion/finalize")}` +
+          `&state=${connection.connection_id}`
+      );
     },
     codeFromQuery: () => null,
     connectionIdFromQuery: () => null,

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -14,13 +14,13 @@ import {
   SUPPORTED_REPORT_USAGE,
 } from "@app/lib/plans/usage/types";
 
-const { STRIPE_SECRET_KEY = "", URL = "" } = process.env;
+import config from "../api/config";
 
 export function getProPlanStripeProductId() {
   return isDevelopment() ? "prod_OwKvN4XrUwFw5a" : "prod_OwALjyfxfi2mln";
 }
 
-const stripe = new Stripe(STRIPE_SECRET_KEY, {
+const stripe = new Stripe(config.getStripeSecretKey(), {
   apiVersion: "2023-10-16",
   typescript: true,
 });
@@ -144,8 +144,8 @@ export const createProPlanCheckoutSession = async ({
     tax_id_collection: {
       enabled: true,
     },
-    success_url: `${URL}/w/${owner.sId}/subscription/payment_processing?type=succeeded&session_id={CHECKOUT_SESSION_ID}&plan_code=${PRO_PLAN_SEAT_29_CODE}`,
-    cancel_url: `${URL}/w/${owner.sId}/subscription?type=cancelled`,
+    success_url: `${config.getClientFacingUrl()}/w/${owner.sId}/subscription/payment_processing?type=succeeded&session_id={CHECKOUT_SESSION_ID}&plan_code=${PRO_PLAN_SEAT_29_CODE}`,
+    cancel_url: `${config.getClientFacingUrl()}/w/${owner.sId}/subscription?type=cancelled`,
     consent_collection: {
       terms_of_service: "required",
     },
@@ -197,7 +197,7 @@ export const createCustomerPortalSession = async ({
 
   const portalSession = await stripe.billingPortal.sessions.create({
     customer: stripeCustomerId,
-    return_url: `${URL}/w/${owner.sId}/subscription`,
+    return_url: `${config.getClientFacingUrl()}/w/${owner.sId}/subscription`,
   });
 
   return portalSession.url;

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -3,6 +3,7 @@ import type { SubscriptionType } from "@dust-tt/types";
 import { Err, isDevelopment, Ok } from "@dust-tt/types";
 import { Stripe } from "stripe";
 
+import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { Plan, Subscription } from "@app/lib/models/plan";
 import { PRO_PLAN_SEAT_29_CODE } from "@app/lib/plans/plan_codes";
@@ -13,8 +14,6 @@ import {
   isSupportedReportUsage,
   SUPPORTED_REPORT_USAGE,
 } from "@app/lib/plans/usage/types";
-
-import config from "../api/config";
 
 export function getProPlanStripeProductId() {
   return isDevelopment() ? "prod_OwKvN4XrUwFw5a" : "prod_OwALjyfxfi2mln";

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -240,7 +240,7 @@ export function fileAttachmentLocation({
     internalUrl: `https://storage.googleapis.com/${
       getPrivateUploadBucket().name
     }/${filePath}`,
-    downloadUrl: `${appConfig.getAppUrl()}/api/w/${workspaceId}/assistant/conversations/${conversationId}/messages/${messageId}/raw_content_fragment?format=${contentFormat}`,
+    downloadUrl: `${appConfig.getClientFacingUrl()}/api/w/${workspaceId}/assistant/conversations/${conversationId}/messages/${messageId}/raw_content_fragment?format=${contentFormat}`,
   };
 }
 

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -204,7 +204,7 @@ export class FileResource extends BaseResource<FileModel> {
       throw new Error("Unexpected unauthenticated call to `getPublicUrl`");
     }
 
-    return `${config.getAppUrl()}/api/w/${owner.sId}/files/${this.sId}`;
+    return `${config.getClientFacingUrl()}/api/w/${owner.sId}/files/${this.sId}`;
   }
 
   getCloudStoragePath(auth: Authenticator, version: FileVersion): string {

--- a/front/pages/api/auth/[auth0].ts
+++ b/front/pages/api/auth/[auth0].ts
@@ -74,7 +74,9 @@ export default handleAuth({
   logout: handleLogout((req) => {
     return {
       returnTo:
-        "query" in req ? (req.query.returnTo as string) : config.getAppUrl(),
+        "query" in req
+          ? (req.query.returnTo as string)
+          : config.getClientFacingUrl(),
     };
   }),
 });

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -6,6 +6,7 @@ import Stripe from "stripe";
 import { promisify } from "util";
 
 import apiConfig from "@app/lib/api/config";
+import apiConfig from "@app/lib/api/config";
 import { getDataSources } from "@app/lib/api/data_sources";
 import { getMembers } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
@@ -33,8 +34,6 @@ import {
   terminateScheduleWorkspaceScrubWorkflow,
 } from "@app/temporal/scrub_workspace/client";
 
-const { STRIPE_SECRET_KEY = "", STRIPE_SECRET_WEBHOOK_KEY = "" } = process.env;
-
 export type GetResponseBody = {
   success: boolean;
   message?: string;
@@ -50,7 +49,7 @@ async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<GetResponseBody>>
 ): Promise<void> {
-  const stripe = new Stripe(STRIPE_SECRET_KEY, {
+  const stripe = new Stripe(apiConfig.getStripeSecretKey(), {
     apiVersion: "2023-10-16",
     typescript: true,
   });
@@ -77,7 +76,7 @@ async function handler(
         event = stripe.webhooks.constructEvent(
           rawBody,
           sig,
-          STRIPE_SECRET_WEBHOOK_KEY
+          apiConfig.getStripeSecretWebhookKey()
         );
       } catch (error) {
         logger.error({ error }, "Error constructing Stripe event in Webhook.");

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -6,7 +6,6 @@ import Stripe from "stripe";
 import { promisify } from "util";
 
 import apiConfig from "@app/lib/api/config";
-import apiConfig from "@app/lib/api/config";
 import { getDataSources } from "@app/lib/api/data_sources";
 import { getMembers } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/index.tsx
+++ b/front/pages/index.tsx
@@ -47,7 +47,7 @@ export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
 
   return {
     props: {
-      gaTrackingId: config.getAppUrl(),
+      gaTrackingId: config.getGaTrackingId(),
       postLoginReturnToUrl: postLoginCallbackUrl,
       shape: 0,
     },

--- a/front/pages/w/[wId]/a/[aId]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/index.tsx
@@ -32,6 +32,7 @@ import {
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { getApp } from "@app/lib/api/app";
+import config from "@app/lib/api/config";
 import { extractConfig } from "@app/lib/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import {
@@ -41,8 +42,6 @@ import {
   moveBlockUp,
 } from "@app/lib/specification";
 import { useSavedRunStatus } from "@app/lib/swr";
-
-const { URL = "", GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   user: UserType | null;
@@ -78,9 +77,9 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       owner,
       subscription,
       readOnly,
-      url: URL,
+      url: config.getClientFacingUrl(),
       app,
-      gaTrackingId: GA_TRACKING_ID,
+      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });

--- a/front/pages/w/[wId]/assistant/[cId]/index.tsx
+++ b/front/pages/w/[wId]/assistant/[cId]/index.tsx
@@ -9,9 +9,8 @@ import { ConversationContainer } from "@app/components/assistant/conversation/Co
 import type { ConversationLayoutProps } from "@app/components/assistant/conversation/ConversationLayout";
 import ConversationLayout from "@app/components/assistant/conversation/ConversationLayout";
 import { CONVERSATION_PARENT_SCROLL_DIV_ID } from "@app/components/assistant/conversation/lib";
+import config from "@app/lib/api/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
-
-const { URL = "", GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps = withDefaultUserAuthRequirements<
   ConversationLayoutProps & {
@@ -51,8 +50,8 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
       user,
       owner,
       subscription,
-      baseUrl: URL,
-      gaTrackingId: GA_TRACKING_ID,
+      baseUrl: config.getClientFacingUrl(),
+      gaTrackingId: config.getGaTrackingId(),
       conversationId: getValidConversationId(cId),
     },
   };

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -21,10 +21,9 @@ import type {
 import { BUILDER_FLOWS } from "@app/components/assistant_builder/types";
 import { getApps } from "@app/lib/api/app";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
+import config from "@app/lib/api/config";
 import { getDataSources } from "@app/lib/api/data_sources";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
-
-const { GA_TRACKING_ID = "", URL = "" } = process.env;
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
@@ -89,7 +88,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       owner,
       plan,
       subscription,
-      gaTrackingId: GA_TRACKING_ID,
+      gaTrackingId: config.getGaTrackingId(),
       dataSources: allDataSources,
       dustApps: allDustApps,
       actions: await buildInitialActions({
@@ -99,7 +98,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       }),
       agentConfiguration: configuration,
       flow,
-      baseUrl: URL,
+      baseUrl: config.getClientFacingUrl(),
     },
   };
 });

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -127,7 +127,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       actions,
       agentConfiguration: configuration,
       flow,
-      baseUrl: config.getAppUrl(),
+      baseUrl: config.getClientFacingUrl(),
       templateId,
     },
   };

--- a/front/pages/w/[wId]/join.tsx
+++ b/front/pages/w/[wId]/join.tsx
@@ -4,14 +4,13 @@ import type { InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 
 import OnboardingLayout from "@app/components/sparkle/OnboardingLayout";
+import config from "@app/lib/api/config";
 import {
   getWorkspaceInfos,
   getWorkspaceVerifiedDomain,
 } from "@app/lib/api/workspace";
 import { getPendingMembershipInvitationForToken } from "@app/lib/iam/invitations";
 import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";
-
-const { URL = "", GA_TRACKING_ID = "" } = process.env;
 
 /**
  * 3 ways to end up here:
@@ -124,8 +123,8 @@ export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
 
   return {
     props: {
-      baseUrl: URL,
-      gaTrackingId: GA_TRACKING_ID,
+      baseUrl: config.getClientFacingUrl(),
+      gaTrackingId: config.getGaTrackingId(),
       invitationEmail,
       onboardingType,
       signUpCallbackUrl,

--- a/front/pages/w/[wId]/welcome.tsx
+++ b/front/pages/w/[wId]/welcome.tsx
@@ -11,11 +11,10 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 
 import OnboardingLayout from "@app/components/sparkle/OnboardingLayout";
+import config from "@app/lib/api/config";
 import { getUserMetadata } from "@app/lib/api/user";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { withDefaultUserAuthPaywallWhitelisted } from "@app/lib/iam/session";
-
-const { URL = "", GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
   user: UserType;
@@ -57,8 +56,8 @@ export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
       defaultExpertise: expertise?.value || "",
       defaultAdminInterest: adminInterest?.value || "",
       conversationId,
-      baseUrl: URL,
-      gaTrackingId: GA_TRACKING_ID,
+      baseUrl: config.getClientFacingUrl(),
+      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });


### PR DESCRIPTION
## Description

- Remove `getAppUrl` from `config` (env varialbe `URL`) and instead rely on `DUST_CLIENT_FACING_URL` as per https://www.notion.so/dust-tt/DesignDoc-Dust-services-URLs-revamp-8e1aab69fdb84809b8be4fc9f75e719e?pvs=4
- Clean up a bit of env config for Stripe secrets
- Introduce the env for notion `oauth` setup redirect

## Risk

High touches critical env variables
`DUST_CLIENT_FACING_URL` is set in `front` production service and equal to `URL` which will be removed

## Deploy Plan

- deploy `front`