### PR TITLE
Upg: improve migration scripts to fail when a migration requires a backfill

### DIFF
--- a/connectors/create_db_migration_file.sh
+++ b/connectors/create_db_migration_file.sh
@@ -17,10 +17,13 @@ trap 'cleanup' SIGINT SIGTERM EXIT
 
 # Get current date in a human-readable format (e.g., May 28, 2024)
 current_date=$(date +"%b %d, %Y")
+current_unix_timestamp=$(date +"%s")
+# Use a unique message to identify the stash in case the script fails before popping the stash.
+stash_commit_message="Temp stash for running diff $current_unix_timestamp"
 
 # Stash any uncommitted changes.
 echo "Stashing uncommitted changes..."
-git stash push -m "Temp stash for running diff" --quiet
+git stash push -m "$stash_commit_message" --quiet
 
 # Get the current branch name.
 original_branch=$(git symbolic-ref --short HEAD)
@@ -38,7 +41,7 @@ NODE_ENV=development DB_LOGGING_ENABLED=true ./admin/init_db.sh --unsafe > main_
 
 # Determine if there were any stashed changes.
 stash_list=$(git stash list)
-if [[ $stash_list == *"Temp stash for running diff"* ]]; then
+if [[ $stash_list == *"$stash_commit_message"* ]]; then
   # Pop the stash if it exists.
   echo "Restoring original changes..."
   git stash pop --quiet
