### PR TITLE
Fix webcrawler page title

### DIFF
--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -224,7 +224,7 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
                     ressourceType: "folder",
                   })
                 : null,
-              title: getDisplayNameForPage(page.url),
+              title: getDisplayNameForPage(page),
               sourceUrl: page.url,
               expandable: isFileAndFolder ? true : false,
               permission: "read",
@@ -280,7 +280,7 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
         provider: "webcrawler",
         internalId: page.documentId,
         parentInternalId: page.parentUrl,
-        title: page.title ?? page.url,
+        title: getDisplayNameForPage(page),
         sourceUrl: page.url,
         expandable: false,
         permission: "read",

--- a/connectors/src/connectors/webcrawler/lib/utils.ts
+++ b/connectors/src/connectors/webcrawler/lib/utils.ts
@@ -2,6 +2,8 @@ import type { ContentNodeType } from "@dust-tt/types";
 import { hash as blake3 } from "blake3";
 import dns from "dns";
 
+import type { WebCrawlerPage } from "@connectors/lib/models/webcrawler";
+
 // Generate a stable id for a given url and ressource type
 // That way we don't have to send URL as documentId to the front API.
 export function stableIdForUrl({
@@ -84,23 +86,8 @@ export function normalizeFolderUrl(url: string) {
   return result;
 }
 
-export function getDisplayNameForPage(url: string): string {
-  const parsed = new URL(url);
-  let result = "";
-  const fragments = parsed.pathname.split("/").filter((x) => x);
-  const lastFragment = fragments.pop();
-  if (lastFragment) {
-    result += lastFragment;
-  }
-  if (parsed.search.length > 0) {
-    result += parsed.search;
-  }
-
-  if (!result) {
-    result = parsed.origin;
-  }
-
-  return result;
+export function getDisplayNameForPage(page: WebCrawlerPage): string {
+  return page.title ?? page.url;
 }
 
 export async function getIpAddressForUrl(url: string) {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The permission endpoint for Webcrawler currently attempts to return a rather intricate title. This PR ensures consistency between `/content_nodes` and the `/permissions` endpoint by always returning the page title, or the page URL if a title is unavailable.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
