### PR TITLE
Fetch data source view in agent configuration

### DIFF
--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -225,6 +225,8 @@ export default function AssistantBuilderDataSourceModal({
                         ...currentConfigurations,
                         [ds.name]: {
                           dataSource: ds,
+                          // TODO(GROUPS_INFRA) Replace with DataSourceViewType once the UI has it.
+                          dataSourceViewId: null,
                           selectedResources: [],
                           isSelectAll: true,
                         },

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -73,7 +73,9 @@ export async function buildInitialActions({
             const dataSource = dataSourcesByName[ds.dataSourceName];
             if (!dataSource.connectorId || !ds.resources) {
               return {
-                dataSource: dataSource,
+                dataSource,
+                // TODO(GROUPS_INFRA) Replace with DataSourceViewType once the UI has it.
+                dataSourceViewId: null,
                 selectedResources: [],
                 isSelectAll: ds.isSelectAll,
               };
@@ -92,7 +94,9 @@ export async function buildInitialActions({
             }
 
             return {
-              dataSource: dataSource,
+              dataSource,
+              // TODO(GROUPS_INFRA) Replace with DataSourceViewType once the UI has it.
+              dataSourceViewId: null,
               selectedResources: response.value.nodes,
               isSelectAll: ds.isSelectAll,
             };

--- a/front/components/assistant_builder/submitAssistantBuilderForm.ts
+++ b/front/components/assistant_builder/submitAssistantBuilderForm.ts
@@ -84,6 +84,8 @@ export async function submitAssistantBuilderForm({
               a.configuration.dataSourceConfigurations
             ).map(({ dataSource, selectedResources, isSelectAll }) => ({
               dataSourceId: dataSource.name,
+              // TODO(GROUPS_INFRA) Replace with DataSourceViewType once the UI has it.
+              dataSourceViewId: null,
               workspaceId: owner.sId,
               filter: {
                 parents: !isSelectAll
@@ -150,6 +152,8 @@ export async function submitAssistantBuilderForm({
               a.configuration.dataSourceConfigurations
             ).map(({ dataSource, selectedResources, isSelectAll }) => ({
               dataSourceId: dataSource.name,
+              // TODO(GROUPS_INFRA) Replace with DataSourceViewType once the UI has it.
+              dataSourceViewId: null,
               workspaceId: owner.sId,
               filter: {
                 parents: !isSelectAll

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -38,6 +38,8 @@ export const ACTION_MODES = [
 
 export type AssistantBuilderDataSourceConfiguration = {
   dataSource: DataSourceType;
+  // TODO(GROUPS_INFRA) Replace with DataSourceViewType once the UI has it.
+  dataSourceViewId: null;
   selectedResources: ContentNode[];
   isSelectAll: boolean;
 };

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -37,8 +37,8 @@ import {
   DEFAULT_TABLES_QUERY_ACTION_NAME,
   DEFAULT_WEBSEARCH_ACTION_NAME,
 } from "@app/lib/api/assistant/actions/names";
-import { fetchAgentProcessConfigurationsActions } from "@app/lib/api/assistant/configuration/process";
-import { fetchAgentRetrievalConfigurationsActions } from "@app/lib/api/assistant/configuration/retrieval";
+import { fetchAgentProcessActionsConfigurations } from "@app/lib/api/assistant/configuration/process";
+import { fetchAgentRetrievalActionsConfigurations } from "@app/lib/api/assistant/configuration/retrieval";
 import {
   getGlobalAgents,
   isGlobalAgentId,
@@ -461,13 +461,13 @@ async function fetchWorkspaceAgentConfigurationsForView(
     : Promise.resolve([]);
 
   const [
-    retrievalConfigurationsActions,
-    processConfigurationsActions,
+    retrievalActionsConfigurationsPerAgent,
+    processActionsConfigurationsPerAgent,
     agentTablesConfigurationTables,
     dustApps,
   ] = await Promise.all([
-    fetchAgentRetrievalConfigurationsActions({ configurationIds, variant }),
-    fetchAgentProcessConfigurationsActions({ configurationIds, variant }),
+    fetchAgentRetrievalActionsConfigurations({ configurationIds, variant }),
+    fetchAgentProcessActionsConfigurations({ configurationIds, variant }),
     agentTablesQueryConfigurationTablesPromise,
     dustAppsPromise,
   ]);
@@ -477,10 +477,10 @@ async function fetchWorkspaceAgentConfigurationsForView(
     const actions: AgentActionConfigurationType[] = [];
 
     if (variant === "full") {
-      const retrievalActions =
-        retrievalConfigurationsActions.get(agent.id) ?? [];
+      const retrievalActionsConfigurations =
+        retrievalActionsConfigurationsPerAgent.get(agent.id) ?? [];
 
-      actions.push(...retrievalActions);
+      actions.push(...retrievalActionsConfigurations);
 
       const dustAppRunConfigurations = dustAppRunConfigs[agent.id] ?? [];
       for (const dustAppRunConfig of dustAppRunConfigurations) {
@@ -544,9 +544,10 @@ async function fetchWorkspaceAgentConfigurationsForView(
         });
       }
 
-      const processActions = processConfigurationsActions.get(agent.id) ?? [];
+      const processActionConfigurations =
+        processActionsConfigurationsPerAgent.get(agent.id) ?? [];
 
-      actions.push(...processActions);
+      actions.push(...processActionConfigurations);
     }
 
     let template: TemplateResource | null = null;

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -37,12 +37,12 @@ import {
   DEFAULT_TABLES_QUERY_ACTION_NAME,
   DEFAULT_WEBSEARCH_ACTION_NAME,
 } from "@app/lib/api/assistant/actions/names";
-import { fetchBrowseActionsConfigurations } from "@app/lib/api/assistant/configuration/browse";
-import { fetchDustAppRunActionsConfigurations } from "@app/lib/api/assistant/configuration/dust_app_run";
-import { fetchAgentProcessActionsConfigurations } from "@app/lib/api/assistant/configuration/process";
-import { fetchAgentRetrievalActionsConfigurations } from "@app/lib/api/assistant/configuration/retrieval";
-import { fetchTableQueryActionsConfigurations } from "@app/lib/api/assistant/configuration/table_query";
-import { fetchWebsearchActionsConfigurations } from "@app/lib/api/assistant/configuration/websearch";
+import { fetchBrowseActionConfigurations } from "@app/lib/api/assistant/configuration/browse";
+import { fetchDustAppRunActionConfigurations } from "@app/lib/api/assistant/configuration/dust_app_run";
+import { fetchAgentProcessActionConfigurations } from "@app/lib/api/assistant/configuration/process";
+import { fetchAgentRetrievalActionConfigurations } from "@app/lib/api/assistant/configuration/retrieval";
+import { fetchTableQueryActionConfigurations } from "@app/lib/api/assistant/configuration/table_query";
+import { fetchWebsearchActionConfigurations } from "@app/lib/api/assistant/configuration/websearch";
 import {
   getGlobalAgents,
   isGlobalAgentId,
@@ -387,12 +387,12 @@ async function fetchWorkspaceAgentConfigurationsForView(
     browseActionsConfigurationsPerAgent,
     agentUserRelations,
   ] = await Promise.all([
-    fetchAgentRetrievalActionsConfigurations({ configurationIds, variant }),
-    fetchAgentProcessActionsConfigurations({ configurationIds, variant }),
-    fetchDustAppRunActionsConfigurations({ configurationIds, variant }),
-    fetchTableQueryActionsConfigurations({ configurationIds, variant }),
-    fetchWebsearchActionsConfigurations({ configurationIds, variant }),
-    fetchBrowseActionsConfigurations({ configurationIds, variant }),
+    fetchAgentRetrievalActionConfigurations({ configurationIds, variant }),
+    fetchAgentProcessActionConfigurations({ configurationIds, variant }),
+    fetchDustAppRunActionConfigurations({ configurationIds, variant }),
+    fetchTableQueryActionConfigurations({ configurationIds, variant }),
+    fetchWebsearchActionConfigurations({ configurationIds, variant }),
+    fetchBrowseActionConfigurations({ configurationIds, variant }),
     user && configurationIds.length > 0
       ? AgentUserRelation.findAll({
           where: {

--- a/front/lib/api/assistant/configuration/browse.ts
+++ b/front/lib/api/assistant/configuration/browse.ts
@@ -4,7 +4,7 @@ import { Op } from "sequelize";
 import { DEFAULT_BROWSE_ACTION_NAME } from "@app/lib/api/assistant/actions/names";
 import { AgentBrowseConfiguration } from "@app/lib/models/assistant/actions/browse";
 
-export async function fetchBrowseActionsConfigurations({
+export async function fetchBrowseActionConfigurations({
   configurationIds,
   variant,
 }: {

--- a/front/lib/api/assistant/configuration/browse.ts
+++ b/front/lib/api/assistant/configuration/browse.ts
@@ -1,0 +1,52 @@
+import type { BrowseConfigurationType, ModelId } from "@dust-tt/types";
+import _ from "lodash";
+import { Op } from "sequelize";
+
+import { DEFAULT_BROWSE_ACTION_NAME } from "@app/lib/api/assistant/actions/names";
+import { AgentBrowseConfiguration } from "@app/lib/models/assistant/actions/browse";
+
+export async function fetchBrowseActionsConfigurations({
+  configurationIds,
+  variant,
+}: {
+  configurationIds: ModelId[];
+  variant: "light" | "full";
+}): Promise<Map<ModelId, BrowseConfigurationType[]>> {
+  if (variant !== "full") {
+    return new Map();
+  }
+
+  const browseConfigurations = await AgentBrowseConfiguration.findAll({
+    where: { agentConfigurationId: { [Op.in]: configurationIds } },
+  });
+
+  if (browseConfigurations.length === 0) {
+    return new Map();
+  }
+
+  const groupedBrowseConfigurations = _.groupBy(
+    browseConfigurations,
+    "agentConfigurationId"
+  );
+
+  const actionsByConfigurationId: Map<ModelId, BrowseConfigurationType[]> =
+    new Map();
+  for (const [agentConfigurationId, configs] of Object.entries(
+    groupedBrowseConfigurations
+  )) {
+    const actions: BrowseConfigurationType[] = [];
+    for (const c of configs) {
+      actions.push({
+        id: c.id,
+        sId: c.sId,
+        type: "browse_configuration",
+        name: c.name || DEFAULT_BROWSE_ACTION_NAME,
+        description: c.description,
+      });
+    }
+
+    actionsByConfigurationId.set(parseInt(agentConfigurationId, 10), actions);
+  }
+
+  return actionsByConfigurationId;
+}

--- a/front/lib/api/assistant/configuration/dust_app_run.ts
+++ b/front/lib/api/assistant/configuration/dust_app_run.ts
@@ -1,0 +1,70 @@
+import type { DustAppRunConfigurationType, ModelId } from "@dust-tt/types";
+import _ from "lodash";
+import { Op } from "sequelize";
+
+import { App } from "@app/lib/models/apps";
+import { AgentDustAppRunConfiguration } from "@app/lib/models/assistant/actions/dust_app_run";
+
+export async function fetchDustAppRunActionsConfigurations({
+  configurationIds,
+  variant,
+}: {
+  configurationIds: ModelId[];
+  variant: "light" | "full";
+}): Promise<Map<ModelId, DustAppRunConfigurationType[]>> {
+  if (variant !== "full") {
+    return new Map();
+  }
+
+  const dustAppRunConfigurations = await AgentDustAppRunConfiguration.findAll({
+    where: { agentConfigurationId: { [Op.in]: configurationIds } },
+  });
+
+  if (dustAppRunConfigurations.length === 0) {
+    return new Map();
+  }
+
+  const dustApps = await App.findAll({
+    where: {
+      sId: {
+        [Op.in]: dustAppRunConfigurations.map((c) => c.appId),
+      },
+    },
+  });
+
+  const groupedDustAppRunConfigurations = _.groupBy(
+    dustAppRunConfigurations,
+    "agentConfigurationId"
+  );
+
+  const actionsByConfigurationId: Map<ModelId, DustAppRunConfigurationType[]> =
+    new Map();
+  for (const [agentConfigurationId, configs] of Object.entries(
+    groupedDustAppRunConfigurations
+  )) {
+    const actions: DustAppRunConfigurationType[] = [];
+    for (const c of configs) {
+      const dustApp = dustApps.find((app) => app.sId === c.appId);
+
+      if (!dustApp) {
+        // unreachable
+        throw new Error(
+          `Couldn't find dust app for dust app run configuration ${c.id}`
+        );
+      }
+      actions.push({
+        id: c.id,
+        sId: c.sId,
+        type: "dust_app_run_configuration",
+        appWorkspaceId: c.appWorkspaceId,
+        appId: c.appId,
+        name: dustApp.name,
+        description: dustApp.description,
+      });
+    }
+
+    actionsByConfigurationId.set(parseInt(agentConfigurationId, 10), actions);
+  }
+
+  return actionsByConfigurationId;
+}

--- a/front/lib/api/assistant/configuration/dust_app_run.ts
+++ b/front/lib/api/assistant/configuration/dust_app_run.ts
@@ -5,7 +5,7 @@ import { Op } from "sequelize";
 import { App } from "@app/lib/models/apps";
 import { AgentDustAppRunConfiguration } from "@app/lib/models/assistant/actions/dust_app_run";
 
-export async function fetchDustAppRunActionsConfigurations({
+export async function fetchDustAppRunActionConfigurations({
   configurationIds,
   variant,
 }: {

--- a/front/lib/api/assistant/configuration/helpers.ts
+++ b/front/lib/api/assistant/configuration/helpers.ts
@@ -1,0 +1,23 @@
+import type { RetrievalTimeframe } from "@dust-tt/types";
+
+import type { AgentProcessConfiguration } from "@app/lib/models/assistant/actions/process";
+import type { AgentRetrievalConfiguration } from "@app/lib/models/assistant/actions/retrieval";
+
+export function renderRetrievalTimeframeType(
+  action: AgentRetrievalConfiguration | AgentProcessConfiguration
+) {
+  let timeframe: RetrievalTimeframe = "auto";
+  if (
+    action.relativeTimeFrame === "custom" &&
+    action.relativeTimeFrameDuration &&
+    action.relativeTimeFrameUnit
+  ) {
+    timeframe = {
+      duration: action.relativeTimeFrameDuration,
+      unit: action.relativeTimeFrameUnit,
+    };
+  } else if (action.relativeTimeFrame === "none") {
+    timeframe = "none";
+  }
+  return timeframe;
+}

--- a/front/lib/api/assistant/configuration/process.ts
+++ b/front/lib/api/assistant/configuration/process.ts
@@ -15,7 +15,7 @@ import { Workspace } from "@app/lib/models/workspace";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 
-export async function fetchAgentProcessConfigurationsActions({
+export async function fetchAgentProcessActionsConfigurations({
   configurationIds,
   variant,
 }: {

--- a/front/lib/api/assistant/configuration/process.ts
+++ b/front/lib/api/assistant/configuration/process.ts
@@ -27,11 +27,11 @@ export async function fetchAgentProcessActionsConfigurations({
   }
 
   // Find the process configurations for the given agent configurations.
-  const processConfigurationIds = await AgentProcessConfiguration.findAll({
+  const processConfiguration = await AgentProcessConfiguration.findAll({
     where: { agentConfigurationId: { [Op.in]: configurationIds } },
   });
 
-  if (processConfigurationIds.length === 0) {
+  if (processConfiguration.length === 0) {
     return new Map();
   }
 
@@ -40,7 +40,7 @@ export async function fetchAgentProcessActionsConfigurations({
     await AgentDataSourceConfiguration.findAll({
       where: {
         processConfigurationId: {
-          [Op.in]: processConfigurationIds.map((r) => r.id),
+          [Op.in]: processConfiguration.map((r) => r.id),
         },
       },
       include: [
@@ -77,7 +77,7 @@ export async function fetchAgentProcessActionsConfigurations({
   );
 
   const groupedAgentProcessConfigurations = _.groupBy(
-    processConfigurationIds,
+    processConfiguration,
     "agentConfigurationId"
   );
 

--- a/front/lib/api/assistant/configuration/process.ts
+++ b/front/lib/api/assistant/configuration/process.ts
@@ -15,7 +15,7 @@ import { Workspace } from "@app/lib/models/workspace";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 
-export async function fetchAgentProcessActionsConfigurations({
+export async function fetchAgentProcessActionConfigurations({
   configurationIds,
   variant,
 }: {

--- a/front/lib/api/assistant/configuration/retrieval.ts
+++ b/front/lib/api/assistant/configuration/retrieval.ts
@@ -27,11 +27,11 @@ export async function fetchAgentRetrievalActionsConfigurations({
   }
 
   // Find the retrieval configurations for the given agent configurations.
-  const retrievalConfigurationIds = await AgentRetrievalConfiguration.findAll({
+  const retrievalConfigurations = await AgentRetrievalConfiguration.findAll({
     where: { agentConfigurationId: { [Op.in]: configurationIds } },
   });
 
-  if (retrievalConfigurationIds.length === 0) {
+  if (retrievalConfigurations.length === 0) {
     return new Map();
   }
 
@@ -40,7 +40,7 @@ export async function fetchAgentRetrievalActionsConfigurations({
     await AgentDataSourceConfiguration.findAll({
       where: {
         retrievalConfigurationId: {
-          [Op.in]: retrievalConfigurationIds.map((r) => r.id),
+          [Op.in]: retrievalConfigurations.map((r) => r.id),
         },
       },
       include: [
@@ -77,7 +77,7 @@ export async function fetchAgentRetrievalActionsConfigurations({
   );
 
   const groupedAgentRetrievalConfigurations = _.groupBy(
-    retrievalConfigurationIds,
+    retrievalConfigurations,
     "agentConfigurationId"
   );
 

--- a/front/lib/api/assistant/configuration/retrieval.ts
+++ b/front/lib/api/assistant/configuration/retrieval.ts
@@ -1,0 +1,157 @@
+import type { AgentActionConfigurationType, ModelId } from "@dust-tt/types";
+import _ from "lodash";
+import { Op } from "sequelize";
+
+import { DEFAULT_RETRIEVAL_ACTION_NAME } from "@app/lib/api/assistant/actions/names";
+import { renderRetrievalTimeframeType } from "@app/lib/api/assistant/configuration/helpers";
+import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
+import { AgentRetrievalConfiguration } from "@app/lib/models/assistant/actions/retrieval";
+import { DataSource } from "@app/lib/models/data_source";
+import { Workspace } from "@app/lib/models/workspace";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
+
+function groupByAgentConfigurationId<
+  T extends { agentConfigurationId: number },
+>(list: T[]): Record<number, T[]> {
+  return _.groupBy(list, "agentConfigurationId");
+}
+
+export async function fetchAgentRetrievalConfigurationsActions({
+  configurationIds,
+  variant,
+}: {
+  configurationIds: ModelId[];
+  variant: "light" | "full";
+}): Promise<Map<ModelId, AgentActionConfigurationType[]>> {
+  if (variant !== "full") {
+    return new Map();
+  }
+
+  // Find the retrieval configurations for the given agent configurations.
+  const retrievalConfigurationIds = await AgentRetrievalConfiguration.findAll({
+    where: { agentConfigurationId: { [Op.in]: configurationIds } },
+  });
+
+  if (retrievalConfigurationIds.length === 0) {
+    return new Map();
+  }
+
+  // Find the associated data sources configurations.
+  const retrievalDatasourceConfigurations =
+    await AgentDataSourceConfiguration.findAll({
+      where: {
+        retrievalConfigurationId: {
+          [Op.in]: retrievalConfigurationIds.map((r) => r.id),
+        },
+      },
+      include: [
+        {
+          model: DataSource,
+          as: "dataSource",
+          include: [
+            {
+              model: Workspace,
+              as: "workspace",
+            },
+          ],
+        },
+        {
+          model: DataSourceViewModel,
+          as: "dataSourceView",
+          include: [
+            {
+              model: Workspace,
+              as: "workspace",
+            },
+          ],
+        },
+      ],
+    });
+
+  const groupedRetrievalDatasourceConfigurations = _.groupBy(
+    retrievalDatasourceConfigurations,
+    "retrievalConfigurationId"
+  );
+
+  const groupedAgentRetrievalConfigurations = groupByAgentConfigurationId(
+    retrievalConfigurationIds
+  );
+
+  const actionsByConfigurationId: Map<ModelId, AgentActionConfigurationType[]> =
+    new Map();
+  for (const [agentConfigurationId, retrievalConfiguration] of Object.entries(
+    groupedAgentRetrievalConfigurations
+  )) {
+    const actions: AgentActionConfigurationType[] = [];
+    for (const retrievalConfig of retrievalConfiguration) {
+      const dataSourceConfig =
+        groupedRetrievalDatasourceConfigurations[retrievalConfig.id] ?? [];
+
+      let topK: number | "auto" = "auto";
+      if (retrievalConfig.topKMode === "custom") {
+        if (!retrievalConfig.topK) {
+          // unreachable
+          throw new Error(
+            `Couldn't find topK for retrieval configuration ${retrievalConfig.id}} with 'custom' topK mode`
+          );
+        }
+
+        topK = retrievalConfig.topK;
+      }
+
+      actions.push({
+        id: retrievalConfig.id,
+        sId: retrievalConfig.sId,
+        type: "retrieval_configuration",
+        query: retrievalConfig.query,
+        relativeTimeFrame: renderRetrievalTimeframeType(retrievalConfig),
+        topK,
+        dataSources: dataSourceConfig.map(getDataSource),
+        name: retrievalConfig.name || DEFAULT_RETRIEVAL_ACTION_NAME,
+        description: retrievalConfig.description,
+      });
+    }
+
+    actionsByConfigurationId.set(parseInt(agentConfigurationId, 10), actions);
+  }
+
+  return actionsByConfigurationId;
+}
+
+function getDataSource(dataSourceConfig: AgentDataSourceConfiguration) {
+  const { dataSourceView, dataSource } = dataSourceConfig;
+
+  if (dataSourceView) {
+    return {
+      dataSourceId: DataSourceViewResource.modelIdToSId({
+        id: dataSourceView.id,
+        workspaceId: dataSourceView.workspaceId,
+      }),
+      workspaceId: dataSourceView.workspace.sId,
+      filter: {
+        parents:
+          dataSourceConfig.parentsIn && dataSourceConfig.parentsNotIn
+            ? {
+                in: dataSourceConfig.parentsIn,
+                not: dataSourceConfig.parentsNotIn,
+              }
+            : null,
+      },
+    };
+  }
+
+  return {
+    dataSourceId: dataSource.name,
+    workspaceId: dataSource.workspace.sId,
+    filter: {
+      parents:
+        dataSourceConfig.parentsIn && dataSourceConfig.parentsNotIn
+          ? {
+              in: dataSourceConfig.parentsIn,
+              not: dataSourceConfig.parentsNotIn,
+            }
+          : null,
+    },
+  };
+}

--- a/front/lib/api/assistant/configuration/retrieval.ts
+++ b/front/lib/api/assistant/configuration/retrieval.ts
@@ -15,7 +15,7 @@ import { Workspace } from "@app/lib/models/workspace";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 
-export async function fetchAgentRetrievalConfigurationsActions({
+export async function fetchAgentRetrievalActionsConfigurations({
   configurationIds,
   variant,
 }: {

--- a/front/lib/api/assistant/configuration/retrieval.ts
+++ b/front/lib/api/assistant/configuration/retrieval.ts
@@ -15,7 +15,7 @@ import { Workspace } from "@app/lib/models/workspace";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 
-export async function fetchAgentRetrievalActionsConfigurations({
+export async function fetchAgentRetrievalActionConfigurations({
   configurationIds,
   variant,
 }: {

--- a/front/lib/api/assistant/configuration/retrieval.ts
+++ b/front/lib/api/assistant/configuration/retrieval.ts
@@ -1,4 +1,8 @@
-import type { AgentActionConfigurationType, ModelId } from "@dust-tt/types";
+import type {
+  AgentActionConfigurationType,
+  DataSourceConfiguration,
+  ModelId,
+} from "@dust-tt/types";
 import _ from "lodash";
 import { Op } from "sequelize";
 
@@ -64,6 +68,10 @@ export async function fetchAgentRetrievalConfigurationsActions({
               model: Workspace,
               as: "workspace",
             },
+            {
+              model: DataSource,
+              as: "dataSourceForView",
+            },
           ],
         },
       ],
@@ -119,15 +127,18 @@ export async function fetchAgentRetrievalConfigurationsActions({
   return actionsByConfigurationId;
 }
 
-function getDataSource(dataSourceConfig: AgentDataSourceConfiguration) {
+function getDataSource(
+  dataSourceConfig: AgentDataSourceConfiguration
+): DataSourceConfiguration {
   const { dataSourceView, dataSource } = dataSourceConfig;
 
   if (dataSourceView) {
     return {
-      dataSourceId: DataSourceViewResource.modelIdToSId({
+      dataSourceViewId: DataSourceViewResource.modelIdToSId({
         id: dataSourceView.id,
         workspaceId: dataSourceView.workspaceId,
       }),
+      dataSourceId: dataSourceView.dataSourceForView.name,
       workspaceId: dataSourceView.workspace.sId,
       filter: {
         parents:
@@ -143,6 +154,7 @@ function getDataSource(dataSourceConfig: AgentDataSourceConfiguration) {
 
   return {
     dataSourceId: dataSource.name,
+    dataSourceViewId: null,
     workspaceId: dataSource.workspace.sId,
     filter: {
       parents:

--- a/front/lib/api/assistant/configuration/table_query.ts
+++ b/front/lib/api/assistant/configuration/table_query.ts
@@ -1,0 +1,79 @@
+import type { ModelId, TablesQueryConfigurationType } from "@dust-tt/types";
+import _ from "lodash";
+import { Op } from "sequelize";
+
+import { DEFAULT_TABLES_QUERY_ACTION_NAME } from "@app/lib/api/assistant/actions/names";
+import {
+  AgentTablesQueryConfiguration,
+  AgentTablesQueryConfigurationTable,
+} from "@app/lib/models/assistant/actions/tables_query";
+
+export async function fetchTableQueryActionsConfigurations({
+  configurationIds,
+  variant,
+}: {
+  configurationIds: ModelId[];
+  variant: "light" | "full";
+}): Promise<Map<ModelId, TablesQueryConfigurationType[]>> {
+  if (variant !== "full") {
+    return new Map();
+  }
+
+  const tableQueryConfigurations = await AgentTablesQueryConfiguration.findAll({
+    where: {
+      agentConfigurationId: { [Op.in]: configurationIds },
+    },
+  });
+
+  if (tableQueryConfigurations.length === 0) {
+    return new Map();
+  }
+
+  const agentTablesQueryConfigurationTables =
+    await AgentTablesQueryConfigurationTable.findAll({
+      where: {
+        tablesQueryConfigurationId: {
+          [Op.in]: tableQueryConfigurations.map((r) => r.id),
+        },
+      },
+    });
+
+  const groupedAgentTablesQueryConfigurationTables = _.groupBy(
+    agentTablesQueryConfigurationTables,
+    "tablesQueryConfigurationId"
+  );
+
+  const groupedTableQueryConfigurations = _.groupBy(
+    tableQueryConfigurations,
+    "agentConfigurationId"
+  );
+
+  const actionsByConfigurationId: Map<ModelId, TablesQueryConfigurationType[]> =
+    new Map();
+  for (const [agentConfigurationId, configs] of Object.entries(
+    groupedTableQueryConfigurations
+  )) {
+    const actions: TablesQueryConfigurationType[] = [];
+    for (const c of configs) {
+      const tablesQueryConfigTables =
+        groupedAgentTablesQueryConfigurationTables[c.id] ?? [];
+
+      actions.push({
+        id: c.id,
+        sId: c.sId,
+        type: "tables_query_configuration",
+        tables: tablesQueryConfigTables.map((tablesQueryConfigTable) => ({
+          dataSourceId: tablesQueryConfigTable.dataSourceId,
+          workspaceId: tablesQueryConfigTable.dataSourceWorkspaceId,
+          tableId: tablesQueryConfigTable.tableId,
+        })),
+        name: c.name || DEFAULT_TABLES_QUERY_ACTION_NAME,
+        description: c.description,
+      });
+    }
+
+    actionsByConfigurationId.set(parseInt(agentConfigurationId, 10), actions);
+  }
+
+  return actionsByConfigurationId;
+}

--- a/front/lib/api/assistant/configuration/table_query.ts
+++ b/front/lib/api/assistant/configuration/table_query.ts
@@ -8,7 +8,7 @@ import {
   AgentTablesQueryConfigurationTable,
 } from "@app/lib/models/assistant/actions/tables_query";
 
-export async function fetchTableQueryActionsConfigurations({
+export async function fetchTableQueryActionConfigurations({
   configurationIds,
   variant,
 }: {

--- a/front/lib/api/assistant/configuration/websearch.ts
+++ b/front/lib/api/assistant/configuration/websearch.ts
@@ -1,0 +1,52 @@
+import type { ModelId, WebsearchConfigurationType } from "@dust-tt/types";
+import _ from "lodash";
+import { Op } from "sequelize";
+
+import { DEFAULT_WEBSEARCH_ACTION_NAME } from "@app/lib/api/assistant/actions/names";
+import { AgentWebsearchConfiguration } from "@app/lib/models/assistant/actions/websearch";
+
+export async function fetchWebsearchActionsConfigurations({
+  configurationIds,
+  variant,
+}: {
+  configurationIds: ModelId[];
+  variant: "light" | "full";
+}): Promise<Map<ModelId, WebsearchConfigurationType[]>> {
+  if (variant !== "full") {
+    return new Map();
+  }
+
+  const websearchConfigurations = await AgentWebsearchConfiguration.findAll({
+    where: { agentConfigurationId: { [Op.in]: configurationIds } },
+  });
+
+  if (websearchConfigurations.length === 0) {
+    return new Map();
+  }
+
+  const groupedWebsearchConfigurations = _.groupBy(
+    websearchConfigurations,
+    "agentConfigurationId"
+  );
+
+  const actionsByConfigurationId: Map<ModelId, WebsearchConfigurationType[]> =
+    new Map();
+  for (const [agentConfigurationId, configs] of Object.entries(
+    groupedWebsearchConfigurations
+  )) {
+    const actions: WebsearchConfigurationType[] = [];
+    for (const c of configs) {
+      actions.push({
+        id: c.id,
+        sId: c.sId,
+        type: "websearch_configuration",
+        name: c.name || DEFAULT_WEBSEARCH_ACTION_NAME,
+        description: c.description,
+      });
+    }
+
+    actionsByConfigurationId.set(parseInt(agentConfigurationId, 10), actions);
+  }
+
+  return actionsByConfigurationId;
+}

--- a/front/lib/api/assistant/configuration/websearch.ts
+++ b/front/lib/api/assistant/configuration/websearch.ts
@@ -4,7 +4,7 @@ import { Op } from "sequelize";
 import { DEFAULT_WEBSEARCH_ACTION_NAME } from "@app/lib/api/assistant/actions/names";
 import { AgentWebsearchConfiguration } from "@app/lib/models/assistant/actions/websearch";
 
-export async function fetchWebsearchActionsConfigurations({
+export async function fetchWebsearchActionConfigurations({
   configurationIds,
   variant,
 }: {

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -690,8 +690,10 @@ function _getManagedDataSourceAgent(
         query: "auto",
         relativeTimeFrame: "auto",
         topK: "auto",
+        // TODO(GROUPS_INFRA) Prefetch data source views for managed data sources.
         dataSources: filteredDataSources.map((ds) => ({
           dataSourceId: ds.name,
+          dataSourceViewId: null,
           workspaceId: preFetchedDataSources.workspaceId,
           filter: { tags: null, parents: null },
         })),
@@ -948,8 +950,10 @@ The assistant always respects the mardown format and generates spaces to nest co
       query: "auto",
       relativeTimeFrame: "auto",
       topK: "auto",
+      // TODO(GROUPS_INFRA) Prefetch data source views for managed data sources.
       dataSources: dataSources.map((ds) => ({
         dataSourceId: ds.name,
+        dataSourceViewId: null,
         workspaceId: preFetchedDataSources.workspaceId,
         filter: { parents: null },
       })),
@@ -980,7 +984,9 @@ The assistant always respects the mardown format and generates spaces to nest co
           topK: "auto",
           dataSources: [
             {
+              // TODO(GROUPS_INFRA) Prefetch data source views for managed data sources.
               dataSourceId: ds.name,
+              dataSourceViewId: null,
               workspaceId: preFetchedDataSources.workspaceId,
               filter: { parents: null },
             },

--- a/front/lib/models/assistant/actions/data_sources.ts
+++ b/front/lib/models/assistant/actions/data_sources.ts
@@ -40,6 +40,7 @@ export class AgentDataSourceConfiguration extends Model<
   > | null;
 
   declare dataSource: NonAttribute<DataSource>;
+  declare dataSourceView: NonAttribute<DataSourceViewModel>;
 }
 AgentDataSourceConfiguration.init(
   {
@@ -119,9 +120,11 @@ AgentDataSourceConfiguration.belongsTo(DataSource, {
 
 // Data source config <> Data source view
 DataSourceViewModel.hasMany(AgentDataSourceConfiguration, {
+  as: "dataSourceView",
   foreignKey: { allowNull: true },
   onDelete: "CASCADE",
 });
 AgentDataSourceConfiguration.belongsTo(DataSourceViewModel, {
+  as: "dataSourceView",
   foreignKey: { allowNull: false },
 });

--- a/types/src/front/api_handlers/internal/agent_configuration.ts
+++ b/types/src/front/api_handlers/internal/agent_configuration.ts
@@ -62,6 +62,7 @@ const RetrievalActionConfigurationSchema = t.type({
   dataSources: t.array(
     t.type({
       dataSourceId: t.string,
+      dataSourceViewId: t.union([t.string, t.null]),
       workspaceId: t.string,
       filter: t.type({
         parents: t.union([
@@ -106,6 +107,7 @@ const ProcessActionConfigurationSchema = t.type({
   dataSources: t.array(
     t.type({
       dataSourceId: t.string,
+      dataSourceViewId: t.union([t.string, t.null]),
       workspaceId: t.string,
       filter: t.type({
         parents: t.union([

--- a/types/src/front/assistant/actions/retrieval.ts
+++ b/types/src/front/assistant/actions/retrieval.ts
@@ -35,6 +35,7 @@ export type DataSourceFilter = {
 export type DataSourceConfiguration = {
   workspaceId: string;
   dataSourceId: string;
+  dataSourceViewId: string | null;
   filter: DataSourceFilter;
 };
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR refactors the fetch agent configuration. Now, we fetch all data sources and any associated data source views for both retrieval and process action configurations. This change is necessary to pass these data source views to the core when performing any of these actions. Data source views are essential for conditioning access to a data source when reading documents from it. The code that calls core will be modified in a subsequent PR.

Additionally, I started splitting the fetch agent configuration code by action, with each file corresponding to a specific action’s fetch logic. Parallelization is still maintained. To keep the same "latency" we should move all the actions fetching logic to this pattern.

I left several TODOs since the UI is not yet aware of data source views. **However, considering that the types are shared for both posting a configuration and fetching, this PR will break the builder UI for users currently on it. Given the current load, this should be manageable.** 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Safe to rollback.

## Deploy Plan

No SQL migration, only some stuff to please Sequelize.
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
