### PR TITLE
Remove NEXTAUTH, fix URL->DUST_CLIENT_FACING_URL on qa/edge

### DIFF
--- a/k8s/deployments/front-edge-deployment.yaml
+++ b/k8s/deployments/front-edge-deployment.yaml
@@ -43,11 +43,9 @@ spec:
             # don't have the same memory limits as the regular front pods
             - name: NODE_OPTIONS
               value: "-r dd-trace/init"
-            - name: NEXTAUTH_URL
-              value: https://front-edge.dust.tt
             - name: AUTH0_BASE_URL
               value: https://front-edge.dust.tt
-            - name: URL
+            - name: DUST_CLIENT_FACING_URL
               value: https://front-edge.dust.tt
 
             - name: DD_AGENT_HOST

--- a/k8s/deployments/front-qa-deployment.yaml
+++ b/k8s/deployments/front-qa-deployment.yaml
@@ -43,11 +43,9 @@ spec:
             # don't have the same memory limits as the regular front pods
             - name: NODE_OPTIONS
               value: "-r dd-trace/init"
-            - name: NEXTAUTH_URL
-              value: https://front-qa.dust.tt
             - name: AUTH0_BASE_URL
               value: https://front-qa.dust.tt
-            - name: URL
+            - name: DUST_CLIENT_FACING_URL
               value: https://front-qa.dust.tt
 
             - name: DD_AGENT_HOST


### PR DESCRIPTION
## Description

We removed the use of "URL" in favor of "DUST_CLIENT_FACING_URL" here: https://github.com/dust-tt/dust/pull/6225

This PR fixes the edge/qa deployments to override the right env variable.

Work as part of https://github.com/dust-tt/tasks/issues/1030

## Risk

qa/edge only

## Deploy Plan

deploy `front-edge`