### PR TITLE
Bumping datadog agent RAM to 512req / 1024 limit (from 256/512).

### DIFF
--- a/k8s/datadog-values.yml
+++ b/k8s/datadog-values.yml
@@ -43,10 +43,10 @@ agents:
       resources:
         requests:
           cpu: 200m
-          memory: 256Mi
+          memory: 512Mi
         limits:
           cpu: 200m
-          memory: 512Mi
+          memory: 1024Mi
 
 providers:
   gke:

--- a/k8s/datadog-values.yml
+++ b/k8s/datadog-values.yml
@@ -46,7 +46,7 @@ agents:
           memory: 512Mi
         limits:
           cpu: 200m
-          memory: 1024Mi
+          memory: 512Mi
 
 providers:
   gke:


### PR DESCRIPTION
## Description

Doing this because we see datadog agents being restarted for OOM and we are missing some datadog traces. Hoping this will fix it.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
