### PR TITLE
oauth: remove expires_in from confluence scrubbed_raw_json

### DIFF
--- a/core/src/oauth/providers/confluence.rs
+++ b/core/src/oauth/providers/confluence.rs
@@ -149,6 +149,8 @@ impl Provider for ConfluenceConnectionProvider {
             serde_json::Value::Object(mut map) => {
                 map.remove("access_token");
                 map.remove("refresh_token");
+                // Misleading for end-user (relative to refresh time).
+                map.remove("expires_in");
                 serde_json::Value::Object(map)
             }
             _ => Err(anyhow!("Invalid raw_json, not an object"))?,


### PR DESCRIPTION
## Description

Remove expires_in since misleading for end users

## Risk

N/A

## Deploy Plan

N/A