### PR TITLE
Lower size of docs from webcrawler

### DIFF
--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -23,7 +23,7 @@ import {
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import {
   deleteFromDataSource,
-  MAX_DOCUMENT_TXT_LEN,
+  MAX_SMALL_DOCUMENT_TXT_LEN,
   upsertToDatasource,
 } from "@connectors/lib/data_sources";
 import {
@@ -274,7 +274,7 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
         try {
           if (
             extracted.length > 0 &&
-            extracted.length <= MAX_DOCUMENT_TXT_LEN
+            extracted.length <= MAX_SMALL_DOCUMENT_TXT_LEN
           ) {
             await upsertToDatasource({
               dataSourceConfig,

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -27,8 +27,9 @@ import { statsDClient } from "@connectors/logger/withlogging";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
 const axiosWithTimeout = axios.create({
-  timeout: 60000,
+  timeout: 120000,
   // Ensure client timeout is lower than the target server timeout.
+  // See --keepAliveTimeout in next start command from front.
   httpAgent: new http.Agent({ keepAlive: true, keepAliveMsecs: 4000 }),
   httpsAgent: new https.Agent({ keepAlive: true, keepAliveMsecs: 4000 }),
 });

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -27,7 +27,7 @@ import { statsDClient } from "@connectors/logger/withlogging";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
 const axiosWithTimeout = axios.create({
-  timeout: 120000,
+  timeout: 60000,
   // Ensure client timeout is lower than the target server timeout.
   // See --keepAliveTimeout in next start command from front.
   httpAgent: new http.Agent({ keepAlive: true, keepAliveMsecs: 4000 }),
@@ -42,6 +42,8 @@ if (!DUST_FRONT_API) {
 // We limit the document size we support. Beyond a certain size, upsert is simply too slow (>300s)
 // and large files are generally less useful anyway.
 export const MAX_DOCUMENT_TXT_LEN = 750000;
+// For some data sources we allow small documents only to be processed.
+export const MAX_SMALL_DOCUMENT_TXT_LEN = 500000;
 // For some data sources we allow large documents (5mb) to be processed (behind flag).
 export const MAX_LARGE_DOCUMENT_TXT_LEN = 5000000;
 


### PR DESCRIPTION
## Description

Increase timeout from request to upsertToDatasource. 

Context: https://github.com/dust-tt/tasks/issues/1082 -> For big webcrawler pages (which are already capped by `MAX_DOCUMENT_TXT_LEN` we have an error `'Upsert error: Failed to upsert document `  with cause = `connection closed before message completed\n' +`. Increasing the timeout fixes the issue. 


## Risk

Can be rolled back. 

## Deploy Plan

Deploy connectors. 
