### PR TITLE
`oauth`: Improved more granular error handling

### DIFF
--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use std::time::Duration;
 use std::{env, fmt};
+use tracing::error;
 
 use super::providers::confluence::ConfluenceConnectionProvider;
 
@@ -24,7 +25,13 @@ use super::providers::confluence::ConfluenceConnectionProvider;
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ConnectionErrorCode {
-    ConnectionAlreadyFinalized,
+    // Finalize
+    ConnectionAlreadyFinalizedError,
+    ProviderFinalizationError,
+    // Refresh Access Token
+    ConnectionNotFinalizedError,
+    ProviderAccessTokenRefreshError,
+    // Internal Errors
     InternalError,
 }
 
@@ -124,8 +131,8 @@ pub trait Provider {
         connection: &Connection,
         code: &str,
         redirect_uri: &str,
-    ) -> Result<FinalizeResult, ConnectionError>;
-    async fn refresh(&self, connection: &Connection) -> Result<RefreshResult, ConnectionError>;
+    ) -> Result<FinalizeResult>;
+    async fn refresh(&self, connection: &Connection) -> Result<RefreshResult>;
 }
 
 pub fn provider(t: ConnectionProvider) -> Box<dyn Provider + Sync + Send> {
@@ -412,26 +419,33 @@ impl Connection {
             ConnectionStatus::Pending => Ok(false),
             // We allow calling finalized twice with the same code (user messes up or refresh).
             // Otherwise we error.
-            ConnectionStatus::Finalized => match self.unseal_authorization_code().map_err(ConnectionError{
-                code: ConnectionErrorCode::InternalError,
-
-            })? {
-                Some(c) => {
-                    // If it's finalized and the code matches, we return early.
-                    if c == code {
-                        return Ok(true);
+            ConnectionStatus::Finalized => {
+                match self.unseal_authorization_code().map_err(|e| {
+                    error!("Failed to unseal authorization_code: error={:?}", e);
+                    ConnectionError {
+                        code: ConnectionErrorCode::InternalError,
+                        message: "Failed to unseal authorization_code".to_string(),
                     }
-                    Err(ConnectionError {
-                        code: ConnectionErrorCode::ConnectionAlreadyFinalized,
-                        message: "Connection is already finalized with a different code"
+                })? {
+                    Some(c) => {
+                        // If it's finalized and the code matches, we return early.
+                        if c == code {
+                            return Ok(true);
+                        }
+                        Err(ConnectionError {
+                            code: ConnectionErrorCode::ConnectionAlreadyFinalizedError,
+                            message: "Connection is already finalized with a different code"
+                                .to_string(),
+                        })?
+                    }
+                    // If we have a finalized connection without `authorization_code`, we error.
+                    None => Err(ConnectionError {
+                        code: ConnectionErrorCode::InternalError,
+                        message: "Unexpected finalized connection without authorization_code"
                             .to_string(),
-                    })?
+                    })?,
                 }
-                // If we have a finalized connection without `authorization_code`, we error.
-                None => Err(anyhow::anyhow!(
-                    "Unexpected connection without `authorization_code`"
-                ))?,
-            },
+            }
         }
     }
 
@@ -487,17 +501,46 @@ impl Connection {
                 format!("oauth:{}", self.connection_id()).as_bytes(),
                 Duration::from_secs(REDIS_LOCK_TTL_SECONDS),
             )
-            .await?;
+            .await
+            .map_err(|e| {
+                error!(error = ?e, "Failed to acquire lock");
+                ConnectionError {
+                    code: ConnectionErrorCode::InternalError,
+                    message: "Failed to acquire lock".to_string(),
+                }
+            })?;
         let res = self.finalize_locked(store, code, redirect_uri).await;
         rl.unlock(&lock).await;
 
-        res
+        match res {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                error!(
+                    error = ?e,
+                    provider = ?self.provider,
+                    "Failed to finalize connection",
+                );
+                Err(ConnectionError {
+                    code: ConnectionErrorCode::ProviderFinalizationError,
+                    message: "Failed to finalize connection with provider".to_string(),
+                })
+            }
+        }
     }
 
