### PR TITLE
[front] - fix(assistant_builder): navigation lock

### DIFF
--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -23,6 +23,7 @@ import type {
   AssistantBuilderDataSourceConfiguration,
   AssistantBuilderDataSourceConfigurations,
 } from "@app/components/assistant_builder/types";
+import { useNavigationLock } from "@app/components/assistant_builder/useNavigationLock";
 import DataSourceResourceSelectorTree from "@app/components/DataSourceResourceSelectorTree";
 import { useParentResourcesById } from "@app/hooks/useParentResourcesById";
 import { orderDatasourceByImportance } from "@app/lib/assistant";
@@ -117,6 +118,13 @@ export default function AssistantBuilderDataSourceModal({
   // Hack to filter out Websites from the list of data sources
   const [shouldDisplayWebsitesScreen, setShouldDisplayWebsitesScreen] =
     useState(false);
+
+  useNavigationLock(true, {
+    title: "Warning",
+    message:
+      "All unsaved changes will be lost, are you sure you want to continue?",
+    validation: "primaryWarning",
+  });
 
   useEffect(() => {
     if (!dataSourceConfigurations && isOpen) {


### PR DESCRIPTION
## Description

This PR aims at fixing part of https://github.com/dust-tt/tasks/issues/1056 by adding a navigation lock on the `AssistantBuilderDataSourceModal`. 

This part of the issue:
> Browser back should ideally bring user back the previous state (from "select data source" to "assistant builder", from "select a Notion data source" to "select data source" and so on)

is a lot more challenging IMHO since we are dealing with modals. So I would probably skip it for now and open an Olympus card if that's fine with you.

## Risk

None

## Deploy Plan

Deploy `front`