### PR TITLE
Enforce isUser in withSessionAuthenticationForWorkspace

### DIFF
--- a/front/lib/api/wrappers.ts
+++ b/front/lib/api/wrappers.ts
@@ -63,7 +63,7 @@ export function withSessionAuthenticationForWorkspace<T>(
     auth: Authenticator,
     session: SessionWithUser
   ) => Promise<void> | void,
-  opts: { isStreaming?: boolean; allowNonWorksapceUser?: boolean } = {}
+  opts: { isStreaming?: boolean; allowUserOutsideCurrentWorkspace?: boolean } = {}
 ) {
   return withSessionAuthentication(
     async (
@@ -109,7 +109,7 @@ export function withSessionAuthenticationForWorkspace<T>(
 
       // If allowNonWorksaceUser is not set or false then we check that the user is a member of the
       // workspace.
-      if (!auth.isUser() && !opts.allowNonWorksapceUser) {
+      if (!auth.isUser() && !opts.allowUserOutsideCurrentWorkspace) {
         return apiError(req, res, {
           status_code: 401,
           api_error: {

--- a/front/lib/api/wrappers.ts
+++ b/front/lib/api/wrappers.ts
@@ -49,8 +49,9 @@ export function withSessionAuthentication<T>(
  * This function is a wrapper for API routes that require session authentication for a workspace.
  * It must be used on all routes that require workspace authentication (prefix: /w/[wId/]).
  *
- * opts.allowNonWorksaceUser allows the handler to be called even if the user is not a member of the
- * workspace. This is useful for routes that share data across workspaces (eg apps runs).
+ * opts.allowUserOutsideCurrentWorkspace allows the handler to be called even if the user is not a
+ * member of the workspace. This is useful for routes that share data across workspaces (eg apps
+ * runs).
  *
  * @param handler
  * @param opts

--- a/front/lib/api/wrappers.ts
+++ b/front/lib/api/wrappers.ts
@@ -49,6 +49,9 @@ export function withSessionAuthentication<T>(
  * This function is a wrapper for API routes that require session authentication for a workspace.
  * It must be used on all routes that require workspace authentication (prefix: /w/[wId/]).
  *
+ * opts.allowNonWorksaceUser allows the handler to be called even if the user is not a member of the
+ * workspace. This is useful for routes that share data across workspaces (eg apps runs).
+ *
  * @param handler
  * @param opts
  * @returns
@@ -60,7 +63,7 @@ export function withSessionAuthenticationForWorkspace<T>(
     auth: Authenticator,
     session: SessionWithUser
   ) => Promise<void> | void,
-  opts: { isStreaming?: boolean } = {}
+  opts: { isStreaming?: boolean; allowNonWorksapceUser?: boolean } = {}
 ) {
   return withSessionAuthentication(
     async (
@@ -100,6 +103,18 @@ export function withSessionAuthenticationForWorkspace<T>(
           api_error: {
             type: "workspace_user_not_found",
             message: "Could not find the user of the current session.",
+          },
+        });
+      }
+
+      // If allowNonWorksaceUser is not set or false then we check that the user is a member of the
+      // workspace.
+      if (!auth.isUser() && !opts.allowNonWorksapceUser) {
+        return apiError(req, res, {
+          status_code: 401,
+          api_error: {
+            type: "workspace_auth_error",
+            message: "Only users of the workspace can access this route.",
           },
         });
       }

--- a/front/lib/api/wrappers.ts
+++ b/front/lib/api/wrappers.ts
@@ -63,7 +63,10 @@ export function withSessionAuthenticationForWorkspace<T>(
     auth: Authenticator,
     session: SessionWithUser
   ) => Promise<void> | void,
-  opts: { isStreaming?: boolean; allowUserOutsideCurrentWorkspace?: boolean } = {}
+  opts: {
+    isStreaming?: boolean;
+    allowUserOutsideCurrentWorkspace?: boolean;
+  } = {}
 ) {
   return withSessionAuthentication(
     async (

--- a/front/lib/api/wrappers.ts
+++ b/front/lib/api/wrappers.ts
@@ -111,8 +111,8 @@ export function withSessionAuthenticationForWorkspace<T>(
         });
       }
 
-      // If allowNonWorksaceUser is not set or false then we check that the user is a member of the
-      // workspace.
+      // If `allowUserOutsideCurrentWorkspace` is not set or false then we check that the user is a
+      // member of the workspace.
       if (!auth.isUser() && !opts.allowUserOutsideCurrentWorkspace) {
         return apiError(req, res, {
           status_code: 401,

--- a/front/pages/api/w/[wId]/apps/[aId]/clone.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/clone.ts
@@ -150,5 +150,5 @@ async function handler(
 }
 
 export default withSessionAuthenticationForWorkspace(handler, {
-  allowNonWorksapceUser: true,
+  allowUserOutsideCurrentWorkspace: true,
 });

--- a/front/pages/api/w/[wId]/apps/[aId]/clone.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/clone.ts
@@ -149,4 +149,6 @@ async function handler(
   }
 }
 
-export default withSessionAuthenticationForWorkspace(handler);
+export default withSessionAuthenticationForWorkspace(handler, {
+  allowNonWorksapceUser: true,
+});

--- a/front/pages/api/w/[wId]/apps/[aId]/datasets/[name]/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/datasets/[name]/index.ts
@@ -23,6 +23,8 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<GetDatasetResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
+  const owner = auth.getNonNullableWorkspace();
+
   const app = await getApp(auth, req.query.aId as string);
   if (!app) {
     return apiError(req, res, {
@@ -33,8 +35,6 @@ async function handler(
       },
     });
   }
-
-  const owner = auth.getNonNullableWorkspace();
 
   const [dataset] = await Promise.all([
     Dataset.findOne({

--- a/front/pages/api/w/[wId]/apps/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/index.ts
@@ -29,12 +29,10 @@ async function handler(
         }
       : {
           workspaceId: owner.id,
-          // Do not include 'unlisted' here.
-          visibility: "public",
+          visibility: ["public", "unlisted"],
           sId: req.query.aId,
         },
   });
-
   if (!app) {
     return apiError(req, res, {
       status_code: 404,
@@ -145,4 +143,6 @@ async function handler(
   }
 }
 
-export default withSessionAuthenticationForWorkspace(handler);
+export default withSessionAuthenticationForWorkspace(handler, {
+  allowNonWorksapceUser: true,
+});

--- a/front/pages/api/w/[wId]/apps/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/index.ts
@@ -29,7 +29,8 @@ async function handler(
         }
       : {
           workspaceId: owner.id,
-          visibility: ["public", "unlisted"],
+          // Do not include `unlisted` here.
+          visibility: ["public"],
           sId: req.query.aId,
         },
   });

--- a/front/pages/api/w/[wId]/apps/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/index.ts
@@ -144,5 +144,5 @@ async function handler(
 }
 
 export default withSessionAuthenticationForWorkspace(handler, {
-  allowNonWorksapceUser: true,
+  allowUserOutsideCurrentWorkspace: true,
 });

--- a/front/pages/api/w/[wId]/apps/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/index.ts
@@ -29,8 +29,8 @@ async function handler(
         }
       : {
           workspaceId: owner.id,
-          // Do not include `unlisted` here.
-          visibility: ["public"],
+          // Do not include 'unlisted' here.
+          visibility: "public",
           sId: req.query.aId,
         },
   });

--- a/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]/index.ts
@@ -39,19 +39,6 @@ async function handler(
   let runId: string | null =
     typeof req.query.runId === "string" ? req.query.runId : null;
 
-  // We allow non builder and hence cross workspace (see withSessionAuthenticationForWorkspace)
-  // users to view the run block status only if the run is the one saved on the app (the app view).
-  if (runId !== "saved" && !auth.isBuilder()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "app_auth_error",
-        message:
-          "Only the users that are `builders` for the current workspace can view run statuses.",
-      },
-    });
-  }
-
   if (runId === "saved") {
     runId = app.savedRun;
   }
@@ -95,6 +82,9 @@ async function handler(
   }
 }
 
+// We allow anyone with access to the app (getApp returns something) and the runId to retrieve the
+// block status. Note: this means if runIds from our dust-apps are leaked they can be used to
+// retrieve user data.
 export default withSessionAuthenticationForWorkspace(handler, {
   allowUserOutsideCurrentWorkspace: true,
 });

--- a/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]/index.ts
@@ -82,4 +82,6 @@ async function handler(
   }
 }
 
-export default withSessionAuthenticationForWorkspace(handler);
+export default withSessionAuthenticationForWorkspace(handler, {
+  allowNonWorksapceUser: true,
+});

--- a/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]/index.ts
@@ -39,6 +39,19 @@ async function handler(
   let runId: string | null =
     typeof req.query.runId === "string" ? req.query.runId : null;
 
+  // We allow non builder and hence cross workspace (see withSessionAuthenticationForWorkspace)
+  // users to view the run block status only if the run is the one saved on the app (the app view).
+  if (runId !== "saved" && !auth.isBuilder()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message:
+          "Only the users that are `builders` for the current workspace can view run statuses.",
+      },
+    });
+  }
+
   if (runId === "saved") {
     runId = app.savedRun;
   }
@@ -83,5 +96,5 @@ async function handler(
 }
 
 export default withSessionAuthenticationForWorkspace(handler, {
-  allowNonWorksapceUser: true,
+  allowUserOutsideCurrentWorkspace: true,
 });

--- a/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/status.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/status.ts
@@ -18,6 +18,17 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<GetRunStatusResponseBody>>,
   auth: Authenticator
 ) {
+  if (!auth.isBuilder()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message:
+          "Only the users that are `builders` for the current workspace can view run statuses.",
+      },
+    });
+  }
+
   const app = await getApp(auth, req.query.aId as string);
   if (!app) {
     return apiError(req, res, {
@@ -31,19 +42,6 @@ async function handler(
 
   let runId: string | null =
     typeof req.query.runId === "string" ? req.query.runId : null;
-
-  // We allow non builder and hence cross workspace (see withSessionAuthenticationForWorkspace)
-  // users to view the run status only if the run is the one saved on the app (the app view).
-  if (runId !== "saved" && !auth.isBuilder()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "app_auth_error",
-        message:
-          "Only the users that are `builders` for the current workspace can view run statuses.",
-      },
-    });
-  }
 
   if (runId === "saved") {
     runId = app.savedRun;
@@ -96,6 +94,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthenticationForWorkspace(handler, {
-  allowUserOutsideCurrentWorkspace: true,
-});
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/status.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/status.ts
@@ -42,6 +42,19 @@ async function handler(
         return;
       }
 
+      // We allow non builder and hence cross workspace (see withSessionAuthenticationForWorkspace)
+      // users to view the run status only if the run is the one saved (the app run).
+      if (runId !== "saved" && !auth.isBuilder()) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "app_auth_error",
+            message:
+              "Only the users that are `builders` for the current workspace can view run statuses.",
+          },
+        });
+      }
+
       const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
       const run = await coreAPI.getRunStatus({
         projectId: app.dustAPIProjectId,

--- a/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/status.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/status.ts
@@ -18,17 +18,6 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<GetRunStatusResponseBody>>,
   auth: Authenticator
 ) {
-  if (!auth.isBuilder()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "app_auth_error",
-        message:
-          "Only the users that are `builders` for the current workspace can view run statuses.",
-      },
-    });
-  }
-
   const app = await getApp(auth, req.query.aId as string);
   if (!app) {
     return apiError(req, res, {
@@ -94,4 +83,6 @@ async function handler(
   }
 }
 
-export default withSessionAuthenticationForWorkspace(handler);
+export default withSessionAuthenticationForWorkspace(handler, {
+  allowUserOutsideCurrentWorkspace: true,
+});

--- a/front/pages/api/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/runs/index.ts
@@ -32,6 +32,20 @@ async function handler(
   auth: Authenticator,
   session: SessionWithUser
 ) {
+  // Only the users that are `builders` for the current workspace can create runs or retrieve
+  // runs. Note that we have a special wIdTarget flow to let dust super users retrieve runs from
+  // other workspaces on apps that they have access to (used for dust-apps).
+  if (!auth.isBuilder()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message:
+          "Only the users that are `builders` for the current workspace can create runs.",
+      },
+    });
+  }
+
   let owner = auth.getNonNullableWorkspace();
 
   const app = await getApp(auth, req.query.aId as string);
