### PR TITLE
[front] feature(vault): Add vault resource

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -26,6 +26,7 @@ import { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_tr
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { generateLegacyModelSId } from "@app/lib/resources/string_ids";
 import { UserResource } from "@app/lib/resources/user_resource";
+import { VaultResource } from "@app/lib/resources/vault_resource";
 import logger from "@app/logger/logger";
 import {
   launchRetrieveTranscriptsWorkflow,
@@ -44,7 +45,7 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
         sId: generateLegacyModelSId(),
         name: args.name,
       });
-      await Promise.all([
+      const groups = await Promise.all([
         GroupResource.makeNew({
           name: "System",
           type: "system",
@@ -54,6 +55,20 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
           name: "Workspace",
           type: "global",
           workspaceId: w.id,
+        }),
+      ]);
+      await Promise.all([
+        VaultResource.makeNew({
+          name: "System",
+          kind: "system",
+          workspaceId: w.id,
+          groupId: groups[0].id,
+        }),
+        VaultResource.makeNew({
+          name: "Workspace",
+          kind: "global",
+          workspaceId: w.id,
+          groupId: groups[1].id,
         }),
       ]);
 

--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -50,12 +50,9 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
       const lightWorkspace = renderLightWorkspaceType({ workspace: w });
 
       const { systemGroup, globalGroup } =
-        await GroupResource.makeDefaultsForWorkspace({
-          workspace: lightWorkspace,
-        });
+        await GroupResource.makeDefaultsForWorkspace(lightWorkspace);
 
-      await VaultResource.makeDefaultsForWorkspace({
-        workspace: renderLightWorkspaceType({ workspace: lightWorkspace }),
+      await VaultResource.makeDefaultsForWorkspace(lightWorkspace, {
         systemGroup,
         globalGroup,
       });

--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -57,20 +57,12 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
           workspaceId: w.id,
         }),
       ]);
-      await Promise.all([
-        VaultResource.makeNew({
-          name: "System",
-          kind: "system",
-          workspaceId: w.id,
-          groupId: groups[0].id,
-        }),
-        VaultResource.makeNew({
-          name: "Workspace",
-          kind: "global",
-          workspaceId: w.id,
-          groupId: groups[1].id,
-        }),
-      ]);
+
+      await VaultResource.makeDefaultForWorkspace(
+        w.id,
+        groups[0].id,
+        groups[1].id
+      );
 
       args.wId = w.sId;
       await workspace("show", args);

--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -79,6 +79,7 @@ import {
   RunUsageModel,
 } from "@app/lib/resources/storage/models/runs";
 import { TemplateModel } from "@app/lib/resources/storage/models/templates";
