### PR TITLE
Support PPTX in text extraction

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/file.ts
+++ b/connectors/src/connectors/google_drive/temporal/file.ts
@@ -244,7 +244,7 @@ export async function syncOneFile(
           if (!(res.data instanceof ArrayBuffer)) {
             localLogger.error(
               { mimeType: file.mimeType },
-              "file download failed."
+              "File download failed."
             );
 
             return false;
@@ -262,7 +262,7 @@ export async function syncOneFile(
               "Error while converting file to text"
             );
 
-            // we don't know what to do with files that fails to be converted to text.
+            // We don't know what to do with files that fails to be converted to text.
             // So we log the error and skip the file.
             return false;
           }

--- a/connectors/src/connectors/google_drive/temporal/file.ts
+++ b/connectors/src/connectors/google_drive/temporal/file.ts
@@ -32,15 +32,14 @@ import {
   GoogleDriveConfig,
   GoogleDriveFiles,
 } from "@connectors/lib/models/google_drive";
-import { PPTX2Text } from "@connectors/lib/pptx2text";
 import logger from "@connectors/logger/logger";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 import type { GoogleDriveObjectType } from "@connectors/types/google_drive";
 
 const pagePrefixesPerMimeType: Record<string, string> = {
-  "application/pdf": "$pdfPage:",
+  "application/pdf": "$pdfPage",
   "application/vnd.openxmlformats-officedocument.presentationml.presentation":
-    "$slideNumber:",
+    "$slideNumber",
 };
 
 export async function syncOneFile(

--- a/connectors/src/connectors/google_drive/temporal/file.ts
+++ b/connectors/src/connectors/google_drive/temporal/file.ts
@@ -318,33 +318,6 @@ export async function syncOneFile(
               return false;
             }
           }
-        } else if (
-          file.mimeType ===
-          "application/vnd.openxmlformats-officedocument.presentationml.presentation"
-        ) {
-          if (res.data instanceof ArrayBuffer) {
-            try {
-              const converted = await PPTX2Text(Buffer.from(res.data), file.id);
-
-              documentContent = {
-                prefix: null,
-                content: null,
-                sections: converted.pages.map((page, i) => ({
-                  prefix: `\n$Page: ${i + 1}/${converted.pages.length}\n`,
-                  content: page.content,
-                  sections: [],
-                })),
-              };
-            } catch (err) {
-              localLogger.warn(
-                {
-                  error: err,
-                },
-                "Error while converting pptx document to text"
-              );
-              return false;
-            }
-          }
         } else if (file.mimeType === "text/csv") {
           if (res.data instanceof ArrayBuffer) {
             // If data is > 4 times the limit, we skip the file since even if

--- a/connectors/src/connectors/google_drive/temporal/mime_types.ts
+++ b/connectors/src/connectors/google_drive/temporal/mime_types.ts
@@ -16,7 +16,7 @@ export function getMimeTypesToDownload({
     // docx files hosted on Gdrive
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     // Temporarily excluding pptx files for debugging purpose.
-    // "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
   ];
   if (pdfEnabled) {
     mimeTypes.push("application/pdf");

--- a/types/src/shared/text_extraction.ts
+++ b/types/src/shared/text_extraction.ts
@@ -120,21 +120,6 @@ export class TextExtraction {
       .get();
   }
 
-  // Process Presentation response.
-  private processPresentationResponse(response: TikaResponse): PageContent[] {
-    const html = response["X-TIKA:content"];
-
-    const $ = cheerio.load(html);
-    const slideContentDivs = $(".slide-content");
-
-    return slideContentDivs
-      .map((index, div) => ({
-        pageNumber: index + 1,
-        content: $(div).text()?.trim() || "",
-      }))
-      .get();
-  }
-
   // Process default response.
   private processDefaultResponse(response: TikaResponse): PageContent[] {
     const content = response["X-TIKA:content"];


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We initially disabled PPTX support in https://github.com/dust-tt/dust/pull/6231 due to the node event loop being overloaded. This PR reintroduces support for PPTX files in our text extraction process using Tika.

Tested locally:
```
>> documentContent {
  "prefix": null,
  "content": null,
  "sections": [
    {
      "prefix": "\n$slideNumber: 1/4\n",
      "content": "Page 1 title  \nPage 1 content",
      "sections": []
    },
    {
      "prefix": "\n$slideNumber: 2/4\n",
      "content": "Page 2 title\nPage 2 content test\nPage 2 super test\nPage 2 test test",
      "sections": []
    },
    {
      "prefix": "\n$slideNumber: 3/4\n",
      "content": "Page 3 content",
      "sections": []
    },
    {
      "prefix": "\n$slideNumber: 4/4\n",
      "content": "Page 4\n\nYoyo page 4",
      "sections": []
    }
  ]
}
```

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

We will need to refactor the Microsoft implementation to use the text extraction as well.