### PR TITLE
POC: Experiment with one action per managed ds for @dust

### DIFF
--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -859,6 +859,13 @@ async function _getDustGlobalAgent(
     };
   }
 
+  let instructions = `The assistant answers with precision and brevity. It produces short and straight to the point answers. The assistant should not provide additional information or content that the user did not ask for. When possible, the assistant should answer using a single sentence.
+# When the user asks a questions to the assistant, the assistant should analyze the situation as follows.
+1. If the user's question requires information that is likely private or internal to the company (and therefore unlikely to be found on the public internet or within the assistant's own knowledge), the assistant should search in the company's internal data sources to answer the question. It's important to not pick a restrictive timeframe unless it's explicitly requested or obviously needed.
+2. If the users's question requires information that is recent and likely to be found on the public internet, the assistant should use the internet to answer the question. That means performing a websearch and potentially browse some webpages.
+3. If it is not obvious whether the information would be included in the internal company data sources or on the public internet, the assistant should both search the internal company data sources and the public internet before answering the user's question.
+4. If the user's query require neither internal company data or recent public knowledge, the assistant is allowed to answer without using any tool.`;
+
   const actions: AgentActionConfigurationType[] = [
     {
       id: -1,
@@ -879,6 +886,14 @@ async function _getDustGlobalAgent(
 
   if (owner.flags.includes("dust_splitted_ds_flag")) {
     // Note: if we want to ungate this, we should make sure to provide a better design in the Assitant detail modal.
+    // The instructions have been edited only to add "Searching in all datasources is the default behavior unless the user has specified the location in which case it is better to search only on the specific data source."
+    instructions = `The assistant answers with precision and brevity. It produces short and straight to the point answers. The assistant should not provide additional information or content that the user did not ask for. When possible, the assistant should answer using a single sentence.
+    # When the user asks a questions to the assistant, the assistant should analyze the situation as follows.
+    1. If the user's question requires information that is likely private or internal to the company (and therefore unlikely to be found on the public internet or within the assistant's own knowledge), the assistant should search in the company's internal data sources to answer the question. Searching in all datasources is the default behavior unless the user has specified the location in which case it is better to search only on the specific data source. It's important to not pick a restrictive timeframe unless it's explicitly requested or obviously needed.
+    2. If the users's question requires information that is recent and likely to be found on the public internet, the assistant should use the internet to answer the question. That means performing a websearch and potentially browse some webpages.
+    3. If it is not obvious whether the information would be included in the internal company data sources or on the public internet, the assistant should both search the internal company data sources and the public internet before answering the user's question.
+    4. If the user's query require neither internal company data or recent public knowledge, the assistant is allowed to answer without using any tool.`;
+
     dataSources.forEach((ds) => {
       if (ds.connectorProvider && ds.connectorProvider !== "webcrawler") {
         actions.push({
@@ -930,12 +945,7 @@ async function _getDustGlobalAgent(
     versionAuthorId: null,
     name,
     description,
-    instructions: `The assistant answers with precision and brevity. It produces short and straight to the point answers. The assistant should not provide additional information or content that the user did not ask for. When possible, the assistant should answer using a single sentence.
-# When the user asks a questions to the assistant, the assistant should analyze the situation as follows.
-1. If the user's question requires information that is likely private or internal to the company (and therefore unlikely to be found on the public internet or within the assistant's own knowledge), the assistant should search in the company's internal data sources to answer the question. It's important to not pick a restrictive timeframe unless it's explicitly requested or obviously needed.
-2. If the users's question requires information that is recent and likely to be found on the public internet, the assistant should use the internet to answer the question. That means performing a websearch and potentially browse some webpages.
-3. If it is not obvious whether the information would be included in the internal company data sources or on the public internet, the assistant should both search the internal company data sources and the public internet before answering the user's question.
-4. If the user's query require neither internal company data or recent public knowledge, the assistant is allowed to answer without using any tool.`,
+    instructions,
     pictureUrl,
     status: "active",
     scope: "global",

--- a/types/src/front/feature_flags.ts
+++ b/types/src/front/feature_flags.ts
@@ -6,6 +6,7 @@ export const WHITELISTABLE_FEATURES = [
   "document_tracker",
   "microsoft_connector",
   "visualization_action_flag",
+  "dust_splitted_ds_flag",
 ] as const;
 export type WhitelistableFeature = (typeof WHITELISTABLE_FEATURES)[number];
 export function isWhitelistableFeature(


### PR DESCRIPTION
## Description

Task: https://github.com/dust-tt/tasks/issues/1001
Split the managed datasources of dust to add one search action by managed ds.

Under a feature flag until we figure out if this gives better results or not. 
The assistant detail is quite ugly as is since we display all actions, but this will be solve if we move forward with this. 

## Risk

Gated, and easily rollbackable.

## Deploy Plan

Deploy front-edge, share with Ed. 
He'll make some tests and tell me if we want to push it on prod for Dust only for a few days. 
