### PR TITLE
Fetch associated data sources when retrieving data source view

### DIFF
--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -104,6 +104,14 @@ export class DataSourceResource extends ResourceWithVault<DataSource> {
     return dataSource ?? null;
   }
 
+  static async fetchByModelIds(auth: Authenticator, ids: ModelId[]) {
+    return this.baseFetchWithAuthorization(auth, {
+      where: {
+        id: ids,
+      },
+    });
+  }
+
   static async listByWorkspace(
     auth: Authenticator,
     options?: FetchDataSourceOptions

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -7,7 +7,7 @@ import type {
   ModelId,
   Result,
 } from "@dust-tt/types";
-import { Err, Ok } from "@dust-tt/types";
+import { Err, Ok, removeNulls } from "@dust-tt/types";
 import type {
   Attributes,
   CreationAttributes,
@@ -17,6 +17,7 @@ import type {
 
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import type { ResourceFindOptions } from "@app/lib/resources/resource_with_vault";
 import { ResourceWithVault } from "@app/lib/resources/resource_with_vault";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
@@ -33,6 +34,8 @@ export interface DataSourceViewResource
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class DataSourceViewResource extends ResourceWithVault<DataSourceViewModel> {
   static model: ModelStatic<DataSourceViewModel> = DataSourceViewModel;
+
+  private ds?: DataSourceResource;
 
   constructor(
     model: ModelStatic<DataSourceViewModel>,
@@ -89,8 +92,33 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
 
   // Fetching.
 
+  private static async baseFetch(
+    auth: Authenticator,
+    options?: ResourceFindOptions<DataSourceViewModel>
+  ) {
+    const dataSourceViews = await this.baseFetchWithAuthorization(
+      auth,
+      options
+    );
+
+    const dataSourceIds = removeNulls(
+      dataSourceViews.map((ds) => ds.dataSourceId)
+    );
+
+    const dataSources = await DataSourceResource.fetchByModelIds(
+      auth,
+      dataSourceIds
+    );
+
+    for (const dsv of dataSourceViews) {
+      dsv.ds = dataSources.find((ds) => ds.id === dsv.dataSourceId);
+    }
+
+    return dataSourceViews;
+  }
+
   static async listByWorkspace(auth: Authenticator) {
-    return this.baseFetchWithAuthorization(auth);
+    return this.baseFetch(auth);
   }
 
   static async listForDataSourcesInVault(
@@ -98,7 +126,7 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
     dataSources: DataSourceResource[],
     vault: VaultResource
   ) {
-    return this.baseFetchWithAuthorization(auth, {
+    return this.baseFetch(auth, {
       where: {
         dataSourceId: dataSources.map((ds) => ds.id),
         vaultId: vault.id,
@@ -112,7 +140,7 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
       return null;
     }
 
-    const [dataSource] = await this.baseFetchWithAuthorization(auth, {
+    const [dataSource] = await this.baseFetch(auth, {
       where: {
         id: fileModelId,
       },
@@ -174,6 +202,12 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
     });
   }
 
+  // Getters.
+
+  get dataSource(): DataSourceResource | undefined {
+    return this.ds;
+  }
+
   // sId logic.
 
   get sId(): string {
@@ -200,7 +234,7 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
     return isResourceSId("data_source_view", sId);
   }
 
-  // Serialization logic.
+  // Serialization.
 
   toJSON(): DataSourceViewType {
     return {

--- a/front/lib/resources/storage/models/data_source_view.ts
+++ b/front/lib/resources/storage/models/data_source_view.ts
@@ -26,8 +26,9 @@ export class DataSourceViewModel extends Model<
   declare vaultId: ForeignKey<VaultModel["id"]>;
   declare workspaceId: ForeignKey<Workspace["id"]>;
 
-  declare dataSource: NonAttribute<DataSource>;
+  declare dataSourceForView: NonAttribute<DataSource>;
   declare vault: NonAttribute<VaultModel>;
+  declare workspace: NonAttribute<Workspace>;
 }
 DataSourceViewModel.init(
   {
@@ -65,13 +66,20 @@ Workspace.hasMany(DataSourceViewModel, {
   foreignKey: { allowNull: false },
   onDelete: "RESTRICT",
 });
+DataSourceViewModel.belongsTo(Workspace);
+
 VaultModel.hasMany(DataSourceViewModel, {
   foreignKey: { allowNull: false },
   onDelete: "RESTRICT",
 });
 DataSourceViewModel.belongsTo(VaultModel);
+
 DataSource.hasMany(DataSourceViewModel, {
-  foreignKey: { allowNull: false },
+  as: "dataSourceForView",
+  foreignKey: { name: "dataSourceId", allowNull: false },
   onDelete: "RESTRICT",
 });
-DataSourceViewModel.belongsTo(DataSource);
+DataSourceViewModel.belongsTo(DataSource, {
+  as: "dataSourceForView",
+  foreignKey: { name: "dataSourceId", allowNull: false },
+});

--- a/types/src/front/data_source.ts
+++ b/types/src/front/data_source.ts
@@ -32,6 +32,10 @@ export type EditedByUser = {
   userId: string | null;
 };
 
+export interface DataSourceOrViewType {
+  sId: string;
+}
+
 export type DataSourceType = {
   id: ModelId;
   createdAt: number;

--- a/types/src/front/data_source.ts
+++ b/types/src/front/data_source.ts
@@ -32,10 +32,6 @@ export type EditedByUser = {
   userId: string | null;
 };
 
-export interface DataSourceOrViewType {
-  sId: string;
-}
-
 export type DataSourceType = {
   id: ModelId;
   createdAt: number;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
As we proceed with Vault, we've decided against unifying everything under the `DataSourceView` concept. Instead, we need a generic common interface that can represent both a data source and a data source view. This approach is essential to maintain simplicity in the UI rendering logic for these entities.

This PR marks the first step towards this goal. It includes fetching the data source along with the data source view, paving the way for the introduction of a `toDataSourceOrViewJSON` method.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
It adds extra queries when fetching data source view, will monitor the impact. Safe to rollback.

## Deploy Plan

There is not DB changes, only some Sequelize logic 🤯.
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
