### PR TITLE
Add: filterPermission support on vault api endpoint

### DIFF
--- a/front/components/vaults/VaultDataSourceViewContentList.tsx
+++ b/front/components/vaults/VaultDataSourceViewContentList.tsx
@@ -66,6 +66,7 @@ export const VaultDataSourceViewContentList = ({
       dataSourceOrViewId: dataSourceViewId,
       type: "data_source_views",
       viewType: "documents",
+      filterPermission: "read",
       parentId,
     });
 

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -1370,6 +1370,7 @@ export function useVaultDataSourceOrViewContent({
   dataSourceOrViewId,
   viewType,
   parentId,
+  filterPermission,
   disabled,
 }: {
   workspaceId: string;
@@ -1378,12 +1379,15 @@ export function useVaultDataSourceOrViewContent({
   dataSourceOrViewId: string;
   viewType: ContentNodesViewType;
   parentId: string | null;
+  filterPermission: ConnectorPermission;
   disabled?: boolean;
 }) {
   const vaultsDataSourcesFetcher: Fetcher<GetDataSourceOrViewContentResponseBody> =
     fetcher;
   const qs =
-    `?viewType=${viewType}` + (parentId ? `&parentId=${parentId}` : "");
+    `?viewType=${viewType}` +
+    `&filterPermission=${filterPermission}` +
+    (parentId ? `&parentId=${parentId}` : "");
   const { data, error } = useSWRWithDefaults(
     disabled
       ? null

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/content.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/content.ts
@@ -1,4 +1,5 @@
 import type {
+  ConnectorPermission,
   GetDataSourceOrViewContentResponseBody,
   WithAPIErrorResponse,
 } from "@dust-tt/types";
@@ -76,8 +77,25 @@ async function handler(
         ? parseInt(req.query.offset as string)
         : 0;
 
+      let filterPermission: ConnectorPermission | undefined = undefined;
+      if (
+        req.query.filterPermission &&
+        typeof req.query.filterPermission === "string"
+      ) {
+        switch (req.query.filterPermission) {
+          case "read":
+            filterPermission = "read";
+            break;
+          case "write":
+            filterPermission = "write";
+            break;
+        }
+      }
+
       const contentRes = await getDataSourceContent(
+        auth,
         dataSourceView.dataSource,
+        filterPermission,
         viewType,
         dataSourceView.parentsIn,
         parentId,

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/[dsId]/content.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/[dsId]/content.ts
@@ -1,4 +1,5 @@
 import type {
+  ConnectorPermission,
   ContentNodesViewType,
   GetDataSourceOrViewContentResponseBody,
   WithAPIErrorResponse,
@@ -76,8 +77,25 @@ async function handler(
         ? parseInt(req.query.offset as string)
         : 0;
 
+      let filterPermission: ConnectorPermission | undefined = undefined;
+      if (
+        req.query.filterPermission &&
+        typeof req.query.filterPermission === "string"
+      ) {
+        switch (req.query.filterPermission) {
+          case "read":
+            filterPermission = "read";
+            break;
+          case "write":
+            filterPermission = "write";
+            break;
+        }
+      }
+
       const contentRes = await getDataSourceContent(
+        auth,
         dataSource,
+        filterPermission,
         viewType,
         null,
         parentId,


### PR DESCRIPTION
## Description

Add support for `filterPermission` in vault content listing endpoint.

## Risk

List nothing.

## Deploy Plan

deploy to `front`