### PR TITLE
If a tool is invalid because a ds has been removed, display it on the chip of the Action in the assistant builder. 

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -57,7 +57,6 @@ import type {
 } from "@app/components/assistant_builder/types";
 import { getDefaultActionConfiguration } from "@app/components/assistant_builder/types";
 import { ACTION_SPECIFICATIONS } from "@app/lib/api/assistant/actions/utils";
-import { classNames } from "@app/lib/utils";
 
 const DATA_SOURCES_ACTION_CATEGORIES = [
   "RETRIEVAL_SEARCH",
@@ -509,6 +508,7 @@ function ActionCard({
     // Unreachable
     return null;
   }
+  const actionError = hasActionError(action);
   return (
     <CardButton
       variant="primary"
@@ -539,14 +539,17 @@ function ActionCard({
             />
           </div>
         ) : (
-          <div
-            className={classNames(
-              "w-full truncate text-base",
-              action.description ? "text-element-700" : "text-warning-500"
+          <>
+            {actionError ? (
+              <div className="w-full truncate text-base text-warning-500">
+                {actionError}
+              </div>
+            ) : (
+              <div className="w-full truncate text-base text-element-700">
+                {action.description}
+              </div>
             )}
-          >
-            {action.description || "Missing description. Click to edit."}
-          </div>
+          </>
         )}
       </div>
     </CardButton>


### PR DESCRIPTION
## Description

### Issue to fix:
@coco had access to a search tool with a datasource "test". 
I remove the "test" datasource. 
Then when I try to edit coco the save button is always disable but I have no way to understand why unless I open all tools to see there's no datasource selected. 

###  Fix
This is not perfect but I'm reusing the logic introduced 2 days ago to have proper validation of an action on the modal. 
We now display the error which should be clearer for the user editing their assistants. 

###  Runner task
https://github.com/dust-tt/tasks/issues/1078

<kbd>
<img width="1641" alt="Screenshot 2024-07-19 at 10 41 24" src="https://github.com/user-attachments/assets/f706901f-c9a9-40ec-a8d6-cf53d31a1258">
</kbd>

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
