### PR TITLE
fix(transcripts): reload conversation object after uploading CF

### DIFF
--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -6,8 +6,6 @@ import {
 } from "@dust-tt/sparkle";
 import type { UserType, WorkspaceType } from "@dust-tt/types";
 
-import { isDevelopmentOrDustWorkspace } from "@app/lib/development";
-
 export function UserMenu({
   user,
   owner,
@@ -15,9 +13,9 @@ export function UserMenu({
   user: UserType;
   owner: WorkspaceType;
 }) {
-  const hasBetaAccess =
-    owner.flags.some((flag: string) => flag.startsWith("labs_")) ||
-    isDevelopmentOrDustWorkspace(owner);
+  const hasBetaAccess = owner.flags.some((flag: string) =>
+    flag.startsWith("labs_")
+  );
 
   return (
     <DropdownMenu>
@@ -39,8 +37,7 @@ export function UserMenu({
         {hasBetaAccess && (
           <>
             <DropdownMenu.SectionHeader label="Beta" />
-            {(owner.flags.includes("labs_transcripts") ||
-              isDevelopmentOrDustWorkspace(owner)) && (
+            {owner.flags.includes("labs_transcripts") && (
               <DropdownMenu.Item
                 label="Transcripts processing"
                 href={`/w/${owner.sId}/assistant/labs/transcripts`}


### PR DESCRIPTION
## Description

since https://github.com/dust-tt/dust/pull/6323, when processing meeting transcripts we create a conversation and we then insert a content fragment into it. 
But we don't reload the conversation, which means we hold onto a `ConversationType` that doesn't include the content fragment. 

This fully breaks the meeting transcripts feature.

## Risk

N/A

## Deploy Plan

N/A