### PR TITLE
Handle user email ambiguity in exchangeSystemKeyForUserAuthByEmail

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -503,8 +503,11 @@ export class Authenticator {
       return null;
     }
 
-    // Take the first user with an active membership in the workspace.
-    const [activeMembership] = activeMemberships;
+    // Take the oldest active membership.
+    const [activeMembership] = activeMemberships.sort(
+      (a, b) => new Date(a.startAt).getTime() - new Date(b.startAt).getTime()
+    );
+    // Find the user associated with the active membership.
     const user = users.find((u) => u.id === activeMembership.userId);
     if (!user) {
       return null;

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -470,6 +470,7 @@ export class Authenticator {
    * @param param1
    * @returns
    */
+  // TODO(2024-08-05 flav) Use user-id instead of email to avoid ambiguity.
   async exchangeSystemKeyForUserAuthByEmail(
     auth: Authenticator,
     { userEmail }: { userEmail: string }
@@ -483,22 +484,29 @@ export class Authenticator {
       throw new Error("Workspace not found.");
     }
 
-    const user = await UserResource.fetchByEmail(userEmail);
-    // If the user does not exist (e.g., whitelisted email addresses),
+    // The same email address might be linked to multiple users.
+    const users = await UserResource.listByEmail(userEmail);
+    // If no user exist (e.g., whitelisted email addresses),
     // simply ignore and return null.
-    if (!user) {
+    if (users.length === 0) {
       return null;
     }
 
-    // Verify that the user has an active membership in the specified workspace.
-    const activeMembership =
-      await MembershipResource.getActiveMembershipOfUserInWorkspace({
-        user,
-        workspace: owner,
-      });
-    // If the user does not have an active membership in the workspace,
+    // Verify that one of the user has an active membership in the specified workspace.
+    const activeMemberships = await MembershipResource.getActiveMemberships({
+      users,
+      workspace: owner,
+    });
+    // If none of the user has an active membership in the workspace,
     // simply ignore and return null.
-    if (!activeMembership) {
+    if (activeMemberships.length === 0) {
+      return null;
+    }
+
+    // Take the first user with an active membership in the workspace.
+    const [activeMembership] = activeMemberships;
+    const user = users.find((u) => u.id === activeMembership.userId);
+    if (!user) {
       return null;
     }
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See https://github.com/dust-tt/dust/issues/6669.

We identified the root cause of the registry lookup calls that would fail if we enforced permission checks tomorrow. It has been associated with Slack. Currently, we set a special header when creating a conversation or posting a message from the Slack endpoint. This header is used to exchange the auth object for a user-linked auth object, allowing us to 1. associate the user message with the correct user and 2. use the appropriate access when querying a data source.

The issue arises with the `exchangeSystemKeyForUserAuthByEmail` function, which selects the first user that matches the email address. This is problematic because we don't have a unique constraint on the `email` column in our table, potentially missing the correct user, the one with an active membership in the workspace.

This fix accounts for this possibility and fetch all matching users to narrow down to the ones with an active membership and takes the one with the oldest membership. 

Although this is an edge case, we have 658 users with duplicated email addresses. This fix is not perfect, and we need a more reliable approach since debugging as an admin could be quite challenging once the permission check is enforced. We could consider using a user-id header, but this would only shift the logic to the connectors to map email to user, and the same issue would arise if two users within one workspace have the same email address. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Tested locally, worst case it does not use the right groups/users. We will monitor through [here](https://app.datadoghq.eu/logs?query=%22No%20access%20to%20data%20source.%22%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAZEkMETsI3_-kwAAAAAAAAAYAAAAAEFaRWtNRV9rQUFEeEUwZzdfMm9yLWdBTwAAACQAAAAAMDE5MTI0MzAtNGU2Mi00ZWE0LThhZWUtMTA4OTUzY2M4ZDk2&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&view=spans&viz=stream&from_ts=1722883386219&to_ts=1722884286219&live=true). Safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
