### PR TITLE
Add support to retrieve children nodes on a data source view

### DIFF
--- a/connectors/src/api/get_connector_permissions.ts
+++ b/connectors/src/api/get_connector_permissions.ts
@@ -6,6 +6,8 @@ import type { ContentNode } from "@dust-tt/types";
 import type { Request, Response } from "express";
 
 import { getConnectorManager } from "@connectors/connectors";
+import { augmentContentNodesWithParentIds } from "@connectors/lib/api/content_nodes";
+import logger from "@connectors/logger/logger";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 
@@ -47,7 +49,7 @@ const _getConnectorPermissions = async (
     }
   }
 
-  const viewType = req.query.viewType;
+  const { includeParents, viewType } = req.query;
   if (
     !viewType ||
     typeof viewType !== "string" ||
@@ -89,6 +91,28 @@ const _getConnectorPermissions = async (
         type: "internal_server_error",
         message: pRes.error.message,
       },
+    });
+  }
+
+  if (includeParents) {
+    const parentsRes = await augmentContentNodesWithParentIds(
+      connector,
+      pRes.value
+    );
+    if (parentsRes.isErr()) {
+      logger.error(parentsRes.error, "Failed to get content node parents.");
+
+      return apiError(req, res, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: parentsRes.error.message,
+        },
+      });
+    }
+
+    return res.status(200).json({
+      resources: parentsRes.value,
     });
   }
 

