### PR TITLE
Get headers Group ids in `POST api/v1/{conversation, message, app/runs}`

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -14,7 +14,6 @@ import type { DustAPICredentials } from "@dust-tt/types";
 import type { Result } from "@dust-tt/types";
 import type { APIErrorWithStatusCode } from "@dust-tt/types";
 import {
-  DustGroupIdsHeader,
   Err,
   groupHasPermission,
   isAdmin,
@@ -894,15 +893,4 @@ export async function prodAPICredentialsForOwner(
     apiKey: systemAPIKeyRes.value.secret,
     workspaceId: owner.sId,
   };
-}
-
-export function getGroupIdsFromHeaders(
-  headers: Record<string, string | string[] | undefined>
-): string[] | undefined {
-  const groupIds = headers[DustGroupIdsHeader];
-  if (typeof groupIds === "string") {
-    return groupIds.split(",").map((id) => id.trim());
-  } else {
-    undefined;
-  }
 }

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -14,6 +14,7 @@ import type { DustAPICredentials } from "@dust-tt/types";
 import type { Result } from "@dust-tt/types";
 import type { APIErrorWithStatusCode } from "@dust-tt/types";
 import {
+  DustGroupIdsHeader,
   Err,
   groupHasPermission,
   isAdmin,
@@ -893,4 +894,15 @@ export async function prodAPICredentialsForOwner(
     apiKey: systemAPIKeyRes.value.secret,
     workspaceId: owner.sId,
   };
+}
+
+export function getGroupIdsFromHeaders(
+  headers: Record<string, string | string[] | undefined>
+): string[] | undefined {
+  const groupIds = headers[DustGroupIdsHeader];
+  if (typeof groupIds === "string") {
+    return groupIds.split(",").map((id) => id.trim());
+  } else {
+    undefined;
+  }
 }

--- a/front/lib/http_api/group_header.ts
+++ b/front/lib/http_api/group_header.ts
@@ -1,0 +1,12 @@
+import { DustGroupIdsHeader } from "@dust-tt/types";
+
+export function getGroupIdsFromHeaders(
+  headers: Record<string, string | string[] | undefined>
+): string[] | undefined {
+  const groupIds = headers[DustGroupIdsHeader];
+  if (typeof groupIds === "string") {
+    return groupIds.split(",").map((id) => id.trim());
+  } else {
+    undefined;
+  }
+}

--- a/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
@@ -21,11 +21,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { getApp } from "@app/lib/api/app";
 import apiConfig from "@app/lib/api/config";
 import { getDustAppSecrets } from "@app/lib/api/dust_app_secrets";
-import {
-  Authenticator,
-  getAPIKey,
-  getGroupIdsFromHeaders,
-} from "@app/lib/auth";
+import { Authenticator, getAPIKey } from "@app/lib/auth";
+import { getGroupIdsFromHeaders } from "@app/lib/http_api/group_header";
 import { Provider } from "@app/lib/models/apps";
 import type { KeyResource } from "@app/lib/resources/key_resource";
 import type { RunUsageType } from "@app/lib/resources/run_resource";

--- a/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
@@ -21,7 +21,11 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { getApp } from "@app/lib/api/app";
 import apiConfig from "@app/lib/api/config";
 import { getDustAppSecrets } from "@app/lib/api/dust_app_secrets";
-import { Authenticator, getAPIKey } from "@app/lib/auth";
+import {
+  Authenticator,
+  getAPIKey,
+  getGroupIdsFromHeaders,
+} from "@app/lib/auth";
 import { Provider } from "@app/lib/models/apps";
 import type { KeyResource } from "@app/lib/resources/key_resource";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
@@ -178,7 +182,8 @@ async function handler(
 
   const { keyAuth, workspaceAuth } = await Authenticator.fromKey(
     keyRes.value,
-    req.query.wId as string
+    req.query.wId as string,
+    getGroupIdsFromHeaders(req.headers)
   );
 
   const owner = workspaceAuth.workspace();

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -13,11 +13,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
 import { postUserMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
-import {
-  Authenticator,
-  getAPIKey,
-  getGroupIdsFromHeaders,
-} from "@app/lib/auth";
+import { Authenticator, getAPIKey } from "@app/lib/auth";
+import { getGroupIdsFromHeaders } from "@app/lib/http_api/group_header";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
 export type PostMessagesResponseBody = {

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -13,7 +13,11 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
 import { postUserMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
-import { Authenticator, getAPIKey } from "@app/lib/auth";
+import {
+  Authenticator,
+  getAPIKey,
+  getGroupIdsFromHeaders,
+} from "@app/lib/auth";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
 export type PostMessagesResponseBody = {
@@ -76,7 +80,8 @@ async function handler(
 
   const authenticator = await Authenticator.fromKey(
     keyRes.value,
-    req.query.wId as string
+    req.query.wId as string,
+    getGroupIdsFromHeaders(req.headers)
   );
   let { workspaceAuth } = authenticator;
   const { keyAuth } = authenticator;

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -19,7 +19,11 @@ import {
   postNewContentFragment,
 } from "@app/lib/api/assistant/conversation";
 import { postUserMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
-import { Authenticator, getAPIKey } from "@app/lib/auth";
+import {
+  Authenticator,
+  getAPIKey,
+  getGroupIdsFromHeaders,
+} from "@app/lib/auth";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
 export type PostConversationsResponseBody = {
@@ -98,7 +102,8 @@ async function handler(
 
   const authenticator = await Authenticator.fromKey(
     keyRes.value,
-    req.query.wId as string
+    req.query.wId as string,
+    getGroupIdsFromHeaders(req.headers)
   );
   let { workspaceAuth } = authenticator;
   const { keyAuth } = authenticator;

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -19,11 +19,8 @@ import {
   postNewContentFragment,
 } from "@app/lib/api/assistant/conversation";
 import { postUserMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
-import {
-  Authenticator,
-  getAPIKey,
-  getGroupIdsFromHeaders,
-} from "@app/lib/auth";
+import { Authenticator, getAPIKey } from "@app/lib/auth";
+import { getGroupIdsFromHeaders } from "@app/lib/http_api/group_header";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
 export type PostConversationsResponseBody = {

--- a/types/src/front/lib/dust_api.ts
+++ b/types/src/front/lib/dust_api.ts
@@ -140,6 +140,7 @@ export type DustAPICredentials = {
 };
 
 export const DustUserIdHeader = "x-dust-user-id";
+export const DustGroupIdsHeader = "x-dust-group-ids";
 
 type PublicPostContentFragmentRequestBody = t.TypeOf<
   typeof PublicPostContentFragmentRequestBodySchema


### PR DESCRIPTION
## Description

Use the `x-dust-group-ids` headers in `POST api/v1/{conversation, message, app/runs}`

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
