### PR TITLE
Disable text/csv support in GDrive

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/mime_types.ts
+++ b/connectors/src/connectors/google_drive/temporal/mime_types.ts
@@ -12,7 +12,7 @@ export function getMimeTypesToDownload({
 }) {
   const mimeTypes = [
     "text/plain",
-    "text/csv",
+    // "text/csv",
     // docx files hosted on Gdrive
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     // Temporarily excluding pptx files for debugging purpose.


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
In https://github.com/dust-tt/dust/pull/6153 we introduced support for `text/csv` files in Google Drive. Since then we have been observing `FATAL ERROR: Reached heap limit Allocation failed`. 

This PR disables it temporarily to see if this is the root cause.

<img width="848" alt="image" src="https://github.com/user-attachments/assets/815068eb-fa6a-41ae-92cd-54a0ed24dbcd">

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
