### PR TITLE
Add new actions to destroyActionsRelatedResources in scrub workspace

### DIFF
--- a/front/lib/conversation.ts
+++ b/front/lib/conversation.ts
@@ -2,6 +2,7 @@ import type { LightWorkspaceType, ModelId } from "@dust-tt/types";
 import { removeNulls } from "@dust-tt/types";
 import { chunk } from "lodash";
 
+import { AgentBrowseAction } from "@app/lib/models/assistant/actions/browse";
 import { AgentDustAppRunAction } from "@app/lib/models/assistant/actions/dust_app_run";
 import { AgentProcessAction } from "@app/lib/models/assistant/actions/process";
 import {
@@ -10,6 +11,8 @@ import {
   RetrievalDocumentChunk,
 } from "@app/lib/models/assistant/actions/retrieval";
 import { AgentTablesQueryAction } from "@app/lib/models/assistant/actions/tables_query";
+import { AgentVisualizationAction } from "@app/lib/models/assistant/actions/visualization";
+import { AgentWebsearchAction } from "@app/lib/models/assistant/actions/websearch";
 import type { Conversation } from "@app/lib/models/assistant/conversation";
 import {
   AgentMessage,
@@ -53,6 +56,15 @@ async function destroyActionsRelatedResources(agentMessageIds: Array<ModelId>) {
     where: { agentMessageId: agentMessageIds },
   });
   await AgentProcessAction.destroy({
+    where: { agentMessageId: agentMessageIds },
+  });
+  await AgentWebsearchAction.destroy({
+    where: { agentMessageId: agentMessageIds },
+  });
+  await AgentBrowseAction.destroy({
+    where: { agentMessageId: agentMessageIds },
+  });
+  await AgentVisualizationAction.destroy({
     where: { agentMessageId: agentMessageIds },
   });
 }


### PR DESCRIPTION
## Description

Fixing https://app.datadoghq.eu/logs?query=service%3Afront-worker%20env%3Aprod%20%22Unhandled%20activity%20error%22%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAZC694TPJun_UQAAAAAAAAAYAAAAAEFaQzY5NDhCQUFBWmRxeXpsU0l6c0FBcgAAACQAAAAAMDE5MGJhZjctYWZmZi00ZDVkLTk4ZTktM2U0NDVjNTE3YjQy&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1720518927225&to_ts=1721123727225&live=true

```
ForeignKeyConstraintError: update or delete on table "agent_messages" violates foreign key constraint "agent_websearch_actions_agentMessageId_fkey" on table "agent_websearch_actions"
```

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 
