### PR TITLE
[MS Connector] Garbage collection workflow

### DIFF
--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -356,6 +356,14 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
       return res;
     }
 
+    const gcRes = await launchMicrosoftGarbageCollectionWorkflow(
+      this.connectorId
+    );
+
+    if (gcRes.isErr()) {
+      return gcRes;
+    }
+
     return new Ok(undefined);
   }
 

--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -37,6 +37,7 @@ import {
 import {
   launchMicrosoftDeletionWorkflow,
   launchMicrosoftFullSyncWorkflow,
+  launchMicrosoftGarbageCollectionWorkflow,
   launchMicrosoftIncrementalSyncWorkflow,
 } from "@connectors/connectors/microsoft/temporal/client";
 import { getOAuthConnectionAccessTokenWithThrow } from "@connectors/lib/oauth";
@@ -326,6 +327,14 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
       return res;
     }
 
+    const gcRes = await launchMicrosoftGarbageCollectionWorkflow(
+      this.connectorId
+    );
+
+    if (gcRes.isErr()) {
+      return gcRes;
+    }
+
     const incrementalRes = await launchMicrosoftIncrementalSyncWorkflow(
       this.connectorId
     );
@@ -548,6 +557,15 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
     if (r.isErr()) {
       return r;
     }
+
+    const gcRes = await launchMicrosoftGarbageCollectionWorkflow(
+      this.connectorId
+    );
+
+    if (gcRes.isErr()) {
+      return gcRes;
+    }
+
     const incrementalSync = await launchMicrosoftIncrementalSyncWorkflow(
       this.connectorId
     );

--- a/connectors/src/connectors/microsoft/lib/graph_api.ts
+++ b/connectors/src/connectors/microsoft/lib/graph_api.ts
@@ -312,7 +312,10 @@ export async function getAllPaginatedEntities<T extends MicrosoftGraph.Entity>(
   return allItems;
 }
 
