### PR TITLE
[front] - feat(data-sources): searchable folders and websites

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,7 @@
         "@amplitude/analytics-browser": "^2.5.2",
         "@amplitude/analytics-node": "^1.3.5",
         "@auth0/nextjs-auth0": "^3.5.0",
-        "@dust-tt/sparkle": "^0.2.197",
+        "@dust-tt/sparkle": "^0.2.198",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -10735,9 +10735,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.197",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.197.tgz",
-      "integrity": "sha512-H1lmZ+CrjIsABO5vsMFZZrBTcUNpc4OtJuVsWQCJSm7Z4TnpeSNrg/u6TY2049lj8AIxtMQH4mNtLHpYXhqT2A==",
+      "version": "0.2.198",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.198.tgz",
+      "integrity": "sha512-QSV29789AKo2qnERpVQIom1hGLGPz6y7jsnUgWTcXwjfqrySRViQ9vnSrTNdjpLZqEEmLfIXbLKVRlWEsBcLIg==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,7 @@
         "@amplitude/analytics-browser": "^2.5.2",
         "@amplitude/analytics-node": "^1.3.5",
         "@auth0/nextjs-auth0": "^3.5.0",
-        "@dust-tt/sparkle": "^0.2.196",
+        "@dust-tt/sparkle": "^0.2.197",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -10735,13 +10735,14 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.196",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.196.tgz",
-      "integrity": "sha512-bDIhU9tHVfsORfmjm9V2ZeLimqjRYvgd3Bb+siGbN5jdMQazrnNeX3I+iFeozufTOx12y8q63V3beQ+nLylJRA==",
+      "version": "0.2.197",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.197.tgz",
+      "integrity": "sha512-H1lmZ+CrjIsABO5vsMFZZrBTcUNpc4OtJuVsWQCJSm7Z4TnpeSNrg/u6TY2049lj8AIxtMQH4mNtLHpYXhqT2A==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
         "@headlessui/react": "^1.7.19",
+        "@tanstack/react-table": "^8.13.0",
         "emoji-mart": "^5.5.2",
         "esbuild": "^0.20.0",
         "eslint-plugin-import": "^2.29.1",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
     "@amplitude/analytics-browser": "^2.5.2",
     "@amplitude/analytics-node": "^1.3.5",
     "@auth0/nextjs-auth0": "^3.5.0",
-    "@dust-tt/sparkle": "^0.2.197",
+    "@dust-tt/sparkle": "^0.2.198",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
     "@amplitude/analytics-browser": "^2.5.2",
     "@amplitude/analytics-node": "^1.3.5",
     "@auth0/nextjs-auth0": "^3.5.0",
-    "@dust-tt/sparkle": "^0.2.196",
+    "@dust-tt/sparkle": "^0.2.197",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",

--- a/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
@@ -1,13 +1,12 @@
 import {
   Button,
+  DataTable,
   LinkIcon,
   Page,
   PlusIcon,
   Popup,
   RobotIcon,
   Searchbar,
-  Table,
-  TableData,
 } from "@dust-tt/sparkle";
 import { GlobeAltIcon } from "@dust-tt/sparkle";
 import type { PlanType, SubscriptionType } from "@dust-tt/types";
