### PR TITLE
oauth: scrubbed raw_json

### DIFF
--- a/connectors/src/lib/api/config.ts
+++ b/connectors/src/lib/api/config.ts
@@ -1,6 +1,11 @@
 import { EnvironmentConfig } from "@dust-tt/types";
 
 export const apiConfig = {
+  getOAuthAPIConfig: (): { url: string } => {
+    return {
+      url: EnvironmentConfig.getEnvVariable("OAUTH_API"),
+    };
+  },
   getDustAPIConfig: (): { url: string; nodeEnv: string } => {
     return {
       // Dust production API URL is hardcoded for now.

--- a/core/bin/oauth.rs
+++ b/core/bin/oauth.rs
@@ -177,7 +177,7 @@ async fn connections_access_token(
                 &e.message,
                 None,
             ),
-            Ok(access_token) => (
+            Ok((access_token, scrubbed_raw_json)) => (
                 StatusCode::OK,
                 Json(APIResponse {
                     error: None,
@@ -191,6 +191,7 @@ async fn connections_access_token(
                         },
                         "access_token": access_token,
                         "access_token_expiry": c.access_token_expiry(),
+                        "scrubbed_raw_json": scrubbed_raw_json,
                     })),
                 }),
             ),

--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -30,9 +30,6 @@ pub static PROVIDER_TIMEOUT_SECONDS: u64 = 10;
 
 lazy_static! {
     static ref REDIS_URI: String = env::var("REDIS_URI").unwrap();
-}
-
-lazy_static! {
     static ref ENCRYPTION_KEY: aead::LessSafeKey = {
         let encoded_key = env::var("OAUTH_ENCRYPTION_KEY").unwrap();
         let key_bytes = general_purpose::STANDARD.decode(&encoded_key).unwrap();

--- a/core/src/oauth/providers/confluence.rs
+++ b/core/src/oauth/providers/confluence.rs
@@ -143,4 +143,16 @@ impl Provider for ConfluenceConnectionProvider {
             raw_json,
         })
     }
+
+    fn scrubbed_raw_json(&self, raw_json: &serde_json::Value) -> Result<serde_json::Value> {
+        let raw_json = match raw_json.clone() {
+            serde_json::Value::Object(mut map) => {
+                map.remove("access_token");
+                map.remove("refresh_token");
+                serde_json::Value::Object(map)
+            }
+            _ => Err(anyhow!("Invalid raw_json, not an object"))?,
+        };
+        Ok(raw_json)
+    }
 }

--- a/core/src/oauth/providers/github.rs
+++ b/core/src/oauth/providers/github.rs
@@ -129,4 +129,15 @@ impl Provider for GithubConnectionProvider {
             raw_json,
         })
     }
+
+    fn scrubbed_raw_json(&self, raw_json: &serde_json::Value) -> Result<serde_json::Value> {
+        let raw_json = match raw_json.clone() {
+            serde_json::Value::Object(mut map) => {
+                map.remove("token");
+                serde_json::Value::Object(map)
+            }
+            _ => Err(anyhow!("Invalid raw_json, not an object"))?,
+        };
+        Ok(raw_json)
+    }
 }

--- a/core/src/oauth/providers/notion.rs
+++ b/core/src/oauth/providers/notion.rs
@@ -74,4 +74,15 @@ impl Provider for NotionConnectionProvider {
     async fn refresh(&self, _connection: &Connection) -> Result<RefreshResult> {
         Err(anyhow!("Notion access tokens do not expire"))?
     }
+
+    fn scrubbed_raw_json(&self, raw_json: &serde_json::Value) -> Result<serde_json::Value> {
+        let raw_json = match raw_json.clone() {
+            serde_json::Value::Object(mut map) => {
+                map.remove("access_token");
+                serde_json::Value::Object(map)
+            }
+            _ => Err(anyhow!("Invalid raw_json, not an object"))?,
+        };
+        Ok(raw_json)
+    }
 }


### PR DESCRIPTION
## Description

Add support for returning a scrubbed raw_json.

We want to remove hard secrets (refresh_json) but also access_tokens to prevent users from leveraging the content of `scrubbed_raw_json` to pull access tokens.

Fixes: https://github.com/dust-tt/dust/issues/6299

## Risk

N/A

## Deploy Plan

- deploy `oauth`