### PR TITLE
[front] - fix(conversation): action chip state

### DIFF
--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -5,28 +5,11 @@ import { useEffect, useMemo, useState } from "react";
 import { getActionSpecification } from "@app/components/actions/types";
 import { AgentMessageActionsDrawer } from "@app/components/assistant/conversation/actions/AgentMessageActionsDrawer";
 import type { MessageSizeType } from "@app/components/assistant/conversation/ConversationMessage";
+import { classNames } from "@app/lib/utils";
 
 interface AgentMessageActionsProps {
   agentMessage: AgentMessageType;
   size?: MessageSizeType;
-}
-
-function isActionComplete(action: AgentActionType): boolean {
-  switch (action.type) {
-    case "retrieval_action":
-      return action.documents !== null;
-    case "tables_query_action":
-    case "process_action":
-    case "websearch_action":
-    case "browse_action":
-      return "output" in action ? action.output !== null : false;
-    case "dust_app_run_action":
-      return action.output !== null && action.runningBlock === null;
-    case "visualization_action":
-      return action.generation !== null;
-    default:
-      return false;
-  }
 }
 
 export function AgentMessageActions({
@@ -41,12 +24,10 @@ export function AgentMessageActions({
   // emitted before actions in which case we will think we're not thinking or acting until an action
   // gets emitted in which case the content will get requalified as chain of thoughts and this will
   // switch back to true.
-  const isThinkingOrActing = useMemo(() => {
-    return (
-      agentMessage.status === "created" &&
-      agentMessage.actions.every((action) => !isActionComplete(action))
-    );
-  }, [agentMessage.status, agentMessage.actions]);
+  const isThinkingOrActing = useMemo(
+    () => agentMessage.status === "created",
+    [agentMessage.status]
+  );
 
   useEffect(() => {
     if (isThinkingOrActing) {
@@ -100,7 +81,10 @@ function ActionDetails({
     <div key={label} className="animate-fadeIn duration-1000 fade-out">
       <Chip size="sm" color="purple">
         <div
-          className="flex flex-row items-center gap-x-2"
+          className={classNames(
+            "flex flex-row items-center gap-x-2",
+            hasActions ? "cursor-pointer" : ""
+          )}
           onClick={hasActions ? onClick : undefined}
         >
           <Spinner variant="purple900" size="xs" />

--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -42,7 +42,10 @@ export function AgentMessageActions({
   // gets emitted in which case the content will get requalified as chain of thoughts and this will
   // switch back to true.
   const isThinkingOrActing = useMemo(() => {
-    return agentMessage.status === "created" && agentMessage.actions.every(action => !isActionComplete(action));
+    return (
+      agentMessage.status === "created" &&
+      agentMessage.actions.every((action) => !isActionComplete(action))
+    );
   }, [agentMessage.status, agentMessage.actions]);
 
   useEffect(() => {


### PR DESCRIPTION
## Description

This PR aims at fixing the action chip tool remains loading state after execution is complete.

It simply adds a cursor-pointer on the `Chip` when there are agent actions.

**References:**:
- https://github.com/dust-tt/tasks/issues/1089

## Risk

Weird UX

## Deploy Plan

Deploy `front`
