### PR TITLE
Flav/pass data source view id to core

### DIFF
--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -432,17 +432,31 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
       DustProdActionRegistry["assistant-v2-retrieval"].config
     );
 
+    // Transform each data source in actionConfiguration.dataSources by adding a
+    // `dataSourceOrViewId` field. This field will hold the value of `dataSourceViewId`
+    // if it exists; otherwise, it will fall back to `dataSourceId`
+    const actionConfigurationDataSources = actionConfiguration.dataSources.map(
+      (d) => {
+        const { dataSourceViewId, dataSourceId, ...rest } = d;
+        return {
+          ...rest,
+          // We use dataSourceViewId if it exists, otherwise dataSourceId.
+          dataSourceOrViewId: dataSourceViewId ?? dataSourceId,
+        };
+      }
+    );
+
     // Handle data sources list and parents/tags filtering.
-    config.DATASOURCE.data_sources = actionConfiguration.dataSources.map(
+    config.DATASOURCE.data_sources = actionConfigurationDataSources.map(
       (d) => ({
         workspace_id: isDevelopment()
           ? PRODUCTION_DUST_WORKSPACE_ID
           : d.workspaceId,
-        data_source_id: d.dataSourceId,
+        data_source_id: d.dataSourceOrViewId,
       })
     );
 
-    for (const ds of actionConfiguration.dataSources) {
+    for (const ds of actionConfigurationDataSources) {
       // Not: empty array in parents/tags.in means "no document match" since no documents has any
       // tags/parents that is in the empty array.
       if (!config.DATASOURCE.filter.parents) {
@@ -452,7 +466,7 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
         if (!config.DATASOURCE.filter.parents.in_map) {
           config.DATASOURCE.filter.parents.in_map = {};
         }
-        config.DATASOURCE.filter.parents.in_map[ds.dataSourceId] =
+        config.DATASOURCE.filter.parents.in_map[ds.dataSourceOrViewId] =
           ds.filter.parents.in;
       }
       if (ds.filter.parents?.not) {
@@ -520,8 +534,8 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
     // want `core` to return the `workspace_id` that was used eventualy.
     // TODO(spolu): make `core` return data source workspace id.
     const dataSourcesIdToWorkspaceId: { [key: string]: string } = {};
-    for (const ds of actionConfiguration.dataSources) {
-      dataSourcesIdToWorkspaceId[ds.dataSourceId] = ds.workspaceId;
+    for (const ds of actionConfigurationDataSources) {
+      dataSourcesIdToWorkspaceId[ds.dataSourceOrViewId] = ds.workspaceId;
     }
 
     for await (const event of eventStream) {
@@ -571,6 +585,7 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
           return;
         }
 
+        // TODO(GROUPS_INFRA): Map the data source of the retrieved documents to the data source view.
         if (event.content.block_name === "DATASOURCE" && e.value) {
           const v = e.value as {
             data_source_id: string;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow-up on https://github.com/dust-tt/dust/pull/6708. This PR ensures that either `dataSourceViewId` or `dataSourceId` (if no view is present) is passed to the core for both retrieval and process actions. Successfully tested locally, see config output below. The retrieved documents will continue to use the data sources in all cases. We will implement a mapping to the associated data source view once the appropriate endpoints are available.

Example config output:
```json
{
  "DATASOURCE": {
    "data_sources": [
      {
        "workspace_id": "AgtPVuhCPc",
        "data_source_id": "dsv_Q8Ac4uf35L"
      }
    ],
    "top_k": 32,
    "filter": {
      "tags": null,
      "parents": {
        "in_map": {
          "dsv_Q8Ac4uf35L": [
            "14iqOnj8T4-FHywPrYoYy53RF02fVx0ux"
          ]
        },
        "not": []
      },
      "timestamp": null
    },
    "use_cache": false
  }
}
```

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Worst case it breaks the retrieval logic. The registry lookup is still pretty flexible. Will monitor from [here](https://app.datadoghq.eu/logs?query=%22No%20access%20to%20data%20source.%22%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAZEkMETsI3_-kwAAAAAAAAAYAAAAAEFaRWtNRV9rQUFEeEUwZzdfMm9yLWdBTwAAACQAAAAAMDE5MTI0MzAtNGU2Mi00ZWE0LThhZWUtMTA4OTUzY2M4ZDk2&fromUser=true&index=%2A&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&view=spans&viz=stream&from_ts=1722883386219&to_ts=1722884286219&live=true).

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
