### PR TITLE
Fix extract tags removal

### DIFF
--- a/front/components/assistant_builder/actions/ProcessAction.tsx
+++ b/front/components/assistant_builder/actions/ProcessAction.tsx
@@ -507,9 +507,12 @@ export function ActionProcess({
 
                         return {
                           ...previousAction,
-                          tagsFilter: {
-                            in: tags,
-                          },
+                          tagsFilter:
+                            tags.length > 0
+                              ? {
+                                  in: tags,
+                                }
+                              : null,
                         };
                       });
                     }}

--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -261,7 +261,11 @@ export class ProcessConfigurationServerRunner extends BaseActionConfigurationSer
       })
     );
 
-    if (actionConfiguration.tagsFilter && actionConfiguration.tagsFilter.in) {
+    if (
+      actionConfiguration.tagsFilter &&
+      actionConfiguration.tagsFilter.in &&
+      actionConfiguration.tagsFilter.in.length > 0
+    ) {
       // Note: empty array in tags/parents.in means "no document match" since no documents has any
       // tags/parents that is in the empty array.
       if (!config.DATASOURCE.filter.tags) {

--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -266,8 +266,8 @@ export class ProcessConfigurationServerRunner extends BaseActionConfigurationSer
       actionConfiguration.tagsFilter.in &&
       actionConfiguration.tagsFilter.in.length > 0
     ) {
-      // Note: empty array in tags/parents.in means "no document match" since no documents has any
-      // tags/parents that is in the empty array.
+      // Note: we explicitely ignore if `tagsFilter.in` is empty as there is no use-case for no
+      // retrieval at all.
       if (!config.DATASOURCE.filter.tags) {
         config.DATASOURCE.filter.tags = {};
       }


### PR DESCRIPTION
## Description

Adding a tag in extract and removing it would lead to the configuration to storing [] as tags_filter instead of removing it entirely preventing any retrieval.

This PR fixes the behavior of assistant builder and also prevents taking tags_in into account if [].

## Risk

N/A

## Deploy Plan

- deploy `front`