### PR TITLE
Add microsoft to connectors-worker-deployment

### DIFF
--- a/k8s/deployments/connectors-worker-deployment.yaml
+++ b/k8s/deployments/connectors-worker-deployment.yaml
@@ -20,7 +20,16 @@ spec:
         - name: web
           image: gcr.io/or1g1n-186209/connectors-image:latest
           command: ["npm", "run", "start:worker"]
-          args: ["--", "--workers", "confluence", "github", "intercom", "slack"]
+          args:
+            [
+              "--",
+              "--workers",
+              "confluence",
+              "github",
+              "intercom",
+              "slack",
+              "microsoft",
+            ]
           imagePullPolicy: Always
           envFrom:
             - configMapRef:


### PR DESCRIPTION
## Description

Add microsoft to connectors-worker-deployment

## Risk

As we're only using microsoft for test it should not overload this deployment. Otherwise can be disabled and put to another deployment.

## Deploy Plan

Apply infra
