### PR TITLE
Apply view filter when fetch document content

### DIFF
--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/documents/[documentId]/index.ts
@@ -72,9 +72,17 @@ async function handler(
   switch (req.method) {
     case "GET":
       const document = await coreAPI.getDataSourceDocument({
-        projectId: dataSourceView.dataSource.dustAPIProjectId,
         dataSourceName: dataSourceView.dataSource.name,
         documentId,
+        projectId: dataSourceView.dataSource.dustAPIProjectId,
+        viewFilter: {
+          parents: {
+            in: dataSourceView.parentsIn,
+            not: null,
+          },
+          tags: null,
+          timestamp: null,
+        },
       });
 
       if (document.isErr()) {

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -736,9 +736,7 @@ export class CoreAPI {
         projectId
       )}/data_sources/${encodeURIComponent(
         dataSourceName
-      )}/documents/${encodeURIComponent(documentId)}${
-        qs ? `?${encodeURIComponent(qs)}` : ""
-      }`,
+      )}/documents/${encodeURIComponent(documentId)}${qs ? `?${qs}` : ""}`,
       {
         method: "GET",
       }

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -702,28 +702,43 @@ export class CoreAPI {
   }
 
   async getDataSourceDocument({
-    projectId,
     dataSourceName,
     documentId,
+    projectId,
     versionHash,
+    viewFilter,
   }: {
-    projectId: string;
     dataSourceName: string;
     documentId: string;
+    projectId: string;
     versionHash?: string | null;
+    viewFilter?: CoreAPISearchFilter | null;
   }): Promise<
     CoreAPIResponse<{
       document: CoreAPIDocument;
       data_source: CoreAPIDataSource;
     }>
   > {
-    const qs = versionHash ? `?version_hash=${versionHash}` : "";
+    const queryParams = new URLSearchParams();
+
+    if (versionHash) {
+      queryParams.append("version_hash", versionHash);
+    }
+
+    if (viewFilter) {
+      queryParams.append("view_filter", JSON.stringify(viewFilter));
+    }
+
+    const qs = queryParams.toString();
+
     const response = await this._fetchWithError(
       `${this._url}/projects/${encodeURIComponent(
         projectId
       )}/data_sources/${encodeURIComponent(
         dataSourceName
-      )}/documents/${encodeURIComponent(documentId)}${qs}`,
+      )}/documents/${encodeURIComponent(documentId)}${
+        qs ? `?${encodeURIComponent(qs)}` : ""
+      }`,
       {
         method: "GET",
       }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We've added an endpoint to retrieve the content of a document from a data source view in https://github.com/dust-tt/dust/pull/6864. This PR ensures that the data source view's parent filter is applied when fetching the requested document, resulting in a 404 error if the document does not meet the view filter criteria. This is necessary to prevent users from accessing the content of a document that exists in the data source but is not included in the data source view.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
