### PR TITLE
Slack `?`

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -390,6 +390,9 @@ async function botAnswerMessage(
     }
   }
 
+  if (message.trim() === "") {
+    message = "?";
+  }
   const messageReqBody = {
     content: message,
     mentions: mentions.map((m) => {


### PR DESCRIPTION
## Description

Adding a `?` to Slack messages sent to `@dust` when they are empty. Anthropic models don't like empty messages, and that's what users mean when they call `@dust` without any message.

See task [here](https://github.com/dust-tt/tasks/issues/1108).

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
