### PR TITLE
Better poke UI for workspace search : sorting by enterprise customer first + labels

### DIFF
--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -20,7 +20,7 @@ import useSWRInfinite from "swr/infinite";
 import type { FetchConversationMessagesResponse } from "@app/lib/api/assistant/messages";
 import { COMMIT_HASH } from "@app/lib/commit-hash";
 import type { GetPokePlansResponseBody } from "@app/pages/api/poke/plans";
-import type { GetWorkspacesResponseBody } from "@app/pages/api/poke/workspaces";
+import type { GetPokeWorkspacesResponseBody } from "@app/pages/api/poke/workspaces";
 import type { GetUserResponseBody } from "@app/pages/api/user";
 import type { GetUserMetadataResponseBody } from "@app/pages/api/user/metadata/[key]";
 import type { GetTableResponseBody } from "@app/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]";
@@ -581,7 +581,7 @@ export function usePokeWorkspaces({
   disabled?: boolean;
   limit?: number;
 } = {}) {
-  const workspacesFetcher: Fetcher<GetWorkspacesResponseBody> = fetcher;
+  const workspacesFetcher: Fetcher<GetPokeWorkspacesResponseBody> = fetcher;
 
   const queryParams = [
     upgraded !== undefined ? `upgraded=${upgraded}` : null,

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -1,4 +1,8 @@
-import type { LightWorkspaceType, WithAPIErrorResponse } from "@dust-tt/types";
+import type {
+  LightWorkpaceTypeWithSubscription,
+  SubscriptionType,
+  WithAPIErrorResponse,
+} from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 import type { FindOptions, WhereOptions } from "sequelize";
 import { Op } from "sequelize";
@@ -8,18 +12,19 @@ import { Authenticator, getSession } from "@app/lib/auth";
 import { Plan, Subscription } from "@app/lib/models/plan";
 import { Workspace } from "@app/lib/models/workspace";
 import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
+import { renderSubscriptionFromModels } from "@app/lib/plans/subscription";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { isEmailValid } from "@app/lib/utils";
 import { apiError } from "@app/logger/withlogging";
 
-export type GetWorkspacesResponseBody = {
-  workspaces: LightWorkspaceType[];
+export type GetPokeWorkspacesResponseBody = {
+  workspaces: LightWorkpaceTypeWithSubscription[];
 };
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetWorkspacesResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetPokeWorkspacesResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(session, null);
@@ -167,19 +172,48 @@ async function handler(
           }
         : {};
 
-      const workspaces = await Workspace.findAll({ where, limit });
+      const workspaces = await Workspace.findAll({
+        where,
+        limit,
+        include: [
+          {
+            model: Subscription,
+            as: "subscriptions",
+            where: { status: "active" },
+            required: false,
+            include: [
+              {
+                model: Plan,
+                as: "plan",
+              },
+            ],
+          },
+        ],
+      });
 
       return res.status(200).json({
-        workspaces: workspaces.map((ws) => ({
-          id: ws.id,
-          sId: ws.sId,
-          name: ws.name,
-          role: "admin",
-          segmentation: ws.segmentation,
-          whiteListedProviders: ws.whiteListedProviders,
-          defaultEmbeddingProvider: ws.defaultEmbeddingProvider,
-        })),
+        workspaces: workspaces.map((ws) => {
+          let subscription: SubscriptionType | null = null;
+          if (ws.subscriptions && ws.subscriptions.length > 0) {
+            subscription = renderSubscriptionFromModels({
+              plan: ws.subscriptions[0].plan,
+              activeSubscription: ws.subscriptions[0],
+            });
+          }
+
+          return {
+            id: ws.id,
+            sId: ws.sId,
+            name: ws.name,
+            role: "admin",
+            segmentation: ws.segmentation,
+            whiteListedProviders: ws.whiteListedProviders,
+            defaultEmbeddingProvider: ws.defaultEmbeddingProvider,
+            subscription,
+          };
+        }),
       });
+
     default:
       return apiError(req, res, {
         status_code: 405,

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -1,5 +1,5 @@
 import type {
-  LightWorkpaceTypeWithSubscription,
+  LightWorkpaceWithSubscriptionType,
   SubscriptionType,
   WithAPIErrorResponse,
 } from "@dust-tt/types";
@@ -19,7 +19,7 @@ import { isEmailValid } from "@app/lib/utils";
 import { apiError } from "@app/logger/withlogging";
 
 export type GetPokeWorkspacesResponseBody = {
-  workspaces: LightWorkpaceTypeWithSubscription[];
+  workspaces: LightWorkpaceWithSubscriptionType[];
 };
 
 async function handler(

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -201,7 +201,7 @@ async function handler(
                 activeSubscription: ws.subscriptions[0],
               });
             }
-      
+
             return {
               id: ws.id,
               sId: ws.sId,
@@ -214,9 +214,11 @@ async function handler(
             };
           })
           .sort((a, b) => {
-            const aStartsWithENT = a.subscription?.plan?.name?.startsWith("ENT_") || false;
-            const bStartsWithENT = b.subscription?.plan?.name?.startsWith("ENT_") || false;
-      
+            const aStartsWithENT =
+              a.subscription?.plan?.name?.startsWith("ENT_") || false;
+            const bStartsWithENT =
+              b.subscription?.plan?.name?.startsWith("ENT_") || false;
+
             if (aStartsWithENT && !bStartsWithENT) {
               return -1;
             } else if (!aStartsWithENT && bStartsWithENT) {
@@ -226,7 +228,6 @@ async function handler(
             }
           }),
       });
-      
 
     default:
       return apiError(req, res, {

--- a/front/pages/poke/[wId]/data_sources/[name]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[name]/index.tsx
@@ -281,7 +281,7 @@ const DataSourcePage = ({
           </div>
 
           <div className="flex flex-row gap-2 text-sm font-bold text-action-500">
-            <Link href={`/poke/${owner.sId}`}>&laquo; workspace </Link>
+            <Link href={`/poke/${owner.sId}`}>&laquo; workspace</Link>
             <div
               className="cursor-pointer"
               onClick={() => {

--- a/front/pages/poke/[wId]/data_sources/[name]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[name]/index.tsx
@@ -277,11 +277,11 @@ const DataSourcePage = ({
         <div className="px-8 py-8"></div>
         <Page.Vertical align="stretch">
           <div className="flex flex-row gap-2">
-            <Page.SectionHeader title={`${dataSource.name}`} />
+            <Page.SectionHeader title={`${owner.name} → ${dataSource.name}`} />
           </div>
 
           <div className="flex flex-row gap-2 text-sm font-bold text-action-500">
-            <Link href={`/poke/${owner.sId}`}>&laquo; workspace</Link>
+            <Link href={`/poke/${owner.sId}`}>&laquo; workspace </Link>
             <div
               className="cursor-pointer"
               onClick={() => {
@@ -296,7 +296,7 @@ const DataSourcePage = ({
                 }
               }}
             >
-              🔒search
+              🔒 search data
             </div>
           </div>
 

--- a/front/pages/poke/index.tsx
+++ b/front/pages/poke/index.tsx
@@ -64,7 +64,18 @@ const Dashboard = () => {
                 <Link href={`/poke/${ws.sId}`} key={ws.id}>
                   <li className="border-material-100 rounded-lg border bg-white p-4 transition-colors duration-200 hover:bg-gray-100">
                     <h2 className="text-xl font-semibold">{ws.name}</h2>
-                    <p className="text-sm text-gray-500">sId: {ws.sId}</p>
+                    <div className="flex items-center space-x-2">
+                      <label className="rounded bg-green-500 px-1 text-sm text-white">
+                        {ws.sId}
+                      </label>
+                      {ws.subscription && (
+                        <label
+                          className={`rounded px-1 text-sm text-gray-500 text-white ${ws.subscription.plan.name.startsWith("ENT_") ? "bg-red-500" : "bg-blue-500"}`}
+                        >
+                          {ws.subscription.plan.name}
+                        </label>
+                      )}
+                    </div>
                   </li>
                 </Link>
               ))}

--- a/types/src/front/user.ts
+++ b/types/src/front/user.ts
@@ -1,6 +1,5 @@
 import * as t from "io-ts";
 
-import { SubscriptionType } from "..";
 import {
   EmbeddingProviderIdType,
   ModelProviderIdType,
@@ -8,6 +7,7 @@ import {
 import { WhitelistableFeature } from "../shared/feature_flags";
 import { ModelId } from "../shared/model_id";
 import { assertNever } from "../shared/utils/assert_never";
+import { SubscriptionType } from "./plan";
 
 export type WorkspaceSegmentationType = "interesting" | null;
 

--- a/types/src/front/user.ts
+++ b/types/src/front/user.ts
@@ -44,7 +44,7 @@ export type LightWorkspaceType = {
   defaultEmbeddingProvider: EmbeddingProviderIdType | null;
 };
 
-export type LightWorkpaceTypeWithSubscription = LightWorkspaceType & {
+export type LightWorkpaceWithSubscriptionType = LightWorkspaceType & {
   subscription: SubscriptionType | null;
 };
 

--- a/types/src/front/user.ts
+++ b/types/src/front/user.ts
@@ -1,5 +1,6 @@
 import * as t from "io-ts";
 
+import { SubscriptionType } from "..";
 import {
   EmbeddingProviderIdType,
   ModelProviderIdType,
@@ -41,6 +42,10 @@ export type LightWorkspaceType = {
   segmentation: WorkspaceSegmentationType;
   whiteListedProviders: ModelProviderIdType[] | null;
   defaultEmbeddingProvider: EmbeddingProviderIdType | null;
+};
+
+export type LightWorkpaceTypeWithSubscription = LightWorkspaceType & {
+  subscription: SubscriptionType | null;
 };
 
 export type WorkspaceType = LightWorkspaceType & {


### PR DESCRIPTION
## Description

This PR tries to fix the constant struggle we have finding enterprise customers' workspace in Poke. 
- Adds displays the plan name in the result results (enterprise in red, rest in blue)
<img width="330" alt="Screenshot 2024-07-25 at 14 13 08" src="https://github.com/user-attachments/assets/fc4ea59b-aa8e-4131-a0e0-92f7fbc57469">


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
