### PR TITLE
[connectors] fix(notion): index relation ids

### DIFF
--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -871,6 +871,7 @@ export function parsePropertyValue(
     case "unique_id":
       return parseUniqueIdProp(property.unique_id);
     case "relation":
+      return property.relation.map((r) => r.id).join(",");
     case "rollup":
     case "verification":
       return null;


### PR DESCRIPTION
## Description

Index page id of the relation. The page is necessarily part of another notion database, thus is a row id that can be used in joins.

## Risk

none

## Deploy Plan

deploy `connectors`
