### PR TITLE
[chore] - Chore/vaults/table upload

### DIFF
--- a/front/components/data_source/DatasourceDocumentsTabView.tsx
+++ b/front/components/data_source/DatasourceDocumentsTabView.tsx
@@ -286,6 +286,7 @@ export function DatasourceDocumentsTabView({
                 icon={PlusIcon}
                 label="Add document"
                 onClick={() => {
+                  setDocumentToLoad(null);
                   // Enforce plan limits: DataSource documents count.
                   if (
                     plan.limits.dataSources.documents.count != -1 &&

--- a/front/components/data_source/DatasourceTablesTabView.tsx
+++ b/front/components/data_source/DatasourceTablesTabView.tsx
@@ -7,8 +7,9 @@ import {
   ServerIcon,
 } from "@dust-tt/sparkle";
 import type { DataSourceType, WorkspaceType } from "@dust-tt/types";
-import { useRouter } from "next/router";
+import { useState } from "react";
 
+import { TableUploadModal } from "@app/components/data_source/TableUploadModal";
 import { tableKey } from "@app/lib/client/tables_query";
 import { useTables } from "@app/lib/swr";
 
@@ -21,11 +22,13 @@ export function DatasourceTablesTabView({
   readOnly: boolean;
   dataSource: DataSourceType;
 }) {
+  const [showTableUploadModal, setShowTableUploadModal] = useState(false);
+  const [tableToLoad, setTableToLoad] = useState<string | null>(null);
+
   const { tables } = useTables({
     workspaceId: owner.sId,
     dataSourceName: dataSource.name,
   });
-  const router = useRouter();
 
   return (
     <>
@@ -49,9 +52,8 @@ export function DatasourceTablesTabView({
                   icon={PlusIcon}
                   label="Add table"
                   onClick={() => {
-                    void router.push(
-                      `/w/${owner.sId}/builder/data-sources/${dataSource.name}/tables/upsert`
-                    );
+                    setTableToLoad(null);
+                    setShowTableUploadModal(true);
                   }}
                 />
               </div>
@@ -84,13 +86,8 @@ export function DatasourceTablesTabView({
                       variant="secondary"
                       icon={PencilSquareIcon}
                       onClick={() => {
-                        void router.push(
-                          `/w/${owner.sId}/builder/data-sources/${
-                            dataSource.name
-                          }/tables/upsert?tableId=${encodeURIComponent(
-                            t.table_id
-                          )}`
-                        );
+                        setTableToLoad(t.table_id);
+                        setShowTableUploadModal(true);
                       }}
                       label="Edit"
                       labelVisible={false}
@@ -111,6 +108,13 @@ export function DatasourceTablesTabView({
             </div>
           ) : null}
         </div>
+        <TableUploadModal
+          isOpen={showTableUploadModal}
+          onClose={() => setShowTableUploadModal(false)}
+          dataSource={dataSource}
+          owner={owner}
+          initialTableId={tableToLoad}
+        />
       </Page.Vertical>
     </>
   );

--- a/front/components/data_source/DocumentUploadModal.tsx
+++ b/front/components/data_source/DocumentUploadModal.tsx
@@ -77,6 +77,11 @@ export function DocumentUploadModal({
           }
         })
         .catch((e) => console.error(e));
+    } else {
+      setDocumentId("");
+      setText("");
+      setTags([]);
+      setSourceUrl("");
     }
   }, [dataSource.name, documentToLoad, owner.sId]);
 
@@ -167,7 +172,7 @@ export function DocumentUploadModal({
           : undefined
       }
       isSaving={loading}
-      title="Add a new document"
+      title={documentToLoad ? "Edit document" : "Add a new document"}
     >
       <Page.Vertical align="stretch">
         <div className="ml-2 mr-2 space-y-2">

--- a/front/components/data_source/TableUploadModal.tsx
+++ b/front/components/data_source/TableUploadModal.tsx
@@ -19,25 +19,17 @@ import type { UpsertTableFromCsvRequestBody } from "@app/pages/api/w/[wId]/data_
 interface TableUploadModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSave: (tableData: TableData) => void;
   dataSource: DataSourceType;
   owner: WorkspaceType;
   initialTableId: string | null;
 }
 
-interface TableData {
-  name: string;
-  description: string;
-  csvContent: string;
-}
-
 export function TableUploadModal({
   isOpen,
-  onClose,
-  onSave,
   dataSource,
   owner,
   initialTableId,
+  onClose,
 }: TableUploadModalProps) {
   const sendNotification = useContext(SendNotificationsContext);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -46,7 +38,7 @@ export function TableUploadModal({
   const [tableDescription, setTableDescription] = useState<string>("");
   const [file, setFile] = useState<File | null>(null);
 
-  const [disabled, setDisabled] = useState(true);
+  const [hasChanged, setHasChanged] = useState(true);
   const [uploading, setUploading] = useState(false);
   const [isBigFile, setIsBigFile] = useState(false);
 
@@ -58,11 +50,10 @@ export function TableUploadModal({
 
   useEffect(() => {
     if (!initialTableId && !file) {
-      // File can be null if we are editing a table.
-      return setDisabled(true);
+      return setHasChanged(true);
     }
     if (!tableName || !tableDescription) {
-      return setDisabled(true);
+      return setHasChanged(true);
     }
 
     const edited =
@@ -71,7 +62,7 @@ export function TableUploadModal({
       table?.description !== tableDescription ||
       file;
 
-    return setDisabled(!edited);
+    return setHasChanged(!edited);
   }, [tableName, tableDescription, file, initialTableId, table]);
 
   useEffect(() => {
@@ -199,12 +190,6 @@ export function TableUploadModal({
         title: "Table successfully added",
         description: `Table ${tableName} was successfully added.`,
       });
-      onSave({
-        name: tableName,
-        description: tableDescription,
-        csvContent: fileContent || "",
-      });
-      onClose();
     } finally {
       setUploading(false);
     }
@@ -214,7 +199,7 @@ export function TableUploadModal({
     <Modal
       isOpen={isOpen}
       onClose={onClose}
-      hasChanged={!disabled}
+      hasChanged={!hasChanged}
       variant="side-md"
       title={initialTableId ? "Edit table" : "Add a new table"}
       onSave={handleUpload}

--- a/front/components/data_source/TableUploadModal.tsx
+++ b/front/components/data_source/TableUploadModal.tsx
@@ -1,0 +1,350 @@
+import {
+  DocumentPlusIcon,
+  ExclamationCircleIcon,
+  Input,
+  Modal,
+  Page,
+} from "@dust-tt/sparkle";
+import type { DataSourceType, Result, WorkspaceType } from "@dust-tt/types";
+import { parseAndStringifyCsv } from "@dust-tt/types";
+import { Err, isSlugified, Ok } from "@dust-tt/types";
+import { useContext, useEffect, useRef, useState } from "react";
+
+import { SendNotificationsContext } from "@app/components/sparkle/Notification";
+import { handleFileUploadToText } from "@app/lib/client/handle_file_upload";
+import { useTable } from "@app/lib/swr";
+import { classNames } from "@app/lib/utils";
+import type { UpsertTableFromCsvRequestBody } from "@app/pages/api/w/[wId]/data_sources/[name]/tables/csv";
+
+interface TableUploadModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (tableData: TableData) => void;
+  dataSource: DataSourceType;
+  owner: WorkspaceType;
+  initialTableId: string | null;
+}
+
+interface TableData {
+  name: string;
+  description: string;
+  csvContent: string;
+}
+
+export function TableUploadModal({
+  isOpen,
+  onClose,
+  onSave,
+  dataSource,
+  owner,
+  initialTableId,
+}: TableUploadModalProps) {
+  const sendNotification = useContext(SendNotificationsContext);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [tableName, setTableName] = useState<string>("");
+  const [tableDescription, setTableDescription] = useState<string>("");
+  const [file, setFile] = useState<File | null>(null);
+
+  const [disabled, setDisabled] = useState(true);
+  const [uploading, setUploading] = useState(false);
+  const [isBigFile, setIsBigFile] = useState(false);
+
+  const { table } = useTable({
+    workspaceId: owner.sId,
+    dataSourceName: dataSource.name,
+    tableId: initialTableId ?? null,
+  });
+
+  useEffect(() => {
+    if (!initialTableId && !file) {
+      // File can be null if we are editing a table.
+      return setDisabled(true);
+    }
+    if (!tableName || !tableDescription) {
+      return setDisabled(true);
+    }
+
+    const edited =
+      !initialTableId ||
+      table?.name !== tableName ||
+      table?.description !== tableDescription ||
+      file;
+
+    return setDisabled(!edited);
+  }, [tableName, tableDescription, file, initialTableId, table]);
+
+  useEffect(() => {
+    setTableName(table ? table.name : "");
+    setTableDescription(table ? table.description : "");
+  }, [initialTableId, table]);
+
+  const isNameValid = (name: string) => name.trim() !== "" && isSlugified(name);
+
+  const handleUpload = async () => {
+    setUploading(true);
+
+    try {
+      const fileContentRes: Result<string | null, null> = await (async () => {
+        if (file) {
+          const res = await handleFileUploadToText(file);
+          if (res.isErr()) {
+            sendNotification({
+              type: "error",
+              title: "Error uploading file",
+              description: `An unexpected error occurred: ${res.error}.`,
+            });
+            return new Err(null);
+          }
+
+          const { content } = res.value;
+          try {
+            const stringifiedContent = await parseAndStringifyCsv(content);
+            return new Ok(stringifiedContent);
+          } catch (err) {
+            if (err instanceof Error) {
+              sendNotification({
+                type: "error",
+                title: "Error uploading file",
+                description: `Invalid headers: ${err.message}.`,
+              });
+              return new Err(null);
+            }
+
+            sendNotification({
+              type: "error",
+              title: "Error uploading file",
+              description: `An error occurred: ${err}.`,
+            });
+            return new Err(null);
+          }
+        }
+
+        return new Ok(null);
+      })();
+
+      if (fileContentRes.isErr()) {
+        return;
+      }
+
+      const fileContent = fileContentRes.value;
+
+      if (fileContent && fileContent.length > 50_000_000) {
+        sendNotification({
+          type: "error",
+          title: "File too large",
+          description:
+            "Please upload a file containing less than 50 million characters.",
+        });
+        return;
+      }
+
+      if (fileContent && fileContent.length > 5_000_000) {
+        setIsBigFile(true);
+      } else {
+        setIsBigFile(false);
+      }
+
+      let body: UpsertTableFromCsvRequestBody;
+      if (fileContent) {
+        body = {
+          name: tableName,
+          description: tableDescription,
+          csv: fileContent,
+          tableId: initialTableId ?? undefined,
+          timestamp: null,
+          tags: [],
+          parents: [],
+          truncate: true,
+          async: false,
+        };
+      } else if (initialTableId) {
+        body = {
+          name: tableName,
+          description: tableDescription,
+          tableId: initialTableId,
+          timestamp: null,
+          tags: [],
+          parents: [],
+          csv: undefined,
+          truncate: false,
+          async: false,
+        };
+      } else {
+        throw new Error("Unreachable: fileContent is null");
+      }
+
+      const uploadRes = await fetch(
+        `/api/w/${owner.sId}/data_sources/${dataSource.name}/tables/csv`,
+        {
+          method: "POST",
+          body: JSON.stringify(body),
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+
+      if (!uploadRes.ok) {
+        sendNotification({
+          type: "error",
+          title: "Error uploading file",
+          description: `An error occurred: ${await uploadRes.text()}.`,
+        });
+        return;
+      }
+
+      sendNotification({
+        type: "success",
+        title: "Table successfully added",
+        description: `Table ${tableName} was successfully added.`,
+      });
+      onSave({
+        name: tableName,
+        description: tableDescription,
+        csvContent: fileContent || "",
+      });
+      onClose();
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      hasChanged={!disabled}
+      variant="side-md"
+      title={initialTableId ? "Edit table" : "Add a new table"}
+      onSave={handleUpload}
+    >
+      <Page.Vertical align="stretch">
+        <div className="pt-4">
+          <Page.SectionHeader
+            title="Table name"
+            description="Enter the table name. This identifier will be used in the Assistant builder to pick tables for querying."
+          />
+          <div className="pt-4">
+            <Input
+              placeholder="table_name"
+              name="table-name"
+              disabled={!!initialTableId}
+              value={tableName}
+              onChange={setTableName}
+              error={
+                !tableName || isNameValid(tableName)
+                  ? null
+                  : "Invalid name: Must be alphanumeric, max 32 characters and no space."
+              }
+              showErrorLabel={true}
+            />
+          </div>
+        </div>
+
+        <div className="pt-4">
+          <Page.SectionHeader
+            title="Description"
+            description="Describe the content of your CSV file. It will be used by the LLM model to generate relevant queries."
+          />
+          <div className="pt-4">
+            <textarea
+              name="table-description"
+              placeholder="This table contains..."
+              rows={10}
+              value={tableDescription}
+              onChange={(e) => setTableDescription(e.target.value)}
+              className={classNames(
+                "font-mono text-normal block w-full min-w-0 flex-1 rounded-md",
+                "border-structure-200 bg-structure-50",
+                "focus:border-action-300 focus:ring-action-300"
+              )}
+            />
+          </div>
+        </div>
+
+        <div className="pt-4">
+          <Page.SectionHeader
+            title="CSV File"
+            description="Select the CSV file for data extraction. The maximum file size allowed is 50MB."
+            action={{
+              label: (() => {
+                if (uploading) {
+                  return "Uploading...";
+                } else if (file) {
+                  return file.name;
+                } else if (initialTableId) {
+                  return "Replace file";
+                } else {
+                  return "Upload file";
+                }
+              })(),
+              variant: "primary",
+              icon: DocumentPlusIcon,
+              onClick: () => {
+                if (fileInputRef.current) {
+                  fileInputRef.current.click();
+                }
+              },
+            }}
+          />
+          {isBigFile && (
+            <div className="pt-4">
+              <div className="flex flex-col gap-y-2">
+                <div className="flex grow flex-row items-center gap-1 text-sm font-medium text-warning-500">
+                  <ExclamationCircleIcon />
+                  Warning: Large file (5MB+)
+                </div>
+                <div className="text-sm font-normal text-element-700">
+                  This file is large and may take a while to upload.
+                </div>
+              </div>
+            </div>
+          )}
+          <input
+            type="file"
+            ref={fileInputRef}
+            style={{ display: "none" }}
+            accept=".csv, .tsv"
+            onChange={async (e) => {
+              setUploading(true);
+              const csvFile = e?.target?.files?.[0];
+              if (!csvFile) {
+                return;
+              }
+              if (csvFile.size > 50_000_000) {
+                sendNotification({
+                  type: "error",
+                  title: "File too large",
+                  description: "Please upload a file smaller than 50MB.",
+                });
+                setUploading(false);
+                return;
+              }
+
+              if (
+                ![
+                  "text/csv",
+                  "text/tsv",
+                  "text/comma-separated-values",
+                  "text/tab-separated-values",
+                ].includes(csvFile.type)
+              ) {
+                sendNotification({
+                  type: "error",
+                  title: "Invalid file type",
+                  description: "Please upload a CSV or TSV file.",
+                });
+                setUploading(false);
+                return;
+              }
+
+              setFile(csvFile);
+              setUploading(false);
+            }}
+          />
+        </div>
+      </Page.Vertical>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## Description

This PR adds views to upload/edit table.

It introduces two new components (which mainly reuse the old ones) which duplicates the logic until we deprecate them. Modifying the existing components to work on the new UX while not breaking the old behaviour was a bit of a nightmare which was going to lead to deadcode (as we deprecate the old data source management) anyways.


<img width="1000" alt="Screenshot 2024-08-14 at 14 51 08" src="https://github.com/user-attachments/assets/6a08fa2d-f7c5-481c-8d0c-5623c0bc3976">

<img width="1004" alt="Screenshot 2024-08-14 at 14 51 37" src="https://github.com/user-attachments/assets/43a569fe-4723-437d-b66f-a0fcfe255228">

## Risk

Minor, as we only introduce new components that are gated

## Deploy Plan

N\A