### PR TITLE
Data source / vaults navigation

### DIFF
--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -129,7 +129,7 @@ export const getTopNavigationTabs = (owner: WorkspaceType) => {
       id: "data_sources",
       label: "Data sources",
       icon: BookOpenIcon,
-      href: `/w/${owner.sId}/data-sources/vaults/global`,
+      href: `/w/${owner.sId}/data-sources/vaults`,
       isCurrent: (currentRoute: string) =>
         currentRoute.startsWith("/w/[wId]/data-sources/vaults/"),
       sizing: "expand",

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -1,4 +1,5 @@
 import {
+  BookOpenIcon,
   ChatBubbleLeftRightIcon,
   CloudArrowLeftRightIcon,
   Cog6ToothIcon,
@@ -22,7 +23,11 @@ import { UsersIcon } from "@heroicons/react/20/solid";
  * ones for the topNavigation (same across the whole app) and for the subNavigation which appears in
  * some section of the app in the AppLayout navigation panel.
  */
-export type TopNavigationId = "conversations" | "assistants" | "admin";
+export type TopNavigationId =
+  | "conversations"
+  | "assistants"
+  | "admin"
+  | "data_sources";
 
 export type SubNavigationConversationsId =
   | "conversation"
@@ -118,6 +123,19 @@ export const getTopNavigationTabs = (owner: WorkspaceType) => {
       sizing: "expand",
     });
   }
