### PR TITLE
[front] - fix: restrict non-admin users from seeing some data sources

### DIFF
--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -597,7 +597,9 @@ export default function DataSourcesView({
         <ContextItem.List>
           {localIntegrations
             .filter(
-              (ds) => !CONNECTOR_CONFIGURATIONS[ds.connectorProvider].hide
+              (ds) =>
+                !CONNECTOR_CONFIGURATIONS[ds.connectorProvider].hide &&
+                (isAdmin || ds.connector)
             )
             .sort((a, b) => {
               if (a.status === b.status) {


### PR DESCRIPTION
 ## Description

This PR aims at filtering out data sources in the UI based on user's admin status and whether the data source connector is defined

It is part of the big refactoring around Data Source management.

**References:**
- https://github.com/dust-tt/tasks/issues/1073

## Risk

No big changes but if the filter is wrong sources can be hidden for everyone

## Deploy Plan

Deploy `front`