### PR TITLE
Add x-dust-user-id header to run dust apps on public api endpoint

### DIFF
--- a/front/lib/actions/helpers.ts
+++ b/front/lib/actions/helpers.ts
@@ -1,4 +1,9 @@
-import type { Action, DustAPIResponse, WorkspaceType } from "@dust-tt/types";
+import type {
+  Action,
+  DustAPIResponse,
+  UserType,
+  WorkspaceType,
+} from "@dust-tt/types";
 import type { DustAppConfigType } from "@dust-tt/types";
 import { cloneBaseConfig } from "@dust-tt/types";
 import { DustAPI } from "@dust-tt/types";
@@ -17,6 +22,7 @@ import logger from "@app/logger/logger";
 
 interface CallActionParams<V extends t.Mixed> {
   owner: WorkspaceType;
+  user: UserType | null;
   input: { [key: string]: unknown };
   action: Action;
   config: DustAppConfigType;
@@ -41,6 +47,7 @@ interface CallActionParams<V extends t.Mixed> {
  */
 export async function callAction<V extends t.Mixed>({
   owner,
+  user,
   input,
   action,
   config,
@@ -58,7 +65,7 @@ export async function callAction<V extends t.Mixed>({
     logger
   );
 
-  const r = await prodAPI.runApp(app, config, [input]);
+  const r = await prodAPI.runApp(auth.user(), app, config, [input]);
 
   if (r.isErr()) {
     return r;

--- a/front/lib/actions/helpers.ts
+++ b/front/lib/actions/helpers.ts
@@ -65,7 +65,7 @@ export async function callAction<V extends t.Mixed>({
     logger
   );
 
-  const r = await prodAPI.runApp(auth.user(), app, config, [input]);
+  const r = await prodAPI.runApp(user, app, config, [input]);
 
   if (r.isErr()) {
     return r;

--- a/front/lib/actions/server.ts
+++ b/front/lib/actions/server.ts
@@ -158,7 +158,7 @@ export async function runActionStreamed(
 
 /**
  * This function is intended to be used server-side to run an action without streaming.
- * @param owner WorkspaceType
+ * @param auth Authenticator
  * @param actionName string Action name as per DustProdActionRegistry
  * @param config DustAppConfigType
  * @param inputs Array<any> the action inputs
@@ -209,12 +209,7 @@ export async function runAction(
     logger
   );
 
-  const res = await api.runApp(
-    auth.getNonNullableUser(),
-    action.app,
-    config,
-    inputs
-  );
+  const res = await api.runApp(auth.user(), action.app, config, inputs);
   if (res.isErr()) {
     logActionError(loggerArgs, tags, "run_error", { error: res.error });
     return new Err(res.error);

--- a/front/lib/actions/server.ts
+++ b/front/lib/actions/server.ts
@@ -92,7 +92,12 @@ export async function runActionStreamed(
     logger
   );
 
-  const res = await api.runAppStreamed(action.app, config, inputs);
+  const res = await api.runAppStreamed(
+    auth.getNonNullableUser(),
+    action.app,
+    config,
+    inputs
+  );
   if (res.isErr()) {
     logActionError(loggerArgs, tags, "run_error", { error: res.error });
     return new Err(res.error);
@@ -204,7 +209,12 @@ export async function runAction(
     logger
   );
 
-  const res = await api.runApp(action.app, config, inputs);
+  const res = await api.runApp(
+    auth.getNonNullableUser(),
+    action.app,
+    config,
+    inputs
+  );
   if (res.isErr()) {
     logActionError(loggerArgs, tags, "run_error", { error: res.error });
     return new Err(res.error);

--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -315,6 +315,7 @@ export class DustAppRunConfigurationServerRunner extends BaseActionConfiguration
     // As we run the app (using a system API key here), we do force using the workspace credentials so
     // that the app executes in the exact same conditions in which they were developed.
     const runRes = await api.runAppStreamed(
+      auth.getNonNullableUser(),
       {
         workspaceId: actionConfiguration.appWorkspaceId,
         appId: actionConfiguration.appId,

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -279,14 +279,6 @@ export class Authenticator {
   }
 
   /**
-   * Get an Authenticator from an API key for a given workspace. Why? because by API you may want to
-   * access a workspace that is not the API key's workspace (eg include running another's workspace
-   * app (dust-apps))
-   * @param key Key the API key
-   * @param wId string the target workspaceId
-   * @returns an Authenticator for wId and the key's own workspaceId
-   */
-  /**
    * Returns two Authenticators, one for the workspace associated with the key and one for the
    * workspace provided as an argument.
    *

--- a/front/lib/documents_post_process_hooks/hooks/document_tracker/suggest_changes/actions/doc_tracker_retrieval.ts
+++ b/front/lib/documents_post_process_hooks/hooks/document_tracker/suggest_changes/actions/doc_tracker_retrieval.ts
@@ -20,11 +20,12 @@ export async function callDocTrackerRetrievalAction(
   config.SEMANTIC_SEARCH.target_document_tokens = targetDocumentTokens;
 
   const res = await callAction({
-    owner,
-    input: { input_text: inputText },
     action,
     config,
+    input: { input_text: inputText },
+    owner,
     responseValueSchema: DocTrackerRetrievalActionValueSchema,
+    user: null,
   });
 
   if (res.isErr()) {

--- a/front/lib/documents_post_process_hooks/hooks/document_tracker/suggest_changes/actions/doc_tracker_suggest_changes.ts
+++ b/front/lib/documents_post_process_hooks/hooks/document_tracker/suggest_changes/actions/doc_tracker_suggest_changes.ts
@@ -29,11 +29,12 @@ export async function callDocTrackerSuggestChangesAction(
   config.SUGGEST_CHANGES.model_id = model.modelId;
 
   const res = await callAction({
-    owner,
-    input: { source_document: sourceDocument, target_document: targetDocument },
     action,
     config,
+    input: { source_document: sourceDocument, target_document: targetDocument },
+    owner,
     responseValueSchema: DocTrackerSuggestChangesActionValueSchema,
+    user: null,
   });
 
   if (res.isErr()) {

--- a/front/pages/api/v1/w/[wId]/apps/[aId]/runs/[runId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/[aId]/runs/[runId]/index.ts
@@ -67,12 +67,12 @@ async function handler(
   if (keyRes.isErr()) {
     return apiError(req, res, keyRes.error);
   }
-  const { auth } = await Authenticator.fromKey(
+  const { workspaceAuth } = await Authenticator.fromKey(
     keyRes.value,
     req.query.wId as string
   );
 
-  const owner = auth.workspace();
+  const owner = workspaceAuth.workspace();
   if (!owner) {
     return apiError(req, res, {
       status_code: 404,
@@ -83,7 +83,7 @@ async function handler(
     });
   }
 
-  const app = await getApp(auth, req.query.aId as string);
+  const app = await getApp(workspaceAuth, req.query.aId as string);
 
   if (!app) {
     return apiError(req, res, {

--- a/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
@@ -1,7 +1,6 @@
 import type {
   BlockType,
   CredentialsType,
-  LightWorkspaceType,
   ModelIdType,
   ModelProviderIdType,
   TraceType,
@@ -24,7 +23,6 @@ import apiConfig from "@app/lib/api/config";
 import { getDustAppSecrets } from "@app/lib/api/dust_app_secrets";
 import { Authenticator, getAPIKey } from "@app/lib/auth";
 import { Provider } from "@app/lib/models/apps";
-import { GroupResource } from "@app/lib/resources/group_resource";
 import type { KeyResource } from "@app/lib/resources/key_resource";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import { RunResource } from "@app/lib/resources/run_resource";

--- a/front/pages/api/v1/w/[wId]/apps/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/index.ts
@@ -86,12 +86,12 @@ async function handler(
   if (keyRes.isErr()) {
     return apiError(req, res, keyRes.error);
   }
-  const { auth } = await Authenticator.fromKey(
+  const { workspaceAuth } = await Authenticator.fromKey(
     keyRes.value,
     req.query.wId as string
   );
 
-  const apps = await getApps(auth);
+  const apps = await getApps(workspaceAuth);
 
   switch (req.method) {
     case "GET":

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
@@ -53,12 +53,15 @@ async function handler(
     return apiError(req, res, keyRes.error);
   }
 
-  const { auth, keyWorkspace } = await Authenticator.fromKey(
+  const { workspaceAuth, keyAuth } = await Authenticator.fromKey(
     keyRes.value,
     req.query.wId as string
   );
 
-  if (!auth.isBuilder() || keyWorkspace.sId !== req.query.wId) {
+  if (
+    !workspaceAuth.isBuilder() ||
+    keyAuth.getNonNullableWorkspace().sId !== req.query.wId
+  ) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -71,7 +74,7 @@ async function handler(
   switch (req.method) {
     case "GET": {
       const agentConfigurations = await getAgentConfigurations({
-        auth,
+        auth: workspaceAuth,
         agentsGetView: "all",
         variant: "light",
       });

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -74,12 +74,15 @@ async function handler(
     return apiError(req, res, keyRes.error);
   }
 
-  const { auth, keyWorkspace } = await Authenticator.fromKey(
+  const { keyAuth, workspaceAuth } = await Authenticator.fromKey(
     keyRes.value,
     req.query.wId as string
   );
 
-  if (!auth.isBuilder() || keyWorkspace.sId !== req.query.wId) {
+  if (
+    !workspaceAuth.isBuilder() ||
+    keyAuth.getNonNullableWorkspace().sId !== req.query.wId
+  ) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -89,7 +92,10 @@ async function handler(
     });
   }
 
-  const conversation = await getConversation(auth, req.query.cId as string);
+  const conversation = await getConversation(
+    workspaceAuth,
+    req.query.cId as string
+  );
   if (!conversation) {
     return apiError(req, res, {
       status_code: 404,
@@ -138,7 +144,7 @@ async function handler(
       });
 
       const contentFragmentRes = await postNewContentFragment(
-        auth,
+        workspaceAuth,
         conversation,
         {
           ...contentFragmentBody,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -53,12 +53,15 @@ async function handler(
     return apiError(req, res, keyRes.error);
   }
 
-  const { auth, keyWorkspace } = await Authenticator.fromKey(
+  const { keyAuth, workspaceAuth } = await Authenticator.fromKey(
     keyRes.value,
     req.query.wId as string
   );
 
-  if (!auth.isBuilder() || keyWorkspace.sId !== req.query.wId) {
+  if (
+    !workspaceAuth.isBuilder() ||
+    keyAuth.getNonNullableWorkspace().sId !== req.query.wId
+  ) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -69,7 +72,7 @@ async function handler(
   }
 
   const conversation = await getConversationWithoutContent(
-    auth,
+    workspaceAuth,
     req.query.cId as string
   );
   if (!conversation) {

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -56,12 +56,15 @@ async function handler(
     return apiError(req, res, keyRes.error);
   }
 
-  const { auth, keyWorkspace } = await Authenticator.fromKey(
+  const { keyAuth, workspaceAuth } = await Authenticator.fromKey(
     keyRes.value,
     req.query.wId as string
   );
 
-  if (!auth.isBuilder() || keyWorkspace.sId !== req.query.wId) {
+  if (
+    !workspaceAuth.isBuilder() ||
+    keyAuth.getNonNullableWorkspace().sId !== req.query.wId
+  ) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -71,7 +74,10 @@ async function handler(
     });
   }
 
-  const conversation = await getConversation(auth, req.query.cId as string);
+  const conversation = await getConversation(
+    workspaceAuth,
+    req.query.cId as string
+  );
   if (!conversation) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
@@ -83,12 +83,15 @@ async function handler(
     return apiError(req, res, keyRes.error);
   }
 
-  const { auth, keyWorkspace } = await Authenticator.fromKey(
+  const { keyAuth, workspaceAuth } = await Authenticator.fromKey(
     keyRes.value,
     req.query.wId as string
   );
 
-  if (!auth.isBuilder() || keyWorkspace.sId !== req.query.wId) {
+  if (
+    !workspaceAuth.isBuilder() ||
+    keyAuth.getNonNullableWorkspace().sId !== req.query.wId
+  ) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -98,7 +101,7 @@ async function handler(
     });
   }
 
-  const owner = auth.workspace();
+  const owner = workspaceAuth.workspace();
   if (!owner) {
     return apiError(req, res, {
       status_code: 404,
@@ -110,7 +113,7 @@ async function handler(
   }
 
   const conversation = await getConversationWithoutContent(
-    auth,
+    workspaceAuth,
     req.query.cId as string
   );
 
@@ -137,7 +140,7 @@ async function handler(
   const messageId = req.query.mId;
 
   const messageType = await getConversationMessageType(
-    auth,
+    workspaceAuth,
     conversation,
     messageId
   );

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -214,14 +214,14 @@ async function handler(
   if (keyRes.isErr()) {
     return apiError(req, res, keyRes.error);
   }
-  const { auth } = await Authenticator.fromKey(
+  const { workspaceAuth } = await Authenticator.fromKey(
     keyRes.value,
     req.query.wId as string
   );
 
-  const owner = auth.workspace();
-  const plan = auth.plan();
-  if (!owner || !plan || !auth.isBuilder()) {
+  const owner = workspaceAuth.workspace();
+  const plan = workspaceAuth.plan();
+  if (!owner || !plan || !workspaceAuth.isBuilder()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -231,7 +231,10 @@ async function handler(
     });
   }
 
-  const dataSource = await getDataSource(auth, req.query.name as string);
+  const dataSource = await getDataSource(
+    workspaceAuth,
+    req.query.name as string
+  );
 
   if (!dataSource) {
     return apiError(req, res, {
@@ -490,7 +493,7 @@ async function handler(
       }
 
     case "DELETE":
-      if (!auth.isBuilder()) {
+      if (!workspaceAuth.isBuilder()) {
         return apiError(req, res, {
           status_code: 403,
           api_error: {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/parents.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/parents.ts
@@ -76,13 +76,13 @@ async function handler(
   if (keyRes.isErr()) {
     return apiError(req, res, keyRes.error);
   }
-  const { auth } = await Authenticator.fromKey(
+  const { workspaceAuth } = await Authenticator.fromKey(
     keyRes.value,
     req.query.wId as string
   );
 
-  const owner = auth.workspace();
-  if (!owner || !auth.isBuilder()) {
+  const owner = workspaceAuth.workspace();
+  if (!owner || !workspaceAuth.isBuilder()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -92,7 +92,10 @@ async function handler(
     });
   }
 
-  const dataSource = await getDataSource(auth, req.query.name as string);
+  const dataSource = await getDataSource(
+    workspaceAuth,
+    req.query.name as string
+  );
 
   if (!dataSource) {
     return apiError(req, res, {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/index.ts
@@ -74,12 +74,12 @@ async function handler(
   if (keyRes.isErr()) {
     return apiError(req, res, keyRes.error);
   }
-  const { auth } = await Authenticator.fromKey(
+  const { workspaceAuth } = await Authenticator.fromKey(
     keyRes.value,
     req.query.wId as string
   );
 
-  if (!auth.isBuilder()) {
+  if (!workspaceAuth.isBuilder()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -89,7 +89,10 @@ async function handler(
     });
   }
 
-  const dataSource = await getDataSource(auth, req.query.name as string);
+  const dataSource = await getDataSource(
+    workspaceAuth,
+    req.query.name as string
+  );
 
   if (!dataSource) {
     return apiError(req, res, {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/search.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/search.ts
@@ -183,12 +183,12 @@ async function handler(
   if (keyRes.isErr()) {
     return apiError(req, res, keyRes.error);
   }
-  const { auth } = await Authenticator.fromKey(
+  const { workspaceAuth } = await Authenticator.fromKey(
     keyRes.value,
     req.query.wId as string
   );
 
-  if (!auth.isBuilder()) {
+  if (!workspaceAuth.isBuilder()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -198,7 +198,10 @@ async function handler(
     });
   }
 
-  const dataSource = await getDataSource(auth, req.query.name as string);
+  const dataSource = await getDataSource(
+    workspaceAuth,
+    req.query.name as string
+  );
 
   if (!dataSource) {
     return apiError(req, res, {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
@@ -102,14 +102,14 @@ async function handler(
     return apiError(req, res, keyRes.error);
   }
 
-  const { auth } = await Authenticator.fromKey(
+  const { workspaceAuth } = await Authenticator.fromKey(
     keyRes.value,
     req.query.wId as string
   );
 
-  const owner = auth.workspace();
-  const plan = auth.plan();
-  if (!owner || !plan || !auth.isBuilder()) {
+  const owner = workspaceAuth.workspace();
+  const plan = workspaceAuth.plan();
+  if (!owner || !plan || !workspaceAuth.isBuilder()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -119,7 +119,10 @@ async function handler(
     });
   }
 
-  const dataSource = await getDataSource(auth, req.query.name as string);
+  const dataSource = await getDataSource(
+    workspaceAuth,
+    req.query.name as string
+  );
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/[rId].ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/[rId].ts
@@ -110,14 +110,14 @@ async function handler(
     return apiError(req, res, keyRes.error);
   }
 
-  const { auth } = await Authenticator.fromKey(
+  const { workspaceAuth } = await Authenticator.fromKey(
     keyRes.value,
     req.query.wId as string
   );
 
-  const owner = auth.workspace();
-  const plan = auth.plan();
-  if (!owner || !plan || !auth.isBuilder()) {
+  const owner = workspaceAuth.workspace();
+  const plan = workspaceAuth.plan();
+  if (!owner || !plan || !workspaceAuth.isBuilder()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -127,7 +127,10 @@ async function handler(
     });
   }
 
-  const dataSource = await getDataSource(auth, req.query.name as string);
+  const dataSource = await getDataSource(
+    workspaceAuth,
+    req.query.name as string
+  );
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/index.ts
@@ -198,14 +198,14 @@ async function handler(
     return apiError(req, res, keyRes.error);
   }
 
-  const { auth } = await Authenticator.fromKey(
+  const { workspaceAuth } = await Authenticator.fromKey(
     keyRes.value,
     req.query.wId as string
   );
 
-  const owner = auth.workspace();
-  const plan = auth.plan();
-  if (!owner || !plan || !auth.isBuilder()) {
+  const owner = workspaceAuth.workspace();
+  const plan = workspaceAuth.plan();
+  if (!owner || !plan || !workspaceAuth.isBuilder()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -215,7 +215,10 @@ async function handler(
     });
   }
 
-  const dataSource = await getDataSource(auth, req.query.name as string);
+  const dataSource = await getDataSource(
+    workspaceAuth,
+    req.query.name as string
+  );
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/csv.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/csv.ts
@@ -26,15 +26,15 @@ async function handler(
     return apiError(req, res, keyRes.error);
   }
 
-  const { auth } = await Authenticator.fromKey(
+  const { workspaceAuth } = await Authenticator.fromKey(
     keyRes.value,
     req.query.wId as string
   );
 
-  const owner = auth.workspace();
-  const plan = auth.plan();
+  const owner = workspaceAuth.workspace();
+  const plan = workspaceAuth.plan();
   const isSystemKey = keyRes.value.isSystem;
-  if (!owner || !plan || !auth.isBuilder() || !isSystemKey) {
+  if (!owner || !plan || !workspaceAuth.isBuilder() || !isSystemKey) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -46,7 +46,7 @@ async function handler(
 
   switch (req.method) {
     case "POST":
-      return handlePostTableCsvUpsertRequest(auth, req, res);
+      return handlePostTableCsvUpsertRequest(workspaceAuth, req, res);
 
     default:
       return apiError(req, res, {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/index.ts
@@ -131,14 +131,14 @@ async function handler(
     return apiError(req, res, keyRes.error);
   }
 
-  const { auth } = await Authenticator.fromKey(
+  const { workspaceAuth } = await Authenticator.fromKey(
     keyRes.value,
     req.query.wId as string
   );
 
-  const owner = auth.workspace();
-  const plan = auth.plan();
-  if (!owner || !plan || !auth.isBuilder()) {
+  const owner = workspaceAuth.workspace();
+  const plan = workspaceAuth.plan();
+  if (!owner || !plan || !workspaceAuth.isBuilder()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -148,7 +148,10 @@ async function handler(
     });
   }
 
-  const dataSource = await getDataSource(auth, req.query.name as string);
+  const dataSource = await getDataSource(
+    workspaceAuth,
+    req.query.name as string
+  );
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tokenize.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tokenize.ts
@@ -36,12 +36,12 @@ async function handler(
   if (keyRes.isErr()) {
     return apiError(req, res, keyRes.error);
   }
-  const { auth } = await Authenticator.fromKey(
+  const { workspaceAuth } = await Authenticator.fromKey(
     keyRes.value,
     req.query.wId as string
   );
 
-  if (!auth.workspace() || !auth.isBuilder()) {
+  if (!workspaceAuth.workspace() || !workspaceAuth.isBuilder()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -51,7 +51,10 @@ async function handler(
     });
   }
 
-  const dataSource = await getDataSource(auth, req.query.name as string);
+  const dataSource = await getDataSource(
+    workspaceAuth,
+    req.query.name as string
+  );
 
   if (!dataSource) {
     return apiError(req, res, {

--- a/front/pages/api/v1/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/index.ts
@@ -52,12 +52,12 @@ async function handler(
   if (keyRes.isErr()) {
     return apiError(req, res, keyRes.error);
   }
-  const { auth } = await Authenticator.fromKey(
+  const { workspaceAuth } = await Authenticator.fromKey(
     keyRes.value,
     req.query.wId as string
   );
 
-  if (!auth.isBuilder()) {
+  if (!workspaceAuth.isBuilder()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -67,7 +67,7 @@ async function handler(
     });
   }
 
-  const dataSources = await getDataSources(auth);
+  const dataSources = await getDataSources(workspaceAuth);
 
   switch (req.method) {
     case "GET":

--- a/front/pages/api/v1/w/[wId]/feature_flags.ts
+++ b/front/pages/api/v1/w/[wId]/feature_flags.ts
@@ -24,14 +24,14 @@ async function handler(
   if (keyRes.isErr()) {
     return apiError(req, res, keyRes.error);
   }
-  const { auth } = await Authenticator.fromKey(
+  const { workspaceAuth } = await Authenticator.fromKey(
     keyRes.value,
     req.query.wId as string
   );
 
-  const owner = auth.workspace();
+  const owner = workspaceAuth.workspace();
   const isSystemKey = keyRes.value.isSystem;
-  if (!owner || !isSystemKey || !auth.isBuilder()) {
+  if (!owner || !isSystemKey || !workspaceAuth.isBuilder()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/api/v1/w/[wId]/members/emails.ts
+++ b/front/pages/api/v1/w/[wId]/members/emails.ts
@@ -22,14 +22,14 @@ async function handler(
   if (keyRes.isErr()) {
     return apiError(req, res, keyRes.error);
   }
-  const { auth } = await Authenticator.fromKey(
+  const { workspaceAuth } = await Authenticator.fromKey(
     keyRes.value,
     req.query.wId as string
   );
 
-  const owner = auth.workspace();
+  const owner = workspaceAuth.workspace();
   const isSystemKey = keyRes.value.isSystem;
-  if (!owner || !isSystemKey || !auth.isBuilder()) {
+  if (!owner || !isSystemKey || !workspaceAuth.isBuilder()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -43,7 +43,7 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const allMembers = await getMembers(auth, {
+      const allMembers = await getMembers(workspaceAuth, {
         activeOnly: !!activeOnly,
       });
 

--- a/front/pages/api/v1/w/[wId]/usage.ts
+++ b/front/pages/api/v1/w/[wId]/usage.ts
@@ -78,13 +78,13 @@ async function handler(
   if (keyRes.isErr()) {
     return apiError(req, res, keyRes.error);
   }
-  const { auth } = await Authenticator.fromKey(
+  const { workspaceAuth } = await Authenticator.fromKey(
     keyRes.value,
     req.query.wId as string
   );
 
-  const owner = auth.workspace();
-  if (!owner || !auth.isBuilder()) {
+  const owner = workspaceAuth.workspace();
+  if (!owner || !workspaceAuth.isBuilder()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/api/v1/w/[wId]/verified_domains.ts
+++ b/front/pages/api/v1/w/[wId]/verified_domains.ts
@@ -22,14 +22,14 @@ async function handler(
   if (keyRes.isErr()) {
     return apiError(req, res, keyRes.error);
   }
-  const { auth } = await Authenticator.fromKey(
+  const { workspaceAuth } = await Authenticator.fromKey(
     keyRes.value,
     req.query.wId as string
   );
 
-  const owner = auth.workspace();
+  const owner = workspaceAuth.workspace();
   const isSystemKey = keyRes.value.isSystem;
-  if (!owner || !isSystemKey || !auth.isBuilder()) {
+  if (!owner || !isSystemKey || !workspaceAuth.isBuilder()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See thread [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1722612328124899).

This PR introduces a new `x-dust-user-id` header on the run endpoint. When used with a system key, it will be used to fetch the user's group within the key's workspace. If the header is not provided, the default will be the key's workspace group. This header is supported exclusively on this public API endpoint and serves as a temporary solution until we refactor our authentication mechanism.

This PR also refactors the `Authenticator.fromKey()` function to returns two authenticator, the one associated with the provided workspace (workspaceAuth) and the one associated with the key (keyAuth).

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
