### PR TITLE
enh: add network policy on sqlite worker

### DIFF
--- a/k8s/apply_infra.sh
+++ b/k8s/apply_infra.sh
@@ -156,3 +156,4 @@ echo "-----------------------------------"
 
 kubectl apply -f "$(dirname "$0")/network-policies/core-network-policy.yaml"
 kubectl apply -f "$(dirname "$0")/network-policies/oauth-network-policy.yaml"
+kubectl apply -f "$(dirname "$0")/network-policies/core-sqlite-worker-network-policy.yaml"

--- a/k8s/network-policies/core-network-policy.yaml
+++ b/k8s/network-policies/core-network-policy.yaml
@@ -19,6 +19,9 @@ spec:
         - podSelector:
             matchLabels:
               app: front-edge
+        - podSelector:
+            matchLabels:
+              app: core-sqlite-worker
       ports:
         - protocol: TCP
           port: 3001

--- a/k8s/network-policies/core-sqlite-worker-network-policy.yaml
+++ b/k8s/network-policies/core-sqlite-worker-network-policy.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: oauth-network-policy
+spec:
+  podSelector:
+    matchLabels:
+      app: core-sqlite-worker
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: core
+      ports:
+        - protocol: TCP
+          port: 3005


### PR DESCRIPTION
## Description

- only `core` should talk to `sqlite-worker`
- `sqlite-worker` should be allowed to talk to `core`

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
