### PR TITLE
Remove `unlisted` options for apps --> `public`

### DIFF
--- a/front/lib/api/app.ts
+++ b/front/lib/api/app.ts
@@ -18,13 +18,13 @@ export async function getApp(
       ? {
           workspaceId: owner.id,
           visibility: {
-            [Op.or]: ["public", "private", "unlisted"],
+            [Op.or]: ["public", "private"],
           },
           sId: aId,
         }
       : {
           workspaceId: owner.id,
-          visibility: ["public", "unlisted"],
+          visibility: ["public"],
           sId: aId,
         },
   });
@@ -57,12 +57,11 @@ export async function getApps(auth: Authenticator): Promise<AppType[]> {
       ? {
           workspaceId: owner.id,
           visibility: {
-            [Op.or]: ["public", "private", "unlisted"],
+            [Op.or]: ["public", "private"],
           },
         }
       : {
           workspaceId: owner.id,
-          // Do not include 'unlisted' here.
           visibility: "public",
         },
     order: [["updatedAt", "DESC"]],

--- a/front/lib/models/apps.ts
+++ b/front/lib/models/apps.ts
@@ -21,7 +21,7 @@ export class App extends Model<
   declare sId: string;
   declare name: string;
   declare description: string | null;
-  declare visibility: "public" | "private" | "unlisted" | "deleted";
+  declare visibility: "public" | "private" | "deleted";
   declare savedSpecification: string | null;
   declare savedConfig: string | null;
   declare savedRun: string | null;

--- a/front/migrations/20240827_migrate_unlisted_apps_as_public.sql
+++ b/front/migrations/20240827_migrate_unlisted_apps_as_public.sql
@@ -1,0 +1,1 @@
+UPDATE apps SET "visibility" = 'public' WHERE "visibility" = 'unlisted';

--- a/front/pages/api/w/[wId]/apps/[aId]/clone.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/clone.ts
@@ -43,7 +43,7 @@ async function handler(
         !req.body ||
         !(typeof req.body.name == "string") ||
         !(typeof req.body.description == "string") ||
-        !["public", "private", "unlisted"].includes(req.body.visibility) ||
+        !["public", "private"].includes(req.body.visibility) ||
         !(typeof req.body.wId == "string")
       ) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/apps/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/index.ts
@@ -23,13 +23,12 @@ async function handler(
       ? {
           workspaceId: owner.id,
           visibility: {
-            [Op.or]: ["public", "private", "unlisted"],
+            [Op.or]: ["public", "private"],
           },
           sId: req.query.aId,
         }
       : {
           workspaceId: owner.id,
-          // Do not include 'unlisted' here.
           visibility: "public",
           sId: req.query.aId,
         },
@@ -76,9 +75,7 @@ async function handler(
         !req.body ||
         !(typeof req.body.name == "string") ||
         !(typeof req.body.description == "string") ||
-        !["public", "private", "unlisted", "deleted"].includes(
-          req.body.visibility
-        )
+        !["public", "private", "deleted"].includes(req.body.visibility)
       ) {
         return apiError(req, res, {
           status_code: 400,

--- a/front/pages/api/w/[wId]/apps/[aId]/state.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/state.ts
@@ -33,7 +33,7 @@ async function handler(
     where: {
       workspaceId: owner.id,
       visibility: {
-        [Op.or]: ["public", "private", "unlisted"],
+        [Op.or]: ["public", "private"],
       },
       sId: req.query.aId,
     },

--- a/front/pages/api/w/[wId]/apps/index.ts
+++ b/front/pages/api/w/[wId]/apps/index.ts
@@ -37,7 +37,7 @@ async function handler(
         !req.body ||
         !(typeof req.body.name == "string") ||
         !(typeof req.body.description == "string") ||
-        !["public", "private", "unlisted"].includes(req.body.visibility)
+        !["public", "private"].includes(req.body.visibility)
       ) {
         return apiError(req, res, {
           status_code: 400,

--- a/front/pages/w/[wId]/a/[aId]/clone.tsx
+++ b/front/pages/w/[wId]/a/[aId]/clone.tsx
@@ -299,8 +299,8 @@ export default function CloneView({
                           >
                             Public
                             <p className="mt-0 text-sm font-normal text-gray-500">
-                              Anyone on the Internet can see the app. Only
-                              builders of your workspace can edit.
+                              Anyone on the Internet with the link can see the
+                              app. Only builders of your workspace can edit.
                             </p>
                           </label>
                         </div>

--- a/front/pages/w/[wId]/a/[aId]/settings.tsx
+++ b/front/pages/w/[wId]/a/[aId]/settings.tsx
@@ -275,8 +275,8 @@ export default function SettingsView({
                           >
                             Public
                             <p className="mt-0 text-sm font-normal text-gray-500">
-                              Anyone on the Internet can see the app. Only you
-                              can edit.
+                              Anyone on the Internet with the link can see the
+                              app. Only builders of your workspace can edit.
                             </p>
                           </label>
                         </div>
@@ -302,42 +302,16 @@ export default function SettingsView({
                           >
                             Private
                             <p className="mt-0 text-sm font-normal text-gray-500">
-                              Only you can see and edit the app.
-                            </p>
-                          </label>
-                        </div>
-                        <div className="flex items-center">
-                          <input
-                            id="appVisibilityUnlisted"
-                            name="visibility"
-                            type="radio"
-                            value="unlisted"
-                            className="h-4 w-4 cursor-pointer border-gray-300 text-action-600 focus:ring-action-500"
-                            checked={appVisibility == "unlisted"}
-                            onChange={(e) => {
-                              if (e.target.value != appVisibility) {
-                                setAppVisibility(
-                                  e.target.value as AppVisibility
-                                );
-                              }
-                            }}
-                          />
-                          <label
-                            htmlFor="app-visibility-unlisted"
-                            className="ml-3 block text-sm font-medium text-gray-700"
-                          >
-                            Unlisted
-                            <p className="mt-0 text-sm font-normal text-gray-500">
-                              Anyone with the link can see the app. Only you can
-                              edit.
+                              Only builders of your workspace can see and edit
+                              the app.
                             </p>
                           </label>
                         </div>
                       </div>
                       {appVisibility == "deleted" ? (
                         <p className="mt-4 text-sm font-normal text-gray-500">
-                          This app is currently marked as deleted. Change its
-                          visibility above to restore it.
+                          with the link can see the app. Only builders of your
+                          workspace can edit.
                         </p>
                       ) : null}
                     </fieldset>

--- a/front/pages/w/[wId]/a/[aId]/settings.tsx
+++ b/front/pages/w/[wId]/a/[aId]/settings.tsx
@@ -310,7 +310,7 @@ export default function SettingsView({
                       </div>
                       {appVisibility == "deleted" ? (
                         <p className="mt-4 text-sm font-normal text-gray-500">
-                          This app is currently marked as deleted. Change its ￼
+                          This app is currently marked as deleted. Change its
                           visibility above to restore it.
                         </p>
                       ) : null}

--- a/front/pages/w/[wId]/a/[aId]/settings.tsx
+++ b/front/pages/w/[wId]/a/[aId]/settings.tsx
@@ -310,8 +310,8 @@ export default function SettingsView({
                       </div>
                       {appVisibility == "deleted" ? (
                         <p className="mt-4 text-sm font-normal text-gray-500">
-                          with the link can see the app. Only builders of your
-                          workspace can edit.
+                          This app is currently marked as deleted. Change its ￼
+                          visibility above to restore it.
                         </p>
                       ) : null}
                     </fieldset>

--- a/front/pages/w/[wId]/a/new.tsx
+++ b/front/pages/w/[wId]/a/new.tsx
@@ -200,8 +200,8 @@ export default function NewApp({
                   >
                     Public
                     <p className="mt-0 text-sm font-normal text-gray-500">
-                      Anyone on the Internet can see the app. Only builders of
-                      your workspace can edit.
+                      Anyone on the Internet with the link can see the app. Only
+                      builders of your workspace can edit.
                     </p>
                   </label>
                 </div>

--- a/types/src/front/app.ts
+++ b/types/src/front/app.ts
@@ -1,6 +1,6 @@
 import { BlockType } from "../front/run";
 import { ModelId } from "../shared/model_id";
-export type AppVisibility = "public" | "private" | "unlisted" | "deleted";
+export type AppVisibility = "public" | "private" | "deleted";
 
 export type BlockRunConfig = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Description

We removed the unlisted option from apps creation in the past. This PR pushes this forward and remove the unlisted option entirely.

## Risk

Low

## Deploy Plan

- run migration
- deploy front
- check that no app were created unlisted during deploy (very unlikely)