### PR TITLE
Prefix Slack bot message with the bot mention.

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -391,9 +391,14 @@ async function botAnswerMessage(
     }
   }
 
-  if (message.trim() === "") {
-    message = "?";
+  const mention = mentions[0];
+  if (mention) {
+    if (!message.includes(":mention")) {
+      // if the message does not contain the mention, we add it as a prefix.
+      message = `:mention[${mention.assistantName}]{sId=${mention.assistantId}} ${message}`;
+    }
   }
+
   const messageReqBody = {
     content: message,
     mentions: mentions.map((m) => {


### PR DESCRIPTION
## Description

When a user talks to the Slack bot, a mention to the assistant can be implicit`*`, in such case, we want to prefix the user message by the assistant mention to comply with the web app behavior.

`*` implicit mention can happen when a Slack channel is linked to a default Dust assistant or when no assistant is specified using the `+` syntax, in which case we default to `@.dust`.


Task is [here](https://github.com/dust-tt/tasks/issues/1160).

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
