### PR TITLE
Flav/default data source views

### DIFF
--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -175,9 +175,7 @@ export class DataSourceResource extends ResourceWithVault<DataSource> {
       transaction,
     });
 
-    if (this.isManaged()) {
-      await DataSourceViewResource.deleteForDataSource(auth, this, transaction);
-    }
+    await DataSourceViewResource.deleteForDataSource(auth, this, transaction);
 
     try {
       await this.model.destroy({

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -247,6 +247,10 @@ export class VaultResource extends BaseResource<VaultModel> {
     return this.kind === "global";
   }
 
+  isSystem() {
+    return this.kind === "system";
+  }
+
   toJSON(): VaultType {
     return {
       sId: this.sId,

--- a/front/migrations/20240820_backfill_data_source_views.ts
+++ b/front/migrations/20240820_backfill_data_source_views.ts
@@ -1,0 +1,100 @@
+import type { LightWorkspaceType } from "@dust-tt/types";
+
+import { Authenticator } from "@app/lib/auth";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
+import { VaultResource } from "@app/lib/resources/vault_resource";
+import type { Logger } from "@app/logger/logger";
+import { makeScript, runOnAllWorkspaces } from "@app/scripts/helpers";
+
+async function backfillDefaultViewForDataSource(
+  workspace: LightWorkspaceType,
+  vault: VaultResource,
+  dataSource: DataSourceResource,
+  logger: Logger,
+  execute: boolean
+): Promise<boolean> {
+  // Check if there is already a view for this managed data source in the vault.
+  const dsv = await DataSourceViewModel.findOne({
+    where: {
+      workspaceId: workspace.id,
+      vaultId: vault.id,
+      dataSourceId: dataSource.id,
+    },
+  });
+
+  if (dsv) {
+    logger.info(
+      `Data source view already exists for data source ${dataSource.id}.`
+    );
+    return false;
+  }
+
+  if (!execute) {
+    return false;
+  }
+
+  // Create a default view for this data source in the vault.
+  await DataSourceViewResource.createViewInVaultFromDataSourceIncludingAllDocuments(
+    vault,
+    dataSource
+  );
+
+  logger.info(`View created for data source ${dataSource.id}.`);
+
+  return true;
+}
+
+async function backfillDataSourceViewsForWorkspace(
+  workspace: LightWorkspaceType,
+  logger: Logger,
+  execute: boolean
+) {
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  const dataSources = await DataSourceResource.listByWorkspace(auth);
+
+  logger.info(
+    `Found ${dataSources.length} data sources for workspace(${workspace.sId}).`
+  );
+
+  const globalVault = await VaultResource.fetchWorkspaceGlobalVault(auth);
+
+  let updated = 0;
+  for (const dataSource of dataSources) {
+    let created: boolean;
+    // If data source's vault is system, create a default view in the global vault for it.
+    if (dataSource.vault.isSystem()) {
+      created = await backfillDefaultViewForDataSource(
+        workspace,
+        globalVault,
+        dataSource,
+        logger,
+        execute
+      );
+    } else {
+      // Otherwise, create a default view in the data source's vault.
+      created = await backfillDefaultViewForDataSource(
+        workspace,
+        dataSource.vault,
+        dataSource,
+        logger,
+        execute
+      );
+    }
+
+    if (created) {
+      updated++;
+    }
+  }
+
+  logger.info(
+    `Backfilled data source views for workspace(${workspace.sId}). (updated: ${updated}/${dataSources.length})`
+  );
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  return runOnAllWorkspaces(async (workspace) => {
+    await backfillDataSourceViewsForWorkspace(workspace, logger, execute);
+  });
+});

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -186,7 +186,7 @@ async function handler(
       );
 
       await DataSourceViewResource.createViewInVaultFromDataSourceIncludingAllDocuments(
-        globalVault,
+        ds.vault,
         ds
       );
 

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -13,6 +13,7 @@ import { getDataSource, getDataSources } from "@app/lib/api/data_sources";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { VaultResource } from "@app/lib/resources/vault_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import logger from "@app/logger/logger";
@@ -182,6 +183,11 @@ async function handler(
           editedByUserId: user.id,
         },
         globalVault
+      );
+
+      await DataSourceViewResource.createViewInVaultFromDataSourceIncludingAllDocuments(
+        globalVault,
+        ds
       );
 
       const dataSourceType = await getDataSource(auth, ds.name);

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -344,15 +344,15 @@ async function handler(
         vault
       );
 
-      // For managed data source, we create a default view in the workspace vault.
-      if (dataSource.isManaged()) {
-        const globalVault = await VaultResource.fetchWorkspaceGlobalVault(auth);
+      // For all data sources, we create a default view in the workspace vault.
+      const globalVault = vault.isGlobal()
+        ? vault
+        : await VaultResource.fetchWorkspaceGlobalVault(auth);
 
-        await DataSourceViewResource.createViewInVaultFromDataSourceIncludingAllDocuments(
-          globalVault,
-          dataSource
-        );
-      }
+      await DataSourceViewResource.createViewInVaultFromDataSourceIncludingAllDocuments(
+        globalVault,
+        dataSource
+      );
 
       const connectorsAPI = new ConnectorsAPI(
         config.getConnectorsAPIConfig(),

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -344,7 +344,7 @@ async function handler(
         vault
       );
 
-      // For all data sources, we create a default view in the workspace vault.
+      // For all data sources, we create a default view in the global vault.
       const globalVault = vault.isGlobal()
         ? vault
         : await VaultResource.fetchWorkspaceGlobalVault(auth);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR resolves https://github.com/dust-tt/dust/issues/6806.

This PR guarantees the creation of a default data source view for every data source. The process is as follows:
- For data sources located in the system vault (managed data sources), we create the default view in the global vault.
- For data sources residing in non-system vaults, we create the default view within the same vault. 

This PR bundles the migration as well.

Follow-up work:
- Refactor the relationship between `DataSourceResource` and `DataSourceViewResource` to enforce stricter relationship.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
Deploy then run the migration to backfill missing data source views.
