### PR TITLE
[connectors] chore(microsoft): Add full path for all synchronized root nodes

### DIFF
--- a/connectors/src/connectors/microsoft/lib/graph_api.ts
+++ b/connectors/src/connectors/microsoft/lib/graph_api.ts
@@ -410,10 +410,9 @@ export function itemToMicrosoftNode<T extends keyof MicrosoftEntityMapping>(
     }
     case "drive": {
       const item = itemRaw as MicrosoftGraph.Drive;
-      const siteName = extractSiteName(item);
       return {
         nodeType,
-        name: (item.name ?? "unknown") + (siteName ? ` (${siteName})` : ""),
+        name: item.name ?? "unknown",
         internalId: getDriveInternalId(item),
         parentInternalId: null,
         mimeType: null,
@@ -531,10 +530,10 @@ export async function wrapMicrosoftGraphAPIWithResult<T>(
   }
 }
 
-export function extractSiteName(item: MicrosoftGraph.BaseItem) {
+export function extractPath(item: MicrosoftGraph.BaseItem) {
   const webUrl = item.webUrl;
   if (webUrl) {
-    const siteName = webUrl.match(/\/sites\/(.+)/);
+    const siteName = webUrl.match(/\/sites\/(.+)\/.*/);
     if (siteName && siteName[1]) {
       return decodeURI(siteName[1]);
     }


### PR DESCRIPTION
## Description

Add full path in root node names for easier identification : 

<img width="738" alt="Screenshot 2024-08-26 at 14 28 12" src="https://github.com/user-attachments/assets/90e995a4-c28e-4e27-acd9-52984cf828cb">

## Risk

## Deploy Plan

deploy `connectors`
