### PR TITLE
Remove updateDataSourceEditedBy

### DIFF
--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -67,47 +67,6 @@ export async function getDataSources(
   return dataSources.map((dataSource) => dataSource.toJSON());
 }
 
-export async function updateDataSourceEditedBy(
-  auth: Authenticator,
-  dataSource: DataSourceType
-): Promise<Result<undefined, APIError>> {
-  const owner = auth.workspace();
-  const user = auth.user();
-  if (!owner || !user) {
-    return new Err({
-      type: "workspace_not_found",
-      message: "Could not find the workspace.",
-    });
-  }
-
-  if (!auth.isAdmin()) {
-    return new Err({
-      type: "workspace_auth_error",
-      message:
-        "Only users that are `admins` for the current workspace can update data sources.",
-    });
-  }
-
-  const dataSourceResource = await DataSourceResource.fetchByModelIdWithAuth(
-    auth,
-    dataSource.id
-  );
-
-  if (!dataSourceResource) {
-    return new Err({
-      type: "data_source_not_found",
-      message: "Could not find the data source.",
-    });
-  }
-
-  await dataSourceResource.update({
-    editedAt: new Date(),
-    editedByUserId: user.id,
-  });
-
-  return new Ok(undefined);
-}
-
 export async function deleteDataSource(
   auth: Authenticator,
   dataSourceName: string

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -227,12 +227,7 @@ export class DataSourceResource extends ResourceWithVault<DataSource> {
     return [affectedCount];
   }
 
-  async setEditedBy(auth: Authenticator, user: UserType) {
-    if (!auth.isAdmin()) {
-      throw new Error(
-        "Unexpected call to DataSourceResource.setEditedBy by non admin"
-      );
-    }
+  async setEditedBy(user: UserType) {
     await this.update({
       editedByUserId: user.id,
       editedAt: new Date(),

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -3,6 +3,7 @@ import type {
   DataSourceType,
   ModelId,
   Result,
+  UserType,
 } from "@dust-tt/types";
 import { Err, formatUserFullName, Ok } from "@dust-tt/types";
 import type {
@@ -224,6 +225,18 @@ export class DataSourceResource extends ResourceWithVault<DataSource> {
     // Update the current instance with the new values to avoid stale data
     Object.assign(this, affectedRows[0].get());
     return [affectedCount];
+  }
+
+  async setEditedBy(auth: Authenticator, user: UserType) {
+    if (!auth.isAdmin()) {
+      throw new Error(
+        "Unexpected call to DataSourceResource.setEditedBy by non admin"
+      );
+    }
+    await this.update({
+      editedByUserId: user.id,
+      editedAt: new Date(),
+    });
   }
 
   private makeEditedBy(

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/update.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/update.ts
@@ -9,12 +9,9 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import config from "@app/lib/api/config";
-import {
-  getDataSource,
-  updateDataSourceEditedBy,
-} from "@app/lib/api/data_sources";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { isDisposableEmailDomain } from "@app/lib/utils/disposable_email_domains";
 import logger from "@app/logger/logger";
@@ -31,7 +28,9 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isAdmin()) {
+  const owner = auth.workspace();
+  const user = auth.user();
+  if (!owner || !user || !auth.isAdmin()) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {
@@ -42,9 +41,11 @@ async function handler(
     });
   }
 
-  const owner = auth.getNonNullableWorkspace();
-
-  const dataSource = await getDataSource(auth, req.query.name as string);
+  // fetchByName enforces through auth the authorization (workspace here mainly).
+  const dataSource = await DataSourceResource.fetchByName(
+    auth,
+    req.query.name as string
+  );
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 404,
@@ -89,11 +90,14 @@ async function handler(
         connectorId: dataSource.connectorId.toString(),
         connectionId: bodyValidation.right.connectionId,
       });
-      const email = auth.user()?.email;
+      const email = user.email;
       if (email && !isDisposableEmailDomain(email)) {
         void sendUserOperationMessage({
           logger: logger,
-          message: `${email} updated the data source \`${dataSource.name}\`  for workspace \`${owner.name}\` sId: \`${owner.sId}\` connectorId: \`${dataSource.connectorId}\``,
+          message:
+            `${email} updated the data source \`${dataSource.name}\` ` +
+            `for workspace \`${owner.name}\` sId: \`${owner.sId}\` ` +
+            `connectorId: \`${dataSource.connectorId}\``,
         });
       }
 
@@ -121,10 +125,10 @@ async function handler(
         }
       }
 
-      await updateDataSourceEditedBy(auth, dataSource);
+      await dataSource.setEditedBy(auth, user);
       void ServerSideTracking.trackDataSourceUpdated({
-        dataSource,
-        user: auth.user() ?? undefined,
+        dataSource: dataSource.toJSON(),
+        user,
         workspace: owner,
       });
 

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/update.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/update.ts
@@ -125,7 +125,7 @@ async function handler(
         }
       }
 
-      await dataSource.setEditedBy(auth, user);
+      await dataSource.setEditedBy(user);
       void ServerSideTracking.trackDataSourceUpdated({
         dataSource: dataSource.toJSON(),
         user,


### PR DESCRIPTION
## Description

Context: 
https://github.com/dust-tt/tasks/issues/1175
https://github.com/dust-tt/dust/pull/3435

Remove the lib/api method updateDataSourceEditedBy to avoid having APIError signature in lib/api.

Start using DataSourceResource in the endpoint where it was used.

## Risk

Low. Tested in dev.

## Deploy Plan

- deploy `front`