### PR TITLE
production check: core document scrub, use replica for big query

### DIFF
--- a/front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts
+++ b/front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts
@@ -14,10 +14,10 @@ export const managedDataSourceGCGdriveCheck: CheckFunction = async (
   reportFailure,
   heartbeat
 ) => {
-  const connectorsSequelize = getConnectorReplicaDbConnection();
-  const frontSequelize = getFrontReplicaDbConnection();
+  const connectorsReplica = getConnectorReplicaDbConnection();
+  const frontReplica = getFrontReplicaDbConnection();
   const GdriveDataSources: { id: number; connectorId: string }[] =
-    await frontSequelize.query(
+    await frontReplica.query(
       `SELECT id, "connectorId" FROM data_sources WHERE "connectorProvider" = 'google_drive'`,
       { type: QueryTypes.SELECT }
     );
@@ -27,7 +27,7 @@ export const managedDataSourceGCGdriveCheck: CheckFunction = async (
 
     // Retrieve all documents from the connector (first)
     const connectorDocuments: { id: number; coreDocumentId: string }[] =
-      await connectorsSequelize.query(
+      await connectorsReplica.query(
         'SELECT id, "dustFileId" as "coreDocumentId" FROM google_drive_files WHERE "connectorId" = :connectorId',
         {
           replacements: {

--- a/front/lib/production_checks/managed_ds.ts
+++ b/front/lib/production_checks/managed_ds.ts
@@ -16,10 +16,10 @@ export type CoreDSDocument = {
 export async function getCoreDocuments(
   frontDataSourceId: number
 ): Promise<Result<CoreDSDocument[], Error>> {
-  const core_sequelize = getCoreReplicaDbConnection();
-  const front_sequelize = getFrontReplicaDbConnection();
+  const coreReplica = getCoreReplicaDbConnection();
+  const frontReplica = getFrontReplicaDbConnection();
 
-  const managedDsData = await front_sequelize.query(
+  const managedDsData = await frontReplica.query(
     'SELECT id, "connectorId", "connectorProvider", "dustAPIProjectId" \
          FROM data_sources WHERE id = :frontDataSourceId',
     {
@@ -39,7 +39,7 @@ export async function getCoreDocuments(
     );
   }
   const ds = managedDs[0];
-  const coreDsData = await core_sequelize.query(
+  const coreDsData = await coreReplica.query(
     `SELECT id FROM data_sources WHERE "project" = :dustAPIProjectId`,
     {
       replacements: {
@@ -54,7 +54,7 @@ export async function getCoreDocuments(
       new Error(`Core data source not found for front datasource  ${ds.id}`)
     );
   }
-  const coreDocumentsData = await core_sequelize.query(
+  const coreDocumentsData = await coreReplica.query(
     `SELECT id, document_id, parents FROM data_sources_documents WHERE "data_source" = :coreDsId AND status = 'latest'`,
     {
       replacements: {

--- a/front/lib/production_checks/utils.ts
+++ b/front/lib/production_checks/utils.ts
@@ -6,6 +6,7 @@ import config from "@app/lib/production_checks/config";
 let connectorReplicaDbInstance: Sequelize | null = null;
 let coreReplicaDbInstance: Sequelize | null = null;
 let frontReplicaDbInstance: Sequelize | null = null;
+let corePrimaryDbInstance: Sequelize | null = null;
 
 export function getConnectorReplicaDbConnection() {
   if (!connectorReplicaDbInstance) {
@@ -44,4 +45,17 @@ export function getFrontReplicaDbConnection() {
   }
 
   return frontReplicaDbInstance;
+}
+
+export function getCorePrimaryDbConnection() {
+  if (!corePrimaryDbInstance) {
+    corePrimaryDbInstance = new Sequelize(
+      config.getPrimaryCoreDatabaseUri() as string,
+      {
+        logging: false,
+      }
+    );
+  }
+
+  return corePrimaryDbInstance;
 }


### PR DESCRIPTION
## Description

- Cohere naming in production checks
- Use coreReplica for the big query to fetch all recently deleted documents

## Risk

N/A

## Deploy Plan

- deploy `front`