### PR TITLE
[Microsoft] Migrate parents in core to correct order

### DIFF
--- a/connectors/migrations/20240828_microsoft_refill_parents_field.ts
+++ b/connectors/migrations/20240828_microsoft_refill_parents_field.ts
@@ -56,7 +56,7 @@ async function updateParentsFieldForConnector(
           workspaceId: connector.workspaceId,
           workspaceAPIKey: connector.workspaceAPIKey,
         },
-        documentId: `microsoft-${node.internalId}`,
+        documentId: node.internalId,
         parents,
       });
     },

--- a/connectors/migrations/20240828_microsoft_refill_parents_field.ts
+++ b/connectors/migrations/20240828_microsoft_refill_parents_field.ts
@@ -1,0 +1,77 @@
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import { Op } from "sequelize";
+
+import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
+import { concurrentExecutor } from "@connectors/lib/async_utils";
+import { updateDocumentParentsField } from "@connectors/lib/data_sources";
+import logger from "@connectors/logger/logger";
+import { getParents } from "@connectors/connectors/microsoft/temporal/file";
+import { MicrosoftNodeModel } from "@connectors/lib/models/microsoft";
+import { makeScript } from "scripts/helpers";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import { execute } from "fp-ts/lib/StateT";
+
+makeScript({}, async ({ execute }) => {
+  const connectors = await ConnectorResource.listByType("microsoft", {});
+  for (const connector of connectors) {
+    logger.info({ connector: connector.toJSON() }, "Processing connector");
+    await updateParentsFieldForConnector(connector, execute);
+  }
+});
+
+async function updateParentsFieldForConnector(
+  connector: ConnectorResource,
+  execute = false
+) {
+  // get all nodes (not using resource here since 1-shot clean migration)
+  const nodes = await MicrosoftNodeModel.findAll({
+    where: {
+      connectorId: connector.id,
+      nodeType: "file",
+      // exclude spreadsheets and csv files (their parents were correct)
+      mimeType: {
+        [Op.notIn]: [
+          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "application/vnd.ms-excel",
+          "text/csv",
+        ],
+      },
+    },
+  });
+
+  const startSyncTs = new Date().getTime();
+  const res = await concurrentExecutor(
+    nodes,
+    async (node) => {
+      const parents = await getParents({
+        connectorId: connector.id,
+        internalId: node.internalId,
+        startSyncTs,
+      });
+
+      if (!execute) {
+        return true;
+      }
+
+      return await updateDocumentParentsField({
+        dataSourceConfig: {
+          dataSourceName: connector.dataSourceName,
+          workspaceId: connector.workspaceId,
+          workspaceAPIKey: connector.workspaceAPIKey,
+        },
+        documentId: `microsoft-${node.internalId}`,
+        parents,
+      });
+    },
+    { concurrency: 10 }
+  );
+
+  logger.info(
+    {
+      connectorId: connector.id,
+      updated: res.filter((r) => r).length,
+      total: res.length,
+    },
+    "Updated parents field for connector"
+  );
+}

--- a/connectors/migrations/20240828_microsoft_refill_parents_field.ts
+++ b/connectors/migrations/20240828_microsoft_refill_parents_field.ts
@@ -1,15 +1,12 @@
-import { existsSync, readFileSync, writeFileSync } from "fs";
+import { makeScript } from "scripts/helpers";
 import { Op } from "sequelize";
 
-import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
+import { getParents } from "@connectors/connectors/microsoft/temporal/file";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { updateDocumentParentsField } from "@connectors/lib/data_sources";
-import logger from "@connectors/logger/logger";
-import { getParents } from "@connectors/connectors/microsoft/temporal/file";
 import { MicrosoftNodeModel } from "@connectors/lib/models/microsoft";
-import { makeScript } from "scripts/helpers";
+import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
-import { execute } from "fp-ts/lib/StateT";
 
 makeScript({}, async ({ execute }) => {
   const connectors = await ConnectorResource.listByType("microsoft", {});
@@ -53,7 +50,7 @@ async function updateParentsFieldForConnector(
         return true;
       }
 
-      return await updateDocumentParentsField({
+      return updateDocumentParentsField({
         dataSourceConfig: {
           dataSourceName: connector.dataSourceName,
           workspaceId: connector.workspaceId,

--- a/connectors/migrations/20240828_microsoft_refill_parents_field.ts
+++ b/connectors/migrations/20240828_microsoft_refill_parents_field.ts
@@ -60,7 +60,7 @@ async function updateParentsFieldForConnector(
         parents,
       });
     },
-    { concurrency: 10 }
+    { concurrency: 64 }
   );
 
   logger.info(

--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -295,7 +295,6 @@ export async function syncOneFile({
             startSyncTs,
           })),
         ];
-        parents.reverse();
 
         await upsertToDatasource({
           dataSourceConfig,
@@ -304,7 +303,7 @@ export async function syncOneFile({
           documentUrl: file.webUrl ?? undefined,
           timestampMs: upsertTimestampMs,
           tags,
-          parents: parents,
+          parents,
           upsertContext: {
             sync_type: isBatchSync ? "batch" : "incremental",
           },


### PR DESCRIPTION
Description
---
Fixes #6975

Remove the reverse making parents in the wrong order, & add the migration script

Risks
---
Radius: microsoft connectors
Risk: messing up with exisiting accounts, but there are only 4; worst case we can full resync

Deploy plan
---
- pause all microsoft connectors
- deploy connectors
- run migration
- restart connectors
