### PR TITLE
[MS Connector] Fix error when selecting root that's not drive or folder

### DIFF
--- a/connectors/migrations/db/migration_08.sql
+++ b/connectors/migrations/db/migration_08.sql
@@ -1,3 +1,3 @@
 -- Migration created on Jul 22, 2024
 ALTER TABLE "public"."microsoft_roots" DROP COLUMN "currentDeltaLink";
-ALTER TABLE "public"."microsoft_nodes" ADD COLUMN "deltaLink" VARCHAR(1024) NOT NULL;
+ALTER TABLE "public"."microsoft_nodes" ADD COLUMN "deltaLink" VARCHAR(1024);

--- a/connectors/migrations/db/migration_08.sql
+++ b/connectors/migrations/db/migration_08.sql
@@ -1,0 +1,3 @@
+-- Migration created on Jul 22, 2024
+ALTER TABLE "public"."microsoft_roots" DROP COLUMN "currentDeltaLink";
+ALTER TABLE "public"."microsoft_nodes" ADD COLUMN "deltaLink" VARCHAR(1024) NOT NULL;

--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -36,7 +36,6 @@ import {
   launchMicrosoftFullSyncWorkflow,
   launchMicrosoftIncrementalSyncWorkflow,
 } from "@connectors/connectors/microsoft/temporal/client";
-import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { getOAuthConnectionAccessTokenWithThrow } from "@connectors/lib/oauth";
 import { syncSucceeded } from "@connectors/lib/sync_status";
 import { terminateAllWorkflowsForConnectorId } from "@connectors/lib/temporal";
@@ -134,7 +133,7 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
   }: {
     fromTs: number | null;
   }): Promise<Result<string, Error>> {
-    return launchMicrosoftFullSyncWorkflow(this.connectorId, null);
+    return launchMicrosoftFullSyncWorkflow(this.connectorId);
   }
 
   async retrievePermissions({
@@ -303,7 +302,6 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
 
     const res = await launchMicrosoftFullSyncWorkflow(
       this.connectorId,
-      null,
       nodesToSync
     );
 
@@ -397,8 +395,7 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
           pdfEnabled: configValue === "true",
         });
         const workflowRes = await launchMicrosoftFullSyncWorkflow(
-          this.connectorId,
-          null
+          this.connectorId
         );
         if (workflowRes.isErr()) {
           return workflowRes;
@@ -411,8 +408,7 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
           largeFilesEnabled: configValue === "true",
         });
         const workflowRes = await launchMicrosoftFullSyncWorkflow(
-          this.connectorId,
-          null
+          this.connectorId
         );
         if (workflowRes.isErr()) {
           return workflowRes;
@@ -480,7 +476,7 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
       );
     }
     await connector.markAsUnpaused();
-    const r = await launchMicrosoftFullSyncWorkflow(this.connectorId, null);
+    const r = await launchMicrosoftFullSyncWorkflow(this.connectorId);
     if (r.isErr()) {
       return r;
     }

--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -284,9 +284,9 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
       connectorId: connector.id,
     });
 
-    const newResourcesBlobs = Object.keys(permissions)
+    const newResourcesBlobs = Object.entries(permissions)
       .filter(([, permission]) => permission === "read")
