### PR TITLE
Augment SSR wrapper to check for user existence

### DIFF
--- a/front/lib/iam/session.ts
+++ b/front/lib/iam/session.ts
@@ -205,6 +205,10 @@ export function makeGetServerSidePropsRequirementsWrapper<
           return {
             notFound: true,
           };
+        } else if (requireUserPrivilege === "user" && !auth?.isUser()) {
+          return {
+            notFound: true,
+          };
         }
 
         // Validate the user's session to guarantee compliance with the workspace's SSO requirements when SSO is enforced.

--- a/front/lib/iam/session.ts
+++ b/front/lib/iam/session.ts
@@ -84,6 +84,7 @@ interface MakeGetServerSidePropsRequirementsWrapperOptions<
   enableLogging?: boolean;
   requireUserPrivilege: R;
   requireCanUseProduct?: boolean;
+  requireUserInCurrentWorkspace?: boolean;
 }
 
 export type CustomGetServerSideProps<
@@ -145,6 +146,7 @@ export function makeGetServerSidePropsRequirementsWrapper<
   enableLogging = true,
   requireUserPrivilege,
   requireCanUseProduct = false,
+  requireUserInCurrentWorkspace = true,
 }: MakeGetServerSidePropsRequirementsWrapperOptions<RequireUserPrivilege>) {
   return <T extends { [key: string]: any } = { [key: string]: any }>(
     getServerSideProps: CustomGetServerSideProps<
@@ -205,7 +207,9 @@ export function makeGetServerSidePropsRequirementsWrapper<
           return {
             notFound: true,
           };
-        } else if (requireUserPrivilege === "user" && !auth?.isUser()) {
+        }
+
+        if (requireUserInCurrentWorkspace && !auth?.isUser()) {
           return {
             notFound: true,
           };
@@ -257,6 +261,15 @@ export const withDefaultUserAuthRequirements =
   makeGetServerSidePropsRequirementsWrapper({
     requireUserPrivilege: "user",
     requireCanUseProduct: true,
+  });
+
+export const withDefaultUserAuthRequirementsNoWorkspaceCheck =
+  makeGetServerSidePropsRequirementsWrapper({
+    requireUserPrivilege: "user",
+    requireCanUseProduct: true,
+    // This is a special case where we don't want to check
+    // if the user is in the current workspace.
+    requireUserInCurrentWorkspace: false,
   });
 
 export const withSuperUserAuthRequirements =

--- a/front/lib/iam/session.ts
+++ b/front/lib/iam/session.ts
@@ -209,7 +209,12 @@ export function makeGetServerSidePropsRequirementsWrapper<
           };
         }
 
-        if (!allowUserOutsideCurrentWorkspace && !auth?.isUser()) {
+        // If we target a workspace and the user is not in the workspace, return not found.
+        if (
+          !allowUserOutsideCurrentWorkspace &&
+          auth?.workspace() &&
+          !auth?.isUser()
+        ) {
           return {
             notFound: true,
           };

--- a/front/lib/iam/session.ts
+++ b/front/lib/iam/session.ts
@@ -263,6 +263,10 @@ export const withDefaultUserAuthRequirements =
     requireCanUseProduct: true,
   });
 
+/**
+ * This should only be used for pages that don't require
+ * the current user to be in the current workspace.
+ */
 export const withDefaultUserAuthRequirementsNoWorkspaceCheck =
   makeGetServerSidePropsRequirementsWrapper({
     requireUserPrivilege: "user",

--- a/front/lib/iam/session.ts
+++ b/front/lib/iam/session.ts
@@ -84,7 +84,7 @@ interface MakeGetServerSidePropsRequirementsWrapperOptions<
   enableLogging?: boolean;
   requireUserPrivilege: R;
   requireCanUseProduct?: boolean;
-  requireUserInCurrentWorkspace?: boolean;
+  allowUserOutsideCurrentWorkspace?: boolean;
 }
 
 export type CustomGetServerSideProps<
@@ -146,7 +146,7 @@ export function makeGetServerSidePropsRequirementsWrapper<
   enableLogging = true,
   requireUserPrivilege,
   requireCanUseProduct = false,
-  requireUserInCurrentWorkspace = true,
+  allowUserOutsideCurrentWorkspace,
 }: MakeGetServerSidePropsRequirementsWrapperOptions<RequireUserPrivilege>) {
   return <T extends { [key: string]: any } = { [key: string]: any }>(
     getServerSideProps: CustomGetServerSideProps<
@@ -209,7 +209,7 @@ export function makeGetServerSidePropsRequirementsWrapper<
           };
         }
 
-        if (requireUserInCurrentWorkspace && !auth?.isUser()) {
+        if (!allowUserOutsideCurrentWorkspace && !auth?.isUser()) {
           return {
             notFound: true,
           };
@@ -255,12 +255,14 @@ export const withDefaultUserAuthPaywallWhitelisted =
   makeGetServerSidePropsRequirementsWrapper({
     requireUserPrivilege: "user",
     requireCanUseProduct: false,
+    allowUserOutsideCurrentWorkspace: false,
   });
 
 export const withDefaultUserAuthRequirements =
   makeGetServerSidePropsRequirementsWrapper({
     requireUserPrivilege: "user",
     requireCanUseProduct: true,
+    allowUserOutsideCurrentWorkspace: false,
   });
 
 /**
@@ -273,11 +275,12 @@ export const withDefaultUserAuthRequirementsNoWorkspaceCheck =
     requireCanUseProduct: true,
     // This is a special case where we don't want to check
     // if the user is in the current workspace.
-    requireUserInCurrentWorkspace: false,
+    allowUserOutsideCurrentWorkspace: true,
   });
 
 export const withSuperUserAuthRequirements =
   makeGetServerSidePropsRequirementsWrapper({
     requireUserPrivilege: "superuser",
     requireCanUseProduct: false,
+    allowUserOutsideCurrentWorkspace: false,
   });


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR augments the SSR wrapper to check for user existence in the `Authenticator` object when the required privilege is "user".  This means the user is a valid user within the workspace. The goal here is to avoid to explicitly check that the user belongs to the current workspace in each `getServerSideProps` implementation.

The sole exception to this logic is for dust apps since we allow other connected users to access other workspace's dust apps to clone then. To serve this purpose, this PR introduces a `withDefaultUserAuthRequirementsNoWorkspaceCheck` to represent this logic.

## Test

- [x] Pages aren't accessible if you don't belong to the workspace
- [x] Access and clone a public dust app
- [x] Users without workspace can still create a workspace

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Those changes are pretty safe as all the pages that uses it are behind `/w/[wId]`. Safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
