### PR TITLE
[front] - fix: update button icon on data source management

### DIFF
--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -742,9 +742,9 @@ export default function DataSourcesView({
             <DropdownMenu>
               <DropdownMenu.Button>
                 <Button
-                  label="Add Connection"
+                  label="Add Connections"
                   variant="primary"
-                  icon={CloudArrowLeftRightIcon}
+                  icon={PlusIcon}
                   size="sm"
                 />
               </DropdownMenu.Button>


### PR DESCRIPTION
## Description

This PR aims at changing the icon of the "Add Connections" button in the connection management screen when no connection has been set up yet.

**References:**
- https://github.com/dust-tt/dust/issues/6737

## Risk

None

## Deploy Plan

Deploy `front`