### PR TITLE
[connectors] - chore(microsoft): content node

### DIFF
--- a/front/components/assistant_builder/AssistantBuilderTablesModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderTablesModal.tsx
@@ -8,12 +8,14 @@ import {
   ServerIcon,
   Spinner,
 } from "@dust-tt/sparkle";
-import type { ContentNode, WorkspaceType } from "@dust-tt/types";
 import type {
   ConnectorProvider,
+  ContentNode,
   CoreAPITable,
   DataSourceType,
+  WorkspaceType,
 } from "@dust-tt/types";
+import { getMicrosoftSheetContentNodeInternalIdFromTableId } from "@dust-tt/types";
 import {
   getGoogleSheetContentNodeInternalIdFromTableId,
   getNotionDatabaseContentNodeInternalIdFromTableId,
@@ -85,6 +87,8 @@ export default function AssistantBuilderTablesModal({
           return getGoogleSheetContentNodeInternalIdFromTableId(c.tableId);
         case "notion":
           return getNotionDatabaseContentNodeInternalIdFromTableId(c.tableId);
+        case "microsoft":
+          return getMicrosoftSheetContentNodeInternalIdFromTableId(c.tableId);
         default:
           throw new Error(
             `Unsupported connector provider: ${selectedDataSource.connectorProvider}`

--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -124,7 +124,7 @@ AgentTablesQueryConfigurationTable.init(
       allowNull: false,
     },
     tableId: {
-      type: DataTypes.STRING,
+      type: DataTypes.STRING(512),
       allowNull: false,
     },
   },

--- a/front/migrations/db/migration_44.sql
+++ b/front/migrations/db/migration_44.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jul 23, 2024
+ALTER TABLE agent_tables_query_configuration_tables ALTER COLUMN "tableId" TYPE VARCHAR(512);

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/content-nodes/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/content-nodes/index.ts
@@ -71,8 +71,10 @@ async function handler(
   switch (req.method) {
     case "POST":
       if (
-        dataSource.connectorProvider !== "notion" &&
-        dataSource.connectorProvider !== "google_drive"
+        !dataSource.connectorProvider ||
+        !["notion", "google_drive", "microsoft"].includes(
+          dataSource.connectorProvider
+        )
       ) {
         return apiError(req, res, {
           status_code: 400,

--- a/types/src/connectors/content_nodes.ts
+++ b/types/src/connectors/content_nodes.ts
@@ -3,6 +3,7 @@ import {
   getGoogleSheetTableIdFromContentNodeInternalId,
   isGoogleSheetContentNodeInternalId,
 } from "./google_drive";
+import { getMicrosoftSheetContentNodeInternalIdFromTableId } from "./microsoft";
 import { getNotionDatabaseTableIdFromContentNodeInternalId } from "./notion";
 
 // When viewing ContentNodes for a connector, we have 2 view types: tables and documents.
@@ -32,7 +33,9 @@ export function getTableIdForContentNode(contentNode: ContentNode): string {
         contentNode.internalId
       );
     case "microsoft":
-      return contentNode.internalId;
+      return getMicrosoftSheetContentNodeInternalIdFromTableId(
+        contentNode.internalId
+      )
     default:
       throw new Error(`Provider ${contentNode.provider} is not supported`);
   }

--- a/types/src/connectors/content_nodes.ts
+++ b/types/src/connectors/content_nodes.ts
@@ -35,7 +35,7 @@ export function getTableIdForContentNode(contentNode: ContentNode): string {
     case "microsoft":
       return getMicrosoftSheetContentNodeInternalIdFromTableId(
         contentNode.internalId
-      )
+      );
     default:
       throw new Error(`Provider ${contentNode.provider} is not supported`);
   }

--- a/types/src/connectors/content_nodes.ts
+++ b/types/src/connectors/content_nodes.ts
@@ -31,6 +31,8 @@ export function getTableIdForContentNode(contentNode: ContentNode): string {
       return getGoogleSheetTableIdFromContentNodeInternalId(
         contentNode.internalId
       );
+    case "microsoft":
+      return contentNode.internalId;
     default:
       throw new Error(`Provider ${contentNode.provider} is not supported`);
   }

--- a/types/src/connectors/microsoft.ts
+++ b/types/src/connectors/microsoft.ts
@@ -3,3 +3,9 @@ import { ModelId } from "../shared/model_id";
 export function microsoftIncrementalSyncWorkflowId(connectorId: ModelId) {
   return `microsoft-incrementalSync-${connectorId}`;
 }
+
+export function getMicrosoftSheetContentNodeInternalIdFromTableId(
+  tableId: string
+): string {
+  return tableId;
+}


### PR DESCRIPTION
## Description

This PR implements the missing methods to use the Microsoft connector in Tables Query. The changes include:
- Implementation of retrieveBatchContentNodes and retrieveContentNodeParents methods in the MicrosoftConnectorManager class.
- Addition of support for Microsoft Sheets in the Assistant Builder.
- Updates to the content nodes API to include Microsoft as a supported connector provider.

## Risk

n\a 

## Deploy Plan

- Apply migration
- Deploy `connectors`
- Deploy `front`

