### PR TITLE
Add managed ds to Vaults

### DIFF
--- a/front/components/DataSourceResourceSelectorTree.tsx
+++ b/front/components/DataSourceResourceSelectorTree.tsx
@@ -7,6 +7,7 @@ import type {
   ContentNode,
   ContentNodesViewType,
   DataSourceType,
+  DataSourceViewType,
   WorkspaceType,
 } from "@dust-tt/types";
 import type { ConnectorPermission, ContentNodeType } from "@dust-tt/types";
@@ -27,7 +28,7 @@ export default function DataSourceResourceSelectorTree({
   viewType = "documents",
 }: {
   owner: WorkspaceType;
-  dataSource: DataSourceType;
+  dataSource: DataSourceType | DataSourceViewType;
   showExpand: boolean;
   parentIsSelected?: boolean;
   selectedParents?: string[];
@@ -98,7 +99,7 @@ function DataSourceResourceSelectorChildren({
   viewType = "documents",
 }: {
   owner: WorkspaceType;
-  dataSource: DataSourceType;
+  dataSource: DataSourceType | DataSourceViewType;
   parentId: string | null;
   parents: string[];
   parentIsSelected?: boolean;

--- a/front/components/assistant_builder/DataSourceResourceSelector.tsx
+++ b/front/components/assistant_builder/DataSourceResourceSelector.tsx
@@ -31,7 +31,7 @@ export default function DataSourceResourceSelector({
   const { parentsById, setParentsById } = useParentResourcesById({
     owner,
     dataSource,
-    selectedResources,
+    internalIds: selectedResources.map((r) => r.internalId),
   });
 
   const selectedParents = [

--- a/front/components/assistant_builder/FolderOrWebsiteTree.tsx
+++ b/front/components/assistant_builder/FolderOrWebsiteTree.tsx
@@ -31,7 +31,7 @@ export default function FolderOrWebsiteTree({
   const { parentsById, setParentsById } = useParentResourcesById({
     owner,
     dataSource,
-    selectedResources,
+    internalIds: selectedResources.map((r) => r.internalId),
   });
 
   const selectedParents = [

--- a/front/components/vaults/EditVaultManagedDatasourcesViews.tsx
+++ b/front/components/vaults/EditVaultManagedDatasourcesViews.tsx
@@ -1,0 +1,162 @@
+import { Button, PlusIcon, Spinner } from "@dust-tt/sparkle";
+import type {
+  APIError,
+  ManagedDataSourceViewsSelectedNodes,
+  VaultType,
+  WorkspaceType,
+} from "@dust-tt/types";
+import React, { useState } from "react";
+
+import { SendNotificationsContext } from "@app/components/sparkle/Notification";
+import VaultManagedDataSourcesViewsModal from "@app/components/vaults/VaultManagedDatasourcesViewsModal";
+import { useVaultDataSourceViews } from "@app/lib/swr";
+
+export function EditVaultManagedDataSourcesViews({
+  owner,
+  vault,
+  systemVault,
+}: {
+  owner: WorkspaceType;
+  vault: VaultType;
+  systemVault: VaultType;
+}) {
+  const sendNotification = React.useContext(SendNotificationsContext);
+
+  const [showDataSourcesModal, setShowDataSourcesModal] = useState(false);
+
+  // DataSources Views of the current vault.
+  const {
+    vaultDataSourceViews,
+    isVaultDataSourceViewsLoading,
+    mutateVaultDataSourceViews,
+  } = useVaultDataSourceViews({
+    workspaceId: owner.sId,
+    vaultId: vault.sId,
+    category: "managed",
+  });
+
+  // DataSources Views of the system vault holding the managed datasources we want to select data from.
+  const {
+    vaultDataSourceViews: systemVaultDataSourceViews,
+    isVaultDataSourceViewsLoading: isSystemVaultDataSourceViewsLoading,
+  } = useVaultDataSourceViews({
+    workspaceId: owner.sId,
+    vaultId: systemVault.sId,
+    category: "managed",
+  });
+
+  const updateVaultDataSourceViews = async (
+    selectedNodes: ManagedDataSourceViewsSelectedNodes
+  ) => {
+    let error = null;
+    await Promise.all(
+      selectedNodes.map(async (sDs) => {
+        const existingViewForDs = vaultDataSourceViews.find(
+          (d) => d.name === sDs.name
+        );
+
+        const body = {
+          name: sDs.name,
+          parentsIn: sDs.parentsIn,
+        };
+
+        try {
+          let res;
+          if (existingViewForDs) {
+            if (sDs.parentsIn !== null && sDs.parentsIn.length === 0) {
+              res = await fetch(
+                `/api/w/${owner.sId}/vaults/${vault.sId}/data_source_views/${existingViewForDs.sId}`,
+                {
+                  method: "DELETE",
+                  headers: {
+                    "Content-Type": "application/json",
+                  },
+                }
+              );
+            } else {
+              res = await fetch(
+                `/api/w/${owner.sId}/vaults/${vault.sId}/data_source_views/${existingViewForDs.sId}`,
+                {
+                  method: "PATCH",
+                  headers: {
+                    "Content-Type": "application/json",
+                  },
+                  body: JSON.stringify(body),
+                }
+              );
+            }
+          } else {
+            res = await fetch(
+              `/api/w/${owner.sId}/vaults/${vault.sId}/data_source_views`,
+              {
+                method: "POST",
+                headers: {
+                  "Content-Type": "application/json",
+                },
+                body: JSON.stringify(body),
+              }
+            );
+          }
+
+          if (!res.ok) {
+            const rawError = (await res.json()) as { error: APIError };
+            error = rawError.error.message;
+          }
+        } catch (e) {
+          error = "An Unknown error occurred while adding data to vault.";
+        }
+      })
+    );
+
+    if (error) {
+      sendNotification({
+        title: "Error Adding Data to Vault",
+        type: "error",
+        description: error,
+      });
+    } else {
+      sendNotification({
+        title: "Data Successfully Added to Vault",
+        type: "success",
+        description: "All data sources were successfully updated.",
+      });
+    }
+    await mutateVaultDataSourceViews();
+  };
+
+  if (isSystemVaultDataSourceViewsLoading || isVaultDataSourceViewsLoading) {
+    return (
+      <div className="mt-8 flex justify-center">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <VaultManagedDataSourcesViewsModal
+        isOpen={showDataSourcesModal}
+        setOpen={(isOpen) => {
+          setShowDataSourcesModal(isOpen);
+        }}
+        owner={owner}
+        systemVaultDataSourceViews={systemVaultDataSourceViews.filter(
+          (ds) => ds.connectorProvider && ds.connectorProvider !== "webcrawler"
+        )}
+        onSave={async (selectedDataSources) => {
+          await updateVaultDataSourceViews(selectedDataSources);
+        }}
+        initialSelectedDataSources={vaultDataSourceViews}
+      />
+      <Button
+        label="Add data from connections"
+        variant="primary"
+        icon={PlusIcon}
+        size="sm"
+        onClick={() => {
+          setShowDataSourcesModal(true);
+        }}
+      />
+    </>
+  );
+}

--- a/front/components/vaults/VaultCategoriesList.tsx
+++ b/front/components/vaults/VaultCategoriesList.tsx
@@ -1,5 +1,4 @@
 import {
-  Button,
   CloudArrowLeftRightIcon,
   CommandLineIcon,
   DataTable,
@@ -147,7 +146,6 @@ export const VaultCategoriesList = ({
             }}
           />
         )}
-        <Button label="Add Data" onClick={() => {}} />
       </div>
       {rows.length > 0 ? (
         <DataTable

--- a/front/components/vaults/VaultManagedDatasourcesModal.tsx
+++ b/front/components/vaults/VaultManagedDatasourcesModal.tsx
@@ -1,8 +1,8 @@
 import { Modal, Tree } from "@dust-tt/sparkle";
 import type {
   ConnectorProvider,
-  DataSourceOrViewInfo,
   DataSourceType,
+  DataSourceViewType,
   VaultSelectedDataSources,
   WorkspaceType,
 } from "@dust-tt/types";
@@ -25,7 +25,7 @@ export default function VaultManagedDataSourcesModal({
   owner: WorkspaceType;
   dataSources: DataSourceType[];
   onSave: (dsConfigs: VaultSelectedDataSources) => void;
-  initialSelectedDataSources: DataSourceOrViewInfo[];
+  initialSelectedDataSources: DataSourceViewType[];
 }) {
   const [selectedDataSources, setSelectedDataSources] =
     useState<VaultSelectedDataSources>(
@@ -34,6 +34,7 @@ export default function VaultManagedDataSourcesModal({
         parentsIn: ds.parentsIn ?? null,
       }))
     );
+  const [hasChanged, setHasChanged] = useState(false);
 
   return (
     <Modal
@@ -45,7 +46,7 @@ export default function VaultManagedDataSourcesModal({
         onSave(selectedDataSources);
         setOpen(false);
       }}
-      hasChanged={true}
+      hasChanged={hasChanged}
       variant="side-md"
       title="Add connected datasources"
     >
@@ -60,6 +61,8 @@ export default function VaultManagedDataSourcesModal({
                   dataSource={dataSource}
                   selectedDataSources={selectedDataSources}
                   setSelectedDataSources={setSelectedDataSources}
+                  hasChanged={hasChanged}
+                  setHasChanged={setHasChanged}
                 />
               );
             })}
@@ -75,6 +78,8 @@ function VaultManagedDataSourceTree({
   dataSource,
   selectedDataSources,
   setSelectedDataSources,
+  hasChanged,
+  setHasChanged,
 }: {
   owner: WorkspaceType;
   dataSource: DataSourceType;
@@ -82,6 +87,8 @@ function VaultManagedDataSourceTree({
   setSelectedDataSources: (
     prevState: (prevState: VaultSelectedDataSources) => VaultSelectedDataSources
   ) => void;
+  hasChanged: boolean;
+  setHasChanged: (hasChanged: boolean) => void;
 }) {
   const config =
     CONNECTOR_CONFIGURATIONS[dataSource.connectorProvider as ConnectorProvider];
@@ -115,6 +122,10 @@ function VaultManagedDataSourceTree({
         checked: isSelectAll,
         partialChecked: isPartiallyChecked,
         onChange: (checked) => {
+          if (!hasChanged) {
+            setHasChanged(true);
+          }
+
           // Setting parentsById
           setParentsById({});
 
@@ -149,6 +160,10 @@ function VaultManagedDataSourceTree({
         selectedResourceIds={selectedDs?.parentsIn ?? []}
         selectedParents={selectedParents}
         onSelectChange={(node, parents, selected) => {
+          if (!hasChanged) {
+            setHasChanged(true);
+          }
+
           // Setting parentsById
           setParentsById((prevState) => {
             const newParentsById = { ...prevState };

--- a/front/components/vaults/VaultManagedDatasourcesModal.tsx
+++ b/front/components/vaults/VaultManagedDatasourcesModal.tsx
@@ -1,0 +1,195 @@
+import { Modal, Tree } from "@dust-tt/sparkle";
+import type {
+  ConnectorProvider,
+  DataSourceOrViewInfo,
+  DataSourceType,
+  VaultSelectedDataSources,
+  WorkspaceType,
+} from "@dust-tt/types";
+import { useState } from "react";
+
+import DataSourceResourceSelectorTree from "@app/components/DataSourceResourceSelectorTree";
+import { useParentResourcesById } from "@app/hooks/useParentResourcesById";
+import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
+
+export default function VaultManagedDataSourcesModal({
+  isOpen,
+  setOpen,
+  owner,
+  dataSources,
+  onSave,
+  initialSelectedDataSources,
+}: {
+  isOpen: boolean;
+  setOpen: (isOpen: boolean) => void;
+  owner: WorkspaceType;
+  dataSources: DataSourceType[];
+  onSave: (dsConfigs: VaultSelectedDataSources) => void;
+  initialSelectedDataSources: DataSourceOrViewInfo[];
+}) {
+  const [selectedDataSources, setSelectedDataSources] =
+    useState<VaultSelectedDataSources>(
+      initialSelectedDataSources.map((ds) => ({
+        name: ds.name,
+        parentsIn: ds.parentsIn ?? null,
+      }))
+    );
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={() => {
+        setOpen(false);
+      }}
+      onSave={() => {
+        onSave(selectedDataSources);
+        setOpen(false);
+      }}
+      hasChanged={true}
+      variant="side-md"
+      title="Add connected datasources"
+    >
+      <div className="w-full pt-12">
+        <div className="overflow-x-auto">
+          <Tree isLoading={false}>
+            {dataSources.map((dataSource) => {
+              return (
+                <VaultManagedDataSourceTree
+                  key={dataSource.name}
+                  owner={owner}
+                  dataSource={dataSource}
+                  selectedDataSources={selectedDataSources}
+                  setSelectedDataSources={setSelectedDataSources}
+                />
+              );
+            })}
+          </Tree>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+function VaultManagedDataSourceTree({
+  owner,
+  dataSource,
+  selectedDataSources,
+  setSelectedDataSources,
+}: {
+  owner: WorkspaceType;
+  dataSource: DataSourceType;
+  selectedDataSources: VaultSelectedDataSources;
+  setSelectedDataSources: (
+    prevState: (prevState: VaultSelectedDataSources) => VaultSelectedDataSources
+  ) => void;
+}) {
+  const config =
+    CONNECTOR_CONFIGURATIONS[dataSource.connectorProvider as ConnectorProvider];
+  const LogoComponent = config?.logoComponent ?? null;
+  const selectedDs = selectedDataSources.find(
+    (ds) => ds.name === dataSource.name
+  );
+  const { parentsById, setParentsById } = useParentResourcesById({
+    owner,
+    dataSource,
+    internalIds: selectedDs?.parentsIn ?? [],
+  });
+
+  const selectedParents = [
+    ...new Set(Object.values(parentsById).flatMap((c) => [...c])),
+  ];
+
+  const isSelectAll = selectedDs?.parentsIn === null;
+  const isPartiallyChecked = !!(
+    selectedDs?.parentsIn?.length && selectedDs?.parentsIn?.length > 0
+  );
+
+  return (
+    <Tree.Item
+      key={dataSource.name}
+      label={config?.name}
+      visual={LogoComponent ? <LogoComponent className="s-h-5 s-w-5" /> : null}
+      variant="folder"
+      type="node"
+      checkbox={{
+        checked: isSelectAll,
+        partialChecked: isPartiallyChecked,
+        onChange: (checked) => {
+          // Setting parentsById
+          setParentsById({});
+
+          // Setting selectedResources
+          setSelectedDataSources((prevState) => {
+            if (checked) {
+              const ds = prevState.find((ds) => ds.name === dataSource.name);
+              if (ds) {
+                ds.parentsIn = null;
+              } else {
+                prevState.push({
+                  name: dataSource.name,
+                  parentsIn: null,
+                });
+              }
+              return prevState;
+            }
+
+            return prevState.filter((ds) => ds.name !== dataSource.name);
+          });
+        },
+      }}
+    >
+      <DataSourceResourceSelectorTree
+        owner={owner}
+        dataSource={dataSource}
+        showExpand={
+          CONNECTOR_CONFIGURATIONS[
+            dataSource.connectorProvider as ConnectorProvider
+          ]?.isNested
+        }
+        selectedResourceIds={selectedDs?.parentsIn ?? []}
+        selectedParents={selectedParents}
+        onSelectChange={(node, parents, selected) => {
+          // Setting parentsById
+          setParentsById((prevState) => {
+            const newParentsById = { ...prevState };
+            if (selected) {
+              newParentsById[node.internalId] = new Set(parents);
+            } else {
+              delete newParentsById[node.internalId];
+            }
+            return newParentsById;
+          });
+
+          // Setting selectedResources
+          setSelectedDataSources((prevState: VaultSelectedDataSources) => {
+            if (selected) {
+              const ds = prevState.find((ds) => ds.name === dataSource.name);
+              if (ds) {
+                if (ds.parentsIn === null) {
+                  ds.parentsIn = [node.internalId];
+                } else {
+                  ds.parentsIn.push(node.internalId);
+                }
+              } else {
+                prevState.push({
+                  name: dataSource.name,
+                  parentsIn: [node.internalId],
+                });
+              }
+              return prevState;
+            }
+
+            const ds = prevState.find((ds) => ds.name === dataSource.name);
+            if (ds && ds.parentsIn) {
+              ds.parentsIn = ds.parentsIn.filter(
+                (id) => id !== node.internalId
+              );
+            }
+            return prevState;
+          });
+        }}
+        parentIsSelected={isSelectAll}
+      />
+    </Tree.Item>
+  );
+}

--- a/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
+++ b/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
@@ -99,6 +99,8 @@ function VaultManagedDataSourceViewsTree({
   const selectedNodesInDataSourceView = selectedNodes.find(
     (ds) => ds.name === dataSourceView.name
   );
+
+  // TODO(GROUPS_INFRA): useParentResourcesById should use views not data sources.
   const { parentsById, setParentsById } = useParentResourcesById({
     owner,
     dataSource: dataSourceView,

--- a/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
+++ b/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
@@ -190,14 +190,12 @@ function VaultManagedDataSourceViewsTree({
           // Setting selectedResources
           setSelectedNodes((prevState: ManagedDataSourceViewsSelectedNodes) => {
             if (selected) {
-              const ds = prevState.find(
-                (ds) => ds.name === dataSourceView.name
-              );
-              if (ds) {
-                if (ds.parentsIn === null) {
-                  ds.parentsIn = [node.internalId];
+              const dsv = prevState.find((v) => v.name === dataSourceView.name);
+              if (dsv) {
+                if (dsv.parentsIn === null) {
+                  dsv.parentsIn = [node.internalId];
                 } else {
-                  ds.parentsIn.push(node.internalId);
+                  dsv.parentsIn.push(node.internalId);
                 }
               } else {
                 prevState.push({
@@ -208,9 +206,9 @@ function VaultManagedDataSourceViewsTree({
               return prevState;
             }
 
-            const ds = prevState.find((ds) => ds.name === dataSourceView.name);
-            if (ds && ds.parentsIn) {
-              ds.parentsIn = ds.parentsIn.filter(
+            const dsv = prevState.find((v) => v.name === dataSourceView.name);
+            if (dsv && dsv.parentsIn) {
+              dsv.parentsIn = dsv.parentsIn.filter(
                 (id) => id !== node.internalId
               );
             }

--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -144,12 +144,15 @@ export const VaultResourcesList = ({
   const searchBarRef = useRef<HTMLInputElement>(null);
 
   // DataSources Views of the current vault.
-  const { vaultDataSourceViews, isVaultDataSourceViewsLoading } =
-    useVaultDataSourceViews({
-      workspaceId: owner.sId,
-      vaultId: vault.sId,
-      category: category,
-    });
+  const {
+    vaultDataSourceViews,
+    isVaultDataSourceViewsLoading,
+    mutateVaultDataSourceViews,
+  } = useVaultDataSourceViews({
+    workspaceId: owner.sId,
+    vaultId: vault.sId,
+    category: category,
+  });
 
   // DataSources Views of the system vault holding the managed datasources we want to select data from.
   const {
@@ -280,7 +283,7 @@ export const VaultResourcesList = ({
         description: "All data sources were successfully updated.",
       });
     }
-    // @todo mutateVaultDataSourceOrViews(); ?
+    await mutateVaultDataSourceViews();
   };
 
   return (

--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -12,8 +12,8 @@ import type {
   ConnectorType,
   DataSourceViewCategory,
   EditedByUser,
+  ManagedDataSourceViewsSelectedNodes,
   PlanType,
-  VaultSelectedDataSources,
   VaultType,
   WorkspaceType,
 } from "@dust-tt/types";
@@ -29,7 +29,7 @@ import ConnectorSyncingChip from "@app/components/data_source/DataSourceSyncChip
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import VaultCreateFolderModal from "@app/components/vaults/VaultCreateFolderModal";
 import VaultCreateWebsiteModal from "@app/components/vaults/VaultCreateWebsiteModal";
-import VaultManagedDataSourcesModal from "@app/components/vaults/VaultManagedDatasourcesModal";
+import VaultManagedDataSourcesViewsModal from "@app/components/vaults/VaultManagedDatasourcesViewsModal";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import {
   CONNECTOR_CONFIGURATIONS,
@@ -207,12 +207,12 @@ export const VaultResourcesList = ({
     );
   }
 
-  const saveSelectedDatasources = async (
-    selectedDataSources: VaultSelectedDataSources
+  const updateVaultDataSourceViews = async (
+    selectedNodes: ManagedDataSourceViewsSelectedNodes
   ) => {
     let error = null;
     await Promise.all(
-      selectedDataSources.map(async (sDs) => {
+      selectedNodes.map(async (sDs) => {
         const existingViewForDs = vaultDataSourceViews.find(
           (d) => d.name === sDs.name
         );
@@ -317,7 +317,7 @@ export const VaultResourcesList = ({
         }}
         owner={owner}
       />
-      <VaultManagedDataSourcesModal
+      <VaultManagedDataSourcesViewsModal
         isOpen={showDataSourcesModal}
         setOpen={(isOpen) => {
           setShowDataSourcesModal(isOpen);
@@ -327,7 +327,7 @@ export const VaultResourcesList = ({
           (ds) => ds.connectorProvider && ds.connectorProvider !== "webcrawler"
         )}
         onSave={async (selectedDataSources) => {
-          await saveSelectedDatasources(selectedDataSources);
+          await updateVaultDataSourceViews(selectedDataSources);
         }}
         initialSelectedDataSources={vaultDataSourceViews}
       />

--- a/front/components/vaults/VaultSideBarMenu.tsx
+++ b/front/components/vaults/VaultSideBarMenu.tsx
@@ -10,6 +10,7 @@ import {
   Tree,
 } from "@dust-tt/sparkle";
 import type {
+  DataSourceViewCategory,
   DataSourceViewType,
   LightWorkspaceType,
   VaultKind,
@@ -129,7 +130,7 @@ const SYSTEM_VAULTS_ITEMS = [
   {
     label: "Connection Management",
     visual: RootItemIconWrapper(CloudArrowLeftRightIcon),
-    category: "managed",
+    category: "managed" as DataSourceViewCategory,
   },
   // TODO(GROUPS_UI) Add support for Dust apps.
 ];
@@ -164,7 +165,7 @@ const SystemVaultItem = ({
   vault,
   visual,
 }: {
-  category: string;
+  category: DataSourceViewCategory;
   label: string;
   owner: LightWorkspaceType;
   vault: VaultType;
@@ -343,7 +344,7 @@ const VaultCategoryItem = ({
 }: {
   owner: LightWorkspaceType;
   vault: VaultType;
-  category: string;
+  category: DataSourceViewCategory;
 }) => {
   const router = useRouter();
 

--- a/front/hooks/useParentResourcesById.ts
+++ b/front/hooks/useParentResourcesById.ts
@@ -1,4 +1,8 @@
-import type { DataSourceType, WorkspaceType } from "@dust-tt/types";
+import type {
+  DataSourceType,
+  DataSourceViewType,
+  WorkspaceType,
+} from "@dust-tt/types";
 import { useCallback, useEffect, useState } from "react";
 
 import type { GetContentNodeParentsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/parents";
@@ -9,7 +13,7 @@ export function useParentResourcesById({
   internalIds,
 }: {
   owner: WorkspaceType;
-  dataSource: DataSourceType | null;
+  dataSource: DataSourceType | DataSourceViewType | null;
   internalIds: string[];
 }) {
   const [parentsById, setParentsById] = useState<Record<string, Set<string>>>(

--- a/front/hooks/useParentResourcesById.ts
+++ b/front/hooks/useParentResourcesById.ts
@@ -1,8 +1,4 @@
-import type {
-  ContentNode,
-  DataSourceType,
-  WorkspaceType,
-} from "@dust-tt/types";
+import type { DataSourceType, WorkspaceType } from "@dust-tt/types";
 import { useCallback, useEffect, useState } from "react";
 
 import type { GetContentNodeParentsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/parents";
@@ -10,11 +6,11 @@ import type { GetContentNodeParentsResponseBody } from "@app/pages/api/w/[wId]/d
 export function useParentResourcesById({
   owner,
   dataSource,
-  selectedResources,
+  internalIds,
 }: {
   owner: WorkspaceType;
   dataSource: DataSourceType | null;
-  selectedResources: ContentNode[];
+  internalIds: string[];
 }) {
   const [parentsById, setParentsById] = useState<Record<string, Set<string>>>(
     {}
@@ -35,9 +31,7 @@ export function useParentResourcesById({
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
-            internalIds: selectedResources.map((resource) => {
-              return resource.internalId;
-            }),
+            internalIds,
           }),
         }
       );
@@ -60,10 +54,10 @@ export function useParentResourcesById({
     } finally {
       setParentsAreLoading(false);
     }
-  }, [owner, dataSource?.name, selectedResources]);
+  }, [owner, dataSource?.name, internalIds]);
 
   const hasParentsById = Object.keys(parentsById || {}).length > 0;
-  const hasSelectedResources = selectedResources.length > 0;
+  const hasSelectedResources = internalIds.length > 0;
 
   useEffect(() => {
     if (parentsAreLoading || parentsAreError) {

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -8,6 +8,7 @@ import type {
   ConversationMessageReactions,
   ConversationType,
   DataSourceType,
+  DataSourceViewCategory,
   DataSourceViewType,
   GetDataSourceViewContentResponseBody,
   LightWorkspaceType,
@@ -1332,7 +1333,7 @@ export function useVaultDataSourceViews({
   vaultId,
   workspaceId,
 }: {
-  category: string;
+  category: DataSourceViewCategory;
   disabled?: boolean;
   vaultId: string;
   workspaceId: string;

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -500,7 +500,7 @@ export function usePokeConnectorPermissions({
   disabled,
 }: {
   owner: WorkspaceType;
-  dataSource: DataSourceType;
+  dataSource: DataSourceType | DataSourceViewType;
   parentId: string | null;
   filterPermission: ConnectorPermission | null;
   disabled?: boolean;

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -1339,8 +1339,7 @@ export function useVaultDataSourceViews({
 }) {
   const vaultsDataSourceViewsFetcher: Fetcher<GetVaultDataSourceViewsResponseBody> =
     fetcher;
-
-  const { data, error } = useSWRWithDefaults(
+  const { data, error, mutate } = useSWRWithDefaults(
     disabled
       ? null
       : `/api/w/${workspaceId}/vaults/${vaultId}/data_source_views?category=${category}`,
@@ -1352,6 +1351,7 @@ export function useVaultDataSourceViews({
       () => (data ? data.dataSourceViews : []),
       [data]
     ),
+    mutateVaultDataSourceViews: mutate,
     isVaultDataSourceViewsLoading: !error && !data,
     isVaultDataSourceViewsError: error,
   };

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -8,6 +8,7 @@ import type {
   ConversationMessageReactions,
   ConversationType,
   DataSourceType,
+  DataSourceViewType,
   GetDataSourceViewContentResponseBody,
   LightWorkspaceType,
   RunRunType,
@@ -460,7 +461,7 @@ export function useConnectorPermissions({
   viewType = "documents",
 }: {
   owner: WorkspaceType;
-  dataSource: DataSourceType;
+  dataSource: DataSourceType | DataSourceViewType;
   parentId: string | null;
   filterPermission: ConnectorPermission | null;
   disabled?: boolean;

--- a/front/pages/api/w/[wId]/vaults/[vId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/index.ts
@@ -1,6 +1,6 @@
 import type { UserType, VaultType, WithAPIErrorResponse } from "@dust-tt/types";
 import {
-  DATA_SOURCE_OR_VIEW_CATEGORIES,
+  DATA_SOURCE_VIEW_CATEGORIES,
   PatchVaultRequestBodySchema,
 } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
@@ -76,7 +76,7 @@ async function handler(
       );
 
       const categories: { [key: string]: VaultCategoryInfo } = {};
-      DATA_SOURCE_OR_VIEW_CATEGORIES.forEach((category) => {
+      DATA_SOURCE_VIEW_CATEGORIES.forEach((category) => {
         categories[category] = {
           count: 0,
           usage: 0,

--- a/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/index.tsx
+++ b/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/index.tsx
@@ -22,6 +22,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     category: DataSourceViewCategory;
     isAdmin: boolean;
     vault: VaultType;
+    systemVault: VaultType;
     plan: PlanType;
   }
 >(async (context, auth) => {
@@ -35,11 +36,12 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     };
   }
 
+  const systemVault = await VaultResource.fetchWorkspaceSystemVault(auth);
   const vault = await VaultResource.fetchById(
     auth,
     context.query.vaultId as string
   );
-  if (!vault) {
+  if (!vault || !systemVault) {
     return {
       notFound: true,
     };
@@ -55,6 +57,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
       plan,
       subscription,
       vault: vault.toJSON(),
+      systemVault: systemVault.toJSON(),
     },
   };
 });
@@ -65,6 +68,7 @@ export default function Vault({
   owner,
   plan,
   vault,
+  systemVault,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
   return (
@@ -92,6 +96,7 @@ export default function Vault({
         owner={owner}
         plan={plan}
         vault={vault}
+        systemVault={systemVault}
         isAdmin={isAdmin}
         category={category}
         onSelect={(sId) => {

--- a/types/src/front/api_handlers/public/vaults.ts
+++ b/types/src/front/api_handlers/public/vaults.ts
@@ -4,7 +4,7 @@ import { ContentNodeType } from "../../lib/connectors_api";
 
 export const ContentSchema = t.type({
   dataSource: t.string,
-  parentsIn: t.array(t.string),
+  parentsIn: t.union([t.array(t.string), t.null]),
 });
 
 export const PostDataSourceViewSchema = t.type({

--- a/types/src/front/vault.ts
+++ b/types/src/front/vault.ts
@@ -7,8 +7,9 @@ export type VaultType = {
   kind: VaultKind;
 };
 
-export type VaultSelectedDataSource = {
+type ManagedDataSourceViewSelectedNodes = {
   name: string;
   parentsIn: string[] | null;
 };
-export type VaultSelectedDataSources = VaultSelectedDataSource[];
+export type ManagedDataSourceViewsSelectedNodes =
+  ManagedDataSourceViewSelectedNodes[];

--- a/types/src/front/vault.ts
+++ b/types/src/front/vault.ts
@@ -6,3 +6,9 @@ export type VaultType = {
   sId: string;
   kind: VaultKind;
 };
+
+export type VaultSelectedDataSource = {
+  name: string;
+  parentsIn: string[] | null;
+};
+export type VaultSelectedDataSources = VaultSelectedDataSource[];


### PR DESCRIPTION
## Description

This adds the ability to add manage datasources into a vault. 
We have a single modal for all managed datasources as in the designs. 
I have not implemented the "select all visible" button of the modal, since I think it's an improvement that can be tackled later. 

<kbd>
<img width="807" alt="Screenshot 2024-08-21 at 11 25 51" src="https://github.com/user-attachments/assets/a437daf6-7654-4d14-ae74-5712ea14ea49">
</kbd>


Currently deploying to front-edge.
Then I need to update the patch endpoint to remove a datasource view if the content is empty, cause if you unselect everything in a Notion it will keep the Notion line and if we click it says "no content". 


## Risk

Internal only, can be rolled back. 

## Deploy Plan

Deploy front. 
