### PR TITLE
Flav/data source views kind

### DIFF
--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -67,6 +67,7 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
         dataSourceId: dataSource.id,
         parentsIn,
         workspaceId: vault.workspaceId,
+        kind: "custom",
       },
       vault,
       dataSource
@@ -84,6 +85,7 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
         dataSourceId: dataSource.id,
         parentsIn: null,
         workspaceId: vault.workspaceId,
+        kind: "default",
       },
       vault,
       dataSource

--- a/front/lib/resources/storage/models/data_source_view.ts
+++ b/front/lib/resources/storage/models/data_source_view.ts
@@ -1,3 +1,4 @@
+import type { DataSourceViewKind } from "@dust-tt/types";
 import type {
   CreationOptional,
   ForeignKey,
@@ -20,6 +21,7 @@ export class DataSourceViewModel extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
+  declare kind: DataSourceViewKind;
   declare parentsIn: string[] | null;
 
   declare dataSourceId: ForeignKey<DataSource["id"]>;
@@ -42,14 +44,19 @@ DataSourceViewModel.init(
       allowNull: false,
       defaultValue: DataTypes.NOW,
     },
-    updatedAt: {
-      type: DataTypes.DATE,
+    kind: {
+      type: DataTypes.STRING,
       allowNull: false,
-      defaultValue: DataTypes.NOW,
+      defaultValue: "default",
     },
     parentsIn: {
       type: DataTypes.ARRAY(DataTypes.STRING),
       allowNull: true,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
     },
   },
   {

--- a/front/migrations/db/migration_58.sql
+++ b/front/migrations/db/migration_58.sql
@@ -1,0 +1,2 @@
+-- Migration created on Aug 20, 2024
+ALTER TABLE "public"."data_source_views" ADD COLUMN "kind" VARCHAR(255) NOT NULL DEFAULT 'default';

--- a/types/src/front/data_source_view.ts
+++ b/types/src/front/data_source_view.ts
@@ -9,3 +9,6 @@ export interface DataSourceViewType {
 }
 
 export type DataSourceOrView = "data_sources" | "data_source_views";
+
+const DATA_SOURCE_VIEW_KINDS = ["default", "custom"] as const;
+export type DataSourceViewKind = (typeof DATA_SOURCE_VIEW_KINDS)[number];


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See thread [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1724087134233439?thread_ts=1722332810.418999&cid=C050SM8NSPK).

This PR adds a `kind` column in the `data_source_views` to track default views automatically created for all data sources. There is also a "custom" kind that will be used when the admins create a data source view in a vault. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

This requires to run a migration to add the new `kind` column.
