### PR TITLE
fix(viz): render tool call / result if last msg is agent

### DIFF
--- a/front/lib/api/assistant/actions/visualization.ts
+++ b/front/lib/api/assistant/actions/visualization.ts
@@ -1,5 +1,6 @@
 import type {
   AgentActionSpecification,
+  AssistantFunctionCallMessageTypeModel,
   FunctionCallType,
   FunctionMessageTypeModel,
   ModelId,
@@ -200,6 +201,46 @@ export class VisualizationConfigurationServerRunner extends BaseActionConfigurat
       return;
     }
 
+    const renderedConversation = modelConversationRes.value.modelConversation;
+    const lastMessage =
+      renderedConversation.messages[renderedConversation.messages.length - 1];
+
+    // If the last message is from the assistant, it means some content might have been generated along with the visualization tool call.
+    // In this case, we want to preserver the content (as it may be relevant to the model, as a "chain of thought"), so we
+    // update the last message to include an "enable_visualization_mode" function call and a dummy "visualization mode enabled" function
+    // result.
+    // This is necessary, as some model providers like Anthropic do not support multiple agent messages in a row.
+    if (lastMessage.role === "assistant") {
+      renderedConversation.messages.pop();
+
+      // Only bother with inserting tool_call/tool_result if there is content to preserve.
+      if (lastMessage.content) {
+        const fCallId = `call_${action.functionCallId ?? action.id.toString()}`;
+
+        const functionCallMessage: AssistantFunctionCallMessageTypeModel = {
+          role: "assistant",
+          content: lastMessage.content,
+          function_calls: [
+            {
+              id: fCallId,
+              name: `enable_visualization_mode`,
+              arguments: "{}",
+            },
+          ],
+        };
+
+        const functionResultMessage: FunctionMessageTypeModel = {
+          role: "function",
+          name: "enable_visualization_mode",
+          function_call_id: fCallId,
+          content: "Visualization mode successfully enabled.",
+        };
+
+        renderedConversation.messages.push(functionCallMessage);
+        renderedConversation.messages.push(functionResultMessage);
+      }
+    }
+
     // Configure the Vizualization Dust App to the assistant model configuration.
     const config = cloneBaseConfig(
       DustProdActionRegistry["assistant-v2-visualization"].config
@@ -216,7 +257,7 @@ export class VisualizationConfigurationServerRunner extends BaseActionConfigurat
       config,
       [
         {
-          conversation: modelConversationRes.value.modelConversation,
+          conversation: renderedConversation,
         },
       ],
       {


### PR DESCRIPTION
## Description

When the agent message containing the "visualization" tool call contains content, we currently have an error from the visualization dust app is the model is Claude.
That's because Anthropic doesn't support input conversation history ending with an ending with an agent message (since the viz dust app is really the tool execution, we are in a weird state where we have the agent message content but not the function result).

There are 2 options: 
- simply drop the agent message from the rendered conversation
- re-write the end of the conversation history so the last agent message contains a tool call followed by a function result message

I went for the latter, as the content generated before the tool use might be valuable.

fixes https://github.com/dust-tt/dust/issues/6481

## Risk

N/A

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
