### PR TITLE
[front] - fix(docs): update quickstart guide link in AppView

### DIFF
--- a/front/pages/w/[wId]/a/[aId]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/index.tsx
@@ -428,7 +428,10 @@ export default function AppView({
                   icon={DocumentTextIcon}
                   label="Follow the QuickStart Guide"
                   onClick={() => {
-                    window.open("https://docs.dust.tt/quickstart", "_blank");
+                    window.open(
+                      "https://docs.dust.tt/reference/developer-platform-overview",
+                      "_blank"
+                    );
                   }}
                 />
               </p>


### PR DESCRIPTION
## Description

This PR aims at fixing the QuickStart Guide URL to the new developer platform overview documentation page when creating an app.

**References:**:
- https://github.com/dust-tt/tasks/issues/1122

## Risk

None

## Deploy Plan

Deploy `front`