### PR TITLE
Check data sources and views permissions in registry lookup

### DIFF
--- a/core/src/blocks/data_source.rs
+++ b/core/src/blocks/data_source.rs
@@ -76,13 +76,18 @@ impl DataSource {
         &self,
         env: &Env,
         workspace_id: String,
-        data_source_id: String,
+        data_source_or_data_source_view_id: String,
         top_k: usize,
         filter: Option<SearchFilter>,
         target_document_tokens: Option<usize>,
     ) -> Result<Vec<Document>> {
-        let (data_source_project, view_filter) =
-            get_data_source_project_and_view_filter(&workspace_id, &data_source_id, env).await?;
+        let (data_source_project, view_filter, data_source_id) =
+            get_data_source_project_and_view_filter(
+                &workspace_id,
+                &data_source_or_data_source_view_id,
+                env,
+            )
+            .await?;
 
         let ds = match env
             .store

--- a/core/src/blocks/helpers.rs
+++ b/core/src/blocks/helpers.rs
@@ -19,7 +19,7 @@ pub async fn get_data_source_project_and_view_filter(
     workspace_id: &String,
     data_source_id: &String,
     env: &Env,
-) -> Result<(Project, Option<SearchFilter>)> {
+) -> Result<(Project, Option<SearchFilter>, String)> {
     let dust_workspace_id = match env.credentials.get("DUST_WORKSPACE_ID") {
         None => Err(anyhow!(
             "DUST_WORKSPACE_ID credentials missing, but `workspace_id` \
@@ -89,5 +89,6 @@ pub async fn get_data_source_project_and_view_filter(
     Ok((
         Project::new_from_id(payload.project_id),
         payload.view_filter,
+        payload.data_source_id,
     ))
 }

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -5,7 +5,7 @@ import type {
   Result,
   UserType,
 } from "@dust-tt/types";
-import { Err, Ok } from "@dust-tt/types";
+import { Err, Ok, removeNulls } from "@dust-tt/types";
 import type {
   Attributes,
   CreationAttributes,
@@ -162,11 +162,11 @@ export class GroupResource extends BaseResource<GroupModel> {
 
   static async fetchById(
     auth: Authenticator,
-    sId: string
+    id: string
   ): Promise<GroupResource | null> {
     const owner = auth.getNonNullableWorkspace();
 
-    const groupModelId = getResourceIdFromSId(sId);
+    const groupModelId = getResourceIdFromSId(id);
     if (!groupModelId) {
       return null;
     }
@@ -183,6 +183,32 @@ export class GroupResource extends BaseResource<GroupModel> {
 
     // Use `.get` to extract model attributes, omitting Sequelize instance metadata.
     return new this(this.model, blob.get());
+  }
+
+  static async fetchByIds(
+    auth: Authenticator,
+    ids: string[]
+  ): Promise<GroupResource[]> {
+    const owner = auth.getNonNullableWorkspace();
+
+    const groupModelIds = removeNulls(
+      ids.map((id) => getResourceIdFromSId(id))
+    );
+    if (groupModelIds.length === 0) {
+      return [];
+    }
+
+    const blobs = await this.model.findAll({
+      where: {
+        id: {
+          [Op.in]: groupModelIds,
+        },
+        workspaceId: owner.id,
+      },
+    });
+
+    // Use `.get` to extract model attributes, omitting Sequelize instance metadata.
+    return blobs.map((b) => new this(this.model, b.get()));
   }
 
   static async superAdminFetchWorkspaceGroups(
@@ -288,31 +314,6 @@ export class GroupResource extends BaseResource<GroupModel> {
     });
 
     return groups.map((group) => new this(GroupModel, group.get()));
-  }
-
-  static async fetchWorkspaceGroup(
-    auth: Authenticator,
-    groupId: string
-  ): Promise<GroupResource | null> {
-    const owner = auth.getNonNullableWorkspace();
-    const groupModelId = getResourceIdFromSId(groupId);
-
-    if (!groupModelId) {
-      throw new Error("Invalid group ID.");
-    }
-
-    const group = await this.model.findOne({
-      where: {
-        workspaceId: owner.id,
-        id: groupModelId,
-      },
-    });
-
-    if (!group) {
-      return null;
-    }
-
-    return new this(GroupModel, group.get());
   }
 
   static async fetchActiveGroupsOfUserInWorkspace({

--- a/front/pages/api/registry/[type]/lookup.ts
+++ b/front/pages/api/registry/[type]/lookup.ts
@@ -171,7 +171,7 @@ async function handleDataSourceView(
 
     return new Ok({
       project_id: parseInt(dataSource.dustAPIProjectId),
-      data_source_id: dataSourceId,
+      data_source_id: dataSource.name,
       view_filter: {
         tags: null,
         parents: {

--- a/front/pages/api/registry/[type]/lookup.ts
+++ b/front/pages/api/registry/[type]/lookup.ts
@@ -1,9 +1,13 @@
-import type { CoreAPISearchFilter } from "@dust-tt/types";
+import type { CoreAPISearchFilter, Result } from "@dust-tt/types";
+import { Err, groupHasPermission, Ok } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator } from "@app/lib/auth";
 import { Workspace } from "@app/lib/models/workspace";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { VaultResource } from "@app/lib/resources/vault_resource";
 import { withLogging } from "@app/logger/withlogging";
 
 const { DUST_REGISTRY_SECRET } = process.env;
@@ -54,24 +58,28 @@ async function handler(
     return;
   }
 
-  if (!req.headers["x-dust-workspace-id"]) {
+  const dustWorkspaceId = req.headers["x-dust-workspace-id"];
+  const rawDustGroupIds = req.headers["x-dust-group-ids"];
+  if (
+    typeof dustWorkspaceId !== "string" ||
+    typeof rawDustGroupIds !== "string"
+  ) {
     res.status(400).end();
     return;
   }
 
-  // TODO(GROUPS_INFRA): Add x-dust-group-ids header retrieval
-  //  - If not set default to the global workspace group
-  //  - Enforce checks for access to data sources and data sources view below
-
-  const dustWorkspaceId = req.headers["x-dust-workspace-id"] as string;
+  const dustGroupIds = rawDustGroupIds.split(",");
 
   switch (req.method) {
     case "GET":
       switch (req.query.type) {
         case "data_sources":
+          const { data_source_id: dataSourceId, workspace_id: workspaceId } =
+            req.query;
+
           if (
-            typeof req.query.workspace_id !== "string" ||
-            typeof req.query.data_source_id !== "string"
+            typeof workspaceId !== "string" ||
+            typeof dataSourceId !== "string"
           ) {
             res.status(400).end();
             return;
@@ -79,45 +87,50 @@ async function handler(
 
           const owner = await Workspace.findOne({
             where: {
-              sId: req.query.workspace_id,
+              sId: workspaceId,
             },
           });
-
-          if (!owner) {
-            res.status(404).end();
-            return;
-          }
-          const auth = await Authenticator.internalBuilderForWorkspace(
-            req.query.workspace_id
-          );
-          const dataSource = await DataSourceResource.fetchByName(
-            auth,
-            req.query.data_source_id
-          );
-
-          if (!dataSource) {
+          if (!owner || dustWorkspaceId !== owner.sId) {
             res.status(404).end();
             return;
           }
 
-          if (dustWorkspaceId != owner.sId) {
+          const auth =
+            await Authenticator.internalBuilderForWorkspace(workspaceId);
+
+          const groups = await GroupResource.fetchByIds(auth, dustGroupIds);
+          if (groups.length === 0) {
             res.status(404).end();
             return;
           }
 
-          // TODO(GROUPS_INFRA):
-          // - Implement view_filter return when a data source view is looked up.
-          // - If data_source_ids is of the form `dsv_...` then it's a data source view
-          //   and we pull the view_filter to return it below
-          // - otherwise it's data source and the view_filter is null
-          // - Obviously this is where we check based on the x-dust-group-ids header that we
-          //   have access to the data source or data source view
+          if (DataSourceViewResource.isDataSourceViewSId(dataSourceId)) {
+            const dataSourceViewRes = await handleDataSourceView(
+              auth,
+              groups,
+              dataSourceId
+            );
+            if (dataSourceViewRes.isErr()) {
+              res.status(404).end();
+              return;
+            }
 
-          res.status(200).json({
-            project_id: parseInt(dataSource.dustAPIProjectId),
-            data_source_id: req.query.data_source_id,
-            view_filter: null,
-          });
+            res.status(200).json(dataSourceViewRes.value);
+            return;
+          } else {
+            const dataSourceRes = await handleDataSource(
+              auth,
+              groups,
+              dataSourceId
+            );
+            if (dataSourceRes.isErr()) {
+              res.status(404).end();
+              return;
+            }
+
+            res.status(200).json(dataSourceRes.value);
+            return;
+          }
           return;
 
         default:
@@ -132,3 +145,81 @@ async function handler(
 }
 
 export default withLogging(handler);
+
+async function handleDataSourceView(
+  auth: Authenticator,
+  groups: GroupResource[],
+  dataSourceId: string
+): Promise<Result<LookupDataSourceResponseBody, Error>> {
+  const dataSourceView = await DataSourceViewResource.fetchById(
+    auth,
+    dataSourceId
+  );
+  if (!dataSourceView) {
+    return new Err(new Error("Data source view not found."));
+  }
+
+  // Ensure provided groups can access the data source view.
+  const hasAccessToDataSourceView = groups.some((g) =>
+    groupHasPermission(dataSourceView.acl(), "read", g.id)
+  );
+  if (hasAccessToDataSourceView) {
+    const dataSource = await dataSourceView.fetchDataSource(auth);
+    if (!dataSource) {
+      return new Err(new Error("Data source not found for view."));
+    }
+
+    return new Ok({
+      project_id: parseInt(dataSource.dustAPIProjectId),
+      data_source_id: dataSourceId,
+      view_filter: {
+        tags: null,
+        parents: {
+          in: dataSourceView.parentsIn,
+          not: null,
+        },
+        timestamp: null,
+      },
+    });
+  }
+
+  return new Err(new Error("No access to data source view."));
+}
+
+async function handleDataSource(
+  auth: Authenticator,
+  groups: GroupResource[],
+  dataSourceId: string
+): Promise<Result<LookupDataSourceResponseBody, Error>> {
+  const dataSource = await DataSourceResource.fetchByName(auth, dataSourceId);
+  if (!dataSource) {
+    return new Err(new Error("Data source not found."));
+  }
+
+  // Until we pass the data source view id for managed data sources, we need to fetch it here.
+  // TODO(2024-08-02 flav) Remove once dust apps rely on the data source view id for managed data sources.
+  if (dataSource.isManaged()) {
+    const globalVault = await VaultResource.fetchWorkspaceGlobalVault(auth);
+    const dataSourceView =
+      await DataSourceViewResource.listForDataSourcesInVault(
+        auth,
+        [dataSource],
+        globalVault
+      );
+
+    return handleDataSourceView(auth, groups, dataSourceView[0].sId);
+  }
+
+  const hasAccessToDataSource = groups.some((g) =>
+    groupHasPermission(dataSource.acl(), "read", g.id)
+  );
+  if (hasAccessToDataSource) {
+    return new Ok({
+      project_id: parseInt(dataSource.dustAPIProjectId),
+      data_source_id: dataSource.name,
+      view_filter: null,
+    });
+  }
+
+  return new Err(new Error("No access to data source."));
+}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR introduces a permission check during registry lookups. It leverages the group ids header introduced in https://github.com/dust-tt/dust/pull/6628. This code path is used by the core to verify that the user, workspace, or key has access to the chosen data sources or data views (modulo tables that don't use this code path yet -- which will be addressed in a subsequent PR).

Managed data sources reside in the system vault, and we continue to use the data source ID to query them. This PR provides a workaround to retrieve the associated data source view from the global/workspace vault. This workaround will be removed once all managed data source queries are applying at the view level. 

A change was required on `core` to also use the `data_source_id` returned by the registry lookup as core has no idea about data source views.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Tested locally with a dust app. Worst case it breaks all the retrieval actions. Can be monitored [here](https://app.datadoghq.eu/logs?query=Processed%20Request%20%40route%3A%22%2Fapi%2Fregistry%2F%5Btype%5D%2Flookup%22%20-%40statusCode%3A200%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1722600516162&to_ts=1722604116162&live=true). Safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
First deploy core, then deploy front.