### PR TITLE
Improve oauth service provider errors

### DIFF
--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -50,7 +50,6 @@ lazy_static! {
 pub enum ConnectionErrorCode {
     // Finalize
     ConnectionAlreadyFinalizedError,
-    ProviderInvalidToken,
     ProviderFinalizationError,
     // Refresh Access Token
     ConnectionNotFinalizedError,
@@ -179,10 +178,7 @@ pub fn provider(t: ConnectionProvider) -> Box<dyn Provider + Sync + Send> {
 pub enum ProviderError {
     #[error("Action not supported: {0}.")]
     ActionNotSupportedError(String),
-    #[error("Invalid token.")]
-    InvalidToken,
-    #[error("Token expired.")]
-    TokenExpired,
+    // TODO(2024-07-19 flav) Implement InvalidToken.
     #[error("Timeout error.")]
     TimeoutError,
     #[error("Unknown error: {0}.")]
@@ -201,8 +197,6 @@ impl From<&ProviderError> for ConnectionError {
     fn from(err: &ProviderError) -> Self {
         match err {
             ProviderError::ActionNotSupportedError(_)
-            | ProviderError::InvalidToken
-            | ProviderError::TokenExpired
             | ProviderError::TimeoutError
             | ProviderError::UnknownError(_) => ConnectionError {
                 code: ConnectionErrorCode::ProviderFinalizationError,

--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -23,6 +23,8 @@ use std::time::Duration;
 use std::{env, fmt};
 use tracing::{error, info};
 
+use super::providers::utils::ProviderHttpRequestError;
+
 // We hold the lock for at most 15s. In case of panic preventing the lock from being released, this
 // is the maximum time the lock will be held.
 static REDIS_LOCK_TTL_SECONDS: u64 = 15;
@@ -40,12 +42,15 @@ lazy_static! {
     };
 }
 
+// API Error types.
+
 // Define the ErrorKind enum with serde attributes for serialization
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ConnectionErrorCode {
     // Finalize
     ConnectionAlreadyFinalizedError,
+    ProviderInvalidToken,
     ProviderFinalizationError,
     // Refresh Access Token
     ConnectionNotFinalizedError,
@@ -128,14 +133,33 @@ pub trait Provider {
         connection: &Connection,
         code: &str,
         redirect_uri: &str,
-    ) -> Result<FinalizeResult>;
+    ) -> Result<FinalizeResult, ProviderError>;
 
-    async fn refresh(&self, connection: &Connection) -> Result<RefreshResult>;
+    async fn refresh(&self, connection: &Connection) -> Result<RefreshResult, ProviderError>;
 
     // This method scrubs raw_json to remove information that should not exfill `oauth`, in
     // particular the `refresh_token`. By convetion the `access_token` should be scrubbed as well
     // to prevent users from relying in the raw_json to access it.
     fn scrubbed_raw_json(&self, raw_json: &serde_json::Value) -> Result<serde_json::Value>;
+
+    // Default implementation for handling errors.
+    fn handle_provider_request_error(&self, error: ProviderHttpRequestError) -> ProviderError {
+        match error {
+            ProviderHttpRequestError::NetworkError(e) => ProviderError::UnknownError(e.to_string()),
+            ProviderHttpRequestError::Timeout => ProviderError::TimeoutError,
+            ProviderHttpRequestError::RequestFailed {
+                provider,
+                status,
+                message: _,
+            } => ProviderError::UnknownError(format!(
+                "Request failed for provider {}. Status: {}.",
+                provider, status
+            )),
+            ProviderHttpRequestError::InvalidResponse(e) => {
+                ProviderError::UnknownError(e.to_string())
+            }
+        }
+    }
 }
 
 pub fn provider(t: ConnectionProvider) -> Box<dyn Provider + Sync + Send> {
@@ -146,6 +170,49 @@ pub fn provider(t: ConnectionProvider) -> Box<dyn Provider + Sync + Send> {
         ConnectionProvider::Intercom => Box::new(IntercomConnectionProvider::new()),
         ConnectionProvider::Notion => Box::new(NotionConnectionProvider::new()),
         ConnectionProvider::Slack => Box::new(SlackConnectionProvider::new()),
+    }
+}
+
+// Internal Error types.
+
+#[derive(Debug, thiserror::Error)]
+pub enum ProviderError {
+    #[error("Action not supported: {0}.")]
+    ActionNotSupportedError(String),
+    #[error("Invalid token.")]
+    InvalidToken,
+    #[error("Token expired.")]
+    TokenExpired,
+    #[error("Timeout error.")]
+    TimeoutError,
+    #[error("Unknown error: {0}.")]
+    UnknownError(String),
+    #[error("Internal error: {0}.")]
+    InternalError(anyhow::Error),
+}
+
+impl From<anyhow::Error> for ProviderError {
+    fn from(error: anyhow::Error) -> Self {
+        ProviderError::InternalError(error)
+    }
+}
+
+impl From<&ProviderError> for ConnectionError {
+    fn from(err: &ProviderError) -> Self {
+        match err {
+            ProviderError::ActionNotSupportedError(_)
+            | ProviderError::InvalidToken
+            | ProviderError::TokenExpired
+            | ProviderError::TimeoutError
+            | ProviderError::UnknownError(_) => ConnectionError {
+                code: ConnectionErrorCode::ProviderFinalizationError,
+                message: err.to_string(),
+            },
+            ProviderError::InternalError(_) => ConnectionError {
+                code: ConnectionErrorCode::InternalError,
+                message: "Failed to finalize connection with provider".to_string(),
+            },
+        }
     }
 }
 
@@ -558,10 +625,15 @@ impl Connection {
                     provider = ?self.provider,
                     "Failed to finalize connection",
                 );
-                Err(ConnectionError {
-                    code: ConnectionErrorCode::ProviderFinalizationError,
-                    message: "Failed to finalize connection with provider".to_string(),
-                })
+
+                if let Some(provider_error) = e.downcast_ref::<ProviderError>() {
+                    Err(ConnectionError::from(provider_error))
+                } else {
+                    Err(ConnectionError {
+                        code: ConnectionErrorCode::InternalError,
+                        message: "Failed to finalize connection with provider".to_string(),
+                    })
+                }
             }
         }
     }

--- a/core/src/oauth/providers/github.rs
+++ b/core/src/oauth/providers/github.rs
@@ -1,6 +1,8 @@
 use crate::{
     oauth::{
-        connection::{Connection, ConnectionProvider, FinalizeResult, Provider, RefreshResult},
+        connection::{
+            Connection, ConnectionProvider, FinalizeResult, Provider, ProviderError, RefreshResult,
+        },
         providers::utils::execute_request,
     },
     utils,
@@ -102,7 +104,7 @@ impl Provider for GithubConnectionProvider {
         _connection: &Connection,
         code: &str,
         redirect_uri: &str,
-    ) -> Result<FinalizeResult> {
+    ) -> Result<FinalizeResult, ProviderError> {
         // `code` is the installation_id returned by Github.
         let (token, expiry, raw_json) = self.refresh_token(code).await?;
 
@@ -117,7 +119,7 @@ impl Provider for GithubConnectionProvider {
         })
     }
 
-    async fn refresh(&self, connection: &Connection) -> Result<RefreshResult> {
+    async fn refresh(&self, connection: &Connection) -> Result<RefreshResult, ProviderError> {
         // `code` is the installation_id returned by Github.
         let code = match connection.unseal_authorization_code()? {
             Some(code) => code,
@@ -145,4 +147,6 @@ impl Provider for GithubConnectionProvider {
         };
         Ok(raw_json)
     }
+
+    // TODO(2024-07-19 flav) Implement custom error handling for GitHub.
 }

--- a/core/src/oauth/providers/utils.rs
+++ b/core/src/oauth/providers/utils.rs
@@ -2,49 +2,66 @@ use crate::{
     oauth::connection::{ConnectionProvider, PROVIDER_TIMEOUT_SECONDS},
     utils,
 };
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use hyper::body::Buf;
 use reqwest::RequestBuilder;
 use std::io::prelude::*;
 use std::time::Duration;
 use tokio::time::timeout;
 
+#[derive(Debug, thiserror::Error)]
+pub enum ProviderHttpRequestError {
+    #[error("Network error: {0}")]
+    NetworkError(reqwest::Error),
+    #[error("Timeout error")]
+    Timeout,
+    #[error("Request failed for provider {provider}. Status: {status}. {message}")]
+    RequestFailed {
+        provider: ConnectionProvider,
+        status: u16,
+        message: String,
+    },
+    #[error("Invalid response: {0}")]
+    InvalidResponse(anyhow::Error),
+}
+
 pub async fn execute_request(
     provider: ConnectionProvider,
     req: RequestBuilder,
-) -> Result<serde_json::Value> {
+) -> Result<serde_json::Value, ProviderHttpRequestError> {
     let now = utils::now_secs();
 
-    let res = match timeout(Duration::new(PROVIDER_TIMEOUT_SECONDS, 0), req.send()).await {
-        Ok(Ok(res)) => res,
-        Ok(Err(e)) => Err(e)?,
-        Err(_) => Err(anyhow!("Timeout sending request: provider={}", provider))?,
-    };
+    let res = timeout(Duration::from_secs(PROVIDER_TIMEOUT_SECONDS), req.send())
+        .await
+        .map_err(|_| ProviderHttpRequestError::Timeout)?
+        .map_err(|e| ProviderHttpRequestError::NetworkError(e))?;
 
     if !res.status().is_success() {
-        Err(anyhow!(
-            "Error generating access token: provider={} status={}",
-            provider,
-            res.status().as_u16(),
-        ))?;
+        let status = res.status();
+        let body = res
+            .text()
+            .await
+            .unwrap_or_else(|_| String::from("Unable to read response body"));
+
+        return Err(ProviderHttpRequestError::RequestFailed {
+            provider: provider,
+            status: status.as_u16(),
+            message: body,
+        });
     }
 
-    let body = match timeout(
-        Duration::new(PROVIDER_TIMEOUT_SECONDS - (utils::now_secs() - now), 0),
+    let body = timeout(
+        Duration::from_secs(PROVIDER_TIMEOUT_SECONDS - (utils::now_secs() - now)),
         res.bytes(),
     )
     .await
-    {
-        Ok(Ok(body)) => body,
-        Ok(Err(e)) => Err(e)?,
-        Err(_) => Err(anyhow!("Timeout reading response from Confluence"))?,
-    };
+    .map_err(|_| ProviderHttpRequestError::Timeout)?
+    .map_err(|e| ProviderHttpRequestError::NetworkError(e))?;
 
     let mut b: Vec<u8> = vec![];
-    body.reader().read_to_end(&mut b)?;
-    let c: &[u8] = &b;
+    body.reader()
+        .read_to_end(&mut b)
+        .map_err(|e| ProviderHttpRequestError::InvalidResponse(e.into()))?;
 
-    let raw_json: serde_json::Value = serde_json::from_slice(c)?;
-
-    Ok(raw_json)
+    serde_json::from_slice(&b).map_err(|e| ProviderHttpRequestError::InvalidResponse(e.into()))
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
As we begin transitioning existing connectors to our own OAuth service implementation, we've noticed that the error messages were not sufficiently explicit and could benefit from improvements. This initial PR restructures the error handling for the OAuth service. Our long-term goal is to implement specific error handling for each provider. However, first, we need to log all types of errors observed during migrations so that we can tailor our handling and display them clearly to our users.

This implementation introduces several custom error types:
- `ConnectionError`: Used at API boundaries to represent an API error response.
- For internal provider errors, we rely on two types:
  - `ProviderHttpRequestError`: Allows us to extract status and body information for future error handling, applicable to all providers.
  - `ProviderHttpError`: Abstracts errors specific to each provider, such as `InvalidToken` or `TokenExpired`.
  
These custom errors enable us to have very explicit error messages while preserving as much context as possible.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