@@ -49,18 +63,6 @@ async function handler(
 
   switch (req.method) {
     case "POST":
-      // Only the users that are `builders` for the current workspace can create runs.
-      if (!auth.isBuilder()) {
-        return apiError(req, res, {
-          status_code: 403,
-          api_error: {
-            type: "app_auth_error",
-            message:
-              "Only the users that are `builders` for the current workspace can create runs.",
-          },
-        });
-      }
-
       const [providers, secrets] = await Promise.all([
         Provider.findAll({
           where: {
@@ -161,20 +163,22 @@ async function handler(
     case "GET":
       if (req.query.wIdTarget) {
         // If we have a `wIdTarget` query parameter, we are fetching runs that were created with an
-        // API key coming from another workspace. So we override the `owner` variable and check that
-        // the user is a user of that workspace.
+        // API key coming from another workspace. So we override the `owner` variable. This is only
+        // available to dust super users.
 
         // Dust super users can view runs of any workspace.
-        let target = await Authenticator.fromSuperUserSession(
+        const target = await Authenticator.fromSuperUserSession(
           session,
           req.query.wIdTarget as string
         );
-        if (!target.isAdmin()) {
-          // If the user is not a super user, we check that the user is a user of the target
-          target = await Authenticator.fromSession(
-            session,
-            req.query.wIdTarget as string
-          );
+        if (!target.isAdmin() || !auth.isDustSuperUser()) {
+          return apiError(req, res, {
+            status_code: 404,
+            api_error: {
+              type: "workspace_auth_error",
+              message: "wIdTarget is only available to Dust super users.",
+            },
+          });
         }
 
         const targetOwner = target.workspace();
@@ -189,28 +193,6 @@ async function handler(
         }
 
         owner = targetOwner;
-
-        if (!target.isUser()) {
-          return apiError(req, res, {
-            status_code: 404,
-            api_error: {
-              type: "app_not_found",
-              message: "The app was not found.",
-            },
-          });
-        }
-      } else {
-        // Otherwise we are retrieving the runs for the app's own workspace let's just check that we
-        // are user of that workspace.
-        if (!auth.isUser()) {
-          return apiError(req, res, {
-            status_code: 404,
-            api_error: {
-              type: "app_not_found",
-              message: "The app was not found.",
-            },
-          });
-        }
       }
 
       const limit = req.query.limit ? parseInt(req.query.limit as string) : 10;

--- a/front/pages/api/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/runs/index.ts
@@ -32,19 +32,9 @@ async function handler(
   auth: Authenticator,
   session: SessionWithUser
 ) {
-  let owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace was not found.",
-      },
-    });
-  }
+  let owner = auth.getNonNullableWorkspace();
 
   const app = await getApp(auth, req.query.aId as string);
-
   if (!app) {
     return apiError(req, res, {
       status_code: 404,
@@ -275,4 +265,6 @@ async function handler(
   }
 }
 
-export default withSessionAuthenticationForWorkspace(handler);
+export default withSessionAuthenticationForWorkspace(handler, {
+  allowNonWorksapceUser: true,
+});

--- a/front/pages/api/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/runs/index.ts
@@ -266,5 +266,5 @@ async function handler(
 }
 
 export default withSessionAuthenticationForWorkspace(handler, {
-  allowNonWorksapceUser: true,
+  allowUserOutsideCurrentWorkspace: true,
 });

--- a/front/pages/api/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/runs/index.ts
@@ -265,6 +265,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthenticationForWorkspace(handler, {
-  allowUserOutsideCurrentWorkspace: true,
-});
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/apps/[aId]/state.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/state.ts
@@ -30,19 +30,13 @@ async function handler(
   const owner = auth.getNonNullableWorkspace();
 
   const app = await App.findOne({
-    where: auth.isUser()
-      ? {
-          workspaceId: owner.id,
-          visibility: {
-            [Op.or]: ["public", "private", "unlisted"],
-          },
-          sId: req.query.aId,
-        }
-      : {
-          workspaceId: owner.id,
-          visibility: ["public", "unlisted"],
-          sId: req.query.aId,
-        },
+    where: {
+      workspaceId: owner.id,
+      visibility: {
+        [Op.or]: ["public", "private", "unlisted"],
+      },
+      sId: req.query.aId,
+    },
   });
   if (!app) {
     return apiError(req, res, {

--- a/front/pages/api/w/[wId]/apps/index.ts
+++ b/front/pages/api/w/[wId]/apps/index.ts
@@ -19,20 +19,20 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<PostAppResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
+  if (!auth.isBuilder()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message:
+          "Only the users that are `builders` for the current workspace can create an app.",
+      },
+    });
+  }
+
   const owner = auth.getNonNullableWorkspace();
   switch (req.method) {
     case "POST":
-      if (!auth.isBuilder()) {
-        return apiError(req, res, {
-          status_code: 403,
-          api_error: {
-            type: "app_auth_error",
-            message:
-              "Only the users that are `builders` for the current workspace can create an app.",
-          },
-        });
-      }
-
       if (
         !req.body ||
         !(typeof req.body.name == "string") ||

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
@@ -35,17 +35,6 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "app_auth_error",
-        message:
-          "Only users of the current workspace can access its assistants.",
-      },
-    });
-  }
-
   const assistant = await getAgentConfiguration(auth, req.query.aId as string);
   if (
     !assistant ||

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
@@ -28,17 +28,6 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<void>>,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "app_auth_error",
-        message:
-          "Only users of the current workspace can access its assistants.",
-      },
-    });
-  }
-
   const assistant = await getAgentConfiguration(auth, req.query.aId as string);
   if (
     !assistant ||

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage.ts
@@ -18,17 +18,6 @@ async function handler(
 ): Promise<void> {
   const owner = auth.getNonNullableWorkspace();
 
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "app_auth_error",
-        message:
-          "Only the users that are members for the current workspace can access the workspace's assistants.",
-      },
-    });
-  }
-
   switch (req.method) {
     case "GET":
       const agentConfiguration = await getAgentConfiguration(

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -55,15 +55,6 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      if (!auth.isUser()) {
-        return apiError(req, res, {
-          status_code: 404,
-          api_error: {
-            type: "app_auth_error",
-            message: "Only the workspace users can see Assistants.",
-          },
-        });
-      }
       // extract the view from the query parameters
       const queryValidation = GetAgentConfigurationsQuerySchema.decode({
         ...req.query,
@@ -154,16 +145,6 @@ async function handler(
         agentConfigurations,
       });
     case "POST":
-      if (!auth.isUser()) {
-        return apiError(req, res, {
-          status_code: 404,
-          api_error: {
-            type: "app_auth_error",
-            message: "Only users of the workspace can create assistants.",
-          },
-        });
-      }
-
       const bodyValidation =
         PostOrPatchAgentConfigurationRequestBodySchema.decode(req.body);
       if (isLeft(bodyValidation)) {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/name_available.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/name_available.ts
@@ -26,15 +26,6 @@ async function handler(
 ): Promise<void> {
   switch (req.method) {
     case "GET":
-      if (!auth.isUser()) {
-        return apiError(req, res, {
-          status_code: 404,
-          api_error: {
-            type: "app_auth_error",
-            message: "Only the workspace users can see Assistants.",
-          },
-        });
-      }
       const bodyValidation = GetAgentConfigurationNameIsAvailable.decode(
         req.query
       );

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
@@ -23,16 +23,6 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<PostMessageEventResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users of the current workspace can access conversations.",
-      },
-    });
-  }
   if (!(typeof req.query.cId === "string")) {
     return apiError(req, res, {
       status_code: 400,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/content_fragment/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/content_fragment/index.ts
@@ -24,16 +24,7 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  const user = auth.user();
-  if (!user || !auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_user_not_found",
-        message: "Could not find the user of the current session.",
-      },
-    });
-  }
+  const user = auth.getNonNullableUser();
 
   if (!(typeof req.query.cId === "string")) {
     return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -12,16 +12,6 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<void>>,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users of the current workspace can access chat sessions.",
-      },
-    });
-  }
   if (!(typeof req.query.cId === "string")) {
     return apiError(req, res, {
       status_code: 400,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -37,17 +37,6 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users of the current workspace can access chat sessions.",
-      },
-    });
-  }
-
   if (!(typeof req.query.cId === "string")) {
     return apiError(req, res, {
       status_code: 400,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
@@ -21,27 +21,6 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<{ message: UserMessageType }>>,
   auth: Authenticator
 ): Promise<void> {
-  const user = auth.user();
-  if (!user) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_user_not_found",
-        message: "Could not find the user of the current session.",
-      },
-    });
-  }
-
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users of the current workspace can update chat sessions.",
-      },
-    });
-  }
   if (!(typeof req.query.cId === "string")) {
     return apiError(req, res, {
       status_code: 400,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
@@ -15,16 +15,6 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<void>>,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users of the current workspace can access chat sessions.",
-      },
-    });
-  }
   if (!(typeof req.query.cId === "string")) {
     return apiError(req, res, {
       status_code: 400,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/raw_content_fragment/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/raw_content_fragment/index.ts
@@ -30,27 +30,6 @@ async function handler(
 ): Promise<void> {
   const owner = auth.getNonNullableWorkspace();
 
-  const user = auth.user();
-  if (!user) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_user_not_found",
-        message: "Could not find the user of the current session.",
-      },
-    });
-  }
-
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users of the current workspace can update chat sessions.",
-      },
-    });
-  }
   if (!(typeof req.query.cId === "string")) {
     return apiError(req, res, {
       status_code: 400,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
@@ -26,26 +26,8 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  const user = auth.user();
-  if (!user) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_user_not_found",
-        message: "Could not find the user of the current session.",
-      },
-    });
-  }
+  const user = auth.getNonNullableUser();
 
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message: "Only users of the current workspace can add reactions.",
-      },
-    });
-  }
   if (!(typeof req.query.cId === "string")) {
     return apiError(req, res, {
       status_code: 400,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
@@ -23,16 +23,6 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<{ message: AgentMessageType }>>,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users of the current workspace can update chat sessions.",
-      },
-    });
-  }
   if (!(typeof req.query.cId === "string")) {
     return apiError(req, res, {
       status_code: 400,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -22,27 +22,8 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  const user = auth.user();
-  if (!user) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_user_not_found",
-        message: "Could not find the user of the current session.",
-      },
-    });
-  }
+  const user = auth.getNonNullableUser();
 
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users of the current workspace can update chat sessions.",
-      },
-    });
-  }
   if (!(typeof req.query.cId === "string")) {
     return apiError(req, res, {
       status_code: 400,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/participants.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/participants.ts
@@ -24,17 +24,6 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users of the current workspace can update chat sessions.",
-      },
-    });
-  }
-
   if (!(typeof req.query.cId === "string")) {
     return apiError(req, res, {
       status_code: 400,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/reactions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/reactions.ts
@@ -17,15 +17,6 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message: "Only users of the current workspace can add reactions.",
-      },
-    });
-  }
   if (!(typeof req.query.cId === "string")) {
     return apiError(req, res, {
       status_code: 400,

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -39,27 +39,7 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  const user = auth.user();
-  if (!user) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_user_not_found",
-        message: "Could not find the user of the current session.",
-      },
-    });
-  }
-
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users of the current workspace can update chat sessions.",
-      },
-    });
-  }
+  const user = auth.getNonNullableUser();
 
   switch (req.method) {
     case "GET":

--- a/front/pages/api/w/[wId]/data_source_views/index.ts
+++ b/front/pages/api/w/[wId]/data_source_views/index.ts
@@ -15,18 +15,6 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<GetDataSourceViewsResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
-  const user = auth.user();
-  const plan = auth.plan();
-  if (!plan || !user || !auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "data_source_not_found",
-        message: "The data source view you requested was not found.",
-      },
-    });
-  }
-
   const dataSourceViews = await DataSourceViewResource.listByWorkspace(auth);
 
   switch (req.method) {

--- a/front/pages/api/w/[wId]/data_sources/[name]/connector.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/connector.ts
@@ -18,16 +18,6 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<GetConnectorResponseBody | void>>,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "data_source_not_found",
-        message: "The data source you requested was not found.",
-      },
-    });
-  }
-
   if (!req.query.name || typeof req.query.name !== "string") {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -38,17 +38,7 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<GetDocumentResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
-  const plan = auth.plan();
-
-  if (!plan || !auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "data_source_not_found",
-        message: "The data source you requested was not found.",
-      },
-    });
-  }
+  const plan = auth.getNonNullablePlan();
 
   const dataSource = await getDataSource(auth, req.query.name as string);
 

