### PR TITLE
Upg: allow to switch role in prod

### DIFF
--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -8,16 +8,14 @@ import {
   UserIcon,
 } from "@dust-tt/sparkle";
 import type { UserType, WorkspaceType } from "@dust-tt/types";
-import {
-  isDevelopment,
-  isOnlyAdmin,
-  isOnlyBuilder,
-  isOnlyUser,
-} from "@dust-tt/types";
+import { isOnlyAdmin, isOnlyBuilder, isOnlyUser } from "@dust-tt/types";
 import { useContext, useMemo } from "react";
 
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
-import { forceUserRole } from "@app/lib/development";
+import {
+  forceUserRole,
+  isDevelopmentOrDustWorkspace,
+} from "@app/lib/development";
 
 export function UserMenu({
   user,
@@ -83,7 +81,7 @@ export function UserMenu({
             )}
           </>
         )}
-        {isDevelopment() && (
+        {isDevelopmentOrDustWorkspace(owner) && (
           <>
             <DropdownMenu.SectionHeader label="Dev Tools" />
             {!isOnlyAdmin(owner) && (

--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -12,10 +12,7 @@ import { isOnlyAdmin, isOnlyBuilder, isOnlyUser } from "@dust-tt/types";
 import { useContext, useMemo } from "react";
 
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
-import {
-  forceUserRole,
-  isDevelopmentOrDustWorkspace,
-} from "@app/lib/development";
+import { canForceUserRole, forceUserRole } from "@app/lib/development";
 
 export function UserMenu({
   user,
@@ -81,7 +78,7 @@ export function UserMenu({
             )}
           </>
         )}
-        {isDevelopmentOrDustWorkspace(owner) && (
+        {canForceUserRole(owner) && (
           <>
             <DropdownMenu.SectionHeader label="Dev Tools" />
             {!isOnlyAdmin(owner) && (

--- a/front/lib/development.ts
+++ b/front/lib/development.ts
@@ -18,7 +18,7 @@ export async function forceUserRole(
   role: "user" | "builder" | "admin"
 ) {
   // Ideally we should check if the user is dust super user but we don't have this information in the front-end
-  if (!isDevelopment()) {
+  if (!isDevelopmentOrDustWorkspace(owner)) {
     return new Err("Not allowed");
   }
 

--- a/front/lib/development.ts
+++ b/front/lib/development.ts
@@ -4,12 +4,15 @@ import { Err, isDevelopment, Ok } from "@dust-tt/types";
 export const PRODUCTION_DUST_WORKSPACE_ID = "0ec9852c2f";
 const PRODUCTION_DUST_APPS_WORKSPACE_ID = "78bda07b39";
 
-export function isDevelopmentOrDustWorkspace(owner: LightWorkspaceType) {
+export function isADustProdWorkspace(owner: LightWorkspaceType) {
   return (
-    isDevelopment() ||
     owner.sId === PRODUCTION_DUST_WORKSPACE_ID ||
     owner.sId === PRODUCTION_DUST_APPS_WORKSPACE_ID
   );
+}
+
+export function canForceUserRole(owner: LightWorkspaceType) {
+  return isDevelopment() || isADustProdWorkspace(owner);
 }
 
 export async function forceUserRole(
@@ -18,7 +21,7 @@ export async function forceUserRole(
   role: "user" | "builder" | "admin"
 ) {
   // Ideally we should check if the user is dust super user but we don't have this information in the front-end
-  if (!isDevelopmentOrDustWorkspace(owner)) {
+  if (!canForceUserRole(owner)) {
     return new Err("Not allowed");
   }
 

--- a/front/pages/api/w/[wId]/members/[uId]/index.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/index.ts
@@ -8,7 +8,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { getUserForWorkspace } from "@app/lib/api/user";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { isDevelopmentOrDustWorkspace } from "@app/lib/development";
+import { canForceUserRole } from "@app/lib/development";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { apiError } from "@app/logger/withlogging";
 import { launchUpdateUsageWorkflow } from "@app/temporal/usage_queue/client";
@@ -27,7 +27,7 @@ async function handler(
   if (!auth.isAdmin()) {
     // Allow Dust Super User to force role for testing
     const allowForTesting =
-      isDevelopmentOrDustWorkspace(owner) &&
+      canForceUserRole(owner) &&
       auth.isDustSuperUser() &&
       req.body.force === "true";
 


### PR DESCRIPTION
## Description

Extends the ability to switch role to dust production workspaces as well as when in dev env.

## Risk

Same as previous [PR](https://github.com/dust-tt/dust/pull/6891).

## Deploy Plan

Deploy front.