### PR TITLE
Zendesk connector - UI

### DIFF
--- a/core/src/oauth/providers/zendesk.rs
+++ b/core/src/oauth/providers/zendesk.rs
@@ -42,7 +42,7 @@ impl Provider for ZendeskConnectionProvider {
             "client_id": *OAUTH_ZENDESK_CLIENT_ID,
             "client_secret": *OAUTH_ZENDESK_CLIENT_SECRET,
             "redirect_uri": redirect_uri,
-            "scope": "read"
+            "scope": "tickets:read hc:read"
         });
 
         let req = reqwest::Client::new()

--- a/front/components/ConnectorPermissionsTree.tsx
+++ b/front/components/ConnectorPermissionsTree.tsx
@@ -40,6 +40,7 @@ const CONNECTOR_TYPE_TO_PERMISSIONS: Record<
     selected: "read",
     unselected: "none",
   },
+  zendesk: undefined,
   notion: undefined,
   github: undefined,
   intercom: {

--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -44,7 +44,7 @@ export const CONNECTOR_PROVIDER_TO_RESOURCE_NAME: Record<
   github: { singular: "repository", plural: "repositories" },
   intercom: { singular: "article", plural: "articles" },
   microsoft: { singular: "folder", plural: "folders" },
-  zendesk: { singular: "ticket", plural: "tickets" },
+  zendesk: { singular: "element", plural: "elements" },
   webcrawler: { singular: "page", plural: "pages" },
 };
 

--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -44,6 +44,7 @@ export const CONNECTOR_PROVIDER_TO_RESOURCE_NAME: Record<
   github: { singular: "repository", plural: "repositories" },
   intercom: { singular: "article", plural: "articles" },
   microsoft: { singular: "folder", plural: "folders" },
+  zendesk: { singular: "ticket", plural: "tickets" },
   webcrawler: { singular: "page", plural: "pages" },
 };
 
@@ -630,6 +631,7 @@ function getDisplayNameForDataSource(ds: DataSourceType) {
       case "intercom":
       case "microsoft":
       case "notion":
+      case "zendesk":
         return CONNECTOR_CONFIGURATIONS[ds.connectorProvider].name;
       case "webcrawler":
         return ds.name;

--- a/front/components/assistant_builder/shared.ts
+++ b/front/components/assistant_builder/shared.ts
@@ -30,6 +30,7 @@ export const CONNECTOR_PROVIDER_TO_RESOURCE_NAME: Record<
   github: { singular: "repository", plural: "repositories" },
   intercom: { singular: "element", plural: "elements" },
   webcrawler: { singular: "page", plural: "pages" },
+  zendesk: { singular: "ticket", plural: "tickets" },
 };
 
 export const DROID_AVATARS_BASE_PATH = "/static/droidavatar/";

--- a/front/components/assistant_builder/shared.ts
+++ b/front/components/assistant_builder/shared.ts
@@ -30,7 +30,7 @@ export const CONNECTOR_PROVIDER_TO_RESOURCE_NAME: Record<
   github: { singular: "repository", plural: "repositories" },
   intercom: { singular: "element", plural: "elements" },
   webcrawler: { singular: "page", plural: "pages" },
