### PR TITLE
Fix authorization for content nodes and parents

### DIFF
--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/content-nodes/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/content-nodes/index.ts
@@ -25,17 +25,6 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<GetContentNodesResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isAdmin()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "data_source_auth_error",
-        message:
-          "Only the users that are `admins` for the current workspace can edit the permissions of a data source.",
-      },
-    });
-  }
-
   const dataSource = await getDataSource(auth, req.query.name as string);
   if (!dataSource) {
     return apiError(req, res, {
@@ -63,7 +52,7 @@ async function handler(
       api_error: {
         type: "data_source_auth_error",
         message:
-          "Only users of the current workspace can view the permissions of a data source.",
+          "Only users of the current workspace can view the content nodes of a data source.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/parents.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/parents.ts
@@ -46,13 +46,13 @@ async function handler(
     });
   }
 
-  if (!auth.isBuilder()) {
+  if (!auth.isUser()) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {
         type: "data_source_auth_error",
         message:
-          "Only the users that are `builders` for the current workspace can retrieve parents of connector resources.",
+          "Only the users of the current workspace can retrieve parents of connector resources.",
       },
     });
   }


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/1183

For the past 5months (since introduction) editing tables query actions that already existed would fail for non admins.

@flvndvd this endpoint is critical to consider for the groups work of course.

Fix tested in dev.

## Risk

N/A

## Deploy Plan

- deploy `front`