### PR TITLE
doc(readme): fix broken links in the Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Amplify your team's potential with customizable and secure AI assistants.
 
 ## :book: Developer Documentation
 
-- [LLM apps Primer](https://docs.dust.tt/introduction)
-- [Developer Platform overview](https://docs.dust.tt/overview)
-- [Blocks documentation](https://docs.dust.tt/core-blocks)
-- [Getting started guide](https://docs.dust.tt/quickstart)
-- [Runs API Reference](https://docs.dust.tt/runs)
+- [LLM apps Primer](https://docs.dust.tt/docs/prompting-101-how-to-talk-to-your-assistants)
+- [Developer Platform overview](https://docs.dust.tt/reference/developer-platform-overview)
+- [Blocks documentation](https://docs.dust.tt/reference/core-blocks)
+- [Getting started guide](https://docs.dust.tt/docs/getting-started#quick-start-guide)
+- [Runs API Reference](https://docs.dust.tt/reference/get_api-v1-w-wid-apps-aid-runs-runid)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Amplify your team's potential with customizable and secure AI assistants.
 
 ## :book: Developer Documentation
 
-- [LLM apps Primer](https://docs.dust.tt/docs/prompting-101-how-to-talk-to-your-assistants)
 - [Developer Platform overview](https://docs.dust.tt/reference/developer-platform-overview)
 - [Blocks documentation](https://docs.dust.tt/reference/core-blocks)
 - [Getting started guide](https://docs.dust.tt/docs/getting-started#quick-start-guide)


### PR DESCRIPTION
## Description
While exploring this repository to learn more about Dust, I noticed that all the links in the README file are broken, likely pointing to an outdated version of the documentation.

In this PR, I have updated these links to what I believe are the corresponding pages in the latest version of the documentation.

Feel free to review and suggest any corrections if the new links are not accurate.


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

NA

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

NA