### PR TITLE
[connectors] - fix: remove CSV mimeType entries from `google_drive_files`

### DIFF
--- a/connectors/migrations/20240717_gdrive_csv_deletion.ts
+++ b/connectors/migrations/20240717_gdrive_csv_deletion.ts
@@ -11,9 +11,16 @@ export async function main(): Promise<void> {
     });
     console.log(`Retrieved ${csvGoogleFiles.length} files from DB.`);
 
-    await Promise.all(csvGoogleFiles.map((file) => deleteFile(file)));
+    const batchSize = 10;
+    for (let i = 0; i < csvGoogleFiles.length; i += batchSize) {
+      const batch = csvGoogleFiles.slice(i, i + batchSize);
+      await Promise.all(batch.map((file) => deleteFile(file)));
+      console.log(`Deleted batch of ${batch.length} CSV file(s).`);
+    }
 
-    console.log("Successfully deleted all CSV files.");
+    console.log(
+      `Successfully deleted all ${csvGoogleFiles.length} CSV file(s).`
+    );
   } catch (error) {
     console.error("Error deleting CSV files:", error);
   }

--- a/connectors/migrations/20240717_gdrive_csv_deletion.ts
+++ b/connectors/migrations/20240717_gdrive_csv_deletion.ts
@@ -1,0 +1,20 @@
+import { deleteFile } from "@connectors/connectors/google_drive/temporal/activities";
+import { GoogleDriveFiles } from "@connectors/lib/models/google_drive";
+
+// Deleting all existing Google Drive CSV files
+export async function main(): Promise<void> {
+  try {
+    const csvGoogleFiles = await GoogleDriveFiles.findAll({
+      where: {
+        mimeType: "text/csv",
+      },
+    });
+
+    await Promise.all(csvGoogleFiles.map((file) => deleteFile(file)));
+
+    console.log(`Successfully deleted ${csvGoogleFiles.length} CSV file(s).`);
+  } catch (error) {
+    console.error("Error deleting CSV files:", error);
+  }
+}
+main().catch(console.error);

--- a/connectors/migrations/20240717_gdrive_csv_deletion.ts
+++ b/connectors/migrations/20240717_gdrive_csv_deletion.ts
@@ -9,10 +9,11 @@ export async function main(): Promise<void> {
         mimeType: "text/csv",
       },
     });
+    console.log(`Retrieved ${csvGoogleFiles.length} files from DB.`);
 
     await Promise.all(csvGoogleFiles.map((file) => deleteFile(file)));
 
-    console.log(`Successfully deleted ${csvGoogleFiles.length} CSV file(s).`);
+    console.log("Successfully deleted all CSV files.");
   } catch (error) {
     console.error("Error deleting CSV files:", error);
   }

--- a/connectors/migrations/db/migration_05.sql
+++ b/connectors/migrations/db/migration_05.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jul 17, 2024
+DELETE FROM google_drive_files WHERE "mimeType" = 'text/csv';

--- a/connectors/migrations/db/migration_05.sql
+++ b/connectors/migrations/db/migration_05.sql
@@ -1,2 +1,0 @@
--- Migration created on Jul 17, 2024
-DELETE FROM google_drive_files WHERE "mimeType" = 'text/csv';

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -702,7 +702,7 @@ async function deleteOneFile(
   await deleteFile(googleDriveFile);
 }
 
-async function deleteFile(googleDriveFile: GoogleDriveFiles) {
+export async function deleteFile(googleDriveFile: GoogleDriveFiles) {
   const connectorId = googleDriveFile.connectorId;
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {


### PR DESCRIPTION
## Description

This PR deletes entries from the `google_drive_files` table where the `mimeType` is 'text/csv'.

We have seen a bunch of CSV sync failing due to malformed headers. CSV syncing is now disabled and will be re-introduced behind a feature flag. In the meantime we want to wipe out all CSV files to get back to a clean state.

**References:**
- https://dust4ai.slack.com/archives/C05B529FHV1/p1721062416006399

## Risk

We are touching prod DB --> risky

## Deploy Plan

Apply migration