### PR TITLE
fix(oauth): network policy should specify target port

### DIFF
--- a/k8s/network-policies/oauth-network-policy.yaml
+++ b/k8s/network-policies/oauth-network-policy.yaml
@@ -15,4 +15,4 @@ spec:
               app: core
       ports:
         - protocol: TCP
-          port: 80
+          port: 3006


### PR DESCRIPTION
## Description

The network policy needs to specify the target port of the pods and not the mapped port.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
