### PR TITLE
Rename Group.type => Group.kind

### DIFF
--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -55,6 +55,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       (await GroupResource.makeNew({
         name: "System",
         type: "system",
+        kind: "system",
         workspaceId: workspace.id,
       }));
     const globalGroup =
@@ -62,6 +63,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       (await GroupResource.makeNew({
         name: "Workspace",
         type: "global",
+        kind: "global",
         workspaceId: workspace.id,
       }));
     return {

--- a/front/lib/resources/storage/models/groups.ts
+++ b/front/lib/resources/storage/models/groups.ts
@@ -1,5 +1,5 @@
-import type { SupportedGroupType } from "@dust-tt/types";
-import { isGlobalGroupType, isSystemGroupType } from "@dust-tt/types";
+import type { SupportedGroupKind } from "@dust-tt/types";
+import { isGlobalGroupKind, isSystemGroupKind } from "@dust-tt/types";
 import type {
   CreationOptional,
   ForeignKey,
@@ -21,7 +21,8 @@ export class GroupModel extends Model<
   declare updatedAt: CreationOptional<Date>;
 
   declare name: string;
-  declare type: SupportedGroupType;
+  declare type: SupportedGroupKind;
+  declare kind: SupportedGroupKind;
 
   declare workspaceId: ForeignKey<Workspace["id"]>;
 }
@@ -50,6 +51,10 @@ GroupModel.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
+    kind: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
   },
   {
     modelName: "groups",
@@ -63,7 +68,7 @@ GroupModel.addHook(
   "enforce_one_system_and_global_group_per_workspace",
   async (group: GroupModel, options: { transaction: Transaction }) => {
     const groupType = group.type;
-    if (isSystemGroupType(groupType) || isGlobalGroupType(groupType)) {
+    if (isSystemGroupKind(groupType) || isGlobalGroupKind(groupType)) {
       const existingSystemOrWorkspaceGroupType = await GroupModel.findOne({
         where: {
           workspaceId: group.workspaceId,

--- a/front/migrations/20240724_workspaces_groups_backfill.ts
+++ b/front/migrations/20240724_workspaces_groups_backfill.ts
@@ -22,11 +22,13 @@ async function backfillWorkspacesGroup(execute: boolean) {
               await GroupResource.makeNew({
                 name: "System",
                 type: "system",
+                kind: "system",
                 workspaceId: w.id,
               });
               await GroupResource.makeNew({
                 name: "Workspace",
                 type: "global",
+                kind: "global",
                 workspaceId: w.id,
               });
               console.log(`System group created for workspace ${w.id}`);

--- a/front/migrations/20240820_backfill_group_kind.sql
+++ b/front/migrations/20240820_backfill_group_kind.sql
@@ -1,0 +1,1 @@
+UPDATE "public"."groups" SET "kind" = "type";

--- a/front/migrations/db/migration_59.sql
+++ b/front/migrations/db/migration_59.sql
@@ -1,0 +1,2 @@
+-- Migration created on Aug 20, 2024
+ALTER TABLE "public"."groups" ADD COLUMN "kind" VARCHAR(255) NOT NULL DEFAULT '';

--- a/front/pages/api/w/[wId]/vaults/index.ts
+++ b/front/pages/api/w/[wId]/vaults/index.ts
@@ -87,6 +87,7 @@ async function handler(
         name: `Group for vault ${name}`,
         workspaceId: owner.id,
         type: "regular",
+        kind: "regular",
       });
 
       const vault = await VaultResource.makeNew({

--- a/types/src/front/groups.ts
+++ b/types/src/front/groups.ts
@@ -13,18 +13,18 @@ import { ModelId } from "../shared/model_id";
  * Contains specific users added by workspace admins.
  * Has access to the list of Vaults configured by workspace admins.
  */
-export const SUPPORTED_GROUP_TYPES = ["regular", "global", "system"] as const;
-export type SupportedGroupType = (typeof SUPPORTED_GROUP_TYPES)[number];
+export const SUPPORTED_GROUP_KINDS = ["regular", "global", "system"] as const;
+export type SupportedGroupKind = (typeof SUPPORTED_GROUP_KINDS)[number];
 
-export function isSupportedGroupType(
+export function isSupportedGroupKind(
   value: unknown
-): value is SupportedGroupType {
-  return SUPPORTED_GROUP_TYPES.includes(value as SupportedGroupType);
+): value is SupportedGroupKind {
+  return SUPPORTED_GROUP_KINDS.includes(value as SupportedGroupKind);
 }
-export function isSystemGroupType(value: SupportedGroupType): boolean {
+export function isSystemGroupKind(value: SupportedGroupKind): boolean {
   return value === "system";
 }
-export function isGlobalGroupType(value: SupportedGroupType): boolean {
+export function isGlobalGroupKind(value: SupportedGroupKind): boolean {
   return value === "global";
 }
 
@@ -32,6 +32,6 @@ export type GroupType = {
   id: ModelId;
   name: string;
   sId: string;
-  type: SupportedGroupType;
+  type: SupportedGroupKind;
   workspaceId: ModelId;
 };


### PR DESCRIPTION
## Description

Rename Group.type to Group.kind for consistency with Vaults.

## Risk

Need to apply migration and deployment in correct order.

## Deploy Plan

- Merge
- Run migration on prodbox
- Deploy front
- Run backfill on dropbox