### PR TITLE
Disable closing a hasChanged modal by clicking outside of it

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.191",
+  "version": "0.2.192",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.191",
+      "version": "0.2.192",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.191",
+  "version": "0.2.192",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/Modal.tsx
+++ b/sparkle/src/components/Modal.tsx
@@ -128,7 +128,12 @@ export function Modal({
       <Dialog
         as="div"
         className="s-fixed s-absolute s-inset-0 s-z-50 s-overflow-hidden"
-        onClose={onClose}
+        onClose={() => {
+          // We allow closing the modal by clicking outside of it only if there are no changes
+          if (!hasChanged) {
+            onClose();
+          }
+        }}
       >
         {/* Smoke screen and transition */}
         <Transition.Child


### PR DESCRIPTION
## Description

Task: https://github.com/dust-tt/tasks/issues/1023

The `hasChanged` is used to display either the close button or the "save/cancel" buttons. 
When hasChanged is true, we disallow users to close the modal by clicking outside of it, they have to click on the close button. 

This avoid loosing ongoing unsaved work, such as when working on a tool. 

## Risk

/

## Deploy Plan

Publish Sparkle. 
Bump Sparkle on front. 