### PR TITLE
[front] dev: Ease setup for local dust-apps

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+if [ -z "$ENABLE_AUTO_SYNC_ON_PULL" ]
+then
+  echo "You can enable dust-apps auto sync by setting ENABLE_AUTO_SYNC_ON_PULL"
+  exit 0
+fi
+
 current_branch=$(git symbolic-ref --short HEAD)
 if [ "$current_branch" = "main" ]
 then

--- a/.husky/pre-rebase
+++ b/.husky/pre-rebase
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+if [ -z "$ENABLE_AUTO_SYNC_ON_PULL" ]
+then
+  echo "You can enable dust-apps auto sync by setting ENABLE_AUTO_SYNC_ON_PULL"
+  exit 0
+fi
+
 current_branch=$(git symbolic-ref --short HEAD)
 if [ "$current_branch" = "main" ]
 then

--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -1,8 +1,6 @@
-import type { DustRegistryActionName } from "@dust-tt/types";
 import {
   CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG,
   ConnectorsAPI,
-  DustProdActionRegistry,
   removeNulls,
   SUPPORTED_MODEL_CONFIGS,
 } from "@dust-tt/types";
@@ -23,6 +21,7 @@ import {
   internalSubscribeWorkspaceToFreeNoPlan,
   internalSubscribeWorkspaceToFreePlan,
 } from "@app/lib/plans/subscription";
+import { DustProdActionRegistry } from "@app/lib/registry";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";

