### PR TITLE
fix: remove where clause from notion GC

### DIFF
--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -820,8 +820,7 @@ export async function garbageCollect({
   do {
     // Find the resources not seen in the GC run (using runTimestamp).
     resourcesToCheck = await findResourcesNotSeenInGarbageCollectionRun(
-      connector.id,
-      runTimestamp
+      connector.id
     );
 
     const NOTION_UNHEALTHY_ERROR_CODES = [
@@ -1074,8 +1073,7 @@ export async function deletePageOrDatabaseIfArchived({
 }
 
 async function findResourcesNotSeenInGarbageCollectionRun(
-  connectorId: ModelId,
-  runTimestamp: number
+  connectorId: ModelId
 ): Promise<
   Array<{
     lastSeenTs: Date;
@@ -1114,10 +1112,8 @@ async function findResourcesNotSeenInGarbageCollectionRun(
     await NotionPage.findAll({
       where: {
         connectorId,
-        lastSeenTs: {
-          [Op.lt]: new Date(runTimestamp),
-        },
       },
+      order: [["lastSeenTs", "ASC"]],
       attributes: ["lastSeenTs", "notionPageId", "skipReason"],
       limit: pageSize,
     })
@@ -1142,10 +1138,8 @@ async function findResourcesNotSeenInGarbageCollectionRun(
     await NotionDatabase.findAll({
       where: {
         connectorId,
-        lastSeenTs: {
-          [Op.lt]: new Date(runTimestamp),
-        },
       },
+      order: [["lastSeenTs", "ASC"]],
       attributes: ["lastSeenTs", "notionDatabaseId", "skipReason"],
       limit: pageSize,
     })


### PR DESCRIPTION
## Description

This is actually useless, since we use redis to track pages seen in the GC run. We have a restrictive limit on the query, so it is fine.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
