### PR TITLE
Fix Agent_message does not load runIds anymore

### DIFF
--- a/docs/src/pages/conversations.mdx
+++ b/docs/src/pages/conversations.mdx
@@ -254,18 +254,6 @@ The `generation_tokens` event is sent when tokens are streamed as the the assist
 }
 ```
 
-The `agent_generation_success` event is sent once the generation has completed.
-
-```
-{
-  type: "agent_generation_success";
-  created: number;
-  configurationId: string;
-  messageId: string;
-  text: string;
-}
-```
-
 ### Other events
 
 The `agent_message_success` event is sent once the message is fully completed and successful.

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -271,6 +271,7 @@ export async function* runMultiActionsAgentLoop(
             configurationId: configuration.sId,
             messageId: agentMessage.sId,
             message: agentMessage,
+            runId: event.runId,
           } satisfies AgentMessageSuccessEvent;
           return;
 

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -61,7 +61,6 @@ export async function* runAgent(
   agentMessage: AgentMessageType
 ): AsyncGenerator<
   | AgentErrorEvent
-  | AgentActionsEvent
   | AgentActionSpecificEvent
   | AgentActionSuccessEvent
   | GenerationTokensEvent
@@ -105,7 +104,6 @@ export async function* runMultiActionsAgentLoop(
   agentMessage: AgentMessageType
 ): AsyncGenerator<
   | AgentErrorEvent
-  | AgentActionsEvent
   | AgentActionSpecificEvent
   | AgentActionSuccessEvent
   | GenerationTokensEvent
@@ -151,6 +149,8 @@ export async function* runMultiActionsAgentLoop(
       isLegacyAgent,
     });
 
+    const runIds = [];
+
     for await (const event of loopIterationStream) {
       switch (event.type) {
         case "agent_error":
@@ -164,6 +164,7 @@ export async function* runMultiActionsAgentLoop(
           yield event;
           return;
         case "agent_actions":
+          runIds.push(event.runId);
           localLogger.info(
             {
               elapsed: Date.now() - now,
@@ -175,8 +176,6 @@ export async function* runMultiActionsAgentLoop(
           // which is very high. Over that the latency will just be too high. This is a guardrail
           // against the model outputing something unreasonable.
           event.actions = event.actions.slice(0, MAX_ACTIONS_PER_STEP);
-
-          yield event;
 
           const eventStreamGenerators = event.actions.map(
             ({ action, inputs, functionCallId, specification }, index) => {
@@ -265,13 +264,16 @@ export async function* runMultiActionsAgentLoop(
           }
           agentMessage.content = processedContent;
           agentMessage.status = "succeeded";
+
+          runIds.push(event.runId);
+
           yield {
             type: "agent_message_success",
             created: Date.now(),
             configurationId: configuration.sId,
             messageId: agentMessage.sId,
             message: agentMessage,
-            runId: event.runId,
+            runIds: runIds,
           } satisfies AgentMessageSuccessEvent;
           return;
 

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -5,7 +5,6 @@ import type {
   AgentDisabledErrorEvent,
   AgentErrorEvent,
   AgentGenerationCancelledEvent,
-  AgentGenerationSuccessEvent,
   AgentMessageErrorEvent,
   AgentMessageNewEvent,
   AgentMessageSuccessEvent,
@@ -1684,7 +1683,6 @@ async function* streamRunAgentEvents(
     | AgentActionSpecificEvent
     | AgentActionSuccessEvent
     | GenerationTokensEvent
-    | AgentGenerationSuccessEvent
     | AgentGenerationCancelledEvent
     | AgentMessageSuccessEvent,
     void
@@ -1729,15 +1727,12 @@ async function* streamRunAgentEvents(
       case "agent_actions":
         runIds.push(event.runId);
         break;
-      case "agent_generation_success":
+      case "agent_message_success":
         // Store message in database.
         runIds.push(event.runId);
         await agentMessageRow.update({
           runIds,
         });
-        break;
-
-      case "agent_message_success":
         // Update status in database.
         await agentMessageRow.update({
           status: "succeeded",

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1,5 +1,4 @@
 import type {
-  AgentActionsEvent,
   AgentActionSpecificEvent,
   AgentActionSuccessEvent,
   AgentDisabledErrorEvent,
@@ -1679,7 +1678,6 @@ async function* streamRunAgentEvents(
   auth: Authenticator,
   eventStream: AsyncGenerator<
     | AgentErrorEvent
-    | AgentActionsEvent
     | AgentActionSpecificEvent
     | AgentActionSuccessEvent
     | GenerationTokensEvent
@@ -1698,7 +1696,6 @@ async function* streamRunAgentEvents(
   | AgentMessageSuccessEvent,
   void
 > {
-  const runIds = [];
   for await (const event of eventStream) {
     switch (event.type) {
       case "agent_error":
@@ -1724,14 +1721,10 @@ async function* streamRunAgentEvents(
       case "agent_action_success":
         yield event;
         break;
-      case "agent_actions":
-        runIds.push(event.runId);
-        break;
       case "agent_message_success":
         // Store message in database.
-        runIds.push(event.runId);
         await agentMessageRow.update({
-          runIds,
+          runIds: event.runIds,
         });
         // Update status in database.
         await agentMessageRow.update({

--- a/types/src/front/lib/api/assistant/agent.ts
+++ b/types/src/front/lib/api/assistant/agent.ts
@@ -82,16 +82,6 @@ export type AgentActionSuccessEvent = {
   action: AgentActionType;
 };
 
-// Event sent once the generation is completed.
-export type AgentGenerationSuccessEvent = {
-  type: "agent_generation_success";
-  created: number;
-  configurationId: string;
-  messageId: string;
-  text: string;
-  runId: string;
-};
-
 // Event sent to stop the generation.
 export type AgentGenerationCancelledEvent = {
   type: "agent_generation_cancelled";
@@ -107,6 +97,7 @@ export type AgentMessageSuccessEvent = {
   configurationId: string;
   messageId: string;
   message: AgentMessageType;
+  runId: string;
 };
 
 export type AgentActionsEvent = {

--- a/types/src/front/lib/api/assistant/agent.ts
+++ b/types/src/front/lib/api/assistant/agent.ts
@@ -97,7 +97,7 @@ export type AgentMessageSuccessEvent = {
   configurationId: string;
   messageId: string;
   message: AgentMessageType;
-  runId: string;
+  runIds: string[];
 };
 
 export type AgentActionsEvent = {


### PR DESCRIPTION
## Description

Task: https://github.com/dust-tt/tasks/issues/1061

Event `agent_generation_success` was in charge of setting the runIds. 
We've stop yielding this event here: https://github.com/dust-tt/dust/pull/6169/files to use instead `agent_message_success`

This PR edits `agent_message_success` to attach the runId and be able to retrieve them and attach them to the agentMessage.

## Risk

Will test on front-edge. 
Can be rolled back. 

## Deploy Plan

Deploy front. 
