### PR TITLE
fix: temporarily switch @dust global agent to openAi

### DIFF
--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -861,9 +861,12 @@ function _getDustGlobalAgent(
   const pictureUrl = "https://dust.tt/static/systemavatar/dust_avatar_full.png";
 
   const modelConfiguration = (() => {
-    // If we can use Sonnet 3.5, we use it. Otherwise we use the default model.
-    if (auth.isUpgraded() && isProviderWhitelisted(owner, "anthropic")) {
-      return CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG;
+    // // If we can use Sonnet 3.5, we use it. Otherwise we use the default model.
+    // if (auth.isUpgraded() && isProviderWhitelisted(owner, "anthropic")) {
+    //   return CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG;
+    // }
+    if (auth.isUpgraded() && isProviderWhitelisted(owner, "openai")) {
+      return GPT_4O_MODEL_CONFIG;
     }
     return auth.isUpgraded()
       ? getLargeWhitelistedModel(owner)


### PR DESCRIPTION
## Description

There is an outage at Anthropic, causing a lot of requests to `@dust` (powered by Claude 3.5 sonnet) to fail.

This PR temporarily switches the model used by `@dust` to GPT4o

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
