### PR TITLE
[front] - feat(vaults): vault creation modal

### DIFF
--- a/front/components/vaults/CreateVaultModal.tsx
+++ b/front/components/vaults/CreateVaultModal.tsx
@@ -62,13 +62,24 @@ function getTableColumns(
       id: "action",
       cell: (info: Info) => {
         const isSelected = selectedMembers.includes(info.row.original.userId);
+        if (isSelected) {
+          return (
+            <Button
+              label="Remove"
+              onClick={() => handleMemberToggle(info.row.original.userId)}
+              variant="tertiary"
+              size="sm"
+              icon={MinusIcon}
+            />
+          );
+        }
         return (
           <Button
-            label={isSelected ? "Remove" : "Add"}
+            label="Add"
             onClick={() => handleMemberToggle(info.row.original.userId)}
-            variant={isSelected ? "tertiary" : "secondary"}
+            variant="secondary"
             size="sm"
-            icon={isSelected ? MinusIcon : PlusIcon}
+            icon={PlusIcon}
           />
         );
       },
@@ -150,6 +161,14 @@ export function CreateVaultModal({
             description: "Vault was successfully created.",
           });
         } catch (err) {
+          if ((err as Error).message === "This vault name is already used.") {
+            sendNotification({
+              type: "error",
+              title: "Vault name is already used.",
+              description: "Please choose a different vault name",
+            });
+            return;
+          }
           logger.error(
             {
               workspaceId: owner.id,

--- a/front/components/vaults/CreateVaultModal.tsx
+++ b/front/components/vaults/CreateVaultModal.tsx
@@ -15,6 +15,7 @@ import { MinusIcon } from "lucide-react";
 import React, { useCallback, useContext, useMemo, useState } from "react";
 
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
+import logger from "@app/logger/logger";
 
 type RowData = {
   icon: string;
@@ -112,7 +113,7 @@ export function CreateVaultModal({
         },
         body: JSON.stringify({
           name: vaultName,
-          memberIds: selectedMembers,
+          members: selectedMembers,
         }),
       });
 
@@ -128,10 +129,7 @@ export function CreateVaultModal({
     }
   };
 
-  const rows = useMemo(
-    () => getTableRows(allUsers),
-    [allUsers]
-  );
+  const rows = useMemo(() => getTableRows(allUsers), [allUsers]);
 
   const columns = useMemo(
     () => getTableColumns(selectedMembers, handleMemberToggle),
@@ -155,7 +153,14 @@ export function CreateVaultModal({
             title: "Successfully created vault",
             description: "Vault was successfully created.",
           });
-        } catch (e) {
+        } catch (err) {
+          logger.error(
+            {
+              workspaceId: owner.id,
+              error: err,
+            },
+            "Error creating vault"
+          );
           sendNotification({
             type: "error",
             title: "Failed to create vault",

--- a/front/components/vaults/CreateVaultModal.tsx
+++ b/front/components/vaults/CreateVaultModal.tsx
@@ -51,8 +51,6 @@ function getTableColumns(
 ): ColumnDef<RowData, unknown>[] {
   return [
     {
-      header: "Name",
-      accessorKey: "name",
       id: "name",
       cell: (info: Info) => (
         <DataTable.Cell avatarUrl={info.row.original.icon}>

--- a/front/components/vaults/CreateVaultModal.tsx
+++ b/front/components/vaults/CreateVaultModal.tsx
@@ -1,0 +1,201 @@
+import {
+  Button,
+  DataTable,
+  Icon,
+  Input,
+  Modal,
+  Page,
+  PlusIcon,
+  Searchbar,
+} from "@dust-tt/sparkle";
+import type { UserType, WorkspaceType } from "@dust-tt/types";
+import { InformationCircleIcon } from "@heroicons/react/20/solid";
+import type { CellContext, ColumnDef } from "@tanstack/react-table";
+import { MinusIcon } from "lucide-react";
+import React, { useCallback, useContext, useMemo, useState } from "react";
+
+import { SendNotificationsContext } from "@app/components/sparkle/Notification";
+
+type RowData = {
+  icon: string;
+  name: string;
+  userId: string;
+  onClick?: () => void;
+  onMoreClick?: () => void;
+};
+
+type Info = CellContext<RowData, unknown>;
+
+interface CreateVaultModalProps {
+  owner: WorkspaceType;
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: () => void;
+  allUsers: UserType[];
+}
+
+function getTableRows(allUsers: UserType[]): RowData[] {
+  return allUsers.map((user) => {
+    return {
+      icon: user.image ?? "",
+      name: user.fullName,
+      userId: user.sId,
+    };
+  });
+}
+
+function getTableColumns(
+  selectedMembers: string[],
+  handleMemberToggle: (member: string) => void
+): ColumnDef<RowData, unknown>[] {
+  return [
+    {
+      header: "Name",
+      accessorKey: "name",
+      id: "name",
+      cell: (info: Info) => (
+        <DataTable.Cell avatarUrl={info.row.original.icon}>
+          {info.row.original.name}
+        </DataTable.Cell>
+      ),
+    },
+    {
+      id: "action",
+      cell: (info: Info) => {
+        const isSelected = selectedMembers.includes(info.row.original.userId);
+        return (
+          <Button
+            label={isSelected ? "Remove" : "Add"}
+            onClick={() => handleMemberToggle(info.row.original.userId)}
+            variant={isSelected ? "tertiary" : "secondary"}
+            size="sm"
+            icon={isSelected ? MinusIcon : PlusIcon}
+          />
+        );
+      },
+    },
+  ];
+}
+
+export function CreateVaultModal({
+  owner,
+  isOpen,
+  onClose,
+  onSave,
+  allUsers,
+}: CreateVaultModalProps) {
+  const [vaultName, setVaultName] = useState<string | null>(null);
+  const [selectedMembers, setSelectedMembers] = useState<string[]>([]);
+  const [searchTerm, setSearchTerm] = useState<string>("");
+  const [isSaving, setIsSaving] = useState(false);
+
+  const sendNotification = useContext(SendNotificationsContext);
+
+  const handleMemberToggle = useCallback((member: string) => {
+    setSelectedMembers((prevSelectedMembers) => {
+      const isCurrentlySelected = prevSelectedMembers.includes(member);
+      if (isCurrentlySelected) {
+        return prevSelectedMembers.filter((m) => m !== member);
+      } else {
+        return [...prevSelectedMembers, member];
+      }
+    });
+  }, []);
+
+  const createVault = async () => {
+    setIsSaving(true);
+    try {
+      const res = await fetch(`/api/w/${owner.sId}/vaults`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          name: vaultName,
+          memberIds: selectedMembers,
+        }),
+      });
+
+      if (!res.ok) {
+        const errorData = await res.json();
+        throw new Error(errorData.error?.message || "Failed to create vault");
+      }
+      onSave();
+      onClose();
+      return await res.json();
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const rows = useMemo(
+    () => getTableRows(allUsers),
+    [allUsers]
+  );
+
+  const columns = useMemo(
+    () => getTableColumns(selectedMembers, handleMemberToggle),
+    [selectedMembers, handleMemberToggle]
+  );
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Create a Vault"
+      saveLabel="Create"
+      variant="side-md"
+      hasChanged={!!vaultName && selectedMembers.length > 0}
+      isSaving={isSaving}
+      onSave={async () => {
+        try {
+          await createVault();
+          sendNotification({
+            type: "success",
+            title: "Successfully created vault",
+            description: "Vault was successfully created.",
+          });
+        } catch (e) {
+          sendNotification({
+            type: "error",
+            title: "Failed to create vault",
+            description:
+              "An unexpected error occurred while creating the vault.",
+          });
+        }
+      }}
+    >
+      <Page.Vertical gap="md">
+        <div className="mb-4 flex w-full max-w-xl flex-col gap-y-2 p-4">
+          <Page.SectionHeader title="Name" />
+          <Input
+            placeholder="Vault's name"
+            value={vaultName}
+            name="vaultName"
+            size="sm"
+            onChange={(value) => setVaultName(value)}
+          />
+          <div className="flex gap-1 text-xs text-element-700">
+            <Icon visual={InformationCircleIcon} size="xs" />
+            <span>Vault name must be unique</span>
+          </div>
+        </div>
+        <div className="flex w-full flex-col gap-y-4 border-t p-4">
+          <Page.SectionHeader title="Vault members" />
+          <Searchbar
+            name="search"
+            placeholder="Search members"
+            value={searchTerm}
+            onChange={setSearchTerm}
+          />
+          <DataTable
+            data={rows}
+            columns={columns}
+            filterColumn="name"
+            filter={searchTerm}
+          />
+        </div>
+      </Page.Vertical>
+    </Modal>
+  );
+}

--- a/front/components/vaults/CreateVaultModal.tsx
+++ b/front/components/vaults/CreateVaultModal.tsx
@@ -121,8 +121,6 @@ export function CreateVaultModal({
         const errorData = await res.json();
         throw new Error(errorData.error?.message || "Failed to create vault");
       }
-      onSave();
-      onClose();
       return await res.json();
     } finally {
       setIsSaving(false);
@@ -168,6 +166,7 @@ export function CreateVaultModal({
               "An unexpected error occurred while creating the vault.",
           });
         }
+        onSave();
       }}
     >
       <Page.Vertical gap="md">


### PR DESCRIPTION
## Description

This PR introduces a new vault creation modal.

The modal allows users to create new vaults. This feature is part of the ongoing implementation of the Groups and Vaults infrastructure.

<img width="1035" alt="Screenshot 2024-08-12 at 17 39 59" src="https://github.com/user-attachments/assets/b5852628-d5d3-434d-b935-78a7d4f2fb33">

**References:**
- [Figma](https://www.figma.com/design/QOxHwppG64GtPocpDhS6Y7/Product?node-id=8551-64599&t=pahGNV47MBfOd8Nz-0)
- https://github.com/dust-tt/dust/issues/6744

## Risk

N/A

## Deploy Plan

N/A