### PR TITLE
New Design Assistant Thoughts

### DIFF
--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -144,11 +144,13 @@ export function RenderMessageMarkdown({
   isStreaming,
   citationsContext,
   textSize,
+  textColor,
 }: {
   content: string;
   isStreaming: boolean;
   citationsContext?: CitationsContextType;
   textSize?: "sm" | "base";
+  textColor?: string;
 }) {
   // Memoize markdown components to avoid unnecessary re-renders that disrupt text selection
   const markdownComponents: Components = useMemo(
@@ -160,9 +162,15 @@ export function RenderMessageMarkdown({
       a: LinkBlock,
       ul: UlBlock,
       ol: OlBlock,
-      li: ({ children }) => <LiBlock textSize={textSize}>{children}</LiBlock>,
+      li: ({ children }) => (
+        <LiBlock textSize={textSize} textColor={textColor}>
+          {children}
+        </LiBlock>
+      ),
       p: ({ children }) => (
-        <ParagraphBlock textSize={textSize}>{children}</ParagraphBlock>
+        <ParagraphBlock textSize={textSize} textColor={textColor}>
+          {children}
+        </ParagraphBlock>
       ),
       sup: CiteBlock,
       table: TableBlock,
@@ -562,30 +570,29 @@ function PreBlock({
 
 function UlBlock({ children }: { children: React.ReactNode }) {
   return (
-    <ul className="list-disc py-2 pl-8 text-element-800 first:pt-0 last:pb-0">
-      {children}
-    </ul>
+    <ul className="list-disc py-2 pl-8 first:pt-0 last:pb-0">{children}</ul>
   );
 }
 function OlBlock({ children }: { children: React.ReactNode }) {
   return (
-    <ol className="list-decimal py-3 pl-8 text-element-800 first:pt-0 last:pb-0">
-      {children}
-    </ol>
+    <ol className="list-decimal py-3 pl-8 first:pt-0 last:pb-0">{children}</ol>
   );
 }
 function LiBlock({
   textSize,
+  textColor,
   children,
 }: {
   textSize?: string;
+  textColor?: string;
   children: React.ReactNode;
 }) {
   return (
     <li
       className={classNames(
-        "break-words text-element-800 first:pt-0 last:pb-0",
-        textSize === "sm" ? "py-1" : "py-2"
+        "break-words first:pt-0 last:pb-0",
+        textSize === "sm" ? "py-1" : "py-2",
+        textColor ? textColor : "text-element-800"
       )}
     >
       {children}
@@ -594,16 +601,19 @@ function LiBlock({
 }
 function ParagraphBlock({
   textSize,
+  textColor,
   children,
 }: {
   textSize?: string;
+  textColor?: string;
   children: React.ReactNode;
 }) {
   return (
     <div
       className={classNames(
-        "whitespace-pre-wrap break-words font-normal text-element-800 first:pt-0 last:pb-0",
-        textSize === "sm" ? "py-1 text-sm" : "py-2 text-base leading-7"
+        "whitespace-pre-wrap break-words font-normal first:pt-0 last:pb-0",
+        textSize === "sm" ? "py-1 text-sm" : "py-2 text-base leading-7",
+        textColor ? textColor : "text-element-800"
       )}
     >
       {children}

--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -143,10 +143,12 @@ export function RenderMessageMarkdown({
   content,
   isStreaming,
   citationsContext,
+  textSize,
 }: {
   content: string;
   isStreaming: boolean;
   citationsContext?: CitationsContextType;
+  textSize?: "sm" | "base";
 }) {
   // Memoize markdown components to avoid unnecessary re-renders that disrupt text selection
   const markdownComponents: Components = useMemo(
@@ -158,8 +160,10 @@ export function RenderMessageMarkdown({
       a: LinkBlock,
       ul: UlBlock,
       ol: OlBlock,
-      li: LiBlock,
-      p: ParagraphBlock,
+      li: ({ children }) => <LiBlock textSize={textSize}>{children}</LiBlock>,
+      p: ({ children }) => (
+        <ParagraphBlock textSize={textSize}>{children}</ParagraphBlock>
+      ),
       sup: CiteBlock,
       table: TableBlock,
       thead: TableHeadBlock,
@@ -570,16 +574,38 @@ function OlBlock({ children }: { children: React.ReactNode }) {
     </ol>
   );
 }
-function LiBlock({ children }: { children: React.ReactNode }) {
+function LiBlock({
+  textSize,
+  children,
+}: {
+  textSize?: string;
+  children: React.ReactNode;
+}) {
   return (
-    <li className="break-words py-2 text-element-800 first:pt-0 last:pb-0">
+    <li
+      className={classNames(
+        "break-words text-element-800 first:pt-0 last:pb-0",
+        textSize === "sm" ? "py-1" : "py-2"
+      )}
+    >
       {children}
     </li>
   );
 }
-function ParagraphBlock({ children }: { children: React.ReactNode }) {
+function ParagraphBlock({
+  textSize,
+  children,
+}: {
+  textSize?: string;
+  children: React.ReactNode;
+}) {
   return (
-    <div className="whitespace-pre-wrap break-words py-2 text-base font-normal leading-7 text-element-800 first:pt-0 last:pb-0">
+    <div
+      className={classNames(
+        "whitespace-pre-wrap break-words font-normal text-element-800 first:pt-0 last:pb-0",
+        textSize === "sm" ? "py-1 text-sm" : "py-2 text-base leading-7"
+      )}
+    >
       {children}
     </div>
   );

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -554,6 +554,7 @@ export function AgentMessage({
               content={agentMessage.chainOfThought}
               isStreaming={false}
               textSize="sm"
+              textColor="purple-800"
             />
           </ContentMessage>
         ) : null}

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1,14 +1,14 @@
 import {
   ArrowPathIcon,
   Button,
+  ChatBubbleThoughtIcon,
   Chip,
   Citation,
   ClipboardIcon,
+  ContentMessage,
   DocumentDuplicateIcon,
   DropdownMenu,
   EyeIcon,
-  Icon,
-  PuzzleIcon,
 } from "@dust-tt/sparkle";
 import type {
   AgentActionSpecificEvent,
@@ -545,19 +545,17 @@ export function AgentMessage({
         </>
 
         {agentMessage.chainOfThought?.length ? (
-          <div className="flex w-full flex-col gap-2 rounded-2xl border border-slate-200 bg-slate-100 p-4 text-sm text-slate-800">
-            <div className="flex flex-row gap-2">
-              <Icon size="sm" visual={PuzzleIcon} />
-              <div className="font-semibold">Assistant thoughts</div>
-            </div>
-
-            <div className="italic">
-              <RenderMessageMarkdown
-                content={agentMessage.chainOfThought}
-                isStreaming={false}
-              />
-            </div>
-          </div>
+          <ContentMessage
+            title="Assistant thoughts"
+            variant="purple"
+            icon={ChatBubbleThoughtIcon}
+          >
+            <RenderMessageMarkdown
+              content={agentMessage.chainOfThought}
+              isStreaming={false}
+              textSize="sm"
+            />
+          </ContentMessage>
         ) : null}
 
         {agentMessage.content !== null && (

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,7 @@
         "@amplitude/analytics-browser": "^2.5.2",
         "@amplitude/analytics-node": "^1.3.5",
         "@auth0/nextjs-auth0": "^3.5.0",
-        "@dust-tt/sparkle": "^0.2.212",
+        "@dust-tt/sparkle": "^0.2.213",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -10735,9 +10735,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.212",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.212.tgz",
-      "integrity": "sha512-EthHoTIxf5OVjCvNOquGMe7+VU7fAYQITZXuGBf5QFTy9NopM4ZlrxM/pljHLZiYuT0rCmFoD3a+zZ/qXwP/BQ==",
+      "version": "0.2.213",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.213.tgz",
+      "integrity": "sha512-4OY8zK3Yy7tAX8wDfVeOAi2J5yJLrsUke5EmRDetYFnV9JstHAj9UWF7ZXfxGDuVbR814pmUuSkVuKXMFfuY6w==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
     "@amplitude/analytics-browser": "^2.5.2",
     "@amplitude/analytics-node": "^1.3.5",
     "@auth0/nextjs-auth0": "^3.5.0",
-    "@dust-tt/sparkle": "^0.2.212",
+    "@dust-tt/sparkle": "^0.2.213",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",


### PR DESCRIPTION
## Description

### Task

Task: https://github.com/dust-tt/tasks/issues/1055
Todo: New design for Assistant Thought.

From Figma: 
<kbd>
![image](https://github.com/user-attachments/assets/6caa3410-5989-4617-9fb8-b2a661d546ac)
</kbd>

### Done

It's a bit annoying to reduce the text size because the text is going through `RenderMessageMarkdown`.
I added an optional `textSize` attribute for this component, and we reduce textSize & paddings in paragraphs & li. 


<kbd>
<img width="781" alt="Screenshot 2024-08-27 at 10 14 10" src="https://github.com/user-attachments/assets/7aeae7a8-a388-4377-932f-a9173640701c">
</kbd>


Here's what a list looks like: 
<kbd>
<img width="539" alt="Screenshot 2024-08-27 at 10 16 33" src="https://github.com/user-attachments/assets/454874c7-697b-4078-a791-749a297947e0">
</kbd>


## Risk

Can be rolled back.

## Deploy Plan

Deploy front. 
