### PR TITLE
`oauth`: Gated Github support & dual mode

### DIFF
--- a/connectors/migrations/db/migration_06.sql
+++ b/connectors/migrations/db/migration_06.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jul 18, 2024
+CREATE INDEX github_connector_states_installation_id ON github_connector_states ("installationId");

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -85,11 +85,12 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
       });
     }
 
-    // TODO(spolu): GITHUB_MIGRATION we will have to retrieve installationId from connector state
-    // for existing and pull from oauth scrubbed_raw_json to get the new installationId.
     if (connectionId) {
-      const oldGithubInstallationId = c.connectionId;
-      const newGithubInstallationId = connectionId;
+      const [oldGithubInstallationId, newGithubInstallationId] =
+        await Promise.all([
+          installationIdFromConnectionId(c.connectionId),
+          installationIdFromConnectionId(connectionId),
+        ]);
 
       if (oldGithubInstallationId !== newGithubInstallationId) {
         return new Err({

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -85,7 +85,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
       });
     }
 
-    // TOOD(spolu): GITHUB_MIGRATION we will have to retrieve installationId from connector state
+    // TODO(spolu): GITHUB_MIGRATION we will have to retrieve installationId from connector state
     // for existing and pull from oauth scrubbed_raw_json to get the new installationId.
     if (connectionId) {
       const oldGithubInstallationId = c.connectionId;

--- a/connectors/src/lib/models/github.ts
+++ b/connectors/src/lib/models/github.ts
@@ -57,7 +57,10 @@ GithubConnectorState.init(
   {
     sequelize: sequelizeConnection,
     modelName: "github_connector_states",
-    indexes: [{ fields: ["connectorId"], unique: true }],
+    indexes: [
+      { fields: ["connectorId"], unique: true },
+      { fields: ["installationId"] },
+    ],
   }
 );
 ConnectorModel.hasOne(GithubConnectorState);

--- a/connectors/src/lib/oauth.ts
+++ b/connectors/src/lib/oauth.ts
@@ -1,5 +1,5 @@
 // This function is used to discreminate between a new OAuth connection and an old Nango/Github
-// connection. It is ussed to support dual-use while migrating and should be unused by a connector
+// connection. It is used to support dual-use while migrating and should be unused by a connector
 // once fully migrated
 export function isDualUseOAuthConnectionId(connectionId: string): boolean {
   // TODO(spolu): make sure this function is removed once fully migrated.

--- a/connectors/src/lib/oauth.ts
+++ b/connectors/src/lib/oauth.ts
@@ -1,0 +1,7 @@
+// This function is used to discreminate between a new OAuth connection and an old Nango/Github
+// connection. It is ussed to support dual-use while migrating and should be unused by a connector
+// once fully migrated
+export function isDualUseOAuthConnectionId(connectionId: string): boolean {
+  // TODO(spolu): make sure this function is removed once fully migrated.
+  return connectionId.startsWith("con_");
+}

--- a/connectors/src/resources/connector_resource.ts
+++ b/connectors/src/resources/connector_resource.ts
@@ -211,6 +211,7 @@ export class ConnectorResource extends BaseResource<ConnectorModel> {
     return {
       id: this.id.toString(),
       type: this.type,
+      connectionId: this.connectionId,
       workspaceId: this.workspaceId,
       dataSourceName: this.dataSourceName,
       lastSyncStatus: this.lastSyncStatus,

--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -576,7 +576,7 @@ impl Connection {
 
         match self.access_token_expiry {
             Some(expiry) => {
-                if expiry < utils::now() {
+                if expiry > utils::now() {
                     // Non-expired access_token.
                     Ok(Some(access_token))
                 } else {

--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -168,7 +168,7 @@ impl fmt::Display for ConnectionStatus {
 impl FromStr for ConnectionStatus {
     type Err = ParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match serde_json::from_str(&format!("\"{}\"", s)) {
+        match serde_json::from_str(&format!("{}\"", s)) {
             Ok(v) => Ok(v),
             Err(_) => Err(ParseError::new()),
         }
@@ -427,7 +427,7 @@ impl Connection {
             // Otherwise we error.
             ConnectionStatus::Finalized => {
                 match self.unseal_authorization_code().map_err(|e| {
-                    error!("Failed to unseal authorization_code: error={:?}", e);
+                    error!(error = ?e, "Failed to unseal authorization_code");
                     ConnectionError {
                         code: ConnectionErrorCode::InternalError,
                         message: "Failed to unseal authorization_code".to_string(),

--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -168,7 +168,7 @@ impl fmt::Display for ConnectionStatus {
 impl FromStr for ConnectionStatus {
     type Err = ParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match serde_json::from_str(&format!("{}\"", s)) {
+        match serde_json::from_str(&format!("\"{}\"", s)) {
             Ok(v) => Ok(v),
             Err(_) => Err(ParseError::new()),
         }

--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use std::time::Duration;
 use std::{env, fmt};
-use tracing::error;
+use tracing::{error, info};
 
 // We hold the lock for at most 15s. In case of panic preventing the lock from being released, this
 // is the maximum time the lock will be held.
@@ -464,8 +464,12 @@ impl Connection {
         self.reload(store.clone()).await?;
 
         if self.is_already_finalized(code)? {
+            info!("Connection already finalized with code");
             return Ok(());
         }
+        info!("Finalizing connection with provider");
+
+        let now = utils::now();
 
         let finalize = provider(self.provider)
             .finalize(self, code, redirect_uri)
@@ -487,6 +491,14 @@ impl Connection {
         )?)?);
         store.update_connection_secrets(self).await?;
 
+        info!(
+            connection_id = self.connection_id(),
+            provider = self.provider.to_string(),
+            access_token_expiry = self.access_token_expiry,
+            provider_finalize_duration = utils::now() - now,
+            "Successful connection finalization"
+        );
+
         Ok(())
     }
 
@@ -500,6 +512,13 @@ impl Connection {
             return Ok(());
         }
 
+        info!(
+            connection_id = self.connection_id(),
+            provider = self.provider.to_string(),
+            "Finalizing connection",
+        );
+
+        let now = utils::now();
         let rl = LockManager::new(vec![REDIS_URI.clone()]);
 
         let lock = rl
@@ -515,7 +534,13 @@ impl Connection {
                     message: "Failed to acquire lock".to_string(),
                 }
             })?;
+        info!(
+            lock_acquisition_duration = utils::now() - now,
+            "Lock acquired"
+        );
+
         let res = self.finalize_locked(store, code, redirect_uri).await;
+
         rl.unlock(&lock).await;
 
         match res {
@@ -579,8 +604,15 @@ impl Connection {
 
         // If we refreshed while waiting for the lock return early.
         if let Some(access_token) = self.valid_access_token()? {
+            info!(
+                access_token_expiry = self.access_token_expiry,
+                "Found refreshed access token after lock acquisition",
+            );
             return Ok((access_token, self.scrubbed_raw_json()?));
         }
+        info!("Refreshing access token with provider");
+
+        let now = utils::now();
 
         let refresh = provider(self.provider).refresh(self).await?;
 
@@ -594,6 +626,14 @@ impl Connection {
             &refresh.raw_json,
         )?)?);
         store.update_connection_secrets(self).await?;
+
+        info!(
+            connection_id = self.connection_id(),
+            provider = self.provider.to_string(),
+            access_token_expiry = self.access_token_expiry,
+            provider_refresh_duration = utils::now() - now,
+            "Successful access token refresh"
+        );
 
         Ok((refresh.access_token, self.scrubbed_raw_json()?))
     }
@@ -621,6 +661,14 @@ impl Connection {
             ));
         }
 
+        info!(
+            connection_id = self.connection_id(),
+            provider = self.provider.to_string(),
+            access_token_expiry = self.access_token_expiry,
+            "Refreshing access token",
+        );
+
+        let now = utils::now();
         let rl = LockManager::new(vec![REDIS_URI.clone()]);
 
         let lock = rl
@@ -636,8 +684,13 @@ impl Connection {
                     message: "Failed to acquire lock".to_string(),
                 }
             })?;
+        info!(
+            lock_acquisition_duration = utils::now() - now,
+            "Lock acquired"
+        );
 
         let res = self.access_token_locked(store).await;
+
         rl.unlock(&lock).await;
 
         match res {

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -131,8 +131,8 @@ pub fn error_response(
     e: Option<anyhow::Error>,
 ) -> (StatusCode, Json<APIResponse>) {
     error!(
-        code = code,
-        message = message,
+        error_code = code,
+        error_message = message,
         error = ?e,
         "API error"
     );

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -41,7 +41,7 @@ export function ViewDataSourceTable({
         onClose={() => setShowRawObjectsModal(false)}
         show={showRawObjectsModal}
       />
-      <div className="flex flex-col space-y-8 pt-4">
+      <div className="flex flex-col space-y-8">
         <div className="flex justify-between gap-3">
           <div className="border-material-200 my-4 flex flex-grow flex-col rounded-lg border p-4">
             <div className="flex items-center justify-between gap-3">

--- a/front/pages/poke/[wId]/data_sources/[name]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[name]/index.tsx
@@ -278,8 +278,12 @@ const DataSourcePage = ({
         <Page.Vertical align="stretch">
           <div className="flex flex-row gap-2">
             <Page.SectionHeader title={`${dataSource.name}`} />
+          </div>
+
+          <div className="flex flex-row gap-2 text-sm font-bold text-action-500">
+            <Link href={`/poke/${owner.sId}`}>&laquo; workspace</Link>
             <div
-              className="cursor-pointer text-sm text-action-500"
+              className="cursor-pointer"
               onClick={() => {
                 if (
                   window.confirm(
@@ -292,12 +296,8 @@ const DataSourcePage = ({
                 }
               }}
             >
-              search
+              🔒search
             </div>
-          </div>
-
-          <div className="text-sm font-bold text-action-500">
-            <Link href={`/poke/${owner.sId}`}>&laquo; workspace</Link>
           </div>
 
           <ViewDataSourceTable

--- a/k8s/deployments/oauth-deployment.yaml
+++ b/k8s/deployments/oauth-deployment.yaml
@@ -58,3 +58,7 @@ spec:
         - name: api-keys-volume
           secret:
             secretName: oauth-api-keys-secret
+
+        - name: private-key-volume
+          secret:
+            secretName: github-app-private-key

--- a/k8s/deployments/oauth-deployment.yaml
+++ b/k8s/deployments/oauth-deployment.yaml
@@ -45,6 +45,8 @@ spec:
           volumeMounts:
             - name: api-keys-volume
               mountPath: /etc/api-keys
+            - name: private-key-volume
+              mountPath: /etc/private-keys
 
           resources:
             requests:

--- a/k8s/deployments/oauth-deployment.yaml
+++ b/k8s/deployments/oauth-deployment.yaml
@@ -57,4 +57,4 @@ spec:
       volumes:
         - name: api-keys-volume
           secret:
-            secretName: core-api-keys-secret
+            secretName: oauth-api-keys-secret

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -48,6 +48,7 @@ export type ConnectorType = {
   type: ConnectorProvider;
   workspaceId: string;
   dataSourceName: string;
+  connectionId: string;
 
   lastSyncStatus?: ConnectorSyncStatus;
   lastSyncStartTime?: number;

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -67,6 +67,7 @@ export * from "./front/provider";
 export * from "./front/run";
 export * from "./front/user";
 export * from "./front/workspace";
+export * from "./oauth/client/access_token";
 export * from "./oauth/client/setup";
 export * from "./oauth/lib";
 export * from "./oauth/oauth_api";

--- a/types/src/oauth/client/access_token.ts
+++ b/types/src/oauth/client/access_token.ts
@@ -36,7 +36,7 @@ export async function getOAuthConnectionAccessToken({
 > {
   const cached = CACHE.get(connectionId);
 
-  if (cached && cached.access_token_expiry < Date.now()) {
+  if (cached && cached.access_token_expiry > Date.now()) {
     return new Ok(cached);
   }
 

--- a/types/src/oauth/client/setup.ts
+++ b/types/src/oauth/client/setup.ts
@@ -20,7 +20,7 @@ export async function setupOAuthConnection({
 }): Promise<Result<OAuthConnectionType, Error>> {
   return new Promise((resolve) => {
     const oauthPopup = window.open(
-      `${dustClientFacingUrl}/w/${owner.sId}/oauth/${provider}/redirect?useCase=${useCase}`
+      `${dustClientFacingUrl}/w/${owner.sId}/oauth/${provider}/setup?useCase=${useCase}`
     );
     let authComplete = false;
 
@@ -32,6 +32,7 @@ export async function setupOAuthConnection({
       if (event.data.type === "connection_finalized") {
         authComplete = true;
         const connection = event.data.connection;
+        console.log("Received connection", connection);
         if (isOAuthConnectionType(connection)) {
           resolve(new Ok(connection));
         } else {

--- a/types/src/oauth/client/setup.ts
+++ b/types/src/oauth/client/setup.ts
@@ -32,7 +32,6 @@ export async function setupOAuthConnection({
       if (event.data.type === "connection_finalized") {
         authComplete = true;
         const connection = event.data.connection;
-        console.log("Received connection", connection);
         if (isOAuthConnectionType(connection)) {
           resolve(new Ok(connection));
         } else {

--- a/types/src/oauth/lib.ts
+++ b/types/src/oauth/lib.ts
@@ -25,9 +25,9 @@ export function isOAuthProvider(obj: unknown): obj is OAuthProvider {
 export type OAuthConnectionType = {
   connection_id: string;
   created: number;
+  metdata: Record<string, unknown>;
   provider: OAuthProvider;
   status: "pending" | "finalized";
-  secret: string;
 };
 
 export function isOAuthConnectionType(
@@ -38,7 +38,6 @@ export function isOAuthConnectionType(
     typeof connection.connection_id === "string" &&
     typeof connection.created === "number" &&
     isOAuthProvider(connection.provider) &&
-    (connection.status === "pending" || connection.status === "finalized") &&
-    typeof connection.secret === "string"
+    (connection.status === "pending" || connection.status === "finalized")
   );
 }

--- a/types/src/shared/feature_flags.ts
+++ b/types/src/shared/feature_flags.ts
@@ -9,6 +9,7 @@ export const WHITELISTABLE_FEATURES = [
   "dust_splitted_ds_flag",
   "microsoft_csv_sync",
   "google_csv_sync",
+  "test_oauth_setup",
 ] as const;
 export type WhitelistableFeature = (typeof WHITELISTABLE_FEATURES)[number];
 export function isWhitelistableFeature(


### PR DESCRIPTION
## Description

- Adds a flag to `test_oauth_setup` to allow flagging Dust to setup github with `oauth`
- Implements dual-mode functioning where we route to our legacy implementation or `oauth` based on the `connectionId` format. 
- Adds an index on GithubConnectorState to efficiently query them by installationId (added yesterday) on webhook receival

## Risk

Low. Gated release to test on Dust. Webhook handling logic is modified: extra review care is needed on this.

## Deploy Plan

Development tests:
- set up github locally with the flag and test initial sync

Production tests:
- run migration in prod
- deploy `oauth`
- deploy `connectors`
- deploy `front`
- flag Dust in and setup Dust with `oauth`
- Ensure fullResync works + incremental webhook based sync

Next steps:
- Migration script for existing connectors