### PR TITLE
[connectors] fix(slack): handle ratelimit with sleep

### DIFF
--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -689,7 +689,10 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
   }
 
   async stop(): Promise<Result<undefined, Error>> {
-    await terminateAllWorkflowsForConnectorId(this.connectorId);
+    logger.info(
+      { connectorId: this.connectorId },
+      `Stopping Slack connector is a no-op.`
+    );
     return new Ok(undefined);
   }
 

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -689,10 +689,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
   }
 
   async stop(): Promise<Result<undefined, Error>> {
-    logger.info(
-      { connectorId: this.connectorId },
-      `Stopping Slack connector is a no-op.`
-    );
+    await terminateAllWorkflowsForConnectorId(this.connectorId);
     return new Ok(undefined);
   }
 

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -14,7 +14,6 @@ import type {
   Channel,
   ConversationsListResponse,
 } from "@slack/web-api/dist/response/ConversationsListResponse";
-import { Context } from "@temporalio/activity";
 import PQueue from "p-queue";
 import { Op, Sequelize } from "sequelize";
 

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -14,6 +14,7 @@ import type {
   Channel,
   ConversationsListResponse,
 } from "@slack/web-api/dist/response/ConversationsListResponse";
+import { Context } from "@temporalio/activity";
 import PQueue from "p-queue";
 import { Op, Sequelize } from "sequelize";
 
@@ -183,7 +184,7 @@ export async function syncChannel(
   const messages = await getMessagesForChannel(
     connectorId,
     channelId,
-    100,
+    50,
     messagesCursor
   );
   if (!messages.messages) {
@@ -349,6 +350,7 @@ export async function syncNonThreaded(
   connectorId: ModelId,
   isBatchSync = false
 ) {
+  Context.current().heartbeat();
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
     throw new Error(`Connector ${connectorId} not found`);
@@ -543,6 +545,7 @@ export async function syncThread(
   connectorId: ModelId,
   isBatchSync = false
 ) {
+  Context.current().heartbeat();
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
     throw new Error(`Connector ${connectorId} not found`);

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -350,7 +350,6 @@ export async function syncNonThreaded(
   connectorId: ModelId,
   isBatchSync = false
 ) {
-  Context.current().heartbeat();
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
     throw new Error(`Connector ${connectorId} not found`);
@@ -545,7 +544,6 @@ export async function syncThread(
   connectorId: ModelId,
   isBatchSync = false
 ) {
-  Context.current().heartbeat();
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
     throw new Error(`Connector ${connectorId} not found`);

--- a/connectors/src/lib/cli.ts
+++ b/connectors/src/lib/cli.ts
@@ -134,6 +134,10 @@ export const connectors = async ({
       await terminateAllWorkflowsForConnectorId(connector.id);
       return { success: true };
     }
+    case "pause": {
+      await throwOnError(manager.pause());
+      return { success: true };
+    }
     case "resume": {
       await throwOnError(manager.resume());
       return { success: true };

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -7,6 +7,7 @@ export const ConnectorsCommandSchema = t.type({
   command: t.union([
     t.literal("stop"),
     t.literal("delete"),
+    t.literal("pause"),
     t.literal("resume"),
     t.literal("full-resync"),
     t.literal("set-error"),


### PR DESCRIPTION
fixes :   https://github.com/dust-tt/tasks/issues/1151

## Description

-Avoid to crash activity when we reach a rate limit. Instead, make activity sleep to and retry 3 times.
-Adjust the number of message in syncChannel to have smaller activities
-Add some heartbeats.
-Add stop support to terminate workflows.
## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy `connectors`