### PR TITLE
[sparkle] improvement(table): Add more dropdown menu

### DIFF
--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.206",
+  "version": "0.2.207",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -20,7 +20,7 @@ import { Icon } from "./Icon";
 interface TBaseData {
   onClick?: () => void;
   onMoreClick?: () => void;
-  onMoreMenuItem?: DropdownItemProps[];
+  moreMenuItems?: DropdownItemProps[];
 }
 
 interface ColumnBreakpoint {
@@ -122,7 +122,7 @@ export function DataTable<TData extends TBaseData, TValue>({
             key={row.id}
             onClick={row.original.onClick}
             onMoreClick={row.original.onMoreClick}
-            onMoreMenuItem={row.original.onMoreMenuItem}
+            moreMenuItems={row.original.moreMenuItems}
           >
             {row.getVisibleCells().map((cell) => (
               <DataTable.Cell
@@ -215,7 +215,7 @@ interface RowProps extends React.HTMLAttributes<HTMLTableRowElement> {
   children: ReactNode;
   onClick?: () => void;
   onMoreClick?: () => void;
-  onMoreMenuItem?: DropdownItemProps[];
+  moreMenuItems?: DropdownItemProps[];
 }
 
 DataTable.Row = function Row({
@@ -223,7 +223,7 @@ DataTable.Row = function Row({
   className,
   onClick,
   onMoreClick,
-  onMoreMenuItem,
+  moreMenuItems,
   ...props
 }: RowProps) {
   return (
@@ -248,7 +248,7 @@ DataTable.Row = function Row({
           <Icon visual={MoreIcon} size="sm" />
         </td>
       )}
-      {onMoreMenuItem && (
+      {moreMenuItems && (
         <td className="s-w-1 s-cursor-pointer s-pl-1 s-text-element-600">
           <DropdownMenu className="s-flex">
             <DropdownMenu.Button
@@ -259,7 +259,7 @@ DataTable.Row = function Row({
               <Icon visual={MoreIcon} size="sm" />
             </DropdownMenu.Button>
             <DropdownMenu.Items origin="topRight" width={220}>
-              {onMoreMenuItem?.map((item, index) => (
+              {moreMenuItems?.map((item, index) => (
                 <DropdownMenu.Item key={index} {...item} />
               ))}
             </DropdownMenu.Items>

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -10,7 +10,8 @@ import {
 } from "@tanstack/react-table";
 import React, { ReactNode, useEffect, useState } from "react";
 
-import { Avatar, MoreIcon } from "@sparkle/index";
+import { DropdownItemProps } from "@sparkle/components/DropdownMenu";
+import { Avatar, DropdownMenu, MoreIcon } from "@sparkle/index";
 import { ArrowDownIcon, ArrowUpIcon } from "@sparkle/index";
 import { classNames } from "@sparkle/lib/utils";
 
@@ -19,6 +20,7 @@ import { Icon } from "./Icon";
 interface TBaseData {
   onClick?: () => void;
   onMoreClick?: () => void;
+  onMoreMenuItem?: DropdownItemProps[];
 }
 
 interface ColumnBreakpoint {
@@ -120,6 +122,7 @@ export function DataTable<TData extends TBaseData, TValue>({
             key={row.id}
             onClick={row.original.onClick}
             onMoreClick={row.original.onMoreClick}
+            onMoreMenuItem={row.original.onMoreMenuItem}
           >
             {row.getVisibleCells().map((cell) => (
               <DataTable.Cell
@@ -212,6 +215,7 @@ interface RowProps extends React.HTMLAttributes<HTMLTableRowElement> {
   children: ReactNode;
   onClick?: () => void;
   onMoreClick?: () => void;
+  onMoreMenuItem?: DropdownItemProps[];
 }
 
 DataTable.Row = function Row({
@@ -219,6 +223,7 @@ DataTable.Row = function Row({
   className,
   onClick,
   onMoreClick,
+  onMoreMenuItem,
   ...props
 }: RowProps) {
   return (
@@ -241,6 +246,24 @@ DataTable.Row = function Row({
           }}
         >
           <Icon visual={MoreIcon} size="sm" />
+        </td>
+      )}
+      {onMoreMenuItem && (
+        <td className="s-w-1 s-cursor-pointer s-pl-1 s-text-element-600">
+          <DropdownMenu className="s-flex">
+            <DropdownMenu.Button
+              onClick={(e) => {
+                e.stopPropagation();
+              }}
+            >
+              <Icon visual={MoreIcon} size="sm" />
+            </DropdownMenu.Button>
+            <DropdownMenu.Items origin="topRight" width={220}>
+              {onMoreMenuItem?.map((item, index) => (
+                <DropdownMenu.Item key={index} {...item} />
+              ))}
+            </DropdownMenu.Items>
+          </DropdownMenu>
         </td>
       )}
     </tr>

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -19,7 +19,6 @@ import { Icon } from "./Icon";
 
 interface TBaseData {
   onClick?: () => void;
-  onMoreClick?: () => void;
   moreMenuItems?: DropdownItemProps[];
 }
 
@@ -121,7 +120,6 @@ export function DataTable<TData extends TBaseData, TValue>({
           <DataTable.Row
             key={row.id}
             onClick={row.original.onClick}
-            onMoreClick={row.original.onMoreClick}
             moreMenuItems={row.original.moreMenuItems}
           >
             {row.getVisibleCells().map((cell) => (
@@ -214,7 +212,6 @@ DataTable.Body = function Body({
 interface RowProps extends React.HTMLAttributes<HTMLTableRowElement> {
   children: ReactNode;
   onClick?: () => void;
-  onMoreClick?: () => void;
   moreMenuItems?: DropdownItemProps[];
 }
 
@@ -222,7 +219,6 @@ DataTable.Row = function Row({
   children,
   className,
   onClick,
-  onMoreClick,
   moreMenuItems,
   ...props
 }: RowProps) {
@@ -237,17 +233,6 @@ DataTable.Row = function Row({
       {...props}
     >
       {children}
-      {onMoreClick && (
-        <td
-          className="s-w-1 s-cursor-pointer s-pl-1 s-text-element-600"
-          onClick={(e) => {
-            e.stopPropagation(); // Prevent row click event
-            onMoreClick?.();
-          }}
-        >
-          <Icon visual={MoreIcon} size="sm" />
-        </td>
-      )}
       {moreMenuItems && (
         <td className="s-w-1 s-cursor-pointer s-pl-1 s-text-element-600">
           <DropdownMenu className="s-flex">

--- a/sparkle/src/components/DropdownMenu.tsx
+++ b/sparkle/src/components/DropdownMenu.tsx
@@ -3,6 +3,7 @@ import React, {
   ComponentType,
   Fragment,
   JSXElementConstructor,
+  MouseEventHandler,
   MutableRefObject,
   ReactElement,
   useContext,
@@ -97,7 +98,7 @@ export interface DropdownButtonProps {
   className?: string;
   disabled?: boolean;
   children?: React.ReactNode;
-  onClick?: () => void;
+  onClick?: MouseEventHandler;
 }
 
 DropdownMenu.Button = function ({
@@ -227,7 +228,7 @@ DropdownMenu.Button = function ({
   );
 };
 
-interface DropdownItemProps {
+export interface DropdownItemProps {
   variant?: "default" | "warning";
   label: string;
   description?: string;

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -23,7 +23,6 @@ type Data = {
   avatarUrl?: string;
   icon?: React.ComponentType<{ className?: string }>;
   onClick?: () => void;
-  onMoreClick?: () => void;
   moreMenuItems?: DropdownItemProps[];
   roundedAvatar?: boolean;
 };
@@ -40,7 +39,6 @@ export const DataTableExample = () => {
       avatarUrl: "https://dust.tt/static/droidavatar/Droid_Lime_3.jpg",
       roundedAvatar: true,
       onClick: () => console.log("hehe"),
-      onMoreClick: () => console.log("show more"),
     },
     {
       name: "Design",

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -24,7 +24,7 @@ type Data = {
   icon?: React.ComponentType<{ className?: string }>;
   onClick?: () => void;
   onMoreClick?: () => void;
-  onMoreMenuItem?: DropdownItemProps[];
+  moreMenuItems?: DropdownItemProps[];
   roundedAvatar?: boolean;
 };
 
@@ -49,7 +49,7 @@ export const DataTableExample = () => {
       lastUpdated: "2023-07-09",
       size: "64kb",
       icon: FolderIcon,
-      onMoreMenuItem: [
+      moreMenuItems: [
         {
           label: "Edit",
           onClick: () => console.log("Edit"),

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -2,6 +2,8 @@ import type { Meta } from "@storybook/react";
 import { ColumnDef } from "@tanstack/react-table";
 import React from "react";
 
+import { DropdownItemProps } from "@sparkle/components/DropdownMenu";
+
 import { DataTable, FolderIcon } from "../index_with_tw_base";
 
 const meta = {
@@ -22,6 +24,7 @@ type Data = {
   icon?: React.ComponentType<{ className?: string }>;
   onClick?: () => void;
   onMoreClick?: () => void;
+  onMoreMenuItem?: DropdownItemProps[];
   roundedAvatar?: boolean;
 };
 
@@ -46,6 +49,12 @@ export const DataTableExample = () => {
       lastUpdated: "2023-07-09",
       size: "64kb",
       icon: FolderIcon,
+      onMoreMenuItem: [
+        {
+          label: "Edit",
+          onClick: () => console.log("Edit"),
+        },
+      ],
     },
     {
       name: "Development",


### PR DESCRIPTION
## Description

This add the possiblity to add dropdown menu items in a table, in a more menu at the end :

<img width="315" alt="Screenshot 2024-08-19 at 15 30 38" src="https://github.com/user-attachments/assets/0331a53f-5c74-4dcf-9301-9de979a97f65">


## Risk

none
## Deploy Plan
deploy `sparkle`