### PR TITLE
[front] - refacto: connection management UI

### DIFF
--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -63,7 +63,6 @@ export async function getDataSources(
   const dataSources = await DataSourceResource.listByWorkspace(auth, {
     includeEditedBy,
   });
-
   return dataSources.map((dataSource) => dataSource.toJSON());
 }
 

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,7 @@
         "@amplitude/analytics-browser": "^2.5.2",
         "@amplitude/analytics-node": "^1.3.5",
         "@auth0/nextjs-auth0": "^3.5.0",
-        "@dust-tt/sparkle": "^0.2.198",
+        "@dust-tt/sparkle": "^0.2.201",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -10735,9 +10735,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.198",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.198.tgz",
-      "integrity": "sha512-QSV29789AKo2qnERpVQIom1hGLGPz6y7jsnUgWTcXwjfqrySRViQ9vnSrTNdjpLZqEEmLfIXbLKVRlWEsBcLIg==",
+      "version": "0.2.201",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.201.tgz",
+      "integrity": "sha512-wE+dGQ9cgdRAiqCsw5UCw2ucLC5VGN/u9PyHFAClFraodfuTp5nuH/Dfn/Ht4fnNVQYOvIdn8gozH/aH/icONQ==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
     "@amplitude/analytics-browser": "^2.5.2",
     "@amplitude/analytics-node": "^1.3.5",
     "@auth0/nextjs-auth0": "^3.5.0",
-    "@dust-tt/sparkle": "^0.2.198",
+    "@dust-tt/sparkle": "^0.2.201",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -75,6 +75,27 @@ type DataSourceIntegration = {
   editedByUser: string | null;
 };
 
