### PR TITLE
Add: invitations in poke with ability to copy invitation link

### DIFF
--- a/front/components/poke/invitations/columns.tsx
+++ b/front/components/poke/invitations/columns.tsx
@@ -1,0 +1,67 @@
+import { ClipboardIcon, IconButton } from "@dust-tt/sparkle";
+import type { MembershipInvitationType } from "@dust-tt/types";
+import type { ColumnDef } from "@tanstack/react-table";
+
+import { formatTimestampToFriendlyDate } from "@app/lib/utils";
+
+export function makeColumnsForInvitations(): ColumnDef<MembershipInvitationType>[] {
+  return [
+    {
+      accessorKey: "sId",
+      header: "ID",
+    },
+
+    {
+      accessorKey: "inviteEmail",
+      header: "email",
+    },
+    {
+      accessorKey: "status",
+      header: "Status",
+    },
+    {
+      accessorKey: "inviteLink",
+      header: "Invitation Link",
+      cell: ({ row }) => {
+        const inviteLink: string = row.getValue("inviteLink");
+        return (
+          <>
+            <a href={inviteLink}>link</a>
+            &nbsp;
+            <IconButton
+              icon={ClipboardIcon}
+              tooltip="Copy invite link to clipboard"
+              size="xs"
+              onClick={() =>
+                navigator.clipboard.write([
+                  new ClipboardItem({
+                    "text/plain": new Blob([inviteLink], {
+                      type: "text/plain",
+                    }),
+                  }),
+                ])
+              }
+            />
+          </>
+        );
+      },
+    },
+    {
+      accessorKey: "createdAt",
+      header: "Created at",
+      cell: ({ row }) => {
+        const createdAt: string | null = row.getValue("createdAt");
+
+        if (!createdAt) {
+          return;
+        }
+
+        return formatTimestampToFriendlyDate(new Date(createdAt).getTime());
+      },
+    },
+    {
+      accessorKey: "initialRole",
+      header: "Role",
+    },
+  ];
+}

--- a/front/components/poke/invitations/table.tsx
+++ b/front/components/poke/invitations/table.tsx
@@ -1,0 +1,29 @@
+import type { WorkspaceType } from "@dust-tt/types";
+
+import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
+import { useWorkspaceInvitations } from "@app/lib/swr";
+
+import { makeColumnsForInvitations } from "./columns";
+
+interface InvitationsDataTableProps {
+  owner: WorkspaceType;
+}
+
+export function InvitationsDataTable({ owner }: InvitationsDataTableProps) {
+  const { invitations } = useWorkspaceInvitations(owner);
+
+  return (
+    <>
+      <div className="border-material-200 my-4 flex w-full flex-col rounded-lg border p-4">
+        <div className="flex justify-between gap-3">
+          <h2 className="text-md mb-4 font-bold">Invitations:</h2>
+        </div>
+        <PokeDataTable
+          columns={makeColumnsForInvitations()}
+          data={invitations}
+          defaultFilterColumn="inviteEmail"
+        />
+      </div>
+    </>
+  );
+}

