### PR TITLE
Upg: move backfill to migrations/db so people will fall into the pit of success

### DIFF
--- a/front/migrations/20240820_backfill_group_kind.sql
+++ b/front/migrations/20240820_backfill_group_kind.sql
@@ -1,1 +1,0 @@
-UPDATE "public"."groups" SET "kind" = "type";

--- a/front/migrations/db/migration_60.sql
+++ b/front/migrations/db/migration_60.sql
@@ -1,2 +1,2 @@
 -- Migration created on Aug 20, 2024
-ALTER TABLE "public"."groups" DROP COLUMN "type";
+UPDATE "public"."groups" SET "kind" = "type";

--- a/front/migrations/db/migration_61.sql
+++ b/front/migrations/db/migration_61.sql
@@ -1,0 +1,2 @@
+-- Migration created on Aug 20, 2024
+ALTER TABLE "public"."groups" DROP COLUMN "type";


### PR DESCRIPTION
## Description

Move pure sql backfill to migrations/db so people will fall into the pit of success and apply them in sequence.

## Risk

None.

## Deploy Plan

None