### PR TITLE
feat: add front-qa environment

### DIFF
--- a/.github/workflows/deploy-front-qa.yml
+++ b/.github/workflows/deploy-front-qa.yml
@@ -1,0 +1,53 @@
+name: Deploy Front Qa
+
+# TODO: deploy on merge to main
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: deploy_front_qa
+  cancel-in-progress: false
+
+env:
+  GCLOUD_PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Get short sha
+        id: short_sha
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: "Authenticate with Google Cloud"
+        uses: "google-github-actions/auth@v1"
+        with:
+          credentials_json: "${{ secrets.GCLOUD_SA_KEY }}"
+
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v1"
+
+      - name: Install gke-gcloud-auth-plugin
+        run: |
+          gcloud components install gke-gcloud-auth-plugin
+
+      - name: Setup kubectl
+        run: |
+          gcloud container clusters get-credentials dust-kube --region us-central1
+
+      - name: Build the image on Cloud Build
+        run: |
+          chmod +x ./k8s/cloud-build.sh
+          ./k8s/cloud-build.sh front ./front/Dockerfile ./
+
+      - name: Deploy the image on Kubernetes
+        run: |
+          chmod +x ./k8s/deploy-image.sh
+          ./k8s/deploy-image.sh gcr.io/$GCLOUD_PROJECT_ID/front-image:${{ steps.short_sha.outputs.short_sha }} front-qa-deployment
+
+      - name: Wait for rollout to complete
+        run: kubectl rollout status deployment/front-qa-deployment --timeout=10m

--- a/k8s/apply_infra.sh
+++ b/k8s/apply_infra.sh
@@ -67,6 +67,7 @@ kubectl apply -f "$(dirname "$0")/configmaps/apache-tika-configmap.yaml"
 kubectl apply -f "$(dirname "$0")/configmaps/front-configmap.yaml"
 kubectl apply -f "$(dirname "$0")/configmaps/front-worker-configmap.yaml"
 kubectl apply -f "$(dirname "$0")/configmaps/front-edge-configmap.yaml"
+kubectl apply -f "$(dirname "$0")/configmaps/front-qa-configmap.yaml"
 kubectl apply -f "$(dirname "$0")/configmaps/connectors-configmap.yaml"
 kubectl apply -f "$(dirname "$0")/configmaps/connectors-worker-configmap.yaml"
 kubectl apply -f "$(dirname "$0")/configmaps/connectors-worker-specific-configmap.yaml"
@@ -95,6 +96,7 @@ echo "-----------------------------------"
 
 kubectl apply -f "$(dirname "$0")/managed-certs/front-managed-cert.yaml"
 kubectl apply -f "$(dirname "$0")/managed-certs/front-edge-managed-cert.yaml"
+kubectl apply -f "$(dirname "$0")/managed-certs/front-qa-managed-cert.yaml"
 kubectl apply -f "$(dirname "$0")/managed-certs/connectors-managed-cert.yaml"
 kubectl apply -f "$(dirname "$0")/managed-certs/metabase-managed-cert.yaml"
 kubectl apply -f "$(dirname "$0")/managed-certs/viz-managed-cert.yaml"
@@ -114,6 +116,7 @@ apply_deployment apache-tika-deployment
 apply_deployment front-deployment
 apply_deployment front-worker-deployment
 apply_deployment front-edge-deployment
+apply_deployment front-qa-deployment
 apply_deployment connectors-deployment
 apply_deployment connectors-worker-deployment
 apply_deployment connectors-worker-notion-deployment
@@ -141,6 +144,7 @@ echo "-----------------------------------"
 kubectl apply -f "$(dirname "$0")/services/apache-tika-service.yaml"
 kubectl apply -f "$(dirname "$0")/services/front-service.yaml"
 kubectl apply -f "$(dirname "$0")/services/front-edge-service.yaml"
+kubectl apply -f "$(dirname "$0")/services/front-qa-service.yaml"
 kubectl apply -f "$(dirname "$0")/services/connectors-service.yaml"
 kubectl apply -f "$(dirname "$0")/services/connectors-worker-service.yaml"
 kubectl apply -f "$(dirname "$0")/services/metabase-service.yaml"

--- a/k8s/configmaps/front-qa-configmap.yaml
+++ b/k8s/configmaps/front-qa-configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: front-qa-config
+data:
+  DD_ENV: "prod"
+  DD_SERVICE: "front-qa"
+  NODE_OPTIONS: "-r dd-trace/init"
+  DD_LOGS_INJECTION: "true"
+  DD_RUNTIME_METRICS_ENABLED: "true"
+  NODE_ENV: "production"

