### PR TITLE
[MS Connector] Incremental sync

### DIFF
--- a/connectors/src/connectors/microsoft/lib/content_nodes.ts
+++ b/connectors/src/connectors/microsoft/lib/content_nodes.ts
@@ -2,7 +2,7 @@ import type { ContentNode } from "@dust-tt/types";
 
 import {
   getDriveAPIPath,
-  getDriveItemAPIPath,
+  getDriveItemInternalId,
   getSiteAPIPath,
   internalIdFromTypeAndPath,
   typeAndPathFromInternalId,
@@ -147,10 +147,7 @@ export function getFolderAsContentNode(
 ): ContentNode {
   return {
     provider: "microsoft",
-    internalId: internalIdFromTypeAndPath({
-      itemAPIPath: getDriveItemAPIPath(folder),
-      nodeType: "folder",
-    }),
+    internalId: getDriveItemInternalId(folder),
     parentInternalId,
     type: "folder",
     title: folder.name || "unnamed",

--- a/connectors/src/connectors/microsoft/lib/content_nodes.ts
+++ b/connectors/src/connectors/microsoft/lib/content_nodes.ts
@@ -1,7 +1,7 @@
 import type { ContentNode } from "@dust-tt/types";
 
 import {
-  getDriveAPIPath,
+  getDriveInternalId,
   getDriveItemInternalId,
   getSiteAPIPath,
   internalIdFromTypeAndPath,
@@ -127,10 +127,7 @@ export function getDriveAsContentNode(
   }
   return {
     provider: "microsoft",
-    internalId: internalIdFromTypeAndPath({
-      itemAPIPath: getDriveAPIPath(drive),
-      nodeType: "drive",
-    }),
+    internalId: getDriveInternalId(drive),
     parentInternalId,
     type: "folder",
     title: drive.name || "unnamed",

--- a/connectors/src/connectors/microsoft/lib/graph_api.ts
+++ b/connectors/src/connectors/microsoft/lib/graph_api.ts
@@ -470,6 +470,13 @@ export function getDriveItemInternalId(item: MicrosoftGraph.DriveItem) {
     throw new Error("Unexpected: item is neither folder nor file");
   }
 
+  if (item.root) {
+    return internalIdFromTypeAndPath({
+      nodeType: "drive",
+      itemAPIPath: `/drives/${parentReference.driveId}`,
+    });
+  }
+
   return internalIdFromTypeAndPath({
     nodeType,
     itemAPIPath: `/drives/${parentReference.driveId}/items/${item.id}`,

--- a/connectors/src/connectors/microsoft/lib/graph_api.ts
+++ b/connectors/src/connectors/microsoft/lib/graph_api.ts
@@ -314,6 +314,18 @@ export async function getItem(client: Client, itemApiPath: string) {
   return client.api(itemApiPath).get();
 }
 
+export async function getFileDownloadURL(client: Client, internalId: string) {
+  const { nodeType, itemAPIPath } = typeAndPathFromInternalId(internalId);
+
+  if (nodeType !== "file") {
+    throw new Error(`Invalid node type: ${nodeType} for getFileDownloadURL`);
+  }
+
+  const res = await client.api(`${itemAPIPath}`).get();
+
+  return res["@microsoft.graph.downloadUrl"];
+}
+
 type MicrosoftEntity = {
   folder: MicrosoftGraph.DriveItem;
   drive: MicrosoftGraph.Drive;

--- a/connectors/src/connectors/microsoft/lib/graph_api.ts
+++ b/connectors/src/connectors/microsoft/lib/graph_api.ts
@@ -99,7 +99,7 @@ export async function getDeltaResults({
 
   if (nodeType !== "drive" && nodeType !== "folder") {
     throw new Error(
-      `Invalid node type: ${nodeType} for getFilesAndFolders, expected drive or folder`
+      `Invalid node type: ${nodeType} for delta, expected drive or folder`
     );
   }
 
@@ -139,7 +139,6 @@ export async function getDeltaResults({
 /**
  * Similar to getDeltaResults but goes through pagination (returning results and
  * the deltalink)
- * @param client
  */
 export async function getFullDeltaResults(
   client: Client,

--- a/connectors/src/connectors/microsoft/lib/graph_api.ts
+++ b/connectors/src/connectors/microsoft/lib/graph_api.ts
@@ -342,7 +342,9 @@ export function itemToMicrosoftNode<T extends keyof MicrosoftEntityMapping>(
         nodeType,
         name: item.name ?? null,
         internalId: getDriveItemInternalId(item),
-        parentInternalId: null,
+        parentInternalId: item.parentReference
+          ? getParentReferenceInternalId(item.parentReference)
+          : null,
         mimeType: null,
       };
     }
@@ -352,7 +354,9 @@ export function itemToMicrosoftNode<T extends keyof MicrosoftEntityMapping>(
         nodeType,
         name: item.name ?? null,
         internalId: getDriveItemInternalId(item),
-        parentInternalId: null,
+        parentInternalId: item.parentReference
+          ? getParentReferenceInternalId(item.parentReference)
+          : null,
         mimeType: item.file?.mimeType ?? null,
       };
     }
@@ -361,10 +365,7 @@ export function itemToMicrosoftNode<T extends keyof MicrosoftEntityMapping>(
       return {
         nodeType,
         name: item.name ?? null,
-        internalId: internalIdFromTypeAndPath({
-          nodeType,
-          itemAPIPath: getDriveAPIPath(item),
-        }),
+        internalId: getDriveInternalId(item),
         parentInternalId: null,
         mimeType: null,
       };
@@ -477,7 +478,7 @@ export function getParentReferenceInternalId(
   });
 }
 
-export function getWorksheetAPIPath(
+export function getWorksheetInternalId(
   item: MicrosoftGraph.WorkbookWorksheet,
   parentInternalId: string
 ) {
@@ -488,29 +489,28 @@ export function getWorksheetAPIPath(
     throw new Error(`Invalid parent nodeType: ${nodeType}`);
   }
 
-  return `${parentItemApiPath}/workbook/worksheets/${item.id}`;
+  return internalIdFromTypeAndPath({
+    itemAPIPath: `${parentItemApiPath}/workbook/worksheets/${item.id}`,
+    nodeType: "worksheet",
+  });
 }
 
-export function getDriveAPIPath(drive: MicrosoftGraph.Drive) {
-  return `/drives/${drive.id}`;
+export function getDriveInternalId(drive: MicrosoftGraph.Drive) {
+  return internalIdFromTypeAndPath({
+    nodeType: "drive",
+    itemAPIPath: `/drives/${drive.id}`,
+  });
 }
 
-export function getDriveAPIPathFromItem(item: MicrosoftGraph.DriveItem) {
+export function getDriveInternalIdFromItem(item: MicrosoftGraph.DriveItem) {
   if (!item.parentReference?.driveId) {
     throw new Error("Unexpected: no drive id for item");
   }
 
-  return `/drives/${item.parentReference.driveId}`;
-}
-
-export function getDriveItemAPIPathFromReference(
-  parentReference: MicrosoftGraph.ItemReference
-) {
-  if (!parentReference.driveId) {
-    throw new Error("Unexpected: no drive id for item");
-  }
-
-  return `/drives/${parentReference.driveId}/items/${parentReference.id}`;
+  return internalIdFromTypeAndPath({
+    nodeType: "drive",
+    itemAPIPath: `/drives/${item.parentReference.driveId}`,
+  });
 }
 
 export function getSiteAPIPath(site: MicrosoftGraph.Site) {

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -648,6 +648,56 @@ export async function syncOneFile({
   return isInSizeRange;
 }
 
+export async function syncDeltaForNode({
+  connectorId,
+  nodeId,
+  startSyncTs,
+}: {
+  connectorId: ModelId;
+  nodeId: string;
+  startSyncTs: number;
+}) {
+  const connector = await ConnectorResource.fetchById(connectorId);
+  if (!connector) {
+    throw new Error(`Connector ${connectorId} not found`);
+  }
+
+  const node = await MicrosoftNodeResource.fetchByInternalId(
+    connectorId,
+    nodeId
+  );
+
+  if (!node) {
+    throw new Error(`Node ${nodeId} not found`);
+  }
+
+  if (node.nodeType !== "drive" && node.nodeType !== "folder") {
+    throw new Error(`Node ${nodeId} is not a drive or folder`);
+  }
+
+  const client = await getClient(connector.connectionId);
+
+  const nodeDelta = 
+
+  const delta = await getDriveOrItemDelta(
+    client,
+    nodeId,
+    node.itemAPIPath,
+    startSyncTs
+  );
+
+  if (delta) {
+    await syncFiles({
+      connectorId,
+      parentInternalId: nodeId,
+      startSyncTs,
+      nextPageLink: delta.nextLink,
+    });
+  }
+
+  return delta;
+}
+
 async function getParents({
   connectorId,
   internalId,

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -752,11 +752,11 @@ export async function syncDeltaForNode({
 
     if (driveItem.file) {
       if (driveItem.deleted) {
-        // if file was just moved from a toplevel folder to another, it's marked
+        // if file was just moved from a toplevel folder to another in the same drive, it's marked
         // as deleted but we don't want to delete it
         // internally means "in the same Drive" here
         if (
-          !(await isFileInternallyMoved({
+          !(await isFileMovedInSameDrive({
             toplevelNode: node,
             fileInternalId: internalId,
           }))
@@ -1060,18 +1060,16 @@ async function deleteFile({
  * Note: this concerns toplevel folders, not drives; it's fine to delete files
  * that move from a drive to another because they change id
  */
-async function isFileInternallyMoved({
+async function isFileMovedInSameDrive({
   toplevelNode,
   fileInternalId,
 }: {
   toplevelNode: MicrosoftNodeResource;
   fileInternalId: string;
 }) {
-  // check the node is a toplevel folder, not a drive
-  if (toplevelNode.nodeType !== "folder") {
-    throw new Error(
-      `Unexpected: toplevel node is not a folder: ${toplevelNode.nodeType}`
-    );
+  if (toplevelNode.nodeType === "drive") {
+    // if the toplevel node is a drive, then the deletion must happen
+    return false;
   }
   // check that the file's parents array does not contain the toplevel folder, in
   // which case it's a file movement; otherwise it's a file deletion

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -781,10 +781,11 @@ export async function syncDeltaForNode({
         // in the delta with the 'deleted' field set
         await deleteFolder({ connectorId, internalId });
       } else {
-        await MicrosoftNodeResource.updateOrCreate(
+        const resource = await MicrosoftNodeResource.updateOrCreate(
           connectorId,
           itemToMicrosoftNode("folder", driveItem)
         );
+        await resource.update({ lastSeenTs: new Date() });
       }
     } else {
       throw new Error(`Unexpected: driveItem is neither file nor folder`);

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -21,6 +21,7 @@ import {
   getDriveInternalIdFromItem,
   getDriveItemInternalId,
   getDrives,
+  getFileDownloadURL,
   getFilesAndFolders,
   getFullDeltaResults,
   getItem,
@@ -444,16 +445,14 @@ export async function syncOneFile({
   const url =
     "@microsoft.graph.downloadUrl" in file
       ? file["@microsoft.graph.downloadUrl"]
-      : null;
+      : await getFileDownloadURL(
+          await getClient(connector.connectionId),
+          documentId
+        );
 
   if (!url) {
     localLogger.error("Unexpected missing download URL");
     throw new Error("Unexpected missing download URL");
-  }
-
-  if (!url) {
-    localLogger.info("No download URL found");
-    return false;
   }
 
   // If the file is too big to be downloaded, we skip it.

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -718,7 +718,7 @@ export async function syncDeltaForNode({
 
   if (!node.deltaLink) {
     throw new Error(
-      `Delta link not found for root node resource ${node.toJSON()}`
+      `Delta link not found for root node resource ${JSON.stringify(node.toJSON())}`
     );
   }
 

--- a/connectors/src/connectors/microsoft/temporal/client.ts
+++ b/connectors/src/connectors/microsoft/temporal/client.ts
@@ -4,7 +4,9 @@ import { Err, Ok } from "@dust-tt/types";
 import { QUEUE_NAME } from "@connectors/connectors/microsoft/temporal/config";
 import {
   fullSyncWorkflow,
+  incrementalSyncWorkflow,
   microsoftFullSyncWorkflowId,
+  microsoftIncrementalSyncWorkflowId,
 } from "@connectors/connectors/microsoft/temporal/workflows";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { getTemporalClient, terminateWorkflow } from "@connectors/lib/temporal";
@@ -72,5 +74,42 @@ export async function launchMicrosoftIncrementalSyncWorkflow(
   if (!connector) {
     return new Err(new Error(`Connector ${connectorId} not found`));
   }
-  return new Ok("Not implemented yet");
+  const client = await getTemporalClient();
+
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+
+  const workflowId = microsoftIncrementalSyncWorkflowId(connectorId);
+
+  try {
+    await terminateWorkflow(workflowId);
+    await client.workflow.start(incrementalSyncWorkflow, {
+      args: [{ connectorId }],
+      taskQueue: QUEUE_NAME,
+      workflowId: workflowId,
+      searchAttributes: {
+        connectorId: [connectorId],
+      },
+      memo: {
+        connectorId: connectorId,
+      },
+    });
+    logger.info(
+      {
+        workspaceId: dataSourceConfig.workspaceId,
+        workflowId,
+      },
+      `Started workflow.`
+    );
+    return new Ok(workflowId);
+  } catch (e) {
+    logger.error(
+      {
+        workspaceId: dataSourceConfig.workspaceId,
+        workflowId,
+        error: e,
+      },
+      `Failed starting workflow.`
+    );
+    return new Err(e as Error);
+  }
 }

--- a/connectors/src/connectors/microsoft/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/microsoft/temporal/spreadsheets.ts
@@ -5,7 +5,7 @@ import { stringify } from "csv-stringify/sync";
 import { getClient } from "@connectors/connectors/microsoft";
 import {
   getAllPaginatedEntities,
-  getDriveItemAPIPath,
+  getDriveItemInternalId,
   getWorksheetAPIPath,
   getWorksheetContent,
   getWorksheets,
@@ -192,12 +192,7 @@ export async function syncSpreadSheet({
 
   localLogger.info("[Spreadsheet] Syncing Excel Spreadsheet.");
 
-  const itemApiPath = getDriveItemAPIPath(file);
-
-  const documentId = internalIdFromTypeAndPath({
-    itemAPIPath: itemApiPath,
-    nodeType: "file",
-  });
+  const documentId = getDriveItemInternalId(file);
 
   const worksheets = await getAllPaginatedEntities((nextLink) =>
     getWorksheets(client, documentId, nextLink)

--- a/connectors/src/connectors/microsoft/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/microsoft/temporal/spreadsheets.ts
@@ -239,14 +239,6 @@ export async function syncSpreadSheet({
   return { isSupported: true };
 }
 
-export function isMicrosoftSpreadsheet(file: MicrosoftNodeResource): boolean {
-  return (
-    file.mimeType ===
-      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" ||
-    file.mimeType === "application/vnd.ms-excel"
-  );
-}
-
 export async function deleteAllSheets(
   dataSourceConfig: DataSourceConfig,
   spreadsheet: MicrosoftNodeResource

--- a/connectors/src/connectors/microsoft/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/microsoft/temporal/spreadsheets.ts
@@ -6,7 +6,7 @@ import { getClient } from "@connectors/connectors/microsoft";
 import {
   getAllPaginatedEntities,
   getDriveItemInternalId,
-  getWorksheetAPIPath,
+  getWorksheetInternalId,
   getWorksheetContent,
   getWorksheets,
   internalIdFromTypeAndPath,
@@ -206,10 +206,7 @@ export async function syncSpreadSheet({
   const successfulSheetIdImports: string[] = [];
   for (const worksheet of worksheets) {
     if (worksheet.id) {
-      const internalWorkSheetId = internalIdFromTypeAndPath({
-        nodeType: "worksheet",
-        itemAPIPath: getWorksheetAPIPath(worksheet, documentId),
-      });
+      const internalWorkSheetId = getWorksheetInternalId(worksheet, documentId);
       const isImported = await processSheet(
         client,
         connector,

--- a/connectors/src/connectors/microsoft/temporal/workflows.ts
+++ b/connectors/src/connectors/microsoft/temporal/workflows.ts
@@ -9,10 +9,16 @@ import {
 import type * as activities from "@connectors/connectors/microsoft/temporal/activities";
 import type * as sync_status from "@connectors/lib/sync_status";
 
-const { getSiteNodesToSync, syncFiles, markNodeAsVisited, syncDeltaForNode } =
-  proxyActivities<typeof activities>({
-    startToCloseTimeout: "20 minutes",
-  });
+const { getSiteNodesToSync, syncFiles, markNodeAsVisited } = proxyActivities<
+  typeof activities
+>({
+  startToCloseTimeout: "30 minutes",
+});
+
+const { syncDeltaForNode } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "120 minutes",
+  heartbeatTimeout: "5 minutes",
+});
 
 const { reportInitialSyncProgress, syncSucceeded } = proxyActivities<
   typeof sync_status

--- a/connectors/src/connectors/microsoft/temporal/workflows.ts
+++ b/connectors/src/connectors/microsoft/temporal/workflows.ts
@@ -9,11 +9,10 @@ import {
 import type * as activities from "@connectors/connectors/microsoft/temporal/activities";
 import type * as sync_status from "@connectors/lib/sync_status";
 
-const { getSiteNodesToSync, syncFiles, markNodeAsVisited } = proxyActivities<
-  typeof activities
->({
-  startToCloseTimeout: "30 minutes",
-});
+const { getSiteNodesToSync, syncFiles, markNodeAsVisited, populateDeltas } =
+  proxyActivities<typeof activities>({
+    startToCloseTimeout: "30 minutes",
+  });
 
 const { syncDeltaForNode } = proxyActivities<typeof activities>({
   startToCloseTimeout: "120 minutes",
@@ -61,6 +60,8 @@ export async function fullSyncSitesWorkflow({
   if (nodeIdsToSync === undefined) {
     nodeIdsToSync = await getSiteNodesToSync(connectorId);
   }
+
+  await populateDeltas(connectorId, nodeIdsToSync);
 
   let nextPageLink: string | undefined = undefined;
 

--- a/connectors/src/lib/models/microsoft.ts
+++ b/connectors/src/lib/models/microsoft.ts
@@ -214,7 +214,7 @@ export class MicrosoftDeltaModel extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare rootId: ForeignKey<MicrosoftRootModel["itemAPIPath"]>;
-  declare deltaToken: string;
+  declare deltaLink: string;
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
 }
 MicrosoftDeltaModel.init(
@@ -242,7 +242,7 @@ MicrosoftDeltaModel.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
-    deltaToken: {
+    deltaLink: {
       type: DataTypes.STRING,
       allowNull: false,
     },

--- a/connectors/src/lib/models/microsoft.ts
+++ b/connectors/src/lib/models/microsoft.ts
@@ -256,4 +256,7 @@ MicrosoftDeltaModel.init(
   }
 );
 ConnectorModel.hasMany(MicrosoftDeltaModel);
-MicrosoftNodeModel.hasOne(MicrosoftDeltaModel);
+MicrosoftNodeModel.belongsTo(MicrosoftDeltaModel, {
+  foreignKey: "nodeId",
+  as: "delta",
+});

--- a/connectors/src/lib/models/microsoft.ts
+++ b/connectors/src/lib/models/microsoft.ts
@@ -3,6 +3,7 @@ import type {
   ForeignKey,
   InferAttributes,
   InferCreationAttributes,
+  NonAttribute,
 } from "sequelize";
 import { DataTypes, Model } from "sequelize";
 
@@ -76,6 +77,7 @@ export class MicrosoftRootModel extends Model<
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
   declare itemAPIPath: string;
   declare nodeType: MicrosoftNodeType;
+  declare delta: NonAttribute<MicrosoftDeltaModel>;
 }
 MicrosoftRootModel.init(
   {

--- a/connectors/src/lib/models/microsoft.ts
+++ b/connectors/src/lib/models/microsoft.ts
@@ -197,17 +197,17 @@ MicrosoftNodeModel.init(
     sequelize: sequelizeConnection,
     modelName: "microsoft_nodes",
     indexes: [
-      { fields: ["connectorId", "internalId"], unique: true },
+      { fields: ["internalId", "connectorId"], unique: true },
       { fields: ["connectorId", "nodeType"], unique: false },
-      { fields: ["connectorId", "parentInternalId"], concurrently: true },
+      { fields: ["parentInternalId", "connectorId"], concurrently: true },
     ],
   }
 );
 ConnectorModel.hasMany(MicrosoftNodeModel);
 
-// Delta token are used for creating a diff from the last calls.
+// Delta links are used for creating a diff from the last calls.
 // On every delta call, we store the new delta token to be used in the next call
-// For each configured root node, we store a delta token.
+// For each configured root node, we store a delta link.
 export class MicrosoftDeltaModel extends Model<
   InferAttributes<MicrosoftDeltaModel>,
   InferCreationAttributes<MicrosoftDeltaModel>
@@ -215,7 +215,7 @@ export class MicrosoftDeltaModel extends Model<
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
-  declare nodeId: ForeignKey<MicrosoftNodeModel["internalId"]>;
+  declare nodeId: ForeignKey<MicrosoftNodeModel["id"]>;
   declare deltaLink: string;
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
 }
@@ -241,7 +241,7 @@ MicrosoftDeltaModel.init(
       allowNull: false,
     },
     nodeId: {
-      type: DataTypes.STRING,
+      type: DataTypes.INTEGER,
       allowNull: false,
     },
     deltaLink: {
@@ -256,7 +256,13 @@ MicrosoftDeltaModel.init(
   }
 );
 ConnectorModel.hasMany(MicrosoftDeltaModel);
-MicrosoftNodeModel.belongsTo(MicrosoftDeltaModel, {
+
+MicrosoftDeltaModel.belongsTo(MicrosoftNodeModel, {
+  foreignKey: "nodeId",
+  as: "node",
+});
+
+MicrosoftNodeModel.hasOne(MicrosoftDeltaModel, {
   foreignKey: "nodeId",
   as: "delta",
 });

--- a/connectors/src/lib/models/microsoft.ts
+++ b/connectors/src/lib/models/microsoft.ts
@@ -77,7 +77,6 @@ export class MicrosoftRootModel extends Model<
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
   declare itemAPIPath: string;
   declare nodeType: MicrosoftNodeType;
-  declare delta: NonAttribute<MicrosoftDeltaModel>;
 }
 MicrosoftRootModel.init(
   {
@@ -137,6 +136,7 @@ export class MicrosoftNodeModel extends Model<
   declare name: string | null;
   declare mimeType: string | null;
   declare parentInternalId: string | null;
+  declare delta: NonAttribute<MicrosoftDeltaModel>;
 }
 
 MicrosoftNodeModel.init(
@@ -215,7 +215,7 @@ export class MicrosoftDeltaModel extends Model<
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
-  declare rootId: ForeignKey<MicrosoftRootModel["itemAPIPath"]>;
+  declare nodeId: ForeignKey<MicrosoftNodeModel["internalId"]>;
   declare deltaLink: string;
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
 }
@@ -240,7 +240,7 @@ MicrosoftDeltaModel.init(
       type: DataTypes.INTEGER,
       allowNull: false,
     },
-    rootId: {
+    nodeId: {
       type: DataTypes.STRING,
       allowNull: false,
     },
@@ -252,8 +252,8 @@ MicrosoftDeltaModel.init(
   {
     sequelize: sequelizeConnection,
     modelName: "microsoft_deltas",
-    indexes: [{ fields: ["connectorId", "rootId"], unique: true }],
+    indexes: [{ fields: ["connectorId", "nodeId"], unique: true }],
   }
 );
 ConnectorModel.hasMany(MicrosoftDeltaModel);
-MicrosoftRootModel.hasOne(MicrosoftDeltaModel);
+MicrosoftNodeModel.hasOne(MicrosoftDeltaModel);

--- a/connectors/src/lib/models/microsoft.ts
+++ b/connectors/src/lib/models/microsoft.ts
@@ -245,7 +245,7 @@ MicrosoftDeltaModel.init(
       allowNull: false,
     },
     deltaLink: {
-      type: DataTypes.STRING,
+      type: DataTypes.STRING(1024),
       allowNull: false,
     },
   },

--- a/connectors/src/resources/microsoft_resource.ts
+++ b/connectors/src/resources/microsoft_resource.ts
@@ -197,6 +197,29 @@ export class MicrosoftRootResource extends BaseResource<MicrosoftRootModel> {
     return new Ok(undefined);
   }
 
+  async fetchByItemAPIPath() {
+    const blob = await this.model.findOne({
+      where: {
+        itemAPIPath: this.itemAPIPath,
+        connectorId: this.connectorId,
+      },
+      include: [{ model: MicrosoftDeltaModel, as: "delta" }],
+    });
+    if (!blob) {
+      return null;
+    }
+
+    return new MicrosoftRootResource(this.model, blob.get());
+  }
+
+  async updateDeltaLink(deltaLink: string) {
+    await MicrosoftDeltaModel.upsert({
+      connectorId: this.connectorId,
+      rootId: this.itemAPIPath,
+      deltaLink,
+    });
+  }
+
   toJSON() {
     return {
       id: this.id,

--- a/connectors/src/resources/microsoft_resource.ts
+++ b/connectors/src/resources/microsoft_resource.ts
@@ -275,7 +275,6 @@ export class MicrosoftNodeResource extends BaseResource<MicrosoftNodeModel> {
     if (!blob) {
       return null;
     }
-    console.log(blob, blob.delta);
     const resource = new this(this.model, blob.get());
     resource.delta = blob.delta;
     return resource;

--- a/connectors/src/resources/microsoft_resource.ts
+++ b/connectors/src/resources/microsoft_resource.ts
@@ -350,6 +350,21 @@ export class MicrosoftNodeResource extends BaseResource<MicrosoftNodeModel> {
     return new Ok(undefined);
   }
 
+  static async updateOrCreate(
+    connectorId: ModelId,
+    node: MicrosoftNode
+  ): Promise<MicrosoftNodeResource> {
+    const res = await this.batchUpdateOrCreate(connectorId, [node]);
+
+    if (res.length !== 1 || !res[0]) {
+      throw new Error(
+        "Unreachable: batchUpdateOrCreate returned 0 or more than 1 resources"
+      );
+    }
+
+    return res[0];
+  }
+
   static async batchUpdateOrCreate(
     connectorId: ModelId,
     nodes: MicrosoftNode[]

--- a/connectors/src/resources/microsoft_resource.ts
+++ b/connectors/src/resources/microsoft_resource.ts
@@ -275,7 +275,7 @@ export class MicrosoftNodeResource extends BaseResource<MicrosoftNodeModel> {
     if (!blob) {
       return null;
     }
-
+    console.log(blob, blob.delta);
     const resource = new this(this.model, blob.get());
     resource.delta = blob.delta;
     return resource;
@@ -316,7 +316,7 @@ export class MicrosoftNodeResource extends BaseResource<MicrosoftNodeModel> {
   async updateDeltaLink(deltaLink: string) {
     await MicrosoftDeltaModel.upsert({
       connectorId: this.connectorId,
-      nodeId: this.internalId,
+      nodeId: this.id,
       deltaLink,
     });
   }


### PR DESCRIPTION
## Description
This PR adds workflow & activity for incremental sync for microsoft connector (sites & drives). Fixes #5747 
It uses microsoft graph api's [deltas](https://learn.microsoft.com/en-us/graph/api/driveitem-delta?view=graph-rest-1.0&tabs=http). Design documentation is [here](https://www.notion.so/dust-tt/Design-Doc-Microsoft-connector-side-topics-c27726652aae45abafaac587b971a41d?pvs=4)

For those purposes the PR:
- implements `deleteFile|Folder|Spreadsheets` functions, 
- -adds deltas to the `MicrosoftNodeResources`, 
- populates the deltas with initial values during the fullsync
- updates the deltas at each incremental sync
- additionally, refactors get***ItemAPIPath to get***InternalId, much more adapted

## Risk
Gated, but test plan is as follows: launch incremental syncs and confirm changes take effect:
  - file is updated
  - file is moved across folders
  - file is moved across drives
  - folder is moved across folders
  - folder is moved across drives
  - file is deleted
  - folder is deleted

## Deploy Plan

connectors
