### PR TITLE
Drop Group.type column from model and DB.

### DIFF
--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -51,18 +51,16 @@ export class GroupResource extends BaseResource<GroupModel> {
       })
     ).map((group) => new this(GroupModel, group.get()));
     const systemGroup =
-      existingGroups.find((v) => v.type === "system") ||
+      existingGroups.find((v) => v.kind === "system") ||
       (await GroupResource.makeNew({
         name: "System",
-        type: "system",
         kind: "system",
         workspaceId: workspace.id,
       }));
     const globalGroup =
-      existingGroups.find((v) => v.type === "global") ||
+      existingGroups.find((v) => v.kind === "global") ||
       (await GroupResource.makeNew({
         name: "Workspace",
-        type: "global",
         kind: "global",
         workspaceId: workspace.id,
       }));
@@ -135,7 +133,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       attributes: ["id"],
       where: {
         workspaceId,
-        type: {
+        kind: {
           [Op.notIn]: ["system", "global"],
         },
       },
@@ -238,7 +236,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       where: {
         workspaceId: key.workspaceId,
         [Op.or]: [
-          { type: key.isSystem ? "system" : "global" },
+          { kind: key.isSystem ? "system" : "global" },
           { id: key.groupId },
         ],
       },
@@ -257,7 +255,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     const group = await this.model.findOne({
       where: {
         workspaceId,
-        type: "global",
+        kind: "global",
       },
     });
 
@@ -275,7 +273,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     const group = await this.model.findOne({
       where: {
         workspaceId: owner.id,
-        type: "system",
+        kind: "system",
       },
     });
 
@@ -293,7 +291,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     const group = await this.model.findOne({
       where: {
         workspaceId: owner.id,
-        type: "global",
+        kind: "global",
       },
     });
 
@@ -340,7 +338,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     const globalGroup = await this.model.findOne({
       where: {
         workspaceId: workspace.id,
-        type: "global",
+        kind: "global",
       },
     });
 
@@ -417,7 +415,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     }
 
     // Users can only be added to regular groups.
-    if (this.type !== "regular") {
+    if (this.kind !== "regular") {
       return new Err(new Error("Not a regular group, cannot be updated."));
     }
 
@@ -487,7 +485,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     }
 
     // Users can only be added to regular groups.
-    if (this.type !== "regular") {
+    if (this.kind !== "regular") {
       return new Err(new Error("Not a regular group, cannot be updated."));
     }
 
@@ -566,7 +564,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       sId: this.sId,
       name: this.name,
       workspaceId: this.workspaceId,
-      type: this.type,
+      kind: this.kind,
     };
   }
 }

--- a/front/lib/resources/storage/models/groups.ts
+++ b/front/lib/resources/storage/models/groups.ts
@@ -1,4 +1,4 @@
-import type { SupportedGroupKind } from "@dust-tt/types";
+import type { GroupKind } from "@dust-tt/types";
 import { isGlobalGroupKind, isSystemGroupKind } from "@dust-tt/types";
 import type {
   CreationOptional,
@@ -21,8 +21,7 @@ export class GroupModel extends Model<
   declare updatedAt: CreationOptional<Date>;
 
   declare name: string;
-  declare type: SupportedGroupKind;
-  declare kind: SupportedGroupKind;
+  declare kind: GroupKind;
 
   declare workspaceId: ForeignKey<Workspace["id"]>;
 }