+import { VaultModel } from "@app/lib/resources/storage/models/vaults";
 import logger from "@app/logger/logger";
 
 async function main() {
@@ -102,6 +103,7 @@ async function main() {
   await KeyModel.sync({ alter: true });
   await FileModel.sync({ alter: true });
   await DustAppSecret.sync({ alter: true });
+  await VaultModel.sync({ alter: true });
   await DataSource.sync({ alter: true });
   await RunModel.sync({ alter: true });
   await RunUsageModel.sync({ alter: true });

--- a/front/lib/iam/workspaces.ts
+++ b/front/lib/iam/workspaces.ts
@@ -4,6 +4,7 @@ import type { SessionWithUser } from "@app/lib/iam/provider";
 import { Workspace, WorkspaceHasDomain } from "@app/lib/models/workspace";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { generateLegacyModelSId } from "@app/lib/resources/string_ids";
+import { VaultResource } from "@app/lib/resources/vault_resource";
 import { isDisposableEmailDomain } from "@app/lib/utils/disposable_email_domains";
 import logger from "@app/logger/logger";
 
@@ -23,7 +24,7 @@ export async function createWorkspace(session: SessionWithUser) {
     name: externalUser.nickname,
   });
 
-  await Promise.all([
+  const groups = await Promise.all([
     GroupResource.makeNew({
       name: "System",
       type: "system",
@@ -33,6 +34,20 @@ export async function createWorkspace(session: SessionWithUser) {
       name: "Workspace",
       type: "global",
       workspaceId: workspace.id,
+    }),
+  ]);
+  await Promise.all([
+    VaultResource.makeNew({
+      name: "System",
+      kind: "system",
+      workspaceId: workspace.id,
+      groupId: groups[0].id,
+    }),
+    VaultResource.makeNew({
+      name: "Workspace",
+      kind: "global",
+      workspaceId: workspace.id,
+      groupId: groups[1].id,
     }),
   ]);
 

--- a/front/lib/iam/workspaces.ts
+++ b/front/lib/iam/workspaces.ts
@@ -36,20 +36,11 @@ export async function createWorkspace(session: SessionWithUser) {
       workspaceId: workspace.id,
     }),
   ]);
-  await Promise.all([
-    VaultResource.makeNew({
-      name: "System",
-      kind: "system",
-      workspaceId: workspace.id,
-      groupId: groups[0].id,
-    }),
-    VaultResource.makeNew({
-      name: "Workspace",
-      kind: "global",
-      workspaceId: workspace.id,
-      groupId: groups[1].id,
-    }),
-  ]);
+  await VaultResource.makeDefaultForWorkspace(
+    workspace.id,
+    groups[0].id,
+    groups[1].id
+  );
 
   sendUserOperationMessage({
     message: `<@U055XEGPR4L> +signupRadar User ${externalUser.email} has created a new workspace.`,

--- a/front/lib/iam/workspaces.ts
+++ b/front/lib/iam/workspaces.ts
@@ -25,15 +25,12 @@ export async function createWorkspace(session: SessionWithUser) {
     name: externalUser.nickname,
   });
 
-  const lightWorkspace = renderLightWorkspaceType({ workspace: w });
+  const lightWorkspace = renderLightWorkspaceType({ workspace });
 
   const { systemGroup, globalGroup } =
-    await GroupResource.makeDefaultsForWorkspace({
-      workspace: lightWorkspace,
-    });
+    await GroupResource.makeDefaultsForWorkspace(lightWorkspace);
 
-  await VaultResource.makeDefaultsForWorkspace({
-    workspace: lightWorkspace,
+  await VaultResource.makeDefaultsForWorkspace(lightWorkspace, {
     systemGroup,
     globalGroup,
   });

--- a/front/lib/models/data_source.ts
+++ b/front/lib/models/data_source.ts
@@ -11,6 +11,7 @@ import { DataTypes, Model } from "sequelize";
 import { User } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { VaultModel } from "@app/lib/resources/storage/models/vaults";
 
 export class DataSource extends Model<
   InferAttributes<DataSource>,
@@ -31,6 +32,7 @@ export class DataSource extends Model<
   declare connectorId: string | null;
   declare connectorProvider: ConnectorProvider | null;
   declare workspaceId: ForeignKey<Workspace["id"]>;
+  declare vaultId: ForeignKey<VaultModel["id"]>;
 
   declare workspace: NonAttribute<Workspace>;
   declare editedByUser: NonAttribute<User>;
@@ -88,6 +90,7 @@ DataSource.init(
     indexes: [
       { fields: ["workspaceId", "name"], unique: true },
       { fields: ["workspaceId", "connectorProvider"] },
+      { fields: ["workspaceId", "vaultId"] },
     ],
   }
 );
@@ -105,4 +108,10 @@ DataSource.belongsTo(User, {
   as: "editedByUser",
   // TODO(2024-01-25 flav) Set `allowNull` to `false` once backfilled.
   foreignKey: { name: "editedByUserId", allowNull: true },
+});
+
+DataSource.belongsTo(VaultModel, {
+  // TODO(2024-07-27 thomas) Set `allowNull` to `false` once backfilled.
+  foreignKey: { name: "vaultId", allowNull: true },
+  onDelete: "RESTRICT",
 });

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -42,11 +42,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     return new this(GroupModel, group.get());
   }
 
-  static async makeDefaultsForWorkspace({
-    workspace,
-  }: {
-    workspace: LightWorkspaceType;
-  }) {
+  static async makeDefaultsForWorkspace(workspace: LightWorkspaceType) {
     const existingGroups = await GroupModel.findAll({
       where: {
         workspaceId: workspace.id,

--- a/front/lib/resources/storage/models/vaults.ts
+++ b/front/lib/resources/storage/models/vaults.ts
@@ -1,0 +1,68 @@
+import type {
+  CreationOptional,
+  ForeignKey,
+  InferAttributes,
+  InferCreationAttributes,
+} from "sequelize";
+import { DataTypes, Model } from "sequelize";
+
+import { Workspace } from "@app/lib/models/workspace";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { GroupModel } from "@app/lib/resources/storage/models/groups";
+
+export class VaultModel extends Model<
+  InferAttributes<VaultModel>,
+  InferCreationAttributes<VaultModel>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+
+  declare name: string;
+  declare kind: string;
+
+  declare groupId: ForeignKey<GroupModel["id"]>;
+  declare workspaceId: ForeignKey<Workspace["id"]>;
+}
+VaultModel.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    kind: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  },
+  {
+    modelName: "vaults",
+    sequelize: frontSequelize,
+    indexes: [
+      { unique: true, fields: ["workspaceId", "name"] },
+      { unique: false, fields: ["workspaceId", "kind"] },
+    ],
+  }
+);
+
+Workspace.hasMany(VaultModel, {
+  foreignKey: { allowNull: false },
+  onDelete: "RESTRICT",
+});
+VaultModel.belongsTo(Workspace, {
+  foreignKey: { allowNull: false },
+  onDelete: "RESTRICT",
+});
+VaultModel.belongsTo(GroupModel, {
+  foreignKey: { allowNull: false },
+  onDelete: "RESTRICT",
+});

--- a/front/lib/resources/storage/models/vaults.ts
+++ b/front/lib/resources/storage/models/vaults.ts
@@ -1,3 +1,4 @@
+import type { VaultKind } from "@dust-tt/types";
 import type {
   CreationOptional,
   ForeignKey,
@@ -16,9 +17,10 @@ export class VaultModel extends Model<
 > {
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
 
   declare name: string;
-  declare kind: string;
+  declare kind: VaultKind;
 
   declare groupId: ForeignKey<GroupModel["id"]>;
   declare workspaceId: ForeignKey<Workspace["id"]>;
@@ -35,6 +37,11 @@ VaultModel.init(
       allowNull: false,
       defaultValue: DataTypes.NOW,
     },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
     name: {
       type: DataTypes.STRING,
       allowNull: false,
@@ -47,10 +54,7 @@ VaultModel.init(
   {
     modelName: "vaults",
     sequelize: frontSequelize,
-    indexes: [
-      { unique: true, fields: ["workspaceId", "name"] },
-      { unique: false, fields: ["workspaceId", "kind"] },
-    ],
+    indexes: [{ unique: false, fields: ["workspaceId", "kind"] }],
   }
 );
 

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -21,6 +21,7 @@ const REGION = 1; // US.
 const RESOURCES_PREFIX = {
   file: "fil",
   group: "grp",
+  vault: "vlt",
 };
 
 const ALL_RESOURCES_PREFIXES = Object.values(RESOURCES_PREFIX);

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -38,15 +38,16 @@ export class VaultResource extends BaseResource<VaultModel> {
     return new this(VaultModel, vault.get());
   }
 
-  static async makeDefaultsForWorkspace({
-    workspace,
-    systemGroup,
-    globalGroup,
-  }: {
-    workspace: LightWorkspaceType;
-    systemGroup: GroupType;
-    globalGroup: GroupType;
-  }) {
+  static async makeDefaultsForWorkspace(
+    workspace: LightWorkspaceType,
+    {
+      systemGroup,
+      globalGroup,
+    }: {
+      systemGroup: GroupType;
+      globalGroup: GroupType;
+    }
+  ) {
     const existingVaults = await VaultModel.findAll({
       where: {
         workspaceId: workspace.id,

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -1,4 +1,9 @@
-import type { ACLType, ModelId, Result } from "@dust-tt/types";
+import type {
+  ACLType,
+  LightWorkspaceType,
+  ModelId,
+  Result,
+} from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 import type {
   Attributes,
@@ -9,8 +14,6 @@ import type {
 
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
-import type { GroupResource } from "@app/lib/resources/group_resource";
-import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import { VaultModel } from "@app/lib/resources/storage/models/vaults";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
@@ -89,7 +92,7 @@ export class VaultResource extends BaseResource<VaultModel> {
     return new this(VaultModel, group.get());
   }
 
-  static async fetchWorkspaceDefaultVault(
+  static async fetchWorkspaceGlobalVault(
     auth: Authenticator,
     transaction?: Transaction
   ): Promise<VaultResource> {
@@ -172,6 +175,18 @@ export class VaultResource extends BaseResource<VaultModel> {
     } catch (err) {
       return new Err(err as Error);
     }
+  }
+
+  static async deleteAllForWorkspace(
+    workspace: LightWorkspaceType,
+    transaction?: Transaction
+  ) {
+    await this.model.destroy({
+      where: {
+        workspaceId: workspace.id,
+      },
+      transaction,
+    });
   }
 
   acl(): ACLType {

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -89,8 +89,7 @@ export class VaultResource extends BaseResource<VaultModel> {
   }
 
   static async listWorkspaceVaults(
-    auth: Authenticator,
-    transaction?: Transaction
+    auth: Authenticator
   ): Promise<VaultResource[]> {
     const owner = auth.getNonNullableWorkspace();
 
@@ -98,15 +97,13 @@ export class VaultResource extends BaseResource<VaultModel> {
       where: {
         workspaceId: owner.id,
       },
-      transaction,
     });
 
     return vaults.map((vault) => new this(VaultModel, vault.get()));
   }
 
   static async fetchWorkspaceSystemVault(
-    auth: Authenticator,
-    transaction?: Transaction
+    auth: Authenticator
   ): Promise<VaultResource> {
     const owner = auth.getNonNullableWorkspace();
     const vault = await this.model.findOne({
@@ -114,7 +111,6 @@ export class VaultResource extends BaseResource<VaultModel> {
         workspaceId: owner.id,
         kind: "system",
       },
-      transaction,
     });
 
     if (!vault) {
@@ -125,8 +121,7 @@ export class VaultResource extends BaseResource<VaultModel> {
   }
 
   static async fetchWorkspaceGlobalVault(
-    auth: Authenticator,
-    transaction?: Transaction
+    auth: Authenticator
   ): Promise<VaultResource> {
     const owner = auth.getNonNullableWorkspace();
     const vault = await this.model.findOne({
@@ -134,7 +129,6 @@ export class VaultResource extends BaseResource<VaultModel> {
         workspaceId: owner.id,
         kind: "global",
       },
-      transaction,
     });
 
     if (!vault) {

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -189,12 +189,13 @@ export class VaultResource extends BaseResource<VaultModel> {
   }
 
   static async deleteAllForWorkspace(
-    workspace: LightWorkspaceType,
+    auth: Authenticator,
     transaction?: Transaction
   ) {
+    const owner = auth.getNonNullableWorkspace();
     await this.model.destroy({
       where: {
-        workspaceId: workspace.id,
+        workspaceId: owner.id,
       },
       transaction,
     });

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -4,7 +4,6 @@ import type {
   LightWorkspaceType,
   ModelId,
   Result,
-  WorkspaceType,
 } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 import type {

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -31,9 +31,9 @@ export class VaultResource extends BaseResource<VaultModel> {
   }
 
   static async makeNew(blob: CreationAttributes<VaultModel>) {
-    const group = await VaultModel.create(blob);
+    const vault = await VaultModel.create(blob);
 
-    return new this(VaultModel, group.get());
+    return new this(VaultModel, vault.get());
   }
 
   get sId(): string {
@@ -50,7 +50,7 @@ export class VaultResource extends BaseResource<VaultModel> {
     id: ModelId;
     workspaceId: ModelId;
   }): string {
-    return makeSId("group", {
+    return makeSId("vault", {
       id,
       workspaceId,
     });
@@ -69,7 +69,7 @@ export class VaultResource extends BaseResource<VaultModel> {
       transaction,
     });
 
-    return vaults.map((group) => new this(VaultModel, group.get()));
+    return vaults.map((vault) => new this(VaultModel, vault.get()));
   }
 
   static async fetchWorkspaceSystemVault(
@@ -77,7 +77,7 @@ export class VaultResource extends BaseResource<VaultModel> {
     transaction?: Transaction
   ): Promise<VaultResource> {
     const owner = auth.getNonNullableWorkspace();
-    const group = await this.model.findOne({
+    const vault = await this.model.findOne({
       where: {
         workspaceId: owner.id,
         kind: "system",
@@ -85,11 +85,11 @@ export class VaultResource extends BaseResource<VaultModel> {
       transaction,
     });
 
-    if (!group) {
-      throw new Error("System group not found.");
+    if (!vault) {
+      throw new Error("System vault not found.");
     }
 
-    return new this(VaultModel, group.get());
+    return new this(VaultModel, vault.get());
   }
 
   static async fetchWorkspaceGlobalVault(
@@ -97,7 +97,7 @@ export class VaultResource extends BaseResource<VaultModel> {
     transaction?: Transaction
   ): Promise<VaultResource> {
     const owner = auth.getNonNullableWorkspace();
-    const group = await this.model.findOne({
+    const vault = await this.model.findOne({
       where: {
         workspaceId: owner.id,
         kind: "global",
@@ -105,11 +105,11 @@ export class VaultResource extends BaseResource<VaultModel> {
       transaction,
     });
 
-    if (!group) {
-      throw new Error("Global group not found.");
+    if (!vault) {
+      throw new Error("Global vault not found.");
     }
 
-    return new this(VaultModel, group.get());
+    return new this(VaultModel, vault.get());
   }
 
   static async fetchById(

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -1,0 +1,187 @@
+import type { ACLType, ModelId, Result } from "@dust-tt/types";
+import { Err, Ok } from "@dust-tt/types";
+import type {
+  Attributes,
+  CreationAttributes,
+  ModelStatic,
+  Transaction,
+} from "sequelize";
+
+import type { Authenticator } from "@app/lib/auth";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import type { GroupResource } from "@app/lib/resources/group_resource";
+import { GroupModel } from "@app/lib/resources/storage/models/groups";
+import { VaultModel } from "@app/lib/resources/storage/models/vaults";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
+
+// Attributes are marked as read-only to reflect the stateless nature of our Resource.
+// This design will be moved up to BaseResource once we transition away from Sequelize.
+// eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unsafe-declaration-merging
+export interface VaultResource extends ReadonlyAttributesType<VaultModel> {}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class VaultResource extends BaseResource<VaultModel> {
+  static model: ModelStatic<VaultModel> = VaultModel;
+
+  constructor(model: ModelStatic<VaultModel>, blob: Attributes<VaultModel>) {
+    super(VaultModel, blob);
+  }
+
+  static async makeNew(blob: CreationAttributes<VaultModel>) {
+    const group = await VaultModel.create(blob);
+
+    return new this(VaultModel, group.get());
+  }
+
+  get sId(): string {
+    return VaultResource.modelIdToSId({
+      id: this.id,
+      workspaceId: this.workspaceId,
+    });
+  }
+
+  static modelIdToSId({
+    id,
+    workspaceId,
+  }: {
+    id: ModelId;
+    workspaceId: ModelId;
+  }): string {
+    return makeSId("group", {
+      id,
+      workspaceId,
+    });
+  }
+
+  static async fetchWorkspaceVaults(
+    auth: Authenticator,
+    transaction?: Transaction
+  ): Promise<VaultResource[]> {
+    const owner = auth.getNonNullableWorkspace();
+
+    const vaults = await this.model.findAll({
+      where: {
+        workspaceId: owner.id,
+      },
+      transaction,
+    });
+
+    return vaults.map((group) => new this(VaultModel, group.get()));
+  }
+
+  static async fetchWorkspaceSystemVault(
+    auth: Authenticator,
+    transaction?: Transaction
+  ): Promise<VaultResource> {
+    const owner = auth.getNonNullableWorkspace();
+    const group = await this.model.findOne({
+      where: {
+        workspaceId: owner.id,
+        kind: "system",
+      },
+      transaction,
+    });
+
+    if (!group) {
+      throw new Error("System group not found.");
+    }
+
+    return new this(VaultModel, group.get());
+  }
+
+  static async fetchWorkspaceDefaultVault(
+    auth: Authenticator,
+    transaction?: Transaction
+  ): Promise<VaultResource> {
+    const owner = auth.getNonNullableWorkspace();
+    const group = await this.model.findOne({
+      where: {
+        workspaceId: owner.id,
+        kind: "global",
+      },
+      transaction,
+    });
+
+    if (!group) {
+      throw new Error("Global group not found.");
+    }
+
+    return new this(VaultModel, group.get());
+  }
+
+  static async fetchById(
+    auth: Authenticator,
+    sId: string
+  ): Promise<VaultResource | null> {
+    const owner = auth.getNonNullableWorkspace();
+
+    const vaultModelId = getResourceIdFromSId(sId);
+    if (!vaultModelId) {
+      return null;
+    }
+
+    const vault = await this.model.findOne({
+      where: {
+        id: vaultModelId,
+        workspaceId: owner.id,
+      },
+    });
+
+    if (!vault) {
+      return null;
+    }
+
+    return new this(VaultModel, vault.get());
+  }
+
+  static async fetchWorkspaceVaultByName(
+    auth: Authenticator,
+    name: string,
+    transaction?: Transaction
+  ): Promise<VaultResource | null> {
+    const owner = auth.getNonNullableWorkspace();
+
+    const vault = await this.model.findOne({
+      where: {
+        workspaceId: owner.id,
+        name: name,
+      },
+      transaction,
+    });
+
+    if (!vault) {
+      return null;
+    }
+
+    return new this(VaultModel, vault.get());
+  }
+
+  async delete(
+    auth: Authenticator,
+    transaction?: Transaction
+  ): Promise<Result<undefined, Error>> {
+    try {
+      await this.model.destroy({
+        where: {
+          id: this.id,
+        },
+        transaction,
+      });
+
+      return new Ok(undefined);
+    } catch (err) {
+      return new Err(err as Error);
+    }
+  }
+
+  acl(): ACLType {
+    return {
+      aclEntries: [
+        {
+          groupId: this.groupId,
+          permissions: ["read", "write"],
+        },
+      ],
+    };
+  }
+}

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -1,8 +1,10 @@
 import type {
   ACLType,
+  GroupType,
   LightWorkspaceType,
   ModelId,
   Result,
+  WorkspaceType,
 } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 import type {
@@ -36,14 +38,18 @@ export class VaultResource extends BaseResource<VaultModel> {
     return new this(VaultModel, vault.get());
   }
 
-  static async makeDefaultForWorkspace(
-    workspaceId: ModelId,
-    systemGroupId: ModelId,
-    workspaceGroupId: ModelId
-  ) {
+  static async makeDefaultsForWorkspace({
+    workspace,
+    systemGroup,
+    globalGroup,
+  }: {
+    workspace: LightWorkspaceType;
+    systemGroup: GroupType;
+    globalGroup: GroupType;
+  }) {
     const existingVaults = await VaultModel.findAll({
       where: {
-        workspaceId: workspaceId,
+        workspaceId: workspace.id,
       },
     });
     const systemVault =
@@ -51,16 +57,16 @@ export class VaultResource extends BaseResource<VaultModel> {
       (await VaultResource.makeNew({
         name: "System",
         kind: "system",
-        workspaceId: workspaceId,
-        groupId: systemGroupId,
+        workspaceId: workspace.id,
+        groupId: systemGroup.id,
       }));
     const globalVault =
       existingVaults.find((v) => v.kind === "global") ||
       (await VaultResource.makeNew({
         name: "Workspace",
         kind: "global",
-        workspaceId: workspaceId,
-        groupId: workspaceGroupId,
+        workspaceId: workspace.id,
+        groupId: globalGroup.id,
       }));
     return {
       systemVault,

--- a/front/migrations/20240726_vault_backfill.ts
+++ b/front/migrations/20240726_vault_backfill.ts
@@ -1,0 +1,98 @@
+import _ from "lodash";
+import { Op } from "sequelize";
+
+import { DataSource } from "@app/lib/models/data_source";
+import { Workspace } from "@app/lib/models/workspace";
+import { GroupModel } from "@app/lib/resources/storage/models/groups";
+import { VaultModel } from "@app/lib/resources/storage/models/vaults";
+import { VaultResource } from "@app/lib/resources/vault_resource";
+import { makeScript } from "@app/scripts/helpers";
+
+async function backfillWorkspacesGroup(execute: boolean) {
+  const workspaces = await Workspace.findAll();
+
+  const chunks = _.chunk(workspaces, 16);
+  for (const [i, c] of chunks.entries()) {
+    console.log(
+      `[execute=${execute}] Processing chunk of ${c.length} workspaces... (${
+        i + 1
+      }/${chunks.length})`
+    );
+    if (execute) {
+      await Promise.all(
+        c.map((w) =>
+          (async () => {
+            try {
+              const groups = await GroupModel.findAll({
+                where: {
+                  workspaceId: w.id,
+                },
+              });
+              const systemGroupId = groups.find((g) => g.type === "system")?.id;
+              const globalGroupId = groups.find((g) => g.type === "global")?.id;
+              const existingVaults = await VaultModel.findAll({
+                where: {
+                  workspaceId: w.id,
+                },
+              });
+              const systemVault =
+                existingVaults.find((v) => v.kind === "system") ||
+                (await VaultResource.makeNew({
+                  name: "System",
+                  kind: "system",
+                  workspaceId: w.id,
+                  groupId: systemGroupId,
+                }));
+              const globalVault =
+                existingVaults.find((v) => v.kind === "global") ||
+                (await VaultResource.makeNew({
+                  name: "Global",
+                  kind: "global",
+                  workspaceId: w.id,
+                  groupId: globalGroupId,
+                }));
+              await DataSource.update(
+                { vaultId: systemVault.id },
+                {
+                  where: {
+                    workspaceId: w.id,
+                  },
+                }
+              );
+              // Move non-connected to global vault
+              await DataSource.update(
+                { vaultId: globalVault.id },
+                {
+                  where: {
+                    workspaceId: w.id,
+                    connectorId: {
+                      [Op.eq]: null,
+                    },
+                  },
+                }
+              );
+              // Move webcrawler to global vault
+              await DataSource.update(
+                { vaultId: globalVault.id },
+                {
+                  where: {
+                    workspaceId: w.id,
+                    connectorProvider: "webcrawler",
+                  },
+                }
+              );
+            } catch (error) {
+              console.error(error);
+            }
+          })()
+        )
+      );
+    }
+  }
+
+  console.log(`Done.`);
+}
+
+makeScript({}, async ({ execute }) => {
+  await backfillWorkspacesGroup(execute);
+});

--- a/front/migrations/20240726_vault_backfill.ts
+++ b/front/migrations/20240726_vault_backfill.ts
@@ -46,16 +46,23 @@ async function backfillWorkspacesGroup(execute: boolean) {
               const globalVault =
                 existingVaults.find((v) => v.kind === "global") ||
                 (await VaultResource.makeNew({
-                  name: "Global",
+                  name: "Workspace",
                   kind: "global",
                   workspaceId: w.id,
                   groupId: globalGroupId,
                 }));
+              // Move connected (non webcrawler) to system vault
               await DataSource.update(
                 { vaultId: systemVault.id },
                 {
                   where: {
                     workspaceId: w.id,
+                    connectorId: {
+                      [Op.ne]: null,
+                    },
+                    connectorProvider: {
+                      [Op.ne]: "webcrawler",
+                    },
                   },
                 }
               );

--- a/front/migrations/20240726_vault_backfill.ts
+++ b/front/migrations/20240726_vault_backfill.ts
@@ -33,11 +33,13 @@ async function backfillWorkspacesGroup(execute: boolean) {
                 throw new Error("System or global group not found.");
               }
               const { systemVault, globalVault } =
-                await VaultResource.makeDefaultsForWorkspace({
-                  workspace: renderLightWorkspaceType({ workspace: w }),
-                  systemGroup,
-                  globalGroup,
-                });
+                await VaultResource.makeDefaultsForWorkspace(
+                  renderLightWorkspaceType({ workspace: w }),
+                  {
+                    systemGroup,
+                    globalGroup,
+                  }
+                );
               // Move connected (non webcrawler) to system vault
               await DataSource.update(
                 { vaultId: systemVault.id },

--- a/front/migrations/db/migration_48.sql
+++ b/front/migrations/db/migration_48.sql
@@ -1,8 +1,51 @@
 -- Migration created on Jul 27, 2024
-SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'vaults';
-CREATE TABLE IF NOT EXISTS "vaults" ("id"  SERIAL , "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL, "name" VARCHAR(255) NOT NULL, "kind" VARCHAR(255) NOT NULL, "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL, "workspaceId" INTEGER NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, "groupId" INTEGER NOT NULL REFERENCES "groups" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, PRIMARY KEY ("id"));
-SELECT i.relname AS name, ix.indisprimary AS primary, ix.indisunique AS unique, ix.indkey AS indkey, array_agg(a.attnum) as column_indexes, array_agg(a.attname) AS column_names, pg_get_indexdef(ix.indexrelid) AS definition FROM pg_class t, pg_class i, pg_index ix, pg_attribute a WHERE t.oid = ix.indrelid AND i.oid = ix.indexrelid AND a.attrelid = t.oid AND t.relkind = 'r' and t.relname = 'vaults' GROUP BY i.relname, ix.indexrelid, ix.indisprimary, ix.indisunique, ix.indkey ORDER BY i.relname;
-CREATE UNIQUE INDEX "vaults_workspace_id_name" ON "vaults" ("workspaceId", "name");
+SELECT table_name
+FROM information_schema.tables
+WHERE
+    table_schema = 'public'
+    AND table_name = 'vaults';
+
+CREATE TABLE IF NOT EXISTS "vaults" (
+    "id" SERIAL,
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "name" VARCHAR(255) NOT NULL,
+    "kind" VARCHAR(255) NOT NULL,
+    "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "workspaceId" INTEGER NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "groupId" INTEGER NOT NULL REFERENCES "groups" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    PRIMARY KEY ("id")
+);
+
+SELECT
+    i.relname AS name,
+    ix.indisprimary AS primary,
+    ix.indisunique AS unique,
+    ix.indkey AS indkey,
+    array_agg(a.attnum) as column_indexes,
+    array_agg(a.attname) AS column_names,
+    pg_get_indexdef(ix.indexrelid) AS definition
+FROM
+    pg_class t,
+    pg_class i,
+    pg_index ix,
+    pg_attribute a
+WHERE
+    t.oid = ix.indrelid
+    AND i.oid = ix.indexrelid
+    AND a.attrelid = t.oid
+    AND t.relkind = 'r'
+    and t.relname = 'vaults'
+GROUP BY
+    i.relname,
+    ix.indexrelid,
+    ix.indisprimary,
+    ix.indisunique,
+    ix.indkey
+ORDER BY i.relname;
+
 CREATE INDEX "vaults_workspace_id_kind" ON "vaults" ("workspaceId", "kind");
-ALTER TABLE "public"."data_sources" ADD COLUMN "vaultId" INTEGER REFERENCES "vaults" ("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "public"."data_sources"
+ADD COLUMN "vaultId" INTEGER REFERENCES "vaults" ("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
 CREATE INDEX "data_sources_workspace_id_vault_id" ON "data_sources" ("workspaceId", "vaultId");

--- a/front/migrations/db/migration_48.sql
+++ b/front/migrations/db/migration_48.sql
@@ -1,0 +1,8 @@
+-- Migration created on Jul 27, 2024
+SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'vaults';
+CREATE TABLE IF NOT EXISTS "vaults" ("id"  SERIAL , "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL, "name" VARCHAR(255) NOT NULL, "kind" VARCHAR(255) NOT NULL, "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL, "workspaceId" INTEGER NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, "groupId" INTEGER NOT NULL REFERENCES "groups" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, PRIMARY KEY ("id"));
+SELECT i.relname AS name, ix.indisprimary AS primary, ix.indisunique AS unique, ix.indkey AS indkey, array_agg(a.attnum) as column_indexes, array_agg(a.attname) AS column_names, pg_get_indexdef(ix.indexrelid) AS definition FROM pg_class t, pg_class i, pg_index ix, pg_attribute a WHERE t.oid = ix.indrelid AND i.oid = ix.indexrelid AND a.attrelid = t.oid AND t.relkind = 'r' and t.relname = 'vaults' GROUP BY i.relname, ix.indexrelid, ix.indisprimary, ix.indisunique, ix.indkey ORDER BY i.relname;
+CREATE UNIQUE INDEX "vaults_workspace_id_name" ON "vaults" ("workspaceId", "name");
+CREATE INDEX "vaults_workspace_id_kind" ON "vaults" ("workspaceId", "kind");
+ALTER TABLE "public"."data_sources" ADD COLUMN "vaultId" INTEGER REFERENCES "vaults" ("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+CREATE INDEX "data_sources_workspace_id_vault_id" ON "data_sources" ("workspaceId", "vaultId");

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -13,6 +13,7 @@ import { getDataSource, getDataSources } from "@app/lib/api/data_sources";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSource } from "@app/lib/models/data_source";
+import { VaultResource } from "@app/lib/resources/vault_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -170,6 +171,7 @@ async function handler(
         });
       }
 
+      const globalVault = await VaultResource.fetchWorkspaceGlobalVault(auth);
       const ds = await DataSource.create({
         name: req.body.name,
         description: description,
@@ -177,6 +179,7 @@ async function handler(
         workspaceId: owner.id,
         assistantDefaultSelected: req.body.assistantDefaultSelected,
         editedByUserId: user.id,
+        vaultId: globalVault.id,
       });
 
       const dataSourceType = await getDataSource(auth, ds.name);

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -1,7 +1,6 @@
 import { CoreAPI } from "@dust-tt/types";
 import { Storage } from "@google-cloud/storage";
 import { chunk } from "lodash";
-import { Vault } from "lucide-react";
 import { Op } from "sequelize";
 
 import config from "@app/lib/api/config";

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -567,7 +567,7 @@ export async function deleteWorkspaceActivity({
       transaction: t,
     });
     await FileResource.deleteAllForWorkspace(workspace, t);
-    await VaultResource.deleteAllForWorkspace(workspace, t);
+    await VaultResource.deleteAllForWorkspace(auth, t);
     await GroupResource.deleteAllForWorkspace(workspace, t);
     logger.info(`[Workspace delete] Deleting Worskpace ${workspace.sId}`);
     await Workspace.destroy({

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -1,6 +1,7 @@
 import { CoreAPI } from "@dust-tt/types";
 import { Storage } from "@google-cloud/storage";
 import { chunk } from "lodash";
+import { Vault } from "lucide-react";
 import { Op } from "sequelize";
 
 import config from "@app/lib/api/config";
@@ -52,6 +53,7 @@ import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { UserResource } from "@app/lib/resources/user_resource";
+import { VaultResource } from "@app/lib/resources/vault_resource";
 import logger from "@app/logger/logger";
 
 const { DUST_DATA_SOURCES_BUCKET, SERVICE_ACCOUNT } = process.env;
@@ -566,6 +568,7 @@ export async function deleteWorkspaceActivity({
       transaction: t,
     });
     await FileResource.deleteAllForWorkspace(workspace, t);
+    await VaultResource.deleteAllForWorkspace(workspace, t);
     await GroupResource.deleteAllForWorkspace(workspace, t);
     logger.info(`[Workspace delete] Deleting Worskpace ${workspace.sId}`);
     await Workspace.destroy({

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -159,10 +159,7 @@ async function deleteDatasources(auth: Authenticator) {
 }
 
 async function deleteVaults(auth: Authenticator) {
-  const workspace = auth.workspace();
-  if (!workspace) {
-    throw new Error("No workspace found");
-  }
+  const workspace = auth.getNonNullableWorkspace();
   const w = renderLightWorkspaceType({ workspace });
   await VaultResource.deleteAllForWorkspace(w);
 }

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -24,6 +24,7 @@ import {
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
+import { VaultResource } from "@app/lib/resources/vault_resource";
 import { CustomerioServerSideTracking } from "@app/lib/tracking/customerio/server";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
@@ -85,6 +86,7 @@ export async function scrubWorkspaceData({
   await deleteAllConversations(auth);
   await archiveAssistants(auth);
   await deleteDatasources(auth);
+  await deleteVaults(auth);
   await deleteGroups(auth);
   await cleanupCustomerio(auth);
 }
@@ -154,6 +156,15 @@ async function deleteDatasources(auth: Authenticator) {
       throw new Error(`Failed to delete data source: ${r.error.message}`);
     }
   }
+}
+
+async function deleteVaults(auth: Authenticator) {
+  const workspace = auth.workspace();
+  if (!workspace) {
+    throw new Error("No workspace found");
+  }
+  const w = renderLightWorkspaceType({ workspace });
+  await VaultResource.deleteAllForWorkspace(w);
 }
 
 async function deleteGroups(auth: Authenticator) {

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -159,9 +159,7 @@ async function deleteDatasources(auth: Authenticator) {
 }
 
 async function deleteVaults(auth: Authenticator) {
-  const workspace = auth.getNonNullableWorkspace();
-  const w = renderLightWorkspaceType({ workspace });
-  await VaultResource.deleteAllForWorkspace(w);
+  await VaultResource.deleteAllForWorkspace(auth);
 }
 
 async function deleteGroups(auth: Authenticator) {

--- a/types/src/front/vault.ts
+++ b/types/src/front/vault.ts
@@ -1,2 +1,2 @@
-export const VAULT_KINDS = ["regular", "global", "system"] as const;
+const VAULT_KINDS = ["regular", "global", "system"] as const;
 export type VaultKind = (typeof VAULT_KINDS)[number];

--- a/types/src/front/vault.ts
+++ b/types/src/front/vault.ts
@@ -1,0 +1,2 @@
+export const VAULT_KINDS = ["regular", "global", "system"] as const;
+export type VaultKind = (typeof VAULT_KINDS)[number];

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -69,6 +69,7 @@ export * from "./front/project";
 export * from "./front/provider";
 export * from "./front/run";
 export * from "./front/user";
+export * from "./front/vault";
 export * from "./front/workspace";
 export * from "./oauth/client/access_token";
 export * from "./oauth/client/setup";


### PR DESCRIPTION
## Description

Adds new vault resource.
Create 2 default vaults for every workspace, associated with the 2 default groups.
Assign datasource to default vault (system for connected, workspace for folder/websites)

https://dust4ai.slack.com/archives/C050SM8NSPK/p1722006720371989
https://dust4ai.slack.com/archives/C050SM8NSPK/p1722002654186619


## Risk

This adds new foreign keys which may prevent some operations :
- vault has a dependency on workspace, workspace cannot be deleted if vaults are not properly removed
- creating a datasource should include vaultId (null is temporarily allowed)

## Deploy Plan

Run `migrations/db/migration_48.sql`
Run `front/migrations/20240726_vault_backfill.ts`
Deploy `front`
