### PR TITLE
[sparkle] - fix: correct click handler prop for DataTable.Row component

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.198",
+  "version": "0.2.199",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.198",
+      "version": "0.2.199",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.198",
+  "version": "0.2.199",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -197,7 +197,7 @@ DataTable.Row = function Row({
     <tr
       className={classNames(
         "s-border-b s-border-structure-200 s-text-sm",
-        onMoreClick ? "s-cursor-pointer" : "",
+        onClick ? "s-cursor-pointer" : "",
         className || ""
       )}
       onClick={onClick ? onClick : undefined}


### PR DESCRIPTION
## Description

This PR aims at replacing the onMoreClick prop with onClick to ensure the correct handling of click events on rows.
Currently, hovering on the row doesn't display any pointer.

## Risk

None

## Deploy Plan

Deploy `sparkle`