### PR TITLE
[front] - enh: bump @dust-tt/sparkle version

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,7 @@
         "@amplitude/analytics-browser": "^2.5.2",
         "@amplitude/analytics-node": "^1.3.5",
         "@auth0/nextjs-auth0": "^3.5.0",
-        "@dust-tt/sparkle": "^0.2.201",
+        "@dust-tt/sparkle": "^0.2.203",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -10735,9 +10735,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.201",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.201.tgz",
-      "integrity": "sha512-wE+dGQ9cgdRAiqCsw5UCw2ucLC5VGN/u9PyHFAClFraodfuTp5nuH/Dfn/Ht4fnNVQYOvIdn8gozH/aH/icONQ==",
+      "version": "0.2.203",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.203.tgz",
+      "integrity": "sha512-0sHBRnhbAoVppr5AuTMaJPypm2rAF3+18rGQQvFsG3+hhmZ8X+bqtLxkCtwXTv4VoMW45KcMwvvQWBRA3sfwig==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
     "@amplitude/analytics-browser": "^2.5.2",
     "@amplitude/analytics-node": "^1.3.5",
     "@auth0/nextjs-auth0": "^3.5.0",
-    "@dust-tt/sparkle": "^0.2.201",
+    "@dust-tt/sparkle": "^0.2.203",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -32,11 +32,11 @@ import {
   Ok,
   setupOAuthConnection,
 } from "@dust-tt/types";
+import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import type { InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import type { NextRouter } from "next/router";
 import { useRouter } from "next/router";
-import type { ComponentType } from "react";
 import { useRef } from "react";
 import { useContext, useEffect, useMemo, useState } from "react";
 import * as React from "react";
@@ -75,23 +75,20 @@ type DataSourceIntegration = {
   editedByUser: string | null;
 };
 
-type Info = {
-  row: {
-    original: {
-      icon: ComponentType;
-      name: string;
-      usage: number | null;
-      editedByUser: string | null;
-      connector: ConnectorType | null;
-      workspaceId: string | undefined;
-      dataSourceName: string | undefined;
-      isLoading: boolean;
-      isAdmin: boolean;
-      fetchConnectorError: boolean;
-      buttonOnClick: () => void;
-    };
-  };
+type RowData = DataSourceIntegration & {
+  isAdmin: boolean;
+  disabled: boolean;
+  isLoading: boolean;
+  readOnly: boolean;
+  dataSourceUrl: string;
+  workspaceId: string | undefined;
+  icon: (props: React.SVGProps<SVGSVGElement>) => React.JSX.Element;
+  buttonOnClick: () => void;
+  onClick?: () => void;
+  onMoreClick?: () => void;
 };
+
+type Info = CellContext<RowData, unknown>;
 
 type GetTableRowParams = {
   integration: DataSourceIntegration;
@@ -819,7 +816,7 @@ export default function DataSourcesView({
   );
 }
 
-function getTableColumns() {
+function getTableColumns(): ColumnDef<RowData, unknown>[] {
   return [
     {
       header: "Name",
@@ -922,7 +919,7 @@ function getTableRow({
   router,
   owner,
   readOnly,
-}: GetTableRowParams) {
+}: GetTableRowParams): RowData {
   const connectorProvider = integration.connectorProvider as ConnectorProvider;
   const isDisabled = isLoadingByProvider[connectorProvider] || !isAdmin;
 
@@ -942,7 +939,7 @@ function getTableRow({
     icon: LogoComponent,
     buttonOnClick,
     workspaceId: integration.connector?.workspaceId,
-    dataSourceName: integration.connector?.dataSourceName,
+    dataSourceName: integration.connector?.dataSourceName ?? null,
     dataSourceUrl: `/w/${owner.sId}/builder/data-sources/${integration.dataSourceName}`,
     isAdmin,
     readOnly,


### PR DESCRIPTION
## Description

This PR aims at bumping the `sparkle` version used in `front`.

The latest `sparkle` changes should mainly include:
- enhance the `DataTable` component to hide columns some screens (won't affect `front` as this require an extra parameter)
- enhance the `Citation` component to not behave as clickable when there's no "href" provided.

**References:**
- https://github.com/dust-tt/dust/pull/6697
- https://github.com/dust-tt/dust/pull/6680

## Risk

Breaking UI changes

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
