### PR TITLE
[sparkle] - fix: `DataTable` responsiveness

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.201",
+  "version": "0.2.202",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.201",
+      "version": "0.2.202",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.201",
+  "version": "0.2.202",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -28,6 +28,7 @@ interface DataTableProps<TData extends TBaseData, TValue> {
   filter?: string;
   filterColumn?: string;
   initialColumnOrder?: SortingState;
+  responsiveHiddenColumns?: string[];
 }
 
 export function DataTable<TData extends TBaseData, TValue>({
@@ -37,6 +38,7 @@ export function DataTable<TData extends TBaseData, TValue>({
   filter,
   filterColumn,
   initialColumnOrder,
+  responsiveHiddenColumns = [],
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = useState<SortingState>(
     initialColumnOrder ?? []
@@ -72,7 +74,12 @@ export function DataTable<TData extends TBaseData, TValue>({
               <DataTable.Head
                 key={header.id}
                 onClick={header.column.getToggleSortingHandler()}
-                className={header.column.getCanSort() ? "s-cursor-pointer" : ""}
+                className={classNames(
+                  header.column.getCanSort() ? "s-cursor-pointer" : "",
+                  responsiveHiddenColumns.includes(header.id)
+                    ? "s-hidden sm:s-block"
+                    : ""
+                )}
               >
                 <div className="s-flex s-items-center s-space-x-1 s-whitespace-nowrap">
                   {flexRender(
@@ -111,7 +118,14 @@ export function DataTable<TData extends TBaseData, TValue>({
             onMoreClick={row.original.onMoreClick}
           >
             {row.getVisibleCells().map((cell) => (
-              <DataTable.Cell key={cell.id}>
+              <DataTable.Cell
+                key={cell.id}
+                className={classNames(
+                  responsiveHiddenColumns.includes(cell.column.id)
+                    ? "s-hidden sm:s-block"
+                    : ""
+                )}
+              >
                 {flexRender(cell.column.columnDef.cell, cell.getContext())}
               </DataTable.Cell>
             ))}

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -21,6 +21,10 @@ interface TBaseData {
   onMoreClick?: () => void;
 }
 
+interface ColumnBreakpoint {
+  [columnId: string]: "xs" | "sm" | "md" | "lg" | "xl";
+}
+
 interface DataTableProps<TData extends TBaseData, TValue> {
   data: TData[];
   columns: ColumnDef<TData, TValue>[];
@@ -28,7 +32,7 @@ interface DataTableProps<TData extends TBaseData, TValue> {
   filter?: string;
   filterColumn?: string;
   initialColumnOrder?: SortingState;
-  mobileHiddenColumns?: string[];
+  columnsBreakpoints?: ColumnBreakpoint;
 }
 
 export function DataTable<TData extends TBaseData, TValue>({
@@ -38,7 +42,7 @@ export function DataTable<TData extends TBaseData, TValue>({
   filter,
   filterColumn,
   initialColumnOrder,
-  mobileHiddenColumns = [],
+  columnsBreakpoints = {},
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = useState<SortingState>(
     initialColumnOrder ?? []
@@ -76,8 +80,8 @@ export function DataTable<TData extends TBaseData, TValue>({
                 onClick={header.column.getToggleSortingHandler()}
                 className={classNames(
                   header.column.getCanSort() ? "s-cursor-pointer" : "",
-                  mobileHiddenColumns.includes(header.id)
-                    ? "s-hidden sm:s-block"
+                  columnsBreakpoints[header.id]
+                    ? `s-hidden ${columnsBreakpoints[header.id]}:s-block`
                     : ""
                 )}
               >
@@ -121,8 +125,8 @@ export function DataTable<TData extends TBaseData, TValue>({
               <DataTable.Cell
                 key={cell.id}
                 className={classNames(
-                  mobileHiddenColumns.includes(cell.column.id)
-                    ? "s-hidden sm:s-block"
+                  columnsBreakpoints[cell.column.id]
+                    ? `s-hidden ${columnsBreakpoints[cell.column.id]}:s-block`
                     : ""
                 )}
               >

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -28,7 +28,7 @@ interface DataTableProps<TData extends TBaseData, TValue> {
   filter?: string;
   filterColumn?: string;
   initialColumnOrder?: SortingState;
-  responsiveHiddenColumns?: string[];
+  mobileHiddenColumns?: string[];
 }
 
 export function DataTable<TData extends TBaseData, TValue>({
@@ -38,7 +38,7 @@ export function DataTable<TData extends TBaseData, TValue>({
   filter,
   filterColumn,
   initialColumnOrder,
-  responsiveHiddenColumns = [],
+  mobileHiddenColumns = [],
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = useState<SortingState>(
     initialColumnOrder ?? []
@@ -76,7 +76,7 @@ export function DataTable<TData extends TBaseData, TValue>({
                 onClick={header.column.getToggleSortingHandler()}
                 className={classNames(
                   header.column.getCanSort() ? "s-cursor-pointer" : "",
-                  responsiveHiddenColumns.includes(header.id)
+                  mobileHiddenColumns.includes(header.id)
                     ? "s-hidden sm:s-block"
                     : ""
                 )}
@@ -121,7 +121,7 @@ export function DataTable<TData extends TBaseData, TValue>({
               <DataTable.Cell
                 key={cell.id}
                 className={classNames(
-                  responsiveHiddenColumns.includes(cell.column.id)
+                  mobileHiddenColumns.includes(cell.column.id)
                     ? "s-hidden sm:s-block"
                     : ""
                 )}

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -117,7 +117,7 @@ export const DataTableExample = () => {
         data={data}
         columns={columns}
         initialColumnOrder={[{ id: "name", desc: false }]}
-        responsiveHiddenColumns={["lastUpdated"]}
+        mobileHiddenColumns={["lastUpdated"]}
       />
     </div>
   );

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -117,7 +117,7 @@ export const DataTableExample = () => {
         data={data}
         columns={columns}
         initialColumnOrder={[{ id: "name", desc: false }]}
-        mobileHiddenColumns={["lastUpdated"]}
+        columnsBreakpoints={{ lastUpdated: "sm" }}
       />
     </div>
   );

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -117,6 +117,7 @@ export const DataTableExample = () => {
         data={data}
         columns={columns}
         initialColumnOrder={[{ id: "name", desc: false }]}
+        responsiveHiddenColumns={["lastUpdated"]}
       />
     </div>
   );


### PR DESCRIPTION
## Description

This PR aims at modifying the `DataTable` sparkle component to accept a list of columns to hide on mobile.

**References:**
- #6679 

## Risk

None

## Deploy Plan

- Deploy new `sparkle` version