-      .map((id) => ({
+      .map(([id]) => ({
         connectorId: connector.id,
         nodeType: typeAndPathFromInternalId(id).nodeType,
         internalId: id,

--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -20,7 +20,6 @@ import {
 import {
   getAllPaginatedEntities,
   getChannels,
-  getDeltaResults,
   getDrives,
   getFilesAndFolders,
   getSites,
@@ -29,6 +28,10 @@ import {
   typeAndPathFromInternalId,
 } from "@connectors/connectors/microsoft/lib/graph_api";
 import type { MicrosoftNodeType } from "@connectors/connectors/microsoft/lib/types";
+import {
+  getSiteNodesToSync,
+  populateDeltas,
+} from "@connectors/connectors/microsoft/temporal/activities";
 import {
   launchMicrosoftFullSyncWorkflow,
   launchMicrosoftIncrementalSyncWorkflow,
@@ -277,39 +280,32 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
       );
     }
 
-    const client = await getClient(connector.connectionId);
-
     await MicrosoftRootResource.batchDelete({
       resourceIds: Object.keys(permissions),
       connectorId: connector.id,
     });
 
-    const newResourcesBlobs = await concurrentExecutor(
-      Object.entries(permissions).filter(
-        ([, permission]) => permission === "read"
-      ),
-      async ([id]) => {
-        const { nodeType } = typeAndPathFromInternalId(id);
-
-        const { deltaLink } = await getDeltaResults({
-          client,
-          parentInternalId: id,
-          token: "latest",
-        });
-
-        return {
-          connectorId: connector.id,
-          nodeType,
-          internalId: id,
-          currentDeltaLink: deltaLink,
-        };
-      },
-      { concurrency: 5 }
-    );
+    const newResourcesBlobs = Object.keys(permissions)
+      .filter(([, permission]) => permission === "read")
+      .map((id) => ({
+        connectorId: connector.id,
+        nodeType: typeAndPathFromInternalId(id).nodeType,
+        internalId: id,
+      }));
 
     await MicrosoftRootResource.batchMakeNew(newResourcesBlobs);
 
-    const res = await launchMicrosoftFullSyncWorkflow(this.connectorId, null);
+    const nodesToSync = await getSiteNodesToSync(this.connectorId);
+
+    // poupulates deltas for the nodes so that if incremental sync starts before
+    // fullsync populated, there's no error
+    await populateDeltas(this.connectorId, nodesToSync);
+
+    const res = await launchMicrosoftFullSyncWorkflow(
+      this.connectorId,
+      null,
+      nodesToSync
+    );
 
     if (res.isErr()) {
       return res;

--- a/connectors/src/connectors/microsoft/temporal/client.ts
+++ b/connectors/src/connectors/microsoft/temporal/client.ts
@@ -15,17 +15,11 @@ import { ConnectorResource } from "@connectors/resources/connector_resource";
 
 export async function launchMicrosoftFullSyncWorkflow(
   connectorId: ModelId,
-  fromTs: number | null,
   nodeIdsToSync?: string[]
 ): Promise<Result<string, Error>> {
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
     return new Err(new Error(`Connector ${connectorId} not found`));
-  }
-  if (fromTs) {
-    return new Err(
-      new Error("Microsoft connector does not support partial resync")
-    );
   }
 
   const client = await getTemporalClient();

--- a/connectors/src/connectors/microsoft/temporal/client.ts
+++ b/connectors/src/connectors/microsoft/temporal/client.ts
@@ -15,7 +15,8 @@ import { ConnectorResource } from "@connectors/resources/connector_resource";
 
 export async function launchMicrosoftFullSyncWorkflow(
   connectorId: ModelId,
-  fromTs: number | null
+  fromTs: number | null,
+  nodeIdsToSync?: string[]
 ): Promise<Result<string, Error>> {
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
@@ -36,7 +37,7 @@ export async function launchMicrosoftFullSyncWorkflow(
   try {
     await terminateWorkflow(workflowId);
     await client.workflow.start(fullSyncWorkflow, {
-      args: [{ connectorId }],
+      args: [{ connectorId, nodeIdsToSync }],
       taskQueue: QUEUE_NAME,
       workflowId: workflowId,
       searchAttributes: {

--- a/connectors/src/connectors/microsoft/temporal/workflows.ts
+++ b/connectors/src/connectors/microsoft/temporal/workflows.ts
@@ -1,7 +1,6 @@
 import type { ModelId } from "@dust-tt/types";
 import {
   continueAsNew,
-  executeChild,
   proxyActivities,
   sleep,
   workflowInfo,
@@ -15,7 +14,7 @@ const { getSiteNodesToSync, syncFiles, markNodeAsSeen, populateDeltas } =
     startToCloseTimeout: "30 minutes",
   });
 
-const { syncDeltaForRoot: syncDeltaForNode } = proxyActivities<
+const { syncDeltaForRootNode: syncDeltaForNode } = proxyActivities<
   typeof activities
 >({
   startToCloseTimeout: "120 minutes",
@@ -30,38 +29,21 @@ const { reportInitialSyncProgress, syncSucceeded } = proxyActivities<
 
 export async function fullSyncWorkflow({
   connectorId,
-  startSyncTs = undefined,
-}: {
-  connectorId: ModelId;
-  startSyncTs?: number;
-}) {
-  if (startSyncTs === undefined) {
-    startSyncTs = new Date().getTime();
-  }
-
-  await executeChild(fullSyncSitesWorkflow, {
-    workflowId: microsoftFullSyncSitesWorkflowId(connectorId),
-    searchAttributes: {
-      connectorId: [connectorId],
-    },
-    args: [{ connectorId, startSyncTs }],
-    memo: workflowInfo().memo,
-  });
-}
-
-export async function fullSyncSitesWorkflow({
-  connectorId,
   startSyncTs,
-  nodeIdsToSync = undefined,
+  nodeIdsToSync,
   totalCount = 0,
 }: {
   connectorId: ModelId;
-  startSyncTs: number;
+  startSyncTs?: number;
   nodeIdsToSync?: string[];
   totalCount?: number;
 }) {
   if (nodeIdsToSync === undefined) {
     nodeIdsToSync = await getSiteNodesToSync(connectorId);
+  }
+
+  if (startSyncTs === undefined) {
+    startSyncTs = new Date().getTime();
   }
 
   await populateDeltas(connectorId, nodeIdsToSync);
@@ -95,7 +77,7 @@ export async function fullSyncSitesWorkflow({
     await markNodeAsSeen(connectorId, nodeId);
 
     if (workflowInfo().historyLength > 4000) {
-      await continueAsNew<typeof fullSyncSitesWorkflow>({
+      await continueAsNew<typeof fullSyncWorkflow>({
         connectorId,
         nodeIdsToSync: nodeIdsToSync,
         totalCount,
@@ -117,7 +99,7 @@ export async function incrementalSyncWorkflow({
   for (const nodeId of nodeIdsToSync) {
     await syncDeltaForNode({
       connectorId,
-      rootId: nodeId,
+      rootNodeId: nodeId,
       startSyncTs,
     });
   }

--- a/connectors/src/lib/models/microsoft.ts
+++ b/connectors/src/lib/models/microsoft.ts
@@ -76,7 +76,6 @@ export class MicrosoftRootModel extends Model<
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
   declare internalId: string;
   declare nodeType: MicrosoftNodeType;
-  declare currentDeltaLink: string;
 }
 MicrosoftRootModel.init(
   {
@@ -105,10 +104,6 @@ MicrosoftRootModel.init(
     },
     nodeType: {
       type: DataTypes.STRING,
-      allowNull: false,
-    },
-    currentDeltaLink: {
-      type: DataTypes.STRING(1024),
       allowNull: false,
     },
   },
@@ -140,6 +135,7 @@ export class MicrosoftNodeModel extends Model<
   declare name: string | null;
   declare mimeType: string | null;
   declare parentInternalId: string | null;
+  declare deltaLink: string | null;
 }
 
 MicrosoftNodeModel.init(
@@ -194,6 +190,10 @@ MicrosoftNodeModel.init(
     parentInternalId: {
       type: DataTypes.STRING(512),
       allowNull: true,
+    },
+    deltaLink: {
+      type: DataTypes.STRING(1024),
+      allowNull: false,
     },
   },
   {

--- a/connectors/src/lib/models/microsoft.ts
+++ b/connectors/src/lib/models/microsoft.ts
@@ -193,7 +193,7 @@ MicrosoftNodeModel.init(
     },
     deltaLink: {
       type: DataTypes.STRING(1024),
-      allowNull: false,
+      allowNull: true,
     },
   },
   {


### PR DESCRIPTION
Description
---
There was an error related to deltas when selecting e.g. a site as microsoft root.

Indeed, sites don't have delta, only drive items do; as such those deltas should not be linked to root selection, but to nodes as was previously done.

This PR migrates (again) `deltaLink` from `microsoft_roots` to `microsoft_nodes` and edits the logic accordingly

Risk
---
Simple migration
