### PR TITLE
Fix scroll data sources sidebar

### DIFF
--- a/front/components/vaults/VaultSideBarMenu.tsx
+++ b/front/components/vaults/VaultSideBarMenu.tsx
@@ -55,36 +55,38 @@ export default function VaultSideBarMenu({
   );
 
   return (
-    <div className="flex flex-col px-3">
-      <Item.List>
-        {sortedGroupedVaults.map((vaults, index) => {
-          if (vaults.length === 0) {
-            return null;
-          }
+    <div className="flex h-0 min-h-full w-full overflow-y-auto">
+      <div className="flex flex-col px-3">
+        <Item.List>
+          {sortedGroupedVaults.map((vaults, index) => {
+            if (vaults.length === 0) {
+              return null;
+            }
 
-          const [vault] = vaults;
-          const sectionLabel = getSectionLabel(vault);
+            const [vault] = vaults;
+            const sectionLabel = getSectionLabel(vault);
 
-          return (
-            <Fragment key={`vault-section-${index}`}>
-              <div className="flex items-center justify-between">
-                <Item.SectionHeader label={sectionLabel} key={vault.sId} />
-                {sectionLabel === "PRIVATE" && (
-                  <Button
-                    className="mt-4"
-                    size="xs"
-                    variant="tertiary"
-                    label="Create Vault "
-                    icon={LockIcon}
-                    onClick={() => setShowVaultCreationModal(true)}
-                  />
-                )}
-              </div>
-              {renderVaultItems(vaults, owner)}
-            </Fragment>
-          );
-        })}
-      </Item.List>
+            return (
+              <Fragment key={`vault-section-${index}`}>
+                <div className="flex items-center justify-between">
+                  <Item.SectionHeader label={sectionLabel} key={vault.sId} />
+                  {sectionLabel === "PRIVATE" && (
+                    <Button
+                      className="mt-4"
+                      size="xs"
+                      variant="tertiary"
+                      label="Create Vault "
+                      icon={LockIcon}
+                      onClick={() => setShowVaultCreationModal(true)}
+                    />
+                  )}
+                </div>
+                {renderVaultItems(vaults, owner)}
+              </Fragment>
+            );
+          })}
+        </Item.List>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/dust/issues/6789
We want to keep the navigation menu when scrolling.

Please review with hidden whitespaces: https://github.com/dust-tt/dust/pull/6802/files?diff=split&w=1
I reused the same classes as we use for the Conversation sidebar. 

Before scrolling: 

<kbd>
<img width="321" alt="Screenshot 2024-08-19 at 15 37 03" src="https://github.com/user-attachments/assets/d8396a18-0696-45a7-b4a1-543b103ea6b0">
</kbd>

After scrolling: 

<kbd>
<img width="322" alt="Screenshot 2024-08-19 at 15 36 57" src="https://github.com/user-attachments/assets/96766edf-e258-440b-ad0f-ace52f1cf009">
</kbd>

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
