### PR TITLE
`oauth`: Notion connector dual-flow + front gating

### DIFF
--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -753,7 +753,7 @@ export async function validateAccessToken(notionAccessToken: string) {
     logger: notionClientLogger,
   });
   try {
-    await notionClient.search({ page_size: 1 });
+    await notionClient.users.me({});
   } catch (e) {
     return false;
   }

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -2,15 +2,12 @@ import type {
   CoreAPIDataSourceDocumentSection,
   ModelId,
   NotionGarbageCollectionMode,
-  Result,
 } from "@dust-tt/types";
 import type { PageObjectProperties, ParsedNotionBlock } from "@dust-tt/types";
 import {
   assertNever,
-  Err,
   getNotionDatabaseTableId,
   getOAuthConnectionAccessToken,
-  Ok,
   slugify,
 } from "@dust-tt/types";
 import { isFullBlock, isFullPage, isNotionClientError } from "@notionhq/client";

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -110,11 +110,9 @@ export async function setupConnection({
     isOAuthProvider(provider) &&
     // `oauth`-ready providers
     (["github", "slack"].includes(provider) ||
-      (["intercom"].includes(provider) &&
+      // Behind flag oauth-ready providers
+      (["intercom", "notion"].includes(provider) &&
         owner.flags.includes("test_oauth_setup")))
-    // Behind flag oauth-ready providers
-    // ([""].includes(provider) &&
-    //   owner.flags.includes("test_oauth_setup"))
   ) {
     // OAuth flow
     const cRes = await setupOAuthConnection({


### PR DESCRIPTION
## Description

- Implenents dual support for Nango and `oauth` for Notion
- Change validation token code to call me vs search (faster?)
- Gate `notion` for `oauth` setup in `front`.

## Risk

Low

Full sync + update tested locally

## Deploy Plan

- deploy `connectors`
- deploy `front`