### PR TITLE
fix: clarify GH mismatch error message

### DIFF
--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -941,7 +941,7 @@ const CONNECTOR_TYPE_TO_MISMATCH_ERROR: Record<ConnectorProvider, string> = {
   notion:
     "You cannot select another Notion Workspace.\nPlease contact us at team@dust.tt if you initially selected a wrong Workspace.",
   github:
-    "You cannot select another Github Organization.\nPlease contact us at team@dust.tt if you initially selected a wrong Organization.",
+    "You cannot create a new Github app installation.\nPlease contact us at team@dust.tt if you initially selected a wrong Organization or if you completely uninstalled the Github app.",
   google_drive:
     "You cannot select another Google Drive Domain.\nPlease contact us at team@dust.tt if you initially selected a wrong shared Drive.",
   intercom:


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/tasks/issues/1084 (kind of -- this is the last of a series of mitigations for that issue)

When a user entirely uninstalls our github app, attempts to re-auth create an entirely separate installation which we don't support. We could technically support it by fetching the org details from `oauth`, but we decided not to do it for now as it is a rare enough case that we're fine doing manual support for now.

## Risk

N/A

## Deploy Plan

N/A