### PR TITLE
Backfill API keys without group ID.

### DIFF
--- a/front/migrations/20240829_backfill_keys_without_group_id.ts
+++ b/front/migrations/20240829_backfill_keys_without_group_id.ts
@@ -18,19 +18,6 @@ async function backfillApiKeys(
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
   if (execute) {
-    const globalGroup = await GroupResource.fetchWorkspaceGlobalGroup(auth);
-    if (globalGroup.isOk()) {
-      await KeyResource.model.update(
-        { groupId: globalGroup.value.id },
-        {
-          where: {
-            workspaceId: workspace.id,
-            isSystem: false,
-          },
-        }
-      );
-    }
-
     const systemGroup = await GroupResource.fetchWorkspaceSystemGroup(auth);
     if (systemGroup.isOk()) {
       await KeyResource.model.update(

--- a/front/migrations/20240829_backfill_keys_without_group_id.ts
+++ b/front/migrations/20240829_backfill_keys_without_group_id.ts
@@ -1,0 +1,79 @@
+import type { LightWorkspaceType } from "@dust-tt/types";
+
+import { Authenticator } from "@app/lib/auth";
+import { Workspace } from "@app/lib/models/workspace";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { KeyResource } from "@app/lib/resources/key_resource";
+import { KeyModel } from "@app/lib/resources/storage/models/keys";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+
+async function backfillApiKeys(
+  workspace: LightWorkspaceType,
+  logger: Logger,
+  execute: boolean
+) {
+  logger.info("Handle workspace " + workspace.id);
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+  if (execute) {
+    const globalGroup = await GroupResource.fetchWorkspaceGlobalGroup(auth);
+    if (globalGroup.isOk()) {
+      await KeyResource.model.update(
+        { groupId: globalGroup.value.id },
+        {
+          where: {
+            workspaceId: workspace.id,
+            isSystem: false,
+          },
+        }
+      );
+    }
+
+    const systemGroup = await GroupResource.fetchWorkspaceSystemGroup(auth);
+    if (systemGroup.isOk()) {
+      await KeyResource.model.update(
+        { groupId: systemGroup.value.id },
+        {
+          where: {
+            workspaceId: workspace.id,
+            isSystem: true,
+          },
+        }
+      );
+    }
+  }
+  logger.info("Done with workspace " + workspace.id);
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  const keys = await KeyModel.findAll({
+    // @ts-expect-error groupId is now not nullable in our database schema, even though we have some null values in the database.
+    where: {
+      isSystem: true,
+      status: "active",
+      groupId: null,
+    },
+  });
+
+  logger.info({ keyCount: keys.length }, "Found keys to backfill");
+  for (const key of keys) {
+    const workspace = await Workspace.findOne({
+      where: {
+        id: key.workspaceId,
+      },
+    });
+    if (!workspace) {
+      throw new Error(
+        `Workspace not found for key: ${key.id}, workspaceId: ${key.workspaceId}`
+      );
+    }
+
+    await backfillApiKeys(
+      await renderLightWorkspaceType({ workspace: workspace }),
+      logger,
+      execute
+    );
+  }
+});


### PR DESCRIPTION
## Description

Backfill system API keys without group ID. As of right now, we have 252 of them in the database and they are all actives.

We'll need to adjust the model or run a migration after that to make the `GroupID` field non nullable.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
