### PR TITLE
Only give back 30 results no matter what in dust apps datasources and data tables

### DIFF
--- a/front/components/data_source/DataSourcePicker.tsx
+++ b/front/components/data_source/DataSourcePicker.tsx
@@ -69,8 +69,8 @@ export default function DataSourcePicker({
       ? dataSources.filter((t) =>
           t.name.toLowerCase().includes(searchFilter.toLowerCase())
         )
-      : dataSources.slice(0, 20);
-    setFilteredDataSources(newDataSources);
+      : dataSources;
+    setFilteredDataSources(newDataSources.slice(0, 30));
   }, [dataSources, searchFilter]);
 
   return (

--- a/front/components/tables/TablePicker.tsx
+++ b/front/components/tables/TablePicker.tsx
@@ -44,8 +44,8 @@ export default function TablePicker({
       ? tables.filter((t) =>
           t.name.toLowerCase().includes(searchFilter.toLowerCase())
         )
-      : tables.slice(0, 20);
-    setFilteredTables(newTables);
+      : tables;
+    setFilteredTables(newTables.slice(0, 30));
   }, [tables, searchFilter]);
 
   return (


### PR DESCRIPTION
## Description

Only give back 30 results no matter what so avoid crashing when search for 1 character 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
