### PR TITLE
Disabling connectors keepAlive for a few hours.

### DIFF
--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -30,8 +30,8 @@ const axiosWithTimeout = axios.create({
   timeout: 60000,
   // Ensure client timeout is lower than the target server timeout.
   // See --keepAliveTimeout in next start command from front.
-  httpAgent: new http.Agent({ keepAlive: true, keepAliveMsecs: 4000 }),
-  httpsAgent: new https.Agent({ keepAlive: true, keepAliveMsecs: 4000 }),
+  httpAgent: new http.Agent({ keepAlive: false }),
+  httpsAgent: new https.Agent({ keepAlive: false }),
 });
 
 const { DUST_FRONT_API } = process.env;


### PR DESCRIPTION
## Description
Disabling connectors keepAlive for a few hours to see if it silences the ECONNRESET errors we are seeing on the connectors side.

I created the eng runner card to revert it: https://github.com/dust-tt/tasks/issues/1115


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
