### PR TITLE
Fix: in case of oauth token revoked, stop the connector instead of terminating the workflow

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -26,19 +26,19 @@ directories=("front" "connectors")
 for directory in "${directories[@]}"; do
     if git diff --cached --name-only | grep -qE "^$directory/"; then
         # Run the linter on root_path concatenated with the directory
-        if ! npm run lint --prefix $root_path/$directory; then
+        if ! npm run lint --if-present --prefix $root_path/$directory; then
             echo "Linting failed. Please fix the issues before committing."
             exit 1
         fi
-        if ! npm run tsc --prefix $root_path/$directory; then
+        if ! npm run tsc --if-present --prefix $root_path/$directory; then
             echo "Type checking failed. Please fix the issues before committing."
             exit 1
         fi
-        if ! npm run format:check --prefix $root_path/$directory; then
+        if ! npm run format:check --if-present --prefix $root_path/$directory; then
             echo "Formatting check failed. Please fix the issues before committing."
             exit 1
         fi
-        if ! npm run docs:check --prefix $root_path/$directory; then
+        if ! npm run docs:check --if-present --prefix $root_path/$directory; then
             echo "Documentation check failed. Please fix the issues before committing."
             exit 1
         fi

--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -136,7 +136,13 @@ export class ActivityInboundLogInterceptor
               connectorProvider: connector.type,
             });
 
-            await connectorManager?.stop();
+            if (connectorManager) {
+              await connectorManager.stop();
+            } else {
+              this.logger.error(
+                `Connector manager not found for connector ${connector.id}`
+              );
+            }
           }
         }
       }


### PR DESCRIPTION
## Description

This previous [PR](https://github.com/dust-tt/dust/pull/6942) terminated a child workflow if the oauth token was revoked instead of cancelling it to prevent false positive in monitoring.

However, if a child workflow is `terminated`, the parent workflow is considered `failed` anyways so it didn't work as expected.

This new proposal uses `stop()` on the `ConnectorManager` to (hopefully) stop it properly.

Note that we could also call `terminateAllWorkflowsForConnectorId()` but it seems more appropriate to leverage the dedicated method. For example, the confluence one `stop()` method retrieve the parent workflow and terminate that one in particular.

## Risk

None

## Deploy Plan

Deploy `connectors`