### PR TITLE
Fix nango catch error on getConnectionFromNango

### DIFF
--- a/connectors/src/lib/nango_helpers.ts
+++ b/connectors/src/lib/nango_helpers.ts
@@ -119,6 +119,6 @@ export async function getConnectionFromNango({
       "Error while getting connection from Nango"
     );
 
-    throw new Error("Error while getting connection from Nango");
+    throw error;
   }
 }


### PR DESCRIPTION
## Description

On https://github.com/dust-tt/dust/pull/5943/files we wrapped the call to _getConnectionFromNango on a try catch to throw a custom error. This swallows some logic from nango_client getConnection where we were throwing specific errors such as `ExternalOauthTokenError` that is handled to set the connector as errored.  

## Risk

/ 

## Deploy Plan

Deploy connectors.
