### PR TITLE
[connectors] fix(microsoft): fix for sortForIncrementalUpdate: correctly handle cases with/without rootId

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -645,7 +645,7 @@ function removeAllButLastOccurences(deltaList: microsoftgraph.DriveItem[]) {
 
 /**
  * Order items as follows:
- * - first those whose parentInternalId is not in the changedList, or the root drive
+ * - first the node in the changedList matching rootid, or the drive root folder if no rootId is specified
  * - then those whose parentInternalId is in in the list above;
  * - then those whose parentInternalId is in the updated list above, and so on
  *


### PR DESCRIPTION
## Description

Incremental sync incorrectly includes all parents of a node up to the root folder, even if only a subfolder was selected.
Fix logic of sortForIncrementalUpdate

## Risk

break microsoft incremental sync

## Deploy Plan

deploy `connectors`