### PR TITLE
[front] - refactor: remove partialChecked 

### DIFF
--- a/front/components/ConnectorPermissionsTree.tsx
+++ b/front/components/ConnectorPermissionsTree.tsx
@@ -14,11 +14,9 @@ import type {
   WorkspaceType,
 } from "@dust-tt/types";
 import type { ConnectorPermission } from "@dust-tt/types";
-import _ from "lodash";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 
 import ManagedDataSourceDocumentModal from "@app/components/ManagedDataSourceDocumentModal";
-import { useParentResourcesById } from "@app/hooks/useParentResourcesById";
 import { useConnectorPermissions } from "@app/lib/swr";
 import { classNames, timeAgoFrom } from "@app/lib/utils";
 
@@ -95,27 +93,6 @@ export function PermissionTreeChildren({
       parentId,
       filterPermission: permissionFilter || null,
     });
-
-  const { resources: selectedResources } = useConnectorPermissionsHook({
-    owner,
-    dataSource,
-    parentId: null,
-    filterPermission: "read",
-  });
-
-  const { parentsById } = useParentResourcesById({
-    owner,
-    dataSource,
-    selectedResources,
-  });
-
-  const parentsWithCheckedChildren = useMemo(() => {
-    return _.chain(parentsById)
-      .values()
-      .flatMap((set) => Array.from(set))
-      .uniq()
-      .value();
-  }, [parentsById]);
 
   const [localStateByInternalId, setLocalStateByInternalId] = useState<
     Record<string, boolean>
@@ -204,9 +181,6 @@ export function PermissionTreeChildren({
                 onPermissionUpdate
                   ? {
                       disabled: parentIsSelected,
-                      partialChecked:
-                        !isChecked &&
-                        parentsWithCheckedChildren.includes(r.internalId),
                       checked: isChecked,
                       onChange: (checked) => {
                         setLocalStateByInternalId((prev) => ({


### PR DESCRIPTION
## Description

This PR aims at removing the `partialChecked` in the `Tree.Item`.  This leads to very weird behaviour depending on the connectors at used.

## Risk

None

## Deploy Plan

Deploy `front`