### PR TITLE
[connectors] - feature(microsoft): implement garbage collector

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/client.ts
+++ b/connectors/src/connectors/microsoft/temporal/client.ts
@@ -5,6 +5,8 @@ import { QUEUE_NAME } from "@connectors/connectors/microsoft/temporal/config";
 import {
   fullSyncWorkflow,
   incrementalSyncWorkflow,
+  microsoftDeletionWorkflow,
+  microsoftDeletionWorkflowId,
   microsoftFullSyncWorkflowId,
   microsoftIncrementalSyncWorkflowId,
 } from "@connectors/connectors/microsoft/temporal/workflows";
@@ -106,5 +108,48 @@ export async function launchMicrosoftIncrementalSyncWorkflow(
       `Failed starting workflow.`
     );
     return new Err(e as Error);
+  }
+}
+
+export async function launchMicrosoftDeletionWorkflow(
+  connectorId: ModelId,
+  nodeIdsToDelete: string[]
+): Promise<Result<void, Error>> {
+  const connector = await ConnectorResource.fetchById(connectorId);
+  if (!connector) {
+    return new Err(new Error(`Connector ${connectorId} not found`));
+  }
+  const client = await getTemporalClient();
+
+  const workflowId = microsoftDeletionWorkflowId(connectorId, nodeIdsToDelete);
+
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+
+  try {
+    await terminateWorkflow(workflowId);
+
+    await client.workflow.start(microsoftDeletionWorkflow, {
+      args: [{ connectorId, nodeIdsToDelete }],
+      taskQueue: QUEUE_NAME,
+      workflowId: workflowId,
+      searchAttributes: {
+        connectorId: [connectorId],
+      },
+      memo: {
+        connectorId: connectorId,
+      },
+    });
+
+    return new Ok(undefined);
+  } catch (err) {
+    logger.error(
+      {
+        workspaceId: dataSourceConfig.workspaceId,
+        workflowId,
+        error: err,
+      },
+      `Failed starting workflow.`
+    );
+    return new Err(err as Error);
   }
 }

--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -1,11 +1,9 @@
 import type {
   CoreAPIDataSourceDocumentSection,
   ModelId,
-  Result} from "@dust-tt/types";
-import {
-  Err,
-  Ok
+  Result,
 } from "@dust-tt/types";
