### PR TITLE
Builder: Action empty description error message only if user has submitted

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -388,6 +388,9 @@ function NewActionModal({
   const [newAction, setNewAction] =
     useState<AssistantBuilderActionConfiguration | null>(null);
 
+  const [showEmptyDescriptionError, setShowEmptyDescriptionError] =
+    useState(false);
+
   useEffect(() => {
     if (initialAction && !newAction) {
       setNewAction(initialAction);
@@ -406,6 +409,7 @@ function NewActionModal({
     onClose();
     setTimeout(() => {
       setNewAction(null);
+      setShowEmptyDescriptionError(false);
     }, 500);
   };
 
@@ -424,7 +428,9 @@ function NewActionModal({
               onSave(newAction);
               onCloseLocal();
             }
-          : undefined
+          : () => {
+              setShowEmptyDescriptionError(!descriptionValid);
+            }
       }
     >
       <div className="w-full pt-8">
@@ -452,7 +458,7 @@ function NewActionModal({
               dustApps={dustApps}
               builderState={builderState}
               titleValid={titleValid}
-              descriptionValid={descriptionValid}
+              showEmptyDescriptionError={showEmptyDescriptionError}
             />
           )}
         </div>
@@ -531,7 +537,7 @@ function ActionConfigEditor({
   setEdited,
   description,
   onDescriptionChange,
-  isDescriptionValid,
+  showEmptyDescriptionError,
 }: {
   owner: WorkspaceType;
   action: AssistantBuilderActionConfiguration;
@@ -548,7 +554,7 @@ function ActionConfigEditor({
   setEdited: (edited: boolean) => void;
   description: string;
   onDescriptionChange: (v: string) => void;
-  isDescriptionValid: boolean;
+  showEmptyDescriptionError: boolean;
 }) {
   switch (action.type) {
     case "DUST_APP_RUN":
@@ -613,7 +619,7 @@ function ActionConfigEditor({
           setEdited={setEdited}
           description={description}
           onDescriptionChange={onDescriptionChange}
-          isDescriptionValid={isDescriptionValid}
+          showEmptyDescriptionError={showEmptyDescriptionError}
         />
       );
     case "TABLES_QUERY":
@@ -645,7 +651,7 @@ function ActionConfigEditor({
 function ActionEditor({
   action,
   titleValid,
-  descriptionValid,
+  showEmptyDescriptionError,
   updateAction,
   owner,
   setEdited,
@@ -655,7 +661,7 @@ function ActionEditor({
 }: {
   action: AssistantBuilderActionConfiguration;
   titleValid: boolean;
-  descriptionValid: boolean;
+  showEmptyDescriptionError: boolean;
   updateAction: (args: {
     actionName: string;
     actionDescription: string;
@@ -751,7 +757,7 @@ function ActionEditor({
                 getNewActionConfig: (old) => old,
               });
             }}
-            isDescriptionValid={descriptionValid}
+            showEmptyDescriptionError={showEmptyDescriptionError}
           />
         </>
       </ActionModeSection>
@@ -787,7 +793,9 @@ function ActionEditor({
                 });
               }
             }}
-            error={!descriptionValid ? "Description cannot be empty." : null}
+            error={
+              showEmptyDescriptionError ? "Description cannot be empty." : null
+            }
             showErrorLabel={true}
           />
         </div>

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -28,7 +28,7 @@ import { useSWRConfig } from "swr";
 
 import { SharingButton } from "@app/components/assistant/Sharing";
 import ActionsScreen, {
-  isActionValid,
+  hasActionError,
 } from "@app/components/assistant_builder/ActionsScreen";
 import AssistantBuilderRightPanel from "@app/components/assistant_builder/AssistantBuilderPreviewDrawer";
 import { BuilderLayout } from "@app/components/assistant_builder/BuilderLayout";
@@ -260,7 +260,7 @@ export default function AssistantBuilder({
       setInstructionsError(null);
     }
 
-    if (!builderState.actions.every((a) => isActionValid(a))) {
+    if (!builderState.actions.every((a) => hasActionError(a) === null)) {
       valid = false;
     }
 

--- a/front/components/assistant_builder/actions/DustAppRunAction.tsx
+++ b/front/components/assistant_builder/actions/DustAppRunAction.tsx
@@ -16,8 +16,10 @@ import {
 
 export function isActionDustAppRunValid(
   action: AssistantBuilderActionConfiguration
-) {
-  return action.type === "DUST_APP_RUN" && !!action.configuration.app;
+): string | null {
+  return action.type === "DUST_APP_RUN" && !!action.configuration.app
+    ? null
+    : "Please select a Dust App.";
 }
 
 export function ActionDustAppRun({

--- a/front/components/assistant_builder/actions/ProcessAction.tsx
+++ b/front/components/assistant_builder/actions/ProcessAction.tsx
@@ -265,7 +265,7 @@ export function ActionProcess({
   dataSources,
   description,
   onDescriptionChange,
-  isDescriptionValid,
+  showEmptyDescriptionError,
 }: {
   owner: WorkspaceType;
   instructions: string | null;
@@ -281,12 +281,12 @@ export function ActionProcess({
   | {
       description: string;
       onDescriptionChange: (description: string) => void;
-      isDescriptionValid: boolean;
+      showEmptyDescriptionError: boolean;
     }
   | {
       description?: undefined;
       onDescriptionChange?: undefined;
-      isDescriptionValid?: undefined;
+      showEmptyDescriptionError?: undefined;
     }
 )) {
   const [showDataSourcesModal, setShowDataSourcesModal] = useState(false);
@@ -541,7 +541,9 @@ export function ActionProcess({
             placeholder={"Extract the list of…"}
             value={description}
             onChange={onDescriptionChange}
-            error={!isDescriptionValid ? "Description cannot be empty" : null}
+            error={
+              showEmptyDescriptionError ? "Description cannot be empty." : null
+            }
           />
         </div>
       )}

--- a/front/components/assistant_builder/actions/ProcessAction.tsx
+++ b/front/components/assistant_builder/actions/ProcessAction.tsx
@@ -32,48 +32,50 @@ import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { classNames } from "@app/lib/utils";
 
-export function isActionProcessValid(
+export function hasErrorActionProcess(
   action: AssistantBuilderActionConfiguration
-) {
+): string | null {
+  const errorMessage =
+    "You must select at least one data source and generate a schema will all fields set.";
   if (action.type !== "PROCESS") {
-    return false;
+    return "Invalid action type.";
   }
   if (action.configuration.schema.length === 0) {
-    return false;
+    return errorMessage;
   }
   for (const prop of action.configuration.schema) {
     if (!prop.name) {
-      return false;
+      return errorMessage;
     }
     if (!prop.description) {
-      return false;
+      return errorMessage;
     }
     if (
       action.configuration.schema.filter((p) => p.name === prop.name).length > 1
     ) {
-      return false;
+      return errorMessage;
     }
   }
   if (Object.keys(action.configuration.dataSourceConfigurations).length === 0) {
-    return false;
+    return errorMessage;
   }
   if (!action.configuration.timeFrame.value) {
-    return false;
+    return errorMessage;
   }
   if (
     action.configuration.tagsFilter &&
     action.configuration.tagsFilter.in.some((tag) => tag === "")
   ) {
-    return false;
+    return errorMessage;
   }
   if (
     action.configuration.tagsFilter &&
     action.configuration.tagsFilter.in.length !==
       new Set(action.configuration.tagsFilter.in).size
   ) {
-    return false;
+    return errorMessage;
   }
-  return true;
+  return null;
 }
 
 function PropertiesFields({
@@ -265,7 +267,6 @@ export function ActionProcess({
   dataSources,
   description,
   onDescriptionChange,
-  showEmptyDescriptionError,
 }: {
   owner: WorkspaceType;
   instructions: string | null;
@@ -281,12 +282,10 @@ export function ActionProcess({
   | {
       description: string;
       onDescriptionChange: (description: string) => void;
-      showEmptyDescriptionError: boolean;
     }
   | {
       description?: undefined;
       onDescriptionChange?: undefined;
-      showEmptyDescriptionError?: undefined;
     }
 )) {
   const [showDataSourcesModal, setShowDataSourcesModal] = useState(false);
@@ -541,9 +540,6 @@ export function ActionProcess({
             placeholder={"Extract the list of…"}
             value={description}
             onChange={onDescriptionChange}
-            error={
-              showEmptyDescriptionError ? "Description cannot be empty." : null
-            }
           />
         </div>
       )}

--- a/front/components/assistant_builder/actions/RetrievalAction.tsx
+++ b/front/components/assistant_builder/actions/RetrievalAction.tsx
@@ -40,15 +40,15 @@ const deleteDataSource = ({
   });
 };
 
-export function isActionRetrievalSearchValid(
+export function hasErrorActionRetrievalSearch(
   action: AssistantBuilderActionConfiguration
-) {
-  return (
-    Object.keys(
-      action.type === "RETRIEVAL_SEARCH" &&
-        action.configuration.dataSourceConfigurations
-    ).length > 0
-  );
+): string | null {
+  return Object.keys(
+    action.type === "RETRIEVAL_SEARCH" &&
+      action.configuration.dataSourceConfigurations
+  ).length > 0
+    ? null
+    : "Please select at least one data source.";
 }
 
 export function ActionRetrievalSearch({
@@ -114,14 +114,14 @@ export function ActionRetrievalSearch({
   );
 }
 
-export function isActionRetrievalExhaustiveValid(
+export function hasErrorActionRetrievalExhaustive(
   action: AssistantBuilderActionConfiguration
-) {
-  return (
-    action.type === "RETRIEVAL_EXHAUSTIVE" &&
+): string | null {
+  return action.type === "RETRIEVAL_EXHAUSTIVE" &&
     Object.keys(action.configuration.dataSourceConfigurations).length > 0 &&
     !!action.configuration.timeFrame.value
-  );
+    ? null
+    : "Please select at least one data source and set a timeframe";
 }
 
 export function ActionRetrievalExhaustive({

--- a/front/components/assistant_builder/actions/TablesQueryAction.tsx
+++ b/front/components/assistant_builder/actions/TablesQueryAction.tsx
@@ -10,13 +10,13 @@ import type {
 } from "@app/components/assistant_builder/types";
 import { tableKey } from "@app/lib/client/tables_query";
 
-export function isActionTablesQueryValid(
+export function hasErrorActionTablesQuery(
   action: AssistantBuilderActionConfiguration
-) {
-  return (
-    action.type === "TABLES_QUERY" &&
+): string | null {
+  return action.type === "TABLES_QUERY" &&
     Object.keys(action.configuration).length > 0
-  );
+    ? null
+    : "Please select one table.";
 }
 
 export function ActionTablesQuery({

--- a/front/components/assistant_builder/actions/VisualizationAction.tsx
+++ b/front/components/assistant_builder/actions/VisualizationAction.tsx
@@ -1,12 +1,12 @@
 import type { AssistantBuilderActionConfiguration } from "@app/components/assistant_builder/types";
 
-export function isActionVisualizationValid(
+export function hasErrorActionVisualization(
   action: AssistantBuilderActionConfiguration
-) {
-  return (
-    action.type === "VISUALIZATION" &&
+): string | null {
+  return action.type === "VISUALIZATION" &&
     Object.keys(action.configuration).length === 0
-  );
+    ? null
+    : "Invalid configuration.";
 }
 
 export function ActionVisualization() {

--- a/front/components/assistant_builder/actions/WebNavigationAction.tsx
+++ b/front/components/assistant_builder/actions/WebNavigationAction.tsx
@@ -1,12 +1,12 @@
 import type { AssistantBuilderActionConfiguration } from "@app/components/assistant_builder/types";
 
-export function isActionWebsearchValid(
+export function hasErrorActionWebNavigation(
   action: AssistantBuilderActionConfiguration
-) {
-  return (
-    action.type === "WEB_NAVIGATION" &&
+): string | null {
+  return action.type === "WEB_NAVIGATION" &&
     Object.keys(action.configuration).length === 0
-  );
+    ? null
+    : "Invalid configuration.";
 }
 
 export function ActionWebNavigation() {


### PR DESCRIPTION
## Description

Currently when we open an action the error message "Description cannot be empty." is immediately displayed.
Task: https://github.com/dust-tt/tasks/issues/1070

This PR edits the AssistantBuilder so that we display this error only if the users tries to submit. Meaning we enable the save button but display an error if action is not valid. 

Deployed to front-edge if you want to check the behavior 🙏🏻 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 