--- a/front/admin/copy_apps.sh
+++ b/front/admin/copy_apps.sh
@@ -50,7 +50,7 @@ function import {
 
 if [ -z "$DUST_APPS_WORKSPACE_ID" ] 
 then
-    echo "Please set DUST_APPS_WORKSPACE_ID with your workspace sId if you want to synchronize dust-apps."
+    echo "Please set DUST_APPS_WORKSPACE_ID with your local workspace sId if you want to synchronize there dust-apps from production."
     exit 0
 fi
 

--- a/front/admin/copy_apps.sh
+++ b/front/admin/copy_apps.sh
@@ -48,11 +48,13 @@ function import {
     psql ${uri} -c "drop table if exists __copy;"
 }
 
-if [ -z "$DUST_APPS_SYNC_WORKSPACE_ID" ] 
+if [ -z "$DUST_APPS_WORKSPACE_ID" ] 
 then
-    echo "Please set DUST_APPS_SYNC_WORKSPACE_ID if you want to synchronize dust-apps."
+    echo "Please set DUST_APPS_WORKSPACE_ID with your workspace sId if you want to synchronize dust-apps."
     exit 0
 fi
+
+DUST_APPS_SYNC_WORKSPACE_ID=$(psql ${FRONT_DATABASE_URI} -c "COPY (select id from workspaces where \"sId\"='${DUST_APPS_WORKSPACE_ID}') TO STDOUT")
 
 mkdir -p /tmp/dust-apps
 

--- a/front/lib/actions/helpers.ts
+++ b/front/lib/actions/helpers.ts
@@ -1,6 +1,5 @@
-import type { Action, DustAPIResponse, WorkspaceType } from "@dust-tt/types";
+import type { DustAPIResponse, WorkspaceType } from "@dust-tt/types";
 import type { DustAppConfigType } from "@dust-tt/types";
-import { cloneBaseConfig } from "@dust-tt/types";
 import { DustAPI } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 import { isLeft, isRight } from "fp-ts/lib/Either";
@@ -13,6 +12,8 @@ import {
 } from "@app/lib/actions/types";
 import apiConfig from "@app/lib/api/config";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";
+import type { Action } from "@app/lib/registry";
+import { cloneBaseConfig } from "@app/lib/registry";
 import logger from "@app/logger/logger";
 
 interface CallActionParams<V extends t.Mixed> {

--- a/front/lib/actions/server.ts
+++ b/front/lib/actions/server.ts
@@ -1,12 +1,12 @@
-import type { DustRegistryActionName } from "@dust-tt/types";
 import type { DustAppConfigType, DustAppType } from "@dust-tt/types";
-import { DustProdActionRegistry } from "@dust-tt/types";
 import { DustAPI } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 
 import apiConfig from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";
+import type { DustRegistryActionName } from "@app/lib/registry";
+import { DustProdActionRegistry } from "@app/lib/registry";
 import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/withlogging";
 

--- a/front/lib/api/assistant/actions/browse.ts
+++ b/front/lib/api/assistant/actions/browse.ts
@@ -11,13 +11,7 @@ import type {
   ModelId,
   Result,
 } from "@dust-tt/types";
-import {
-  BaseAction,
-  BrowseActionOutputSchema,
-  cloneBaseConfig,
-  DustProdActionRegistry,
-  Ok,
-} from "@dust-tt/types";
+import { BaseAction, BrowseActionOutputSchema, Ok } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 
 import { runActionStreamed } from "@app/lib/actions/server";
@@ -26,6 +20,7 @@ import type { BaseActionRunParams } from "@app/lib/api/assistant/actions/types";
 import { BaseActionConfigurationServerRunner } from "@app/lib/api/assistant/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentBrowseAction } from "@app/lib/models/assistant/actions/browse";
+import { cloneBaseConfig, DustProdActionRegistry } from "@app/lib/registry";
 import logger from "@app/logger/logger";
 
 interface BrowseActionBlob {

--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -18,9 +18,11 @@ import {
   BaseAction,
   cloneBaseConfig,
   DustProdActionRegistry,
+  isCustomDustAppsWorkspaceId,
   isDevelopment,
   Ok,
   PROCESS_ACTION_TOP_K,
+  PRODUCTION_DUST_WORKSPACE_ID,
   renderSchemaPropertiesAsJSONSchema,
 } from "@dust-tt/types";
 
@@ -36,7 +38,6 @@ import { BaseActionConfigurationServerRunner } from "@app/lib/api/assistant/acti
 import { constructPromptMultiActions } from "@app/lib/api/assistant/generation";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
-import { PRODUCTION_DUST_WORKSPACE_ID } from "@app/lib/development";
 import { AgentProcessAction } from "@app/lib/models/assistant/actions/process";
 import logger from "@app/logger/logger";
 
@@ -255,9 +256,10 @@ export class ProcessConfigurationServerRunner extends BaseActionConfigurationSer
     // Handle data sources list and parents/tags filtering.
     config.DATASOURCE.data_sources = actionConfiguration.dataSources.map(
       (d) => ({
-        workspace_id: isDevelopment()
-          ? PRODUCTION_DUST_WORKSPACE_ID
-          : d.workspaceId,
+        workspace_id:
+          isDevelopment() && !isCustomDustAppsWorkspaceId()
+            ? PRODUCTION_DUST_WORKSPACE_ID
+            : d.workspaceId,
 
         // Use dataSourceViewId if it exists; otherwise, use dataSourceId.
         // Note: This value is passed to the registry for lookup.

--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -16,13 +16,9 @@ import type {
 } from "@dust-tt/types";
 import {
   BaseAction,
-  cloneBaseConfig,
-  DustProdActionRegistry,
-  isCustomDustAppsWorkspaceId,
   isDevelopment,
   Ok,
   PROCESS_ACTION_TOP_K,
-  PRODUCTION_DUST_WORKSPACE_ID,
   renderSchemaPropertiesAsJSONSchema,
 } from "@dust-tt/types";
 
@@ -36,9 +32,15 @@ import {
 import type { BaseActionRunParams } from "@app/lib/api/assistant/actions/types";
 import { BaseActionConfigurationServerRunner } from "@app/lib/api/assistant/actions/types";
 import { constructPromptMultiActions } from "@app/lib/api/assistant/generation";
+import { PRODUCTION_DUST_WORKSPACE_ID } from "@app/lib/api/config";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentProcessAction } from "@app/lib/models/assistant/actions/process";
+import {
+  cloneBaseConfig,
+  DustProdActionRegistry,
+  isProductionDustAppsWorkspaceId,
+} from "@app/lib/registry";
 import logger from "@app/logger/logger";
 
 interface ProcessActionBlob {
@@ -257,7 +259,7 @@ export class ProcessConfigurationServerRunner extends BaseActionConfigurationSer
     config.DATASOURCE.data_sources = actionConfiguration.dataSources.map(
       (d) => ({
         workspace_id:
-          isDevelopment() && !isCustomDustAppsWorkspaceId()
+          isDevelopment() && isProductionDustAppsWorkspaceId()
             ? PRODUCTION_DUST_WORKSPACE_ID
             : d.workspaceId,
 

--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -32,14 +32,14 @@ import {
 import type { BaseActionRunParams } from "@app/lib/api/assistant/actions/types";
 import { BaseActionConfigurationServerRunner } from "@app/lib/api/assistant/actions/types";
 import { constructPromptMultiActions } from "@app/lib/api/assistant/generation";
-import { PRODUCTION_DUST_WORKSPACE_ID } from "@app/lib/api/config";
+import apiConfig from "@app/lib/api/config";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentProcessAction } from "@app/lib/models/assistant/actions/process";
 import {
   cloneBaseConfig,
   DustProdActionRegistry,
-  isProductionDustAppsWorkspaceId,
+  PRODUCTION_DUST_WORKSPACE_ID,
 } from "@app/lib/registry";
 import logger from "@app/logger/logger";
 
@@ -259,7 +259,7 @@ export class ProcessConfigurationServerRunner extends BaseActionConfigurationSer
     config.DATASOURCE.data_sources = actionConfiguration.dataSources.map(
       (d) => ({
         workspace_id:
-          isDevelopment() && isProductionDustAppsWorkspaceId()
+          isDevelopment() && !apiConfig.getDevelopmentDustAppsWorkspaceId()
             ? PRODUCTION_DUST_WORKSPACE_ID
             : d.workspaceId,
 

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -16,14 +16,7 @@ import type {
 } from "@dust-tt/types";
 import type { AgentActionSpecification } from "@dust-tt/types";
 import type { Result } from "@dust-tt/types";
-import {
-  BaseAction,
-  cloneBaseConfig,
-  DustProdActionRegistry,
-  isCustomDustAppsWorkspaceId,
-  isDevelopment,
-  PRODUCTION_DUST_WORKSPACE_ID,
-} from "@dust-tt/types";
+import { BaseAction, isDevelopment } from "@dust-tt/types";
 import { Ok } from "@dust-tt/types";
 
 import { runActionStreamed } from "@app/lib/actions/server";
@@ -32,12 +25,18 @@ import type { BaseActionRunParams } from "@app/lib/api/assistant/actions/types";
 import { BaseActionConfigurationServerRunner } from "@app/lib/api/assistant/actions/types";
 import { getCitationsCount } from "@app/lib/api/assistant/actions/utils";
 import { getRefs } from "@app/lib/api/assistant/citations";
+import { PRODUCTION_DUST_WORKSPACE_ID } from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import {
   AgentRetrievalAction,
   RetrievalDocument,
   RetrievalDocumentChunk,
 } from "@app/lib/models/assistant/actions/retrieval";
+import {
+  cloneBaseConfig,
+  DustProdActionRegistry,
+  isProductionDustAppsWorkspaceId,
+} from "@app/lib/registry";
 import { frontSequelize } from "@app/lib/resources/storage";
 import logger from "@app/logger/logger";
 
@@ -437,7 +436,7 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
     config.DATASOURCE.data_sources = actionConfiguration.dataSources.map(
       (d) => ({
         workspace_id:
-          isDevelopment() && !isCustomDustAppsWorkspaceId()
+          isDevelopment() && isProductionDustAppsWorkspaceId()
             ? PRODUCTION_DUST_WORKSPACE_ID
             : d.workspaceId,
         // Use dataSourceViewId if it exists; otherwise, use dataSourceId.

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -25,7 +25,7 @@ import type { BaseActionRunParams } from "@app/lib/api/assistant/actions/types";
 import { BaseActionConfigurationServerRunner } from "@app/lib/api/assistant/actions/types";
 import { getCitationsCount } from "@app/lib/api/assistant/actions/utils";
 import { getRefs } from "@app/lib/api/assistant/citations";
-import { PRODUCTION_DUST_WORKSPACE_ID } from "@app/lib/api/config";
+import apiConfig from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import {
   AgentRetrievalAction,
@@ -35,7 +35,7 @@ import {
 import {
   cloneBaseConfig,
   DustProdActionRegistry,
-  isProductionDustAppsWorkspaceId,
+  PRODUCTION_DUST_WORKSPACE_ID,
 } from "@app/lib/registry";
 import { frontSequelize } from "@app/lib/resources/storage";
 import logger from "@app/logger/logger";
@@ -436,7 +436,7 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
     config.DATASOURCE.data_sources = actionConfiguration.dataSources.map(
       (d) => ({
         workspace_id:
-          isDevelopment() && isProductionDustAppsWorkspaceId()
+          isDevelopment() && !apiConfig.getDevelopmentDustAppsWorkspaceId()
             ? PRODUCTION_DUST_WORKSPACE_ID
             : d.workspaceId,
         // Use dataSourceViewId if it exists; otherwise, use dataSourceId.

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -20,7 +20,9 @@ import {
   BaseAction,
   cloneBaseConfig,
   DustProdActionRegistry,
+  isCustomDustAppsWorkspaceId,
   isDevelopment,
+  PRODUCTION_DUST_WORKSPACE_ID,
 } from "@dust-tt/types";
 import { Ok } from "@dust-tt/types";
 
@@ -31,7 +33,6 @@ import { BaseActionConfigurationServerRunner } from "@app/lib/api/assistant/acti
 import { getCitationsCount } from "@app/lib/api/assistant/actions/utils";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import type { Authenticator } from "@app/lib/auth";
-import { PRODUCTION_DUST_WORKSPACE_ID } from "@app/lib/development";
 import {
   AgentRetrievalAction,
   RetrievalDocument,
@@ -435,9 +436,10 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
     // Handle data sources list and parents/tags filtering.
     config.DATASOURCE.data_sources = actionConfiguration.dataSources.map(
       (d) => ({
-        workspace_id: isDevelopment()
-          ? PRODUCTION_DUST_WORKSPACE_ID
-          : d.workspaceId,
+        workspace_id:
+          isDevelopment() && !isCustomDustAppsWorkspaceId()
+            ? PRODUCTION_DUST_WORKSPACE_ID
+            : d.workspaceId,
         // Use dataSourceViewId if it exists; otherwise, use dataSourceId.
         // Note: This value is passed to the registry for lookup.
         data_source_id: d.dataSourceViewId ?? d.dataSourceId,

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -12,12 +12,7 @@ import type {
   TablesQueryParamsEvent,
   TablesQuerySuccessEvent,
 } from "@dust-tt/types";
-import {
-  BaseAction,
-  cloneBaseConfig,
-  DustProdActionRegistry,
-  Ok,
-} from "@dust-tt/types";
+import { BaseAction, Ok } from "@dust-tt/types";
 
 import { runActionStreamed } from "@app/lib/actions/server";
 import { DEFAULT_TABLES_QUERY_ACTION_NAME } from "@app/lib/api/assistant/actions/names";
@@ -27,6 +22,7 @@ import { renderConversationForModelMultiActions } from "@app/lib/api/assistant/g
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentTablesQueryAction } from "@app/lib/models/assistant/actions/tables_query";
+import { cloneBaseConfig, DustProdActionRegistry } from "@app/lib/registry";
 import { sanitizeJSONOutput } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 

--- a/front/lib/api/assistant/actions/websearch.ts
+++ b/front/lib/api/assistant/actions/websearch.ts
@@ -14,13 +14,7 @@ import type {
   WebsearchResultType,
   WebsearchSuccessEvent,
 } from "@dust-tt/types";
-import {
-  BaseAction,
-  cloneBaseConfig,
-  DustProdActionRegistry,
-  Ok,
-  WebsearchAppActionOutputSchema,
-} from "@dust-tt/types";
+import { BaseAction, Ok, WebsearchAppActionOutputSchema } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 
 import { runActionStreamed } from "@app/lib/actions/server";
@@ -31,6 +25,7 @@ import { getCitationsCount } from "@app/lib/api/assistant/actions/utils";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentWebsearchAction } from "@app/lib/models/assistant/actions/websearch";
+import { cloneBaseConfig, DustProdActionRegistry } from "@app/lib/registry";
 import logger from "@app/logger/logger";
 
 import { getRunnerforActionConfiguration } from "./runners";

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -20,8 +20,6 @@ import type {
 } from "@dust-tt/types";
 import {
   assertNever,
-  cloneBaseConfig,
-  DustProdActionRegistry,
   isBrowseConfiguration,
   isDustAppRunConfiguration,
   isProcessConfiguration,
@@ -46,6 +44,7 @@ import { isLegacyAgentConfiguration } from "@app/lib/api/assistant/legacy_agent"
 import { getRedisClient } from "@app/lib/api/redis";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMessageContent } from "@app/lib/models/assistant/agent_message_content";
+import { cloneBaseConfig, DustProdActionRegistry } from "@app/lib/registry";
 import logger from "@app/logger/logger";
 
 const CANCELLATION_CHECK_INTERVAL = 500;

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -35,8 +35,6 @@ import {
   md5,
 } from "@dust-tt/types";
 import {
-  cloneBaseConfig,
-  DustProdActionRegistry,
   Err,
   getTimeframeSecondsFromLiteral,
   isAgentMention,
@@ -71,6 +69,7 @@ import {
   UserMessage,
 } from "@app/lib/models/assistant/conversation";
 import { countActiveSeatsInWorkspaceCached } from "@app/lib/plans/usage/seats";
+import { cloneBaseConfig, DustProdActionRegistry } from "@app/lib/registry";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -1,5 +1,9 @@
 import { EnvironmentConfig } from "@dust-tt/types";
 
+export const PRODUCTION_DUST_API = "https://dust.tt";
+export const PRODUCTION_DUST_WORKSPACE_ID = "0ec9852c2f";
+export const PRODUCTION_DUST_APPS_WORKSPACE_ID = "78bda07b39";
+
 const config = {
   getClientFacingUrl: (): string => {
     return EnvironmentConfig.getEnvVariable("DUST_CLIENT_FACING_URL");
@@ -82,7 +86,7 @@ const config = {
       // Dust production API URL is hardcoded for now.
       url:
         EnvironmentConfig.getOptionalEnvVariable("DUST_PROD_API") ??
-        "https://dust.tt",
+        PRODUCTION_DUST_API,
       nodeEnv: EnvironmentConfig.getEnvVariable("NODE_ENV"),
     };
   },
@@ -91,6 +95,12 @@ const config = {
       url: EnvironmentConfig.getEnvVariable("OAUTH_API"),
       apiKey: EnvironmentConfig.getOptionalEnvVariable("OAUTH_API_KEY") ?? null,
     };
+  },
+  getDustAppsWorkspaceId: (): string => {
+    return (
+      EnvironmentConfig.getOptionalEnvVariable("DUST_APPS_WORKSPACE_ID") ??
+      PRODUCTION_DUST_APPS_WORKSPACE_ID
+    );
   },
   // OAuth
   getOAuthGithubApp: (): string => {

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -1,8 +1,6 @@
 import { EnvironmentConfig } from "@dust-tt/types";
 
 export const PRODUCTION_DUST_API = "https://dust.tt";
-export const PRODUCTION_DUST_WORKSPACE_ID = "0ec9852c2f";
-export const PRODUCTION_DUST_APPS_WORKSPACE_ID = "78bda07b39";
 
 const config = {
   getClientFacingUrl: (): string => {
@@ -96,10 +94,9 @@ const config = {
       apiKey: EnvironmentConfig.getOptionalEnvVariable("OAUTH_API_KEY") ?? null,
     };
   },
-  getDustAppsWorkspaceId: (): string => {
-    return (
-      EnvironmentConfig.getOptionalEnvVariable("DUST_APPS_WORKSPACE_ID") ??
-      PRODUCTION_DUST_APPS_WORKSPACE_ID
+  getDevelopmentDustAppsWorkspaceId: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable(
+      "DEVELOPMENT_DUST_APPS_WORKSPACE_ID"
     );
   },
   // OAuth

--- a/front/lib/development.ts
+++ b/front/lib/development.ts
@@ -4,7 +4,7 @@ import { Err, isDevelopment, Ok } from "@dust-tt/types";
 import {
   PRODUCTION_DUST_APPS_WORKSPACE_ID,
   PRODUCTION_DUST_WORKSPACE_ID,
-} from "@app/lib/api/config";
+} from "@app/lib/registry";
 
 function isADustProdWorkspace(owner: LightWorkspaceType) {
   return (

--- a/front/lib/development.ts
+++ b/front/lib/development.ts
@@ -1,11 +1,10 @@
 import type { LightWorkspaceType, UserType } from "@dust-tt/types";
+import { Err, isDevelopment, Ok } from "@dust-tt/types";
+
 import {
-  Err,
-  isDevelopment,
-  Ok,
   PRODUCTION_DUST_APPS_WORKSPACE_ID,
   PRODUCTION_DUST_WORKSPACE_ID,
-} from "@dust-tt/types";
+} from "@app/lib/api/config";
 
 function isADustProdWorkspace(owner: LightWorkspaceType) {
   return (

--- a/front/lib/development.ts
+++ b/front/lib/development.ts
@@ -1,10 +1,13 @@
 import type { LightWorkspaceType, UserType } from "@dust-tt/types";
-import { Err, isDevelopment, Ok } from "@dust-tt/types";
+import {
+  Err,
+  isDevelopment,
+  Ok,
+  PRODUCTION_DUST_APPS_WORKSPACE_ID,
+  PRODUCTION_DUST_WORKSPACE_ID,
+} from "@dust-tt/types";
 
-export const PRODUCTION_DUST_WORKSPACE_ID = "0ec9852c2f";
-const PRODUCTION_DUST_APPS_WORKSPACE_ID = "78bda07b39";
-
-export function isADustProdWorkspace(owner: LightWorkspaceType) {
+function isADustProdWorkspace(owner: LightWorkspaceType) {
   return (
     owner.sId === PRODUCTION_DUST_WORKSPACE_ID ||
     owner.sId === PRODUCTION_DUST_APPS_WORKSPACE_ID

--- a/front/lib/documents_post_process_hooks/hooks/document_tracker/suggest_changes/actions/doc_tracker_retrieval.ts
+++ b/front/lib/documents_post_process_hooks/hooks/document_tracker/suggest_changes/actions/doc_tracker_retrieval.ts
@@ -1,9 +1,9 @@
 import type { WorkspaceType } from "@dust-tt/types";
-import { cloneBaseConfig, DustProdActionRegistry } from "@dust-tt/types";
 import * as t from "io-ts";
 
 import { callAction } from "@app/lib/actions/helpers";
 import { getTrackableDataSources } from "@app/lib/documents_post_process_hooks/hooks/document_tracker/lib";
+import { cloneBaseConfig, DustProdActionRegistry } from "@app/lib/registry";
 
 // Part of the new doc tracker pipeline, performs the retrieval (semantic search) step
 // it takes {input_text: string} as input

--- a/front/lib/documents_post_process_hooks/hooks/document_tracker/suggest_changes/actions/doc_tracker_suggest_changes.ts
+++ b/front/lib/documents_post_process_hooks/hooks/document_tracker/suggest_changes/actions/doc_tracker_suggest_changes.ts
@@ -1,12 +1,9 @@
 import type { WorkspaceType } from "@dust-tt/types";
-import {
-  cloneBaseConfig,
-  DustProdActionRegistry,
-  getLargeWhitelistedModel,
-} from "@dust-tt/types";
+import { getLargeWhitelistedModel } from "@dust-tt/types";
 import * as t from "io-ts";
 
 import { callAction } from "@app/lib/actions/helpers";
+import { cloneBaseConfig, DustProdActionRegistry } from "@app/lib/registry";
 
 // Part of the new doc tracker pipeline, suggest changes  based on a "source_document" (new incoming doc)
 // and a "target_document" (the tracked doc)

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -1,26 +1,18 @@
-import { DustAppType } from "../../../front/lib/dust_api";
-import { EnvironmentConfig } from "../../../shared/utils/config";
+import type { DustAppType } from "@dust-tt/types";
 
-export const PRODUCTION_DUST_WORKSPACE_ID = "0ec9852c2f";
-export const PRODUCTION_DUST_APPS_WORKSPACE_ID = "78bda07b39";
+import config, { PRODUCTION_DUST_WORKSPACE_ID } from "@app/lib/api/config";
 
-const DUST_APPS_WORKSPACE_ID =
-  EnvironmentConfig.getOptionalEnvVariable("DUST_APPS_WORKSPACE_ID") ??
-  PRODUCTION_DUST_APPS_WORKSPACE_ID;
+const DUST_APPS_WORKSPACE_ID = config.getDustAppsWorkspaceId();
 
-export const isCustomDustAppsWorkspaceId = () =>
-  PRODUCTION_DUST_WORKSPACE_ID !== DUST_APPS_WORKSPACE_ID;
+export const isProductionDustAppsWorkspaceId = () =>
+  PRODUCTION_DUST_WORKSPACE_ID === DUST_APPS_WORKSPACE_ID;
 
 export type Action = {
   app: DustAppType;
   config: { [key: string]: unknown };
 };
 
-const createActionRegistry = <K extends string, R extends Record<K, Action>>(
-  registry: R
-) => registry;
-
-export const DustProdActionRegistry = createActionRegistry({
+export const DustProdActionRegistry = {
   "assistant-v2-multi-actions-agent": {
     app: {
       workspaceId: DUST_APPS_WORKSPACE_ID,
@@ -257,7 +249,7 @@ export const DustProdActionRegistry = createActionRegistry({
       },
     },
   },
-});
+};
 
 export type DustRegistryActionName = keyof typeof DustProdActionRegistry;
 

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -1,21 +1,35 @@
 import type { DustAppType } from "@dust-tt/types";
+import { isDevelopment } from "@dust-tt/types";
 
-import config, { PRODUCTION_DUST_WORKSPACE_ID } from "@app/lib/api/config";
+import config from "@app/lib/api/config";
 
-const DUST_APPS_WORKSPACE_ID = config.getDustAppsWorkspaceId();
-
-export const isProductionDustAppsWorkspaceId = () =>
-  PRODUCTION_DUST_WORKSPACE_ID === DUST_APPS_WORKSPACE_ID;
+export const PRODUCTION_DUST_WORKSPACE_ID = "0ec9852c2f";
+export const PRODUCTION_DUST_APPS_WORKSPACE_ID = "78bda07b39";
 
 export type Action = {
   app: DustAppType;
   config: { [key: string]: unknown };
 };
 
-export const DustProdActionRegistry = {
+const createActionRegistry = <K extends string, R extends Record<K, Action>>(
+  registry: R
+) => {
+  const developmentWorkspaceId = config.getDevelopmentDustAppsWorkspaceId();
+
+  if (isDevelopment() && developmentWorkspaceId) {
+    const actions: Action[] = Object.values(registry);
+    actions.forEach((action) => {
+      action.app.workspaceId = developmentWorkspaceId;
+    });
+  }
+
+  return registry;
+};
+
+export const DustProdActionRegistry = createActionRegistry({
   "assistant-v2-multi-actions-agent": {
     app: {
-      workspaceId: DUST_APPS_WORKSPACE_ID,
+      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "0e9889c787",
       appHash:
         "4e896f08ef6c2c69c97610c861cd444e3d34c839eab44f9b4fd7dd1d166c40a2",
@@ -31,7 +45,7 @@ export const DustProdActionRegistry = {
   },
   "assistant-v2-title-generator": {
     app: {
-      workspaceId: DUST_APPS_WORKSPACE_ID,
+      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "84dfc1d4f7",
       appHash:
         "6ea231add2ae690ee959c5d8d5d06420ea2feae7dd32ac13a4e655910087e313",
@@ -46,7 +60,7 @@ export const DustProdActionRegistry = {
   },
   "assistant-v2-retrieval": {
     app: {
-      workspaceId: DUST_APPS_WORKSPACE_ID,
+      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "471b6aa923",
       appHash:
         "3b634a84930020a7a18d3b32f4c5f5cd85690bf4958127ba51061fb101edea33",
@@ -62,7 +76,7 @@ export const DustProdActionRegistry = {
   },
   "assistant-v2-process": {
     app: {
-      workspaceId: DUST_APPS_WORKSPACE_ID,
+      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "953b79fe89",
       appHash:
         "06e0af3c215ee205d2eff01826f763e36f5694c0650bf645ab156ee189e50b3a",
@@ -84,7 +98,7 @@ export const DustProdActionRegistry = {
 
   "doc-tracker-retrieval": {
     app: {
-      workspaceId: DUST_APPS_WORKSPACE_ID,
+      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "4180309c80",
       appHash:
         "8adcc9ae33a63cc735c9a23a97d7bffe658c6ef2400fc997e61e8817f611a1f8",
@@ -107,7 +121,7 @@ export const DustProdActionRegistry = {
   },
   "doc-tracker-suggest-changes": {
     app: {
-      workspaceId: DUST_APPS_WORKSPACE_ID,
+      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "76b40f14fb",
       appHash:
         "93877e16b59a07eff3b4f154b8f568f172d6a463f27bd3bcbf5f6aa264216163",
@@ -122,7 +136,7 @@ export const DustProdActionRegistry = {
   },
   "assistant-v2-query-tables": {
     app: {
-      workspaceId: DUST_APPS_WORKSPACE_ID,
+      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "b4f205e453",
       appHash:
         "1ab6657b93c28ffe8a5c9678e646581cffe69bd4d6b307781a3d576da5acb03e",
@@ -137,7 +151,7 @@ export const DustProdActionRegistry = {
   },
   "assistant-v2-websearch": {
     app: {
-      workspaceId: DUST_APPS_WORKSPACE_ID,
+      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "098b515f8e",
       appHash:
         "514d54c0967638656b437417228efec26de465796b5ab67ae0480d6976250768",
@@ -146,7 +160,7 @@ export const DustProdActionRegistry = {
   },
   "assistant-v2-browse": {
     app: {
-      workspaceId: DUST_APPS_WORKSPACE_ID,
+      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "21092925b9",
       appHash:
         "766618e57ff6600cac27d170395c74f4067e8671ef5bf36db5a820fb411f044b",
@@ -161,7 +175,7 @@ export const DustProdActionRegistry = {
   },
   "assistant-builder-instructions-suggestions": {
     app: {
-      workspaceId: DUST_APPS_WORKSPACE_ID,
+      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "d995d868a8",
       appHash:
         "7fb9c826d9de74c98de2a675093f66eab9da93a1a2cb9bc0bcc919fd074cd7eb",
@@ -176,7 +190,7 @@ export const DustProdActionRegistry = {
   },
   "assistant-builder-name-suggestions": {
     app: {
-      workspaceId: DUST_APPS_WORKSPACE_ID,
+      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "34a8c4a2aa",
       appHash:
         "65020161030b555f4d2efc9d1ce3a6d0020dcf76e663f746bd98213c90a0675f",
@@ -191,7 +205,7 @@ export const DustProdActionRegistry = {
   },
   "assistant-builder-emoji-suggestions": {
     app: {
-      workspaceId: DUST_APPS_WORKSPACE_ID,
+      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "b69YdlJ3PJ",
       appHash:
         "0b6b63def0224321f2bece0751bad632baca33f6d5bb596bbeb3f95b6bea5966",
@@ -206,7 +220,7 @@ export const DustProdActionRegistry = {
   },
   "assistant-builder-description-suggestions": {
     app: {
-      workspaceId: DUST_APPS_WORKSPACE_ID,
+      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "aba0057f4c",
       appHash:
         "e4bda2ba50f160712c08309628b4a6bf2b68dd7e9709669cc29ac43e36d663f7",
@@ -221,7 +235,7 @@ export const DustProdActionRegistry = {
   },
   "assistant-builder-process-action-schema-generator": {
     app: {
-      workspaceId: DUST_APPS_WORKSPACE_ID,
+      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "b36c7416bd",
       appHash:
         "1ca7b9568681b06ef6cc0830239a479644a3ecc203c812983f3386a72e214d48",
@@ -236,7 +250,7 @@ export const DustProdActionRegistry = {
   },
   "assistant-v2-visualization": {
     app: {
-      workspaceId: DUST_APPS_WORKSPACE_ID,
+      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "tWcuYDj1OE",
       appHash:
         "8298c6543759d1d11db0e360a8b7aa7b8ec0fa71ed274f2667678302073e4f8d",
@@ -249,7 +263,7 @@ export const DustProdActionRegistry = {
       },
     },
   },
-};
+});
 
 export type DustRegistryActionName = keyof typeof DustProdActionRegistry;
 

--- a/front/pages/api/w/[wId]/assistant/builder/process/generate_schema.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/process/generate_schema.ts
@@ -3,19 +3,18 @@ import type {
   WithAPIErrorResponse,
 } from "@dust-tt/types";
 import {
-  cloneBaseConfig,
   getLargeWhitelistedModel,
   getSmallWhitelistedModel,
   ioTsParsePayload,
   PROCESS_SCHEMA_ALLOWED_TYPES,
 } from "@dust-tt/types";
 import { InternalPostBuilderProcessActionGenerateSchemaRequestBodySchema } from "@dust-tt/types";
-import { DustProdActionRegistry } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { runAction } from "@app/lib/actions/server";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import { cloneBaseConfig, DustProdActionRegistry } from "@app/lib/registry";
 import { apiError } from "@app/logger/withlogging";
 
 async function handler(

--- a/front/pages/api/w/[wId]/assistant/builder/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/suggestions.ts
@@ -8,8 +8,6 @@ import {
   assertNever,
   BuilderEmojiSuggestionsResponseBodySchema,
   BuilderSuggestionsResponseBodySchema,
-  cloneBaseConfig,
-  DustProdActionRegistry,
   getLargeWhitelistedModel,
   getSmallWhitelistedModel,
   InternalPostBuilderSuggestionsRequestBodySchema,
@@ -22,6 +20,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { runAction } from "@app/lib/actions/server";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import { cloneBaseConfig, DustProdActionRegistry } from "@app/lib/registry";
 import { apiError } from "@app/logger/withlogging";
 
 async function handler(

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -8,7 +8,7 @@ import type {
 } from "@dust-tt/types";
 import type { WorkspaceType } from "@dust-tt/types";
 import type { SubscriptionType } from "@dust-tt/types";
-import { DustProdActionRegistry, WHITELISTABLE_FEATURES } from "@dust-tt/types";
+import { WHITELISTABLE_FEATURES } from "@dust-tt/types";
 import { format } from "date-fns/format";
 import { keyBy } from "lodash";
 import type { InferGetServerSidePropsType } from "next";
@@ -38,6 +38,7 @@ import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { Plan, Subscription } from "@app/lib/models/plan";
 import { FREE_NO_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { renderSubscriptionFromModels } from "@app/lib/plans/subscription";
+import { DustProdActionRegistry } from "@app/lib/registry";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
   owner: WorkspaceType;

--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -1,6 +1,15 @@
 import { DustAppType } from "../../../front/lib/dust_api";
+import { EnvironmentConfig } from "../../../shared/utils/config";
 
-const PRODUCTION_DUST_APPS_WORKSPACE_ID = "78bda07b39";
+export const PRODUCTION_DUST_WORKSPACE_ID = "0ec9852c2f";
+export const PRODUCTION_DUST_APPS_WORKSPACE_ID = "78bda07b39";
+
+const DUST_APPS_WORKSPACE_ID =
+  EnvironmentConfig.getOptionalEnvVariable("DUST_APPS_WORKSPACE_ID") ??
+  PRODUCTION_DUST_APPS_WORKSPACE_ID;
+
+export const isCustomDustAppsWorkspaceId = () =>
+  PRODUCTION_DUST_WORKSPACE_ID !== DUST_APPS_WORKSPACE_ID;
 
 export type Action = {
   app: DustAppType;
@@ -14,7 +23,7 @@ const createActionRegistry = <K extends string, R extends Record<K, Action>>(
 export const DustProdActionRegistry = createActionRegistry({
   "assistant-v2-multi-actions-agent": {
     app: {
-      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
+      workspaceId: DUST_APPS_WORKSPACE_ID,
       appId: "0e9889c787",
       appHash:
         "4e896f08ef6c2c69c97610c861cd444e3d34c839eab44f9b4fd7dd1d166c40a2",
@@ -30,7 +39,7 @@ export const DustProdActionRegistry = createActionRegistry({
   },
   "assistant-v2-title-generator": {
     app: {
-      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
+      workspaceId: DUST_APPS_WORKSPACE_ID,
       appId: "84dfc1d4f7",
       appHash:
         "6ea231add2ae690ee959c5d8d5d06420ea2feae7dd32ac13a4e655910087e313",
@@ -45,7 +54,7 @@ export const DustProdActionRegistry = createActionRegistry({
   },
   "assistant-v2-retrieval": {
     app: {
-      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
+      workspaceId: DUST_APPS_WORKSPACE_ID,
       appId: "471b6aa923",
       appHash:
         "3b634a84930020a7a18d3b32f4c5f5cd85690bf4958127ba51061fb101edea33",
@@ -61,7 +70,7 @@ export const DustProdActionRegistry = createActionRegistry({
   },
   "assistant-v2-process": {
     app: {
-      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
+      workspaceId: DUST_APPS_WORKSPACE_ID,
       appId: "953b79fe89",
       appHash:
         "06e0af3c215ee205d2eff01826f763e36f5694c0650bf645ab156ee189e50b3a",
@@ -83,7 +92,7 @@ export const DustProdActionRegistry = createActionRegistry({
 
   "doc-tracker-retrieval": {
     app: {
-      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
+      workspaceId: DUST_APPS_WORKSPACE_ID,
       appId: "4180309c80",
       appHash:
         "8adcc9ae33a63cc735c9a23a97d7bffe658c6ef2400fc997e61e8817f611a1f8",
@@ -106,7 +115,7 @@ export const DustProdActionRegistry = createActionRegistry({
   },
   "doc-tracker-suggest-changes": {
     app: {
-      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
+      workspaceId: DUST_APPS_WORKSPACE_ID,
       appId: "76b40f14fb",
       appHash:
         "93877e16b59a07eff3b4f154b8f568f172d6a463f27bd3bcbf5f6aa264216163",
@@ -121,7 +130,7 @@ export const DustProdActionRegistry = createActionRegistry({
   },
   "assistant-v2-query-tables": {
     app: {
-      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
+      workspaceId: DUST_APPS_WORKSPACE_ID,
       appId: "b4f205e453",
       appHash:
         "1ab6657b93c28ffe8a5c9678e646581cffe69bd4d6b307781a3d576da5acb03e",
@@ -136,7 +145,7 @@ export const DustProdActionRegistry = createActionRegistry({
   },
   "assistant-v2-websearch": {
     app: {
-      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
+      workspaceId: DUST_APPS_WORKSPACE_ID,
       appId: "098b515f8e",
       appHash:
         "514d54c0967638656b437417228efec26de465796b5ab67ae0480d6976250768",
@@ -145,7 +154,7 @@ export const DustProdActionRegistry = createActionRegistry({
   },
   "assistant-v2-browse": {
     app: {
-      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
+      workspaceId: DUST_APPS_WORKSPACE_ID,
       appId: "21092925b9",
       appHash:
         "766618e57ff6600cac27d170395c74f4067e8671ef5bf36db5a820fb411f044b",
@@ -160,7 +169,7 @@ export const DustProdActionRegistry = createActionRegistry({
   },
   "assistant-builder-instructions-suggestions": {
     app: {
-      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
+      workspaceId: DUST_APPS_WORKSPACE_ID,
       appId: "d995d868a8",
       appHash:
         "7fb9c826d9de74c98de2a675093f66eab9da93a1a2cb9bc0bcc919fd074cd7eb",
@@ -175,7 +184,7 @@ export const DustProdActionRegistry = createActionRegistry({
   },
   "assistant-builder-name-suggestions": {
     app: {
-      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
+      workspaceId: DUST_APPS_WORKSPACE_ID,
       appId: "34a8c4a2aa",
       appHash:
         "65020161030b555f4d2efc9d1ce3a6d0020dcf76e663f746bd98213c90a0675f",
@@ -190,7 +199,7 @@ export const DustProdActionRegistry = createActionRegistry({
   },
   "assistant-builder-emoji-suggestions": {
     app: {
-      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
+      workspaceId: DUST_APPS_WORKSPACE_ID,
       appId: "b69YdlJ3PJ",
       appHash:
         "0b6b63def0224321f2bece0751bad632baca33f6d5bb596bbeb3f95b6bea5966",
@@ -205,7 +214,7 @@ export const DustProdActionRegistry = createActionRegistry({
   },
   "assistant-builder-description-suggestions": {
     app: {
-      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
+      workspaceId: DUST_APPS_WORKSPACE_ID,
       appId: "aba0057f4c",
       appHash:
         "e4bda2ba50f160712c08309628b4a6bf2b68dd7e9709669cc29ac43e36d663f7",
@@ -220,7 +229,7 @@ export const DustProdActionRegistry = createActionRegistry({
   },
   "assistant-builder-process-action-schema-generator": {
     app: {
-      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
+      workspaceId: DUST_APPS_WORKSPACE_ID,
       appId: "b36c7416bd",
       appHash:
         "1ca7b9568681b06ef6cc0830239a479644a3ecc203c812983f3386a72e214d48",
@@ -235,7 +244,7 @@ export const DustProdActionRegistry = createActionRegistry({
   },
   "assistant-v2-visualization": {
     app: {
-      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
+      workspaceId: DUST_APPS_WORKSPACE_ID,
       appId: "tWcuYDj1OE",
       appHash:
         "8298c6543759d1d11db0e360a8b7aa7b8ec0fa71ed274f2667678302073e4f8d",

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -43,7 +43,6 @@ export * from "./front/dust_app_secret";
 export * from "./front/files";
 export * from "./front/groups";
 export * from "./front/key";
-export * from "./front/lib/actions/registry";
 export * from "./front/lib/actions/types";
 export * from "./front/lib/api/assistant/actions/browse";
 export * from "./front/lib/api/assistant/actions/dust_app_run";


### PR DESCRIPTION
## Description

Ease the usage of the sync script and setup local env.
You just need to set `DUST_APPS_WORKSPACE_ID` with the workspace sId , and `DUST_PROD_API` with `http://localhost:3000` - the script will synchronize the apps to the local workspace, and front will use local core. No change to any file required.

Note: you need to be authenticated to gcloud cli to run the script 

## Risk

No impact if DUST_APPS_WORKSPACE_ID is not set

## Deploy Plan

deploy `front`