### PR TITLE
Fix outputs hiding/non-hiding in runs view

### DIFF
--- a/front/components/app/SpecRunView.tsx
+++ b/front/components/app/SpecRunView.tsx
@@ -26,6 +26,7 @@ export default function SpecRunView({
   owner,
   app,
   readOnly,
+  showOutputs,
   spec,
   run,
   runRequested,
@@ -38,6 +39,7 @@ export default function SpecRunView({
   owner: WorkspaceType;
   app: AppType;
   readOnly: boolean;
+  showOutputs: boolean;
   spec: SpecificationType;
   run: RunType | null;
   runRequested: boolean;
@@ -91,6 +93,7 @@ export default function SpecRunView({
                   status={status}
                   running={runRequested || run?.status.run == "running"}
                   readOnly={readOnly}
+                  showOutputs={showOutputs}
                   onBlockUpdate={(block) => handleSetBlock(idx, block)}
                   onBlockDelete={() => handleDeleteBlock(idx)}
                   onBlockUp={() => handleMoveBlockUp(idx)}
@@ -111,6 +114,7 @@ export default function SpecRunView({
                   status={status}
                   running={runRequested || run?.status.run == "running"}
                   readOnly={readOnly}
+                  showOutputs={showOutputs}
                   onBlockUpdate={(block) => handleSetBlock(idx, block)}
                   onBlockDelete={() => handleDeleteBlock(idx)}
                   onBlockUp={() => handleMoveBlockUp(idx)}
@@ -131,6 +135,7 @@ export default function SpecRunView({
                   status={status}
                   running={runRequested || run?.status.run == "running"}
                   readOnly={readOnly}
+                  showOutputs={showOutputs}
                   onBlockUpdate={(block) => handleSetBlock(idx, block)}
                   onBlockDelete={() => handleDeleteBlock(idx)}
                   onBlockUp={() => handleMoveBlockUp(idx)}
@@ -151,6 +156,7 @@ export default function SpecRunView({
                   status={status}
                   running={runRequested || run?.status.run == "running"}
                   readOnly={readOnly}
+                  showOutputs={showOutputs}
                   onBlockUpdate={(block) => handleSetBlock(idx, block)}
                   onBlockDelete={() => handleDeleteBlock(idx)}
                   onBlockUp={() => handleMoveBlockUp(idx)}
@@ -171,6 +177,7 @@ export default function SpecRunView({
                   status={status}
                   running={runRequested || run?.status.run == "running"}
                   readOnly={readOnly}
+                  showOutputs={showOutputs}
                   onBlockUpdate={(block) => handleSetBlock(idx, block)}
                   onBlockDelete={() => handleDeleteBlock(idx)}
                   onBlockUp={() => handleMoveBlockUp(idx)}
@@ -191,6 +198,7 @@ export default function SpecRunView({
                   status={status}
                   running={runRequested || run?.status.run == "running"}
                   readOnly={readOnly}
+                  showOutputs={showOutputs}
                   onBlockUpdate={(block) => handleSetBlock(idx, block)}
                   onBlockDelete={() => handleDeleteBlock(idx)}
                   onBlockUp={() => handleMoveBlockUp(idx)}
@@ -211,6 +219,7 @@ export default function SpecRunView({
                   status={status}
                   running={runRequested || run?.status.run == "running"}
                   readOnly={readOnly}
+                  showOutputs={showOutputs}
                   onBlockUpdate={(block) => handleSetBlock(idx, block)}
                   onBlockDelete={() => handleDeleteBlock(idx)}
                   onBlockUp={() => handleMoveBlockUp(idx)}
@@ -231,6 +240,7 @@ export default function SpecRunView({
                   status={status}
                   running={runRequested || run?.status.run == "running"}
                   readOnly={readOnly}
+                  showOutputs={showOutputs}
                   onBlockUpdate={(block) => handleSetBlock(idx, block)}
                   onBlockDelete={() => handleDeleteBlock(idx)}
                   onBlockUp={() => handleMoveBlockUp(idx)}
@@ -251,6 +261,7 @@ export default function SpecRunView({
                   status={status}
                   running={runRequested || run?.status.run == "running"}
                   readOnly={readOnly}
+                  showOutputs={showOutputs}
                   onBlockUpdate={(block) => handleSetBlock(idx, block)}
                   onBlockDelete={() => handleDeleteBlock(idx)}
                   onBlockUp={() => handleMoveBlockUp(idx)}
@@ -271,6 +282,7 @@ export default function SpecRunView({
                   status={status}
                   running={runRequested || run?.status.run == "running"}
                   readOnly={readOnly}
+                  showOutputs={showOutputs}
                   onBlockUpdate={(block) => handleSetBlock(idx, block)}
                   onBlockDelete={() => handleDeleteBlock(idx)}
                   onBlockUp={() => handleMoveBlockUp(idx)}
@@ -291,6 +303,7 @@ export default function SpecRunView({
                   status={status}
                   running={runRequested || run?.status.run == "running"}
                   readOnly={readOnly}
+                  showOutputs={showOutputs}
                   onBlockUpdate={(block) => handleSetBlock(idx, block)}
                   onBlockDelete={() => handleDeleteBlock(idx)}
                   onBlockUp={() => handleMoveBlockUp(idx)}
@@ -311,6 +324,7 @@ export default function SpecRunView({
                   status={status}
                   running={runRequested || run?.status.run == "running"}
                   readOnly={readOnly}
+                  showOutputs={showOutputs}
                   onBlockUpdate={(block) => handleSetBlock(idx, block)}
                   onBlockDelete={() => handleDeleteBlock(idx)}
                   onBlockUp={() => handleMoveBlockUp(idx)}
@@ -331,6 +345,7 @@ export default function SpecRunView({
                   status={status}
                   running={runRequested || run?.status.run == "running"}
                   readOnly={readOnly}
+                  showOutputs={showOutputs}
                   onBlockUpdate={(block) => handleSetBlock(idx, block)}
                   onBlockDelete={() => handleDeleteBlock(idx)}
                   onBlockUp={() => handleMoveBlockUp(idx)}
@@ -351,6 +366,7 @@ export default function SpecRunView({
                   status={status}
                   running={runRequested || run?.status.run == "running"}
                   readOnly={readOnly}
+                  showOutputs={showOutputs}
                   onBlockUpdate={(block) => handleSetBlock(idx, block)}
                   onBlockDelete={() => handleDeleteBlock(idx)}
                   onBlockUp={() => handleMoveBlockUp(idx)}
@@ -371,6 +387,7 @@ export default function SpecRunView({
                   status={status}
                   running={runRequested || run?.status.run == "running"}
                   readOnly={readOnly}
+                  showOutputs={showOutputs}
                   onBlockUpdate={(block) => handleSetBlock(idx, block)}
                   onBlockDelete={() => handleDeleteBlock(idx)}
                   onBlockUp={() => handleMoveBlockUp(idx)}

--- a/front/components/app/blocks/Block.tsx
+++ b/front/components/app/blocks/Block.tsx
@@ -30,6 +30,7 @@ export default function Block({
   status,
   running,
   readOnly,
+  showOutputs,
   children,
   canUseCache,
   onBlockUpdate,
@@ -46,6 +47,7 @@ export default function Block({
   status: any;
   running: boolean;
   readOnly: boolean;
+  showOutputs: boolean;
   canUseCache: boolean;
   onBlockUpdate: (block: SpecificationBlockType) => void;
   onBlockDelete: () => void;
@@ -216,7 +218,7 @@ export default function Block({
             {` 0 successes 0 errors`}
           </div>
         ) : null}
-        {status && status.status != "running" && run && !readOnly ? (
+        {status && status.status != "running" && run && showOutputs ? (
           <Output owner={owner} runId={run.run_id} block={block} app={app} />
         ) : null}
       </div>

--- a/front/components/app/blocks/Browser.tsx
+++ b/front/components/app/blocks/Browser.tsx
@@ -24,6 +24,7 @@ export default function Browser({
   status,
   running,
   readOnly,
+  showOutputs,
   onBlockUpdate,
   onBlockDelete,
   onBlockUp,
@@ -38,6 +39,7 @@ export default function Browser({
   status: any;
   running: boolean;
   readOnly: boolean;
+  showOutputs: boolean;
   onBlockUpdate: (block: SpecificationBlockType) => void;
   onBlockDelete: () => void;
   onBlockUp: () => void;
@@ -127,6 +129,7 @@ export default function Browser({
       status={status}
       running={running}
       readOnly={readOnly}
+      showOutputs={showOutputs}
       canUseCache={true}
       onBlockUpdate={onBlockUpdate}
       onBlockDelete={onBlockDelete}

--- a/front/components/app/blocks/Chat.tsx
+++ b/front/components/app/blocks/Chat.tsx
@@ -28,6 +28,7 @@ export default function Chat({
   status,
   running,
   readOnly,
+  showOutputs,
   onBlockUpdate,
   onBlockDelete,
   onBlockUp,
@@ -42,6 +43,7 @@ export default function Chat({
   status: any;
   running: boolean;
   readOnly: boolean;
+  showOutputs: boolean;
   onBlockUpdate: (block: SpecificationBlockType) => void;
   onBlockDelete: () => void;
   onBlockUp: () => void;
@@ -156,6 +158,7 @@ export default function Chat({
       status={status}
       running={running}
       readOnly={readOnly}
+      showOutputs={showOutputs}
       canUseCache={true}
       onBlockUpdate={onBlockUpdate}
       onBlockDelete={onBlockDelete}

--- a/front/components/app/blocks/Code.tsx
+++ b/front/components/app/blocks/Code.tsx
@@ -27,6 +27,7 @@ export default function Code({
   status,
   running,
   readOnly,
+  showOutputs,
   onBlockUpdate,
   onBlockDelete,
   onBlockUp,
@@ -41,6 +42,7 @@ export default function Code({
   status: any;
   running: boolean;
   readOnly: boolean;
+  showOutputs: boolean;
   onBlockUpdate: (block: SpecificationBlockType) => void;
   onBlockDelete: () => void;
   onBlockUp: () => void;
@@ -63,6 +65,7 @@ export default function Code({
       status={status}
       running={running}
       readOnly={readOnly}
+      showOutputs={showOutputs}
       onBlockUpdate={onBlockUpdate}
       onBlockDelete={onBlockDelete}
       onBlockUp={onBlockUp}

--- a/front/components/app/blocks/Curl.tsx
+++ b/front/components/app/blocks/Curl.tsx
@@ -30,6 +30,7 @@ export default function Curl({
   status,
   running,
   readOnly,
+  showOutputs,
   onBlockUpdate,
   onBlockDelete,
   onBlockUp,
@@ -44,6 +45,7 @@ export default function Curl({
   status: any;
   running: boolean;
   readOnly: boolean;
+  showOutputs: boolean;
   onBlockUpdate: (block: SpecificationBlockType) => void;
   onBlockDelete: () => void;
   onBlockUp: () => void;
@@ -107,6 +109,7 @@ export default function Curl({
       status={status}
       running={running}
       readOnly={readOnly}
+      showOutputs={showOutputs}
       canUseCache={true}
       onBlockUpdate={onBlockUpdate}
       onBlockDelete={onBlockDelete}

--- a/front/components/app/blocks/Data.tsx
+++ b/front/components/app/blocks/Data.tsx
@@ -21,6 +21,7 @@ export default function Data({
   status,
   running,
   readOnly,
+  showOutputs,
   onBlockUpdate,
   onBlockDelete,
   onBlockUp,
@@ -35,6 +36,7 @@ export default function Data({
   status: any;
   running: boolean;
   readOnly: boolean;
+  showOutputs: boolean;
   onBlockUpdate: (block: SpecificationBlockType) => void;
   onBlockDelete: () => void;
   onBlockUp: () => void;
@@ -57,6 +59,7 @@ export default function Data({
       status={status}
       running={running}
       readOnly={readOnly}
+      showOutputs={showOutputs}
       onBlockUpdate={onBlockUpdate}
       onBlockDelete={onBlockDelete}
       onBlockUp={onBlockUp}

--- a/front/components/app/blocks/DataSource.tsx
+++ b/front/components/app/blocks/DataSource.tsx
@@ -31,6 +31,7 @@ export default function DataSource({
   status,
   running,
   readOnly,
+  showOutputs,
   onBlockUpdate,
   onBlockDelete,
   onBlockUp,
@@ -45,6 +46,7 @@ export default function DataSource({
   status: any;
   running: boolean;
   readOnly: boolean;
+  showOutputs: boolean;
   onBlockUpdate: (block: SpecificationBlockType) => void;
   onBlockDelete: () => void;
   onBlockUp: () => void;
@@ -198,6 +200,7 @@ export default function DataSource({
       status={status}
       running={running}
       readOnly={readOnly}
+      showOutputs={showOutputs}
       canUseCache={false}
       onBlockUpdate={onBlockUpdate}
       onBlockDelete={onBlockDelete}

--- a/front/components/app/blocks/Database.tsx
+++ b/front/components/app/blocks/Database.tsx
@@ -29,6 +29,7 @@ export default function Database({
   status,
   running,
   readOnly,
+  showOutputs,
   onBlockUpdate,
   onBlockDelete,
   onBlockUp,
@@ -43,6 +44,7 @@ export default function Database({
   status: any;
   running: boolean;
   readOnly: boolean;
+  showOutputs: boolean;
   onBlockUpdate: (block: SpecificationBlockType) => void;
   onBlockDelete: () => void;
   onBlockUp: () => void;
@@ -59,6 +61,7 @@ export default function Database({
       status={status}
       running={running}
       readOnly={readOnly}
+      showOutputs={showOutputs}
       canUseCache={false}
       onBlockUpdate={onBlockUpdate}
       onBlockDelete={onBlockDelete}

--- a/front/components/app/blocks/DatabaseSchema.tsx
+++ b/front/components/app/blocks/DatabaseSchema.tsx
@@ -23,6 +23,7 @@ export default function DatabaseSchema({
   status,
   running,
   readOnly,
+  showOutputs,
   onBlockUpdate,
   onBlockDelete,
   onBlockUp,
@@ -37,6 +38,7 @@ export default function DatabaseSchema({
   status: any;
   running: boolean;
   readOnly: boolean;
+  showOutputs: boolean;
   onBlockUpdate: (block: SpecificationBlockType) => void;
   onBlockDelete: () => void;
   onBlockUp: () => void;
@@ -53,6 +55,7 @@ export default function DatabaseSchema({
       status={status}
       running={running}
       readOnly={readOnly}
+      showOutputs={showOutputs}
       canUseCache={false}
       onBlockUpdate={onBlockUpdate}
       onBlockDelete={onBlockDelete}

--- a/front/components/app/blocks/Input.tsx
+++ b/front/components/app/blocks/Input.tsx
@@ -26,6 +26,7 @@ export default function Input({
   status,
   running,
   readOnly,
+  showOutputs,
   onBlockUpdate,
   onBlockDelete,
   onBlockUp,
@@ -40,6 +41,7 @@ export default function Input({
   status: any;
   running: boolean;
   readOnly: boolean;
+  showOutputs: boolean;
   onBlockUpdate: (block: SpecificationBlockType) => void;
   onBlockDelete: () => void;
   onBlockUp: () => void;
@@ -102,6 +104,7 @@ export default function Input({
       status={status}
       running={running}
       readOnly={readOnly}
+      showOutputs={showOutputs}
       onBlockUpdate={onBlockUpdate}
       onBlockDelete={onBlockDelete}
       onBlockUp={onBlockUp}

--- a/front/components/app/blocks/LLM.tsx
+++ b/front/components/app/blocks/LLM.tsx
@@ -31,6 +31,7 @@ export default function LLM({
   status,
   running,
   readOnly,
+  showOutputs,
   onBlockUpdate,
   onBlockDelete,
   onBlockUp,
@@ -45,6 +46,7 @@ export default function LLM({
   status: any;
   running: boolean;
   readOnly: boolean;
+  showOutputs: boolean;
   onBlockUpdate: (block: SpecificationBlockType) => void;
   onBlockDelete: () => void;
   onBlockUp: () => void;
@@ -157,6 +159,7 @@ export default function LLM({
       status={status}
       running={running}
       readOnly={readOnly}
+      showOutputs={showOutputs}
       canUseCache={true}
       onBlockUpdate={onBlockUpdate}
       onBlockDelete={onBlockDelete}

--- a/front/components/app/blocks/MapReduce.tsx
+++ b/front/components/app/blocks/MapReduce.tsx
@@ -19,6 +19,7 @@ export function Map({
   status,
   running,
   readOnly,
+  showOutputs,
   onBlockUpdate,
   onBlockDelete,
   onBlockUp,
@@ -33,6 +34,7 @@ export function Map({
   status: any;
   running: boolean;
   readOnly: boolean;
+  showOutputs: boolean;
   onBlockUpdate: (block: SpecificationBlockType) => void;
   onBlockDelete: () => void;
   onBlockUp: () => void;
@@ -61,6 +63,7 @@ export function Map({
       status={status}
       running={running}
       readOnly={readOnly}
+      showOutputs={showOutputs}
       onBlockUpdate={onBlockUpdate}
       onBlockDelete={onBlockDelete}
       onBlockUp={onBlockUp}
@@ -120,6 +123,7 @@ export function Reduce({
   status,
   running,
   readOnly,
+  showOutputs,
   onBlockUpdate,
   onBlockDelete,
   onBlockUp,
@@ -134,6 +138,7 @@ export function Reduce({
   status: any;
   running: boolean;
   readOnly: boolean;
+  showOutputs: boolean;
   onBlockUpdate: (block: SpecificationBlockType) => void;
   onBlockDelete: () => void;
   onBlockUp: () => void;
@@ -150,6 +155,7 @@ export function Reduce({
       status={status}
       running={running}
       readOnly={readOnly}
+      showOutputs={showOutputs}
       onBlockUpdate={onBlockUpdate}
       onBlockDelete={onBlockDelete}
       onBlockUp={onBlockUp}

--- a/front/components/app/blocks/Search.tsx
+++ b/front/components/app/blocks/Search.tsx
@@ -22,6 +22,7 @@ export default function Search({
   status,
   running,
   readOnly,
+  showOutputs,
   onBlockUpdate,
   onBlockDelete,
   onBlockUp,
@@ -36,6 +37,7 @@ export default function Search({
   status: any;
   running: boolean;
   readOnly: boolean;
+  showOutputs: boolean;
   onBlockUpdate: (block: SpecificationBlockType) => void;
   onBlockDelete: () => void;
   onBlockUp: () => void;
@@ -94,6 +96,7 @@ export default function Search({
       status={status}
       running={running}
       readOnly={readOnly}
+      showOutputs={showOutputs}
       canUseCache={true}
       onBlockUpdate={onBlockUpdate}
       onBlockDelete={onBlockDelete}

--- a/front/components/app/blocks/WhileEnd.tsx
+++ b/front/components/app/blocks/WhileEnd.tsx
@@ -25,6 +25,7 @@ export function While({
   status,
   running,
   readOnly,
+  showOutputs,
   onBlockUpdate,
   onBlockDelete,
   onBlockUp,
@@ -39,6 +40,7 @@ export function While({
   status: any;
   running: boolean;
   readOnly: boolean;
+  showOutputs: boolean;
   onBlockUpdate: (block: SpecificationBlockType) => void;
   onBlockDelete: () => void;
   onBlockUp: () => void;
@@ -67,6 +69,7 @@ export function While({
       status={status}
       running={running}
       readOnly={readOnly}
+      showOutputs={showOutputs}
       onBlockUpdate={onBlockUpdate}
       onBlockDelete={onBlockDelete}
       onBlockUp={onBlockUp}
@@ -138,6 +141,7 @@ export function End({
   status,
   running,
   readOnly,
+  showOutputs,
   onBlockUpdate,
   onBlockDelete,
   onBlockUp,
@@ -152,6 +156,7 @@ export function End({
   status: any;
   running: boolean;
   readOnly: boolean;
+  showOutputs: boolean;
   onBlockUpdate: (block: SpecificationBlockType) => void;
   onBlockDelete: () => void;
   onBlockUp: () => void;
@@ -168,6 +173,7 @@ export function End({
       status={status}
       running={running}
       readOnly={readOnly}
+      showOutputs={showOutputs}
       onBlockUpdate={onBlockUpdate}
       onBlockDelete={onBlockDelete}
       onBlockUp={onBlockUp}

--- a/front/pages/w/[wId]/a/[aId]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/index.tsx
@@ -408,6 +408,7 @@ export default function AppView({
             owner={owner}
             app={app}
             readOnly={readOnly}
+            showOutputs={!readOnly}
             spec={spec}
             run={run}
             runRequested={runRequested}

--- a/front/pages/w/[wId]/a/[aId]/runs/[runId]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/runs/[runId]/index.tsx
@@ -25,7 +25,7 @@ const { GA_TRACKING_ID = "" } = process.env;
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
-  readOnly: boolean;
+  isBuilder: boolean;
   app: AppType;
   run: RunType;
   spec: SpecificationType;
@@ -40,7 +40,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
-  const readOnly = !auth.isBuilder();
+  const isBuilder = auth.isBuilder();
 
   const app = await getApp(auth, context.params?.aId as string);
   if (!app) {
@@ -61,7 +61,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     props: {
       owner,
       subscription,
-      readOnly,
+      isBuilder,
       app,
       spec,
       run,
@@ -73,7 +73,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
 export default function AppRun({
   owner,
   subscription,
-  readOnly,
+  isBuilder,
   app,
   spec,
   run,
@@ -86,7 +86,7 @@ export default function AppRun({
   const confirm = useContext(ConfirmContext);
 
   const restore = async () => {
-    if (readOnly) {
+    if (!isBuilder) {
       return;
     }
 
@@ -222,6 +222,7 @@ export default function AppRun({
             owner={owner}
             app={app}
             readOnly={true}
+            showOutputs={isBuilder}
             spec={spec}
             run={run}
             runRequested={false}


### PR DESCRIPTION
## Description

This PR introduced a regression preventing seeing outputs in the runs view (which is loaded readOnly but should show outputs for builders)

We fix that by introducing a new props `showOutputs` that controls that precisely.

## Risk

N/A

## Deploy Plan

- deploy `front`