### PR TITLE
Fix: do not allow going within folders

### DIFF
--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -4,7 +4,7 @@ import type {
   DataSourceViewSelectionConfigurations,
   WorkspaceType,
 } from "@dust-tt/types";
-import { defaultSelectionConfiguration } from "@dust-tt/types";
+import { defaultSelectionConfiguration, isFolder } from "@dust-tt/types";
 import _ from "lodash";
 import type { Dispatch, SetStateAction } from "react";
 import { useMemo } from "react";
@@ -90,7 +90,7 @@ export function DataSourceViewSelector({
       key={dataSourceView.dataSource.name}
       label={getDisplayNameForDataSource(dataSourceView.dataSource)}
       visual={LogoComponent}
-      type="node"
+      type={isFolder(dataSourceView.dataSource) ? "leaf" : "node"}
       checkbox={{
         checked: checkedStatus,
         onChange: onToggleSelectAll,


### PR DESCRIPTION
## Description

Block navigation within folders datasource because, for now, we do not list more than 10 items.

## Risk

None

## Deploy Plan

Deploy `front`