### PR TITLE
[front] - chore: bump sparkle

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -4,13 +4,12 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "front",
       "dependencies": {
         "@amplitude/ampli": "^1.35.0",
         "@amplitude/analytics-browser": "^2.5.2",
         "@amplitude/analytics-node": "^1.3.5",
         "@auth0/nextjs-auth0": "^3.5.0",
-        "@dust-tt/sparkle": "^0.2.193",
+        "@dust-tt/sparkle": "^0.2.196",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -10736,9 +10735,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.193",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.193.tgz",
-      "integrity": "sha512-ehUgBTsBv6kqZD/eWxeZ7CD5fMRBBSrkddCvs6YMI+QxD1yhpLut4mc9aJ0XMreVx6FwHnQCoqkWMisgZtT4fQ==",
+      "version": "0.2.196",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.196.tgz",
+      "integrity": "sha512-bDIhU9tHVfsORfmjm9V2ZeLimqjRYvgd3Bb+siGbN5jdMQazrnNeX3I+iFeozufTOx12y8q63V3beQ+nLylJRA==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
     "@amplitude/analytics-browser": "^2.5.2",
     "@amplitude/analytics-node": "^1.3.5",
     "@auth0/nextjs-auth0": "^3.5.0",
-    "@dust-tt/sparkle": "^0.2.193",
+    "@dust-tt/sparkle": "^0.2.196",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",


### PR DESCRIPTION
## Description

This PR aims at updating `front` to fit with the new sparkle `Tree` component introduced in https://github.com/dust-tt/dust/pull/6606

## Risk

Breaking UI

## Deploy Plan

- [x]  Wait for https://github.com/dust-tt/dust/pull/6606 to be deployed
- [x]  Test on front-edge
- [x] Bump sparkle version in front
