### PR TITLE
enh(viz): use claude 3.5 sonnet unless forbidden

### DIFF
--- a/front/lib/api/assistant/actions/visualization.ts
+++ b/front/lib/api/assistant/actions/visualization.ts
@@ -14,8 +14,10 @@ import type {
 } from "@dust-tt/types";
 import {
   BaseAction,
+  CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG,
   cloneBaseConfig,
   DustProdActionRegistry,
+  isProviderWhitelisted,
   Ok,
   VisualizationActionOutputSchema,
 } from "@dust-tt/types";
@@ -245,10 +247,19 @@ export class VisualizationConfigurationServerRunner extends BaseActionConfigurat
     const config = cloneBaseConfig(
       DustProdActionRegistry["assistant-v2-visualization"].config
     );
-    const model = agentConfiguration.model;
+
+    // If we can use Sonnet 3.5, we use it.
+    // Otherwise, we use the model from the agent configuration.
+    const model =
+      auth.isUpgraded() && isProviderWhitelisted(owner, "anthropic")
+        ? CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG
+        : agentConfiguration.model;
+
     config.MODEL.provider_id = model.providerId;
     config.MODEL.model_id = model.modelId;
-    config.MODEL.temperature = model.temperature;
+
+    // Preserve the temperature from the agent configuration.
+    config.MODEL.temperature = agentConfiguration.model.temperature;
 
     // Execute the Vizualization Dust App.
     const visualizationRes = await runActionStreamed(


### PR DESCRIPTION
## Description

Claude 3.5 sonnet is the best model we have to generate code (opinion)

We want to use it for the `viz` action, unless it's not in the workspace's whitelist.

fixes https://github.com/dust-tt/dust/issues/6484

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
