### PR TITLE
Authenticator::fromKey(key, requestedGroupsIds)

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -350,7 +350,7 @@ export class Authenticator {
         // Key related attributes.
         GroupResource.listWorkspaceGroupsFromKey(key),
         requestedGroupIds
-          ? GroupResource.getGroupsFromSystemKey(key, requestedGroupIds)
+          ? GroupResource.getGroupsWithSystemKey(key, requestedGroupIds)
           : [],
         getSubscriptionForWorkspace(keyWorkspace),
         getFeatureFlags(keyWorkspace),

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -288,7 +288,8 @@ export class Authenticator {
    */
   static async fromKey(
     key: KeyResource,
-    wId: string
+    wId: string,
+    requestedGroupIds?: string[]
   ): Promise<{
     workspaceAuth: Authenticator;
     keyAuth: Authenticator;
@@ -330,6 +331,7 @@ export class Authenticator {
       );
 
     let keyGroups: GroupResource[] = [];
+    let requestedGroups: GroupResource[] = [];
     let keyFlags: WhitelistableFeature[] = [];
     let workspaceFlags: WhitelistableFeature[] = [];
 
@@ -339,6 +341,7 @@ export class Authenticator {
     if (workspace) {
       [
         keyGroups,
+        requestedGroups,
         keySubscription,
         keyFlags,
         workspaceSubscription,
@@ -346,6 +349,9 @@ export class Authenticator {
       ] = await Promise.all([
         // Key related attributes.
         GroupResource.listWorkspaceGroupsFromKey(key),
+        requestedGroupIds
+          ? GroupResource.getGroupsFromSystemKey(key, requestedGroupIds)
+          : [],
         getSubscriptionForWorkspace(keyWorkspace),
         getFeatureFlags(keyWorkspace),
         // Workspace related attributes.
@@ -353,6 +359,16 @@ export class Authenticator {
         getFeatureFlags(workspace),
       ]);
     }
+
+    const allGroups = Object.entries(
+      keyGroups.concat(requestedGroups).reduce(
+        (acc, group) => {
+          acc[group.id] = group;
+          return acc;
+        },
+        {} as Record<string, GroupResource>
+      )
+    ).map(([, group]) => group);
 
     return {
       workspaceAuth: new Authenticator({
@@ -365,7 +381,7 @@ export class Authenticator {
       }),
       keyAuth: new Authenticator({
         flags: keyFlags,
-        groups: keyGroups,
+        groups: allGroups,
         key: key.toAuthJSON(),
         role: "builder",
         subscription: keySubscription,

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -273,10 +273,6 @@ export class GroupResource extends BaseResource<GroupModel> {
       },
     });
 
-    if (groups.length === 0) {
-      throw new Error("Group for key not found.");
-    }
-
     return groups.map((group) => new this(GroupModel, group.get()));
   }
 

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -257,7 +257,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     return groups.map((group) => new this(GroupModel, group.get()));
   }
 
-  static async getGroupsFromSystemKey(
+  static async getGroupsWithSystemKey(
     key: KeyResource,
     groupIds: string[]
   ): Promise<GroupResource[]> {

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -257,6 +257,29 @@ export class GroupResource extends BaseResource<GroupModel> {
     return groups.map((group) => new this(GroupModel, group.get()));
   }
 
+  static async getGroupsFromSystemKey(
+    key: KeyResource,
+    groupIds: string[]
+  ): Promise<GroupResource[]> {
+    if (!key.isSystem) {
+      throw new Error("Only system keys are supported.");
+    }
+    const groups = await this.model.findAll({
+      where: {
+        workspaceId: key.workspaceId,
+        id: {
+          [Op.in]: removeNulls(groupIds.map((id) => getResourceIdFromSId(id))),
+        },
+      },
+    });
+
+    if (groups.length === 0) {
+      throw new Error("Group for key not found.");
+    }
+
+    return groups.map((group) => new this(GroupModel, group.get()));
+  }
+
   static async internalFetchWorkspaceGlobalGroup(
     workspaceId: ModelId
   ): Promise<GroupResource> {


### PR DESCRIPTION
## Description

Allow system API keys to request to be authenticated as groups.

This is the first part of this [task](https://github.com/dust-tt/dust/issues/6664).

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