+import { Err, Ok } from "@dust-tt/types";
 import {
   cacheWithRedis,
   isTextExtractionSupportedContentType,
@@ -616,7 +614,11 @@ export async function recursiveNodeDeletion(
 
   if (nodeType === "file") {
     try {
-      await deleteFromDataSource(dataSourceConfig, node.internalId);
+      await deleteFile({
+        connectorId,
+        dataSourceConfig,
+        internalId: node.internalId,
+      });
     } catch (error) {
       logger.error(
         { connectorId, nodeId, error },
@@ -640,10 +642,13 @@ export async function recursiveNodeDeletion(
         return result;
       }
     }
+    await deleteFolder({
+      connectorId,
+      internalId: node.internalId,
+    });
   }
 
   try {
-    await node.delete();
     const root = await MicrosoftRootResource.fetchByInternalId(
       connectorId,
       nodeId

--- a/connectors/src/connectors/microsoft/temporal/workflows.ts
+++ b/connectors/src/connectors/microsoft/temporal/workflows.ts
@@ -140,17 +140,17 @@ export function microsoftDeletionWorkflowId(
   connectorId: ModelId,
   nodeIdsToDelete: string[]
 ) {
-  // Simple, deterministic hashing function
-  function simpleHash(input: string): string {
-    let hash = 0;
-    for (let i = 0; i < input.length; i++) {
-      const char = input.charCodeAt(i);
-      hash = (hash << 5) - hash + char;
-      hash = hash & hash; // Convert to 32-bit integer
-    }
-    return Math.abs(hash).toString(16).slice(0, 8).padStart(8, "0");
+  function getLast4Chars(input: string) {
+    return input.slice(-4);
   }
-  const sortedNodeIds = nodeIdsToDelete.sort().join(",");
-  const hash = simpleHash(sortedNodeIds);
-  return `microsoft-deletion-${connectorId}-${hash}`;
+
+  // Sort the node IDs and concatenate the last 4 characters of each
+  // up to 256 characters
+  const sortedNodeIds = nodeIdsToDelete.sort();
+  const concatenatedLast4Chars = sortedNodeIds
+    .map(getLast4Chars)
+    .join("")
+    .slice(0, 256);
+
+  return `microsoft-deletion-${connectorId}-${concatenatedLast4Chars}`;
 }

--- a/connectors/src/connectors/microsoft/temporal/workflows.ts
+++ b/connectors/src/connectors/microsoft/temporal/workflows.ts
@@ -15,7 +15,7 @@ const { getSiteNodesToSync, syncFiles, markNodeAsSeen, populateDeltas } =
   });
 
 const { microsoftDeletionActivity } = proxyActivities<typeof activities>({
-  startToCloseTimeout: "5 minutes",
+  startToCloseTimeout: "15 minutes",
 });
 
 const { syncDeltaForRootNode: syncDeltaForNode } = proxyActivities<

--- a/connectors/src/connectors/microsoft/temporal/workflows.ts
+++ b/connectors/src/connectors/microsoft/temporal/workflows.ts
@@ -14,6 +14,10 @@ const { getSiteNodesToSync, syncFiles, markNodeAsSeen, populateDeltas } =
     startToCloseTimeout: "30 minutes",
   });
 
+const { microsoftDeletionActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "5 minutes",
+});
+
 const { syncDeltaForRootNode: syncDeltaForNode } = proxyActivities<
   typeof activities
 >({
@@ -110,6 +114,16 @@ export async function incrementalSyncWorkflow({
   });
 }
 
+export async function microsoftDeletionWorkflow({
+  connectorId,
+  nodeIdsToDelete,
+}: {
+  connectorId: number;
+  nodeIdsToDelete: string[];
+}) {
+  await microsoftDeletionActivity({ connectorId, nodeIdsToDelete });
+}
+
 export function microsoftFullSyncWorkflowId(connectorId: ModelId) {
   return `microsoft-fullSync-${connectorId}`;
 }
@@ -120,4 +134,23 @@ export function microsoftFullSyncSitesWorkflowId(connectorId: ModelId) {
 
 export function microsoftIncrementalSyncWorkflowId(connectorId: ModelId) {
   return `microsoft-incrementalSync-${connectorId}`;
+}
+
+export function microsoftDeletionWorkflowId(
+  connectorId: ModelId,
+  nodeIdsToDelete: string[]
+) {
+  // Simple, deterministic hashing function
+  function simpleHash(input: string): string {
+    let hash = 0;
+    for (let i = 0; i < input.length; i++) {
+      const char = input.charCodeAt(i);
+      hash = (hash << 5) - hash + char;
+      hash = hash & hash; // Convert to 32-bit integer
+    }
+    return Math.abs(hash).toString(16).slice(0, 8).padStart(8, "0");
+  }
+  const sortedNodeIds = nodeIdsToDelete.sort().join(",");
+  const hash = simpleHash(sortedNodeIds);
+  return `microsoft-deletion-${connectorId}-${hash}`;
 }


### PR DESCRIPTION
## Description

This PR aims at adding a deletion workflow to scrub nodes that were unselected from the "Add / Remove data" panel. 

Changes are:
 - Create the Microsoft deletion workflow to delete nodes from the data source and core dataSource
 - Ensure node deletion is triggered based on the "none" permission in permissions reconciliation
 
**References:**
- https://github.com/dust-tt/dust/issues/6367
## Risk

n\a

## Deploy Plan

n\a