### PR TITLE
[connectors] fix(microsoft): Fix folder id, add site in drive name

### DIFF
--- a/connectors/src/connectors/microsoft/lib/cli.ts
+++ b/connectors/src/connectors/microsoft/lib/cli.ts
@@ -80,9 +80,6 @@ export const microsoft = async ({
       const { nodeType, itemAPIPath } = typeAndPathFromInternalId(
         args.internalId
       );
-      if (nodeType !== "file") {
-        throw new Error(`Can only skip file, got ${nodeType} / ${itemAPIPath}`);
-      }
 
       const client = await getClient(connector.connectionId);
       const driveItem = (await getItem(client, itemAPIPath)) as DriveItem;

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -551,9 +551,20 @@ export async function syncDeltaForRootNodesInDrive({
           folder: driveItem,
           internalId,
         });
+
+        const blob = driveItem.root
+          ? itemToMicrosoftNode(
+              "drive",
+              await getItem(
+                client,
+                `/drives/${driveItem.parentReference.driveId}`
+              )
+            )
+          : itemToMicrosoftNode("folder", driveItem);
+
         const resource = await MicrosoftNodeResource.updateOrCreate(
           connectorId,
-          itemToMicrosoftNode("folder", driveItem)
+          blob
         );
 
         // add parent information to new node resource. for the toplevel folder,


### PR DESCRIPTION
fixes: https://github.com/dust-tt/dust/issues/6611

## Description

- Fixed "getDriveItemInternalId" which was retuning drive id for root item
- Correctly takes the drive when getting changes on root folder 
- Tries to add site in drive name to avoid confusion in ui

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy `connectors`
