### PR TITLE
enh: use latest gpt-4o model

### DIFF
--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -79,7 +79,8 @@ export function getLargeWhitelistedModel(
  */
 
 export const GPT_4_TURBO_MODEL_ID = "gpt-4-turbo" as const;
-export const GPT_4O_MODEL_ID = "gpt-4o" as const;
+export const GPT_4O_LEGACY_MODEL_ID = "gpt-4o" as const;
+export const GPT_4O_MODEL_ID = "gpt-4o-2024-08-06" as const;
 export const GPT_4O_MINI_MODEL_ID = "gpt-4o-mini" as const;
 export const GPT_3_5_TURBO_MODEL_ID = "gpt-3.5-turbo" as const;
 export const CLAUDE_3_OPUS_2024029_MODEL_ID = "claude-3-opus-20240229" as const;
@@ -101,6 +102,7 @@ export const MODEL_IDS = [
   GPT_4_TURBO_MODEL_ID,
   GPT_3_5_TURBO_MODEL_ID,
   GPT_4O_MODEL_ID,
+  GPT_4O_LEGACY_MODEL_ID,
   GPT_4O_MINI_MODEL_ID,
   CLAUDE_3_OPUS_2024029_MODEL_ID,
   CLAUDE_3_5_SONNET_20240620_MODEL_ID,
@@ -182,6 +184,20 @@ export const GPT_4_TURBO_MODEL_CONFIG: ModelConfigurationType = {
 export const GPT_4O_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
   modelId: GPT_4O_MODEL_ID,
+  displayName: "GPT 4o",
+  contextSize: 128_000,
+  recommendedTopK: 32,
+  recommendedExhaustiveTopK: 128, // 65_536
+  largeModel: true,
+  description: "OpenAI's GPT 4o model (128k context).",
+  shortDescription: "OpenAI's most advanced model.",
+  isLegacy: false,
+  toolUseMetaPrompt: OPEN_AI_TOOL_USE_META_PROMPT,
+  supportsVision: true,
+};
+export const GPT_4O_LEGACY_MODEL_CONFIG: ModelConfigurationType = {
+  providerId: "openai",
+  modelId: GPT_4O_LEGACY_MODEL_ID,
   displayName: "GPT 4o",
   contextSize: 128_000,
   recommendedTopK: 32,
@@ -424,6 +440,7 @@ export const SUPPORTED_MODEL_CONFIGS: ModelConfigurationType[] = [
   GPT_3_5_TURBO_MODEL_CONFIG,
   GPT_4_TURBO_MODEL_CONFIG,
   GPT_4O_MODEL_CONFIG,
+  GPT_4O_LEGACY_MODEL_CONFIG,
   GPT_4O_MINI_MODEL_CONFIG,
   CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG,
   CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG,


### PR DESCRIPTION
## Description

We were wrongly assuming that `gpt-4o` would always point to the latest snapshot of the `gpt-4o`, but this is not the case.

In order to not break assistants that have `gpt-4o` as  model ID, we're temporarily keeping `gpt-4o`  as a supported model ID. We'll remove that once existing assistants have been migrated. 

Global assistants will be automatically migrated.

## Risk

Always risky touching model IDs

## Deploy Plan

deploy code, then use update model script to switch from legacy model ID to latest dated model ID