### PR TITLE
Groups: core data_sources_documents_retrieve view filtering

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1749,12 +1749,11 @@ async fn data_sources_documents_retrieve(
                 .retrieve(
                     state.store.clone(),
                     &document_id,
+                    match query.view_filter {
+                        Some(filter) => Some(filter.postprocess_for_data_source(&data_source_id)),
+                        None => None,
+                    },
                     true,
-                    // TODO(spolu): follow_up PR.
-                    // match query.view_filter {
-                    //     Some(filter) => Some(filter.postprocess_for_data_source(&data_source_id)),
-                    //     None => None,
-                    // },
                     &query.version_hash,
                 )
                 .await

--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1749,7 +1749,7 @@ async fn data_sources_documents_retrieve(
                 .retrieve(
                     state.store.clone(),
                     &document_id,
-                    match query.view_filter {
+                    &match query.view_filter {
                         Some(filter) => Some(filter.postprocess_for_data_source(&data_source_id)),
                         None => None,
                     },

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -404,11 +404,11 @@ impl Document {
         })
     }
 
-    pub fn match_filter(&self, filter: Option<SearchFilter>) -> bool {
-        match filter {
+    pub fn match_filter(&self, filter: &Option<SearchFilter>) -> bool {
+        match filter.as_ref() {
             Some(filter) => {
                 let mut m = true;
-                match filter.tags {
+                match &filter.tags {
                     Some(tags) => {
                         m = m
                             && match &tags.is_in {
@@ -423,7 +423,7 @@ impl Document {
                     }
                     None => (),
                 }
-                match filter.parents {
+                match &filter.parents {
                     Some(parents) => {
                         m = m
                             && match &parents.is_in {
@@ -442,7 +442,7 @@ impl Document {
                     }
                     None => (),
                 }
-                match filter.timestamp {
+                match &filter.timestamp {
                     Some(timestamp) => {
                         m = m
                             && match timestamp.gt {
@@ -1815,6 +1815,7 @@ impl DataSource {
         &self,
         store: Box<dyn Store + Sync + Send>,
         document_id: &str,
+        view_filter: &Option<SearchFilter>,
         remove_system_tags: bool,
         version_hash: &Option<String>,
     ) -> Result<Option<Document>> {
@@ -1834,6 +1835,11 @@ impl DataSource {
                 return Ok(None);
             }
         };
+
+        // If the view_filter does not match the document we return as if it didn't exist.
+        if !d.match_filter(view_filter) {
+            return Ok(None);
+        }
 
         d.tags = if remove_system_tags {
             // remove tags that are prefixed with the system tag prefix

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -405,7 +405,7 @@ impl Document {
     }
 
     pub fn match_filter(&self, filter: &Option<SearchFilter>) -> bool {
-        match filter.as_ref() {
+        match &filter {
             Some(filter) => {
                 let mut m = true;
                 match &filter.tags {


### PR DESCRIPTION
## Description

Adds support for `view_filter` to `data_sources_documents_retrieve`

## Risk

Low unused.

## Deploy Plan

- deploy `core`