### PR TITLE
[connectors] fix(microsoft): Log instead of throwing error when saving deltas

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -212,10 +212,10 @@ export async function populateDeltas(connectorId: ModelId, nodeIds: string[]) {
       );
 
       if (!node) {
-        throw new Error(`Node ${nodeId} not found`);
+        logger.warn({ nodeId }, `Node not found while saving delta, skipping`);
+      } else {
+        await node.update({ deltaLink });
       }
-
-      await node.update({ deltaLink });
     }
   }
 }


### PR DESCRIPTION
## Description

The node may have been deleted if it has been removed from sync while the incremental sync is running. Activity should not crash if delta cannot be saved.

## Risk

None

## Deploy Plan

deploy `connectors`
