### PR TITLE
Dust apps: do not show block outputs in readOnly

### DIFF
--- a/front/components/app/blocks/Block.tsx
+++ b/front/components/app/blocks/Block.tsx
@@ -216,7 +216,7 @@ export default function Block({
             {` 0 successes 0 errors`}
           </div>
         ) : null}
-        {status && status.status != "running" && run ? (
+        {status && status.status != "running" && run && !readOnly ? (
           <Output owner={owner} runId={run.run_id} block={block} app={app} />
         ) : null}
       </div>


### PR DESCRIPTION
## Description

When viewing Dust apps in readOnly (not builder, aka users wandering there or people viewing a dust app from a different workspace), this PR prevents loading the block outputs.

The goal is to reduce the product surface capable of leaking sensitive data even: even if runIds from a workspace on a public apps were leaked an attacked would not be able to retrieve the content of blocks outputs with it which is highly desirable

Context: https://github.com/dust-tt/tasks/issues/1194

## Risk

N/A

## Deploy Plan

- deploy `front`