-export async function getItem(client: Client, itemApiPath: string) {
+export async function getItem(
+  client: Client,
+  itemApiPath: string
+): Promise<MicrosoftGraph.Entity> {
   return client.api(itemApiPath).get();
 }
 

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -835,6 +835,10 @@ export async function microsoftNodesGarbageCollectionActivity({
     throw new Error(`Connector ${connectorId} not found`);
   }
 
+  logger.info(
+    { connectorId, idCursor },
+    "Garbage collection activity for cursor"
+  );
   const client = await getClient(connector.connectionId);
 
   const dataSourceConfig = dataSourceConfigFromConnector(connector);

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -823,7 +823,7 @@ export async function microsoftDeletionActivity({
   return new Ok(undefined);
 }
 
-export async function microsoftNodesGCActivity({
+export async function microsoftNodesGarbageCollectionActivity({
   connectorId,
   idCursor,
 }: {
@@ -848,7 +848,7 @@ export async function microsoftNodesGCActivity({
   const lastNode = nodes.length > 0 ? nodes[nodes.length - 1] : null;
 
   if (!lastNode) {
-    throw new Error("Unreachable: last node not found");
+    return null;
   }
 
   const nextIdCursor = lastNode.id + 1;

--- a/connectors/src/connectors/microsoft/temporal/client.ts
+++ b/connectors/src/connectors/microsoft/temporal/client.ts
@@ -1,13 +1,17 @@
 import type { ModelId, Result } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
+import type { WorkflowHandle } from "@temporalio/client";
+import { WorkflowNotFoundError } from "@temporalio/common";
 
 import { QUEUE_NAME } from "@connectors/connectors/microsoft/temporal/config";
+import type { microsoftGarbageCollectionWorkflow } from "@connectors/connectors/microsoft/temporal/workflows";
 import {
   fullSyncWorkflow,
   incrementalSyncWorkflow,
   microsoftDeletionWorkflow,
   microsoftDeletionWorkflowId,
   microsoftFullSyncWorkflowId,
+  microsoftGarbageCollectionWorkflowId,
   microsoftIncrementalSyncWorkflowId,
 } from "@connectors/connectors/microsoft/temporal/workflows";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
@@ -86,6 +90,77 @@ export async function launchMicrosoftIncrementalSyncWorkflow(
       searchAttributes: {
         connectorId: [connectorId],
       },
+      memo: {
+        connectorId: connectorId,
+      },
+    });
+    logger.info(
+      {
+        workspaceId: dataSourceConfig.workspaceId,
+        workflowId,
+      },
+      `Started workflow.`
+    );
+    return new Ok(workflowId);
+  } catch (e) {
+    logger.error(
+      {
+        workspaceId: dataSourceConfig.workspaceId,
+        workflowId,
+        error: e,
+      },
+      `Failed starting workflow.`
+    );
+    return new Err(e as Error);
+  }
+}
+
+export async function launchMicrosoftGarbageCollectionWorkflow(
+  connectorId: ModelId
+): Promise<Result<string, Error>> {
+  const connector = await ConnectorResource.fetchById(connectorId);
+  if (!connector) {
+    return new Err(new Error(`Connector ${connectorId} not found`));
+  }
+  const client = await getTemporalClient();
+
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+
+  const workflowId = microsoftGarbageCollectionWorkflowId(connectorId);
+
+  try {
+    const handle: WorkflowHandle<typeof microsoftGarbageCollectionWorkflow> =
+      client.workflow.getHandle(workflowId);
+
+    // if the workflow is running, do nothing
+    try {
+      const description = await handle.describe();
+
+      if (description.status.name === "RUNNING") {
+        logger.info(
+          {
+            workspaceId: dataSourceConfig.workspaceId,
+            workflowId,
+          },
+          `Microsoft GC Workflow is already running, not relaunching.`
+        );
+        return new Ok(workflowId);
+      }
+    } catch (e) {
+      if (!(e instanceof WorkflowNotFoundError)) {
+        throw e;
+      }
+    }
+
+    await client.workflow.start(incrementalSyncWorkflow, {
+      args: [{ connectorId }],
+      taskQueue: QUEUE_NAME,
+      workflowId: workflowId,
+      searchAttributes: {
+        connectorId: [connectorId],
+      },
+      // every day
+      cronSchedule: "0 0 * * *",
       memo: {
         connectorId: connectorId,
       },

--- a/connectors/src/connectors/microsoft/temporal/client.ts
+++ b/connectors/src/connectors/microsoft/temporal/client.ts
@@ -4,7 +4,7 @@ import type { WorkflowHandle } from "@temporalio/client";
 import { WorkflowNotFoundError } from "@temporalio/common";
 
 import { QUEUE_NAME } from "@connectors/connectors/microsoft/temporal/config";
-import type { microsoftGarbageCollectionWorkflow } from "@connectors/connectors/microsoft/temporal/workflows";
+import { microsoftGarbageCollectionWorkflow } from "@connectors/connectors/microsoft/temporal/workflows";
 import {
   fullSyncWorkflow,
   incrementalSyncWorkflow,
@@ -152,7 +152,7 @@ export async function launchMicrosoftGarbageCollectionWorkflow(
       }
     }
 
-    await client.workflow.start(incrementalSyncWorkflow, {
+    await client.workflow.start(microsoftGarbageCollectionWorkflow, {
       args: [{ connectorId }],
       taskQueue: QUEUE_NAME,
       workflowId: workflowId,

--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -51,7 +51,7 @@ import {
 } from "@connectors/resources/microsoft_resource";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
-const PARENT_SYNC_CACHE_TTL_MS = 10 * 60 * 1000;
+const PARENT_SYNC_CACHE_TTL_MS = 30 * 60 * 1000;
 
 const pagePrefixesPerMimeType: Record<string, string> = {
   "application/pdf": "$pdfPage",
@@ -377,7 +377,7 @@ export async function getParents({
 }
 
 /* Fetching parent's parent id queries the db for a resource; since those
- * fetches can be made a lot of times during a sync, cache for 10mins in a
+ * fetches can be made a lot of times during a sync, cache for a while in a
  * per-sync basis (given by startSyncTs) */
 const getParentParentId = cacheWithRedis(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/connectors/src/connectors/microsoft/temporal/workflows.ts
+++ b/connectors/src/connectors/microsoft/temporal/workflows.ts
@@ -19,9 +19,10 @@ const {
   startToCloseTimeout: "30 minutes",
 });
 
-const { microsoftDeletionActivity, microsoftNodesGCActivity } = proxyActivities<
-  typeof activities
->({
+const {
+  microsoftDeletionActivity,
+  microsoftNodesGarbageCollectionActivity: microsoftNodesGCActivity,
+} = proxyActivities<typeof activities>({
   startToCloseTimeout: "15 minutes",
 });
 
@@ -138,7 +139,7 @@ export async function microsoftGarbageCollectionWorkflow({
 }: {
   connectorId: number;
 }) {
-  let idCursor = 0;
+  let idCursor: number | null = 0;
   while (idCursor !== null) {
     idCursor = await microsoftNodesGCActivity({ connectorId, idCursor });
     await sleep("1 minute");

--- a/connectors/src/connectors/microsoft/temporal/workflows.ts
+++ b/connectors/src/connectors/microsoft/temporal/workflows.ts
@@ -19,12 +19,10 @@ const {
   startToCloseTimeout: "30 minutes",
 });
 
-const {
-  microsoftDeletionActivity,
-  microsoftNodesGarbageCollectionActivity: microsoftNodesGCActivity,
-} = proxyActivities<typeof activities>({
-  startToCloseTimeout: "15 minutes",
-});
+const { microsoftDeletionActivity, microsoftNodesGarbageCollectionActivity } =
+  proxyActivities<typeof activities>({
+    startToCloseTimeout: "15 minutes",
+  });
 
 const { syncDeltaForRootNodesInDrive } = proxyActivities<typeof activities>({
   startToCloseTimeout: "120 minutes",
@@ -141,7 +139,10 @@ export async function microsoftGarbageCollectionWorkflow({
 }) {
   let idCursor: number | null = 0;
   while (idCursor !== null) {
-    idCursor = await microsoftNodesGCActivity({ connectorId, idCursor });
+    idCursor = await microsoftNodesGarbageCollectionActivity({
+      connectorId,
+      idCursor,
+    });
     await sleep("1 minute");
   }
 }

--- a/connectors/src/connectors/microsoft/temporal/workflows.ts
+++ b/connectors/src/connectors/microsoft/temporal/workflows.ts
@@ -19,7 +19,9 @@ const {
   startToCloseTimeout: "30 minutes",
 });
 
-const { microsoftDeletionActivity } = proxyActivities<typeof activities>({
+const { microsoftDeletionActivity, microsoftNodesGCActivity } = proxyActivities<
+  typeof activities
+>({
   startToCloseTimeout: "15 minutes",
 });
 
@@ -131,6 +133,18 @@ export async function microsoftDeletionWorkflow({
   await microsoftDeletionActivity({ connectorId, nodeIdsToDelete });
 }
 
+export async function microsoftGarbageCollectionWorkflow({
+  connectorId,
+}: {
+  connectorId: number;
+}) {
+  let idCursor = 0;
+  while (idCursor !== null) {
+    idCursor = await microsoftNodesGCActivity({ connectorId, idCursor });
+    await sleep("1 minute");
+  }
+}
+
 export function microsoftFullSyncWorkflowId(connectorId: ModelId) {
   return `microsoft-fullSync-${connectorId}`;
 }
@@ -141,6 +155,10 @@ export function microsoftFullSyncSitesWorkflowId(connectorId: ModelId) {
 
 export function microsoftIncrementalSyncWorkflowId(connectorId: ModelId) {
   return `microsoft-incrementalSync-${connectorId}`;
+}
+
+export function microsoftGarbageCollectionWorkflowId(connectorId: ModelId) {
+  return `microsoft-garbageCollection-${connectorId}`;
 }
 
 export function microsoftDeletionWorkflowId(

--- a/connectors/src/connectors/microsoft/temporal/workflows.ts
+++ b/connectors/src/connectors/microsoft/temporal/workflows.ts
@@ -19,7 +19,7 @@ const {
   startToCloseTimeout: "30 minutes",
 });
 
-const { microsoftDeletionActivity, microsoftNodesGarbageCollectionActivity } =
+const { microsoftDeletionActivity, microsoftGarbageCollectionActivity } =
   proxyActivities<typeof activities>({
     startToCloseTimeout: "15 minutes",
   });
@@ -137,11 +137,15 @@ export async function microsoftGarbageCollectionWorkflow({
 }: {
   connectorId: number;
 }) {
+  const rootNodeIds = await getRootNodesToSync(connectorId);
+  const startGarbageCollectionTs = new Date().getTime();
   let idCursor: number | null = 0;
   while (idCursor !== null) {
-    idCursor = await microsoftNodesGarbageCollectionActivity({
+    idCursor = await microsoftGarbageCollectionActivity({
       connectorId,
       idCursor,
+      rootNodeIds,
+      startGarbageCollectionTs,
     });
     await sleep("1 minute");
   }

--- a/connectors/src/resources/microsoft_resource.ts
+++ b/connectors/src/resources/microsoft_resource.ts
@@ -421,6 +421,29 @@ export class MicrosoftNodeResource extends BaseResource<MicrosoftNodeModel> {
     };
   }
 
+  static async fetchByPaginatedIds({
+    connectorId,
+    pageSize,
+    idCursor,
+  }: {
+    connectorId: ModelId;
+    pageSize: number;
+    idCursor: ModelId;
+  }): Promise<MicrosoftNodeResource[]> {
+    const blobs = await this.model.findAll({
+      where: {
+        connectorId,
+        id: {
+          [Op.gt]: idCursor,
+        },
+      },
+      limit: pageSize,
+      order: [["id", "ASC"]],
+    });
+
+    return blobs.map((blob) => new this(this.model, blob.get()));
+  }
+
   /** String representation of this node and its descendants in treeLike fashion */
   async treeString(level = 0): Promise<string> {
     const childrenStrings = await Promise.all(

--- a/connectors/src/resources/microsoft_resource.ts
+++ b/connectors/src/resources/microsoft_resource.ts
@@ -434,7 +434,7 @@ export class MicrosoftNodeResource extends BaseResource<MicrosoftNodeModel> {
       where: {
         connectorId,
         id: {
-          [Op.gt]: idCursor,
+          [Op.gte]: idCursor,
         },
       },
       limit: pageSize,


### PR DESCRIPTION
Description
---
Fixes #5751 and #6290

Runs a garbage collection workflow every day, going through all microsoft nodes for a connector and checking whether they should be deleted.

Uses a sleep to avoid deleting too fast and getting api rate limits, since the workflow is not critical.

Notably, handles the case of a partially synced drive: if user moves a folder from a synced part to a non-synced part, we don't get deletion / removal events in the changelist but we oughta delete it

Risks
---
na

Deploy
---
connectors
