### PR TITLE
Display list of Dust Apps on Global Vault

### DIFF
--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -217,7 +217,7 @@ export function RenderMessageMarkdown({
         return <MentionBlock agentName={agentName} />;
       },
     }),
-    [isStreaming]
+    [isStreaming, textSize, textColor]
   );
 
   const markdownPlugins = useMemo(

--- a/front/components/vaults/VaultAppsList.tsx
+++ b/front/components/vaults/VaultAppsList.tsx
@@ -1,0 +1,136 @@
+import {
+  Chip,
+  CommandLineIcon,
+  DataTable,
+  Searchbar,
+  Spinner,
+} from "@dust-tt/sparkle";
+import type {
+  ConnectorType,
+  DataSourceViewCategory,
+  PlanType,
+  VaultType,
+  WorkspaceType,
+} from "@dust-tt/types";
+import type { CellContext } from "@tanstack/react-table";
+import type { ComponentType } from "react";
+import { useRef } from "react";
+import { useState } from "react";
+import * as React from "react";
+
+import { useApps } from "@app/lib/swr";
+import { classNames } from "@app/lib/utils";
+
+type RowData = {
+  category: string;
+  label: string;
+  icon: ComponentType;
+  connector?: ConnectorType;
+  fetchConnectorError?: string;
+  visibility: string;
+  workspaceId: string;
+  onClick?: () => void;
+};
+
+type Info = CellContext<RowData, unknown>;
+
+type VaultResourcesListProps = {
+  owner: WorkspaceType;
+  plan: PlanType;
+  isAdmin: boolean;
+  vault: VaultType;
+  systemVault: VaultType;
+  category: DataSourceViewCategory;
+  onSelect: (sId: string) => void;
+};
+
+const getTableColumns = () => {
+  return [
+    {
+      header: "Name",
+      accessorKey: "label",
+      id: "label",
+      cell: (info: Info) => (
+        <DataTable.CellContent icon={info.row.original.icon}>
+          <span className="font-bold">{info.row.original.label}</span>
+        </DataTable.CellContent>
+      ),
+    },
+    {
+      header: "Visibility",
+      cell: (info: Info) => (
+        <DataTable.CellContent>
+          <Chip color="slate">
+            {info.row.original.visibility === "private" ? "Private" : "Public"}
+          </Chip>
+        </DataTable.CellContent>
+      ),
+    },
+  ];
+};
+
+export const VaultAppsList = ({
+  owner,
+  isAdmin,
+  onSelect,
+}: VaultResourcesListProps) => {
+  const [appSearch, setAppSearch] = useState<string>("");
+
+  const { apps, isAppsLoading } = useApps(owner);
+
+  const searchBarRef = useRef<HTMLInputElement>(null);
+
+  const rows: RowData[] =
+    apps?.map((app) => ({
+      sId: app.sId,
+      category: "apps",
+      label: app.name,
+      icon: CommandLineIcon,
+      workspaceId: owner.sId,
+      visibility: app.visibility,
+      onClick: () => onSelect(app.sId),
+    })) || [];
+
+  if (isAppsLoading) {
+    return (
+      <div className="mt-8 flex justify-center">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={classNames(
+        "flex gap-2",
+        rows.length === 0 && isAdmin
+          ? "h-36 w-full max-w-4xl items-center justify-center rounded-lg border bg-structure-50"
+          : ""
+      )}
+    >
+      {rows.length > 0 ? (
+        <>
+          <Searchbar
+            name="search"
+            ref={searchBarRef}
+            placeholder="Search (Name)"
+            value={appSearch}
+            onChange={(s) => {
+              setAppSearch(s);
+            }}
+          />
+          <DataTable
+            data={rows}
+            columns={getTableColumns()}
+            filter={appSearch}
+            filterColumn="label"
+          />
+        </>
+      ) : (
+        <div className="flex items-center justify-center text-sm font-normal text-element-700">
+          No available Dust Apps
+        </div>
+      )}
+    </div>
+  );
+};

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -27,6 +27,7 @@ import type { GetPokePlansResponseBody } from "@app/pages/api/poke/plans";
 import type { GetPokeWorkspacesResponseBody } from "@app/pages/api/poke/workspaces";
 import type { GetUserResponseBody } from "@app/pages/api/user";
 import type { GetUserMetadataResponseBody } from "@app/pages/api/user/metadata/[key]";
+import type { GetAppsResponseBody } from "@app/pages/api/v1/w/[wId]/apps";
 import type { GetTableResponseBody } from "@app/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]";
 import type { GetDatasetsResponseBody } from "@app/pages/api/w/[wId]/apps/[aId]/datasets";
 import type { GetDatasetResponseBody } from "@app/pages/api/w/[wId]/apps/[aId]/datasets/[name]";
@@ -142,6 +143,21 @@ export function useAppStatus() {
     appStatus: useMemo(() => (data ? data : null), [data]),
     isAppStatusLoading: !error && !data,
     isAppStatusError: !!error,
+  };
+}
+
+export function useApps(owner: LightWorkspaceType) {
+  const appsFetcher: Fetcher<GetAppsResponseBody> = fetcher;
+
+  const { data, error } = useSWRWithDefaults(
+    `/api/w/${owner.sId}/apps`,
+    appsFetcher
+  );
+
+  return {
+    apps: useMemo(() => (data ? data.apps : []), [data]),
+    isAppsLoading: !error && !data,
+    isAppsError: !!error,
   };
 }
 

--- a/front/pages/api/w/[wId]/vaults/[vId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/index.ts
@@ -65,7 +65,13 @@ async function handler(
       );
 
       const categories: { [key: string]: VaultCategoryInfo } = {};
-      DATA_SOURCE_VIEW_CATEGORIES.forEach((category) => {
+
+      // TODO(GROUPS_INFRA)[DUST_APPS_MIGRATED_TO_VAULTS]: Remove the filter on categories once apps are moved to vaults.
+      const allCategories = vault.isGlobal()
+        ? DATA_SOURCE_VIEW_CATEGORIES
+        : DATA_SOURCE_VIEW_CATEGORIES.filter((category) => category !== "apps");
+
+      allCategories.forEach((category) => {
         categories[category] = {
           count: 0,
           usage: 0,

--- a/front/pages/w/[wId]/a/[aId]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/index.tsx
@@ -321,7 +321,11 @@ export default function AppView({
         <AppLayoutSimpleCloseTitle
           title={app.name}
           onClose={() => {
-            void router.push(`/w/${owner.sId}/a`);
+            if (window.history.length > 1) {
+              void router.back();
+            } else {
+              void router.push(`/w/${owner.sId}/a`);
+            }
           }}
         />
       }

--- a/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/index.tsx
+++ b/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/index.tsx
@@ -75,13 +75,8 @@ export default function Vault({
       {category === "apps" ? (
         <VaultAppsList
           owner={owner}
-          plan={plan}
-          vault={vault}
-          systemVault={systemVault}
-          isAdmin={isAdmin}
-          category={category}
-          onSelect={() => {
-            alert("Not implemented");
+          onSelect={(sId) => {
+            void router.push(`/w/${owner.sId}/a/${sId}`);
           }}
         />
       ) : (

--- a/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/index.tsx
+++ b/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/index.tsx
@@ -8,6 +8,7 @@ import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import type { ReactElement } from "react";
 
+import { VaultAppsList } from "@app/components/vaults/VaultAppsList";
 import type { VaultLayoutProps } from "@app/components/vaults/VaultLayout";
 import { VaultLayout } from "@app/components/vaults/VaultLayout";
 import { VaultResourcesList } from "@app/components/vaults/VaultResourcesList";
@@ -71,19 +72,33 @@ export default function Vault({
   const router = useRouter();
   return (
     <Page.Vertical gap="xl" align="stretch">
-      <VaultResourcesList
-        owner={owner}
-        plan={plan}
-        vault={vault}
-        systemVault={systemVault}
-        isAdmin={isAdmin}
-        category={category}
-        onSelect={(sId) => {
-          void router.push(
-            `/w/${owner.sId}/data-sources/vaults/${vault.sId}/categories/${category}/data_source_views/${sId}`
-          );
-        }}
-      />
+      {category === "apps" ? (
+        <VaultAppsList
+          owner={owner}
+          plan={plan}
+          vault={vault}
+          systemVault={systemVault}
+          isAdmin={isAdmin}
+          category={category}
+          onSelect={() => {
+            alert("Not implemented");
+          }}
+        />
+      ) : (
+        <VaultResourcesList
+          owner={owner}
+          plan={plan}
+          vault={vault}
+          systemVault={systemVault}
+          isAdmin={isAdmin}
+          category={category}
+          onSelect={(sId) => {
+            void router.push(
+              `/w/${owner.sId}/data-sources/vaults/${vault.sId}/categories/${category}/data_source_views/${sId}`
+            );
+          }}
+        />
+      )}
     </Page.Vertical>
   );
 }


### PR DESCRIPTION
## Description

1st step of Dust Apps UI tasks.
- Create a new route to get the list of app with a useApps().
- Display the App category only for the global Vault. 
- When clicking on the App category of a Vault, we display a new component listing the apps. 

<kbd>
<img width="1808" alt="Screenshot 2024-08-28 at 13 30 19" src="https://github.com/user-attachments/assets/634a298b-5aab-4e82-9d0a-80595e2b39da">
</kbd>

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
