### PR TITLE
feat: setup infra for oauth service

### DIFF
--- a/.github/workflows/deploy-oauth.yml
+++ b/.github/workflows/deploy-oauth.yml
@@ -1,0 +1,56 @@
+name: Deploy Oauth
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: deploy_oauth
+  cancel-in-progress: false
+
+env:
+  GCLOUD_PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    if: github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Get short sha
+        id: short_sha
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: "Authenticate with Google Cloud"
+        uses: "google-github-actions/auth@v1"
+        with:
+          credentials_json: "${{ secrets.GCLOUD_SA_KEY }}"
+
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v1"
+
+      - name: Install gke-gcloud-auth-plugin
+        run: |
+          gcloud components install gke-gcloud-auth-plugin
+
+      - name: Setup kubectl
+        run: |
+          gcloud container clusters get-credentials dust-kube --region us-central1
+
+      - name: Build the image on Cloud Build
+        run: |
+          chmod +x ./k8s/cloud-build.sh
+          ./k8s/cloud-build.sh core ./Dockerfile ./core/
+
+      - name: Deploy the image on Kubernetes
+        run: |
+          chmod +x ./k8s/deploy-image.sh
+          ./k8s/deploy-image.sh gcr.io/$GCLOUD_PROJECT_ID/core-image:${{ steps.short_sha.outputs.short_sha }} oauth-deployment
+
+      - name: Wait for rollout to complete
+        run: |
+          echo "Waiting for rollout to complete"
+          kubectl rollout status deployment/oauth-deployment --timeout=10m

--- a/.github/workflows/deploy-oauth.yml
+++ b/.github/workflows/deploy-oauth.yml
@@ -43,12 +43,12 @@ jobs:
       - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build.sh core ./Dockerfile ./core/
+          ./k8s/cloud-build.sh oauth ./oauth.Dockerfile ./core/
 
       - name: Deploy the image on Kubernetes
         run: |
           chmod +x ./k8s/deploy-image.sh
-          ./k8s/deploy-image.sh gcr.io/$GCLOUD_PROJECT_ID/core-image:${{ steps.short_sha.outputs.short_sha }} oauth-deployment
+          ./k8s/deploy-image.sh gcr.io/$GCLOUD_PROJECT_ID/oauth-image:${{ steps.short_sha.outputs.short_sha }} oauth-deployment
 
       - name: Wait for rollout to complete
         run: |

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN cargo build --release --bin dust-api --bin sqlite-worker
+RUN cargo build --release --bin dust-api --bin sqlite-worker --bin oauth
 
 EXPOSE 3001
 

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN cargo build --release --bin dust-api --bin sqlite-worker --bin oauth
+RUN cargo build --release --bin dust-api --bin sqlite-worker
 
 EXPOSE 3001
 

--- a/core/oauth.Dockerfile
+++ b/core/oauth.Dockerfile
@@ -1,0 +1,14 @@
+FROM rust:1.79.0 as core
+
+RUN apt-get update && apt-get install -y vim redis-tools postgresql-client htop cmake
+
+WORKDIR /app
+
+COPY . .
+
+RUN cargo build --release --bin oauth
+
+EXPOSE 3006
+
+# Set a default command, it will start the oauth service if no command is provided
+CMD ["cargo", "run", "--release", "--bin", "oauth"]

--- a/k8s/apply_infra.sh
+++ b/k8s/apply_infra.sh
@@ -56,6 +56,7 @@ kubectl apply -f "$(dirname "$0")/configmaps/connectors-worker-specific-configma
 kubectl apply -f "$(dirname "$0")/configmaps/alerting-temporal-configmap.yaml"
 kubectl apply -f "$(dirname "$0")/configmaps/core-configmap.yaml"
 kubectl apply -f "$(dirname "$0")/configmaps/core-sqlite-worker-configmap.yaml"
+kubectl apply -f "$(dirname "$0")/configmaps/oauth-configmap.yaml"
 kubectl apply -f "$(dirname "$0")/configmaps/prodbox-configmap.yaml"
 
 echo "-----------------------------------"
@@ -66,6 +67,7 @@ kubectl apply -f "$(dirname "$0")/backend-configs/front-backend-config.yaml"
 kubectl apply -f "$(dirname "$0")/backend-configs/connectors-backend-config.yaml"
 kubectl apply -f "$(dirname "$0")/backend-configs/metabase-backend-config.yaml"
 kubectl apply -f "$(dirname "$0")/backend-configs/core-backend-config.yaml"
+kubectl apply -f "$(dirname "$0")/backend-configs/oauth-backend-config.yaml"
 
 echo "-----------------------------------"
 echo "Applying managed certificates"
@@ -99,6 +101,7 @@ apply_deployment metabase-deployment
 apply_deployment alerting-temporal-deployment
 apply_deployment core-deployment
 apply_deployment core-sqlite-worker-deployment
