### PR TITLE
Intercom cli to force resync all articles, and articles only

### DIFF
--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -145,13 +145,15 @@ export type TemporalCommandType = t.TypeOf<typeof TemporalCommandSchema>;
 export const IntercomCommandSchema = t.type({
   majorCommand: t.literal("intercom"),
   command: t.union([
+    t.literal("force-resync-articles"),
     t.literal("check-conversation"),
     t.literal("fetch-conversation"),
     t.literal("check-missing-conversations"),
     t.literal("check-teams"),
   ]),
   args: t.type({
-    connectorId: t.number,
+    force: t.union([t.literal("true"), t.undefined]),
+    connectorId: t.union([t.number, t.undefined]),
     conversationId: t.union([t.number, t.undefined]),
     day: t.union([t.string, t.undefined]),
   }),
@@ -197,6 +199,12 @@ export const IntercomCheckMissingConversationsResponseSchema = t.type({
 });
 export type IntercomCheckMissingConversationsResponseType = t.TypeOf<
   typeof IntercomCheckMissingConversationsResponseSchema
+>;
+export const IntercomForceResyncArticlesResponseSchema = t.type({
+  affectedCount: t.number,
+});
+export type IntercomForceResyncArticlesResponseType = t.TypeOf<
+  typeof IntercomForceResyncArticlesResponseSchema
 >;
 /**
  * </ Intercom>
@@ -351,6 +359,7 @@ export const AdminResponseSchema = t.union([
   NotionUpsertResponseSchema,
   TemporalCheckQueueResponseSchema,
   TemporalUnprocessedWorkflowsResponseSchema,
+  IntercomForceResyncArticlesResponseSchema,
 ]);
 
 export type AdminResponseType = t.TypeOf<typeof AdminResponseSchema>;


### PR DESCRIPTION
## Description

This is the most straightforward way to force resync of Intercom articles only. 
We're setting their `lastUpsertedTs` to null so that they will be resynced on next cron (every 30 minutes). 
This is needed to recompute the parents for Vaults.

Command is: 
```
./admin/cli.sh intercom force-resync-articles --force=true
```


## Risk

?

## Deploy Plan

Merge https://github.com/dust-tt/dust/pull/6950
Merge this one.
Deploy connectors.
Run command. 
