### PR TITLE
enh: override oauth/core api keys for front edge/worker

### DIFF
--- a/k8s/deployments/front-edge-deployment.yaml
+++ b/k8s/deployments/front-edge-deployment.yaml
@@ -35,6 +35,9 @@ spec:
                 name: front-edge-config
             - secretRef:
                 name: front-secrets
+            - secretRef:
+                name: front-edge-secrets
+
           env:
             # we override --max-old-space-size for edge as pods
             # don't have the same memory limits as the regular front pods

--- a/k8s/deployments/front-worker-deployment.yaml
+++ b/k8s/deployments/front-worker-deployment.yaml
@@ -27,6 +27,9 @@ spec:
                 name: front-worker-config
             - secretRef:
                 name: front-secrets
+            - secretRef:
+                name: front-worker-secrets
+
           env:
             - name: DD_AGENT_HOST
               valueFrom:


### PR DESCRIPTION
## Description

Override `CORE_API_KEY` (for `front-edge` and `front-worker`) and `OAUTH_API_KEY` (for `front-edge`) in order to have the correct `dust_client_name` (for now they are identifying as `front`)

## Risk

If I messed up `front-edge` and `front-worker` will be ~down

## Deploy Plan

N/A secrets are in prod