### PR TITLE
fix: properly share the topK of all retrievals of a step

### DIFF
--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -285,9 +285,14 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
     const model = getSupportedModelConfig(agentConfiguration.model);
 
     // We find the retrieval action in the step with the highest topK.
+    const retrievalActions: RetrievalConfigurationType[] = [];
+    for (const a of stepActions) {
+      if (a.type === "retrieval_configuration") {
+        retrievalActions.push(a);
+      }
+    }
     const maxTopK = (() => {
-      return stepActions
-        .filter((a) => a.type === this.actionConfiguration.type)
+      return retrievalActions
         .map((a) => {
           if (a.topK === "auto") {
             if (a.query === "none") {

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -289,21 +289,19 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
     const model = getSupportedModelConfig(agentConfiguration.model);
 
     // We find the retrieval action in the step with the highest topK.
-    const maxTopK = (() => {
-      return retrievalActions
-        .map((a) => {
-          if (a.topK === "auto") {
-            if (a.query === "none") {
-              return model.recommendedExhaustiveTopK;
-            } else {
-              return model.recommendedTopK;
-            }
+    const maxTopK = retrievalActions
+      .map((a) => {
+        if (a.topK === "auto") {
+          if (a.query === "none") {
+            return model.recommendedExhaustiveTopK;
           } else {
-            return a.topK;
+            return model.recommendedTopK;
           }
-        })
-        .reduce((acc, topK) => Math.max(acc, topK), 0);
-    })();
+        } else {
+          return a.topK;
+        }
+      })
+      .reduce((acc, topK) => Math.max(acc, topK), 0);
 
     // We split the topK evenly among all retrieval actions of the step.
     return Math.ceil(maxTopK / retrievalActionsCount);

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -274,23 +274,21 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
     agentConfiguration: AgentConfigurationType;
     stepActions: AgentActionConfigurationType[];
   }): number {
-    const actionCount = stepActions.filter(
-      (a) => a.type === this.actionConfiguration.type
-    ).length;
-
-    if (actionCount === 0) {
-      throw new Error("Unexpected: found 0 retrieval actions");
-    }
-
-    const model = getSupportedModelConfig(agentConfiguration.model);
-
-    // We find the retrieval action in the step with the highest topK.
     const retrievalActions: RetrievalConfigurationType[] = [];
     for (const a of stepActions) {
       if (a.type === "retrieval_configuration") {
         retrievalActions.push(a);
       }
     }
+    const retrievalActionsCount = retrievalActions.length;
+
+    if (retrievalActionsCount === 0) {
+      throw new Error("Unexpected: found 0 retrieval actions");
+    }
+
+    const model = getSupportedModelConfig(agentConfiguration.model);
+
+    // We find the retrieval action in the step with the highest topK.
     const maxTopK = (() => {
       return retrievalActions
         .map((a) => {
@@ -308,7 +306,7 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
     })();
 
     // We split the topK evenly among all retrieval actions of the step.
-    return Math.ceil(maxTopK / actionCount);
+    return Math.ceil(maxTopK / retrievalActionsCount);
   }
 
   // stepTopKAndRefsOffsetForAction returns the references offset and the number of documents an


### PR DESCRIPTION
## Description
This PR addresses the "Exhausted the total number of references available" error occurring in our citation system. The error is triggered when the number of search results across multiple retrieval steps exceeds our current limit of 1296 unique reference identifiers. Our investigation revealed that we're not properly sharing the `topK` parameter among exhaustive retrievals within a single step, leading to an unexpectedly high number of results.

## Risk
This change modifies the retrieval logic, which is a core part of our assistant's functionality

## Deploy Plan
N/A
