### PR TITLE
github: connectionId -> connectorId

### DIFF
--- a/connectors/src/api/webhooks/webhook_github.ts
+++ b/connectors/src/api/webhooks/webhook_github.ts
@@ -365,7 +365,7 @@ async function garbageCollectRepos(
       for (const { name, id } of repos) {
         try {
           await launchGithubRepoGarbageCollectWorkflow(
-            c.id.toString(),
+            c.id,
             orgLogin,
             name,
             id
@@ -501,7 +501,7 @@ async function syncIssue(
   await Promise.all(
     connectors.map((c) =>
       launchGithubIssueSyncWorkflow(
-        c.id.toString(),
+        c.id,
         orgLogin,
         repoName,
         repoId,
@@ -543,7 +543,7 @@ async function syncDiscussion(
   await Promise.all(
     connectors.map((c) =>
       launchGithubDiscussionSyncWorkflow(
-        c.id.toString(),
+        c.id,
         orgLogin,
         repoName,
         repoId,
@@ -585,7 +585,7 @@ async function garbageCollectIssue(
   await Promise.all(
     connectors.map((c) =>
       launchGithubIssueGarbageCollectWorkflow(
-        c.id.toString(),
+        c.id,
         orgLogin,
         repoName,
         repoId,
@@ -627,7 +627,7 @@ async function garbageCollectDiscussion(
   await Promise.all(
     connectors.map((c) =>
       launchGithubDiscussionGarbageCollectWorkflow(
-        c.id.toString(),
+        c.id,
         orgLogin,
         repoName,
         repoId,

--- a/connectors/src/connectors/github/temporal/client.ts
+++ b/connectors/src/connectors/github/temporal/client.ts
@@ -51,8 +51,6 @@ export async function launchGithubFullSyncWorkflow({
   }
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
 
-  const connectionId = connector.connectionId;
-
   const workflow = await getGithubFullSyncWorkflow(connectorId);
 
   if (workflow && workflow.executionDescription.status.name === "RUNNING") {
@@ -67,13 +65,7 @@ export async function launchGithubFullSyncWorkflow({
   }
 
   await client.workflow.start(githubFullSyncWorkflow, {
-    args: [
-      dataSourceConfig,
-      connectionId,
-      connectorId,
-      syncCodeOnly,
-      forceCodeResync,
-    ],
+    args: [dataSourceConfig, connectorId, syncCodeOnly, forceCodeResync],
     taskQueue: QUEUE_NAME,
     workflowId: getFullSyncWorkflowId(dataSourceConfig),
     searchAttributes: {
@@ -125,10 +117,9 @@ export async function launchGithubReposSyncWorkflow(
     throw new Error(`Connector not found. ConnectorId: ${connectorId}`);
   }
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
-  const connectionId = connector.connectionId;
 
   await client.workflow.start(githubReposSyncWorkflow, {
-    args: [dataSourceConfig, connectionId, orgLogin, repos, connectorId],
+    args: [dataSourceConfig, connectorId, orgLogin, repos],
     taskQueue: QUEUE_NAME,
     workflowId: getReposSyncWorkflowId(dataSourceConfig),
     searchAttributes: {
@@ -153,10 +144,9 @@ export async function launchGithubCodeSyncWorkflow(
     throw new Error(`Connector not found. ConnectorId: ${connectorId}`);
   }
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
-  const connectionId = connector.connectionId;
 
   await client.workflow.signalWithStart(githubCodeSyncWorkflow, {
-    args: [dataSourceConfig, connectionId, repoName, repoId, repoLogin],
+    args: [dataSourceConfig, connectorId, repoName, repoId, repoLogin],
     taskQueue: QUEUE_NAME,
     workflowId: getCodeSyncWorkflowId(dataSourceConfig, repoId),
     searchAttributes: {
@@ -171,7 +161,7 @@ export async function launchGithubCodeSyncWorkflow(
 }
 
 export async function launchGithubIssueSyncWorkflow(
-  connectorId: string,
+  connectorId: ModelId,
   repoLogin: string,
   repoName: string,
   repoId: number,
@@ -184,7 +174,6 @@ export async function launchGithubIssueSyncWorkflow(
     throw new Error(`Connector not found. ConnectorId: ${connectorId}`);
   }
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
-  const connectionId = connector.connectionId;
 
   const workflowId = getIssueSyncWorkflowId(
     dataSourceConfig,
@@ -195,7 +184,7 @@ export async function launchGithubIssueSyncWorkflow(
   await client.workflow.signalWithStart(githubIssueSyncWorkflow, {
     args: [
       dataSourceConfig,
-      connectionId,
+      connector.id,
       repoName,
       repoId,
       repoLogin,
@@ -204,7 +193,7 @@ export async function launchGithubIssueSyncWorkflow(
     taskQueue: QUEUE_NAME,
     workflowId,
     searchAttributes: {
-      connectorId: [parseInt(connectorId)],
+      connectorId: [connectorId],
     },
     signal: newWebhookSignal,
     signalArgs: undefined,
@@ -215,7 +204,7 @@ export async function launchGithubIssueSyncWorkflow(
 }
 
 export async function launchGithubDiscussionSyncWorkflow(
-  connectorId: string,
+  connectorId: ModelId,
   repoLogin: string,
   repoName: string,
   repoId: number,
@@ -228,7 +217,6 @@ export async function launchGithubDiscussionSyncWorkflow(
     throw new Error(`Connector not found. ConnectorId: ${connectorId}`);
   }
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
-  const connectionId = connector.connectionId;
 
   const workflowId = getDiscussionSyncWorkflowId(
     connectorId,
@@ -240,14 +228,14 @@ export async function launchGithubDiscussionSyncWorkflow(
   await client.workflow.signalWithStart(githubDiscussionSyncWorkflow, {
     args: [
       dataSourceConfig,
-      connectionId,
+      connectorId,
       repoName,
       repoId,
       repoLogin,
       discussionNumber,
     ],
     searchAttributes: {
-      connectorId: [parseInt(connectorId)],
+      connectorId: [connectorId],
     },
     taskQueue: QUEUE_NAME,
     workflowId,
@@ -260,7 +248,7 @@ export async function launchGithubDiscussionSyncWorkflow(
 }
 
 export async function launchGithubIssueGarbageCollectWorkflow(
-  connectorId: string,
+  connectorId: ModelId,
   repoLogin: string,
   repoName: string,
   repoId: number,
@@ -274,13 +262,12 @@ export async function launchGithubIssueGarbageCollectWorkflow(
   }
 
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
-  const connectionId = connector.connectionId;
 
   await client.workflow.start(githubIssueGarbageCollectWorkflow, {
-    args: [dataSourceConfig, connectionId, repoId.toString(), issueNumber],
+    args: [dataSourceConfig, connectorId, repoId.toString(), issueNumber],
     taskQueue: QUEUE_NAME,
     searchAttributes: {
-      connectorId: [parseInt(connectorId)],
+      connectorId: [connectorId],
     },
     workflowId: getIssueGarbageCollectWorkflowId(
       dataSourceConfig,
@@ -294,7 +281,7 @@ export async function launchGithubIssueGarbageCollectWorkflow(
 }
 
 export async function launchGithubDiscussionGarbageCollectWorkflow(
-  connectorId: string,
+  connectorId: ModelId,
   repoLogin: string,
   repoName: string,
   repoId: number,
@@ -308,10 +295,9 @@ export async function launchGithubDiscussionGarbageCollectWorkflow(
   }
 
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
-  const connectionId = connector.connectionId;
 
   await client.workflow.start(githubDiscussionGarbageCollectWorkflow, {
-    args: [dataSourceConfig, connectionId, repoId.toString(), discussionNumber],
+    args: [dataSourceConfig, connectorId, repoId.toString(), discussionNumber],
     memo: {
       connectorId: connectorId,
     },
@@ -323,13 +309,13 @@ export async function launchGithubDiscussionGarbageCollectWorkflow(
       discussionNumber
     ),
     searchAttributes: {
-      connectorId: [parseInt(connectorId)],
+      connectorId: [connectorId],
     },
   });
 }
 
 export async function launchGithubRepoGarbageCollectWorkflow(
-  connectorId: string,
+  connectorId: ModelId,
   repoLogin: string,
   repoName: string,
   repoId: number
@@ -342,14 +328,13 @@ export async function launchGithubRepoGarbageCollectWorkflow(
   }
 
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
-  const connectionId = connector.connectionId;
 
   await client.workflow.start(githubRepoGarbageCollectWorkflow, {
-    args: [dataSourceConfig, connectionId, repoId.toString()],
+    args: [dataSourceConfig, connectorId, repoId.toString()],
     taskQueue: QUEUE_NAME,
     workflowId: getRepoGarbageCollectWorkflowId(dataSourceConfig, repoId),
     searchAttributes: {
-      connectorId: [parseInt(connectorId)],
+      connectorId: [connectorId],
     },
     memo: {
       connectorId: connectorId,

--- a/connectors/src/connectors/github/temporal/utils.ts
+++ b/connectors/src/connectors/github/temporal/utils.ts
@@ -1,3 +1,5 @@
+import type { ModelId } from "@dust-tt/types";
+
 import type { DataSourceInfo } from "@connectors/types/data_source_config";
 
 export function getFullSyncWorkflowId(dataSourceInfo: DataSourceInfo) {
@@ -24,7 +26,7 @@ export function getIssueSyncWorkflowId(
 }
 
 export function getDiscussionSyncWorkflowId(
-  connectorId: string,
+  connectorId: ModelId,
   dataSourceInfo: DataSourceInfo,
   repoId: number,
   discussionNumber: number
@@ -41,7 +43,7 @@ export function getIssueGarbageCollectWorkflowId(
 }
 
 export function getDiscussionGarbageCollectWorkflowId(
-  connectorId: string,
+  connectorId: ModelId,
   dataSourceInfo: DataSourceInfo,
   repoId: number,
   issueNumber: number

--- a/connectors/src/connectors/github/temporal/workflows.ts
+++ b/connectors/src/connectors/github/temporal/workflows.ts
@@ -57,7 +57,6 @@ const MAX_CONCURRENT_ISSUE_SYNC_ACTIVITIES_PER_WORKFLOW = 8;
 
 export async function githubFullSyncWorkflow(
   dataSourceConfig: DataSourceConfig,
-  connectionId: string,
   connectorId: ModelId,
   // Used to re-trigger a code-only full-sync after code syncing is enabled/disabled.
   syncCodeOnly: boolean,
@@ -65,9 +64,9 @@ export async function githubFullSyncWorkflow(
 ) {
   await githubSaveStartSyncActivity(dataSourceConfig);
   const loggerArgs = {
+    connectorId,
     dataSourceName: dataSourceConfig.dataSourceName,
     workspaceId: dataSourceConfig.workspaceId,
-    connectionId,
     syncCodeOnly: syncCodeOnly.toString(),
   };
 
@@ -78,7 +77,7 @@ export async function githubFullSyncWorkflow(
 
   for (;;) {
     const resultsPage = await githubGetReposResultPageActivity(
-      connectionId,
+      connectorId,
       pageNumber,
       loggerArgs
     );
@@ -101,7 +100,6 @@ export async function githubFullSyncWorkflow(
               {
                 dataSourceConfig,
                 connectorId,
-                connectionId,
                 repoName: repo.name,
                 repoId: repo.id,
                 repoLogin: repo.login,
@@ -125,10 +123,9 @@ export async function githubFullSyncWorkflow(
 
 export async function githubReposSyncWorkflow(
   dataSourceConfig: DataSourceConfig,
-  connectionId: string,
+  connectorId: ModelId,
   orgLogin: string,
-  repos: { name: string; id: number }[],
-  connectorId: ModelId
+  repos: { name: string; id: number }[]
 ) {
   const queue = new PQueue({ concurrency: MAX_CONCURRENT_REPO_SYNC_WORKFLOWS });
   const promises: Promise<void>[] = [];
@@ -147,7 +144,6 @@ export async function githubReposSyncWorkflow(
             {
               dataSourceConfig,
               connectorId,
-              connectionId,
               repoName: repo.name,
               repoId: repo.id,
               repoLogin: orgLogin,
@@ -168,14 +164,14 @@ export async function githubReposSyncWorkflow(
 
 export async function githubRepoIssuesSyncWorkflow({
   dataSourceConfig,
-  connectionId,
+  connectorId,
   repoName,
   repoId,
   repoLogin,
   pageNumber,
 }: {
   dataSourceConfig: DataSourceConfig;
-  connectionId: string;
+  connectorId: ModelId;
   repoName: string;
   repoId: number;
   repoLogin: string;
@@ -184,7 +180,7 @@ export async function githubRepoIssuesSyncWorkflow({
   const loggerArgs = {
     dataSourceName: dataSourceConfig.dataSourceName,
     workspaceId: dataSourceConfig.workspaceId,
-    connectionId,
+    connectorId,
     repoName,
     repoLogin,
   };
@@ -195,7 +191,7 @@ export async function githubRepoIssuesSyncWorkflow({
   const promises: Promise<void>[] = [];
 
   const resultsPage = await githubGetRepoIssuesResultPageActivity(
-    connectionId,
+    connectorId,
     repoName,
     repoLogin,
     pageNumber,
@@ -210,7 +206,7 @@ export async function githubRepoIssuesSyncWorkflow({
     promises.push(
       queue.add(() =>
         githubUpsertIssueActivity(
-          connectionId,
+          connectorId,
           repoName,
           repoId,
           repoLogin,
@@ -230,14 +226,14 @@ export async function githubRepoIssuesSyncWorkflow({
 
 export async function githubRepoDiscussionsSyncWorkflow({
   dataSourceConfig,
-  connectionId,
+  connectorId,
   repoName,
   repoId,
   repoLogin,
   nextCursor,
 }: {
   dataSourceConfig: DataSourceConfig;
-  connectionId: string;
+  connectorId: ModelId;
   repoName: string;
   repoId: number;
   repoLogin: string;
@@ -246,7 +242,7 @@ export async function githubRepoDiscussionsSyncWorkflow({
   const loggerArgs = {
     dataSourceName: dataSourceConfig.dataSourceName,
     workspaceId: dataSourceConfig.workspaceId,
-    connectionId,
+    connectorId,
     repoName,
     repoLogin,
   };
@@ -258,7 +254,7 @@ export async function githubRepoDiscussionsSyncWorkflow({
 
   const { cursor, discussionNumbers } =
     await githubGetRepoDiscussionsResultPageActivity(
-      connectionId,
+      connectorId,
       repoName,
       repoLogin,
       nextCursor,
@@ -269,7 +265,7 @@ export async function githubRepoDiscussionsSyncWorkflow({
     promises.push(
       queue.add(() =>
         githubUpsertDiscussionActivity(
-          connectionId,
+          connectorId,
           repoName,
           repoId,
           repoLogin,
@@ -290,7 +286,6 @@ export async function githubRepoDiscussionsSyncWorkflow({
 export async function githubRepoSyncWorkflow({
   dataSourceConfig,
   connectorId,
-  connectionId,
   repoName,
   repoId,
   repoLogin,
@@ -300,7 +295,6 @@ export async function githubRepoSyncWorkflow({
 }: {
   dataSourceConfig: DataSourceConfig;
   connectorId: ModelId;
-  connectionId: string;
   repoName: string;
   repoId: number;
   repoLogin: string;
@@ -311,7 +305,7 @@ export async function githubRepoSyncWorkflow({
   const loggerArgs = {
     dataSourceName: dataSourceConfig.dataSourceName,
     workspaceId: dataSourceConfig.workspaceId,
-    connectionId,
+    connectorId,
     repoName,
     repoLogin,
     syncCodeOnly: syncCodeOnly ? "true" : "false",
@@ -334,7 +328,7 @@ export async function githubRepoSyncWorkflow({
         args: [
           {
             dataSourceConfig,
-            connectionId,
+            connectorId,
             repoName,
             repoId,
             repoLogin,
@@ -368,7 +362,7 @@ export async function githubRepoSyncWorkflow({
         args: [
           {
             dataSourceConfig,
-            connectionId,
+            connectorId,
             repoName,
             repoId,
             repoLogin,
@@ -389,7 +383,7 @@ export async function githubRepoSyncWorkflow({
   // Start code syncing activity.
   await githubCodeSyncActivity({
     dataSourceConfig,
-    connectionId,
+    connectionIdOrConnectorId: connectorId,
     repoLogin,
     repoName,
     repoId,
@@ -401,7 +395,7 @@ export async function githubRepoSyncWorkflow({
 
 export async function githubCodeSyncWorkflow(
   dataSourceConfig: DataSourceConfig,
-  connectionId: string,
+  connectorId: ModelId,
   repoName: string,
   repoId: number,
   repoLogin: string
@@ -409,7 +403,7 @@ export async function githubCodeSyncWorkflow(
   const loggerArgs = {
     dataSourceName: dataSourceConfig.dataSourceName,
     workspaceId: dataSourceConfig.workspaceId,
-    connectionId,
+    connectorId,
     repoName,
     repoLogin,
   };
@@ -434,7 +428,7 @@ export async function githubCodeSyncWorkflow(
     }
     await githubCodeSyncActivity({
       dataSourceConfig,
-      connectionId,
+      connectionIdOrConnectorId: connectorId,
       repoLogin,
       repoName,
       repoId,
@@ -447,7 +441,7 @@ export async function githubCodeSyncWorkflow(
 
 export async function githubIssueSyncWorkflow(
   dataSourceConfig: DataSourceConfig,
-  connectionId: string,
+  connectorId: ModelId,
   repoName: string,
   repoId: number,
   repoLogin: string,
@@ -456,7 +450,7 @@ export async function githubIssueSyncWorkflow(
   const loggerArgs = {
     dataSourceName: dataSourceConfig.dataSourceName,
     workspaceId: dataSourceConfig.workspaceId,
-    connectionId,
+    connectorId,
     repoName,
     repoLogin,
     issueNumber,
@@ -477,7 +471,7 @@ export async function githubIssueSyncWorkflow(
       continue;
     }
     await githubUpsertIssueActivity(
-      connectionId,
+      connectorId,
       repoName,
       repoId,
       repoLogin,
@@ -491,7 +485,7 @@ export async function githubIssueSyncWorkflow(
 
 export async function githubDiscussionSyncWorkflow(
   dataSourceConfig: DataSourceConfig,
-  connectionId: string,
+  connectorId: ModelId,
   repoName: string,
   repoId: number,
   repoLogin: string,
@@ -500,7 +494,7 @@ export async function githubDiscussionSyncWorkflow(
   const loggerArgs = {
     dataSourceName: dataSourceConfig.dataSourceName,
     workspaceId: dataSourceConfig.workspaceId,
-    connectionId,
+    connectorId,
     repoName,
     repoLogin,
     discussionNumber,
@@ -521,7 +515,7 @@ export async function githubDiscussionSyncWorkflow(
       continue;
     }
     await githubUpsertDiscussionActivity(
-      connectionId,
+      connectorId,
       repoName,
       repoId,
       repoLogin,
@@ -537,20 +531,20 @@ export async function githubDiscussionSyncWorkflow(
 
 export async function githubIssueGarbageCollectWorkflow(
   dataSourceConfig: DataSourceConfig,
-  connectionId: string,
+  connectorId: ModelId,
   repoId: string,
   issueNumber: number
 ) {
   const loggerArgs = {
     dataSourceName: dataSourceConfig.dataSourceName,
     workspaceId: dataSourceConfig.workspaceId,
-    connectionId,
+    connectorId,
     issueNumber,
   };
 
   await githubIssueGarbageCollectActivity(
     dataSourceConfig,
-    connectionId,
+    connectorId,
     repoId,
     issueNumber,
     loggerArgs
@@ -560,20 +554,20 @@ export async function githubIssueGarbageCollectWorkflow(
 
 export async function githubDiscussionGarbageCollectWorkflow(
   dataSourceConfig: DataSourceConfig,
-  connectionId: string,
+  connectorId: ModelId,
   repoId: string,
   discussionNumber: number
 ) {
   const loggerArgs = {
     dataSourceName: dataSourceConfig.dataSourceName,
     workspaceId: dataSourceConfig.workspaceId,
-    connectionId,
+    connectorId,
     discussionNumber,
   };
 
   await githubDiscussionGarbageCollectActivity(
     dataSourceConfig,
-    connectionId,
+    connectorId,
     repoId,
     discussionNumber,
     loggerArgs
@@ -583,18 +577,18 @@ export async function githubDiscussionGarbageCollectWorkflow(
 
 export async function githubRepoGarbageCollectWorkflow(
   dataSourceConfig: DataSourceConfig,
-  connectionId: string,
+  connectorId: ModelId,
   repoId: string
 ) {
   const loggerArgs = {
     dataSourceName: dataSourceConfig.dataSourceName,
     workspaceId: dataSourceConfig.workspaceId,
-    connectionId,
+    connectorId,
   };
 
   await githubRepoGarbageCollectActivity(
     dataSourceConfig,
-    connectionId,
+    connectorId,
     repoId,
     loggerArgs
   );

--- a/connectors/src/connectors/github/temporal/workflows.ts
+++ b/connectors/src/connectors/github/temporal/workflows.ts
@@ -383,7 +383,7 @@ export async function githubRepoSyncWorkflow({
   // Start code syncing activity.
   await githubCodeSyncActivity({
     dataSourceConfig,
-    connectionIdOrConnectorId: connectorId,
+    connectorId,
     repoLogin,
     repoName,
     repoId,
@@ -428,7 +428,7 @@ export async function githubCodeSyncWorkflow(
     }
     await githubCodeSyncActivity({
       dataSourceConfig,
-      connectionIdOrConnectorId: connectorId,
+      connectorId,
       repoLogin,
       repoName,
       repoId,

--- a/connectors/src/resources/connector_resource.ts
+++ b/connectors/src/resources/connector_resource.ts
@@ -114,6 +114,7 @@ export class ConnectorResource extends BaseResource<ConnectorModel> {
     return connectors;
   }
 
+  // TODO(spolu): GITHUB_MIGRATION_REMOVE (the connectionId param)
   static async findByDataSourceAndConnection(
     dataSource: {
       workspaceId: string;
@@ -132,6 +133,22 @@ export class ConnectorResource extends BaseResource<ConnectorModel> {
 
     const blob = await ConnectorResource.model.findOne({
       where,
+    });
+    if (!blob) {
+      return null;
+    }
+
+    const c = new this(this.model, blob.get());
+    await c.postFetchHook();
+    return c;
+  }
+
+  // TODO(spolu): GITHUB_MIGRATION_REMOVE
+  static async fetchByConnectionId(connectionId: string) {
+    const blob = await ConnectorResource.model.findOne({
+      where: {
+        connectionId,
+      },
     });
     if (!blob) {
       return null;

--- a/connectors/src/resources/connector_resource.ts
+++ b/connectors/src/resources/connector_resource.ts
@@ -114,41 +114,17 @@ export class ConnectorResource extends BaseResource<ConnectorModel> {
     return connectors;
   }
 
-  // TODO(spolu): GITHUB_MIGRATION_REMOVE (the connectionId param)
-  static async findByDataSourceAndConnection(
-    dataSource: {
-      workspaceId: string;
-      dataSourceName: string;
-    },
-    { connectionId }: { connectionId?: string } = {}
-  ) {
+  static async findByDataSourceAndConnection(dataSource: {
+    workspaceId: string;
+    dataSourceName: string;
+  }) {
     const where: WhereOptions<ConnectorModel> = {
       workspaceId: dataSource.workspaceId,
       dataSourceName: dataSource.dataSourceName,
     };
 
-    if (connectionId) {
-      where.connectionId = connectionId;
-    }
-
     const blob = await ConnectorResource.model.findOne({
       where,
-    });
-    if (!blob) {
-      return null;
-    }
-
-    const c = new this(this.model, blob.get());
-    await c.postFetchHook();
-    return c;
-  }
-
-  // TODO(spolu): GITHUB_MIGRATION_REMOVE
-  static async fetchByConnectionId(connectionId: string) {
-    const blob = await ConnectorResource.model.findOne({
-      where: {
-        connectionId,
-      },
     });
     if (!blob) {
       return null;


### PR DESCRIPTION
## Description

- All activities: accept `connectionIdOrConnectorId: ConnectionIdOrConnectorId = ModelId | string;` and based on the type retrieve the connector from the `connectionId` or the `connectorId`. Support currently running workflows starting activities with `connectionId: string` and newly created workflows which will start activities with `connectorId: ModelId`. This is safe since there is no change of number of args.
- All workflows transition to using `connectorId` everywhere
- Clients updated
- All other remain unchanged since the activities are in charge of fetching the `connector: ConnectorResource` and then call in the sub function with the `connectionId` as before.

## Risk

High for github, low overall.

## Deploy Plan

- deploy `connector`
- once all old workflows are done, remove `connectionIdOrConnectorId` and remove the `connectionId` param in `findByDataSourceAndConnection` as well as the one introduced here: `fetchByConnectionId`