--- a/front/pages/api/w/[wId]/data_sources/[name]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/index.ts
@@ -21,16 +21,6 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "data_source_not_found",
-        message: "The data source you requested was not found.",
-      },
-    });
-  }
-
   if (!req.query.name || typeof req.query.name !== "string") {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/config/[key]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/config/[key]/index.ts
@@ -27,16 +27,6 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "data_source_not_found",
-        message: "The data source you requested was not found.",
-      },
-    });
-  }
-
   if (!req.query.name || typeof req.query.name !== "string") {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/content-nodes/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/content-nodes/index.ts
@@ -46,17 +46,6 @@ async function handler(
     });
   }
 
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "data_source_auth_error",
-        message:
-          "Only users of the current workspace can view the content nodes of a data source.",
-      },
-    });
-  }
-
   switch (req.method) {
     case "POST":
       if (

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/content_nodes.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/content_nodes.ts
@@ -25,16 +25,6 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<GetContentNodeResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "data_source_not_found",
-        message: "The data source you requested was not found.",
-      },
-    });
-  }
-
   const dataSource = await getDataSource(auth, req.query.name as string);
   if (!dataSource) {
     return apiError(req, res, {

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/parents.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/parents.ts
@@ -46,17 +46,6 @@ async function handler(
     });
   }
 
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "data_source_auth_error",
-        message:
-          "Only the users of the current workspace can retrieve parents of connector resources.",
-      },
-    });
-  }
-
   switch (req.method) {
     case "POST":
       // We use post because we need a body, but we don't create anything

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
@@ -49,16 +49,6 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "data_source_not_found",
-        message: "The data source you requested was not found.",
-      },
-    });
-  }
-
   const dataSource = await getDataSource(auth, req.query.name as string);
   if (!dataSource) {
     return apiError(req, res, {
@@ -80,17 +70,6 @@ async function handler(
     });
   }
 
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "data_source_auth_error",
-        message:
-          "Only users of the current workspace can view the permissions of a data source.",
-      },
-    });
-  }
-
   switch (req.method) {
     case "GET":
       return getManagedDataSourcePermissionsHandler(
@@ -101,10 +80,6 @@ async function handler(
         res
       );
     case "POST":
-      const connectorsAPI = new ConnectorsAPI(
-        config.getConnectorsAPIConfig(),
-        logger
-      );
       if (!auth.isAdmin()) {
         return apiError(req, res, {
           status_code: 403,
@@ -115,6 +90,11 @@ async function handler(
           },
         });
       }
+
+      const connectorsAPI = new ConnectorsAPI(
+        config.getConnectorsAPIConfig(),
+        logger
+      );
 
       const body = req.body;
       if (!body) {

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/slack/channels_linked_with_agent.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/slack/channels_linked_with_agent.ts
@@ -24,6 +24,17 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
+  if (!auth.isBuilder()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "data_source_auth_error",
+        message:
+          "Only the users that are `builders` for the current workspace can modify linked Slack channels.",
+      },
+    });
+  }
+
   const dataSource = await getDataSource(auth, req.query.name as string);
   if (!dataSource) {
     return apiError(req, res, {
@@ -55,17 +66,6 @@ async function handler(
         type: "data_source_not_managed",
         message:
           "The data source you requested is not managed by a Slack connector.",
-      },
-    });
-  }
-
-  if (!auth.isBuilder()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "data_source_auth_error",
-        message:
-          "Only the users that are `builders` for the current workspace can modify linked Slack channels.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/update.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/update.ts
@@ -28,9 +28,7 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  const owner = auth.workspace();
-  const user = auth.user();
-  if (!owner || !user || !auth.isAdmin()) {
+  if (!auth.isAdmin()) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {
@@ -40,6 +38,9 @@ async function handler(
       },
     });
   }
