### PR TITLE
Fix scheduled scrub workspace if workspace was deleted in between

### DIFF
--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -10,6 +10,7 @@ import config from "@app/lib/api/config";
 import { deleteDataSource, getDataSources } from "@app/lib/api/data_sources";
 import {
   getMembers,
+  getWorkspaceInfos,
   unsafeGetWorkspacesByModelId,
 } from "@app/lib/api/workspace";
 import { Authenticator, subscriptionForWorkspaces } from "@app/lib/auth";
@@ -65,6 +66,10 @@ export async function shouldStillScrubData({
 }: {
   workspaceId: string;
 }): Promise<boolean> {
+  const workspace = await getWorkspaceInfos(workspaceId);
+  if (!workspace) {
+    return false;
+  }
   return !(
     await Authenticator.internalAdminForWorkspace(workspaceId)
   ).isUpgraded();


### PR DESCRIPTION
## Description

On `shouldStillScrubData` we call `internalAdminForWorkspace` which throws an error if the workspace does not exists. This makes the scrub workflow fail if the workspace was deleted in between. 

This PR just starts by fetching the workspace and if it does not exists it returns false. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front.
