### PR TITLE
Prevent very big lines on rendermessage markdown

### DIFF
--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -572,12 +572,14 @@ function OlBlock({ children }: { children: React.ReactNode }) {
 }
 function LiBlock({ children }: { children: React.ReactNode }) {
   return (
-    <li className="py-2 text-element-800 first:pt-0 last:pb-0">{children}</li>
+    <li className="break-words py-2 text-element-800 first:pt-0 last:pb-0">
+      {children}
+    </li>
   );
 }
 function ParagraphBlock({ children }: { children: React.ReactNode }) {
   return (
-    <div className="whitespace-pre-wrap py-2 text-base font-normal leading-7 text-element-800 first:pt-0 last:pb-0">
+    <div className="whitespace-pre-wrap break-words py-2 text-base font-normal leading-7 text-element-800 first:pt-0 last:pb-0">
       {children}
     </div>
   );


### PR DESCRIPTION
## Description

Task: https://github.com/dust-tt/tasks/issues/1063


Fixes as is: 
<img width="895" alt="Screenshot 2024-07-19 at 11 03 15" src="https://github.com/user-attachments/assets/ae450c3c-63f6-46c5-80ef-749a3906952a">


## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
