### PR TITLE
Connector: add temporary slack logging for debugging

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -552,6 +552,16 @@ export async function syncThread(
 
   let allMessages: MessageElement[] = [];
 
+  logger.info(
+    {
+      messagesCount: allMessages.length,
+      channelName,
+      channelId,
+      threadTs,
+    },
+    "Fetching messages from channel thread."
+  );
+
   try {
     allMessages = await getRepliesFromThread({
       slackClient,
@@ -570,6 +580,16 @@ export async function syncThread(
     }
     throw e;
   }
+
+  logger.info(
+    {
+      messagesCount: allMessages.length,
+      channelName,
+      channelId,
+      threadTs,
+    },
+    "Got messages from channel thread."
+  );
 
   const documentId = `slack-${channelId}-thread-${threadTs}`;
 


### PR DESCRIPTION
## Description

Add temporary logging around syncChannel to better understand a channel that has been failing to aggregate for weeks on on of our user.

Context: 
https://dust4ai.slack.com/archives/C05F84CFP0E/p1724179499990289
https://dust4ai.slack.com/archives/C05F84CFP0E/p1724198087658749

## Risk

N/A

## Deploy Plan

- deploy `connectors`