### PR TITLE
[front] fix(transcripts): ensure one single conversation per transcript

### DIFF
--- a/front/lib/resources/labs_transcripts_resource.ts
+++ b/front/lib/resources/labs_transcripts_resource.ts
@@ -170,6 +170,25 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
     return history.get();
   }
 
+  async setConversationHistory(
+    fileId: string,
+    conversationId: string
+  ): Promise<InferAttributes<LabsTranscriptsHistoryModel> | null> {
+    const history = await LabsTranscriptsHistoryModel.findOne({
+      where: {
+        fileId,
+      },
+    });
+
+    if (!history) {
+      return null;
+    }
+
+    await history?.update({ conversationId });
+
+    return history.get();
+  }
+
   async fetchHistoryForFileId(
     fileId: LabsTranscriptsHistoryModel["fileId"]
   ): Promise<InferAttributes<LabsTranscriptsHistoryModel> | null> {


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/1156

## Description

Create one single conversation when transcript is sent to multiple people. If the same transcript is sent to multiple people, multiple activities are started in parallel and create conversation, but one fails when creating the history object.

Related log : 

https://app.datadoghq.eu/logs?query=%22%5BprocessTranscriptActivity%5D%22%20@workspaceId:0ec9852c2f%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host,service&fromUser=true&messageDisplay=inline&storage=hot&stream_sort=desc&viz=stream&from_ts=1723563072194&to_ts=1723572304452&live=false

## Risk

none

## Deploy Plan

deploy `front`