### PR TITLE
feat(oauth): intercom dual flow connectors + gated setup

### DIFF
--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -67,8 +67,9 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
     let connector = null;
 
     try {
-      const intercomWorkspace =
-        await fetchIntercomWorkspace(intercomAccessToken);
+      const intercomWorkspace = await fetchIntercomWorkspace({
+        accessToken: intercomAccessToken,
+      });
       if (!intercomWorkspace) {
         return new Err(
           new Error(
@@ -158,8 +159,10 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
 
     if (connectionId) {
       const newConnectionId = connectionId;
-      const newIntercomWorkspace =
-        await fetchIntercomWorkspace(newConnectionId);
+      const accessToken = await getIntercomAccessToken(newConnectionId);
+      const newIntercomWorkspace = await fetchIntercomWorkspace({
+        accessToken,
+      });
 
       if (!newIntercomWorkspace) {
         return new Err({

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -20,6 +20,7 @@ import {
   revokeSyncCollection,
   revokeSyncHelpCenter,
 } from "@connectors/connectors/intercom/lib/help_center_permissions";
+import { getIntercomAccessToken } from "@connectors/connectors/intercom/lib/intercom_access_token";
 import { fetchIntercomWorkspace } from "@connectors/connectors/intercom/lib/intercom_api";
 import {
   getHelpCenterArticleIdFromInternalId,
@@ -61,16 +62,13 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
     dataSourceConfig: DataSourceConfig;
     connectionId: string;
   }): Promise<Result<string, Error>> {
-    const nangoConnectionId = connectionId;
-
-    if (!NANGO_INTERCOM_CONNECTOR_ID) {
-      throw new Error("NANGO_INTERCOM_CONNECTOR_ID not set");
-    }
+    const intercomAccessToken = await getIntercomAccessToken(connectionId);
 
     let connector = null;
 
     try {
-      const intercomWorkspace = await fetchIntercomWorkspace(nangoConnectionId);
+      const intercomWorkspace =
+        await fetchIntercomWorkspace(intercomAccessToken);
       if (!intercomWorkspace) {
         return new Err(
           new Error(
@@ -91,7 +89,7 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
       connector = await ConnectorResource.makeNew(
         "intercom",
         {
-          connectionId: nangoConnectionId,
+          connectionId,
           workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
           workspaceId: dataSourceConfig.workspaceId,
           dataSourceName: dataSourceConfig.dataSourceName,

--- a/connectors/src/connectors/intercom/lib/conversation_permissions.ts
+++ b/connectors/src/connectors/intercom/lib/conversation_permissions.ts
@@ -5,6 +5,7 @@ import type {
   ModelId,
 } from "@dust-tt/types";
 
+import { getIntercomAccessToken } from "@connectors/connectors/intercom/lib/intercom_access_token";
 import {
   fetchIntercomTeam,
   fetchIntercomTeams,
@@ -41,7 +42,8 @@ export async function allowSyncTeam({
     });
   }
   if (!team) {
-    const teamOnIntercom = await fetchIntercomTeam(connectionId, teamId);
+    const accessToken = await getIntercomAccessToken(connectionId);
+    const teamOnIntercom = await fetchIntercomTeam({ accessToken, teamId });
     if (teamOnIntercom) {
       team = await IntercomTeam.create({
         connectorId,
@@ -177,7 +179,8 @@ export async function retrieveIntercomConversationsPermissions({
       });
     }
   } else {
-    const teams = await fetchIntercomTeams(connector.connectionId);
+    const accessToken = await getIntercomAccessToken(connector.connectionId);
+    const teams = await fetchIntercomTeams({ accessToken });
     if (isRootLevel) {
       nodes.push({
         provider: "intercom",

--- a/connectors/src/connectors/intercom/lib/intercom_access_token.ts
+++ b/connectors/src/connectors/intercom/lib/intercom_access_token.ts
@@ -1,0 +1,40 @@
+import { getOAuthConnectionAccessToken } from "@dust-tt/types";
+
+import { apiConfig } from "@connectors/lib/api/config";
+import { getAccessTokenFromNango } from "@connectors/lib/nango_helpers";
+import { isDualUseOAuthConnectionId } from "@connectors/lib/oauth";
+import logger from "@connectors/logger/logger";
+
+const { NANGO_INTERCOM_CONNECTOR_ID } = process.env;
+
+export async function getIntercomAccessToken(
+  connectionId: string
+): Promise<string> {
+  if (isDualUseOAuthConnectionId(connectionId)) {
+    const tokRes = await getOAuthConnectionAccessToken({
+      config: apiConfig.getOAuthAPIConfig(),
+      logger,
+      provider: "intercom",
+      connectionId,
+    });
+    if (tokRes.isErr()) {
+      logger.error(
+        { connectionId, error: tokRes.error },
+        "Error retrieving Intercom access token"
+      );
+      throw new Error("Error retrieving Intercom access token");
+    }
+
+    return tokRes.value.access_token;
+  } else {
+    // TODO(@fontanierh) INTERCOM_MIGRATION remove once migrated
+    if (!NANGO_INTERCOM_CONNECTOR_ID) {
+      throw new Error("NANGO_INTERCOM_CONNECTOR_ID is not defined");
+    }
+    return getAccessTokenFromNango({
+      connectionId: connectionId,
+      integrationId: NANGO_INTERCOM_CONNECTOR_ID,
+      useCache: true,
+    });
+  }
+}

--- a/connectors/src/connectors/intercom/lib/intercom_api.ts
+++ b/connectors/src/connectors/intercom/lib/intercom_api.ts
@@ -101,7 +101,11 @@ async function queryIntercomAPI({
 /**
  * Return the Intercom Workspace.
  */
-export async function fetchIntercomWorkspace(accessToken: string): Promise<{
+export async function fetchIntercomWorkspace({
+  accessToken,
+}: {
+  accessToken: string;
+}): Promise<{
   id: string;
   name: string;
   region: string;
@@ -130,9 +134,11 @@ export async function fetchIntercomWorkspace(accessToken: string): Promise<{
 /**
  * Return the list of Help Centers of the Intercom workspace
  */
-export async function fetchIntercomHelpCenters(
-  accessToken: string
-): Promise<IntercomHelpCenterType[]> {
+export async function fetchIntercomHelpCenters({
+  accessToken,
+}: {
+  accessToken: string;
+}): Promise<IntercomHelpCenterType[]> {
   const response: {
     type: "list";
     data: IntercomHelpCenterType[];
@@ -148,10 +154,13 @@ export async function fetchIntercomHelpCenters(
 /**
  * Return the detail of Help Center
  */
-export async function fetchIntercomHelpCenter(
-  accessToken: string,
-  helpCenterId: string
-): Promise<IntercomHelpCenterType | null> {
+export async function fetchIntercomHelpCenter({
+  accessToken,
+  helpCenterId,
+}: {
+  accessToken: string;
+  helpCenterId: string;
+}): Promise<IntercomHelpCenterType | null> {
   const response = await queryIntercomAPI({
     accessToken,
     path: `help_center/help_centers/${helpCenterId}`,
@@ -164,11 +173,15 @@ export async function fetchIntercomHelpCenter(
 /**
  * Return the list of Collections filtered by Help Center and parent Collection.
  */
-export async function fetchIntercomCollections(
-  accessToken: string,
-  helpCenterId: string,
-  parentId: string | null
-): Promise<IntercomCollectionType[]> {
+export async function fetchIntercomCollections({
+  accessToken,
+  helpCenterId,
+  parentId,
+}: {
+  accessToken: string;
+  helpCenterId: string;
+  parentId: string | null;
+}): Promise<IntercomCollectionType[]> {
   let response, hasMore;
   let page = 1;
   const collections: IntercomCollectionType[] = [];
@@ -204,10 +217,13 @@ export async function fetchIntercomCollections(
 /**
  * Return the detail of a Collection.
  */
-export async function fetchIntercomCollection(
-  accessToken: string,
-  collectionId: string
-): Promise<IntercomCollectionType | null> {
+export async function fetchIntercomCollection({
+  accessToken,
+  collectionId,
+}: {
+  accessToken: string;
+  collectionId: string;
+}): Promise<IntercomCollectionType | null> {
   const response = await queryIntercomAPI({
     accessToken,
     path: `help_center/collections/${collectionId}`,
@@ -255,9 +271,11 @@ export async function fetchIntercomArticles({
 /**
  * Return the list of Teams.
  */
-export async function fetchIntercomTeams(
-  accessToken: string
-): Promise<IntercomTeamType[]> {
+export async function fetchIntercomTeams({
+  accessToken,
+}: {
+  accessToken: string;
+}): Promise<IntercomTeamType[]> {
   const response = await queryIntercomAPI({
     accessToken,
     path: `teams`,
@@ -270,10 +288,13 @@ export async function fetchIntercomTeams(
 /**
  * Return the detail of a Team.
  */
-export async function fetchIntercomTeam(
-  accessToken: string,
-  teamId: string
-): Promise<IntercomTeamType | null> {
+export async function fetchIntercomTeam({
+  accessToken,
+  teamId,
+}: {
+  accessToken: string;
+  teamId: string;
+}): Promise<IntercomTeamType | null> {
   const response = await queryIntercomAPI({
     accessToken,
     path: `teams/${teamId}`,

--- a/connectors/src/connectors/intercom/temporal/activities.ts
+++ b/connectors/src/connectors/intercom/temporal/activities.ts
@@ -145,10 +145,11 @@ export async function syncHelpCenterOnlyActivity({
   }
 
   // If the help center is not on intercom anymore we delete the Help Center data
-  const helpCenterOnIntercom = await fetchIntercomHelpCenter(
-    connector.connectionId,
-    helpCenterOnDb.helpCenterId
-  );
+  const accessToken = await getIntercomAccessToken(connector.connectionId);
+  const helpCenterOnIntercom = await fetchIntercomHelpCenter({
+    accessToken,
+    helpCenterId: helpCenterOnDb.helpCenterId,
+  });
   if (!helpCenterOnIntercom) {
     await removeHelpCenter({
       connectorId,
@@ -289,10 +290,11 @@ export async function syncLevel1CollectionWithChildrenActivity({
   }
 
   // If the collection is not present on Intercom anymore we delete the collection and its children
-  const collectionOnIntercom = await fetchIntercomCollection(
-    connector.connectionId,
-    collectionOnDB.collectionId
-  );
+  const accessToken = await getIntercomAccessToken(connector.connectionId);
+  const collectionOnIntercom = await fetchIntercomCollection({
+    accessToken,
+    collectionId: collectionOnDB.collectionId,
+  });
   if (collectionOnIntercom === null) {
     await deleteCollectionWithChildren({
       connectorId,
@@ -463,10 +465,8 @@ export async function syncTeamOnlyActivity({
   }
 
   // If the team does not exists on Intercom we delete the team and its conversations
-  const teamOnIntercom = await fetchIntercomTeam(
-    connector.connectionId,
-    teamId
-  );
+  const accessToken = await getIntercomAccessToken(connector.connectionId);
+  const teamOnIntercom = await fetchIntercomTeam({ accessToken, teamId });
   if (!teamOnIntercom) {
     await deleteTeamAndConversations({
       connectorId,

--- a/connectors/src/connectors/intercom/temporal/sync_conversation.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_conversation.ts
@@ -1,6 +1,7 @@
 import type { ModelId } from "@dust-tt/types";
 import TurndownService from "turndown";
 
+import { getIntercomAccessToken } from "@connectors/connectors/intercom/lib/intercom_access_token";
 import { fetchIntercomConversation } from "@connectors/connectors/intercom/lib/intercom_api";
 import type {
   ConversationPartType,
@@ -92,7 +93,7 @@ export async function deleteConversation({
 
 export async function fetchAndSyncConversation({
   connectorId,
-  nangoConnectionId,
+  connectionId,
   dataSourceConfig,
   conversationId,
   currentSyncMs,
@@ -100,15 +101,16 @@ export async function fetchAndSyncConversation({
   loggerArgs,
 }: {
   connectorId: ModelId;
-  nangoConnectionId: string;
+  connectionId: string;
   dataSourceConfig: DataSourceConfig;
   conversationId: string;
   currentSyncMs: number;
   syncType: "incremental" | "batch";
   loggerArgs: Record<string, string | number | null>;
 }) {
+  const accessToken = await getIntercomAccessToken(connectionId);
   const conversation = await fetchIntercomConversation({
-    nangoConnectionId,
+    accessToken,
     conversationId,
   });
 

--- a/connectors/src/connectors/intercom/temporal/sync_help_center.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_help_center.ts
@@ -1,6 +1,7 @@
 import type { ModelId } from "@dust-tt/types";
 import TurndownService from "turndown";
 
+import { getIntercomAccessToken } from "@connectors/connectors/intercom/lib/intercom_access_token";
 import { fetchIntercomCollections } from "@connectors/connectors/intercom/lib/intercom_api";
 import type {
   IntercomArticleType,
@@ -201,11 +202,12 @@ export async function upsertCollectionWithChildren({
   }
 
   // Then we call ourself recursively on the children collections
-  const childrenCollectionsOnIntercom = await fetchIntercomCollections(
-    connectionId,
+  const accessToken = await getIntercomAccessToken(connectionId);
+  const childrenCollectionsOnIntercom = await fetchIntercomCollections({
+    accessToken,
     helpCenterId,
-    collection.id
-  );
+    parentId: collection.id,
+  });
 
   await Promise.all(
     childrenCollectionsOnIntercom.map(async (collectionOnIntercom) => {

--- a/connectors/src/lib/cli.ts
+++ b/connectors/src/lib/cli.ts
@@ -1392,8 +1392,8 @@ export const intercom = async ({
     }
     case "check-teams": {
       logger.info("[Admin] Checking teams");
-
-      const teamsOnIntercom = await fetchIntercomTeams(connector.connectionId);
+      const accessToken = await getIntercomAccessToken(connector.connectionId);
+      const teamsOnIntercom = await fetchIntercomTeams({ accessToken });
       const teamsOnDb = await IntercomTeam.findAll({
         where: {
           connectorId,

--- a/connectors/src/lib/cli.ts
+++ b/connectors/src/lib/cli.ts
@@ -48,6 +48,7 @@ import {
   getDocumentId,
   getDriveClient,
 } from "@connectors/connectors/google_drive/temporal/utils";
+import { getIntercomAccessToken } from "@connectors/connectors/intercom/lib/intercom_access_token";
 import {
   fetchIntercomConversation,
   fetchIntercomConversationsForDay,
@@ -1286,8 +1287,9 @@ export const intercom = async ({
 
       logger.info("[Admin] Checking conversation");
 
+      const accessToken = await getIntercomAccessToken(connector.connectionId);
       const conversationOnIntercom = await fetchIntercomConversation({
-        nangoConnectionId: connector.connectionId,
+        accessToken,
         conversationId,
       });
       const teamIdOnIntercom =
@@ -1317,8 +1319,9 @@ export const intercom = async ({
 
       logger.info("[Admin] Checking conversation");
 
+      const accessToken = await getIntercomAccessToken(connector.connectionId);
       const conversationOnIntercom = await fetchIntercomConversation({
-        nangoConnectionId: connector.connectionId,
+        accessToken,
         conversationId,
       });
 
@@ -1346,10 +1349,10 @@ export const intercom = async ({
       const convosOnIntercom = [];
       let cursor = null;
       let convosOnIntercomRes;
-
+      const accessToken = await getIntercomAccessToken(connector.connectionId);
       do {
         convosOnIntercomRes = await fetchIntercomConversationsForDay({
-          nangoConnectionId: connector.connectionId,
+          accessToken,
           minCreatedAt: startOfDay.getTime() / 1000,
           maxCreatedAt: endOfDay.getTime() / 1000,
           cursor,

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -109,7 +109,9 @@ export async function setupConnection({
   if (
     isOAuthProvider(provider) &&
     // `oauth`-ready providers
-    ["github", "slack"].includes(provider)
+    (["github", "slack"].includes(provider) ||
+      (["intercom"].includes(provider) &&
+        owner.flags.includes("test_oauth_setup")))
     // Behind flag oauth-ready providers
     // ([""].includes(provider) &&
     //   owner.flags.includes("test_oauth_setup"))


### PR DESCRIPTION
## Description

-  add dual support for intercom
- add gated use for `oauth` to setup intercom in `front`

Same as https://github.com/dust-tt/dust/pull/6351 but for Intercom

## Risk

Gated, but still involves some refactoring wrt `nangoConnectionId` being passed around

## Deploy Plan

- deploy `oauth` (secrets are there already) -- intercom likely not deployed there yet
- deploy `connectors` -> to get the dual support
- deploy `front` to have gated workspace go through `oauth` instead of nango