### PR TITLE
delete datasource configs when deleting data source

### DIFF
--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -11,6 +11,7 @@ import { getMembers } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import { sendGithubDeletionEmail } from "@app/lib/email";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
 import logger from "@app/logger/logger";
 import { launchScrubDataSourceWorkflow } from "@app/poke/temporal/client";
 
@@ -186,7 +187,9 @@ export async function deleteDataSource(
     }
   }
 
-  await dataSource.delete(auth);
+  await frontSequelize.transaction(async (t) => {
+    await dataSource.delete(auth, t);
+  });
 
   await launchScrubDataSourceWorkflow({
     wId: owner.sId,

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -14,6 +14,7 @@ import type {
 import { Op } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
+import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
 import { DataSource } from "@app/lib/models/data_source";
 import { User } from "@app/lib/models/user";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -150,8 +151,15 @@ export class DataSourceResource extends ResourceWithVault<DataSource> {
     auth: Authenticator,
     transaction?: Transaction
   ): Promise<Result<undefined, Error>> {
+    await AgentDataSourceConfiguration.destroy({
+      where: {
+        dataSourceId: this.id,
+      },
+      transaction,
+    });
+
     if (this.isManaged()) {
-      await DataSourceViewResource.deleteForDataSource(auth, this);
+      await DataSourceViewResource.deleteForDataSource(auth, this, transaction);
     }
 
     try {

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -106,6 +106,17 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
     });
   }
 
+  static async listForDataSource(
+    auth: Authenticator,
+    dataSource: DataSourceResource
+  ) {
+    return this.baseFetchWithAuthorization(auth, {
+      where: {
+        dataSourceId: dataSource.id,
+      },
+    });
+  }
+
   static async fetchById(auth: Authenticator, id: string) {
     const fileModelId = getResourceIdFromSId(id);
     if (!fileModelId) {
@@ -164,13 +175,15 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
 
   static async deleteForDataSource(
     auth: Authenticator,
-    dataSource: DataSourceResource
+    dataSource: DataSourceResource,
+    transaction?: Transaction
   ) {
     return this.model.destroy({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
         dataSourceId: dataSource.id,
       },
+      transaction,
     });
   }
 


### PR DESCRIPTION
## Description

https://github.com/dust-tt/tasks/issues/1136

Deleting a data source view doesn't work when there are data source configs that depend on it.
When deleting a data source we should:
- do it in a tx (since we do deletes on several tables)
- delete the data source configs before attempting to delete the views

## Risk

N/A

## Deploy Plan

N/A