### PR TITLE
Dust apps: log wIdTarget accesses

### DIFF
--- a/front/pages/api/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/runs/index.ts
@@ -47,6 +47,7 @@ async function handler(
   }
 
   let owner = auth.getNonNullableWorkspace();
+  const user = auth.getNonNullableUser();
 
   const app = await getApp(auth, req.query.aId as string);
   if (!app) {
@@ -191,6 +192,16 @@ async function handler(
             },
           });
         }
+
+        logger.info(
+          {
+            owner: owner.sId,
+            targetOwner: targetOwner.sId,
+            user: user.sId,
+            app: app.sId,
+          },
+          "wIdTarget access"
+        );
 
         owner = targetOwner;
       }


### PR DESCRIPTION
## Description

Following up authentication re-work today, it appeared clear that `wIdTarget` access is a critical safety consideration. Adding a log of access will let us monitor its use and detect any abnormal use.

Context: https://github.com/dust-tt/tasks/issues/1194

## Risk

N/A

## Deploy Plan

- deploy `front`