### PR TITLE
[core] - refactor: fix MistralChatMessage serialization

### DIFF
--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -151,9 +151,9 @@ impl TryFrom<&ChatMessage> for MistralChatMessage {
         match cm {
             ChatMessage::Assistant(assistant_msg) => Ok(MistralChatMessage {
                 role: MistralChatMessageRole::Assistant,
-                content: match assistant_msg.clone().function_calls {
+                content: match assistant_msg.function_calls {
                     Some(_) => None,
-                    None => assistant_msg.clone().content,
+                    None => assistant_msg.content.clone(),
                 },
                 tool_calls: assistant_msg
                     .function_calls


### PR DESCRIPTION
## Description

This PR aims at fixing the following issue encountered with Mistral Large:
```
[{"value":null,"error":"Error querying `mistral:mistral-large-latest`: error=[model_error(retryable=, request_id=...)] \"Assistant message must have either content or tool_calls, but not both.\"","meta":null}]
```

It introduces the following changes:
 - Serialize `content` in `MistralChatMessage` only when there are no `tool_calls` present
 - Ensure `AssistantChatMessage` creation aligns with conditional presence of `tool_calls` or `content`
 - Strip `content` from `AssistantChatMessage` if `tool_calls` are present to prevent unnecessary data
 - Adjust `MistralAILLM` to clear `content` when `tool_calls` are set to maintain data consistency

**References:**
- https://github.com/dust-tt/tasks/issues/1101

## Risk

Breaking/unexpected interactions with Mistral

## Deploy Plan

- Deploy `core`