--- a/front/components/poke/shadcn/ui/data_table.tsx
+++ b/front/components/poke/shadcn/ui/data_table.tsx
@@ -40,14 +40,16 @@ interface Facet {
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
+  defaultFilterColumn?: string;
   isLoading?: boolean;
   facets?: Facet[];
   pageSize?: number;
 }
 
 export function PokeDataTable<TData, TValue>({
-  columns,
   data,
+  columns,
+  defaultFilterColumn = "name",
   facets,
   isLoading,
   pageSize = 10,
@@ -87,9 +89,13 @@ export function PokeDataTable<TData, TValue>({
         <PokeInput
           name="filter"
           placeholder="Filter ..."
-          value={(table.getColumn("name")?.getFilterValue() as string) ?? ""}
+          value={
+            (table
+              .getColumn(defaultFilterColumn)
+              ?.getFilterValue() as string) ?? ""
+          }
           onChange={(e) =>
-            table.getColumn("name")?.setFilterValue(e.target.value)
+            table.getColumn(defaultFilterColumn)?.setFilterValue(e.target.value)
           }
           className="max-w-sm"
         />

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -29,12 +29,14 @@ const INVITATION_EXPIRATION_TIME_SEC = 60 * 60 * 24 * 7;
 sgMail.setApiKey(config.getSendgridApiKey());
 
 function typeFromModel(
+  owner: WorkspaceType,
   invitation: MembershipInvitation
 ): MembershipInvitationType {
   return {
     sId: invitation.sId,
     id: invitation.id,
     inviteEmail: invitation.inviteEmail,
+    inviteLink: getMembershipInvitationUrl(owner, invitation.id),
     status: invitation.status,
     initialRole: invitation.initialRole,
     createdAt: invitation.createdAt.getTime(),
@@ -65,7 +67,7 @@ export async function getInvitation(
     return null;
   }
 
-  return typeFromModel(invitation);
+  return typeFromModel(owner, invitation);
 }
 
 export async function updateInvitationStatusAndRole(
@@ -101,7 +103,7 @@ export async function updateInvitationStatusAndRole(
     initialRole: role,
   });
 
-  return typeFromModel(existingInvitation);
+  return typeFromModel(owner, existingInvitation);
 }
 
 export async function updateOrCreateInvitation(
@@ -122,10 +124,11 @@ export async function updateOrCreateInvitation(
     await existingInvitation.update({
       initialRole,
     });
-    return typeFromModel(existingInvitation);
+    return typeFromModel(owner, existingInvitation);
   }
 
   return typeFromModel(
+    owner,
     await MembershipInvitation.create({
       sId: generateLegacyModelSId(),
       workspaceId: owner.id,
@@ -136,23 +139,29 @@ export async function updateOrCreateInvitation(
   );
 }
 
-export function getMembershipInvitationToken(
-  invitation: MembershipInvitationType
-) {
+function getMembershipInvitationToken(invitationId: number) {
   return sign(
     {
-      membershipInvitationId: invitation.id,
+      membershipInvitationId: invitationId,
       exp: Math.floor(Date.now() / 1000) + INVITATION_EXPIRATION_TIME_SEC,
     },
     config.getDustInviteTokenSecret()
   );
 }
 
-export function getMembershipInvitationUrlForToken(
+function getMembershipInvitationUrlForToken(
   owner: LightWorkspaceType,
   invitationToken: string
 ) {
   return `${config.getClientFacingUrl()}/w/${owner.sId}/join/?t=${invitationToken}`;
+}
+
+export function getMembershipInvitationUrl(
+  owner: LightWorkspaceType,
+  invitationId: number
+) {
+  const invitationToken = getMembershipInvitationToken(invitationId);
+  return getMembershipInvitationUrlForToken(owner, invitationToken);
 }
 
 export async function sendWorkspaceInvitationEmail(
@@ -160,12 +169,6 @@ export async function sendWorkspaceInvitationEmail(
   user: UserType,
   invitation: MembershipInvitationType
 ) {
-  const invitationToken = getMembershipInvitationToken(invitation);
-  const invitationUrl = getMembershipInvitationUrlForToken(
-    owner,
-    invitationToken
-  );
-
   // Send invite email.
   const message = {
     to: invitation.inviteEmail,
@@ -175,7 +178,7 @@ export async function sendWorkspaceInvitationEmail(
     },
     templateId: config.getInvitationEmailTemplate(),
     dynamic_template_data: {
-      inviteLink: invitationUrl,
+      inviteLink: invitation.inviteLink,
       inviterName: user.fullName,
       workspaceName: owner.name,
     },
@@ -214,6 +217,7 @@ export async function getPendingInvitations(
       id: i.id,
       status: i.status,
       inviteEmail: i.inviteEmail,
+      inviteLink: getMembershipInvitationUrl(owner, i.id),
       initialRole: i.initialRole,
       createdAt: i.createdAt.getTime(),
     };
@@ -272,6 +276,7 @@ export async function getRecentPendingAndRevokedInvitations(
       id: i.id,
       status,
       inviteEmail: i.inviteEmail,
+      inviteLink: getMembershipInvitationUrl(owner, i.id),
       initialRole: i.initialRole,
       createdAt: i.createdAt.getTime(),
     });

--- a/front/lib/iam/invitations.ts
+++ b/front/lib/iam/invitations.ts
@@ -7,6 +7,7 @@ import { Err, Ok } from "@dust-tt/types";
 import { verify } from "jsonwebtoken";
 
 import config from "@app/lib/api/config";
+import { getMembershipInvitationUrl } from "@app/lib/api/invitation";
 import { AuthFlowError } from "@app/lib/iam/errors";
 import { MembershipInvitation, Workspace } from "@app/lib/models/workspace";
 import type { UserResource } from "@app/lib/resources/user_resource";
@@ -89,18 +90,21 @@ export async function getPendingMembershipInvitationWithWorkspaceForEmail(
   });
 
   if (pendingInvitation) {
+    const workspace = renderLightWorkspaceType({
+      workspace: pendingInvitation.workspace,
+    });
+
     return {
       invitation: {
         createdAt: pendingInvitation.createdAt.getTime(),
         id: pendingInvitation.id,
         initialRole: pendingInvitation.initialRole,
+        inviteLink: getMembershipInvitationUrl(workspace, pendingInvitation.id),
         inviteEmail: pendingInvitation.inviteEmail,
         sId: pendingInvitation.sId,
         status: pendingInvitation.status,
       },
-      workspace: renderLightWorkspaceType({
-        workspace: pendingInvitation.workspace,
-      }),
+      workspace,
     };
   }
 

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -6,10 +6,6 @@ import type {
 import { Err, Ok } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import {
-  getMembershipInvitationToken,
-  getMembershipInvitationUrlForToken,
-} from "@app/lib/api/invitation";
 import { evaluateWorkspaceSeatAvailability } from "@app/lib/api/workspace";
 import { getSession, subscriptionForWorkspace } from "@app/lib/auth";
 import { AuthFlowError, SSOEnforcedError } from "@app/lib/iam/errors";
@@ -368,16 +364,9 @@ async function handler(
       const pendingInvitationAndWorkspace =
         await getPendingMembershipInvitationWithWorkspaceForEmail(user.email);
       if (pendingInvitationAndWorkspace) {
-        const { invitation: pendingInvitation, workspace } =
-          pendingInvitationAndWorkspace;
+        const { invitation: pendingInvitation } = pendingInvitationAndWorkspace;
 
-        const invitationToken = getMembershipInvitationToken(pendingInvitation);
-        const invitationUrl = getMembershipInvitationUrlForToken(
-          workspace,
-          invitationToken
-        );
-
-        res.redirect(invitationUrl);
+        res.redirect(pendingInvitation.inviteLink);
         return;
       }
     }

--- a/front/pages/poke/[wId]/memberships.tsx
+++ b/front/pages/poke/[wId]/memberships.tsx
@@ -3,6 +3,7 @@ import type { UserType } from "@dust-tt/types";
 import type { InferGetServerSidePropsType } from "next";
 import React from "react";
 
+import { InvitationsDataTable } from "@app/components/poke/invitations/table";
 import { MembersDataTable } from "@app/components/poke/members/table";
 import PokeNavbar from "@app/components/poke/PokeNavbar";
 import { getMembers } from "@app/lib/api/workspace";
@@ -45,6 +46,9 @@ const MembershipsPage = ({
         <h1 className="mb-8 text-2xl font-bold">{owner.name}</h1>
         <div className="flex justify-center">
           <MembersDataTable members={members} owner={owner} user={user} />
+        </div>
+        <div className="flex justify-center">
+          <InvitationsDataTable owner={owner} />
         </div>
       </div>
     </div>

--- a/types/src/front/membership_invitation.ts
+++ b/types/src/front/membership_invitation.ts
@@ -9,6 +9,7 @@ export type MembershipInvitationType = {
   id: ModelId;
   status: "pending" | "consumed" | "revoked";
   inviteEmail: string;
+  inviteLink: string;
   initialRole: ActiveRoleType;
   createdAt: number;
 };


### PR DESCRIPTION
## Description

Some users are stuck with an invitation that "never reach" the recipient for some reason (even if sendgrid says otherwise).
This PR add the ability to see the invitations and grab the invitation link within Poke.

It refactored a bit the code so the invitation link is part of the `MembershipInvitationType` to make it simpler (and potentially exposing the same feature in the product itself).

![image](https://github.com/user-attachments/assets/7d974f0c-ee53-4b15-b7dc-ebd8aaba3f75)

## Risk

I don't see any security risk but there might one that I overlooked.

## Deploy Plan

Deploy `front`