### PR TITLE
[front] - enh(vault): use DataTable folders

### DIFF
--- a/front/components/data_source/DatasourceDocumentsTabView.tsx
+++ b/front/components/data_source/DatasourceDocumentsTabView.tsx
@@ -3,14 +3,10 @@ import {
   DataTable,
   Dialog,
   DocumentTextIcon,
-  DropdownMenu,
-  MoreIcon,
   Page,
-  PencilSquareIcon,
   PlusIcon,
   Popup,
   Searchbar,
-  TrashIcon,
 } from "@dust-tt/sparkle";
 import type {
   DataSourceType,
@@ -25,6 +21,7 @@ import { useContext, useEffect, useRef, useState } from "react";
 import * as React from "react";
 
 import { DocumentUploadModal } from "@app/components/data_source/DocumentUploadModal";
+import { EditOrDeleteDropdown } from "@app/components/misc/EditOrDeleteDropdown";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { handleFileUploadToText } from "@app/lib/client/handle_file_upload";
 import { getDisplayNameForDocument } from "@app/lib/data_sources";
@@ -41,40 +38,6 @@ type RowData = {
 };
 
 type Info = CellContext<RowData, unknown>;
-
-interface ActionDropdownProps {
-  onEdit: () => void;
-  onDelete: () => void;
-}
-
-export function ActionDropdown({ onEdit, onDelete }: ActionDropdownProps) {
-  return (
-    <DropdownMenu>
-      <DropdownMenu.Button>
-        <Button
-          variant="tertiary"
-          icon={MoreIcon}
-          label="More"
-          labelVisible={false}
-          size="sm"
-        />
-      </DropdownMenu.Button>
-      <DropdownMenu.Items origin="topRight" width={220}>
-        <DropdownMenu.Item
-          label="Edit"
-          icon={PencilSquareIcon}
-          onClick={onEdit}
-        />
-        <DropdownMenu.Item
-          label="Delete"
-          icon={TrashIcon}
-          onClick={onDelete}
-          variant="warning"
-        />
-      </DropdownMenu.Items>
-    </DropdownMenu>
-  );
-}
 
 interface ConfirmDeleteDialogProps {
   isOpen: boolean;
@@ -270,7 +233,7 @@ export function DatasourceDocumentsTabView({
     {
       id: "actions",
       cell: (info: Info) => (
-        <ActionDropdown
+        <EditOrDeleteDropdown
           onEdit={() => {
             setDocumentId(info.row.original.name);
             setShowDataSourceUploadModal(true);

--- a/front/components/data_source/DatasourceDocumentsTabView.tsx
+++ b/front/components/data_source/DatasourceDocumentsTabView.tsx
@@ -1,23 +1,28 @@
 import {
   Button,
-  ContextItem,
+  DataTable,
   Dialog,
   DocumentTextIcon,
+  DropdownMenu,
+  MoreIcon,
   Page,
   PencilSquareIcon,
   PlusIcon,
   Popup,
+  Searchbar,
+  TrashIcon,
 } from "@dust-tt/sparkle";
 import type {
-  CoreAPIDocument,
   DataSourceType,
   PlanType,
   PostDataSourceDocumentRequestBody,
   WorkspaceType,
 } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
+import type { CellContext } from "@tanstack/react-table";
 import { useRouter } from "next/router";
 import { useContext, useEffect, useRef, useState } from "react";
+import * as React from "react";
 
 import { DocumentUploadModal } from "@app/components/data_source/DocumentUploadModal";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
@@ -26,6 +31,84 @@ import { getDisplayNameForDocument } from "@app/lib/data_sources";
 import { useDocuments } from "@app/lib/swr";
 import { ClientSideTracking } from "@app/lib/tracking/client";
 import { timeAgoFrom } from "@app/lib/utils";
+
+type RowData = {
+  name: string;
+  size: number;
+  timestamp: number;
+  onClick?: () => void;
+  onMoreClick?: () => void;
+};
+
+type Info = CellContext<RowData, unknown>;
+
+interface ActionDropdownProps {
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+export function ActionDropdown({ onEdit, onDelete }: ActionDropdownProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenu.Button>
+        <Button
+          variant="tertiary"
+          icon={MoreIcon}
+          label="More"
+          labelVisible={false}
+          size="sm"
+        />
+      </DropdownMenu.Button>
+      <DropdownMenu.Items origin="topRight" width={220}>
+        <DropdownMenu.Item
+          label="Edit"
+          icon={PencilSquareIcon}
+          onClick={onEdit}
+        />
+        <DropdownMenu.Item
+          label="Delete"
+          icon={TrashIcon}
+          onClick={onDelete}
+          variant="warning"
+        />
+      </DropdownMenu.Items>
+    </DropdownMenu>
+  );
+}
+
+interface ConfirmDeleteDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onValidate: () => void;
+  documentName: string;
+}
+
+export function ConfirmDeleteDialog({
+  isOpen,
+  onClose,
+  onValidate,
+  documentName,
+}: ConfirmDeleteDialogProps) {
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onCancel={onClose}
+      onValidate={onValidate}
+      title="Confirm deletion"
+      validateVariant="primaryWarning"
+      validateLabel="Delete"
+    >
+      <div className="mt-1 text-left">
+        <p className="mb-4">
+          Are you sure you want to delete the document "{documentName}"?
+        </p>
+        <p className="mb-4 font-bold text-warning-500">
+          This action cannot be undone.
+        </p>
+      </div>
+    </Dialog>
+  );
+}
 
 export function DatasourceDocumentsTabView({
   owner,
@@ -39,7 +122,6 @@ export function DatasourceDocumentsTabView({
   dataSource: DataSourceType;
 }) {
   const [limit] = useState(10);
-  const [offset, setOffset] = useState(0);
 
   const router = useRouter();
 
@@ -49,22 +131,48 @@ export function DatasourceDocumentsTabView({
     isDocumentsLoading,
     isDocumentsError,
     mutateDocuments,
-  } = useDocuments(owner, dataSource, limit, offset);
+  } = useDocuments(owner, dataSource, limit, 0);
   const [showDocumentsLimitPopup, setShowDocumentsLimitPopup] = useState(false);
   const [showDataSourceUploadModal, setShowDataSourceUploadModal] =
     useState(false);
+  const [showDataSourceDeleteDialog, setShowDataSourceDeleteDialog] =
+    useState(false);
+  const [dataSourceSearch, setDataSourceSearch] = useState<string>("");
   const [displayNameByDocId, setDisplayNameByDocId] = useState<
     Record<string, string>
   >({});
-  const [documentToLoad, setDocumentToLoad] = useState<CoreAPIDocument | null>(
-    null
-  );
+  const [documentId, setDocumentId] = useState<string | null>(null);
   const sendNotification = useContext(SendNotificationsContext);
+
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [bulkFilesUploading, setBulkFilesUploading] = useState<null | {
     total: number;
     completed: number;
   }>(null);
+
+  const handleDelete = async () => {
+    if (!documentId) {
+      return;
+    }
+    const res = await fetch(
+      `/api/w/${owner.sId}/data_sources/${
+        dataSource.name
+      }/documents/${encodeURIComponent(documentId)}`,
+      {
+        method: "DELETE",
+      }
+    );
+
+    if (!res.ok) {
+      alert("There was an error deleting the document.");
+      return;
+    }
+    sendNotification({
+      type: "success",
+      title: "Document successfully deleted",
+      description: `Document ${documentId} was successfully deleted`,
+    });
+  };
 
   const handleUpsert = async (text: string, documentId: string) => {
     const body: PostDataSourceDocumentRequestBody = {
@@ -131,55 +239,69 @@ export function DatasourceDocumentsTabView({
     }
   }, [documents, isDocumentsLoading, isDocumentsError]);
 
-  let last = offset + limit;
-  if (offset + limit > total) {
-    last = total;
-  }
+  const columns = [
+    {
+      accessorKey: "document_id",
+      header: "Name",
+      id: "name",
+      cell: (info: Info) => (
+        <DataTable.Cell icon={DocumentTextIcon}>
+          {info.row.original.name}
+        </DataTable.Cell>
+      ),
+    },
+    {
+      header: "Size",
+      accessorKey: "size",
+      cell: (info: Info) => (
+        <DataTable.Cell>
+          {Math.floor(info.row.original.size / 1024)} kb
+        </DataTable.Cell>
+      ),
+    },
+    {
+      header: "Last Edited",
+      accessorKey: "lastEdited",
+      cell: (info: Info) => (
+        <DataTable.Cell>
+          {timeAgoFrom(info.row.original.timestamp)} ago
+        </DataTable.Cell>
+      ),
+    },
+    {
+      id: "actions",
+      cell: (info: Info) => (
+        <ActionDropdown
+          onEdit={() => {
+            setDocumentId(info.row.original.name);
+            setShowDataSourceUploadModal(true);
+          }}
+          onDelete={async () => {
+            // Implement delete functionality
+            setDocumentId(info.row.original.name);
+            setShowDataSourceDeleteDialog(true);
+            console.log("Delete", info.row.original.name);
+          }}
+        />
+      ),
+    },
+  ];
+
+  const rows = !isDocumentsLoading
+    ? documents.map((document) => {
+        return {
+          name: displayNameByDocId[document.document_id],
+          size: document.text_size,
+          timestamp: document.timestamp,
+        };
+      })
+    : [];
 
   return (
     <Page.Vertical align="stretch">
-      <div className="mt-16 flex flex-row">
-        <div className="flex flex-1">
-          <div className="flex flex-col">
-            <div className="flex flex-row">
-              <div className="flex flex-initial gap-x-2">
-                <Button
-                  variant="tertiary"
-                  disabled={offset < limit}
-                  onClick={() => {
-                    if (offset >= limit) {
-                      setOffset(offset - limit);
-                    } else {
-                      setOffset(0);
-                    }
-                  }}
-                  label="Previous"
-                />
-                <Button
-                  variant="tertiary"
-                  label="Next"
-                  disabled={offset + limit >= total}
-                  onClick={() => {
-                    if (offset + limit < total) {
-                      setOffset(offset + limit);
-                    }
-                  }}
-                />
-              </div>
-            </div>
-
-            <div className="mt-3 flex flex-auto pl-2 text-sm text-gray-700">
-              {total > 0 && (
-                <span>
-                  Showing documents {offset + 1} - {last} of {total} documents
-                </span>
-              )}
-            </div>
-          </div>
-        </div>
-
+      <div className="mt-1 flex flex-row">
         {readOnly ? null : (
-          <div className="">
+          <div className="w-full">
             <div className="relative mt-0 flex-none">
               <Popup
                 show={showDocumentsLimitPopup}
@@ -195,7 +317,7 @@ export function DatasourceDocumentsTabView({
                 className="absolute bottom-8 right-0"
               />
 
-              <>
+              <div className="flex w-full flex-row gap-2">
                 <Dialog
                   onCancel={() => {
                     //no-op as we can't cancel file upload
@@ -270,84 +392,51 @@ export function DatasourceDocumentsTabView({
                   }}
                 ></input>
 
+                <Searchbar
+                  name="search"
+                  placeholder="Search (Name)"
+                  value={dataSourceSearch}
+                  onChange={(s) => {
+                    setDataSourceSearch(s);
+                  }}
+                />
                 <Button
-                  className="mr-2"
                   variant="secondary"
                   icon={PlusIcon}
-                  label="Upload multiples files"
+                  label="Upload multiple files"
                   onClick={() => {
                     fileInputRef.current?.click();
                   }}
                 />
-              </>
-
-              <Button
-                variant="primary"
-                icon={PlusIcon}
-                label="Add document"
-                onClick={() => {
-                  setDocumentToLoad(null);
-                  // Enforce plan limits: DataSource documents count.
-                  if (
-                    plan.limits.dataSources.documents.count != -1 &&
-                    total >= plan.limits.dataSources.documents.count
-                  ) {
-                    setShowDocumentsLimitPopup(true);
-                  } else {
-                    setShowDataSourceUploadModal(true);
-                  }
-                }}
-              />
+                <Button
+                  variant="primary"
+                  icon={PlusIcon}
+                  label="Add document"
+                  onClick={() => {
+                    setDocumentId(null);
+                    // Enforce plan limits: DataSource documents count.
+                    if (
+                      plan.limits.dataSources.documents.count != -1 &&
+                      total >= plan.limits.dataSources.documents.count
+                    ) {
+                      setShowDocumentsLimitPopup(true);
+                    } else {
+                      setShowDataSourceUploadModal(true);
+                    }
+                  }}
+                />
+              </div>
             </div>
           </div>
         )}
       </div>
 
       <div className="py-8">
-        <ContextItem.List>
-          {documents.map((d) => (
-            <ContextItem
-              key={d.document_id}
-              title={displayNameByDocId[d.document_id]}
-              visual={
-                <ContextItem.Visual
-                  visual={({ className }) =>
-                    DocumentTextIcon({
-                      className: className + " text-element-600",
-                    })
-                  }
-                />
-              }
-              action={
-                <Button.List>
-                  <Button
-                    variant="secondary"
-                    icon={PencilSquareIcon}
-                    onClick={() => {
-                      setDocumentToLoad(d);
-                      setShowDataSourceUploadModal(true);
-                    }}
-                    label="Edit"
-                    labelVisible={false}
-                  />
-                </Button.List>
-              }
-            >
-              <ContextItem.Description>
-                <div className="pt-2 text-sm text-element-700">
-                  {Math.floor(d.text_size / 1024)} kb,{" "}
-                  {timeAgoFrom(d.timestamp)} ago
-                </div>
-              </ContextItem.Description>
-            </ContextItem>
-          ))}
-        </ContextItem.List>
-        {documents.length == 0 ? (
-          <div className="mt-10 flex flex-col items-center justify-center text-sm text-gray-500">
-            <p>No documents found for this Folder.</p>
-            <p className="mt-2">You can add documents manually or by API.</p>
-          </div>
-        ) : null}
+        <DataTable
+          data={rows}
+          columns={columns}
+          initialColumnOrder={[{ id: "name", desc: false }]}
+        />
       </div>
       <DocumentUploadModal
         isOpen={showDataSourceUploadModal}
@@ -355,7 +444,16 @@ export function DatasourceDocumentsTabView({
         owner={owner}
         dataSource={dataSource}
         plan={plan}
-        documentToLoad={documentToLoad}
+        documentIdToLoad={documentId}
+      />
+      <ConfirmDeleteDialog
+        isOpen={showDataSourceDeleteDialog}
+        onClose={() => setShowDataSourceDeleteDialog(false)}
+        onValidate={async () => {
+          await handleDelete();
+          setShowDataSourceDeleteDialog(false);
+        }}
+        documentName={documentId ?? ""}
       />
     </Page.Vertical>
   );

--- a/front/components/data_source/DatasourceDocumentsTabView.tsx
+++ b/front/components/data_source/DatasourceDocumentsTabView.tsx
@@ -241,9 +241,8 @@ export function DatasourceDocumentsTabView({
 
   const columns = [
     {
-      accessorKey: "document_id",
+      accessorKey: "name",
       header: "Name",
-      id: "name",
       cell: (info: Info) => (
         <DataTable.Cell icon={DocumentTextIcon}>
           {info.row.original.name}
@@ -436,6 +435,8 @@ export function DatasourceDocumentsTabView({
           data={rows}
           columns={columns}
           initialColumnOrder={[{ id: "name", desc: false }]}
+          filter={dataSourceSearch}
+          filterColumn={"name"}
         />
       </div>
       <DocumentUploadModal

--- a/front/components/data_source/DatasourceTablesTabView.tsx
+++ b/front/components/data_source/DatasourceTablesTabView.tsx
@@ -2,14 +2,10 @@ import {
   Button,
   DataTable,
   Dialog,
-  DropdownMenu,
-  MoreIcon,
   Page,
-  PencilSquareIcon,
   PlusIcon,
   Searchbar,
   ServerIcon,
-  TrashIcon,
 } from "@dust-tt/sparkle";
 import type { DataSourceType, WorkspaceType } from "@dust-tt/types";
 import type { CellContext } from "@tanstack/react-table";
@@ -17,6 +13,7 @@ import { useContext, useState } from "react";
 import * as React from "react";
 
 import { TableUploadModal } from "@app/components/data_source/TableUploadModal";
+import { EditOrDeleteDropdown } from "@app/components/misc/EditOrDeleteDropdown";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { useTables } from "@app/lib/swr";
 import { timeAgoFrom } from "@app/lib/utils";
@@ -31,40 +28,6 @@ type RowData = {
 };
 
 type Info = CellContext<RowData, unknown>;
-
-interface ActionDropdownProps {
-  onEdit: () => void;
-  onDelete: () => void;
-}
-
-function ActionDropdown({ onEdit, onDelete }: ActionDropdownProps) {
-  return (
-    <DropdownMenu>
-      <DropdownMenu.Button>
-        <Button
-          variant="tertiary"
-          icon={MoreIcon}
-          label="More"
-          labelVisible={false}
-          size="sm"
-        />
-      </DropdownMenu.Button>
-      <DropdownMenu.Items origin="topRight" width={220}>
-        <DropdownMenu.Item
-          label="Edit"
-          icon={PencilSquareIcon}
-          onClick={onEdit}
-        />
-        <DropdownMenu.Item
-          label="Delete"
-          icon={TrashIcon}
-          onClick={onDelete}
-          variant="warning"
-        />
-      </DropdownMenu.Items>
-    </DropdownMenu>
-  );
-}
 
 interface ConfirmDeleteDialogProps {
   isOpen: boolean;
@@ -168,7 +131,7 @@ export function DatasourceTablesTabView({
     {
       id: "actions",
       cell: (info: Info) => (
-        <ActionDropdown
+        <EditOrDeleteDropdown
           onEdit={() => {
             setTableToLoad(info.row.original.tableId);
             setShowTableUploadModal(true);

--- a/front/components/data_source/DatasourceTablesTabView.tsx
+++ b/front/components/data_source/DatasourceTablesTabView.tsx
@@ -200,6 +200,7 @@ export function DatasourceTablesTabView({
       <TableUploadModal
         isOpen={showTableUploadModal}
         onClose={() => setShowTableUploadModal(false)}
+        onSave={() => setShowTableUploadModal(false)}
         dataSource={dataSource}
         owner={owner}
         initialTableId={tableToLoad}

--- a/front/components/data_source/DatasourceTablesTabView.tsx
+++ b/front/components/data_source/DatasourceTablesTabView.tsx
@@ -1,17 +1,100 @@
 import {
   Button,
-  ContextItem,
+  DataTable,
+  Dialog,
+  DropdownMenu,
+  MoreIcon,
   Page,
   PencilSquareIcon,
   PlusIcon,
+  Searchbar,
   ServerIcon,
+  TrashIcon,
 } from "@dust-tt/sparkle";
 import type { DataSourceType, WorkspaceType } from "@dust-tt/types";
-import { useState } from "react";
+import type { CellContext } from "@tanstack/react-table";
+import { useContext, useState } from "react";
+import * as React from "react";
 
 import { TableUploadModal } from "@app/components/data_source/TableUploadModal";
-import { tableKey } from "@app/lib/client/tables_query";
+import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { useTables } from "@app/lib/swr";
+import { timeAgoFrom } from "@app/lib/utils";
+
+type RowData = {
+  tableId: string;
+  name: string;
+  dataSourceId: string;
+  timestamp: number;
+  onClick?: () => void;
+  onMoreClick?: () => void;
+};
+
+type Info = CellContext<RowData, unknown>;
+
+interface ActionDropdownProps {
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+function ActionDropdown({ onEdit, onDelete }: ActionDropdownProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenu.Button>
+        <Button
+          variant="tertiary"
+          icon={MoreIcon}
+          label="More"
+          labelVisible={false}
+          size="sm"
+        />
+      </DropdownMenu.Button>
+      <DropdownMenu.Items origin="topRight" width={220}>
+        <DropdownMenu.Item
+          label="Edit"
+          icon={PencilSquareIcon}
+          onClick={onEdit}
+        />
+        <DropdownMenu.Item
+          label="Delete"
+          icon={TrashIcon}
+          onClick={onDelete}
+          variant="warning"
+        />
+      </DropdownMenu.Items>
+    </DropdownMenu>
+  );
+}
+
+interface ConfirmDeleteDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onValidate: () => void;
+}
+
+function ConfirmDeleteDialog({
+  isOpen,
+  onClose,
+  onValidate,
+}: ConfirmDeleteDialogProps) {
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onCancel={onClose}
+      onValidate={onValidate}
+      title="Confirm deletion"
+      validateVariant="primaryWarning"
+      validateLabel="Delete"
+    >
+      <div className="mt-1 text-left">
+        <p className="mb-4">Are you sure you want to delete this table?</p>
+        <p className="mb-4 font-bold text-warning-500">
+          This action cannot be undone.
+        </p>
+      </div>
+    </Dialog>
+  );
+}
 
 export function DatasourceTablesTabView({
   owner,
@@ -24,98 +107,150 @@ export function DatasourceTablesTabView({
 }) {
   const [showTableUploadModal, setShowTableUploadModal] = useState(false);
   const [tableToLoad, setTableToLoad] = useState<string | null>(null);
+  const [showTableDeleteDialog, setShowTableDeleteDialog] = useState(false);
+  const [tableSearch, setTableSearch] = useState<string>("");
 
-  const { tables } = useTables({
+  const sendNotification = useContext(SendNotificationsContext);
+
+  const { tables, mutateTables } = useTables({
     workspaceId: owner.sId,
     dataSourceName: dataSource.name,
   });
 
+  const handleDelete = async (tableId: string) => {
+    try {
+      const res = await fetch(
+        `/api/w/${owner.sId}/data_sources/${dataSource.name}/tables/${tableId}`,
+        {
+          method: "DELETE",
+        }
+      );
+
+      if (!res.ok) {
+        throw new Error("Failed to delete table");
+      }
+
+      sendNotification({
+        type: "success",
+        title: "Table successfully deleted",
+        description: `The table was successfully deleted`,
+      });
+
+      await mutateTables();
+    } catch (error) {
+      sendNotification({
+        type: "error",
+        title: "Error deleting table",
+        description: "An error occurred while deleting the table.",
+      });
+    }
+  };
+
+  const columns = [
+    {
+      accessorKey: "name",
+      header: "Name",
+      cell: (info: Info) => (
+        <DataTable.Cell icon={ServerIcon}>
+          {info.row.original.name}
+        </DataTable.Cell>
+      ),
+    },
+    {
+      header: "Last Edited",
+      accessorKey: "lastEdited",
+      cell: (info: Info) => (
+        <DataTable.Cell>
+          {timeAgoFrom(info.row.original.timestamp)} ago
+        </DataTable.Cell>
+      ),
+    },
+    {
+      id: "actions",
+      cell: (info: Info) => (
+        <ActionDropdown
+          onEdit={() => {
+            setTableToLoad(info.row.original.tableId);
+            setShowTableUploadModal(true);
+          }}
+          onDelete={() => {
+            setTableToLoad(info.row.original.tableId);
+            setShowTableDeleteDialog(true);
+          }}
+        />
+      ),
+    },
+  ];
+
+  const rows = tables.map((t) => ({
+    tableId: t.table_id,
+    name: t.name,
+    dataSourceId: t.data_source_id,
+    timestamp: t.timestamp,
+  }));
+
   return (
-    <>
-      <Page.Vertical align="stretch">
-        <div className="mt-16 flex flex-row">
-          <div className="flex flex-1">
-            <div className="flex flex-col">
-              <div className="flex flex-row">
-                <div className="flex flex-initial gap-x-2">
-                  <Button variant="tertiary" disabled={true} label="Previous" />
-                  <Button variant="tertiary" label="Next" disabled={true} />
-                </div>
-              </div>
+    <Page.Vertical align="stretch">
+      <div className="mt-1 flex flex-row">
+        {!readOnly && (
+          <div className="w-full">
+            <div className="flex w-full flex-row gap-2">
+              <Searchbar
+                name="search"
+                placeholder="Search (Name)"
+                value={tableSearch}
+                onChange={setTableSearch}
+              />
+              <Button
+                variant="primary"
+                icon={PlusIcon}
+                label="Add table"
+                onClick={() => {
+                  setTableToLoad(null);
+                  setShowTableUploadModal(true);
+                }}
+              />
             </div>
           </div>
-          {readOnly ? null : (
-            <div className="">
-              <div className="relative mt-0 flex-none">
-                <Button
-                  variant="primary"
-                  icon={PlusIcon}
-                  label="Add table"
-                  onClick={() => {
-                    setTableToLoad(null);
-                    setShowTableUploadModal(true);
-                  }}
-                />
-              </div>
-            </div>
-          )}
-        </div>
+        )}
+      </div>
 
-        <div className="py-8">
-          <ContextItem.List>
-            {tables.map((t) => (
-              <ContextItem
-                key={tableKey({
-                  workspaceId: owner.sId,
-                  tableId: t.table_id,
-                  dataSourceId: dataSource.name,
-                })}
-                title={`${t.name} (${t.data_source_id})`}
-                visual={
-                  <ContextItem.Visual
-                    visual={({ className }) =>
-                      ServerIcon({
-                        className: className + " text-element-600",
-                      })
-                    }
-                  />
-                }
-                action={
-                  <Button.List>
-                    <Button
-                      variant="secondary"
-                      icon={PencilSquareIcon}
-                      onClick={() => {
-                        setTableToLoad(t.table_id);
-                        setShowTableUploadModal(true);
-                      }}
-                      label="Edit"
-                      labelVisible={false}
-                    />
-                  </Button.List>
-                }
-              ></ContextItem>
-            ))}
-          </ContextItem.List>
-          {tables.length == 0 ? (
-            <div className="mt-10 flex flex-col items-center justify-center text-sm text-gray-500">
-              <p>No tables found for this Folder.</p>
-              <p className="mt-2">
-                Tables let you create assistants that can query structured data
-                from uploaded CSV files. You can add tables manually by clicking
-                on the &quot;Add&nbsp;table&quot; button.
-              </p>
-            </div>
-          ) : null}
-        </div>
-        <TableUploadModal
-          isOpen={showTableUploadModal}
-          onClose={() => setShowTableUploadModal(false)}
-          dataSource={dataSource}
-          owner={owner}
-          initialTableId={tableToLoad}
+      <div className="py-8">
+        <DataTable
+          data={rows}
+          columns={columns}
+          initialColumnOrder={[{ id: "name", desc: false }]}
+          filter={tableSearch}
+          filterColumn={"name"}
         />
-      </Page.Vertical>
-    </>
+        {tables.length === 0 && (
+          <div className="mt-10 flex flex-col items-center justify-center text-sm text-gray-500">
+            <p>No tables found for this Folder.</p>
+            <p className="mt-2">
+              Tables let you create assistants that can query structured data
+              from uploaded CSV files. You can add tables manually by clicking
+              on the "Add table" button.
+            </p>
+          </div>
+        )}
+      </div>
+      <TableUploadModal
+        isOpen={showTableUploadModal}
+        onClose={() => setShowTableUploadModal(false)}
+        dataSource={dataSource}
+        owner={owner}
+        initialTableId={tableToLoad}
+      />
+      <ConfirmDeleteDialog
+        isOpen={showTableDeleteDialog}
+        onClose={() => setShowTableDeleteDialog(false)}
+        onValidate={async () => {
+          if (tableToLoad) {
+            await handleDelete(tableToLoad);
+          }
+          setShowTableDeleteDialog(false);
+        }}
+      />
+    </Page.Vertical>
   );
 }

--- a/front/components/data_source/DocumentUploadModal.tsx
+++ b/front/components/data_source/DocumentUploadModal.tsx
@@ -10,7 +10,6 @@ import {
   TrashIcon,
 } from "@dust-tt/sparkle";
 import type {
-  CoreAPIDocument,
   DataSourceType,
   PlanType,
   PostDataSourceDocumentRequestBody,
@@ -28,7 +27,7 @@ export interface DocumentUploadModalProps {
   owner: WorkspaceType;
   dataSource: DataSourceType;
   plan: PlanType;
-  documentToLoad: CoreAPIDocument | null;
+  documentIdToLoad: string | null;
 }
 
 export function DocumentUploadModal({
@@ -37,7 +36,7 @@ export function DocumentUploadModal({
   owner,
   dataSource,
   plan,
-  documentToLoad,
+  documentIdToLoad,
 }: DocumentUploadModalProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -59,13 +58,13 @@ export function DocumentUploadModal({
   }, [documentId, text]);
 
   useEffect(() => {
-    if (documentToLoad) {
-      setDocumentId(documentToLoad.document_id);
+    if (documentIdToLoad) {
+      setDocumentId(documentIdToLoad);
       setDisabled(true);
       fetch(
         `/api/w/${owner.sId}/data_sources/${
           dataSource.name
-        }/documents/${encodeURIComponent(documentToLoad.document_id)}`
+        }/documents/${encodeURIComponent(documentIdToLoad)}`
       )
         .then(async (res) => {
           if (res.ok) {
@@ -83,7 +82,7 @@ export function DocumentUploadModal({
       setTags([]);
       setSourceUrl("");
     }
-  }, [dataSource.name, documentToLoad, owner.sId]);
+  }, [dataSource.name, documentIdToLoad, owner.sId]);
 
   const handleUpsert = async () => {
     setLoading(true);
@@ -172,7 +171,7 @@ export function DocumentUploadModal({
           : undefined
       }
       isSaving={loading}
-      title={documentToLoad ? "Edit document" : "Add a new document"}
+      title={documentIdToLoad ? "Edit document" : "Add a new document"}
     >
       <Page.Vertical align="stretch">
         <div className="ml-2 mr-2 space-y-2">

--- a/front/components/data_source/StandardDataSourceView.tsx
+++ b/front/components/data_source/StandardDataSourceView.tsx
@@ -52,13 +52,6 @@ export function StandardDataSourceView({
   return (
     <div className="pt-6">
       <Page.Vertical gap="xl" align="stretch">
-        <Page.SectionHeader
-          title={dataSource.name}
-          description={
-            "Use this page to view and upload documents and tables to your Folder."
-          }
-        />
-
         <Tab tabs={tabs} setCurrentTab={setCurrentTab} />
 
         {currentTab === "documents" && (

--- a/front/components/data_source/TableUploadModal.tsx
+++ b/front/components/data_source/TableUploadModal.tsx
@@ -19,6 +19,7 @@ import type { UpsertTableFromCsvRequestBody } from "@app/pages/api/w/[wId]/data_
 interface TableUploadModalProps {
   isOpen: boolean;
   onClose: () => void;
+  onSave: () => void;
   dataSource: DataSourceType;
   owner: WorkspaceType;
   initialTableId: string | null;
@@ -30,6 +31,7 @@ export function TableUploadModal({
   owner,
   initialTableId,
   onClose,
+  onSave,
 }: TableUploadModalProps) {
   const sendNotification = useContext(SendNotificationsContext);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -202,7 +204,10 @@ export function TableUploadModal({
       hasChanged={!hasChanged}
       variant="side-md"
       title={initialTableId ? "Edit table" : "Add a new table"}
-      onSave={handleUpload}
+      onSave={async () => {
+        await handleUpload();
+        onSave();
+      }}
     >
       <Page.Vertical align="stretch">
         <div className="pt-4">

--- a/front/components/misc/EditOrDeleteDropdown.tsx
+++ b/front/components/misc/EditOrDeleteDropdown.tsx
@@ -1,0 +1,45 @@
+import {
+  Button,
+  DropdownMenu,
+  MoreIcon,
+  PencilSquareIcon,
+  TrashIcon,
+} from "@dust-tt/sparkle";
+import * as React from "react";
+
+interface EditOrDeleteDropdownProps {
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+export function EditOrDeleteDropdown({
+  onEdit,
+  onDelete,
+}: EditOrDeleteDropdownProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenu.Button>
+        <Button
+          variant="tertiary"
+          icon={MoreIcon}
+          label="More"
+          labelVisible={false}
+          size="sm"
+        />
+      </DropdownMenu.Button>
+      <DropdownMenu.Items origin="topRight" width={220}>
+        <DropdownMenu.Item
+          label="Edit"
+          icon={PencilSquareIcon}
+          onClick={onEdit}
+        />
+        <DropdownMenu.Item
+          label="Delete"
+          icon={TrashIcon}
+          onClick={onDelete}
+          variant="warning"
+        />
+      </DropdownMenu.Items>
+    </DropdownMenu>
+  );
+}


### PR DESCRIPTION
## Description

This PR aims at using `DataTable` to render documents and tables in vaults.

<img width="1003" alt="Screenshot 2024-08-14 at 16 41 33" src="https://github.com/user-attachments/assets/4f342eb5-e2fa-4361-9468-c5d33c667df2">


## Risk

Limited

## Deploy Plan

N/A
