### PR TITLE
github: preparation work for dual mode connectionId

### DIFF
--- a/connectors/migrations/20240717_migrate_github_installation_id.sql
+++ b/connectors/migrations/20240717_migrate_github_installation_id.sql
@@ -1,0 +1,6 @@
+UPDATE github_connector_states
+SET "installationId" = (
+    SELECT "connectionId"
+    FROM connectors
+    WHERE connectors.id = github_connector_states."connectorId"
+);

--- a/connectors/migrations/db/migration_05.sql
+++ b/connectors/migrations/db/migration_05.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."github_connector_states" ADD COLUMN "installationId" VARCHAR(255);

--- a/connectors/migrations/db/migration_05.sql
+++ b/connectors/migrations/db/migration_05.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jul 17, 2024
+[18:56:02.509] INFO (2981186): Done;

--- a/connectors/migrations/db/migration_05.sql
+++ b/connectors/migrations/db/migration_05.sql
@@ -1,2 +1,0 @@
--- Migration created on Jul 17, 2024
-[18:56:02.509] INFO (2981186): Done;

--- a/connectors/src/api/webhooks/webhook_github.ts
+++ b/connectors/src/api/webhooks/webhook_github.ts
@@ -110,6 +110,7 @@ const _webhookGithubAPIHandler = async (
 
   const installationId = payload.installation.id.toString();
 
+  // TODO(spolu): GITHUB_MIGRATION find by ConnectorState.installationId
   const connectors = await ConnectorResource.listByType("github", {
     connectionId: installationId,
   });

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -86,7 +86,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
     }
 
     // TOOD(spolu): GITHUB_MIGRATION we will have to retrieve installationId from connector state
