### PR TITLE
[sparkle] - feature: enhance DataTable with interactive row elements

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.197",
+  "version": "0.2.198",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.197",
+      "version": "0.2.198",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.197",
+  "version": "0.2.198",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -97,9 +97,7 @@ export function DataTable<TData, TValue>({
         {table.getRowModel().rows.map((row) => (
           <DataTable.Row
             key={row.id}
-            clickable={row.original.clickable}
             onClick={row.original.onClick}
-            showMore={row.original.showMore}
             onMoreClick={row.original.onMoreClick}
           >
             {row.getVisibleCells().map((cell) => (

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -80,7 +80,7 @@ export function DataTable<TData, TValue>({
                             : ArrowDownIcon
                       }
                       className={classNames(
-                        "s-h-4 s-w-3 s-font-extralight",
+                        "s-ml-1 s-w-2.5 s-font-extralight",
                         header.column.getIsSorted()
                           ? "s-opacity-100"
                           : "s-opacity-0"

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -58,7 +58,7 @@ export function DataTable<TData, TValue>({
     <DataTable.Root className={className}>
       <DataTable.Header>
         {table.getHeaderGroups().map((headerGroup) => (
-          <DataTable.Row key={headerGroup.id}>
+          <DataTable.Row key={headerGroup.id} >
             {headerGroup.headers.map((header) => (
               <DataTable.Head
                 key={header.id}
@@ -99,6 +99,8 @@ export function DataTable<TData, TValue>({
             key={row.id}
             clickable={row.original.clickable}
             onClick={row.original.onClick}
+            showMore={row.original.showMore}
+            onMoreClick={row.original.onMoreClick}
           >
             {row.getVisibleCells().map((cell) => (
               <DataTable.Cell key={cell.id}>
@@ -184,6 +186,8 @@ interface RowProps extends React.HTMLAttributes<HTMLTableRowElement> {
   children: ReactNode;
   clickable?: boolean;
   onClick?: () => void;
+  showMore?: boolean;
+  onMoreClick?: () => void;
 }
 
 DataTable.Row = function Row({
@@ -191,29 +195,32 @@ DataTable.Row = function Row({
   className,
   clickable = false,
   onClick,
+  showMore = false,
+  onMoreClick,
   ...props
 }: RowProps) {
   return (
     <tr
       className={classNames(
         "s-border-b s-border-structure-200 s-text-sm",
+        clickable ? "s-cursor-pointer" : "",
         className || ""
       )}
+      onClick={clickable ? onClick : undefined}
       {...props}
     >
       {children}
-      {clickable && (
-        <td
-          className="s-w-1 s-cursor-pointer s-pl-1 s-text-element-600"
-          onClick={clickable ? onClick : undefined}
-        >
+      {showMore && (
+        <td className="s-w-1 s-cursor-pointer s-pl-1 s-text-element-600" onClick={(e) => {
+          e.stopPropagation(); // Prevent row click event
+          onMoreClick?.();
+        }}>
           <Icon visual={MoreIcon} size="sm" />
         </td>
       )}
     </tr>
   );
 };
-
 interface CellProps extends React.TdHTMLAttributes<HTMLTableCellElement> {
   avatarUrl?: string;
   icon?: React.ComponentType<{ className?: string }>;

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -58,7 +58,7 @@ export function DataTable<TData, TValue>({
     <DataTable.Root className={className}>
       <DataTable.Header>
         {table.getHeaderGroups().map((headerGroup) => (
-          <DataTable.Row key={headerGroup.id} >
+          <DataTable.Row key={headerGroup.id}>
             {headerGroup.headers.map((header) => (
               <DataTable.Head
                 key={header.id}
@@ -184,18 +184,14 @@ DataTable.Body = function Body({
 
 interface RowProps extends React.HTMLAttributes<HTMLTableRowElement> {
   children: ReactNode;
-  clickable?: boolean;
   onClick?: () => void;
-  showMore?: boolean;
   onMoreClick?: () => void;
 }
 
 DataTable.Row = function Row({
   children,
   className,
-  clickable = false,
   onClick,
-  showMore = false,
   onMoreClick,
   ...props
 }: RowProps) {
@@ -203,18 +199,21 @@ DataTable.Row = function Row({
     <tr
       className={classNames(
         "s-border-b s-border-structure-200 s-text-sm",
-        clickable ? "s-cursor-pointer" : "",
+        onMoreClick ? "s-cursor-pointer" : "",
         className || ""
       )}
-      onClick={clickable ? onClick : undefined}
+      onClick={onClick ? onClick : undefined}
       {...props}
     >
       {children}
-      {showMore && (
-        <td className="s-w-1 s-cursor-pointer s-pl-1 s-text-element-600" onClick={(e) => {
-          e.stopPropagation(); // Prevent row click event
-          onMoreClick?.();
-        }}>
+      {onMoreClick && (
+        <td
+          className="s-w-1 s-cursor-pointer s-pl-1 s-text-element-600"
+          onClick={(e) => {
+            e.stopPropagation(); // Prevent row click event
+            onMoreClick?.();
+          }}
+        >
           <Icon visual={MoreIcon} size="sm" />
         </td>
       )}

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -37,9 +37,7 @@ const DataTableExample = () => {
       lastUpdated: "July 8, 2023",
       size: "32kb",
       avatarUrl: "https://dust.tt/static/droidavatar/Droid_Lime_3.jpg",
-      clickable: true,
       onClick: () => console.log("hehe"),
-      showMore: true,
       onMoreClick: () => console.log("show more"),
     },
     {
@@ -49,7 +47,6 @@ const DataTableExample = () => {
       lastUpdated: "2023-07-09",
       size: "64kb",
       icon: FolderIcon,
-      clickable: false,
     },
     {
       name: "Development",

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -23,6 +23,8 @@ type Data = {
   icon?: React.ComponentType<{ className?: string }>;
   clickable?: boolean;
   onClick?: () => void;
+  showMore?: boolean;
+  onMoreClick?: () => void;
 };
 
 const DataTableExample = () => {
@@ -37,6 +39,8 @@ const DataTableExample = () => {
       avatarUrl: "https://dust.tt/static/droidavatar/Droid_Lime_3.jpg",
       clickable: true,
       onClick: () => console.log("hehe"),
+      showMore: true,
+      onMoreClick: () => console.log("show more"),
     },
     {
       name: "Design",


### PR DESCRIPTION
## Description

This PR aims at enhancing the `DataTable` component in sparkle. Main changes include:
 - Add functionality to DataTable rows for additional interactivity, enabling click events on the entire row
 - Introduce a 'showMore' option with its corresponding 'onMoreClick' callback to handle secondary actions within rows

## Risk

None

## Deploy Plan

- Deploy `sparkle`