### PR TITLE
Gdrive skipping files with 404 errors in handleFileExport.

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/file.ts
+++ b/connectors/src/connectors/google_drive/temporal/file.ts
@@ -125,6 +125,15 @@ async function handleFileExport(
       }
     );
   } catch (e) {
+    if (e instanceof GaxiosError && e.response?.status === 404) {
+      localLogger.info(
+        {
+          error: e,
+        },
+        "Can't export Gdrive file. 404 error returned. Skipping."
+      );
+      return null;
+    }
     const maybeErrorWithCode = e as { code: string };
     if (maybeErrorWithCode.code === "ERR_OUT_OF_RANGE") {
       localLogger.info({}, "File too big to be downloaded. Skipping");


### PR DESCRIPTION
## Description

Gdrive skipping files with 404 errors in handleFileExport.
This is weird as this should never happened because we just listed the file, but that's how it is for now.


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
