### PR TITLE
[Microsoft] Detect and scrub folders moved out of toplevel folders in incr. sync.

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -521,25 +521,14 @@ export async function syncDeltaForRootNodesInDrive({
       );
     });
 
+    // if only parts of the drive are selected, look for folders that may
+    // have been removed from selection and scrub them
     await scrubRemovedFolders({
       connector,
       uniqueChangedItems,
       sortedChangedItems,
     });
   }
-
-  // @thomas - I don't get that code block below; the deleted items should
-  // already be in sortedChangedItems if they're in the selected roots, right?
-  // maybe it's legacy and we can now delete it?
-
-  // Finally add all removed items, which may not have been included even if they are in
-  // the selected roots
-  sortedChangedItems.push(
-    ...uniqueChangedItems.filter(
-      (item) =>
-        !sortedChangedItems.includes(item) && item.deleted?.state === "deleted"
-    )
-  );
 
   for (const driveItem of sortedChangedItems) {
     heartbeat();

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -520,15 +520,27 @@ export async function syncDeltaForRootNodesInDrive({
         ...sortForIncrementalUpdate(uniqueChangedItems, rootNode.id)
       );
     });
+
+    await scrubRemovedFolders({
+      connector,
+      uniqueChangedItems,
+      sortedChangedItems,
+    });
   }
 
-  // Finally add all removed items, which may not have been included even if they are in the selected roots
+  // @thomas - I don't get that code block below; the deleted items should
+  // already be in sortedChangedItems if they're in the selected roots, right?
+  // maybe it's legacy and we can now delete it?
+
+  // Finally add all removed items, which may not have been included even if they are in
+  // the selected roots
   sortedChangedItems.push(
     ...uniqueChangedItems.filter(
       (item) =>
         !sortedChangedItems.includes(item) && item.deleted?.state === "deleted"
     )
   );
+
   for (const driveItem of sortedChangedItems) {
     heartbeat();
     if (!driveItem.parentReference) {
@@ -1052,4 +1064,60 @@ async function isOutsideRootNodes({
   } while (parentInternalId !== null);
 
   return true;
+}
+
+/**
+ * Detect files & folders moved out of toplevel folders and delete them
+ * Such a case is e.g.:
+ * - only folder A is selected for sync, not the whole drive
+ * - folder B is not selected for sync
+ * - folder C was a subfolder of A and is moved out of A into B
+ * In that case, C should be deleted from the sync
+ */
+async function scrubRemovedFolders({
+  connector,
+  uniqueChangedItems,
+  sortedChangedItems,
+}: {
+  connector: ConnectorResource;
+  uniqueChangedItems: DriveItem[];
+  sortedChangedItems: DriveItem[];
+}) {
+  // all elements from the changelist that are in uniqueChangedItems but not in
+  // sortedChangedItems are out of the selected roots
+  // we use a set to avoid O(n^2) complexity
+  const sortedChangedItemsSet = new Set(
+    sortedChangedItems.map((item) => item.id)
+  );
+  const outOfRoots = uniqueChangedItems.filter(
+    // the drive root folder is always in the list but we never need to delete it
+    (item) => !sortedChangedItemsSet.has(item.id) && !item.root
+  );
+
+  const outOfRootsInternalIds = outOfRoots.map((item) =>
+    getDriveItemInternalId(item)
+  );
+
+  const nodes = await MicrosoftNodeResource.fetchByInternalIds(
+    connector.id,
+    outOfRootsInternalIds
+  );
+
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+
+  for (const node of nodes) {
+    if (node.nodeType === "file") {
+      await deleteFile({
+        connectorId: connector.id,
+        internalId: node.internalId,
+        dataSourceConfig,
+      });
+    } else if (node.nodeType === "folder") {
+      await recursiveNodeDeletion(
+        node.internalId,
+        connector.id,
+        dataSourceConfig
+      );
+    }
+  }
 }


### PR DESCRIPTION
Description
---
Fixes #6552 as described in the issue

Risks
---
Wrongful deletion. Mitigation:
- code made clear on the fact we avoid that
- tested locally
- not many clients yet :)

Deploy
---
connectors
