### PR TITLE
`core` data sources `view_filter` support

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1300,10 +1300,11 @@ async fn data_sources_search(
                         Some(filter) => Some(filter.postprocess_for_data_source(&data_source_id)),
                         None => None,
                     },
-                    match payload.view_filter {
-                        Some(filter) => Some(filter.postprocess_for_data_source(&data_source_id)),
-                        None => None,
-                    },
+                    // TODO(spolu): follow_up PR.
+                    // match payload.view_filter {
+                    //     Some(filter) => Some(filter.postprocess_for_data_source(&data_source_id)),
+                    //     None => None,
+                    // },
                     payload.full_text,
                     payload.target_document_tokens,
                 )
@@ -1503,7 +1504,7 @@ async fn data_sources_documents_versions_list(
             &data_source_id,
             &document_id,
             Some((query.limit, query.offset)),
-            match query.view_filter {
+            &match query.view_filter {
                 Some(filter) => Some(filter.postprocess_for_data_source(&data_source_id)),
                 None => None,
             },
@@ -1651,7 +1652,7 @@ async fn data_sources_documents_list(
             &project,
             &data_source_id,
             Some((query.limit, query.offset)),
-            match query.view_filter {
+            &match query.view_filter {
                 Some(filter) => Some(filter.postprocess_for_data_source(&data_source_id)),
                 None => None,
             },
@@ -1716,10 +1717,11 @@ async fn data_sources_documents_retrieve(
                     state.store.clone(),
                     &document_id,
                     true,
-                    match query.view_filter {
-                        Some(filter) => Some(filter.postprocess_for_data_source(&data_source_id)),
-                        None => None,
-                    },
+                    // TODO(spolu): follow_up PR.
+                    // match query.view_filter {
+                    //     Some(filter) => Some(filter.postprocess_for_data_source(&data_source_id)),
+                    //     None => None,
+                    // },
                     &query.version_hash,
                 )
                 .await

--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1503,11 +1503,11 @@ async fn data_sources_documents_versions_list(
             &data_source_id,
             &document_id,
             Some((query.limit, query.offset)),
-            &query.latest_hash,
             match query.view_filter {
                 Some(filter) => Some(filter.postprocess_for_data_source(&data_source_id)),
                 None => None,
             },
+            &query.latest_hash,
         )
         .await
     {

--- a/core/bin/qdrant/migrate_embedder.rs
+++ b/core/bin/qdrant/migrate_embedder.rs
@@ -624,8 +624,8 @@ async fn refresh_chunk_count_for_updated_documents(
 
     let filter = SearchFilter {
         timestamp: Some(TimestampFilter {
-            gt: Some(from_timestamp),
-            lt: Some(now),
+            gt: Some(from_timestamp as i64),
+            lt: Some(now as i64),
         }),
         tags: None,
         parents: None,

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -54,8 +54,8 @@ pub struct ParentsFilter {
 /// timestamp greater than `gt` and less than `lt`.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TimestampFilter {
-    pub gt: Option<u64>,
-    pub lt: Option<u64>,
+    pub gt: Option<i64>,
+    pub lt: Option<i64>,
 }
 
 // Custom deserializer for `TimestampFilter`
@@ -73,8 +73,8 @@ where
 
     let f = Option::<InnerTimestampFilter>::deserialize(deserializer)?.map(|inner_filter| {
         TimestampFilter {
-            gt: inner_filter.gt.map(|value| value as u64), // Convert f64 to u64
-            lt: inner_filter.lt.map(|value| value as u64), // Convert f64 to u64
+            gt: inner_filter.gt.map(|value| value as i64), // Convert f64 to u64
+            lt: inner_filter.lt.map(|value| value as i64), // Convert f64 to u64
         }
     });
 
@@ -402,6 +402,65 @@ impl Document {
             text: None,
             token_count: None,
         })
+    }
+
+    pub fn match_filter(&self, filter: Option<SearchFilter>) -> bool {
+        match filter {
+            Some(filter) => {
+                let mut m = true;
+                match filter.tags {
+                    Some(tags) => {
+                        m = m
+                            && match &tags.is_in {
+                                Some(is_in) => is_in.iter().any(|tag| self.tags.contains(tag)),
+                                None => true,
+                            };
+                        m = m
+                            && match &tags.is_not {
+                                Some(is_not) => is_not.iter().all(|tag| !self.tags.contains(tag)),
+                                None => true,
+                            };
+                    }
+                    None => (),
+                }
+                match filter.parents {
+                    Some(parents) => {
+                        m = m
+                            && match &parents.is_in {
+                                Some(is_in) => {
+                                    is_in.iter().any(|parent| self.parents.contains(parent))
+                                }
+                                None => true,
+                            };
+                        m = m
+                            && match &parents.is_not {
+                                Some(is_not) => {
+                                    is_not.iter().all(|parent| !self.parents.contains(parent))
+                                }
+                                None => true,
+                            };
+                    }
+                    None => (),
+                }
+                match filter.timestamp {
+                    Some(timestamp) => {
+                        m = m
+                            && match timestamp.gt {
+                                Some(gt) => self.timestamp as i64 >= gt,
+                                None => true,
+                            };
+                        m = m
+                            && match timestamp.lt {
+                                Some(lt) => self.timestamp as i64 <= lt,
+                                None => true,
+                            };
+                    }
+                    None => (),
+                }
+                m
+            }
+            None => true,
+        }
     }
 }
 

--- a/core/src/data_sources/file_storage_document.rs
+++ b/core/src/data_sources/file_storage_document.rs
@@ -1,7 +1,6 @@
 use anyhow::{anyhow, Result};
 use cloud_storage::Object;
 use serde::{Deserialize, Serialize};
-use tokio::try_join;
 use tracing::info;
 
 use crate::utils;

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -68,6 +68,58 @@ impl PostgresStore {
 
         Ok(())
     }
+
+    fn where_clauses_and_params_for_filter<'a>(
+        filter: &'a Option<SearchFilter>,
+        from_idx: usize,
+    ) -> (Vec<String>, Vec<&'a (dyn ToSql + Sync)>, usize) {
+        let mut where_clauses: Vec<String> = vec![];
+        let mut params: Vec<&'a (dyn ToSql + Sync)> = vec![];
+        let mut p_idx: usize = from_idx;
+
+        if let Some(filter) = filter {
+            if let Some(tags_filter) = &filter.tags {
+                if let Some(tags) = &tags_filter.is_in {
+                    where_clauses.push(format!("tags_array && ${}", p_idx));
+                    params.push(tags as &(dyn ToSql + Sync));
+                    p_idx += 1;
+                }
+                if let Some(tags) = &tags_filter.is_not {
+                    where_clauses.push(format!("NOT tags_array && ${}", p_idx));
+                    params.push(tags as &(dyn ToSql + Sync));
+                    p_idx += 1;
+                }
+            }
+
+            if let Some(parents_filter) = &filter.parents {
+                if let Some(parents) = &parents_filter.is_in {
+                    where_clauses.push(format!("parents && ${}", p_idx));
+                    params.push(parents as &(dyn ToSql + Sync));
+                    p_idx += 1;
+                }
+                if let Some(parents) = &parents_filter.is_not {
+                    where_clauses.push(format!("NOT parents && ${}", p_idx));
+                    params.push(parents as &(dyn ToSql + Sync));
+                    p_idx += 1;
+                }
+            }
+
+            if let Some(ts_filter) = &filter.timestamp {
+                if let Some(ts) = ts_filter.gt.as_ref() {
+                    where_clauses.push(format!("timestamp > ${}", p_idx));
+                    params.push(ts as &(dyn ToSql + Sync));
+                    p_idx += 1;
+                }
+                if let Some(ts) = ts_filter.lt.as_ref() {
+                    where_clauses.push(format!("timestamp < ${}", p_idx));
+                    params.push(ts as &(dyn ToSql + Sync));
+                    p_idx += 1;
+                }
+            }
+        }
+
+        (where_clauses, params, p_idx)
+    }
 }
 
 #[async_trait]
@@ -1405,7 +1457,7 @@ impl Store for PostgresStore {
         data_source_id: &str,
         document_id: &str,
         limit_offset: Option<(usize, usize)>,
-        view_filter: Option<SearchFilter>,
+        view_filter: &Option<SearchFilter>,
         latest_hash: &Option<String>,
     ) -> Result<(Vec<DocumentVersion>, usize)> {
         let project_id = project.project_id();
@@ -1466,75 +1518,45 @@ impl Store for PostgresStore {
             }
         };
 
-        let view_filter_sql = "
-            AND ($4::text[] IS NULL OR tags_array && $4::text[]) \
-            AND ($5::text[] IS NULL OR NOT (tags_array && $5::text[])) \
-            AND ($6::text[] IS NULL OR parents && $6::text[]) \
-            AND ($7::text[] IS NULL OR NOT (parents && $7::text[])) \
-            AND ($8 IS NULL OR timestamp > $8) \
-            AND ($9 IS NULL OR timestamp < $9) \
-        ";
+        let mut where_clauses: Vec<String> = vec![];
+        let mut params: Vec<&(dyn ToSql + Sync)> = vec![];
 
-        let tags_in = view_filter
-            .as_ref()
-            .and_then(|f| f.tags.as_ref().and_then(|t| t.is_in.as_ref()));
-        let tags_not = view_filter
-            .as_ref()
-            .and_then(|f| f.tags.as_ref().and_then(|t| t.is_not.as_ref()));
-        let parents_in = view_filter
-            .as_ref()
-            .and_then(|f| f.parents.as_ref().and_then(|p| p.is_in.as_ref()));
-        let parents_not = view_filter
-            .as_ref()
-            .and_then(|f| f.parents.as_ref().and_then(|p| p.is_not.as_ref()));
-        let timestamp_gt = view_filter
-            .as_ref()
-            .and_then(|f| f.timestamp.as_ref().and_then(|t| t.gt.map(|v| v as i64)));
-        let timestamp_lt = view_filter
-            .as_ref()
-            .and_then(|f| f.timestamp.as_ref().and_then(|t| t.lt.map(|v| v as i64)));
+        where_clauses.push("data_source = $1".to_string());
+        params.push(&data_source_row_id);
+        where_clauses.push("document_id = '$2'".to_string());
+        params.push(&document_id);
+        where_clauses.push("created <= $3'".to_string());
+        params.push(&latest_hash_created);
 
-        let params: Vec<&(dyn ToSql + Sync)> = vec![
-            &data_source_row_id,
-            &document_id,
-            &latest_hash_created,
-            &tags_in,
-            &tags_not,
-            &parents_in,
-            &parents_not,
-            &timestamp_gt,
-            &timestamp_lt,
-        ];
+        let (filter_clauses, filter_params, p_idx) =
+            Self::where_clauses_and_params_for_filter(view_filter, params.len() + 1);
+
+        where_clauses.extend(filter_clauses);
+        params.extend(filter_params);
+
+        let sql = format!(
+            "SELECT hash, created FROM data_sources_documents \
+               WHERE {} ORDER BY created DESC",
+            where_clauses.join(" AND ")
+        );
 
         let rows = match limit_offset {
             None => {
-                let stmt = c
-                    .prepare(
-                        format!(
-                            "SELECT hash, created FROM data_sources_documents \
-                               WHERE data_source = $1 AND document_id = $2 AND created <= $3 \
-                               {} ORDER BY created DESC",
-                            view_filter_sql
-                        )
-                        .as_str(),
-                    )
-                    .await?;
+                let stmt = c.prepare(&sql).await?;
                 c.query(&stmt, &params).await?
             }
             Some((limit, offset)) => {
-                let stmt = c
-                    .prepare(
-                        "SELECT hash, created FROM data_sources_documents \
-                           WHERE data_source = $1 AND document_id = $2 AND created <= $3 \
-                           {} ORDER BY created DESC LIMIT $10 OFFSET $11",
-                    )
-                    .await?;
-                let mut params_with_limit_offset = params.clone();
                 let limit = limit as i64;
                 let offset = offset as i64;
-                params_with_limit_offset.push(&limit);
-                params_with_limit_offset.push(&offset);
-                c.query(&stmt, &params_with_limit_offset).await?
+
+                let mut params = params.clone();
+                params.push(&limit);
+                params.push(&offset);
+
+                let stmt = c
+                    .prepare(&(sql + &format!(" LIMIT ${} OFFSET ${}", p_idx, p_idx + 1)))
+                    .await?;
+                c.query(&stmt, &params).await?
             }
         };
 
@@ -1554,9 +1576,8 @@ impl Store for PostgresStore {
                 let stmt = c
                     .prepare(
                         format!(
-                            "SELECT COUNT(*) FROM data_sources_documents \
-                               WHERE data_source = $1 AND document_id = $2 AND created <= $3 {}",
-                            view_filter_sql
+                            "SELECT COUNT(*) FROM data_sources_documents WHERE {}",
+                            where_clauses.join(" AND ")
                         )
                         .as_str(),
                     )
@@ -1584,89 +1605,39 @@ impl Store for PostgresStore {
         let mut where_clauses: Vec<String> = vec![];
         let mut params: Vec<&(dyn ToSql + Sync)> = vec![];
 
-        let data_source_internal_id_rows = c
-            .query_one(
-                "SELECT id FROM data_sources WHERE project = $1 AND data_source_id = $2",
+        let r = c
+            .query(
+                "SELECT id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
                 &[&project_id, &data_source_id],
             )
             .await?;
 
-        let data_source_internal_id: i64 = data_source_internal_id_rows.get(0);
+        let data_source_row_id: i64 = match r.len() {
+            0 => Err(anyhow!("Unknown DataSource: {}", data_source_id))?,
+            1 => r[0].get(0),
+            _ => unreachable!(),
+        };
 
         where_clauses.push("data_source = $1".to_string());
-        params.push(&data_source_internal_id);
-
-        let mut p_idx: usize = 2;
-
-        let tags_is_in: Vec<String>;
-        let tags_is_not: Vec<String>;
-        let parents_is_in: Vec<String>;
-        let parents_is_not: Vec<String>;
-        let ts_gt: i64;
-        let ts_lt: i64;
-
-        if let Some(filter) = filter {
-            if let Some(tags_filter) = &filter.tags {
-                if let Some(tags) = &tags_filter.is_in {
-                    tags_is_in = tags.to_vec();
-                    where_clauses.push(format!("tags_array && ${}", p_idx));
-                    params.push(&tags_is_in);
-                    p_idx += 1;
-                }
-                if let Some(tags) = &tags_filter.is_not {
-                    tags_is_not = tags.to_vec();
-                    where_clauses.push(format!("NOT tags_array && ${}", p_idx));
-                    params.push(&tags_is_not);
-                    p_idx += 1;
-                }
-            }
-
-            if let Some(parents_filter) = &filter.parents {
-                if let Some(parents) = &parents_filter.is_in {
-                    parents_is_in = parents.to_vec();
-                    where_clauses.push(format!("parents && ${}", p_idx));
-                    params.push(&parents_is_in);
-                    p_idx += 1;
-                }
-                if let Some(parents) = &parents_filter.is_not {
-                    parents_is_not = parents.to_vec();
-                    where_clauses.push(format!("NOT parents && ${}", p_idx));
-                    params.push(&parents_is_not);
-                    p_idx += 1;
-                }
-            }
-
-            if let Some(ts_filter) = &filter.timestamp {
-                if let Some(ts) = ts_filter.gt {
-                    where_clauses.push(format!("timestamp > ${}", p_idx));
-                    ts_gt = ts as i64;
-                    params.push(&ts_gt);
-                    p_idx += 1;
-                }
-                if let Some(ts) = ts_filter.lt {
-                    where_clauses.push(format!("timestamp < ${}", p_idx));
-                    ts_lt = ts as i64;
-                    params.push(&ts_lt);
-                    p_idx += 1;
-                }
-            }
-        }
-
+        params.push(&data_source_row_id);
         where_clauses.push("status = 'latest'".to_string());
 
-        let serialized_where_clauses = where_clauses.join(" AND ");
+        let (filter_clauses, filter_params, p_idx) =
+            Self::where_clauses_and_params_for_filter(filter, params.len() + 1);
+
+        where_clauses.extend(filter_clauses);
+        params.extend(filter_params);
 
         // compute the total count
         let count_query = format!(
             "SELECT COUNT(*) FROM data_sources_documents WHERE {}",
-            serialized_where_clauses
+            where_clauses.join(" AND ")
         );
         let count: i64 = c.query_one(&count_query, &params).await?.get(0);
 
         let mut query = format!(
-            "SELECT document_id FROM data_sources_documents \
-            WHERE {} ORDER BY timestamp DESC",
-            serialized_where_clauses
+            "SELECT document_id FROM data_sources_documents WHERE {} ORDER BY timestamp DESC",
+            where_clauses.join(" AND ")
         );
 
         let limit: i64;
@@ -1769,7 +1740,7 @@ impl Store for PostgresStore {
         project: &Project,
         data_source_id: &str,
         limit_offset: Option<(usize, usize)>,
-        view_filter: Option<SearchFilter>,
+        view_filter: &Option<SearchFilter>,
         remove_system_tags: bool,
     ) -> Result<(Vec<Document>, usize)> {
         let project_id = project.project_id();
@@ -1791,51 +1762,26 @@ impl Store for PostgresStore {
             _ => unreachable!(),
         };
 
-        let view_filter_sql = "
-            AND ($2::text[] IS NULL OR tags_array && $2::text[]) \
-            AND ($3::text[] IS NULL OR NOT (tags_array && $3::text[])) \
-            AND ($4::text[] IS NULL OR parents && $4::text[]) \
-            AND ($5::text[] IS NULL OR NOT (parents && $5::text[])) \
-            AND ($6 IS NULL OR timestamp > $6) \
-            AND ($7 IS NULL OR timestamp < $7) \
-        ";
+        let mut where_clauses: Vec<String> = vec![];
+        let mut params: Vec<&(dyn ToSql + Sync)> = vec![];
 
-        let tags_in = view_filter
-            .as_ref()
-            .and_then(|f| f.tags.as_ref().and_then(|t| t.is_in.as_ref()));
-        let tags_not = view_filter
-            .as_ref()
-            .and_then(|f| f.tags.as_ref().and_then(|t| t.is_not.as_ref()));
-        let parents_in = view_filter
-            .as_ref()
-            .and_then(|f| f.parents.as_ref().and_then(|p| p.is_in.as_ref()));
-        let parents_not = view_filter
-            .as_ref()
-            .and_then(|f| f.parents.as_ref().and_then(|p| p.is_not.as_ref()));
-        let timestamp_gt = view_filter
-            .as_ref()
-            .and_then(|f| f.timestamp.as_ref().and_then(|t| t.gt.map(|v| v as i64)));
-        let timestamp_lt = view_filter
-            .as_ref()
-            .and_then(|f| f.timestamp.as_ref().and_then(|t| t.lt.map(|v| v as i64)));
+        where_clauses.push("data_source = $1".to_string());
+        params.push(&data_source_row_id);
+        where_clauses.push("status = 'latest'".to_string());
+
+        let (filter_clauses, filter_params, p_idx) =
+            Self::where_clauses_and_params_for_filter(view_filter, params.len() + 1);
+
+        where_clauses.extend(filter_clauses);
+        params.extend(filter_params);
 
         let sql = format!(
             "SELECT id, created, document_id, timestamp, tags_array, parents, source_url, hash, \
-                   text_size, chunk_count \
-              FROM data_sources_documents \
-              WHERE data_source = $1 AND status = 'latest' {} ORDER BY timestamp DESC",
-            view_filter_sql
+                    text_size, chunk_count \
+               FROM data_sources_documents \
+               WHERE {} ORDER BY timestamp DESC",
+            where_clauses.join(" AND "),
         );
-
-        let params: Vec<&(dyn ToSql + Sync)> = vec![
-            &data_source_row_id,
-            &tags_in,
-            &tags_not,
-            &parents_in,
-            &parents_not,
-            &timestamp_gt,
-            &timestamp_lt,
-        ];
 
         let rows = match limit_offset {
             None => {
@@ -1843,15 +1789,17 @@ impl Store for PostgresStore {
                 c.query(&stmt, &params).await?
             }
             Some((limit, offset)) => {
-                let stmt = c
-                    .prepare(format!("{} LIMIT $8 OFFSET $9", sql).as_str())
-                    .await?;
-                let mut params_with_limit_offset = params.clone();
                 let limit = limit as i64;
                 let offset = offset as i64;
-                params_with_limit_offset.push(&limit);
-                params_with_limit_offset.push(&offset);
-                c.query(&stmt, &params_with_limit_offset).await?
+
+                let mut params = params.clone();
+                params.push(&limit);
+                params.push(&offset);
+
+                let stmt = c
+                    .prepare(&(sql + &format!(" LIMIT ${} OFFSET ${}", p_idx, p_idx + 1)))
+                    .await?;
+                c.query(&stmt, &params).await?
             }
         };
 
@@ -1902,8 +1850,8 @@ impl Store for PostgresStore {
                     .prepare(
                         format!(
                             "SELECT COUNT(*) FROM data_sources_documents \
-                               WHERE data_source = $1 AND status = 'latest' {}",
-                            view_filter_sql
+                               WHERE {}",
+                            where_clauses.join(" AND ")
                         )
                         .as_str(),
                     )

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -1523,7 +1523,7 @@ impl Store for PostgresStore {
 
         where_clauses.push("data_source = $1".to_string());
         params.push(&data_source_row_id);
-        where_clauses.push("document_id = '$2'".to_string());
+        where_clauses.push("document_id = $2".to_string());
         params.push(&document_id);
         where_clauses.push("created <= $3'".to_string());
         params.push(&latest_hash_created);

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -1606,17 +1606,13 @@ impl Store for PostgresStore {
         let mut params: Vec<&(dyn ToSql + Sync)> = vec![];
 
         let r = c
-            .query(
-                "SELECT id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
+            .query_one(
+                "SELECT id FROM data_sources WHERE project = $1 AND data_source_id = $2",
                 &[&project_id, &data_source_id],
             )
             .await?;
 
-        let data_source_row_id: i64 = match r.len() {
-            0 => Err(anyhow!("Unknown DataSource: {}", data_source_id))?,
-            1 => r[0].get(0),
-            _ => unreachable!(),
-        };
+        let data_source_row_id: i64 = r.get(0);
 
         where_clauses.push("data_source = $1".to_string());
         params.push(&data_source_row_id);

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -154,6 +154,7 @@ pub trait Store {
         data_source_id: &str,
         document_id: &str,
         limit_offset: Option<(usize, usize)>,
+        view_filter: Option<SearchFilter>,
         latest_hash: &Option<String>,
     ) -> Result<(Vec<DocumentVersion>, usize)>;
     async fn list_data_source_documents(

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -154,7 +154,7 @@ pub trait Store {
         data_source_id: &str,
         document_id: &str,
         limit_offset: Option<(usize, usize)>,
-        view_filter: Option<SearchFilter>,
+        view_filter: &Option<SearchFilter>,
         latest_hash: &Option<String>,
     ) -> Result<(Vec<DocumentVersion>, usize)>;
     async fn list_data_source_documents(
@@ -162,7 +162,7 @@ pub trait Store {
         project: &Project,
         data_source_id: &str,
         limit_offset: Option<(usize, usize)>,
-        view_filter: Option<SearchFilter>,
+        view_filter: &Option<SearchFilter>,
         remove_system_tags: bool,
     ) -> Result<(Vec<Document>, usize)>;
     async fn delete_data_source_document(

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -161,6 +161,7 @@ pub trait Store {
         project: &Project,
         data_source_id: &str,
         limit_offset: Option<(usize, usize)>,
+        view_filter: Option<SearchFilter>,
         remove_system_tags: bool,
     ) -> Result<(Vec<Document>, usize)>;
     async fn delete_data_source_document(


### PR DESCRIPTION
## Description

Adds optional ` view_filter` to a first batch of data source read endpoints (the ones talking to `store` directly) + associated implementations.

- DRYs out the `where_clause` constructions from a `SearchFilter` to reuse in the 2 new methods where we need to support them.
- Adds (not used yet) `match_filter` function on Document (to check whether a document is within a view_filter).

This query is quite involved but was already used in `find_data_source_document_ids` which is the no-query "include/most recent data" codepath which already well in use in production.
 
Dev tests:
- [x] check list data source documents view_filtering
- [x] check Data Source block filtering 

## Risk

Low, unused for now

## Deploy Plan

- deploy `core`