### PR TITLE
CLI to stop/start transcripts workflows

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -21,10 +21,15 @@ import {
   internalSubscribeWorkspaceToFreeNoPlan,
   internalSubscribeWorkspaceToFreePlan,
 } from "@app/lib/plans/subscription";
+import { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { generateLegacyModelSId } from "@app/lib/resources/string_ids";
 import { UserResource } from "@app/lib/resources/user_resource";
 import logger from "@app/logger/logger";
+import {
+  launchRetrieveTranscriptsWorkflow,
+  stopRetrieveTranscriptsWorkflow,
+} from "@app/temporal/labs/client";
 
 // `cli` takes an object type and a command as first two arguments and then a list of arguments.
 const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
@@ -489,6 +494,57 @@ const conversation = async (command: string, args: parseArgs.ParsedArgs) => {
   }
 };
 
+const transcripts = async (command: string, args: parseArgs.ParsedArgs) => {
+  switch (command) {
+    case "stop": {
+      if (!args.cId) {
+        throw new Error("Missing --cId argument");
+      }
+      const transcriptsConfiguration =
+        await LabsTranscriptsConfigurationResource.fetchByModelId(args.cId);
+
+      if (!transcriptsConfiguration) {
+        throw new Error(
+          `Transcripts configuration not found: cId='${args.cId}'`
+        );
+      }
+
+      await stopRetrieveTranscriptsWorkflow(transcriptsConfiguration);
+
+      logger.info(
+        {
+          transcriptsConfiguration,
+        },
+        "Transcript retrieval workflow stopped."
+      );
+
+      return;
+    }
+    case "start": {
+      if (!args.cId) {
+        throw new Error("Missing --cId argument");
+      }
+      const transcriptsConfiguration =
+        await LabsTranscriptsConfigurationResource.fetchByModelId(args.cId);
+
+      if (!transcriptsConfiguration) {
+        throw new Error(
+          `Transcripts configuration not found: cId='${args.cId}'`
+        );
+      }
+
+      await launchRetrieveTranscriptsWorkflow(transcriptsConfiguration);
+
+      logger.info(
+        {
+          transcriptsConfiguration,
+        },
+        "Transcript retrieval workflow started."
+      );
+    }
+  }
+};
+
 const main = async () => {
   const argv = parseArgs(process.argv.slice(2));
 
@@ -516,9 +572,11 @@ const main = async () => {
       return;
     case "conversation":
       return conversation(command, argv);
+    case "transcripts":
+      return transcripts(command, argv);
     default:
       console.log(
-        "Unknown object type, possible values: `workspace`, `user`, `data-source`, `event-schema`, `conversation`"
+        "Unknown object type, possible values: `workspace`, `user`, `data-source`, `event-schema`, `conversation`, `transcripts`"
       );
       return;
   }


### PR DESCRIPTION
## Description

Allows stopping/starting transcripts temporal workflows by passing their transcriptsConfigurationId (the number in the workflow name)

`./admin/cli.sh transcripts start --cId 82`

![Screenshot 2024-07-22 at 10 38 21](https://github.com/user-attachments/assets/4a69780f-bb10-4a69-a1af-cd9e5ce10b92)



## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
