### PR TITLE
[front] - feat(assistants): sort by date

### DIFF
--- a/front/components/assistant/SearchOrderDropdown.tsx
+++ b/front/components/assistant/SearchOrderDropdown.tsx
@@ -6,7 +6,7 @@ export type SearchOrderType = (typeof SearchOrder)[number];
 const prettyfiedSearchOrder: { [key in SearchOrderType]: string } = {
   name: "Name",
   usage: "Usage",
-  edited_at: "Edited at",
+  edited_at: "Last edited at",
 };
 
 // Headless UI does not inherently handle Portal-based rendering,

--- a/front/components/assistant/SearchOrderDropdown.tsx
+++ b/front/components/assistant/SearchOrderDropdown.tsx
@@ -1,7 +1,13 @@
 import { Button, DropdownMenu } from "@dust-tt/sparkle";
 
-export const SearchOrder = ["name", "usage"] as const;
+export const SearchOrder = ["name", "usage", "edited_at"] as const;
 export type SearchOrderType = (typeof SearchOrder)[number];
+
+const prettyfiedSearchOrder: { [key in SearchOrderType]: string } = {
+  name: "Name",
+  usage: "Usage",
+  edited_at: "Edited at",
+};
 
 // Headless UI does not inherently handle Portal-based rendering,
 // leading to dropdown menus being hidden by parent divs with overflow settings.
@@ -21,7 +27,7 @@ export function SearchOrderDropdown({
         <Button
           type="select"
           labelVisible={true}
-          label={`Order by: ${orderBy}`}
+          label={`Order by: ${prettyfiedSearchOrder[orderBy]}`}
           variant="tertiary"
           hasMagnifying={false}
           size="sm"
@@ -32,7 +38,7 @@ export function SearchOrderDropdown({
         {SearchOrder.map((order) => (
           <DropdownMenu.Item
             key={order}
-            label={order}
+            label={prettyfiedSearchOrder[order]}
             onClick={() => setOrderBy(order)}
           />
         ))}

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -196,6 +196,17 @@ export default function WorkspaceAssistants({
       });
       break;
     }
+    case "edited_at":
+      filteredAgents.sort((a, b) => {
+        const dateA = a.versionCreatedAt
+          ? new Date(a.versionCreatedAt).getTime()
+          : -Infinity;
+        const dateB = b.versionCreatedAt
+          ? new Date(b.versionCreatedAt).getTime()
+          : -Infinity;
+        return dateB - dateA;
+      });
+      break;
     default:
       assertNever(orderBy);
   }


### PR DESCRIPTION
## Description

This PR aims at enabling to sort assistants by creation and edition timestamp.

This requires to modify the `/agent_configurations/` endpoint to be able to compute the initial creation timestamp ("createdAt" of the the first assistant version) and return it.

## Risk

Breaking endpoints (which should be fine as we introduce a new parameter 

## Deploy Plan

- Deploy to `front-edge`
- Deploy to `front`
