### PR TITLE
Flav/use default data sourcev views

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -1253,7 +1253,7 @@ async function _createAgentDataSourcesConfigData(
         await DataSourceViewResource.listForDataSourcesInVault(
           // We can use `auth` because we limit to one workspace.
           auth,
-          uniqueDataSources.filter((ds) => ds.isManaged()),
+          uniqueDataSources,
           globalVault
         );
 

--- a/front/lib/models/assistant/actions/data_sources.ts
+++ b/front/lib/models/assistant/actions/data_sources.ts
@@ -28,7 +28,7 @@ export class AgentDataSourceConfiguration extends Model<
   declare parentsNotIn: string[] | null;
 
   declare dataSourceId: ForeignKey<DataSource["id"]>;
-  declare dataSourceViewId: ForeignKey<DataSourceViewModel["id"]>;
+  declare dataSourceViewId: ForeignKey<DataSourceViewModel["id"]> | null;
 
   // AgentDataSourceConfiguration can be used by both the retrieval and the process actions'
   // configurations.
@@ -126,5 +126,5 @@ DataSourceViewModel.hasMany(AgentDataSourceConfiguration, {
 });
 AgentDataSourceConfiguration.belongsTo(DataSourceViewModel, {
   as: "dataSourceView",
-  foreignKey: { allowNull: false },
+  foreignKey: { allowNull: true },
 });

--- a/front/migrations/20240820_backfill_views_in_agent_data_source_configurations.ts
+++ b/front/migrations/20240820_backfill_views_in_agent_data_source_configurations.ts
@@ -1,0 +1,95 @@
+import type { LightWorkspaceType } from "@dust-tt/types";
+import assert from "assert";
+import { Op } from "sequelize";
+
+import { Authenticator } from "@app/lib/auth";
+import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { VaultResource } from "@app/lib/resources/vault_resource";
+import type { Logger } from "@app/logger/logger";
+import { makeScript, runOnAllWorkspaces } from "@app/scripts/helpers";
+
+async function backfillViewsInAgentDataSourceConfigurationForWorkspace(
+  workspace: LightWorkspaceType,
+  logger: Logger,
+  execute: boolean
+) {
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+  // List workspace data sources.
+  const dataSources = await DataSourceResource.listByWorkspace(auth);
+
+  logger.info(
+    `Found ${dataSources.length} data sources for workspace(${workspace.sId}).`
+  );
+
+  const globalVault = await VaultResource.fetchWorkspaceGlobalVault(auth);
+
+  // Retrieve data source views for data sources.
+  const dataSourceViews =
+    await DataSourceViewResource.listForDataSourcesInVault(
+      auth,
+      dataSources,
+      globalVault
+    );
+
+  // Count agent data source configurations that uses those data sources and have no dataSourceViewId.
+
+  const agentDataSourceConfigurationsCount =
+    await AgentDataSourceConfiguration.count({
+      where: {
+        dataSourceId: dataSources.map((ds) => ds.id),
+        dataSourceViewId: {
+          [Op.is]: null,
+        },
+      },
+    });
+
+  logger.info(
+    `About to update ${agentDataSourceConfigurationsCount} agent data source configurations for workspace(${workspace.sId}).`
+  );
+
+  if (!execute) {
+    return;
+  }
+
+  for (const ds of dataSources) {
+    const dataSourceView = dataSourceViews.find(
+      (dsv) => dsv.dataSourceId === ds.id
+    );
+    assert(
+      dataSourceView,
+      `Data source view not found for data source ${ds.id}.`
+    );
+
+    await AgentDataSourceConfiguration.update(
+      { dataSourceViewId: dataSourceView.id },
+      {
+        where: {
+          dataSourceId: ds.id,
+        },
+      }
+    );
+
+    logger.info(
+      `Updated agent data source configuration for data source ${ds.id}.`
+    );
+  }
+
+  logger.info(
+    `Updated all agent data source configurations for workspace(${workspace.sId}).`
+  );
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  return runOnAllWorkspaces(async (workspace) => {
+    await backfillViewsInAgentDataSourceConfigurationForWorkspace(
+      workspace,
+      logger,
+      execute
+    );
+
+    logger.info(`Finished backfilling views for workspace(${workspace.sId}).`);
+  });
+});


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Now that we have a data source view for everything, this PR ensures we save it alongside `AgentDataSourceConfiguration` so it's being used for the registry look up.

## Risk

Worst case could breaks the permission check in the registry lookup. Safe still, as we don't enforce it yet and only log when it would fail.
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Run the backfill once it's deployed.

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
