### PR TITLE
Allow specifying the group while whitelisting Slack workflows

### DIFF
--- a/connectors/migrations/db/migration_12.sql
+++ b/connectors/migrations/db/migration_12.sql
@@ -1,0 +1,5 @@
+-- Migration created on Aug 26, 2024
+ALTER TABLE
+    "public"."slack_bot_whitelist"
+ADD
+    COLUMN "groupIds" VARCHAR(255) [];

--- a/connectors/src/connectors/slack/lib/cli.ts
+++ b/connectors/src/connectors/slack/lib/cli.ts
@@ -163,12 +163,16 @@ export const slack = async ({
     }
 
     case "whitelist-bot": {
-      const { wId, botName } = args;
+      const { wId, botName, groupId } = args;
       if (!wId) {
         throw new Error("Missing --wId argument");
       }
       if (!botName) {
         throw new Error("Missing --botName argument");
+      }
+
+      if (!groupId) {
+        throw new Error("Missing --groupId argument");
       }
 
       const connector = await ConnectorModel.findOne({
@@ -188,7 +192,7 @@ export const slack = async ({
         connector.id
       );
       if (slackConfig) {
-        await slackConfig.whitelistBot(botName);
+        await slackConfig.whitelistBot(botName, [groupId]);
       }
 
       return { success: true };

--- a/connectors/src/lib/models/slack.ts
+++ b/connectors/src/lib/models/slack.ts
@@ -309,6 +309,7 @@ export class SlackBotWhitelistModel extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare botName: string;
+  declare groupIds: string[];
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
   declare slackConfigurationId: ForeignKey<SlackConfigurationModel["id"]>;
 }
@@ -333,6 +334,10 @@ SlackBotWhitelistModel.init(
     botName: {
       type: DataTypes.STRING,
       allowNull: false,
+    },
+    groupIds: {
+      type: DataTypes.ARRAY(DataTypes.STRING),
+      allowNull: true,
     },
   },
   {

--- a/connectors/src/resources/slack_configuration_resource.ts
+++ b/connectors/src/resources/slack_configuration_resource.ts
@@ -115,11 +115,15 @@ export class SlackConfigurationResource extends BaseResource<SlackConfigurationM
     }));
   }
 
-  async whitelistBot(botName: string): Promise<Result<undefined, Error>> {
+  async whitelistBot(
+    botName: string,
+    groupIds: string[]
+  ): Promise<Result<undefined, Error>> {
     await SlackBotWhitelistModel.create({
       connectorId: this.connectorId,
       slackConfigurationId: this.id,
       botName,
+      groupIds,
     });
 
     return new Ok(undefined);

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -685,6 +685,10 @@ export class GroupResource extends BaseResource<GroupModel> {
     return auth.isAdmin();
   }
 
+  isSystem(): boolean {
+    return this.kind === "system";
+  }
+
   // JSON Serialization
 
   toJSON(): GroupType {

--- a/front/migrations/20240826_backfill_slack_whitelisted_bots.ts
+++ b/front/migrations/20240826_backfill_slack_whitelisted_bots.ts
@@ -1,0 +1,62 @@
+import { EnvironmentConfig } from "@dust-tt/types";
+import { QueryTypes, Sequelize } from "sequelize";
+
+import { Authenticator } from "@app/lib/auth";
+import { Workspace } from "@app/lib/models/workspace";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { makeSId } from "@app/lib/resources/string_ids";
+import { makeScript } from "@app/scripts/helpers";
+
+makeScript({}, async ({ execute }, logger) => {
+  const connectorDB = new Sequelize(
+    EnvironmentConfig.getEnvVariable("CONNECTORS_DATABASE_URI")
+  );
+  const bots: { id: number; workspaceid: string }[] = await connectorDB.query(
+    `SELECT swb.id as id, c."workspaceId" as workspaceid FROM slack_bot_whitelist swb INNER JOIN connectors c ON swb."connectorId" = c.id WHERE c.type = 'slack'`,
+    {
+      type: QueryTypes.SELECT,
+    }
+  );
+
+  for (const bot of bots) {
+    const auth = await Authenticator.internalAdminForWorkspace(bot.workspaceid);
+    const groupRes = await GroupResource.fetchWorkspaceGlobalGroup(auth);
+    if (groupRes.isErr()) {
+      throw new Error(
+        `Failed to fetch global group for workspace ${bot.workspaceid}`
+      );
+    }
+    const workspace = await Workspace.findOne({
+      where: { sId: bot.workspaceid },
+    });
+    if (!workspace) {
+      throw new Error(`Workspace not found for workspaceId ${bot.workspaceid}`);
+    }
+
+    const groupId = makeSId("group", {
+      id: groupRes.value.id,
+      workspaceId: workspace.id,
+    });
+
+    logger.info(
+      {
+        botId: bot.id,
+        workspaceId: bot.workspaceid,
+        groupId: groupId,
+      },
+      "Updating slack_bot_whitelist with groupId"
+    );
+
+    if (execute) {
+      await connectorDB.query(
+        `UPDATE slack_bot_whitelist SET "groupIds" = array_appen("groupIds", :groupId) WHERE id = :id`,
+        {
+          replacements: {
+            groupId: groupId,
+            id: bot.id,
+          },
+        }
+      );
+    }
+  }
+});

--- a/front/migrations/20240826_backfill_slack_whitelisted_bots.ts
+++ b/front/migrations/20240826_backfill_slack_whitelisted_bots.ts
@@ -12,7 +12,7 @@ makeScript({}, async ({ execute }, logger) => {
     EnvironmentConfig.getEnvVariable("CONNECTORS_DATABASE_URI")
   );
   const bots: { id: number; workspaceid: string }[] = await connectorDB.query(
-    `SELECT swb.id as id, c."workspaceId" as workspaceid FROM slack_bot_whitelist swb INNER JOIN connectors c ON swb."connectorId" = c.id WHERE c.type = 'slack'`,
+    `SELECT sbw.id as id, c."workspaceId" as workspaceId FROM slack_bot_whitelist sbw INNER JOIN connectors c ON sbw."connectorId" = c.id WHERE c.type = 'slack'`,
     {
       type: QueryTypes.SELECT,
     }

--- a/front/pages/poke/[wId]/data_sources/[name]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[name]/index.tsx
@@ -2,6 +2,7 @@ import {
   Button,
   ContextItem,
   DocumentTextIcon,
+  DropdownMenu,
   EyeIcon,
   Input,
   Page,
@@ -10,6 +11,7 @@ import {
 import type {
   CoreAPIDataSource,
   DataSourceType,
+  GroupType,
   NotionCheckUrlResponseType,
   NotionFindUrlResponseType,
 } from "@dust-tt/types";
@@ -29,9 +31,11 @@ import PokeNavbar from "@app/components/poke/PokeNavbar";
 import { SlackChannelPatternInput } from "@app/components/poke/PokeSlackChannelPatternInput";
 import config from "@app/lib/api/config";
 import { getDataSource } from "@app/lib/api/data_sources";
+import { Authenticator } from "@app/lib/auth";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { getDisplayNameForDocument } from "@app/lib/data_sources";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
+import { GroupResource } from "@app/lib/resources/group_resource";
 import { useDocuments } from "@app/lib/swr";
 import { classNames, timeAgoFrom } from "@app/lib/utils";
 import logger from "@app/logger/logger";
@@ -57,6 +61,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   connector: ConnectorType | null;
   features: FeaturesType;
   temporalWorkspace: string;
+  groupsForSlackBot: GroupType[];
 }>(async (context, auth) => {
   const owner = auth.workspace();
 
@@ -226,6 +231,16 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
     }
   }
 
+  // Getting groups that a Slack bot/workflow can be assigned to
+  const authForSlackBot = await Authenticator.internalAdminForWorkspace(
+    owner.sId
+  );
+  const groupsForSlackBot = (
+    await GroupResource.listWorkspaceGroups(authForSlackBot)
+  )
+    .filter((g) => g.kind !== "system")
+    .map((g) => g.toJSON());
+
   return {
     props: {
       owner,
@@ -234,6 +249,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
       connector,
       features,
       temporalWorkspace: TEMPORAL_CONNECTORS_NAMESPACE,
+      groupsForSlackBot,
     },
   };
 });
@@ -245,6 +261,7 @@ const DataSourcePage = ({
   connector,
   temporalWorkspace,
   features,
+  groupsForSlackBot,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const [limit] = useState(10);
   const [offset, setOffset] = useState(0);
@@ -341,7 +358,11 @@ const DataSourcePage = ({
                 configKey="botEnabled"
                 featureKey="slackBotEnabled"
               />
-              <SlackWhitelistBot owner={owner} connectorId={connector?.id} />
+              <SlackWhitelistBot
+                owner={owner}
+                connectorId={connector?.id}
+                groups={groupsForSlackBot}
+              />
               <div className="border-material-200 mb-4 flex flex-grow flex-col rounded-lg border p-4">
                 <SlackChannelPatternInput
                   initialValue={features.autoReadChannelPattern || ""}
@@ -558,7 +579,11 @@ async function handleCheckOrFindNotionUrl(
   return res.json();
 }
 
-async function handleWhitelistBot(botName: string, wId: string): Promise<void> {
+async function handleWhitelistBot(
+  botName: string,
+  wId: string,
+  groupId: string
+): Promise<void> {
   const res = await fetch(`/api/poke/admin`, {
     method: "POST",
     headers: {
@@ -570,6 +595,7 @@ async function handleWhitelistBot(botName: string, wId: string): Promise<void> {
       args: {
         botName,
         wId,
+        groupId,
       },
     }),
   });
@@ -791,11 +817,18 @@ const ConfigToggle = ({
 function SlackWhitelistBot({
   owner,
   connectorId,
+  groups,
 }: {
   owner: WorkspaceType;
   connectorId?: string;
+  groups: GroupType[];
 }) {
   const [botName, setBotName] = useState("");
+  const [selectedGroup, setSelectedGroup] = useState<string | null>(null);
+
+  const selectedGroupName = groups.find(
+    (group) => group.sId === selectedGroup
+  )?.name;
 
   return (
     <div className="mb-2 flex flex-col gap-2 rounded-md border px-2 py-2 text-sm text-gray-600">
@@ -809,11 +842,37 @@ function SlackWhitelistBot({
             name={""}
           />
         </div>
+        <div>
+          <DropdownMenu>
+            <DropdownMenu.Button
+              label={selectedGroupName ?? "Select a group"}
+            />
+
+            <DropdownMenu.Items width={220}>
+              {groups.map((group) => (
+                <DropdownMenu.Item
+                  selected={selectedGroup === group.sId}
+                  key={group.sId}
+                  label={group.name}
+                  onClick={() => setSelectedGroup(group.sId)}
+                />
+              ))}
+            </DropdownMenu.Items>
+          </DropdownMenu>
+        </div>
         <Button
           variant="secondary"
           label="Whitelist"
           onClick={async () => {
-            await handleWhitelistBot(botName, owner.sId);
+            if (!botName) {
+              alert("Please enter a bot name");
+              return;
+            }
+            if (!selectedGroup) {
+              alert("Please select a group");
+              return;
+            }
+            await handleWhitelistBot(botName, owner.sId, selectedGroup);
             setBotName("");
           }}
         />

--- a/front/pages/poke/[wId]/data_sources/[name]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[name]/index.tsx
@@ -238,7 +238,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   const groupsForSlackBot = (
     await GroupResource.listWorkspaceGroups(authForSlackBot)
   )
-    .filter((g) => g.kind !== "system")
+    .filter((g) => !g.isSystem())
     .map((g) => g.toJSON());
 
   return {


### PR DESCRIPTION
## Description

Allow specifying the group while whitelisting Slack workflows.

Last part of https://github.com/dust-tt/dust/issues/6460

![Screenshot 2024-08-26 at 17 04 04](https://github.com/user-attachments/assets/a3da478d-9021-4c9b-95e1-6813bab7476e)


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- deploy connectors
- Run migration connectors migration id 12 from prodbox.
- run the backfill script from front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