-    fn valid_access_token(&self) -> Result<Option<String>> {
+    fn valid_access_token(&self) -> Result<Option<String>, ConnectionError> {
         let access_token = match &self.encrypted_access_token {
-            Some(t) => Connection::unseal_str(t)?,
-            None => Err(anyhow::anyhow!("Missing access_token in connection"))?,
+            Some(t) => Connection::unseal_str(t).map_err(|e| {
+                error!(error = ?e, "Failed to unseal access_token");
+                ConnectionError {
+                    code: ConnectionErrorCode::InternalError,
+                    message: "Failed to unseal access_token".to_string(),
+                }
+            })?,
+            None => Err(ConnectionError {
+                code: ConnectionErrorCode::InternalError,
+                message: "Missing access_token in connection".to_string(),
+            })?,
         };
 
         match self.access_token_expiry {
@@ -545,7 +588,13 @@ impl Connection {
     pub async fn access_token(
         &mut self,
         store: Box<dyn OAuthStore + Sync + Send>,
-    ) -> Result<String> {
+    ) -> Result<String, ConnectionError> {
+        if self.status != ConnectionStatus::Finalized {
+            return Err(ConnectionError {
+                code: ConnectionErrorCode::ConnectionNotFinalizedError,
+                message: "Connection is not finalized".to_string(),
+            });
+        }
         if let Some(access_token) = self.valid_access_token()? {
             return Ok(access_token);
         }
@@ -557,10 +606,31 @@ impl Connection {
                 format!("oauth:{}", self.connection_id()).as_bytes(),
                 Duration::from_secs(REDIS_LOCK_TTL_SECONDS),
             )
-            .await?;
+            .await
+            .map_err(|e| {
+                error!(error = ?e, "Failed to acquire lock");
+                ConnectionError {
+                    code: ConnectionErrorCode::InternalError,
+                    message: "Failed to acquire lock".to_string(),
+                }
+            })?;
+
         let res = self.access_token_locked(store).await;
         rl.unlock(&lock).await;
 
-        res
+        match res {
+            Ok(t) => Ok(t),
+            Err(e) => {
+                error!(
+                    error = ?e,
+                    provider = ?self.provider,
+                    "Failed to refresh access token",
+                );
+                Err(ConnectionError {
+                    code: ConnectionErrorCode::ProviderFinalizationError,
+                    message: "Failed to refresh access token with provider".to_string(),
+                })
+            }
+        }
     }
 }

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -7,6 +7,7 @@ use serde_json::Value;
 use sqids::Sqids;
 use std::{io::Write, sync::Arc};
 use tower_http::trace::MakeSpan;
+use tracing::error;
 use uuid::Uuid;
 
 #[derive(Debug)]
@@ -129,7 +130,12 @@ pub fn error_response(
     message: &str,
     e: Option<anyhow::Error>,
 ) -> (StatusCode, Json<APIResponse>) {
-    error(&format!("{}: {}\nError: {:?}", code, message, e));
+    error!(
+        code = code,
+        message = message,
+        error = ?e,
+        "API error"
+    );
     (
         status,
         Json(APIResponse {


### PR DESCRIPTION
## Description

Tie the `Connection` interface to always return a `ConnetionError` that we can use to return better errors codes and more precise codes and messages.

It's a bit verbose but much better in terms of error handling. Will be required to properly expose predictable and granular codes to front/connectors so that they can be properly actioned.

Fixes: https://github.com/dust-tt/dust/issues/6261

Also tweaks error_response used in `core` to use tracing::error! with a searchable message "API error".

From a devx perspective we can look for "API Error" and then filter on trace_span_id to get the whole log of the request and investigate logging of internal errors

## Risk

N/A

## Deploy Plan

- deploy `oauth`