### PR TITLE
Add support for Anthropic vision

### DIFF
--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -223,7 +223,7 @@ async fn fetch_image_base64(image_url: &str) -> Result<(String, AnthropicImageCo
     ))
 }
 
-async fn fetch_image_base64_and_substitute(
+async fn fetch_and_encode_images(
     messages: Vec<ChatMessage>,
 ) -> Result<HashMap<String, AnthropicImageContent>, anyhow::Error> {
     let futures = messages
@@ -1668,7 +1668,7 @@ impl LLM for AnthropicLLM {
             None => None,
         };
 
-        let base64_map = fetch_image_base64_and_substitute(messages.clone()).await?;
+        let base64_map = fetch_and_encode_images(messages.clone()).await?;
         let mut messages = messages
             .iter()
             .skip(match system.as_ref() {

--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -260,17 +260,17 @@ async fn fetch_and_encode_images(
     Ok(base64_pairs)
 }
 
-struct ChatMessageConversionInput {
-    chat_message: ChatMessage,
-    base64_map: HashMap<String, AnthropicImageContent>,
+struct ChatMessageConversionInput<'a> {
+    chat_message: &'a ChatMessage,
+    base64_map: &'a HashMap<String, AnthropicImageContent>,
 }
 
-impl TryFrom<&ChatMessageConversionInput> for AnthropicChatMessage {
+impl<'a> TryFrom<&'a ChatMessageConversionInput<'a>> for AnthropicChatMessage {
     type Error = anyhow::Error;
 
     fn try_from(input: &ChatMessageConversionInput) -> Result<Self, Self::Error> {
-        let cm = input.chat_message.clone();
-        let base64_map = input.base64_map.clone();
+        let cm = input.chat_message;
+        let base64_map = input.base64_map;
 
         match cm {
             ChatMessage::Assistant(assistant_msg) => {
@@ -1677,8 +1677,8 @@ impl LLM for AnthropicLLM {
             })
             .map(|cm| {
                 let conversion_input = ChatMessageConversionInput {
-                    chat_message: cm.clone(),
-                    base64_map: base64_map.clone(),
+                    chat_message: &cm,
+                    base64_map: &base64_map,
                 };
 
                 AnthropicChatMessage::try_from(&conversion_input)

--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -257,7 +257,7 @@ export const CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   shortDescription: "Anthropic's largest model.",
   isLegacy: false,
   delimitersConfiguration: ANTHROPIC_DELIMITERS_CONFIGURATION,
-  supportsVision: false,
+  supportsVision: true,
 };
 export const CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",
@@ -271,7 +271,7 @@ export const CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   shortDescription: "Anthropic's latest model.",
   isLegacy: false,
   delimitersConfiguration: ANTHROPIC_DELIMITERS_CONFIGURATION,
-  supportsVision: false,
+  supportsVision: true,
 };
 export const CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",
@@ -285,7 +285,7 @@ export const CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
     "Anthropic's Claude 3 Haiku model, cost effective and high throughput (200k context).",
   shortDescription: "Anthropic's cost-effective model.",
   isLegacy: false,
-  supportsVision: false,
+  supportsVision: true,
 };
 export const CLAUDE_2_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR introduces Vision support in our Anthropic implementation. Our API will only support a file URL. Core is responsible for fetching this URL and encoding the image in base64, as Anthropic currently does not support URLs directly.

The implemented approach involves fetching all file URLs and constructing a lookup map for subsequent use. All three Anthropic models available on Dust support Vision functionality.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
First deploy connectors, then front.
