### PR TITLE
Sparkle: Add icon to ContentMessage

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.212",
+  "version": "0.2.213",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.212",
+      "version": "0.2.213",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.212",
+  "version": "0.2.213",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/ContentMessage.tsx
+++ b/sparkle/src/components/ContentMessage.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { ComponentType } from "react";
 
 import { classNames } from "@sparkle/lib/utils";
 
@@ -19,6 +19,7 @@ export interface ContentMessageProps {
     | "pink"
     | "action"
     | "red";
+  icon?: ComponentType;
 }
 
 export function ContentMessage({
@@ -27,6 +28,7 @@ export function ContentMessage({
   children,
   size = "md",
   className = "",
+  icon,
 }: ContentMessageProps) {
   const variantClasses = {
     border: `s-border-${variant}-200`,
@@ -52,7 +54,7 @@ export function ContentMessage({
         <>
           <Icon
             size="md"
-            visual={InformationCircleIcon}
+            visual={icon ?? InformationCircleIcon}
             className={classNames("s-shrink-0", variantClasses.iconColor)}
           />
           <div className="s-flex s-flex-col s-gap-2">

--- a/sparkle/src/stories/ContentMessage.stories.tsx
+++ b/sparkle/src/stories/ContentMessage.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta } from "@storybook/react";
 import React from "react";
 
-import { ContentMessage } from "../index_with_tw_base";
+import { ContentMessage, HeartIcon } from "../index_with_tw_base";
 
 const meta = {
   title: "Components/ContentMessage",
@@ -19,8 +19,8 @@ export const ContentExample = () => (
     <ContentMessage title="This is a title" variant="pink">
       This is a message. It can be multiple lines long.
     </ContentMessage>
-    <ContentMessage title="This is a title" variant="emerald">
-      This is a message. It can be multiple lines long.
+    <ContentMessage title="This is a cat" variant="purple" icon={HeartIcon}>
+      This is a Soupinou. It is cute.
     </ContentMessage>
     <h2>Size "sm"</h2>
     <ContentMessage title="This is a title" size="sm">


### PR DESCRIPTION
## Description

Just adding the possibility to choose the icon we display in a `ContentMessage`. It was always the info icon. 

<kbd>
<img width="1019" alt="Screenshot 2024-08-26 at 18 19 27" src="https://github.com/user-attachments/assets/599aab2e-84e4-400f-933f-dca449f7d8c5">
</kbd>


## Risk

/ 

## Deploy Plan

Merge, publish sparkle. 
Use on front. 
