### PR TITLE
[front] - enh(connections): add "Add Connections" button

### DIFF
--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -720,7 +720,7 @@ export default function DataSourcesView({
               setDataSourceSearch(s);
             }}
           />
-          {isAdmin && (
+          {isAdmin && nonSetUpIntegrations.length > 0 && (
             <DropdownMenu>
               <DropdownMenu.Button>
                 <Button

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -711,7 +711,7 @@ export default function DataSourcesView({
           </ContentMessage>
         )}
         <div className="flex gap-2">
-          {isAdmin && setUpIntegrations.length > 0 && (
+          {connectionRows.length > 0 && (
             <Searchbar
               ref={searchBarRef}
               name="search"
@@ -761,13 +761,17 @@ export default function DataSourcesView({
             </DropdownMenu>
           )}
         </div>
-        {isAdmin && setUpIntegrations.length > 0 && (
+        {connectionRows.length > 0 ? (
           <DataTable
             data={connectionRows}
             columns={getTableColumns()}
             filter={dataSourceSearch}
             filterColumn={"name"}
           />
+        ) : (
+          <div className="flex items-center justify-center text-sm font-normal text-element-700">
+            No available connection
+          </div>
         )}
       </Page.Vertical>
       {showUpgradePopup && (

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -51,7 +51,7 @@ import { getDataSources } from "@app/lib/api/data_sources";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useAdmins } from "@app/lib/swr";
-import { timeAgoFrom } from "@app/lib/utils";
+import { classNames, timeAgoFrom } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import type { PostManagedDataSourceRequestBody } from "@app/pages/api/w/[wId]/data_sources/managed";
 
@@ -710,7 +710,14 @@ export default function DataSourcesView({
             </Hoverable>
           </ContentMessage>
         )}
-        <div className="flex gap-2">
+        <div
+          className={classNames(
+            "flex gap-2",
+            connectionRows.length === 0 && isAdmin
+              ? "h-36 w-full max-w-4xl items-center justify-center rounded-lg border bg-structure-50"
+              : ""
+          )}
+        >
           {connectionRows.length > 0 && (
             <Searchbar
               ref={searchBarRef}
@@ -768,10 +775,12 @@ export default function DataSourcesView({
             filter={dataSourceSearch}
             filterColumn={"name"}
           />
-        ) : (
+        ) : !isAdmin ? (
           <div className="flex items-center justify-center text-sm font-normal text-element-700">
             No available connection
           </div>
+        ) : (
+          <></>
         )}
       </Page.Vertical>
       {showUpgradePopup && (

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -711,15 +711,18 @@ export default function DataSourcesView({
           </ContentMessage>
         )}
         <div className="flex gap-2">
-          <Searchbar
-            ref={searchBarRef}
-            name="search"
-            placeholder="Search (Name)"
-            value={dataSourceSearch}
-            onChange={(s) => {
-              setDataSourceSearch(s);
-            }}
-          />
+          {isAdmin && setUpIntegrations.length > 0 && (
+            <Searchbar
+              ref={searchBarRef}
+              name="search"
+              placeholder="Search (Name)"
+              value={dataSourceSearch}
+              onChange={(s) => {
+                setDataSourceSearch(s);
+              }}
+            />
+          )}
+
           {isAdmin && nonSetUpIntegrations.length > 0 && (
             <DropdownMenu>
               <DropdownMenu.Button>
@@ -758,12 +761,14 @@ export default function DataSourcesView({
             </DropdownMenu>
           )}
         </div>
-        <DataTable
-          data={connectionRows}
-          columns={getTableColumns()}
-          filter={dataSourceSearch}
-          filterColumn={"name"}
-        />
+        {isAdmin && setUpIntegrations.length > 0 && (
+          <DataTable
+            data={connectionRows}
+            columns={getTableColumns()}
+            filter={dataSourceSearch}
+            filterColumn={"name"}
+          />
+        )}
       </Page.Vertical>
       {showUpgradePopup && (
         <Dialog


### PR DESCRIPTION
## Description

This PR adds an "Add Connections" button to the Connection Management screen for administrators. Also, it simplifies the screen by only displaying the already set up data sources.

The main changes include:
- Adding an "Add Connection" button that opens a dropdown menu with non-setup integrations
- Refactoring the DataTable rows generation as we only display already set up integrations

This change aims to simplify the process of adding new connections and improve the overall user experience for workspace administrators.

<img width="1000" alt="Screenshot 2024-08-07 at 10 45 53" src="https://github.com/user-attachments/assets/77d987b4-7862-48ee-81b6-c285a001b211">

**References:**
- #6688 
- [Figma](https://www.figma.com/design/QOxHwppG64GtPocpDhS6Y7/Product?node-id=8382-44401&t=LlBLc9OGG3iiERM8-0)

## Risk

Moderate risk of breaking existing UI interactions on the Connection Management screen

## Deploy Plan

- Deploy to `front-edge`
- Deploy to `front`