### PR TITLE
Adding Slack tracing logs to debug answers from the Slack bot that ar…

### DIFF
--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -131,6 +131,11 @@ export async function streamConversationToSlack(
   let answer = botIdentity;
   const actions: AgentActionType[] = [];
   for await (const event of streamRes.value.eventStream) {
+    // This logger.info(Received event from Dust) is to be removed after august 30 2024.
+    logger.info(
+      { connectorId: connector.id, conversationId: conversation.sId },
+      "Received event from Dust"
+    );
     switch (event.type) {
       case "user_message_error": {
         return new Err(

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -133,7 +133,11 @@ export async function streamConversationToSlack(
   for await (const event of streamRes.value.eventStream) {
     // This logger.info(Received event from Dust) is to be removed after august 30 2024.
     logger.info(
-      { connectorId: connector.id, conversationId: conversation.sId },
+      {
+        connectorId: connector.id,
+        conversationId: conversation.sId,
+        type: event.type,
+      },
       "Received event from Dust"
     );
     switch (event.type) {


### PR DESCRIPTION
Adding Slack tracing logs to debug answers from the Slack bot that are not being sent.

To be reverted after the debug. Eng runner card created [here](https://github.com/dust-tt/tasks/issues/1120).


## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
