### PR TITLE
enh(core+oauth): don't log health check endpoint

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -2539,8 +2539,6 @@ fn main() {
         ));
 
         let router = Router::new()
-        // Index
-        .route("/", get(index))
         // Projects
         .route("/projects", post(projects_create))
         .route("/projects/:project_id", delete(projects_delete))
@@ -2687,11 +2685,12 @@ fn main() {
         .with_state(state.clone());
 
         // In a separate router, to avoid noisy tracing.
-        let sqlite_heartbeat_router = Router::new()
+        let untraced_router = Router::new()
+            .route("/", get(index))
             .route("/sqlite_workers", post(sqlite_workers_heartbeat))
             .with_state(state.clone());
 
-        let app = Router::new().merge(router).merge(sqlite_heartbeat_router);
+        let app = Router::new().merge(router).merge(untraced_router);
 
         // Start the APIState run loop.
         let runloop_state = state.clone();

--- a/core/bin/oauth.rs
+++ b/core/bin/oauth.rs
@@ -217,9 +217,7 @@ fn main() {
 
         let state = Arc::new(OAuthState::new(store));
 
-        let app = Router::new()
-            // Index
-            .route("/", get(index))
+        let router = Router::new()
             // Connections
             .route("/connections", post(connections_create))
             .route(
@@ -237,6 +235,10 @@ fn main() {
                     .on_response(trace::DefaultOnResponse::new().level(Level::INFO)),
             )
             .with_state(state.clone());
+
+        let health_check_router = Router::new().route("/", get(index));
+
+        let app = Router::new().merge(router).merge(health_check_router);
 
         let (tx1, rx1) = tokio::sync::oneshot::channel::<()>();
         let (tx2, rx2) = tokio::sync::oneshot::channel::<()>();


### PR DESCRIPTION
## Description

The `/` is called automatically by kube to check the pod's liveness. It is not useful to log this.

## Risk

N/A

## Deploy Plan

Deploy `core` and `oauth`