### PR TITLE
Flav/data source views everywhere wave 1

### DIFF
--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -80,11 +80,11 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
     );
   }
 
-  // For now, we create a default view for all data sources in the global vault.
   // This view has access to all documents, which is represented by null.
   static async createViewInVaultFromDataSourceIncludingAllDocuments(
     vault: VaultResource,
-    dataSource: DataSourceResource
+    dataSource: DataSourceResource,
+    kind: DataSourceViewKind = "default"
   ) {
     return this.makeNew(
       {

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -1,7 +1,12 @@
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-import type { DataSourceViewType, ModelId, Result } from "@dust-tt/types";
+import type {
+  DataSourceViewKind,
+  DataSourceViewType,
+  ModelId,
+  Result,
+} from "@dust-tt/types";
 import { Err, Ok, removeNulls } from "@dust-tt/types";
 import type {
   Attributes,
@@ -190,6 +195,23 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
       }
     );
     Object.assign(this, affectedRows[0].get());
+
+    return new Ok(undefined);
+  }
+
+  // TODO(GROUPS_INFRA) Remove once backfilled.
+  async updateKind(auth: Authenticator, kind: DataSourceViewKind) {
+    await this.model.update(
+      {
+        kind,
+      },
+      {
+        where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          id: this.id,
+        },
+      }
+    );
 
     return new Ok(undefined);
   }

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -91,7 +91,7 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
         dataSourceId: dataSource.id,
         parentsIn: null,
         workspaceId: vault.workspaceId,
-        kind: "default",
+        kind,
       },
       vault,
       dataSource

--- a/front/migrations/20240821_backfill_all_data_source_views.ts
+++ b/front/migrations/20240821_backfill_all_data_source_views.ts
@@ -1,0 +1,101 @@
+import type { LightWorkspaceType } from "@dust-tt/types";
+
+import { Authenticator } from "@app/lib/auth";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { VaultResource } from "@app/lib/resources/vault_resource";
+import type { Logger } from "@app/logger/logger";
+import { makeScript, runOnAllWorkspaces } from "@app/scripts/helpers";
+
+async function backfillDefaultViewForDataSource(
+  auth: Authenticator,
+  dataSource: DataSourceResource,
+  logger: Logger,
+  execute: boolean
+): Promise<boolean> {
+  const { vault } = dataSource;
+  // Check if there is already a view for this managed data source in the vault.
+  const dataSourceViews =
+    await DataSourceViewResource.listForDataSourcesInVault(
+      auth,
+      [dataSource],
+      vault
+    );
+
+  if (dataSourceViews.length > 0) {
+    logger.info(
+      `Data source view already exists for data source ${dataSource.id} in vault ${vault.kind} (id: ${dataSourceViews[0].id}).`
+    );
+    return false;
+  }
+
+  if (!execute) {
+    return false;
+  }
+
+  // Create a default view for this data source in the vault.
+  await DataSourceViewResource.createViewInVaultFromDataSourceIncludingAllDocuments(
+    vault,
+    dataSource
+  );
+
+  logger.info(`View created for data source ${dataSource.id}.`);
+
+  return true;
+}
+
+async function backfillDataSourceViewsForWorkspace(
+  workspace: LightWorkspaceType,
+  logger: Logger,
+  execute: boolean
+) {
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  const dataSources = await DataSourceResource.listByWorkspace(auth);
+
+  logger.info(
+    `Found ${dataSources.length} data sources for workspace(${workspace.sId}).`
+  );
+
+  const globalVault = await VaultResource.fetchWorkspaceGlobalVault(auth);
+
+  let updated = 0;
+  for (const dataSource of dataSources) {
+    let created: boolean;
+    if (dataSource.vault.isSystem()) {
+      // Update the kind to "custom" for the data source view created in the global vault.
+      const dataSourceViews =
+        await DataSourceViewResource.listForDataSourcesInVault(
+          auth,
+          [dataSource],
+          globalVault
+        );
+      if (dataSourceViews.length > 0) {
+        const [dataSourceView] = dataSourceViews;
+
+        await dataSourceView.updateKind(auth, "custom");
+      }
+    }
+
+    // Otherwise, create a default view in the data source's vault.
+    created = await backfillDefaultViewForDataSource(
+      auth,
+      dataSource,
+      logger,
+      execute
+    );
+
+    if (created) {
+      updated++;
+    }
+  }
+
+  logger.info(
+    `Backfilled data source views for workspace(${workspace.sId}). (updated: ${updated}/${dataSources.length})`
+  );
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  return runOnAllWorkspaces(async (workspace) => {
+    await backfillDataSourceViewsForWorkspace(workspace, logger, execute);
+  });
+});

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -344,13 +344,8 @@ async function handler(
         vault
       );
 
-      // For all data sources, we create a default view in the global vault.
-      const globalVault = vault.isGlobal()
-        ? vault
-        : await VaultResource.fetchWorkspaceGlobalVault(auth);
-
       await DataSourceViewResource.createViewInVaultFromDataSourceIncludingAllDocuments(
-        globalVault,
+        dataSource.vault,
         dataSource
       );
 

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -344,6 +344,19 @@ async function handler(
         vault
       );
 
+      // For each data source, we create two views:
+      // - One view in its associated vault
+      // - If the data source resides in the system vault, we also create a view in the global vault until vault are released.
+
+      if (dataSource.vault.isSystem()) {
+        const globalVault = await VaultResource.fetchWorkspaceGlobalVault(auth);
+
+        await DataSourceViewResource.createViewInVaultFromDataSourceIncludingAllDocuments(
+          globalVault,
+          dataSource
+        );
+      }
+
       await DataSourceViewResource.createViewInVaultFromDataSourceIncludingAllDocuments(
         dataSource.vault,
         dataSource

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -345,15 +345,16 @@ async function handler(
       );
 
       // For each data source, we create two views:
-      // - One view in its associated vault
-      // - If the data source resides in the system vault, we also create a view in the global vault until vault are released.
+      // - One default view in its associated vault
+      // - If the data source resides in the system vault, we also create a custom view in the global vault until vault are released.
 
       if (dataSource.vault.isSystem()) {
         const globalVault = await VaultResource.fetchWorkspaceGlobalVault(auth);
 
         await DataSourceViewResource.createViewInVaultFromDataSourceIncludingAllDocuments(
           globalVault,
-          dataSource
+          dataSource,
+          "custom"
         );
       }
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR guarantees the creation of a data source view for each data source within the same vault, including the system vault. We will continue to create a data source view for managed data sources in the global vault until vaults are released. 

Additionally, this PR includes a migration to:
1. Change the kind from `default` to `custom` for views associated with managed data sources in the global vault.
2. Create any missing data source views in the system vault.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
