### PR TITLE
Sparkle: Hoverable primary

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.190",
+  "version": "0.2.191",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.190",
+      "version": "0.2.191",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.190",
+  "version": "0.2.191",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/Hoverable.tsx
+++ b/sparkle/src/components/Hoverable.tsx
@@ -7,19 +7,25 @@ interface HoverableProps {
   children: ReactNode;
   className?: string;
   onClick: (e: SyntheticEvent) => void;
+  variant?: "primary" | "invisible";
 }
 
 export function Hoverable({
   children,
   className = "",
   onClick,
+  variant = "invisible",
 }: HoverableProps) {
+  const baseClasses = "s-cursor-pointer s-duration-300";
+
+  const variantClasses = {
+    invisible: "hover:s-text-action-500 active:s-text-action-600",
+    primary: "s-font-bold s-text-blue-500 hover:active:s-text-action-600",
+  };
+
   return (
     <span
-      className={classNames(
-        "s-cursor-pointer s-duration-300 hover:s-text-action-500 active:s-text-action-600",
-        className
-      )}
+      className={classNames(baseClasses, variantClasses[variant], className)}
       onClick={onClick}
     >
       {children}

--- a/sparkle/src/stories/Hoverable.stories.tsx
+++ b/sparkle/src/stories/Hoverable.stories.tsx
@@ -19,7 +19,17 @@ export const HoverableExample = () => {
             alert("Clicked!");
           }}
         >
-          You can hover me.
+          I am invisible but you can hover me.
+        </Hoverable>
+      </div>
+      <div>
+        <Hoverable
+          variant="primary"
+          onClick={() => {
+            alert("Soupinou!");
+          }}
+        >
+          I am primary, you can hover me.
         </Hoverable>
       </div>
     </div>


### PR DESCRIPTION
## Description

Adding a primary variant to Hoverable to have blue links. 

<img width="1025" alt="Screenshot 2024-07-16 at 11 08 05" src="https://github.com/user-attachments/assets/de90c25c-f192-4e3f-8961-3a9dc132b70c">


## Risk

Default style has not changed.  

## Deploy Plan

Deploy Sparkle. 
