### PR TITLE
Changing Help drawer icon to "?"

### DIFF
--- a/front/components/assistant/conversation/HelpAndQuickGuideWrapper.tsx
+++ b/front/components/assistant/conversation/HelpAndQuickGuideWrapper.tsx
@@ -1,4 +1,4 @@
-import { HeartAltIcon, Icon } from "@dust-tt/sparkle";
+import { Icon,QuestionMarkCircleIcon } from "@dust-tt/sparkle";
 import type { UserType, WorkspaceType } from "@dust-tt/types";
 import { useEffect, useState } from "react";
 
@@ -78,7 +78,7 @@ export function HelpAndQuickGuideWrapper({
           )}
           onClick={() => setIsHelpDrawerOpen(true)}
         >
-          <Icon visual={HeartAltIcon} className="text-white" size="md" />
+          <Icon visual={QuestionMarkCircleIcon} className="text-white" size="xl" />
         </div>
       </div>
     </>

--- a/front/components/assistant/conversation/HelpAndQuickGuideWrapper.tsx
+++ b/front/components/assistant/conversation/HelpAndQuickGuideWrapper.tsx
@@ -1,4 +1,4 @@
-import { Icon,QuestionMarkCircleIcon } from "@dust-tt/sparkle";
+import { Icon, QuestionMarkCircleIcon } from "@dust-tt/sparkle";
 import type { UserType, WorkspaceType } from "@dust-tt/types";
 import { useEffect, useState } from "react";
 
@@ -78,7 +78,11 @@ export function HelpAndQuickGuideWrapper({
           )}
           onClick={() => setIsHelpDrawerOpen(true)}
         >
-          <Icon visual={QuestionMarkCircleIcon} className="text-white" size="xl" />
+          <Icon
+            visual={QuestionMarkCircleIcon}
+            className="text-white"
+            size="xl"
+          />
         </div>
       </div>
     </>

--- a/front/components/assistant/conversation/HelpAndQuickGuideWrapper.tsx
+++ b/front/components/assistant/conversation/HelpAndQuickGuideWrapper.tsx
@@ -1,4 +1,3 @@
-import { Icon, QuestionMarkCircleIcon } from "@dust-tt/sparkle";
 import type { UserType, WorkspaceType } from "@dust-tt/types";
 import { useEffect, useState } from "react";
 
@@ -78,11 +77,11 @@ export function HelpAndQuickGuideWrapper({
           )}
           onClick={() => setIsHelpDrawerOpen(true)}
         >
-          <Icon
-            visual={QuestionMarkCircleIcon}
-            className="text-white"
-            size="xl"
-          />
+          <span
+            style={{ fontSize: "32px", color: "white", fontWeight: "bold" }}
+          >
+            ?
+          </span>
         </div>
       </div>
     </>


### PR DESCRIPTION
## Description

The current "Heart" help drawer icon does not give any info how what to explain when clicking on it. 
Changing to a question mark.

<img width="1510" alt="Screenshot 2024-07-29 at 15 00 51" src="https://github.com/user-attachments/assets/a3fb49df-4821-4ce3-b5db-618e9c6a177e">


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
