### PR TITLE
getOAuthConnectionAccessTokenWithThrow

### DIFF
--- a/connectors/src/connectors/github/lib/github_api.ts
+++ b/connectors/src/connectors/github/lib/github_api.ts
@@ -30,6 +30,7 @@ import {
 } from "@connectors/connectors/github/lib/github_graphql";
 import { apiConfig } from "@connectors/lib/api/config";
 import { ExternalOauthTokenError } from "@connectors/lib/error";
+import { getOAuthConnectionAccessTokenWithThrow } from "@connectors/lib/oauth";
 import logger from "@connectors/logger/logger";
 
 const API_PAGE_SIZE = 100;
@@ -543,22 +544,13 @@ export async function getDiscussion(
 }
 
 export async function getOctokit(connectionId: string): Promise<Octokit> {
-  const tokRes = await getOAuthConnectionAccessToken({
-    config: apiConfig.getOAuthAPIConfig(),
+  const token = await getOAuthConnectionAccessTokenWithThrow({
     logger,
     provider: "github",
     connectionId,
   });
 
-  if (tokRes.isErr()) {
-    logger.error(
-      { connectionId, error: tokRes.error },
-      "Error retrieving Github access token"
-    );
-    throw new Error("Error retrieving Github access token");
-  }
-
-  return new Octokit({ auth: tokRes.value.access_token });
+  return new Octokit({ auth: token.access_token });
 }
 
 // Repository processing

--- a/connectors/src/connectors/google_drive/temporal/utils.ts
+++ b/connectors/src/connectors/google_drive/temporal/utils.ts
@@ -1,10 +1,9 @@
-import { cacheWithRedis, getOAuthConnectionAccessToken } from "@dust-tt/types";
+import { cacheWithRedis } from "@dust-tt/types";
 import type { drive_v3 } from "googleapis";
 import { google } from "googleapis";
 import { OAuth2Client } from "googleapis-common";
 
 import { googleDriveConfig } from "@connectors/connectors/google_drive/lib/config";
-import { apiConfig } from "@connectors/lib/api/config";
 import type { NangoConnectionResponse } from "@connectors/lib/nango_helpers";
 import { getConnectionFromNango } from "@connectors/lib/nango_helpers";
 import { getOAuthConnectionAccessTokenWithThrow, isDualUseOAuthConnectionId } from "@connectors/lib/oauth";

--- a/connectors/src/connectors/google_drive/temporal/utils.ts
+++ b/connectors/src/connectors/google_drive/temporal/utils.ts
@@ -6,7 +6,10 @@ import { OAuth2Client } from "googleapis-common";
 import { googleDriveConfig } from "@connectors/connectors/google_drive/lib/config";
 import type { NangoConnectionResponse } from "@connectors/lib/nango_helpers";
 import { getConnectionFromNango } from "@connectors/lib/nango_helpers";
-import { getOAuthConnectionAccessTokenWithThrow, isDualUseOAuthConnectionId } from "@connectors/lib/oauth";
+import {
+  getOAuthConnectionAccessTokenWithThrow,
+  isDualUseOAuthConnectionId,
+} from "@connectors/lib/oauth";
 import logger from "@connectors/logger/logger";
 import type { GoogleDriveObjectType } from "@connectors/types/google_drive";
 

--- a/connectors/src/connectors/intercom/lib/intercom_access_token.ts
+++ b/connectors/src/connectors/intercom/lib/intercom_access_token.ts
@@ -1,8 +1,8 @@
-import { getOAuthConnectionAccessToken } from "@dust-tt/types";
-
-import { apiConfig } from "@connectors/lib/api/config";
 import { getAccessTokenFromNango } from "@connectors/lib/nango_helpers";
-import { isDualUseOAuthConnectionId } from "@connectors/lib/oauth";
+import {
+  getOAuthConnectionAccessTokenWithThrow,
+  isDualUseOAuthConnectionId,
+} from "@connectors/lib/oauth";
 import logger from "@connectors/logger/logger";
 
 const { NANGO_INTERCOM_CONNECTOR_ID } = process.env;
@@ -11,21 +11,12 @@ export async function getIntercomAccessToken(
   connectionId: string
 ): Promise<string> {
   if (isDualUseOAuthConnectionId(connectionId)) {
-    const tokRes = await getOAuthConnectionAccessToken({
-      config: apiConfig.getOAuthAPIConfig(),
+    const token = await getOAuthConnectionAccessTokenWithThrow({
       logger,
       provider: "intercom",
       connectionId,
     });
-    if (tokRes.isErr()) {
-      logger.error(
-        { connectionId, error: tokRes.error },
-        "Error retrieving Intercom access token"
-      );
-      throw new Error("Error retrieving Intercom access token");
-    }
-
-    return tokRes.value.access_token;
+    return token.access_token;
   } else {
     // TODO(@fontanierh) INTERCOM_MIGRATION remove once migrated
     if (!NANGO_INTERCOM_CONNECTOR_ID) {

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -71,7 +71,10 @@ import {
   NotionPage,
 } from "@connectors/lib/models/notion";
 import { getAccessTokenFromNango } from "@connectors/lib/nango_helpers";
-import { isDualUseOAuthConnectionId } from "@connectors/lib/oauth";
+import {
+  getOAuthConnectionAccessTokenWithThrow,
+  isDualUseOAuthConnectionId,
+} from "@connectors/lib/oauth";
 import { redisClient } from "@connectors/lib/redis";
 import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
 import { heartbeat } from "@connectors/lib/temporal";
@@ -559,20 +562,12 @@ export async function getNotionAccessToken(
   connectionId: string
 ): Promise<string> {
   if (isDualUseOAuthConnectionId(connectionId)) {
-    const tokRes = await getOAuthConnectionAccessToken({
-      config: apiConfig.getOAuthAPIConfig(),
+    const token = await getOAuthConnectionAccessTokenWithThrow({
       logger,
       provider: "notion",
       connectionId,
     });
-    if (tokRes.isErr()) {
-      logger.error(
-        { connectionId, error: tokRes.error },
-        "Error retrieving Notion access token"
-      );
-      throw new Error("Error retrieving Notion access token");
-    }
-    return tokRes.value.access_token;
+    return token.access_token;
   } else {
     return getAccessTokenFromNango({
       connectionId: connectionId,

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -4,11 +4,7 @@ import type {
   NotionGarbageCollectionMode,
 } from "@dust-tt/types";
 import type { PageObjectProperties, ParsedNotionBlock } from "@dust-tt/types";
-import {
-  assertNever,
-  getNotionDatabaseTableId,
-  slugify,
-} from "@dust-tt/types";
+import { assertNever, getNotionDatabaseTableId, slugify } from "@dust-tt/types";
 import { isFullBlock, isFullPage, isNotionClientError } from "@notionhq/client";
 import type { PageObjectResponse } from "@notionhq/client/build/src/api-endpoints";
 import { Context } from "@temporalio/activity";

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -7,7 +7,6 @@ import type { PageObjectProperties, ParsedNotionBlock } from "@dust-tt/types";
 import {
   assertNever,
   getNotionDatabaseTableId,
-  getOAuthConnectionAccessToken,
   slugify,
 } from "@dust-tt/types";
 import { isFullBlock, isFullPage, isNotionClientError } from "@notionhq/client";
@@ -46,7 +45,6 @@ import {
   updateAllParentsFields,
 } from "@connectors/connectors/notion/lib/parents";
 import { getTagsForPage } from "@connectors/connectors/notion/lib/tags";
-import { apiConfig } from "@connectors/lib/api/config";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import {

--- a/connectors/src/connectors/slack/lib/slack_client.ts
+++ b/connectors/src/connectors/slack/lib/slack_client.ts
@@ -1,5 +1,4 @@
 import type { ModelId } from "@dust-tt/types";
-import { getOAuthConnectionAccessToken } from "@dust-tt/types";
 import type {
   CodedError,
   WebAPIHTTPError,
@@ -7,7 +6,6 @@ import type {
 } from "@slack/web-api";
 import { ErrorCode, WebClient } from "@slack/web-api";
 
-import { apiConfig } from "@connectors/lib/api/config";
 import {
   ExternalOauthTokenError,
   ProviderWorkflowError,

--- a/connectors/src/connectors/slack/lib/slack_client.ts
+++ b/connectors/src/connectors/slack/lib/slack_client.ts
@@ -12,6 +12,7 @@ import {
   ExternalOauthTokenError,
   ProviderWorkflowError,
 } from "@connectors/lib/error";
+import {getOAuthConnectionAccessTokenWithThrow} from "@connectors/lib/oauth";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 
@@ -183,19 +184,11 @@ export async function getSlackConversationInfo(
 export async function getSlackAccessToken(
   connectionId: string
 ): Promise<string> {
-  const tokRes = await getOAuthConnectionAccessToken({
-    config: apiConfig.getOAuthAPIConfig(),
+  const token = await getOAuthConnectionAccessTokenWithThrow({
     logger,
     provider: "slack",
     connectionId,
   });
-  if (tokRes.isErr()) {
-    logger.error(
-      { connectionId, error: tokRes.error },
-      "Error retrieving Slack access token"
-    );
-    throw new Error("Error retrieving Slack access token");
-  }
 
-  return tokRes.value.access_token;
+  return token.access_token;
 }

--- a/connectors/src/connectors/slack/lib/slack_client.ts
+++ b/connectors/src/connectors/slack/lib/slack_client.ts
@@ -10,7 +10,7 @@ import {
   ExternalOauthTokenError,
   ProviderWorkflowError,
 } from "@connectors/lib/error";
-import {getOAuthConnectionAccessTokenWithThrow} from "@connectors/lib/oauth";
+import { getOAuthConnectionAccessTokenWithThrow } from "@connectors/lib/oauth";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 

--- a/connectors/src/lib/oauth.ts
+++ b/connectors/src/lib/oauth.ts
@@ -1,7 +1,4 @@
-import type {
-  OAuthConnectionType,
-  OAuthProvider,
-} from "@dust-tt/types";
+import type { OAuthConnectionType, OAuthProvider } from "@dust-tt/types";
 import { getOAuthConnectionAccessToken } from "@dust-tt/types";
 import type { LoggerInterface } from "@dust-tt/types/dist/shared/logger";
 

--- a/connectors/src/lib/oauth.ts
+++ b/connectors/src/lib/oauth.ts
@@ -1,7 +1,57 @@
+import type {
+  OAuthConnectionType,
+  OAuthProvider,
+} from "@dust-tt/types";
+import { getOAuthConnectionAccessToken } from "@dust-tt/types";
+import type { LoggerInterface } from "@dust-tt/types/dist/shared/logger";
+
+import { apiConfig } from "@connectors/lib/api/config";
+import { ExternalOauthTokenError } from "@connectors/lib/error";
+
 // This function is used to discreminate between a new OAuth connection and an old Nango/Github
 // connection. It is used to support dual-use while migrating and should be unused by a connector
 // once fully migrated
 export function isDualUseOAuthConnectionId(connectionId: string): boolean {
   // TODO(spolu): make sure this function is removed once fully migrated.
   return connectionId.startsWith("con_");
+}
+
+// Most connectors are built on the assumption that errors are thrown with special handling of
+// selected errors such as ExternalOauthTokenError. This function is used to retrieve an OAuth
+// connection access token and throw an ExternalOauthTokenError if the token is revoked.
+export async function getOAuthConnectionAccessTokenWithThrow({
+  logger,
+  provider,
+  connectionId,
+}: {
+  logger: LoggerInterface;
+  provider: OAuthProvider;
+  connectionId: string;
+}): Promise<{
+  connection: OAuthConnectionType;
+  access_token: string;
+  access_token_expiry: number;
+  scrubbed_raw_json: unknown;
+}> {
+  const tokRes = await getOAuthConnectionAccessToken({
+    config: apiConfig.getOAuthAPIConfig(),
+    logger,
+    provider,
+    connectionId,
+  });
+
+  if (tokRes.isErr()) {
+    logger.error(
+      { connectionId, error: tokRes.error, provider },
+      "Error retrieving access token"
+    );
+
+    if (tokRes.error.code === "token_revoked_error") {
+      throw new ExternalOauthTokenError();
+    } else {
+      throw new Error(`Error retrieving access token from ${provider}`);
+    }
+  }
+
+  return tokRes.value;
 }

--- a/core/src/oauth/providers/utils.rs
+++ b/core/src/oauth/providers/utils.rs
@@ -44,7 +44,7 @@ pub async fn execute_request(
             .unwrap_or_else(|_| String::from("Unable to read response body"));
 
         return Err(ProviderHttpRequestError::RequestFailed {
-            provider: provider,
+            provider,
             status: status.as_u16(),
             message: body,
         });


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/dust/issues/6384

Introduce `getOAuthConnectionAccessTokenWithThrow` which throws error including `ExternalOauthTokenError` when we know that a token was revoked.

This is used for all activities code paths that rely on throwing errors. Other "API" code path generally rely on results and will call directly the non throwing types version.

## Risk

None

## Deploy Plan

- deploy `conectors`