### PR TITLE
Skip connector not found in confluence reporting

### DIFF
--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -645,7 +645,10 @@ export async function confluenceGetReportPersonalActionActivity(
 ) {
   const { connectorId, userAccountId } = params;
 
-  const connector = await fetchConfluenceConnector(connectorId);
+  const connector = await ConnectorResource.fetchById(connectorId);
+  if (!connector) {
+    return false;
+  }
   if (connector.isAuthTokenRevoked) {
     return false;
   }


### PR DESCRIPTION
## Description

Ignore connector not found in confluence reporting likely due to the connector having been deleted while the workflow was running.

Context: https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E14%20&agg_m=count&agg_m_source=base&agg_t=count&cols=service%2C%40workflowName%2C%40activityName%2C%40error.__is_dust_error&event=AgAAAZFwL8fUJxGWRQAAAAAAAAAYAAAAAEFaRndMOF9zQUFDS2xreWVMd2pqbVFBQgAAACQAAAAAMDE5MTcwMmYtZDc5Yi00OGE3LTkzZmItMTJkNzNhZTEwZTAy&fromUser=true&messageDisplay=inline&refresh_mode=sliding&saved-view-id=99802&storage=hot&stream_sort=%40duration%2Cdesc&viz=stream&from_ts=1724149710072&to_ts=1724164110072&live=true

## Risk

N/A

## Deploy Plan

Deploy connectors