### PR TITLE
enh: add network policy for core and fix it for oauth

### DIFF
--- a/k8s/apply_infra.sh
+++ b/k8s/apply_infra.sh
@@ -129,4 +129,5 @@ echo "-----------------------------------"
 echo "Applying network policies"
 echo "-----------------------------------"
 
+kubectl apply -f "$(dirname "$0")/network-policies/core-network-policy.yaml"
 kubectl apply -f "$(dirname "$0")/network-policies/oauth-network-policy.yaml"

--- a/k8s/network-policies/core-network-policy.yaml
+++ b/k8s/network-policies/core-network-policy.yaml
@@ -1,11 +1,11 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: oauth-network-policy
+  name: core-network-policy
 spec:
   podSelector:
     matchLabels:
-      app: oauth
+      app: core
   policyTypes:
     - Ingress
   ingress:
@@ -15,7 +15,7 @@ spec:
               app: front
         - podSelector:
             matchLabels:
-              app: connectors
+              app: front-worker
       ports:
         - protocol: TCP
-          port: 3006
+          port: 3001


### PR DESCRIPTION
## Description

- `oauth` policy is wrong (`front` and `connectors` should be allowed, but not `core`)
- add network policy for `core` (should only be reachable from `front` or `front-worker`)

Should we have `prodbox` as well ? 🤔 

## Risk

Should be fine, but if something is wrong we can't reach `core` anymore

## Deploy Plan

apply infra