### PR TITLE
Remove use of front endpoint in poke

### DIFF
--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -312,16 +312,13 @@ export function useDocuments(
   owner: LightWorkspaceType,
   dataSource: { name: string },
   limit: number,
-  offset: number,
-  asDustSuperUser?: boolean
+  offset: number
 ) {
   const documentsFetcher: Fetcher<GetDocumentsResponseBody> = fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
     `/api/w/${owner.sId}/data_sources/${
       dataSource.name
-    }/documents?limit=${limit}&offset=${offset}${
-      asDustSuperUser ? "&asDustSuperUser=true" : ""
-    }`,
+    }/documents?limit=${limit}&offset=${offset}`,
     documentsFetcher
   );
 
@@ -624,6 +621,29 @@ export function usePokeConnectorPermissions({
     resources: useMemo(() => (data ? data.resources : []), [data]),
     isResourcesLoading: !error && !data,
     isResourcesError: error,
+  };
+}
+
+export function usePokeDocuments(
+  owner: LightWorkspaceType,
+  dataSource: { name: string },
+  limit: number,
+  offset: number
+) {
+  const documentsFetcher: Fetcher<GetDocumentsResponseBody> = fetcher;
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/poke/workspaces/${owner.sId}/data_sources/${encodeURIComponent(
+      dataSource.name
+    )}/documents?limit=${limit}&offset=${offset}`,
+    documentsFetcher
+  );
+
+  return {
+    documents: useMemo(() => (data ? data.documents : []), [data]),
+    total: data ? data.total : 0,
+    isDocumentsLoading: !error && !data,
+    isDocumentsError: error,
+    mutateDocuments: mutate,
   };
 }
 

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -624,29 +624,6 @@ export function usePokeConnectorPermissions({
   };
 }
 
-export function usePokeDocuments(
-  owner: LightWorkspaceType,
-  dataSource: { name: string },
-  limit: number,
-  offset: number
-) {
-  const documentsFetcher: Fetcher<GetDocumentsResponseBody> = fetcher;
-  const { data, error, mutate } = useSWRWithDefaults(
-    `/api/poke/workspaces/${owner.sId}/data_sources/${encodeURIComponent(
-      dataSource.name
-    )}/documents?limit=${limit}&offset=${offset}`,
-    documentsFetcher
-  );
-
-  return {
-    documents: useMemo(() => (data ? data.documents : []), [data]),
-    total: data ? data.total : 0,
-    isDocumentsLoading: !error && !data,
-    isDocumentsError: error,
-    mutateDocuments: mutate,
-  };
-}
-
 export function useConnectorConfig({
   owner,
   dataSource,

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/documents/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/documents/index.ts
@@ -20,8 +20,8 @@ async function handler(
 ): Promise<void> {
   const session = await getSession(req, res);
 
-  const { wId, name  } = req.query;
-  if(typeof wId !== "string" || typeof name !== "string") {
+  const { wId, name } = req.query;
+  if (typeof wId !== "string" || typeof name !== "string") {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -31,10 +31,7 @@ async function handler(
     });
   }
 
-  const auth = await Authenticator.fromSuperUserSession(
-    session,
-    wId,
-  );
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
   const owner = auth.workspace();
 
   if (!owner || !auth.isDustSuperUser()) {

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/documents/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/documents/index.ts
@@ -1,0 +1,94 @@
+import type { DocumentType, WithAPIErrorResponse } from "@dust-tt/types";
+import { CoreAPI } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import config from "@app/lib/api/config";
+import { getDataSource } from "@app/lib/api/data_sources";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
+import { Authenticator, getSession } from "@app/lib/auth";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+
+export type GetDocumentsResponseBody = {
+  documents: Array<DocumentType>;
+  total: number;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetDocumentsResponseBody>>
+): Promise<void> {
+  const session = await getSession(req, res);
+  const auth = await Authenticator.fromSuperUserSession(
+    session,
+    req.query.wId as string
+  );
+  const owner = auth.workspace();
+
+  if (!owner || !auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "user_not_found",
+        message: "Could not find the user.",
+      },
+    });
+  }
+
+  const dataSource = await getDataSource(auth, req.query.name as string);
+
+  if (!dataSource) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "The data source you requested was not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const limit = req.query.limit ? parseInt(req.query.limit as string) : 10;
+      const offset = req.query.offset
+        ? parseInt(req.query.offset as string)
+        : 0;
+
+      const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+      const documents = await coreAPI.getDataSourceDocuments({
+        projectId: dataSource.dustAPIProjectId,
+        dataSourceName: dataSource.name,
+        limit,
+        offset,
+      });
+
+      if (documents.isErr()) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "internal_server_error",
+            message:
+              "We encountered an error while fetching the data source documents.",
+            data_source_error: documents.error,
+          },
+        });
+      }
+
+      res.status(200).json({
+        documents: documents.value.documents,
+        total: documents.value.total,
+      });
+      return;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthentication(handler);

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/documents/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/documents/index.ts
@@ -19,9 +19,21 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<GetDocumentsResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
+
+  const { wId, name  } = req.query;
+  if(typeof wId !== "string" || typeof name !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "The request query parameters are invalid.",
+      },
+    });
+  }
+
   const auth = await Authenticator.fromSuperUserSession(
     session,
-    req.query.wId as string
+    wId,
   );
   const owner = auth.workspace();
 
