### PR TITLE
enh: increase core CPU, reduce replicas and split tokenize batch requests

### DIFF
--- a/k8s/deployments/core-deployment.yaml
+++ b/k8s/deployments/core-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: core-deployment
 spec:
-  replicas: 6
+  replicas: 3
   selector:
     matchLabels:
       app: core
@@ -48,10 +48,10 @@ spec:
 
           resources:
             requests:
-              cpu: 1250m
+              cpu: 4000m
               memory: 8Gi
             limits:
-              cpu: 1250m
+              cpu: 4000m
               memory: 8Gi
 
       volumes:


### PR DESCRIPTION
## Description

Some of the workloads on `core` is CPU-bound (eg: tokenization). So far, we have been allocating 1250 millicores of CPU to each pod.
Our K8s nodes have hyperthreading enabled, so the number of logical cores we see is 8.

We use `rayon` for parallelism, and `rayon` uses one thread per logical core. This means we are doing a lot of context switching, because the 8 threads are all ran on 1.25 physical CPU cores. 

The `tokenize` endpoint used to only take a single text chunk to tokenize, so to tokenize big batches of text, `front` would concurrently send a lot of HTTP requests to `core`. This takes a lot of connections and adds overhead, but in terms of parallelism, this was actually pretty good, since large batches of text chunks to tokenize were evenly spread across all CPU cores.

We recently moved to a new "batch tokenize" endpoint, that accepts an array of texts to tokenize (using `rayon`).
This turns out to be actually less efficient since large batches are now processed by a single CPU core with a lot of context switching (so likely even worse than just doing it sequentially with a single core).

The goal of this PR is to make our setup more efficient by giving 4 CPU cores to each pod (and reducing the number of pods, we almost certainly don't need 6 of them).
Ideally, we want to split large batches in smaller batches (the perfect number of sub-batches is the number of `core` instances running). For simplicity, we'll just hardcode this to 3 sub-batches for now.

There's also the question of whether we want to reduce the number of rayon threads to 4 (number of physical cores) or keep the default (i.e, the number of logical cores, likely still 8 with 4 CPU cores). Hyperthreading is desirable if the workload doesn't make full use of the execution units and has eg stalls for memory (HT can use that time for other work), which may or may not be the case here. For now I will keep it default and monitor latencies.

## Risk

- We're dividing by 2 the total memory of `core`
- We're dividing by 2 the number of `core` instances

## Deploy Plan

1- Apply infra 
2- deploy front-edge and do some real-world tests
3- deploy front