### PR TITLE
chore: delete maxToolsUsePerRun

### DIFF
--- a/front/components/assistant/AssistantActions.tsx
+++ b/front/components/assistant/AssistantActions.tsx
@@ -199,8 +199,6 @@ export function RemoveAssistantFromWorkspaceDialog({
             actions: detailedConfiguration.actions,
             templateId: agentConfiguration.templateId,
             maxStepsPerRun: agentConfiguration.maxStepsPerRun,
-            // TODO(@fontanierh): remove
-            maxToolsUsePerRun: agentConfiguration.maxStepsPerRun,
           },
         };
 

--- a/front/components/assistant_builder/submitAssistantBuilderForm.ts
+++ b/front/components/assistant_builder/submitAssistantBuilderForm.ts
@@ -210,8 +210,6 @@ export async function submitAssistantBuilderForm({
           temperature: builderState.generationSettings.temperature,
         },
         maxStepsPerRun,
-        // TODO(@fontanierh): remove
-        maxToolsUsePerRun: maxStepsPerRun,
         templateId: builderState.templateId,
       },
     };

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -719,7 +719,7 @@ async function fetchWorkspaceAgentConfigurationsForView(
       status: agent.status,
       actions,
       versionAuthorId: agent.authorId,
-      maxStepsPerRun: agent.maxToolsUsePerRun,
+      maxStepsPerRun: agent.maxStepsPerRun,
       templateId: template?.sId ?? null,
     };
 
@@ -1034,7 +1034,6 @@ export async function createAgentConfiguration(
             providerId: model.providerId,
             modelId: model.modelId,
             temperature: model.temperature,
-            maxToolsUsePerRun: maxStepsPerRun,
             maxStepsPerRun,
             pictureUrl,
             workspaceId: owner.id,
@@ -1069,7 +1068,7 @@ export async function createAgentConfiguration(
       },
       pictureUrl: agent.pictureUrl,
       status: agent.status,
-      maxStepsPerRun: agent.maxToolsUsePerRun,
+      maxStepsPerRun: agent.maxStepsPerRun,
       templateId: template?.sId ?? null,
     };
 

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -50,7 +50,6 @@ export class AgentConfiguration extends Model<
   declare workspaceId: ForeignKey<Workspace["id"]>;
   declare authorId: ForeignKey<User["id"]>;
 
-  declare maxToolsUsePerRun: number;
   declare maxStepsPerRun: number;
 
   declare templateId: ForeignKey<TemplateModel["id"]> | null;
@@ -118,10 +117,6 @@ AgentConfiguration.init(
       type: DataTypes.FLOAT,
       allowNull: false,
       defaultValue: 0.7,
-    },
-    maxToolsUsePerRun: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
     },
     maxStepsPerRun: {
       type: DataTypes.INTEGER,

--- a/front/migrations/db/migration_43.sql
+++ b/front/migrations/db/migration_43.sql
@@ -1,0 +1,3 @@
+-- Migration created on Jul 15, 2024
+ALTER TABLE
+    "public"."agent_configurations" DROP COLUMN "maxToolsUsePerRun";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
@@ -97,10 +97,7 @@ async function handler(
         });
       }
 
-      // TODO(@fontanierh): remove
-      const maxStepsPerRun =
-        bodyValidation.right.assistant.maxStepsPerRun ??
-        bodyValidation.right.assistant.maxToolsUsePerRun;
+      const maxStepsPerRun = bodyValidation.right.assistant.maxStepsPerRun;
 
       const isLegacyConfiguration =
         bodyValidation.right.assistant.actions.length === 1 &&

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
@@ -117,8 +117,6 @@ async function handler(
         auth,
         assistant: {
           ...assistant,
-          // TODO(@fontanierh): remove
-          maxToolsUsePerRun: assistant.maxStepsPerRun,
           scope: bodyValidation.right.scope,
           status: assistant.status as AgentStatus,
           templateId: assistant.templateId,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -189,10 +189,7 @@ async function handler(
         });
       }
 
-      const maxStepsPerRun =
-        bodyValidation.right.assistant.maxStepsPerRun ??
-        // TODO(@fontanierh): remove
-        bodyValidation.right.assistant.maxToolsUsePerRun;
+      const maxStepsPerRun = bodyValidation.right.assistant.maxStepsPerRun;
 
       const isLegacyConfiguration =
         bodyValidation.right.assistant.actions.length === 1 &&

--- a/types/src/front/api_handlers/internal/agent_configuration.ts
+++ b/types/src/front/api_handlers/internal/agent_configuration.ts
@@ -201,7 +201,6 @@ export const PostOrPatchAgentConfigurationRequestBodySchema = t.type({
     model: t.intersection([ModelConfigurationSchema, IsSupportedModelSchema]),
     actions: t.array(ActionConfigurationSchema),
     templateId: t.union([t.string, t.null, t.undefined]),
-    maxToolsUsePerRun: t.union([t.number, t.undefined]),
     maxStepsPerRun: t.union([t.number, t.undefined]),
   }),
 });


### PR DESCRIPTION
## Description

Follow for https://github.com/dust-tt/dust/pull/6213

We now have `maxStepsPerRun` to replace `maxToolsUsePerRun`. The new field is being populated and has been backfilled.

Now we can get rid of the legacy field
## Risk

migration
## Deploy Plan

deploy code then apply the migration