### PR TITLE
Replace X-Dust-User-Id by X-Dust-Group-Ids

### DIFF
--- a/front/lib/actions/helpers.ts
+++ b/front/lib/actions/helpers.ts
@@ -1,9 +1,4 @@
-import type {
-  Action,
-  DustAPIResponse,
-  UserType,
-  WorkspaceType,
-} from "@dust-tt/types";
+import type { Action, DustAPIResponse, WorkspaceType } from "@dust-tt/types";
 import type { DustAppConfigType } from "@dust-tt/types";
 import { cloneBaseConfig } from "@dust-tt/types";
 import { DustAPI } from "@dust-tt/types";
@@ -22,7 +17,6 @@ import logger from "@app/logger/logger";
 
 interface CallActionParams<V extends t.Mixed> {
   owner: WorkspaceType;
-  user: UserType | null;
   input: { [key: string]: unknown };
   action: Action;
   config: DustAppConfigType;
@@ -47,7 +41,6 @@ interface CallActionParams<V extends t.Mixed> {
  */
 export async function callAction<V extends t.Mixed>({
   owner,
-  user,
   input,
   action,
   config,
@@ -65,7 +58,8 @@ export async function callAction<V extends t.Mixed>({
     logger
   );
 
-  const r = await prodAPI.runApp(user, app, config, [input]);
+  // The doc tracker apps are running without any group privileges for now.
+  const r = await prodAPI.runApp([], app, config, [input]);
 
   if (r.isErr()) {
     return r;

--- a/front/lib/actions/server.ts
+++ b/front/lib/actions/server.ts
@@ -92,7 +92,12 @@ export async function runActionStreamed(
     logger
   );
 
-  const res = await api.runAppStreamed(auth.user(), action.app, config, inputs);
+  const res = await api.runAppStreamed(
+    auth.groups(),
+    action.app,
+    config,
+    inputs
+  );
   if (res.isErr()) {
     logActionError(loggerArgs, tags, "run_error", { error: res.error });
     return new Err(res.error);
@@ -204,7 +209,7 @@ export async function runAction(
     logger
   );
 
-  const res = await api.runApp(auth.user(), action.app, config, inputs);
+  const res = await api.runApp(auth.groups(), action.app, config, inputs);
   if (res.isErr()) {
     logActionError(loggerArgs, tags, "run_error", { error: res.error });
     return new Err(res.error);

--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -315,7 +315,7 @@ export class DustAppRunConfigurationServerRunner extends BaseActionConfiguration
     // As we run the app (using a system API key here), we do force using the workspace credentials so
     // that the app executes in the exact same conditions in which they were developed.
     const runRes = await api.runAppStreamed(
-      auth.user(),
+      auth.groups(),
       {
         workspaceId: actionConfiguration.appWorkspaceId,
         appId: actionConfiguration.appId,

--- a/front/lib/documents_post_process_hooks/hooks/document_tracker/suggest_changes/actions/doc_tracker_retrieval.ts
+++ b/front/lib/documents_post_process_hooks/hooks/document_tracker/suggest_changes/actions/doc_tracker_retrieval.ts
@@ -25,7 +25,6 @@ export async function callDocTrackerRetrievalAction(
     input: { input_text: inputText },
     owner,
     responseValueSchema: DocTrackerRetrievalActionValueSchema,
-    user: null,
   });
 
   if (res.isErr()) {

--- a/front/lib/documents_post_process_hooks/hooks/document_tracker/suggest_changes/actions/doc_tracker_suggest_changes.ts
+++ b/front/lib/documents_post_process_hooks/hooks/document_tracker/suggest_changes/actions/doc_tracker_suggest_changes.ts
@@ -34,7 +34,6 @@ export async function callDocTrackerSuggestChangesAction(
     input: { source_document: sourceDocument, target_document: targetDocument },
     owner,
     responseValueSchema: DocTrackerSuggestChangesActionValueSchema,
-    user: null,
   });
 
   if (res.isErr()) {

--- a/types/src/front/lib/dust_api.ts
+++ b/types/src/front/lib/dust_api.ts
@@ -20,7 +20,7 @@ import { WhitelistableFeature } from "../../shared/feature_flags";
 import { LoggerInterface } from "../../shared/logger";
 import { Err, Ok, Result } from "../../shared/result";
 import { ContentFragmentType } from "../content_fragment";
-import { UserType } from "../user";
+import { GroupType } from "../groups";
 import {
   AgentActionSuccessEvent,
   AgentErrorEvent,
@@ -139,8 +139,7 @@ export type DustAPICredentials = {
   workspaceId: string;
 };
 
-export const DustUserIdHeader = "x-dust-user-id";
-export const DustGroupIdsHeader = "x-dust-group-ids";
+export const DustGroupIdsHeader = "X-Dust-Group-Ids";
 
 type PublicPostContentFragmentRequestBody = t.TypeOf<
   typeof PublicPostContentFragmentRequestBodySchema
@@ -361,7 +360,7 @@ export class DustAPI {
    * @param inputs any[] the app inputs
    */
   async runApp(
-    user: UserType | null,
+    groups: GroupType[],
     app: DustAppType,
     config: DustAppConfigType,
     inputs: unknown[],
@@ -380,8 +379,8 @@ export class DustAPI {
       "Content-Type": "application/json",
       Authorization: `Bearer ${this._credentials.apiKey}`,
     };
-    if (user) {
-      headers[DustUserIdHeader] = user.sId;
+    if (groups.length > 0) {
+      headers[DustGroupIdsHeader] = groups.map((g) => g.sId).join(",");
     }
 
     const res = await this._fetchWithError(url, {
@@ -413,7 +412,7 @@ export class DustAPI {
    * @param inputs any[] the app inputs
    */
   async runAppStreamed(
-    user: UserType | null,
+    groups: GroupType[],
     app: DustAppType,
     config: DustAppConfigType,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -433,8 +432,8 @@ export class DustAPI {
       "Content-Type": "application/json",
       Authorization: `Bearer ${this._credentials.apiKey}`,
     };
-    if (user) {
-      headers[DustUserIdHeader] = user.sId;
+    if (groups) {
+      headers[DustGroupIdsHeader] = groups.map((g) => g.sId).join(",");
     }
 
     const res = await this._fetchWithError(url, {


### PR DESCRIPTION
## Description

Replace the `X-Dust-User-Id` header by the `X-Dust-Group-Ids` header.

We now honor the `X-Dust-Group-Ids` header and remove support for the `X-Dust-User-Id` header.

Part of https://github.com/dust-tt/dust/issues/6664

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