+
+  const owner = auth.getNonNullableWorkspace();
+  const user = auth.getNonNullableUser();
 
   // fetchByName enforces through auth the authorization (workspace here mainly).
   const dataSource = await DataSourceResource.fetchByName(

--- a/front/pages/api/w/[wId]/data_sources/[name]/search.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/search.ts
@@ -51,16 +51,6 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<DatasourceSearchResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "data_source_not_found",
-        message: "The data source you requested was not found.",
-      },
-    });
-  }
-
   switch (req.method) {
     case "GET": {
       return handleSearchDataSource({ req, res, auth });

--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
@@ -24,16 +24,6 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<GetTableResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "data_source_not_found",
-        message: "The data source you requested was not found.",
-      },
-    });
-  }
-
   const owner = auth.getNonNullableWorkspace();
 
   if (!req.query.name || typeof req.query.name !== "string") {

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -38,17 +38,8 @@ async function handler(
   auth: Authenticator
 ): Promise<void> {
   const owner = auth.getNonNullableWorkspace();
-  const user = auth.user();
-  const plan = auth.plan();
-  if (!plan || !user || !auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "data_source_not_found",
-        message: "The data source you requested was not found.",
-      },
-    });
-  }
+  const user = auth.getNonNullableUser();
+  const plan = auth.getNonNullablePlan();
 
   const dataSources = await getDataSources(auth);
 

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -58,18 +58,12 @@ async function handler(
   auth: Authenticator
 ): Promise<void> {
   const owner = auth.getNonNullableWorkspace();
+  const plan = auth.getNonNullablePlan();
+  const user = auth.getNonNullableUser();
 
-  const plan = auth.plan();
-  const user = auth.user();
-  if (
-    !owner ||
-    !plan ||
-    !user ||
-    // No role under "builder" can create a managed data source.
-    // We perform a more detailed check below for each provider,
-    // but this is a first line of defense.
-    !auth.isBuilder()
-  ) {
+  // No role under "builder" can create a managed data source. We perform a more detailed check
+  // below for each provider, but this is a first line of defense.
+  if (!auth.isBuilder()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/api/w/[wId]/data_sources/request_access.ts
+++ b/front/pages/api/w/[wId]/data_sources/request_access.ts
@@ -28,28 +28,7 @@ async function handler(
   res: NextApiResponse,
   auth: Authenticator
 ) {
-  const owner = auth.workspace();
-  const user = auth.user();
-
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_auth_error",
-        message: "Only the workspace users can send data sources requests.",
-      },
-    });
-  }
-
-  if (!user || !owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "data_source_not_found",
-        message: "The data source you requested was not found.",
-      },
-    });
-  }
+  const user = auth.getNonNullableUser();
 
   const { method } = req;
 