--- a/connectors/src/api/get_content_node_parents.ts
+++ b/connectors/src/api/get_content_node_parents.ts
@@ -59,7 +59,7 @@ const _getContentNodesParents = async (
 
   const parentsRes = await getParentIdsForContentNodes(connector, internalIds);
   if (parentsRes.isErr()) {
-    logger.error(parentsRes.error, "Failed to get content node parents");
+    logger.error(parentsRes.error, "Failed to get content node parents.");
     return apiError(req, res, {
       status_code: 500,
       api_error: {

--- a/connectors/src/lib/api/content_nodes.ts
+++ b/connectors/src/lib/api/content_nodes.ts
@@ -1,4 +1,8 @@
-import type { Result } from "@dust-tt/types";
+import type {
+  ContentNode,
+  ContentNodeWithParentIds,
+  Result,
+} from "@dust-tt/types";
 import { Ok } from "@dust-tt/types";
 import { zip } from "fp-ts/lib/Array";
 
@@ -46,4 +50,31 @@ export async function getParentIdsForContentNodes(
   }
 
   return new Ok(nodes);
+}
+
+export async function augmentContentNodesWithParentIds(
+  connector: ConnectorResource,
+  contentNodes: ContentNode[]
+): Promise<Promise<Result<ContentNodeWithParentIds[], Error>>> {
+  const internalIds = contentNodes.map((node) => node.internalId);
+
+  const parentsRes = await getParentIdsForContentNodes(connector, internalIds);
+  if (parentsRes.isErr()) {
+    return parentsRes;
+  }
+
+  const nodesWithParentIds: ContentNodeWithParentIds[] = [];
+
+  for (const { internalId, parentInternalIds } of parentsRes.value) {
+    const node = contentNodes.find((n) => n.internalId === internalId);
+
+    if (node) {
+      nodesWithParentIds.push({
+        ...node,
+        parentInternalIds,
+      });
+    }
+  }
+
+  return new Ok(nodesWithParentIds);
 }

--- a/front/components/ConnectorPermissionsTree.tsx
+++ b/front/components/ConnectorPermissionsTree.tsx
@@ -220,8 +220,8 @@ function PermissionTreeChildren({
         ?.unselected) ||
     "none";
 
-  const resourcesFiltered = nodes.filter(
-    (r) => search.trim().length === 0 || r.title.includes(search)
+  const filteredNodes = nodes.filter(
+    (n) => search.trim().length === 0 || n.title.includes(search)
   );
 
   return (
@@ -256,15 +256,15 @@ function PermissionTreeChildren({
                   setSelectAllClicked((prev) => !prev);
                   setLocalStateByInternalId((prev) => {
                     const newState = { ...prev };
-                    resourcesFiltered.forEach((r) => {
-                      newState[r.internalId] = !selectAllClicked;
+                    filteredNodes.forEach((n) => {
+                      newState[n.internalId] = !selectAllClicked;
                     });
                     return newState;
                   });
                   if (onPermissionUpdate) {
-                    resourcesFiltered.forEach((r) => {
+                    filteredNodes.forEach((n) => {
                       onPermissionUpdate({
-                        internalId: r.internalId,
+                        internalId: n.internalId,
                         permission: !selectAllClicked
                           ? selectedPermission
                           : unselectedPermission,
@@ -278,21 +278,21 @@ function PermissionTreeChildren({
         </>
       )}
       <Tree isLoading={isLoading}>
-        {resourcesFiltered.map((r, i) => {
+        {filteredNodes.map((n, i) => {
           const isChecked =
             parentIsSelected ||
-            (localStateByInternalId[r.internalId] ??
-              ["read", "read_write"].includes(r.permission));
+            (localStateByInternalId[n.internalId] ??
+              ["read", "read_write"].includes(n.permission));
 
           return (
             <Tree.Item
-              key={r.internalId}
-              type={r.expandable ? "node" : "leaf"}
-              label={r.title}
-              visual={getVisualForContentNode(r)}
+              key={n.internalId}
+              type={n.expandable ? "node" : "leaf"}
+              label={n.title}
+              visual={getVisualForContentNode(n)}
               className="whitespace-nowrap"
               checkbox={
-                r.preventSelection !== true &&
+                n.preventSelection !== true &&
                 canUpdatePermissions &&
                 onPermissionUpdate
                   ? {
@@ -301,10 +301,10 @@ function PermissionTreeChildren({
                       onChange: (checked) => {
                         setLocalStateByInternalId((prev) => ({
                           ...prev,
-                          [r.internalId]: checked,
+                          [n.internalId]: checked,
                         }));
                         onPermissionUpdate({
-                          internalId: r.internalId,
+                          internalId: n.internalId,
                           permission: checked
                             ? selectedPermission
                             : unselectedPermission,
@@ -315,17 +315,17 @@ function PermissionTreeChildren({
               }
               actions={
                 <div className="mr-8 flex flex-row gap-2">
-                  {r.lastUpdatedAt ? (
+                  {n.lastUpdatedAt ? (
                     <Tooltip
                       contentChildren={
                         <span>
-                          {new Date(r.lastUpdatedAt).toLocaleString()}
+                          {new Date(n.lastUpdatedAt).toLocaleString()}
                         </span>
                       }
                       position={i === 0 ? "below" : "above"}
                     >
                       <span className="text-xs text-gray-500">
-                        {timeAgoFrom(r.lastUpdatedAt)} ago
+                        {timeAgoFrom(n.lastUpdatedAt)} ago
                       </span>
                     </Tooltip>
                   ) : null}
@@ -333,38 +333,38 @@ function PermissionTreeChildren({
                     size="xs"
                     icon={ExternalLinkIcon}
                     onClick={() => {
-                      if (r.sourceUrl) {
-                        window.open(r.sourceUrl, "_blank");
+                      if (n.sourceUrl) {
+                        window.open(n.sourceUrl, "_blank");
                       }
                     }}
                     className={classNames(
-                      r.sourceUrl ? "" : "pointer-events-none opacity-0"
+                      n.sourceUrl ? "" : "pointer-events-none opacity-0"
                     )}
-                    disabled={!r.sourceUrl}
+                    disabled={!n.sourceUrl}
                     variant="tertiary"
                   />
                   <IconButton
                     size="xs"
                     icon={BracesIcon}
                     onClick={() => {
-                      if (r.dustDocumentId) {
-                        displayDocumentSource(r.dustDocumentId);
+                      if (n.dustDocumentId) {
+                        displayDocumentSource(n.dustDocumentId);
                       }
                     }}
                     className={classNames(
-                      r.dustDocumentId ? "" : "pointer-events-none opacity-0"
+                      n.dustDocumentId ? "" : "pointer-events-none opacity-0"
                     )}
-                    disabled={!r.dustDocumentId}
+                    disabled={!n.dustDocumentId}
                     variant="tertiary"
                   />
                 </div>
               }
               renderTreeItems={() => {
                 const isParentNodeSelected =
-                  (parentIsSelected || localStateByInternalId[r.internalId]) ??
-                  ["read", "read_write"].includes(r.permission);
+                  (parentIsSelected || localStateByInternalId[n.internalId]) ??
+                  ["read", "read_write"].includes(n.permission);
 
-                return renderChildItem(r, { isParentNodeSelected });
+                return renderChildItem(n, { isParentNodeSelected });
               }}
             />
           );

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -43,7 +43,7 @@ import AssistantListActions from "@app/components/assistant/AssistantListActions
 import { ReadOnlyTextArea } from "@app/components/assistant/ReadOnlyTextArea";
 import { assistantUsageMessage } from "@app/components/assistant/Usage";
 import { SharingDropdown } from "@app/components/assistant_builder/Sharing";
-import { PermissionTreeChildren } from "@app/components/ConnectorPermissionsTree";
+import { DataSourceViewPermissionTreeChildren } from "@app/components/ConnectorPermissionsTree";
 import DataSourceViewDocumentModal from "@app/components/DataSourceViewDocumentModal";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { updateAgentScope } from "@app/lib/client/dust_api";
@@ -54,7 +54,6 @@ import {
   useAgentConfiguration,
   useAgentUsage,
   useApp,
-  useConnectorPermissions,
   useDataSourceViewContentNodes,
   useDataSourceViews,
 } from "@app/lib/swr";
@@ -400,17 +399,15 @@ function DataSourceViewsSection({
               className="whitespace-nowrap"
             >
               {dataSourceView && isAllSelected && (
-                <PermissionTreeChildren
+                <DataSourceViewPermissionTreeChildren
                   owner={owner}
-                  dataSource={dataSourceView.dataSource}
+                  dataSourceView={dataSourceView}
                   parentId={null}
-                  permissionFilter="read"
                   canUpdatePermissions={false}
                   displayDocumentSource={(documentId: string) => {
                     setDataSourceViewToDisplay(dataSourceView);
                     setDocumentToDisplay(documentId);
                   }}
-                  useConnectorPermissionsHook={useConnectorPermissions}
                   isSearchEnabled={false}
                 />
               )}
@@ -444,8 +441,6 @@ function DataSourceViewSelectedNodes({
   setDataSourceViewToDisplay: (dsv: DataSourceViewType) => void;
   setDocumentToDisplay: (documentId: string) => void;
 }) {
-  const { dataSource } = dataSourceView;
-
   const dataSourceViewSelectedNodes = useDataSourceViewContentNodes({
     owner,
     dataSourceView,
@@ -495,17 +490,15 @@ function DataSourceViewSelectedNodes({
             </div>
           }
         >
-          <PermissionTreeChildren
+          <DataSourceViewPermissionTreeChildren
             owner={owner}
-            dataSource={dataSource}
+            dataSourceView={dataSourceView}
             parentId={node.internalId}
-            permissionFilter="read"
             canUpdatePermissions={true}
             displayDocumentSource={(documentId: string) => {
               setDataSourceViewToDisplay(dataSourceView);
               setDocumentToDisplay(documentId);
             }}
-            useConnectorPermissionsHook={useConnectorPermissions}
             isSearchEnabled={false}
           />
         </Tree.Item>

--- a/front/components/assistant_builder/DataSourceSelectionSection.tsx
+++ b/front/components/assistant_builder/DataSourceSelectionSection.tsx
@@ -14,14 +14,13 @@ import type {
 import { useContext, useState } from "react";
 
 import { AssistantBuilderContext } from "@app/components/assistant_builder/AssistantBuilderContext";
-import { PermissionTreeChildren } from "@app/components/ConnectorPermissionsTree";
+import { DataSourceViewPermissionTreeChildren } from "@app/components/ConnectorPermissionsTree";
 import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
 import ManagedDataSourceDocumentModal from "@app/components/ManagedDataSourceDocumentModal";
 import { orderDatasourceViewSelectionConfigurationByImportance } from "@app/lib/assistant";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { getVisualForContentNode } from "@app/lib/content_nodes";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
-import { useConnectorPermissions } from "@app/lib/swr";
 import { classNames } from "@app/lib/utils";
 
 export default function DataSourceSelectionSection({
@@ -106,17 +105,15 @@ export default function DataSourceSelectionSection({
                   className="whitespace-nowrap"
                 >
                   {dsConfig.isSelectAll && (
-                    <PermissionTreeChildren
+                    <DataSourceViewPermissionTreeChildren
                       owner={owner}
-                      dataSource={dsConfig.dataSourceView.dataSource}
+                      dataSourceView={dsConfig.dataSourceView}
                       parentId={null}
-                      permissionFilter="read"
                       canUpdatePermissions={true}
                       displayDocumentSource={(documentId: string) => {
                         setDataSourceViewToDisplay(dsConfig.dataSourceView);
                         setDocumentToDisplay(documentId);
                       }}
-                      useConnectorPermissionsHook={useConnectorPermissions}
                       isSearchEnabled={false}
                     />
                   )}
@@ -168,17 +165,15 @@ export default function DataSourceSelectionSection({
                           </div>
                         }
                       >
-                        <PermissionTreeChildren
+                        <DataSourceViewPermissionTreeChildren
                           owner={owner}
-                          dataSource={dsConfig.dataSourceView.dataSource}
+                          dataSourceView={dsConfig.dataSourceView}
                           parentId={node.internalId}
-                          permissionFilter="read"
                           canUpdatePermissions={true}
                           displayDocumentSource={(documentId: string) => {
                             setDataSourceViewToDisplay(dsConfig.dataSourceView);
                             setDocumentToDisplay(documentId);
                           }}
-                          useConnectorPermissionsHook={useConnectorPermissions}
                           isSearchEnabled={false}
                         />
                       </Tree.Item>

--- a/front/components/poke/PokeConnectorPermissionsTree.tsx
+++ b/front/components/poke/PokeConnectorPermissionsTree.tsx
@@ -4,7 +4,7 @@ import type {
   WorkspaceType,
 } from "@dust-tt/types";
 
-import { PermissionTreeChildren } from "@app/components/ConnectorPermissionsTree";
+import { DataSourcePermissionTreeChildren } from "@app/components/ConnectorPermissionsTree";
 import { usePokeConnectorPermissions } from "@app/lib/swr";
 
 export function PokePermissionTree({
@@ -33,7 +33,7 @@ export function PokePermissionTree({
   return (
     <>
       <div className="overflow-x-auto">
-        <PermissionTreeChildren
+        <DataSourcePermissionTreeChildren
           owner={owner}
           dataSource={dataSource}
           parentId={null}

--- a/front/components/poke/PokeConnectorPermissionsTree.tsx
+++ b/front/components/poke/PokeConnectorPermissionsTree.tsx
@@ -31,22 +31,20 @@ export function PokePermissionTree({
   displayDocumentSource: (documentId: string) => void;
 }) {
   return (
-    <>
-      <div className="overflow-x-auto">
-        <DataSourcePermissionTreeChildren
-          owner={owner}
-          dataSource={dataSource}
-          parentId={null}
-          permissionFilter={permissionFilter}
-          canUpdatePermissions={canUpdatePermissions}
-          onPermissionUpdate={onPermissionUpdate}
-          showExpand={showExpand}
-          parentIsSelected={false}
-          displayDocumentSource={displayDocumentSource}
-          useConnectorPermissionsHook={usePokeConnectorPermissions}
-          isSearchEnabled={false}
-        />
-      </div>
-    </>
+    <div className="overflow-x-auto">
+      <DataSourcePermissionTreeChildren
+        owner={owner}
+        dataSource={dataSource}
+        parentId={null}
+        permissionFilter={permissionFilter}
+        canUpdatePermissions={canUpdatePermissions}
+        onPermissionUpdate={onPermissionUpdate}
+        showExpand={showExpand}
+        parentIsSelected={false}
+        displayDocumentSource={displayDocumentSource}
+        useConnectorPermissionsHook={usePokeConnectorPermissions}
+        isSearchEnabled={false}
+      />
+    </div>
   );
 }

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
@@ -49,6 +49,17 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "data_source_auth_error",
+        message:
+          "Only the users that are `admins` for the current workspace can see or edit the permissions of a data source.",
+      },
+    });
+  }
+
   const dataSource = await getDataSource(auth, req.query.name as string);
   if (!dataSource) {
     return apiError(req, res, {
@@ -79,18 +90,8 @@ async function handler(
         req,
         res
       );
-    case "POST":
-      if (!auth.isAdmin()) {
-        return apiError(req, res, {
-          status_code: 403,
-          api_error: {
-            type: "data_source_auth_error",
-            message:
-              "Only the users that are `admins` for the current workspace can edit the permissions of a data source.",
-          },
-        });
-      }
 
+    case "POST":
       const connectorsAPI = new ConnectorsAPI(
         config.getConnectorsAPIConfig(),
         logger


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR is a follow up of https://github.com/dust-tt/dust/pull/6972.

It enhances the endpoint introduced in #6972 to support returning all children for a given internal ID. While the request body always accepts `internalIds` as an array, the `includeChildren` option only functions when **there is exactly one element** in the array. This is an initial design decision, which may be revisited later if we decide to pre-fetch children for all nodes at the current level. Given the significant query complexity required at the moment, we've chosen to keep this limitation. However, using an array ensures future flexibility. 

The endpoint then calls the connector’s `/permissions` endpoint, which now also accepts the `includeParents` parameter to return children nodes with their parent information. This is necessary to enforce data source view restrictions on accessible child nodes. It trims the parent IDs returned with these nodes to ensure they are all included in the current data source view.

On the front end, we introduced two wrappers around the `PermissionTreeChildren` component. The goal is to consistently manage Data Source Views, except on the connected data source screen, where different levels of filter permissions ("read" and "write") are still necessary. In subsequent PRs, we'll continue to reduce the product surface where DataSources are directly exposed.

With this PR we can now restrict the legacy endpoint to list permissions to admins only.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Worst case it breaks the `AssistantDetails` and part of the AssistantBuilder for search and process actions. Safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
