### PR TITLE
Public apps: Fix datasets view

### DIFF
--- a/front/components/app/DatasetPicker.tsx
+++ b/front/components/app/DatasetPicker.tsx
@@ -57,7 +57,7 @@ export default function DatasetPicker({
             >
               {isDatasetsLoading ? "Loading..." : "Create dataset"}
             </Link>
-          ) : readOnly ? null : (
+          ) : (
             <Menu.Button
               className={classNames(
                 "inline-flex items-center rounded-md px-3 py-1 text-sm font-normal",
@@ -65,6 +65,7 @@ export default function DatasetPicker({
                 readOnly ? "border-white text-gray-300" : "text-gray-700",
                 "focus:outline-none focus:ring-0"
               )}
+              disabled={readOnly}
             >
               {dataset ? (
                 <>
@@ -72,7 +73,9 @@ export default function DatasetPicker({
                     {dataset}
                   </div>
                   &nbsp;
-                  <ChevronDownIcon className="mt-0.5 h-4 w-4 hover:text-gray-700" />
+                  {readOnly ? null : (
+                    <ChevronDownIcon className="mt-0.5 h-4 w-4 hover:text-gray-700" />
+                  )}
                 </>
               ) : (
                 "Select dataset"

--- a/front/components/app/blocks/Data.tsx
+++ b/front/components/app/blocks/Data.tsx
@@ -93,7 +93,7 @@ export default function Data({
                 window.location.href = `/w/${owner.sId}/a/${app.sId}/datasets/${block.spec.dataset}`;
               }}
               icon={PencilSquareIcon}
-              label="Edit"
+              label={readOnly ? "View" : "Edit"}
               size="xs"
             />
           )}

--- a/front/components/app/blocks/Input.tsx
+++ b/front/components/app/blocks/Input.tsx
@@ -131,7 +131,7 @@ export default function Input({
                       variant="secondary"
                       onClick={() => setIsDatasetModalOpen(true)}
                       icon={PencilSquareIcon}
-                      label="Edit"
+                      label={readOnly ? "View" : "Edit"}
                       size="xs"
                     />
                   </>
@@ -149,15 +149,17 @@ export default function Input({
               variant="side-md"
               title={block.config.dataset}
             >
-              <Button
-                className="ml-auto mt-2"
-                variant="secondary"
-                onClick={() => {
-                  window.location.href = `/w/${owner.sId}/a/${app.sId}/datasets/${block.config.dataset}`;
-                }}
-                icon={PencilSquareIcon}
-                label="Edit schema"
-              />
+              {readOnly ? null : (
+                <Button
+                  className="ml-1 mt-2"
+                  variant="secondary"
+                  onClick={() => {
+                    window.location.href = `/w/${owner.sId}/a/${app.sId}/datasets/${block.config.dataset}`;
+                  }}
+                  icon={PencilSquareIcon}
+                  label={"Edit schema"}
+                />
+              )}
               <DatasetView
                 readOnly={false}
                 datasets={[dataset]}

--- a/front/pages/api/w/[wId]/apps/[aId]/datasets/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/datasets/index.ts
@@ -50,6 +50,17 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
+  if (!auth.isBuilder()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message:
+          "Only the users that are `builders` for the current workspace can interact with datasets.",
+      },
+    });
+  }
+
   const owner = auth.getNonNullableWorkspace();
 
   const app = await getApp(auth, req.query.aId as string);
@@ -73,17 +84,6 @@ async function handler(
       return;
 
     case "POST":
-      if (!auth.isBuilder()) {
-        return apiError(req, res, {
-          status_code: 403,
-          api_error: {
-            type: "app_auth_error",
-            message:
-              "Only the users that are `builders` for the current workspace can modify an app.",
-          },
-        });
-      }
-
       const bodyValidation = PostDatasetRequestBodySchema.decode(req.body);
       if (isLeft(bodyValidation)) {
         const pathError = reporter.formatValidationErrors(bodyValidation.left);

--- a/front/pages/w/[wId]/a/[aId]/datasets/[name]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/[name]/index.tsx
@@ -19,65 +19,66 @@ import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitl
 import { getApp } from "@app/lib/api/app";
 import { getDatasetHash, getDatasetSchema } from "@app/lib/api/datasets";
 import { useRegisterUnloadHandlers } from "@app/lib/front";
-import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirementsNoWorkspaceCheck } from "@app/lib/iam/session";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withDefaultUserAuthRequirements<{
-  owner: WorkspaceType;
-  subscription: SubscriptionType;
-  readOnly: boolean;
-  app: AppType;
-  dataset: DatasetType;
-  schema: DatasetSchema | null;
-  gaTrackingId: string;
-}>(async (context, auth) => {
-  const owner = auth.workspace();
-  const subscription = auth.subscription();
+export const getServerSideProps =
+  withDefaultUserAuthRequirementsNoWorkspaceCheck<{
+    owner: WorkspaceType;
+    subscription: SubscriptionType;
+    readOnly: boolean;
+    app: AppType;
+    dataset: DatasetType;
+    schema: DatasetSchema | null;
+    gaTrackingId: string;
+  }>(async (context, auth) => {
+    const owner = auth.workspace();
+    const subscription = auth.subscription();
 
-  if (!owner || !subscription) {
-    return {
-      notFound: true,
-    };
-  }
+    if (!owner || !subscription) {
+      return {
+        notFound: true,
+      };
+    }
 
-  const readOnly = !auth.isBuilder();
+    const readOnly = !auth.isBuilder();
 
-  const app = await getApp(auth, context.params?.aId as string);
+    const app = await getApp(auth, context.params?.aId as string);
 
-  if (!app) {
-    return {
-      notFound: true,
-    };
-  }
+    if (!app) {
+      return {
+        notFound: true,
+      };
+    }
 
-  const dataset = await getDatasetHash(
-    auth,
-    app,
-    context.params?.name as string,
-    "latest"
-  );
-
-  if (!dataset) {
-    return {
-      notFound: true,
-    };
-  }
-
-  const schema = await getDatasetSchema(auth, app, dataset.name);
-
-  return {
-    props: {
-      owner,
-      subscription,
-      readOnly,
+    const dataset = await getDatasetHash(
+      auth,
       app,
-      dataset,
-      schema,
-      gaTrackingId: GA_TRACKING_ID,
-    },
-  };
-});
+      context.params?.name as string,
+      "latest"
+    );
+
+    if (!dataset) {
+      return {
+        notFound: true,
+      };
+    }
+
+    const schema = await getDatasetSchema(auth, app, dataset.name);
+
+    return {
+      props: {
+        owner,
+        subscription,
+        readOnly,
+        app,
+        dataset,
+        schema,
+        gaTrackingId: GA_TRACKING_ID,
+      },
+    };
+  });
 
 export default function ViewDatasetView({
   owner,


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/1194

Before when viewing a public dust app without being part of the workspace we would:
- See the specification and datasets tabs but the datasets pages were not accessible
- Input block would fail to show the dataset properly with some networking errors

![Screenshot from 2024-08-27 14-29-54](https://github.com/user-attachments/assets/eb0d0aa9-d4a5-4031-9297-dd8dfa635d40)

We now properly allow to see the datasets page and also fix the input and data block display of the current dataset:

![Screenshot from 2024-08-27 14-29-24](https://github.com/user-attachments/assets/e969b9e7-0d7f-4340-9714-f25d5960897b)


This public app flow is used when we share apps with our users for them to clone. So we want it to "work"

## Risk

Opens up some endpoints but they are all dataset related and read only assuming getApp returns aka it's public.

## Deploy Plan

- deploy `front`