### PR TITLE
[sparkle] - fix: citation hover

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.202",
+  "version": "0.2.203",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.202",
+      "version": "0.2.203",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.202",
+  "version": "0.2.203",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/CardButton.tsx
+++ b/sparkle/src/components/CardButton.tsx
@@ -24,12 +24,18 @@ interface CardButtonProps {
 }
 
 const variantClasses = {
+  primary: "s-bg-structure-50 s-border s-border-structure-200",
+  secondary: "s-bg-structure-0 s-border s-border-structure-100",
+  tertiary: "s-border-structure-100/0 s-border s-border-structure-0",
+};
+
+const hoverVariantClasses = {
   primary:
-    "s-bg-structure-50 s-border s-border-structure-200 hover:s-bg-white hover:s-border-structure-100 active:s-bg-structure-100 active:s-border-structure-200",
+    "hover:s-bg-white hover:s-border-structure-100 active:s-bg-structure-100 active:s-border-structure-200 s-cursor-pointer",
   secondary:
-    "s-bg-structure-0 s-border s-border-structure-100 hover:s-bg-structure-50 hover:s-border-structure-200 active:s-bg-structure-100 active:s-border-structure-300",
+    "hover:s-bg-structure-50 hover:s-border-structure-200 active:s-bg-structure-100 active:s-border-structure-300 s-cursor-pointer",
   tertiary:
-    "s-border-structure-100/0 s-border s-border-structure-0 hover:s-bg-structure-50 hover:s-border-structure-100 active:s-bg-structure-100 active:s-border-structure-200",
+    "hover:s-bg-structure-50 hover:s-border-structure-100 active:s-bg-structure-100 active:s-border-structure-200 s-cursor-pointer",
 };
 
 const sizeClasses = {
@@ -57,7 +63,8 @@ export function CardButton({
   const Link: SparkleContextLinkType = href ? components.link : noHrefLink;
 
   const commonClasses = classNames(
-    "s-flex s-group s-cursor-pointer s-transition s-duration-200 s-overflow-hidden",
+    "s-flex s-group s-transition s-duration-200 s-overflow-hidden",
+    onClick ? hoverVariantClasses[variant] : "",
     variantClasses[variant],
     sizeClasses[size],
     className

--- a/sparkle/src/components/Citation.tsx
+++ b/sparkle/src/components/Citation.tsx
@@ -86,7 +86,12 @@ export function Citation({
     <>
       {type === "image" && imgSrc && (
         <div
-          className="s-absolute s-left-0 s-top-0 s-brightness-90 s-filter s-transition s-duration-200 s-ease-out hover:s-brightness-110 active:s-brightness-100 group-hover:s-brightness-110 group-hover:s-filter group-active:s-brightness-100"
+          className={classNames(
+            "s-absolute s-left-0 s-top-0 s-brightness-90 s-filter s-transition s-duration-200 s-ease-out active:s-brightness-100 group-active:s-brightness-100",
+            href
+              ? "hover:s-brightness-110 group-hover:s-brightness-110 group-hover:s-filter"
+              : ""
+          )}
           style={{
             backgroundImage: `url(${imgSrc})`,
             backgroundSize: "cover",
@@ -146,27 +151,32 @@ export function Citation({
     </>
   );
 
-  return (
+  const cardButton = (
+    <CardButton
+      variant="secondary"
+      size="sm"
+      className={classNames(
+        "s-relative s-flex s-w-48 s-flex-none s-flex-col s-gap-1",
+        sizing === "fluid" ? typeSizing[sizing] : typeSizing[sizing][size],
+        size === "sm" ? "sm:s-w-64" : "",
+        isBlinking ? "s-animate-[bgblink_500ms_3]" : "",
+        type === "image" ? "s-min-h-20" : ""
+      )}
+      {...(href && { href, target: "_blank", rel: "noopener noreferrer" })}
+    >
+      {isLoading && (
+        <div className="s-absolute s-inset-0 s-flex s-items-center s-justify-center">
+          <Spinner size="xs" variant="color" />
+        </div>
+      )}
+      <div className={isLoading ? "s-opacity-50" : ""}>{cardContent}</div>
+    </CardButton>
+  );
+  return href ? (
     <Tooltip label={title} position="above">
-      <CardButton
-        variant="secondary"
-        size="sm"
-        className={classNames(
-          "s-relative s-flex s-w-48 s-flex-none s-flex-col s-gap-1",
-          sizing === "fluid" ? typeSizing[sizing] : typeSizing[sizing][size],
-          size === "sm" ? "sm:s-w-64" : "",
-          isBlinking ? "s-animate-[bgblink_500ms_3]" : "",
-          type === "image" ? "s-min-h-20" : ""
-        )}
-        {...(href && { href, target: "_blank", rel: "noopener noreferrer" })}
-      >
-        {isLoading && (
-          <div className="s-absolute s-inset-0 s-flex s-items-center s-justify-center">
-            <Spinner size="xs" variant="color" />
-          </div>
-        )}
-        <div className={isLoading ? "s-opacity-50" : ""}>{cardContent}</div>
-      </CardButton>
+      {cardButton}
     </Tooltip>
+  ) : (
+    cardButton
   );
 }


### PR DESCRIPTION
## Description

This PR aims at fixing the hover behaviour non clickable citations. They use to behave as if their clickable (change of opacity, brightness, pointer, ...) suggesting that something would occur on click.

We now rely on the optional `href` parameter of the citation to add behaviours on hover or not.

## Risk

UI breaking changes

## Deploy Plan

- Deploy `sparkle`
- Deploy `front`
