### PR TITLE
[sparkle] - refactor: extend DataTable to accept TBaseData constraints

### DIFF
--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -25,7 +25,12 @@ interface DataTableProps<TData, TValue> {
   initialColumnOrder?: SortingState;
 }
 
-export function DataTable<TData, TValue>({
+interface TBaseData {
+  onClick?: () => void;
+  onMoreClick?: () => void;
+}
+
+export function DataTable<TData extends TBaseData, TValue>({
   data,
   columns,
   className,

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -16,18 +16,18 @@ import { classNames } from "@sparkle/lib/utils";
 
 import { Icon } from "./Icon";
 
-interface DataTableProps<TData, TValue> {
+interface TBaseData {
+  onClick?: () => void;
+  onMoreClick?: () => void;
+}
+
+interface DataTableProps<TData extends TBaseData, TValue> {
   data: TData[];
   columns: ColumnDef<TData, TValue>[];
   className?: string;
   filter?: string;
   filterColumn?: string;
   initialColumnOrder?: SortingState;
-}
-
-interface TBaseData {
-  onClick?: () => void;
-  onMoreClick?: () => void;
 }
 
 export function DataTable<TData extends TBaseData, TValue>({

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -20,9 +20,7 @@ type Data = {
   size: string;
   avatarUrl?: string;
   icon?: React.ComponentType<{ className?: string }>;
-  clickable?: boolean;
   onClick?: () => void;
-  showMore?: boolean;
   onMoreClick?: () => void;
 };
 


### PR DESCRIPTION
## Description

This PR extends the DataTable component in Sparkle to accept TBaseData constraints. It introduces a new TBaseData interface with optional onClick and onMoreClick properties, allowing for more flexible and interactive table rows. This change enhances the component's functionality by enabling click events on entire rows and supporting secondary actions within rows.


## Risk

Low. This change is backwards compatible and should not break existing implementations.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
