### PR TITLE
Dust Apps navigation with vaults

### DIFF
--- a/front/lib/vault_rollout.ts
+++ b/front/lib/vault_rollout.ts
@@ -1,0 +1,20 @@
+import type { Authenticator } from "@app/lib/auth";
+import { VaultResource } from "@app/lib/resources/vault_resource";
+
+export const getDustAppsListUrl = async (
+  auth: Authenticator
+): Promise<string> => {
+  const owner = auth.getNonNullableWorkspace();
+
+  const defaultUrl = `/w/${owner.sId}/a`;
+
+  if (!owner.flags.includes("data_vaults_feature")) {
+    return defaultUrl;
+  }
+
+  const vault = await VaultResource.fetchWorkspaceGlobalVault(auth);
+  if (!vault) {
+    return defaultUrl;
+  }
+  return `/w/${owner.sId}/data-sources/vaults/${vault.sId}/categories/apps`;
+};

--- a/front/pages/w/[wId]/a/[aId]/clone.tsx
+++ b/front/pages/w/[wId]/a/[aId]/clone.tsx
@@ -24,6 +24,7 @@ import { getApp } from "@app/lib/api/app";
 import { getUserFromSession } from "@app/lib/iam/session";
 import { withDefaultUserAuthRequirementsNoWorkspaceCheck } from "@app/lib/iam/session";
 import { classNames } from "@app/lib/utils";
+import { getDustAppsListUrl } from "@app/lib/vault_rollout";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
@@ -33,6 +34,7 @@ export const getServerSideProps =
     owner: WorkspaceType;
     subscription: SubscriptionType;
     app: AppType;
+    dustAppsListUrl: string;
     gaTrackingId: string;
   }>(async (context, auth, session) => {
     // This is a rare case where we need the full user object as we need to know the user available
@@ -67,6 +69,7 @@ export const getServerSideProps =
         owner,
         subscription,
         app,
+        dustAppsListUrl: await getDustAppsListUrl(auth),
         gaTrackingId: GA_TRACKING_ID,
       },
     };
@@ -77,6 +80,7 @@ export default function CloneView({
   owner,
   subscription,
   app,
+  dustAppsListUrl,
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [disable, setDisabled] = useState(true);
@@ -150,7 +154,7 @@ export default function CloneView({
         <AppLayoutSimpleCloseTitle
           title={app.name}
           onClose={() => {
-            void router.push(`/w/${owner.sId}/a`);
+            void router.push(dustAppsListUrl);
           }}
         />
       }

--- a/front/pages/w/[wId]/a/[aId]/clone.tsx
+++ b/front/pages/w/[wId]/a/[aId]/clone.tsx
@@ -63,13 +63,15 @@ export const getServerSideProps =
       };
     }
 
+    const dustAppsListUrl = await getDustAppsListUrl(auth);
+
     return {
       props: {
         user,
         owner,
         subscription,
         app,
-        dustAppsListUrl: await getDustAppsListUrl(auth),
+        dustAppsListUrl,
         gaTrackingId: GA_TRACKING_ID,
       },
     };

--- a/front/pages/w/[wId]/a/[aId]/datasets/[name]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/[name]/index.tsx
@@ -68,6 +68,7 @@ export const getServerSideProps =
     }
 
     const schema = await getDatasetSchema(auth, app, dataset.name);
+    const dustAppsListUrl = await getDustAppsListUrl(auth);
 
     return {
       props: {
@@ -77,7 +78,7 @@ export const getServerSideProps =
         app,
         dataset,
         schema,
-        dustAppsListUrl: await getDustAppsListUrl(auth),
+        dustAppsListUrl,
         gaTrackingId: GA_TRACKING_ID,
       },
     };

--- a/front/pages/w/[wId]/a/[aId]/datasets/[name]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/[name]/index.tsx
@@ -20,6 +20,7 @@ import { getApp } from "@app/lib/api/app";
 import { getDatasetHash, getDatasetSchema } from "@app/lib/api/datasets";
 import { useRegisterUnloadHandlers } from "@app/lib/front";
 import { withDefaultUserAuthRequirementsNoWorkspaceCheck } from "@app/lib/iam/session";
