### PR TITLE
Intercom: fix help center articles parent ids

### DIFF
--- a/connectors/src/connectors/intercom/temporal/sync_help_center.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_help_center.ts
@@ -271,8 +271,10 @@ export async function upsertArticle({
     ? article.url
     : getArticleInAppUrl(article, region);
 
+  const documentId = getHelpCenterArticleInternalId(connectorId, article.id);
   const parentCollectionId = article.parent_id?.toString();
   const parentCollectionIds = article.parent_ids.map((id) => id.toString());
+  parentCollectionIds.push(documentId); // Append the internal ID of the article to the parent collection IDs.
 
   if (!parentCollectionId) {
     logger.error(
@@ -378,7 +380,7 @@ export async function upsertArticle({
 
     await upsertToDatasource({
       dataSourceConfig,
-      documentId: getHelpCenterArticleInternalId(connectorId, article.id),
+      documentId,
       documentContent: renderedPage,
       documentUrl: articleUrl,
       timestampMs: updatedAtDate.getTime(),


### PR DESCRIPTION
## Description

I was missing the id of the document in the parentids. 
As a result, if an assistant has selected directly the node of an article it could never be retrieved. 

## Risk

/ 

## Deploy Plan

Deploy connector. 
Full resync the help centers. 
