### PR TITLE
Fetch default workspace vaults in assistant builder

### DIFF
--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -101,18 +101,13 @@ export class VaultResource extends BaseResource<VaultModel> {
   }
 
   static async listWorkspaceVaults(
-    auth: Authenticator,
-    onlySystemAndGlobal = false
+    auth: Authenticator
   ): Promise<VaultResource[]> {
     const owner = auth.getNonNullableWorkspace();
 
     const where: WhereOptions = {
       workspaceId: owner.id,
     };
-
-    if (onlySystemAndGlobal) {
-      where["kind"] = ["system", "global"];
-    }
 
     const vaults = await this.model.findAll({
       where,

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -7,7 +7,6 @@ import type {
   VaultType,
 } from "@dust-tt/types";
 import { Ok } from "@dust-tt/types";
-import { auth } from "googleapis/build/src/apis/abusiveexperiencereport";
 import type {
   Attributes,
   CreationAttributes,

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -7,6 +7,7 @@ import type {
   VaultType,
 } from "@dust-tt/types";
 import { Ok } from "@dust-tt/types";
+import { auth } from "googleapis/build/src/apis/abusiveexperiencereport";
 import type {
   Attributes,
   CreationAttributes,
@@ -122,6 +123,21 @@ export class VaultResource extends BaseResource<VaultModel> {
       .filter(
         (vault) => auth.isAdmin() || auth.hasPermission([vault.acl()], "read")
       );
+  }
+
+  static async listWorkspaceDefaultVaults(auth: Authenticator) {
+    const owner = auth.getNonNullableWorkspace();
+
+    const vaults = await this.model.findAll({
+      where: {
+        workspaceId: owner.id,
+        kind: {
+          [Op.in]: ["system", "global"],
+        },
+      },
+    });
+
+    return vaults.map((vault) => new this(VaultModel, vault.get()));
   }
 
   static async fetchWorkspaceSystemVault(

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -54,10 +54,8 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
-  const globalAndSystemVault = await VaultResource.listWorkspaceVaults(
-    auth,
-    true
-  );
+  const globalAndSystemVault =
+    await VaultResource.listWorkspaceDefaultVaults(auth);
 
   const [ds, dsViews, configuration, allDustApps] = await Promise.all([
     DataSourceResource.listByVaults(auth, globalAndSystemVault),

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -66,10 +66,8 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
-  const globalAndSystemVault = await VaultResource.listWorkspaceVaults(
-    auth,
-    true
-  );
+  const globalAndSystemVault =
+    await VaultResource.listWorkspaceDefaultVaults(auth);
 
   const [ds, dsViews, allDustApps] = await Promise.all([
     DataSourceResource.listByVaults(auth, globalAndSystemVault),


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes a regression introduced in https://github.com/dust-tt/dust/issues/6819 . We were fetching the default vaults using `listWorkspaceVaults` which apply user's permissions to filter out vaults that can't be accessed. For non-admin users, this led to only retrieving the global vaults, leaving out the system vault with all the managed data sources. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