+apply_deployment oauth-deployment
 apply_deployment prodbox-deployment
 
 
@@ -113,6 +116,7 @@ kubectl apply -f "$(dirname "$0")/services/connectors-worker-service.yaml"
 kubectl apply -f "$(dirname "$0")/services/metabase-service.yaml"
 kubectl apply -f "$(dirname "$0")/services/core-service.yaml"
 kubectl apply -f "$(dirname "$0")/services/core-sqlite-worker-headless-service.yaml"
+kubectl apply -f "$(dirname "$0")/services/oauth-service.yaml"
 
 
 echo "-----------------------------------"
@@ -121,3 +125,8 @@ echo "-----------------------------------"
 
 kubectl apply -f "$(dirname "$0")/ingress.yaml"
 
+echo "-----------------------------------"
+echo "Applying network policies"
+echo "-----------------------------------"
+
+kubectl apply -f "$(dirname "$0")/network-policies/oauth-network-policy.yaml"

--- a/k8s/backend-configs/oauth-backend-config.yaml
+++ b/k8s/backend-configs/oauth-backend-config.yaml
@@ -1,0 +1,6 @@
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: oauth-backendconfig
+spec:
+  timeoutSec: 30

--- a/k8s/configmaps/oauth-configmap.yaml
+++ b/k8s/configmaps/oauth-configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: oauth-config
+data:
+  DD_ENV: "prod"
+  DD_SERVICE: "oauth"
+  DD_LOGS_INJECTION: "true"
+  DD_RUNTIME_METRICS_ENABLED: "true"

--- a/k8s/deployments/oauth-deployment.yaml
+++ b/k8s/deployments/oauth-deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oauth-deployment
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: oauth
+  template:
+    metadata:
+      labels:
+        app: oauth
+        name: oauth-pod
+        admission.datadoghq.com/enabled: "true"
+      annotations:
+        ad.datadoghq.com/web.logs: '[{"source": "oauth","service": "oauth","tags": ["env:prod"]}]'
+    spec:
+      terminationGracePeriodSeconds: 180
+      containers:
+        - name: web
+          image: gcr.io/or1g1n-186209/core-image:latest
+          command: ["cargo", "run", "--release", "--bin", "oauth"]
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 3006
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3006
+            initialDelaySeconds: 10
+            periodSeconds: 5
+
+          envFrom:
+            - configMapRef:
+                name: oauth-config
+            - secretRef:
+                name: oauth-secrets
+          env:
+            - name: DD_AGENT_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+
+          resources:
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+            limits:
+              cpu: 1000m
+              memory: 1Gi

--- a/k8s/deployments/oauth-deployment.yaml
+++ b/k8s/deployments/oauth-deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: web
-          image: gcr.io/or1g1n-186209/core-image:latest
+          image: gcr.io/or1g1n-186209/oauth-image:latest
           command: ["cargo", "run", "--release", "--bin", "oauth"]
           imagePullPolicy: Always
           ports:

--- a/k8s/network-policies/oauth-network-policy.yaml
+++ b/k8s/network-policies/oauth-network-policy.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: oauth-network-policy
+spec:
+  podSelector:
+    matchLabels:
+      app: oauth
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: core
+      ports:
+        - protocol: TCP
+          port: 80

--- a/k8s/services/oauth-service.yaml
+++ b/k8s/services/oauth-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: oauth-service
+  annotations:
+    cloud.google.com/backend-config: '{"default": "oauth-backendconfig"}'
+spec:
+  selector:
+    app: oauth
+    name: oauth-pod
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 3006
+  type: ClusterIP


### PR DESCRIPTION
## Description

https://github.com/dust-tt/dust/issues/6221 and https://github.com/dust-tt/dust/issues/6219

Setup the deployment, service, network policy and deployment action for the new `oauth` binary.

Along with the usual pedestrian yaml associated with our deployments, there are some specifics:

- Event though it is part of the `core` codebase, this new service has its own Docker image. This should help make builds a little bit faster, and avoid changing the image for `oauth` when deploying `core` (or the other way around)
- `oauth` is deployed separately from `core` (different Github action)
- This provides a bit more flexibility (no need to deploy it unless needed)
- However, this also means we might build almost the same image twice, and `oauth` doesn't benefit from cached layers of the `core` image (and vice versa). We can decide to improve later.
- This PR introduces a new k8s resource: the network policy. This is what will prevent pods (except `core`) from talking to the `oauth` service.


If everything works as expected, I'll add a network policy on `core` as well so that only `front` can talk to it.

## Risk

For now, this should not have impact on any production system.

## Deploy Plan

1-  run apply infra -- the new deployment will be in `CrashloopBackoff` because the `oauth-image` won't exist yet
2- deploy `oauth` using the new github action -- this will replace the image on the deployment with a newly built image, which should work
3- test that the network policy works as expected (test `GET /` from `core` and from eg a `front` pod -- only `core` should work)