@@ -35,7 +47,7 @@ async function handler(
     });
   }
 
-  const dataSource = await getDataSource(auth, req.query.name as string);
+  const dataSource = await getDataSource(auth, name);
 
   if (!dataSource) {
     return apiError(req, res, {

--- a/front/pages/api/w/[wId]/data_sources/[name]/documents/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/documents/index.ts
@@ -4,8 +4,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import config from "@app/lib/api/config";
 import { getDataSource } from "@app/lib/api/data_sources";
-import { withSessionAuthentication } from "@app/lib/api/wrappers";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 
@@ -14,32 +14,11 @@ export type GetDocumentsResponseBody = {
   total: number;
 };
 
-// TODO(2024-07-09 flav) Create a dedicated endpoint on Poke.
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetDocumentsResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetDocumentsResponseBody>>,
+  auth: Authenticator
 ): Promise<void> {
-  const session = await getSession(req, res);
-  const auth =
-    req.query.asDustSuperUser === "true"
-      ? await Authenticator.fromSuperUserSession(
-          session,
-          req.query.wId as string
-        )
-      : await Authenticator.fromSession(session, req.query.wId as string);
-
-  const owner = auth.workspace();
-
-  if (!owner || !auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "data_source_not_found",
-        message: "The data source you requested was not found.",
-      },
-    });
-  }
-
   const dataSource = await getDataSource(auth, req.query.name as string);
 
   if (!dataSource) {
@@ -96,4 +75,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/poke/[wId]/data_sources/[name]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[name]/index.tsx
@@ -36,7 +36,7 @@ import { useSubmitFunction } from "@app/lib/client/utils";
 import { getDisplayNameForDocument } from "@app/lib/data_sources";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { GroupResource } from "@app/lib/resources/group_resource";
-import { useDocuments } from "@app/lib/swr";
+import { usePokeDocuments } from "@app/lib/swr";
 import { classNames, timeAgoFrom } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 
@@ -267,7 +267,7 @@ const DataSourcePage = ({
   const [offset, setOffset] = useState(0);
 
   const { documents, total, isDocumentsLoading, isDocumentsError } =
-    useDocuments(owner, dataSource, limit, offset, true);
+    usePokeDocuments(owner, dataSource, limit, offset);
 
   const [displayNameByDocId, setDisplayNameByDocId] = useState<
     Record<string, string>

--- a/front/pages/poke/[wId]/data_sources/[name]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[name]/index.tsx
@@ -36,9 +36,9 @@ import { useSubmitFunction } from "@app/lib/client/utils";
 import { getDisplayNameForDocument } from "@app/lib/data_sources";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { GroupResource } from "@app/lib/resources/group_resource";
-import { usePokeDocuments } from "@app/lib/swr";
 import { classNames, timeAgoFrom } from "@app/lib/utils";
 import logger from "@app/logger/logger";
+import {useDocuments} from "@app/poke/swr";
 
 const { TEMPORAL_CONNECTORS_NAMESPACE = "" } = process.env;
 
@@ -267,7 +267,7 @@ const DataSourcePage = ({
   const [offset, setOffset] = useState(0);
 
   const { documents, total, isDocumentsLoading, isDocumentsError } =
-    usePokeDocuments(owner, dataSource, limit, offset);
+    useDocuments(owner, dataSource, limit, offset);
 
   const [displayNameByDocId, setDisplayNameByDocId] = useState<
     Record<string, string>

--- a/front/pages/poke/[wId]/data_sources/[name]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[name]/index.tsx
@@ -38,7 +38,7 @@ import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { classNames, timeAgoFrom } from "@app/lib/utils";
 import logger from "@app/logger/logger";
-import {useDocuments} from "@app/poke/swr";
+import { useDocuments } from "@app/poke/swr";
 
 const { TEMPORAL_CONNECTORS_NAMESPACE = "" } = process.env;
 

--- a/front/poke/swr.ts
+++ b/front/poke/swr.ts
@@ -5,7 +5,7 @@ import useSWR from "swr";
 
 import { fetcher } from "@app/lib/swr";
 import type { PokeFetchAssistantTemplateResponse } from "@app/pages/api/poke/templates/[tId]";
-import type {GetDocumentsResponseBody} from "@app/pages/api/poke/workspaces/[wId]/data_sources/[name]/documents";
+import type { GetDocumentsResponseBody } from "@app/pages/api/poke/workspaces/[wId]/data_sources/[name]/documents";
 import type { FetchAssistantTemplatesResponse } from "@app/pages/api/w/[wId]/assistant/builder/templates";
 
 export function usePokeAssistantTemplates() {
@@ -95,4 +95,3 @@ export function useDocuments(
     mutateDocuments: mutate,
   };
 }
-

--- a/front/poke/swr.ts
+++ b/front/poke/swr.ts
@@ -1,10 +1,11 @@
-import type { ConversationType } from "@dust-tt/types";
+import type { ConversationType, LightWorkspaceType } from "@dust-tt/types";
 import { useMemo } from "react";
 import type { Fetcher } from "swr";
 import useSWR from "swr";
 
 import { fetcher } from "@app/lib/swr";
 import type { PokeFetchAssistantTemplateResponse } from "@app/pages/api/poke/templates/[tId]";
+import type {GetDocumentsResponseBody} from "@app/pages/api/poke/workspaces/[wId]/data_sources/[name]/documents";
 import type { FetchAssistantTemplatesResponse } from "@app/pages/api/w/[wId]/assistant/builder/templates";
 
 export function usePokeAssistantTemplates() {
@@ -71,3 +72,27 @@ export function useConversation({
     mutateConversation: mutate,
   };
 }
+
+export function useDocuments(
+  owner: LightWorkspaceType,
+  dataSource: { name: string },
+  limit: number,
+  offset: number
+) {
+  const documentsFetcher: Fetcher<GetDocumentsResponseBody> = fetcher;
+  const { data, error, mutate } = useSWR(
+    `/api/poke/workspaces/${owner.sId}/data_sources/${encodeURIComponent(
+      dataSource.name
+    )}/documents?limit=${limit}&offset=${offset}`,
+    documentsFetcher
+  );
+
+  return {
+    documents: useMemo(() => (data ? data.documents : []), [data]),
+    total: data ? data.total : 0,
+    isDocumentsLoading: !error && !data,
+    isDocumentsError: error,
+    mutateDocuments: mutate,
+  };
+}
+


### PR DESCRIPTION
## Description

Goals is to properly enforce everywhere under `/w/[wId]/` the use of `withSessionAuthenticationForWorkspace`

Fixes: https://github.com/dust-tt/tasks/issues/1205

r? @flvndvd 
```
- // TODO(2024-07-09 flav) Create a dedicated endpoint on Poke.
```

## Risk

Auth: double check poke logic

## Deploy Plan

- deploy `front`