### PR TITLE
Add TextExtraction class

### DIFF
--- a/connectors/src/lib/api/config.ts
+++ b/connectors/src/lib/api/config.ts
@@ -8,4 +8,7 @@ export const apiConfig = {
       nodeEnv: EnvironmentConfig.getEnvVariable("NODE_ENV"),
     };
   },
+  getTextExtractionUrl: (): string => {
+    return EnvironmentConfig.getEnvVariable("TEXT_EXTRACTION_URL");
+  },
 };

--- a/types/package-lock.json
+++ b/types/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@notionhq/client": "^2.2.4",
+        "cheerio": "^1.0.0-rc.12",
         "dts-cli": "^2.0.5",
         "eslint-plugin-simple-import-sort": "^12.1.0",
         "eventsource-parser": "^1.1.1",
@@ -3527,6 +3528,11 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "license": "MIT",
@@ -3705,6 +3711,42 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cheerio": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
+      "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "htmlparser2": "^8.0.1",
+        "parse5": "^7.0.0",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/ci-info": {
@@ -3931,6 +3973,32 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/cssom": {
@@ -4212,6 +4280,30 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
     "node_modules/domexception": {
       "version": "4.0.0",
       "license": "MIT",
@@ -4220,6 +4312,33 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dts-cli": {
@@ -5645,6 +5764,24 @@
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "license": "MIT"
+    },
+    "node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
@@ -7531,6 +7668,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/nwsapi": {
       "version": "2.2.7",
       "license": "MIT"
@@ -7785,6 +7933,18 @@
       "license": "MIT",
       "dependencies": {
         "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
+      "integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
+      "dependencies": {
+        "domhandler": "^5.0.2",
+        "parse5": "^7.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"

--- a/types/package.json
+++ b/types/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@notionhq/client": "^2.2.4",
+    "cheerio": "^1.0.0-rc.12",
     "dts-cli": "^2.0.5",
     "eslint-plugin-simple-import-sort": "^12.1.0",
     "eventsource-parser": "^1.1.1",

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -77,6 +77,7 @@ export * from "./shared/model_id";
 export * from "./shared/nango_errors";
 export * from "./shared/rate_limiter";
 export * from "./shared/result";
+export * from "./shared/text_extraction";
 export * from "./shared/typescipt_utils";
 export * from "./shared/user_operation";
 export * from "./shared/utils/assert_never";

--- a/types/src/shared/text_extraction.ts
+++ b/types/src/shared/text_extraction.ts
@@ -1,0 +1,113 @@
+import * as cheerio from "cheerio";
+import { isLeft } from "fp-ts/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+
+import { Err, Ok, Result } from "./result";
+
+// Define the codec for the response.
+const TikaResponseCodec = t.type({
+  "Content-Type": t.string,
+  "X-TIKA:content": t.string,
+});
+
+// Define the type for the decoded response
+type TikaResponse = t.TypeOf<typeof TikaResponseCodec>;
+
+interface PageContent {
+  pageNumber: number;
+  content: string;
+}
+
+export class TextExtraction {
+  constructor(readonly url: string) {}
+
+  // Method to extract text from a buffer.
+  async fromBuffer(
+    fileBuffer: Buffer,
+    contentType: string
+  ): Promise<Result<PageContent[], Error>> {
+    const response = await this.queryTika(fileBuffer, contentType);
+    if (response.isErr()) {
+      return response;
+    }
+
+    return new Ok(this.processResponse(response.value));
+  }
+
+  // Query the Tika server and return the response data.
+  private async queryTika(
+    fileBuffer: Buffer,
+    contentType: string
+  ): Promise<Result<TikaResponse, Error>> {
+    // Determine the handler type based on the content type.
+    // The HTML handler preserves the structural information of the document
+    // like page structure, etc. The text handler does not.
+    const handlerType = contentType === "application/pdf" ? "html" : "text";
+
+    try {
+      const response = await fetch(`${this.url}/tika/${handlerType}`, {
+        method: "PUT",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": contentType,
+        },
+        body: fileBuffer,
+      });
+
+      if (!response.ok) {
+        return new Err(new Error(`HTTP error! status: ${response.status}`));
+      }
+
+      const data = await response.json();
+      const decodedReponse = TikaResponseCodec.decode(data);
+      if (isLeft(decodedReponse)) {
+        const pathError = reporter.formatValidationErrors(decodedReponse.left);
+        return new Err(new Error(`Invalid response format: ${pathError}`));
+      }
+
+      return new Ok(decodedReponse.right);
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : "Unexpected error";
+
+      return new Err(new Error(`Failed extracting text: ${errorMessage}`));
+    }
+  }
+
+  // Process the Tika response and return an array of PageContent.
+  private processResponse(response: TikaResponse): PageContent[] {
+    const contentType = response["Content-Type"];
+
+    switch (contentType) {
+      case "application/pdf":
+        return this.processPdfResponse(response);
+
+      default:
+        return this.processDefaultResponse(response);
+    }
+  }
+
+  // Process PDF response.
+  private processPdfResponse(response: TikaResponse): PageContent[] {
+    const html = response["X-TIKA:content"];
+
+    const $ = cheerio.load(html);
+    const slideContentDivs = $(".page");
+
+    return slideContentDivs
+      .map((index, div) => ({
+        pageNumber: index + 1,
+        content: $(div).text()?.trim() || "",
+      }))
+      .get();
+  }
+
+  // Process default response.
+  private processDefaultResponse(response: TikaResponse): PageContent[] {
+    const content = response["X-TIKA:content"];
+
+    // Treat the entire content as a single page.
+    return [{ pageNumber: 1, content: content.trim() }];
+  }
+}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of https://github.com/dust-tt/dust/pull/6246.

This PR introduces the `TextExtraction` class, which encapsulates the logic for interacting with our Tika server. It also adds a dependency on [cheerio](https://www.npmjs.com/package/cheerio) for handling page structure in our `types` module, which isn't ideal but necessary for querying the text extraction service from both `connectors` and `front`. The cheerio library helps us extract the relevant document structure.

Tika is queried in two different ways based on the content type:
- For `application/pdf`, we use the HTML type handler to preserve the document structure. Combined with cheerio, this allows us to extract the page representation and retrieve the text. In the future, we plan to include more content types in this category, such as PPTX and DOCX.
- For all other content types, we use the text handler since pagination logic is currently not implemented.

All this code has been successfully tested locally.

This PR updates the existing Google Drive logic to use this new service.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

- [x] Add `TEXT_EXTRACTION_URL` env variable to `connector-secrets`.
