### PR TITLE
Fix datasource selection when cancel

### DIFF
--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -239,6 +239,7 @@ export default function AssistantBuilderDataSourceModal({
         if (displayMode === "PickKind") {
           setOpen(false);
         } else {
+          setDataSourceConfigurations(initialDataSourceConfigurations);
           setDisplayMode("PickKind");
         }
       }}

--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -236,9 +236,12 @@ export default function AssistantBuilderDataSourceModal({
     <Modal
       isOpen={isOpen}
       onClose={() => {
+        // If we are in the PickKind mode, we close the modal, otherwise we go back to the PickKind mode
         if (displayMode === "PickKind") {
           setOpen(false);
-        } else {
+        }
+        // We are one of the selection modes, we didn't save so we cancel the changes and go back to the PickKind mode
+        else {
           setDataSourceConfigurations(initialDataSourceConfigurations);
           setDisplayMode("PickKind");
         }


### PR DESCRIPTION
## Description

In the assistant builder, when you cancelled, the selection was kept.

## Risk

None

## Deploy Plan

Deploy `front`