### PR TITLE
Add manage vault members screen

### DIFF
--- a/front/components/vaults/CreateVaultModal.tsx
+++ b/front/components/vaults/CreateVaultModal.tsx
@@ -35,7 +35,6 @@ interface CreateVaultModalProps {
   owner: LightWorkspaceType;
   isOpen: boolean;
   onClose: () => void;
-  onSave: () => void;
 }
 
 function getTableRows(allUsers: UserType[]): RowData[] {
@@ -50,7 +49,6 @@ export function CreateVaultModal({
   owner,
   isOpen,
   onClose,
-  onSave,
 }: CreateVaultModalProps) {
   const [vaultName, setVaultName] = useState<string | null>(null);
   const [selectedMembers, setSelectedMembers] = useState<string[]>([]);
@@ -77,34 +75,38 @@ export function CreateVaultModal({
           const isSelected = selectedMembers.includes(info.row.original.userId);
           if (isSelected) {
             return (
-              <Button
-                label="Remove"
-                onClick={() =>
-                  setSelectedMembers(
-                    selectedMembers.filter(
-                      (m) => m !== info.row.original.userId
+              <div className="full-width flex justify-end">
+                <Button
+                  label="Remove"
+                  onClick={() =>
+                    setSelectedMembers(
+                      selectedMembers.filter(
+                        (m) => m !== info.row.original.userId
+                      )
                     )
-                  )
-                }
-                variant="tertiary"
-                size="sm"
-                icon={MinusIcon}
-              />
+                  }
+                  variant="tertiary"
+                  size="sm"
+                  icon={MinusIcon}
+                />
+              </div>
             );
           }
           return (
-            <Button
-              label="Add"
-              onClick={() =>
-                setSelectedMembers([
-                  ...selectedMembers,
-                  info.row.original.userId,
-                ])
-              }
-              variant="secondary"
-              size="sm"
-              icon={PlusIcon}
-            />
+            <div className="full-width flex justify-end">
+              <Button
+                label="Add"
+                onClick={() =>
+                  setSelectedMembers([
+                    ...selectedMembers,
+                    info.row.original.userId,
+                  ])
+                }
+                variant="secondary"
+                size="sm"
+                icon={PlusIcon}
+              />
+            </div>
           );
         },
       },
@@ -185,7 +187,7 @@ export function CreateVaultModal({
               "An unexpected error occurred while creating the vault.",
           });
         }
-        onSave();
+        onClose();
       }}
     >
       <Page.Vertical gap="md" sizing="grow">

