### PR TITLE
[front] fix: cascade data_source_view delete on agent_data_sources

### DIFF
--- a/front/lib/models/assistant/actions/data_sources.ts
+++ b/front/lib/models/assistant/actions/data_sources.ts
@@ -120,7 +120,7 @@ AgentDataSourceConfiguration.belongsTo(DataSource, {
 // Data source config <> Data source view
 DataSourceViewModel.hasMany(AgentDataSourceConfiguration, {
   foreignKey: { allowNull: true },
-  onDelete: "RESTRICT",
+  onDelete: "CASCADE",
 });
 AgentDataSourceConfiguration.belongsTo(DataSourceViewModel, {
   foreignKey: { allowNull: false },

--- a/front/migrations/db/migration_55.sql
+++ b/front/migrations/db/migration_55.sql
@@ -1,0 +1,2 @@
+-- Migration created on Aug 06, 2024
+ALTER TABLE "agent_data_source_configurations"  ADD FOREIGN KEY ("dataSourceViewId") REFERENCES "data_source_views" ("id") ON DELETE CASCADE ON UPDATE CASCADE;


### PR DESCRIPTION
## Description

fix constraint to use cascade to have the same behaviour as data_sources

## Risk

none

## Deploy Plan

run migration script on front.
