### PR TITLE
Upg: only sync newly added folders for google drive

### DIFF
--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -517,9 +517,8 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
       );
     }
 
-    let shouldFullSync = false;
+    const addedFolderIds: string[] = [];
     for (const [id, permission] of Object.entries(permissions)) {
-      shouldFullSync = true;
       if (permission === "none") {
         await GoogleDriveFolders.destroy({
           where: {
@@ -528,6 +527,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
           },
         });
       } else if (permission === "read") {
+        addedFolderIds.push(id);
         await GoogleDriveFolders.upsert({
           connectorId: this.connectorId,
           folderId: id,
@@ -539,10 +539,11 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
       }
     }
 
-    if (shouldFullSync) {
+    if (addedFolderIds.length > 0) {
       const res = await launchGoogleDriveFullSyncWorkflow(
         this.connectorId,
-        null
+        null,
+        addedFolderIds
       );
       if (res.isErr()) {
         return res;

--- a/connectors/src/connectors/google_drive/temporal/client.ts
+++ b/connectors/src/connectors/google_drive/temporal/client.ts
@@ -26,8 +26,8 @@ const logger = mainLogger.child({ provider: "google" });
 export async function launchGoogleDriveFullSyncWorkflow(
   connectorId: ModelId,
   fromTs: number | null,
-  mimeTypeFilter?: string[],
-  addedFolderIds?: string[]
+  addedFolderIds: string[],
+  mimeTypeFilter?: string[]
 ): Promise<Result<string, Error>> {
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
@@ -45,7 +45,7 @@ export async function launchGoogleDriveFullSyncWorkflow(
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
 
   const signalArgs: FolderUpdatesSignal[] =
-    addedFolderIds?.map((sId) => ({
+    addedFolderIds.map((sId) => ({
       action: "added",
       folderId: sId,
     })) ?? [];

--- a/connectors/src/connectors/google_drive/temporal/signals.ts
+++ b/connectors/src/connectors/google_drive/temporal/signals.ts
@@ -1,0 +1,9 @@
+import { defineSignal } from "@temporalio/workflow";
+
+export interface FolderUpdatesSignal {
+  action: "added" | "removed";
+  folderId: string;
+}
+
+export const folderUpdatesSignal =
+  defineSignal<[FolderUpdatesSignal[]]>("folderUpdateSignal");

--- a/connectors/src/connectors/google_drive/temporal/worker.ts
+++ b/connectors/src/connectors/google_drive/temporal/worker.ts
@@ -1,5 +1,6 @@
 import type { Context } from "@temporalio/activity";
 import { Worker } from "@temporalio/worker";
+import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 
 import * as activities from "@connectors/connectors/google_drive/temporal/activities";
 import { GoogleDriveCastKnownErrorsInterceptor } from "@connectors/connectors/google_drive/temporal/cast_known_errors";
@@ -31,6 +32,15 @@ export async function runGoogleWorkers() {
         },
         () => new GoogleDriveCastKnownErrorsInterceptor(),
       ],
+    },
+    bundlerOptions: {
+      // Update the webpack config to use aliases from our tsconfig.json.
+      webpackConfigHook: (config) => {
+        const plugins = config.resolve?.plugins ?? [];
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        config.resolve!.plugins = [...plugins, new TsconfigPathsPlugin({})];
+        return config;
+      },
     },
   });
 

--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -48,14 +48,14 @@ const { reportInitialSyncProgress, syncSucceeded } = proxyActivities<
 export async function googleDriveFullSync({
   connectorId,
   garbageCollect = true,
-  foldersToBrowse = undefined,
+  foldersToBrowse = [],
   totalCount = 0,
   startSyncTs = undefined,
   mimeTypeFilter,
 }: {
   connectorId: ModelId;
   garbageCollect: boolean;
-  foldersToBrowse: string[] | undefined;
+  foldersToBrowse: string[];
   totalCount: number;
   startSyncTs: number | undefined;
   mimeTypeFilter?: string[];
@@ -68,7 +68,7 @@ export async function googleDriveFullSync({
   if (startSyncTs === undefined) {
     startSyncTs = new Date().getTime();
   }
-  if (foldersToBrowse === undefined) {
+  if (!foldersToBrowse) {
     foldersToBrowse = await getFoldersToSync(connectorId);
   }
 
@@ -77,14 +77,14 @@ export async function googleDriveFullSync({
     for (const { action, folderId } of folderUpdates) {
       switch (action) {
         case "added":
-          foldersToBrowse!.push(folderId);
+          foldersToBrowse.push(folderId);
           break;
         case "removed":
-          foldersToBrowse!.splice(foldersToBrowse!.indexOf(folderId), 1);
+          foldersToBrowse.splice(foldersToBrowse.indexOf(folderId), 1);
           break;
         default:
           assertNever(
-            "You must handle all values of the variable: action",
+            `Unexpected signal action ${action} received for Google Drive full sync workflow.`,
             action
           );
       }


### PR DESCRIPTION
## Description

Allow Google Drive connector to only sync the newly added folders when permissions are updated. Inspired a lot by the same feature in the Confluence connector ;-)

## Risk

The behavior was changed so now if we only remove folders, no full sync is triggered, meaning we rely on the garbage collector to remove the dangling items.
If there is a bug, we might break Google sync in prod.

## Deploy Plan

Deploy `connectors`.