### PR TITLE
Pass datasource view id to core

### DIFF
--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -258,7 +258,10 @@ export class ProcessConfigurationServerRunner extends BaseActionConfigurationSer
         workspace_id: isDevelopment()
           ? PRODUCTION_DUST_WORKSPACE_ID
           : d.workspaceId,
-        data_source_id: d.dataSourceId,
+
+        // Use dataSourceViewId if it exists; otherwise, use dataSourceId.
+        // Note: This value is passed to the registry for lookup.
+        data_source_id: d.dataSourceViewId ?? d.dataSourceId,
       })
     );
 
@@ -283,6 +286,9 @@ export class ProcessConfigurationServerRunner extends BaseActionConfigurationSer
         if (!config.DATASOURCE.filter.parents.in_map) {
           config.DATASOURCE.filter.parents.in_map = {};
         }
+
+        // Note: We use dataSourceId here because after the registry lookup,
+        // it returns either the data source itself or the data source associated with the data source view.
         config.DATASOURCE.filter.parents.in_map[ds.dataSourceId] =
           ds.filter.parents.in;
       }

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -438,7 +438,9 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
         workspace_id: isDevelopment()
           ? PRODUCTION_DUST_WORKSPACE_ID
           : d.workspaceId,
-        data_source_id: d.dataSourceId,
+        // Use dataSourceViewId if it exists; otherwise, use dataSourceId.
+        // Note: This value is passed to the registry for lookup.
+        data_source_id: d.dataSourceViewId ?? d.dataSourceId,
       })
     );
 
@@ -452,6 +454,9 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
         if (!config.DATASOURCE.filter.parents.in_map) {
           config.DATASOURCE.filter.parents.in_map = {};
         }
+
+        // Note: We use dataSourceId here because after the registry lookup,
+        // it returns either the data source itself or the data source associated with the data source view.
         config.DATASOURCE.filter.parents.in_map[ds.dataSourceId] =
           ds.filter.parents.in;
       }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Take 2 of https://github.com/dust-tt/dust/pull/6726.

The initial attempt did not work as expected for the following reason: we pass the dataSourceViewId, if present in the dataSources configuration, along with the filter mapping (in_map). The filter mapping, which represents the assistant-selected files, is always applied at the data source level. This occurs once the call to `get_data_source_project_and_view_filter` is made, which returns the data source id or associated data source id and any view filter parent restrictions (if any). In the previous PR, since the mapping sometimes included the data source view id, none of the assistant file filters were actually applied.

https://github.com/dust-tt/dust/blob/739dbb4a3abb982573f3ec9401cd9dbd388e767e/core/src/blocks/data_source.rs#L84-L119

With this new PR, we now have this config payload:
```json
{
  "DATASOURCE": {
    "data_sources": [
      {
        "workspace_id": "0ec9852c2f",
        "data_source_id": "dsv_Q8Ac4uf35L"
      }
    ],
    "top_k": 32,
    "filter": {
      "tags": null,
      "parents": {
        "in_map": {
          "managed-google_drive": [
            "14iqOnj8T4-FHywPrYoYy53RF02fVx0ux"
          ]
        },
        "not": []
      },
      "timestamp": null
    },
    "use_cache": false
  }
}
```

Which gives the following Qdrant query (with parent filters + data source filter):
```
Filter { should: [], must: [Condition { condition_one_of: Some(Field(FieldCondition { key: "parents", r#match: Some(Match { match_value: Some(Keywords(RepeatedStrings { strings: ["14iqOnj8T4-FHywPrYoYy53RF02fVx0ux"] })) }), range: None, geo_bounding_box: None, geo_radius: None, values_count: None, geo_polygon: None, datetime_range: None })) }, Condition { condition_one_of: Some(Field(FieldCondition { key: "data_source_internal_id", r#match: Some(Match { match_value: Some(Keyword("c750afb23c189929281f5c052bb701271e8a65f5eab7635760211f307fb989d1")) }), range: None, geo_bounding_box: None, geo_radius: None, values_count: None, geo_polygon: None, datetime_range: None })) }], must_not: [Condition { condition_one_of: Some(Field(FieldCondition { key: "parents", r#match: Some(Match { match_value: Some(Keywords(RepeatedStrings { strings: [] })) }), range: None, geo_bounding_box: None, geo_radius: None, values_count: None, geo_polygon: None, datetime_range: None })) }], min_should: None }
```

With the faulty PR we were not passing assistant parent ids filter only the data source filter:
```
Filter { should: [], must: [Condition { condition_one_of: Some(Field(FieldCondition { key: "data_source_internal_id", r#match: Some(Match { match_value: Some(Keyword("c750afb23c189929281f5c052bb701271e8a65f5eab7635760211f307fb989d1")) }), range: None, geo_bounding_box: None, geo_radius: None, values_count: None, geo_polygon: None, datetime_range: None })) }], must_not: [Condition { condition_one_of: Some(Field(FieldCondition { key: "parents", r#match: Some(Match { match_value: Some(Keywords(RepeatedStrings { strings: [] })) }), range: None, geo_bounding_box: None, geo_radius: None, values_count: None, geo_polygon: None, datetime_range: None })) }], min_should: None }
```

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