--- a/front/pages/api/w/[wId]/dust_app_secrets/[name]/destroy.ts
+++ b/front/pages/api/w/[wId]/dust_app_secrets/[name]/destroy.ts
@@ -17,7 +17,7 @@ async function handler(
   auth: Authenticator
 ): Promise<void> {
   if (!auth.isBuilder()) {
-    apiError(req, res, {
+    return apiError(req, res, {
       status_code: 403,
       api_error: {
         type: "workspace_auth_error",
@@ -25,20 +25,18 @@ async function handler(
           "Only users that are `builders` for the current workspace can manage secrets.",
       },
     });
-    return;
   }
 
   const secret = await getDustAppSecret(auth, <string>req.query.name);
 
   if (secret == null) {
-    apiError(req, res, {
+    return apiError(req, res, {
       status_code: 404,
       api_error: {
         type: "dust_app_secret_not_found",
         message: "Workspace not found.",
       },
     });
-    return;
   }
 
   switch (req.method) {
@@ -55,7 +53,6 @@ async function handler(
           message: "The method passed is not supported, POST is expected.",
         },
       });
-      return;
   }
 }
 

--- a/front/pages/api/w/[wId]/dust_app_secrets/index.ts
+++ b/front/pages/api/w/[wId]/dust_app_secrets/index.ts
@@ -29,19 +29,6 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  const owner = auth.getNonNullableWorkspace();
-
-  const user = auth.user();
-  if (!user) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace or user is missing.",
-      },
-    });
-  }
-
   if (!auth.isBuilder()) {
     return apiError(req, res, {
       status_code: 403,
@@ -51,6 +38,9 @@ async function handler(
       },
     });
   }
