### PR TITLE
Groups: `core` view_filter support in `search`

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1300,11 +1300,10 @@ async fn data_sources_search(
                         Some(filter) => Some(filter.postprocess_for_data_source(&data_source_id)),
                         None => None,
                     },
-                    // TODO(spolu): follow_up PR.
-                    // match payload.view_filter {
-                    //     Some(filter) => Some(filter.postprocess_for_data_source(&data_source_id)),
-                    //     None => None,
-                    // },
+                    match payload.view_filter {
+                        Some(filter) => Some(filter.postprocess_for_data_source(&data_source_id)),
+                        None => None,
+                    },
                     payload.full_text,
                     payload.target_document_tokens,
                 )

--- a/core/bin/qdrant/migrate_embedder.rs
+++ b/core/bin/qdrant/migrate_embedder.rs
@@ -643,6 +643,7 @@ async fn refresh_chunk_count_for_updated_documents(
                 ds.project(),
                 ds.data_source_id(),
                 &Some(filter.clone()),
+                &None,
                 Some((batch_size, offset)),
             )
             .await?;

--- a/core/src/blocks/data_source.rs
+++ b/core/src/blocks/data_source.rs
@@ -110,6 +110,8 @@ impl DataSource {
                     Some(filter) => Some(filter.postprocess_for_data_source(&data_source_id)),
                     None => None,
                 },
+                // TODO(spolu): add in subsequent PR (data_source block view_filter support).
+                None,
                 self.full_text,
                 target_document_tokens,
             )

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -1595,6 +1595,7 @@ impl Store for PostgresStore {
         project: &Project,
         data_source_id: &str,
         filter: &Option<SearchFilter>,
+        view_filter: &Option<SearchFilter>,
         limit_offset: Option<(usize, usize)>,
     ) -> Result<(Vec<String>, usize)> {
         let pool = self.pool.clone();
@@ -1623,6 +1624,12 @@ impl Store for PostgresStore {
 
         where_clauses.extend(filter_clauses);
         params.extend(filter_params);
+
+        let (view_filter_clauses, view_filter_params, p_idx) =
+            Self::where_clauses_and_params_for_filter(view_filter, p_idx);
+
+        where_clauses.extend(view_filter_clauses);
+        params.extend(view_filter_params);
 
         // compute the total count
         let count_query = format!(

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -118,6 +118,7 @@ pub trait Store {
         project: &Project,
         data_source_id: &str,
         filter: &Option<SearchFilter>,
+        view_filter: &Option<SearchFilter>,
         limit_offset: Option<(usize, usize)>,
     ) -> Result<(Vec<String>, usize)>;
     async fn upsert_data_source_document(


### PR DESCRIPTION
## Description

Adds support for `view_filter` in the core data source search endpoint.

Fixes: https://github.com/dust-tt/dust/issues/6455

- [x] local test of existing data source block with query
- [x] local test of existing data source block without query

## Risk

Low, tested locally

## Deploy Plan

- deploy `core`