### PR TITLE
[front] fix: set id as in parents for unmanaged tables

### DIFF
--- a/core/src/stores/migrations/20240809_backfill_unconnected_tables.sql
+++ b/core/src/stores/migrations/20240809_backfill_unconnected_tables.sql
@@ -1,0 +1,5 @@
+UPDATE "tables"
+SET
+    "parents" = ARRAY["table_id"]
+WHERE
+    array_length(parents, 1) is null;

--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
@@ -157,7 +157,7 @@ export async function handlePostTableCsvUpsertRequest(
   }
 
   const tableId = bodyValidation.right.tableId ?? generateLegacyModelSId();
-  const tableParents: string[] = bodyValidation.right.parents || [];
+  const tableParents: string[] = bodyValidation.right.parents ?? [];
 
   if (!tableParents.includes(tableId)) {
     tableParents.push(tableId);
@@ -185,7 +185,7 @@ export async function handlePostTableCsvUpsertRequest(
         tableName: name,
         tableDescription: description,
         tableTimestamp: bodyValidation.right.timestamp ?? null,
-        tableTags: bodyValidation.right.tags || [],
+        tableTags: bodyValidation.right.tags ?? [],
         tableParents,
         csv: csv ?? null,
         truncate,

--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
@@ -155,7 +155,13 @@ export async function handlePostTableCsvUpsertRequest(
       status_code: 400,
     });
   }
+
   const tableId = bodyValidation.right.tableId ?? generateLegacyModelSId();
+  const tableParents: string[] = bodyValidation.right.parents || [];
+
+  if (!tableParents.includes(tableId)) {
+    tableParents.push(tableId);
+  }
 
   if (async) {
     // Ensure the CSV is valid before enqueuing the upsert.
@@ -180,7 +186,7 @@ export async function handlePostTableCsvUpsertRequest(
         tableDescription: description,
         tableTimestamp: bodyValidation.right.timestamp ?? null,
         tableTags: bodyValidation.right.tags || [],
-        tableParents: bodyValidation.right.parents || [],
+        tableParents,
         csv: csv ?? null,
         truncate,
       },
@@ -216,7 +222,7 @@ export async function handlePostTableCsvUpsertRequest(
     tableDescription: description,
     tableTimestamp: bodyValidation.right.timestamp ?? null,
     tableTags: bodyValidation.right.tags || [],
-    tableParents: bodyValidation.right.parents || [],
+    tableParents,
     csv: csv ?? null,
     truncate,
   });


### PR DESCRIPTION
## Description

Put the table in parents list.
Backfill remaining tables in core

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy `front`
run migration script 