+
+  const owner = auth.getNonNullableWorkspace();
+  const user = auth.getNonNullableUser();
 
   const remaining = await rateLimiter({
     key: `workspace:${owner.id}:dust_app_secrets`,

--- a/front/pages/api/w/[wId]/files/[fileId].ts
+++ b/front/pages/api/w/[wId]/files/[fileId].ts
@@ -27,17 +27,6 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<FileUploadedRequestResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users of the current workspace can update chat sessions.",
-      },
-    });
-  }
-
   const { fileId } = req.query;
   if (typeof fileId !== "string") {
     return apiError(req, res, {

--- a/front/pages/api/w/[wId]/files/index.ts
+++ b/front/pages/api/w/[wId]/files/index.ts
@@ -24,28 +24,7 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<FileUploadRequestResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
-  const user = auth.user();
-  if (!user) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_user_not_found",
-        message: "Could not find the user of the current session.",
-      },
-    });
-  }
-
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users of the current workspace can update chat sessions.",
-      },
-    });
-  }
-
+  const user = auth.getNonNullableUser();
   const owner = auth.getNonNullableWorkspace();
 
   switch (req.method) {

--- a/front/pages/api/w/[wId]/groups/[gId]/index.ts
+++ b/front/pages/api/w/[wId]/groups/[gId]/index.ts
@@ -27,17 +27,6 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you requested was not found.",
-      },
-    });
-  }
-
   const { gId } = req.query;
 
   if (typeof gId !== "string") {

--- a/front/pages/api/w/[wId]/groups/index.ts
+++ b/front/pages/api/w/[wId]/groups/index.ts
@@ -15,17 +15,6 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<GetGroupsResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you requested was not found.",
-      },
-    });
-  }
-
   switch (req.method) {
     case "GET":
       const groups = await GroupResource.listWorkspaceGroups(auth);

--- a/front/pages/api/w/[wId]/invitations/index.ts
+++ b/front/pages/api/w/[wId]/invitations/index.ts
@@ -44,16 +44,8 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  const user = auth.user();
-  if (!user) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace was not found.",
-      },
-    });
-  }
+  const user = auth.getNonNullableUser();
+  const owner = auth.getNonNullableWorkspace();
 
   if (!auth.isAdmin()) {
     return apiError(req, res, {
@@ -65,8 +57,6 @@ async function handler(
       },
     });
   }
