### PR TITLE
Refactor Slack Sharing in Assistant Builder

### DIFF
--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -128,10 +128,12 @@ export function ConnectorPermissionsModal({
                 owner={owner}
                 dataSource={dataSource}
                 canUpdatePermissions={canUpdatePermissions}
-                onPermissionUpdate={({ internalId, permission }) => {
+                onPermissionUpdate={(node, { newPermission }) => {
+                  const { internalId } = node;
+
                   setUpdatedPermissionByInternalId((prev) => ({
                     ...prev,
-                    [internalId]: permission,
+                    [internalId]: newPermission,
                   }));
                 }}
                 showExpand={CONNECTOR_CONFIGURATIONS[connector.type]?.isNested}

--- a/front/components/DataSourceResourceSelectorTree.tsx
+++ b/front/components/DataSourceResourceSelectorTree.tsx
@@ -10,13 +10,12 @@ import type {
   LightContentNode,
   LightWorkspaceType,
 } from "@dust-tt/types";
-import type { ConnectorPermission } from "@dust-tt/types";
 import { useEffect, useState } from "react";
 
 import DataSourceViewDocumentModal from "@app/components/DataSourceViewDocumentModal";
+import { getVisualForContentNode } from "@app/lib/content_nodes";
 import { useVaultDataSourceViewContent } from "@app/lib/swr";
 import { classNames } from "@app/lib/utils";
-import { getVisualForContentNode } from "@app/lib/content_nodes";
 
 export default function DataSourceResourceSelectorTree({
   owner,

--- a/front/components/DataSourceResourceSelectorTree.tsx
+++ b/front/components/DataSourceResourceSelectorTree.tsx
@@ -26,7 +26,6 @@ export default function DataSourceResourceSelectorTree({
   selectedParents = [],
   selectedResourceIds,
   onSelectChange,
-  filterPermission = "read",
   viewType = "documents",
 }: {
   owner: LightWorkspaceType;
@@ -40,7 +39,6 @@ export default function DataSourceResourceSelectorTree({
     parents: string[],
     selected: boolean
   ) => void;
-  filterPermission?: ConnectorPermission;
   viewType?: ContentNodesViewType;
 }) {
   return (
@@ -56,7 +54,6 @@ export default function DataSourceResourceSelectorTree({
         onSelectChange={(resource, parents, selected) => {
           onSelectChange(resource, parents, selected);
         }}
-        filterPermission={filterPermission}
         viewType={viewType}
       />
     </div>
@@ -73,7 +70,6 @@ function DataSourceResourceSelectorChildren({
   showExpand,
   selectedResourceIds,
   onSelectChange,
-  filterPermission,
   viewType = "documents",
 }: {
   owner: LightWorkspaceType;
@@ -89,13 +85,11 @@ function DataSourceResourceSelectorChildren({
     parents: string[],
     selected: boolean
   ) => void;
-  filterPermission: ConnectorPermission;
   viewType: ContentNodesViewType;
 }) {
   const { vaultContent, isVaultContentLoading, isVaultContentError } =
     useVaultDataSourceViewContent({
       dataSourceView: dataSourceView,
-      filterPermission,
       owner,
       parentId,
       vaultId: dataSourceView.vaultId,
@@ -194,7 +188,6 @@ function DataSourceResourceSelectorChildren({
                   onSelectChange={onSelectChange}
                   parents={[...parents, r.internalId]}
                   parentIsSelected={parentIsSelected || isSelected}
-                  filterPermission={filterPermission}
                   viewType={viewType}
                 />
               )}

--- a/front/components/DataSourceResourceSelectorTree.tsx
+++ b/front/components/DataSourceResourceSelectorTree.tsx
@@ -1,7 +1,5 @@
 import {
   BracesIcon,
-  ChatBubbleLeftRightIcon,
-  DocumentTextIcon,
   ExternalLinkIcon,
   IconButton,
   Tree,
@@ -12,8 +10,7 @@ import type {
   LightContentNode,
   LightWorkspaceType,
 } from "@dust-tt/types";
-import type { ConnectorPermission, ContentNodeType } from "@dust-tt/types";
-import { CircleStackIcon, FolderIcon } from "@heroicons/react/20/solid";
+import type { ConnectorPermission } from "@dust-tt/types";
 import { useEffect, useState } from "react";
 
 import DataSourceViewDocumentModal from "@app/components/DataSourceViewDocumentModal";

--- a/front/components/DataSourceResourceSelectorTree.tsx
+++ b/front/components/DataSourceResourceSelectorTree.tsx
@@ -19,6 +19,7 @@ import { useEffect, useState } from "react";
 import DataSourceViewDocumentModal from "@app/components/DataSourceViewDocumentModal";
 import { useVaultDataSourceViewContent } from "@app/lib/swr";
 import { classNames } from "@app/lib/utils";
+import { getVisualForContentNode } from "@app/lib/content_nodes";
 
 export default function DataSourceResourceSelectorTree({
   owner,
@@ -63,29 +64,6 @@ export default function DataSourceResourceSelectorTree({
       />
     </div>
   );
-}
-
-export type IconComponentType =
-  | typeof DocumentTextIcon
-  | typeof FolderIcon
-  | typeof CircleStackIcon
-  | typeof ChatBubbleLeftRightIcon;
-
-function getIconForType(type: ContentNodeType): IconComponentType {
-  switch (type) {
-    case "file":
-      return DocumentTextIcon;
-    case "folder":
-      return FolderIcon;
-    case "database":
-      return CircleStackIcon;
-    case "channel":
-      return ChatBubbleLeftRightIcon;
-    default:
-      ((n: never) => {
-        throw new Error("Unreachable " + n);
-      })(type);
-  }
 }
 
 function DataSourceResourceSelectorChildren({
@@ -178,7 +156,6 @@ function DataSourceResourceSelectorChildren({
             !isSelected &&
             Boolean(selectedParents.find((id) => id === r.internalId));
 
-          const IconComponent = getIconForType(r.type);
           const checkable =
             (!isTablesView || r.type === "database") &&
             r.preventSelection !== true;
@@ -193,7 +170,7 @@ function DataSourceResourceSelectorChildren({
           return (
             <Tree.Item
               key={r.internalId}
-              visual={IconComponent}
+              visual={getVisualForContentNode(r)}
               type={r.expandable && showExpand ? "node" : "leaf"}
               label={r.title}
               className="whitespace-nowrap"

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -78,12 +78,15 @@ export default function AssistantBuilder({
   defaultIsEdited,
   baseUrl,
   defaultTemplate,
+  isAdmin,
 }: AssistantBuilderProps) {
   const { dataSourceViews } = useContext(AssistantBuilderContext);
   const router = useRouter();
   const { mutate } = useSWRConfig();
   const sendNotification = React.useContext(SendNotificationsContext);
-  const slackDataSource = dataSourceViews.find(
+
+  // TODO(GROUPS_INFRA) We should find the slack data source view from the system vault!
+  const slackDataSourceView = dataSourceViews.find(
     (dsv) => dsv.dataSource.connectorProvider === "slack"
   );
   const defaultScope =
@@ -322,7 +325,7 @@ export default function AssistantBuilder({
       });
     } else {
       await mutate(
-        `/api/w/${owner.sId}/data_sources/${slackDataSource?.dataSource.name}/managed/slack/channels_linked_with_agent`
+        `/api/w/${owner.sId}/data_sources/${slackDataSourceView?.dataSource.name}/managed/slack/channels_linked_with_agent`
       );
 
       // Redirect to the assistant list once saved.
@@ -424,13 +427,14 @@ export default function AssistantBuilder({
                 <Tab tabs={tabs} variant="stepper" />
                 <div className="flex flex-row gap-2 self-end pt-0.5">
                   <SharingButton
-                    showSlackIntegration={showSlackIntegration}
-                    slackDataSource={slackDataSource || null}
-                    owner={owner}
                     agentConfigurationId={agentConfigurationId}
                     initialScope={initialBuilderState?.scope ?? defaultScope}
-                    slackChannelSelected={selectedSlackChannels || []}
+                    isAdmin={isAdmin}
                     newScope={builderState.scope}
+                    owner={owner}
+                    showSlackIntegration={showSlackIntegration}
+                    slackChannelSelected={selectedSlackChannels || []}
+                    slackDataSourceView={slackDataSourceView || null}
                     setNewScope={(
                       scope: Exclude<AgentConfigurationScope, "global">
                     ) => {

--- a/front/components/assistant_builder/PickTablesManaged.tsx
+++ b/front/components/assistant_builder/PickTablesManaged.tsx
@@ -45,7 +45,6 @@ export const PickTablesManaged = ({
           selectedParents={[
             ...new Set(Object.values(parentsById || {}).flatMap((c) => [...c])),
           ]}
-          filterPermission="read"
           viewType="tables"
           onSelectChange={(
             resource: LightContentNode,

--- a/front/components/assistant_builder/Sharing.tsx
+++ b/front/components/assistant_builder/Sharing.tsx
@@ -229,6 +229,8 @@ export function SharingButton({
                   <div className="pt-4">
                     <SliderToggle
                       selected={slackChannelSelected.length > 0}
+                      // If not admins, but there are channels selected, prevent from removing.
+                      disabled={slackChannelSelected.length > 0 && !isAdmin}
                       onClick={() => {
                         if (slackChannelSelected.length > 0) {
                           setNewLinkedSlackChannels([]);

--- a/front/components/assistant_builder/Sharing.tsx
+++ b/front/components/assistant_builder/Sharing.tsx
@@ -26,7 +26,10 @@ import { useState } from "react";
 
 import { assistantUsageMessage } from "@app/components/assistant/Usage";
 import type { SlackChannel } from "@app/components/assistant_builder/SlackIntegration";
-import { SlackIntegration } from "@app/components/assistant_builder/SlackIntegration";
+import {
+  SlackAssistantDefaultManager,
+  SlackIntegration,
+} from "@app/components/assistant_builder/SlackIntegration";
 import { useAgentConfiguration, useAgentUsage } from "@app/lib/swr";
 
 type ConfirmationModalDataType = {
@@ -100,29 +103,33 @@ export const SCOPE_INFO: Record<
 
 type NonGlobalScope = Exclude<AgentConfigurationScope, "global">;
 
-export function SharingButton({
-  owner,
-  agentConfigurationId,
-  initialScope,
-  newScope,
-  setNewScope,
-  baseUrl,
-  showSlackIntegration,
-  slackDataSource,
-  slackChannelSelected,
-  setNewLinkedSlackChannels,
-}: {
-  owner: WorkspaceType;
+interface SharingButtonProps {
   agentConfigurationId: string | null;
-  initialScope: NonGlobalScope;
-  newScope: NonGlobalScope;
-  setNewScope: (scope: NonGlobalScope) => void;
   baseUrl: string;
-  showSlackIntegration: boolean;
-  slackDataSource: DataSourceViewType | null;
-  slackChannelSelected: SlackChannel[];
+  initialScope: NonGlobalScope;
+  isAdmin: boolean;
+  newScope: NonGlobalScope;
+  owner: WorkspaceType;
   setNewLinkedSlackChannels: (channels: SlackChannel[]) => void;
-}) {
+  setNewScope: (scope: NonGlobalScope) => void;
+  showSlackIntegration: boolean;
+  slackChannelSelected: SlackChannel[];
+  slackDataSourceView: DataSourceViewType | null;
+}
+
+export function SharingButton({
+  agentConfigurationId,
+  baseUrl,
+  initialScope,
+  isAdmin,
+  newScope,
+  owner,
+  setNewLinkedSlackChannels,
+  setNewScope,
+  showSlackIntegration,
+  slackChannelSelected,
+  slackDataSourceView,
+}: SharingButtonProps) {
   const { agentUsage, isAgentUsageLoading, isAgentUsageError } = useAgentUsage({
     workspaceId: owner.sId,
     agentConfigurationId,
@@ -149,15 +156,16 @@ export function SharingButton({
 
   return (
     <>
-      {slackDataSource && (
-        <SlackIntegrationDrawer
+      {slackDataSourceView && (
+        <SlackAssistantDefaultManager
           existingSelection={slackChannelSelected}
-          slackDataSource={slackDataSource}
+          slackDataSourceView={slackDataSourceView}
           owner={owner}
           onSave={(slackChannels: SlackChannel[]) => {
             setNewLinkedSlackChannels(slackChannels);
           }}
           assistantHandle="@Dust"
+          isAdmin={isAdmin}
           show={slackDrawerOpened}
           onClose={() => setSlackDrawerOpened(false)}
         />
@@ -450,71 +458,5 @@ function ScopeChangeModal({
         <div className="font-bold">Are you sure you want to proceed ?</div>
       </div>
     </Dialog>
-  );
-}
-
-function SlackIntegrationDrawer({
-  slackDataSource,
-  owner,
-  existingSelection,
-  onSave,
-  assistantHandle,
-  show,
-  onClose,
-}: {
-  show: boolean;
-  onClose: () => void;
-  slackDataSource: DataSourceViewType;
-  owner: WorkspaceType;
-  existingSelection: SlackChannel[];
-  onSave: (channels: SlackChannel[]) => void;
-  assistantHandle?: string;
-}) {
-  const [slackIntegrationOpened, setSlackIntegrationOpened] = useState(false);
-  return (
-    <>
-      <SlackIntegration
-        slackDataSource={slackDataSource}
-        owner={owner}
-        existingSelection={existingSelection}
-        onSave={(slackChannels) => {
-          onSave(slackChannels);
-          setSlackIntegrationOpened(false);
-        }}
-        onClose={() => setSlackIntegrationOpened(false)}
-        show={slackIntegrationOpened}
-        assistantHandle={assistantHandle}
-      />
-      <Modal
-        isOpen={show}
-        title={`Slack Integration`}
-        onClose={onClose}
-        hasChanged={false}
-        variant="side-sm"
-      >
-        <div className="pt-8">
-          <Page.Vertical gap="lg" align="stretch">
-            <div className="flex flex-col gap-y-2">
-              <div className="grow text-sm font-medium text-element-800">
-                <SlackLogo className="h-8 w-8" />
-              </div>
-              <div className="text-sm font-normal text-element-900">
-                Set this assistant as the default assistant on one or several of
-                your Slack channels. It will answer by default when the{" "}
-                <span className="font-bold">{assistantHandle}</span> Slack bot
-                is mentionned in these channels.
-              </div>
-              <div className="justify-end pt-2">
-                <Button
-                  hasMagnifying={false}
-                  label="Select channels"
-                  onClick={() => setSlackIntegrationOpened(true)}
-                />
-              </div>
-            </div>
-          </Page.Vertical>
-        </div>
-      </Modal>
-    </>
   );
 }

--- a/front/components/assistant_builder/Sharing.tsx
+++ b/front/components/assistant_builder/Sharing.tsx
@@ -8,10 +8,8 @@ import {
   DustIcon,
   IconButton,
   LockIcon,
-  Modal,
   Page,
   PlanetIcon,
-  SlackLogo,
   SliderToggle,
   UserGroupIcon,
 } from "@dust-tt/sparkle";
@@ -26,10 +24,7 @@ import { useState } from "react";
 
 import { assistantUsageMessage } from "@app/components/assistant/Usage";
 import type { SlackChannel } from "@app/components/assistant_builder/SlackIntegration";
-import {
-  SlackAssistantDefaultManager,
-  SlackIntegration,
-} from "@app/components/assistant_builder/SlackIntegration";
+import { SlackAssistantDefaultManager } from "@app/components/assistant_builder/SlackIntegration";
 import { useAgentConfiguration, useAgentUsage } from "@app/lib/swr";
 
 type ConfirmationModalDataType = {

--- a/front/components/assistant_builder/SlackIntegration.tsx
+++ b/front/components/assistant_builder/SlackIntegration.tsx
@@ -1,39 +1,32 @@
-import "react-image-crop/dist/ReactCrop.css";
-
-import { Modal, Page } from "@dust-tt/sparkle";
-import type { DataSourceViewType, WorkspaceType } from "@dust-tt/types";
-import { useEffect, useState } from "react";
+import { ContentMessage, Modal, Page, SlackLogo } from "@dust-tt/sparkle";
+import type {
+  BaseContentNode,
+  ConnectorPermission,
+  DataSourceViewType,
+  WorkspaceType,
+} from "@dust-tt/types";
+import { useCallback, useEffect, useState } from "react";
 import React from "react";
 
-import DataSourceResourceSelectorTree from "@app/components/DataSourceResourceSelectorTree";
-import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
+import { DataSourcePermissionTreeChildren } from "@app/components/ConnectorPermissionsTree";
+import { useConnectorPermissions } from "@app/lib/swr";
 
 export type SlackChannel = { slackChannelId: string; slackChannelName: string };
 
-export function SlackIntegration({
-  slackDataSource,
-  owner,
-  existingSelection,
-  assistantHandle,
-  show,
-  onSave,
-  onClose,
-}: {
-  slackDataSource: DataSourceViewType;
-  owner: WorkspaceType;
+interface SlacIntegrationProps {
   existingSelection: SlackChannel[];
-  show: boolean;
-  onSave: (channels: SlackChannel[]) => void;
-  onClose: () => void;
-  assistantHandle?: string;
-}) {
+  onSelectionChange: (channels: SlackChannel[]) => void;
+  owner: WorkspaceType;
+  slackDataSourceView: DataSourceViewType;
+}
+
+export function SlackIntegration({
+  existingSelection,
+  onSelectionChange,
+  owner,
+  slackDataSourceView,
+}: SlacIntegrationProps) {
   const [newSelection, setNewSelection] = useState<SlackChannel[] | null>(null);
-
-  const [hasChanged, setHasChanged] = useState(false);
-
-  const selectedChannelIds = [
-    ...new Set(newSelection?.map((c) => c.slackChannelId) ?? []),
-  ];
 
   useEffect(() => {
     if (existingSelection.length > 0 && newSelection === null) {
@@ -41,74 +34,165 @@ export function SlackIntegration({
     }
   }, [existingSelection, newSelection]);
 
-  const save = async () => {
-    if (newSelection) {
-      onSave(newSelection);
+  const customIsNodeChecked = useCallback(
+    (node: BaseContentNode) => {
+      return (
+        newSelection?.some((c) => c.slackChannelId === node.internalId) || false
+      );
+    },
+    [newSelection]
+  );
+
+  const handlePermissionUpdate = useCallback(
+    (
+      node: BaseContentNode,
+      { newPermission }: { newPermission: ConnectorPermission }
+    ) => {
+      const { internalId, title } = node;
+
+      setNewSelection((prevSelection) => {
+        if (!prevSelection) {
+          return [];
+        }
+
+        // Create a copy of the previous selection.
+        const updatedSelection = [...prevSelection];
+
+        // Find the index of the channel in the selection.
+        const index = updatedSelection.findIndex(
+          (channel) => channel.slackChannelId === internalId
+        );
+
+        if (newPermission === "read_write") {
+          // If the channel isn't already in the selection, add it.
+          if (index === -1) {
+            updatedSelection.push({
+              slackChannelId: internalId,
+              slackChannelName: title,
+            });
+          }
+        } else {
+          // If the channel is in the selection, remove it.
+          if (index !== -1) {
+            updatedSelection.splice(index, 1);
+          }
+        }
+
+        return updatedSelection;
+      });
+    },
+    [setNewSelection]
+  );
+
+  // Notify parent component when newSelection changes.
+  useEffect(() => {
+    if (newSelection !== null) {
+      onSelectionChange(newSelection);
     }
+  }, [newSelection, onSelectionChange]);
+
+  return (
+    <DataSourcePermissionTreeChildren
+      owner={owner}
+      dataSource={slackDataSourceView.dataSource}
+      parentId={null}
+      // The "write" permission filter is applied to retrieve all available channels on Slack,
+      // not limited to those synced with Dust.
+      permissionFilter="write"
+      canUpdatePermissions={true}
+      onPermissionUpdate={handlePermissionUpdate}
+      showExpand={false}
+      isSearchEnabled={false}
+      customIsNodeChecked={customIsNodeChecked}
+      useConnectorPermissionsHook={useConnectorPermissions}
+    />
+  );
+}
+
+interface SlackAssistantDefaultManagerProps {
+  assistantHandle?: string;
+  existingSelection: SlackChannel[];
+  isAdmin: boolean;
+  onClose: () => void;
+  onSave: (channels: SlackChannel[]) => void;
+  owner: WorkspaceType;
+  show: boolean;
+  slackDataSourceView: DataSourceViewType;
+}
+
+export function SlackAssistantDefaultManager({
+  assistantHandle,
+  existingSelection,
+  isAdmin,
+  onClose,
+  onSave,
+  owner,
+  show,
+  slackDataSourceView,
+}: SlackAssistantDefaultManagerProps) {
+  const [selectedChannels, setSelectedChannels] =
+    useState<SlackChannel[]>(existingSelection);
+  const [hasChanged, setHasChanged] = useState(false);
+
+  const handleSelectionChange = (newSelection: SlackChannel[]) => {
+    setSelectedChannels(newSelection);
+    setHasChanged(true);
   };
 
-  const assistantName = assistantHandle
-    ? `${assistantHandle}`
-    : "This assistant";
+  const saveChanges = () => {
+    onSave(selectedChannels);
+    setHasChanged(false);
+    onClose();
+  };
 
   return (
     <>
       <Modal
-        isOpen={show}
-        variant="full-screen"
         hasChanged={hasChanged}
+        isOpen={show}
         onClose={onClose}
-        title="Slack bot configuration"
-        onSave={save}
+        onSave={saveChanges}
+        title="Slack Integration"
+        variant="side-sm"
       >
-        <Page>
-          <Page.Header
-            title={"Select Slack channels"}
-            icon={CONNECTOR_CONFIGURATIONS["slack"].logoComponent}
-            description={`Select the channels in which ${assistantName} will answer by default.`}
-          />
-          <DataSourceResourceSelectorTree
-            owner={owner}
-            dataSourceView={slackDataSource}
-            selectedResourceIds={selectedChannelIds}
-            onSelectChange={(node, parents, selected) => {
-              setHasChanged(true);
+        <div className="pt-8">
+          <Page.Vertical gap="lg" align="stretch">
+            <div className="flex flex-col gap-y-2">
+              <div className="grow text-sm font-medium text-element-800">
+                <SlackLogo className="h-8 w-8" />
+              </div>
 
-              if (selected) {
-                setNewSelection((sel) => {
-                  const finalState: SlackChannel[] = [];
-                  if (sel) {
-                    finalState.push(...sel);
-                  }
-                  finalState.push({
-                    slackChannelId: node.internalId,
-                    slackChannelName: node.title,
-                  });
+              <div className="text-sm font-normal text-element-900">
+                Set this assistant as the default assistant on one or several of
+                your Slack channels. It will answer by default when the{" "}
+                <span className="font-bold">{assistantHandle}</span> Slack bot
+                is mentionned in these channels.
+              </div>
 
-                  return finalState;
-                });
-              } else {
-                setNewSelection((sel) => {
-                  const finalState: SlackChannel[] = [];
-                  if (sel) {
-                    finalState.push(...sel);
-                  }
-                  finalState.splice(
-                    finalState.findIndex(
-                      (c) => c.slackChannelId === node.internalId
-                    ),
-                    1
-                  );
-                  return finalState;
-                });
-              }
-            }}
-            showExpand={false}
-            // Write are the channels we're in. Builders can get write but cannot get "none"
-            // (reserved to admins).
-            filterPermission="write"
-          />
-        </Page>
+              {!isAdmin && (
+                <ContentMessage
+                  size="md"
+                  variant="pink"
+                  title="Admin Access Required"
+                >
+                  <p>
+                    Only administrators can enable default assistants for
+                    specific Slack channels.
+                  </p>
+                </ContentMessage>
+              )}
+
+              {isAdmin && (
+                <SlackIntegration
+                  existingSelection={existingSelection}
+                  onSelectionChange={handleSelectionChange}
+                  owner={owner}
+                  slackDataSourceView={slackDataSourceView}
+                />
+              )}
+            </div>
+          </Page.Vertical>
+        </div>
       </Modal>
     </>
   );

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -312,16 +312,17 @@ export const BUILDER_FLOWS = [
 export type BuilderFlow = (typeof BUILDER_FLOWS)[number];
 
 export type AssistantBuilderProps = {
-  owner: WorkspaceType;
-  subscription: SubscriptionType;
-  plan: PlanType;
+  agentConfigurationId: string | null;
+  baseUrl: string;
+  defaultIsEdited?: boolean;
+  defaultTemplate: FetchAssistantTemplateResponse | null;
+  flow: BuilderFlow;
   gaTrackingId: string;
   initialBuilderState: AssistantBuilderInitialState | null;
-  agentConfigurationId: string | null;
-  flow: BuilderFlow;
-  defaultIsEdited?: boolean;
-  baseUrl: string;
-  defaultTemplate: FetchAssistantTemplateResponse | null;
+  isAdmin: boolean;
+  owner: WorkspaceType;
+  plan: PlanType;
+  subscription: SubscriptionType;
 };
 
 export const BUILDER_SCREENS = {

--- a/front/components/assistant_builder/useSlackChannels.tsx
+++ b/front/components/assistant_builder/useSlackChannels.tsx
@@ -4,23 +4,25 @@ import { useEffect, useState } from "react";
 import type { SlackChannel } from "@app/components/assistant_builder/SlackIntegration";
 import { useSlackChannelsLinkedWithAgent } from "@app/lib/swr";
 
-export function useSlackChannel({
-  dataSourceViews,
-  initialChannels,
-  workspaceId,
-  isPrivateAssistant,
-  isBuilder,
-  isEdited,
-  agentConfigurationId,
-}: {
+interface useSlackChannelProps {
+  agentConfigurationId: string | null;
   dataSourceViews: DataSourceViewType[];
   initialChannels: SlackChannel[];
-  workspaceId: string;
-  isPrivateAssistant: boolean;
   isBuilder: boolean;
   isEdited: boolean;
-  agentConfigurationId: string | null;
-}) {
+  isPrivateAssistant: boolean;
+  workspaceId: string;
+}
+
+export function useSlackChannel({
+  agentConfigurationId,
+  dataSourceViews,
+  initialChannels,
+  isBuilder,
+  isEdited,
+  isPrivateAssistant,
+  workspaceId,
+}: useSlackChannelProps) {
   // This state stores the slack channels that should have the current agent as default.
   const [selectedSlackChannels, setSelectedSlackChannels] =
     useState<SlackChannel[]>(initialChannels);

--- a/front/components/poke/PokeConnectorPermissionsTree.tsx
+++ b/front/components/poke/PokeConnectorPermissionsTree.tsx
@@ -12,7 +12,6 @@ export function PokePermissionTree({
   dataSource,
   permissionFilter,
   canUpdatePermissions,
-  onPermissionUpdate,
   showExpand,
   displayDocumentSource,
 }: {
@@ -20,13 +19,6 @@ export function PokePermissionTree({
   dataSource: DataSourceType;
   permissionFilter?: ConnectorPermission;
   canUpdatePermissions?: boolean;
-  onPermissionUpdate?: ({
-    internalId,
-    permission,
-  }: {
-    internalId: string;
-    permission: ConnectorPermission;
-  }) => void;
   showExpand?: boolean;
   displayDocumentSource: (documentId: string) => void;
 }) {
@@ -38,7 +30,6 @@ export function PokePermissionTree({
         parentId={null}
         permissionFilter={permissionFilter}
         canUpdatePermissions={canUpdatePermissions}
-        onPermissionUpdate={onPermissionUpdate}
         showExpand={showExpand}
         parentIsSelected={false}
         displayDocumentSource={displayDocumentSource}

--- a/front/components/vaults/VaultDataSourceViewContentList.tsx
+++ b/front/components/vaults/VaultDataSourceViewContentList.tsx
@@ -85,7 +85,6 @@ export const VaultDataSourceViewContentList = ({
     mutateVaultDataSourceViewContent,
   } = useVaultDataSourceViewContent({
     dataSourceView,
-    filterPermission: "read",
     owner,
     parentId,
     vaultId: vault.sId,

--- a/front/lib/content_nodes.ts
+++ b/front/lib/content_nodes.ts
@@ -1,5 +1,6 @@
 import {
   ChatBubbleBottomCenterTextIcon,
+  ChatBubbleLeftRightIcon,
   DocumentTextIcon,
   FolderIcon,
   Square3Stack3DIcon,
@@ -10,7 +11,7 @@ import { assertNever } from "@dust-tt/types";
 export function getVisualForContentNode(node: ContentNode | LightContentNode) {
   switch (node.type) {
     case "channel":
-      return ChatBubbleBottomCenterTextIcon;
+      return ChatBubbleLeftRightIcon;
 
     case "database":
       return Square3Stack3DIcon;

--- a/front/lib/content_nodes.ts
+++ b/front/lib/content_nodes.ts
@@ -1,5 +1,4 @@
 import {
-  ChatBubbleBottomCenterTextIcon,
   ChatBubbleLeftRightIcon,
   DocumentTextIcon,
   FolderIcon,

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -1509,7 +1509,6 @@ export function useVaultDataSourceViews({
 export function useVaultDataSourceViewContent({
   dataSourceView,
   disabled,
-  filterPermission,
   owner,
   parentId,
   vaultId,
@@ -1517,7 +1516,6 @@ export function useVaultDataSourceViewContent({
 }: {
   dataSourceView: DataSourceViewType;
   disabled?: boolean;
-  filterPermission: ConnectorPermission;
   owner: LightWorkspaceType;
   parentId?: string;
   vaultId: string;
@@ -1525,14 +1523,19 @@ export function useVaultDataSourceViewContent({
 }) {
   const vaultsDataSourcesFetcher: Fetcher<GetDataSourceViewContentResponseBody> =
     fetcher;
-  const qs =
-    `?viewType=${viewType}` +
-    `&filterPermission=${filterPermission}` +
-    (parentId ? `&parentId=${parentId}` : "");
+
+  const queryParams = new URLSearchParams({
+    viewType,
+  });
+
+  if (parentId) {
+    queryParams.set("parentId", parentId);
+  }
+
   const { data, error, mutate } = useSWRWithDefaults(
     disabled
       ? null
-      : `/api/w/${owner.sId}/vaults/${vaultId}/data_source_views/${dataSourceView.sId}/content${qs}`,
+      : `/api/w/${owner.sId}/vaults/${vaultId}/data_source_views/${dataSourceView.sId}/content${queryParams.toString()}`,
     vaultsDataSourcesFetcher
   );
 

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/content.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/content.ts
@@ -11,6 +11,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { apiError } from "@app/logger/withlogging";
 
+// TODO(2024-08-29 flav) Remove `filterPermission` from here once front-end is updated.
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
@@ -26,8 +27,7 @@ async function handler(
   if (
     !dataSourceView ||
     req.query.vId !== dataSourceView.vault.sId ||
-    (!auth.isAdmin() &&
-      !auth.hasPermission([dataSourceView.vault.acl()], "read"))
+    !dataSourceView.canRead(auth)
   ) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -25,16 +25,17 @@ import config from "@app/lib/api/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
-  owner: WorkspaceType;
-  subscription: SubscriptionType;
-  plan: PlanType;
-  gaTrackingId: string;
-  dataSourceViews: DataSourceViewType[];
-  dustApps: AppType[];
   actions: AssistantBuilderInitialState["actions"];
   agentConfiguration: AgentConfigurationType;
-  flow: BuilderFlow;
   baseUrl: string;
+  dataSourceViews: DataSourceViewType[];
+  dustApps: AppType[];
+  flow: BuilderFlow;
+  gaTrackingId: string;
+  isAdmin: boolean;
+  owner: WorkspaceType;
+  plan: PlanType;
+  subscription: SubscriptionType;
 }>(async (context, auth) => {
   const owner = auth.workspace();
   const plan = auth.plan();
@@ -74,37 +75,41 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     ? (context.query.flow as BuilderFlow)
     : "personal_assistants";
 
+  const actions = await buildInitialActions({
+    dataSourceViews,
+    dustApps,
+    configuration,
+  });
+
   return {
     props: {
+      actions,
+      agentConfiguration: configuration,
+      baseUrl: config.getClientFacingUrl(),
+      dataSourceViews,
+      dustApps,
+      flow,
+      gaTrackingId: config.getGaTrackingId(),
+      isAdmin: auth.isAdmin(),
       owner,
       plan,
       subscription,
-      gaTrackingId: config.getGaTrackingId(),
-      dataSourceViews,
-      dustApps,
-      actions: await buildInitialActions({
-        dataSourceViews,
-        dustApps,
-        configuration,
-      }),
-      agentConfiguration: configuration,
-      flow,
-      baseUrl: config.getClientFacingUrl(),
     },
   };
 });
 
 export default function EditAssistant({
-  owner,
-  subscription,
-  plan,
-  gaTrackingId,
-  dataSourceViews,
-  dustApps,
   actions,
   agentConfiguration,
-  flow,
   baseUrl,
+  dataSourceViews,
+  dustApps,
+  flow,
+  gaTrackingId,
+  isAdmin,
+  owner,
+  plan,
+  subscription,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   throwIfInvalidAgentConfiguration(agentConfiguration);
 
@@ -147,6 +152,7 @@ export default function EditAssistant({
         }}
         agentConfigurationId={agentConfiguration.sId}
         baseUrl={baseUrl}
+        isAdmin={isAdmin}
         defaultTemplate={null}
       />
     </AssistantBuilderProvider>

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -39,6 +39,7 @@ function getDuplicateAndTemplateIdFromQuery(query: ParsedUrlQuery) {
 }
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
+  isAdmin: boolean;
   owner: WorkspaceType;
   subscription: SubscriptionType;
   plan: PlanType;
@@ -111,32 +112,34 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
 
   return {
     props: {
+      actions,
+      agentConfiguration: configuration,
+      baseUrl: config.getClientFacingUrl(),
+      dataSourceViews,
+      dustApps,
+      flow,
+      gaTrackingId: config.getGaTrackingId(),
+      isAdmin: auth.isAdmin(),
       owner,
       plan,
       subscription,
-      gaTrackingId: config.getGaTrackingId(),
-      dataSourceViews,
-      dustApps,
-      actions,
-      agentConfiguration: configuration,
-      flow,
-      baseUrl: config.getClientFacingUrl(),
       templateId,
     },
   };
 });
 
 export default function CreateAssistant({
-  owner,
-  subscription,
-  plan,
-  gaTrackingId,
-  dataSourceViews,
-  dustApps,
   actions,
   agentConfiguration,
-  flow,
   baseUrl,
+  dataSourceViews,
+  dustApps,
+  flow,
+  gaTrackingId,
+  isAdmin,
+  owner,
+  plan,
+  subscription,
   templateId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const { assistantTemplate } = useAssistantTemplate({
@@ -194,6 +197,7 @@ export default function CreateAssistant({
             : null
         }
         agentConfigurationId={null}
+        isAdmin={isAdmin}
         defaultIsEdited={true}
         baseUrl={baseUrl}
         defaultTemplate={assistantTemplate}

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -78,8 +78,7 @@ export type ContentNodeType = "file" | "folder" | "database" | "channel";
  * information. More details here:
  * https://www.notion.so/dust-tt/Design-Doc-Microsoft-ids-parents-c27726652aae45abafaac587b971a41d?pvs=4
  */
-export type ContentNode = {
-  provider: ConnectorProvider;
+export interface BaseContentNode {
   internalId: string;
   // The direct parent ID of this content node
   parentInternalId: string | null;
@@ -92,6 +91,10 @@ export type ContentNode = {
   permission: ConnectorPermission;
   dustDocumentId: string | null;
   lastUpdatedAt: number | null;
+}
+
+export type ContentNode = BaseContentNode & {
+  provider: ConnectorProvider;
 };
 
 export type ContentNodeWithParentIds = ContentNode & {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes https://github.com/dust-tt/dust/issues/6977.

In the assistant builder, the sharing menu allows you to set an assistant as the default when `@dust` is mentioned in Slack channels. When data source views were introduced, this part was mistakenly moved to the data source view, which shouldn't have happened. We want to allow setting an assistant as the default for Slack channels not integrated with Dust, meaning using data source view endpoints won't work. Instead, we need to retrieve the `write` permissions from connectors.

This PR addresses this issue by removing the last exception where data source views were used inappropriately. This change requires some heavy refactoring. Now, only Admins can set an assistant as the default for specific Slack channels. More product thinking is necessary, but this PR mainly focuses on ensuring consistent use of the Data source view concept.

With this PR, we are moving towards exclusively using `PermissionTree` related components for accessing the connector permission tree, while all other instances will rely on `DataSourceViewSelector`. These two components will share most of the logic.

I deliberately took the opportunity to remove one extra modal from the Slack list of channels it now looks like this:

<img width="446" alt="image" src="https://github.com/user-attachments/assets/2d16c259-555c-4406-a18b-09cc3b75f748">

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
In the worst-case scenario, this change might disrupt the trees displayed in `AssistantDetails`, some assistant actions in the builder, and the connection screens of managed data sources. It is safe to roll back if needed.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
