### PR TITLE
Segregate help drawer per user type

### DIFF
--- a/front/components/assistant/HelpDrawer.tsx
+++ b/front/components/assistant/HelpDrawer.tsx
@@ -16,7 +16,6 @@ import type {
   UserType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { isBuilder } from "@dust-tt/types";
 import { useRouter } from "next/router";
 import type { ComponentType } from "react";
 import { useCallback, useContext } from "react";
@@ -29,14 +28,17 @@ import { useSubmitFunction } from "@app/lib/client/utils";
 
 // describe the type of userContent where the
 
-const userContent: Record<RoleType, {
-  topPicks: {
-    title: string;
-    href: string;
-    icon: React.ComponentType;
-  }[];
-  helpIceBreakers: string[];
-}> = {
+const userContent: Record<
+  RoleType,
+  {
+    topPicks: {
+      title: string;
+      href: string;
+      icon: React.ComponentType;
+    }[];
+    helpIceBreakers: string[];
+  }
+> = {
   user: {
     topPicks: [
       {
@@ -46,10 +48,10 @@ const userContent: Record<RoleType, {
       },
     ],
     helpIceBreakers: [
-       "What are assistants?",
-       "What are the limitations of assistants?"
+      "What are assistants?",
+      "What are the limitations of assistants?",
     ],
-},
+  },
   builder: {
     topPicks: [
       {
@@ -69,9 +71,9 @@ const userContent: Record<RoleType, {
       },
     ],
     helpIceBreakers: [
-       "How to upload a file to a folder in Dust?",
-       "What are good use-cases for Customer support?",
-       "What does the Extract Data tool do?"
+      "How to upload a file to a folder in Dust?",
+      "What are good use-cases for Customer support?",
+      "What does the Extract Data tool do?",
     ],
   },
   admin: {
@@ -93,9 +95,9 @@ const userContent: Record<RoleType, {
       },
     ],
     helpIceBreakers: [
-       "How to create a new user?",
-       "How to add a new connection?",
-       "How to manage users?"
+      "How to invite a new user?",
+      "How to use assistants in Slack workflows?",
+      "How to manage billing?",
     ],
   },
   none: {
@@ -195,56 +197,55 @@ export function HelpDrawer({
     <Modal isOpen={show} variant="side-sm" hasChanged={false} onClose={onClose}>
       <div className="flex flex-col gap-5 pt-5">
         <Page.SectionHeader title="Learn about Dust" />
-          <LinksList
-            linksList={
-              [
-                    {
-                      title: "Quickstart Guide",
-                      onClick: () => setShowQuickGuide(true),
-                      icon: LightbulbIcon,
-                    },
-                    {
-                      title: "All help content",
-                      href: "https://docs.dust.tt",
-                      description: "Guides, best practices, and more",
-                      icon: FolderIcon,
-                    },
-                    {
-                      title: "Community Support",
-                      href: "https://docs.dust.tt/discuss",
-                      description: "Stuck? Ask your questions to the community",
-                      icon: QuestionMarkCircleIcon,
-                    },
-                  ]
-            }
-          />
+        <LinksList
+          linksList={[
+            {
+              title: "Quickstart Guide",
+              onClick: () => setShowQuickGuide(true),
+              icon: LightbulbIcon,
+            },
+            {
+              title: "All help content",
+              href: "https://docs.dust.tt",
+              description: "Guides, best practices, and more",
+              icon: FolderIcon,
+            },
+            {
+              title: "Community Support",
+              href: "https://docs.dust.tt/discuss",
+              description: "Stuck? Ask your questions to the community",
+              icon: QuestionMarkCircleIcon,
+            },
+          ]}
+        />
         <Page.SectionHeader title="Top picks for you" />
-          <LinksList linksList={userContent[owner.role].topPicks} />
-        
+        <LinksList linksList={userContent[owner.role].topPicks} />
+
         <div className="flex flex-col gap-4 [&>*]:pl-px">
           <Page.SectionHeader title="Ask questions to @help" />
           <Button.List isWrapping={true}>
-          <div className="flex flex-col gap-8">
-            <div className="flex flex-wrap gap-2">
-              {userContent[owner.role].helpIceBreakers.map((iceBreaker, index) => (
-                <Button
-                  variant="tertiary"
-                  icon={ChatBubbleBottomCenterTextIcon}
-                  label={iceBreaker}
-                  size="sm"
-                  hasMagnifying={false}
-                  onClick={() => {
-                    void handleHelpSubmit(
-                      `@help ${iceBreaker}`,
-                      [{ configurationId: GLOBAL_AGENTS_SID.HELPER }]
-                    );
-                  }}
-                  key={index}
-                />
-              ))}
+            <div className="flex flex-col gap-8">
+              <div className="flex flex-wrap gap-2">
+                {userContent[owner.role].helpIceBreakers.map(
+                  (iceBreaker, index) => (
+                    <Button
+                      variant="tertiary"
+                      icon={ChatBubbleBottomCenterTextIcon}
+                      label={iceBreaker}
+                      size="sm"
+                      hasMagnifying={false}
+                      onClick={() => {
+                        void handleHelpSubmit(`@help ${iceBreaker}`, [
+                          { configurationId: GLOBAL_AGENTS_SID.HELPER },
+                        ]);
+                      }}
+                      key={index}
+                    />
+                  )
+                )}
+              </div>
             </div>
-          </div>
-        </Button.List>
+          </Button.List>
           <AssistantInputBar
             owner={owner}
             onSubmit={handleHelpSubmit}

--- a/front/components/assistant/HelpDrawer.tsx
+++ b/front/components/assistant/HelpDrawer.tsx
@@ -12,6 +12,7 @@ import {
 import type {
   AgentMention,
   MentionType,
+  RoleType,
   UserType,
   WorkspaceType,
 } from "@dust-tt/types";
@@ -26,23 +27,82 @@ import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { GLOBAL_AGENTS_SID } from "@app/lib/assistant";
 import { useSubmitFunction } from "@app/lib/client/utils";
 
-const topPicks = [
-  {
-    title: "How to create assistants?",
-    href: "https://docs.dust.tt/docs/prompting-101-how-to-talk-to-your-assistants",
-    icon: ArrowRightIcon,
+// describe the type of userContent where the
+
+const userContent: Record<RoleType, {
+  topPicks: {
+    title: string;
+    href: string;
+    icon: React.ComponentType;
+  }[];
+  helpIceBreakers: string[];
+}> = {
+  user: {
+    topPicks: [
+      {
+        title: "How to talk to assistants?",
+        href: "https://docs.dust.tt/docs/prompting-101-how-to-talk-to-your-assistants",
+        icon: ArrowRightIcon,
+      },
+    ],
+    helpIceBreakers: [
+       "What are assistants?",
+       "What are the limitations of assistants?"
+    ],
+},
+  builder: {
+    topPicks: [
+      {
+        title: "How to create assistants?",
+        href: "https://docs.dust.tt/docs/prompting-101-how-to-talk-to-your-assistants",
+        icon: ArrowRightIcon,
+      },
+      {
+        title: "What can I use Dust for?",
+        href: "https://docs.dust.tt/docs/use-cases",
+        icon: ArrowRightIcon,
+      },
+      {
+        title: "What is a Dust App?",
+        href: "https://docs.dust.tt/reference/developer-platform-overview",
+        icon: ArrowRightIcon,
+      },
+    ],
+    helpIceBreakers: [
+       "How to upload a file to a folder in Dust?",
+       "What are good use-cases for Customer support?",
+       "What does the Extract Data tool do?"
+    ],
   },
-  {
-    title: "How to add new connections?",
-    href: "https://docs.dust.tt/docs/google-drive-connection",
-    icon: ArrowRightIcon,
+  admin: {
+    topPicks: [
+      {
+        title: "How to create assistants?",
+        href: "https://docs.dust.tt/docs/prompting-101-how-to-talk-to-your-assistants",
+        icon: ArrowRightIcon,
+      },
+      {
+        title: "How to add new connections?",
+        href: "https://docs.dust.tt/docs/google-drive-connection",
+        icon: ArrowRightIcon,
+      },
+      {
+        title: "How to manage users?",
+        href: "https://docs.dust.tt/docs/manage-users",
+        icon: ArrowRightIcon,
+      },
+    ],
+    helpIceBreakers: [
+       "How to create a new user?",
+       "How to add a new connection?",
+       "How to manage users?"
+    ],
   },
-  {
-    title: "What can I use Dust for?",
-    href: "https://docs.dust.tt/docs/use-cases",
-    icon: ArrowRightIcon,
+  none: {
+    topPicks: [],
+    helpIceBreakers: [],
   },
-];
+};
 
 function LinksList({
   linksList,
@@ -135,11 +195,9 @@ export function HelpDrawer({
     <Modal isOpen={show} variant="side-sm" hasChanged={false} onClose={onClose}>
       <div className="flex flex-col gap-5 pt-5">
         <Page.SectionHeader title="Learn about Dust" />
-        <div>
           <LinksList
             linksList={
-              isBuilder(owner)
-                ? [
+              [
                     {
                       title: "Quickstart Guide",
                       onClick: () => setShowQuickGuide(true),
@@ -158,55 +216,35 @@ export function HelpDrawer({
                       icon: QuestionMarkCircleIcon,
                     },
                   ]
-                : [
-                    {
-                      title: "Quickstart Guide",
-                      href: "https://docs.dust.tt/docs/getting-started",
-                      icon: LightbulbIcon,
-                    },
-                  ]
             }
           />
-          {isBuilder(owner) && (
-            <LinksList linksList={topPicks} title="Top Picks" />
-          )}
-        </div>
-        {!isBuilder(owner) && (
-          <Button.List isWrapping={true}>
-            <div className="flex flex-col gap-8">
-              <div className="flex flex-wrap gap-2">
-                <Button
-                  variant="tertiary"
-                  icon={ChatBubbleBottomCenterTextIcon}
-                  label={"What can I use the assistants for?"}
-                  size="sm"
-                  hasMagnifying={false}
-                  onClick={() => {
-                    void handleHelpSubmit(
-                      "@help What can I use the assistants for?",
-                      [{ configurationId: GLOBAL_AGENTS_SID.HELPER }]
-                    );
-                  }}
-                />
-                <Button
-                  variant="tertiary"
-                  icon={ChatBubbleBottomCenterTextIcon}
-                  label={"What are the limitations of assistants?"}
-                  size="sm"
-                  hasMagnifying={false}
-                  onClick={() => {
-                    void handleHelpSubmit(
-                      "@help What are the limitations of assistants?",
-                      [{ configurationId: GLOBAL_AGENTS_SID.HELPER }]
-                    );
-                  }}
-                />
-              </div>
-            </div>
-          </Button.List>
-        )}
+        <Page.SectionHeader title="Top picks for you" />
+          <LinksList linksList={userContent[owner.role].topPicks} />
+        
         <div className="flex flex-col gap-4 [&>*]:pl-px">
-          <Page.SectionHeader title="Ask questions" />
+          <Page.SectionHeader title="Ask questions to @help" />
+          <Button.List isWrapping={true}>
+          <div className="flex flex-col gap-8">
+            <div className="flex flex-wrap gap-2">
+              {userContent[owner.role].helpIceBreakers.map((iceBreaker, index) => (
+                <Button
+                  variant="tertiary"
+                  icon={ChatBubbleBottomCenterTextIcon}
+                  label={iceBreaker}
+                  size="sm"
+                  hasMagnifying={false}
+                  onClick={() => {
+                    void handleHelpSubmit(
+                      `@help ${iceBreaker}`,
+                      [{ configurationId: GLOBAL_AGENTS_SID.HELPER }]
+                    );
+                  }}
+                  key={index}
+                />
+              ))}
+            </div>
+          </div>
+        </Button.List>
           <AssistantInputBar
             owner={owner}
             onSubmit={handleHelpSubmit}


### PR DESCRIPTION
## Description

Admins, members and builders don't see the same help drawer anymore

Admin:
<img width="445" alt="Screenshot 2024-07-31 at 17 02 59" src="https://github.com/user-attachments/assets/6c1fecb2-d3b2-468e-a14e-df74508fc64e">
Builder:
<img width="439" alt="Screenshot 2024-07-31 at 17 03 58" src="https://github.com/user-attachments/assets/9c6dc1fe-736e-4041-90b1-439df473bfc1">
Member:
<img width="443" alt="Screenshot 2024-07-31 at 17 04 49" src="https://github.com/user-attachments/assets/61dc45aa-995a-4442-8ff0-0dea9a4e5589">


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
