### PR TITLE
Flav/stable use event source

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -41,7 +41,14 @@ import {
 } from "@dust-tt/types";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { useCallback, useContext, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import { makeDocumentCitations } from "@app/components/actions/retrieval/utils";
 import { AssistantDetailsDropdownMenu } from "@app/components/assistant/AssistantDetailsDropdownMenu";
@@ -113,7 +120,7 @@ export function AgentMessage({
     { index: number; document: RetrievalDocumentType | WebsearchResultType }[]
   >([]);
 
-  const shouldStream = (() => {
+  const shouldStream = useMemo(() => {
     if (message.status !== "created") {
       return false;
     }
@@ -128,7 +135,7 @@ export function AgentMessage({
       default:
         assertNever(streamedAgentMessage.status);
     }
-  })();
+  }, [message.status, streamedAgentMessage.status]);
 
   const [lastTokenClassification, setLastTokenClassification] = useState<
     null | "tokens" | "chain_of_thought"

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -41,14 +41,7 @@ import {
 } from "@dust-tt/types";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import {
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
 
 import { makeDocumentCitations } from "@app/components/actions/retrieval/utils";
 import { AssistantDetailsDropdownMenu } from "@app/components/assistant/AssistantDetailsDropdownMenu";
@@ -120,7 +113,7 @@ export function AgentMessage({
     { index: number; document: RetrievalDocumentType | WebsearchResultType }[]
   >([]);
 
-  const shouldStream = useMemo(() => {
+  const shouldStream = (() => {
     if (message.status !== "created") {
       return false;
     }
@@ -135,7 +128,7 @@ export function AgentMessage({
       default:
         assertNever(streamedAgentMessage.status);
     }
-  }, [message.status, streamedAgentMessage.status]);
+  })();
 
   const [lastTokenClassification, setLastTokenClassification] = useState<
     null | "tokens" | "chain_of_thought"
@@ -143,9 +136,6 @@ export function AgentMessage({
 
   const buildEventSourceURL = useCallback(
     (lastEvent: string | null) => {
-      if (!shouldStream) {
-        return null;
-      }
       const esURL = `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages/${message.sId}/events`;
       let lastEventId = "";
       if (lastEvent) {
@@ -158,7 +148,7 @@ export function AgentMessage({
 
       return url;
     },
-    [conversationId, message.sId, owner.sId, shouldStream]
+    [conversationId, message.sId, owner.sId]
   );
 
   const onEventCallback = useCallback((eventStr: string) => {
@@ -280,7 +270,8 @@ export function AgentMessage({
   useEventSource(
     buildEventSourceURL,
     onEventCallback,
-    `message-${message.sId}`
+    `message-${message.sId}`,
+    { isReadyToConsumeStream: shouldStream }
   );
 
   const agentMessageToRender = ((): AgentMessageType => {

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -277,7 +277,11 @@ export function AgentMessage({
     }
   }, []);
 
-  useEventSource(buildEventSourceURL, onEventCallback);
+  useEventSource(
+    buildEventSourceURL,
+    onEventCallback,
+    `message-${message.sId}`
+  );
 
   const agentMessageToRender = ((): AgentMessageType => {
     switch (message.status) {

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -1,17 +1,14 @@
 import { Page } from "@dust-tt/sparkle";
 import type {
   AgentMention,
-  AgentMessageWithRankType,
   LightAgentConfigurationType,
   MentionType,
   SubscriptionType,
-  UserMessageWithRankType,
   UserType,
   WorkspaceType,
 } from "@dust-tt/types";
 import type { UploadedContentFragment } from "@dust-tt/types";
 import { Transition } from "@headlessui/react";
-import { cloneDeep } from "lodash";
 import { useRouter } from "next/router";
 import {
   Fragment,
@@ -35,7 +32,7 @@ import {
 } from "@app/components/assistant/conversation/lib";
 import { DropzoneContainer } from "@app/components/misc/DropzoneContainer";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
-import type { FetchConversationMessagesResponse } from "@app/lib/api/assistant/messages";
+import { updateMessagePagesWithOptimisticData } from "@app/lib/client/conversation/event_handlers";
 import { getRandomGreetingForName } from "@app/lib/client/greetings";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { useConversationMessages } from "@app/lib/swr";
@@ -329,30 +326,4 @@ export function ConversationContainer({
       />
     </DropzoneContainer>
   );
-}
-
-/**
- * If no message pages exist, create a single page with the optimistic message.
- * If message pages exist, add the optimistic message to the first page, since
- * the message pages array is not yet reversed.
- */
-export function updateMessagePagesWithOptimisticData(
-  currentMessagePages: FetchConversationMessagesResponse[] | undefined,
-  messageOrPlaceholder: AgentMessageWithRankType | UserMessageWithRankType
-): FetchConversationMessagesResponse[] {
-  if (!currentMessagePages || currentMessagePages.length === 0) {
-    return [
-      {
-        messages: [messageOrPlaceholder],
-        hasMore: false,
-        lastValue: null,
-      },
-    ];
-  }
-
-  // We need to deep clone here, since SWR relies on the reference.
-  const updatedMessages = cloneDeep(currentMessagePages);
-  updatedMessages.at(0)?.messages.push(messageOrPlaceholder);
-
-  return updatedMessages;
 }

--- a/front/hooks/useEventSource.ts
+++ b/front/hooks/useEventSource.ts
@@ -73,7 +73,7 @@ export function useEventSource(
   const reconnectAttempts = useRef(0);
 
   // We use a counter to trigger reconnects when the counter changes.
-  const [reconnectCounter, setReconnectCounter] = useState(0); // Use a counter
+  const [reconnectCounter, setReconnectCounter] = useState(0);
 
   // Store the reconnect timeout reference to clear it when needed.
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);

--- a/front/hooks/useEventSource.ts
+++ b/front/hooks/useEventSource.ts
@@ -56,7 +56,6 @@ const stableEventSourceManager = {
   remove(uniqueId: string) {
     const source = this.sources.get(uniqueId);
     if (source) {
-      console.log("Closing EventSource connection", uniqueId);
       source.close();
       this.sources.delete(uniqueId);
     }
@@ -100,8 +99,6 @@ export function useEventSource(
     }
 
     source.onopen = () => {
-      console.log("EventSource connection opened", uniqueId);
-
       // If connected, reset the reconnect attempts and clear the reconnect timeout.
       reconnectAttempts.current = 0;
       if (reconnectTimeoutRef.current) {
@@ -128,6 +125,15 @@ export function useEventSource(
 
       reconnectAttempts.current++;
 
+      if (reconnectAttempts.current >= 10) {
+        console.log(
+          "Too many errors, not reconnecting. Please refresh the page."
+        );
+        setIsError(new Error("Too many errors, closing connection."));
+
+        return;
+      }
+
       console.error(
         `Connection error. Attempting to reconnect in ${RECONNECT_DELAY}ms`
       );
@@ -136,8 +142,6 @@ export function useEventSource(
       reconnectTimeoutRef.current = setTimeout(() => {
         setReconnectCounter((c) => c + 1);
       }, RECONNECT_DELAY);
-
-      setIsError(new Error("Connection error. Attempting to reconnect."));
     };
 
     return source;

--- a/front/hooks/useEventSource.ts
+++ b/front/hooks/useEventSource.ts
@@ -1,67 +1,143 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const RECONNECT_DELAY = 5000; // 5 seconds.
+
+/**
+ * Stable EventSource Manager
+ *
+ * This singleton object manages EventSource instances across the entire application.
+ * It provides methods to create, retrieve, and remove EventSource connections,
+ * ensuring that each unique connection is properly managed and can be accessed
+ * or closed as needed.
+ *
+ * Key features:
+ * - Maintains a single source of truth for all EventSource instances.
+ * - Prevents duplicate EventSource creations for the same unique identifier.
+ * - Allows for centralized management of EventSource lifecycle.
+ * - Improves performance by reusing existing connections when possible.
+ *
+ * Usage:
+ * - Create a new EventSource: stableEventSourceManager.create(url, uniqueId)
+ * - Retrieve an existing EventSource: stableEventSourceManager.get(uniqueId)
+ * - Close and remove an EventSource: stableEventSourceManager.remove(uniqueId)
+ *
+ * This manager is designed to be used in conjunction with the useEventSource hook
+ * to provide stable and efficient EventSource handling across React component lifecycles.
+ */
+const stableEventSourceManager = {
+  // Map to store active EventSource instances, keyed by unique identifiers
+  sources: new Map<string, EventSource>(),
+
+  /**
+   * Creates a new EventSource instance and stores it in the sources map.
+   * @param url The URL to connect the EventSource to
+   * @param uniqueId A unique identifier for this EventSource instance
+   * @returns The newly created EventSource instance
+   */
+  create(url: string, uniqueId: string) {
+    const newSource = new EventSource(url);
+    this.sources.set(uniqueId, newSource);
+    return newSource;
+  },
+
+  /**
+   * Retrieves an existing EventSource instance by its unique identifier.
+   * @param uniqueId The unique identifier of the EventSource to retrieve
+   * @returns The EventSource instance if found, undefined otherwise
+   */
+  get(uniqueId: string) {
+    return this.sources.get(uniqueId);
+  },
+
+  /**
+   * Closes and removes an EventSource instance from the sources map.
+   * @param uniqueId The unique identifier of the EventSource to remove
+   */
+  remove(uniqueId: string) {
+    const source = this.sources.get(uniqueId);
+    if (source) {
+      console.log("Closing EventSource connection", uniqueId);
+      source.close();
+      this.sources.delete(uniqueId);
+    }
+  },
+};
 
 export function useEventSource(
-  buildURL: (lastMessage: string | null) => string | null,
+  buildURL: (lastEvent: string | null) => string | null,
   onEventCallback: (event: string) => void,
-  { isReadyToConsumeStream }: { isReadyToConsumeStream: boolean } = {
-    isReadyToConsumeStream: true,
-  }
+  uniqueId: string,
+  { isReadyToConsumeStream = true }: { isReadyToConsumeStream?: boolean } = {}
 ) {
-  // State used to re-connect to the events stream; this is a hack to re-trigger
-  // the useEffect that set-up the EventSource to the streaming endpoint.
-  const [reconnectCounter, setReconnectCounter] = useState(0);
-  const lastEvent = useRef<string | null>(null);
-  const errorCount = useRef(0);
   const [isError, setIsError] = useState<Error | null>(null);
+  const lastEvent = useRef<string | null>(null);
+  const reconnectAttempts = useRef(0);
 
-  useEffect(() => {
-    if (!isReadyToConsumeStream) {
-      return;
-    }
+  // Use the stable event source manager to ensure consistent EventSource management
+  // across renders and component lifecycles.
+  const sourceManager = stableEventSourceManager;
 
+  const connect = useCallback(() => {
     const url = buildURL(lastEvent.current);
     if (!url) {
-      return;
+      // If the url is empty, it means streaming is done.
+      // Close any previous connections for this uniqueId and remove it from the manager.
+      sourceManager.remove(uniqueId);
+
+      return null;
     }
-    let reconnectTimeout: NodeJS.Timeout | null = null;
 
-    const es = new EventSource(url);
+    let source = sourceManager.get(uniqueId);
+    // If the source is closed or doesn't exist, create a new one.
+    if (!source || source.readyState === EventSource.CLOSED) {
+      source = sourceManager.create(url, uniqueId);
+    }
 
-    es.onopen = () => {
-      errorCount.current = 0;
+    source.onopen = () => {
+      console.log("EventSource connection opened", uniqueId);
+      reconnectAttempts.current = 0;
     };
 
-    es.onmessage = (event: MessageEvent<string>) => {
+    source.onmessage = (event: MessageEvent<string>) => {
       if (event.data === "done") {
-        setReconnectCounter((c) => c + 1);
-        es.close();
+        source.close();
+        setTimeout(connect, RECONNECT_DELAY);
         return;
       }
       onEventCallback(event.data);
       lastEvent.current = event.data;
     };
 
-    es.onerror = (event) => {
-      console.error("useEventSource.onerror()", event);
-      errorCount.current += 1;
-      if (errorCount.current >= 3) {
-        console.log("too many errors, not reconnecting..");
-        setIsError(new Error("Too many errors, closing connection."));
-        es.close();
-        return;
-      }
-      reconnectTimeout = setTimeout(() => {
-        setReconnectCounter((c) => c + 1);
-      }, 1000);
+    source.onerror = (event: Event) => {
+      console.error("EventSource error", event);
+      source.close();
+      reconnectAttempts.current++;
+
+      console.error(
+        `Connection error. Attempting to reconnect in ${RECONNECT_DELAY}ms`
+      );
+
+      setTimeout(connect, RECONNECT_DELAY);
+      setIsError(new Error("Connection error. Attempting to reconnect."));
     };
 
+    return source;
+  }, [buildURL, onEventCallback, uniqueId, sourceManager]);
+
+  useEffect(() => {
+    if (!isReadyToConsumeStream) {
+      return;
+    }
+
+    connect();
+  }, [isReadyToConsumeStream, connect]);
+
+  // Cleanup the EventSource connection when the component unmounts.
+  useEffect(() => {
     return () => {
-      if (reconnectTimeout) {
-        clearTimeout(reconnectTimeout);
-      }
-      es.close();
+      sourceManager.remove(uniqueId);
     };
-  }, [buildURL, onEventCallback, reconnectCounter, isReadyToConsumeStream]);
+  }, [uniqueId, sourceManager]);
 
   return { isError };
 }

--- a/front/lib/client/conversation/event_handlers.ts
+++ b/front/lib/client/conversation/event_handlers.ts
@@ -1,0 +1,116 @@
+import type {
+  AgentMessageNewEvent,
+  AgentMessageWithRankType,
+  UserMessageNewEvent,
+  UserMessageWithRankType,
+} from "@dust-tt/types";
+import { isAgentMessageType, isUserMessageType } from "@dust-tt/types";
+import { cloneDeep } from "lodash";
+
+import type { FetchConversationMessagesResponse } from "@app/lib/api/assistant/messages";
+import type { FetchConversationParticipantsResponse } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/participants";
+
+/**
+ * If no message pages exist, create a single page with the optimistic message.
+ * If message pages exist, add the optimistic message to the first page, since
+ * the message pages array is not yet reversed.
+ */
+export function updateMessagePagesWithOptimisticData(
+  currentMessagePages: FetchConversationMessagesResponse[] | undefined,
+  messageOrPlaceholder: AgentMessageWithRankType | UserMessageWithRankType
+): FetchConversationMessagesResponse[] {
+  if (!currentMessagePages || currentMessagePages.length === 0) {
+    return [
+      {
+        messages: [messageOrPlaceholder],
+        hasMore: false,
+        lastValue: null,
+      },
+    ];
+  }
+
+  // We need to deep clone here, since SWR relies on the reference.
+  const updatedMessages = cloneDeep(currentMessagePages);
+  updatedMessages.at(0)?.messages.push(messageOrPlaceholder);
+
+  return updatedMessages;
+}
+
+// Function to update the message pages with the new message from the event.
+export function getUpdatedMessagesFromEvent(
+  currentMessagePages: FetchConversationMessagesResponse[] | undefined,
+  event: AgentMessageNewEvent | UserMessageNewEvent
+) {
+  if (!currentMessagePages) {
+    return undefined;
+  }
+
+  // Check if the message already exists in the cache.
+  const isMessageAlreadyInCache = currentMessagePages.some((page) =>
+    page.messages.some((message) => message.sId === event.message.sId)
+  );
+
+  // If the message is already in the cache, ignore the event.
+  if (isMessageAlreadyInCache) {
+    return currentMessagePages;
+  }
+
+  const { rank } = event.message;
+
+  // We only support adding at the end of the first page.
+  const [firstPage] = currentMessagePages;
+  const firstPageLastMessage = firstPage.messages.at(-1);
+  if (firstPageLastMessage && firstPageLastMessage.rank < rank) {
+    return updateMessagePagesWithOptimisticData(
+      currentMessagePages,
+      event.message
+    );
+  }
+
+  return currentMessagePages;
+}
+
+// Function to update the participants with the new message from the event.
+export function getUpdatedParticipantsFromEvent(
+  participants: FetchConversationParticipantsResponse | undefined,
+  event: AgentMessageNewEvent | UserMessageNewEvent
+) {
+  if (!participants) {
+    return undefined;
+  }
+
+  const { message } = event;
+  if (isUserMessageType(message)) {
+    const { user } = message;
+    const isAlreadyParticipant = participants.participants.users.some(
+      (u) => u.username === message.user?.username
+    );
+
+    if (!user || isAlreadyParticipant) {
+      return participants;
+    } else {
+      participants.participants.users.push({
+        username: user.username,
+        fullName: user.fullName,
+        pictureUrl: user.image,
+      });
+    }
+  } else if (isAgentMessageType(message)) {
+    const { configuration } = message;
+    const isAlreadyParticipant = participants.participants.agents.some(
+      (a) => a.configurationId === configuration.sId
+    );
+
+    if (isAlreadyParticipant) {
+      return participants;
+    } else {
+      participants.participants.agents.push({
+        configurationId: configuration.sId,
+        name: configuration.name,
+        pictureUrl: configuration.pictureUrl,
+      });
+    }
+  }
+
+  return participants;
+}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We have observed a significant increase in Redis connections over the past few weeks. Despite multiple efforts in https://github.com/dust-tt/dust/pull/6187 and https://github.com/dust-tt/dust/pull/6202 to improve our Redis connection hygiene, we have been unable to reduce the load sufficiently. The math is straightforward: on the private API, the maximum number of Redis connections for the stream corresponds either to the number of conversations/messages created per minute or the number of active users.

After spending some hours 🥵, I discovered issues with how we handle the event stream at the conversation level. Specifically, the `useEventSource` hook is being re-created and re-opening a new connection on every render, resulting in unnecessary remounts and causing excess Redis connections. If you inspect the network, you will notice numerous calls to the `/events` endpoint.

This PR is based on the principle that our streaming logic should be independent of render cycles. Regardless of the number of re-renders, only one connection per conversationId/messageId should be maintained. This PR implements a stable, global EventSource manager to ensure consistent EventSource connections across renders and component lifecycles.

### Changes
- Created `stableEventSourceManager` as a global to manage EventSource instances.
- Modified the `useEventSource` hook to use the stable manager instead of creating a new one on each render.
- Optimized and restructured event handling.

## Testing

- [x] Verified that EventSource connections remain stable across component re-renders.
- [x] Checked that participant lists are only updated when necessary.
- [x] Ensured existing functionality remains intact.
- [x] Test on front-edge

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Worst case it breaks the conversation/message streaming logic. Thoroughly tested locally. Safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