+
+  if (owner.flags.includes("data_vaults_feature")) {
+    nav.push({
+      id: "data_sources",
+      label: "Data sources",
+      icon: BookOpenIcon,
+      href: `/w/${owner.sId}/data-sources/vaults/global`,
+      isCurrent: (currentRoute: string) =>
+        currentRoute.startsWith("/w/[wId]/data-sources/vaults/"),
+      sizing: "expand",
+    });
+  }
+
   if (isAdmin(owner)) {
     nav.push({
       id: "settings",

--- a/front/components/vaults/VaultLayout.tsx
+++ b/front/components/vaults/VaultLayout.tsx
@@ -1,0 +1,35 @@
+import type { SubscriptionType, WorkspaceType } from "@dust-tt/types";
+import type React from "react";
+
+import RootLayout from "@app/components/app/RootLayout";
+import AppLayout from "@app/components/sparkle/AppLayout";
+import VaultSideBarMenu from "@app/components/vaults/VaultSideBarMenu";
+
+export interface VaultLayoutProps {
+  gaTrackingId: string;
+  owner: WorkspaceType;
+  subscription: SubscriptionType;
+}
+
+export function VaultLayout({
+  children,
+  pageProps,
+}: {
+  children: React.ReactNode;
+  pageProps: VaultLayoutProps;
+}) {
+  const { gaTrackingId, owner, subscription } = pageProps;
+
+  return (
+    <RootLayout>
+      <AppLayout
+        subscription={subscription}
+        owner={owner}
+        gaTrackingId={gaTrackingId}
+        navChildren={<VaultSideBarMenu owner={owner} />}
+      >
+        {children}
+      </AppLayout>
+    </RootLayout>
+  );
+}

--- a/front/components/vaults/VaultSideBarMenu.tsx
+++ b/front/components/vaults/VaultSideBarMenu.tsx
@@ -14,6 +14,7 @@ import type {
   VaultType,
 } from "@dust-tt/types";
 import { DATA_SOURCE_OR_VIEW_CATEGORIES } from "@dust-tt/types";
+import { groupBy } from "lodash";
 import { useRouter } from "next/router";
 import type { ReactElement } from "react";
 import { Fragment, useState } from "react";
@@ -29,6 +30,8 @@ interface VaultSideBarMenuProps {
   owner: LightWorkspaceType;
 }
 
+const VAULTS_SORT_ORDER = ["system", "global", "regular"];
+
 export default function VaultSideBarMenu({ owner }: VaultSideBarMenuProps) {
   const { vaults, isVaultsLoading } = useVaults({ workspaceId: owner.sId });
 
@@ -36,20 +39,30 @@ export default function VaultSideBarMenu({ owner }: VaultSideBarMenuProps) {
     return <></>;
   }
 
+  // Group by kind and sort.
+  const groupedVaults = groupBy(vaults, (vault) => vault.kind);
+  const sortedGroupedVaults = VAULTS_SORT_ORDER.map(
+    (kind) => groupedVaults[kind] || []
+  );
+
   return (
     <div className="flex flex-col px-3">
       <Item.List>
-        {vaults.map((vault) => (
-          <Fragment key={`vault-${vault.sId}`}>
-            <Item.SectionHeader
-              label={vault.kind === "global" ? "SHARED" : vault.name}
-              key={vault.sId}
-            />
-            {vault.kind === "system" ? (
-              <SystemVaultMenu />
-            ) : (
-              <VaultMenuItem owner={owner} vault={vault} />
-            )}
+        {sortedGroupedVaults.map((vaults, index) => (
+          <Fragment key={`vault-section-${index}`}>
+            {vaults.map((vault) => (
+              <Fragment key={`vault-${vault.sId}`}>
+                <Item.SectionHeader
+                  label={vault.kind === "global" ? "SHARED" : vault.name}
+                  key={vault.sId}
+                />
+                {vault.kind === "system" ? (
+                  <SystemVaultMenu />
+                ) : (
+                  <VaultMenuItem owner={owner} vault={vault} />
+                )}
+              </Fragment>
+            ))}
           </Fragment>
         ))}
       </Item.List>

--- a/front/components/vaults/VaultSideBarMenu.tsx
+++ b/front/components/vaults/VaultSideBarMenu.tsx
@@ -87,15 +87,17 @@ const VaultMenuItem = ({
 }) => {
   const router = useRouter();
 
-  const [isExpanded, setIsExpanded] = useState(false);
+  const vaultPath = `/w/${owner.sId}/data-sources/vaults/${vault.sId}`;
+  const isAncestorToCurrentPage = router.asPath.includes(vaultPath);
+
+  // Unfold the vault if it's an ancestor of the current page.
+  const [isExpanded, setIsExpanded] = useState(isAncestorToCurrentPage);
 
   const { vaultInfo, isVaultInfoLoading } = useVaultInfo({
     workspaceId: owner.sId,
     vaultId: vault.sId,
     disabled: !isExpanded,
   });
-
-  const vaultPath = `/w/${owner.sId}/data-sources/vaults/${vault.sId}`;
 
   return (
     <Tree.Item
@@ -205,7 +207,12 @@ const VaultCategoryItem = ({
   category: string;
 }) => {
   const router = useRouter();
-  const [isExpanded, setIsExpanded] = useState(false);
+
+  const vaultCategoryPath = `/w/${owner.sId}/data-sources/vaults/${vault.sId}/categories/${category}`;
+  const isAncestorToCurrentPage = router.asPath.includes(vaultCategoryPath);
+
+  // Unfold the vault's category if it's an ancestor of the current page.
+  const [isExpanded, setIsExpanded] = useState(isAncestorToCurrentPage);
 
   const categoryDetails = DATA_SOURCE_OR_VIEW_SUB_ITEMS[category];
   const { isVaultDataSourceOrViewsLoading, vaultDataSourceOrViews } =
@@ -216,8 +223,6 @@ const VaultCategoryItem = ({
       type: categoryDetails.dataSourceOrView,
       disabled: !isExpanded,
     });
-
-  const vaultCategoryPath = `/w/${owner.sId}/data-sources/vaults/${vault.sId}/categories/${category}`;
 
   return (
     <Tree.Item

--- a/front/components/vaults/VaultSideBarMenu.tsx
+++ b/front/components/vaults/VaultSideBarMenu.tsx
@@ -1,0 +1,247 @@
+import {
+  CloudArrowLeftRightIcon,
+  CommandLineIcon,
+  FolderIcon,
+  GlobeAltIcon,
+  Item,
+  LockIcon,
+  PlanetIcon,
+  Tree,
+} from "@dust-tt/sparkle";
+import type {
+  DataSourceOrViewInfo,
+  LightWorkspaceType,
+  VaultType,
+} from "@dust-tt/types";
+import { DATA_SOURCE_OR_VIEW_CATEGORIES } from "@dust-tt/types";
+import { useRouter } from "next/router";
+import type { ReactElement } from "react";
+import { Fragment, useState } from "react";
+
+import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
+import {
+  useVaultDataSourceOrViews,
+  useVaultInfo,
+  useVaults,
+} from "@app/lib/swr";
+
+interface VaultSideBarMenuProps {
+  owner: LightWorkspaceType;
+}
+
+export default function VaultSideBarMenu({ owner }: VaultSideBarMenuProps) {
+  const { vaults, isVaultsLoading } = useVaults({ workspaceId: owner.sId });
+
+  if (!vaults || isVaultsLoading) {
+    return <></>;
+  }
+
+  return (
+    <div className="flex flex-col px-3">
+      <Item.List>
+        {vaults.map((vault) => (
+          <Fragment key={`vault-${vault.sId}`}>
+            <Item.SectionHeader
+              label={vault.kind === "global" ? "SHARED" : vault.name}
+              key={vault.sId}
+            />
+            {vault.kind === "system" ? (
+              <SystemVaultMenu />
+            ) : (
+              <VaultMenuItem owner={owner} vault={vault} />
+            )}
+          </Fragment>
+        ))}
+      </Item.List>
+    </div>
+  );
+}
+
+const RootItemIconWrapper = (
+  IconComponent: React.ComponentType<React.SVGProps<SVGSVGElement>>
+) => {
+  return <IconComponent className="text-brand" />;
+};
+
+const SubItemIconItemWrapper = (
+  IconComponent: React.ComponentType<React.SVGProps<SVGSVGElement>>
+) => {
+  return <IconComponent className="text-element-700" />;
+};
+
+// System vault.
+
+const SystemVaultMenu = () => {
+  // TODO(Groups UI) Implement system vault menu.
+  return <></>;
+};
+
+// Global + regular vaults.
+
+const VaultMenuItem = ({
+  owner,
+  vault,
+}: {
+  owner: LightWorkspaceType;
+  vault: VaultType;
+}) => {
+  const router = useRouter();
+
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const { vaultInfo, isVaultInfoLoading } = useVaultInfo({
+    workspaceId: owner.sId,
+    vaultId: vault.sId,
+    disabled: !isExpanded,
+  });
+
+  const vaultPath = `/w/${owner.sId}/data-sources/vaults/${vault.sId}`;
+
+  return (
+    <Tree.Item
+      label={vault.kind === "global" ? "Company Data" : vault.name}
+      collapsed={!isExpanded}
+      onItemClick={() => router.push(vaultPath)}
+      isSelected={router.asPath === vaultPath}
+      onChevronClick={() => setIsExpanded(!isExpanded)}
+      visual={
+        vault.kind === "global"
+          ? RootItemIconWrapper(PlanetIcon)
+          : RootItemIconWrapper(LockIcon)
+      }
+      size="md"
+      areActionsFading={false}
+    >
+      {isExpanded && (
+        <Tree isLoading={isVaultInfoLoading}>
+          {vaultInfo?.categories &&
+            DATA_SOURCE_OR_VIEW_CATEGORIES.map(
+              (c) =>
+                vaultInfo.categories[c] && (
+                  <VaultCategoryItem
+                    key={c}
+                    category={c}
+                    owner={owner}
+                    vault={vault}
+                  />
+                )
+            )}
+        </Tree>
+      )}
+    </Tree.Item>
+  );
+};
+
+const DATA_SOURCE_OR_VIEW_SUB_ITEMS: {
+  [key: string]: {
+    label: string;
+    icon: ReactElement<{
+      className?: string;
+    }>;
+    dataSourceOrView: "data_sources" | "data_source_views";
+  };
+} = {
+  managed: {
+    label: "Connected Data",
+    icon: SubItemIconItemWrapper(CloudArrowLeftRightIcon),
+    dataSourceOrView: "data_source_views",
+  },
+  files: {
+    label: "Files",
+    icon: SubItemIconItemWrapper(FolderIcon),
+    dataSourceOrView: "data_sources",
+  },
+  webfolder: {
+    label: "Websites",
+    icon: SubItemIconItemWrapper(GlobeAltIcon),
+    dataSourceOrView: "data_sources",
+  },
+  apps: {
+    label: "Apps",
+    icon: SubItemIconItemWrapper(CommandLineIcon),
+    dataSourceOrView: "data_sources",
+  },
+};
+
+const VaultDataSourceOrViewItem = ({
+  owner,
+  vault,
+  item,
+}: {
+  owner: LightWorkspaceType;
+  vault: VaultType;
+  item: DataSourceOrViewInfo;
+}): ReactElement => {
+  const router = useRouter();
+  const configuration = item.connectorProvider
+    ? CONNECTOR_CONFIGURATIONS[item.connectorProvider]
+    : null;
+
+  const LogoComponent = configuration?.logoComponent ?? FolderIcon;
+  const label = configuration?.name ?? item.name;
+  const viewType =
+    DATA_SOURCE_OR_VIEW_SUB_ITEMS[item.category].dataSourceOrView;
+  const dataSourceOrViewPath = `/w/${owner.sId}/data-sources/vaults/${vault.sId}/categories/${item.category}/${viewType}/${item.sId}`;
+
+  return (
+    <Tree.Item
+      type="leaf"
+      isSelected={router.asPath === dataSourceOrViewPath}
+      onItemClick={() => router.push(dataSourceOrViewPath)}
+      label={label}
+      visual={SubItemIconItemWrapper(LogoComponent)}
+      areActionsFading={false}
+    />
+  );
+};
+
+const VaultCategoryItem = ({
+  owner,
+  vault,
+  category,
+}: {
+  owner: LightWorkspaceType;
+  vault: VaultType;
+  category: string;
+}) => {
+  const router = useRouter();
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const categoryDetails = DATA_SOURCE_OR_VIEW_SUB_ITEMS[category];
+  const { isVaultDataSourceOrViewsLoading, vaultDataSourceOrViews } =
+    useVaultDataSourceOrViews({
+      workspaceId: owner.sId,
+      vaultId: vault.sId,
+      category,
+      type: categoryDetails.dataSourceOrView,
+      disabled: !isExpanded,
+    });
+
+  const vaultCategoryPath = `/w/${owner.sId}/data-sources/vaults/${vault.sId}/categories/${category}`;
+
+  return (
+    <Tree.Item
+      label={categoryDetails.label}
+      collapsed={!isExpanded}
+      onItemClick={() => router.push(vaultCategoryPath)}
+      isSelected={router.asPath === vaultCategoryPath}
+      onChevronClick={() => setIsExpanded(!isExpanded)}
+      visual={categoryDetails.icon}
+      areActionsFading={false}
+    >
+      {isExpanded && (
+        <Tree isLoading={isVaultDataSourceOrViewsLoading}>
+          {vaultDataSourceOrViews &&
+            vaultDataSourceOrViews.map((ds) => (
+              <VaultDataSourceOrViewItem
+                key={ds.sId}
+                owner={owner}
+                vault={vault}
+                item={ds}
+              />
+            ))}
+        </Tree>
+      )}
+    </Tree.Item>
+  );
+};

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,7 @@
         "@amplitude/analytics-browser": "^2.5.2",
         "@amplitude/analytics-node": "^1.3.5",
         "@auth0/nextjs-auth0": "^3.5.0",
-        "@dust-tt/sparkle": "^0.2.203",
+        "@dust-tt/sparkle": "^0.2.204",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -10735,9 +10735,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.203",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.203.tgz",
-      "integrity": "sha512-0sHBRnhbAoVppr5AuTMaJPypm2rAF3+18rGQQvFsG3+hhmZ8X+bqtLxkCtwXTv4VoMW45KcMwvvQWBRA3sfwig==",
+      "version": "0.2.204",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.204.tgz",
+      "integrity": "sha512-JSePfugJLG7ONPF85W9ZNrQeDWkpjl1k3ieqPt8EItTRPzzXFLYJucRB6iN+ijG2UBrivA9amp5Hnik8ZkCAIA==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
     "@amplitude/analytics-browser": "^2.5.2",
     "@amplitude/analytics-node": "^1.3.5",
     "@auth0/nextjs-auth0": "^3.5.0",
-    "@dust-tt/sparkle": "^0.2.203",
+    "@dust-tt/sparkle": "^0.2.204",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",

--- a/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
+++ b/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
@@ -1,0 +1,81 @@
+import type { DataSourceViewType, UserType, VaultType } from "@dust-tt/types";
+import type { InferGetServerSidePropsType } from "next";
+import type { ReactElement } from "react";
+
+import type { VaultLayoutProps } from "@app/components/vaults/VaultLayout";
+import { VaultLayout } from "@app/components/vaults/VaultLayout";
+import config from "@app/lib/api/config";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { VaultResource } from "@app/lib/resources/vault_resource";
+
+export const getServerSideProps = withDefaultUserAuthRequirements<
+  VaultLayoutProps & {
+    dataSourceView: DataSourceViewType;
+    user: UserType;
+    vault: VaultType;
+  }
+>(async (context, auth) => {
+  const owner = auth.getNonNullableWorkspace();
+  const user = auth.getNonNullableUser();
+  const subscription = auth.subscription();
+
+  if (!subscription) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const vault = await VaultResource.fetchById(
+    auth,
+    context.query.vaultId as string
+  );
+  if (!vault) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const { dataSourceViewId } = context.query;
+  if (typeof dataSourceViewId !== "string") {
+    return {
+      notFound: true,
+    };
+  }
+
+  const dataSourceView = await DataSourceViewResource.fetchById(
+    auth,
+    dataSourceViewId
+  );
+  if (!dataSourceView) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      dataSourceView: dataSourceView.toJSON(),
+      gaTrackingId: config.getGaTrackingId(),
+      owner,
+      subscription,
+      user,
+      vault: vault.toJSON(),
+    },
+  };
+});
+
+export default function Vault({
+  dataSourceView,
+  vault,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  return (
+    <>
+      Data source view {dataSourceView.sId} in vault {vault.name}
+    </>
+  );
+}
+
+Vault.getLayout = (page: ReactElement, pageProps: any) => {
+  return <VaultLayout pageProps={pageProps}>{page}</VaultLayout>;
+};

--- a/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/data_sources/[dataSourceId].tsx
+++ b/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/data_sources/[dataSourceId].tsx
@@ -1,0 +1,78 @@
+import type { DataSourceType, UserType, VaultType } from "@dust-tt/types";
+import type { InferGetServerSidePropsType } from "next";
+import type { ReactElement } from "react";
+
+import type { VaultLayoutProps } from "@app/components/vaults/VaultLayout";
+import { VaultLayout } from "@app/components/vaults/VaultLayout";
+import config from "@app/lib/api/config";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { VaultResource } from "@app/lib/resources/vault_resource";
+
+export const getServerSideProps = withDefaultUserAuthRequirements<
+  VaultLayoutProps & {
+    dataSource: DataSourceType;
+    user: UserType;
+    vault: VaultType;
+  }
+>(async (context, auth) => {
+  const owner = auth.getNonNullableWorkspace();
+  const user = auth.getNonNullableUser();
+  const subscription = auth.subscription();
+
+  if (!subscription) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const vault = await VaultResource.fetchById(
+    auth,
+    context.query.vaultId as string
+  );
+  if (!vault) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const { dataSourceId } = context.query;
+  if (typeof dataSourceId !== "string") {
+    return {
+      notFound: true,
+    };
+  }
+
+  const dataSource = await DataSourceResource.fetchByName(auth, dataSourceId);
+  if (!dataSource) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      dataSource: dataSource.toJSON(),
+      gaTrackingId: config.getGaTrackingId(),
+      owner,
+      subscription,
+      user,
+      vault: vault.toJSON(),
+    },
+  };
+});
+
+export default function Vault({
+  dataSource,
+  vault,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  return (
+    <>
+      Data source {dataSource.name} in vault {vault.name}
+    </>
+  );
+}
+
+Vault.getLayout = (page: ReactElement, pageProps: any) => {
+  return <VaultLayout pageProps={pageProps}>{page}</VaultLayout>;
+};

--- a/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/index.tsx
+++ b/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/index.tsx
@@ -1,0 +1,63 @@
+import type { UserType, VaultType } from "@dust-tt/types";
+import type { InferGetServerSidePropsType } from "next";
+import type { ReactElement } from "react";
+
+import type { VaultLayoutProps } from "@app/components/vaults/VaultLayout";
+import { VaultLayout } from "@app/components/vaults/VaultLayout";
+import config from "@app/lib/api/config";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+import { VaultResource } from "@app/lib/resources/vault_resource";
+
+export const getServerSideProps = withDefaultUserAuthRequirements<
+  VaultLayoutProps & {
+    category: string;
+    user: UserType;
+    vault: VaultType;
+  }
+>(async (context, auth) => {
+  const owner = auth.getNonNullableWorkspace();
+  const user = auth.getNonNullableUser();
+  const subscription = auth.subscription();
+
+  if (!subscription) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const vault = await VaultResource.fetchById(
+    auth,
+    context.query.vaultId as string
+  );
+  if (!vault) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      category: context.query.category as string,
+      gaTrackingId: config.getGaTrackingId(),
+      owner,
+      subscription,
+      user,
+      vault: vault.toJSON(),
+    },
+  };
+});
+
+export default function Vault({
+  category,
+  vault,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  return (
+    <>
+      Category {category} for vault {vault.name}
+    </>
+  );
+}
+
+Vault.getLayout = (page: ReactElement, pageProps: any) => {
+  return <VaultLayout pageProps={pageProps}>{page}</VaultLayout>;
+};

--- a/front/pages/w/[wId]/data-sources/vaults/[vaultId]/index.tsx
+++ b/front/pages/w/[wId]/data-sources/vaults/[vaultId]/index.tsx
@@ -1,0 +1,56 @@
+import type { UserType, VaultType } from "@dust-tt/types";
+import type { InferGetServerSidePropsType } from "next";
+import type { ReactElement } from "react";
+
+import type { VaultLayoutProps } from "@app/components/vaults/VaultLayout";
+import { VaultLayout } from "@app/components/vaults/VaultLayout";
+import config from "@app/lib/api/config";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+import { VaultResource } from "@app/lib/resources/vault_resource";
+
+export const getServerSideProps = withDefaultUserAuthRequirements<
+  VaultLayoutProps & {
+    user: UserType;
+    vault: VaultType;
+  }
+>(async (context, auth) => {
+  const owner = auth.getNonNullableWorkspace();
+  const user = auth.getNonNullableUser();
+  const subscription = auth.subscription();
+
+  if (!subscription) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const vault = await VaultResource.fetchById(
+    auth,
+    context.query.vaultId as string
+  );
+  if (!vault) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      gaTrackingId: config.getGaTrackingId(),
+      owner,
+      subscription,
+      user,
+      vault: vault.toJSON(),
+    },
+  };
+});
+
+export default function Vault({
+  vault,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  return <>Vault {vault.name}</>;
+}
+
+Vault.getLayout = (page: ReactElement, pageProps: any) => {
+  return <VaultLayout pageProps={pageProps}>{page}</VaultLayout>;
+};

--- a/front/pages/w/[wId]/data-sources/vaults/index.tsx
+++ b/front/pages/w/[wId]/data-sources/vaults/index.tsx
@@ -1,0 +1,32 @@
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+import { VaultResource } from "@app/lib/resources/vault_resource";
+
+// This endpoint is used as a pass through to redirect to the global vault.
+export const getServerSideProps = withDefaultUserAuthRequirements(
+  async (context, auth) => {
+    const owner = auth.getNonNullableWorkspace();
+    const subscription = auth.subscription();
+
+    if (!subscription) {
+      return {
+        notFound: true,
+      };
+    }
+
+    const vault = await VaultResource.fetchWorkspaceGlobalVault(auth);
+    if (!vault) {
+      return {
+        notFound: true,
+      };
+    }
+
+    return {
+      redirect: {
+        destination: `/w/${owner.sId}/data-sources/vaults/${vault.sId}`,
+        permanent: false,
+      },
+    };
+  }
+);
+
+export default function DefaultVault() {}

--- a/types/src/shared/feature_flags.ts
+++ b/types/src/shared/feature_flags.ts
@@ -5,6 +5,7 @@ export const WHITELISTABLE_FEATURES = [
   "document_tracker",
   "microsoft_connector",
   "dust_splitted_ds_flag",
+  "data_vaults_feature",
 ] as const;
 export type WhitelistableFeature = (typeof WHITELISTABLE_FEATURES)[number];
 export function isWhitelistableFeature(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See figma [here](https://www.figma.com/design/QOxHwppG64GtPocpDhS6Y7/Product?node-id=8382-44390&m=dev).

This PR introduces a new "Data Sources" tab in the menu, which becomes visible when the feature flag is enabled. This tab will be accessible to all users, with the content displayed according to their permissions. It also includes the implementation of side navigation, which is synchronized with the router to ensure the side navigation and the page on the right remain consistent. Currently, only the `global` and `regular` vaults will be displayed, with the `system` vault to be added in a subsequent PR. I also added skeleton pages so we can start parallelizing the work.

The navigation leverages the [Layout Pattern](https://nextjs.org/docs/pages/building-your-application/routing/pages-and-layouts#layout-pattern) from NextJS to avoid re-rendering the navigation every time. The breadcrumb (not yet implemented will also be included in this `VaultLayout`.

![vaultNavigation](https://github.com/user-attachments/assets/0f162136-e0ab-40a4-8af5-6d1ac64c7627)

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Low risk, everything is gated behind a FF.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
