### PR TITLE
Disable select all without search term

### DIFF
--- a/front/components/ConnectorPermissionsTree.tsx
+++ b/front/components/ConnectorPermissionsTree.tsx
@@ -147,6 +147,7 @@ export function PermissionTreeChildren({
                 size="sm"
                 label={selectAllClicked ? "Unselect All" : "Select All"}
                 icon={ListCheckIcon}
+                disabled={search.trim().length === 0}
                 onClick={() => {
                   setSelectAllClicked((prev) => !prev);
                   setLocalStateByInternalId((prev) => {


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/1180

We disable `Select All` in Slack channel selection if there is no search term. Some users are using it to select everything without thinking and we easily end-up with low quality high volume slack channels.

## Risk

None

## Deploy Plan

- deploy `front`