### PR TITLE
Create group when we create a workspace + backfill the past

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -21,6 +21,7 @@ import {
   internalSubscribeWorkspaceToFreeNoPlan,
   internalSubscribeWorkspaceToFreePlan,
 } from "@app/lib/plans/subscription";
+import { GroupResource } from "@app/lib/resources/group_resource";
 import { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { generateLegacyModelSId } from "@app/lib/resources/string_ids";
@@ -42,6 +43,11 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
       const w = await Workspace.create({
         sId: generateLegacyModelSId(),
         name: args.name,
+      });
+      await GroupResource.makeNew({
+        name: "System",
+        type: "system",
+        workspaceId: w.id,
       });
 
       args.wId = w.sId;

--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -49,6 +49,11 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
         type: "system",
         workspaceId: w.id,
       });
+      await GroupResource.makeNew({
+        name: "Workspace",
+        type: "workspace",
+        workspaceId: w.id,
+      });
 
       args.wId = w.sId;
       await workspace("show", args);

--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -44,16 +44,18 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
         sId: generateLegacyModelSId(),
         name: args.name,
       });
-      await GroupResource.makeNew({
-        name: "System",
-        type: "system",
-        workspaceId: w.id,
-      });
-      await GroupResource.makeNew({
-        name: "Workspace",
-        type: "workspace",
-        workspaceId: w.id,
-      });
+      await Promise.all([
+        GroupResource.makeNew({
+          name: "System",
+          type: "system",
+          workspaceId: w.id,
+        }),
+        GroupResource.makeNew({
+          name: "Workspace",
+          type: "workspace",
+          workspaceId: w.id,
+        }),
+      ]);
 
       args.wId = w.sId;
       await workspace("show", args);

--- a/front/lib/iam/workspaces.ts
+++ b/front/lib/iam/workspaces.ts
@@ -2,6 +2,7 @@ import { sendUserOperationMessage } from "@dust-tt/types";
 
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { Workspace, WorkspaceHasDomain } from "@app/lib/models/workspace";
+import { GroupResource } from "@app/lib/resources/group_resource";
 import { generateLegacyModelSId } from "@app/lib/resources/string_ids";
 import { isDisposableEmailDomain } from "@app/lib/utils/disposable_email_domains";
 import logger from "@app/logger/logger";
@@ -20,6 +21,12 @@ export async function createWorkspace(session: SessionWithUser) {
   const workspace = await Workspace.create({
     sId: generateLegacyModelSId(),
     name: externalUser.nickname,
+  });
+
+  await GroupResource.makeNew({
+    name: "System",
+    type: "system",
+    workspaceId: workspace.id,
   });
 
   sendUserOperationMessage({

--- a/front/lib/iam/workspaces.ts
+++ b/front/lib/iam/workspaces.ts
@@ -28,6 +28,11 @@ export async function createWorkspace(session: SessionWithUser) {
     type: "system",
     workspaceId: workspace.id,
   });
+  await GroupResource.makeNew({
+    name: "Workspace",
+    type: "workspace",
+    workspaceId: workspace.id,
+  });
 
   sendUserOperationMessage({
     message: `<@U055XEGPR4L> +signupRadar User ${externalUser.email} has created a new workspace.`,

--- a/front/lib/iam/workspaces.ts
+++ b/front/lib/iam/workspaces.ts
@@ -23,16 +23,18 @@ export async function createWorkspace(session: SessionWithUser) {
     name: externalUser.nickname,
   });
 
-  await GroupResource.makeNew({
-    name: "System",
-    type: "system",
-    workspaceId: workspace.id,
-  });
-  await GroupResource.makeNew({
-    name: "Workspace",
-    type: "workspace",
-    workspaceId: workspace.id,
-  });
+  await Promise.all([
+    GroupResource.makeNew({
+      name: "System",
+      type: "system",
+      workspaceId: workspace.id,
+    }),
+    GroupResource.makeNew({
+      name: "Workspace",
+      type: "workspace",
+      workspaceId: workspace.id,
+    }),
+  ]);
 
   sendUserOperationMessage({
     message: `<@U055XEGPR4L> +signupRadar User ${externalUser.email} has created a new workspace.`,

--- a/front/lib/resources/storage/models/groups.ts
+++ b/front/lib/resources/storage/models/groups.ts
@@ -72,7 +72,9 @@ GroupModel.addHook(
       });
 
       if (existingSystemGroupType) {
-        throw new Error("A system group exists for this workspace.");
+        throw new Error("A system group exists for this workspace.", {
+          cause: "enforce_one_system_group_per_workspace",
+        });
       }
     }
   }

--- a/front/migrations/20240724_workspaces_groups_backfill.ts
+++ b/front/migrations/20240724_workspaces_groups_backfill.ts
@@ -24,6 +24,11 @@ async function backfillWorkspacesGroup(execute: boolean) {
                 type: "system",
                 workspaceId: w.id,
               });
+              await GroupResource.makeNew({
+                name: "Workspace",
+                type: "workspace",
+                workspaceId: w.id,
+              });
               console.log(`System group created for workspace ${w.id}`);
             } catch (error) {
               if (

--- a/front/migrations/20240724_workspaces_groups_backfill.ts
+++ b/front/migrations/20240724_workspaces_groups_backfill.ts
@@ -1,0 +1,52 @@
+import _ from "lodash";
+
+import { Workspace } from "@app/lib/models/workspace";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { makeScript } from "@app/scripts/helpers";
+
+async function backfillWorkspacesGroup(execute: boolean) {
+  const workspaces = await Workspace.findAll();
+
+  const chunks = _.chunk(workspaces, 16);
+  for (const [i, c] of chunks.entries()) {
+    console.log(
+      `[execute=${execute}] Processing chunk of ${c.length} workspaces... (${
+        i + 1
+      }/${chunks.length})`
+    );
+    if (execute) {
+      await Promise.all(
+        c.map((w) =>
+          (async () => {
+            try {
+              await GroupResource.makeNew({
+                name: "System",
+                type: "system",
+                workspaceId: w.id,
+              });
+              console.log(`System group created for workspace ${w.id}`);
+            } catch (error) {
+              if (
+                error instanceof Error &&
+                error.cause &&
+                error.cause === "enforce_one_system_group_per_workspace"
+              ) {
+                console.log(
+                  `System group already exists for workspace ${w.id}`
+                );
+              } else {
+                console.error(error);
+              }
+            }
+          })()
+        )
+      );
+    }
+  }
+
+  console.log(`Done.`);
+}
+
+makeScript({}, async ({ execute }) => {
+  await backfillWorkspacesGroup(execute);
+});


### PR DESCRIPTION
## Description

- create a `system` group when we create a workspace. 
- script to backfill a system` group for all existing workspaces. 

## Risk

Groups are not used yet so should not be too risky. 


## Deploy Plan

https://github.com/dust-tt/dust/pull/6474 must be merged first. 
Then deploy front. 
Then execute the backfill script. 