### PR TITLE
Do not display <br> on tables in renderMessageMarkdown

### DIFF
--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -314,22 +314,22 @@ function CiteBlock(props: ReactMarkdownProps) {
   }
 }
 
+const getNodeText = (node: ReactNode): string => {
+  if (["string", "number"].includes(typeof node)) {
+    return node as string;
+  }
+  if (node instanceof Array) {
+    return node.map(getNodeText).join("");
+  }
+  if (node && typeof node === "object" && "props" in node) {
+    return getNodeText(node.props.children);
+  }
+
+  return "";
+};
+
 function TableBlock({ children }: { children: React.ReactNode }) {
   const tableData = useMemo(() => {
-    const getNodeText = (node: ReactNode): string => {
-      if (["string", "number"].includes(typeof node)) {
-        return node as string;
-      }
-      if (node instanceof Array) {
-        return node.map(getNodeText).join("");
-      }
-      if (node && typeof node === "object" && "props" in node) {
-        return getNodeText(node.props.children);
-      }
-
-      return "";
-    };
-
     const [headNode, bodyNode] = Array.from(children as [any, any]);
     if (
       !headNode ||
@@ -400,7 +400,16 @@ function TableHeaderBlock({ children }: { children: React.ReactNode }) {
 function TableDataBlock({ children }: { children: React.ReactNode }) {
   return (
     <td className="px-6 py-4 text-sm text-element-800 dark:text-element-800-dark">
-      {children}
+      {Array.isArray(children) ? (
+        children.map((child: any, i) => {
+          if (child === "<br>") {
+            return <br key={i} />;
+          }
+          return <React.Fragment key={i}>{getNodeText(child)}</React.Fragment>;
+        })
+      ) : (
+        <> {getNodeText(children)}</>
+      )}
     </td>
   );
 }


### PR DESCRIPTION
## Description

Fixing the rendering of line breaks on tables in our renderUsermessage. 


### Before: 
<kbd>
<img width="899" alt="Screenshot 2024-07-19 at 10 17 51" src="https://github.com/user-attachments/assets/d90e2de0-b0b6-44ca-aaec-974fa415cebb">
</kbd>

### After: 
<kbd>
<img width="922" alt="Screenshot 2024-07-19 at 10 17 43" src="https://github.com/user-attachments/assets/519998b7-e884-4e0e-830b-d1e60676b403">
</kbd>

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
