### PR TITLE
Stopping a Github connector stops the workflows

### DIFF
--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -129,6 +129,8 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         webhooksEnabledAt: null,
       });
 
+      await terminateAllWorkflowsForConnectorId(this.connectorId);
+
       return new Ok(undefined);
     } catch (err) {
       return new Err(err as Error);


### PR DESCRIPTION
## Description

Stopping a Github connector should also stop the workflows. 

## Risk

/ 

## Deploy Plan

Deploy connectors