### PR TITLE
front:fix connection creation flow

### DIFF
--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -512,23 +512,13 @@ export default function DataSourcesView({
           dataSource: DataSourceType;
           connector: ConnectorType;
         } = await res.json();
-        setDataSourceIntegrations((prev) =>
-          prev.map((ds) => {
-            return ds.connector === null && ds.connectorProvider == provider
-              ? {
-                  ...ds,
-                  connector: createdManagedDataSource.connector,
-                  setupWithSuffix: null,
-                  dataSourceName: createdManagedDataSource.dataSource.name,
-                }
-              : ds;
-          })
+        // Once the connection is enabled, redirect to the data source page.
+        void router.push(
+          `/w/${owner.sId}/builder/data-sources/${createdManagedDataSource.dataSource.name}` +
+            (REDIRECT_TO_EDIT_PERMISSIONS.includes(provider)
+              ? `?edit_permissions=true`
+              : "")
         );
-        if (REDIRECT_TO_EDIT_PERMISSIONS.includes(provider)) {
-          void router.push(
-            `/w/${owner.sId}/builder/data-sources/${createdManagedDataSource.dataSource.name}?edit_permissions=true`
-          );
-        }
       } else {
         const responseText = await res.text();
         sendNotification({


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/1177

Following:
https://github.com/dust-tt/dust/pull/6649
https://github.com/dust-tt/dust/pull/6691

We don't have a list of connections to activate but an add button and a table served from getServerSideProps. This led to a bad experience as adding a connection you would come back to the connection page and nothing would happen

Instead we directly redirect to the new connection page always.

r? @flvndvd 
cc @JulesBelveze 

## Risk

Low

## Deploy Plan

- deploy `front`