### PR TITLE
Add commit hash to front build

### DIFF
--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -19,5 +19,7 @@ COPY /front .
 # is undefined, and `next build` imports the `models.ts` file while "Collecting page data"
 RUN FRONT_DATABASE_URI="sqlite:foo.sqlite" npm run build
 
+ARG COMMIT_HASH
+ENV NEXT_PUBLIC_COMMIT_HASH=${COMMIT_HASH}
 
 CMD ["npm", "--silent", "run", "start"]

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -15,11 +15,11 @@ RUN npm ci
 
 COPY /front .
 
+ARG COMMIT_HASH
+ENV NEXT_PUBLIC_COMMIT_HASH=${COMMIT_HASH}
+
 # fake database URIs are needed because Sequelize will throw if the `url` parameter
 # is undefined, and `next build` imports the `models.ts` file while "Collecting page data"
 RUN FRONT_DATABASE_URI="sqlite:foo.sqlite" npm run build
-
-ARG COMMIT_HASH
-ENV NEXT_PUBLIC_COMMIT_HASH=${COMMIT_HASH}
 
 CMD ["npm", "--silent", "run", "start"]

--- a/front/lib/commit-hash.ts
+++ b/front/lib/commit-hash.ts
@@ -1,0 +1,2 @@
+// We must use NEXT_PUBLIC_ prefix to make it available on the client side.
+export const COMMIT_HASH = process.env.NEXT_PUBLIC_COMMIT_HASH || "development";

--- a/front/logger/withlogging.ts
+++ b/front/logger/withlogging.ts
@@ -47,19 +47,23 @@ export function withLogging<T>(
       }
     }
 
+    // Extract commit hash from headers.
+    const commitHash = req.headers["x-commit-hash"];
+
     try {
       await handler(req, res);
     } catch (err) {
       const elapsed = new Date().getTime() - now.getTime();
       logger.error(
         {
-          method: req.method,
-          url: req.url,
-          route,
+          commitHash,
           durationMs: elapsed,
-          streaming,
           error: err,
+          method: req.method,
+          route,
           sessionId,
+          streaming,
+          url: req.url,
           // @ts-expect-error best effort to get err.stack if it exists
           error_stack: err?.stack,
         },
@@ -99,13 +103,14 @@ export function withLogging<T>(
 
     logger.info(
       {
-        method: req.method,
-        url: req.url,
-        route,
-        statusCode: res.statusCode,
+        commitHash,
         durationMs: elapsed,
+        method: req.method,
+        route,
         sessionId,
+        statusCode: res.statusCode,
         streaming,
+        url: req.url,
       },
       "Processed request"
     );

--- a/k8s/cloudbuild.yaml
+++ b/k8s/cloudbuild.yaml
@@ -11,7 +11,8 @@ steps:
       - --push
       - -f
       - ${_DOCKERFILE_PATH}
-      - --build-arg', 'COMMIT_HASH=${SHORT_SHA}'
+      - --build-arg
+      - COMMIT_HASH=${SHORT_SHA}
       - .
     secretEnv: ["DEPOT_TOKEN"]
 

--- a/k8s/cloudbuild.yaml
+++ b/k8s/cloudbuild.yaml
@@ -11,6 +11,7 @@ steps:
       - --push
       - -f
       - ${_DOCKERFILE_PATH}
+      - --build-arg', 'COMMIT_HASH=${SHORT_SHA}'
       - .
     secretEnv: ["DEPOT_TOKEN"]
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This pull request includes the commit hash in our Next.js build to enable tracking of the app version our users are running in every SWR query. This feature will help us monitor refresh times, especially since we observed that most users don't refresh their screens after we refactored the conversation view.

In the future, we plan to implement a forced refresh mechanism based on the commit hash.

💡 **Side note:**
Next.js bundles environment variables prefixed with NEXT_PUBLIC_ at build time and makes them accessible to the UI.

Tested on front-edge.

<img width="319" alt="image" src="https://github.com/user-attachments/assets/8cc20c96-259a-42fe-956f-a845ab0b6848">

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