+type Info = {
+  row: {
+    original: {
+      icon: ComponentType;
+      name: string;
+      usage: number | null;
+      editedByUser: string | null;
+      connector: ConnectorType | null;
+      workspaceId: string | undefined;
+      dataSourceName: string | undefined;
+      isLoading: boolean;
+      isBuilt: boolean;
+      isAdmin: boolean;
+      fetchConnectorError: boolean;
+      buttonOnClick: () => void;
+      upgradeDialog: React.JSX.Element;
+      comingSoonDialog: React.JSX.Element;
+    };
+  };
+};
+
 const REDIRECT_TO_EDIT_PERMISSIONS = [
   "confluence",
   "google_drive",
@@ -678,26 +699,6 @@ export default function DataSourcesView({
 }
 
 function getTableColumns() {
-  type Info = {
-    row: {
-      original: {
-        icon: ComponentType;
-        name: string;
-        usage: number | null;
-        editedByUser: string | null;
-        connector: ConnectorType | null;
-        workspaceId: string | undefined;
-        dataSourceName: string | undefined;
-        isLoading: boolean;
-        isBuilt: boolean;
-        isAdmin: boolean;
-        fetchConnectorError: boolean;
-        buttonOnClick: () => void;
-        upgradeDialog: React.JSX.Element;
-        comingSoonDialog: React.JSX.Element;
-      };
-    };
-  };
   return [
     {
       header: "Name",

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -463,7 +463,8 @@ export default function DataSourcesView({
   dustClientFacingUrl,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const sendNotification = useContext(SendNotificationsContext);
-  const [localIntegrations, setLocalIntegrations] = useState(integrations);
+  const [dataSourceIntegrations, setDataSourceIntegrations] =
+    useState(integrations);
   const [isLoadingByProvider, setIsLoadingByProvider] = useState<
     Record<ConnectorProvider, boolean | undefined>
   >({} as Record<ConnectorProvider, boolean | undefined>);
@@ -521,7 +522,7 @@ export default function DataSourcesView({
           dataSource: DataSourceType;
           connector: ConnectorType;
         } = await res.json();
-        setLocalIntegrations((prev) =>
+        setDataSourceIntegrations((prev) =>
           prev.map((ds) => {
             return ds.connector === null && ds.connectorProvider == provider
               ? {
@@ -558,8 +559,8 @@ export default function DataSourcesView({
   };
 
   useEffect(() => {
-    setLocalIntegrations(localIntegrations);
-  }, [localIntegrations]);
+    setDataSourceIntegrations(dataSourceIntegrations);
+  }, [dataSourceIntegrations]);
 
   const searchBarRef = useRef<HTMLInputElement>(null);
 

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -862,7 +862,7 @@ function getTableRow(
 
   const comingSoonDialog = (
     <Dialog
-      isOpen={showPreviewPopupForProvider !== connectorProvider}
+      isOpen={showPreviewPopupForProvider === connectorProvider}
       title="Coming Soon!"
       validateLabel="Contact us"
       onValidate={() => {

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -150,6 +150,10 @@ export async function setupConnection({
   return new Ok(connectionId);
 }
 
+function getUserImageUrl(dataSource: DataSourceType) {
+  return dataSource.editedByUser?.imageUrl ?? null;
+}
+
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
@@ -207,7 +211,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
             connector: null,
             fetchConnectorError: true,
             fetchConnectorErrorMessage: statusRes.error.message,
-            editedByUser: mds.editedByUser?.imageUrl ?? null,
+            editedByUser: getUserImageUrl(mds),
             usage: await getDataSourceUsage({
               auth,
               dataSource: mds,
@@ -220,7 +224,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
           connector: statusRes.value,
           fetchConnectorError: false,
           fetchConnectorErrorMessage: null,
-          editedByUser: mds.editedByUser?.imageUrl ?? null,
+          editedByUser: getUserImageUrl(mds),
           usage: await getDataSourceUsage({
             auth,
             dataSource: mds,
@@ -236,7 +240,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
           connector: null,
           fetchConnectorError: true,
           fetchConnectorErrorMessage: "Synchonization service is down",
-          editedByUser: mds.editedByUser?.imageUrl ?? "",
+          editedByUser: getUserImageUrl(mds),
           usage: null,
         };
       }

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -96,6 +96,22 @@ type Info = {
   };
 };
 
+type GetTableRowParams = {
+  integration: DataSourceIntegration;
+  isAdmin: boolean;
+  isLoadingByProvider: Record<ConnectorProvider, boolean | undefined>;
+  router: NextRouter;
+  owner: WorkspaceType;
+  readOnly: boolean;
+  plan: PlanType;
+  limits: ManageDataSourcesLimitsType;
+  showPreviewPopupForProvider: ConnectorProvider | null;
+  showUpgradePopupForProvider: ConnectorProvider | null;
+  setShowUpgradePopupForProvider: (provider: ConnectorProvider | null) => void;
+  setShowConfirmConnection: (integration: DataSourceIntegration | null) => void;
+  setShowPreviewPopupForProvider: (provider: ConnectorProvider | null) => void;
+};
+
 const REDIRECT_TO_EDIT_PERMISSIONS = [
   "confluence",
   "google_drive",
@@ -555,7 +571,7 @@ export default function DataSourcesView({
         (isAdmin || ds.connector)
     );
     return filteredRows.map((integration) =>
-      getTableRow(
+      getTableRow({
         integration,
         isAdmin,
         isLoadingByProvider,
@@ -563,13 +579,13 @@ export default function DataSourcesView({
         owner,
         readOnly,
         plan,
-        planConnectionsLimits,
+        limits: planConnectionsLimits,
         showPreviewPopupForProvider,
         showUpgradePopupForProvider,
         setShowUpgradePopupForProvider,
         setShowConfirmConnection,
-        setShowPreviewPopupForProvider
-      )
+        setShowPreviewPopupForProvider,
+      })
     );
   }, [
     integrations,
@@ -807,21 +823,21 @@ function getTableColumns() {
   ];
 }
 
-function getTableRow(
-  integration: DataSourceIntegration,
-  isAdmin: boolean,
-  isLoadingByProvider: Record<ConnectorProvider, boolean | undefined>,
-  router: NextRouter,
-  owner: WorkspaceType,
-  readOnly: boolean,
-  plan: PlanType,
-  limits: ManageDataSourcesLimitsType,
-  showPreviewPopupForProvider: ConnectorProvider | null,
-  showUpgradePopupForProvider: ConnectorProvider | null,
-  setShowUpgradePopupForProvider: (provider: ConnectorProvider | null) => void,
-  setShowConfirmConnection: (integration: DataSourceIntegration | null) => void,
-  setShowPreviewPopupForProvider: (provider: ConnectorProvider | null) => void
-) {
+function getTableRow({
+  integration,
+  isAdmin,
+  isLoadingByProvider,
+  router,
+  owner,
+  readOnly,
+  plan,
+  limits,
+  showPreviewPopupForProvider,
+  showUpgradePopupForProvider,
+  setShowUpgradePopupForProvider,
+  setShowConfirmConnection,
+  setShowPreviewPopupForProvider,
+}: GetTableRowParams) {
   const connectorProvider = integration.connectorProvider as ConnectorProvider;
 
   const isBuilt =

--- a/types/src/front/data_source.ts
+++ b/types/src/front/data_source.ts
@@ -24,7 +24,7 @@ export function isConnectorProvider(val: string): val is ConnectorProvider {
 
 export const PROVIDERS_WITH_SETTINGS: ConnectorProvider[] = ["webcrawler"];
 
-interface EditedByUser {
+export interface EditedByUser {
   editedAt: number | null;
   fullName: string | null;
   imageUrl: string | null;


### PR DESCRIPTION
## Description

This PR refactors the connection management UI in the Dust front-end. The changes aim to simplify the look and feel, make available knowledge easier to understand, and allow for better management of connections. 

Key improvements include:
- Replacing the existing ContextItem.List with a DataTable component for better organization and searchability of connections.
- Adding a search functionality to quickly find specific connections.

The changes are part of the connection management efforts (cf. [Figma](https://www.figma.com/design/QOxHwppG64GtPocpDhS6Y7/Product?node-id=8487-51614&t=tULLJbvnBoSkntMf-1)).

New look:
<img width="1000" alt="Screenshot 2024-08-05 at 12 22 08" src="https://github.com/user-attachments/assets/629fe0e5-bfa0-4582-900a-a6ef1fbeb79f">


**References:**:
- https://www.figma.com/design/QOxHwppG64GtPocpDhS6Y7/Product?node-id=8487-51614&t=tULLJbvnBoSkntMf-1

## Risk

Breaking UX changes

## Deploy Plan

- Deploy to `front-edge`
- Deploy to `front`