### PR TITLE
[Vaults] Breadcrumbs

### DIFF
--- a/front/components/DataSourceResourceSelectorTree.tsx
+++ b/front/components/DataSourceResourceSelectorTree.tsx
@@ -45,7 +45,6 @@ export default function DataSourceResourceSelectorTree({
       <DataSourceResourceSelectorChildren
         owner={owner}
         dataSourceView={dataSourceView}
-        parentId={null}
         showExpand={showExpand}
         parents={[]}
         parentIsSelected={parentIsSelected}
@@ -99,7 +98,7 @@ function DataSourceResourceSelectorChildren({
 }: {
   owner: LightWorkspaceType;
   dataSourceView: DataSourceViewType;
-  parentId: string | null;
+  parentId?: string;
   parents: string[];
   parentIsSelected?: boolean;
   selectedParents: string[];

--- a/front/components/vaults/Breadcrumb.tsx
+++ b/front/components/vaults/Breadcrumb.tsx
@@ -1,12 +1,12 @@
-import { ChevronRightIcon } from "@dust-tt/sparkle";
+import { ChevronRightIcon, Icon } from "@dust-tt/sparkle";
 import Link from "next/link";
-import type { ReactElement } from "react";
+import type { ComponentType } from "react";
 import React from "react";
 
 type BreadcrumbProps = {
   items: {
     label: string;
-    icon?: ReactElement;
+    icon?: ComponentType<{ className?: string }>;
     href?: string;
   }[];
 };
@@ -16,7 +16,7 @@ export const BreadCrumb = ({ items }: BreadcrumbProps) => {
     <span className="inline-flex items-center gap-2">
       {items.map((item, index) => (
         <React.Fragment key={index}>
-          {item.icon}
+          <Icon visual={item.icon} className="text-brand" />
           <span className="inline-flex">
             {item.href ? (
               <Link

--- a/front/components/vaults/VaultCategoriesList.tsx
+++ b/front/components/vaults/VaultCategoriesList.tsx
@@ -11,7 +11,7 @@ import {
 import type { VaultType, WorkspaceType } from "@dust-tt/types";
 import { DATA_SOURCE_VIEW_CATEGORIES, removeNulls } from "@dust-tt/types";
 import type { CellContext } from "@tanstack/react-table";
-import type { ComponentType, ReactElement } from "react";
+import type { ComponentType } from "react";
 import { useState } from "react";
 
 import { useVaultInfo } from "@app/lib/swr";
@@ -38,26 +38,26 @@ type VaultCategoriesListProps = {
 export const CATEGORY_DETAILS: {
   [key: string]: {
     label: string;
-    icon: ReactElement<{
+    icon: ComponentType<{
       className?: string;
     }>;
   };
 } = {
   managed: {
     label: "Connected Data",
-    icon: <CloudArrowLeftRightIcon className="text-brand" />,
+    icon: CloudArrowLeftRightIcon,
   },
   folder: {
     label: "Folders",
-    icon: <FolderIcon className="text-brand" />,
+    icon: FolderIcon,
   },
   website: {
     label: "Websites",
-    icon: <GlobeAltIcon className="text-brand" />,
+    icon: GlobeAltIcon,
   },
   apps: {
     label: "Apps",
-    icon: <CommandLineIcon className="text-brand" />,
+    icon: CommandLineIcon,
   },
 };
 
@@ -110,7 +110,7 @@ export const VaultCategoriesList = ({
                 category,
                 ...vaultInfo.categories[category],
                 name: CATEGORY_DETAILS[category].label,
-                icon: CATEGORY_DETAILS[category].icon.type as ComponentType,
+                icon: CATEGORY_DETAILS[category].icon as ComponentType,
                 onClick: () => onSelect(category),
               }
             : null

--- a/front/components/vaults/VaultCategoriesList.tsx
+++ b/front/components/vaults/VaultCategoriesList.tsx
@@ -110,7 +110,7 @@ export const VaultCategoriesList = ({
                 category,
                 ...vaultInfo.categories[category],
                 name: CATEGORY_DETAILS[category].label,
-                icon: CATEGORY_DETAILS[category].icon as ComponentType,
+                icon: CATEGORY_DETAILS[category].icon,
                 onClick: () => onSelect(category),
               }
             : null

--- a/front/components/vaults/VaultDataSourceViewContentList.tsx
+++ b/front/components/vaults/VaultDataSourceViewContentList.tsx
@@ -30,7 +30,7 @@ type VaultDataSourceViewContentListProps = {
   isAdmin: boolean;
   onSelect: (parentId: string) => void;
   owner: WorkspaceType;
-  parentId: string | null;
+  parentId?: string;
   vault: VaultType;
 };
 

--- a/front/components/vaults/VaultLayout.tsx
+++ b/front/components/vaults/VaultLayout.tsx
@@ -1,15 +1,32 @@
-import type { SubscriptionType, WorkspaceType } from "@dust-tt/types";
+import { FolderIcon, LockIcon, PlanetIcon } from "@dust-tt/sparkle";
+import type {
+  DataSourceType,
+  DataSourceViewCategory,
+  DataSourceViewType,
+  SubscriptionType,
+  VaultType,
+  WorkspaceType,
+} from "@dust-tt/types";
 import React, { useState } from "react";
 
 import RootLayout from "@app/components/app/RootLayout";
 import AppLayout from "@app/components/sparkle/AppLayout";
+import { BreadCrumb } from "@app/components/vaults/Breadcrumb";
 import { CreateVaultModal } from "@app/components/vaults/CreateVaultModal";
+import { CATEGORY_DETAILS } from "@app/components/vaults/VaultCategoriesList";
 import VaultSideBarMenu from "@app/components/vaults/VaultSideBarMenu";
+import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
+import { useDataSourceContentNodes } from "@app/lib/swr";
 
 export interface VaultLayoutProps {
   gaTrackingId: string;
   owner: WorkspaceType;
   subscription: SubscriptionType;
+  vault: VaultType;
+  category?: DataSourceViewCategory;
+  dataSource?: DataSourceType;
+  dataSourceView?: DataSourceViewType;
+  parentId?: string | null;
 }
 
 export function VaultLayout({
@@ -20,7 +37,16 @@ export function VaultLayout({
   pageProps: VaultLayoutProps;
 }) {
   const [showVaultCreationModal, setShowVaultCreationModal] = useState(false);
-  const { gaTrackingId, owner, subscription } = pageProps;
+  const {
+    gaTrackingId,
+    owner,
+    subscription,
+    vault,
+    category,
+    dataSource,
+    dataSourceView,
+    parentId,
+  } = pageProps;
 
   return (
     <RootLayout>
@@ -35,6 +61,14 @@ export function VaultLayout({
           />
         }
       >
+        <VaultBreadCrumbs
+          vault={vault}
+          category={category}
+          owner={owner}
+          dataSource={dataSource}
+          dataSourceView={dataSourceView}
+          parentId={parentId ?? undefined}
+        />
         {children}
         <CreateVaultModal
           owner={owner}
@@ -43,5 +77,87 @@ export function VaultLayout({
         />
       </AppLayout>
     </RootLayout>
+  );
+}
+
+function VaultBreadCrumbs({
+  owner,
+  vault,
+  category,
+  dataSource,
+  dataSourceView,
+  parentId,
+}: {
+  owner: WorkspaceType;
+  vault: VaultType;
+  category?: DataSourceViewCategory;
+  dataSource?: DataSourceType;
+  dataSourceView?: DataSourceViewType;
+  parentId?: string;
+}) {
+  const { nodes } = useDataSourceContentNodes({
+    owner,
+    dataSource: dataSource,
+    internalIds: parentId ? [parentId] : [],
+  });
+
+  const { title: folderName, parentInternalId } = nodes[0] || {};
+
+  if (!category) {
+    return null;
+  }
+
+  const items: { label: string; [key: string]: any }[] = [
+    {
+      icon:
+        vault.kind === "global" ? (
+          <PlanetIcon className="text-brand" />
+        ) : (
+          <LockIcon className="text-brand" />
+        ),
+      label: vault.name,
+      href: `/w/${owner.sId}/data-sources/vaults/${vault.sId}`,
+    },
+    {
+      icon: CATEGORY_DETAILS[category].icon,
+      label: CATEGORY_DETAILS[category].label,
+      href: `/w/${owner.sId}/data-sources/vaults/${vault.sId}/categories/${category}`,
+    },
+  ];
+
+  if (dataSourceView) {
+    items.push({
+      icon: dataSourceView.connectorProvider ? (
+        React.createElement(
+          CONNECTOR_CONFIGURATIONS[dataSourceView.connectorProvider]
+            .logoComponent
+        )
+      ) : (
+        <FolderIcon className="text-brand" />
+      ),
+      label: dataSourceView.connectorProvider
+        ? CONNECTOR_CONFIGURATIONS[dataSourceView.connectorProvider].name
+        : dataSourceView.name,
+      href: `/w/${owner.sId}/data-sources/vaults/${vault.sId}/categories/${category}/data_source_views/${dataSourceView.sId}`,
+    });
+
+    if (folderName) {
+      if (parentInternalId) {
+        items.push({
+          label: "...",
+          href: `/w/${owner.sId}/data-sources/vaults/${vault.sId}/categories/${category}/data_source_views/${dataSourceView.sId}?parentId=${parentInternalId}`,
+        });
+      }
+      items.push({
+        label: folderName,
+        icon: <FolderIcon className="text-brand" />,
+      });
+    }
+  }
+
+  return (
+    <div className="pb-8">
+      <BreadCrumb items={items} />
+    </div>
   );
 }

--- a/front/components/vaults/VaultLayout.tsx
+++ b/front/components/vaults/VaultLayout.tsx
@@ -28,7 +28,7 @@ export interface VaultLayoutProps {
   vault: VaultType;
   category?: DataSourceViewCategory;
   dataSourceView?: DataSourceViewType;
-  parentId?: string | null;
+  parentId?: string;
 }
 
 export function VaultLayout({

--- a/front/components/vaults/VaultLayout.tsx
+++ b/front/components/vaults/VaultLayout.tsx
@@ -15,7 +15,10 @@ import { BreadCrumb } from "@app/components/vaults/Breadcrumb";
 import { CreateVaultModal } from "@app/components/vaults/CreateVaultModal";
 import { CATEGORY_DETAILS } from "@app/components/vaults/VaultCategoriesList";
 import VaultSideBarMenu from "@app/components/vaults/VaultSideBarMenu";
-import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
+import {
+  CONNECTOR_CONFIGURATIONS,
+  getConnectorProviderLogoWithFallback,
+} from "@app/lib/connector_providers";
 import { useDataSourceContentNodes } from "@app/lib/swr";
 
 export interface VaultLayoutProps {
@@ -24,7 +27,6 @@ export interface VaultLayoutProps {
   subscription: SubscriptionType;
   vault: VaultType;
   category?: DataSourceViewCategory;
-  dataSource?: DataSourceType;
   dataSourceView?: DataSourceViewType;
   parentId?: string | null;
 }
@@ -43,7 +45,6 @@ export function VaultLayout({
     subscription,
     vault,
     category,
-    dataSource,
     dataSourceView,
     parentId,
   } = pageProps;
@@ -65,7 +66,6 @@ export function VaultLayout({
           vault={vault}
           category={category}
           owner={owner}
-          dataSource={dataSource}
           dataSourceView={dataSourceView}
           parentId={parentId ?? undefined}
         />
@@ -124,20 +124,16 @@ function VaultBreadCrumbs({
       href: `/w/${owner.sId}/data-sources/vaults/${vault.sId}/categories/${category}`,
     },
   ];
-
   if (dataSourceView) {
     items.push({
-      icon: dataSourceView.connectorProvider ? (
-        React.createElement(
-          CONNECTOR_CONFIGURATIONS[dataSourceView.connectorProvider]
-            .logoComponent
-        )
-      ) : (
-        <FolderIcon className="text-brand" />
+      icon: getConnectorProviderLogoWithFallback(
+        dataSourceView.dataSource.connectorProvider,
+        FolderIcon
       ),
-      label: dataSourceView.connectorProvider
-        ? CONNECTOR_CONFIGURATIONS[dataSourceView.connectorProvider].name
-        : dataSourceView.name,
+      label: dataSourceView.dataSource.connectorProvider
+        ? CONNECTOR_CONFIGURATIONS[dataSourceView.dataSource.connectorProvider]
+            .name
+        : dataSourceView.dataSource.name,
       href: `/w/${owner.sId}/data-sources/vaults/${vault.sId}/categories/${category}/data_source_views/${dataSourceView.sId}`,
     });
 

--- a/front/components/vaults/VaultLayout.tsx
+++ b/front/components/vaults/VaultLayout.tsx
@@ -16,7 +16,6 @@ import { CreateVaultModal } from "@app/components/vaults/CreateVaultModal";
 import { CATEGORY_DETAILS } from "@app/components/vaults/VaultCategoriesList";
 import VaultSideBarMenu from "@app/components/vaults/VaultSideBarMenu";
 import {
-  CONNECTOR_CONFIGURATIONS,
   getConnectorProviderLogoWithFallback,
   getDataSourceNameFromView,
 } from "@app/lib/connector_providers";

--- a/front/components/vaults/VaultLayout.tsx
+++ b/front/components/vaults/VaultLayout.tsx
@@ -1,12 +1,12 @@
-import { FolderIcon, LockIcon, PlanetIcon } from "@dust-tt/sparkle";
+import { CompanyIcon, FolderIcon, LockIcon } from "@dust-tt/sparkle";
 import type {
-  DataSourceType,
   DataSourceViewCategory,
   DataSourceViewType,
   SubscriptionType,
   VaultType,
   WorkspaceType,
 } from "@dust-tt/types";
+import type { ComponentType } from "react";
 import React, { useState } from "react";
 
 import RootLayout from "@app/components/app/RootLayout";
@@ -18,6 +18,7 @@ import VaultSideBarMenu from "@app/components/vaults/VaultSideBarMenu";
 import {
   CONNECTOR_CONFIGURATIONS,
   getConnectorProviderLogoWithFallback,
+  getDataSourceNameFromView,
 } from "@app/lib/connector_providers";
 import { useDataSourceContentNodes } from "@app/lib/swr";
 
@@ -84,20 +85,18 @@ function VaultBreadCrumbs({
   owner,
   vault,
   category,
-  dataSource,
   dataSourceView,
   parentId,
 }: {
   owner: WorkspaceType;
   vault: VaultType;
   category?: DataSourceViewCategory;
-  dataSource?: DataSourceType;
   dataSourceView?: DataSourceViewType;
   parentId?: string;
 }) {
   const { nodes } = useDataSourceContentNodes({
     owner,
-    dataSource: dataSource,
+    dataSource: dataSourceView?.dataSource,
     internalIds: parentId ? [parentId] : [],
   });
 
@@ -107,14 +106,13 @@ function VaultBreadCrumbs({
     return null;
   }
 
-  const items: { label: string; [key: string]: any }[] = [
+  const items: {
+    label: string;
+    icon?: ComponentType;
+    href?: string;
+  }[] = [
     {
-      icon:
-        vault.kind === "global" ? (
-          <PlanetIcon className="text-brand" />
-        ) : (
-          <LockIcon className="text-brand" />
-        ),
+      icon: vault.kind === "global" ? CompanyIcon : LockIcon,
       label: vault.name,
       href: `/w/${owner.sId}/data-sources/vaults/${vault.sId}`,
     },
@@ -130,10 +128,7 @@ function VaultBreadCrumbs({
         dataSourceView.dataSource.connectorProvider,
         FolderIcon
       ),
-      label: dataSourceView.dataSource.connectorProvider
-        ? CONNECTOR_CONFIGURATIONS[dataSourceView.dataSource.connectorProvider]
-            .name
-        : dataSourceView.dataSource.name,
+      label: getDataSourceNameFromView(dataSourceView),
       href: `/w/${owner.sId}/data-sources/vaults/${vault.sId}/categories/${category}/data_source_views/${dataSourceView.sId}`,
     });
 
@@ -146,7 +141,7 @@ function VaultBreadCrumbs({
       }
       items.push({
         label: folderName,
-        icon: <FolderIcon className="text-brand" />,
+        icon: FolderIcon,
       });
     }
   }

--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -1,4 +1,4 @@
-import { Chip, DataTable, Searchbar, Spinner } from "@dust-tt/sparkle";
+import { Chip, DataTable, FolderIcon, Searchbar, Spinner } from "@dust-tt/sparkle";
 import type {
   ConnectorType,
   DataSourceViewCategory,
@@ -8,7 +8,6 @@ import type {
   WorkspaceType,
 } from "@dust-tt/types";
 import type { CellContext } from "@tanstack/react-table";
-import { FolderIcon } from "lucide-react";
 import type { ComponentType } from "react";
 import { useRef } from "react";
 import { useState } from "react";

--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -1,4 +1,10 @@
-import { Chip, DataTable, FolderIcon, Searchbar, Spinner } from "@dust-tt/sparkle";
+import {
+  Chip,
+  DataTable,
+  FolderIcon,
+  Searchbar,
+  Spinner,
+} from "@dust-tt/sparkle";
 import type {
   ConnectorType,
   DataSourceViewCategory,

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -15,8 +15,7 @@ import type {
   WhitelistableFeature,
 } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
-import type { LucideIcon } from "lucide-react";
-import type { SVGProps } from "react";
+import type { ComponentType } from "react";
 
 export const CONNECTOR_CONFIGURATIONS: Record<
   ConnectorProvider,
@@ -153,12 +152,19 @@ export function getDataSourceNameFromView(dsv: DataSourceViewType): string {
   return dsv.dataSource.name;
 }
 
-type LogoType = ((props: SVGProps<SVGSVGElement>) => JSX.Element) | LucideIcon;
+export function getConnectorProviderLogo(
+  provider: ConnectorProvider | null
+): ComponentType | null {
+  if (!provider) {
+    return null;
+  }
+  return CONNECTOR_CONFIGURATIONS[provider].logoComponent;
+}
 
 export function getConnectorProviderLogoWithFallback(
   provider: ConnectorProvider | null,
-  fallback: LogoType
-): LogoType {
+  fallback: ComponentType
+): ComponentType {
   if (!provider) {
     return fallback;
   }

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -152,15 +152,6 @@ export function getDataSourceNameFromView(dsv: DataSourceViewType): string {
   return dsv.dataSource.name;
 }
 
-export function getConnectorProviderLogo(
-  provider: ConnectorProvider | null
-): ComponentType | null {
-  if (!provider) {
-    return null;
-  }
-  return CONNECTOR_CONFIGURATIONS[provider].logoComponent;
-}
-
 export function getConnectorProviderLogoWithFallback(
   provider: ConnectorProvider | null,
   fallback: ComponentType

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -1401,7 +1401,7 @@ export function useVaultDataSourceViewContent({
   disabled?: boolean;
   filterPermission: ConnectorPermission;
   owner: LightWorkspaceType;
-  parentId: string | null;
+  parentId?: string;
   vaultId: string;
   viewType: ContentNodesViewType;
 }) {

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -443,16 +443,19 @@ export function useDataSourceContentNodes({
   internalIds,
 }: {
   owner: LightWorkspaceType;
-  dataSource: DataSourceType;
+  dataSource?: DataSourceType;
   internalIds: string[];
 }): {
   nodes: GetContentNodeResponseBody["nodes"];
   isNodesLoading: boolean;
   isNodesError: boolean;
 } {
-  const url = `/api/w/${owner.sId}/data_sources/${encodeURIComponent(
-    dataSource.name
-  )}/managed/content_nodes`;
+  const url =
+    dataSource && internalIds.length > 0
+      ? `/api/w/${owner.sId}/data_sources/${encodeURIComponent(
+          dataSource.name
+        )}/managed/content_nodes`
+      : null;
   const body = JSON.stringify({ internalIds });
 
   const fetchKey = useMemo(() => {
@@ -465,6 +468,9 @@ export function useDataSourceContentNodes({
       headers: { "Content-Type": "application/json" },
       body,
     };
+    if (!url) {
+      return null;
+    }
     return fetcher(url, options);
   });
 

--- a/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
+++ b/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
@@ -24,7 +24,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     dataSource: DataSourceType;
     dataSourceView: DataSourceViewType;
     isAdmin: boolean;
-    parentId: string | null;
+    parentId?: string;
     vault: VaultType;
   }
 >(async (context, auth) => {
@@ -54,7 +54,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     };
   }
   const isAdmin = auth.isAdmin();
-  const parentId = context.query?.parentId as string;
+  const parentId = context.query?.parentId as string | undefined;
 
   const dataSourceView = await DataSourceViewResource.fetchById(
     auth,
@@ -74,7 +74,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
       gaTrackingId: config.getGaTrackingId(),
       isAdmin,
       owner,
-      parentId: parentId || null,
+      parentId,
       subscription,
       vault: vault.toJSON(),
     },

--- a/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
+++ b/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
@@ -74,7 +74,8 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
       gaTrackingId: config.getGaTrackingId(),
       isAdmin,
       owner,
-      parentId,
+      // undefined is not allowed in the JSON response
+      ...(parentId && { parentId }),
       subscription,
       vault: vault.toJSON(),
     },

--- a/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
+++ b/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
@@ -1,4 +1,4 @@
-import { FolderIcon, LockIcon, Page, PlanetIcon } from "@dust-tt/sparkle";
+import { Page } from "@dust-tt/sparkle";
 import type {
   DataSourceType,
   DataSourceViewCategory,
@@ -10,13 +10,10 @@ import { useRouter } from "next/router";
 import type { ReactElement } from "react";
 import React from "react";
 
-import { BreadCrumb } from "@app/components/vaults/Breadcrumb";
-import { CATEGORY_DETAILS } from "@app/components/vaults/VaultCategoriesList";
 import { VaultDataSourceViewContentList } from "@app/components/vaults/VaultDataSourceViewContentList";
 import type { VaultLayoutProps } from "@app/components/vaults/VaultLayout";
 import { VaultLayout } from "@app/components/vaults/VaultLayout";
 import config from "@app/lib/api/config";
-import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { VaultResource } from "@app/lib/resources/vault_resource";
@@ -86,7 +83,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
 
 export default function Vault({
   category,
-  dataSource,
   dataSourceView,
   isAdmin,
   owner,
@@ -96,43 +92,6 @@ export default function Vault({
   const router = useRouter();
   return (
     <Page.Vertical gap="xl" align="stretch">
-      <BreadCrumb
-        items={[
-          {
-            icon:
-              vault.kind === "global" ? (
-                <PlanetIcon className="text-brand" />
-              ) : (
-                <LockIcon className="text-brand" />
-              ),
-            label: vault.name,
-            href: `/w/${owner.sId}/data-sources/vaults/${vault.sId}`,
-          },
-          {
-            icon: CATEGORY_DETAILS[category].icon,
-            label: CATEGORY_DETAILS.managed.label,
-            href: `/w/${owner.sId}/data-sources/vaults/${vault.sId}/categories/${category}`,
-          },
-          {
-            icon: dataSource.connectorProvider ? (
-              React.createElement(
-                CONNECTOR_CONFIGURATIONS[dataSource.connectorProvider]
-                  .logoComponent
-              )
-            ) : (
-              <FolderIcon className="text-brand" />
-            ),
-            label: dataSource.connectorProvider
-              ? CONNECTOR_CONFIGURATIONS[dataSource.connectorProvider].name
-              : dataSource.name,
-            href: `/w/${owner.sId}/data-sources/vaults/${vault.sId}/categories/${category}/data_source_views/${dataSourceView.sId}`,
-          },
-          {
-            label: "...",
-          },
-        ]}
-      />
-
       <VaultDataSourceViewContentList
         owner={owner}
         vault={vault}

--- a/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/data_sources/[dataSourceId].tsx
+++ b/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/data_sources/[dataSourceId].tsx
@@ -71,7 +71,8 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
       gaTrackingId: config.getGaTrackingId(),
       hasWritePermission,
       owner,
-      parentId,
+      // undefined is not allowed in the JSON response
+      ...(parentId && { parentId }),
       subscription,
       vault: vault.toJSON(),
       plan,

--- a/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/data_sources/[dataSourceId].tsx
+++ b/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/data_sources/[dataSourceId].tsx
@@ -1,4 +1,4 @@
-import { FolderIcon, LockIcon, Page, PlanetIcon } from "@dust-tt/sparkle";
+import { Page } from "@dust-tt/sparkle";
 import type {
   DataSourceType,
   DataSourceViewCategory,
@@ -9,13 +9,10 @@ import type { InferGetServerSidePropsType } from "next";
 import type { ReactElement } from "react";
 import React from "react";
 
-import { BreadCrumb } from "@app/components/vaults/Breadcrumb";
-import { CATEGORY_DETAILS } from "@app/components/vaults/VaultCategoriesList";
 import { VaultDataSourceContentList } from "@app/components/vaults/VaultDataSourceContentList";
 import type { VaultLayoutProps } from "@app/components/vaults/VaultLayout";
 import { VaultLayout } from "@app/components/vaults/VaultLayout";
 import config from "@app/lib/api/config";
-import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { VaultResource } from "@app/lib/resources/vault_resource";
@@ -83,48 +80,13 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
 });
 
 export default function Vault({
-  category,
   dataSource,
   hasWritePermission,
   owner,
-  vault,
   plan,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   return (
     <Page.Vertical gap="xl" align="stretch">
-      <BreadCrumb
-        items={[
-          {
-            icon:
-              vault.kind === "global" ? (
-                <PlanetIcon className="text-brand" />
-              ) : (
-                <LockIcon className="text-brand" />
-              ),
-            label: vault.name,
-            href: `/w/${owner.sId}/data-sources/vaults/${vault.sId}`,
-          },
-          {
-            label: CATEGORY_DETAILS[category].label,
-            icon: CATEGORY_DETAILS[category].icon,
-            href: `/w/${owner.sId}/data-sources/vaults/${vault.sId}/categories/${category}`,
-          },
-          {
-            icon: dataSource.connectorProvider ? (
-              React.createElement(
-                CONNECTOR_CONFIGURATIONS[dataSource.connectorProvider]
-                  .logoComponent
-              )
-            ) : (
-              <FolderIcon className="text-brand" />
-            ),
-            label: dataSource.connectorProvider
-              ? CONNECTOR_CONFIGURATIONS[dataSource.connectorProvider].name
-              : dataSource.name,
-            href: `/w/${owner.sId}/data-sources/vaults/${vault.sId}/categories/${category}/data_source/${dataSource.name}`,
-          },
-        ]}
-      />
       <VaultDataSourceContentList
         owner={owner}
         hasWritePermission={hasWritePermission}

--- a/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/data_sources/[dataSourceId].tsx
+++ b/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/data_sources/[dataSourceId].tsx
@@ -22,7 +22,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     category: DataSourceViewCategory;
     dataSource: DataSourceType;
     hasWritePermission: boolean;
-    parentId: string | null;
+    parentId?: string;
     vault: VaultType;
     plan: PlanType;
   }
@@ -62,7 +62,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
   }
   const hasWritePermission =
     auth.isBuilder() && auth.hasPermission([vault.acl()], "write");
-  const parentId = context.query?.parentId as string;
+  const parentId = context.query?.parentId as string | undefined;
 
   return {
     props: {
@@ -71,7 +71,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
       gaTrackingId: config.getGaTrackingId(),
       hasWritePermission,
       owner,
-      parentId: parentId || null,
+      parentId,
       subscription,
       vault: vault.toJSON(),
       plan,

--- a/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/index.tsx
+++ b/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/index.tsx
@@ -1,4 +1,4 @@
-import { LockIcon, Page, PlanetIcon } from "@dust-tt/sparkle";
+import { Page } from "@dust-tt/sparkle";
 import type {
   DataSourceViewCategory,
   PlanType,
@@ -8,8 +8,6 @@ import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import type { ReactElement } from "react";
 
-import { BreadCrumb } from "@app/components/vaults/Breadcrumb";
-import { CATEGORY_DETAILS } from "@app/components/vaults/VaultCategoriesList";
 import type { VaultLayoutProps } from "@app/components/vaults/VaultLayout";
 import { VaultLayout } from "@app/components/vaults/VaultLayout";
 import { VaultResourcesList } from "@app/components/vaults/VaultResourcesList";
@@ -73,25 +71,6 @@ export default function Vault({
   const router = useRouter();
   return (
     <Page.Vertical gap="xl" align="stretch">
-      <BreadCrumb
-        items={[
-          {
-            icon:
-              vault.kind === "global" ? (
-                <PlanetIcon className="text-brand" />
-              ) : (
-                <LockIcon className="text-brand" />
-              ),
-            label: vault.name,
-            href: `/w/${owner.sId}/data-sources/vaults/${vault.sId}`,
-          },
-          {
-            icon: CATEGORY_DETAILS[category].icon,
-            label: CATEGORY_DETAILS[category].label,
-          },
-        ]}
-      />
-
       <VaultResourcesList
         owner={owner}
         plan={plan}


### PR DESCRIPTION
Description
---
Fixes #6674
![image](https://github.com/user-attachments/assets/5d92eb15-e83e-4f94-b0ba-9869e0f7eaec)

- Refactor breadcrumbs & move them in a single place (VaultLayout)
- Fix them:
  - last item of breadcrumbs always visible
  - ellipsis appears in middle instead of end
  - clic on ellipsis goes up in the hierarchy
  - fixes mixed up category names & changed url paths

Risk
---
- call to useSWR in VaultLayout, likely harmless (null call when not in hierarchy, otherwise small call) => @reviewer do you agree?

Deploy
---
front