-  zendesk: { singular: "ticket", plural: "tickets" },
+  zendesk: { singular: "element", plural: "elements" },
 };
 
 export const DROID_AVATARS_BASE_PATH = "/static/droidavatar/";

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -109,6 +109,9 @@ const config = {
   getOAuthGongClientId: (): string => {
     return EnvironmentConfig.getEnvVariable("OAUTH_GONG_CLIENT_ID");
   },
+  getOAuthZendeskClientId: (): string => {
+    return EnvironmentConfig.getEnvVariable("OAUTH_ZENDESK_CLIENT_ID");
+  },
   getOAuthMicrosoftClientId: (): string => {
     return EnvironmentConfig.getEnvVariable("OAUTH_MICROSOFT_CLIENT_ID");
   },

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -218,10 +218,7 @@ const PROVIDER_STRATEGIES: Record<
   },
   zendesk: {
     setupUri: (connection) => {
-      const scopes = [
-        "tickets:read",
-        "hc:read",
-      ];
+      const scopes = ["tickets:read", "hc:read"];
       return (
         `https://d3v-dust.zendesk.com/oauth/authorizations/new?` +
         `client_id=${config.getOAuthZendeskClientId()}` +

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -216,6 +216,28 @@ const PROVIDER_STRATEGIES: Record<
       return getStringFromQuery(query, "state");
     },
   },
+  zendesk: {
+    setupUri: (connection) => {
+      const scopes = [
+        "tickets:read",
+        "hc:read",
+      ];
+      return (
+        `https://d3v-dust.zendesk.com/oauth/authorizations/new?` +
+        `client_id=${config.getOAuthZendeskClientId()}` +
+        `&scope=${encodeURIComponent(scopes.join(" "))}` +
+        `&response_type=code` +
+        `&state=${connection.connection_id}` +
+        `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("zendesk"))}`
+      );
+    },
+    codeFromQuery: (query) => {
+      return getStringFromQuery(query, "code");
+    },
+    connectionIdFromQuery: (query) => {
+      return getStringFromQuery(query, "state");
+    },
+  },
   microsoft: {
     setupUri: (connection) => {
       const scopes = [

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -7,6 +7,7 @@ import {
   MicrosoftLogo,
   NotionLogo,
   SlackLogo,
+  ZendeskLogo,
 } from "@dust-tt/sparkle";
 import type { ConnectorProvider, WhitelistableFeature } from "@dust-tt/types";
 
@@ -123,6 +124,22 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     isNested: true,
     isSearchEnabled: false,
   },
+  zendesk: {
+    name: "Zendesk",
+    connectorProvider: "zendesk",
+    status: "rolling_out",
+    rollingOutFlag: "zendesk_connector",
+    hide: false,
+    description:
+      "Authorize access to Zendesk for indexing tickets, articles, and comments from your help center.",
+    limitations:
+      "Dust will index the content accessible to the authorized account only. Attachments are not indexed.",
+    guideLink: "https://docs.dust.tt/docs/zendesk-connection",
+    logoComponent: ZendeskLogo,
+    isNested: false,
+    isSearchEnabled: true,
+  },
+
   webcrawler: {
     name: "Web Crawler",
     connectorProvider: "webcrawler",

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -139,7 +139,6 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     isNested: false,
     isSearchEnabled: true,
   },
-
   webcrawler: {
     name: "Web Crawler",
     connectorProvider: "webcrawler",

--- a/front/lib/data_sources.ts
+++ b/front/lib/data_sources.ts
@@ -22,6 +22,7 @@ export function getDisplayNameForDataSource(ds: DataSourceType) {
       case "github":
       case "intercom":
       case "microsoft":
+      case "zendesk":
       case "notion":
         return CONNECTOR_CONFIGURATIONS[ds.connectorProvider].name;
         break;

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -10736,9 +10736,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.193",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.193.tgz",
-      "integrity": "sha512-ehUgBTsBv6kqZD/eWxeZ7CD5fMRBBSrkddCvs6YMI+QxD1yhpLut4mc9aJ0XMreVx6FwHnQCoqkWMisgZtT4fQ==",
+      "version": "0.2.195",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.195.tgz",
+      "integrity": "sha512-HRe9aVA+958cQb6EV7NPhy4cux5UOjJDQRNrbL4LjzLjviQUn0tKXd5YS7x+6yRg+4hP8Otbf8XS+a32mO1w0Q==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/pages/api/w/[wId]/data_sources/[name]/configuration.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/configuration.ts
@@ -78,6 +78,7 @@ async function handler(
     case "intercom":
     case "notion":
     case "microsoft":
+    case "zendesk":
     case "slack":
       if (!auth.isAdmin()) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -124,6 +124,7 @@ async function handler(
         case "intercom":
         case "notion":
         case "microsoft":
+        case "zendesk":
         case "slack": {
           if (!auth.isAdmin()) {
             return apiError(req, res, {
@@ -237,6 +238,10 @@ async function handler(
           assistantDefaultSelected = true;
           break;
         case "microsoft":
+          isDataSourceAllowedInPlan = true;
+          assistantDefaultSelected = true;
+          break;
+        case "zendesk":
           isDataSourceAllowedInPlan = true;
           assistantDefaultSelected = true;
           break;

--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -920,6 +920,8 @@ const CONNECTOR_TYPE_TO_MISMATCH_ERROR: Record<ConnectorProvider, string> = {
   intercom:
     "You cannot select another Intercom Workspace.\nPlease contact us at support@dust.tt if you initially selected a wrong Workspace.",
   microsoft: `Microsoft / mismatch error.`,
+  zendesk:
+    "You cannot select another Zendesk Workspace.\nPlease contact us at support@dust.tt if you initially selected a wrong Workspace.",
   webcrawler: "You cannot change the URL. Please add a new Public URL instead.",
 };
 
@@ -945,6 +947,7 @@ function getRenderingConfigForConnectorProvider(
     case "confluence":
     case "google_drive":
     case "microsoft":
+    case "zendesk":
       return {
         ...commonConfig,
         displayDataSourceDetailsModal: true,
@@ -1168,6 +1171,7 @@ function ManagedDataSourceView({
                 case "notion":
                 case "intercom":
                 case "microsoft":
+                case "zendesk":
                   return `Manage Dust connection to ${CONNECTOR_CONFIGURATIONS[connectorProvider].name}`;
                 case "webcrawler":
                   return `Manage Website`;
@@ -1267,6 +1271,7 @@ function ManagedDataSourceView({
                     case "notion":
                     case "intercom":
                     case "microsoft":
+                    case "zendesk":
                       return (
                         <>
                           Selected resources will be accessible to all members

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -685,6 +685,9 @@ export default function DataSourcesView({
                               case "microsoft":
                                 isDataSourceAllowedInPlan = true;
                                 break;
+                              case "zendesk":
+                                isDataSourceAllowedInPlan = true;
+                                break;
                               case "webcrawler":
                                 // Web crawler connector is not displayed on this web page.
                                 isDataSourceAllowedInPlan = false;

--- a/types/src/front/data_source.ts
+++ b/types/src/front/data_source.ts
@@ -10,6 +10,7 @@ export const CONNECTOR_PROVIDERS = [
   "slack",
   "microsoft",
   "webcrawler",
+  "zendesk",
 ] as const;
 
 export const DEFAULT_EMBEDDING_PROVIDER_ID = "openai";

--- a/types/src/oauth/lib.ts
+++ b/types/src/oauth/lib.ts
@@ -14,6 +14,7 @@ export const OAUTH_PROVIDERS = [
   "notion",
   "slack",
   "gong",
+  "zendesk",
   "microsoft",
 ] as const;
 

--- a/types/src/shared/feature_flags.ts
+++ b/types/src/shared/feature_flags.ts
@@ -7,6 +7,7 @@ export const WHITELISTABLE_FEATURES = [
   "visualization_action_flag",
   "dust_splitted_ds_flag",
   "test_oauth_setup",
+  "zendesk_connector",
 ] as const;
 export type WhitelistableFeature = (typeof WHITELISTABLE_FEATURES)[number];
 export function isWhitelistableFeature(


### PR DESCRIPTION
## Description

This PR drafts a simple version of the Zendesk connector oauth. The actual connector will likely start as a labs alpha feature (will need to show in the UI). This allows getting started on the Zendesk oauth flow and showing it to the users as we did with microsoft - we'll keep a list of users asking for Zendesk beta testing. 

- This PR handles the UI 
- This PR handles the oAuth flow (dependent on https://github.com/dust-tt/dust/pull/6589)
- oAuth flow is gated behind FF - preview for the rest

<img width="886" alt="Screenshot 2024-07-29 at 19 46 45" src="https://github.com/user-attachments/assets/9bf3c008-22a7-47ab-a9b9-aba37fd2d374">

https://github.com/user-attachments/assets/fca35211-ada5-489c-bdf7-f4122bc85f45

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
https://github.com/dust-tt/dust/pull/6589 needs to be merged first
Once this is live we can start asking Zendesk for a *global oAuth client* - we will have to go through a review process so better to do it early on
