### PR TITLE
Create new website in a vault

### DIFF
--- a/front/components/vaults/EditVaultStaticDatasourcesViews.tsx
+++ b/front/components/vaults/EditVaultStaticDatasourcesViews.tsx
@@ -76,7 +76,7 @@ export function EditVaultStaticDataSourcesViews({
         owner={owner}
         vault={vault}
         dataSources={dataSources}
-        dataSourceOrView={null} // null for a website creation.
+        dataSourceView={null} // null for a website creation.
         webCrawlerConfiguration={null} // null for a website creation.
       />
       <Button

--- a/front/components/vaults/EditVaultStaticDatasourcesViews.tsx
+++ b/front/components/vaults/EditVaultStaticDatasourcesViews.tsx
@@ -74,6 +74,10 @@ export function EditVaultStaticDataSourcesViews({
           setShowAddWebsiteModal(isOpen);
         }}
         owner={owner}
+        vault={vault}
+        dataSources={dataSources}
+        dataSourceOrView={null} // null for a website creation.
+        webCrawlerConfiguration={null} // null for a website creation.
       />
       <Button
         label={category === "folder" ? "Add folder" : "Add website"}

--- a/front/components/vaults/VaultCreateWebsiteModal.tsx
+++ b/front/components/vaults/VaultCreateWebsiteModal.tsx
@@ -1,16 +1,305 @@
-import { Modal } from "@dust-tt/sparkle";
-import type { WorkspaceType } from "@dust-tt/types";
+import {
+  Button,
+  ContentMessage,
+  DropdownMenu,
+  Input,
+  Modal,
+  Page,
+  RadioButton,
+  TrashIcon,
+  XMarkIcon,
+} from "@dust-tt/sparkle";
+import type {
+  APIError,
+  CrawlingFrequency,
+  DataSourceType,
+  DataSourceViewCategory,
+  DataSourceViewType,
+  DepthOption,
+  VaultType,
+} from "@dust-tt/types";
+import type {
+  UpdateConnectorConfigurationType,
+  WebCrawlerConfigurationType,
+  WorkspaceType,
+} from "@dust-tt/types";
+import {
+  CrawlingFrequencies,
+  DepthOptions,
+  isDataSourceNameValid,
+  WEBCRAWLER_MAX_PAGES,
+} from "@dust-tt/types";
+import type * as t from "io-ts";
+import { useRouter } from "next/router";
+import { useCallback, useEffect, useState } from "react";
+import React from "react";
+
+import { DeleteDataSourceDialog } from "@app/components/data_source/DeleteDataSourceDialog";
+import { SendNotificationsContext } from "@app/components/sparkle/Notification";
+import { useVaultDataSourceViews } from "@app/lib/swr";
+import { isUrlValid, urlToDataSourceName } from "@app/lib/webcrawler";
+import type { PostManagedDataSourceRequestBodySchema } from "@app/pages/api/w/[wId]/data_sources/managed";
+
+const WEBSITE_CAT: DataSourceViewCategory = "website";
 
 export default function VaultCreateWebsiteModal({
   isOpen,
   setOpen,
   owner,
+  dataSources,
+  vault,
+  dataSourceOrView,
+  webCrawlerConfiguration,
 }: {
   isOpen: boolean;
   setOpen: (isOpen: boolean) => void;
   owner: WorkspaceType;
+  vault: VaultType;
+  dataSources: DataSourceType[];
+  dataSourceOrView: DataSourceType | DataSourceViewType | null;
+  webCrawlerConfiguration: WebCrawlerConfigurationType | null;
 }) {
-  console.log(owner);
+  const router = useRouter();
+  const sendNotification = React.useContext(SendNotificationsContext);
+
+  const [isSaving, setIsSaving] = useState(false);
+  const [isSubmitted, setIsSubmitted] = useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+
+  const [dataSourceUrl, setDataSourceUrl] = useState(
+    webCrawlerConfiguration?.url || ""
+  );
+  const [dataSourceUrlError, setDataSourceUrlError] = useState<string | null>(
+    null
+  );
+
+  const [dataSourceName, setDataSourceName] = useState(
+    dataSourceOrView?.name || ""
+  );
+  const [dataSourceNameError, setDataSourceNameError] = useState<string | null>(
+    null
+  );
+
+  const [maxPages, setMaxPages] = useState<number | null>(
+    webCrawlerConfiguration?.maxPageToCrawl || 50
+  );
+  const [maxDepth, setMaxDepth] = useState<DepthOption>(
+    webCrawlerConfiguration ? webCrawlerConfiguration.depth : 2
+  );
+  const [crawlMode, setCrawlMode] = useState<"child" | "website">(
+    webCrawlerConfiguration?.crawlMode || "website"
+  );
+  const [selectedCrawlFrequency, setSelectedCrawlFrequency] =
+    useState<CrawlingFrequency>(
+      webCrawlerConfiguration?.crawlFrequency || "monthly"
+    );
+  const [advancedSettingsOpened, setAdvancedSettingsOpened] = useState(false);
+
+  const existingHeaders = webCrawlerConfiguration?.headers
+    ? Object.entries(webCrawlerConfiguration.headers).map(([key, value]) => {
+        return { key, value };
+      })
+    : [];
+  const [headers, setHeaders] = useState(existingHeaders);
+
+  const { mutateVaultDataSourceViews } = useVaultDataSourceViews({
+    workspaceId: owner.sId,
+    vaultId: vault.sId,
+    category: WEBSITE_CAT,
+  });
+
+  const frequencyDisplayText: Record<CrawlingFrequency, string> = {
+    never: "Never",
+    daily: "Every day",
+    weekly: "Every week",
+    monthly: "Every month",
+  };
+
+  const depthDisplayText: Record<DepthOption, string> = {
+    0: "0 level",
+    1: "1 level",
+    2: "2 levels",
+    3: "3 levels",
+    4: "4 levels",
+    5: "5 levels",
+  };
+
+  useEffect(() => {
+    if (isUrlValid(dataSourceUrl)) {
+      setDataSourceName(urlToDataSourceName(dataSourceUrl));
+    }
+  }, [dataSourceUrl]);
+
+  const validateForm = useCallback(() => {
+    let urlError = null;
+    let nameError = null;
+
+    // Validate URL
+    if (!isUrlValid(dataSourceUrl)) {
+      urlError =
+        "Please provide a valid URL (e.g. https://example.com or https://example.com/a/b/c)).";
+    }
+
+    // Validate Name
+    const nameExists = dataSources.some(
+      (d) => d.name === dataSourceName && d.id !== dataSourceOrView?.id
+    );
+    const dataSourceNameRes = isDataSourceNameValid(dataSourceName);
+    if (nameExists) {
+      nameError = "A Folder with the same name already exists";
+    } else if (!dataSourceName.length) {
+      nameError = "Please provide a name.";
+    } else if (dataSourceNameRes.isErr()) {
+      nameError = dataSourceNameRes.error;
+    }
+
+    setDataSourceUrlError(urlError);
+    setDataSourceNameError(nameError);
+    return !urlError && !nameError;
+  }, [dataSourceName, dataSources, dataSourceUrl, dataSourceOrView?.id]);
+
+  useEffect(() => {
+    if (isSubmitted) {
+      validateForm();
+    }
+  }, [dataSourceName, dataSourceUrl, isSubmitted, validateForm]);
+
+  const handleCreate = async () => {
+    setIsSubmitted(true);
+
+    if (!validateForm()) {
+      return;
+    }
+
+    setIsSaving(true);
+    if (webCrawlerConfiguration === null) {
+      const sanitizedDataSourceUrl = dataSourceUrl.trim();
+      const res = await fetch(`/api/w/${owner.sId}/data_sources/managed`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          provider: "webcrawler",
+          connectionId: "none",
+          vaultId: vault.sId,
+          name: dataSourceName,
+          configuration: {
+            url: sanitizedDataSourceUrl,
+            maxPageToCrawl: maxPages || WEBCRAWLER_MAX_PAGES,
+            depth: maxDepth,
+            crawlMode: crawlMode,
+            crawlFrequency: selectedCrawlFrequency,
+            headers: headers.reduce(
+              (acc, { key, value }) => {
+                if (key && value) {
+                  acc[key] = value;
+                }
+                return acc;
+              },
+              {} as Record<string, string>
+            ),
+          } satisfies WebCrawlerConfigurationType,
+        } satisfies t.TypeOf<typeof PostManagedDataSourceRequestBodySchema>),
+      });
+      if (res.ok) {
+        setOpen(false);
+        sendNotification({
+          title: "Website created",
+          type: "success",
+          description: "The website has been successfully created.",
+        });
+        await mutateVaultDataSourceViews();
+        await router.push(
+          `/w/${owner.sId}/data-sources/vaults/${vault.sId}/categories/${WEBSITE_CAT}/data_sources/${dataSourceName}`
+        );
+      } else {
+        const err = (await res.json()) as { error: APIError };
+        setIsSaving(false);
+        sendNotification({
+          title: "Error creating website",
+          type: "error",
+          description: err.error.message,
+        });
+      }
+    } else if (dataSourceOrView) {
+      const res = await fetch(
+        `/api/w/${owner.sId}/data_sources/${encodeURIComponent(
+          dataSourceOrView.name
+        )}/configuration`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            configuration: {
+              url: dataSourceUrl,
+              maxPageToCrawl: maxPages || WEBCRAWLER_MAX_PAGES,
+              depth: maxDepth,
+              crawlMode: crawlMode,
+              crawlFrequency: selectedCrawlFrequency,
+              headers: headers.reduce(
+                (acc, { key, value }) => {
+                  if (key && value) {
+                    acc[key] = value;
+                  }
+                  return acc;
+                },
+                {} as Record<string, string>
+              ),
+            } satisfies WebCrawlerConfigurationType,
+          } satisfies UpdateConnectorConfigurationType),
+        }
+      );
+      if (res.ok) {
+        setOpen(false);
+        sendNotification({
+          title: "Website updated",
+          type: "success",
+          description: "The website has been successfully updated.",
+        });
+        await mutateVaultDataSourceViews();
+        await router.push(
+          `/w/${owner.sId}/data-sources/vaults/${vault.sId}/categories/${WEBSITE_CAT}/data_sources/${dataSourceName}`
+        );
+      } else {
+        const err = (await res.json()) as { error: APIError };
+        setIsSaving(false);
+        sendNotification({
+          title: "Error creating website",
+          type: "error",
+          description: err.error.message,
+        });
+      }
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!dataSourceOrView) {
+      return;
+    }
+    setIsSaving(true);
+    const res = await fetch(
+      `/api/w/${owner.sId}/data_sources/${encodeURIComponent(dataSourceOrView.name)}`,
+      {
+        method: "DELETE",
+      }
+    );
+    setIsSaving(false);
+    if (res.ok) {
+      await mutateVaultDataSourceViews();
+    } else {
+      const err = (await res.json()) as { error: APIError };
+      sendNotification({
+        title: "Error deleting website",
+        type: "error",
+        description: err.error.message,
+      });
+    }
+    return true;
+  };
+
   return (
     <Modal
       isOpen={isOpen}
@@ -18,15 +307,281 @@ export default function VaultCreateWebsiteModal({
         setOpen(false);
       }}
       onSave={() => {
-        alert("To be implemented");
-        setOpen(false);
+        setIsSubmitted(true);
+        if (!isSaving) {
+          void handleCreate();
+        }
       }}
       hasChanged={true}
       variant="side-md"
       title="Create a website"
     >
       <div className="w-full pt-12">
-        <div className="overflow-x-auto">To be implemented</div>
+        <div className="overflow-x-auto">
+          <Modal
+            isOpen={advancedSettingsOpened}
+            title={`Advanced settings`}
+            onClose={() => {
+              setAdvancedSettingsOpened(false);
+            }}
+            hasChanged={false}
+            isSaving={false}
+            variant="side-sm"
+          >
+            <Page.Layout direction="vertical" gap="md">
+              <Page.H variant="h3">Custom Headers</Page.H>
+              <Page.P>Add custom request headers for the web crawler.</Page.P>
+              <div className="flex flex-col gap-1 px-1">
+                {headers.map((header, index) => (
+                  <div key={index} className="flex gap-2">
+                    <Input
+                      placeholder="Header Name"
+                      value={header.key}
+                      name="headerName"
+                      onChange={(value) => {
+                        const newHeaders = [...headers];
+                        newHeaders[index].key = value;
+                        setHeaders(newHeaders);
+                      }}
+                      className="flex-1"
+                    />
+                    <Input
+                      name="headerValue"
+                      placeholder="Header Value"
+                      value={header.value}
+                      onChange={(value) => {
+                        const newHeaders = [...headers];
+                        newHeaders[index].value = value;
+                        setHeaders(newHeaders);
+                      }}
+                      className="flex-1"
+                    />
+                    <Button
+                      variant="tertiary"
+                      labelVisible={false}
+                      label=""
+                      icon={XMarkIcon}
+                      disabledTooltip={true}
+                      onClick={() => {
+                        const newHeaders = headers.filter(
+                          (_, i) => i !== index
+                        );
+                        setHeaders(newHeaders);
+                      }}
+                    />
+                  </div>
+                ))}
+              </div>
+              <div className="flex">
+                <Button
+                  variant="secondary"
+                  className="shrink"
+                  label="Add Header"
+                  onClick={() => {
+                    setHeaders([...headers, { key: "", value: "" }]);
+                  }}
+                />
+              </div>
+            </Page.Layout>
+          </Modal>
+          <div className="flex flex-col gap-2">
+            <Page.Layout direction="vertical" gap="xl">
+              <Page.Layout direction="vertical" gap="md">
+                <Page.H variant="h3">Website Entry Point</Page.H>
+                <Page.P>
+                  Enter the address of the website you'd like to index.
+                </Page.P>
+                <Input
+                  placeholder="https://example.com/articles"
+                  value={dataSourceUrl}
+                  onChange={(value) => setDataSourceUrl(value)}
+                  error={dataSourceUrlError}
+                  name="dataSourceUrl"
+                  showErrorLabel={true}
+                  className="text-sm"
+                />
+                <ContentMessage
+                  title="Ensure the website is public"
+                  variant="pink"
+                >
+                  Only public websites accessible without authentication will
+                  work.
+                </ContentMessage>
+              </Page.Layout>
+
+              <Page.Layout direction="vertical" gap="md">
+                <Page.H variant="h3">Indexing settings</Page.H>
+                <Page.P>
+                  Adjust the settings in order to only index the data you are
+                  interested in.
+                </Page.P>
+              </Page.Layout>
+              <div className="grid grid-cols-2 gap-x-6 gap-y-8">
+                <Page.Layout direction="vertical" sizing="grow">
+                  <Page.SectionHeader
+                    title="Crawling strategy"
+                    description="Do you want to limit to child pages or not?"
+                  />
+                  <RadioButton
+                    value={crawlMode}
+                    className="flex-col font-medium"
+                    onChange={(value) => {
+                      setCrawlMode(value == "child" ? "child" : "website");
+                    }}
+                    name="crawlMode"
+                    choices={[
+                      {
+                        label: "Only child pages of the provided URL",
+                        value: "child",
+                        disabled: false,
+                      },
+                      {
+                        label: "Follow all the links within the domain",
+                        value: "website",
+                        disabled: false,
+                      },
+                    ]}
+                  />
+                </Page.Layout>
+                <Page.Layout direction="vertical" sizing="grow">
+                  <Page.SectionHeader
+                    title="Refresh schedule"
+                    description="How often would you like to check for updates?"
+                  />
+                  <div>
+                    {(() => {
+                      return (
+                        <DropdownMenu>
+                          <DropdownMenu.Button
+                            label={frequencyDisplayText[selectedCrawlFrequency]}
+                          />
+                          <DropdownMenu.Items origin="topLeft">
+                            {CrawlingFrequencies.map((frequency) => {
+                              return (
+                                <DropdownMenu.Item
+                                  selected={selectedCrawlFrequency == frequency}
+                                  key={frequency}
+                                  label={frequencyDisplayText[frequency]}
+                                  onClick={() => {
+                                    setSelectedCrawlFrequency(frequency);
+                                  }}
+                                />
+                              );
+                            })}
+                          </DropdownMenu.Items>
+                        </DropdownMenu>
+                      );
+                    })()}
+                  </div>
+                </Page.Layout>
+                <Page.Layout direction="vertical" sizing="grow">
+                  <Page.SectionHeader
+                    title="Depth of Search"
+                    description="How far from the initial page would you like to go?"
+                  />
+                  {(() => {
+                    return (
+                      <DropdownMenu>
+                        <DropdownMenu.Button
+                          label={depthDisplayText[maxDepth]}
+                        />
+                        <DropdownMenu.Items origin="bottomLeft">
+                          {DepthOptions.map((depthOption) => {
+                            return (
+                              <DropdownMenu.Item
+                                selected={depthOption === maxDepth}
+                                key={depthOption}
+                                label={depthDisplayText[depthOption]}
+                                onClick={() => {
+                                  setMaxDepth(depthOption);
+                                }}
+                              />
+                            );
+                          })}
+                        </DropdownMenu.Items>
+                      </DropdownMenu>
+                    );
+                  })()}
+                </Page.Layout>
+                <Page.Layout direction="vertical" sizing="grow">
+                  <Page.SectionHeader
+                    title="Page Limit"
+                    description="What is the maximum number of pages you'd like to index?"
+                  />
+                  <Input
+                    placeholder={WEBCRAWLER_MAX_PAGES.toString()}
+                    value={maxPages?.toString() || ""}
+                    onChange={(value) => {
+                      const parsed = parseInt(value);
+                      if (!isNaN(parsed)) {
+                        setMaxPages(parseInt(value));
+                      } else if (value == "") {
+                        setMaxPages(null);
+                      }
+                    }}
+                    showErrorLabel={
+                      maxPages &&
+                      maxPages > WEBCRAWLER_MAX_PAGES &&
+                      maxPages &&
+                      maxPages < 1
+                        ? false
+                        : true
+                    }
+                    error={
+                      (maxPages && maxPages > WEBCRAWLER_MAX_PAGES) ||
+                      (maxPages && maxPages < 1)
+                        ? `Maximum pages must be between 1 and ${WEBCRAWLER_MAX_PAGES}`
+                        : null
+                    }
+                    name="maxPages"
+                  />
+                </Page.Layout>
+              </div>
+              <Page.Layout direction="vertical" gap="md">
+                <Page.H variant="h3">Name</Page.H>
+                <Page.P>Give a name to this Data Source.</Page.P>
+                <Input
+                  placeholder=""
+                  value={dataSourceName}
+                  onChange={(value) => setDataSourceName(value)}
+                  error={dataSourceNameError}
+                  name="dataSourceName"
+                  showErrorLabel={true}
+                  className="text-sm"
+                  disabled={webCrawlerConfiguration !== null}
+                />
+              </Page.Layout>
+
+              <div className="flex">
+                <Button
+                  label="Advanced settings"
+                  variant="secondary"
+                  onClick={() => {
+                    setAdvancedSettingsOpened(true);
+                  }}
+                ></Button>
+              </div>
+              {webCrawlerConfiguration && (
+                <div className="flex py-16">
+                  <Button
+                    variant="secondaryWarning"
+                    icon={TrashIcon}
+                    label={"Delete this website"}
+                    onClick={() => {
+                      setIsDeleteModalOpen(true);
+                    }}
+                  />
+                  <DeleteDataSourceDialog
+                    handleDelete={handleDelete}
+                    isOpen={isDeleteModalOpen}
+                    setIsOpen={setIsDeleteModalOpen}
+                    dataSourceUsage={0} // TODO: get usage
+                  />
+                </div>
+              )}
+            </Page.Layout>
+          </div>
+        </div>
       </div>
     </Modal>
   );

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -36,12 +36,17 @@ import { isDisposableEmailDomain } from "@app/lib/utils/disposable_email_domains
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 
-export const PostManagedDataSourceRequestBodySchema = t.type({
-  provider: t.string,
-  connectionId: t.string,
-  name: t.union([t.string, t.undefined]),
-  configuration: ConnectorConfigurationTypeSchema,
-});
+export const PostManagedDataSourceRequestBodySchema = t.intersection([
+  t.type({
+    provider: t.string,
+    connectionId: t.string,
+    name: t.union([t.string, t.undefined]),
+    configuration: ConnectorConfigurationTypeSchema,
+  }),
+  t.partial({
+    vaultId: t.string,
+  }),
+]);
 
 export type PostManagedDataSourceRequestBody = t.TypeOf<
   typeof PostManagedDataSourceRequestBodySchema
