### PR TITLE
[MS Connector] Compute parents array for document upsertion

### DIFF
--- a/connectors/src/connectors/microsoft/lib/graph_api.ts
+++ b/connectors/src/connectors/microsoft/lib/graph_api.ts
@@ -373,6 +373,16 @@ export function getDriveItemAPIPath(item: MicrosoftGraph.DriveItem) {
   return `/drives/${parentReference.driveId}/items/${item.id}`;
 }
 
+export function getParentReferenceAPIPath(
+  parentReference: MicrosoftGraph.ItemReference
+) {
+  if (!parentReference.driveId) {
+    throw new Error("Unexpected: no drive id for item");
+  }
+
+  return `/drives/${parentReference.driveId}/items/${parentReference.id}`;
+}
+
 export function getWorksheetAPIPath(
   item: MicrosoftGraph.WorkbookWorksheet,
   parentInternalId: string
@@ -389,6 +399,24 @@ export function getWorksheetAPIPath(
 
 export function getDriveAPIPath(drive: MicrosoftGraph.Drive) {
   return `/drives/${drive.id}`;
+}
+
+export function getDriveAPIPathFromItem(item: MicrosoftGraph.DriveItem) {
+  if (!item.parentReference?.driveId) {
+    throw new Error("Unexpected: no drive id for item");
+  }
+
+  return `/drives/${item.parentReference.driveId}`;
+}
+
+export function getDriveItemAPIPathFromReference(
+  parentReference: MicrosoftGraph.ItemReference
+) {
+  if (!parentReference.driveId) {
+    throw new Error("Unexpected: no drive id for item");
+  }
+
+  return `/drives/${parentReference.driveId}/items/${parentReference.id}`;
 }
 
 export function getSiteAPIPath(site: MicrosoftGraph.Site) {

--- a/connectors/src/connectors/microsoft/lib/types.ts
+++ b/connectors/src/connectors/microsoft/lib/types.ts
@@ -19,6 +19,13 @@ export function isValidNodeType(
   return MICROSOFT_NODE_TYPES.includes(nodeType as MicrosoftNodeType);
 }
 
+/* A specific situation for the Microsoft connector leads us to not use the
+ * externally provided id (although it exists and is unique), but to compute our
+ * own `internal id`. This is because the Microsoft API does not allow to query a document or
+ * list its children using its id alone. We compute an internal id that contains all
+ * information. More details
+ * [here](https://www.notion.so/dust-tt/Design-Doc-Microsoft-ids-parents-c27726652aae45abafaac587b971a41d?pvs=4)
+ */
 export type MicrosoftNode = {
   nodeType: MicrosoftNodeType;
   name: string | null;

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -47,6 +47,7 @@ import {
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
 const FILES_SYNC_CONCURRENCY = 10;
+const PARENT_SYNC_CACHE_TTL_MS = 10 * 60 * 1000;
 
 export async function getSiteNodesToSync(
   connectorId: ModelId
@@ -123,8 +124,8 @@ export async function getSiteNodesToSync(
   );
 
   // for all folders, check if a parent folder or drive is already in the list,
-  // in which case remove it this can happen because when a user selects a
-  // folder to sync, then a parent folder, both are storeed in Microsoft Roots
+  // in which case remove it. This can happen because when a user selects a
+  // folder to sync, then a parent folder, both are stored in Microsoft Roots
   // table
 
   // Keeping them both in the sync list can result in various kinds of issues,
@@ -637,7 +638,7 @@ const getParentParentId = cacheWithRedis(
   },
   (connectorId, parentInternalId, startSyncTs) =>
     `microsoft-${connectorId}-parent-${parentInternalId}-syncms-${startSyncTs}`,
-  10 * 60 * 1000
+  PARENT_SYNC_CACHE_TTL_MS
 );
 
 async function handlePptxFile(

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -130,8 +130,9 @@ export async function getSiteNodesToSync(
   // Keeping them both in the sync list can result in various kinds of issues,
   // e.g. if a child folder is synced before the parent, then the child folder's
   // files' parents array will be incomplete, thus the need to prune the list
-  const nodesToSync = allNodes.filter(
-    async (node) =>
+  const nodesToSync = [];
+  for (const node of allNodes) {
+    if (
       !(
         node.nodeType === "folder" &&
         (await isParentAlreadyInNodes({
@@ -140,7 +141,10 @@ export async function getSiteNodesToSync(
           folder: node,
         }))
       )
-  );
+    ) {
+      nodesToSync.push(node);
+    }
+  }
 
   const nodeResources = await MicrosoftNodeResource.batchUpdateOrCreate(
     connectorId,

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -1,4 +1,6 @@
 import type { CoreAPIDataSourceDocumentSection, ModelId } from "@dust-tt/types";
+import { cacheWithRedis } from "@dust-tt/types";
+import type { Client } from "@microsoft/microsoft-graph-client";
 import axios from "axios";
 import mammoth from "mammoth";
 import type { Logger } from "pino";
@@ -43,8 +45,6 @@ import {
   MicrosoftRootResource,
 } from "@connectors/resources/microsoft_resource";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
-import { Client } from "@microsoft/microsoft-graph-client";
-import { start } from "repl";
 
 const FILES_SYNC_CONCURRENCY = 10;
 
@@ -619,6 +619,7 @@ async function getParents({
  * fetches can be made a lot of times during a sync, cache for 10mins in a
  * per-sync basis (given by startSyncTs) */
 const getParentParentId = cacheWithRedis(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async (connectorId, parentInternalId, startSyncTs) => {
     const parent = await MicrosoftNodeResource.fetchByInternalId(
       connectorId,

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -326,6 +326,15 @@ pub struct Chunk {
 /// considered a parent, and has a proper external “repo id”, which is stored at
 /// 2nd place in the array
 ///
+/// Additional note: in cases where selection of elements to sync is done on
+/// Dust side and not on provider's side, we need to be able to list all the
+/// children of a resource given its id (this is the case for google drive and
+/// microsoft for instance). While google drive's API and ids allows it, this is
+/// not the case for Microsoft. Therefore, for microsoft, instead of using the
+/// provider id directly, we compute our own document id containing all
+/// information for the querying the document using Microsoft's API. More details
+/// [here](https://www.notion.so/dust-tt/Design-Doc-Microsoft-ids-parents-c27726652aae45abafaac587b971a41d?pvs=4)
+///
 /// Parents array
 /// -------------
 /// At index 0 is the string id of the document itself, then at index 1 its

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -86,8 +86,14 @@ export type ContentNodeType = "file" | "folder" | "database" | "channel";
  * provided id when possible (e.g. Notion page id, Github repository id,
  * etc...). When not possible, such as for Github issues whose id is not
  * workspace-unique, a custom function to create a unique id is created, and
- * used both in the parents field management code and the connectors node
- * code.
+ * used both in the parents field management code and the connectors node code.
+ *
+ * A specific situation for the Microsoft connector leads us to not use the
+ * externally provided id (although it exists and is unique), but to compute our
+ * own. This is because the Microsoft API does not allow to query a document or
+ * list its children using its id alone. We compute an internal id that contains all
+ * information. More details here:
+ * https://www.notion.so/dust-tt/Design-Doc-Microsoft-ids-parents-c27726652aae45abafaac587b971a41d?pvs=4
  */
 export type ContentNode = {
   provider: ConnectorProvider;


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/1053

This PR adds computation of parents array when we upsert a document, allowing hierarchy selection in datasources actions for assistants to work. Additionally:
- it ensures root selected folders are not redundant, i.e. when a folder is selected but a parent is also selected, the folder is not added to the sync (it would break parents computation in some edge cases);
- it adds comments explaining the design choices for a specific, internal microsoft id, rather than using the external id of the provider as in other connectors.

Risk & deploy
---
na (gated)