@@ -47,10 +46,6 @@ GroupModel.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
-    type: {
-      type: DataTypes.STRING,
-      allowNull: false,
-    },
     kind: {
       type: DataTypes.STRING,
       allowNull: false,
@@ -67,19 +62,19 @@ GroupModel.addHook(
   "beforeCreate",
   "enforce_one_system_and_global_group_per_workspace",
   async (group: GroupModel, options: { transaction: Transaction }) => {
-    const groupType = group.type;
-    if (isSystemGroupKind(groupType) || isGlobalGroupKind(groupType)) {
+    const groupKind = group.kind;
+    if (isSystemGroupKind(groupKind) || isGlobalGroupKind(groupKind)) {
       const existingSystemOrWorkspaceGroupType = await GroupModel.findOne({
         where: {
           workspaceId: group.workspaceId,
-          type: groupType,
+          kind: groupKind,
         },
         transaction: options.transaction,
       });
 
       if (existingSystemOrWorkspaceGroupType) {
-        throw new Error(`A ${groupType} group exists for this workspace.`, {
-          cause: `enforce_one_${groupType}_group_per_workspace`,
+        throw new Error(`A ${groupKind} group exists for this workspace.`, {
+          cause: `enforce_one_${groupKind}_group_per_workspace`,
         });
       }
     }

--- a/front/migrations/20240724_workspaces_groups_backfill.ts
+++ b/front/migrations/20240724_workspaces_groups_backfill.ts
@@ -21,13 +21,11 @@ async function backfillWorkspacesGroup(execute: boolean) {
             try {
               await GroupResource.makeNew({
                 name: "System",
-                type: "system",
                 kind: "system",
                 workspaceId: w.id,
               });
               await GroupResource.makeNew({
                 name: "Workspace",
-                type: "global",
                 kind: "global",
                 workspaceId: w.id,
               });

--- a/front/migrations/db/migration_60.sql
+++ b/front/migrations/db/migration_60.sql
@@ -1,0 +1,2 @@
+-- Migration created on Aug 20, 2024
+ALTER TABLE "public"."groups" DROP COLUMN "type";

--- a/front/pages/api/w/[wId]/vaults/index.ts
+++ b/front/pages/api/w/[wId]/vaults/index.ts
@@ -86,7 +86,6 @@ async function handler(
       const group = await GroupResource.makeNew({
         name: `Group for vault ${name}`,
         workspaceId: owner.id,
-        type: "regular",
         kind: "regular",
       });
 

--- a/front/pages/w/[wId]/a/index.tsx
+++ b/front/pages/w/[wId]/a/index.tsx
@@ -267,7 +267,7 @@ export function APIKeys({
   groups: GroupType[];
 }) {
   const { mutate } = useSWRConfig();
-  const globalGroup = groups.find((group) => group.type === "global");
+  const globalGroup = groups.find((group) => group.kind === "global");
   const [newApiKeyName, setNewApiKeyName] = useState("");
   const [newApiKeyGroup] = useState(globalGroup);
   const [isNewApiKeyPromptOpen, setIsNewApiKeyPromptOpen] = useState(false);

--- a/types/src/front/groups.ts
+++ b/types/src/front/groups.ts
@@ -13,18 +13,16 @@ import { ModelId } from "../shared/model_id";
  * Contains specific users added by workspace admins.
  * Has access to the list of Vaults configured by workspace admins.
  */
-export const SUPPORTED_GROUP_KINDS = ["regular", "global", "system"] as const;
-export type SupportedGroupKind = (typeof SUPPORTED_GROUP_KINDS)[number];
+export const GROUP_KINDS = ["regular", "global", "system"] as const;
+export type GroupKind = (typeof GROUP_KINDS)[number];
 
-export function isSupportedGroupKind(
-  value: unknown
-): value is SupportedGroupKind {
-  return SUPPORTED_GROUP_KINDS.includes(value as SupportedGroupKind);
+export function isGroupKind(value: unknown): value is GroupKind {
+  return GROUP_KINDS.includes(value as GroupKind);
 }
-export function isSystemGroupKind(value: SupportedGroupKind): boolean {
+export function isSystemGroupKind(value: GroupKind): boolean {
   return value === "system";
 }
-export function isGlobalGroupKind(value: SupportedGroupKind): boolean {
+export function isGlobalGroupKind(value: GroupKind): boolean {
   return value === "global";
 }
 
@@ -32,6 +30,6 @@ export type GroupType = {
   id: ModelId;
   name: string;
   sId: string;
-  type: SupportedGroupKind;
+  kind: GroupKind;
   workspaceId: ModelId;
 };


### PR DESCRIPTION
## Description

Remove declaration & usage of `Group.type`.

## Risk

Deploy must be ordered.

## Deploy Plan

Deploy front - no more usage of Group.type
Run migration 60.