### PR TITLE
feat: make intercom oauth-ready

### DIFF
--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -106,16 +106,7 @@ export async function setupConnection({
 }): Promise<Result<string, Error>> {
   let connectionId: string;
 
-  if (
-    isOAuthProvider(provider) &&
-    // `oauth`-ready providers
-    (["confluence", "github", "slack", "notion", "microsoft", "google_drive"].includes(
-      provider
-    ) ||
-      // Behind flag oauth-ready providers
-      (["intercom"].includes(provider) &&
-        owner.flags.includes("test_oauth_setup")))
-  ) {
+  if (isOAuthProvider(provider)) {
     // OAuth flow
     const cRes = await setupOAuthConnection({
       dustClientFacingUrl,


### PR DESCRIPTION
## Description

All oauth providers now "oauth-ready"

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front then migrate intercom connectors to oauth, then remove the flag.