### PR TITLE
[front] - chore(microsoft): add Microsoft workflow check

### DIFF
--- a/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
+++ b/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
@@ -1,8 +1,5 @@
-import type {
-  ConnectorProvider} from "@dust-tt/types";
-import {
-  microsoftIncrementalSyncWorkflowId,
-} from "@dust-tt/types";
+import type { ConnectorProvider } from "@dust-tt/types";
+import { microsoftIncrementalSyncWorkflowId } from "@dust-tt/types";
 import {
   getIntercomSyncWorkflowId,
   googleDriveIncrementalSyncWorkflowId,

--- a/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
+++ b/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
@@ -1,4 +1,8 @@
-import type { ConnectorProvider } from "@dust-tt/types";
+import type {
+  ConnectorProvider} from "@dust-tt/types";
+import {
+  microsoftIncrementalSyncWorkflowId,
+} from "@dust-tt/types";
 import {
   getIntercomSyncWorkflowId,
   googleDriveIncrementalSyncWorkflowId,
@@ -36,6 +40,10 @@ const providersToCheck: Partial<Record<ConnectorProvider, ProviderCheck>> = {
   google_drive: {
     makeIdFn: (connector: ConnectorBlob) =>
       googleDriveIncrementalSyncWorkflowId(connector.id),
+  },
+  microsoft: {
+    makeIdFn: (connector: ConnectorBlob) =>
+      microsoftIncrementalSyncWorkflowId(connector.id),
   },
 };
 

--- a/types/src/connectors/microsoft.ts
+++ b/types/src/connectors/microsoft.ts
@@ -1,0 +1,5 @@
+import { ModelId } from "../shared/model_id";
+
+export function microsoftIncrementalSyncWorkflowId(connectorId: ModelId) {
+  return `microsoft-incrementalSync-${connectorId}`;
+}

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -8,6 +8,7 @@ export * from "./connectors/confluence";
 export * from "./connectors/content_nodes";
 export * from "./connectors/google_drive";
 export * from "./connectors/intercom";
+export * from "./connectors/microsoft";
 export * from "./connectors/notion";
 export * from "./connectors/slack";
 export * from "./connectors/webcrawler";


### PR DESCRIPTION
## Description

This PR aims at monitoring Microsoft incremental sync workflow. Changes consist in extending `providersToCheck` to include new Microsoft provider with workflow ID generation

Note: this hasn't been tested yet

**References:**
- https://github.com/dust-tt/tasks/issues/1074

## Risk

n\a

## Deploy Plan

n\a
