### PR TITLE
[k8s] - fix(front-worker): allow front-worker to communicate with oauth

### DIFF
--- a/k8s/network-policies/oauth-network-policy.yaml
+++ b/k8s/network-policies/oauth-network-policy.yaml
@@ -22,6 +22,9 @@ spec:
         - podSelector:
             matchLabels:
               app: connectors-worker
+        - podSelector:
+            matchLabels:
+              app: front-worker
       ports:
         - protocol: TCP
           port: 3006


### PR DESCRIPTION
## Description

This PR aims at allowing `front-worker` to communicate with the `oauth` service, to fix [1]. It addds a network policy rule to permit traffic from front-worker pods to oauth service on TCP port 3006

**References:**
[1] https://github.com/dust-tt/tasks/issues/1092

## Risk

Allowing communication between to services

## Deploy Plan

Apply `infra`