### PR TITLE
Lock redis bot on one answer per channel at the same time.

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -35,6 +35,7 @@ import {
   SlackChannel,
   SlackChatBotMessage,
 } from "@connectors/lib/models/slack";
+import { lockWithRedis } from "@connectors/lib/redis";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
@@ -70,16 +71,22 @@ export async function botAnswerMessageWithErrorHandling(
     return new Err(new Error("Failed to find connector"));
   }
   try {
-    const res = await botAnswerMessage(
-      message,
-      slackTeamId,
-      slackChannel,
-      slackUserId,
-      slackBotId,
-      slackMessageTs,
-      slackThreadTs,
-      connector,
-      slackConfig
+    const res = await lockWithRedis(
+      `slack-bot-answer:${slackTeamId}:${slackChannel}`,
+      60,
+      async () => {
+        return botAnswerMessage(
+          message,
+          slackTeamId,
+          slackChannel,
+          slackUserId,
+          slackBotId,
+          slackMessageTs,
+          slackThreadTs,
+          connector,
+          slackConfig
+        );
+      }
     );
     if (res.isErr()) {
       logger.error(

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -72,7 +72,7 @@ export async function botAnswerMessageWithErrorHandling(
   }
   try {
     const res = await lockWithRedis(
-      `slack-bot-answer:${slackTeamId}:${slackChannel}`,
+      `slack-bot-answer:${slackTeamId}:${slackChannel}:${slackThreadTs || slackMessageTs}`,
       60,
       async () => {
         return botAnswerMessage(

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -72,7 +72,7 @@ export async function botAnswerMessageWithErrorHandling(
   }
   try {
     const res = await lockWithRedis(
-      `slack-bot-answer:${slackTeamId}:${slackChannel}:${slackThreadTs || slackMessageTs}`,
+      `slack-bot-answer:${slackTeamId}:${slackChannel}:${slackThreadTs ?? slackMessageTs}`,
       60,
       async () => {
         return botAnswerMessage(

--- a/connectors/src/lib/redis.ts
+++ b/connectors/src/lib/redis.ts
@@ -1,16 +1,70 @@
+import type { RedisClientType } from "redis";
 import { createClient } from "redis";
 
-export async function redisClient() {
-  const { REDIS_URI } = process.env;
-  if (!REDIS_URI) {
-    throw new Error("REDIS_URI is not defined");
-  }
-  const client = createClient({
-    url: REDIS_URI,
-  });
-  client.on("error", (err) => console.log("Redis Client Error", err));
+import logger from "@connectors/logger/logger";
 
-  await client.connect();
+let client: RedisClientType;
+
+export async function redisClient(): Promise<RedisClientType> {
+  if (!client) {
+    const { REDIS_URI } = process.env;
+    if (!REDIS_URI) {
+      throw new Error("REDIS_URI is not defined");
+    }
+
+    client = createClient({
+      url: REDIS_URI,
+      isolationPoolOptions: {
+        acquireTimeoutMillis: 10000, // Max time to wait for a connection: 10 seconds.
+        max: 500, // Maximum number of concurrent connections for streaming.
+        evictionRunIntervalMillis: 15000, // Check for idle connections every 15 seconds.
+        idleTimeoutMillis: 30000, // Connections idle for more than 30 seconds will be eligible for eviction.
+      },
+    });
+    client.on("error", (err) => logger.info({ err }, "Redis Client Error"));
+    client.on("ready", () => logger.info({}, "Redis Client Ready"));
+    client.on("connect", () => logger.info({}, "Redis Client Connected"));
+    client.on("end", () => logger.info({}, "Redis Client End"));
+
+    await client.connect();
+  }
 
   return client;
+}
+
+export async function lockWithRedis<T>(
+  lockKey: string,
+  timeoutSecs: number,
+  fn: () => Promise<T>
+): Promise<T> {
+  const client = await redisClient();
+  let lockAcquired = false;
+  try {
+    const start = new Date();
+
+    let result: null | number = null;
+    do {
+      result = await client.incr(lockKey);
+      if (result === 1) {
+        // Lock acquired. Release will be done by the finally block.
+        await client.expire(lockKey, timeoutSecs);
+        lockAcquired = true;
+        return await fn();
+      } else {
+        // The lock is already acquired by another process.
+        // We decrement the lock key and wait, we'll try again.
+        await client.decr(lockKey);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+    } while (new Date().getTime() - start.getTime() < timeoutSecs * 1000);
+  } finally {
+    if (lockAcquired) {
+      // Release the lock only if it was successfully acquired.
+      await client.decr(lockKey);
+    }
+  }
+
+  throw new Error(
+    `Failed to acquire lock for key: ${lockKey} after ${timeoutSecs} seconds`
+  );
 }


### PR DESCRIPTION
## Description

We have a [bug](https://github.com/dust-tt/tasks/issues/1118) where the Slack bot stops answering when being triggered by two messages on the same thread, on agent messages taking a lot of time to complete.
I could not find the real issue but I noticed that the double trigger seems to be the root cause of the issue, so I am adding a temporary lock to see if it fixes it.

It's really hard to reproduce locally, hence this PR.

I created an [eng runner task](https://github.com/dust-tt/tasks/issues/1169) to revert this PR afterward if needed.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
