### PR TITLE
[front] fix: Remove duplicate constraint

### DIFF
--- a/front/migrations/db/migration_56.sql
+++ b/front/migrations/db/migration_56.sql
@@ -1,2 +1,8 @@
 ALTER TABLE "agent_data_source_configurations"
-DROP CONSTRAINT "agent_data_source_configurations_dataSourceViewId_fkey";
+DROP CONSTRAINT IF EXISTS "agent_data_source_configurations_dataSourceViewId_fkey";
+
+ALTER TABLE "agent_data_source_configurations"
+DROP CONSTRAINT IF EXISTS "agent_data_source_configurations_dataSourceViewId_fkey1";
+
+ALTER TABLE "agent_data_source_configurations"
+ADD FOREIGN KEY ("dataSourceViewId") REFERENCES "data_source_views" ("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/front/migrations/db/migration_56.sql
+++ b/front/migrations/db/migration_56.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "agent_data_source_configurations"
+DROP CONSTRAINT "agent_data_source_configurations_dataSourceViewId_fkey";


### PR DESCRIPTION
## Description

This remove the foreign key constraint from agent_data_source_configurations to data_source_views with on delete restrict. We keep only the on delete cascade one.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
