### PR TITLE
Fix: confluence child pages 404 do not trigger alert

### DIFF
--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -261,8 +261,8 @@ export async function confluenceCheckAndUpsertPageActivity({
   const page = await client.getPageById(pageId);
   if (!page) {
     localLogger.info("Confluence page not found.");
-    // Return true so we still try to import the child pages.
-    return true;
+    // Return false to skip the child pages.
+    return false;
   }
 
   const hasReadRestrictions = await pageHasReadRestrictions(client, pageId);


### PR DESCRIPTION
## Description

Do not navigate the child pages of a notion workflow and ignore 404 on child pages as well.

## Risk

## Deploy Plan

Deploy `connectors`