### PR TITLE
Add app statuses logic and component

### DIFF
--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -102,7 +102,7 @@ export const NavigationSidebar = React.forwardRef<
           {user && <UserMenu user={user} owner={owner} />}
         </div>
 
-        <AppStatusesBanner />
+        <AppStatusBanner />
         {subscription.endDate && (
           <SubscriptionEndBanner endDate={subscription.endDate} />
         )}
@@ -172,7 +172,7 @@ export const NavigationSidebar = React.forwardRef<
   );
 });
 
-function AppStatusesBanner() {
+function AppStatusBanner() {
   const { appStatus } = useAppStatus();
   const { providerStatus } = appStatus ?? {};
 

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -11,7 +11,7 @@ import type {
 import { getTopNavigationTabs } from "@app/components/navigation/config";
 import { UserMenu } from "@app/components/UserMenu";
 import WorkspacePicker from "@app/components/WorkspacePicker";
-import { useAppStatuses, useUser } from "@app/lib/swr";
+import { useAppStatus, useUser } from "@app/lib/swr";
 
 interface NavigationSidebarProps {
   children: React.ReactNode;
@@ -173,10 +173,10 @@ export const NavigationSidebar = React.forwardRef<
 });
 
 function AppStatusesBanner() {
-  const { appStatuses } = useAppStatuses();
-  const { providerStatus } = appStatuses ?? {};
+  const { appStatus } = useAppStatus();
+  const { providerStatus } = appStatus ?? {};
 
-  if (!appStatuses || !providerStatus) {
+  if (!appStatus || !providerStatus) {
     return null;
   }
 

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -11,7 +11,7 @@ import type {
 import { getTopNavigationTabs } from "@app/components/navigation/config";
 import { UserMenu } from "@app/components/UserMenu";
 import WorkspacePicker from "@app/components/WorkspacePicker";
-import { useUser } from "@app/lib/swr";
+import { useAppStatuses, useUser } from "@app/lib/swr";
 
 interface NavigationSidebarProps {
   children: React.ReactNode;
@@ -102,6 +102,7 @@ export const NavigationSidebar = React.forwardRef<
           {user && <UserMenu user={user} owner={owner} />}
         </div>
 
+        <AppStatusesBanner />
         {subscription.endDate && (
           <SubscriptionEndBanner endDate={subscription.endDate} />
         )}
@@ -170,6 +171,32 @@ export const NavigationSidebar = React.forwardRef<
     </div>
   );
 });
+
+function AppStatusesBanner() {
+  const { appStatuses } = useAppStatuses();
+  const { providerStatus } = appStatuses ?? {};
+
+  if (!appStatuses || !providerStatus) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-2 border-y border-orange-200 bg-orange-100 px-3 py-3 text-xs text-orange-900">
+      <div className="font-bold">{providerStatus.name}</div>
+      <div className="font-normal">
+        {providerStatus.description} More Info{" "}
+        <Link
+          href="https://docs.dust.tt/docs/subscriptions#what-happens-when-we-cancel-our-dust-subscription"
+          target="_blank"
+          className="underline"
+        >
+          here
+        </Link>
+        .
+      </div>
+    </div>
+  );
+}
 
 function SubscriptionEndBanner({ endDate }: { endDate: number }) {
   const formattedEndDate = new Date(endDate).toLocaleDateString("en-US", {

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -121,6 +121,13 @@ const config = {
   getTextExtractionUrl: (): string => {
     return EnvironmentConfig.getEnvVariable("TEXT_EXTRACTION_URL");
   },
+  // Status page.
+  getProviderStatusPageId: (): string => {
+    return EnvironmentConfig.getEnvVariable("PROVIDER_STATUS_PAGE_ID");
+  },
+  getStatusPageApiToken: (): string => {
+    return EnvironmentConfig.getEnvVariable("STATUS_PAGE_API_TOKEN");
+  },
 };
 
 export default config;

--- a/front/lib/api/status/index.ts
+++ b/front/lib/api/status/index.ts
@@ -19,7 +19,7 @@ async function getProviderStatus() {
 
   const [incident] = providerIncidents;
   const { name, incident_updates: incidentUpdates } = incident;
-  const [latestUpdate] = incidentUpdates.reverse();
+  const [latestUpdate] = incidentUpdates;
 
   return {
     name,

--- a/front/lib/api/status/index.ts
+++ b/front/lib/api/status/index.ts
@@ -1,0 +1,39 @@
+import { cacheWithRedis, isDevelopment } from "@dust-tt/types";
+
+import config from "@app/lib/api/config";
+import { getUnresolvedIncidents } from "@app/lib/api/status/status_page";
+
+async function getProviderStatus() {
+  if (isDevelopment()) {
+    return null;
+  }
+
+  const providerIncidents = await getUnresolvedIncidents({
+    apiToken: config.getStatusPageApiToken(),
+    pageId: config.getProviderStatusPageId(),
+  });
+
+  if (providerIncidents.length === 0) {
+    return null;
+  }
+
+  const [incident] = providerIncidents;
+  const { name, incident_updates: incidentUpdates } = incident;
+  const [latestUpdate] = incidentUpdates.reverse();
+
+  return {
+    name,
+    description: latestUpdate.body,
+    link: incident.shortlink,
+  };
+}
+
+export const getProviderStatusMemoized = cacheWithRedis(
+  getProviderStatus,
+  () => {
+    return "provider-status";
+  },
+  // Caches data for 2 minutes to limit frequent API calls.
+  // Status page rate limit is pretty aggressive.
+  2 * 60 * 1000
+);

--- a/front/lib/api/status/status_page.ts
+++ b/front/lib/api/status/status_page.ts
@@ -1,0 +1,57 @@
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+
+import logger from "@app/logger/logger";
+
+const StatusPageUnresolvedIncident = t.type({
+  name: t.string,
+  incident_updates: t.array(
+    t.type({
+      body: t.string,
+    })
+  ),
+  shortlink: t.string,
+});
+
+const StatusPageResponseSchema = t.array(StatusPageUnresolvedIncident);
+
+type StatusPageReponseType = t.TypeOf<typeof StatusPageResponseSchema>;
+
+export async function getUnresolvedIncidents({
+  apiToken,
+  pageId,
+}: {
+  apiToken: string;
+  pageId: string;
+}): Promise<StatusPageReponseType> {
+  try {
+    const res = await fetch(
+      `https://api.statuspage.io/v1/pages/${pageId}/incidents/unresolved`,
+      {
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `OAuth ${apiToken}`,
+        },
+        method: "GET",
+      }
+    );
+
+    const data = await res.json();
+
+    const validation = StatusPageResponseSchema.decode(data);
+    if (isLeft(validation)) {
+      const pathError = reporter.formatValidationErrors(validation.left);
+      logger.error({ pathError }, "Could not parse status page response");
+
+      return [];
+    }
+
+    const { right: incidents } = validation;
+
+    return incidents;
+  } catch (err) {
+    logger.error({ err }, "Error fetching provider status");
+    return [];
+  }
+}

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -20,6 +20,7 @@ import useSWRInfinite from "swr/infinite";
 
 import type { FetchConversationMessagesResponse } from "@app/lib/api/assistant/messages";
 import { COMMIT_HASH } from "@app/lib/commit-hash";
+import type { GetAppStatusResponseBody } from "@app/pages/api/app-status";
 import type { GetPokePlansResponseBody } from "@app/pages/api/poke/plans";
 import type { GetPokeWorkspacesResponseBody } from "@app/pages/api/poke/workspaces";
 import type { GetUserResponseBody } from "@app/pages/api/user";
@@ -111,6 +112,21 @@ export const postFetcher = async ([url, body]: [string, object]) => {
 
   return resHandler(res);
 };
+
+export function useAppStatuses() {
+  const appStatusesFetcher: Fetcher<GetAppStatusResponseBody> = fetcher;
+
+  const { data, error } = useSWRWithDefaults(
+    "/api/app-status",
+    appStatusesFetcher
+  );
+
+  return {
+    appStatuses: useMemo(() => (data ? data : null), [data]),
+    isAppStatusesLoading: !error && !data,
+    isAppStatusesError: !!error,
+  };
+}
 
 export function useDatasets({
   owner,

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -113,18 +113,18 @@ export const postFetcher = async ([url, body]: [string, object]) => {
   return resHandler(res);
 };
 
-export function useAppStatuses() {
-  const appStatusesFetcher: Fetcher<GetAppStatusResponseBody> = fetcher;
+export function useAppStatus() {
+  const appStatusFetcher: Fetcher<GetAppStatusResponseBody> = fetcher;
 
   const { data, error } = useSWRWithDefaults(
     "/api/app-status",
-    appStatusesFetcher
+    appStatusFetcher
   );
 
   return {
-    appStatuses: useMemo(() => (data ? data : null), [data]),
-    isAppStatusesLoading: !error && !data,
-    isAppStatusesError: !!error,
+    appStatus: useMemo(() => (data ? data : null), [data]),
+    isAppStatusLoading: !error && !data,
+    isAppStatusError: !!error,
   };
 }
 

--- a/front/pages/api/app-status.ts
+++ b/front/pages/api/app-status.ts
@@ -1,0 +1,42 @@
+import type { WithAPIErrorResponse } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getProviderStatusMemoized } from "@app/lib/api/status";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
+import { getSession } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+
+export interface GetAppStatusResponseBody {
+  providerStatus: {
+    description: string;
+    link: string;
+    name: string;
+  } | null;
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetAppStatusResponseBody>>
+): Promise<void> {
+  const session = await getSession(req, res);
+  if (!session) {
+    res.status(401).end();
+    return;
+  }
+
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, POST is expected.",
+      },
+    });
+  }
+
+  const providerStatus = await getProviderStatusMemoized();
+
+  res.status(200).json({ providerStatus });
+}
+
+export default withSessionAuthentication(handler);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR resolves https://github.com/dust-tt/dust/issues/6746. For more context see [thread](https://dust4ai.slack.com/archives/C05B529FHV1/p1723139777736699).
Runbook is [here](https://www.notion.so/dust-tt/Runbook-How-to-Update-Provider-Status-Page-566335635569422893fc2bc71e6857e7).

This PR introduces a new API endpoint to retrieve app statuses. Initially, these app statuses will only include provider statuses, but future enhancements will expand this to include more. This naive approach, addresses the following needs:
1. We do not want to update our status page for provider incidents since these incidents are beyond our control.
2. We need a method so that **anyone in the team** can easily surface provider issues within the app.

To meet these requirements, this implementation uses a dedicated status page that exclusively tracks our provider incidents. This status page is public but unlisted, meaning it can only be accessed via a direct link. Due to the aggressive rate limits of the Atlassian status page API, we cache the app status, which is acceptable even if it takes a few minutes for an incident to appear.

When an incident occurs, a banner will appear in the navigation bar, displaying the incident's title, description, and a link to the incident. Currently, this implementation does not support provider-specific logic and can only handle one provider incident at a time.

In the future, we may leverage status page components to represent each of our providers and perform advanced actions in the UI, but this is beyond the scope of the initial implementation.

<img width="318" alt="image" src="https://github.com/user-attachments/assets/ffc6f7e0-b334-42be-b76b-27d8f7b5fb75">

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
We need to adds the following environment variables in the `front-secrets` secret:
- [x] `PROVIDER_STATUS_PAGE_ID`
- [x] `STATUS_PAGE_API_TOKEN`