-    // for existing and pull from octokit the new one for comparison.
+    // for existing and pull from oauth scrubbed_raw_json to get the new installationId.
     if (connectionId) {
       const oldGithubInstallationId = c.connectionId;
       const newGithubInstallationId = connectionId;

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -47,7 +47,7 @@ const logger = mainLogger.child({
 });
 
 export async function githubGetReposResultPageActivity(
-  githubInstallationId: string,
+  connectionId: string,
   pageNumber: number, // 1-indexed
   loggerArgs: Record<string, string | number>
 ): Promise<{ name: string; id: number; login: string }[]> {
@@ -61,7 +61,7 @@ export async function githubGetReposResultPageActivity(
   }
 
   localLogger.info("Fetching GitHub repos result page.");
-  const pageRes = await getReposPage(githubInstallationId, pageNumber);
+  const pageRes = await getReposPage(connectionId, pageNumber);
   if (pageRes.isErr()) {
     throw pageRes.error;
   }
@@ -74,7 +74,7 @@ export async function githubGetReposResultPageActivity(
 }
 
 export async function githubGetRepoIssuesResultPageActivity(
-  githubInstallationId: string,
+  connectionId: string,
   repoName: string,
   login: string,
   pageNumber: number, // 1-indexed
@@ -91,7 +91,7 @@ export async function githubGetRepoIssuesResultPageActivity(
 
   localLogger.info("Fetching GitHub repo issues result page.");
   const page = await getRepoIssuesPage(
-    githubInstallationId,
+    connectionId,
     repoName,
     login,
     pageNumber
@@ -102,7 +102,7 @@ export async function githubGetRepoIssuesResultPageActivity(
 
 async function renderIssue(
   dataSourceConfig: DataSourceConfig,
-  installationId: string,
+  connectionId: string,
   repoName: string,
   repoId: number,
   login: string,
@@ -119,7 +119,7 @@ async function renderIssue(
   });
 
   const issue = await getIssue(
-    installationId,
+    connectionId,
     repoName,
     login,
     issueNumber,
@@ -151,7 +151,7 @@ async function renderIssue(
     let comments = undefined;
     try {
       comments = await getIssueCommentsPage(
-        installationId,
+        connectionId,
         repoName,
         login,
         issueNumber,
@@ -207,7 +207,7 @@ async function renderIssue(
 }
 
 export async function githubUpsertIssueActivity(
-  installationId: string,
+  connectionId: string,
   repoName: string,
   repoId: number,
   login: string,
@@ -225,7 +225,7 @@ export async function githubUpsertIssueActivity(
 
   const renderedIssueResult = await renderIssue(
     dataSourceConfig,
-    installationId,
+    connectionId,
     repoName,
     repoId,
     login,
@@ -281,10 +281,10 @@ export async function githubUpsertIssueActivity(
 
   const connector = await ConnectorResource.findByDataSourceAndConnection(
     dataSourceConfig,
-    { connectionId: installationId }
+    { connectionId }
   );
   if (!connector) {
-    throw new Error(`Connector not found (installationId: ${installationId})`);
+    throw new Error(`Connector not found (connectionId: ${connectionId})`);
   }
 
   localLogger.info("Upserting GitHub issue in DB.");
@@ -297,7 +297,7 @@ export async function githubUpsertIssueActivity(
 
 async function renderDiscussion(
   dataSourceConfig: DataSourceConfig,
-  installationId: string,
+  connectionId: string,
   repoName: string,
   login: string,
   discussionNumber: number,
@@ -309,7 +309,7 @@ async function renderDiscussion(
   });
 
   const discussion = await getDiscussion(
-    installationId,
+    connectionId,
     repoName,
     login,
     discussionNumber
@@ -338,7 +338,7 @@ async function renderDiscussion(
     cursorLogger.info("Fetching GitHub discussion comments page.");
 
     const { cursor, comments } = await getDiscussionCommentsPage(
-      installationId,
+      connectionId,
       repoName,
       login,
       discussionNumber,
@@ -376,7 +376,7 @@ async function renderDiscussion(
 
         const { cursor: childCursor, comments: childComments } =
           await getDiscussionCommentRepliesPage(
-            installationId,
+            connectionId,
             comment.id,
             nextChildCursor
           );
@@ -416,7 +416,7 @@ async function renderDiscussion(
 }
 
 export async function githubUpsertDiscussionActivity(
-  installationId: string,
+  connectionId: string,
   repoName: string,
   repoId: number,
   login: string,
@@ -434,7 +434,7 @@ export async function githubUpsertDiscussionActivity(
 
   const { discussion, content: renderedDiscussion } = await renderDiscussion(
     dataSourceConfig,
-    installationId,
+    connectionId,
     repoName,
     login,
     discussionNumber,
@@ -474,7 +474,7 @@ export async function githubUpsertDiscussionActivity(
 
   const connector = await ConnectorResource.findByDataSourceAndConnection(
     dataSourceConfig,
-    { connectionId: installationId }
+    { connectionId }
   );
   if (!connector) {
     throw new Error("Connector not found");
@@ -489,7 +489,7 @@ export async function githubUpsertDiscussionActivity(
 }
 
 export async function githubGetRepoDiscussionsResultPageActivity(
-  installationId: string,
+  connectionId: string,
   repoName: string,
   login: string,
   cursor: string | null,
@@ -503,7 +503,7 @@ export async function githubGetRepoDiscussionsResultPageActivity(
   localLogger.info("Fetching GitHub discussions result page.");
 
   const { cursor: nextCursor, discussions } = await getRepoDiscussionsPage(
-    installationId,
+    connectionId,
     repoName,
     login,
     cursor
@@ -546,14 +546,14 @@ export async function githubSaveSuccessSyncActivity(
 
 export async function githubIssueGarbageCollectActivity(
   dataSourceConfig: DataSourceConfig,
-  installationId: string,
+  connectionId: string,
   repoId: string,
   issueNumber: number,
   loggerArgs: Record<string, string | number>
 ) {
   await deleteIssue(
     dataSourceConfig,
-    installationId,
+    connectionId,
     repoId,
     issueNumber,
     loggerArgs
@@ -562,14 +562,14 @@ export async function githubIssueGarbageCollectActivity(
 
 export async function githubDiscussionGarbageCollectActivity(
   dataSourceConfig: DataSourceConfig,
-  installationId: string,
+  connectionId: string,
   repoId: string,
   discussionNumber: number,
   loggerArgs: Record<string, string | number>
 ) {
   await deleteDiscussion(
     dataSourceConfig,
-    installationId,
+    connectionId,
     repoId,
     discussionNumber,
     loggerArgs
@@ -578,13 +578,13 @@ export async function githubDiscussionGarbageCollectActivity(
 
 export async function githubRepoGarbageCollectActivity(
   dataSourceConfig: DataSourceConfig,
-  installationId: string,
+  connectionId: string,
   repoId: string,
   loggerArgs: Record<string, string | number>
 ) {
   const connector = await ConnectorResource.findByDataSourceAndConnection(
     dataSourceConfig,
-    { connectionId: installationId }
+    { connectionId }
   );
 
   if (!connector) {
@@ -606,7 +606,7 @@ export async function githubRepoGarbageCollectActivity(
       queue.add(() =>
         deleteIssue(
           dataSourceConfig,
-          installationId,
+          connectionId,
           repoId,
           issue.issueNumber,
           loggerArgs
@@ -627,7 +627,7 @@ export async function githubRepoGarbageCollectActivity(
       queue.add(() =>
         deleteDiscussion(
           dataSourceConfig,
-          installationId,
+          connectionId,
           repoId,
           discussion.discussionNumber,
           loggerArgs
@@ -657,7 +657,7 @@ export async function githubRepoGarbageCollectActivity(
 
 async function deleteIssue(
   dataSourceConfig: DataSourceConfig,
-  installationId: string,
+  connectionId: string,
   repoId: string,
   issueNumber: number,
   loggerArgs: Record<string, string | number>
@@ -666,10 +666,10 @@ async function deleteIssue(
 
   const connector = await ConnectorResource.findByDataSourceAndConnection(
     dataSourceConfig,
-    { connectionId: installationId }
+    { connectionId }
   );
   if (!connector) {
-    throw new Error(`Connector not found (installationId: ${installationId})`);
+    throw new Error(`Connector not found (connectionId: ${connectionId})`);
   }
 
   const issueInDb = await GithubIssue.findOne({
@@ -707,7 +707,7 @@ async function deleteIssue(
 
 async function deleteDiscussion(
   dataSourceConfig: DataSourceConfig,
-  installationId: string,
+  connectionId: string,
   repoId: string,
   discussionNumber: number,
   loggerArgs: Record<string, string | number>
@@ -716,10 +716,10 @@ async function deleteDiscussion(
 
   const connector = await ConnectorResource.findByDataSourceAndConnection(
     dataSourceConfig,
-    { connectionId: installationId }
+    { connectionId }
   );
   if (!connector) {
-    throw new Error(`Connector not found (installationId: ${installationId})`);
+    throw new Error(`Connector not found (connectionId: ${connectionId})`);
   }
 
   const discussionInDb = await GithubDiscussion.findOne({
@@ -862,7 +862,7 @@ async function garbageCollectCodeSync(
 
 export async function githubCodeSyncActivity({
   dataSourceConfig,
-  installationId,
+  connectionId,
   repoLogin,
   repoName,
   repoId,
@@ -871,7 +871,7 @@ export async function githubCodeSyncActivity({
   forceResync = false,
 }: {
   dataSourceConfig: DataSourceConfig;
-  installationId: string;
+  connectionId: string;
   repoLogin: string;
   repoName: string;
   repoId: number;
@@ -884,10 +884,10 @@ export async function githubCodeSyncActivity({
 
   const connector = await ConnectorResource.findByDataSourceAndConnection(
     dataSourceConfig,
-    { connectionId: installationId }
+    { connectionId }
   );
   if (!connector) {
-    throw new Error(`Connector not found (installationId: ${installationId})`);
+    throw new Error(`Connector not found (connectionId: ${connectionId})`);
   }
 
   const connectorState = await GithubConnectorState.findOne({
@@ -960,7 +960,7 @@ export async function githubCodeSyncActivity({
 
   Context.current().heartbeat();
   const repoRes = await processRepository({
-    installationId,
+    connectionId,
     repoLogin,
     repoName,
     repoId,

--- a/connectors/src/connectors/github/temporal/client.ts
+++ b/connectors/src/connectors/github/temporal/client.ts
@@ -51,7 +51,7 @@ export async function launchGithubFullSyncWorkflow({
   }
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
 
-  const githubInstallationId = connector.connectionId;
+  const connectionId = connector.connectionId;
 
   const workflow = await getGithubFullSyncWorkflow(connectorId);
 
@@ -69,7 +69,7 @@ export async function launchGithubFullSyncWorkflow({
   await client.workflow.start(githubFullSyncWorkflow, {
     args: [
       dataSourceConfig,
-      githubInstallationId,
+      connectionId,
       connectorId,
       syncCodeOnly,
       forceCodeResync,
@@ -125,16 +125,10 @@ export async function launchGithubReposSyncWorkflow(
     throw new Error(`Connector not found. ConnectorId: ${connectorId}`);
   }
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
-  const githubInstallationId = connector.connectionId;
+  const connectionId = connector.connectionId;
 
   await client.workflow.start(githubReposSyncWorkflow, {
-    args: [
-      dataSourceConfig,
-      githubInstallationId,
-      orgLogin,
-      repos,
-      connectorId,
-    ],
+    args: [dataSourceConfig, connectionId, orgLogin, repos, connectorId],
     taskQueue: QUEUE_NAME,
     workflowId: getReposSyncWorkflowId(dataSourceConfig),
     searchAttributes: {
@@ -159,10 +153,10 @@ export async function launchGithubCodeSyncWorkflow(
     throw new Error(`Connector not found. ConnectorId: ${connectorId}`);
   }
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
-  const githubInstallationId = connector.connectionId;
+  const connectionId = connector.connectionId;
 
   await client.workflow.signalWithStart(githubCodeSyncWorkflow, {
-    args: [dataSourceConfig, githubInstallationId, repoName, repoId, repoLogin],
+    args: [dataSourceConfig, connectionId, repoName, repoId, repoLogin],
     taskQueue: QUEUE_NAME,
     workflowId: getCodeSyncWorkflowId(dataSourceConfig, repoId),
     searchAttributes: {
@@ -190,7 +184,7 @@ export async function launchGithubIssueSyncWorkflow(
     throw new Error(`Connector not found. ConnectorId: ${connectorId}`);
   }
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
-  const githubInstallationId = connector.connectionId;
+  const connectionId = connector.connectionId;
 
   const workflowId = getIssueSyncWorkflowId(
     dataSourceConfig,
@@ -201,7 +195,7 @@ export async function launchGithubIssueSyncWorkflow(
   await client.workflow.signalWithStart(githubIssueSyncWorkflow, {
     args: [
       dataSourceConfig,
-      githubInstallationId,
+      connectionId,
       repoName,
       repoId,
       repoLogin,
@@ -234,7 +228,7 @@ export async function launchGithubDiscussionSyncWorkflow(
     throw new Error(`Connector not found. ConnectorId: ${connectorId}`);
   }
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
-  const githubInstallationId = connector.connectionId;
+  const connectionId = connector.connectionId;
 
   const workflowId = getDiscussionSyncWorkflowId(
     connectorId,
@@ -246,7 +240,7 @@ export async function launchGithubDiscussionSyncWorkflow(
   await client.workflow.signalWithStart(githubDiscussionSyncWorkflow, {
     args: [
       dataSourceConfig,
-      githubInstallationId,
+      connectionId,
       repoName,
       repoId,
       repoLogin,
@@ -280,15 +274,10 @@ export async function launchGithubIssueGarbageCollectWorkflow(
   }
 
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
-  const githubInstallationId = connector.connectionId;
+  const connectionId = connector.connectionId;
 
   await client.workflow.start(githubIssueGarbageCollectWorkflow, {
-    args: [
-      dataSourceConfig,
-      githubInstallationId,
-      repoId.toString(),
-      issueNumber,
-    ],
+    args: [dataSourceConfig, connectionId, repoId.toString(), issueNumber],
     taskQueue: QUEUE_NAME,
     searchAttributes: {
       connectorId: [parseInt(connectorId)],
@@ -319,15 +308,10 @@ export async function launchGithubDiscussionGarbageCollectWorkflow(
   }
 
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
-  const githubInstallationId = connector.connectionId;
+  const connectionId = connector.connectionId;
 
   await client.workflow.start(githubDiscussionGarbageCollectWorkflow, {
-    args: [
-      dataSourceConfig,
-      githubInstallationId,
-      repoId.toString(),
-      discussionNumber,
-    ],
+    args: [dataSourceConfig, connectionId, repoId.toString(), discussionNumber],
     memo: {
       connectorId: connectorId,
     },
@@ -358,10 +342,10 @@ export async function launchGithubRepoGarbageCollectWorkflow(
   }
 
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
-  const githubInstallationId = connector.connectionId;
+  const connectionId = connector.connectionId;
 
   await client.workflow.start(githubRepoGarbageCollectWorkflow, {
-    args: [dataSourceConfig, githubInstallationId, repoId.toString()],
+    args: [dataSourceConfig, connectionId, repoId.toString()],
     taskQueue: QUEUE_NAME,
     workflowId: getRepoGarbageCollectWorkflowId(dataSourceConfig, repoId),
     searchAttributes: {

--- a/connectors/src/connectors/github/temporal/workflows.ts
+++ b/connectors/src/connectors/github/temporal/workflows.ts
@@ -57,7 +57,7 @@ const MAX_CONCURRENT_ISSUE_SYNC_ACTIVITIES_PER_WORKFLOW = 8;
 
 export async function githubFullSyncWorkflow(
   dataSourceConfig: DataSourceConfig,
-  githubInstallationId: string,
+  connectionId: string,
   connectorId: ModelId,
   // Used to re-trigger a code-only full-sync after code syncing is enabled/disabled.
   syncCodeOnly: boolean,
@@ -67,7 +67,7 @@ export async function githubFullSyncWorkflow(
   const loggerArgs = {
     dataSourceName: dataSourceConfig.dataSourceName,
     workspaceId: dataSourceConfig.workspaceId,
-    githubInstallationId,
+    connectionId,
     syncCodeOnly: syncCodeOnly.toString(),
   };
 
@@ -78,7 +78,7 @@ export async function githubFullSyncWorkflow(
 
   for (;;) {
     const resultsPage = await githubGetReposResultPageActivity(
-      githubInstallationId,
+      connectionId,
       pageNumber,
       loggerArgs
     );
@@ -101,7 +101,7 @@ export async function githubFullSyncWorkflow(
               {
                 dataSourceConfig,
                 connectorId,
-                githubInstallationId,
+                connectionId,
                 repoName: repo.name,
                 repoId: repo.id,
                 repoLogin: repo.login,
@@ -125,7 +125,7 @@ export async function githubFullSyncWorkflow(
 
 export async function githubReposSyncWorkflow(
   dataSourceConfig: DataSourceConfig,
-  githubInstallationId: string,
+  connectionId: string,
   orgLogin: string,
   repos: { name: string; id: number }[],
   connectorId: ModelId
@@ -147,7 +147,7 @@ export async function githubReposSyncWorkflow(
             {
               dataSourceConfig,
               connectorId,
-              githubInstallationId,
+              connectionId,
               repoName: repo.name,
               repoId: repo.id,
               repoLogin: orgLogin,
@@ -168,14 +168,14 @@ export async function githubReposSyncWorkflow(
 
 export async function githubRepoIssuesSyncWorkflow({
   dataSourceConfig,
-  githubInstallationId,
+  connectionId,
   repoName,
   repoId,
   repoLogin,
   pageNumber,
 }: {
   dataSourceConfig: DataSourceConfig;
-  githubInstallationId: string;
+  connectionId: string;
   repoName: string;
   repoId: number;
   repoLogin: string;
@@ -184,7 +184,7 @@ export async function githubRepoIssuesSyncWorkflow({
   const loggerArgs = {
     dataSourceName: dataSourceConfig.dataSourceName,
     workspaceId: dataSourceConfig.workspaceId,
-    githubInstallationId,
+    connectionId,
     repoName,
     repoLogin,
   };
@@ -195,7 +195,7 @@ export async function githubRepoIssuesSyncWorkflow({
   const promises: Promise<void>[] = [];
 
   const resultsPage = await githubGetRepoIssuesResultPageActivity(
-    githubInstallationId,
+    connectionId,
     repoName,
     repoLogin,
     pageNumber,
@@ -210,7 +210,7 @@ export async function githubRepoIssuesSyncWorkflow({
     promises.push(
       queue.add(() =>
         githubUpsertIssueActivity(
-          githubInstallationId,
+          connectionId,
           repoName,
           repoId,
           repoLogin,
@@ -230,14 +230,14 @@ export async function githubRepoIssuesSyncWorkflow({
 
 export async function githubRepoDiscussionsSyncWorkflow({
   dataSourceConfig,
-  githubInstallationId,
+  connectionId,
   repoName,
   repoId,
   repoLogin,
   nextCursor,
 }: {
   dataSourceConfig: DataSourceConfig;
-  githubInstallationId: string;
+  connectionId: string;
   repoName: string;
   repoId: number;
   repoLogin: string;
@@ -246,7 +246,7 @@ export async function githubRepoDiscussionsSyncWorkflow({
   const loggerArgs = {
     dataSourceName: dataSourceConfig.dataSourceName,
     workspaceId: dataSourceConfig.workspaceId,
-    githubInstallationId,
+    connectionId,
     repoName,
     repoLogin,
   };
@@ -258,7 +258,7 @@ export async function githubRepoDiscussionsSyncWorkflow({
 
   const { cursor, discussionNumbers } =
     await githubGetRepoDiscussionsResultPageActivity(
-      githubInstallationId,
+      connectionId,
       repoName,
       repoLogin,
       nextCursor,
@@ -269,7 +269,7 @@ export async function githubRepoDiscussionsSyncWorkflow({
     promises.push(
       queue.add(() =>
         githubUpsertDiscussionActivity(
-          githubInstallationId,
+          connectionId,
           repoName,
           repoId,
           repoLogin,
@@ -290,7 +290,7 @@ export async function githubRepoDiscussionsSyncWorkflow({
 export async function githubRepoSyncWorkflow({
   dataSourceConfig,
   connectorId,
-  githubInstallationId,
+  connectionId,
   repoName,
   repoId,
   repoLogin,
@@ -300,7 +300,7 @@ export async function githubRepoSyncWorkflow({
 }: {
   dataSourceConfig: DataSourceConfig;
   connectorId: ModelId;
-  githubInstallationId: string;
+  connectionId: string;
   repoName: string;
   repoId: number;
   repoLogin: string;
@@ -311,7 +311,7 @@ export async function githubRepoSyncWorkflow({
   const loggerArgs = {
     dataSourceName: dataSourceConfig.dataSourceName,
     workspaceId: dataSourceConfig.workspaceId,
-    githubInstallationId,
+    connectionId,
     repoName,
     repoLogin,
     syncCodeOnly: syncCodeOnly ? "true" : "false",
@@ -334,7 +334,7 @@ export async function githubRepoSyncWorkflow({
         args: [
           {
             dataSourceConfig,
-            githubInstallationId,
+            connectionId,
             repoName,
             repoId,
             repoLogin,
@@ -368,7 +368,7 @@ export async function githubRepoSyncWorkflow({
         args: [
           {
             dataSourceConfig,
-            githubInstallationId,
+            connectionId,
             repoName,
             repoId,
             repoLogin,
@@ -389,7 +389,7 @@ export async function githubRepoSyncWorkflow({
   // Start code syncing activity.
   await githubCodeSyncActivity({
     dataSourceConfig,
-    installationId: githubInstallationId,
+    connectionId,
     repoLogin,
     repoName,
     repoId,
@@ -401,7 +401,7 @@ export async function githubRepoSyncWorkflow({
 
 export async function githubCodeSyncWorkflow(
   dataSourceConfig: DataSourceConfig,
-  githubInstallationId: string,
+  connectionId: string,
   repoName: string,
   repoId: number,
   repoLogin: string
@@ -409,7 +409,7 @@ export async function githubCodeSyncWorkflow(
   const loggerArgs = {
     dataSourceName: dataSourceConfig.dataSourceName,
     workspaceId: dataSourceConfig.workspaceId,
-    githubInstallationId,
+    connectionId,
     repoName,
     repoLogin,
   };
@@ -434,7 +434,7 @@ export async function githubCodeSyncWorkflow(
     }
     await githubCodeSyncActivity({
       dataSourceConfig,
-      installationId: githubInstallationId,
+      connectionId,
       repoLogin,
       repoName,
       repoId,
@@ -447,7 +447,7 @@ export async function githubCodeSyncWorkflow(
 
 export async function githubIssueSyncWorkflow(
   dataSourceConfig: DataSourceConfig,
-  githubInstallationId: string,
+  connectionId: string,
   repoName: string,
   repoId: number,
   repoLogin: string,
@@ -456,7 +456,7 @@ export async function githubIssueSyncWorkflow(
   const loggerArgs = {
     dataSourceName: dataSourceConfig.dataSourceName,
     workspaceId: dataSourceConfig.workspaceId,
-    githubInstallationId,
+    connectionId,
     repoName,
     repoLogin,
     issueNumber,
@@ -477,7 +477,7 @@ export async function githubIssueSyncWorkflow(
       continue;
     }
     await githubUpsertIssueActivity(
-      githubInstallationId,
+      connectionId,
       repoName,
       repoId,
       repoLogin,
@@ -491,7 +491,7 @@ export async function githubIssueSyncWorkflow(
 
 export async function githubDiscussionSyncWorkflow(
   dataSourceConfig: DataSourceConfig,
-  githubInstallationId: string,
+  connectionId: string,
   repoName: string,
   repoId: number,
   repoLogin: string,
@@ -500,7 +500,7 @@ export async function githubDiscussionSyncWorkflow(
   const loggerArgs = {
     dataSourceName: dataSourceConfig.dataSourceName,
     workspaceId: dataSourceConfig.workspaceId,
-    githubInstallationId,
+    connectionId,
     repoName,
     repoLogin,
     discussionNumber,
@@ -521,7 +521,7 @@ export async function githubDiscussionSyncWorkflow(
       continue;
     }
     await githubUpsertDiscussionActivity(
-      githubInstallationId,
+      connectionId,
       repoName,
       repoId,
       repoLogin,
@@ -537,20 +537,20 @@ export async function githubDiscussionSyncWorkflow(
 
 export async function githubIssueGarbageCollectWorkflow(
   dataSourceConfig: DataSourceConfig,
-  githubInstallationId: string,
+  connectionId: string,
   repoId: string,
   issueNumber: number
 ) {
   const loggerArgs = {
     dataSourceName: dataSourceConfig.dataSourceName,
     workspaceId: dataSourceConfig.workspaceId,
-    githubInstallationId,
+    connectionId,
     issueNumber,
   };
 
   await githubIssueGarbageCollectActivity(
     dataSourceConfig,
-    githubInstallationId,
+    connectionId,
     repoId,
     issueNumber,
     loggerArgs
@@ -560,20 +560,20 @@ export async function githubIssueGarbageCollectWorkflow(
 
 export async function githubDiscussionGarbageCollectWorkflow(
   dataSourceConfig: DataSourceConfig,
-  githubInstallationId: string,
+  connectionId: string,
   repoId: string,
   discussionNumber: number
 ) {
   const loggerArgs = {
     dataSourceName: dataSourceConfig.dataSourceName,
     workspaceId: dataSourceConfig.workspaceId,
-    githubInstallationId,
+    connectionId,
     discussionNumber,
   };
 
   await githubDiscussionGarbageCollectActivity(
     dataSourceConfig,
-    githubInstallationId,
+    connectionId,
     repoId,
     discussionNumber,
     loggerArgs
@@ -583,18 +583,18 @@ export async function githubDiscussionGarbageCollectWorkflow(
 
 export async function githubRepoGarbageCollectWorkflow(
   dataSourceConfig: DataSourceConfig,
-  githubInstallationId: string,
+  connectionId: string,
   repoId: string
 ) {
   const loggerArgs = {
     dataSourceName: dataSourceConfig.dataSourceName,
     workspaceId: dataSourceConfig.workspaceId,
-    githubInstallationId,
+    connectionId,
   };
 
   await githubRepoGarbageCollectActivity(
     dataSourceConfig,
-    githubInstallationId,
+    connectionId,
     repoId,
     loggerArgs
   );

--- a/connectors/src/lib/cli.ts
+++ b/connectors/src/lib/cli.ts
@@ -223,9 +223,7 @@ export const github = async ({
       }
       logger.info("[Admin] Resyncing repo " + args.owner + "/" + args.repo);
 
-      const installationId = connector.connectionId;
-
-      const octokit = await getOctokit(installationId);
+      const octokit = await getOctokit(connector.connectionId);
 
       const { data } = await octokit.rest.repos.get({
         owner: args.owner,

--- a/connectors/src/lib/models/github.ts
+++ b/connectors/src/lib/models/github.ts
@@ -17,6 +17,7 @@ export class GithubConnectorState extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
+  declare installationId: string | null;
   declare webhooksEnabledAt?: Date | null;
   declare codeSyncEnabled: boolean;
 
@@ -38,6 +39,10 @@ GithubConnectorState.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
+    },
+    installationId: {
+      type: DataTypes.STRING,
+      allowNull: true,
     },
     webhooksEnabledAt: {
       type: DataTypes.DATE,

--- a/connectors/src/resources/connector/github.ts
+++ b/connectors/src/resources/connector/github.ts
@@ -2,7 +2,11 @@ import type { ModelId } from "@dust-tt/types";
 import type { Transaction } from "sequelize";
 
 import {
+  GithubCodeDirectory,
+  GithubCodeFile,
+  GithubCodeRepository,
   GithubConnectorState,
+  GithubDiscussion,
   GithubIssue,
 } from "@connectors/lib/models/github";
 import type {
@@ -33,6 +37,30 @@ export class GithubConnectorStrategy
 
   async delete(connector: ConnectorResource, transaction: Transaction) {
     await GithubIssue.destroy({
+      where: {
+        connectorId: connector.id,
+      },
+      transaction,
+    });
+    await GithubDiscussion.destroy({
+      where: {
+        connectorId: connector.id,
+      },
+      transaction,
+    });
+    await GithubCodeRepository.destroy({
+      where: {
+        connectorId: connector.id,
+      },
+      transaction,
+    });
+    await GithubCodeFile.destroy({
+      where: {
+        connectorId: connector.id,
+      },
+      transaction,
+    });
+    await GithubCodeDirectory.destroy({
       where: {
         connectorId: connector.id,
       },


### PR DESCRIPTION
## Description

- rename installationId -> connectionId everywhere
- store installationId on github_connector_state + migration (so that we can retrieve the connector from the installationId when receiving a webhook even when we start having connectionIds that are not installationIds (yet to be done))
- left some TODOs to mark critical points for support of a dual Nango/oauth mode

## Risk

blast-radius = Github connectors 

## Deploy Plan

- run DB migration (adds a column allow_null true)
- deploy `connectors`
- run population migration to copy installation_id in existing connector_state
- subsequent PR to start using it to process webhooks