### PR TITLE
Do not delete default groups and vaults when scrubbing a workspace.

### DIFF
--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -128,6 +128,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     const workspaceId = auth.getNonNullableWorkspace().id;
 
     const groups = await this.model.findAll({
+      include: ["id"],
       where: {
         workspaceId,
         type: {
@@ -136,11 +137,13 @@ export class GroupResource extends BaseResource<GroupModel> {
       },
     });
 
+    const groupIds = groups.map((group) => group.id);
+
     await GroupMembershipModel.destroy({
       where: {
         workspaceId,
         groupId: {
-          [Op.in]: groups.map((group) => group.id),
+          [Op.in]: groupIds,
         },
       },
     });
@@ -148,7 +151,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     await this.model.destroy({
       where: {
         id: {
-          [Op.in]: groups.map((group) => group.id),
+          [Op.in]: groupIds,
         },
         workspaceId,
       },

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -12,6 +12,7 @@ import type {
   ModelStatic,
   Transaction,
 } from "sequelize";
+import { Op } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
@@ -197,6 +198,18 @@ export class VaultResource extends BaseResource<VaultModel> {
         workspaceId: owner.id,
       },
       transaction,
+    });
+  }
+
+  static async deleteAllForWorkspaceExceptDefaults(auth: Authenticator) {
+    const owner = auth.getNonNullableWorkspace();
+    await this.model.destroy({
+      where: {
+        workspaceId: owner.id,
+        kind: {
+          [Op.notIn]: ["system", "global"],
+        },
+      },
     });
   }
 

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -162,17 +162,19 @@ async function deleteDatasources(auth: Authenticator) {
   }
 }
 
+// Delete all vaults except the system and global vaults.
 async function deleteVaults(auth: Authenticator) {
-  await VaultResource.deleteAllForWorkspace(auth);
+  await VaultResource.deleteAllForWorkspaceExceptDefaults(auth);
 }
 
+// Delete all groups except the default groups.
 async function deleteGroups(auth: Authenticator) {
   const workspace = auth.workspace();
   if (!workspace) {
     throw new Error("No workspace found");
   }
-  const w = renderLightWorkspaceType({ workspace });
-  await GroupResource.deleteAllForWorkspace(w);
+
+  await GroupResource.deleteAllForWorkspaceExceptDefaults(auth);
 }
 
 async function cleanupCustomerio(auth: Authenticator) {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR revisits the logic for scrubbing a workspace to prevent the deletion of default groups and vaults. The current definition of scrubbing entails removing all data while retaining the workspace itself. To ensure continued usability of the workspace post-scrubbing, it's necessary to preserve the default groups and vaults.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
