### PR TITLE
Fix auth used to create a conversation/post a message

### DIFF
--- a/front/lib/actions/server.ts
+++ b/front/lib/actions/server.ts
@@ -105,9 +105,10 @@ export async function runActionStreamed(
     .then((runId) => {
       logger.info(
         {
-          runId,
           loggerArgs,
+          runId,
           tracingRecords,
+          userId: auth.user()?.sId,
         },
         "Got runId for runActionStreamed"
       );

--- a/front/lib/actions/server.ts
+++ b/front/lib/actions/server.ts
@@ -105,10 +105,9 @@ export async function runActionStreamed(
     .then((runId) => {
       logger.info(
         {
-          loggerArgs,
           runId,
+          loggerArgs,
           tracingRecords,
-          userId: auth.user()?.sId,
         },
         "Got runId for runActionStreamed"
       );


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The investigation into missing permissions for enforcing the correct group permissions to read from a data source revealed an issue with the public API for posting a message. This PR modifies those two endpoints to use `keyAuth` instead of `workspaceAuth`. This change is safe because an early check ensures that the workspaceId in the URL (`wId`) matches the one associated with the key.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
