### PR TITLE
Fix navigation issues on /builder/assistants/create modal.

### DIFF
--- a/front/components/assistant_builder/TemplateGrid.tsx
+++ b/front/components/assistant_builder/TemplateGrid.tsx
@@ -1,39 +1,31 @@
 import { AssistantPreview } from "@dust-tt/sparkle";
-import { useRouter } from "next/router";
 
 import type { AssistantTemplateListType } from "@app/pages/api/w/[wId]/assistant/builder/templates";
 
 interface TemplateGridProps {
   templates: AssistantTemplateListType[];
+  setSelectedTemplateId: (templateId: string) => void;
 }
 
-export function TemplateGrid({ templates }: TemplateGridProps) {
-  const router = useRouter();
-
-  const makeTemplateModalHref = (templateId: string) => {
-    return {
-      pathname: router.pathname,
-      query: {
-        ...router.query,
-        templateId,
-      },
-    };
-  };
-
-  const items = templates.map((t) => (
-    <AssistantPreview
-      key={t.sId}
-      title={t.handle}
-      pictureUrl={t.pictureUrl}
-      description={t.description ?? ""}
-      variant="list"
-      onClick={() => router.push(makeTemplateModalHref(t.sId))}
-    />
-  ));
-
-  if (items.length === 0) {
+export function TemplateGrid({
+  templates,
+  setSelectedTemplateId,
+}: TemplateGridProps) {
+  if (!templates?.length) {
     return null;
   }
-
-  return <div className="grid grid-cols-2 gap-2">{items}</div>;
+  return (
+    <div className="grid grid-cols-2 gap-2">
+      {templates.map((t) => (
+        <AssistantPreview
+          key={t.sId}
+          title={t.handle}
+          pictureUrl={t.pictureUrl}
+          description={t.description ?? ""}
+          variant="list"
+          onClick={() => setSelectedTemplateId(t.sId)}
+        />
+      ))}
+    </div>
+  );
 }

--- a/front/components/assistant_builder/TemplateGrid.tsx
+++ b/front/components/assistant_builder/TemplateGrid.tsx
@@ -11,7 +11,7 @@ export function TemplateGrid({
   templates,
   openTemplateModal,
 }: TemplateGridProps) {
-  if (!templates?.length) {
+  if (!templates.length) {
     return null;
   }
   return (

--- a/front/components/assistant_builder/TemplateGrid.tsx
+++ b/front/components/assistant_builder/TemplateGrid.tsx
@@ -4,12 +4,12 @@ import type { AssistantTemplateListType } from "@app/pages/api/w/[wId]/assistant
 
 interface TemplateGridProps {
   templates: AssistantTemplateListType[];
-  setSelectedTemplateId: (templateId: string) => void;
+  openTemplateModal: (templateId: string) => void;
 }
 
 export function TemplateGrid({
   templates,
-  setSelectedTemplateId,
+  openTemplateModal,
 }: TemplateGridProps) {
   if (!templates?.length) {
     return null;
@@ -23,7 +23,7 @@ export function TemplateGrid({
           pictureUrl={t.pictureUrl}
           description={t.description ?? ""}
           variant="list"
-          onClick={() => setSelectedTemplateId(t.sId)}
+          onClick={() => openTemplateModal(t.sId)}
         />
       ))}
     </div>

--- a/front/components/assistant_builder/useNavigationLock.tsx
+++ b/front/components/assistant_builder/useNavigationLock.tsx
@@ -52,7 +52,7 @@ export function useNavigationLock(
       void confirm(warningData).then((result) => {
         if (result) {
           isNavigatingAway.current = true;
-          void router.push(url);
+          void router.back();
         }
       });
 
@@ -68,5 +68,5 @@ export function useNavigationLock(
       window.removeEventListener("beforeunload", handleWindowClose);
       router.events.off("routeChangeStart", handleBrowseAway);
     };
-  }, [isEnabled, warningData, router.events, router.asPath, confirm, router]);
+  }, [isEnabled, warningData, confirm, router]);
 }

--- a/front/pages/w/[wId]/builder/assistants/create.tsx
+++ b/front/pages/w/[wId]/builder/assistants/create.tsx
@@ -18,7 +18,7 @@ import _ from "lodash";
 import type { InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { createRef, useEffect, useRef, useState } from "react";
+import { createRef, useCallback, useEffect, useRef, useState } from "react";
 
 import { AssistantTemplateModal } from "@app/components/assistant_builder/AssistantTemplateModal";
 import { TemplateGrid } from "@app/components/assistant_builder/TemplateGrid";
@@ -97,6 +97,29 @@ export default function CreateAssistant({
       tags: _.uniq(templatesToDisplay.map((template) => template.tags).flat()),
     });
   }, [assistantTemplates]);
+
+  const openTemplateModal = useCallback(
+    async (templateId: string) => {
+      setSelectedTemplateId(templateId);
+      const wId = owner.sId;
+
+      await router.replace(
+        { pathname: router.pathname, query: { wId, templateId } },
+        undefined,
+        { shallow: true }
+      );
+    },
+    [router, owner.sId]
+  );
+
+  const closeTemplateModal = useCallback(async () => {
+    setSelectedTemplateId(null);
+    await router.replace(
+      { pathname: router.pathname, query: _.omit(router.query, "templateId") },
+      undefined,
+      { shallow: true }
+    );
+  }, [router]);
 
   const handleSearch = (searchTerm: string) => {
     setTemplateSearchTerm(searchTerm);
@@ -226,7 +249,7 @@ export default function CreateAssistant({
                 <>
                   <TemplateGrid
                     templates={filteredTemplates.templates}
-                    setSelectedTemplateId={setSelectedTemplateId}
+                    openTemplateModal={openTemplateModal}
                   />
                 </>
               ) : (
@@ -243,7 +266,7 @@ export default function CreateAssistant({
                         />
                         <TemplateGrid
                           templates={templatesForTag}
-                          setSelectedTemplateId={setSelectedTemplateId}
+                          openTemplateModal={openTemplateModal}
                         />
                       </div>
                     );
@@ -257,7 +280,7 @@ export default function CreateAssistant({
           flow={flow}
           owner={owner}
           templateId={selectedTemplateId}
-          onClose={() => setSelectedTemplateId(null)}
+          onClose={() => closeTemplateModal()}
         />
       </div>
     </AppLayout>

--- a/front/pages/w/[wId]/builder/assistants/create.tsx
+++ b/front/pages/w/[wId]/builder/assistants/create.tsx
@@ -76,7 +76,7 @@ export default function CreateAssistant({
     null
   );
   const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(
-    null
+    router.query.templateId ? (router.query.templateId as string) : null
   );
 
   const { assistantTemplates } = useAssistantTemplates({
@@ -123,19 +123,6 @@ export default function CreateAssistant({
     });
   };
 
-  const handleCloseModal = () => {
-    const currentPathname = router.pathname;
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { templateId, ...restQuery } = router.query;
-    void router.replace(
-      { pathname: currentPathname, query: restQuery },
-      undefined,
-      {
-        shallow: true,
-      }
-    );
-  };
-
   const tagsRefsMap = useRef<{
     [key: string]: React.MutableRefObject<HTMLDivElement | null>;
   }>({});
@@ -178,25 +165,6 @@ export default function CreateAssistant({
       element.classList.remove("animate-shake");
     }, 500);
   };
-
-  useEffect(() => {
-    const handleRouteChange = () => {
-      const templateId = router.query.templateId ?? [];
-      if (templateId && typeof templateId === "string") {
-        setSelectedTemplateId(templateId);
-      } else {
-        setSelectedTemplateId(null);
-      }
-    };
-
-    // Initial check in case the component mounts with the query already set.
-    handleRouteChange();
-
-    router.events.on("routeChangeComplete", handleRouteChange);
-    return () => {
-      router.events.off("routeChangeComplete", handleRouteChange);
-    };
-  }, [router.query, router.events]);
 
   return (
     <AppLayout
@@ -256,7 +224,10 @@ export default function CreateAssistant({
             <div className="flex flex-col pb-56">
               {templateSearchTerm?.length ? (
                 <>
-                  <TemplateGrid templates={filteredTemplates.templates} />
+                  <TemplateGrid
+                    templates={filteredTemplates.templates}
+                    setSelectedTemplateId={setSelectedTemplateId}
+                  />
                 </>
               ) : (
                 <>
@@ -270,7 +241,10 @@ export default function CreateAssistant({
                           title={templateTagsMapping[tagName].label}
                           hasBorder={false}
                         />
-                        <TemplateGrid templates={templatesForTag} />
+                        <TemplateGrid
+                          templates={templatesForTag}
+                          setSelectedTemplateId={setSelectedTemplateId}
+                        />
                       </div>
                     );
                   })}
@@ -283,7 +257,7 @@ export default function CreateAssistant({
           flow={flow}
           owner={owner}
           templateId={selectedTemplateId}
-          onClose={handleCloseModal}
+          onClose={() => setSelectedTemplateId(null)}
         />
       </div>
     </AppLayout>


### PR DESCRIPTION
## Description

Task: https://github.com/dust-tt/tasks/issues/1067
Videos of bugs: https://dust4ai.slack.com/archives/C050A0S2Z7F/p1721146935631249

In this PR: 
- Simplify management of displaying a template modal in the /builder/assistants/create modal. 
- Fix on useNavigation lock to indeed router.back when we wanted to. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
