### PR TITLE
Upg: redirect to the right screen and show the error when saving is not possible for an assistant

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -12,6 +12,7 @@ fi
 
 # If env var DUST_LINT_ON_COMMIT = 1, run the linter
 if [ -z "$DUST_LINT_ON_COMMIT" ]; then
+    echo "Please set DUST_LINT_ON_COMMIT if you want to locally run the lint, type check etc.. before committing."
     exit 0
 fi
 

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -94,15 +94,19 @@ export default function AssistantBuilder({
 
   const [edited, setEdited] = useState(defaultIsEdited ?? false);
   const [isSavingOrDeleting, setIsSavingOrDeleting] = useState(false);
-  const [submitEnabled, setSubmitEnabled] = useState(false);
   const [disableUnsavedChangesPrompt, setDisableUnsavedChangesPrompt] =
     useState(false);
+
+  // The 4 kind of errors that can be displayed in the assistant builder
   const [assistantHandleError, setAssistantHandleError] = useState<
     string | null
   >(null);
   const [instructionsError, setInstructionsError] = useState<string | null>(
     null
   );
+  const [descriptionError, setDescriptionError] = useState<string | null>(null);
+  const [hasAnyActionsError, setHasAnyActionsError] = useState<boolean>(false);
+
   const [builderState, setBuilderState] = useState<AssistantBuilderState>(
     initialBuilderState
       ? {
@@ -209,36 +213,6 @@ export default function AssistantBuilder({
   };
 
   const formValidation = useCallback(async () => {
-    let valid = true;
-
-    const { handleValid, handleErrorMessage } = await validateHandle({
-      owner,
-      handle: builderState.handle,
-      initialHandle: initialBuilderState?.handle,
-      checkUsernameTimeout,
-    });
-    valid = handleValid;
-    setAssistantHandleError(handleErrorMessage);
-
-    if (
-      !builderState.description?.trim() ||
-      !builderState.instructions?.trim()
-    ) {
-      valid = false;
-    }
-
-    if (
-      builderState.instructions &&
-      builderState.instructions.length > INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT
-    ) {
-      setInstructionsError(
-        `Instructions must be less than ${INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT} characters.`
-      );
-      valid = false;
-    } else {
-      setInstructionsError(null);
-    }
-
     const modelConfig = SUPPORTED_MODEL_CONFIGS.filter(
       (config) =>
         config.modelId === builderState.generationSettings.modelSettings.modelId
@@ -248,7 +222,29 @@ export default function AssistantBuilder({
       throw new Error("Model configuration not found");
     }
 
-    if (
+    const { handleErrorMessage } = await validateHandle({
+      owner,
+      handle: builderState.handle,
+      initialHandle: initialBuilderState?.handle,
+      checkUsernameTimeout,
+    });
+    setAssistantHandleError(handleErrorMessage);
+
+    let localDescriptionError: string | null = null;
+    if (!builderState.description?.trim()) {
+      localDescriptionError = "You must provide a description.";
+    }
+    setDescriptionError(localDescriptionError);
+
+    let localInstructionError: string | null = null;
+    if (!builderState.instructions?.trim()) {
+      localInstructionError = "You must provide some instructions.";
+    } else if (
+      builderState.instructions &&
+      builderState.instructions.length > INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT
+    ) {
+      localInstructionError = `Instructions must be less than ${INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT} characters.`;
+    } else if (
       builderState.instructions &&
       builderState.instructions.trim().length / 4 >
         modelConfig.contextSize * 0.9
@@ -258,17 +254,16 @@ export default function AssistantBuilder({
           modelConfig.contextSize * 0.9
         }`
       );
-      setInstructionsError(`Instructions may exceed context size window.`);
-      valid = false;
-    } else {
-      setInstructionsError(null);
+      localInstructionError = `Instructions may exceed context size window.`;
     }
 
-    if (!builderState.actions.every((a) => hasActionError(a) === null)) {
-      valid = false;
-    }
+    // We only keep the first error. If there are multiple errors, the user will have to fix them one by one.
+    setInstructionsError(localInstructionError);
 
-    setSubmitEnabled(valid);
+    // Check if there are any errors in the actions
+    const anyActionError = builderState.actions.some(hasActionError);
+
+    setHasAnyActionsError(anyActionError);
   }, [builderState, owner, initialBuilderState?.handle]);
 
   useEffect(() => {
@@ -304,38 +299,48 @@ export default function AssistantBuilder({
   );
 
   const onAssistantSave = async () => {
-    setDisableUnsavedChangesPrompt(true);
-    setIsSavingOrDeleting(true);
-    const res = await submitAssistantBuilderForm({
-      owner,
-      builderState,
-      agentConfigurationId,
-      slackData: {
-        selectedSlackChannels: selectedSlackChannels || [],
-        slackChannelsLinkedWithAgent,
-      },
-    });
-
-    if (res.isErr()) {
-      setIsSavingOrDeleting(false);
-      sendNotification({
-        title: "Error saving Assistant",
-        description: res.error.message,
-        type: "error",
-      });
+    // Redirect to the right screen if there are errors.
+    if (instructionsError) {
+      setScreen("instructions");
+    } else if (hasAnyActionsError) {
+      setScreen("actions");
+    } else if (assistantHandleError || descriptionError) {
+      setScreen("naming");
     } else {
-      await mutate(
-        `/api/w/${owner.sId}/data_sources/${slackDataSourceView?.dataSource.name}/managed/slack/channels_linked_with_agent`
-      );
+      setDisableUnsavedChangesPrompt(true);
+      setIsSavingOrDeleting(true);
+      const res = await submitAssistantBuilderForm({
+        owner,
+        builderState,
+        agentConfigurationId,
+        slackData: {
+          selectedSlackChannels: selectedSlackChannels || [],
+          slackChannelsLinkedWithAgent,
+        },
+      });
 
-      // Redirect to the assistant list once saved.
-      if (flow === "personal_assistants") {
-        await router.push(`/w/${owner.sId}/assistant/new`);
+      if (res.isErr()) {
+        setIsSavingOrDeleting(false);
+        sendNotification({
+          title: "Error saving Assistant",
+          description: res.error.message,
+          type: "error",
+        });
       } else {
-        await router.push(`/w/${owner.sId}/builder/assistants`);
+        await mutate(
+          `/api/w/${owner.sId}/data_sources/${slackDataSourceView?.dataSource.name}/managed/slack/channels_linked_with_agent`
+        );
+
+        // Redirect to the assistant list once saved.
+        if (flow === "personal_assistants") {
+          await router.push(`/w/${owner.sId}/assistant/new`);
+        } else {
+          await router.push(`/w/${owner.sId}/builder/assistants`);
+        }
       }
     }
   };
+
   const [screen, setScreen] = useState<BuilderScreen>("instructions");
   const tabs = useMemo(
     () =>
@@ -414,7 +419,7 @@ export default function AssistantBuilder({
               onCancel={async () => {
                 await appLayoutBack(owner, router);
               }}
-              onSave={submitEnabled ? onAssistantSave : undefined}
+              onSave={onAssistantSave}
               isSaving={isSavingOrDeleting}
             />
           )
@@ -487,6 +492,7 @@ export default function AssistantBuilder({
                         setBuilderState={setBuilderState}
                         setEdited={setEdited}
                         assistantHandleError={assistantHandleError}
+                        descriptionError={descriptionError}
                       />
                     );
                   default:

--- a/front/components/assistant_builder/NamingScreen.tsx
+++ b/front/components/assistant_builder/NamingScreen.tsx
@@ -99,20 +99,16 @@ export async function validateHandle({
   handleValid: boolean;
   handleErrorMessage: string | null;
 }> {
+  let errorMessage: string | null = null;
+
   if (!handle || handle === "@") {
-    return { handleValid: false, handleErrorMessage: null };
+    errorMessage = "The name cannot be empty";
   } else {
     if (!assistantHandleIsValid(handle)) {
       if (handle.length > 30) {
-        return {
-          handleValid: false,
-          handleErrorMessage: "The name must be 30 characters or less",
-        };
+        errorMessage = "The name must be 30 characters or less";
       } else {
-        return {
-          handleValid: false,
-          handleErrorMessage: "Only letters, numbers, _ and - allowed",
-        };
+        errorMessage = "Only letters, numbers, _ and - allowed";
       }
     } else if (
       !(await assistantHandleIsAvailable({
@@ -122,14 +118,14 @@ export async function validateHandle({
         checkUsernameTimeout,
       }))
     ) {
-      return {
-        handleValid: false,
-        handleErrorMessage: "This handle is already taken",
-      };
-    } else {
-      return { handleValid: true, handleErrorMessage: null };
+      errorMessage = "This name is already taken";
     }
   }
+
+  return {
+    handleValid: !errorMessage,
+    handleErrorMessage: errorMessage,
+  };
 }
 
 export default function NamingScreen({
@@ -139,6 +135,7 @@ export default function NamingScreen({
   setBuilderState,
   setEdited,
   assistantHandleError,
+  descriptionError,
 }: {
   owner: WorkspaceType;
   builderState: AssistantBuilderState;
@@ -148,6 +145,7 @@ export default function NamingScreen({
   ) => void;
   setEdited: (edited: boolean) => void;
   assistantHandleError: string | null;
+  descriptionError: string | null;
 }) {
   const confirm = useContext(ConfirmContext);
   const sendNotification = useContext(SendNotificationsContext);
@@ -414,6 +412,7 @@ export default function NamingScreen({
                   }));
                 }}
                 name="assistantDescription"
+                error={descriptionError}
                 className="text-sm"
                 disabled={generatingDescription}
               />


### PR DESCRIPTION
## Description

We disabled the save button when the form wasn't valid but we did give any explanation why and in some case, the error was on another "screen".

Now the button is always enabled but will redirect to the right screen with the right error message if the form is not valid.

## Risk

None

## Deploy Plan

Deploy `front`