### PR TITLE
feat: add `forceDailySync` to GH code sync

### DIFF
--- a/connectors/migrations/db/migration_11.sql
+++ b/connectors/migrations/db/migration_11.sql
@@ -1,0 +1,5 @@
+-- Migration created on Aug 05, 2024
+ALTER TABLE
+    "public"."github_code_repositories"
+ADD
+    COLUMN "forceDailySync" BOOLEAN NOT NULL DEFAULT false;

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -22,6 +22,10 @@ import {
   getReposPage,
   processRepository,
 } from "@connectors/connectors/github/lib/github_api";
+import { QUEUE_NAME } from "@connectors/connectors/github/temporal/config";
+import { newWebhookSignal } from "@connectors/connectors/github/temporal/signals";
+import { getCodeSyncWorkflowId } from "@connectors/connectors/github/temporal/utils";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import {
   deleteFromDataSource,
   renderDocumentTitleAndContent,
@@ -38,6 +42,7 @@ import {
   GithubIssue,
 } from "@connectors/lib/models/github";
 import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
+import { getTemporalClient } from "@connectors/lib/temporal";
 import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
@@ -1206,4 +1211,41 @@ export async function githubCodeSyncActivity({
       "Cleaned-up Github repository post sync"
     );
   }
+}
+
+// This activity simply signalWithStart the main githubCodeSyncWorkflow for a repo.
+// This is used for repos that are flagged with `forceDailyCodeSync`, which we use for
+// specific repos that do not use pull requests.
+export async function githubCodeSyncDailyCronActivity({
+  connectorId,
+  repoId,
+  repoLogin,
+  repoName,
+}: {
+  connectorId: ModelId;
+  repoLogin: string;
+  repoName: string;
+  repoId: number;
+}) {
+  const client = await getTemporalClient();
+
+  const connector = await ConnectorResource.fetchById(connectorId);
+  if (!connector) {
+    throw new Error(`Connector not found. ConnectorId: ${connectorId}`);
+  }
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+
+  await client.workflow.signalWithStart("githubCodeSyncWorkflow", {
+    args: [dataSourceConfig, connectorId, repoName, repoId, repoLogin],
+    taskQueue: QUEUE_NAME,
+    workflowId: getCodeSyncWorkflowId(dataSourceConfig, repoId),
+    searchAttributes: {
+      connectorId: [connectorId],
+    },
+    signal: newWebhookSignal,
+    signalArgs: undefined,
+    memo: {
+      connectorId: connectorId,
+    },
+  });
 }

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -932,6 +932,7 @@ export async function githubCodeSyncActivity({
       updatedAt: codeSyncStartedAt,
       lastSeenAt: codeSyncStartedAt,
       sourceUrl: `https://github.com/${repoLogin}/${repoName}`,
+      forceDailySync: false,
     });
   }
 

--- a/connectors/src/connectors/github/temporal/utils.ts
+++ b/connectors/src/connectors/github/temporal/utils.ts
@@ -17,6 +17,13 @@ export function getCodeSyncWorkflowId(
   return `workflow-github-code-sync-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceName}-${repoId}`;
 }
 
+export function getCodeSyncDailyCronWorkflowId(
+  dataSourceInfo: DataSourceInfo,
+  repoId: number
+) {
+  return `workflow-github-code-sync-daily-cron-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceName}-${repoId}`;
+}
+
 export function getIssueSyncWorkflowId(
   dataSourceInfo: DataSourceInfo,
   repoId: number,

--- a/connectors/src/connectors/github/temporal/workflows.ts
+++ b/connectors/src/connectors/github/temporal/workflows.ts
@@ -15,10 +15,13 @@ import type { DataSourceConfig } from "@connectors/types/data_source_config";
 import { newWebhookSignal } from "./signals";
 import { getFullSyncWorkflowId, getReposSyncWorkflowId } from "./utils";
 
-const { githubSaveStartSyncActivity, githubSaveSuccessSyncActivity } =
-  proxyActivities<typeof activities>({
-    startToCloseTimeout: "1 minute",
-  });
+const {
+  githubSaveStartSyncActivity,
+  githubSaveSuccessSyncActivity,
+  githubCodeSyncDailyCronActivity,
+} = proxyActivities<typeof activities>({
+  startToCloseTimeout: "1 minute",
+});
 
 const {
   githubGetReposResultPageActivity,
@@ -437,6 +440,24 @@ export async function githubCodeSyncWorkflow(
     });
     await githubSaveSuccessSyncActivity(dataSourceConfig);
   }
+}
+
+// This workflow simply signals `githubCodeSyncWorkflow` for repos that have `forceDailySync` set to
+// true.
+// This is used for repos that don't use pull requests, and thus don't have a webhook to trigger
+// the sync.
+export async function githubCodeSyncDailyCronWorkflow(
+  connectorId: ModelId,
+  repoName: string,
+  repoId: number,
+  repoLogin: string
+) {
+  await githubCodeSyncDailyCronActivity({
+    connectorId,
+    repoLogin,
+    repoName,
+    repoId,
+  });
 }
 
 export async function githubIssueSyncWorkflow(

--- a/connectors/src/lib/models/github.ts
+++ b/connectors/src/lib/models/github.ts
@@ -176,6 +176,7 @@ export class GithubCodeRepository extends Model<
   declare updatedAt: CreationOptional<Date>;
   declare lastSeenAt: CreationOptional<Date>;
   declare codeUpdatedAt: CreationOptional<Date>;
+  declare forceDailySync: boolean;
 
   declare repoId: string;
   declare repoLogin: string;
@@ -211,6 +212,11 @@ GithubCodeRepository.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
+    },
+    forceDailySync: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
     },
     repoId: {
       type: DataTypes.STRING,

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -21,6 +21,7 @@ export const GithubCommandSchema = t.type({
     t.literal("resync-repo"),
     t.literal("code-sync"),
     t.literal("sync-issue"),
+    t.literal("force-daily-code-sync"),
   ]),
   args: t.record(t.string, t.union([t.string, t.undefined])),
 });


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/dust/issues/6658

Currently, github code sync only works for repos that have pull requests. In some very specific cases, we want to support syncing code daily for repos that do not use pull requests.

- add a `forceDailySync` column to the `github_code_repositories` table
- add a new workflow (`githubCodeSyncDailyCronWorkflow`) to GH connector that just calls a single activity that signals / starts the `githubCodeSyncWorkflow` for a specific repo
- add a CLI that sets `forceDailySync` to true for a specific repo and then launches `githubCodeSyncDailyCronWorkflow` with a daily CRON schedule

To sum up, for a repos we manually decide to daily sync, we set a flag in DB and create a temporal CRON to sync code. , It's a separate workflow that calls an activity which itself uses temporal client to trigger a workflow. But this setup is quite simple, as it is fully additive, doesn't change the existing workflow, and doesn't require cancelling a potentially already running workflow. It essentially simulates a daily pull request webhook.

## Risk

N/A

## Deploy Plan

run migration (connectors) then deploy connectors