### PR TITLE
Remove delete cli command in connectors

### DIFF
--- a/connectors/src/lib/cli.ts
+++ b/connectors/src/lib/cli.ts
@@ -129,11 +129,6 @@ export const connectors = async ({
       await throwOnError(manager.stop());
       return { success: true };
     }
-    case "delete": {
-      await throwOnError(manager.clean({ force: true }));
-      await terminateAllWorkflowsForConnectorId(connector.id);
-      return { success: true };
-    }
     case "pause": {
       await throwOnError(manager.pause());
       return { success: true };

--- a/connectors/src/lib/cli.ts
+++ b/connectors/src/lib/cli.ts
@@ -23,10 +23,7 @@ import { microsoft } from "@connectors/connectors/microsoft/lib/cli";
 import { notion } from "@connectors/connectors/notion/lib/cli";
 import { slack } from "@connectors/connectors/slack/lib/cli";
 import { launchCrawlWebsiteSchedulerWorkflow } from "@connectors/connectors/webcrawler/temporal/client";
-import {
-  getTemporalClient,
-  terminateAllWorkflowsForConnectorId,
-} from "@connectors/lib/temporal";
+import { getTemporalClient } from "@connectors/lib/temporal";
 import { default as topLogger } from "@connectors/logger/logger";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/dust/issues/6336

This is confusing as this only deletes the connector since it's a connector cli. Some people could expect that it deletes the data source as well.

## Risk

N/A

## Deploy Plan

N/A