### PR TITLE
[connectors] fix(microsoft) : Url full URL to display on roots

### DIFF
--- a/connectors/src/connectors/microsoft/lib/graph_api.ts
+++ b/connectors/src/connectors/microsoft/lib/graph_api.ts
@@ -533,9 +533,8 @@ export async function wrapMicrosoftGraphAPIWithResult<T>(
 export function extractPath(item: MicrosoftGraph.BaseItem) {
   const webUrl = item.webUrl;
   if (webUrl) {
-    const siteName = webUrl.match(/\/sites\/(.+)\/.*/);
-    if (siteName && siteName[1]) {
-      return decodeURI(siteName[1]);
-    }
+    return decodeURI(webUrl);
+  } else {
+    return "unknown";
   }
 }


### PR DESCRIPTION
## Description

Previous site extraction was not working in some cases where the `/sites/xx` was not part of the url. It could happen if domain names (`xxx.sharepoint.com`) is linked to a sharepoint site - which results in something like `https://xxx.sharepoint.com/Documents`

Instead, for easier identification and to avoid the possible issues with different format, just use the full URL 

## Risk

none

## Deploy Plan

deploy `connectors`