### PR TITLE
enh: make viz responsive, remove extra renders, handle err in main window

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -211,6 +211,12 @@ export function AgentMessage({
             ...event.message,
           };
         });
+        // Mark the last viz as complete if it is not already.
+        setVisualizations((v) =>
+          v.map((item, index) =>
+            index === v.length - 1 ? { ...item, complete: true } : item
+          )
+        );
         break;
       }
 

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -226,7 +226,6 @@ export function VisualizationActionIframe({
                 style={{
                   height: !isErrored ? `${contentHeight}px` : "100%",
                   minHeight: !isErrored ? "96" : undefined,
-                  maxHeight: "60vh",
                 }}
                 className={classNames("max-h-[60vh] w-full")}
               >

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -1,4 +1,4 @@
-import { Spinner } from "@dust-tt/sparkle";
+import { Button, Spinner } from "@dust-tt/sparkle";
 import type {
   CommandResultMap,
   VisualizationRPCCommand,
@@ -38,14 +38,14 @@ const sendResponseToIframe = <T extends VisualizationRPCCommand>(
 // Custom hook to encapsulate the logic for handling visualization messages.
 function useVisualizationDataHandler({
   visualization,
-  onRetry,
   setContentHeight,
+  setErrored,
   vizIframeRef,
   workspaceId,
 }: {
   visualization: Visualization;
-  onRetry: () => void;
   setContentHeight: (v: SetStateAction<number>) => void;
+  setErrored: (v: SetStateAction<boolean>) => void;
   vizIframeRef: React.MutableRefObject<HTMLIFrameElement | null>;
   workspaceId: string;
 }) {
@@ -98,12 +98,12 @@ function useVisualizationDataHandler({
 
           break;
 
-        case "retry":
-          onRetry();
-          break;
-
         case "setContentHeight":
           setContentHeight(data.params.height);
+          break;
+
+        case "setErrored":
+          setErrored(true);
           break;
 
         default:
@@ -117,8 +117,8 @@ function useVisualizationDataHandler({
     visualization.identifier,
     code,
     getFileBlob,
-    onRetry,
     setContentHeight,
+    setErrored,
     vizIframeRef,
   ]);
 }
@@ -130,45 +130,41 @@ export function VisualizationActionIframe({
 }: {
   owner: WorkspaceType;
   visualization: Visualization;
-
   onRetry: () => void;
 }) {
-  const [contentHeight, setContentHeight] = useState(0);
-  const [iframeLoaded, setIframeLoaded] = useState(false);
-  const [showSpinner, setShowSpinner] = useState(true);
+  const [contentHeight, setContentHeight] = useState<number>(0);
+  const [errored, setErrored] = useState(false);
   const [activeIndex, setActiveIndex] = useState(1);
 
   const vizIframeRef = useRef<HTMLIFrameElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const codeRef = useRef<HTMLDivElement>(null);
+  const errorRef = useRef<HTMLDivElement>(null);
 
   const workspaceId = owner.sId;
 
   useVisualizationDataHandler({
     visualization,
     workspaceId,
-    onRetry,
     setContentHeight,
+    setErrored,
     vizIframeRef,
   });
 
   const { code, complete: codeFullyGenerated } = visualization;
 
+  const iframeLoaded = contentHeight > 0;
+  const showSpinner =
+    ((!codeFullyGenerated && !code) || (codeFullyGenerated && !iframeLoaded)) &&
+    !errored;
+
   useEffect(() => {
     if (!codeFullyGenerated) {
-      // Display spinner over the code block while waiting for code generation.
-      setShowSpinner(!code);
       setActiveIndex(0);
-    } else if (iframeLoaded) {
-      // Display iframe if code is generated and iframe has loaded.
-      setShowSpinner(false);
-      setActiveIndex(1);
     } else {
-      // Show spinner while iframe is loading.
-      setShowSpinner(true);
       setActiveIndex(1);
     }
-  }, [codeFullyGenerated, code, iframeLoaded]);
+  }, [codeFullyGenerated, code]);
 
   useEffect(() => {
     if (!containerRef.current) {
@@ -182,9 +178,12 @@ export function VisualizationActionIframe({
         ? `${codeRef.current?.scrollHeight}px`
         : "100%";
     } else if (activeIndex === 1) {
-      containerRef.current.style.height = `${contentHeight}px`;
+      containerRef.current.style.height = !errored ? `${contentHeight}px` : "";
+      if (errored && errorRef.current) {
+        containerRef.current.style.height = `${errorRef.current.scrollHeight}px`;
+      }
     }
-  }, [activeIndex, contentHeight, codeFullyGenerated]);
+  }, [activeIndex, contentHeight, codeFullyGenerated, errored]);
 
   return (
     <div className="relative flex flex-col">
@@ -202,7 +201,9 @@ export function VisualizationActionIframe({
       <div
         className={classNames(
           "transition-height relative w-full overflow-hidden duration-500 ease-in-out",
-          codeFullyGenerated ? "min-h-96" : ""
+          codeFullyGenerated && !errored ? "min-h-96" : "",
+          errored ? "h-full" : "",
+          activeIndex === 1 ? "max-h-[60vh]" : ""
         )}
         ref={containerRef}
       >
@@ -219,19 +220,38 @@ export function VisualizationActionIframe({
             />
           </div>
           <div className="relative flex h-full w-full shrink-0 items-center justify-center">
-            {codeFullyGenerated && (
+            {codeFullyGenerated && !errored && (
               <div
-                style={{ height: `${contentHeight}px` }}
+                style={{
+                  height: !errored ? `${contentHeight}px` : "100%",
+                  minHeight: !errored ? "96" : undefined,
+                  maxHeight: "60vh",
+                }}
                 className={classNames("max-h-[60vh] w-full")}
               >
                 <iframe
                   ref={vizIframeRef}
                   // Set a min height so iframe can display error.
-                  className="h-full min-h-96 w-full"
+                  className={classNames(
+                    "h-full w-full",
+                    !errored ? "min-h-96" : ""
+                  )}
                   src={`${process.env.NEXT_PUBLIC_VIZ_URL}/content?identifier=${visualization.identifier}`}
                   sandbox="allow-scripts"
-                  onLoad={() => setIframeLoaded(true)}
                 />
+              </div>
+            )}
+            {errored && (
+              <div
+                className="flex h-full w-full flex-col items-center gap-4 py-8"
+                ref={errorRef}
+              >
+                <div className="text-sm text-element-800">
+                  An error occured while rendering the visualization.
+                </div>
+                <div>
+                  <Button label="Retry" onClick={onRetry} size="sm" />
+                </div>
               </div>
             )}
           </div>

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -232,7 +232,6 @@ export function VisualizationActionIframe({
               >
                 <iframe
                   ref={vizIframeRef}
-                  // Set a min height so iframe can display error.
                   className={classNames(
                     "h-full w-full",
                     !isErrored ? "min-h-96" : ""

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -39,13 +39,13 @@ const sendResponseToIframe = <T extends VisualizationRPCCommand>(
 function useVisualizationDataHandler({
   visualization,
   setContentHeight,
-  setErrored,
+  setIsErrored,
   vizIframeRef,
   workspaceId,
 }: {
   visualization: Visualization;
   setContentHeight: (v: SetStateAction<number>) => void;
-  setErrored: (v: SetStateAction<boolean>) => void;
+  setIsErrored: (v: SetStateAction<boolean>) => void;
   vizIframeRef: React.MutableRefObject<HTMLIFrameElement | null>;
   workspaceId: string;
 }) {
@@ -103,7 +103,7 @@ function useVisualizationDataHandler({
           break;
 
         case "setErrored":
-          setErrored(true);
+          setIsErrored(true);
           break;
 
         default:
@@ -118,7 +118,7 @@ function useVisualizationDataHandler({
     code,
     getFileBlob,
     setContentHeight,
-    setErrored,
+    setIsErrored,
     vizIframeRef,
   ]);
 }
@@ -133,7 +133,7 @@ export function VisualizationActionIframe({
   onRetry: () => void;
 }) {
   const [contentHeight, setContentHeight] = useState<number>(0);
-  const [errored, setErrored] = useState(false);
+  const [isErrored, setIsErrored] = useState(false);
   const [activeIndex, setActiveIndex] = useState(1);
 
   const vizIframeRef = useRef<HTMLIFrameElement>(null);
@@ -147,7 +147,7 @@ export function VisualizationActionIframe({
     visualization,
     workspaceId,
     setContentHeight,
-    setErrored,
+    setIsErrored,
     vizIframeRef,
   });
 
@@ -156,7 +156,7 @@ export function VisualizationActionIframe({
   const iframeLoaded = contentHeight > 0;
   const showSpinner =
     ((!codeFullyGenerated && !code) || (codeFullyGenerated && !iframeLoaded)) &&
-    !errored;
+    !isErrored;
 
   useEffect(() => {
     if (!codeFullyGenerated) {
@@ -178,12 +178,14 @@ export function VisualizationActionIframe({
         ? `${codeRef.current?.scrollHeight}px`
         : "100%";
     } else if (activeIndex === 1) {
-      containerRef.current.style.height = !errored ? `${contentHeight}px` : "";
-      if (errored && errorRef.current) {
+      containerRef.current.style.height = !isErrored
+        ? `${contentHeight}px`
+        : "";
+      if (isErrored && errorRef.current) {
         containerRef.current.style.height = `${errorRef.current.scrollHeight}px`;
       }
     }
-  }, [activeIndex, contentHeight, codeFullyGenerated, errored]);
+  }, [activeIndex, contentHeight, codeFullyGenerated, isErrored]);
 
   return (
     <div className="relative flex flex-col">
@@ -201,8 +203,8 @@ export function VisualizationActionIframe({
       <div
         className={classNames(
           "transition-height relative w-full overflow-hidden duration-500 ease-in-out",
-          codeFullyGenerated && !errored ? "min-h-96" : "",
-          errored ? "h-full" : "",
+          codeFullyGenerated && !isErrored ? "min-h-96" : "",
+          isErrored ? "h-full" : "",
           activeIndex === 1 ? "max-h-[60vh]" : ""
         )}
         ref={containerRef}
@@ -220,11 +222,11 @@ export function VisualizationActionIframe({
             />
           </div>
           <div className="relative flex h-full w-full shrink-0 items-center justify-center">
-            {codeFullyGenerated && !errored && (
+            {codeFullyGenerated && !isErrored && (
               <div
                 style={{
-                  height: !errored ? `${contentHeight}px` : "100%",
-                  minHeight: !errored ? "96" : undefined,
+                  height: !isErrored ? `${contentHeight}px` : "100%",
+                  minHeight: !isErrored ? "96" : undefined,
                   maxHeight: "60vh",
                 }}
                 className={classNames("max-h-[60vh] w-full")}
@@ -234,14 +236,14 @@ export function VisualizationActionIframe({
                   // Set a min height so iframe can display error.
                   className={classNames(
                     "h-full w-full",
-                    !errored ? "min-h-96" : ""
+                    !isErrored ? "min-h-96" : ""
                   )}
                   src={`${process.env.NEXT_PUBLIC_VIZ_URL}/content?identifier=${visualization.identifier}`}
                   sandbox="allow-scripts"
                 />
               </div>
             )}
-            {errored && (
+            {isErrored && (
               <div
                 className="flex h-full w-full flex-col items-center gap-4 py-8"
                 ref={errorRef}

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -178,11 +178,10 @@ export function VisualizationActionIframe({
         ? `${codeRef.current?.scrollHeight}px`
         : "100%";
     } else if (activeIndex === 1) {
-      containerRef.current.style.height = !isErrored
-        ? `${contentHeight}px`
-        : "";
       if (isErrored && errorRef.current) {
         containerRef.current.style.height = `${errorRef.current.scrollHeight}px`;
+      } else if (!isErrored) {
+        containerRef.current.style.height = `${contentHeight}px`;
       }
     }
   }, [activeIndex, contentHeight, codeFullyGenerated, isErrored]);

--- a/front/lib/api/assistant/visualization.ts
+++ b/front/lib/api/assistant/visualization.ts
@@ -119,11 +119,15 @@ The generated component should not have any required props / parameters.
 
    
 
-### Outermost div height and width    
+### Responsiveness
 
-The component's outermost JSX tag should have a fixed height and width in pixels, set using the \`style\` prop, e.g. \`<div style={{ height: '600px', width: '600px' }}>...</div>\`.
+The content should be responsive and should not have fixed widths or heights. The component should be able to adapt to different screen sizes.
+The content should never overflow the viewport and should never have horizontal or vertical scrollbars.
 
-The height and width should be set to a fixed value, not a percentage. This style should not use tailwind CSS or any type of custom class. There should be a few pixels of horizontal padding to ensure the content is fully visible by the user.
+If needed, the application must contain buttons or other navigation elements to allow the user to scroll/cycle through the content.
+Never use tailwind's specific values like \`h-[600px]\`.
+
+Always add padding to the content (both horizontal and vertical) to make it look better and make sure the labels are fully visible.
 
     
 
@@ -173,7 +177,7 @@ if (file) {
 
 - Base React is available to be imported. In order to use hooks, they have to be imported at the top of the script, e.g. \`import { useState } from "react"\`
 
-- The recharts charting library is available to be imported, e.g. \`import { LineChart, XAxis, ... } from "recharts"\` & \`<LineChart ...><XAxis dataKey="name"> ...\`. Support for defaultProps will be removed from function components in a future major release. JavaScript default parameters should be used instead.
+- The recharts charting library is available to be imported, e.g. \`import { LineChart, XAxis, ... } from "recharts"\` & \`<LineChart ...><XAxis dataKey="name"> ...\`.
 
 - The papaparse library is available to be imported, e.g. \`import Papa from "papaparse"\` & \`const parsed = Papa.parse(fileContent, {header:true, skipEmptyLines: "greedy"});\`. The \`skipEmptyLines:"greedy"\` configuration should always be used.
 

--- a/types/src/front/assistant/visualization.ts
+++ b/types/src/front/assistant/visualization.ts
@@ -12,10 +12,6 @@ interface GetFileParams {
   fileId: string;
 }
 
-interface RetryParams {
-  errorMessage: string;
-}
-
 interface SetContentHeightParams {
   height: number;
 }
@@ -24,8 +20,8 @@ interface SetContentHeightParams {
 export type VisualizationRPCRequestMap = {
   getFile: GetFileParams;
   getCodeToExecute: null;
-  retry: RetryParams;
   setContentHeight: SetContentHeightParams;
+  setErrored: void;
 };
 
 // Derive the command type from the keys of the request map
@@ -42,8 +38,8 @@ export type VisualizationRPCRequest = {
 export const validCommands: VisualizationRPCCommand[] = [
   "getFile",
   "getCodeToExecute",
-  "retry",
   "setContentHeight",
+  "setErrored",
 ];
 
 // Command results.
@@ -51,8 +47,8 @@ export const validCommands: VisualizationRPCCommand[] = [
 export interface CommandResultMap {
   getFile: { fileBlob: Blob | null };
   getCodeToExecute: { code: string };
-  retry: void;
   setContentHeight: void;
+  setErrored: void;
 }
 
 // TODO(@fontanierh): refactor all these guards to use io-ts instead of manual checks.
@@ -100,29 +96,6 @@ export function isGetCodeToExecuteRequest(
   );
 }
 
-// Type guard for retry.
-export function isRetryRequest(
-  value: unknown
-): value is VisualizationRPCRequest & {
-  command: "retry";
-  params: RetryParams;
-} {
-  if (typeof value !== "object" || value === null) {
-    return false;
-  }
-
-  const v = value as Partial<VisualizationRPCRequest>;
-
-  return (
-    v.command === "retry" &&
-    typeof v.identifier === "string" &&
-    typeof v.messageUniqueId === "string" &&
-    typeof v.params === "object" &&
-    v.params !== null &&
-    typeof (v.params as RetryParams).errorMessage === "string"
-  );
-}
-
 // Type guard for setContentHeight.
 export function isSetContentHeightRequest(
   value: unknown
@@ -146,6 +119,24 @@ export function isSetContentHeightRequest(
   );
 }
 
+export function isSetErroredRequest(
+  value: unknown
+): value is VisualizationRPCRequest & {
+  command: "setErrored";
+} {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const v = value as Partial<VisualizationRPCRequest>;
+
+  return (
+    v.command === "setErrored" &&
+    typeof v.identifier === "string" &&
+    typeof v.messageUniqueId === "string"
+  );
+}
+
 export function isVisualizationRPCRequest(
   value: unknown
 ): value is VisualizationRPCRequest {
@@ -156,7 +147,7 @@ export function isVisualizationRPCRequest(
   return (
     isGetCodeToExecuteRequest(value) ||
     isGetFileRequest(value) ||
-    isRetryRequest(value) ||
-    isSetContentHeightRequest(value)
+    isSetContentHeightRequest(value) ||
+    isSetErroredRequest(value)
   );
 }

--- a/viz/app/components/Components.tsx
+++ b/viz/app/components/Components.tsx
@@ -1,54 +1,5 @@
 "use client";
 
-// We can't use Sparkle components in the viz app,
-// because of client-side rendering issue.
-// So we define the components here.
-
-export const Button = ({
-  label,
-  onClick,
-}: {
-  label: string;
-  onClick: () => void;
-}) => {
-  return (
-    <button
-      onClick={onClick}
-      className="px-4 py-2 text-sm font-medium text-white bg-blue-500 rounded hover:bg-blue-600"
-    >
-      {label}
-    </button>
-  );
-};
-
-export const ErrorMessage = ({
-  children,
-  title,
-}: {
-  children: React.ReactNode;
-  title: string;
-}) => {
-  return (
-    <div className="bg-pink-100 border-l-4 border-pink-500 rounded-lg p-4 max-w-md">
-      <div className="flex items-center mb-2">
-        <svg
-          className="w-6 h-6 text-pink-500 mr-2"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-        >
-          <path
-            fillRule="evenodd"
-            d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
-            clipRule="evenodd"
-          />
-        </svg>
-        <h3 className="text-lg font-semibold text-pink-800">{title}</h3>
-      </div>
-      <div className="text-pink-700">{children}</div>
-    </div>
-  );
-};
-
 export const Spinner = () => {
   return (
     <div className="flex items-center justify-center">

--- a/viz/app/components/ErrorBoundary.tsx
+++ b/viz/app/components/ErrorBoundary.tsx
@@ -1,5 +1,4 @@
-import { Button, ErrorMessage } from "@viz/app/components/Components";
-import React, { useState } from "react";
+import React from "react";
 
 interface ErrorBoundaryState {
   error: unknown;
@@ -8,8 +7,7 @@ interface ErrorBoundaryState {
 
 interface ErrorBoundaryProps {
   children: React.ReactNode;
-  errorMessage: string;
-  onRetryClick: (errorMessage: string) => void;
+  onErrored: () => void;
 }
 
 export class ErrorBoundary extends React.Component<
@@ -28,65 +26,14 @@ export class ErrorBoundary extends React.Component<
 
   componentDidCatch(error: unknown) {
     this.setState({ hasError: true, error });
+    this.props.onErrored();
   }
 
   render() {
     if (this.state.hasError) {
-      let error: Error;
-      if (this.state.error instanceof Error) {
-        error = this.state.error;
-      } else {
-        error = new Error("Unknown error.");
-      }
-
-      return (
-        <RenderError
-          error={error}
-          onRetryClick={this.props.onRetryClick}
-          message={this.props.errorMessage}
-        />
-      );
+      return null;
     }
 
     return <>{this.props.children}</>;
   }
-}
-
-// This is the component to render when an error occurs.
-export function RenderError({
-  error,
-  message,
-  onRetryClick,
-}: {
-  error: Error;
-  message: string;
-  onRetryClick: (errorMessage: string) => void;
-}) {
-  const [showDetails, setShowDetails] = useState(false);
-
-  return (
-    <div className="flex w-full flex-col items-center justify-center gap-4">
-      <ErrorMessage title="Error">
-        <>
-          {message}
-          <div className="mt-2">
-            <button
-              onClick={() => setShowDetails(!showDetails)}
-              className="text-pink-700 underline focus:outline-none"
-            >
-              {showDetails ? "Hide details" : "Show details"}
-            </button>
-            {showDetails && (
-              <div className="mt-2 p-2 bg-pink-50 rounded">
-                <strong>Error message:</strong> {error.message}
-              </div>
-            )}
-          </div>
-        </>
-      </ErrorMessage>
-      <div>
-        <Button label="Retry" onClick={() => onRetryClick(error.message)} />
-      </div>
-    </div>
-  );
 }

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -61,15 +61,6 @@ export function useVisualizationAPI(
     [sendCrossDocumentMessage]
   );
 
-  // This retry function sends a command to the host window requesting a retry of a previous
-  // operation, typically if the generated code fails.
-  const retry = useCallback(
-    async (errorMessage: string): Promise<void> => {
-      await sendCrossDocumentMessage("retry", { errorMessage });
-    },
-    [sendCrossDocumentMessage]
-  );
-
   const sendHeightToParent = useCallback(
     async ({ height }: { height: number | null }) => {
       if (height === null) {
@@ -83,7 +74,7 @@ export function useVisualizationAPI(
     [sendCrossDocumentMessage]
   );
 
-  return { fetchCode, fetchFile, error, retry, sendHeightToParent };
+  return { fetchCode, fetchFile, error, sendHeightToParent };
 }
 
 const useFile = (
@@ -134,9 +125,8 @@ export function VisualizationWrapperWithErrorBoundary({
 
   return (
     <ErrorBoundary
-      errorMessage="We encountered an error while running the code generated above. You can try again by clicking the button below."
-      onRetryClick={(errorMessage: string) => {
-        sendCrossDocumentMessage("retry", { errorMessage });
+      onErrored={() => {
+        sendCrossDocumentMessage("setErrored", undefined);
       }}
     >
       <VisualizationWrapper api={api} />

--- a/viz/package-lock.json
+++ b/viz/package-lock.json
@@ -16,7 +16,7 @@
         "react-dom": "^18",
         "react-resize-detector": "^11.0.1",
         "react-runner": "^1.0.5",
-        "recharts": "^2.12.7"
+        "recharts": "^2.13.0-alpha.4"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -4819,14 +4819,14 @@
       }
     },
     "node_modules/recharts": {
-      "version": "2.12.7",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.12.7.tgz",
-      "integrity": "sha512-hlLJMhPQfv4/3NBSAyq3gzGg4h2v69RJh6KU7b3pXYNNAELs9kEoXOjbkxdXpALqKBoVmVptGfLpxdaVYqjmXQ==",
+      "version": "2.13.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.13.0-alpha.4.tgz",
+      "integrity": "sha512-K9naL6F7pEcDYJE6yFQASSCQecSLPP0JagnvQ9hPtA/aHgsxsnIOjouLP5yrFZehxzfCkV5TEORr7/uNtSr7Qw==",
       "dependencies": {
         "clsx": "^2.0.0",
         "eventemitter3": "^4.0.1",
         "lodash": "^4.17.21",
-        "react-is": "^16.10.2",
+        "react-is": "^18.3.1",
         "react-smooth": "^4.0.0",
         "recharts-scale": "^0.4.4",
         "tiny-invariant": "^1.3.1",
@@ -4847,6 +4847,11 @@
       "dependencies": {
         "decimal.js-light": "^2.4.1"
       }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.6",

--- a/viz/package.json
+++ b/viz/package.json
@@ -17,7 +17,7 @@
     "react-dom": "^18",
     "react-resize-detector": "^11.0.1",
     "react-runner": "^1.0.5",
-    "recharts": "^2.12.7"
+    "recharts": "^2.13.0-alpha.4"
   },
   "devDependencies": {
     "@types/node": "^20",


### PR DESCRIPTION
## Description

1. improve the responsiveness of viz components by changing the prompt
2. improve overall latency by not relying on onLoad (and instead relying on contentHeight)
3. stop displaying error through the iframe (instead, use a `setErrored` cross-doc call to set error state on parent window)
4. improve latency / smoothness by removing state vars (enabled by removing `onLoad` and not relying on iframe to display the error)

After this PR, we can release viz

## Risk

N/A

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
