### PR TITLE
Rename workspace group to global group

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -52,7 +52,7 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
         }),
         GroupResource.makeNew({
           name: "Workspace",
-          type: "workspace",
+          type: "global",
           workspaceId: w.id,
         }),
       ]);

--- a/front/lib/iam/workspaces.ts
+++ b/front/lib/iam/workspaces.ts
@@ -31,7 +31,7 @@ export async function createWorkspace(session: SessionWithUser) {
     }),
     GroupResource.makeNew({
       name: "Workspace",
-      type: "workspace",
+      type: "global",
       workspaceId: workspace.id,
     }),
   ]);

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -94,7 +94,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     return new this(this.model, blob.get());
   }
 
-  static async fetchByAuthWorkspace(
+  static async fetchWorkspaceGroups(
     auth: Authenticator,
     transaction?: Transaction
   ): Promise<GroupResource[]> {
@@ -108,6 +108,73 @@ export class GroupResource extends BaseResource<GroupModel> {
     });
 
     return groups.map((group) => new this(GroupModel, group.get()));
+  }
+
+  static async fetchWorkspaceSystemGroup(
+    auth: Authenticator,
+    transaction?: Transaction
+  ): Promise<GroupResource> {
+    const owner = auth.getNonNullableWorkspace();
+    const group = await this.model.findOne({
+      where: {
+        workspaceId: owner.id,
+        type: "system",
+      },
+      transaction,
+    });
+
+    if (!group) {
+      throw new Error("System group not found.");
+    }
+
+    return new this(GroupModel, group.get());
+  }
+
+  static async fetchWorkspaceGlobalGroup(
+    auth: Authenticator,
+    transaction?: Transaction
+  ): Promise<GroupResource> {
+    const owner = auth.getNonNullableWorkspace();
+    const group = await this.model.findOne({
+      where: {
+        workspaceId: owner.id,
+        type: "global",
+      },
+      transaction,
+    });
+
+    if (!group) {
+      throw new Error("Global group not found.");
+    }
+
+    return new this(GroupModel, group.get());
+  }
+
+  static async fetchWorkspaceGroup(
+    auth: Authenticator,
+    groupId: string,
+    transaction?: Transaction
+  ): Promise<GroupResource | null> {
+    const owner = auth.getNonNullableWorkspace();
+    const groupModelId = getResourceIdFromSId(groupId);
+
+    if (!groupModelId) {
+      throw new Error("Invalid group ID.");
+    }
+
+    const group = await this.model.findOne({
+      where: {
+        workspaceId: owner.id,
+        id: groupModelId,
+      },
+      transaction,
+    });
+
+    if (!group) {
+      return null;
+    }
+
+    return new this(GroupModel, group.get());
   }
 
   toJSON() {

--- a/front/lib/resources/storage/models/groups.ts
+++ b/front/lib/resources/storage/models/groups.ts
@@ -1,5 +1,5 @@
 import type { GroupType } from "@dust-tt/types";
-import { isSystemGroupType, isWorkspaceGroupType } from "@dust-tt/types";
+import { isGlobalGroupType, isSystemGroupType } from "@dust-tt/types";
 import type {
   CreationOptional,
   ForeignKey,
@@ -60,10 +60,10 @@ GroupModel.init(
 
 GroupModel.addHook(
   "beforeCreate",
-  "enforce_one_system_and_workspace_group_per_workspace",
+  "enforce_one_system_and_global_group_per_workspace",
   async (group: GroupModel, options: { transaction: Transaction }) => {
     const groupType = group.type;
-    if (isSystemGroupType(groupType) || isWorkspaceGroupType(groupType)) {
+    if (isSystemGroupType(groupType) || isGlobalGroupType(groupType)) {
       const existingSystemOrWorkspaceGroupType = await GroupModel.findOne({
         where: {
           workspaceId: group.workspaceId,

--- a/front/migrations/20240724_workspaces_groups_backfill.ts
+++ b/front/migrations/20240724_workspaces_groups_backfill.ts
@@ -26,7 +26,7 @@ async function backfillWorkspacesGroup(execute: boolean) {
               });
               await GroupResource.makeNew({
                 name: "Workspace",
-                type: "workspace",
+                type: "global",
                 workspaceId: w.id,
               });
               console.log(`System group created for workspace ${w.id}`);
@@ -38,9 +38,9 @@ async function backfillWorkspacesGroup(execute: boolean) {
                       `System group already exists for workspace ${w.id}`
                     );
                     break;
-                  case "enforce_one_workspace_group_per_workspace":
+                  case "enforce_one_global_group_per_workspace":
                     console.log(
-                      `Workspace group already exists for workspace ${w.id}`
+                      `Global group already exists for workspace ${w.id}`
                     );
                     break;
                   default:

--- a/front/migrations/db/migration_46.sql
+++ b/front/migrations/db/migration_46.sql
@@ -1,0 +1,1 @@
+UPDATE "groups" SET "type" = 'global' WHERE "type" = 'workspace';

--- a/types/src/front/groups.ts
+++ b/types/src/front/groups.ts
@@ -1,4 +1,17 @@
-export const GROUP_TYPES = ["regular", "workspace", "system"] as const;
+/**
+ * system group:
+ * Accessible by no-one other than our system API keys.
+ * Has access to the system Vault which holds the connected data sources.
+ *
+ * global group:
+ * Contains all users from the workspace.
+ * Has access to the global Vault which holds all existing datasource created before vaults.
+ *
+ * regular group:
+ * Contains specific users added by workspace admins.
+ * Has access to the list of Vaults configured by workspace admins.
+ */
+export const GROUP_TYPES = ["regular", "global", "system"] as const;
 export type GroupType = (typeof GROUP_TYPES)[number];
 
 export function isValidGroupType(value: unknown): value is GroupType {
@@ -7,6 +20,6 @@ export function isValidGroupType(value: unknown): value is GroupType {
 export function isSystemGroupType(value: GroupType): boolean {
   return value === "system";
 }
-export function isWorkspaceGroupType(value: GroupType): boolean {
-  return value === "workspace";
+export function isGlobalGroupType(value: GroupType): boolean {
+  return value === "global";
 }


### PR DESCRIPTION
## Description

- rename `workspace` group to `global` group. 
- implement some group fetch functions. 
- migration for existing entries in db

## Risk

Groups are not used yet on prod, we are only creating some. 

## Deploy Plan

Merge.
Deploy front. 
Run migration 46
