### PR TITLE
Refactor: cleanup add vault static data in dedicated component

### DIFF
--- a/front/components/vaults/EditVaultStaticDatasourcesViews.tsx
+++ b/front/components/vaults/EditVaultStaticDatasourcesViews.tsx
@@ -6,11 +6,10 @@ import type {
   WorkspaceType,
 } from "@dust-tt/types";
 import { useRouter } from "next/router";
-import React, { useState } from "react";
+import React, { useCallback, useState } from "react";
 
 import VaultCreateFolderModal from "@app/components/vaults/VaultCreateFolderModal";
 import VaultCreateWebsiteModal from "@app/components/vaults/VaultCreateWebsiteModal";
-import { useSubmitFunction } from "@app/lib/client/utils";
 
 export function EditVaultStaticDataSourcesViews({
   owner,
@@ -32,7 +31,7 @@ export function EditVaultStaticDataSourcesViews({
     useState(false);
 
   const planDataSourcesLimit = plan.limits.dataSources.count;
-  const { submit: checkLimitsAndOpenModal } = useSubmitFunction(async () => {
+  const checkLimitsAndOpenModal = useCallback(() => {
     if (
       planDataSourcesLimit != -1 &&
       dataSources.length >= planDataSourcesLimit
@@ -43,7 +42,7 @@ export function EditVaultStaticDataSourcesViews({
     } else if (category === "website") {
       setShowAddWebsiteModal(true);
     }
-  });
+  }, [category, dataSources, planDataSourcesLimit]);
 
   return (
     <>

--- a/front/components/vaults/EditVaultStaticDatasourcesViews.tsx
+++ b/front/components/vaults/EditVaultStaticDatasourcesViews.tsx
@@ -1,0 +1,88 @@
+import { Button, PlusIcon, Popup } from "@dust-tt/sparkle";
+import type {
+  DataSourceType,
+  PlanType,
+  VaultType,
+  WorkspaceType,
+} from "@dust-tt/types";
+import { useRouter } from "next/router";
+import React, { useState } from "react";
+
+import VaultCreateFolderModal from "@app/components/vaults/VaultCreateFolderModal";
+import VaultCreateWebsiteModal from "@app/components/vaults/VaultCreateWebsiteModal";
+import { useSubmitFunction } from "@app/lib/client/utils";
+
+export function EditVaultStaticDataSourcesViews({
+  owner,
+  plan,
+  vault,
+  category,
+  dataSources,
+}: {
+  owner: WorkspaceType;
+  plan: PlanType;
+  vault: VaultType;
+  category: "folder" | "website";
+  dataSources: DataSourceType[];
+}) {
+  const router = useRouter();
+  const [showAddFolderModal, setShowAddFolderModal] = useState(false);
+  const [showAddWebsiteModal, setShowAddWebsiteModal] = useState(false);
+  const [showDatasourceLimitPopup, setShowDatasourceLimitPopup] =
+    useState(false);
+
+  const planDataSourcesLimit = plan.limits.dataSources.count;
+  const { submit: checkLimitsAndOpenModal } = useSubmitFunction(async () => {
+    if (
+      planDataSourcesLimit != -1 &&
+      dataSources.length >= planDataSourcesLimit
+    ) {
+      setShowDatasourceLimitPopup(true);
+    } else if (category === "folder") {
+      setShowAddFolderModal(true);
+    } else if (category === "website") {
+      setShowAddWebsiteModal(true);
+    }
+  });
+
+  return (
+    <>
+      <Popup
+        show={showDatasourceLimitPopup}
+        chipLabel={`${plan.name} plan`}
+        description={`You have reached the limit of data sources (${plan.limits.dataSources.count} data sources). Upgrade your plan for unlimited datasources.`}
+        buttonLabel="Check Dust plans"
+        buttonClick={() => {
+          void router.push(`/w/${owner.sId}/subscription`);
+        }}
+        onClose={() => {
+          setShowDatasourceLimitPopup(false);
+        }}
+        className="absolute bottom-8 right-0"
+      />
+      <VaultCreateFolderModal
+        isOpen={showAddFolderModal}
+        setOpen={(isOpen) => {
+          setShowAddFolderModal(isOpen);
+        }}
+        owner={owner}
+        vault={vault}
+        dataSources={dataSources}
+      />
+      <VaultCreateWebsiteModal
+        isOpen={showAddWebsiteModal}
+        setOpen={(isOpen) => {
+          setShowAddWebsiteModal(isOpen);
+        }}
+        owner={owner}
+      />
+      <Button
+        label={category === "folder" ? "Add folder" : "Add website"}
+        onClick={async () => {
+          await checkLimitsAndOpenModal();
+        }}
+        icon={PlusIcon}
+      />
+    </>
+  );
+}

--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -1,12 +1,4 @@
-import {
-  Button,
-  Chip,
-  DataTable,
-  PlusIcon,
-  Popup,
-  Searchbar,
-  Spinner,
-} from "@dust-tt/sparkle";
+import { Chip, DataTable, Searchbar, Spinner } from "@dust-tt/sparkle";
 import type {
   ConnectorType,
   DataSourceViewCategory,
@@ -17,7 +9,6 @@ import type {
 } from "@dust-tt/types";
 import type { CellContext } from "@tanstack/react-table";
 import { FolderIcon } from "lucide-react";
-import { useRouter } from "next/router";
 import type { ComponentType } from "react";
 import { useRef } from "react";
 import { useState } from "react";
@@ -25,9 +16,7 @@ import * as React from "react";
 
 import ConnectorSyncingChip from "@app/components/data_source/DataSourceSyncChip";
 import { EditVaultManagedDataSourcesViews } from "@app/components/vaults/EditVaultManagedDatasourcesViews";
-import VaultCreateFolderModal from "@app/components/vaults/VaultCreateFolderModal";
-import VaultCreateWebsiteModal from "@app/components/vaults/VaultCreateWebsiteModal";
-import { useSubmitFunction } from "@app/lib/client/utils";
+import { EditVaultStaticDataSourcesViews } from "@app/components/vaults/EditVaultStaticDatasourcesViews";
 import {
   CONNECTOR_CONFIGURATIONS,
   getDataSourceNameFromView,
@@ -125,13 +114,6 @@ export const VaultResourcesList = ({
   category,
   onSelect,
 }: VaultResourcesListProps) => {
-  const router = useRouter();
-
-  const [showDatasourceLimitPopup, setShowDatasourceLimitPopup] =
-    useState(false);
-  const [showAddFolderModal, setShowAddFolderModal] = useState(false);
-  const [showAddWebsiteModal, setShowAddWebsiteModal] = useState(false);
-
   const [dataSourceSearch, setDataSourceSearch] = useState<string>("");
 
   const { dataSources, isDataSourcesLoading } = useDataSources(owner);
@@ -145,21 +127,6 @@ export const VaultResourcesList = ({
       vaultId: vault.sId,
       category: category,
     });
-
-  const { submit: handleCreateStaticDataSource } = useSubmitFunction(
-    async (type: "folder" | "website") => {
-      if (
-        plan.limits.dataSources.count != -1 &&
-        dataSources.length >= plan.limits.dataSources.count
-      ) {
-        setShowDatasourceLimitPopup(true);
-      } else if (type === "folder") {
-        setShowAddFolderModal(true);
-      } else if (type === "website") {
-        setShowAddWebsiteModal(true);
-      }
-    }
-  );
 
   const rows: RowData[] =
     vaultDataSourceViews?.map((r) => ({
@@ -187,35 +154,6 @@ export const VaultResourcesList = ({
 
   return (
     <>
-      <Popup
-        show={showDatasourceLimitPopup}
-        chipLabel={`${plan.name} plan`}
-        description={`You have reached the limit of data sources (${plan.limits.dataSources.count} data sources). Upgrade your plan for unlimited datasources.`}
-        buttonLabel="Check Dust plans"
-        buttonClick={() => {
-          void router.push(`/w/${owner.sId}/subscription`);
-        }}
-        onClose={() => {
-          setShowDatasourceLimitPopup(false);
-        }}
-        className="absolute bottom-8 right-0"
-      />
-      <VaultCreateFolderModal
-        isOpen={showAddFolderModal}
-        setOpen={(isOpen) => {
-          setShowAddFolderModal(isOpen);
-        }}
-        owner={owner}
-        vault={vault}
-        dataSources={dataSources}
-      />
-      <VaultCreateWebsiteModal
-        isOpen={showAddWebsiteModal}
-        setOpen={(isOpen) => {
-          setShowAddWebsiteModal(isOpen);
-        }}
-        owner={owner}
-      />
       <div
         className={classNames(
           "flex gap-2",
@@ -242,22 +180,13 @@ export const VaultResourcesList = ({
             systemVault={systemVault}
           />
         )}
-        {category === "folder" && (
-          <Button
-            label="Add folder"
-            onClick={async () => {
-              await handleCreateStaticDataSource("folder");
-            }}
-            icon={PlusIcon}
-          />
-        )}
-        {category === "website" && (
-          <Button
-            label="Add site"
-            onClick={async () => {
-              await handleCreateStaticDataSource("website");
-            }}
-            icon={PlusIcon}
+        {(category === "folder" || category === "website") && (
+          <EditVaultStaticDataSourcesViews
+            owner={owner}
+            plan={plan}
+            vault={vault}
+            category={category}
+            dataSources={dataSources}
           />
         )}
       </div>


### PR DESCRIPTION
## Description

Simply moving some logic from front/components/vaults/VaultResourcesList.tsx to a dedicated component for the modal to add a new Folder or Website to a vault.

That way VaultResourcesList keeps simple and it calls `EditVaultManagedDataSourcesViews` or `EditVaultStaticDataSourcesViews` depending on the category. 

Refactoring so no feature changes.

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
