### PR TITLE
[Sparkle] Fix: DataTable: remove table cells nested in table cells

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.206",
+  "version": "0.2.209",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.206",
+      "version": "0.2.209",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.207",
+  "version": "0.2.209",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -254,25 +254,12 @@ DataTable.Row = function Row({
     </tr>
   );
 };
-interface CellProps extends React.TdHTMLAttributes<HTMLTableCellElement> {
-  avatarUrl?: string;
-  icon?: React.ComponentType<{ className?: string }>;
-  iconClassName?: string;
-  roundedAvatar?: boolean;
-  children?: ReactNode;
-  description?: string;
+
+interface CellProps extends React.HTMLAttributes<HTMLTableCellElement> {
+  children: ReactNode;
 }
 
-DataTable.Cell = function Cell({
-  children,
-  className,
-  avatarUrl,
-  roundedAvatar,
-  icon,
-  iconClassName,
-  description,
-  ...props
-}: CellProps) {
+DataTable.Cell = function Cell({ children, className, ...props }: CellProps) {
   return (
     <td
       className={classNames(
@@ -281,35 +268,59 @@ DataTable.Cell = function Cell({
       )}
       {...props}
     >
-      <div className="s-flex">
-        {avatarUrl && (
-          <Avatar
-            visual={avatarUrl}
-            size="xs"
-            className="s-mr-2"
-            isRounded={roundedAvatar ?? false}
-          />
-        )}
-        {icon && (
-          <Icon
-            visual={icon}
-            size="sm"
-            className={classNames(
-              "s-mr-2 s-text-element-600",
-              iconClassName || ""
-            )}
-          />
-        )}
-        <div className="s-flex">
-          <span className="s-text-sm s-text-element-800">{children}</span>
-          {description && (
-            <span className="s-pl-2 s-text-sm s-text-element-600">
-              {description}
-            </span>
-          )}
-        </div>
-      </div>
+      {children}
     </td>
+  );
+};
+
+interface CellContentProps extends React.TdHTMLAttributes<HTMLDivElement> {
+  avatarUrl?: string;
+  icon?: React.ComponentType<{ className?: string }>;
+  iconClassName?: string;
+  roundedAvatar?: boolean;
+  children?: ReactNode;
+  description?: string;
+}
+
+DataTable.CellContent = function CellContent({
+  children,
+  className,
+  avatarUrl,
+  roundedAvatar,
+  icon,
+  iconClassName,
+  description,
+  ...props
+}: CellContentProps) {
+  return (
+    <div className={classNames("s-flex s-py-2", className || "")} {...props}>
+      {avatarUrl && (
+        <Avatar
+          visual={avatarUrl}
+          size="xs"
+          className="s-mr-2"
+          isRounded={roundedAvatar ?? false}
+        />
+      )}
+      {icon && (
+        <Icon
+          visual={icon}
+          size="sm"
+          className={classNames(
+            "s-mr-2 s-text-element-600",
+            iconClassName || ""
+          )}
+        />
+      )}
+      <div className="s-flex">
+        <span className="s-text-sm s-text-element-800">{children}</span>
+        {description && (
+          <span className="s-pl-2 s-text-sm s-text-element-600">
+            {description}
+          </span>
+        )}
+      </div>
+    </div>
   );
 };
 

--- a/sparkle/src/stories/Citation.stories.tsx
+++ b/sparkle/src/stories/Citation.stories.tsx
@@ -201,6 +201,7 @@ export const CitationsExample = () => (
     <h2>With zoom effect</h2>
     <div className="s-flex s-gap-2">
       <ZoomableImageCitationWrapper
+        size="sm"
         title="With imgSrc"
         // size="xs"
         imgSrc="https://dust.tt/static/droidavatar/Droid_Black_4.jpg"

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -82,42 +82,50 @@ export const DataTableExample = () => {
       accessorKey: "name",
       header: "Name",
       cell: (info) => (
-        <DataTable.Cell
+        <DataTable.CellContent
           avatarUrl={info.row.original.avatarUrl}
           icon={info.row.original.icon}
           description={info.row.original.description}
           roundedAvatar={info.row.original.roundedAvatar}
         >
           {info.row.original.name}
-        </DataTable.Cell>
+        </DataTable.CellContent>
       ),
     },
     {
       accessorKey: "usedBy",
       header: "Used by",
       cell: (info) => (
-        <DataTable.Cell>{info.row.original.usedBy}</DataTable.Cell>
+        <DataTable.CellContent>
+          {info.row.original.usedBy}
+        </DataTable.CellContent>
       ),
     },
     {
       accessorKey: "addedBy",
       header: "Added by",
       cell: (info) => (
-        <DataTable.Cell>{info.row.original.addedBy}</DataTable.Cell>
+        <DataTable.CellContent>
+          {info.row.original.addedBy}
+        </DataTable.CellContent>
       ),
     },
     {
       accessorKey: "lastUpdated",
       header: "Last updated",
       cell: (info) => (
-        <DataTable.Cell>{info.row.original.lastUpdated}</DataTable.Cell>
+        <DataTable.CellContent>
+          {info.row.original.lastUpdated}
+        </DataTable.CellContent>
       ),
       enableSorting: false,
     },
     {
       accessorKey: "size",
       header: "Size",
-      cell: (info) => <DataTable.Cell>{info.row.original.size}</DataTable.Cell>,
+      cell: (info) => (
+        <DataTable.CellContent>{info.row.original.size}</DataTable.CellContent>
+      ),
     },
   ];
 


### PR DESCRIPTION
Description
---
Fixes the error in screenshot. `DataTable.Cell` rendering in `DataTable` renders a cell whose content is given by a function in `columns` definition, but this content is itself also a DataTable.Cell; the DataTable component seems designed this way. It results in nested `td` tags which make react complain.

The issue is fixed by extracting `DataTable.CellContent` from `DataTable.Cell` and changing code so that columns' cells definitions return `DataTable.CellContent` instead of `DataTable.Cell`

![image](https://github.com/user-attachments/assets/09ed5283-afa9-49ee-bd67-44584a9a0c87)

Risk
---
na

Deploy
---
- publish sparkle
- change front code & deploy front in follow-up PR
