### PR TITLE
connectors: report sync started in google_drive and microsoft

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -39,11 +39,10 @@ const { syncFiles } = proxyActivities<typeof activities>({
   startToCloseTimeout: "30 minutes",
 });
 
-const { reportInitialSyncProgress, syncSucceeded } = proxyActivities<
-  typeof sync_status
->({
-  startToCloseTimeout: "10 minutes",
-});
+const { reportInitialSyncProgress, syncSucceeded, syncStarted } =
+  proxyActivities<typeof sync_status>({
+    startToCloseTimeout: "10 minutes",
+  });
 
 export async function googleDriveFullSync({
   connectorId,
@@ -60,6 +59,8 @@ export async function googleDriveFullSync({
   startSyncTs: number | undefined;
   mimeTypeFilter?: string[];
 }) {
+  await syncStarted(connectorId);
+
   // Running the incremental sync workflow before the full sync to populate the
   // Google Drive sync tokens.
   await populateSyncTokens(connectorId);
@@ -147,6 +148,8 @@ export async function googleDriveIncrementalSync(
   connectorId: ModelId,
   dataSourceConfig: DataSourceConfig
 ) {
+  await syncStarted(connectorId);
+
   const drives = await getDrivesToSync(connectorId);
   const startSyncTs = new Date().getTime();
   for (const googleDrive of drives) {

--- a/connectors/src/connectors/microsoft/temporal/workflows.ts
+++ b/connectors/src/connectors/microsoft/temporal/workflows.ts
@@ -29,11 +29,10 @@ const { syncDeltaForRootNodesInDrive } = proxyActivities<typeof activities>({
   heartbeatTimeout: "5 minutes",
 });
 
-const { reportInitialSyncProgress, syncSucceeded } = proxyActivities<
-  typeof sync_status
->({
-  startToCloseTimeout: "10 minutes",
-});
+const { reportInitialSyncProgress, syncSucceeded, syncStarted } =
+  proxyActivities<typeof sync_status>({
+    startToCloseTimeout: "10 minutes",
+  });
 
 export async function fullSyncWorkflow({
   connectorId,
@@ -46,6 +45,8 @@ export async function fullSyncWorkflow({
   nodeIdsToSync?: string[];
   totalCount?: number;
 }) {
+  await syncStarted(connectorId);
+
   if (nodeIdsToSync === undefined) {
     nodeIdsToSync = await getRootNodesToSync(connectorId);
   }
@@ -102,6 +103,8 @@ export async function incrementalSyncWorkflow({
 }: {
   connectorId: ModelId;
 }) {
+  await syncStarted(connectorId);
+
   const nodeIdsToSync = await getRootNodesToSync(connectorId);
 
   const groupedItems = await groupRootItemsByDriveId(nodeIdsToSync);


### PR DESCRIPTION
## Description

Add reporting for syncStarted in both google drive and microsoft.
Context: https://github.com/dust-tt/dust/pull/6943

## Risk

N/A

## Deploy Plan

- deploy `connectors`
- restart all google and microsoft incremental workflows