### PR TITLE
6653 improve poke search

### DIFF
--- a/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
+++ b/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
@@ -21,6 +21,7 @@ import {
   InputField,
   SelectField,
 } from "@app/components/poke/shadcn/ui/form/fields";
+import { isEntreprisePlan } from "@app/lib/plans/plan_codes";
 import { usePokePlans } from "@app/lib/swr";
 
 export default function EnterpriseUpgradeDialog({
@@ -122,7 +123,7 @@ export default function EnterpriseUpgradeDialog({
                     name="planCode"
                     title="Enterprise Plan"
                     options={plans
-                      .filter((plan) => plan.code.startsWith("ENT_"))
+                      .filter((plan) => isEntreprisePlan(plan.code))
                       .map((plan) => ({
                         value: plan.code,
                         display: `${plan.name} (${plan.code})`,

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -29,7 +29,12 @@ import type { SubscriptionsDisplayType } from "@app/components/poke/subscription
 import { makeColumnsForSubscriptions } from "@app/components/poke/subscriptions/columns";
 import EnterpriseUpgradeDialog from "@app/components/poke/subscriptions/EnterpriseUpgradeDialog";
 import { useSubmitFunction } from "@app/lib/client/utils";
-import { FREE_NO_PLAN_CODE } from "@app/lib/plans/plan_codes";
+import {
+  FREE_NO_PLAN_CODE,
+  isEntreprisePlan,
+  isFreePlan,
+  isProPlan,
+} from "@app/lib/plans/plan_codes";
 import { usePokePlans } from "@app/lib/swr";
 
 interface SubscriptionsDataTableProps {
@@ -381,7 +386,7 @@ function UpgradeDowngradeModal({
         />
         <div>
           {plans
-            .filter((p) => p.code.startsWith("FREE_")) // Hack to exclude The Pro and Enteprise plans
+            .filter((p) => isFreePlan(p.code)) // Hack to exclude The Pro and Enteprise plans
             .map((p) => {
               return (
                 <div key={p.code} className="pt-2">
@@ -403,11 +408,11 @@ function UpgradeDowngradeModal({
         />
         <div>
           <EnterpriseUpgradeDialog
-            disabled={subscription.plan.code.startsWith("ENT_")}
+            disabled={isEntreprisePlan(subscription.plan.code)}
             owner={owner}
           />
         </div>
-        {subscription.plan.code.startsWith("PRO_") && (
+        {isProPlan(subscription.plan.code) && (
           <>
             <Page.SectionHeader
               title="Change the Pro Plan of this workspace"
@@ -415,7 +420,7 @@ function UpgradeDowngradeModal({
             />
             <div>
               {plans
-                .filter((p) => p.code.startsWith("PRO_"))
+                .filter((p) => isProPlan(p.code))
                 .map((p) => {
                   return (
                     <div key={p.code} className="pt-2">

--- a/front/lib/plans/plan_codes.ts
+++ b/front/lib/plans/plan_codes.ts
@@ -15,6 +15,21 @@ export const PRO_PLAN_LARGE_FILES_CODE = "PRO_PLAN_LARGE_FILES";
  */
 export const ENT_PLAN_FAKE_CODE = "ENT_PLAN_FAKE_CODE";
 
+// If the plan code starts with ENT_, it's an entreprise plan
+export const isEntreprisePlan = (planCode: string) =>
+  planCode.startsWith("ENT_");
+
+// If the plan code starts with PRO_, it's a pro plan
+export const isProPlan = (planCode: string) => planCode.startsWith("PRO_");
+
+// Everything else is free
+export const isFreePlan = (planCode: string) =>
+  !isEntreprisePlan(planCode) && !isProPlan(planCode);
+
+// Early plan when anyone could create a dust account
+export const isOldFreePlan = (planCode: string) =>
+  planCode === "FREE_TEST_PLAN";
+
 /**
  * `isUpgraded` returns true if the plan has access to all features of Dust, including large
  * language models (meaning it's either a paid plan or free plan with (eg friends and family, or

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -13,7 +13,11 @@ import { Plan, Subscription } from "@app/lib/models/plan";
 import { Workspace } from "@app/lib/models/workspace";
 import type { PlanAttributes } from "@app/lib/plans/free_plans";
 import { FREE_NO_PLAN_DATA } from "@app/lib/plans/free_plans";
-import { PRO_PLAN_SEAT_29_CODE } from "@app/lib/plans/plan_codes";
+import {
+  isEntreprisePlan,
+  isProPlan,
+  PRO_PLAN_SEAT_29_CODE,
+} from "@app/lib/plans/plan_codes";
 import {
   cancelSubscriptionImmediately,
   createProPlanCheckoutSession,
@@ -307,11 +311,8 @@ export const pokeUpgradeWorkspaceToPlan = async (
     );
   }
 
-  const isUgradeToEnterprise = newPlan.code.startsWith("ENT_");
-  const isUpgradeToPro = newPlan.code.startsWith("PRO_");
-
   // Ugrade to Enterprise is not allowed through this function.
-  if (isUgradeToEnterprise) {
+  if (isEntreprisePlan(newPlan.code)) {
     throw new Error(
       `Cannot subscribe to plan ${planCode}: Enterprise Plans requires a special process.`
     );
@@ -319,7 +320,7 @@ export const pokeUpgradeWorkspaceToPlan = async (
 
   // Upgrade to Pro is allowed only if the workspace is already subscribed to a Pro plan.
   // This is a way to change the plan limitations but stay on Pro.
-  if (isUpgradeToPro) {
+  if (isProPlan(newPlan.code)) {
     if (
       !activeSubscription ||
       !activeSubscription.sId ||

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -111,7 +111,7 @@ export const isEmailValid = (email: string | null): boolean => {
 const DOMAIN_REGEX =
   /^(((?!-))(xn--|_)?[a-z0-9-]{0,61}[a-z0-9]{1,1}\.)*(xn--)?([a-z0-9][a-z0-9-]{0,60}|[a-z0-9-]{1,30}\.[a-z]{2,})$/;
 
-export const isADomain = (domain: string | null): boolean => {
+export const isDomain = (domain: string | null): boolean => {
   if (!domain) {
     return false;
   }

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -108,6 +108,16 @@ export const isEmailValid = (email: string | null): boolean => {
   return EMAIL_REGEX.test(email);
 };
 
+const DOMAIN_REGEX =
+  /^(((?!-))(xn--|_)?[a-z0-9-]{0,61}[a-z0-9]{1,1}\.)*(xn--)?([a-z0-9][a-z0-9\-]{0,60}|[a-z0-9-]{1,30}\.[a-z]{2,})$/;
+
+export const isADomain = (domain: string | null): boolean => {
+  if (!domain) {
+    return false;
+  }
+  return DOMAIN_REGEX.test(domain);
+};
+
 export const objectToMarkdown = (obj: any, indent = 0) => {
   let markdown = "";
 

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -109,7 +109,7 @@ export const isEmailValid = (email: string | null): boolean => {
 };
 
 const DOMAIN_REGEX =
-  /^(((?!-))(xn--|_)?[a-z0-9-]{0,61}[a-z0-9]{1,1}\.)*(xn--)?([a-z0-9][a-z0-9\-]{0,60}|[a-z0-9-]{1,30}\.[a-z]{2,})$/;
+  /^(((?!-))(xn--|_)?[a-z0-9-]{0,61}[a-z0-9]{1,1}\.)*(xn--)?([a-z0-9][a-z0-9-]{0,60}|[a-z0-9-]{1,30}\.[a-z]{2,})$/;
 
 export const isADomain = (domain: string | null): boolean => {
   if (!domain) {

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from "uuid";
 
 export const MODELS_STRING_MAX_LENGTH = 255;
 
-export function classNames(...classes: string[]) {
+export function classNames(...classes: (string | null | boolean)[]) {
   return classes.filter(Boolean).join(" ");
 }
 

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -25,7 +25,7 @@ import { renderSubscriptionFromModels } from "@app/lib/plans/subscription";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
-import { isADomain, isEmailValid } from "@app/lib/utils";
+import { isDomain, isEmailValid } from "@app/lib/utils";
 import { apiError } from "@app/logger/withlogging";
 
 export type PokeWorkspaceType = LightWorkspaceType & {
@@ -192,7 +192,7 @@ async function handler(
         }
 
         let isSearchByDomain = false;
-        if (isADomain(searchTerm)) {
+        if (isDomain(searchTerm)) {
           const workspaceDomain = await WorkspaceHasDomain.findOne({
             where: { domain: searchTerm },
           });

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -1,25 +1,35 @@
 import type {
-  LightWorkpaceWithSubscriptionType,
+  LightWorkspaceType,
+  MembershipRoleType,
   SubscriptionType,
   WithAPIErrorResponse,
+  WorkspaceDomain,
 } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
-import type { FindOptions, WhereOptions } from "sequelize";
+import type { FindOptions, Order, WhereOptions } from "sequelize";
 import { Op } from "sequelize";
 
+import { getWorkspaceVerifiedDomain } from "@app/lib/api/workspace";
 import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { Plan, Subscription } from "@app/lib/models/plan";
-import { Workspace } from "@app/lib/models/workspace";
+import { Workspace, WorkspaceHasDomain } from "@app/lib/models/workspace";
 import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { renderSubscriptionFromModels } from "@app/lib/plans/subscription";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
-import { isEmailValid } from "@app/lib/utils";
+import { isADomain, isEmailValid } from "@app/lib/utils";
 import { apiError } from "@app/logger/withlogging";
 
+export type PokeWorkspaceType = LightWorkspaceType & {
+  subscription: SubscriptionType | null;
+  adminEmail: string | null;
+  membersCount: number;
+  workspaceDomain: WorkspaceDomain | null;
+};
+
 export type GetPokeWorkspacesResponseBody = {
-  workspaces: LightWorkpaceWithSubscriptionType[];
+  workspaces: PokeWorkspaceType[];
 };
 
 async function handler(
@@ -41,11 +51,13 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      let upgraded: boolean | undefined;
-      const search = req.query.search
+      let listUpgraded: boolean | undefined;
+      const searchTerm = req.query.search
         ? (req.query.search as string).trim()
         : undefined;
-      let limit: number | undefined;
+      let limit: number = 0;
+      let originalLimit: number = 0;
+      const order: Order = [["createdAt", "DESC"]];
 
       if (req.query.upgraded !== undefined) {
         if (
@@ -62,10 +74,10 @@ async function handler(
           });
         }
 
-        upgraded = req.query.upgraded === "true";
+        listUpgraded = req.query.upgraded === "true";
       }
 
-      if (search !== undefined && typeof search !== "string") {
+      if (searchTerm !== undefined && typeof searchTerm !== "string") {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
@@ -91,12 +103,13 @@ async function handler(
           });
         }
 
-        limit = parseInt(req.query.limit, 10);
+        originalLimit = parseInt(req.query.limit, 10);
+        limit = originalLimit;
       }
 
       const conditions: WhereOptions<Workspace>[] = [];
 
-      if (upgraded !== undefined) {
+      if (listUpgraded !== undefined) {
         const subscriptions = await Subscription.findAll({
           where: {
             status: "active",
@@ -113,7 +126,7 @@ async function handler(
           ],
         });
         const workspaceIds = subscriptions.map((s) => s.workspaceId);
-        if (upgraded) {
+        if (listUpgraded) {
           conditions.push({
             id: {
               [Op.in]: workspaceIds,
@@ -128,11 +141,11 @@ async function handler(
         }
       }
 
-      if (search) {
+      if (searchTerm) {
         let isSearchByEmail = false;
-        if (isEmailValid(search)) {
+        if (isEmailValid(searchTerm)) {
           // We can have 2 users with the same email if a Google user and a Github user have the same email.
-          const users = await UserResource.listByEmail(search);
+          const users = await UserResource.listByEmail(searchTerm);
           if (users.length) {
             const memberships = await MembershipResource.getLatestMemberships({
               users,
@@ -148,22 +161,40 @@ async function handler(
           }
         }
 
-        if (!isSearchByEmail) {
+        let isSearchByDomain = false;
+        if (isADomain(searchTerm)) {
+          const workspaceDomain = await WorkspaceHasDomain.findOne({
+            where: { domain: searchTerm },
+          });
+
+          if (workspaceDomain) {
+            isSearchByDomain = true;
+            conditions.push({
+              id: workspaceDomain.workspaceId,
+            });
+          }
+        }
+
+        if (!isSearchByEmail && !isSearchByDomain) {
           conditions.push({
             [Op.or]: [
               {
                 sId: {
-                  [Op.iLike]: `${search}%`,
+                  [Op.iLike]: `${searchTerm}%`,
                 },
               },
               {
                 name: {
-                  [Op.iLike]: `${search}%`,
+                  [Op.iLike]: `${searchTerm}%`,
                 },
               },
             ],
           });
         }
+
+        // In case of search, we increase the limit for the sql query to 100 because we'll sort manually (until a better solution is found).
+        // Note from seb: I tried ordering directly in the query but I stumbled into sequelize behaviors that I don't understand.
+        limit = 100;
       }
 
       const where: FindOptions<Workspace>["where"] = conditions.length
@@ -189,11 +220,44 @@ async function handler(
             ],
           },
         ],
+        order: order,
+        logging: console.log,
       });
 
+      // if limit is above originalLimit, sort manually and then slice
+      if (limit > originalLimit) {
+        // Check out the plan code prefix and sort by arbitrary order
+        const prefixesOrder = [
+          "ENT_",
+          "PRO_",
+          "FREE_UPGRADED_",
+          "FREE_FRIENDSAMILY",
+          "FREE_",
+        ];
+
+        workspaces.sort((a, b) => {
+          const aPrefix = prefixesOrder.findIndex((p) =>
+            a.subscriptions?.[0].plan.code.startsWith(p)
+          );
+          const bPrefix = prefixesOrder.findIndex((p) =>
+            b.subscriptions?.[0].plan.code.startsWith(p)
+          );
+
+          if (aPrefix !== bPrefix) {
+            return aPrefix - bPrefix;
+          }
+
+          return a.subscriptions?.[0].plan.code.localeCompare(
+            b.subscriptions?.[0].plan.code
+          );
+        });
+
+        workspaces.splice(originalLimit);
+      }
+
       return res.status(200).json({
-        workspaces: workspaces
-          .map((ws): LightWorkpaceWithSubscriptionType => {
+        workspaces: await Promise.all(
+          workspaces.map(async (ws): Promise<PokeWorkspaceType> => {
             let subscription: SubscriptionType | null = null;
             if (ws.subscriptions && ws.subscriptions.length > 0) {
               subscription = renderSubscriptionFromModels({
@@ -202,7 +266,7 @@ async function handler(
               });
             }
 
-            return {
+            const lightWorkspace: LightWorkspaceType = {
               id: ws.id,
               sId: ws.sId,
               name: ws.name,
@@ -210,23 +274,39 @@ async function handler(
               segmentation: ws.segmentation,
               whiteListedProviders: ws.whiteListedProviders,
               defaultEmbeddingProvider: ws.defaultEmbeddingProvider,
+            };
+
+            const memberships = await MembershipResource.getActiveMemberships({
+              workspace: lightWorkspace,
+              roles: ["admin" as MembershipRoleType],
+            });
+
+            const firstAdmin = memberships.length
+              ? await UserResource.fetchByModelId(
+                  memberships.sort(
+                    (a, b) => a.createdAt.getTime() - b.createdAt.getTime()
+                  )[0].userId
+                )
+              : null;
+
+            const membersCount =
+              await MembershipResource.getMembersCountForWorkspace({
+                workspace: lightWorkspace,
+                activeOnly: true,
+              });
+
+            const verifiedDomain =
+              await getWorkspaceVerifiedDomain(lightWorkspace);
+
+            return {
+              ...lightWorkspace,
               subscription,
+              adminEmail: firstAdmin?.email ?? null,
+              membersCount,
+              workspaceDomain: verifiedDomain,
             };
           })
-          .sort((a, b) => {
-            const aStartsWithENT =
-              a.subscription?.plan?.code?.startsWith("ENT_") || false;
-            const bStartsWithENT =
-              b.subscription?.plan?.code?.startsWith("ENT_") || false;
-
-            if (aStartsWithENT && !bStartsWithENT) {
-              return -1;
-            } else if (!aStartsWithENT && bStartsWithENT) {
-              return 1;
-            } else {
-              return 0;
-            }
-          }),
+        ),
       });
 
     default:

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -42,6 +42,26 @@ export type GetPokeWorkspacesResponseBody = {
   workspaces: PokeWorkspaceType[];
 };
 
+const getPlanPriority = (planCode: string) => {
+  if (isEntreprisePlan(planCode)) {
+    return 1;
+  }
+
+  if (isProPlan(planCode)) {
+    return 2;
+  }
+
+  if (isFreePlan(planCode)) {
+    return 3;
+  }
+
+  if (isOldFreePlan(planCode)) {
+    return 4;
+  }
+
+  return 5;
+};
+
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<GetPokeWorkspacesResponseBody>>
@@ -237,35 +257,10 @@ async function handler(
       if (limit > originalLimit) {
         // Order by plan, entreprise first, then pro, then free and old free using isEntreprisePlan, isProPlan and isFreePlan, isOldFreePlan methods
         workspaces.sort((a, b) => {
-          const planACode = a.subscriptions[0].plan.code;
-          const planBCode = b.subscriptions[0].plan.code;
+          const planAPriority = getPlanPriority(a.subscriptions[0].plan.code);
+          const planBPriority = getPlanPriority(b.subscriptions[0].plan.code);
 
-          if (isEntreprisePlan(planACode) && !isEntreprisePlan(planBCode)) {
-            return -1;
-          }
-          if (!isEntreprisePlan(planACode) && isEntreprisePlan(planBCode)) {
-            return 1;
-          }
-          if (isProPlan(planACode) && !isProPlan(planBCode)) {
-            return -1;
-          }
-          if (!isProPlan(planACode) && isProPlan(planBCode)) {
-            return 1;
-          }
-          if (isFreePlan(planACode) && !isFreePlan(planBCode)) {
-            return -1;
-          }
-          if (!isFreePlan(planACode) && isFreePlan(planBCode)) {
-            return 1;
-          }
-          if (!isOldFreePlan(planACode) && isOldFreePlan(planBCode)) {
-            return -1;
-          }
-          if (isOldFreePlan(planACode) && !isOldFreePlan(planBCode)) {
-            return 1;
-          }
-
-          return planACode.localeCompare(planBCode);
+          return planAPriority - planBPriority;
         });
 
         workspaces.splice(originalLimit);

--- a/front/pages/poke/index.tsx
+++ b/front/pages/poke/index.tsx
@@ -19,6 +19,7 @@ import {
   isProPlan,
 } from "@app/lib/plans/plan_codes";
 import { usePokeWorkspaces } from "@app/lib/swr";
+import { classNames } from "@app/lib/utils";
 import type { PokeWorkspaceType } from "@app/pages/api/poke/workspaces";
 
 const limit: number = 20;
@@ -38,7 +39,7 @@ const renderWorkspaces = (title: string, workspaces: PokeWorkspaceType[]) => (
       {workspaces.length === 0 && <p>No workspaces found.</p>}
       {workspaces.map((ws) => (
         <Link href={`/poke/${ws.sId}`} key={ws.id}>
-          <li className="border-material-100 s-w-[320px] rounded-lg border bg-white p-4 transition-colors duration-200 hover:bg-gray-100">
+          <li className="border-material-100 w-80 rounded-lg border bg-white p-4 transition-colors duration-200 hover:bg-gray-100">
             <h2 className="text-md flex-grow pb-2 font-bold">{ws.name}</h2>
             <PokeTable>
               <PokeTableBody>
@@ -62,28 +63,15 @@ const renderWorkspaces = (title: string, workspaces: PokeWorkspaceType[]) => (
                     )}
                   </PokeTableCell>
                   <PokeTableCell align="center">
-                    {ws.membersCount && ws.membersCount > 1 ? (
-                      <label>
-                        <Icon visual={UsersIcon} /> {ws.membersCount}
-                      </label>
-                    ) : (
-                      <label>
-                        <Icon visual={UsersIcon} /> {ws.membersCount}
-                      </label>
-                    )}
+                    <label>
+                      <Icon visual={UsersIcon} /> {ws.membersCount}
+                    </label>
                   </PokeTableCell>
                   <PokeTableCell align="center">
-                    {ws.dataSourcesCount && ws.dataSourcesCount > 1 ? (
-                      <label>
-                        <Icon visual={CloudArrowLeftRightIcon} />{" "}
-                        {ws.dataSourcesCount}
-                      </label>
-                    ) : (
-                      <label>
-                        <Icon visual={CloudArrowLeftRightIcon} />{" "}
-                        {ws.dataSourcesCount}
-                      </label>
-                    )}
+                    <label>
+                      <Icon visual={CloudArrowLeftRightIcon} />{" "}
+                      {ws.dataSourcesCount}
+                    </label>
                   </PokeTableCell>
                 </PokeTableRow>
                 <PokeTableRow>
@@ -93,7 +81,15 @@ const renderWorkspaces = (title: string, workspaces: PokeWorkspaceType[]) => (
                     </label>
                     {ws.subscription && (
                       <label
-                        className={`rounded px-1 text-sm text-gray-500 text-white ${isEntreprisePlan(ws.subscription.plan.code) ? "bg-red-500" : isProPlan(ws.subscription.plan.code) ? "bg-orange-500" : isOldFreePlan(ws.subscription.plan.code) ? "bg-gray-300" : "bg-blue-500"}`}
+                        className={classNames(
+                          "rounded px-1 text-sm text-gray-500 text-white",
+                          isEntreprisePlan(ws.subscription.plan.code) &&
+                            "bg-red-500",
+                          isProPlan(ws.subscription.plan.code) &&
+                            "bg-orange-500",
+                          isOldFreePlan(ws.subscription.plan.code) &&
+                            "bg-gray-300"
+                        )}
                       >
                         {ws.subscription.plan.name}
                       </label>

--- a/front/pages/poke/index.tsx
+++ b/front/pages/poke/index.tsx
@@ -1,4 +1,6 @@
-import { Spinner } from "@dust-tt/sparkle";
+import { CloudArrowLeftRightIcon, Icon, Spinner } from "@dust-tt/sparkle";
+import { UsersIcon } from "lucide-react";
+import moment from "moment";
 import Link from "next/link";
 import type { ChangeEvent } from "react";
 import React, { useState } from "react";
@@ -11,10 +13,15 @@ import {
   PokeTableRow,
 } from "@app/components/poke/shadcn/ui/table";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
+import {
+  isEntreprisePlan,
+  isOldFreePlan,
+  isProPlan,
+} from "@app/lib/plans/plan_codes";
 import { usePokeWorkspaces } from "@app/lib/swr";
 import type { PokeWorkspaceType } from "@app/pages/api/poke/workspaces";
 
-const limit: number = 12;
+const limit: number = 20;
 
 export const getServerSideProps = withSuperUserAuthRequirements<object>(
   async () => {
@@ -32,9 +39,21 @@ const renderWorkspaces = (title: string, workspaces: PokeWorkspaceType[]) => (
       {workspaces.map((ws) => (
         <Link href={`/poke/${ws.sId}`} key={ws.id}>
           <li className="border-material-100 s-w-[320px] rounded-lg border bg-white p-4 transition-colors duration-200 hover:bg-gray-100">
-            <h2 className="text-md flex-grow pb-4 font-bold">{ws.name}</h2>
+            <h2 className="text-md flex-grow pb-2 font-bold">{ws.name}</h2>
             <PokeTable>
               <PokeTableBody>
+                <PokeTableRow>
+                  <PokeTableCell colSpan={3}>
+                    <label>
+                      Created: {moment(ws.createdAt).format("DD-MM-YYYY")}
+                    </label>
+                    {ws.upgradedAt && (
+                      <label>
+                        Upgraded: {moment(ws.upgradedAt).format("DD-MM-YYYY")}
+                      </label>
+                    )}
+                  </PokeTableCell>
+                </PokeTableRow>
                 <PokeTableRow>
                   <PokeTableCell>
                     {ws.adminEmail}{" "}
@@ -42,22 +61,39 @@ const renderWorkspaces = (title: string, workspaces: PokeWorkspaceType[]) => (
                       <label>({ws.workspaceDomain.domain})</label>
                     )}
                   </PokeTableCell>
-                  <PokeTableCell>
+                  <PokeTableCell align="center">
                     {ws.membersCount && ws.membersCount > 1 ? (
-                      <label>{ws.membersCount} members</label>
+                      <label>
+                        <Icon visual={UsersIcon} /> {ws.membersCount}
+                      </label>
                     ) : (
-                      <label>{ws.membersCount} member</label>
+                      <label>
+                        <Icon visual={UsersIcon} /> {ws.membersCount}
+                      </label>
+                    )}
+                  </PokeTableCell>
+                  <PokeTableCell align="center">
+                    {ws.dataSourcesCount && ws.dataSourcesCount > 1 ? (
+                      <label>
+                        <Icon visual={CloudArrowLeftRightIcon} />{" "}
+                        {ws.dataSourcesCount}
+                      </label>
+                    ) : (
+                      <label>
+                        <Icon visual={CloudArrowLeftRightIcon} />{" "}
+                        {ws.dataSourcesCount}
+                      </label>
                     )}
                   </PokeTableCell>
                 </PokeTableRow>
                 <PokeTableRow>
-                  <PokeTableCell className="space-x-2">
+                  <PokeTableCell className="space-x-2" colSpan={3}>
                     <label className="rounded bg-green-500 px-1 text-sm text-white">
                       {ws.sId}
                     </label>
                     {ws.subscription && (
                       <label
-                        className={`rounded px-1 text-sm text-gray-500 text-white ${ws.subscription.plan.code.startsWith("ENT_") ? "bg-red-500" : "bg-blue-500"}`}
+                        className={`rounded px-1 text-sm text-gray-500 text-white ${isEntreprisePlan(ws.subscription.plan.code) ? "bg-red-500" : isProPlan(ws.subscription.plan.code) ? "bg-orange-500" : isOldFreePlan(ws.subscription.plan.code) ? "bg-gray-300" : "bg-blue-500"}`}
                       >
                         {ws.subscription.plan.name}
                       </label>

--- a/front/scripts/create_test_workspaces.ts
+++ b/front/scripts/create_test_workspaces.ts
@@ -1,0 +1,100 @@
+import type { WorkspaceSegmentationType } from "@dust-tt/types";
+import type { ActiveRoleType } from "@dust-tt/types";
+
+import { Plan, Subscription } from "@app/lib/models/plan";
+import { Workspace } from "@app/lib/models/workspace";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { MembershipModel } from "@app/lib/resources/storage/models/membership";
+import { generateLegacyModelSId } from "@app/lib/resources/string_ids";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+
+async function createTestWorkspaces(
+  { userId, count }: { userId: number; count: number },
+  execute: boolean,
+  logger: Logger
+) {
+  const plans = await Plan.findAll();
+  if (plans.length === 0) {
+    throw new Error(
+      "No plans found in the database. Please create some plans first."
+    );
+  }
+
+  if (!count || count <= 0) {
+    throw new Error("Count must be greater than 0.");
+  }
+
+  if (!userId || userId <= 0) {
+    throw new Error("User ID must be greater than 0.");
+  }
+
+  logger.info(`About to create ${count} test workspaces for user ${userId}.`);
+
+  const workspaces: Workspace[] = [];
+
+  await frontSequelize.transaction(async (t) => {
+    for (let i = 0; i < count; i++) {
+      const segmentations: WorkspaceSegmentationType[] = ["interesting", null];
+      const workspace = await Workspace.create(
+        {
+          sId: generateLegacyModelSId(),
+          name: `Test Workspace ${i + 1}`,
+          description: `This is a test workspace ${i + 1}`,
+          segmentation: segmentations[i % segmentations.length],
+          whiteListedProviders: null,
+          defaultEmbeddingProvider: null,
+        },
+        { transaction: t }
+      );
+
+      logger.info(`Workspace ${workspace.id} created.`);
+
+      // Randomly select a plan
+      const randomPlan = plans[Math.floor(Math.random() * plans.length)];
+
+      // Create a subscription for the workspace
+      await Subscription.create(
+        {
+          sId: generateLegacyModelSId(),
+          workspaceId: workspace.id,
+          planId: randomPlan.id,
+          status: "active",
+          startDate: new Date(),
+          stripeSubscriptionId: `test_stripe_sub_${i}`,
+        },
+        { transaction: t }
+      );
+
+      // Create a new membership
+      await MembershipModel.create(
+        {
+          startAt: new Date(),
+          userId: userId,
+          workspaceId: workspace.id,
+          role: "admin" as ActiveRoleType,
+        },
+        { transaction: t }
+      );
+      workspaces.push(workspace);
+    }
+  });
+
+  return workspaces;
+}
+
+makeScript(
+  {
+    userId: {
+      type: "number",
+      description: "The user ID to assign to the workspace",
+    },
+    count: {
+      type: "number",
+      description: "The number of workspaces to create",
+    },
+  },
+  async ({ userId, count, execute }, logger) => {
+    await createTestWorkspaces({ userId, count }, execute, logger);
+  }
+);

--- a/front/scripts/create_test_workspaces.ts
+++ b/front/scripts/create_test_workspaces.ts
@@ -72,30 +72,6 @@ async function createTestWorkspaces(
 
     await pokeUpgradeWorkspaceToPlan(authenticator, FREE_UPGRADED_PLAN_CODE);
   }
-  /*
-  workspaces.forEach(async (workspace) => {
-    // Randomly select a plan
-    const randomPlan = plans[Math.floor(Math.random() * plans.length)];
-
-    // Create a subscription for the workspace
-    await Subscription.create({
-      sId: generateLegacyModelSId(),
-      workspaceId: workspace.id,
-      planId: randomPlan.id,
-      status: "active",
-      startDate: new Date(),
-      stripeSubscriptionId: `test_stripe_sub_${workspace.sId}`,
-    });
-
-    // Create a new membership
-    await MembershipModel.create({
-      startAt: new Date(),
-      userId: userId,
-      workspaceId: workspace.id,
-      role: "admin" as ActiveRoleType,
-    });
-  });
-*/
 }
 
 makeScript(

--- a/front/scripts/dev/create_test_workspaces.ts
+++ b/front/scripts/dev/create_test_workspaces.ts
@@ -14,7 +14,12 @@ async function createTestWorkspaces(
   execute: boolean,
   logger: Logger
 ) {
+  if (process.env.NODE_ENV !== "development") {
+    throw new Error("This script can only be run in development.");
+  }
+
   const plans = await Plan.findAll();
+
   if (plans.length === 0) {
     throw new Error(
       "No plans found in the database. Please create some plans first."

--- a/types/src/front/user.ts
+++ b/types/src/front/user.ts
@@ -44,10 +44,6 @@ export type LightWorkspaceType = {
   defaultEmbeddingProvider: EmbeddingProviderIdType | null;
 };
 
-export type LightWorkpaceWithSubscriptionType = LightWorkspaceType & {
-  subscription: SubscriptionType | null;
-};
-
 export type WorkspaceType = LightWorkspaceType & {
   flags: WhitelistableFeature[];
   ssoEnforced?: boolean;

--- a/types/src/front/user.ts
+++ b/types/src/front/user.ts
@@ -7,7 +7,6 @@ import {
 import { WhitelistableFeature } from "../shared/feature_flags";
 import { ModelId } from "../shared/model_id";
 import { assertNever } from "../shared/utils/assert_never";
-import { SubscriptionType } from "./plan";
 
 export type WorkspaceSegmentationType = "interesting" | null;
 


### PR DESCRIPTION
## Description

Improved the index page of poke:
- Search results are now reordered by kind: entreprise, then pro, then free upgrade and finally free.
- Default list now order by creation date descending.
- Upgraded visuals and added more informations (creation date, members & datasources counts)
- Added a script to generate tests workspaces
- Fixed: url decode the search term (couldn't search for "Sébastien").
- Refactored a bit to avoid magic strings (`ENT_`, `PRO_`)
- Refactored a bit to be able to expose a method that create workspace outside of a session context (`createWorkspaceInternal`).

<img width="1376" alt="image" src="https://github.com/user-attachments/assets/8aa5d905-f8ba-41ba-98b8-bd429af04174">

<img width="1378" alt="image" src="https://github.com/user-attachments/assets/37fd72ce-1922-4c08-8eed-590db8140dce">

<img width="455" alt="image" src="https://github.com/user-attachments/assets/184c79f1-41a8-4612-a296-a2d2a2af9988">
 
## Risk

None

## Deploy Plan

deploy `front`