### PR TITLE
Ignore Confluence not found pages

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -415,10 +415,19 @@ export class ConfluenceClient {
       "include-labels": "true", // Include labels.
     });
 
-    return this.request(
-      `${this.restApiBaseUrl}/pages/${pageId}?${params.toString()}`,
-      ConfluencePageWithBodyCodec
-    );
+    try {
+      return await this.request(
+        `${this.restApiBaseUrl}/pages/${pageId}?${params.toString()}`,
+        ConfluencePageWithBodyCodec
+      );
+    } catch (err) {
+      if (err instanceof ConfluenceClientError && err.status === 404) {
+        // If the page is not found, return null.
+        return null;
+      }
+
+      throw err;
+    }
   }
 
   async getPageReadRestrictions(pageId: string) {

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -256,10 +256,13 @@ export async function confluenceCheckAndUpsertPageActivity({
 
   localLogger.info("Upserting Confluence page.");
 
+  // There is a small delta between the page being listed and the page being imported.
+  // If the page has been deleted in the meantime, we should ignore it.
   const page = await client.getPageById(pageId);
   if (!page) {
     localLogger.info("Confluence page not found.");
-    return false;
+    // Return true so we still try to import the child pages.
+    return true;
   }
 
   const hasReadRestrictions = await pageHasReadRestrictions(client, pageId);

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -257,6 +257,11 @@ export async function confluenceCheckAndUpsertPageActivity({
   localLogger.info("Upserting Confluence page.");
 
   const page = await client.getPageById(pageId);
+  if (!page) {
+    localLogger.info("Confluence page not found.");
+    return false;
+  }
+
   const hasReadRestrictions = await pageHasReadRestrictions(client, pageId);
   if (hasReadRestrictions) {
     localLogger.info("Skipping restricted Confluence page.");


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The process we use to import Confluence pages into Dust may cause a slight discrepancy between the listing of pages and their importation. Since we import live data, there is a chance that a page could be moved or deleted between the time it is listed and when it is imported, resulting in a Temporal activity that continuously fails. This PR addresses this issue by ensuring that we simply ignore any pages that are missing.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
