### PR TITLE
[connectors] fix: Use csv document internalId for tableId, add csv in migration

### DIFF
--- a/connectors/migrations/20240802_table_parents.ts
+++ b/connectors/migrations/20240802_table_parents.ts
@@ -116,7 +116,7 @@ export async function microsoftTables(
         },
         {
           nodeType: "file",
-          mimeType: "application/vnd.ms-excel",
+          mimeType: ["application/vnd.ms-excel", "text/csv"],
           connectorId: connector.id,
         },
       ],

--- a/connectors/src/connectors/google_drive/temporal/file.ts
+++ b/connectors/src/connectors/google_drive/temporal/file.ts
@@ -107,6 +107,7 @@ async function handleGoogleDriveExport(
 
 async function handleFileExport(
   oauth2client: OAuth2Client,
+  documentId: string,
   file: GoogleDriveObjectType,
   maxDocumentLen: number,
   localLogger: Logger,
@@ -164,12 +165,13 @@ async function handleFileExport(
 
     result = await handleCsvFile({
       data: res.data,
-      file,
+      tableId: documentId,
+      fileName: file.name || "",
       maxDocumentLen,
       localLogger,
       dataSourceConfig,
       connectorId,
-      parents,
+      parents: [file.id, ...parents],
     });
   } else {
     result = await handleTextExtraction(res.data, localLogger, file.mimeType);
@@ -319,6 +321,7 @@ async function syncOneFileTable(
   } else {
     await handleFileExport(
       oauth2client,
+      documentId,
       file,
       maxDocumentLen,
       localLogger,
@@ -367,6 +370,7 @@ async function syncOneFileTextDocument(
   } else if (mimeTypesToDownload.includes(file.mimeType)) {
     documentContent = await handleFileExport(
       oauth2client,
+      documentId,
       file,
       maxDocumentLen,
       localLogger,

--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -167,7 +167,8 @@ export async function syncOneFile({
     result = await handleCsvFile({
       dataSourceConfig,
       data,
-      file,
+      tableId: documentId,
+      fileName: file.name || "",
       localLogger,
       maxDocumentLen,
       connectorId,

--- a/connectors/src/connectors/shared/file.ts
+++ b/connectors/src/connectors/shared/file.ts
@@ -10,13 +10,11 @@ import {
   TextExtraction,
 } from "@dust-tt/types";
 import { parseAndStringifyCsv, slugify } from "@dust-tt/types";
-import type { DriveItem } from "@microsoft/microsoft-graph-types";
 
 import { apiConfig } from "@connectors/lib/api/config";
 import { upsertTableFromCsv } from "@connectors/lib/data_sources";
 import type { Logger } from "@connectors/logger/logger";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
-import type { GoogleDriveObjectType } from "@connectors/types/google_drive";
 
 const pagePrefixesPerMimeType: Record<string, string> = {
   "application/pdf": "$pdfPage",
@@ -45,7 +43,8 @@ export function handleTextFile(
 
 export async function handleCsvFile({
   data,
-  file,
+  tableId,
+  fileName,
   maxDocumentLen,
   localLogger,
   dataSourceConfig,
@@ -53,7 +52,8 @@ export async function handleCsvFile({
   parents,
 }: {
   data: ArrayBuffer;
-  file: GoogleDriveObjectType | DriveItem;
+  tableId: string;
+  fileName: string;
   maxDocumentLen: number;
   localLogger: Logger;
   dataSourceConfig: DataSourceConfig;
@@ -65,12 +65,9 @@ export async function handleCsvFile({
     return new Err(new Error("file_too_big"));
   }
 
-  const fileName = file.name ?? "";
-
   const tableCsv = Buffer.from(data).toString("utf-8").trim();
-  const tableId = file.id ?? "";
   const tableName = slugify(fileName.substring(0, 32));
-  const tableDescription = `Structured data from ${dataSourceNameToConnectorName[dataSourceConfig.dataSourceName]} (${file.name})`;
+  const tableDescription = `Structured data from ${dataSourceNameToConnectorName[dataSourceConfig.dataSourceName]} (${fileName})`;
 
   try {
     const stringifiedContent = await parseAndStringifyCsv(tableCsv);


### PR DESCRIPTION
## Description

Currently, for csv files in google/microsoft, we use the google/ms id as a table_id . We should rather use here our internalId to avoid conflicts.
Added google/microsoft csv in parents migration .

We have only one datasource with csv enabled (doctolib), we may need a full reindex as the table ids are changed for csv.

## Risk


## Deploy Plan

Deploy `connectors`
Reindex datasources with csv