### PR TITLE
[sparkle] - feature: rounded avatars in DataTable

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.204",
+  "version": "0.2.206",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.204",
+      "version": "0.2.206",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.205",
+  "version": "0.2.206",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -250,6 +250,7 @@ interface CellProps extends React.TdHTMLAttributes<HTMLTableCellElement> {
   avatarUrl?: string;
   icon?: React.ComponentType<{ className?: string }>;
   iconClassName?: string;
+  roundedAvatar?: boolean;
   children?: ReactNode;
   description?: string;
 }
@@ -258,6 +259,7 @@ DataTable.Cell = function Cell({
   children,
   className,
   avatarUrl,
+  roundedAvatar,
   icon,
   iconClassName,
   description,
@@ -273,7 +275,12 @@ DataTable.Cell = function Cell({
     >
       <div className="s-flex">
         {avatarUrl && (
-          <Avatar visual={avatarUrl} size="xs" className="s-mr-2" />
+          <Avatar
+            visual={avatarUrl}
+            size="xs"
+            className="s-mr-2"
+            isRounded={roundedAvatar ?? false}
+          />
         )}
         {icon && (
           <Icon

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -22,6 +22,7 @@ type Data = {
   icon?: React.ComponentType<{ className?: string }>;
   onClick?: () => void;
   onMoreClick?: () => void;
+  roundedAvatar?: boolean;
 };
 
 export const DataTableExample = () => {
@@ -34,6 +35,7 @@ export const DataTableExample = () => {
       lastUpdated: "July 8, 2023",
       size: "32kb",
       avatarUrl: "https://dust.tt/static/droidavatar/Droid_Lime_3.jpg",
+      roundedAvatar: true,
       onClick: () => console.log("hehe"),
       onMoreClick: () => console.log("show more"),
     },
@@ -77,6 +79,7 @@ export const DataTableExample = () => {
           avatarUrl={info.row.original.avatarUrl}
           icon={info.row.original.icon}
           description={info.row.original.description}
+          roundedAvatar={info.row.original.roundedAvatar}
         >
           {info.row.original.name}
         </DataTable.Cell>


### PR DESCRIPTION
## Description

This PR  implement the ability to display rounded avatars in DataTable components

**References:**
- [Slack messge](https://dust4ai.slack.com/archives/C050A0S2Z7F/p1723558191184589)
## Risk

Very limited as this is an optional parameter

## Deploy Plan

- Deploy `sparkle`
