### PR TITLE
[sparkle] - enh: `DataTable`

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.199",
+  "version": "0.2.200",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.199",
+      "version": "0.2.200",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.199",
+  "version": "0.2.200",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -202,7 +202,9 @@ DataTable.Row = function Row({
     <tr
       className={classNames(
         "s-border-b s-border-structure-200 s-text-sm",
-        onClick ? "s-cursor-pointer" : "",
+        onClick
+          ? "s-cursor-pointer hover:s-border-b-neutral-500 hover:s-opacity-70"
+          : "",
         className || ""
       )}
       onClick={onClick ? onClick : undefined}

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -203,7 +203,7 @@ DataTable.Row = function Row({
       className={classNames(
         "s-border-b s-border-structure-200 s-text-sm",
         onClick
-          ? "s-cursor-pointer hover:s-border-b-neutral-500 hover:s-opacity-70"
+          ? "s-cursor-pointer hover:s-border-b-neutral-500 hover:s-bg-gray-50"
           : "",
         className || ""
       )}

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -202,9 +202,7 @@ DataTable.Row = function Row({
     <tr
       className={classNames(
         "s-border-b s-border-structure-200 s-text-sm",
-        onClick
-          ? "s-cursor-pointer hover:s-border-b-neutral-500 hover:s-bg-gray-50"
-          : "",
+        onClick ? "s-cursor-pointer hover:s-bg-gray-50" : "",
         className || ""
       )}
       onClick={onClick ? onClick : undefined}

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -22,6 +22,7 @@ interface DataTableProps<TData, TValue> {
   className?: string;
   filter?: string;
   filterColumn?: string;
+  initialColumnOrder?: SortingState;
 }
 
 export function DataTable<TData, TValue>({
@@ -30,8 +31,11 @@ export function DataTable<TData, TValue>({
   className,
   filter,
   filterColumn,
+  initialColumnOrder,
 }: DataTableProps<TData, TValue>) {
-  const [sorting, setSorting] = useState<SortingState>([]);
+  const [sorting, setSorting] = useState<SortingState>(
+    initialColumnOrder ?? []
+  );
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
 
   const table = useReactTable({

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -83,8 +83,9 @@ export function DataTable<TData, TValue>({
                             ? ArrowDownIcon
                             : ArrowDownIcon
                       }
+                      size="xs"
                       className={classNames(
-                        "s-ml-1 s-w-2.5 s-font-extralight",
+                        "s-ml-1",
                         header.column.getIsSorted()
                           ? "s-opacity-100"
                           : "s-opacity-0"

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -10,7 +10,6 @@ const meta = {
 } satisfies Meta<typeof DataTable>;
 
 export default meta;
-type Story = StoryObj<typeof meta>;
 
 type Data = {
   name: string;
@@ -27,7 +26,7 @@ type Data = {
   onMoreClick?: () => void;
 };
 
-const DataTableExample = () => {
+export const DataTableExample = () => {
   const data: Data[] = [
     {
       name: "Marketing",
@@ -116,11 +115,11 @@ const DataTableExample = () => {
 
   return (
     <div className="s-w-full s-max-w-4xl s-overflow-x-auto">
-      <DataTable data={data} columns={columns} />
+      <DataTable
+        data={data}
+        columns={columns}
+        initialColumnOrder={[{ id: "name", desc: false }]}
+      />
     </div>
   );
-};
-
-export const Default: Story = {
-  render: () => <DataTableExample />,
 };

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta } from "@storybook/react";
 import { ColumnDef } from "@tanstack/react-table";
 import React from "react";
 


### PR DESCRIPTION
## Description

This PR aims at enhancing the `DataTable` component, which includes:
- change row opacity on hover
- pass default column ordering
- fix storybook

## Risk

Breaking UI

## Deploy Plan

- Deploy sparkle
- Bump sparkle version in `front` in another PR