### PR TITLE
[front] - fix(assistant): assistant drawer

### DIFF
--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -242,7 +242,7 @@ export function AssistantDetails({
   }: {
     actions: AgentConfigurationType["actions"];
   }) => {
-    const [retrievalAction, otherActions] = useMemo(() => {
+    const [retrievalActions, otherActions] = useMemo(() => {
       return actions.reduce(
         ([dataSources, otherActions], a) => {
           if (isRetrievalConfiguration(a)) {
@@ -262,12 +262,12 @@ export function AssistantDetails({
     return (
       !!actions.length && (
         <>
-          {retrievalAction.length > 0 && (
+          {retrievalActions.length && (
             <div>
               <div className="pb-2 text-lg font-bold text-element-800">
                 Data sources
               </div>
-              {retrievalAction.map((a, index) => (
+              {retrievalActions.map((a, index) => (
                 <div className="flex flex-col gap-2" key={`action-${index}`}>
                   <DataSourcesSection
                     owner={owner}

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -15,6 +15,7 @@ import {
   Tree,
 } from "@dust-tt/sparkle";
 import type {
+  AgentActionConfigurationType,
   AgentConfigurationScope,
   AgentConfigurationType,
   ContentNode,
@@ -22,6 +23,7 @@ import type {
   DataSourceConfiguration,
   DataSourceType,
   DustAppRunConfigurationType,
+  RetrievalConfigurationType,
   TablesQueryConfigurationType,
   WorkspaceType,
 } from "@dust-tt/types";
@@ -239,76 +241,96 @@ export function AssistantDetails({
     actions,
   }: {
     actions: AgentConfigurationType["actions"];
-  }) =>
-    !!actions.length && (
-      <>
-        {actions.map((action, index) =>
-          isDustAppRunConfiguration(action) ? (
-            <div className="flex flex-col gap-2" key={`action-${index}`}>
-              <div className="text-lg font-bold text-element-800">Action</div>
-              <DustAppSection dustApp={action} owner={owner} />
-            </div>
-          ) : isRetrievalConfiguration(action) ? (
-            <div className="flex flex-col gap-2" key={`action-${index}`}>
-              <div className="text-lg font-bold text-element-800">
-                Data sources
-              </div>
-              <DataSourcesSection
-                owner={owner}
-                dataSources={dataSources}
-                dataSourceConfigurations={action.dataSources}
-              />
-            </div>
-          ) : isTablesQueryConfiguration(action) ? (
-            <div className="flex flex-col gap-2" key={`action-${index}`}>
-              <div className="text-lg font-bold text-element-800">Tables</div>
-              <TablesQuerySection tablesQueryConfig={action} />
-            </div>
-          ) : isProcessConfiguration(action) ? (
-            <div className="flex flex-col gap-2" key={`action-${index}`}>
-              <div className="text-lg font-bold text-element-800">
-                Extract from data sources
-              </div>
-              <DataSourcesSection
-                owner={owner}
-                dataSources={dataSources}
-                dataSourceConfigurations={action.dataSources}
-              />
-            </div>
-          ) : isWebsearchConfiguration(action) ? (
-            <div className="flex flex-col gap-2" key={`action-${index}`}>
-              <div className="text-lg font-bold text-element-800">
-                Web navigation
-              </div>
-              <div className="flex items-center gap-2">
-                <Icon visual={PlanetIcon} size="xs" />
-                <div>
-                  Assistant can navigate the web (browse any provided links,
-                  make a google search, etc.) to answer
-                </div>
-              </div>
-            </div>
-          ) : isBrowseConfiguration(action) ? (
-            false
-          ) : isVisualizationConfiguration(action) ? (
-            <div className="flex flex-col gap-2" key={`action-${index}`}>
-              <div className="text-lg font-bold text-element-800">
-                Visualization
-              </div>
-              <div className="flex items-center gap-2">
-                <Icon visual={ShapesIcon} size="xs" />
-                <div>
-                  Assistant can generate graphs to visually represent your data.
-                </div>
-              </div>
-            </div>
-          ) : (
-            assertNever(action)
-          )
-        )}
-      </>
+  }) => {
+    const [retrievalAction, otherActions] = actions.reduce(
+      ([dataSources, otherActions], a) => {
+        if (isRetrievalConfiguration(a)) {
+          dataSources.push(a);
+        } else {
+          otherActions.push(a);
+        }
+        return [dataSources, otherActions];
+      },
+      [[] as RetrievalConfigurationType[], [] as AgentActionConfigurationType[]]
     );
 
+    return (
+      !!actions.length && (
+        <>
+          {retrievalAction.length > 0 && (
+            <div>
+              <div className="pb-2 text-lg font-bold text-element-800">
+                Data sources
+              </div>
+              {retrievalAction.map((a, index) => (
+                <div className="flex flex-col gap-2" key={`action-${index}`}>
+                  <DataSourcesSection
+                    owner={owner}
+                    dataSources={dataSources}
+                    dataSourceConfigurations={a.dataSources}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+          {otherActions.map((action, index) =>
+            isDustAppRunConfiguration(action) ? (
+              <div className="flex flex-col gap-2" key={`action-${index}`}>
+                <div className="text-lg font-bold text-element-800">Action</div>
+                <DustAppSection dustApp={action} owner={owner} />
+              </div>
+            ) : isTablesQueryConfiguration(action) ? (
+              <div className="flex flex-col gap-2" key={`action-${index}`}>
+                <div className="text-lg font-bold text-element-800">Tables</div>
+                <TablesQuerySection tablesQueryConfig={action} />
+              </div>
+            ) : isProcessConfiguration(action) ? (
+              <div className="flex flex-col gap-2" key={`action-${index}`}>
+                <div className="text-lg font-bold text-element-800">
+                  Extract from data sources
+                </div>
+                <DataSourcesSection
+                  owner={owner}
+                  dataSources={dataSources}
+                  dataSourceConfigurations={action.dataSources}
+                />
+              </div>
+            ) : isWebsearchConfiguration(action) ? (
+              <div className="flex flex-col gap-2" key={`action-${index}`}>
+                <div className="text-lg font-bold text-element-800">
+                  Web navigation
+                </div>
+                <div className="flex items-center gap-2">
+                  <Icon visual={PlanetIcon} size="xs" />
+                  <div>
+                    Assistant can navigate the web (browse any provided links,
+                    make a google search, etc.) to answer
+                  </div>
+                </div>
+              </div>
+            ) : isBrowseConfiguration(action) ? (
+              false
+            ) : isVisualizationConfiguration(action) ? (
+              <div className="flex flex-col gap-2" key={`action-${index}`}>
+                <div className="text-lg font-bold text-element-800">
+                  Visualization
+                </div>
+                <div className="flex items-center gap-2">
+                  <Icon visual={ShapesIcon} size="xs" />
+                  <div>
+                    Assistant can generate graphs to visually represent your
+                    data.
+                  </div>
+                </div>
+              </div>
+            ) : (
+              assertNever(action)
+            )
+          )}
+        </>
+      )
+    );
+  };
   return (
     <ElementModal
       openOnElement={agentConfiguration}

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -37,7 +37,7 @@ import {
   isVisualizationConfiguration,
   isWebsearchConfiguration,
 } from "@dust-tt/types";
-import { useCallback, useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import type { KeyedMutator } from "swr";
 
 import { AssistantDetailsDropdownMenu } from "@app/components/assistant/AssistantDetailsDropdownMenu";
@@ -242,17 +242,22 @@ export function AssistantDetails({
   }: {
     actions: AgentConfigurationType["actions"];
   }) => {
-    const [retrievalAction, otherActions] = actions.reduce(
-      ([dataSources, otherActions], a) => {
-        if (isRetrievalConfiguration(a)) {
-          dataSources.push(a);
-        } else {
-          otherActions.push(a);
-        }
-        return [dataSources, otherActions];
-      },
-      [[] as RetrievalConfigurationType[], [] as AgentActionConfigurationType[]]
-    );
+    const [retrievalAction, otherActions] = useMemo(() => {
+      return actions.reduce(
+        ([dataSources, otherActions], a) => {
+          if (isRetrievalConfiguration(a)) {
+            dataSources.push(a);
+          } else {
+            otherActions.push(a);
+          }
+          return [dataSources, otherActions];
+        },
+        [
+          [] as RetrievalConfigurationType[],
+          [] as AgentActionConfigurationType[],
+        ]
+      );
+    }, [actions]);
 
     return (
       !!actions.length && (

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -262,7 +262,7 @@ export function AssistantDetails({
     return (
       !!actions.length && (
         <>
-          {retrievalActions.length && (
+          {!!retrievalActions.length && (
             <div>
               <div className="pb-2 text-lg font-bold text-element-800">
                 Data sources

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -329,7 +329,7 @@ export function AssistantDetails({
                 </div>
               </div>
             ) : (
-              assertNever(action)
+              !isRetrievalConfiguration(action) && assertNever(action)
             )
           )}
         </>


### PR DESCRIPTION
## Description

This PR aims at fixing the Assistant Details drawer to only display the "Data Sources" header once.

New behaviour:

<img width="1000" alt="Screenshot 2024-07-26 at 16 38 53" src="https://github.com/user-attachments/assets/a37539a9-3981-4647-9694-79154451ddbf">

Old behaviour (multiple times "Data Sources"

<img width="1000" alt="Screenshot 2024-07-26 at 16 39 48" src="https://github.com/user-attachments/assets/19816d00-d5b0-4ca1-8339-4d4627bb509e">


**References:**
- https://github.com/dust-tt/tasks/issues/1093

## Risk

Breaking UX

## Deploy Plan

Deploy `front`
