### PR TITLE
Add workspace name in datasource poke view

### DIFF
--- a/front/pages/poke/[wId]/data_sources/[name]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[name]/index.tsx
@@ -277,11 +277,11 @@ const DataSourcePage = ({
         <div className="px-8 py-8"></div>
         <Page.Vertical align="stretch">
           <div className="flex flex-row gap-2">
-            <Page.SectionHeader title={`${dataSource.name}`} />
+            <Page.SectionHeader title={`${owner.name} → ${dataSource.name}`} />
           </div>
 
           <div className="flex flex-row gap-2 text-sm font-bold text-action-500">
-            <Link href={`/poke/${owner.sId}`}>&laquo; workspace</Link>
+            <Link href={`/poke/${owner.sId}`}>&laquo; workspace </Link>
             <div
               className="cursor-pointer"
               onClick={() => {
@@ -296,7 +296,7 @@ const DataSourcePage = ({
                 }
               }}
             >
-              🔒search
+              🔒 search data
             </div>
           </div>
 


### PR DESCRIPTION
## Description

Got bored of having to go back to the workspace page to know which workspace I was looking at in poke on the datasource page
<img width="340" alt="Screenshot 2024-07-25 at 09 55 48" src="https://github.com/user-attachments/assets/71f4e436-f5df-446f-9029-425d04781619">


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