--- a/k8s/deployments/front-qa-deployment.yaml
+++ b/k8s/deployments/front-qa-deployment.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: front-qa-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: front-qa
+  template:
+    metadata:
+      labels:
+        app: front-qa
+        name: front-qa-pod
+        admission.datadoghq.com/enabled: "true"
+      annotations:
+        ad.datadoghq.com/web.logs: '[{"source": "front","service": "front-qa","tags": ["env:prod"]}]'
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: web
+          image: gcr.io/or1g1n-186209/front-image:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 3000
+          readinessProbe:
+            httpGet:
+              path: /api/healthz
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+
+          envFrom:
+            - configMapRef:
+                name: front-qa-config
+            - secretRef:
+                name: front-secrets
+            - secretRef:
+                name: front-qa-secrets
+
+          env:
+            # we override --max-old-space-size for edge as pods
+            # don't have the same memory limits as the regular front pods
+            - name: NODE_OPTIONS
+              value: "-r dd-trace/init"
+            - name: NEXTAUTH_URL
+              value: https://front-qa.dust.tt
+            - name: AUTH0_BASE_URL
+              value: https://front-qa.dust.tt
+            - name: URL
+              value: https://front-qa.dust.tt
+
+            - name: DD_AGENT_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+
+            - name: PRESTOP_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: prestop-secret
+                  key: PRESTOP_SECRET
+
+          volumeMounts:
+            - name: cert-volume
+              mountPath: /etc/certs
+            - name: service-account-volume
+              mountPath: /etc/service-accounts
+
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "admin/prestop.sh"]
+
+          resources:
+            requests:
+              cpu: 1000m
+              memory: 1.5Gi
+
+      imagePullSecrets:
+        - name: gcr-json-key
+
+      volumes:
+        - name: cert-volume
+          secret:
+            secretName: temporal-front-cert
+        - name: service-account-volume
+          secret:
+            secretName: gcp-service-account-secret

--- a/k8s/deployments/front-qa-deployment.yaml
+++ b/k8s/deployments/front-qa-deployment.yaml
@@ -36,7 +36,7 @@ spec:
             - secretRef:
                 name: front-secrets
             - secretRef:
-                name: front-qa-secrets
+                name: front-edge-secrets
 
           env:
             # we override --max-old-space-size for edge as pods

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: dust-ingress
   annotations:
     kubernetes.io/ingress.global-static-ip-name: dust-kube-ingress-ip-address
-    networking.gke.io/managed-certificates: front-managed-cert,front-edge-managed-cert,connectors-managed-cert,metabase-managed-cert,viz-managed-cert
+    networking.gke.io/managed-certificates: front-managed-cert,front-edge-managed-cert,front-qa-managed-cert,connectors-managed-cert,metabase-managed-cert,viz-managed-cert
     networking.gke.io/v1beta1.FrontendConfig: "dust-frontendconfig"
     kubernetes.io/ingress.class: "gce"
 

--- a/k8s/managed-certs/front-qa-managed-cert.yaml
+++ b/k8s/managed-certs/front-qa-managed-cert.yaml
@@ -1,0 +1,7 @@
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: front-qa-managed-cert
+spec:
+  domains:
+    - front-qa.dust.tt

--- a/k8s/network-policies/core-network-policy.yaml
+++ b/k8s/network-policies/core-network-policy.yaml
@@ -21,6 +21,9 @@ spec:
               app: front-edge
         - podSelector:
             matchLabels:
+              app: front-qa
+        - podSelector:
+            matchLabels:
               app: core-sqlite-worker
         - podSelector:
             matchLabels:

--- a/k8s/network-policies/oauth-network-policy.yaml
+++ b/k8s/network-policies/oauth-network-policy.yaml
@@ -18,6 +18,9 @@ spec:
               app: front-edge
         - podSelector:
             matchLabels:
+              app: front-qa
+        - podSelector:
+            matchLabels:
               app: connectors
         - podSelector:
             matchLabels:

--- a/k8s/services/front-qa-service.yaml
+++ b/k8s/services/front-qa-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: front-qa-service
+  annotations:
+    cloud.google.com/backend-config: '{"default": "front-backendconfig"}'
+spec:
+  selector:
+    app: front-qa
+    name: front-qa-pod
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 3000
+  type: ClusterIP


### PR DESCRIPTION
## Description

Adds an environment where front QA automated tests will be ran.
Will be deployed at `front-qa.dust.tt`, with a config similar to front-edge's

## Risk

N/A

## Deploy Plan

Apply infra, then deploy code.  DNS record already created.