### PR TITLE
Fix convo tool chip

### DIFF
--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -24,8 +24,8 @@ export function AgentMessageActions({
   // gets emitted in which case the content will get requalified as chain of thoughts and this will
   // switch back to true.
   const isThinkingOrActing = useMemo(
-    () => !agentMessage.content?.length && agentMessage.status === "created",
-    [agentMessage.content, agentMessage.status]
+    () => agentMessage.status === "created",
+    [agentMessage.status]
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Description

Since now we render immediately the content of the message prior to executing action, we were immediately displaying the "Inspect Tools" button instead of the chip. 
Changing the condition to base it only on the message status. 

Task: https://github.com/dust-tt/tasks/issues/1080

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
