### PR TITLE
Migration to backfill AgentDataSourceConfiguration with dataSourceViewId

### DIFF
--- a/front/migrations/20240731_backfill_views_in_agent_data_source_configurations.ts
+++ b/front/migrations/20240731_backfill_views_in_agent_data_source_configurations.ts
@@ -1,0 +1,95 @@
+import type { LightWorkspaceType } from "@dust-tt/types";
+import { CONNECTOR_PROVIDERS } from "@dust-tt/types";
+import assert from "assert";
+
+import { Authenticator } from "@app/lib/auth";
+import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { VaultResource } from "@app/lib/resources/vault_resource";
+import type { Logger } from "@app/logger/logger";
+import { makeScript, runOnAllWorkspaces } from "@app/scripts/helpers";
+
+async function backfillViewsInAgentDataSourceConfigurationForWorkspace(
+  workspace: LightWorkspaceType,
+  logger: Logger,
+  execute: boolean
+) {
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+  // List workspace data sources.
+  const dataSources = await DataSourceResource.listByWorkspace(auth);
+
+  // Filter managed data sources.
+  const managedDataSources = dataSources.filter((ds) => ds.isManaged());
+
+  logger.info(
+    `Found ${managedDataSources.length} managed data sources for workspace(${workspace.sId}).`
+  );
+
+  const globalVault = await VaultResource.fetchWorkspaceGlobalVault(auth);
+
+  // Retrieve data source views for managed data sources.
+  const dataSourceViews =
+    await DataSourceViewResource.listForDataSourcesInVault(
+      auth.getNonNullableWorkspace(),
+      managedDataSources,
+      globalVault
+    );
+
+  // Count agent data source configurations that uses those data sources.
+
+  const agentDataSourceConfigurationsCount =
+    await AgentDataSourceConfiguration.count({
+      where: {
+        dataSourceId: managedDataSources.map((ds) => ds.id),
+      },
+    });
+
+  logger.info(
+    `About to update ${agentDataSourceConfigurationsCount} agent data source configurations for workspace(${workspace.sId}).`
+  );
+
+  if (!execute) {
+    return;
+  }
+
+  for (const ds of managedDataSources) {
+    const dataSourceView = dataSourceViews.find(
+      (dsv) => dsv.dataSourceId === ds.id
+    );
+    assert(
+      dataSourceView,
+      `Data source view not found for data source ${ds.id}.`
+    );
+
+    await AgentDataSourceConfiguration.update(
+      { dataSourceViewId: dataSourceView.id },
+      {
+        where: {
+          dataSourceId: ds.id,
+        },
+      }
+    );
+
+    logger.info(
+      `Updated agent data source configuration for data source ${ds.id}.`
+    );
+  }
+
+  logger.info(
+    `Updated all agent data source configurations for workspace(${workspace.sId}).`
+  );
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  return runOnAllWorkspaces(async (workspace) => {
+    await backfillViewsInAgentDataSourceConfigurationForWorkspace(
+      workspace,
+      logger,
+      execute
+    );
+
+    logger.info(`Finished backfilling views for workspace(${workspace.sId}).`);
+  });
+});

--- a/front/migrations/20240731_backfill_views_in_agent_data_source_configurations.ts
+++ b/front/migrations/20240731_backfill_views_in_agent_data_source_configurations.ts
@@ -1,5 +1,4 @@
 import type { LightWorkspaceType } from "@dust-tt/types";
-import { CONNECTOR_PROVIDERS } from "@dust-tt/types";
 import assert from "assert";
 
 import { Authenticator } from "@app/lib/auth";


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of https://github.com/dust-tt/dust/pull/6596. This PR adds the migration to backfill the existing `agent_data_source_configurations` to add the missing `dataSourceViewId`.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Tested locally.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