@@ -220,10 +219,9 @@ export default function DataSourcesView({
           />
         )}
         {clickableDataSources.length > 0 && (
-          <Table
+          <DataTable
             data={clickableDataSources}
             columns={columns}
-            width="expanded"
             filter={dataSourceSearch}
             filterColumn={"name"}
           />
@@ -247,24 +245,24 @@ function getTableColumns() {
       header: "Name",
       accessorKey: "name",
       cell: (info: Info) => (
-        <TableData.Cell icon={info.row.original.icon}>
+        <DataTable.Cell icon={info.row.original.icon}>
           {info.row.original.name}
-        </TableData.Cell>
+        </DataTable.Cell>
       ),
     },
     {
       header: "Used by",
       accessorKey: "usage",
       cell: (info: Info) => (
-        <TableData.Cell icon={RobotIcon}>
+        <DataTable.Cell icon={RobotIcon}>
           {info.row.original.usage}
-        </TableData.Cell>
+        </DataTable.Cell>
       ),
     },
     {
       header: "Added by",
       cell: (info: Info) => (
-        <TableData.Cell
+        <DataTable.Cell
           avatarUrl={info.row.original.editedByUser?.imageUrl ?? ""}
         />
       ),
@@ -273,13 +271,13 @@ function getTableColumns() {
       header: "Last updated",
       accessorKey: "editedByUser.editedAt",
       cell: (info: Info) => (
-        <TableData.Cell>
+        <DataTable.Cell>
           {info.row.original.editedByUser?.editedAt
             ? new Date(
                 info.row.original.editedByUser.editedAt
               ).toLocaleDateString()
             : null}
-        </TableData.Cell>
+        </DataTable.Cell>
       ),
     },
   ];

--- a/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
@@ -232,13 +232,14 @@ export default function DataSourcesView({
 
 function getTableColumns() {
   // to please typescript
-  type OriginalType = DataSourceType & {
-    icon: ComponentType;
-    usage: number;
+  type Info = {
+    row: {
+      original: DataSourceType & {
+        icon: ComponentType;
+        usage: number;
+      };
+    };
   };
-  interface Info {
-    row: { original: OriginalType };
-  }
   return [
     {
       header: "Name",

--- a/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
@@ -19,6 +19,7 @@ import type {
 import { ConnectorsAPI } from "@dust-tt/types";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
+import type { ComponentType } from "react";
 import { useMemo, useRef, useState } from "react";
 import * as React from "react";
 
@@ -233,11 +234,19 @@ export default function DataSourcesView({
 }
 
 function getTableColumns() {
+  // to please typescript
+  type OriginalType = DataSourceType & {
+    icon: ComponentType;
+    usage: number;
+  };
+  interface Info {
+    row: { original: OriginalType };
+  }
   return [
     {
       header: "Name",
       accessorKey: "name",
-      cell: (info) => (
+      cell: (info: Info) => (
         <TableData.Cell icon={info.row.original.icon}>
           {info.row.original.name}
         </TableData.Cell>
@@ -246,7 +255,7 @@ function getTableColumns() {
     {
       header: "Used by",
       accessorKey: "usage",
-      cell: (info) => (
+      cell: (info: Info) => (
         <TableData.Cell icon={RobotIcon}>
           {info.row.original.usage}
         </TableData.Cell>
@@ -254,18 +263,22 @@ function getTableColumns() {
     },
     {
       header: "Added by",
-      cell: (info) => (
-        <TableData.Cell avatarUrl={info.row.original.editedByUser.imageUrl} />
+      cell: (info: Info) => (
+        <TableData.Cell
+          avatarUrl={info.row.original.editedByUser?.imageUrl ?? ""}
+        />
       ),
     },
     {
       header: "Last updated",
       accessorKey: "editedByUser.editedAt",
-      cell: (info) => (
+      cell: (info: Info) => (
         <TableData.Cell>
-          {new Date(
-            info.row.original.editedByUser.editedAt
-          ).toLocaleDateString()}
+          {info.row.original.editedByUser?.editedAt
+            ? new Date(
+                info.row.original.editedByUser.editedAt
+              ).toLocaleDateString()
+            : null}
         </TableData.Cell>
       ),
     },

--- a/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
@@ -144,7 +144,6 @@ export default function DataSourcesView({
   const clickableDataSources = useMemo(() => {
     return dataSources.map((dataSource) => ({
       ...dataSource,
-      clickable: true,
       onClick: () => {
         void router.push(
           `/w/${owner.sId}/builder/data-sources/${dataSource.name}`

--- a/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   ContextItem,
   FolderOpenIcon,
   Icon,
@@ -6,6 +7,7 @@ import {
   PlusIcon,
   Popup,
   RobotIcon,
+  Searchbar,
 } from "@dust-tt/sparkle";
 import { GlobeAltIcon } from "@dust-tt/sparkle";
 import type { PlanType, SubscriptionType } from "@dust-tt/types";
@@ -17,7 +19,8 @@ import type {
 import { ConnectorsAPI } from "@dust-tt/types";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
-import { useState } from "react";
+import { useRef, useState } from "react";
+import * as React from "react";
 
 import ConnectorSyncingChip from "@app/components/data_source/DataSourceSyncChip";
 import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
@@ -123,11 +126,8 @@ export default function DataSourcesView({
   const router = useRouter();
   const [showDatasourceLimitPopup, setShowDatasourceLimitPopup] =
     useState(false);
-
-  const {
-    submit: handleCreateDataSource,
-    isSubmitting: isSubmittingCreateDataSource,
-  } = useSubmitFunction(async () => {
+  const [dataSourceSearch, setDataSourceSearch] = useState<string>("");
+  const { submit: handleCreateDataSource } = useSubmitFunction(async () => {
     // Enforce plan limits: DataSources count.
     if (
       plan.limits.dataSources.count != -1 &&
@@ -138,6 +138,7 @@ export default function DataSourcesView({
       void router.push(`/w/${owner.sId}/builder/data-sources/new-public-url`);
     }
   });
+  const searchBarRef = useRef<HTMLInputElement>(null);
   return (
     <AppLayout
       subscription={subscription}
@@ -157,22 +158,29 @@ export default function DataSourcesView({
 
         {dataSources.length > 0 ? (
           <div className="relative">
-            <Page.SectionHeader
-              title=""
-              description=""
-              action={
-                !readOnly
-                  ? {
-                      label: "Add a public URL",
-                      variant: "primary",
-                      icon: PlusIcon,
-                      onClick: handleCreateDataSource,
-
-                      disabled: isSubmittingCreateDataSource,
-                    }
-                  : undefined
-              }
-            />
+            <div className="flex flex-row gap-2">
+              <Searchbar
+                ref={searchBarRef}
+                name="search"
+                placeholder="Search (Name)"
+                value={dataSourceSearch}
+                onChange={(s) => {
+                  setDataSourceSearch(s);
+                }}
+              />
+              {!readOnly && (
+                <Button.List>
+                  <Button
+                    variant="primary"
+                    icon={PlusIcon}
+                    label="Create a wesbite"
+                    onClick={async () => {
+                      await handleCreateDataSource();
+                    }}
+                  />
+                </Button.List>
+              )}
+            </div>
             <Popup
               show={showDatasourceLimitPopup}
               chipLabel={`${plan.name} plan`}

--- a/front/pages/w/[wId]/builder/data-sources/static.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/static.tsx
@@ -126,7 +126,7 @@ export default function DataSourcesView({
           icon={FolderOpenIcon}
           description="Make more documents accessible to this workspace. Manage folders manually or via API."
         />
-        {dataSources.length > 0 ? (
+        {clickableDataSources.length > 0 ? (
           <div className="relative">
             <div className="flex flex-row gap-2">
               <Searchbar
@@ -174,13 +174,15 @@ export default function DataSourcesView({
             }}
           />
         )}
-        <Table
-          data={clickableDataSources}
-          columns={columns}
-          width="expanded"
-          filter={dataSourceSearch}
-          filterColumn={"name"}
-        />
+        {clickableDataSources.length > 0 && (
+          <Table
+            data={clickableDataSources}
+            columns={columns}
+            width="expanded"
+            filter={dataSourceSearch}
+            filterColumn={"name"}
+          />
+        )}
       </Page.Vertical>
     </AppLayout>
   );

--- a/front/pages/w/[wId]/builder/data-sources/static.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/static.tsx
@@ -100,7 +100,6 @@ export default function DataSourcesView({
   const clickableDataSources = useMemo(() => {
     return dataSources.map((dataSource) => ({
       ...dataSource,
-      clickable: true,
       onClick: () => {
         void router.push(
           `/w/${owner.sId}/builder/data-sources/${dataSource.name}`

--- a/front/pages/w/[wId]/builder/data-sources/static.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/static.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  DataTable,
   FolderIcon,
   FolderOpenIcon,
   Page,
@@ -7,8 +8,6 @@ import {
   Popup,
   RobotIcon,
   Searchbar,
-  Table,
-  TableData,
 } from "@dust-tt/sparkle";
 import type { DataSourceType, WorkspaceType } from "@dust-tt/types";
 import type { PlanType, SubscriptionType } from "@dust-tt/types";
@@ -176,10 +175,9 @@ export default function DataSourcesView({
           />
         )}
         {clickableDataSources.length > 0 && (
-          <Table
+          <DataTable
             data={clickableDataSources}
             columns={columns}
-            width="expanded"
             filter={dataSourceSearch}
             filterColumn={"name"}
           />
@@ -203,24 +201,24 @@ function getTableColumns() {
       header: "Name",
       accessorKey: "name",
       cell: (info: Info) => (
-        <TableData.Cell icon={info.row.original.icon}>
+        <DataTable.Cell icon={info.row.original.icon}>
           {info.row.original.name}
-        </TableData.Cell>
+        </DataTable.Cell>
       ),
     },
     {
       header: "Used by",
       accessorKey: "usage",
       cell: (info: Info) => (
-        <TableData.Cell icon={RobotIcon}>
+        <DataTable.Cell icon={RobotIcon}>
           {info.row.original.usage}
-        </TableData.Cell>
+        </DataTable.Cell>
       ),
     },
     {
       header: "Added by",
       cell: (info: Info) => (
-        <TableData.Cell
+        <DataTable.Cell
           avatarUrl={info.row.original.editedByUser?.imageUrl ?? ""}
         />
       ),
@@ -229,13 +227,13 @@ function getTableColumns() {
       header: "Last updated",
       accessorKey: "editedByUser.editedAt",
       cell: (info: Info) => (
-        <TableData.Cell>
+        <DataTable.Cell>
           {info.row.original.editedByUser?.editedAt
             ? new Date(
                 info.row.original.editedByUser.editedAt
               ).toLocaleDateString()
             : null}
-        </TableData.Cell>
+        </DataTable.Cell>
       ),
     },
   ];

--- a/front/pages/w/[wId]/builder/data-sources/static.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/static.tsx
@@ -177,9 +177,9 @@ export default function DataSourcesView({
         <Table
           data={clickableDataSources}
           columns={columns}
-          // onRowClick={(row) => {
-          //   void router.push(`/w/${owner.sId}/builder/data-sources/${row.original.name}`);
-          // }}
+          width="expanded"
+          filter={dataSourceSearch}
+          filterColumn={"name"}
         />
       </Page.Vertical>
     </AppLayout>
@@ -213,7 +213,7 @@ function getTableColumns() {
       ),
     },
     {
-      header: "Lasted updated",
+      header: "Last updated",
       accessorKey: "editedByUser.editedAt",
       cell: (info) => (
         <TableData.Cell>

--- a/front/pages/w/[wId]/builder/data-sources/static.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/static.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   ContextItem,
   FolderOpenIcon,
   Icon,
@@ -6,12 +7,14 @@ import {
   PlusIcon,
   Popup,
   RobotIcon,
+  Searchbar,
 } from "@dust-tt/sparkle";
 import type { DataSourceType, WorkspaceType } from "@dust-tt/types";
 import type { PlanType, SubscriptionType } from "@dust-tt/types";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
-import { useState } from "react";
+import { useRef, useState } from "react";
+import * as React from "react";
 
 import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
 import { subNavigationBuild } from "@app/components/navigation/config";
@@ -76,10 +79,8 @@ export default function DataSourcesView({
   const router = useRouter();
   const [showDatasourceLimitPopup, setShowDatasourceLimitPopup] =
     useState(false);
-  const {
-    submit: handleCreateDataSource,
-    isSubmitting: isSubmittingCreateDataSource,
-  } = useSubmitFunction(async () => {
+  const [dataSourceSearch, setDataSourceSearch] = useState<string>("");
+  const { submit: handleCreateDataSource } = useSubmitFunction(async () => {
     // Enforce plan limits: DataSources count.
     if (
       plan.limits.dataSources.count != -1 &&
@@ -90,6 +91,9 @@ export default function DataSourcesView({
       void router.push(`/w/${owner.sId}/builder/data-sources/new`);
     }
   });
+
+  const searchBarRef = useRef<HTMLInputElement>(null);
+
   return (
     <AppLayout
       subscription={subscription}
@@ -106,26 +110,31 @@ export default function DataSourcesView({
           icon={FolderOpenIcon}
           description="Make more documents accessible to this workspace. Manage folders manually or via API."
         />
-
         {dataSources.length > 0 ? (
           <div className="relative">
-            <Page.SectionHeader
-              title=""
-              description=""
-              action={
-                !readOnly
-                  ? {
-                      label: "Add a new Folder",
-                      variant: "primary",
-                      icon: PlusIcon,
-                      onClick: async () => {
-                        await handleCreateDataSource();
-                      },
-                      disabled: isSubmittingCreateDataSource,
-                    }
-                  : undefined
-              }
-            />
+            <div className="flex flex-row gap-2">
+              <Searchbar
+                ref={searchBarRef}
+                name="search"
+                placeholder="Search (Name)"
+                value={dataSourceSearch}
+                onChange={(s) => {
+                  setDataSourceSearch(s);
+                }}
+              />
+              {!readOnly && (
+                <Button.List>
+                  <Button
+                    variant="primary"
+                    icon={PlusIcon}
+                    label="Create a folder"
+                    onClick={async () => {
+                      await handleCreateDataSource();
+                    }}
+                  />
+                </Button.List>
+              )}
+            </div>
             <Popup
               show={showDatasourceLimitPopup}
               chipLabel={`${plan.name} plan`}

--- a/front/pages/w/[wId]/builder/data-sources/static.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/static.tsx
@@ -14,6 +14,7 @@ import type { DataSourceType, WorkspaceType } from "@dust-tt/types";
 import type { PlanType, SubscriptionType } from "@dust-tt/types";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
+import type { ComponentType } from "react";
 import { useMemo, useRef, useState } from "react";
 import * as React from "react";
 
@@ -189,11 +190,19 @@ export default function DataSourcesView({
 }
 
 function getTableColumns() {
+  // to please typescript
+  type OriginalType = DataSourceType & {
+    icon: ComponentType;
+    usage: number;
+  };
+  interface Info {
+    row: { original: OriginalType };
+  }
   return [
     {
       header: "Name",
       accessorKey: "name",
-      cell: (info) => (
+      cell: (info: Info) => (
         <TableData.Cell icon={info.row.original.icon}>
           {info.row.original.name}
         </TableData.Cell>
@@ -202,7 +211,7 @@ function getTableColumns() {
     {
       header: "Used by",
       accessorKey: "usage",
-      cell: (info) => (
+      cell: (info: Info) => (
         <TableData.Cell icon={RobotIcon}>
           {info.row.original.usage}
         </TableData.Cell>
@@ -210,18 +219,22 @@ function getTableColumns() {
     },
     {
       header: "Added by",
-      cell: (info) => (
-        <TableData.Cell avatarUrl={info.row.original.editedByUser.imageUrl} />
+      cell: (info: Info) => (
+        <TableData.Cell
+          avatarUrl={info.row.original.editedByUser?.imageUrl ?? ""}
+        />
       ),
     },
     {
       header: "Last updated",
       accessorKey: "editedByUser.editedAt",
-      cell: (info) => (
+      cell: (info: Info) => (
         <TableData.Cell>
-          {new Date(
-            info.row.original.editedByUser.editedAt
-          ).toLocaleDateString()}
+          {info.row.original.editedByUser?.editedAt
+            ? new Date(
+                info.row.original.editedByUser.editedAt
+              ).toLocaleDateString()
+            : null}
         </TableData.Cell>
       ),
     },

--- a/front/pages/w/[wId]/builder/data-sources/static.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/static.tsx
@@ -188,13 +188,14 @@ export default function DataSourcesView({
 
 function getTableColumns() {
   // to please typescript
-  type OriginalType = DataSourceType & {
-    icon: ComponentType;
-    usage: number;
+  type Info = {
+    row: {
+      original: DataSourceType & {
+        icon: ComponentType;
+        usage: number;
+      };
+    };
   };
-  interface Info {
-    row: { original: OriginalType };
-  }
   return [
     {
       header: "Name",


### PR DESCRIPTION
## Description

This PR aims at making folders and websites searchable as described in https://github.com/dust-tt/tasks/issues/1073.

It uses the newly introduced `Table` component from sparkle (see PR https://github.com/dust-tt/dust/pull/6583).

New UI look:

<img width="1020" alt="Screenshot 2024-08-01 at 13 48 58" src="https://github.com/user-attachments/assets/c0f9d005-c0e8-4b06-8e1a-bbf65b1bbdb4">


**References:**
- https://github.com/dust-tt/dust/pull/6583
- https://github.com/dust-tt/tasks/issues/1073

## Risk

Broken UI

## Deploy Plan

- Wait for https://github.com/dust-tt/dust/pull/6583 to be merged
- Update sparkle version in `front`
- Deploy to `front-edge`
- Deploy to `front`