### PR TITLE
Support fetching children for content nodes without parents

### DIFF
--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -564,10 +564,9 @@ export function useDataSourceViewContentNodeChildren({
   isNodesLoading: boolean;
   isNodesError: boolean;
 } {
-  const url =
-    dataSourceView && parentInternalId
-      ? `/api/w/${owner.sId}/vaults/${dataSourceView.vaultId}/data_source_views/${dataSourceView.sId}/content-nodes`
-      : null;
+  const url = dataSourceView
+    ? `/api/w/${owner.sId}/vaults/${dataSourceView.vaultId}/data_source_views/${dataSourceView.sId}/content-nodes`
+    : null;
 
   const body = JSON.stringify({
     internalIds: [parentInternalId],


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
https://github.com/dust-tt/dust/pull/6984 left one case out of the picture. The endpoint `data_source_view/[dsvId]/content-nodes` should also accept returning children for content nodes without parents.

This PR accounts for this use case.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
