### PR TITLE
Data source view resource

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -64,6 +64,7 @@ import {
   WorkspaceHasDomain,
 } from "@app/lib/models/workspace";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
+import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 import { FileModel } from "@app/lib/resources/storage/models/files";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
@@ -105,6 +106,7 @@ async function main() {
   await DustAppSecret.sync({ alter: true });
   await VaultModel.sync({ alter: true });
   await DataSource.sync({ alter: true });
+  await DataSourceViewModel.sync({ alter: true });
   await RunModel.sync({ alter: true });
   await RunUsageModel.sync({ alter: true });
   await TrackedDocument.sync({ alter: true });

--- a/front/lib/data_sources.ts
+++ b/front/lib/data_sources.ts
@@ -2,6 +2,7 @@ import type { CoreAPIDocument, DataSourceType } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
 
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
+import type { DataSource } from "@app/lib/models/data_source";
 
 export function getDisplayNameForDocument(document: CoreAPIDocument): string {
   const titleTagPrefix = "title:";
@@ -32,4 +33,18 @@ export function getDisplayNameForDataSource(ds: DataSourceType) {
   } else {
     return ds.name;
   }
+}
+
+export function renderDataSourceType(dataSource: DataSource): DataSourceType {
+  return {
+    id: dataSource.id,
+    createdAt: dataSource.createdAt.getTime(),
+    name: dataSource.name,
+    description: dataSource.description,
+    assistantDefaultSelected: dataSource.assistantDefaultSelected,
+    dustAPIProjectId: dataSource.dustAPIProjectId,
+    connectorId: dataSource.connectorId,
+    connectorProvider: dataSource.connectorProvider,
+    editedByUser: undefined,
+  };
 }

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -1,12 +1,7 @@
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-import type {
-  DataSourceViewType,
-  LightWorkspaceType,
-  ModelId,
-  Result,
-} from "@dust-tt/types";
+import type { DataSourceViewType, ModelId, Result } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 import type {
   Attributes,
@@ -128,12 +123,11 @@ export class DataSourceViewResource extends BaseResource<DataSourceViewModel> {
 
   static async deleteAllForWorkspace(
     auth: Authenticator,
-    workspace: LightWorkspaceType,
     transaction?: Transaction
   ) {
     return this.model.destroy({
       where: {
-        workspaceId: workspace.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
       },
       transaction,
     });
@@ -164,7 +158,6 @@ export class DataSourceViewResource extends BaseResource<DataSourceViewModel> {
   toJSON(): DataSourceViewType {
     return {
       createdAt: this.createdAt.getTime(),
-      name: this.name,
       parentsIn: this.parentsIn,
       sId: this.sId,
       updatedAt: this.updatedAt.getTime(),

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -22,9 +22,6 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { VaultResource } from "@app/lib/resources/vault_resource";
 
-type AllDocumentsType = "*";
-const ALL_DOCUMENTS_TYPE: AllDocumentsType = "*";
-
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface DataSourceViewResource
   extends ReadonlyAttributesType<DataSourceViewModel> {}
@@ -68,7 +65,7 @@ export class DataSourceViewResource extends BaseResource<DataSourceViewModel> {
   ) {
     return this.makeNew({
       dataSourceId: dataSource.id,
-      parentsIn: [ALL_DOCUMENTS_TYPE],
+      parentsIn: null,
       vaultId: vault.id,
       workspaceId: vault.workspaceId,
     });

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -1,7 +1,12 @@
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-import type { DataSourceViewType, ModelId, Result } from "@dust-tt/types";
+import type {
+  DataSourceType,
+  DataSourceViewType,
+  ModelId,
+  Result,
+} from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 import type {
   Attributes,
@@ -44,25 +49,25 @@ export class DataSourceViewResource extends BaseResource<DataSourceViewModel> {
 
   static async createViewInVaultFromDataSource(
     vault: VaultResource,
-    { dataSourceId }: { dataSourceId: ModelId },
+    dataSource: DataSourceType,
     parentsIn: string[]
   ) {
     return this.makeNew({
-      dataSourceId,
+      dataSourceId: dataSource.id,
       parentsIn,
       workspaceId: vault.workspaceId,
     });
   }
 
   // TODO(2024-07-29 flav) Replace dataSourceId by DataSourceResource once implemented.
-  // For now, we create a default view for all managed connections.
+  // For now, we create a default view for all data sources in the global vault.
   // This view has access to all documents, which is represented by the special value "*".
   static async createViewInVaultFromDataSourceIncludingAllDocuments(
     vault: VaultResource,
-    { dataSourceId }: { dataSourceId: ModelId }
+    dataSource: DataSourceType
   ) {
     return this.makeNew({
-      dataSourceId,
+      dataSourceId: dataSource.id,
       parentsIn: [ALL_DOCUMENTS_TYPE],
       vaultId: vault.id,
       workspaceId: vault.workspaceId,

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -58,7 +58,7 @@ export class DataSourceViewResource extends BaseResource<DataSourceViewModel> {
 
   // TODO(2024-07-29 flav) Replace dataSourceId by DataSourceResource once implemented.
   // For now, we create a default view for all data sources in the global vault.
-  // This view has access to all documents, which is represented by the special value "*".
+  // This view has access to all documents, which is represented by null.
   static async createViewInVaultFromDataSourceIncludingAllDocuments(
     vault: VaultResource,
     dataSource: DataSourceType

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -64,6 +64,7 @@ export class DataSourceViewResource extends BaseResource<DataSourceViewModel> {
     return this.makeNew({
       dataSourceId,
       parentsIn: [ALL_DOCUMENTS_TYPE],
+      vaultId: vault.id,
       workspaceId: vault.workspaceId,
     });
   }

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -55,7 +55,7 @@ export class DataSourceViewResource extends BaseResource<DataSourceViewModel> {
   }
 
   // TODO(2024-07-29 flav) Replace dataSourceId by DataSourceResource once implemented.
-  // For now, we create a default view for all managed connections (except webcrawler).
+  // For now, we create a default view for all managed connections.
   // This view has access to all documents, which is represented by the special value "*".
   static async createViewInVaultFromDataSourceIncludingAllDocuments(
     vault: VaultResource,

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -22,6 +22,9 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { VaultResource } from "@app/lib/resources/vault_resource";
 
+type AllDocumentsType = "*";
+const ALL_DOCUMENTS_TYPE: AllDocumentsType = "*";
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface DataSourceViewResource
   extends ReadonlyAttributesType<DataSourceViewModel> {}
@@ -44,7 +47,6 @@ export class DataSourceViewResource extends BaseResource<DataSourceViewModel> {
     return new this(DataSourceViewResource.model, key.get());
   }
 
-  // TODO(2024-07-29 flav) Replace dataSourceId by DataSourceResource once implemented.
   static async createViewInVaultFromDataSource(
     vault: VaultResource,
     { dataSourceId }: { dataSourceId: ModelId },
@@ -52,8 +54,21 @@ export class DataSourceViewResource extends BaseResource<DataSourceViewModel> {
   ) {
     return this.makeNew({
       dataSourceId,
-      name: vault.name,
       parentsIn,
+      workspaceId: vault.workspaceId,
+    });
+  }
+
+  // TODO(2024-07-29 flav) Replace dataSourceId by DataSourceResource once implemented.
+  // For now, we create a default view for all managed connections (except webcrawler).
+  // This view has access to all documents, which is represented by the special value "*".
+  static async createViewInVaultFromDataSourceIncludingAllDocuments(
+    vault: VaultResource,
+    { dataSourceId }: { dataSourceId: ModelId }
+  ) {
+    return this.makeNew({
+      dataSourceId,
+      parentsIn: [ALL_DOCUMENTS_TYPE],
       workspaceId: vault.workspaceId,
     });
   }

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -1,0 +1,158 @@
+// Attributes are marked as read-only to reflect the stateless nature of our Resource.
+// This design will be moved up to BaseResource once we transition away from Sequelize.
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+import type {
+  DataSourceViewType,
+  LightWorkspaceType,
+  ModelId,
+  Result,
+} from "@dust-tt/types";
+import { Err, Ok } from "@dust-tt/types";
+import type {
+  Attributes,
+  CreationAttributes,
+  ModelStatic,
+  Transaction,
+} from "sequelize";
+
+import type { Authenticator } from "@app/lib/auth";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
+import type { VaultResource } from "@app/lib/resources/vault_resource";
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface DataSourceViewResource
+  extends ReadonlyAttributesType<DataSourceViewModel> {}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class DataSourceViewResource extends BaseResource<DataSourceViewModel> {
+  static model: ModelStatic<DataSourceViewModel> = DataSourceViewModel;
+
+  constructor(
+    model: ModelStatic<DataSourceViewModel>,
+    blob: Attributes<DataSourceViewModel>
+  ) {
+    super(DataSourceViewModel, blob);
+  }
+
+  // Creation.
+
+  private static async makeNew(blob: CreationAttributes<DataSourceViewModel>) {
+    const key = await DataSourceViewResource.model.create(blob);
+
+    return new this(DataSourceViewResource.model, key.get());
+  }
+
+  // TODO(2024-07-29 flav) Replace dataSourceId by DataSourceResource once implemented.
+  static async createViewInVaultFromDataSource(
+    vault: VaultResource,
+    { dataSourceId }: { dataSourceId: ModelId },
+    parentsIn: string[]
+  ) {
+    return this.makeNew({
+      dataSourceId,
+      name: vault.name,
+      parentsIn,
+      workspaceId: vault.workspaceId,
+    });
+  }
+
+  // Fetching.
+
+  static async listByWorkspace(auth: Authenticator) {
+    const blobs = await this.model.findAll({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+
+    return blobs.map((b) => new this(this.model, b.get()));
+  }
+
+  static async fetchById(auth: Authenticator, id: string) {
+    const fileModelId = getResourceIdFromSId(id);
+    if (!fileModelId) {
+      return null;
+    }
+
+    const blob = await this.model.findOne({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        id: fileModelId,
+      },
+    });
+    if (!blob) {
+      return null;
+    }
+
+    // Use `.get` to extract model attributes, omitting Sequelize instance metadata.
+    return new this(this.model, blob.get());
+  }
+
+  // Deletion.
+
+  async delete(
+    auth: Authenticator,
+    transaction?: Transaction
+  ): Promise<Result<undefined, Error>> {
+    try {
+      await this.model.destroy({
+        where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          id: this.id,
+        },
+        transaction,
+      });
+
+      return new Ok(undefined);
+    } catch (err) {
+      return new Err(err as Error);
+    }
+  }
+
+  static async deleteAllForWorkspace(
+    auth: Authenticator,
+    workspace: LightWorkspaceType,
+    transaction?: Transaction
+  ) {
+    return this.model.destroy({
+      where: {
+        workspaceId: workspace.id,
+      },
+      transaction,
+    });
+  }
+
+  get sId(): string {
+    return DataSourceViewResource.modelIdToSId({
+      id: this.id,
+      workspaceId: this.workspaceId,
+    });
+  }
+
+  static modelIdToSId({
+    id,
+    workspaceId,
+  }: {
+    id: ModelId;
+    workspaceId: ModelId;
+  }): string {
+    return makeSId("data_source_view", {
+      id,
+      workspaceId,
+    });
+  }
+
+  // Serialization logic.
+
+  toJSON(): DataSourceViewType {
+    return {
+      createdAt: this.createdAt.getTime(),
+      name: this.name,
+      parentsIn: this.parentsIn,
+      sId: this.sId,
+      updatedAt: this.updatedAt.getTime(),
+    };
+  }
+}

--- a/front/lib/resources/storage/models/data_source_view.ts
+++ b/front/lib/resources/storage/models/data_source_view.ts
@@ -1,0 +1,77 @@
+import type {
+  CreationOptional,
+  ForeignKey,
+  InferAttributes,
+  InferCreationAttributes,
+} from "sequelize";
+import { DataTypes, Model } from "sequelize";
+
+import { DataSource } from "@app/lib/models/data_source";
+import { Workspace } from "@app/lib/models/workspace";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { VaultModel } from "@app/lib/resources/storage/models/vaults";
+
+export class DataSourceViewModel extends Model<
+  InferAttributes<DataSourceViewModel>,
+  InferCreationAttributes<DataSourceViewModel>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare name: string;
+  declare parentsIn: string[];
+
+  declare dataSourceId: ForeignKey<DataSource["id"]>;
+  declare vaultId: ForeignKey<VaultModel["id"]>;
+  declare workspaceId: ForeignKey<Workspace["id"]>;
+}
+DataSourceViewModel.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    parentsIn: {
+      type: DataTypes.ARRAY(DataTypes.STRING),
+      allowNull: false,
+    },
+  },
+  {
+    modelName: "data_source_view",
+    sequelize: frontSequelize,
+    indexes: [
+      { fields: ["workspaceId", "id"] },
+      { fields: ["workspaceId", "vaultId"] },
+      { fields: ["workspaceId", "dataSourceId"] },
+    ],
+  }
+);
+Workspace.hasMany(DataSourceViewModel, {
+  foreignKey: { allowNull: false },
+  onDelete: "RESTRICT",
+});
+VaultModel.hasMany(DataSourceViewModel, {
+  foreignKey: { allowNull: false },
+  onDelete: "RESTRICT",
+});
+DataSource.hasMany(DataSourceViewModel, {
+  foreignKey: { allowNull: false },
+  onDelete: "RESTRICT",
+});
+DataSourceViewModel.belongsTo(DataSource);

--- a/front/lib/resources/storage/models/data_source_view.ts
+++ b/front/lib/resources/storage/models/data_source_view.ts
@@ -19,7 +19,6 @@ export class DataSourceViewModel extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare name: string;
   declare parentsIn: string[];
 
   declare dataSourceId: ForeignKey<DataSource["id"]>;
@@ -42,10 +41,6 @@ DataSourceViewModel.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
-    },
-    name: {
-      type: DataTypes.STRING,
-      allowNull: false,
     },
     parentsIn: {
       type: DataTypes.ARRAY(DataTypes.STRING),

--- a/front/lib/resources/storage/models/data_source_view.ts
+++ b/front/lib/resources/storage/models/data_source_view.ts
@@ -19,7 +19,7 @@ export class DataSourceViewModel extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare parentsIn: string[];
+  declare parentsIn: string[] | null;
 
   declare dataSourceId: ForeignKey<DataSource["id"]>;
   declare vaultId: ForeignKey<VaultModel["id"]>;
@@ -44,7 +44,7 @@ DataSourceViewModel.init(
     },
     parentsIn: {
       type: DataTypes.ARRAY(DataTypes.STRING),
-      allowNull: false,
+      allowNull: true,
     },
   },
   {

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -22,6 +22,7 @@ const RESOURCES_PREFIX = {
   file: "fil",
   group: "grp",
   vault: "vlt",
+  data_source_view: "dsv",
 };
 
 const ALL_RESOURCES_PREFIXES = Object.values(RESOURCES_PREFIX);

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -4,7 +4,6 @@ import type {
   LightWorkspaceType,
   ModelId,
   Result,
-  VaultKind,
 } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 import type {

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -4,6 +4,7 @@ import type {
   LightWorkspaceType,
   ModelId,
   Result,
+  VaultKind,
 } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 import type {
@@ -209,5 +210,9 @@ export class VaultResource extends BaseResource<VaultModel> {
         },
       ],
     };
+  }
+
+  isGlobal() {
+    return this.kind === "global";
   }
 }

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -210,8 +210,4 @@ export class VaultResource extends BaseResource<VaultModel> {
       ],
     };
   }
-
-  isGlobal(): boolean {
-    return this.kind === "global";
-  }
 }

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -210,4 +210,8 @@ export class VaultResource extends BaseResource<VaultModel> {
       ],
     };
   }
+
+  isGlobal(): boolean {
+    return this.kind === "global";
+  }
 }

--- a/front/migrations/20240730_backfill_data_source_views.ts
+++ b/front/migrations/20240730_backfill_data_source_views.ts
@@ -1,0 +1,73 @@
+import type { LightWorkspaceType } from "@dust-tt/types";
+
+import { Authenticator } from "@app/lib/auth";
+import { renderDataSourceType } from "@app/lib/data_sources";
+import { DataSource } from "@app/lib/models/data_source";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
+import { VaultResource } from "@app/lib/resources/vault_resource";
+import type { Logger } from "@app/logger/logger";
+import { makeScript, runOnAllWorkspaces } from "@app/scripts/helpers";
+
+async function backfillDataSourceViewsForWorkspace(
+  workspace: LightWorkspaceType,
+  logger: Logger,
+  execute: boolean
+) {
+  const dataSources = await DataSource.findAll({
+    where: {
+      workspaceId: workspace.id,
+    },
+  });
+
+  logger.info(
+    `Found ${dataSources.length} data sources for workspace(${workspace.sId}).`
+  );
+
+  if (!execute) {
+    return;
+  }
+
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+  const globalVault = await VaultResource.fetchWorkspaceGlobalVault(auth);
+
+  let updated = 0;
+  for (const dataSource of dataSources) {
+    // Check if there is already a view for this data source.
+    const dsv = await DataSourceViewModel.findOne({
+      where: {
+        workspaceId: workspace.id,
+        vaultId: globalVault.id,
+        dataSourceId: dataSource.id,
+      },
+    });
+
+    if (dsv) {
+      logger.info(
+        `Data source view already exists for data source ${dataSource.id}.`
+      );
+      continue;
+    }
+
+    // Create a view for this data source in the global vault.
+    await DataSourceViewResource.createViewInVaultFromDataSourceIncludingAllDocuments(
+      globalVault,
+      renderDataSourceType(dataSource)
+    );
+
+    updated++;
+
+    logger.info(`View created for data source ${dataSource.id}.`);
+  }
+
+  logger.info(
+    `Backfilled data source views for workspace(${workspace.sId}). (updated: ${updated}/${dataSources.length})`
+  );
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  return runOnAllWorkspaces(async (workspace) => {
+    await backfillDataSourceViewsForWorkspace(workspace, logger, execute);
+  });
+});

--- a/front/migrations/db/migration_49.sql
+++ b/front/migrations/db/migration_49.sql
@@ -1,4 +1,2 @@
 -- Migration created on Jul 29, 2024
-DELETE FROM feature_flags
-WHERE
-  name = 'workspace_analytics';
+DELETE FROM  feature_flags WHERE name = 'workspace_analytics';

--- a/front/migrations/db/migration_49.sql
+++ b/front/migrations/db/migration_49.sql
@@ -1,0 +1,5 @@
+-- Migration created on Jul 29, 2024
+CREATE TABLE IF NOT EXISTS "data_source_views" ("id"  SERIAL , "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL, "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL, "name" VARCHAR(255) NOT NULL, "parentsIn" VARCHAR(255)[] NOT NULL, "workspaceId" INTEGER NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, "vaultId" INTEGER NOT NULL REFERENCES "vaults" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, "dataSourceId" INTEGER NOT NULL REFERENCES "data_sources" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, PRIMARY KEY ("id"));
+CREATE INDEX "data_source_views_workspace_id_id" ON "data_source_views" ("workspaceId", "id");
+CREATE INDEX "data_source_views_workspace_id_vault_id" ON "data_source_views" ("workspaceId", "vaultId");
+CREATE INDEX "data_source_views_workspace_id_data_source_id" ON "data_source_views" ("workspaceId", "dataSourceId");

--- a/front/migrations/db/migration_50.sql
+++ b/front/migrations/db/migration_50.sql
@@ -1,5 +1,5 @@
 -- Migration created on Jul 29, 2024
-CREATE TABLE IF NOT EXISTS "data_source_views" ("id"  SERIAL , "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL, "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL, "parentsIn" VARCHAR(255)[] NOT NULL, "workspaceId" INTEGER NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, "vaultId" INTEGER NOT NULL REFERENCES "vaults" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, "dataSourceId" INTEGER NOT NULL REFERENCES "data_sources" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, PRIMARY KEY ("id"));
+CREATE TABLE IF NOT EXISTS "data_source_views" ("id"  SERIAL , "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL, "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL, "parentsIn" VARCHAR(255)[], "workspaceId" INTEGER NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, "vaultId" INTEGER NOT NULL REFERENCES "vaults" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, "dataSourceId" INTEGER NOT NULL REFERENCES "data_sources" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, PRIMARY KEY ("id"));
 CREATE INDEX "data_source_views_workspace_id_id" ON "data_source_views" ("workspaceId", "id");
 CREATE INDEX "data_source_views_workspace_id_vault_id" ON "data_source_views" ("workspaceId", "vaultId");
 CREATE INDEX "data_source_views_workspace_id_data_source_id" ON "data_source_views" ("workspaceId", "dataSourceId");

--- a/front/migrations/db/migration_50.sql
+++ b/front/migrations/db/migration_50.sql
@@ -1,0 +1,5 @@
+-- Migration created on Jul 29, 2024
+CREATE TABLE IF NOT EXISTS "data_source_views" ("id"  SERIAL , "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL, "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL, "parentsIn" VARCHAR(255)[] NOT NULL, "workspaceId" INTEGER NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, "vaultId" INTEGER NOT NULL REFERENCES "vaults" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, "dataSourceId" INTEGER NOT NULL REFERENCES "data_sources" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, PRIMARY KEY ("id"));
+CREATE INDEX "data_source_views_workspace_id_id" ON "data_source_views" ("workspaceId", "id");
+CREATE INDEX "data_source_views_workspace_id_vault_id" ON "data_source_views" ("workspaceId", "vaultId");
+CREATE INDEX "data_source_views_workspace_id_data_source_id" ON "data_source_views" ("workspaceId", "dataSourceId");

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -12,7 +12,9 @@ import config from "@app/lib/api/config";
 import { getDataSource, getDataSources } from "@app/lib/api/data_sources";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import { renderDataSourceType } from "@app/lib/data_sources";
 import { DataSource } from "@app/lib/models/data_source";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { VaultResource } from "@app/lib/resources/vault_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import logger from "@app/logger/logger";
@@ -181,6 +183,11 @@ async function handler(
         editedByUserId: user.id,
         vaultId: globalVault.id,
       });
+
+      await DataSourceViewResource.createViewInVaultFromDataSourceIncludingAllDocuments(
+        globalVault,
+        renderDataSourceType(ds)
+      );
 
       const dataSourceType = await getDataSource(auth, ds.name);
       if (dataSourceType) {

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -341,13 +341,11 @@ async function handler(
         vaultId: vault.id,
       });
 
-      if (vault.isGlobal()) {
-        // For data source in the global vault, we create a default view in the vault.
-        await DataSourceViewResource.createViewInVaultFromDataSourceIncludingAllDocuments(
-          vault,
-          { dataSourceId: dataSource.id }
-        );
-      }
+      // For managed data source, we create a default view in the vault.
+      await DataSourceViewResource.createViewInVaultFromDataSourceIncludingAllDocuments(
+        vault,
+        { dataSourceId: dataSource.id }
+      );
 
       const connectorsAPI = new ConnectorsAPI(
         config.getConnectorsAPIConfig(),

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -342,7 +342,7 @@ async function handler(
       });
 
       if (vault.isGlobal()) {
-        // For data source in the default vault, we create a view in the vault.
+        // For data source in the global vault, we create a default view in the vault.
         await DataSourceViewResource.createViewInVaultFromDataSourceIncludingAllDocuments(
           vault,
           { dataSourceId: dataSource.id }

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -24,6 +24,7 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getOrCreateSystemApiKey } from "@app/lib/auth";
 import { DataSource } from "@app/lib/models/data_source";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { VaultResource } from "@app/lib/resources/vault_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { isDisposableEmailDomain } from "@app/lib/utils/disposable_email_domains";
@@ -339,6 +340,14 @@ async function handler(
         editedByUserId: user.id,
         vaultId: vault.id,
       });
+
+      if (vault.isGlobal()) {
+        // For data source in the default vault, we create a view in the vault.
+        await DataSourceViewResource.createViewInVaultFromDataSourceIncludingAllDocuments(
+          vault,
+          { dataSourceId: dataSource.id }
+        );
+      }
 
       const connectorsAPI = new ConnectorsAPI(
         config.getConnectorsAPIConfig(),

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -23,6 +23,7 @@ import { getDataSource } from "@app/lib/api/data_sources";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getOrCreateSystemApiKey } from "@app/lib/auth";
+import { renderDataSourceType } from "@app/lib/data_sources";
 import { DataSource } from "@app/lib/models/data_source";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { VaultResource } from "@app/lib/resources/vault_resource";
@@ -341,10 +342,14 @@ async function handler(
         vaultId: vault.id,
       });
 
-      // For managed data source, we create a default view in the vault.
+      const globalVault = vault.isGlobal()
+        ? vault
+        : await VaultResource.fetchWorkspaceGlobalVault(auth);
+
+      // For managed data source, we create a default view in the workspace vault.
       await DataSourceViewResource.createViewInVaultFromDataSourceIncludingAllDocuments(
-        vault,
-        { dataSourceId: dataSource.id }
+        globalVault,
+        renderDataSourceType(dataSource)
       );
 
       const connectorsAPI = new ConnectorsAPI(

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -45,6 +45,7 @@ import { Subscription } from "@app/lib/models/plan";
 import { UserMetadata } from "@app/lib/models/user";
 import { MembershipInvitation, Workspace } from "@app/lib/models/workspace";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
@@ -567,6 +568,7 @@ export async function deleteWorkspaceActivity({
       transaction: t,
     });
     await FileResource.deleteAllForWorkspace(workspace, t);
+    await DataSourceViewResource.deleteAllForWorkspace(auth, t);
     await VaultResource.deleteAllForWorkspace(auth, t);
     await GroupResource.deleteAllForWorkspace(workspace, t);
     logger.info(`[Workspace delete] Deleting Worskpace ${workspace.sId}`);

--- a/front/scripts/helpers.ts
+++ b/front/scripts/helpers.ts
@@ -61,6 +61,8 @@ export function makeScript<T extends ArgumentSpecs>(
       });
 
       await worker(args as InferArgs<T & { execute: boolean }>, scriptLogger);
+
+      process.exit(0);
     })
     .catch((error) => {
       console.error("An error occurred:", error);
@@ -68,8 +70,8 @@ export function makeScript<T extends ArgumentSpecs>(
     });
 }
 
-export async function runOnAllWorkspaceIds(
-  worker: (workspaceId: LightWorkspaceType) => Promise<void>
+export async function runOnAllWorkspaces(
+  worker: (workspace: LightWorkspaceType) => Promise<void>
 ) {
   const workspaces = await Workspace.findAll({});
 

--- a/front/scripts/remove_draft_agent_configurations.ts
+++ b/front/scripts/remove_draft_agent_configurations.ts
@@ -16,7 +16,7 @@ import { Mention } from "@app/lib/models/assistant/conversation";
 import { Workspace } from "@app/lib/models/workspace";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import type { Logger } from "@app/logger/logger";
-import { makeScript, runOnAllWorkspaceIds } from "@app/scripts/helpers";
+import { makeScript, runOnAllWorkspaces } from "@app/scripts/helpers";
 
 async function deleteRetrievalConfigurationForAgent(agent: AgentConfiguration) {
   const retrievalConfigurations = await AgentRetrievalConfiguration.findAll({
@@ -222,7 +222,7 @@ makeScript(
         execute
       );
     }
-    return runOnAllWorkspaceIds(async (workspace) => {
+    return runOnAllWorkspaces(async (workspace) => {
       await removeDraftAgentConfigurationsForWorkspace(
         workspace,
         logger,

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -21,6 +21,7 @@ import {
   FREE_NO_PLAN_CODE,
   FREE_TEST_PLAN_CODE,
 } from "@app/lib/plans/plan_codes";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -150,6 +151,9 @@ async function archiveAssistants(auth: Authenticator) {
 
 async function deleteDatasources(auth: Authenticator) {
   const dataSources = await getDataSources(auth);
+  // First, we delete all the data source views.
+  await DataSourceViewResource.deleteAllForWorkspace(auth);
+
   for (const dataSource of dataSources) {
     const r = await deleteDataSource(auth, dataSource.name);
     if (r.isErr()) {

--- a/types/src/front/data_source_view.ts
+++ b/types/src/front/data_source_view.ts
@@ -1,6 +1,5 @@
 export interface DataSourceViewType {
   createdAt: number;
-  name: string;
   parentsIn: string[];
   sId: string;
   updatedAt: number;

--- a/types/src/front/data_source_view.ts
+++ b/types/src/front/data_source_view.ts
@@ -1,0 +1,7 @@
+export interface DataSourceViewType {
+  createdAt: number;
+  name: string;
+  parentsIn: string[];
+  sId: string;
+  updatedAt: number;
+}

--- a/types/src/front/data_source_view.ts
+++ b/types/src/front/data_source_view.ts
@@ -1,6 +1,6 @@
 export interface DataSourceViewType {
   createdAt: number;
-  parentsIn: string[];
+  parentsIn: string[] | null;
   sId: string;
   updatedAt: number;
 }

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -34,6 +34,7 @@ export * from "./front/assistant/conversation";
 export * from "./front/assistant/templates";
 export * from "./front/content_fragment";
 export * from "./front/data_source";
+export * from "./front/data_source_view";
 export * from "./front/dataset";
 export * from "./front/document";
 export * from "./front/dust_app_secret";


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR introduces a `DataSourceViewResource` along with its corresponding SQL table. This resource represents a filtered view of a data source, acting as a bridge between the vault and the data source to manage data access for users and assistants. There's a special case in the implementation of `parentIds`, which represents all documents. This case is necessary to align with the current behavior where no restrictions are applied to all data sources. For those data sources, we will create a default view setting `parentsIn` to `null`, which signifies all documents. This is needed because, until the connection is fully synchronized, we can't access the highest parent IDs.

With this PR we will start creating default views for all newly created data sources. The is a migration included in the PR to create the default view of all existing data sources.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
- [x] Create table in DB
- [ ] Run migration to backfill views
