### PR TITLE
[front] - feature: clear selected assistant on route change to '/new'

### DIFF
--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -226,7 +226,14 @@ export function ConversationContainer({
       );
       observer.observe(scrollContainerElement);
     }
-  }, [setAnimate, setInputbarMention]);
+    const handleRouteChange = (url: string) => {
+      if (url.endsWith("/new")) {
+        setSelectedAssistant(null);
+        assistantToMention.current = null;
+      }
+    };
+    router.events.on("routeChangeComplete", handleRouteChange);
+  }, [setAnimate, setInputbarMention, router, setSelectedAssistant]);
 
   const [greeting, setGreeting] = useState<string>("");
   useEffect(() => {


### PR DESCRIPTION
## Description

This PR addresses an issue where the selected assistant was not being cleared when navigating to a new conversation. It adds a route change handler to reset the selected assistant and the assistant to mention when the user navigates to the `/new` route. This ensures that starting a new conversation provides a clean slate without any pre-selected assistants.

The main changes include:
- Adding a handleRouteChange function in the ConversationContainer component.
- Listening for the routeChangeComplete event and resetting the selected assistant when navigating to '/new'.
- Updating the dependencies array of the useEffect hook to include the new dependencies.

## Risk

The risk associated with this change is low. It only affects the behavior when navigating to a new conversation and should not impact existing conversations or other functionality. The change is isolated to the ConversationContainer component and can be easily rolled back if any issues arise.

## Deploy Plan

Deploy `front`
