### PR TITLE
Add auth.isUser to vaults endpoints + nits

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -605,6 +605,18 @@ export class Authenticator {
     return this._subscription ? this._subscription.plan : null;
   }
 
+  getNonNullablePlan(): PlanType {
+    const plan = this.plan();
+
+    if (!plan) {
+      throw new Error(
+        "Unexpected unauthenticated call to `getNonNullablePlan`."
+      );
+    }
+
+    return plan;
+  }
+
   isUpgraded(): boolean {
     return isUpgraded(this.plan());
   }

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/content.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/content.ts
@@ -18,13 +18,13 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  const owner = auth.workspace();
-  if (!owner) {
+  if (!auth.isUser()) {
     return apiError(req, res, {
-      status_code: 404,
+      status_code: 403,
       api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you requested was not found.",
+        type: "workspace_auth_error",
+        message:
+          "Only users of the current workspace can interact with vaults.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/documents/[documentId]/index.ts
@@ -28,16 +28,20 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  const plan = auth.plan();
+  if (!auth.isUser()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users of the current workspace can interact with vaults.",
+      },
+    });
+  }
 
   const { dsvId, documentId } = req.query;
 
-  if (
-    !plan ||
-    !auth.isUser() ||
-    typeof dsvId !== "string" ||
-    typeof documentId !== "string"
-  ) {
+  if (typeof dsvId !== "string" || typeof documentId !== "string") {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.ts
@@ -18,13 +18,13 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<GetDataSourceViewResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
-  const owner = auth.workspace();
-  if (!owner) {
+  if (!auth.isUser()) {
     return apiError(req, res, {
-      status_code: 404,
+      status_code: 403,
       api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you requested was not found.",
+        type: "workspace_auth_error",
+        message:
+          "Only users of the current workspace can interact with vaults.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/index.ts
@@ -28,13 +28,13 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  const owner = auth.workspace();
-  if (!owner) {
+  if (!auth.isUser()) {
     return apiError(req, res, {
-      status_code: 404,
+      status_code: 403,
       api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you requested was not found.",
+        type: "workspace_auth_error",
+        message:
+          "Only users of the current workspace can interact with vaults.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/managed.ts
@@ -59,19 +59,20 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<PostVaultDataSourceResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
-  const owner = auth.workspace();
-  const plan = auth.plan();
-  const user = auth.user();
-
-  if (!owner || !plan || !user) {
+  if (!auth.isUser()) {
     return apiError(req, res, {
-      status_code: 404,
+      status_code: 403,
       api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you requested was not found.",
+        type: "workspace_auth_error",
+        message:
+          "Only users of the current workspace can interact with vaults.",
       },
     });
   }
+
+  const owner = auth.getNonNullableWorkspace();
+  const plan = auth.getNonNullablePlan();
+  const user = auth.getNonNullableUser();
 
   const vault = await VaultResource.fetchById(auth, req.query.vId as string);
 

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/static.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/static.ts
@@ -43,19 +43,20 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<PostVaultDataSourceResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
-  const owner = auth.workspace();
-  const plan = auth.plan();
-  const user = auth.user();
-
-  if (!owner || !plan || !user) {
+  if (!auth.isUser()) {
     return apiError(req, res, {
-      status_code: 404,
+      status_code: 403,
       api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you requested was not found.",
+        type: "workspace_auth_error",
+        message:
+          "Only users of the current workspace can interact with vaults.",
       },
     });
   }
+
+  const owner = auth.getNonNullableWorkspace();
+  const plan = auth.getNonNullablePlan();
+  const user = auth.getNonNullableUser();
 
   const vault = await VaultResource.fetchById(auth, req.query.vId as string);
 

--- a/front/pages/api/w/[wId]/vaults/[vId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/index.ts
@@ -37,13 +37,13 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  const owner = auth.workspace();
-  if (!owner) {
+  if (!auth.isUser()) {
     return apiError(req, res, {
-      status_code: 404,
+      status_code: 403,
       api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you requested was not found.",
+        type: "workspace_auth_error",
+        message:
+          "Only users of the current workspace can interact with vaults.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/vaults/index.ts
+++ b/front/pages/api/w/[wId]/vaults/index.ts
@@ -27,16 +27,18 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  const owner = auth.workspace();
-  if (!owner) {
+  if (!auth.isUser()) {
     return apiError(req, res, {
-      status_code: 404,
+      status_code: 403,
       api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you requested was not found.",
+        type: "workspace_auth_error",
+        message:
+          "Only users of the current workspace can interact with vaults.",
       },
     });
   }
+
+  const owner = auth.getNonNullableWorkspace();
 
   switch (req.method) {
     case "GET":


### PR DESCRIPTION
## Description

All our endpoints should always start by checking that `auth.isUser()` + we can use getNonNullable function since owner, plan, user have already been checked by the internal API endpoints wrappers.

## Risk

N/A

## Deploy Plan

- deploy `front`