### PR TITLE
Fix: poke members page

### DIFF
--- a/front/components/poke/invitations/table.tsx
+++ b/front/components/poke/invitations/table.tsx
@@ -1,22 +1,21 @@
-import type { WorkspaceType } from "@dust-tt/types";
+import type { MembershipInvitationType } from "@dust-tt/types";
 
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
-import { useWorkspaceInvitations } from "@app/lib/swr";
 
 import { makeColumnsForInvitations } from "./columns";
 
 interface InvitationsDataTableProps {
-  owner: WorkspaceType;
+  invitations: MembershipInvitationType[];
 }
 
-export function InvitationsDataTable({ owner }: InvitationsDataTableProps) {
-  const { invitations } = useWorkspaceInvitations(owner);
-
+export function InvitationsDataTable({
+  invitations,
+}: InvitationsDataTableProps) {
   return (
     <>
       <div className="border-material-200 my-4 flex w-full flex-col rounded-lg border p-4">
         <div className="flex justify-between gap-3">
-          <h2 className="text-md mb-4 font-bold">Invitations:</h2>
+          <h2 className="text-md mb-4 font-bold">Pending Invitations:</h2>
         </div>
         <PokeDataTable
           columns={makeColumnsForInvitations()}


### PR DESCRIPTION
## Description

I didn't realize we couldn't call the regular api endpoint from poke and bypass the permissions.
Refactored to use server side props.

## Risk

None

## Deploy Plan

Deploy `front`