### PR TITLE
Limit the number of  Slack blocks footnotes to 5.

### DIFF
--- a/connectors/src/connectors/slack/chat/blocks.ts
+++ b/connectors/src/connectors/slack/chat/blocks.ts
@@ -52,7 +52,7 @@ function makeMarkdownBlock(text: string) {
 }
 
 function makeFootnotesBlock(footnotes: SlackMessageFootnotes) {
-  const elements = footnotes.map((f) => ({
+  const elements = footnotes.slice(0, 5).map((f) => ({
     type: "mrkdwn",
     text: `<${f.link}|[${f.index}] ${truncate(f.text, 20)}>`,
   }));

--- a/connectors/src/connectors/slack/chat/blocks.ts
+++ b/connectors/src/connectors/slack/chat/blocks.ts
@@ -87,8 +87,7 @@ function makeContextSectionBlocks(
 
   const resultBlocks = blocks.length ? [makeDividerBlock(), ...blocks] : [];
 
-  // Slack limits the number of blocks to 10.
-  return resultBlocks.slice(0, 10);
+  return resultBlocks;
 }
 
 export type SlackMessageUpdate =

--- a/connectors/src/connectors/slack/chat/blocks.ts
+++ b/connectors/src/connectors/slack/chat/blocks.ts
@@ -52,6 +52,8 @@ function makeMarkdownBlock(text: string) {
 }
 
 function makeFootnotesBlock(footnotes: SlackMessageFootnotes) {
+  // We are limited to 10 blocks when posting a message on Slack,
+  // so we are posting 5 footnotes at most to leave rooms for other blocks (e.g. conversation link, divier, ...).
   const elements = footnotes.slice(0, 5).map((f) => ({
     type: "mrkdwn",
     text: `<${f.link}|[${f.index}] ${truncate(f.text, 20)}>`,


### PR DESCRIPTION
## Description

Limit the number of  Slack blocks footnotes to 5 because we are getting some "too many blocks" errors when posting to Slack.
5 is enough to display on Slack while giving us space for the other information (conversation links, divider...).

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
