### PR TITLE
[front] feature(vault): Add "edited by" on data source views

### DIFF
--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -77,7 +77,9 @@ const getTableColumns = ({
   const managedByColumn = {
     header: "Managed by",
     accessorFn: (row: RowData) =>
-      row.dataSourceView.dataSource.editedByUser?.imageUrl ?? "",
+      (row.dataSourceView.kind === "default"
+        ? row.dataSourceView.dataSource.editedByUser?.imageUrl
+        : row.dataSourceView.editedByUser?.imageUrl) ?? "",
     id: "managedBy",
     cell: (info: CellContext<RowData, string>) => (
       <DataTable.CellContent avatarUrl={info.getValue()} roundedAvatar={true} />
@@ -191,6 +193,7 @@ export const VaultResourcesList = ({
       workspaceId: owner.sId,
       vaultId: vault.sId,
       category: category,
+      includeEditedBy: true,
       includeConnectorDetails: true,
     });
 

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -39,7 +39,7 @@ export interface DataSourceResource
 export class DataSourceResource extends ResourceWithVault<DataSource> {
   static model: ModelStatic<DataSource> = DataSource;
 
-  readonly editedByUser: Attributes<User> | undefined;
+  readonly editedByUser?: Attributes<User>;
 
   constructor(
     model: ModelStatic<DataSource>,

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -118,8 +118,13 @@ export class DataSourceResource extends ResourceWithVault<DataSource> {
     return dataSource ?? null;
   }
 
-  static async fetchByModelIds(auth: Authenticator, ids: ModelId[]) {
+  static async fetchByModelIds(
+    auth: Authenticator,
+    ids: ModelId[],
+    options?: FetchDataSourceOptions
+  ) {
     return this.baseFetchWithAuthorization(auth, {
+      ...this.getOptions(options),
       where: {
         id: ids,
       },

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -3,7 +3,6 @@ import type {
   DataSourceType,
   ModelId,
   Result,
-  UserType,
 } from "@dust-tt/types";
 import { Err, formatUserFullName, Ok } from "@dust-tt/types";
 import type {
@@ -228,9 +227,9 @@ export class DataSourceResource extends ResourceWithVault<DataSource> {
     return [affectedCount];
   }
 
-  async setEditedBy(user: UserType) {
+  async setEditedBy(auth: Authenticator) {
     await this.update({
-      editedByUserId: user.id,
+      editedByUserId: auth.getNonNullableUser().id,
       editedAt: new Date(),
     });
   }

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -262,21 +262,6 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
     return [affectedCount];
   }
 
-  // TODO(GROUPS_INFRA) Remove once backfilled.
-  async updateKind(auth: Authenticator, kind: DataSourceViewKind) {
-    await this.model.update(
-      {
-        kind,
-      },
-      {
-        where: {
-          workspaceId: auth.getNonNullableWorkspace().id,
-          id: this.id,
-        },
-      }
-    );
-  }
-
   async setEditedBy(auth: Authenticator) {
     await this.update(auth, {
       editedByUserId: auth.getNonNullableUser().id,

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -45,7 +45,7 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
   static model: ModelStatic<DataSourceViewModel> = DataSourceViewModel;
 
   private ds?: DataSourceResource;
-  readonly editedByUser: Attributes<User> | undefined;
+  readonly editedByUser?: Attributes<User>;
 
   constructor(
     model: ModelStatic<DataSourceViewModel>,

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -7,7 +7,7 @@ import type {
   ModelId,
   Result,
 } from "@dust-tt/types";
-import { Err, Ok, removeNulls } from "@dust-tt/types";
+import { Err, formatUserFullName, Ok, removeNulls } from "@dust-tt/types";
 import type {
   Attributes,
   CreationAttributes,
@@ -18,6 +18,7 @@ import type {
 import { getDataSourceViewUsage } from "@app/lib/api/agent_data_sources";
 import { getDataSourceCategory } from "@app/lib/api/vaults";
 import type { Authenticator } from "@app/lib/auth";
+import { User } from "@app/lib/models/user";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { ResourceWithVault } from "@app/lib/resources/resource_with_vault";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
@@ -30,6 +31,12 @@ import {
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { VaultResource } from "@app/lib/resources/vault_resource";
 
+export type FetchDataSourceViewOptions = {
+  includeEditedBy?: boolean;
+  limit?: number;
+  order?: [string, "ASC" | "DESC"][];
+};
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface DataSourceViewResource
   extends ReadonlyAttributesType<DataSourceViewModel> {}
@@ -38,13 +45,17 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
   static model: ModelStatic<DataSourceViewModel> = DataSourceViewModel;
 
   private ds?: DataSourceResource;
+  readonly editedByUser: Attributes<User> | undefined;
 
   constructor(
     model: ModelStatic<DataSourceViewModel>,
     blob: Attributes<DataSourceViewModel>,
-    vault: VaultResource
+    vault: VaultResource,
+    { editedByUser }: { editedByUser?: Attributes<User> } = {}
   ) {
     super(DataSourceViewModel, blob, vault);
+
+    this.editedByUser = editedByUser;
   }
 
   // Creation.
@@ -64,11 +75,12 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
   }
 
   static async createViewInVaultFromDataSource(
+    auth: Authenticator,
     vault: VaultResource,
     dataSource: DataSourceResource,
     parentsIn: string[] | null
   ) {
-    return this.makeNew(
+    const dataSourceView = await this.makeNew(
       {
         dataSourceId: dataSource.id,
         parentsIn,
@@ -78,6 +90,13 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
       vault,
       dataSource
     );
+
+    const user = auth.user();
+    if (user) {
+      await dataSourceView.setEditedBy(user);
+    }
+
+    return dataSourceView;
   }
 
   // This view has access to all documents, which is represented by null.
@@ -100,14 +119,40 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
 
   // Fetching.
 
+  private static getOptions(
+    options?: FetchDataSourceViewOptions
+  ): ResourceFindOptions<DataSourceViewModel> {
+    const result: ResourceFindOptions<DataSourceViewModel> = {};
+
+    if (options?.includeEditedBy) {
+      result.includes = [
+        {
+          model: User,
+          as: "editedByUser",
+        },
+      ];
+    }
+
+    if (options?.limit) {
+      result.limit = options.limit;
+    }
+
+    if (options?.order) {
+      result.order = options.order;
+    }
+
+    return result;
+  }
+
   private static async baseFetch(
     auth: Authenticator,
+    fetchDataSourceViewOptions?: FetchDataSourceViewOptions,
     options?: ResourceFindOptions<DataSourceViewModel>
   ) {
-    const dataSourceViews = await this.baseFetchWithAuthorization(
-      auth,
-      options
-    );
+    const dataSourceViews = await this.baseFetchWithAuthorization(auth, {
+      ...this.getOptions(fetchDataSourceViewOptions),
+      ...options,
+    });
 
     const dataSourceIds = removeNulls(
       dataSourceViews.map((ds) => ds.dataSourceId)
@@ -115,7 +160,10 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
 
     const dataSources = await DataSourceResource.fetchByModelIds(
       auth,
-      dataSourceIds
+      dataSourceIds,
+      {
+        includeEditedBy: fetchDataSourceViewOptions?.includeEditedBy,
+      }
     );
 
     for (const dsv of dataSourceViews) {
@@ -125,20 +173,34 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
     return dataSourceViews;
   }
 
-  static async listByWorkspace(auth: Authenticator) {
-    const dataSourceViews = await this.baseFetch(auth);
+  static async listByWorkspace(
+    auth: Authenticator,
+    fetchDataSourceViewOptions?: FetchDataSourceViewOptions
+  ) {
+    const dataSourceViews = await this.baseFetch(
+      auth,
+      fetchDataSourceViewOptions
+    );
 
     return dataSourceViews.filter(
       (dsv) => auth.isAdmin() || auth.hasPermission([dsv.vault.acl()], "read")
     );
   }
 
-  static async listByVault(auth: Authenticator, vault: VaultResource) {
-    return this.listByVaults(auth, [vault]);
+  static async listByVault(
+    auth: Authenticator,
+    vault: VaultResource,
+    fetchDataSourceViewOptions?: FetchDataSourceViewOptions
+  ) {
+    return this.listByVaults(auth, [vault], fetchDataSourceViewOptions);
   }
 
-  static async listByVaults(auth: Authenticator, vaults: VaultResource[]) {
-    return this.baseFetch(auth, {
+  static async listByVaults(
+    auth: Authenticator,
+    vaults: VaultResource[],
+    fetchDataSourceViewOptions?: FetchDataSourceViewOptions
+  ) {
+    return this.baseFetch(auth, fetchDataSourceViewOptions, {
       where: {
         vaultId: vaults.map((v) => v.id),
       },
@@ -148,9 +210,10 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
   static async listForDataSourcesInVault(
     auth: Authenticator,
     dataSources: DataSourceResource[],
-    vault: VaultResource
+    vault: VaultResource,
+    fetchDataSourceViewOptions?: FetchDataSourceViewOptions
   ) {
-    return this.baseFetch(auth, {
+    return this.baseFetch(auth, fetchDataSourceViewOptions, {
       where: {
         dataSourceId: dataSources.map((ds) => ds.id),
         vaultId: vault.id,
@@ -158,56 +221,79 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
     });
   }
 
-  static async fetchById(auth: Authenticator, id: string) {
+  static async fetchById(
+    auth: Authenticator,
+    id: string,
+    fetchDataSourceViewOptions?: Omit<
+      FetchDataSourceViewOptions,
+      "limit" | "order"
+    >
+  ) {
     const fileModelId = getResourceIdFromSId(id);
     if (!fileModelId) {
       return null;
     }
 
-    const [dataSource] = await this.baseFetch(auth, {
-      where: {
-        id: fileModelId,
-      },
-    });
+    const [dataSource] = await this.baseFetch(
+      auth,
+      fetchDataSourceViewOptions,
+      {
+        where: {
+          id: fileModelId,
+        },
+      }
+    );
 
     return dataSource ?? null;
   }
 
   // Updating.
+
+  private async update(
+    auth: Authenticator,
+    blob: Partial<Attributes<DataSourceViewModel>>
+  ): Promise<[affectedCount: number]> {
+    blob.editedAt = new Date();
+    const user = auth.user();
+    if (user) {
+      blob.editedByUserId = user.id;
+    }
+    const [affectedCount, affectedRows] = await this.model.update(blob, {
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        id: this.id,
+      },
+      returning: true,
+    });
+    // Update the current instance with the new values to avoid stale data
+    Object.assign(this, affectedRows[0].get());
+    return [affectedCount];
+  }
+
+  private makeEditedBy(
+    editedByUser: Attributes<User> | undefined,
+    editedAt: Date | undefined
+  ) {
+    if (!editedByUser || !editedAt) {
+      return undefined;
+    }
+
+    return {
+      editedByUser: {
+        editedAt: editedAt.getTime(),
+        fullName: formatUserFullName(editedByUser),
+        imageUrl: editedByUser.imageUrl,
+        email: editedByUser.email,
+        userId: editedByUser.sId,
+      },
+    };
+  }
+
   async updateParents(
     auth: Authenticator,
     parentsIn: string[] | null
   ): Promise<Result<undefined, Error>> {
-    const [, affectedRows] = await this.model.update(
-      {
-        parentsIn,
-      },
-      {
-        where: {
-          workspaceId: auth.getNonNullableWorkspace().id,
-          id: this.id,
-        },
-        returning: true,
-      }
-    );
-    Object.assign(this, affectedRows[0].get());
-
-    return new Ok(undefined);
-  }
-
-  // TODO(GROUPS_INFRA) Remove once backfilled.
-  async updateKind(auth: Authenticator, kind: DataSourceViewKind) {
-    await this.model.update(
-      {
-        kind,
-      },
-      {
-        where: {
-          workspaceId: auth.getNonNullableWorkspace().id,
-          id: this.id,
-        },
-      }
-    );
+    await this.update(auth, { parentsIn });
 
     return new Ok(undefined);
   }
@@ -319,6 +405,7 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
       updatedAt: this.updatedAt.getTime(),
       usage: 0,
       vaultId: this.vault.sId,
+      ...this.makeEditedBy(this.editedByUser, this.editedAt),
     };
   }
 }

--- a/front/lib/resources/storage/models/data_source_view.ts
+++ b/front/lib/resources/storage/models/data_source_view.ts
@@ -9,6 +9,7 @@ import type {
 import { DataTypes, Model } from "sequelize";
 
 import { DataSource } from "@app/lib/models/data_source";
+import { User } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { VaultModel } from "@app/lib/resources/storage/models/vaults";
@@ -21,6 +22,10 @@ export class DataSourceViewModel extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
+  // Corresponds to the ID of the last user to configure the connection.
+  declare editedByUserId: ForeignKey<User["id"]>;
+  declare editedAt: CreationOptional<Date>;
+
   declare kind: DataSourceViewKind;
   declare parentsIn: string[] | null;
 
@@ -29,6 +34,7 @@ export class DataSourceViewModel extends Model<
   declare workspaceId: ForeignKey<Workspace["id"]>;
 
   declare dataSourceForView: NonAttribute<DataSource>;
+  declare editedByUser: NonAttribute<User>;
   declare vault: NonAttribute<VaultModel>;
   declare workspace: NonAttribute<Workspace>;
 }
@@ -42,6 +48,12 @@ DataSourceViewModel.init(
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    editedAt: {
+      type: DataTypes.DATE,
+      // TODO(2024-08-28 (thomas) Set `allowNull` to `false` once backfilled.
+      allowNull: true,
       defaultValue: DataTypes.NOW,
     },
     kind: {
@@ -89,4 +101,10 @@ DataSource.hasMany(DataSourceViewModel, {
 DataSourceViewModel.belongsTo(DataSource, {
   as: "dataSourceForView",
   foreignKey: { name: "dataSourceId", allowNull: false },
+});
+
+DataSourceViewModel.belongsTo(User, {
+  as: "editedByUser",
+  // TODO(2024-08-28 (thomas) Set `allowNull` to `false` once backfilled.
+  foreignKey: { name: "editedByUserId", allowNull: true },
 });

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -1481,12 +1481,14 @@ export function useVaultDataSourceViews<
   category,
   disabled,
   includeConnectorDetails,
+  includeEditedBy,
   vaultId,
   workspaceId,
 }: {
   category: DataSourceViewCategory;
   disabled?: boolean;
   includeConnectorDetails?: IncludeConnectorDetails;
+  includeEditedBy?: boolean;
   vaultId: string;
   workspaceId: string;
 }) {
@@ -1500,6 +1502,9 @@ export function useVaultDataSourceViews<
 
   if (includeConnectorDetails) {
     queryParams.set("includeConnectorDetails", "true");
+  }
+  if (includeEditedBy) {
+    queryParams.set("includeEditedBy", "true");
   }
 
   const { data, error, mutate } = useSWRWithDefaults(

--- a/front/migrations/20240821_backfill_all_data_source_views.ts
+++ b/front/migrations/20240821_backfill_all_data_source_views.ts
@@ -70,9 +70,9 @@ async function backfillDataSourceViewsForWorkspace(
           globalVault
         );
       if (dataSourceViews.length > 0) {
-        const [dataSourceView] = dataSourceViews;
-
-        await dataSourceView.updateKind(auth, "custom");
+        // Method `updateKind` removed from `DataSourceViewResource`
+        // const [dataSourceView] = dataSourceViews;
+        // await dataSourceView.updateKind(auth, "custom");
       }
     }
 

--- a/front/migrations/db/migration_66.sql
+++ b/front/migrations/db/migration_66.sql
@@ -1,0 +1,15 @@
+-- Migration created on Aug 30, 2024
+ALTER TABLE "public"."data_source_views"
+ADD COLUMN "editedAt" TIMESTAMP WITH TIME ZONE;
+
+ALTER TABLE "public"."data_source_views"
+ADD COLUMN "editedByUserId" INTEGER REFERENCES "users" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+UPDATE "public"."data_source_views" SET "editedAt" = "updatedAt";
+
+UPDATE "public"."data_source_views"
+SET
+    "editedByUserId" = "data_sources"."editedByUserId"
+FROM "public"."data_sources"
+WHERE
+    "data_sources"."id" = "data_source_views"."dataSourceId";

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/update.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/update.ts
@@ -126,7 +126,7 @@ async function handler(
         }
       }
 
-      await dataSource.setEditedBy(user);
+      await dataSource.setEditedBy(auth);
       void ServerSideTracking.trackDataSourceUpdated({
         dataSource: dataSource.toJSON(),
         user,

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.ts
@@ -82,6 +82,8 @@ async function handler(
           },
         });
       }
+
+      await dataSourceView.setEditedBy(auth);
       return res.status(200).json({
         dataSourceView: dataSourceView.toJSON(),
       });

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/index.ts
@@ -148,6 +148,7 @@ async function handler(
       }
       const dataSourceView =
         await DataSourceViewResource.createViewInVaultFromDataSource(
+          auth,
           vault,
           dataSource,
           parentsIn

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/index.ts
@@ -61,7 +61,9 @@ async function handler(
           : null;
 
       const dataSourceViews = (
-        await DataSourceViewResource.listByVault(auth, vault)
+        await DataSourceViewResource.listByVault(auth, vault, {
+          includeEditedBy: !!req.query.includeEditedBy,
+        })
       )
         .map((ds) => ds.toJSON())
         .filter((d) => !category || d.category === category);

--- a/front/pages/api/w/[wId]/vaults/[vId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/index.ts
@@ -146,6 +146,7 @@ async function handler(
           if (view) {
             // Update existing view
             await view.updateParents(auth, dataSourceConfig.parentsIn);
+            await view.setEditedBy(auth);
           } else {
             // Create a new view
             const dataSource = await DataSourceResource.fetchByName(

--- a/front/pages/api/w/[wId]/vaults/[vId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/index.ts
@@ -154,6 +154,7 @@ async function handler(
             );
             if (dataSource) {
               await DataSourceViewResource.createViewInVaultFromDataSource(
+                auth,
                 vault,
                 dataSource,
                 dataSourceConfig.parentsIn

--- a/types/src/front/data_source_view.ts
+++ b/types/src/front/data_source_view.ts
@@ -13,7 +13,6 @@ export interface DataSourceViewType {
   category: DataSourceViewCategory;
   createdAt: number;
   dataSource: DataSourceType;
-  // TODO(GROUPS_INFRA) Add support for edited by on data source view.
   editedByUser?: EditedByUser | null;
   id: ModelId;
   kind: DataSourceViewKind;


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/1206

## Description

Store the editedByUser and date for each data_source_view, as for data_source
Display it in vault resources list
In case of "default" data_source_view, we display the information of the data source instead, which is more useful as the datasource view cannot be edited.

<img width="917" alt="Screenshot 2024-08-30 at 15 19 54" src="https://github.com/user-attachments/assets/fea741bc-6dab-4f3c-a124-aada13f134cf">
<img width="902" alt="Screenshot 2024-08-30 at 15 19 48" src="https://github.com/user-attachments/assets/9df0b8ac-4da5-4aa7-8549-cf7ecc55bf78">
<img width="919" alt="Screenshot 2024-08-30 at 15 19 36" src="https://github.com/user-attachments/assets/1c210dc0-8023-4586-916e-661fc9a40201">


## Risk

none

## Deploy Plan

run `migration_66.sql`
deploy `front`