### PR TITLE
[front] - fix(datatable): rounded avatars & centered items

### DIFF
--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -87,6 +87,7 @@ const getTableColumns = () => {
       cell: (info: Info) => (
         <DataTable.Cell
           avatarUrl={info.row.original.editedByUser?.imageUrl ?? ""}
+          roundedAvatar={true}
         />
       ),
     },

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,7 @@
         "@amplitude/analytics-browser": "^2.5.2",
         "@amplitude/analytics-node": "^1.3.5",
         "@auth0/nextjs-auth0": "^3.5.0",
-        "@dust-tt/sparkle": "^0.2.204",
+        "@dust-tt/sparkle": "^0.2.206",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -10735,9 +10735,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.204",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.204.tgz",
-      "integrity": "sha512-JSePfugJLG7ONPF85W9ZNrQeDWkpjl1k3ieqPt8EItTRPzzXFLYJucRB6iN+ijG2UBrivA9amp5Hnik8ZkCAIA==",
+      "version": "0.2.206",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.206.tgz",
+      "integrity": "sha512-U/qVid+mTWKc7VRWgwIK9VSFy8dXOFsTcDXor/haM/ke8f65oZjiQFnMQdKe5R+CW16lyqJaWmXIRKu1SgZ7FA==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
     "@amplitude/analytics-browser": "^2.5.2",
     "@amplitude/analytics-node": "^1.3.5",
     "@auth0/nextjs-auth0": "^3.5.0",
-    "@dust-tt/sparkle": "^0.2.204",
+    "@dust-tt/sparkle": "^0.2.206",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -850,7 +850,6 @@ function getTableColumns(): ColumnDef<RowData, unknown>[] {
     },
     {
       header: "Used by",
-      id: "usedBy",
       accessorKey: "usage",
       cell: (info: Info) => (
         <>
@@ -868,12 +867,12 @@ function getTableColumns(): ColumnDef<RowData, unknown>[] {
       cell: (info: Info) => (
         <DataTable.Cell
           avatarUrl={info.row.original.editedByUser?.imageUrl ?? ""}
+          roundedAvatar={true}
         />
       ),
     },
     {
       header: "Last sync",
-      id: "lastSync",
       accessorKey: "editedByUser.editedAt",
       cell: (info: Info) => (
         <DataTable.Cell className="w-10">

--- a/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
@@ -288,6 +288,7 @@ function getTableColumns() {
       cell: (info: Info) => (
         <DataTable.Cell
           avatarUrl={info.row.original.editedByUser?.imageUrl ?? ""}
+          roundedAvatar={true}
         />
       ),
     },

--- a/front/pages/w/[wId]/builder/data-sources/static.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/static.tsx
@@ -238,6 +238,7 @@ function getTableColumns() {
       cell: (info: Info) => (
         <DataTable.Cell
           avatarUrl={info.row.original.editedByUser?.imageUrl ?? ""}
+          roundedAvatar={true}
         />
       ),
     },


### PR DESCRIPTION
## Description

This PR aims at fixing the DataTable used in front, to vertically center the items and round avatars.

## Risk

Limited

## Deploy Plan

Deploy `front`