--- a/front/components/vaults/ManageMembersModal.tsx
+++ b/front/components/vaults/ManageMembersModal.tsx
@@ -30,11 +30,13 @@ interface ManageMembersModalProps {
 }
 
 function getTableRows(allUsers: UserType[]): RowData[] {
-  return allUsers.map((user) => ({
-    icon: user.image ?? "",
-    name: user.fullName,
-    userId: user.sId,
-  }));
+  return allUsers
+    .map((user) => ({
+      icon: user.image ?? "",
+      name: user.fullName,
+      userId: user.sId,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
 }
 
 export function ManageMembersModal({

--- a/front/components/vaults/ManageMembersModal.tsx
+++ b/front/components/vaults/ManageMembersModal.tsx
@@ -1,0 +1,171 @@
+import {
+  Button,
+  DataTable,
+  Modal,
+  Page,
+  PlusIcon,
+  Searchbar,
+  Spinner,
+} from "@dust-tt/sparkle";
+import type { LightWorkspaceType, UserType } from "@dust-tt/types";
+import type { CellContext } from "@tanstack/react-table";
+import { MinusIcon } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { useMembers } from "@app/lib/swr";
+
+type RowData = {
+  icon: string;
+  name: string;
+  userId: string;
+  onClick?: () => void;
+};
+
+interface ManageMembersModalProps {
+  owner: LightWorkspaceType;
+  isOpen: boolean;
+  existingMembers: UserType[];
+  setMemberIds: (s: string[]) => Promise<void>;
+  onClose: () => void;
+}
+
+function getTableRows(allUsers: UserType[]): RowData[] {
+  return allUsers.map((user) => ({
+    icon: user.image ?? "",
+    name: user.fullName,
+    userId: user.sId,
+  }));
+}
+
+export function ManageMembersModal({
+  owner,
+  isOpen,
+  existingMembers,
+  setMemberIds,
+  onClose,
+}: ManageMembersModalProps) {
+  const [selectedMemberIds, setSelectedMemberIds] = useState<string[]>([]);
+  const [searchTerm, setSearchTerm] = useState<string>("");
+  const [isSaving, setIsSaving] = useState(false);
+  const { members, isMembersLoading } = useMembers(owner);
+
+  const existingMemberIds = useMemo(
+    () => existingMembers.map((m) => m.sId).sort(),
+    [existingMembers]
+  );
+
+  useEffect(() => {
+    setSelectedMemberIds(existingMemberIds);
+  }, [existingMemberIds]);
+
+  const getTableColumns = useCallback(() => {
+    return [
+      {
+        id: "name",
+        cell: (info: CellContext<RowData, string>) => (
+          <DataTable.CellContent avatarUrl={info.row.original.icon}>
+            {info.getValue()}
+          </DataTable.CellContent>
+        ),
+        accessorFn: (row: RowData) => row.name,
+      },
+      {
+        id: "action",
+        cell: (info: CellContext<RowData, unknown>) => {
+          const isSelected = selectedMemberIds.includes(
+            info.row.original.userId
+          );
+          if (isSelected) {
+            return (
+              <div className="full-width flex justify-end">
+                <Button
+                  label="Remove"
+                  onClick={() =>
+                    setSelectedMemberIds(
+                      selectedMemberIds
+                        .filter((m) => m !== info.row.original.userId)
+                        .sort()
+                    )
+                  }
+                  variant="tertiary"
+                  size="sm"
+                  icon={MinusIcon}
+                />
+              </div>
+            );
+          }
+          return (
+            <div className="full-width flex justify-end">
+              <Button
+                label="Add"
+                onClick={() =>
+                  setSelectedMemberIds([
+                    ...selectedMemberIds,
+                    info.row.original.userId,
+                  ])
+                }
+                variant="secondary"
+                size="sm"
+                icon={PlusIcon}
+              />
+            </div>
+          );
+        },
+      },
+    ];
+  }, [selectedMemberIds]);
+
+  const rows = useMemo(() => getTableRows(members), [members]);
+
+  const columns = useMemo(() => getTableColumns(), [getTableColumns]);
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={() => {
+        setSelectedMemberIds(existingMemberIds);
+        onClose();
+      }}
+      title="Edit members"
+      saveLabel="Save"
+      variant="side-md"
+      hasChanged={existingMemberIds.join(",") !== selectedMemberIds.join(",")}
+      isSaving={isSaving}
+      className="flex"
+      onSave={async () => {
+        setIsSaving(true);
+        await setMemberIds(selectedMemberIds);
+        setIsSaving(false);
+        onClose();
+      }}
+    >
+      <Page.Vertical gap="md" sizing="grow">
+        <div className="flex w-full grow flex-col gap-y-4 overflow-y-hidden border-t p-4">
+          <Page.SectionHeader title="Vault members" />
+          <div className="flex w-full">
+            <Searchbar
+              name="search"
+              placeholder="Search members"
+              value={searchTerm}
+              onChange={setSearchTerm}
+            />
+          </div>
+          {isMembersLoading ? (
+            <div className="mt-8 flex justify-center">
+              <Spinner size="lg" variant="color" />
+            </div>
+          ) : (
+            <div className="flex grow flex-col overflow-y-auto p-4">
+              <DataTable
+                data={rows}
+                columns={columns}
+                filterColumn="name"
+                filter={searchTerm}
+              />
+            </div>
+          )}
+        </div>
+      </Page.Vertical>
+    </Modal>
+  );
+}

--- a/front/components/vaults/VaultLayout.tsx
+++ b/front/components/vaults/VaultLayout.tsx
@@ -40,7 +40,6 @@ export function VaultLayout({
           owner={owner}
           isOpen={showVaultCreationModal}
           onClose={() => setShowVaultCreationModal(false)}
-          onSave={() => setShowVaultCreationModal(false)}
         />
       </AppLayout>
     </RootLayout>

--- a/front/components/vaults/VaultMembers.tsx
+++ b/front/components/vaults/VaultMembers.tsx
@@ -87,8 +87,8 @@ export const VaultMembers = ({ owner, isAdmin, vault }: VaultMembersProps) => {
     } else {
       sendNotification({
         type: "success",
-        title: "Successfully updated members",
-        description: "Members have been updated successfully updated.",
+        title: "Members updated",
+        description: "Members have been updated successfully.",
       });
 
       await mutateVaultInfo();

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -296,6 +296,7 @@ export class VaultResource extends BaseResource<VaultModel> {
       sId: this.sId,
       name: this.name,
       kind: this.kind,
+      groupIds: this.groups.map((group) => group.sId),
     };
   }
 }

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -1315,13 +1315,14 @@ export function useVaultInfo({
 }) {
   const vaultsCategoriesFetcher: Fetcher<GetVaultResponseBody> = fetcher;
 
-  const { data, error } = useSWRWithDefaults(
+  const { data, error, mutate } = useSWRWithDefaults(
     disabled ? null : `/api/w/${workspaceId}/vaults/${vaultId}`,
     vaultsCategoriesFetcher
   );
 
   return {
     vaultInfo: data ? data.vault : null,
+    mutateVaultInfo: mutate,
     isVaultInfoLoading: !error && !data,
     isVaultInfoError: error,
   };

--- a/types/src/front/vault.ts
+++ b/types/src/front/vault.ts
@@ -5,6 +5,7 @@ export type VaultType = {
   name: string;
   sId: string;
   kind: VaultKind;
+  groupIds: string[];
 };
 
 type ManagedDataSourceViewSelectedNodes = {


### PR DESCRIPTION
fixes: https://github.com/dust-tt/dust/issues/6790

## Description

- Add members table and handle the "Add members" modal. Add members modal allows to add or remove members from the group (same display as when creating a vault).
- Members can also be removed by going into the more menu


![Capture-2024-08-23-104637](https://github.com/user-attachments/assets/d24568c9-dc6a-4607-afc3-d866af93cbcc)
![Capture-2024-08-23-104723](https://github.com/user-attachments/assets/bc993ac1-ce4a-4b64-ab2b-c54484a00204)
![Capture-2024-08-23-104758](https://github.com/user-attachments/assets/7856c6fc-ef51-4d2b-8157-a10149f44a96)


## Risk

none

## Deploy Plan

deploy `front`