### PR TITLE
Rename data source view categories

### DIFF
--- a/front/components/vaults/VaultCategoriesList.tsx
+++ b/front/components/vaults/VaultCategoriesList.tsx
@@ -47,11 +47,11 @@ export const CATEGORY_DETAILS: {
     label: "Connected Data",
     icon: <CloudArrowLeftRightIcon className="text-brand" />,
   },
-  files: {
+  folder: {
     label: "Folders",
     icon: <FolderIcon className="text-brand" />,
   },
-  webfolder: {
+  website: {
     label: "Websites",
     icon: <GlobeAltIcon className="text-brand" />,
   },

--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -147,15 +147,15 @@ export const VaultResourcesList = ({
     });
 
   const { submit: handleCreateStaticDataSource } = useSubmitFunction(
-    async (type: "files" | "webfolder") => {
+    async (type: "folder" | "website") => {
       if (
         plan.limits.dataSources.count != -1 &&
         dataSources.length >= plan.limits.dataSources.count
       ) {
         setShowDatasourceLimitPopup(true);
-      } else if (type === "files") {
+      } else if (type === "folder") {
         setShowAddFolderModal(true);
-      } else if (type === "webfolder") {
+      } else if (type === "website") {
         setShowAddWebsiteModal(true);
       }
     }
@@ -242,20 +242,20 @@ export const VaultResourcesList = ({
             systemVault={systemVault}
           />
         )}
-        {category === "files" && (
+        {category === "folder" && (
           <Button
             label="Add folder"
             onClick={async () => {
-              await handleCreateStaticDataSource("files");
+              await handleCreateStaticDataSource("folder");
             }}
             icon={PlusIcon}
           />
         )}
-        {category === "webfolder" && (
+        {category === "website" && (
           <Button
             label="Add site"
             onClick={async () => {
-              await handleCreateStaticDataSource("webfolder");
+              await handleCreateStaticDataSource("website");
             }}
             icon={PlusIcon}
           />

--- a/front/components/vaults/VaultSideBarMenu.tsx
+++ b/front/components/vaults/VaultSideBarMenu.tsx
@@ -290,11 +290,11 @@ const DATA_SOURCE_OR_VIEW_SUB_ITEMS: {
     label: "Connected Data",
     icon: SubItemIconItemWrapper(CloudArrowLeftRightIcon),
   },
-  files: {
+  folder: {
     label: "Files",
     icon: SubItemIconItemWrapper(FolderIcon),
   },
-  webfolder: {
+  website: {
     label: "Websites",
     icon: SubItemIconItemWrapper(GlobeAltIcon),
   },

--- a/front/lib/api/vaults.ts
+++ b/front/lib/api/vaults.ts
@@ -18,11 +18,11 @@ export const getDataSourceCategory = (
   dataSource: DataSourceResource
 ): DataSourceViewCategory => {
   if (dataSource.isFolder()) {
-    return "files";
+    return "folder";
   }
 
   if (dataSource.isWebcrawler()) {
-    return "webfolder";
+    return "website";
   }
 
   return "managed";

--- a/types/src/front/api_handlers/public/vaults.ts
+++ b/types/src/front/api_handlers/public/vaults.ts
@@ -57,8 +57,8 @@ export type GetDataSourceViewContentResponseBody = {
 
 export const DATA_SOURCE_VIEW_CATEGORIES = [
   "managed",
-  "files",
-  "webfolder",
+  "folder",
+  "website",
   "apps",
 ] as const;
 


### PR DESCRIPTION
## Description

Renaming the data source views categories to match a more unified naming. 

- managed datasources = `managed`   -> no change
- dust apps = `apps`    -> no change
- folder datasources = `files`   -> renamed to `folder`
- website datasources = `webfolder`    -> renamed to `website`

## Risk

Annoy everyone with rebasing their PR, including me. 
Can be rolled back. 

## Deploy Plan

Deploy front. 