+import { getDustAppsListUrl } from "@app/lib/vault_rollout";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
@@ -31,6 +32,7 @@ export const getServerSideProps =
     app: AppType;
     dataset: DatasetType;
     schema: DatasetSchema | null;
+    dustAppsListUrl: string;
     gaTrackingId: string;
   }>(async (context, auth) => {
     const owner = auth.workspace();
@@ -75,6 +77,7 @@ export const getServerSideProps =
         app,
         dataset,
         schema,
+        dustAppsListUrl: await getDustAppsListUrl(auth),
         gaTrackingId: GA_TRACKING_ID,
       },
     };
@@ -87,6 +90,7 @@ export default function ViewDatasetView({
   app,
   dataset,
   schema,
+  dustAppsListUrl,
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
@@ -174,7 +178,7 @@ export default function ViewDatasetView({
         <AppLayoutSimpleCloseTitle
           title={app.name}
           onClose={() => {
-            void router.push(`/w/${owner.sId}/a`);
+            void router.push(dustAppsListUrl);
           }}
         />
       }

--- a/front/pages/w/[wId]/a/[aId]/datasets/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/index.tsx
@@ -19,6 +19,7 @@ import { getApp } from "@app/lib/api/app";
 import { getDatasets } from "@app/lib/api/datasets";
 import { withDefaultUserAuthRequirementsNoWorkspaceCheck } from "@app/lib/iam/session";
 import { classNames } from "@app/lib/utils";
+import { getDustAppsListUrl } from "@app/lib/vault_rollout";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
@@ -29,6 +30,7 @@ export const getServerSideProps =
     readOnly: boolean;
     app: AppType;
     datasets: DatasetType[];
+    dustAppsListUrl: string;
     gaTrackingId: string;
   }>(async (context, auth) => {
     const owner = auth.workspace();
@@ -59,6 +61,7 @@ export const getServerSideProps =
         readOnly,
         app,
         datasets,
+        dustAppsListUrl: await getDustAppsListUrl(auth),
         gaTrackingId: GA_TRACKING_ID,
       },
     };
@@ -70,6 +73,7 @@ export default function DatasetsView({
   readOnly,
   app,
   datasets,
+  dustAppsListUrl,
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
@@ -109,7 +113,7 @@ export default function DatasetsView({
         <AppLayoutSimpleCloseTitle
           title={app.name}
           onClose={() => {
-            void router.push(`/w/${owner.sId}/a`);
+            void router.push(dustAppsListUrl);
           }}
         />
       }

--- a/front/pages/w/[wId]/a/[aId]/datasets/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/index.tsx
@@ -53,6 +53,7 @@ export const getServerSideProps =
     }
 
     const datasets = await getDatasets(auth, app);
+    const dustAppsListUrl = await getDustAppsListUrl(auth);
 
     return {
       props: {
@@ -61,7 +62,7 @@ export const getServerSideProps =
         readOnly,
         app,
         datasets,
-        dustAppsListUrl: await getDustAppsListUrl(auth),
+        dustAppsListUrl,
         gaTrackingId: GA_TRACKING_ID,
       },
     };

--- a/front/pages/w/[wId]/a/[aId]/datasets/new.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/new.tsx
@@ -50,6 +50,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   }
 
   const datasets = await getDatasets(auth, app);
+  const dustAppsListUrl = await getDustAppsListUrl(auth);
 
   return {
     props: {
@@ -57,7 +58,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       subscription,
       app,
       datasets,
-      dustAppsListUrl: await getDustAppsListUrl(auth),
+      dustAppsListUrl,
       gaTrackingId: GA_TRACKING_ID,
     },
   };

--- a/front/pages/w/[wId]/a/[aId]/datasets/new.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/new.tsx
@@ -20,6 +20,7 @@ import { getApp } from "@app/lib/api/app";
 import { getDatasets } from "@app/lib/api/datasets";
 import { useRegisterUnloadHandlers } from "@app/lib/front";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+import { getDustAppsListUrl } from "@app/lib/vault_rollout";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
@@ -28,6 +29,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   subscription: SubscriptionType;
   app: AppType;
   datasets: DatasetType[];
+  dustAppsListUrl: string;
   gaTrackingId: string;
 }>(async (context, auth) => {
   const owner = auth.workspace();
@@ -55,6 +57,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       subscription,
       app,
       datasets,
+      dustAppsListUrl: await getDustAppsListUrl(auth),
       gaTrackingId: GA_TRACKING_ID,
     },
   };
@@ -65,6 +68,7 @@ export default function NewDatasetView({
   subscription,
   app,
   datasets,
+  dustAppsListUrl,
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
@@ -136,7 +140,7 @@ export default function NewDatasetView({
         <AppLayoutSimpleCloseTitle
           title={app.name}
           onClose={() => {
-            void router.push(`/w/${owner.sId}/a`);
+            void router.push(dustAppsListUrl);
           }}
         />
       }

--- a/front/pages/w/[wId]/a/[aId]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/index.tsx
@@ -42,6 +42,7 @@ import {
   moveBlockUp,
 } from "@app/lib/specification";
 import { useSavedRunStatus } from "@app/lib/swr";
+import { getDustAppsListUrl } from "@app/lib/vault_rollout";
 
 export const getServerSideProps =
   withDefaultUserAuthRequirementsNoWorkspaceCheck<{
@@ -50,6 +51,7 @@ export const getServerSideProps =
     subscription: SubscriptionType;
     readOnly: boolean;
     url: string;
+    dustAppsListUrl: string;
     app: AppType;
     gaTrackingId: string;
   }>(async (context, auth) => {
@@ -79,6 +81,7 @@ export const getServerSideProps =
         subscription,
         readOnly,
         url: config.getClientFacingUrl(),
+        dustAppsListUrl: await getDustAppsListUrl(auth),
         app,
         gaTrackingId: config.getGaTrackingId(),
       },
@@ -146,6 +149,7 @@ export default function AppView({
   readOnly,
   app,
   url,
+  dustAppsListUrl,
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const { mutate } = useSWRConfig();
@@ -321,11 +325,7 @@ export default function AppView({
         <AppLayoutSimpleCloseTitle
           title={app.name}
           onClose={() => {
-            if (window.history.length > 1) {
-              void router.back();
-            } else {
-              void router.push(`/w/${owner.sId}/a`);
-            }
+            void router.push(dustAppsListUrl);
           }}
         />
       }

--- a/front/pages/w/[wId]/a/[aId]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/index.tsx
@@ -74,6 +74,8 @@ export const getServerSideProps =
       };
     }
 
+    const dustAppsListUrl = await getDustAppsListUrl(auth);
+
     return {
       props: {
         user: auth.user(),
@@ -81,7 +83,7 @@ export const getServerSideProps =
         subscription,
         readOnly,
         url: config.getClientFacingUrl(),
-        dustAppsListUrl: await getDustAppsListUrl(auth),
+        dustAppsListUrl,
         app,
         gaTrackingId: config.getGaTrackingId(),
       },

--- a/front/pages/w/[wId]/a/[aId]/runs/[runId]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/runs/[runId]/index.tsx
@@ -59,6 +59,8 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   }
   const { run, spec } = r;
 
+  const dustAppsListUrl = await getDustAppsListUrl(auth);
+
   return {
     props: {
       owner,
@@ -67,7 +69,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       app,
       spec,
       run,
-      dustAppsListUrl: await getDustAppsListUrl(auth),
+      dustAppsListUrl,
       gaTrackingId: GA_TRACKING_ID,
     },
   };

--- a/front/pages/w/[wId]/a/[aId]/runs/[runId]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/runs/[runId]/index.tsx
@@ -19,6 +19,7 @@ import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitl
 import { getApp } from "@app/lib/api/app";
 import { getRun } from "@app/lib/api/run";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+import { getDustAppsListUrl } from "@app/lib/vault_rollout";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
@@ -29,6 +30,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   app: AppType;
   run: RunType;
   spec: SpecificationType;
+  dustAppsListUrl: string;
   gaTrackingId: string;
 }>(async (context, auth) => {
   const owner = auth.workspace();
@@ -65,6 +67,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       app,
       spec,
       run,
+      dustAppsListUrl: await getDustAppsListUrl(auth),
       gaTrackingId: GA_TRACKING_ID,
     },
   };
@@ -77,6 +80,7 @@ export default function AppRun({
   app,
   spec,
   run,
+  dustAppsListUrl,
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [savedRunId, setSavedRunId] = useState<string | null | undefined>(
@@ -151,7 +155,7 @@ export default function AppRun({
         <AppLayoutSimpleCloseTitle
           title={app.name}
           onClose={() => {
-            void router.push(`/w/${owner.sId}/a`);
+            void router.push(dustAppsListUrl);
           }}
         />
       }

--- a/front/pages/w/[wId]/a/[aId]/runs/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/runs/index.tsx
@@ -18,6 +18,7 @@ import { getApp } from "@app/lib/api/app";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useRuns } from "@app/lib/swr";
 import { classNames, timeAgoFrom } from "@app/lib/utils";
+import { getDustAppsListUrl } from "@app/lib/vault_rollout";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
@@ -27,6 +28,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   readOnly: boolean;
   app: AppType;
   wIdTarget: string | null;
+  dustAppsListUrl: string;
   gaTrackingId: string;
 }>(async (context, auth) => {
   const owner = auth.workspace();
@@ -59,6 +61,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       readOnly,
       app,
       wIdTarget,
+      dustAppsListUrl: await getDustAppsListUrl(auth),
       gaTrackingId: GA_TRACKING_ID,
     },
   };
@@ -86,6 +89,7 @@ export default function RunsView({
   readOnly,
   app,
   wIdTarget,
+  dustAppsListUrl,
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [runType, setRunType] = useState(
@@ -134,7 +138,7 @@ export default function RunsView({
         <AppLayoutSimpleCloseTitle
           title={app.name}
           onClose={() => {
-            void router.push(`/w/${owner.sId}/a`);
+            void router.push(dustAppsListUrl);
           }}
         />
       }

--- a/front/pages/w/[wId]/a/[aId]/runs/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/runs/index.tsx
@@ -53,6 +53,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   // `wIdTarget` is used to change the workspace owning the runs of the apps we're looking at.
   // Mostly useful for debugging as an example our use of `dust-apps` as `dust`.
   const wIdTarget = (context.query?.wIdTarget as string) || null;
+  const dustAppsListUrl = await getDustAppsListUrl(auth);
 
   return {
     props: {
@@ -61,7 +62,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       readOnly,
       app,
       wIdTarget,
-      dustAppsListUrl: await getDustAppsListUrl(auth),
+      dustAppsListUrl,
       gaTrackingId: GA_TRACKING_ID,
     },
   };

--- a/front/pages/w/[wId]/a/[aId]/settings.tsx
+++ b/front/pages/w/[wId]/a/[aId]/settings.tsx
@@ -19,6 +19,7 @@ import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitl
 import { getApp } from "@app/lib/api/app";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { classNames, MODELS_STRING_MAX_LENGTH } from "@app/lib/utils";
+import { getDustAppsListUrl } from "@app/lib/vault_rollout";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
@@ -26,6 +27,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   app: AppType;
+  dustAppsListUrl: string;
   gaTrackingId: string;
 }>(async (context, auth) => {
   const owner = auth.workspace();
@@ -58,6 +60,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       owner,
       subscription,
       app,
+      dustAppsListUrl: await getDustAppsListUrl(auth),
       gaTrackingId: GA_TRACKING_ID,
     },
   };
@@ -67,6 +70,7 @@ export default function SettingsView({
   owner,
   subscription,
   app,
+  dustAppsListUrl,
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [disable, setDisabled] = useState(true);
@@ -112,7 +116,7 @@ export default function SettingsView({
         method: "DELETE",
       });
       if (res.ok) {
-        await router.push(`/w/${owner.sId}/a`);
+        await router.push(dustAppsListUrl);
       } else {
         setIsDeleting(false);
         const err = (await res.json()) as { error: APIError };
@@ -169,7 +173,7 @@ export default function SettingsView({
         <AppLayoutSimpleCloseTitle
           title={app.name}
           onClose={() => {
-            void router.push(`/w/${owner.sId}/a`);
+            void router.push(dustAppsListUrl);
           }}
         />
       }

--- a/front/pages/w/[wId]/a/[aId]/settings.tsx
+++ b/front/pages/w/[wId]/a/[aId]/settings.tsx
@@ -55,12 +55,14 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
+  const dustAppsListUrl = await getDustAppsListUrl(auth);
+
   return {
     props: {
       owner,
       subscription,
       app,
-      dustAppsListUrl: await getDustAppsListUrl(auth),
+      dustAppsListUrl,
       gaTrackingId: GA_TRACKING_ID,
     },
   };

--- a/front/pages/w/[wId]/a/[aId]/specification.tsx
+++ b/front/pages/w/[wId]/a/[aId]/specification.tsx
@@ -67,6 +67,8 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     latestDatasets
   );
 
+  const dustAppsListUrl = await getDustAppsListUrl(auth);
+
   return {
     props: {
       owner,
@@ -74,7 +76,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       readOnly,
       app,
       specification: spec,
-      dustAppsListUrl: await getDustAppsListUrl(auth),
+      dustAppsListUrl,
       gaTrackingId: GA_TRACKING_ID,
     },
   };

--- a/front/pages/w/[wId]/a/[aId]/specification.tsx
+++ b/front/pages/w/[wId]/a/[aId]/specification.tsx
@@ -14,6 +14,7 @@ import { getApp } from "@app/lib/api/app";
 import config from "@app/lib/api/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { dumpSpecification } from "@app/lib/specification";
+import { getDustAppsListUrl } from "@app/lib/vault_rollout";
 import logger from "@app/logger/logger";
 
 const { GA_TRACKING_ID = "" } = process.env;
@@ -24,6 +25,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   readOnly: boolean;
   app: AppType;
   specification: string;
+  dustAppsListUrl: string;
   gaTrackingId: string;
 }>(async (context, auth) => {
   const owner = auth.workspace();
@@ -72,6 +74,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       readOnly,
       app,
       specification: spec,
+      dustAppsListUrl: await getDustAppsListUrl(auth),
       gaTrackingId: GA_TRACKING_ID,
     },
   };
@@ -82,6 +85,7 @@ export default function Specification({
   subscription,
   app,
   specification,
+  dustAppsListUrl,
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
@@ -99,7 +103,7 @@ export default function Specification({
         <AppLayoutSimpleCloseTitle
           title={app.name}
           onClose={() => {
-            void router.push(`/w/${owner.sId}/a`);
+            void router.push(dustAppsListUrl);
           }}
         />
       }

--- a/front/pages/w/[wId]/a/new.tsx
+++ b/front/pages/w/[wId]/a/new.tsx
@@ -12,12 +12,14 @@ import { subNavigationBuild } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { classNames, MODELS_STRING_MAX_LENGTH } from "@app/lib/utils";
+import { getDustAppsListUrl } from "@app/lib/vault_rollout";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
+  dustAppsListUrl: string;
   gaTrackingId: string;
 }>(async (context, auth) => {
   const owner = auth.workspace();
@@ -33,6 +35,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     props: {
       owner,
       subscription,
+      dustAppsListUrl: await getDustAppsListUrl(auth),
       gaTrackingId: GA_TRACKING_ID,
     },
   };
@@ -41,6 +44,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
 export default function NewApp({
   owner,
   subscription,
+  dustAppsListUrl,
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [disable, setDisabled] = useState(true);
@@ -242,7 +246,7 @@ export default function NewApp({
                 variant="tertiary"
                 disabled={creating}
                 onClick={async () => {
-                  void router.push(`/w/${owner.sId}/a`);
+                  void router.push(dustAppsListUrl);
                 }}
                 label="Cancel"
               />

--- a/front/pages/w/[wId]/a/new.tsx
+++ b/front/pages/w/[wId]/a/new.tsx
@@ -31,11 +31,13 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
+  const dustAppsListUrl = await getDustAppsListUrl(auth);
+
   return {
     props: {
       owner,
       subscription,
-      dustAppsListUrl: await getDustAppsListUrl(auth),
+      dustAppsListUrl,
       gaTrackingId: GA_TRACKING_ID,
     },
   };


### PR DESCRIPTION
## Description

When vaults is activated and we're navigating on Dust Apps screens, if we close the modals we want to be redirected to the Dust apps list view from the Global Vault screen rather than from the old "Build" menu. 

I introduce a tiny function to define the valid url in a file called `front/lib/vault_rollout.ts` to make it clear this is related to the rollout and needs to be killed. 

## Risk

Break Dust Apps navigation.

## Deploy Plan

Deploy front. 
