### PR TITLE
Refactor: rename dataSource to dataSourceOrView to be more explicit

### DIFF
--- a/front/components/ConnectorPermissionsTree.tsx
+++ b/front/components/ConnectorPermissionsTree.tsx
@@ -89,7 +89,7 @@ export function PermissionTreeChildren({
   const { resources, isResourcesLoading, isResourcesError } =
     useConnectorPermissionsHook({
       owner,
-      dataSource,
+      dataSourceOrView: dataSource,
       parentId,
       filterPermission: permissionFilter || null,
     });

--- a/front/components/DataSourceResourceSelectorTree.tsx
+++ b/front/components/DataSourceResourceSelectorTree.tsx
@@ -18,7 +18,7 @@ import { useConnectorPermissions } from "@app/lib/swr";
 
 export default function DataSourceResourceSelectorTree({
   owner,
-  dataSource,
+  dataSourceOrView,
   showExpand, //if not, it's flat
   parentIsSelected,
   selectedParents = [],
@@ -28,7 +28,7 @@ export default function DataSourceResourceSelectorTree({
   viewType = "documents",
 }: {
   owner: WorkspaceType;
-  dataSource: DataSourceType | DataSourceViewType;
+  dataSourceOrView: DataSourceType | DataSourceViewType;
   showExpand: boolean;
   parentIsSelected?: boolean;
   selectedParents?: string[];
@@ -45,7 +45,7 @@ export default function DataSourceResourceSelectorTree({
     <div className="overflow-x-auto">
       <DataSourceResourceSelectorChildren
         owner={owner}
-        dataSource={dataSource}
+        dataSourceOrView={dataSourceOrView}
         parentId={null}
         showExpand={showExpand}
         parents={[]}
@@ -87,7 +87,7 @@ function getIconForType(type: ContentNodeType): IconComponentType {
 
 function DataSourceResourceSelectorChildren({
   owner,
-  dataSource,
+  dataSourceOrView,
   parentId,
   parents,
   parentIsSelected,
@@ -99,7 +99,7 @@ function DataSourceResourceSelectorChildren({
   viewType = "documents",
 }: {
   owner: WorkspaceType;
-  dataSource: DataSourceType | DataSourceViewType;
+  dataSourceOrView: DataSourceType | DataSourceViewType;
   parentId: string | null;
   parents: string[];
   parentIsSelected?: boolean;
@@ -117,10 +117,10 @@ function DataSourceResourceSelectorChildren({
   const { resources, isResourcesLoading, isResourcesError } =
     useConnectorPermissions({
       owner: owner,
-      dataSource,
+      dataSourceOrView,
       parentId,
       filterPermission,
-      disabled: dataSource.connectorId === null,
+      disabled: dataSourceOrView.connectorId === null,
       viewType,
     });
 
@@ -186,7 +186,7 @@ function DataSourceResourceSelectorChildren({
             renderTreeItems={() => (
               <DataSourceResourceSelectorChildren
                 owner={owner}
-                dataSource={dataSource}
+                dataSourceOrView={dataSourceOrView}
                 parentId={r.internalId}
                 showExpand={showExpand}
                 // In table view, only manually selected nodes are considered and hierarchy does not apply.

--- a/front/components/assistant/SlackIntegration.tsx
+++ b/front/components/assistant/SlackIntegration.tsx
@@ -70,7 +70,7 @@ export function SlackIntegration({
           />
           <DataSourceResourceSelectorTree
             owner={owner}
-            dataSource={slackDataSource}
+            dataSourceOrView={slackDataSource}
             selectedResourceIds={selectedChannelIds}
             onSelectChange={(node, parents, selected) => {
               setHasChanged(true);

--- a/front/components/assistant_builder/DataSourceResourceSelector.tsx
+++ b/front/components/assistant_builder/DataSourceResourceSelector.tsx
@@ -77,7 +77,7 @@ export default function DataSourceResourceSelector({
               </div>
               <DataSourceResourceSelectorTree
                 owner={owner}
-                dataSource={dataSource}
+                dataSourceOrView={dataSource}
                 showExpand={
                   CONNECTOR_CONFIGURATIONS[
                     dataSource.connectorProvider as ConnectorProvider

--- a/front/components/assistant_builder/FolderOrWebsiteTree.tsx
+++ b/front/components/assistant_builder/FolderOrWebsiteTree.tsx
@@ -61,7 +61,7 @@ export default function FolderOrWebsiteTree({
         <DataSourceResourceSelectorTree
           showExpand
           owner={owner}
-          dataSource={dataSource}
+          dataSourceOrView={dataSource}
           parentIsSelected={currentConfig?.isSelectAll ?? false}
           selectedParents={selectedParents}
           onSelectChange={(resource, parents, selected) => {

--- a/front/components/assistant_builder/PickTablesManaged.tsx
+++ b/front/components/assistant_builder/PickTablesManaged.tsx
@@ -33,7 +33,7 @@ export const PickTablesManaged = ({
         <Page.Header title="Select a Table" icon={ServerIcon} />
         <DataSourceResourceSelectorTree
           owner={owner}
-          dataSource={dataSource}
+          dataSourceOrView={dataSource}
           showExpand={true}
           selectedResourceIds={
             selectedNodes

--- a/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
+++ b/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
@@ -163,7 +163,7 @@ function VaultManagedDataSourceViewsTree({
     >
       <DataSourceResourceSelectorTree
         owner={owner}
-        dataSource={dataSourceView}
+        dataSourceOrView={dataSourceView}
         showExpand={
           CONNECTOR_CONFIGURATIONS[
             dataSourceView.connectorProvider as ConnectorProvider

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -455,14 +455,14 @@ export function useDataSourceContentNodes({
 
 export function useConnectorPermissions({
   owner,
-  dataSource,
+  dataSourceOrView,
   parentId,
   filterPermission,
   disabled,
   viewType = "documents",
 }: {
   owner: WorkspaceType;
-  dataSource: DataSourceType | DataSourceViewType;
+  dataSourceOrView: DataSourceType | DataSourceViewType;
   parentId: string | null;
   filterPermission: ConnectorPermission | null;
   disabled?: boolean;
@@ -472,7 +472,7 @@ export function useConnectorPermissions({
     fetcher;
 
   let url = `/api/w/${owner.sId}/data_sources/${encodeURIComponent(
-    dataSource.name
+    dataSourceOrView.name
   )}/managed/permissions?viewType=${viewType}`;
   if (parentId) {
     url += `&parentId=${parentId}`;
@@ -495,13 +495,13 @@ export function useConnectorPermissions({
 
 export function usePokeConnectorPermissions({
   owner,
-  dataSource,
+  dataSourceOrView,
   parentId,
   filterPermission,
   disabled,
 }: {
   owner: WorkspaceType;
-  dataSource: DataSourceType | DataSourceViewType;
+  dataSourceOrView: DataSourceType | DataSourceViewType;
   parentId: string | null;
   filterPermission: ConnectorPermission | null;
   disabled?: boolean;
@@ -509,7 +509,7 @@ export function usePokeConnectorPermissions({
   const permissionsFetcher: Fetcher<GetDataSourcePermissionsResponseBody> =
     fetcher;
 
-  let url = `/api/poke/workspaces/${owner.sId}/data_sources/${dataSource.name}/managed/permissions?viewType=documents`;
+  let url = `/api/poke/workspaces/${owner.sId}/data_sources/${dataSourceOrView.name}/managed/permissions?viewType=documents`;
   if (parentId) {
     url += `&parentId=${parentId}`;
   }


### PR DESCRIPTION
## Description

Simply rename `dataSource` to `dataSourceOrView` when we accept both. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
