### PR TITLE
feat(oauth): add Microsoft provider

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -89,6 +89,7 @@ pub mod oauth {
         pub mod github;
         pub mod google_drive;
         pub mod intercom;
+        pub mod microsoft;
         pub mod notion;
         pub mod slack;
         pub mod utils;

--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -2,7 +2,8 @@ use crate::oauth::{
     providers::{
         confluence::ConfluenceConnectionProvider, github::GithubConnectionProvider,
         google_drive::GoogleDriveConnectionProvider, intercom::IntercomConnectionProvider,
-        notion::NotionConnectionProvider, slack::SlackConnectionProvider,
+        microsoft::MicrosoftConnectionProvider, notion::NotionConnectionProvider,
+        slack::SlackConnectionProvider, utils::ProviderHttpRequestError,
     },
     store::OAuthStore,
 };
@@ -22,8 +23,6 @@ use std::str::FromStr;
 use std::time::Duration;
 use std::{env, fmt};
 use tracing::{error, info};
-
-use super::providers::utils::ProviderHttpRequestError;
 
 // We hold the lock for at most 15s. In case of panic preventing the lock from being released, this
 // is the maximum time the lock will be held.
@@ -93,6 +92,7 @@ pub enum ConnectionProvider {
     Intercom,
     Notion,
     Slack,
+    Microsoft,
 }
 
 impl fmt::Display for ConnectionProvider {
@@ -177,6 +177,7 @@ pub fn provider(t: ConnectionProvider) -> Box<dyn Provider + Sync + Send> {
         ConnectionProvider::Intercom => Box::new(IntercomConnectionProvider::new()),
         ConnectionProvider::Notion => Box::new(NotionConnectionProvider::new()),
         ConnectionProvider::Slack => Box::new(SlackConnectionProvider::new()),
+        ConnectionProvider::Microsoft => Box::new(MicrosoftConnectionProvider::new()),
     }
 }
 

--- a/core/src/oauth/providers/microsoft.rs
+++ b/core/src/oauth/providers/microsoft.rs
@@ -1,0 +1,142 @@
+use crate::{
+    oauth::{
+        connection::{
+            Connection, ConnectionProvider, FinalizeResult, Provider, ProviderError, RefreshResult,
+            PROVIDER_TIMEOUT_SECONDS,
+        },
+        providers::utils::execute_request,
+    },
+    utils,
+};
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use lazy_static::lazy_static;
+use serde_json::json;
+use std::env;
+
+lazy_static! {
+    static ref OAUTH_MICROSOFT_CLIENT_ID: String = env::var("OAUTH_MICROSOFT_CLIENT_ID").unwrap();
+    static ref OAUTH_MICROSOFT_CLIENT_SECRET: String =
+        env::var("OAUTH_MICROSOFT_CLIENT_SECRET").unwrap();
+}
+
+pub struct MicrosoftConnectionProvider {}
+
+impl MicrosoftConnectionProvider {
+    pub fn new() -> Self {
+        MicrosoftConnectionProvider {}
+    }
+}
+
+#[async_trait]
+impl Provider for MicrosoftConnectionProvider {
+    fn id(&self) -> ConnectionProvider {
+        ConnectionProvider::Microsoft
+    }
+
+    async fn finalize(
+        &self,
+        _connection: &Connection,
+        code: &str,
+        redirect_uri: &str,
+    ) -> Result<FinalizeResult, ProviderError> {
+        let body = json!({
+            "grant_type": "authorization_code",
+            "client_id": *OAUTH_MICROSOFT_CLIENT_ID,
+            "client_secret": *OAUTH_MICROSOFT_CLIENT_SECRET,
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "scope": "User.Read Sites.Read.All Directory.Read.All Files.Read.All Team.ReadBasic.All ChannelSettings.Read.All ChannelMessage.Read.All",
+        });
+
+        let req = reqwest::Client::new()
+            .post("https://login.microsoftonline.com/common/oauth2/v2.0/token")
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .form(&body);
+
+        let raw_json = execute_request(ConnectionProvider::Microsoft, req)
+            .await
+            .map_err(|e| self.handle_provider_request_error(e))?;
+
+        let access_token = raw_json["access_token"]
+            .as_str()
+            .ok_or_else(|| anyhow!("Missing `access_token` in response from Microsoft"))?;
+
+        let expires_in = raw_json["expires_in"]
+            .as_u64()
+            .ok_or_else(|| anyhow!("Missing `expires_in` in response from Microsoft"))?;
+
+        let refresh_token = raw_json["refresh_token"]
+            .as_str()
+            .ok_or_else(|| anyhow!("Missing `refresh_token` in response from Microsoft"))?;
+
+        Ok(FinalizeResult {
+            redirect_uri: redirect_uri.to_string(),
+            code: code.to_string(),
+            access_token: access_token.to_string(),
+            access_token_expiry: Some(
+                utils::now() + (expires_in - PROVIDER_TIMEOUT_SECONDS) * 1000,
+            ),
+            refresh_token: Some(refresh_token.to_string()),
+            raw_json,
+        })
+    }
+
+    async fn refresh(&self, connection: &Connection) -> Result<RefreshResult, ProviderError> {
+        let refresh_token = connection
+            .unseal_refresh_token()?
+            .ok_or_else(|| anyhow!("Missing `refresh_token` in Microsoft connection"))?;
+
+        let body = json!({
+            "grant_type": "refresh_token",
+            "client_id": *OAUTH_MICROSOFT_CLIENT_ID,
+            "client_secret": *OAUTH_MICROSOFT_CLIENT_SECRET,
+            "refresh_token": refresh_token,
+            "scope": "User.Read Sites.Read.All Directory.Read.All Files.Read.All Team.ReadBasic.All ChannelSettings.Read.All ChannelMessage.Read.All",
+        });
+
+        let req = reqwest::Client::new()
+            .post("https://login.microsoftonline.com/common/oauth2/v2.0/token")
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .form(&body);
+
+        let raw_json = execute_request(ConnectionProvider::Microsoft, req)
+            .await
+            .map_err(|e| self.handle_provider_request_error(e))?;
+
+        let access_token = raw_json["access_token"]
+            .as_str()
+            .ok_or_else(|| anyhow!("Missing `access_token` in response from Microsoft"))?;
+
+        let expires_in = raw_json["expires_in"]
+            .as_u64()
+            .ok_or_else(|| anyhow!("Missing `expires_in` in response from Microsoft"))?;
+
+        let refresh_token = raw_json["refresh_token"]
+            .as_str()
+            .ok_or_else(|| anyhow!("Missing `refresh_token` in response from Microsoft"))?;
+
+        Ok(RefreshResult {
+            access_token: access_token.to_string(),
+            access_token_expiry: Some(
+                utils::now() + (expires_in - PROVIDER_TIMEOUT_SECONDS) * 1000,
+            ),
+            refresh_token: Some(refresh_token.to_string()),
+            raw_json,
+        })
+    }
+
+    fn scrubbed_raw_json(&self, raw_json: &serde_json::Value) -> Result<serde_json::Value> {
+        let raw_json = match raw_json.clone() {
+            serde_json::Value::Object(mut map) => {
+                map.remove("access_token");
+                map.remove("refresh_token");
+                map.remove("expires_in");
+                serde_json::Value::Object(map)
+            }
+            _ => Err(anyhow!("Invalid raw_json, not an object"))?,
+        };
+
+        Ok(raw_json)
+    }
+}

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -106,6 +106,9 @@ const config = {
   getOAuthIntercomClientId: (): string => {
     return EnvironmentConfig.getEnvVariable("OAUTH_INTERCOM_CLIENT_ID");
   },
+  getOAuthMicrosoftClientId: (): string => {
+    return EnvironmentConfig.getEnvVariable("OAUTH_MICROSOFT_CLIENT_ID");
+  },
   // Text extraction.
   getTextExtractionUrl: (): string => {
     return EnvironmentConfig.getEnvVariable("TEXT_EXTRACTION_URL");

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -193,11 +193,32 @@ const PROVIDER_STRATEGIES: Record<
     },
   },
   microsoft: {
-    setupUri: () => {
-      throw new Error("Slack OAuth is not implemented");
+    setupUri: (connection) => {
+      const scopes = [
+        "User.Read",
+        "Sites.Read.All",
+        "Directory.Read.All",
+        "Files.Read.All",
+        "Team.ReadBasic.All",
+        "ChannelSettings.Read.All",
+        "ChannelMessage.Read.All",
+        "offline_access",
+      ];
+      const qs = querystring.stringify({
+        response_type: "code",
+        client_id: config.getOAuthMicrosoftClientId(),
+        state: connection.connection_id,
+        redirect_uri: finalizeUriForProvider("microsoft"),
+        scope: scopes.join(" "),
+      });
+      return `https://login.microsoftonline.com/common/oauth2/v2.0/authorize?${qs}`;
     },
-    codeFromQuery: () => null,
-    connectionIdFromQuery: () => null,
+    codeFromQuery: (query) => {
+      return getStringFromQuery(query, "code");
+    },
+    connectionIdFromQuery: (query) => {
+      return getStringFromQuery(query, "state");
+    },
   },
 };
 

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -109,7 +109,7 @@ export async function setupConnection({
   if (
     isOAuthProvider(provider) &&
     // `oauth`-ready providers
-    (["github", "slack", "notion"].includes(provider) ||
+    (["github", "slack", "notion", "microsoft"].includes(provider) ||
       // Behind flag oauth-ready providers
       (["intercom", "google_drive"].includes(provider) &&
         owner.flags.includes("test_oauth_setup")))


### PR DESCRIPTION
## Description
This PR implements the Microsoft OAuth provider for Dust. It adds support for authenticating and authorizing Microsoft services, allowing users to connect their Microsoft accounts for data integration. The implementation follows the OAuth 2.0 protocol and includes token refresh functionality.

Also fully de-nangoize the microsoft setup (no need for dual mode or migration)

fixes https://github.com/dust-tt/dust/issues/6344

## Risk
Low. This is a new feature and doesn't modify existing functionality. However, careful testing is required to ensure proper handling of access tokens and refresh tokens.

## Deploy Plan
1.  Deploy the `oauth` service
2.  Deploy `front`.
3.  Update dev env vars to include `OAUTH_MICROSOFT_CLIENT_ID` and `OAUTH_MICROSOFT_CLIENT_SECRET`