### PR TITLE
`oauth`: Confluence provider

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -85,7 +85,9 @@ pub mod oauth {
     pub mod connection;
     pub mod store;
     pub mod providers {
+        pub mod confluence;
         pub mod github;
         pub mod notion;
+        pub mod utils;
     }
 }

--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -18,6 +18,8 @@ use std::str::FromStr;
 use std::time::Duration;
 use std::{env, fmt};
 
+use super::providers::confluence::ConfluenceConnectionProvider;
+
 // We hold the lock for at most 15s. In case of panic preventing the lock from being released, this
 // is the maximum time the lock will be held.
 static REDIS_LOCK_TTL_SECONDS: u64 = 15;
@@ -99,7 +101,7 @@ pub trait Provider {
 
 pub fn provider(t: ConnectionProvider) -> Box<dyn Provider + Sync + Send> {
     match t {
-        ConnectionProvider::Confluence => unimplemented!(),
+        ConnectionProvider::Confluence => Box::new(ConfluenceConnectionProvider::new()),
         ConnectionProvider::Github => Box::new(GithubConnectionProvider::new()),
         ConnectionProvider::GoogleDrive => unimplemented!(),
         ConnectionProvider::Intercom => unimplemented!(),

--- a/core/src/oauth/providers/confluence.rs
+++ b/core/src/oauth/providers/confluence.rs
@@ -1,0 +1,142 @@
+use crate::{
+    oauth::{
+        connection::{
+            Connection, ConnectionProvider, FinalizeResult, Provider, RefreshResult,
+            PROVIDER_TIMEOUT_SECONDS,
+        },
+        providers::utils::execute_request,
+    },
+    utils,
+};
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use lazy_static::lazy_static;
+use serde_json::json;
+use std::env;
+
+lazy_static! {
+    static ref OAUTH_CONFLUENCE_CLIENT_ID: String = env::var("OAUTH_CONFLUENCE_CLIENT_ID").unwrap();
+    static ref OAUTH_CONFLUENCE_CLIENT_SECRET: String =
+        env::var("OAUTH_CONFLUENCE_CLIENT_SECRET").unwrap();
+}
+
+pub struct ConfluenceConnectionProvider {}
+
+impl ConfluenceConnectionProvider {
+    pub fn new() -> Self {
+        ConfluenceConnectionProvider {}
+    }
+}
+
+#[async_trait]
+impl Provider for ConfluenceConnectionProvider {
+    fn id(&self) -> ConnectionProvider {
+        ConnectionProvider::Confluence
+    }
+
+    async fn finalize(
+        &self,
+        _connection: &Connection,
+        code: &str,
+        redirect_uri: &str,
+    ) -> Result<FinalizeResult> {
+        let body = json!({
+            "grant_type": "authorization_code",
+            "client_id": *OAUTH_CONFLUENCE_CLIENT_ID,
+            "client_secret": *OAUTH_CONFLUENCE_CLIENT_SECRET,
+            "code": code,
+            "redirect_uri": redirect_uri,
+        });
+
+        let req = reqwest::Client::new()
+            .post("https://auth.atlassian.com/oauth/token")
+            .header("Content-Type", "application/json")
+            .json(&body);
+
+        let raw_json = execute_request(ConnectionProvider::Confluence, req).await?;
+
+        let access_token = match raw_json["access_token"].as_str() {
+            Some(token) => token,
+            None => Err(anyhow!(
+                "Missing `access_token` in response from Confluence"
+            ))?,
+        };
+        // expires_in is the number of seconds until the token expires.
+        let expires_in = match raw_json.get("expires_in") {
+            Some(serde_json::Value::Number(n)) => match n.as_u64() {
+                Some(n) => n,
+                None => Err(anyhow!("Invalid `expires_in` in response from Confluence"))?,
+            },
+            _ => Err(anyhow!("Missing `expires_in` in response from Confluence"))?,
+        };
+        let refresh_token = match raw_json["refresh_token"].as_str() {
+            Some(token) => token,
+            None => Err(anyhow!(
+                "Missing `refresh_token` in response from Confluence"
+            ))?,
+        };
+
+        Ok(FinalizeResult {
+            redirect_uri: redirect_uri.to_string(),
+            code: code.to_string(),
+            access_token: access_token.to_string(),
+            access_token_expiry: Some(
+                utils::now() + (expires_in - PROVIDER_TIMEOUT_SECONDS) * 1000,
+            ),
+            refresh_token: Some(refresh_token.to_string()),
+            raw_json,
+        })
+    }
+
+    async fn refresh(&self, connection: &Connection) -> Result<RefreshResult> {
+        let refresh_token = match connection.unseal_refresh_token() {
+            Ok(Some(token)) => token,
+            Ok(None) => Err(anyhow!("Missing `refresh_token` in Confluence connection"))?,
+            Err(e) => Err(e)?,
+        };
+
+        let body = json!({
+            "grant_type": "refresh_token",
+            "client_id": *OAUTH_CONFLUENCE_CLIENT_ID,
+            "client_secret": *OAUTH_CONFLUENCE_CLIENT_SECRET,
+            "refresh_token": refresh_token,
+        });
+
+        let req = reqwest::Client::new()
+            .post("https://auth.atlassian.com/oauth/token")
+            .header("Content-Type", "application/json")
+            .json(&body);
+
+        let raw_json = execute_request(ConnectionProvider::Confluence, req).await?;
+
+        let access_token = match raw_json["access_token"].as_str() {
+            Some(token) => token,
+            None => Err(anyhow!(
+                "Missing `access_token` in response from Confluence"
+            ))?,
+        };
+        // expires_in is the number of seconds until the token expires.
+        let expires_in = match raw_json.get("expires_in") {
+            Some(serde_json::Value::Number(n)) => match n.as_u64() {
+                Some(n) => n,
+                None => Err(anyhow!("Invalid `expires_in` in response from Confluence"))?,
+            },
+            _ => Err(anyhow!("Missing `expires_in` in response from Confluence"))?,
+        };
+        let refresh_token = match raw_json["refresh_token"].as_str() {
+            Some(token) => token,
+            None => Err(anyhow!(
+                "Missing `refresh_token` in response from Confluence"
+            ))?,
+        };
+
+        Ok(RefreshResult {
+            access_token: access_token.to_string(),
+            access_token_expiry: Some(
+                utils::now() + (expires_in - PROVIDER_TIMEOUT_SECONDS) * 1000,
+            ),
+            refresh_token: Some(refresh_token.to_string()),
+            raw_json,
+        })
+    }
+}

--- a/core/src/oauth/providers/confluence.rs
+++ b/core/src/oauth/providers/confluence.rs
@@ -28,6 +28,7 @@ impl ConfluenceConnectionProvider {
     }
 }
 
+/// Confluence documentation: https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/
 #[async_trait]
 impl Provider for ConfluenceConnectionProvider {
     fn id(&self) -> ConnectionProvider {
@@ -88,6 +89,9 @@ impl Provider for ConfluenceConnectionProvider {
         })
     }
 
+    /// Note: Confluence hard expires refresh_tokens after 360 days.
+    ///       Confluence expires access_tokens after 1 hour.
+    ///       Confluence expires refresh_tokens after 30 days of inactivity.
     async fn refresh(&self, connection: &Connection) -> Result<RefreshResult> {
         let refresh_token = match connection.unseal_refresh_token() {
             Ok(Some(token)) => token,

--- a/core/src/oauth/providers/utils.rs
+++ b/core/src/oauth/providers/utils.rs
@@ -1,0 +1,50 @@
+use crate::{
+    oauth::connection::{ConnectionProvider, PROVIDER_TIMEOUT_SECONDS},
+    utils,
+};
+use anyhow::{anyhow, Result};
+use hyper::body::Buf;
+use reqwest::RequestBuilder;
+use std::io::prelude::*;
+use std::time::Duration;
+use tokio::time::timeout;
+
+pub async fn execute_request(
+    provider: ConnectionProvider,
+    req: RequestBuilder,
+) -> Result<serde_json::Value> {
+    let now = utils::now_secs();
+
+    let res = match timeout(Duration::new(PROVIDER_TIMEOUT_SECONDS, 0), req.send()).await {
+        Ok(Ok(res)) => res,
+        Ok(Err(e)) => Err(e)?,
+        Err(_) => Err(anyhow!("Timeout sending request: provider={}", provider))?,
+    };
+
+    if !res.status().is_success() {
+        Err(anyhow!(
+            "Error generating access token: provider={} status={}",
+            provider,
+            res.status().as_u16(),
+        ))?;
+    }
+
+    let body = match timeout(
+        Duration::new(PROVIDER_TIMEOUT_SECONDS - (utils::now_secs() - now), 0),
+        res.bytes(),
+    )
+    .await
+    {
+        Ok(Ok(body)) => body,
+        Ok(Err(e)) => Err(e)?,
+        Err(_) => Err(anyhow!("Timeout reading response from Confluence"))?,
+    };
+
+    let mut b: Vec<u8> = vec![];
+    body.reader().read_to_end(&mut b)?;
+    let c: &[u8] = &b;
+
+    let raw_json: serde_json::Value = serde_json::from_slice(c)?;
+
+    Ok(raw_json)
+}

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -83,6 +83,9 @@ const config = {
   getOAuthNotionClientId: (): string => {
     return EnvironmentConfig.getEnvVariable("OAUTH_NOTION_CLIENT_ID");
   },
+  getOAuthConfluenceClientId: (): string => {
+    return EnvironmentConfig.getEnvVariable("OAUTH_CONFLUENCE_CLIENT_ID");
+  },
 };
 
 export default config;

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -105,11 +105,40 @@ const PROVIDER_STRATEGIES: Record<
     connectionIdFromQuery: () => null,
   },
   confluence: {
-    setupUri: () => {
-      throw new Error("Slack OAuth is not implemented");
+    setupUri: (connection) => {
+      const scopes = [
+        "read:confluence-space.summary",
+        "read:confluence-content.all",
+        "read:confluence-user",
+        "search:confluence",
+        "read:space:confluence",
+        "read:page:confluence",
+        "read:confluence-props",
+        "read:confluence-content.summary",
+        "report:personal-data",
+        "read:me",
+        "read:label:confluence",
+        "offline_access",
+      ];
+      return (
+        `https://auth.atlassian.com/authorize?audience=api.atlassian.com` +
+        `&client_id=${config.getOAuthConfluenceClientId()}` +
+        `&scope=${encodeURIComponent(scopes.join(" "))}` +
+        `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("confluence"))}` +
+        `&state=${connection.connection_id}` +
+        `&response_type=code&prompt=consent`
+      );
     },
-    codeFromQuery: () => null,
-    connectionIdFromQuery: () => null,
+    // {
+    //   code: 'ey...',
+    //   state: 'con_...-...',
+    // }
+    codeFromQuery: (query) => {
+      return getStringFromQuery(query, "code");
+    },
+    connectionIdFromQuery: (query) => {
+      return getStringFromQuery(query, "state");
+    },
   },
   intercom: {
     setupUri: () => {

--- a/front/pages/w/[wId]/oauth/[provider]/setup.tsx
+++ b/front/pages/w/[wId]/oauth/[provider]/setup.tsx
@@ -14,11 +14,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<object>(
       };
     }
 
-    console.log(
-      ">>>>>>>>>>>>>>>>>>>>>>>>>>>>> HEADERS <<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
-    );
-    console.log(context.req.headers);
-
     const provider = context.query.provider as string;
     if (!isOAuthProvider(provider)) {
       return {

--- a/front/pages/w/[wId]/oauth/[provider]/setup.tsx
+++ b/front/pages/w/[wId]/oauth/[provider]/setup.tsx
@@ -14,6 +14,11 @@ export const getServerSideProps = withDefaultUserAuthRequirements<object>(
       };
     }
 
+    console.log(
+      ">>>>>>>>>>>>>>>>>>>>>>>>>>>>> HEADERS <<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
+    );
+    console.log(context.req.headers);
+
     const provider = context.query.provider as string;
     if (!isOAuthProvider(provider)) {
       return {


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/dust/issues/6125

- Implements the Confluence provider (`oauth` and `front` setup).
- Dries the logic for executing prepared request in providers to comply with the `PROVIDER_TIMEOUT_SECONDS`.

Tests:
- Setup at: http://localhost:3000/w/UriWRtz9C3/oauth/confluence/setup?useCase=connection
- Accessing access_token with:
```
spolu@spolu-box ~ $ curl -XPOST http://localhost:3006/connections/con_2hYM5S9sVj-bd1c4d5d43c8a915dc51b64942d394bc9dfe95cac3aaa5bbe8639b003f26298e/access_token -H "Content-Type: application/json" -d '{ "provider": "confluence" }'
{"error":null,"response":{"connection":{"connection_id":"con_2hYM5S9sVj-bd1c4d5d43c8a915dc51b64942d394bc9dfe95cac3aaa5bbe8639b003f26298e","created":1721147666416,"provider":"confluence","status":"finalized","metadata":{"user_id":"YYflFW48Rk","use_case":"connection","workspace_id":"UriWRtz9C3"}},"access_token":"...","access_token_expiry":1721151301490}}
```
- Will test refresh in 1h

## Risk

N/A

## Deploy Plan

N/A