### PR TITLE
Upg: Terminate instead of cancel workflows when oauth token expires.

### DIFF
--- a/connectors/src/lib/temporal.ts
+++ b/connectors/src/lib/temporal.ts
@@ -112,11 +112,11 @@ export async function cancelWorkflow(workflowId: string) {
   return false;
 }
 
-export async function terminateWorkflow(workflowId: string) {
+export async function terminateWorkflow(workflowId: string, reason?: string) {
   const client = await getTemporalClient();
   try {
     const workflowHandle = client.workflow.getHandle(workflowId);
-    await workflowHandle.terminate();
+    await workflowHandle.terminate(reason);
     return true;
   } catch (e) {
     if (!(e instanceof WorkflowNotFoundError)) {

--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -12,7 +12,7 @@ import { statsDClient } from "@connectors/logger/withlogging";
 
 import { DustConnectorWorkflowError, ExternalOAuthTokenError } from "./error";
 import { syncFailed } from "./sync_status";
-import { cancelWorkflow, getConnectorId } from "./temporal";
+import { getConnectorId, terminateWorkflow } from "./temporal";
 
 /** An Activity Context with an attached logger */
 export interface ContextWithLogger extends Context {
@@ -122,8 +122,10 @@ export class ActivityInboundLogInterceptor
           await syncFailed(connectorId, "oauth_token_revoked");
 
           // In case of an invalid token, abort the workflow.
-          this.logger.info("Cancelling workflow because of expired token.");
-          await cancelWorkflow(workflowId);
+          this.logger.info(
+            `Terminating workflow ${workflowId} because of expired token.`
+          );
+          await terminateWorkflow(workflowId, "oauth_token_revoked");
         }
       }
 

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -131,6 +131,11 @@ export function ViewDataSourceTable({
                     {connector?.lastSyncStatus ? (
                       <span className="font-bold">
                         {connector?.lastSyncStatus}
+                        {connector.lastSyncStatus === "failed" && (
+                          <span className="text-warning-500">
+                            {connector.errorType}
+                          </span>
+                        )}
                       </span>
                     ) : (
                       <span className="font-bold text-warning-500">N/A</span>


### PR DESCRIPTION
## Description

Try to avoid false-positive alerts when a workflow is cancelled because the oauth-token expired.
- Terminate instead of cancel workflows when oauth token expires. (with a reason)
- Expose error type of last sync failure in poke.

## Risk

Terminate is more brutal than cancel and cannot be ignored. However, we are using it in many places in the code already.

## Deploy Plan

Deploy `front` and `connector`.