### PR TITLE
Create App modal in vault

### DIFF
--- a/front/components/vaults/VaultAppsList.tsx
+++ b/front/components/vaults/VaultAppsList.tsx
@@ -3,6 +3,7 @@ import {
   Chip,
   CommandLineIcon,
   DataTable,
+  PlusIcon,
   Searchbar,
   Spinner,
 } from "@dust-tt/sparkle";
@@ -13,6 +14,7 @@ import { useRef } from "react";
 import { useState } from "react";
 import * as React from "react";
 
+import { VaultCreateAppModal } from "@app/components/vaults/VaultCreateAppModal";
 import { useApps } from "@app/lib/swr";
 
 type RowData = {
@@ -28,6 +30,7 @@ type RowData = {
 
 type VaultAppListProps = {
   owner: WorkspaceType;
+  isBuilder: boolean;
   onSelect: (sId: string) => void;
 };
 
@@ -54,7 +57,12 @@ const getTableColumns = () => {
   ];
 };
 
-export const VaultAppsList = ({ owner, onSelect }: VaultAppListProps) => {
+export const VaultAppsList = ({
+  owner,
+  isBuilder,
+  onSelect,
+}: VaultAppListProps) => {
+  const [isCreateAppModalOpened, setIsCreateAppModalOpened] = useState(false);
   const [appSearch, setAppSearch] = useState<string>("");
 
   const { apps, isAppsLoading } = useApps(owner);
@@ -85,8 +93,9 @@ export const VaultAppsList = ({ owner, onSelect }: VaultAppListProps) => {
       <div className="flex h-36 w-full max-w-4xl items-center justify-center gap-2 rounded-lg border bg-structure-50">
         <Button
           label="Create App"
+          disabled={!isBuilder}
           onClick={() => {
-            alert("Not implemented"); // Check which role should be allowed to create an app or disable button.
+            setIsCreateAppModalOpened(true);
           }}
         />
       </div>
@@ -95,7 +104,12 @@ export const VaultAppsList = ({ owner, onSelect }: VaultAppListProps) => {
 
   return (
     <>
-      <div className="gap-2">
+      <VaultCreateAppModal
+        owner={owner}
+        isOpen={isCreateAppModalOpened}
+        setIsOpen={setIsCreateAppModalOpened}
+      />
+      <div className="flex gap-2">
         <Searchbar
           name="search"
           ref={searchBarRef}
@@ -105,12 +119,23 @@ export const VaultAppsList = ({ owner, onSelect }: VaultAppListProps) => {
             setAppSearch(s);
           }}
         />
+        {isBuilder && (
+          <Button
+            label="New App"
+            variant="primary"
+            icon={PlusIcon}
+            size="sm"
+            onClick={() => {
+              setIsCreateAppModalOpened(true);
+            }}
+          />
+        )}
       </div>
       <DataTable
         data={rows}
         columns={getTableColumns()}
         filter={appSearch}
-        filterColumn="label"
+        filterColumn="Name"
       />
     </>
   );

--- a/front/components/vaults/VaultAppsList.tsx
+++ b/front/components/vaults/VaultAppsList.tsx
@@ -37,7 +37,7 @@ type VaultAppListProps = {
 const getTableColumns = () => {
   return [
     {
-      id: "Name",
+      id: "name",
       cell: (info: CellContext<RowData, string>) => (
         <DataTable.CellContent icon={info.row.original.icon}>
           {info.getValue()}
@@ -46,7 +46,7 @@ const getTableColumns = () => {
       accessorFn: (row: RowData) => row.name,
     },
     {
-      id: "Visibility",
+      id: "visibility",
       cell: (info: CellContext<RowData, string>) => (
         <DataTable.CellContent>
           <Chip color="slate">{info.getValue()}</Chip>
@@ -135,7 +135,7 @@ export const VaultAppsList = ({
         data={rows}
         columns={getTableColumns()}
         filter={appSearch}
-        filterColumn="Name"
+        filterColumn="name"
       />
     </>
   );

--- a/front/components/vaults/VaultCreateAppModal.tsx
+++ b/front/components/vaults/VaultCreateAppModal.tsx
@@ -1,0 +1,174 @@
+import {
+  ExclamationCircleStrokeIcon,
+  Input,
+  Modal,
+  Page,
+  RadioButton,
+  TextArea,
+} from "@dust-tt/sparkle";
+import type { APIError, AppVisibility, WorkspaceType } from "@dust-tt/types";
+import { useContext, useState } from "react";
+
+import { SendNotificationsContext } from "@app/components/sparkle/Notification";
+import { useApps } from "@app/lib/swr";
+import { MODELS_STRING_MAX_LENGTH } from "@app/lib/utils";
+
+export const VaultCreateAppModal = ({
+  owner,
+  isOpen,
+  setIsOpen,
+}: {
+  owner: WorkspaceType;
+  isOpen: boolean;
+  setIsOpen: (isOpen: boolean) => void;
+}) => {
+  const sendNotification = useContext(SendNotificationsContext);
+
+  const [name, setName] = useState<string | null>(null);
+  const [nameError, setNameError] = useState<string | null>(null);
+
+  const [description, setDescription] = useState<string | null>(null);
+  const [descriptionError, setDescriptionError] = useState<string | null>(null);
+
+  const [visibility, setVisibility] = useState<AppVisibility>("private");
+
+  const { apps, mutateApps } = useApps(owner);
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={() => {
+        setIsOpen(false);
+      }}
+      onSave={async () => {
+        if (!name || name.trim() === "") {
+          setNameError("Name is required.");
+        } else if (!name.match(/^[a-zA-Z0-9._-]+$/)) {
+          setNameError(
+            "App name must only contain letters, numbers, and the characters `._-`"
+          );
+        } else if (apps.find((app) => app.name === name)) {
+          setNameError("An App with this name already exists.");
+        }
+
+        if (!description || description.trim() === "") {
+          setDescriptionError(
+            "A description is required for your app to be selectable in the Assistant Builder."
+          );
+        }
+
+        if (name && description && !nameError && !descriptionError) {
+          const res = await fetch(`/api/w/${owner.sId}/apps`, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              name: name.slice(0, MODELS_STRING_MAX_LENGTH),
+              description: description.slice(0, MODELS_STRING_MAX_LENGTH),
+              visibility,
+            }),
+          });
+          if (res.ok) {
+            await mutateApps();
+            setIsOpen(false);
+            // @todo Daph next PR: rework the modal detail so we can propertly redirect
+            // on the edition view.
+            // const response: PostAppResponseBody = await res.json();
+            // const { app } = response;
+            // await router.push(`/w/${owner.sId}/a/${app.sId}`);
+
+            sendNotification({
+              type: "success",
+              title: "Successfully created app",
+              description: "App was successfully created.",
+            });
+          } else {
+            const err = (await res.json()) as { error: APIError };
+            sendNotification({
+              title: "Error Saving App",
+              type: "error",
+              description: `Error: ${err.error.message}`,
+            });
+          }
+        }
+      }}
+      hasChanged={name !== null || description !== null}
+      title="Create a new App"
+      variant="side-sm"
+    >
+      <Page variant="modal">
+        <div className="w-full">
+          <Page.Vertical sizing="grow">
+            <Page.SectionHeader title="Name" />
+            <div className="w-full">
+              <Input
+                placeholder="app_name"
+                name="name"
+                value={name}
+                onChange={(value) => {
+                  setName(value);
+                  setNameError(null);
+                }}
+                error={nameError}
+                showErrorLabel
+              />
+              <p className="mt-1 flex items-center gap-1 text-sm text-gray-500">
+                <ExclamationCircleStrokeIcon /> Must be unique and not use
+                spaces or special characters.
+              </p>
+            </div>
+
+            <Page.Separator />
+            <Page.SectionHeader title="Description" />
+            <div className="w-full">
+              <TextArea
+                placeholder="This description guides assistants in understanding how to use
+                your app effectively and determines its relevance in responding to user inquiries."
+                value={description}
+                onChange={(value) => {
+                  setDescription(value);
+                  setDescriptionError(null);
+                }}
+                error={descriptionError}
+                showErrorLabel
+              />
+            </div>
+            <Page.Separator />
+            <Page.SectionHeader title="Visibility" />
+            <RadioButton
+              name="test2"
+              className="s-flex-col"
+              choices={[
+                {
+                  label: "Private",
+                  value: "private",
+                  disabled: false,
+                },
+                {
+                  label: "Public",
+                  value: "public",
+                  disabled: false,
+                },
+              ]}
+              value={visibility}
+              onChange={(v) => {
+                setVisibility(v as AppVisibility);
+              }}
+            />
+            <div className="mt-4 space-y-4">
+              <p className="text-sm text-gray-500">
+                <b>Private: </b> Only builders of your workspace can see and
+                edit the app.
+              </p>
+              <p className="text-sm text-gray-500">
+                <b>Public: </b> Anyone on the Internet with the link can see the
+                app. Only builders of your workspace can edit.
+              </p>
+            </div>
+          </Page.Vertical>
+        </div>
+      </Page>
+    </Modal>
+  );
+};

--- a/front/components/vaults/VaultCreateFolderModal.tsx
+++ b/front/components/vaults/VaultCreateFolderModal.tsx
@@ -110,7 +110,7 @@ export default function VaultCreateFolderModal({
       <Page variant="modal">
         <div className="w-full">
           <Page.Vertical sizing="grow">
-            <Page.H>Name</Page.H>
+            <Page.SectionHeader title="Name" />
             <div className="w-full">
               <Input
                 placeholder="folder_name"
@@ -130,7 +130,7 @@ export default function VaultCreateFolderModal({
             </div>
 
             <Page.Separator />
-            <Page.H>Description</Page.H>
+            <Page.SectionHeader title="Description" />
             <div className="w-full">
               <TextArea
                 placeholder="Folder description"

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -149,7 +149,7 @@ export function useAppStatus() {
 export function useApps(owner: LightWorkspaceType) {
   const appsFetcher: Fetcher<GetAppsResponseBody> = fetcher;
 
-  const { data, error } = useSWRWithDefaults(
+  const { data, error, mutate } = useSWRWithDefaults(
     `/api/w/${owner.sId}/apps`,
     appsFetcher
   );
@@ -158,6 +158,7 @@ export function useApps(owner: LightWorkspaceType) {
     apps: useMemo(() => (data ? data.apps : []), [data]),
     isAppsLoading: !error && !data,
     isAppsError: !!error,
+    mutateApps: mutate,
   };
 }
 

--- a/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/index.tsx
+++ b/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/index.tsx
@@ -20,6 +20,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
   VaultLayoutProps & {
     category: DataSourceViewCategory;
     isAdmin: boolean;
+    isBuilder: boolean;
     vault: VaultType;
     systemVault: VaultType;
     plan: PlanType;
@@ -46,12 +47,14 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     };
   }
   const isAdmin = auth.isAdmin();
+  const isBuilder = auth.isBuilder();
 
   return {
     props: {
       category: context.query.category as DataSourceViewCategory,
       gaTrackingId: config.getGaTrackingId(),
       isAdmin,
+      isBuilder,
       owner,
       plan,
       subscription,
@@ -64,6 +67,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
 export default function Vault({
   category,
   isAdmin,
+  isBuilder,
   owner,
   plan,
   vault,
@@ -75,6 +79,7 @@ export default function Vault({
       {category === "apps" ? (
         <VaultAppsList
           owner={owner}
+          isBuilder={isBuilder}
           onSelect={(sId) => {
             void router.push(`/w/${owner.sId}/a/${sId}`);
           }}


### PR DESCRIPTION
## Description

This PR introduces a new modal to create apps. 
It matches the new design implemented for folders. 
Once submitted, we'll want to redirect to the detail view to define the blocks -> this will be done in the next PR (keeping small PRs to ease review). Currently we close the modal and refresh the list. 

<kbd>
<img width="499" alt="Screenshot 2024-08-29 at 11 07 15" src="https://github.com/user-attachments/assets/661af440-90ad-4f73-aa2d-340c92045713">
</kbd>


## Risk

/ 

## Deploy Plan

Deploy front; 
