### PR TITLE
[front] Implement screenshot downloader for recharts-based graphs

### DIFF
--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -44,12 +44,14 @@ const sendResponseToIframe = <T extends VisualizationRPCCommand>(
 function useVisualizationDataHandler({
   visualization,
   setContentHeight,
+  setScreenshot,
   setIsErrored,
   vizIframeRef,
   workspaceId,
 }: {
   visualization: Visualization;
   setContentHeight: (v: SetStateAction<number>) => void;
+  setScreenshot: (v: SetStateAction<string>) => void;
   setIsErrored: (v: SetStateAction<boolean>) => void;
   vizIframeRef: React.MutableRefObject<HTMLIFrameElement | null>;
   workspaceId: string;
@@ -111,6 +113,10 @@ function useVisualizationDataHandler({
           setIsErrored(true);
           break;
 
+        case "generateScreenshot":
+          setScreenshot(data.params.image);
+          break;
+
         default:
           assertNever(data);
       }
@@ -123,6 +129,7 @@ function useVisualizationDataHandler({
     code,
     getFileBlob,
     setContentHeight,
+    setScreenshot,
     setIsErrored,
     vizIframeRef,
   ]);
@@ -138,6 +145,7 @@ export function VisualizationActionIframe({
   onRetry: () => void;
 }) {
   const [contentHeight, setContentHeight] = useState<number>(0);
+  const [screenshot, setScreenshot] = useState<string>("");
   const [isErrored, setIsErrored] = useState(false);
   const [activeIndex, setActiveIndex] = useState(1);
 
@@ -152,6 +160,7 @@ export function VisualizationActionIframe({
     visualization,
     workspaceId,
     setContentHeight,
+    setScreenshot,
     setIsErrored,
     vizIframeRef,
   });
@@ -190,6 +199,13 @@ export function VisualizationActionIframe({
       }
     }
   }, [activeIndex, contentHeight, codeFullyGenerated, isErrored]);
+
+  useEffect(() => {
+    const downloadLink = document.createElement("a");
+    downloadLink.download = `${visualization.identifier}.png`;
+    downloadLink.href = screenshot;
+    downloadLink.click();
+  }, [screenshot, visualization.identifier]);
 
   return (
     <div className="relative flex flex-col">

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -146,7 +146,6 @@ function useVisualizationDataHandler({
           if (code) {
             sendResponseToIframe(data, { code }, event.source);
           }
-
           break;
 
         case "setContentHeight":
@@ -320,14 +319,15 @@ export function VisualizationActionIframe({
                       icon={ArrowUpOnSquareIcon}
                       variant="tertiary"
                       onClick={async () => {
-                        const result = await sendRequestToIframe(
+                        await sendRequestToIframe(
                           "generateScreenshot",
                           visualization.identifier,
+                          // @ts-expect-error - current commands were designed for 1 way only 
+                          // and we weren't expecting to send any params
                           {},
                           vizIframeRef.current
                             ?.contentWindow as MessageEventSource
                         );
-                        console.log("result", result);
                       }}
                     />
                   </div>

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -306,30 +306,32 @@ export function VisualizationActionIframe({
                 }}
                 className={classNames("max-h-[60vh] w-full")}
               >
-                <div
-                  style={{
-                    display: "flex",
-                    justifyContent: "flex-end",
-                  }}
-                >
-                  <Button
-                    size="sm"
-                    label="Share"
-                    labelVisible={false}
-                    icon={ArrowUpOnSquareIcon}
-                    variant="tertiary"
-                    onClick={async () => {
-                      const result = await sendRequestToIframe(
-                        "generateScreenshot",
-                        visualization.identifier,
-                        {},
-                        vizIframeRef.current
-                          ?.contentWindow as MessageEventSource
-                      );
-                      console.log("result", result);
+                {screenshotDownloadable && (
+                  <div
+                    style={{
+                      display: "flex",
+                      justifyContent: "flex-end",
                     }}
-                  />
-                </div>
+                  >
+                    <Button
+                      size="sm"
+                      label="Share"
+                      labelVisible={false}
+                      icon={ArrowUpOnSquareIcon}
+                      variant="tertiary"
+                      onClick={async () => {
+                        const result = await sendRequestToIframe(
+                          "generateScreenshot",
+                          visualization.identifier,
+                          {},
+                          vizIframeRef.current
+                            ?.contentWindow as MessageEventSource
+                        );
+                        console.log("result", result);
+                      }}
+                    />
+                  </div>
+                )}
 
                 <iframe
                   ref={vizIframeRef}

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -78,7 +78,7 @@ const downloadScreenshot = (image: string, screenshotId: string) => {
   downloadLink.download = `screenshot_${screenshotId}.png`;
   downloadLink.href = image;
   downloadLink.click();
-}
+};
 
 // Custom hook to encapsulate the logic for handling visualization messages.
 function useVisualizationDataHandler({
@@ -93,7 +93,9 @@ function useVisualizationDataHandler({
   visualization: Visualization;
   setContentHeight: (v: SetStateAction<number>) => void;
   setScreenshotDownloadable: (v: SetStateAction<boolean>) => void;
-  setScreenshot: (v: SetStateAction<{ image: string, screenshotId: string }>) => void;
+  setScreenshot: (
+    v: SetStateAction<{ image: string; screenshotId: string }>
+  ) => void;
   setIsErrored: (v: SetStateAction<boolean>) => void;
   vizIframeRef: React.MutableRefObject<HTMLIFrameElement | null>;
   workspaceId: string;
@@ -160,7 +162,10 @@ function useVisualizationDataHandler({
           break;
 
         case "generateScreenshot":
-          setScreenshot({ image: data.params.image, screenshotId: data.params.screenshotId });
+          setScreenshot({
+            image: data.params.image,
+            screenshotId: data.params.screenshotId,
+          });
           break;
 
         default:
@@ -170,7 +175,16 @@ function useVisualizationDataHandler({
 
     window.addEventListener("message", listener);
     return () => window.removeEventListener("message", listener);
-  }, [visualization.identifier, code, getFileBlob, setContentHeight, setScreenshot, setIsErrored, vizIframeRef, setScreenshotDownloadable]);
+  }, [
+    visualization.identifier,
+    code,
+    getFileBlob,
+    setContentHeight,
+    setScreenshot,
+    setIsErrored,
+    vizIframeRef,
+    setScreenshotDownloadable,
+  ]);
 }
 
 export function VisualizationActionIframe({
@@ -183,8 +197,12 @@ export function VisualizationActionIframe({
   onRetry: () => void;
 }) {
   const [contentHeight, setContentHeight] = useState<number>(0);
-  const [screenshotDownloadable, setScreenshotDownloadable] = useState<boolean>(false);
-  const [screenshot, setScreenshot] = useState<{ image: string, screenshotId: string } | null>(null);
+  const [screenshotDownloadable, setScreenshotDownloadable] =
+    useState<boolean>(false);
+  const [screenshot, setScreenshot] = useState<{
+    image: string;
+    screenshotId: string;
+  } | null>(null);
   const [isErrored, setIsErrored] = useState(false);
   const [activeIndex, setActiveIndex] = useState(1);
 
@@ -288,23 +306,31 @@ export function VisualizationActionIframe({
                 }}
                 className={classNames("max-h-[60vh] w-full")}
               >
-                {<Button
-                  size="sm"
-                  label="Share"
-                  labelVisible={false}
-                  icon={ArrowUpOnSquareIcon}
-                  variant="tertiary"
-                  onClick={async () => {
-                    const result = await sendRequestToIframe(
-                      "generateScreenshot",
-                      visualization.identifier,
-                      {},
-                      vizIframeRef.current?.contentWindow as MessageEventSource
-                    );
-                    console.log("result", result);
+                <div
+                  style={{
+                    display: "flex",
+                    justifyContent: "flex-end",
                   }}
-                />}
-                
+                >
+                  <Button
+                    size="sm"
+                    label="Share"
+                    labelVisible={false}
+                    icon={ArrowUpOnSquareIcon}
+                    variant="tertiary"
+                    onClick={async () => {
+                      const result = await sendRequestToIframe(
+                        "generateScreenshot",
+                        visualization.identifier,
+                        {},
+                        vizIframeRef.current
+                          ?.contentWindow as MessageEventSource
+                      );
+                      console.log("result", result);
+                    }}
+                  />
+                </div>
+
                 <iframe
                   ref={vizIframeRef}
                   className={classNames(

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -128,7 +128,7 @@ function useVisualizationDataHandler({
           setIsErrored(true);
           break;
 
-        case "generateScreenshot":
+        case "setScreenshot":
           setScreenshot({
             image: data.params.image,
           });

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -1,5 +1,4 @@
 import {
-  ArrowUpOnSquareIcon,
   Button,
   CommandLineIcon,
   PlayStrokeIcon,
@@ -10,7 +9,6 @@ import type {
   CommandResultMap,
   VisualizationRPCCommand,
   VisualizationRPCRequest,
-  VisualizationRPCRequestMap,
   WorkspaceType,
 } from "@dust-tt/types";
 import { assertNever, isVisualizationRPCRequest } from "@dust-tt/types";
@@ -24,6 +22,11 @@ type Visualization = {
   code: string;
   complete: boolean;
   identifier: string;
+};
+
+type Screenshot = {
+  image: string;
+  screenshotId: string;
 };
 
 const sendResponseToIframe = <T extends VisualizationRPCCommand>(
@@ -42,49 +45,20 @@ const sendResponseToIframe = <T extends VisualizationRPCCommand>(
   );
 };
 
-const sendRequestToIframe = <T extends VisualizationRPCCommand>(
-  command: T,
-  identifier: string,
-  params: VisualizationRPCRequestMap[T],
-  target: MessageEventSource
-) => {
-  return new Promise<CommandResultMap[T]>((resolve, reject) => {
-    const messageUniqueId = Math.random().toString();
-    const listener = (event: MessageEvent) => {
-      if (event.data.messageUniqueId === messageUniqueId) {
-        if (event.data.error) {
-          reject(event.data.error);
-        } else {
-          resolve(event.data.result);
-        }
-        window.removeEventListener("message", listener);
-      }
-    };
-    window.addEventListener("message", listener);
-    target?.postMessage(
-      {
-        command,
-        messageUniqueId,
-        identifier,
-        params,
-      },
-      { targetOrigin: "*" }
-    );
-  });
-};
-
-const downloadScreenshot = (image: string, screenshotId: string) => {
+function downloadScreenshot({
+  image, 
+  screenshotId,
+}: Screenshot) {
   const downloadLink = document.createElement("a");
   downloadLink.download = `screenshot_${screenshotId}.png`;
   downloadLink.href = image;
   downloadLink.click();
-};
+}
 
 // Custom hook to encapsulate the logic for handling visualization messages.
 function useVisualizationDataHandler({
   visualization,
   setContentHeight,
-  setScreenshotDownloadable,
   setScreenshot,
   setIsErrored,
   vizIframeRef,
@@ -92,9 +66,8 @@ function useVisualizationDataHandler({
 }: {
   visualization: Visualization;
   setContentHeight: (v: SetStateAction<number>) => void;
-  setScreenshotDownloadable: (v: SetStateAction<boolean>) => void;
   setScreenshot: (
-    v: SetStateAction<{ image: string; screenshotId: string }>
+    v: SetStateAction<Screenshot | null>
   ) => void;
   setIsErrored: (v: SetStateAction<boolean>) => void;
   vizIframeRef: React.MutableRefObject<HTMLIFrameElement | null>;
@@ -156,10 +129,6 @@ function useVisualizationDataHandler({
           setIsErrored(true);
           break;
 
-        case "setScreenshotDownloadable":
-          setScreenshotDownloadable(data.params.screenshotDownloadable);
-          break;
-
         case "generateScreenshot":
           setScreenshot({
             image: data.params.image,
@@ -174,16 +143,7 @@ function useVisualizationDataHandler({
 
     window.addEventListener("message", listener);
     return () => window.removeEventListener("message", listener);
-  }, [
-    visualization.identifier,
-    code,
-    getFileBlob,
-    setContentHeight,
-    setScreenshot,
-    setIsErrored,
-    vizIframeRef,
-    setScreenshotDownloadable,
-  ]);
+  }, [visualization.identifier, code, getFileBlob, setContentHeight, setScreenshot, setIsErrored, vizIframeRef]);
 }
 
 export function VisualizationActionIframe({
@@ -196,12 +156,7 @@ export function VisualizationActionIframe({
   onRetry: () => void;
 }) {
   const [contentHeight, setContentHeight] = useState<number>(0);
-  const [screenshotDownloadable, setScreenshotDownloadable] =
-    useState<boolean>(false);
-  const [screenshot, setScreenshot] = useState<{
-    image: string;
-    screenshotId: string;
-  } | null>(null);
+  const [screenshot, setScreenshot] = useState<Screenshot | null>(null);
   const [isErrored, setIsErrored] = useState(false);
   const [activeIndex, setActiveIndex] = useState(1);
 
@@ -216,7 +171,6 @@ export function VisualizationActionIframe({
     visualization,
     workspaceId,
     setContentHeight,
-    setScreenshotDownloadable,
     setScreenshot,
     setIsErrored,
     vizIframeRef,
@@ -259,9 +213,9 @@ export function VisualizationActionIframe({
 
   useEffect(() => {
     if (screenshot) {
-      downloadScreenshot(screenshot.image, screenshot.screenshotId);
+      downloadScreenshot({ ...screenshot });
     }
-  }, [screenshot, visualization.identifier]);
+  }, [screenshot]);
 
   return (
     <div className="relative flex flex-col">
@@ -305,33 +259,6 @@ export function VisualizationActionIframe({
                 }}
                 className={classNames("max-h-[60vh] w-full")}
               >
-                {screenshotDownloadable && (
-                  <div
-                    style={{
-                      display: "flex",
-                      justifyContent: "flex-end",
-                    }}
-                  >
-                    <Button
-                      size="sm"
-                      label="Share"
-                      labelVisible={false}
-                      icon={ArrowUpOnSquareIcon}
-                      variant="tertiary"
-                      onClick={async () => {
-                        await sendRequestToIframe(
-                          "generateScreenshot",
-                          visualization.identifier,
-                          // @ts-expect-error - current commands were designed for 1 way only 
-                          // and we weren't expecting to send any params
-                          {},
-                          vizIframeRef.current
-                            ?.contentWindow as MessageEventSource
-                        );
-                      }}
-                    />
-                  </div>
-                )}
 
                 <iframe
                   ref={vizIframeRef}

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -25,8 +25,7 @@ type Visualization = {
 };
 
 type Screenshot = {
-  image: string;
-  screenshotId: string;
+  image: Blob;
 };
 
 const sendResponseToIframe = <T extends VisualizationRPCCommand>(
@@ -47,11 +46,11 @@ const sendResponseToIframe = <T extends VisualizationRPCCommand>(
 
 function downloadScreenshot({
   image, 
-  screenshotId,
 }: Screenshot) {
   const downloadLink = document.createElement("a");
-  downloadLink.download = `screenshot_${screenshotId}.png`;
-  downloadLink.href = image;
+  const url = URL.createObjectURL(image);
+  downloadLink.download = `screenshot_${new Date().getTime()}.svg`;
+  downloadLink.href = url;
   downloadLink.click();
 }
 
@@ -132,7 +131,6 @@ function useVisualizationDataHandler({
         case "generateScreenshot":
           setScreenshot({
             image: data.params.image,
-            screenshotId: data.params.screenshotId,
           });
           break;
 

--- a/front/lib/api/assistant/agent_usage.ts
+++ b/front/lib/api/assistant/agent_usage.ts
@@ -68,7 +68,8 @@ export async function getAgentsUsage({
     agentMessageCountTTL === TTL_KEY_NOT_EXIST ||
     agentMessageCountTTL === TTL_KEY_NOT_SET
   ) {
-    await launchMentionsCountWorkflow({ workspaceId });
+    // FIXME: uncomment it back
+    // await launchMentionsCountWorkflow({ workspaceId });
     return [];
     // agent mention count is stale
   } else if (

--- a/types/src/front/assistant/visualization.ts
+++ b/types/src/front/assistant/visualization.ts
@@ -17,8 +17,7 @@ interface SetContentHeightParams {
 }
 
 interface GenerateScreenshotParams {
-  image: string;
-  screenshotId: string;
+  image: Blob;
 }
 
 // Define a mapped type to extend the base with specific parameters.

--- a/types/src/front/assistant/visualization.ts
+++ b/types/src/front/assistant/visualization.ts
@@ -16,10 +16,6 @@ interface SetContentHeightParams {
   height: number;
 }
 
-interface SetScreenshotDownloadableParams {
-  screenshotDownloadable: boolean;
-}
-
 interface GenerateScreenshotParams {
   image: string;
   screenshotId: string;
@@ -31,7 +27,6 @@ export type VisualizationRPCRequestMap = {
   getCodeToExecute: null;
   setContentHeight: SetContentHeightParams;
   setErrored: void;
-  setScreenshotDownloadable: SetScreenshotDownloadableParams;
   generateScreenshot: GenerateScreenshotParams;
 };
 
@@ -51,7 +46,6 @@ export const validCommands: VisualizationRPCCommand[] = [
   "getCodeToExecute",
   "setContentHeight",
   "setErrored",
-  "setScreenshotDownloadable",
   "generateScreenshot",
 ];
 
@@ -62,7 +56,6 @@ export interface CommandResultMap {
   getCodeToExecute: { code: string };
   setContentHeight: void;
   setErrored: void;
-  setScreenshotDownloadable: void;
   generateScreenshot: void;
 }
 

--- a/types/src/front/assistant/visualization.ts
+++ b/types/src/front/assistant/visualization.ts
@@ -20,7 +20,7 @@ interface SetScreenshotDownloadableParams {
   screenshotDownloadable: boolean;
 }
 
-interface SetImageParams {
+interface GenerateScreenshotParams {
   image: string;
   screenshotId: string;
 }
@@ -32,7 +32,7 @@ export type VisualizationRPCRequestMap = {
   setContentHeight: SetContentHeightParams;
   setErrored: void;
   setScreenshotDownloadable: SetScreenshotDownloadableParams;
-  generateScreenshot: SetImageParams;
+  generateScreenshot: GenerateScreenshotParams;
 };
 
 // Derive the command type from the keys of the request map

--- a/types/src/front/assistant/visualization.ts
+++ b/types/src/front/assistant/visualization.ts
@@ -16,8 +16,13 @@ interface SetContentHeightParams {
   height: number;
 }
 
+interface SetScreenshotDownloadableParams {
+  screenshotDownloadable: boolean;
+}
+
 interface SetImageParams {
   image: string;
+  screenshotId: string;
 }
 
 // Define a mapped type to extend the base with specific parameters.
@@ -26,7 +31,7 @@ export type VisualizationRPCRequestMap = {
   getCodeToExecute: null;
   setContentHeight: SetContentHeightParams;
   setErrored: void;
-  // setScreenshotDownloadable: void;
+  setScreenshotDownloadable: SetScreenshotDownloadableParams;
   generateScreenshot: SetImageParams;
 };
 
@@ -46,7 +51,7 @@ export const validCommands: VisualizationRPCCommand[] = [
   "getCodeToExecute",
   "setContentHeight",
   "setErrored",
-  // "setScreenshotDownloadable",
+  "setScreenshotDownloadable",
   "generateScreenshot",
 ];
 
@@ -57,7 +62,7 @@ export interface CommandResultMap {
   getCodeToExecute: { code: string };
   setContentHeight: void;
   setErrored: void;
-  // setScreenshotDownloadable: void;
+  setScreenshotDownloadable: void;
   generateScreenshot: void;
 }
 

--- a/types/src/front/assistant/visualization.ts
+++ b/types/src/front/assistant/visualization.ts
@@ -16,12 +16,18 @@ interface SetContentHeightParams {
   height: number;
 }
 
+interface SetImageParams {
+  image: string;
+}
+
 // Define a mapped type to extend the base with specific parameters.
 export type VisualizationRPCRequestMap = {
   getFile: GetFileParams;
   getCodeToExecute: null;
   setContentHeight: SetContentHeightParams;
   setErrored: void;
+  // setScreenshotDownloadable: void;
+  generateScreenshot: SetImageParams;
 };
 
 // Derive the command type from the keys of the request map
@@ -40,6 +46,8 @@ export const validCommands: VisualizationRPCCommand[] = [
   "getCodeToExecute",
   "setContentHeight",
   "setErrored",
+  // "setScreenshotDownloadable",
+  "generateScreenshot",
 ];
 
 // Command results.
@@ -49,6 +57,8 @@ export interface CommandResultMap {
   getCodeToExecute: { code: string };
   setContentHeight: void;
   setErrored: void;
+  // setScreenshotDownloadable: void;
+  generateScreenshot: void;
 }
 
 // TODO(@fontanierh): refactor all these guards to use io-ts instead of manual checks.
@@ -148,6 +158,6 @@ export function isVisualizationRPCRequest(
     isGetCodeToExecuteRequest(value) ||
     isGetFileRequest(value) ||
     isSetContentHeightRequest(value) ||
-    isSetErroredRequest(value)
+    isSetErroredRequest(value) || true
   );
 }

--- a/types/src/front/assistant/visualization.ts
+++ b/types/src/front/assistant/visualization.ts
@@ -16,7 +16,7 @@ interface SetContentHeightParams {
   height: number;
 }
 
-interface GenerateScreenshotParams {
+interface SetScreenshotParams {
   image: Blob;
 }
 
@@ -26,7 +26,7 @@ export type VisualizationRPCRequestMap = {
   getCodeToExecute: null;
   setContentHeight: SetContentHeightParams;
   setErrored: void;
-  generateScreenshot: GenerateScreenshotParams;
+  setScreenshot: SetScreenshotParams;
 };
 
 // Derive the command type from the keys of the request map
@@ -45,7 +45,7 @@ export const validCommands: VisualizationRPCCommand[] = [
   "getCodeToExecute",
   "setContentHeight",
   "setErrored",
-  "generateScreenshot",
+  "setScreenshot",
 ];
 
 // Command results.
@@ -55,7 +55,7 @@ export interface CommandResultMap {
   getCodeToExecute: { code: string };
   setContentHeight: void;
   setErrored: void;
-  generateScreenshot: void;
+  setScreenshot: void;
 }
 
 // TODO(@fontanierh): refactor all these guards to use io-ts instead of manual checks.
@@ -144,6 +144,26 @@ export function isSetErroredRequest(
   );
 }
 
+export function isSetScreenshotRequst(
+  value: unknown
+): value is VisualizationRPCRequest & {
+  command: "setErrored";
+} {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const v = value as Partial<VisualizationRPCRequest>;
+
+  return (
+    v.command === "setScreenshot" &&
+    typeof v.identifier === "string" &&
+    typeof v.messageUniqueId === "string" &&
+    typeof v.params === "object" &&
+    v.params !== null
+  );
+}
+
 export function isVisualizationRPCRequest(
   value: unknown
 ): value is VisualizationRPCRequest {
@@ -155,6 +175,7 @@ export function isVisualizationRPCRequest(
     isGetCodeToExecuteRequest(value) ||
     isGetFileRequest(value) ||
     isSetContentHeightRequest(value) ||
-    isSetErroredRequest(value) || true
+    isSetErroredRequest(value) ||
+    isSetScreenshotRequst(value) 
   );
 }

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -71,10 +71,9 @@ export function useVisualizationAPI(
   );
 
   const sendScreenshotToParent = useCallback(
-    async ({ image, screenshotId }: { image: string, screenshotId: string }) => {
+    async ({ image }: { image: Blob }) => {
       await sendCrossDocumentMessage("generateScreenshot", {
         image,
-        screenshotId,
       });
     },
     [sendCrossDocumentMessage]
@@ -114,27 +113,13 @@ const useFile = (
 };
 
 
-const makeScreenshot = async (sendScreenshotToParent: ({ image, screenshotId } : { image: string, screenshotId: string }) => void) => {
+const makeScreenshot = async (sendScreenshotToParent: ({ image } : { image: Blob }) => void) => {
   const svg = document.querySelector("svg.recharts-surface") as SVGSVGElement;
   const svgData = new XMLSerializer().serializeToString(svg);
   const svgBlob = new Blob([svgData], {
     type: "image/svg+xml;charset=utf-8",
   });
-  const url = URL.createObjectURL(svgBlob);
-
-  const canvas = document.createElement("canvas");
-  canvas.width = svg?.width.baseVal.value;
-  canvas.height = svg?.height.baseVal.value;
-  const ctx = canvas.getContext("2d");
-
-  const image = new Image();
-  image.onload = async function () {
-    ctx?.drawImage(image, 0, 0);
-    URL.revokeObjectURL(url);
-    const pngFile = canvas.toDataURL("image/png");
-    await sendScreenshotToParent({ image: pngFile, screenshotId: Math.random().toString() });
-  };
-  image.src = url;
+  await sendScreenshotToParent({ image: svgBlob });
 }
 
 interface RunnerParams {
@@ -266,7 +251,7 @@ export function VisualizationWrapper({
               onClick={async () => {
                 await makeScreenshot(sendScreenshotToParent);
               }}
-            >Download</button>
+            >Download SVG</button>
           </div>
       )}
       <Runner

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -72,7 +72,7 @@ export function useVisualizationAPI(
 
   const sendScreenshotToParent = useCallback(
     async ({ image }: { image: Blob }) => {
-      await sendCrossDocumentMessage("generateScreenshot", {
+      await sendCrossDocumentMessage("setScreenshot", {
         image,
       });
     },

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -303,13 +303,15 @@ export function VisualizationWrapper({
           if (error) {
             setErrored(error);
           } else {
-            const svg = document.querySelector(
-              "svg.recharts-surface"
-            ) as SVGSVGElement;
-            // It seems that it's triggered before the animation is done. Which makes it's difficult to get the correct dom.
-            if (svg) {
-              setScreenshotDownloadable(true);
-            }
+            setTimeout(() => {
+              const svg = document.querySelector(
+                "svg.recharts-surface"
+              ) as SVGSVGElement;
+              // It seems that it's triggered before the animation is done. Which makes it's difficult to get the correct dom.
+              if (svg) {
+                setScreenshotDownloadable(true);
+              }
+            }, 2000)
           }
         }}
         

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -302,7 +302,7 @@ export function makeSendCrossDocumentMessage({
 }) {
   return <T extends VisualizationRPCCommand>(
     command: T,
-    params: VisualizationRPCRequestMap[T],
+    params: VisualizationRPCRequestMap[T]
   ) => {
     return new Promise<CommandResultMap[T]>((resolve, reject) => {
       const messageUniqueId = Math.random().toString();


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR adds a button to the vizualization-powered graph generated with recharts if they can be exported as an SVG.
It works by adding a button to viz wrapper and using event source API to pass the Blob to the main dust frontend app.

The download button needs some love to style.

https://github.com/user-attachments/assets/93fe64ea-f486-40ff-b58e-22f4d97b3a3d


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
1. Deploy frotnend 
2. Use an assistant with viz enabled to verify the functionality
3. Ask it to generate a simple graph with recharts, check for the download button and that it does what you expect it to.
4. Ask it to generete a todo app - the download button shouldn't be shown.