-
-  const owner = auth.getNonNullableWorkspace();
 
   const subscription = auth.subscription();
   const plan = auth.plan();

--- a/front/pages/api/w/[wId]/keys/index.ts
+++ b/front/pages/api/w/[wId]/keys/index.ts
@@ -29,11 +29,17 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  const user = auth.user();
+  const user = auth.getNonNullableUser();
 
   if (!auth.isBuilder()) {
-    res.status(403).end();
-    return;
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message:
+          "Only the users that are `builders` for the current workspace can interact with keys.",
+      },
+    });
   }
 
   const owner = auth.getNonNullableWorkspace();
@@ -78,7 +84,7 @@ async function handler(
       const key = await KeyResource.makeNew({
         name: name,
         status: "active",
-        userId: user?.id,
+        userId: user.id,
         groupId: group.value.id,
         workspaceId: owner.id,
         isSystem: false,

--- a/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
@@ -33,16 +33,6 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users of the current workspace can interact with Transcripts",
-      },
-    });
-  }
   const user = auth.getNonNullableUser();
   const owner = auth.getNonNullableWorkspace();
 

--- a/front/pages/api/w/[wId]/labs/transcripts/index.ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/index.ts
@@ -30,18 +30,7 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  const userId = auth.user()?.id;
-
-  if (!userId) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace or user was not found.",
-      },
-    });
-  }
-
+  const user = auth.getNonNullableUser();
   const owner = auth.getNonNullableWorkspace();
 
   if (!owner.flags.includes("labs_transcripts")) {
@@ -59,7 +48,7 @@ async function handler(
       const transcriptsConfiguration =
         await LabsTranscriptsConfigurationResource.findByUserAndWorkspace({
           auth,
-          userId,
+          userId: user.id,
         });
 
       if (!transcriptsConfiguration) {
@@ -94,7 +83,7 @@ async function handler(
       const transcriptsConfigurationAlreadyExists =
         await LabsTranscriptsConfigurationResource.findByUserAndWorkspace({
           auth,
-          userId,
+          userId: user.id,
         });
 
       if (transcriptsConfigurationAlreadyExists) {
@@ -109,7 +98,7 @@ async function handler(
 
       const transcriptsConfigurationPostResource =
         await LabsTranscriptsConfigurationResource.makeNew({
-          userId,
+          userId: user.id,
           workspaceId: owner.id,
           provider,
           connectionId,

--- a/front/pages/api/w/[wId]/members/[uId]/index.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/index.ts
@@ -24,23 +24,21 @@ async function handler(
 ): Promise<void> {
   const owner = auth.getNonNullableWorkspace();
 
-  if (!auth.isAdmin()) {
-    // Allow Dust Super User to force role for testing
-    const allowForTesting =
-      canForceUserRole(owner) &&
-      auth.isDustSuperUser() &&
-      req.body.force === "true";
+  // Allow Dust Super User to force role for testing
+  const allowForSuperUserTesting =
+    canForceUserRole(owner) &&
+    auth.isDustSuperUser() &&
+    req.body.force === "true";
 
-    if (!allowForTesting) {
-      return apiError(req, res, {
-        status_code: 403,
-        api_error: {
-          type: "workspace_auth_error",
-          message:
-            "Only users that are `admins` for the current workspace can see memberships or modify it.",
-        },
-      });
-    }
+  if (!auth.isAdmin() && !allowForSuperUserTesting) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can see memberships or modify it.",
+      },
+    });
   }
 
   const userId = req.query.uId;

--- a/front/pages/api/w/[wId]/members/me/agent_list_status.ts
+++ b/front/pages/api/w/[wId]/members/me/agent_list_status.ts
@@ -29,17 +29,6 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<PostAgentListStatusResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users of the current workspace are authorized to access this endpoint.",
-      },
-    });
-  }
-
   switch (req.method) {
     case "POST":
       const bodyValidation = PostAgentListStatusRequestBodySchema.decode(

--- a/front/pages/api/w/[wId]/providers/[pId]/models.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/models.ts
@@ -22,17 +22,6 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "provider_auth_error",
-        message:
-          "Only the users of a workspace can list models from providers.",
-      },
-    });
-  }
-
   const owner = auth.getNonNullableWorkspace();
 
   const [provider] = await Promise.all([

--- a/front/pages/api/w/[wId]/providers/index.ts
+++ b/front/pages/api/w/[wId]/providers/index.ts
@@ -64,7 +64,6 @@ async function handler(
           message: "The method passed is not supported, GET is expected.",
         },
       });
