### PR TITLE
[front] - fix: folder icon

### DIFF
--- a/front/pages/w/[wId]/builder/data-sources/static.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/static.tsx
@@ -1,6 +1,5 @@
 import {
   ContextItem,
-  DocumentPileIcon,
   FolderOpenIcon,
   Icon,
   Page,
@@ -104,7 +103,7 @@ export default function DataSourcesView({
       <Page.Vertical gap="xl" align="stretch">
         <Page.Header
           title="Folders"
-          icon={DocumentPileIcon}
+          icon={FolderOpenIcon}
           description="Make more documents accessible to this workspace. Manage folders manually or via API."
         />
 


### PR DESCRIPTION
## Description

This PR changes the icon from DocumentPileIcon to FolderOpenIcon to better represent the Folders section

**References:**
- https://github.com/dust-tt/tasks/issues/1094

## Risk

None

## Deploy Plan

Deploy `front`