@@ -97,7 +102,7 @@ async function handler(
       }
 
       let { configuration } = bodyValidation.right;
-      const { connectionId, provider, name } = bodyValidation.right;
+      const { connectionId, provider, name, vaultId } = bodyValidation.right;
 
       if (!isConnectorProvider(provider)) {
         return apiError(req, res, {
@@ -299,9 +304,35 @@ async function handler(
         });
       }
 
-      const vault = await (provider === "webcrawler"
-        ? VaultResource.fetchWorkspaceGlobalVault(auth)
-        : VaultResource.fetchWorkspaceSystemVault(auth));
+      let vault: VaultResource | null = null;
+      if (provider === "webcrawler" && vaultId) {
+        vault = await VaultResource.fetchById(auth, vaultId);
+      } else if (provider === "webcrawler") {
+        vault = await VaultResource.fetchWorkspaceGlobalVault(auth);
+      } else {
+        vault = await VaultResource.fetchWorkspaceSystemVault(auth);
+      }
+
+      if (!vault) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to fetch the vault.",
+          },
+        });
+      }
+      if (!auth.hasPermission([vault.acl()], "write")) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "data_source_auth_error",
+            message:
+              "Only the users that have `write` permission for the current vault can create a data source.",
+          },
+        });
+      }
+
       const dataSource = await DataSourceResource.makeNew(
         {
           assistantDefaultSelected,

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/[dsId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/[dsId]/index.ts
@@ -1,0 +1,137 @@
+import type { WithAPIErrorResponse } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import {
+  deleteDataSource,
+  MANAGED_DS_DELETABLE_AS_BUILDER,
+} from "@app/lib/api/data_sources";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { VaultResource } from "@app/lib/resources/vault_resource";
+import { apiError } from "@app/logger/withlogging";
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<void>>,
+  auth: Authenticator
+): Promise<void> {
+  const owner = auth.workspace();
+  const plan = auth.plan();
+  const user = auth.user();
+
+  if (!owner || !plan || !user || !auth.isUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace you requested was not found.",
+      },
+    });
+  }
+
+  if (typeof req.query.vId !== "string") {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "vault_not_found",
+        message: "The vault you requested was not found.",
+      },
+    });
+  }
+
+  const vault = await VaultResource.fetchById(auth, req.query.vId);
+
+  if (!vault || !auth.hasPermission([vault.acl()], "write")) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "vault_not_found",
+        message: "The vault you requested was not found.",
+      },
+    });
+  }
+
+  if (vault.isSystem() && !auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message:
+          "Only the users that are `admins` for the current workspace can update a data source.",
+      },
+    });
+  } else if (vault.isGlobal() && !auth.isBuilder()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "data_source_auth_error",
+        message:
+          "Only the users that are `builders` for the current workspace can update a data source.",
+      },
+    });
+  }
+
+  if (!req.query.dsId || typeof req.query.dsId !== "string") {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "The data source you requested was not found.",
+      },
+    });
+  }
+  const dataSource = await DataSourceResource.fetchById(auth, req.query.dsId);
+  if (!dataSource) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "The data source you requested was not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "DELETE": {
+      if (
+        dataSource.connectorId &&
+        dataSource.connectorProvider &&
+        !MANAGED_DS_DELETABLE_AS_BUILDER.includes(dataSource.connectorProvider)
+      ) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Managed data sources cannot be deleted.",
+          },
+        });
+      }
+
+      const dRes = await deleteDataSource(auth, dataSource.name);
+      if (dRes.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: dRes.error.message,
+          },
+        });
+      }
+
+      res.status(204).end();
+      return;
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported DELETE is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/managed.ts
@@ -51,6 +51,7 @@ export function getConnectorProviderCodec(): t.Mixed {
 const PostManagedDataSourceRequestBodySchema = t.type({
   provider: getConnectorProviderCodec(),
   connectionId: t.union([t.string, t.undefined]),
+  name: t.union([t.string, t.undefined]),
   configuration: ConnectorConfigurationTypeSchema,
 });
 
@@ -104,7 +105,7 @@ async function handler(
         });
       }
 
