### PR TITLE
Disabling PPTX temporarily

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/mime_types.ts
+++ b/connectors/src/connectors/google_drive/temporal/mime_types.ts
@@ -15,7 +15,8 @@ export function getMimeTypesToDownload({
     "text/csv",
     // docx files hosted on Gdrive
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    // Temporarily excluding pptx files for debugging purpose.
+    // "application/vnd.openxmlformats-officedocument.presentationml.presentation",
   ];
   if (pdfEnabled) {
     mimeTypes.push("application/pdf");


### PR DESCRIPTION
## Description

Disabling PPTX in Gdrive temporarily because we suspect that the parsing function is blocking the javascript event loop and causing synchronization downtime.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
