### PR TITLE
Rename GroupType to SupportedGroupType

### DIFF
--- a/front/lib/resources/storage/models/groups.ts
+++ b/front/lib/resources/storage/models/groups.ts
@@ -1,4 +1,4 @@
-import type { GroupType } from "@dust-tt/types";
+import type { SupportedGroupType } from "@dust-tt/types";
 import { isGlobalGroupType, isSystemGroupType } from "@dust-tt/types";
 import type {
   CreationOptional,
@@ -21,7 +21,7 @@ export class GroupModel extends Model<
   declare updatedAt: CreationOptional<Date>;
 
   declare name: string;
-  declare type: GroupType;
+  declare type: SupportedGroupType;
 
   declare workspaceId: ForeignKey<Workspace["id"]>;
 }

--- a/types/src/front/groups.ts
+++ b/types/src/front/groups.ts
@@ -11,15 +11,17 @@
  * Contains specific users added by workspace admins.
  * Has access to the list of Vaults configured by workspace admins.
  */
-export const GROUP_TYPES = ["regular", "global", "system"] as const;
-export type GroupType = (typeof GROUP_TYPES)[number];
+export const SUPPORTED_GROUP_TYPES = ["regular", "global", "system"] as const;
+export type SupportedGroupType = (typeof SUPPORTED_GROUP_TYPES)[number];
 
-export function isValidGroupType(value: unknown): value is GroupType {
-  return GROUP_TYPES.includes(value as GroupType);
+export function isSupportedGroupType(
+  value: unknown
+): value is SupportedGroupType {
+  return SUPPORTED_GROUP_TYPES.includes(value as SupportedGroupType);
 }
-export function isSystemGroupType(value: GroupType): boolean {
+export function isSystemGroupType(value: SupportedGroupType): boolean {
   return value === "system";
 }
-export function isGlobalGroupType(value: GroupType): boolean {
+export function isGlobalGroupType(value: SupportedGroupType): boolean {
   return value === "global";
 }


### PR DESCRIPTION
## Description

Rename `GroupType` to `SupportedGroupType` to free `GroupType` for the type related to a `GroupModel`.
🙃 

## Risk

/

## Deploy Plan

Deploy front. 
