### PR TITLE
[connections] - feat: datasource request flow

### DIFF
--- a/front/components/data_source/RequestDataSourcesModal.tsx
+++ b/front/components/data_source/RequestDataSourcesModal.tsx
@@ -26,9 +26,11 @@ async function sendRequestDataSourceEmail(
       email: "team@dust.tt",
     },
     subject: `[Dust] Request Data source - ${dataSourceName}`,
-    text: emailContent,
+    html: `<p>${ccEmail} has sent you a request regarding the connection ${dataSourceName}</p><br /> 
+    <p>Message:</p><br/> 
+    ${emailContent}`,
   };
-  return sendEmail(email, mail, ccEmail);
+  return sendEmail(email, mail);
 }
 
 export function RequestDataSourcesModal({

--- a/front/components/data_source/RequestDataSourcesModal.tsx
+++ b/front/components/data_source/RequestDataSourcesModal.tsx
@@ -2,18 +2,37 @@ import { Button, DropdownMenu, Modal, TextArea } from "@dust-tt/sparkle";
 import React, { useState } from "react";
 
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
+import { sendEmail } from "@app/lib/email";
 import type { DataSourceIntegration } from "@app/pages/w/[wId]/builder/data-sources/managed";
 
 type RequestDataSourceProps = {
   isOpen: boolean;
   onClose: () => void;
   dataSourceIntegrations: DataSourceIntegration[];
+  currentUserEmail: string;
 };
+
+async function sendRequestDataSourceEmail(
+  email: string,
+  emailContent: string,
+  ccEmail: string
+) {
+  const mail = {
+    from: {
+      name: "Dust team",
+      email: "team@dust.tt",
+    },
+    subject: `[Dust] Request Data source`,
+    text: emailContent,
+  };
+  await sendEmail(email, mail, [ccEmail]);
+}
 
 export function RequestDataSourcesModal({
   isOpen,
   onClose,
   dataSourceIntegrations,
+  currentUserEmail,
 }: RequestDataSourceProps) {
   const [selectedDataSourceIntegration, setSelectedDataSourceIntegration] =
     useState<DataSourceIntegration | null>(null);
@@ -22,7 +41,6 @@ export function RequestDataSourcesModal({
   const filteredDataSourceIntegrations = dataSourceIntegrations.filter(
     (ds) => ds.connector
   );
-  console.log(filteredDataSourceIntegrations);
   return (
     <Modal
       isOpen={isOpen}
@@ -107,9 +125,12 @@ export function RequestDataSourcesModal({
               label="Send"
               variant="primary"
               size="sm"
-              onClick={() => {
-                // Handle sending the message
-                console.log("Sending message:", message);
+              onClick={async () => {
+                await sendRequestDataSourceEmail(
+                  currentUserEmail,
+                  message,
+                  selectedDataSourceIntegration?.editedByUser?.email
+                );
                 onClose();
               }}
             />

--- a/front/components/data_source/RequestDataSourcesModal.tsx
+++ b/front/components/data_source/RequestDataSourcesModal.tsx
@@ -64,7 +64,6 @@ export function RequestDataSourcesModal({
                 {selectedDataSourceIntegration ? (
                   <Button
                     variant="tertiary"
-                    size="xs"
                     label={
                       CONNECTOR_CONFIGURATIONS[
                         selectedDataSourceIntegration.connectorProvider
@@ -85,7 +84,7 @@ export function RequestDataSourcesModal({
                   />
                 )}
               </DropdownMenu.Button>
-              <DropdownMenu.Items>
+              <DropdownMenu.Items width={180}>
                 {filteredDataSourceIntegrations.map((ds) => (
                   <DropdownMenu.Item
                     key={ds.dataSourceName}

--- a/front/components/data_source/RequestDataSourcesModal.tsx
+++ b/front/components/data_source/RequestDataSourcesModal.tsx
@@ -15,7 +15,7 @@ type RequestDataSourceProps = {
 async function sendRequestDataSourceEmail(
   email: string,
   emailContent: string,
-  ccEmail: string
+  ccEmail?: string
 ) {
   const mail = {
     from: {
@@ -25,7 +25,11 @@ async function sendRequestDataSourceEmail(
     subject: `[Dust] Request Data source`,
     text: emailContent,
   };
-  await sendEmail(email, mail, [ccEmail]);
+  if (ccEmail) {
+    await sendEmail(email, mail, [ccEmail]);
+  } else {
+    await sendEmail(email, mail);
+  }
 }
 
 export function RequestDataSourcesModal({
@@ -128,7 +132,8 @@ export function RequestDataSourcesModal({
                 await sendRequestDataSourceEmail(
                   currentUserEmail,
                   message,
-                  selectedDataSourceIntegration?.editedByUser?.email
+                  selectedDataSourceIntegration?.editedByUser?.email ??
+                    undefined
                 );
                 onClose();
               }}

--- a/front/components/data_source/RequestDataSourcesModal.tsx
+++ b/front/components/data_source/RequestDataSourcesModal.tsx
@@ -17,6 +17,7 @@ type RequestDataSourceProps = {
 async function sendRequestDataSourceEmail(
   email: string,
   emailContent: string,
+  dataSourceName: string,
   ccEmail?: string
 ) {
   const mail = {
@@ -24,14 +25,10 @@ async function sendRequestDataSourceEmail(
       name: "Dust team",
       email: "team@dust.tt",
     },
-    subject: `[Dust] Request Data source`,
+    subject: `[Dust] Request Data source - ${dataSourceName}`,
     text: emailContent,
   };
-  if (ccEmail) {
-    return sendEmail(email, mail, [ccEmail]);
-  } else {
-    return sendEmail(email, mail);
-  }
+  return sendEmail(email, mail, ccEmail);
 }
 
 export function RequestDataSourcesModal({
@@ -51,7 +48,11 @@ export function RequestDataSourcesModal({
   return (
     <Modal
       isOpen={isOpen}
-      onClose={onClose}
+      onClose={() => {
+        onClose();
+        setMessage("");
+        setSelectedDataSourceIntegration(null);
+      }}
       hasChanged={false}
       variant="side-md"
       title="Requesting Data sources"
@@ -134,7 +135,7 @@ export function RequestDataSourcesModal({
               onClick={async () => {
                 const userEmail =
                   selectedDataSourceIntegration?.editedByUser?.email;
-                if (!userEmail) {
+                if (!userEmail || !selectedDataSourceIntegration) {
                   sendNotification({
                     type: "error",
                     title: "Error sending email",
@@ -146,7 +147,8 @@ export function RequestDataSourcesModal({
                     await sendRequestDataSourceEmail(
                       userEmail,
                       message,
-                      currentUserEmail
+                      currentUserEmail,
+                      selectedDataSourceIntegration.name
                     );
                   } catch (e) {
                     logger.error(

--- a/front/components/data_source/RequestDataSourcesModal.tsx
+++ b/front/components/data_source/RequestDataSourcesModal.tsx
@@ -1,0 +1,121 @@
+import { Button, DropdownMenu, Modal, TextArea } from "@dust-tt/sparkle";
+import React, { useState } from "react";
+
+import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
+import type { DataSourceIntegration } from "@app/pages/w/[wId]/builder/data-sources/managed";
+
+type RequestDataSourceProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  dataSourceIntegrations: DataSourceIntegration[];
+};
+
+export function RequestDataSourcesModal({
+  isOpen,
+  onClose,
+  dataSourceIntegrations,
+}: RequestDataSourceProps) {
+  const [selectedDataSourceIntegration, setSelectedDataSourceIntegration] =
+    useState<DataSourceIntegration | null>(null);
+  const [message, setMessage] = useState("");
+
+  const filteredDataSourceIntegrations = dataSourceIntegrations.filter(
+    (ds) => ds.connector
+  );
+  console.log(filteredDataSourceIntegrations);
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      hasChanged={false}
+      variant="side-md"
+      title="Requesting Data sources"
+    >
+      <div className="flex flex-col gap-4 p-4">
+        <div className="flex items-center gap-2">
+          <label className="block text-sm font-medium text-element-800">
+            {filteredDataSourceIntegrations.length ? (
+              <p>Where are the requested Data hosted?</p>
+            ) : (
+              <p>You have no connection set up. Ask an admin to set one up.</p>
+            )}
+          </label>
+          {!!filteredDataSourceIntegrations.length && (
+            <DropdownMenu>
+              <DropdownMenu.Button>
+                {selectedDataSourceIntegration ? (
+                  <Button
+                    variant="tertiary"
+                    size="xs"
+                    label={
+                      CONNECTOR_CONFIGURATIONS[
+                        selectedDataSourceIntegration.connectorProvider
+                      ].name
+                    }
+                    icon={
+                      CONNECTOR_CONFIGURATIONS[
+                        selectedDataSourceIntegration.connectorProvider
+                      ].logoComponent
+                    }
+                  />
+                ) : (
+                  <Button
+                    label="Pick your platform"
+                    variant="tertiary"
+                    size="sm"
+                    type="select"
+                  />
+                )}
+              </DropdownMenu.Button>
+              <DropdownMenu.Items>
+                {filteredDataSourceIntegrations.map((ds) => (
+                  <DropdownMenu.Item
+                    key={ds.dataSourceName}
+                    label={ds.name}
+                    onClick={() => setSelectedDataSourceIntegration(ds)}
+                    icon={
+                      CONNECTOR_CONFIGURATIONS[ds.connectorProvider]
+                        .logoComponent
+                    }
+                  />
+                ))}
+              </DropdownMenu.Items>
+            </DropdownMenu>
+          )}
+        </div>
+
+        {selectedDataSourceIntegration && (
+          <div>
+            <p className="s-mb-2 s-text-sm s-text-element-700">
+              The administrator for{" "}
+              {
+                CONNECTOR_CONFIGURATIONS[
+                  selectedDataSourceIntegration.connectorProvider
+                ].name
+              }{" "}
+              is {selectedDataSourceIntegration.editedByUser?.fullName}. Send an
+              email to {selectedDataSourceIntegration.editedByUser?.fullName},
+              explaining your request.
+            </p>
+            <TextArea
+              placeholder={`Hello ${selectedDataSourceIntegration.editedByUser?.fullName},`}
+              value={message}
+              onChange={setMessage}
+              className="s-mb-2"
+            />
+            <Button
+              label="Send"
+              variant="primary"
+              size="sm"
+              onClick={() => {
+                // Handle sending the message
+                console.log("Sending message:", message);
+                onClose();
+              }}
+            />
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/front/components/data_source/RequestDataSourcesModal.tsx
+++ b/front/components/data_source/RequestDataSourcesModal.tsx
@@ -135,6 +135,8 @@ export function RequestDataSourcesModal({
                   selectedDataSourceIntegration?.editedByUser?.email ??
                     undefined
                 );
+                setMessage("");
+                setSelectedDataSourceIntegration(null);
                 onClose();
               }}
             />

--- a/front/lib/email.ts
+++ b/front/lib/email.ts
@@ -10,8 +10,12 @@ const { SENDGRID_API_KEY = "" } = process.env;
 
 sgMail.setApiKey(SENDGRID_API_KEY);
 
-export async function sendEmail(email: string, message: any, cc?: string[]) {
-  const msg = { ...message, to: email, cc };
+export async function sendEmail(email: string, message: any, cc?: string) {
+  const msg = { ...message, to: email };
+
+  if (cc) {
+    msg.cc = cc;
+  }
   try {
     await sgMail.send(msg);
     logger.info({ email, cc, subject: message.subject }, "Sending email");

--- a/front/lib/email.ts
+++ b/front/lib/email.ts
@@ -10,18 +10,14 @@ const { SENDGRID_API_KEY = "" } = process.env;
 
 sgMail.setApiKey(SENDGRID_API_KEY);
 
-export async function sendEmail(email: string, message: any, cc?: string) {
+export async function sendEmail(email: string, message: any) {
   const msg = { ...message, to: email };
-
-  if (cc) {
-    msg.cc = cc;
-  }
   try {
     await sgMail.send(msg);
-    logger.info({ email, cc, subject: message.subject }, "Sending email");
+    logger.info({ email, subject: message.subject }, "Sending email");
   } catch (error) {
     logger.error(
-      { error, email, cc, subject: message.subject },
+      { error, email, subject: message.subject },
       "Error sending email."
     );
   }

--- a/front/lib/email.ts
+++ b/front/lib/email.ts
@@ -10,14 +10,14 @@ const { SENDGRID_API_KEY = "" } = process.env;
 
 sgMail.setApiKey(SENDGRID_API_KEY);
 
-export async function sendEmail(email: string, message: any) {
-  const msg = { ...message, to: email };
+export async function sendEmail(email: string, message: any, cc?: string[]) {
+  const msg = { ...message, to: email, cc };
   try {
     await sgMail.send(msg);
-    logger.info({ email, subject: message.subject }, "Sending email");
+    logger.info({ email, cc, subject: message.subject }, "Sending email");
   } catch (error) {
     logger.error(
-      { error, email, subject: message.subject },
+      { error, email, cc, subject: message.subject },
       "Error sending email."
     );
   }

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -197,6 +197,7 @@ export class DataSourceResource extends ResourceWithVault<DataSource> {
         editedAt: editedAt.getTime(),
         fullName: formatUserFullName(editedByUser),
         imageUrl: editedByUser.imageUrl,
+        email: editedByUser.email,
       },
     };
   }

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -21,6 +21,7 @@ import type {
   EditedByUser,
   ManageDataSourcesLimitsType,
   Result,
+  UserType,
   WhitelistableFeature,
   WorkspaceType,
 } from "@dust-tt/types";
@@ -171,12 +172,14 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   plan: PlanType;
   gaTrackingId: string;
   dustClientFacingUrl: string;
+  user: UserType;
 }>(async (context, auth) => {
   const owner = auth.workspace();
   const plan = auth.plan();
   const subscription = auth.subscription();
+  const user = auth.user();
 
-  if (!owner || !plan || !subscription) {
+  if (!owner || !plan || !subscription || !user) {
     return {
       notFound: true,
     };
@@ -319,6 +322,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   return {
     props: {
       owner,
+      user,
       subscription,
       readOnly,
       isAdmin,
@@ -458,6 +462,7 @@ function ConfirmationModal({
 
 export default function DataSourcesView({
   owner,
+  user,
   subscription,
   readOnly,
   isAdmin,
@@ -482,7 +487,6 @@ export default function DataSourcesView({
     useState<DataSourceIntegration | null>(null);
 
   const { admins, isAdminsLoading } = useAdmins(owner);
-
   const planConnectionsLimits = plan.limits.connections;
   const handleEnableManagedDataSource = async (
     provider: ConnectorProvider,
@@ -718,6 +722,7 @@ export default function DataSourcesView({
           isOpen={true}
           onClose={() => console.log()}
           dataSourceIntegrations={dataSourceIntegrations}
+          currentUserEmail={user.email}
         />
       </Page.Vertical>
     </AppLayout>

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -12,6 +12,7 @@ import {
   InformationCircleIcon,
   Modal,
   Page,
+  PlusIcon,
   RobotIcon,
   Searchbar,
 } from "@dust-tt/sparkle";
@@ -485,6 +486,8 @@ export default function DataSourcesView({
     useState<ConnectorProvider | null>(null);
   const [showConfirmConnection, setShowConfirmConnection] =
     useState<DataSourceIntegration | null>(null);
+  const [isRequestDataSourceModalOpen, setIsRequestDataSourceModalOpen] =
+    useState(false);
 
   const { admins, isAdminsLoading } = useAdmins(owner);
   const planConnectionsLimits = plan.limits.connections;
@@ -703,15 +706,22 @@ export default function DataSourcesView({
             </Hoverable>
           </ContentMessage>
         )}
-        <Searchbar
-          ref={searchBarRef}
-          name="search"
-          placeholder="Search (Name)"
-          value={dataSourceSearch}
-          onChange={(s) => {
-            setDataSourceSearch(s);
-          }}
-        />
+        <div className="flex gap-2">
+          <Button
+            label="Request"
+            icon={PlusIcon}
+            onClick={() => setIsRequestDataSourceModalOpen(true)}
+          />
+          <Searchbar
+            ref={searchBarRef}
+            name="search"
+            placeholder="Search (Name)"
+            value={dataSourceSearch}
+            onChange={(s) => {
+              setDataSourceSearch(s);
+            }}
+          />
+        </div>
         <DataTable
           data={connectionRows}
           columns={getTableColumns()}
@@ -719,8 +729,8 @@ export default function DataSourcesView({
           filterColumn={"name"}
         />
         <RequestDataSourcesModal
-          isOpen={true}
-          onClose={() => console.log()}
+          isOpen={isRequestDataSourceModalOpen}
+          onClose={() => setIsRequestDataSourceModalOpen(false)}
           dataSourceIntegrations={dataSourceIntegrations}
           currentUserEmail={user.email}
         />

--- a/types/src/front/data_source.ts
+++ b/types/src/front/data_source.ts
@@ -24,7 +24,7 @@ export function isConnectorProvider(val: string): val is ConnectorProvider {
 
 export const PROVIDERS_WITH_SETTINGS: ConnectorProvider[] = ["webcrawler"];
 
-export interface EditedByUser {
+export type EditedByUser = {
   editedAt: number | null;
   fullName: string | null;
   imageUrl: string | null;

--- a/types/src/front/data_source.ts
+++ b/types/src/front/data_source.ts
@@ -28,7 +28,8 @@ export type EditedByUser = {
   editedAt: number | null;
   fullName: string | null;
   imageUrl: string | null;
-}
+  email: string | null;
+};
 
 export type DataSourceType = {
   id: ModelId;


### PR DESCRIPTION
## Description

This PR implements a new data source request flow, introducing a `RequestDataSourcesModal` component. 

The main changes include:
- A new RequestDataSourcesModal component that allows users to request access to data sources they don't currently have permissions for.
- Enhancement of the sendEmail function to support cc recipients, enabling the inclusion of data source administrators in request emails.
- Integration of the new request flow in the data sources management page.
- Updates to the data source selection UI in the assistant builder to accommodate the new request flow.

New look:

<img width="1100" alt="Screenshot 2024-08-06 at 12 02 17" src="https://github.com/user-attachments/assets/2badbe6c-63e1-4486-a7da-7bc858213215">
<img width="1100" alt="Screenshot 2024-08-06 at 12 02 28" src="https://github.com/user-attachments/assets/b434ea2a-1f42-4705-8e61-9f7aef6c60f6">


**References:**
- https://github.com/dust-tt/dust/issues/6630

## Risk

Breaking UX changes

## Deploy Plan

- Deploy to`front-edge`
- Deploy `front`