### PR TITLE
Builders have access to admin list on Connections page

### DIFF
--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -15,7 +15,7 @@ export function MembersList({
   users: UserTypeWithWorkspaces[];
   currentUserId: number;
   isMembersLoading: boolean;
-  onClickEvent: (role: UserTypeWithWorkspaces) => void;
+  onClickEvent?: (role: UserTypeWithWorkspaces) => void;
   searchText?: string;
 }) {
   const filteredUsers = users
@@ -41,7 +41,7 @@ export function MembersList({
             key={`member-${user.id}`}
             className="transition-color flex cursor-pointer items-center justify-center gap-3 border-t border-structure-200 p-2 text-xs duration-200 hover:bg-action-50 sm:text-sm"
             onClick={async () => {
-              if (currentUserId === user.id) {
+              if (currentUserId === user.id || !onClickEvent) {
                 return;
               }
               onClickEvent(user);
@@ -73,7 +73,7 @@ export function MembersList({
                 visual={ChevronRightIcon}
                 className={classNames(
                   "text-element-600",
-                  user.id === currentUserId ? "invisible" : ""
+                  user.id === currentUserId || !onClickEvent ? "invisible" : ""
                 )}
               />
             </div>

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -15,7 +15,7 @@ export function MembersList({
   users: UserTypeWithWorkspaces[];
   currentUserId: number;
   isMembersLoading: boolean;
-  onClickEvent?: (role: UserTypeWithWorkspaces) => void;
+  onClickEvent: (role: UserTypeWithWorkspaces) => void;
   searchText?: string;
 }) {
   const filteredUsers = users
@@ -41,7 +41,7 @@ export function MembersList({
             key={`member-${user.id}`}
             className="transition-color flex cursor-pointer items-center justify-center gap-3 border-t border-structure-200 p-2 text-xs duration-200 hover:bg-action-50 sm:text-sm"
             onClick={async () => {
-              if (currentUserId === user.id || !onClickEvent) {
+              if (currentUserId === user.id) {
                 return;
               }
               onClickEvent(user);
@@ -73,7 +73,7 @@ export function MembersList({
                 visual={ChevronRightIcon}
                 className={classNames(
                   "text-element-600",
-                  user.id === currentUserId || !onClickEvent ? "invisible" : ""
+                  user.id === currentUserId ? "invisible" : ""
                 )}
               />
             </div>

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -317,6 +317,21 @@ export function useMembers(owner: WorkspaceType) {
   };
 }
 
+export function useAdmins(owner: WorkspaceType) {
+  const membersFetcher: Fetcher<GetMembersResponseBody> = fetcher;
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/w/${owner.sId}/members?role=admin`,
+    membersFetcher
+  );
+
+  return {
+    admins: useMemo(() => (data ? data.members : []), [data]),
+    isAdminsLoading: !error && !data,
+    iAdminsError: error,
+    mutateMembers: mutate,
+  };
+}
+
 export function useWorkspaceInvitations(owner: WorkspaceType) {
   const workspaceInvitationsFetcher: Fetcher<GetWorkspaceInvitationsResponseBody> =
     fetcher;

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,7 @@
         "@amplitude/analytics-browser": "^2.5.2",
         "@amplitude/analytics-node": "^1.3.5",
         "@auth0/nextjs-auth0": "^3.5.0",
-        "@dust-tt/sparkle": "^0.2.190",
+        "@dust-tt/sparkle": "^0.2.191",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -10734,9 +10734,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.190",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.190.tgz",
-      "integrity": "sha512-ErmlgHpflKFujCnzscMi1WRoHImVAPNR8rEdSCXoecpaDlOO4fYcthEj3EvYPq74enxkG3vdMOQt2asRfrFdQg==",
+      "version": "0.2.191",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.191.tgz",
+      "integrity": "sha512-3KMfAidH2/gyEUu5tRqzGUchdhEq/lek/yehVb3iq4T3FkSoFNRqjEZf1jjpNtXMcysILBJRkSzvzR6BfNCRzQ==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
     "@amplitude/analytics-browser": "^2.5.2",
     "@amplitude/analytics-node": "^1.3.5",
     "@auth0/nextjs-auth0": "^3.5.0",
-    "@dust-tt/sparkle": "^0.2.190",
+    "@dust-tt/sparkle": "^0.2.191",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",

--- a/front/pages/api/w/[wId]/members/index.ts
+++ b/front/pages/api/w/[wId]/members/index.ts
@@ -18,19 +18,25 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<GetMembersResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isAdmin()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users that are `admins` for the current workspace can see memberships or modify it.",
-      },
-    });
-  }
-
   switch (req.method) {
     case "GET":
+      if (req.query.role && req.query.role === "admin") {
+        const members = await getMembers(auth, { roles: ["admin"] });
+        res.status(200).json({ members });
+        return;
+      }
+
+      if (!auth.isAdmin()) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message:
+              "Only users that are `admins` for the current workspace can see memberships or modify it.",
+          },
+        });
+      }
+
       const members = await getMembers(auth);
 
       res.status(200).json({ members });

--- a/front/pages/api/w/[wId]/members/index.ts
+++ b/front/pages/api/w/[wId]/members/index.ts
@@ -20,7 +20,7 @@ async function handler(
 ): Promise<void> {
   switch (req.method) {
     case "GET":
-      if (req.query.role && req.query.role === "admin") {
+      if (auth.isBuilder() && req.query.role && req.query.role === "admin") {
         const members = await getMembers(auth, { roles: ["admin"] });
         res.status(200).json({ members });
         return;

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -1,4 +1,5 @@
 import {
+  Avatar,
   BookOpenIcon,
   Button,
   Chip,
@@ -29,7 +30,6 @@ import { useRouter } from "next/router";
 import { useContext, useEffect, useState } from "react";
 
 import ConnectorSyncingChip from "@app/components/data_source/DataSourceSyncChip";
-import { MembersList } from "@app/components/members/MembersList";
 import { subNavigationBuild } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
@@ -544,11 +544,44 @@ export default function DataSourcesView({
               title="Administrators"
               description={`${owner.name} has the following administrators:`}
             />
-            <MembersList
-              users={admins}
-              currentUserId={user.id}
-              isMembersLoading={isAdminsLoading}
-            />
+            {isAdminsLoading ? (
+              <div className="flex animate-pulse items-center justify-center gap-3 border-t border-structure-200 bg-structure-50 py-2 text-xs sm:text-sm">
+                <div className="hidden sm:block">
+                  <Avatar size="xs" />
+                </div>
+                <div className="flex grow flex-col gap-1 sm:flex-row sm:gap-3">
+                  <div className="font-medium text-element-900">Loading...</div>
+                  <div className="grow font-normal text-element-700"></div>
+                </div>
+              </div>
+            ) : (
+              <div className="s-w-full">
+                {admins.map((admin) => {
+                  return (
+                    <div
+                      key={`member-${admin.id}`}
+                      className="flex items-center justify-center gap-3 border-t border-structure-200 p-2 text-xs sm:text-sm"
+                    >
+                      <div className="hidden sm:block">
+                        <Avatar
+                          visual={admin.image}
+                          name={admin.fullName}
+                          size="sm"
+                        />
+                      </div>
+                      <div className="flex grow flex-col gap-1 sm:flex-row sm:gap-3">
+                        <div className="font-medium text-element-900">
+                          {admin.fullName}
+                        </div>
+                        <div className="grow font-normal text-element-700">
+                          {admin.email}
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
           </div>
         </Modal>
       )}

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -16,7 +16,6 @@ import {
 import type {
   ConnectorProvider,
   DataSourceType,
-  UserType,
   WhitelistableFeature,
   WorkspaceType,
 } from "@dust-tt/types";
@@ -81,7 +80,6 @@ const REDIRECT_TO_EDIT_PERMISSIONS = [
 ];
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
-  user: UserType;
   owner: WorkspaceType;
   subscription: SubscriptionType;
   readOnly: boolean;
@@ -100,12 +98,11 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   };
   githubAppUrl: string;
 }>(async (context, auth) => {
-  const user = auth.user();
   const owner = auth.workspace();
   const plan = auth.plan();
   const subscription = auth.subscription();
 
-  if (!user || !owner || !plan || !subscription) {
+  if (!owner || !plan || !subscription) {
     return {
       notFound: true,
     };
@@ -237,7 +234,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
 
   return {
     props: {
-      user,
       owner,
       subscription,
       readOnly,
@@ -386,7 +382,6 @@ function ConfirmationModal({
 }
 
 export default function DataSourcesView({
-  user,
   owner,
   subscription,
   readOnly,


### PR DESCRIPTION
## Description

Task: https://github.com/dust-tt/tasks/issues/1054
On the Connections page, if the user is not admin, we display a button opening a modal to display the list of admins in the workspace. 

We're loading the list of admins even if the user is currently admin. This is both me being lazy and me wanted to keep the code simple. 

<kbd>
<img width="980" alt="Screenshot 2024-07-16 at 13 23 37" src="https://github.com/user-attachments/assets/ffd8f557-1a12-4bc2-a50e-eb7701425f54">
</kbd>
<kbd>
<img width="458" alt="Screenshot 2024-07-16 at 14 14 56" src="https://github.com/user-attachments/assets/6aa81e24-c112-4c03-aeb5-1beddb3dbe34">
</kbd>

## Risk

PR can be rolled back. 

## Deploy Plan

Deploy front. 