@@ -71,5 +74,22 @@ last_version=$(ls ./migrations/db | grep -oE 'migration_([0-9]+).sql' | grep -oE
 next_version=$(printf "%02d" $((10#$last_version + 1)))
 echo "Creating SQL migration $next_version."
 
+OUTPUT_FILE="./migrations/db/migration_${next_version}.sql"
+
 # Save the latest changes to a new migration file.
-mv diff_output.txt "./migrations/db/migration_${next_version}.sql"
+mv diff_output.txt "$OUTPUT_FILE"
+
+# Ask for user Y/n input wether this migration is dependant on a backfill
+read -p "Does this migration depends on a backfill script ? (y/n): " backfill_dependant
+if [ "$backfill_dependant" == "y" ]; then
+  # Ask for user input for backfill script name
+  read -p "Please enter the name of the backfill script: " backfill_script_name
+  
+  TEMPLATE_FILE="./migration_with_backfill_template.sql"
+
+  # Create an sql command that will fail when executed and put it at the TOP of the migration file before the rest of the sql commands
+  sed -e "/MIGRATION_STATEMENTS/r $OUTPUT_FILE" \
+    -e "/MIGRATION_STATEMENTS/d" \
+    -e "s/BACKFILL_SCRIPT_NAME/$backfill_script_name/g" \
+    "$TEMPLATE_FILE" > temp_output.sql && mv temp_output.sql "$OUTPUT_FILE"
+fi

--- a/connectors/migration_with_backfill_template.sql
+++ b/connectors/migration_with_backfill_template.sql
@@ -1,0 +1,25 @@
+-- -- This migration is dependant on a backfill script
+-- -- The backfill script is: BACKFILL_SCRIPT_NAME
+-- -- run psql with --set=backfilled=1 argument if you have rune the script.
+
+CREATE OR REPLACE FUNCTION perform_migration(backfilled boolean DEFAULT false)
+RETURNS VARCHAR AS $$
+BEGIN
+    IF NOT backfilled THEN
+        RAISE NOTICE 'The backfill script: BACKFILL_SCRIPT_NAME is required before applying this migation. If you already did it, run psql with --set=backfilled=1 argument.';
+    END IF;
+
+    MIGRATION_STATEMENTS
+
+    RETURN 'success';
+END;
+$$ LANGUAGE plpgsql;
+
+\if :{?backfilled}
+   SELECT perform_migration(:'backfilled'::boolean);
+\else
+    \echo '!! Migration was NOT applied !!'
+    \echo 'The backfill script: BACKFILL_SCRIPT_NAME is required before applying this migation. If you already did it, run psql with --set=backfilled=1 argument.'
+\endif
+
+DROP FUNCTION perform_migration(boolean);

--- a/front/create_db_migration_file.sh
+++ b/front/create_db_migration_file.sh
@@ -17,10 +17,13 @@ trap 'cleanup' SIGINT SIGTERM EXIT
 
 # Get current date in a human-readable format (e.g., May 28, 2024)
 current_date=$(date +"%b %d, %Y")
+current_unix_timestamp=$(date +"%s")
+# Use a unique message to identify the stash in case the script fails before popping the stash.
+stash_commit_message="Temp stash for running diff $current_unix_timestamp"
 
 # Stash any uncommitted changes.
 echo "Stashing uncommitted changes..."
-git stash push -m "Temp stash for running diff" --quiet
+git stash push -m "$stash_commit_message" --quiet
 
 # Get the current branch name.
 original_branch=$(git symbolic-ref --short HEAD)
@@ -38,7 +41,7 @@ NODE_ENV=development DB_LOGGING_ENABLED=true ./admin/init_db.sh --unsafe > main_
 
 # Determine if there were any stashed changes.
 stash_list=$(git stash list)
-if [[ $stash_list == *"Temp stash for running diff"* ]]; then
+if [[ $stash_list == *"$stash_commit_message"* ]]; then
   # Pop the stash if it exists.
   echo "Restoring original changes..."
   git stash pop --quiet
@@ -71,5 +74,22 @@ last_version=$(ls ./migrations/db | grep -oE 'migration_([0-9]+).sql' | grep -oE
 next_version=$(printf "%02d" $((10#$last_version + 1)))
 echo "Creating SQL migration $next_version."
 
+OUTPUT_FILE="./migrations/db/migration_${next_version}.sql"
+
 # Save the latest changes to a new migration file.
-mv diff_output.txt "./migrations/db/migration_${next_version}.sql"
+mv diff_output.txt "$OUTPUT_FILE"
+
+# Ask for user Y/n input wether this migration is dependant on a backfill
+read -p "Does this migration depends on a backfill script ? (y/n): " backfill_dependant
+if [ "$backfill_dependant" == "y" ]; then
+  # Ask for user input for backfill script name
+  read -p "Please enter the name of the backfill script: " backfill_script_name
+  
+  TEMPLATE_FILE="./migration_with_backfill_template.sql"
+
+  # Create an sql command that will fail when executed and put it at the TOP of the migration file before the rest of the sql commands
+  sed -e "/MIGRATION_STATEMENTS/r $OUTPUT_FILE" \
+    -e "/MIGRATION_STATEMENTS/d" \
+    -e "s/BACKFILL_SCRIPT_NAME/$backfill_script_name/g" \
+    "$TEMPLATE_FILE" > temp_output.sql && mv temp_output.sql "$OUTPUT_FILE"
+fi

--- a/front/migration_with_backfill_template.sql
+++ b/front/migration_with_backfill_template.sql
@@ -1,0 +1,25 @@
+-- -- This migration is dependant on a backfill script
+-- -- The backfill script is: BACKFILL_SCRIPT_NAME
+-- -- run psql with --set=backfilled=1 argument if you have rune the script.
+
+CREATE OR REPLACE FUNCTION perform_migration(backfilled boolean DEFAULT false)
+RETURNS VARCHAR AS $$
+BEGIN
+    IF NOT backfilled THEN
+        RAISE NOTICE 'The backfill script: BACKFILL_SCRIPT_NAME is required before applying this migation. If you already did it, run psql with --set=backfilled=1 argument.';
+    END IF;
+
+    MIGRATION_STATEMENTS
+
+    RETURN 'success';
+END;
+$$ LANGUAGE plpgsql;
+
+\if :{?backfilled}
+   SELECT perform_migration(:'backfilled'::boolean);
+\else
+    \echo '!! Migration was NOT applied !!'
+    \echo 'The backfill script: BACKFILL_SCRIPT_NAME is required before applying this migation. If you already did it, run psql with --set=backfilled=1 argument.'
+\endif
+
+DROP FUNCTION perform_migration(boolean);


### PR DESCRIPTION
## Description

This PR aim to help us fall into the pit of success when running migrations.
- Prompt if the migration requires a backfill script first
  - If so, wrap the migration statements in a function and refuse to run the migration unless the backfilled variable is truthy
  - Display a message to let the dev know that they are supposed to do to explicitely confirm the backfill has been applied (re-run `psql` with `--set=backfilled=1`) 

Note: I also slightly improved the script behavior if it fails between stash and stash pop.

## Risk

None

## Deploy Plan

None