-      return;
   }
 }
 

--- a/front/pages/api/w/[wId]/subscriptions/index.ts
+++ b/front/pages/api/w/[wId]/subscriptions/index.ts
@@ -80,7 +80,6 @@ async function handler(
           },
         });
       }
-      break;
     }
     case "POST": {
       const bodyValidation = PostSubscriptionRequestBody.decode(req.body);
@@ -111,7 +110,6 @@ async function handler(
           },
         });
       }
-      break;
     }
 
     case "PATCH": {

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/content.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/content.ts
@@ -18,17 +18,6 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users of the current workspace can interact with vaults.",
-      },
-    });
-  }
-
   const dataSourceView = await DataSourceViewResource.fetchById(
     auth,
     req.query.dsvId as string

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/documents/[documentId]/index.ts
@@ -28,17 +28,6 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users of the current workspace can interact with vaults.",
-      },
-    });
-  }
-
   const { dsvId, documentId } = req.query;
 
   if (typeof dsvId !== "string" || typeof documentId !== "string") {

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.ts
@@ -18,17 +18,6 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<GetDataSourceViewResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users of the current workspace can interact with vaults.",
-      },
-    });
-  }
-
   const dataSourceView = await DataSourceViewResource.fetchById(
     auth,
     req.query.dsvId as string

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/index.ts
@@ -28,17 +28,6 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users of the current workspace can interact with vaults.",
-      },
-    });
-  }
-
   const vault = await VaultResource.fetchById(auth, req.query.vId as string);
 
   if (

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/managed.ts
@@ -60,17 +60,6 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<PostVaultDataSourceResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users of the current workspace can interact with vaults.",
-      },
-    });
-  }
-
   const owner = auth.getNonNullableWorkspace();
   const plan = auth.getNonNullablePlan();
   const user = auth.getNonNullableUser();

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/static.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/static.ts
@@ -43,16 +43,6 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<PostVaultDataSourceResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 401,
-      api_error: {
-        type: "workspace_auth_error",
-        message: "Only users of the workspace can access this route.",
-      },
-    });
-  }
-
   const owner = auth.getNonNullableWorkspace();
   const plan = auth.getNonNullablePlan();
   const user = auth.getNonNullableUser();

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/static.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/static.ts
@@ -45,11 +45,10 @@ async function handler(
 ): Promise<void> {
   if (!auth.isUser()) {
     return apiError(req, res, {
-      status_code: 403,
+      status_code: 401,
       api_error: {
         type: "workspace_auth_error",
-        message:
-          "Only users of the current workspace can interact with vaults.",
+        message: "Only users of the workspace can access this route.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/vaults/[vId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/index.ts
@@ -37,17 +37,6 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users of the current workspace can interact with vaults.",
-      },
-    });
-  }
-
   const vault = await VaultResource.fetchById(auth, req.query.vId as string);
 
   // Check if the user has access to the vault - either they are an admin or they have read access

--- a/front/pages/api/w/[wId]/vaults/index.ts
+++ b/front/pages/api/w/[wId]/vaults/index.ts
@@ -27,17 +27,6 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users of the current workspace can interact with vaults.",
-      },
-    });
-  }
-
   const owner = auth.getNonNullableWorkspace();
 
   switch (req.method) {


### PR DESCRIPTION
## Description

Enforce `isUser` in `withSessionAuthenticationForWorkspace` unless `allowUserOutsideCurrentWorkspace` is set as option.

- Remove all unnecessary call to isUser in internal endpoints
- Move to call to getNonNullable methods in all endpoints

For Dust Apps:
- We allow external users for:
  - `/w/[wId]/apps/[aId]/index.ts` (only public apps are returned if not Builder)
  - `/w/[wId]/apps/[aId]/clone` (cloning logic)
  -  `/w/[wId]/apps/[aId]/runs/[runId]/status` (access to the stored run status of public apps) 
  - `/w/[wId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]` (access the stored block statuses of public apps) 

This is for displaying public/unlisted dust apps (so that they can be cloned)
  
Among all theses the riskier is the last one. This means for public/unlisted apps, one can retrieve the content of a run block if it has the runId. Since Dust runs on public apps, this means that we rely on the runId randomness to secure the conversations data. This is the current state of affairs and this PR only restricts do not open anything. We may want to remove showing the run outputs when accessing a public dust app which would allow us closing a few more endpoints. Will tackle that in a subsequent PR. Also the dataset part public dust apps is quite broken already. Will fix in subsequent PR. Here we are being restrictive.
  
We don't need and don't want it on
  - `/w/[wId]/apps/[aId]/runs/index.ts

As we are part of the `dust-apps` workspace, so we have access to runs and we can get other workspace runs because we hare super users. This PR removes wIdTarget support for non dust super users.

Only one endpoint below `w/[wId]` does not use `withSessionAuthenticationForWorkspace`: `data_sources/[name]/documents/index.ts` because it's shared by poke. Follow-up actions, cut a different endpoint in poke.

## Risk

High - Authorization tweaks

## Deploy Plan

- deploy `front`