### PR TITLE
[connectors] - fix(google_drive): missing sheets

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/file.ts
+++ b/connectors/src/connectors/google_drive/temporal/file.ts
@@ -289,10 +289,6 @@ export async function syncOneFile(
         return false;
       }
 
-      if (!documentContent) {
-        return false;
-      }
-
       let upsertTimestampMs: number | undefined;
 
       if (!isGoogleDriveSpreadSheetFile(file) || file.mimeType === "text/csv") {

--- a/connectors/src/connectors/google_drive/temporal/mime_types.ts
+++ b/connectors/src/connectors/google_drive/temporal/mime_types.ts
@@ -54,3 +54,10 @@ export function isGoogleDriveFolder(file: GoogleDriveFiles) {
 export function isGoogleDriveSpreadSheetFile(file: { mimeType: string }) {
   return file.mimeType === "application/vnd.google-apps.spreadsheet";
 }
+
+export function isTableFile(file: { mimeType: string }) {
+  return (
+    file.mimeType === "application/vnd.google-apps.spreadsheet" ||
+    file.mimeType === "text/csv"
+  );
+}


### PR DESCRIPTION
## Description

This PR aims at fixing the Google Drive syncing logic. We were accurately processing spreadsheets, but not storing them as `google_drive_files` because of an early return condition.

**References:**
- https://github.com/dust-tt/tasks/issues/1114

## Risk

Moderated 

## Deploy Plan

- Deploy `connectors`