### PR TITLE
Fixing the truncate function.

### DIFF
--- a/types/src/shared/utils/string_utils.ts
+++ b/types/src/shared/utils/string_utils.ts
@@ -71,5 +71,7 @@ export function redactString(str: string, n: number) {
 }
 
 export function truncate(text: string, length: number, omission = "...") {
-  return text.length > length ? `${text.substring(0, 20)}${omission}` : text;
+  return text.length > length
+    ? `${text.substring(0, length - omission.length)}${omission}`
+    : text;
 }


### PR DESCRIPTION
## Description

The truncate function truncate after 20 characters, regardless of the max length.
This PR fixes it. I strongly believe this is causing the bug we are seeing with the Slack answers not properly being [updated](https://github.com/dust-tt/tasks/issues/1118).


Took us a long time to figure it out because there is so much more complex things going on with this slack message updates, we were convinced the problem was coming from the streaming logic.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
