### PR TITLE
New route to post a data source in a vault

### DIFF
--- a/front/components/vaults/VaultCreateFolderModal.tsx
+++ b/front/components/vaults/VaultCreateFolderModal.tsx
@@ -8,7 +8,6 @@ import {
 import type {
   APIError,
   DataSourceType,
-  DataSourceViewType,
   VaultType,
   WorkspaceType,
 } from "@dust-tt/types";
@@ -17,6 +16,7 @@ import { useRouter } from "next/router";
 import { useContext, useState } from "react";
 
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
+import type { PostVaultDataSourceResponseBody } from "@app/pages/api/w/[wId]/vaults/[vId]/data_sources";
 
 export default function VaultCreateFolderModal({
   isOpen,
@@ -84,9 +84,8 @@ export default function VaultCreateFolderModal({
         );
         if (res.ok) {
           setOpen(false);
-          const { dataSourceView } = (await res.json()) as {
-            dataSourceView: DataSourceViewType;
-          };
+          const response: PostVaultDataSourceResponseBody = await res.json();
+          const { dataSourceView } = response;
           await router.push(
             `/w/${owner.sId}/data-sources/vaults/${vault.sId}/categories/folder/data_source_views/${dataSourceView.sId}`
           );

--- a/front/components/vaults/VaultCreateFolderModal.tsx
+++ b/front/components/vaults/VaultCreateFolderModal.tsx
@@ -8,6 +8,7 @@ import {
 import type {
   APIError,
   DataSourceType,
+  DataSourceViewType,
   VaultType,
   WorkspaceType,
 } from "@dust-tt/types";
@@ -67,22 +68,27 @@ export default function VaultCreateFolderModal({
           return;
         }
 
-        const res = await fetch(`/api/w/${owner.sId}/data_sources`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            name,
-            description,
-            assistantDefaultSelected: false,
-            vaultId: vault.sId,
-          }),
-        });
+        const res = await fetch(
+          `/api/w/${owner.sId}/vaults/${vault.sId}/data_sources`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              name,
+              description,
+              assistantDefaultSelected: false,
+            }),
+          }
+        );
         if (res.ok) {
           setOpen(false);
+          const { dataSourceView } = (await res.json()) as {
+            dataSourceView: DataSourceViewType;
+          };
           await router.push(
-            `/w/${owner.sId}/data-sources/vaults/${vault.sId}/categories/files/data_sources/${name}`
+            `/w/${owner.sId}/data-sources/vaults/${vault.sId}/categories/folder/data_source_views/${dataSourceView.sId}`
           );
           sendNotification({
             type: "success",
@@ -109,7 +115,7 @@ export default function VaultCreateFolderModal({
             <Page.H>Name</Page.H>
             <div className="w-full">
               <Input
-                placeholder="Folder name"
+                placeholder="folder_name"
                 name="name"
                 value={name}
                 onChange={(value) => {

--- a/front/components/vaults/VaultCreateFolderModal.tsx
+++ b/front/components/vaults/VaultCreateFolderModal.tsx
@@ -16,7 +16,7 @@ import { useRouter } from "next/router";
 import { useContext, useState } from "react";
 
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
-import type { PostVaultDataSourceResponseBody } from "@app/pages/api/w/[wId]/vaults/[vId]/data_sources";
+import type { PostVaultDataSourceResponseBody } from "@app/pages/api/w/[wId]/vaults/[vId]/data_sources/static";
 
 export default function VaultCreateFolderModal({
   isOpen,
@@ -69,7 +69,7 @@ export default function VaultCreateFolderModal({
         }
 
         const res = await fetch(
-          `/api/w/${owner.sId}/vaults/${vault.sId}/data_sources`,
+          `/api/w/${owner.sId}/vaults/${vault.sId}/data_sources/static`,
           {
             method: "POST",
             headers: {

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -182,36 +182,28 @@ export const isConnectorProviderAllowedForPlan = (
   plan: PlanType,
   provider: ConnectorProvider
 ): boolean => {
-  let isDataSourceAllowedInPlan = false;
   switch (provider) {
     case "confluence":
-      isDataSourceAllowedInPlan = plan.limits.connections.isConfluenceAllowed;
-      break;
+      return plan.limits.connections.isConfluenceAllowed;
     case "slack":
-      isDataSourceAllowedInPlan = plan.limits.connections.isSlackAllowed;
-      break;
+      return plan.limits.connections.isSlackAllowed;
     case "notion":
-      isDataSourceAllowedInPlan = plan.limits.connections.isNotionAllowed;
+      return plan.limits.connections.isNotionAllowed;
       break;
     case "github":
-      isDataSourceAllowedInPlan = plan.limits.connections.isGithubAllowed;
-      break;
+      return plan.limits.connections.isGithubAllowed;
     case "google_drive":
-      isDataSourceAllowedInPlan = plan.limits.connections.isGoogleDriveAllowed;
-      break;
+      return plan.limits.connections.isGoogleDriveAllowed;
     case "intercom":
-      isDataSourceAllowedInPlan = plan.limits.connections.isIntercomAllowed;
+      return plan.limits.connections.isIntercomAllowed;
       break;
     case "microsoft":
-      isDataSourceAllowedInPlan = true;
-      break;
+      return true;
     case "webcrawler":
-      isDataSourceAllowedInPlan = plan.limits.connections.isWebCrawlerAllowed;
-      break;
+      return plan.limits.connections.isWebCrawlerAllowed;
     default:
       assertNever(provider);
   }
-  return isDataSourceAllowedInPlan;
 };
 
 export const isConnectorProviderAssistantDefaultSelected = (

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -11,8 +11,10 @@ import {
 import type {
   ConnectorProvider,
   DataSourceViewType,
+  PlanType,
   WhitelistableFeature,
 } from "@dust-tt/types";
+import { assertNever } from "@dust-tt/types";
 import type { LucideIcon } from "lucide-react";
 import type { SVGProps } from "react";
 
@@ -170,4 +172,83 @@ export function getConnectorProviderLogoWithFallback(
     return fallback;
   }
   return CONNECTOR_CONFIGURATIONS[provider].logoComponent;
+}
+
+export const isValidConnectorSuffix = (suffix: string): boolean => {
+  return /^[a-z0-9\-_]{1,16}$/.test(suffix);
+};
+
+export const isConnectorProviderAllowedForPlan = (
+  plan: PlanType,
+  provider: ConnectorProvider
+): boolean => {
+  let isDataSourceAllowedInPlan = false;
+  switch (provider) {
+    case "confluence":
+      isDataSourceAllowedInPlan = plan.limits.connections.isConfluenceAllowed;
+      break;
+    case "slack":
+      isDataSourceAllowedInPlan = plan.limits.connections.isSlackAllowed;
+      break;
+    case "notion":
+      isDataSourceAllowedInPlan = plan.limits.connections.isNotionAllowed;
+      break;
+    case "github":
+      isDataSourceAllowedInPlan = plan.limits.connections.isGithubAllowed;
+      break;
+    case "google_drive":
+      isDataSourceAllowedInPlan = plan.limits.connections.isGoogleDriveAllowed;
+      break;
+    case "intercom":
+      isDataSourceAllowedInPlan = plan.limits.connections.isIntercomAllowed;
+      break;
+    case "microsoft":
+      isDataSourceAllowedInPlan = true;
+      break;
+    case "webcrawler":
+      isDataSourceAllowedInPlan = plan.limits.connections.isWebCrawlerAllowed;
+      break;
+    default:
+      assertNever(provider);
+  }
+  return isDataSourceAllowedInPlan;
+};
+
+export const isConnectorProviderAssistantDefaultSelected = (
+  provider: ConnectorProvider
+): boolean => {
+  let assistantDefaultSelected = false;
+  switch (provider) {
+    case "confluence":
+    case "slack":
+    case "notion":
+    case "github":
+    case "google_drive":
+    case "intercom":
+    case "microsoft":
+      assistantDefaultSelected = true;
+      break;
+    case "webcrawler":
+      assistantDefaultSelected = false;
+      break;
+    default:
+      assertNever(provider);
+  }
+  return assistantDefaultSelected;
+};
+
+export function getDefaultDataSourceName(
+  provider: ConnectorProvider,
+  suffix: string | null
+): string {
+  return suffix ? `managed-${provider}-${suffix}` : `managed-${provider}`;
+}
+
+export function getDefaultDataSourceDescription(
+  provider: ConnectorProvider,
+  suffix: string | null
+): string {
+  return suffix
+    ? `Managed Data Source for ${provider} (${suffix})`
+    : `Managed Data Source for ${provider}`;
 }

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -189,14 +189,12 @@ export const isConnectorProviderAllowedForPlan = (
       return plan.limits.connections.isSlackAllowed;
     case "notion":
       return plan.limits.connections.isNotionAllowed;
-      break;
     case "github":
       return plan.limits.connections.isGithubAllowed;
     case "google_drive":
       return plan.limits.connections.isGoogleDriveAllowed;
     case "intercom":
       return plan.limits.connections.isIntercomAllowed;
-      break;
     case "microsoft":
       return true;
     case "webcrawler":
@@ -209,7 +207,6 @@ export const isConnectorProviderAllowedForPlan = (
 export const isConnectorProviderAssistantDefaultSelected = (
   provider: ConnectorProvider
 ): boolean => {
-  let assistantDefaultSelected = false;
   switch (provider) {
     case "confluence":
     case "slack":
@@ -218,15 +215,12 @@ export const isConnectorProviderAssistantDefaultSelected = (
     case "google_drive":
     case "intercom":
     case "microsoft":
-      assistantDefaultSelected = true;
-      break;
+      return true;
     case "webcrawler":
-      assistantDefaultSelected = false;
-      break;
+      return false;
     default:
       assertNever(provider);
   }
-  return assistantDefaultSelected;
 };
 
 export function getDefaultDataSourceName(

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -1,5 +1,6 @@
 import type { DataSourceType, WithAPIErrorResponse } from "@dust-tt/types";
 import {
+  DEFAULT_EMBEDDING_PROVIDER_ID,
   DEFAULT_QDRANT_CLUSTER,
   dustManagedCredentials,
   EMBEDDING_CONFIGS,
@@ -139,7 +140,8 @@ async function handler(
       // Dust managed credentials: all data sources.
       const credentials = dustManagedCredentials();
 
-      const dataSourceEmbedder = owner.defaultEmbeddingProvider ?? "openai";
+      const dataSourceEmbedder =
+        owner.defaultEmbeddingProvider ?? DEFAULT_EMBEDDING_PROVIDER_ID;
       const embedderConfig = EMBEDDING_CONFIGS[dataSourceEmbedder];
       const dustDataSource = await coreAPI.createDataSource({
         projectId: dustProject.value.project.project_id.toString(),

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/index.ts
@@ -1,0 +1,542 @@
+import type { DataSourceViewType, WithAPIErrorResponse } from "@dust-tt/types";
+import {
+  CONNECTOR_PROVIDERS,
+  ConnectorConfigurationTypeSchema,
+  ConnectorsAPI,
+  CoreAPI,
+  DEFAULT_QDRANT_CLUSTER,
+  dustManagedCredentials,
+  EMBEDDING_CONFIGS,
+  ioTsParsePayload,
+  isConnectorProvider,
+  isDataSourceNameValid,
+  sendUserOperationMessage,
+  WebCrawlerConfigurationTypeSchema,
+} from "@dust-tt/types";
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import config from "@app/lib/api/config";
+import { getDataSource, getDataSources } from "@app/lib/api/data_sources";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { getOrCreateSystemApiKey } from "@app/lib/auth";
+import {
+  getDefaultDataSourceDescription,
+  getDefaultDataSourceName,
+  isConnectorProviderAllowedForPlan,
+  isConnectorProviderAssistantDefaultSelected,
+  isValidConnectorSuffix,
+} from "@app/lib/connector_providers";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { VaultResource } from "@app/lib/resources/vault_resource";
+import { ServerSideTracking } from "@app/lib/tracking/server";
+import { isDisposableEmailDomain } from "@app/lib/utils/disposable_email_domains";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+
+// Sorcery: Create a union type with at least two elements to satisfy t.union
+const ConnectorProviderCodec = t.union([
+  t.literal(CONNECTOR_PROVIDERS[0]),
+  t.literal(CONNECTOR_PROVIDERS[1]),
+  ...CONNECTOR_PROVIDERS.slice(2).map((provider) => t.literal(provider)),
+]);
+
+const PostManagedDataSourceRequestBodySchema = t.type({
+  provider: ConnectorProviderCodec,
+  connectionId: t.union([t.string, t.undefined]),
+  configuration: ConnectorConfigurationTypeSchema,
+});
+
+const PostStaticDataSourceRequestBodySchema = t.type({
+  name: t.string,
+  description: t.string,
+  assistantDefaultSelected: t.boolean,
+});
+
+type PostVaultDataSourceResponseBody = {
+  dataSourceView: DataSourceViewType;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PostVaultDataSourceResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  const owner = auth.workspace();
+  const plan = auth.plan();
+  const user = auth.user();
+
+  if (!owner || !plan || !user) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace you requested was not found.",
+      },
+    });
+  }
+
+  const vault = await VaultResource.fetchById(auth, req.query.vId as string);
+
+  if (
+    !vault ||
+    (!auth.isAdmin() && !auth.hasPermission([vault.acl()], "write"))
+  ) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "vault_not_found",
+        message: "The vault you requested was not found.",
+      },
+    });
+  }
+
+  const dataSourceEmbedder = owner.defaultEmbeddingProvider ?? "openai";
+  const embedderConfig = EMBEDDING_CONFIGS[dataSourceEmbedder];
+  const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+
+  switch (req.method) {
+    case "POST": {
+      const isStaticDataSource = typeof req.body.provider !== "string";
+
+      /**
+       * Posting a static data source
+       * (folder)
+       */
+      if (isStaticDataSource) {
+        const bodyValidation = PostStaticDataSourceRequestBodySchema.decode(
+          req.body
+        );
+        if (isLeft(bodyValidation)) {
+          const pathError = reporter.formatValidationErrors(
+            bodyValidation.left
+          );
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: `Invalid request body to post a static data source: ${pathError}`,
+            },
+          });
+        }
+
+        const { name, description, assistantDefaultSelected } =
+          bodyValidation.right;
+
+        if (name.startsWith("managed-")) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: "The data source name cannot start with `managed-`.",
+            },
+          });
+        }
+        if (!isDataSourceNameValid(name)) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message:
+                "Data source names must only contain letters, numbers, and the characters `._-`, and cannot be empty.",
+            },
+          });
+        }
+        const dataSources = await getDataSources(auth);
+        if (
+          plan.limits.dataSources.count != -1 &&
+          dataSources.length >= plan.limits.dataSources.count
+        ) {
+          return apiError(req, res, {
+            status_code: 401,
+            api_error: {
+              type: "plan_limit_error",
+              message:
+                "Your plan does not allow you to create managed data sources.",
+            },
+          });
+        }
+
+        const dustProject = await coreAPI.createProject();
+        if (dustProject.isErr()) {
+          return apiError(req, res, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: `Failed to create internal project for the data source.`,
+              data_source_error: dustProject.error,
+            },
+          });
+        }
+
+        const dustDataSource = await coreAPI.createDataSource({
+          projectId: dustProject.value.project.project_id.toString(),
+          dataSourceId: name,
+          config: {
+            qdrant_config: {
+              cluster: DEFAULT_QDRANT_CLUSTER,
+              shadow_write_cluster: null,
+            },
+            embedder_config: {
+              embedder: {
+                max_chunk_size: embedderConfig.max_chunk_size,
+                model_id: embedderConfig.model_id,
+                provider_id: embedderConfig.provider_id,
+                splitter_id: embedderConfig.splitter_id,
+              },
+            },
+          },
+          credentials: dustManagedCredentials(),
+        });
+
+        if (dustDataSource.isErr()) {
+          return apiError(req, res, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: "Failed to create the data source.",
+              data_source_error: dustDataSource.error,
+            },
+          });
+        }
+
+        const dataSource = await DataSourceResource.makeNew(
+          {
+            name,
+            description,
+            dustAPIProjectId: dustProject.value.project.project_id.toString(),
+            workspaceId: owner.id,
+            assistantDefaultSelected,
+            editedByUserId: user.id,
+          },
+          vault
+        );
+
+        const dataSourceView =
+          await DataSourceViewResource.createViewInVaultFromDataSourceIncludingAllDocuments(
+            dataSource.vault,
+            dataSource
+          );
+
+        const dataSourceType = await getDataSource(auth, dataSource.name);
+        if (dataSourceType) {
+          void ServerSideTracking.trackDataSourceCreated({
+            user,
+            workspace: owner,
+            dataSource: dataSourceType,
+          });
+        }
+
+        return res.status(201).json({
+          dataSourceView: dataSourceView.toJSON(),
+        });
+      }
+
+      /**
+       * Posting a managed data source
+       * (all providers including webcrawler)
+       */
+      const bodyValidation = PostManagedDataSourceRequestBodySchema.decode(
+        req.body
+      );
+      if (isLeft(bodyValidation)) {
+        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body to post a static data source: ${pathError}`,
+          },
+        });
+      }
+
+      const { connectionId, provider } = bodyValidation.right;
+
+      // Checking that the provider is allowed for the workspace plan
+      const isDataSourceAllowedInPlan = isConnectorProviderAllowedForPlan(
+        plan,
+        provider
+      );
+      if (!isDataSourceAllowedInPlan) {
+        return apiError(req, res, {
+          status_code: 401,
+          api_error: {
+            type: "plan_limit_error",
+            message:
+              "Your plan does not allow you to create managed data sources.",
+          },
+        });
+      }
+
+      // Checking that the vault type is correct for the type of data source being posted:
+      // - System vaults only allow managed data sources (provider is set and not webcrawler)
+      // - Regular vaults only allow folder or website data sources
+      // - Global vaults do not allow data sources to be posted
+      const isFolder = !!provider;
+      const isWebsite =
+        isConnectorProvider(provider) && provider === "webcrawler";
+      const isManaged =
+        isConnectorProvider(provider) && provider !== "webcrawler";
+      if (vault.isGlobal()) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message: "Cannot administrate global vaults.",
+          },
+        });
+      } else if (vault.isSystem()) {
+        if (!isManaged) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: `Cannot post a datasource for provider: ${provider} in system vault.`,
+            },
+          });
+        }
+      } else {
+        if (!isFolder && !isWebsite) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: `Cannot post a datasource for provider: ${provider} in regular vault.`,
+            },
+          });
+        }
+      }
+
+      // Computing data source name, description & configuration.
+      // The suffix is optionnal and used manually to allow multiple data sources of the same provider.
+      // Search for "setupWithSuffixConnector" in the codebase.
+      const suffix =
+        typeof req.query?.suffix === "string" ? req.query.suffix : null;
+      if (suffix && !isValidConnectorSuffix(suffix)) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Invalid suffix.",
+          },
+        });
+      }
+      const dataSourceName = getDefaultDataSourceName(provider, suffix);
+      let dataSourceDescription = getDefaultDataSourceDescription(
+        provider,
+        suffix
+      );
+
+      let { configuration } = bodyValidation.right;
+      if (provider === "slack") {
+        configuration = {
+          botEnabled: true,
+          whitelistedDomains: undefined,
+          autoReadChannelPattern: undefined,
+        };
+      }
+
+      if (provider === "webcrawler") {
+        const configurationRes = ioTsParsePayload(
+          configuration,
+          WebCrawlerConfigurationTypeSchema
+        );
+        if (configurationRes.isErr()) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message:
+                "Invalid configuration: " + configurationRes.error.join(", "),
+            },
+          });
+        }
+        dataSourceDescription = configurationRes.value.url;
+      }
+
+      // Creating the datasource
+      const systemAPIKeyRes = await getOrCreateSystemApiKey(owner);
+      if (systemAPIKeyRes.isErr()) {
+        logger.error(
+          {
+            error: systemAPIKeyRes.error,
+          },
+          "Could not create the system API key"
+        );
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message:
+              "Could not create a system API key for the managed data source.",
+          },
+        });
+      }
+
+      const dustProject = await coreAPI.createProject();
+      if (dustProject.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to create internal project for the data source.`,
+            data_source_error: dustProject.error,
+          },
+        });
+      }
+
+      const dustDataSource = await coreAPI.createDataSource({
+        projectId: dustProject.value.project.project_id.toString(),
+        dataSourceId: dataSourceName,
+        config: {
+          embedder_config: {
+            embedder: {
+              max_chunk_size: embedderConfig.max_chunk_size,
+              model_id: embedderConfig.model_id,
+              provider_id: embedderConfig.provider_id,
+              splitter_id: embedderConfig.splitter_id,
+            },
+          },
+          qdrant_config: {
+            cluster: DEFAULT_QDRANT_CLUSTER,
+            shadow_write_cluster: null,
+          },
+        },
+        credentials: dustManagedCredentials(),
+      });
+
+      if (dustDataSource.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to create the data source.",
+            data_source_error: dustDataSource.error,
+          },
+        });
+      }
+
+      const dataSource = await DataSourceResource.makeNew(
+        {
+          assistantDefaultSelected:
+            isConnectorProviderAssistantDefaultSelected(provider),
+          connectorProvider: provider,
+          description: dataSourceDescription,
+          dustAPIProjectId: dustProject.value.project.project_id.toString(),
+          editedByUserId: user.id,
+          name: dataSourceName,
+          workspaceId: owner.id,
+        },
+        vault
+      );
+
+      // For each data source, we create two views:
+      // - One default view in its associated vault
+      // - If the data source resides in the system vault, we also create a custom view in the global vault until vault are released.
+      if (dataSource.vault.isSystem()) {
+        const globalVault = await VaultResource.fetchWorkspaceGlobalVault(auth);
+
+        await DataSourceViewResource.createViewInVaultFromDataSourceIncludingAllDocuments(
+          globalVault,
+          dataSource,
+          "custom"
+        );
+      }
+
+      const dataSourceView =
+        await DataSourceViewResource.createViewInVaultFromDataSourceIncludingAllDocuments(
+          dataSource.vault,
+          dataSource
+        );
+
+      const connectorsAPI = new ConnectorsAPI(
+        config.getConnectorsAPIConfig(),
+        logger
+      );
+
+      const connectorsRes = await connectorsAPI.createConnector(
+        provider,
+        owner.sId,
+        systemAPIKeyRes.value.secret,
+        dataSourceName,
+        connectionId || "none",
+        configuration
+      );
+
+      if (connectorsRes.isErr()) {
+        logger.error(
+          {
+            error: connectorsRes.error,
+          },
+          "Failed to create the connector"
+        );
+        await dataSource.delete(auth);
+        const deleteRes = await coreAPI.deleteDataSource({
+          projectId: dustProject.value.project.project_id.toString(),
+          dataSourceName: dustDataSource.value.data_source.data_source_id,
+        });
+        if (deleteRes.isErr()) {
+          logger.error(
+            {
+              error: deleteRes.error,
+            },
+            "Failed to delete the data source"
+          );
+        }
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to create the connector.",
+            connectors_error: connectorsRes.error,
+          },
+        });
+      }
+      const email = auth.user()?.email;
+      if (email && !isDisposableEmailDomain(email)) {
+        void sendUserOperationMessage({
+          logger,
+          message: `${email} \`${dataSource.name}\`  for workspace \`${
+            owner.name
+          }\` sId: \`${owner.sId}\` connectorId: \`${
+            connectorsRes.value.id
+          }\` provider: \`${provider}\` trialing: \`${
+            auth.subscription()?.trialing ? "true" : "false"
+          }\``,
+        });
+      }
+
+      await dataSource.update({
+        connectorId: connectorsRes.value.id,
+      });
+      const dataSourceType = await getDataSource(auth, dataSource.name);
+      if (dataSourceType) {
+        void ServerSideTracking.trackDataSourceCreated({
+          dataSource: dataSourceType,
+          user,
+          workspace: owner,
+        });
+      }
+
+      return res.status(201).json({
+        dataSourceView: dataSourceView.toJSON(),
+      });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message:
+            "The method passed is not supported, GET or POST is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/static.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/static.ts
@@ -1,0 +1,228 @@
+import type {
+  DataSourceType,
+  DataSourceViewType,
+  WithAPIErrorResponse,
+} from "@dust-tt/types";
+import {
+  CoreAPI,
+  DEFAULT_EMBEDDING_PROVIDER_ID,
+  DEFAULT_QDRANT_CLUSTER,
+  dustManagedCredentials,
+  EMBEDDING_CONFIGS,
+  isDataSourceNameValid,
+} from "@dust-tt/types";
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import config from "@app/lib/api/config";
+import { getDataSource } from "@app/lib/api/data_sources";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { VaultResource } from "@app/lib/resources/vault_resource";
+import { ServerSideTracking } from "@app/lib/tracking/server";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+
+const PostStaticDataSourceRequestBodySchema = t.type({
+  name: t.string,
+  description: t.string,
+  assistantDefaultSelected: t.boolean,
+});
+
+export type PostVaultDataSourceResponseBody = {
+  dataSource: DataSourceType;
+  dataSourceView: DataSourceViewType;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PostVaultDataSourceResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  const owner = auth.workspace();
+  const plan = auth.plan();
+  const user = auth.user();
+
+  if (!owner || !plan || !user) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace you requested was not found.",
+      },
+    });
+  }
+
+  const vault = await VaultResource.fetchById(auth, req.query.vId as string);
+
+  if (!vault || !auth.hasPermission([vault.acl()], "write")) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "vault_not_found",
+        message: "The vault you requested was not found.",
+      },
+    });
+  }
+
+  if (vault.isSystem()) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Cannot post a static datasource in a system vault.`,
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST": {
+      const bodyValidation = PostStaticDataSourceRequestBodySchema.decode(
+        req.body
+      );
+      if (isLeft(bodyValidation)) {
+        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body to post a static data source: ${pathError}`,
+          },
+        });
+      }
+
+      const { name, description, assistantDefaultSelected } =
+        bodyValidation.right;
+
+      if (name.startsWith("managed-")) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "The data source name cannot start with `managed-`.",
+          },
+        });
+      }
+      if (!isDataSourceNameValid(name)) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "Data source names must only contain letters, numbers, and the characters `._-`, and cannot be empty.",
+          },
+        });
+      }
+      const dataSources = await DataSourceResource.listByWorkspace(auth);
+      if (
+        plan.limits.dataSources.count != -1 &&
+        dataSources.length >= plan.limits.dataSources.count
+      ) {
+        return apiError(req, res, {
+          status_code: 401,
+          api_error: {
+            type: "plan_limit_error",
+            message:
+              "Your plan does not allow you to create managed data sources.",
+          },
+        });
+      }
+
+      const dataSourceEmbedder =
+        owner.defaultEmbeddingProvider ?? DEFAULT_EMBEDDING_PROVIDER_ID;
+      const embedderConfig = EMBEDDING_CONFIGS[dataSourceEmbedder];
+      const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+
+      const dustProject = await coreAPI.createProject();
+      if (dustProject.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to create internal project for the data source.`,
+            data_source_error: dustProject.error,
+          },
+        });
+      }
+
+      const dustDataSource = await coreAPI.createDataSource({
+        projectId: dustProject.value.project.project_id.toString(),
+        dataSourceId: name,
+        config: {
+          qdrant_config: {
+            cluster: DEFAULT_QDRANT_CLUSTER,
+            shadow_write_cluster: null,
+          },
+          embedder_config: {
+            embedder: {
+              max_chunk_size: embedderConfig.max_chunk_size,
+              model_id: embedderConfig.model_id,
+              provider_id: embedderConfig.provider_id,
+              splitter_id: embedderConfig.splitter_id,
+            },
+          },
+        },
+        credentials: dustManagedCredentials(),
+      });
+
+      if (dustDataSource.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to create the data source.",
+            data_source_error: dustDataSource.error,
+          },
+        });
+      }
+
+      const dataSource = await DataSourceResource.makeNew(
+        {
+          name,
+          description,
+          dustAPIProjectId: dustProject.value.project.project_id.toString(),
+          workspaceId: owner.id,
+          assistantDefaultSelected,
+          editedByUserId: user.id,
+        },
+        vault
+      );
+
+      const dataSourceView =
+        await DataSourceViewResource.createViewInVaultFromDataSourceIncludingAllDocuments(
+          dataSource.vault,
+          dataSource
+        );
+
+      const dataSourceType = await getDataSource(auth, dataSource.name);
+      if (dataSourceType) {
+        void ServerSideTracking.trackDataSourceCreated({
+          user,
+          workspace: owner,
+          dataSource: dataSourceType,
+        });
+      }
+
+      return res.status(201).json({
+        dataSource: dataSource.toJSON(),
+        dataSourceView: dataSourceView.toJSON(),
+      });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message:
+            "The method passed is not supported, GET or POST is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/types/src/front/data_source.ts
+++ b/types/src/front/data_source.ts
@@ -32,8 +32,6 @@ export const CONNECTOR_TYPE_TO_MISMATCH_ERROR: Record<
   webcrawler: "You cannot change the URL. Please add a new Public URL instead.",
 };
 
-export const DEFAULT_EMBEDDING_PROVIDER_ID = "openai";
-
 export type ConnectorProvider = (typeof CONNECTOR_PROVIDERS)[number];
 
 export type LabsConnectorProvider = "google_drive" | "gong";

--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -15,7 +15,7 @@ export const MODEL_PROVIDER_IDS = [
 ] as const;
 export type ModelProviderIdType = (typeof MODEL_PROVIDER_IDS)[number];
 
-export const DEFAULT_EMBEDDING_PROVIDER_ID = "openai" as const;
+export const DEFAULT_EMBEDDING_PROVIDER_ID = "openai";
 export const EMBEDDING_PROVIDER_IDS = [
   DEFAULT_EMBEDDING_PROVIDER_ID,
   "mistral",

--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -15,7 +15,11 @@ export const MODEL_PROVIDER_IDS = [
 ] as const;
 export type ModelProviderIdType = (typeof MODEL_PROVIDER_IDS)[number];
 
-export const EMBEDDING_PROVIDER_IDS = ["openai", "mistral"] as const;
+export const DEFAULT_EMBEDDING_PROVIDER_ID = "openai" as const;
+export const EMBEDDING_PROVIDER_IDS = [
+  DEFAULT_EMBEDDING_PROVIDER_ID,
+  "mistral",
+] as const;
 export type EmbeddingProviderIdType = (typeof EMBEDDING_PROVIDER_IDS)[number];
 
 export const isModelProviderId = (


### PR DESCRIPTION
## Description

~New route `/api/w/${owner.sId}/vaults/${vault.sId}/data_sources` to post a datasource in a vault.~

New routes to post a datasource in a vault: 
- `/api/w/${owner.sId}/vaults/${vault.sId}/data_sources/static`   
- `/api/w/${owner.sId}/vaults/${vault.sId}/data_sources/managed`


Works for managed & static datasource -> uses the presence of "provider" in the body to process one type of the other. 

On this PR, I'm using this new route on the modal to create a folder in a vault. 

## Risk

Should not be dangerous since it's a new route and I did not touch the existing ones. 
Can be rolled back. 

## Deploy Plan

Deploy front. 
