### PR TITLE
fix(gh cli): don't parseInt on repoId + allow numeric string as arg

### DIFF
--- a/connectors/src/connectors/github/lib/cli.ts
+++ b/connectors/src/connectors/github/lib/cli.ts
@@ -182,7 +182,7 @@ export const github = async ({
       const githubCodeRepository = await GithubCodeRepository.findOne({
         where: {
           connectorId: connector.id,
-          repoId: parseInt(`${args.repoId}`),
+          repoId: args.repoId,
         },
       });
       if (!githubCodeRepository) {

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -1,5 +1,7 @@
 import * as t from "io-ts";
 
+import { NumberAsStringCodec } from "../../shared/utils/iots_utils";
+
 export const ConnectorsCommandSchema = t.type({
   majorCommand: t.literal("connectors"),
   command: t.union([
@@ -10,7 +12,10 @@ export const ConnectorsCommandSchema = t.type({
     t.literal("set-error"),
     t.literal("restart"),
   ]),
-  args: t.record(t.string, t.union([t.string, t.undefined])),
+  args: t.record(
+    t.string,
+    t.union([t.string, NumberAsStringCodec, t.undefined])
+  ),
 });
 
 export type ConnectorsCommandType = t.TypeOf<typeof ConnectorsCommandSchema>;
@@ -23,7 +28,10 @@ export const GithubCommandSchema = t.type({
     t.literal("sync-issue"),
     t.literal("force-daily-code-sync"),
   ]),
-  args: t.record(t.string, t.union([t.string, t.undefined])),
+  args: t.record(
+    t.string,
+    t.union([t.string, NumberAsStringCodec, t.undefined])
+  ),
 });
 
 export type GithubCommandType = t.TypeOf<typeof GithubCommandSchema>;
@@ -43,7 +51,10 @@ export const NotionCommandSchema = t.type({
     t.literal("stop-all-garbage-collectors"),
     t.literal("update-parents-fields"),
   ]),
-  args: t.record(t.string, t.union([t.string, t.undefined])),
+  args: t.record(
+    t.string,
+    t.union([t.string, NumberAsStringCodec, t.undefined])
+  ),
 });
 
 export type NotionCommandType = t.TypeOf<typeof NotionCommandSchema>;
@@ -60,7 +71,10 @@ export const GoogleDriveCommandSchema = t.type({
     t.literal("register-webhook"),
     t.literal("register-all-webhooks"),
   ]),
-  args: t.record(t.string, t.union([t.string, t.undefined])),
+  args: t.record(
+    t.string,
+    t.union([t.string, NumberAsStringCodec, t.undefined])
+  ),
 });
 
 export type GoogleDriveCommandType = t.TypeOf<typeof GoogleDriveCommandSchema>;
@@ -75,7 +89,10 @@ export const SlackCommandSchema = t.type({
     t.literal("whitelist-domains"),
     t.literal("whitelist-bot"),
   ]),
-  args: t.record(t.string, t.union([t.string, t.undefined])),
+  args: t.record(
+    t.string,
+    t.union([t.string, NumberAsStringCodec, t.undefined])
+  ),
 });
 
 export type SlackCommandType = t.TypeOf<typeof SlackCommandSchema>;
@@ -83,7 +100,10 @@ export type SlackCommandType = t.TypeOf<typeof SlackCommandSchema>;
 export const BatchCommandSchema = t.type({
   majorCommand: t.literal("batch"),
   command: t.union([t.literal("full-resync"), t.literal("restart-all")]),
-  args: t.record(t.string, t.union([t.string, t.undefined])),
+  args: t.record(
+    t.string,
+    t.union([t.string, NumberAsStringCodec, t.undefined])
+  ),
 });
 
 export type BatchCommandType = t.TypeOf<typeof BatchCommandSchema>;
@@ -109,7 +129,10 @@ export const TemporalCommandSchema = t.type({
     t.literal("find-unprocessed-workflows"),
     t.literal("check-queue"),
   ]),
-  args: t.record(t.string, t.union([t.string, t.undefined])),
+  args: t.record(
+    t.string,
+    t.union([t.string, NumberAsStringCodec, t.undefined])
+  ),
 });
 
 export type TemporalCommandType = t.TypeOf<typeof TemporalCommandSchema>;
@@ -186,7 +209,10 @@ export const MicrosoftCommandSchema = t.type({
     t.literal("restart-all-incremental-sync-workflows"),
     t.literal("skip-file"),
   ]),
-  args: t.record(t.string, t.union([t.string, t.undefined])),
+  args: t.record(
+    t.string,
+    t.union([t.string, NumberAsStringCodec, t.undefined])
+  ),
 });
 
 export type MicrosoftCommandType = t.TypeOf<typeof MicrosoftCommandSchema>;

--- a/types/src/shared/utils/iots_utils.ts
+++ b/types/src/shared/utils/iots_utils.ts
@@ -56,3 +56,16 @@ export function ioTsParsePayload<T>(
 
   return new Ok(bodyValidation.right);
 }
+
+// Parses numbers as strings. Must not be used in union types with number.
+export const NumberAsStringCodec = new t.Type<string, string, unknown>(
+  "NumberAsString",
+  (u): u is string => typeof u === "number",
+  (u, c) => {
+    if (typeof u === "number") {
+      return t.success(u.toString());
+    }
+    return t.failure(u, c, "Value must be a number");
+  },
+  t.identity
+);


### PR DESCRIPTION
## Description

- don't parseInt on repo ID before passing to sequelize
- allow passing numbers as connector cli args, but still parse them into strings (create `NumberAsString` in iots_utils -- the args parsing lib extracts numbers if the arg is numeric)

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
