### PR TITLE
Disable transcripts Gong until we have the oauth callback updated 

### DIFF
--- a/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
+++ b/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
@@ -6,6 +6,7 @@ import {
   Page,
   SliderToggle,
   Spinner,
+  Tooltip,
   XMarkIcon,
 } from "@dust-tt/sparkle";
 import type { SubscriptionType } from "@dust-tt/types";
@@ -442,19 +443,21 @@ export default function LabsTranscriptsIndex({
                   style={{ maxHeight: "35px" }}
                 />
               </div>
-              <div
-                className={`cursor-pointer rounded-md border p-4 hover:border-gray-400 ${
-                  transcriptsConfigurationState.provider == "gong"
-                    ? "border-gray-400"
-                    : "border-gray-200"
-                }`}
-                onClick={() => handleProviderChange("gong")}
-              >
-                <img
-                  src="/static/labs/transcripts/gong.jpeg"
-                  style={{ maxHeight: "35px" }}
-                />
-              </div>
+              <Tooltip label="Gong is under maintenance, check back soon.">
+                <div
+                  className={`cursor-pointer rounded-md border p-4 ${
+                    transcriptsConfigurationState.provider == "gong"
+                      ? "border-gray-400"
+                      : "border-gray-200"
+                  }`}
+                  // onClick={() => handleProviderChange("gong")}
+                >
+                  <img
+                    src="/static/labs/transcripts/gong.jpeg"
+                    style={{ maxHeight: "35px" }}
+                  />
+                </div>
+              </Tooltip>
             </Page.Layout>
           )}
 

--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.192",
+  "version": "0.2.194",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.192",
+      "version": "0.2.194",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.193",
+  "version": "0.2.194",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/Tooltip.tsx
+++ b/sparkle/src/components/Tooltip.tsx
@@ -22,7 +22,7 @@ export function Tooltip({
   const handleMouseOver = () => {
     const id = window.setTimeout(() => {
       setIsHovered(true);
-    }, 800);
+    }, 600);
     setTimerId(id);
   };
 


### PR DESCRIPTION
## Description

- Disable Gong in transcripts until we have the oauth callback updated (0 users impacted so far)
- Make Tooltips appear in 600 ms, 800 just feels too long for a tooltip. No need for sparkle bump, can go live in the next sparkle deploy whenever.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
