### PR TITLE
core: remove optional timestamp (db) and optiona tags, parents (api)

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1926,8 +1926,8 @@ struct DatabasesTablesUpsertPayload {
     name: String,
     description: String,
     timestamp: Option<u64>,
-    tags: Option<Vec<String>>,
-    parents: Option<Vec<String>>,
+    tags: Vec<String>,
+    parents: Vec<String>,
 }
 
 async fn tables_upsert(
@@ -1949,14 +1949,8 @@ async fn tables_upsert(
                 Some(timestamp) => timestamp,
                 None => utils::now(),
             },
-            &match payload.tags {
-                Some(tags) => tags,
-                None => vec![],
-            },
-            &match payload.parents {
-                Some(parents) => parents,
-                None => vec![],
-            },
+            &payload.tags,
+            &payload.parents,
         )
         .await
     {

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -2435,7 +2435,7 @@ impl Store for PostgresStore {
             String,
             String,
             String,
-            Option<i64>,
+            i64,
             Vec<String>,
             Vec<String>,
             Option<String>,
@@ -2486,10 +2486,7 @@ impl Store for PostgresStore {
                     &table_id,
                     &name,
                     &description,
-                    match timestamp {
-                        None => created as u64,
-                        Some(t) => t as u64,
-                    },
+                    timestamp as u64,
                     tags,
                     parents,
                     &parsed_schema,
@@ -2559,7 +2556,7 @@ impl Store for PostgresStore {
                 let table_id: String = r.get(1);
                 let name: String = r.get(2);
                 let description: String = r.get(3);
-                let timestamp: Option<i64> = r.get(4);
+                let timestamp: i64 = r.get(4);
                 let tags: Vec<String> = r.get(5);
                 let parents: Vec<String> = r.get(6);
                 let schema: Option<String> = r.get(7);
@@ -2583,10 +2580,7 @@ impl Store for PostgresStore {
                     &table_id,
                     &name,
                     &description,
-                    match timestamp {
-                        None => created as u64,
-                        Some(t) => t as u64,
-                    },
+                    timestamp as u64,
                     tags,
                     parents,
                     &parsed_schema,


### PR DESCRIPTION
## Description

Clean-up of code that allowed the deploy of `core` before `front` in https://github.com/dust-tt/dust/pull/6539

## Risk

N/A

## Deploy Plan

- deploy `front`