-      const { connectionId, provider } = bodyValidation.right;
+      const { connectionId, provider, name } = bodyValidation.right;
 
       // Checking that the provider is allowed for the workspace plan
       const isDataSourceAllowedInPlan = isConnectorProviderAllowedForPlan(
@@ -155,7 +156,7 @@ async function handler(
           },
         });
       }
-      const dataSourceName = getDefaultDataSourceName(provider, suffix);
+      const dataSourceName = name ?? getDefaultDataSourceName(provider, suffix);
       let dataSourceDescription = getDefaultDataSourceDescription(
         provider,
         suffix

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/static.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/static.ts
@@ -218,8 +218,7 @@ async function handler(
         status_code: 405,
         api_error: {
           type: "method_not_supported_error",
-          message:
-            "The method passed is not supported, GET or POST is expected.",
+          message: "The method passed is not supported POST is expected.",
         },
       });
   }


### PR DESCRIPTION
## Description

This PR adds the ability to add a website in a vault. 
I shamelessly copy pasted most content from https://github.com/dust-tt/dust/blob/main/front/components/data_source/WebsiteConfiguration.tsx#L40 in VaultCreateWebsiteModal since this new modal will replace the old one when we release the project. 

Unclear to me if calling the existing endpoint to create the website (adding the vaultId) is what we want, not sure if it should create a datasource view, will ask.  

<kbd>
<img width="902" alt="Screenshot 2024-08-22 at 16 49 50" src="https://github.com/user-attachments/assets/d09e9c6e-ec8f-4a6f-9c13-4e4b692e351a">
</kbd>


## Risk

Internal only, can be rolled back. 

## Deploy Plan

Deploy front. 
