### PR TITLE
[sparkle] fix: Fix table column types

### DIFF
--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.209",
+  "version": "0.2.210",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -27,9 +27,9 @@ interface ColumnBreakpoint {
   [columnId: string]: "xs" | "sm" | "md" | "lg" | "xl";
 }
 
-interface DataTableProps<TData extends TBaseData, TValue> {
+interface DataTableProps<TData extends TBaseData> {
   data: TData[];
-  columns: ColumnDef<TData, TValue>[];
+  columns: ColumnDef<TData, string & number>[];
   className?: string;
   filter?: string;
   filterColumn?: string;
@@ -47,7 +47,7 @@ function shouldRenderColumn(
   return windowWidth >= breakpoints[breakpoint];
 }
 
-export function DataTable<TData extends TBaseData, TValue>({
+export function DataTable<TData extends TBaseData>({
   data,
   columns,
   className,
@@ -55,7 +55,7 @@ export function DataTable<TData extends TBaseData, TValue>({
   filterColumn,
   initialColumnOrder,
   columnsBreakpoints = {},
-}: DataTableProps<TData, TValue>) {
+}: DataTableProps<TData>) {
   const windowSize = useWindowSize();
   const [sorting, setSorting] = useState<SortingState>(
     initialColumnOrder ?? []


### PR DESCRIPTION
## Description

The `TValue` type of a column def is the value type of all cells of a column. In the current code we force a single type in the table that must be used for all columns (usually string), by binding it to a type param of the table itself. The `TValue` must be kept free for each column. 
Note that tan-stack use `ColumnDef<TData, any>` when calling `useTable()`, which might be a little too permissive - in our cases we usually have string or number as column values.

## Risk

none

## Deploy Plan

deploy `sparkle`