### PR TITLE
Upg: improve builder UX when using a template for instructions

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -377,6 +377,10 @@ export default function AssistantBuilder({
     screen,
   ]);
 
+  const [doTypewriterEffect, setDoTypewriterEffect] = useState(
+    template !== null && builderState.instructions
+  );
+
   const modalTitle = agentConfigurationId
     ? `Edit @${builderState.handle}`
     : "New Assistant";
@@ -454,6 +458,8 @@ export default function AssistantBuilder({
                         resetAt={instructionsResetAt}
                         isUsingTemplate={template !== null}
                         instructionsError={instructionsError}
+                        doTypewriterEffect={doTypewriterEffect}
+                        setDoTypewriterEffect={setDoTypewriterEffect}
                       />
                     );
                   case "actions":

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -378,7 +378,7 @@ export default function AssistantBuilder({
   ]);
 
   const [doTypewriterEffect, setDoTypewriterEffect] = useState(
-    template !== null && builderState.instructions
+    Boolean(template !== null && builderState.instructions)
   );
 
   const modalTitle = agentConfigurationId

--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -150,6 +150,8 @@ export function InstructionScreen({
 
   const [letterIndex, setLetterIndex] = useState(0);
 
+  // Beware that using this useEffect will cause a lot of re-rendering until we finished the visual effect
+  // We must be careful to avoid any heavy rendering in this component
   useEffect(() => {
     if (doTypewriterEffect && editor && builderState.instructions) {
       // Get the text from content and strip HTML tags for simplicity and being able to write letter by letter


### PR DESCRIPTION
## Description

Animate as a typewriter the instructions for an assistant when using a template, then focus on it and put cursor at the end.

In respect to [this comment](https://github.com/dust-tt/dust/pull/6722#discussion_r1711185660) we investigated a bit more and found a couple things:
- `editor` from `useEditor` will mutate (eg: as part of hook dependencies) on content change ([doc](https://tiptap.dev/docs/guides/performance))
- even when using an extension with a lower access to the input component, it still mutate.
- hence, useMemo() (such as for `xxxEditorService`) will probably not do what we expect.
- other solutions to achieve the typewriter effect will not work for multi-lines content (we cannot access individual letters)

We decided to keep the implementation like that for now and revisit later.

https://github.com/user-attachments/assets/1c676de1-271d-49ff-bbbd-f48a43e42106

## Risk

A bug could led the input box to be uneditable.

## Deploy Plan

Deploy `front`