### PR TITLE
Vault: Add Providers & API Keys page on Admin menu

### DIFF
--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -6,6 +6,7 @@ import {
   CommandLineIcon,
   DocumentTextIcon,
   FolderOpenIcon,
+  LockIcon,
   PlanetIcon,
   PuzzleIcon,
   QuestionMarkCircleIcon,
@@ -45,7 +46,12 @@ export type SubNavigationAssistantsId =
   | "community"
   | "vaults";
 
-export type SubNavigationAdminId = "subscription" | "workspace" | "members";
+export type SubNavigationAdminId =
+  | "subscription"
+  | "workspace"
+  | "members"
+  | "providers"
+  | "api_keys";
 
 export type SubNavigationAppId =
   | "specification"
@@ -326,6 +332,34 @@ export const subNavigationAdmin = ({
         },
       ],
     });
+
+    if (owner.flags.includes("data_vaults_feature")) {
+      nav.push({
+        id: "developers",
+        label: "Developers",
+        variant: "secondary",
+        menus: [
+          {
+            id: "providers",
+            label: "Providers",
+            icon: ShapesIcon,
+            href: `/w/${owner.sId}/developers/providers`,
+            current: current === "providers",
+            subMenuLabel: current === "providers" ? subMenuLabel : undefined,
+            subMenu: current === "providers" ? subMenu : undefined,
+          },
+          {
+            id: "api_keys",
+            label: "API Keys",
+            icon: LockIcon,
+            href: `/w/${owner.sId}/developers/api-keys`,
+            current: current === "api_keys",
+            subMenuLabel: current === "api_keys" ? subMenuLabel : undefined,
+            subMenu: current === "api_keys" ? subMenu : undefined,
+          },
+        ],
+      });
+    }
   }
 
   return nav;

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -601,6 +601,18 @@ export class Authenticator {
     return this._subscription;
   }
 
+  getNonNullableSubscription(): SubscriptionType {
+    const subscription = this.subscription();
+
+    if (!subscription) {
+      throw new Error(
+        "Unexpected unauthenticated call to `getNonNullableSubscription`."
+      );
+    }
+
+    return subscription;
+  }
+
   plan(): PlanType | null {
     return this._subscription ? this._subscription.plan : null;
   }

--- a/front/pages/api/w/[wId]/keys/[id]/disable.ts
+++ b/front/pages/api/w/[wId]/keys/[id]/disable.ts
@@ -15,18 +15,27 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<PostKeysResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isBuilder()) {
+  const owner = auth.getNonNullableWorkspace();
+
+  // With Vaults we're moving API Keys management to the Admin role.
+  const isVaultsFeatureEnabled = owner.flags.includes("data_vaults_feature");
+  const hasValidRole = isVaultsFeatureEnabled
+    ? auth.isAdmin()
+    : auth.isBuilder();
+
+  if (!hasValidRole) {
+    const errorMessage = isVaultsFeatureEnabled
+      ? "Only the users that are `admins` for the current workspace can disable a key."
+      : "Only the users that are `builders` for the current workspace can disable a key.";
+
     return apiError(req, res, {
       status_code: 403,
       api_error: {
         type: "app_auth_error",
-        message:
-          "Only the users that are `builders` for the current workspace can disable a key.",
+        message: errorMessage,
       },
     });
   }
-
-  const owner = auth.getNonNullableWorkspace();
 
   const { id } = req.query;
   if (typeof id !== "string") {

--- a/front/pages/api/w/[wId]/keys/index.ts
+++ b/front/pages/api/w/[wId]/keys/index.ts
@@ -30,19 +30,26 @@ async function handler(
   auth: Authenticator
 ): Promise<void> {
   const user = auth.getNonNullableUser();
+  const owner = auth.getNonNullableWorkspace();
 
-  if (!auth.isBuilder()) {
+  // With Vaults we're moving API keys management to the Admin role.
+  const isVaultsFeatureEnabled = owner.flags.includes("data_vaults_feature");
+  const hasValidRole = isVaultsFeatureEnabled
+    ? auth.isAdmin()
+    : auth.isBuilder();
+
+  if (!hasValidRole) {
+    const errorMessage = isVaultsFeatureEnabled
+      ? "Only the users that are `admins` for the current workspace can interact with keys"
+      : "Only the users that are `builders` for the current workspace can interact with keys.";
     return apiError(req, res, {
       status_code: 403,
       api_error: {
         type: "app_auth_error",
-        message:
-          "Only the users that are `builders` for the current workspace can interact with keys.",
+        message: errorMessage,
       },
     });
   }
-
-  const owner = auth.getNonNullableWorkspace();
 
   switch (req.method) {
     case "GET":

--- a/front/pages/api/w/[wId]/providers/[pId]/index.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/index.ts
@@ -23,18 +23,27 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isBuilder()) {
+  const owner = auth.getNonNullableWorkspace();
+
+  // With Vaults we're moving Providers management to the Admin role.
+  const isVaultsFeatureEnabled = owner.flags.includes("data_vaults_feature");
+  const hasValidRole = isVaultsFeatureEnabled
+    ? auth.isAdmin()
+    : auth.isBuilder();
+
+  if (!hasValidRole) {
+    const errorMessage = isVaultsFeatureEnabled
+      ? "Only the users that are `admins` for the current workspace can configure providers."
+      : "Only the users that are `builders` for the current workspace can configure providers.";
+
     return apiError(req, res, {
       status_code: 403,
       api_error: {
         type: "provider_auth_error",
-        message:
-          "Only the users that are `builders` for the current workspace can configure providers.",
+        message: errorMessage,
       },
     });
   }
-
-  const owner = auth.getNonNullableWorkspace();
 
   let [provider] = await Promise.all([
     Provider.findOne({

--- a/front/pages/api/w/[wId]/providers/index.ts
+++ b/front/pages/api/w/[wId]/providers/index.ts
@@ -25,18 +25,27 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<GetProvidersResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isBuilder()) {
+  const owner = auth.getNonNullableWorkspace();
+
+  // With Vaults we're moving Providers management to the Admin role.
+  const isVaultsFeatureEnabled = owner.flags.includes("data_vaults_feature");
+  const hasValidRole = isVaultsFeatureEnabled
+    ? auth.isAdmin()
+    : auth.isBuilder();
+
+  if (!hasValidRole) {
+    const errorMessage = isVaultsFeatureEnabled
+      ? "Only the users that are `admins` for the current workspace can list providers."
+      : "Only the users that are `builders` for the current workspace can list providers.";
+
     return apiError(req, res, {
       status_code: 403,
       api_error: {
         type: "provider_auth_error",
-        message:
-          "Only the users that are `builders` for the current workspace can list providers.",
+        message: errorMessage,
       },
     });
   }
-
-  const owner = auth.getNonNullableWorkspace();
 
   switch (req.method) {
     case "GET":

--- a/front/pages/w/[wId]/a/index.tsx
+++ b/front/pages/w/[wId]/a/index.tsx
@@ -538,7 +538,7 @@ export function Providers({ owner }: { owner: WorkspaceType }) {
       <>
         <Page.SectionHeader
           title="Model Providers"
-          description="Model providers available to your apps. These providers are not required to run our assistant apps, only your own custom large language model apps."
+          description="Model providers available to your apps."
         />
         <ul role="list" className="pt-4">
           {filteredProviders.map((provider) => (

--- a/front/pages/w/[wId]/a/index.tsx
+++ b/front/pages/w/[wId]/a/index.tsx
@@ -538,7 +538,7 @@ export function Providers({ owner }: { owner: WorkspaceType }) {
       <>
         <Page.SectionHeader
           title="Model Providers"
-          description="Model providers available to your apps."
+          description="Model providers available to your Dust apps."
         />
         <ul role="list" className="pt-4">
           {filteredProviders.map((provider) => (
@@ -617,7 +617,7 @@ export function Providers({ owner }: { owner: WorkspaceType }) {
 
         <Page.SectionHeader
           title="Service Providers"
-          description="Service providers enable your apps to query external data or write to&nbsp;external&nbsp;services."
+          description="Service providers enable your Dust Apps to query external data or write to&nbsp;external&nbsp;services."
         />
 
         <ul role="list" className="pt-4">

--- a/front/pages/w/[wId]/developers/api-keys.tsx
+++ b/front/pages/w/[wId]/developers/api-keys.tsx
@@ -1,0 +1,69 @@
+import { Page, ShapesIcon } from "@dust-tt/sparkle";
+import type { GroupType, UserType, WorkspaceType } from "@dust-tt/types";
+import type { SubscriptionType } from "@dust-tt/types";
+import type { InferGetServerSidePropsType } from "next";
+import React from "react";
+
+import { subNavigationAdmin } from "@app/components/navigation/config";
+import AppLayout from "@app/components/sparkle/AppLayout";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+import { APIKeys } from "@app/pages/w/[wId]/a";
+
+const { GA_TRACKING_ID = "" } = process.env;
+
+export const getServerSideProps = withDefaultUserAuthRequirements<{
+  owner: WorkspaceType;
+  subscription: SubscriptionType;
+  groups: GroupType[];
+  user: UserType;
+  gaTrackingId: string;
+}>(async (context, auth) => {
+  const owner = auth.workspace();
+  const subscription = auth.subscription();
+  const user = auth.user();
+  if (!owner || !auth.isAdmin() || !subscription || !user) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const groups = await auth.groups();
+
+  return {
+    props: {
+      owner,
+      groups,
+      subscription,
+      gaTrackingId: GA_TRACKING_ID,
+      user,
+    },
+  };
+});
+
+export default function APIKeysPage({
+  owner,
+  subscription,
+  groups,
+  gaTrackingId,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  return (
+    <AppLayout
+      subscription={subscription}
+      owner={owner}
+      gaTrackingId={gaTrackingId}
+      subNavigation={subNavigationAdmin({ owner, current: "api_keys" })}
+    >
+      <Page.Vertical gap="xl" align="stretch">
+        <Page.Header
+          title="API Keys"
+          icon={ShapesIcon}
+          description="Manage your API Keys. API Keys allows you to securely connect to Dust from other applications and work with your data."
+        />
+        <Page.Vertical align="stretch" gap="md">
+          <APIKeys owner={owner} groups={groups} />
+        </Page.Vertical>
+      </Page.Vertical>
+      <div className="h-12" />
+    </AppLayout>
+  );
+}

--- a/front/pages/w/[wId]/developers/api-keys.tsx
+++ b/front/pages/w/[wId]/developers/api-keys.tsx
@@ -6,10 +6,9 @@ import React from "react";
 
 import { subNavigationAdmin } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
+import config from "@app/lib/api/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { APIKeys } from "@app/pages/w/[wId]/a";
-
-const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
@@ -18,10 +17,10 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   user: UserType;
   gaTrackingId: string;
 }>(async (context, auth) => {
-  const owner = auth.workspace();
-  const subscription = auth.subscription();
-  const user = auth.user();
-  if (!owner || !auth.isAdmin() || !subscription || !user) {
+  const owner = auth.getNonNullableWorkspace();
+  const subscription = auth.getNonNullableSubscription();
+  const user = auth.getNonNullableUser();
+  if (!auth.isAdmin()) {
     return {
       notFound: true,
     };
@@ -34,7 +33,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       owner,
       groups,
       subscription,
-      gaTrackingId: GA_TRACKING_ID,
+      gaTrackingId: config.getGaTrackingId(),
       user,
     },
   };

--- a/front/pages/w/[wId]/developers/providers.tsx
+++ b/front/pages/w/[wId]/developers/providers.tsx
@@ -1,0 +1,64 @@
+import { Page, ShapesIcon } from "@dust-tt/sparkle";
+import type { UserType, WorkspaceType } from "@dust-tt/types";
+import type { SubscriptionType } from "@dust-tt/types";
+import type { InferGetServerSidePropsType } from "next";
+import React from "react";
+
+import { subNavigationAdmin } from "@app/components/navigation/config";
+import AppLayout from "@app/components/sparkle/AppLayout";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+import { Providers } from "@app/pages/w/[wId]/a";
+
+const { GA_TRACKING_ID = "" } = process.env;
+
+export const getServerSideProps = withDefaultUserAuthRequirements<{
+  owner: WorkspaceType;
+  subscription: SubscriptionType;
+  user: UserType;
+  gaTrackingId: string;
+}>(async (context, auth) => {
+  const owner = auth.workspace();
+  const subscription = auth.subscription();
+  const user = auth.user();
+  if (!owner || !auth.isAdmin() || !subscription || !user) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      owner,
+      subscription,
+      gaTrackingId: GA_TRACKING_ID,
+      user,
+    },
+  };
+});
+
+export default function ProvidersPage({
+  owner,
+  subscription,
+  gaTrackingId,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  return (
+    <AppLayout
+      subscription={subscription}
+      owner={owner}
+      gaTrackingId={gaTrackingId}
+      subNavigation={subNavigationAdmin({ owner, current: "providers" })}
+    >
+      <Page.Vertical gap="xl" align="stretch">
+        <Page.Header
+          title="Providers"
+          icon={ShapesIcon}
+          description="Configure model and service providers to enable advanced capabilities in your Apps. Note: These providers are not used by Dust assistants at all, but are required for running your own custom Dust Apps."
+        />
+        <Page.Vertical align="stretch" gap="md">
+          <Providers owner={owner} />
+        </Page.Vertical>
+      </Page.Vertical>
+      <div className="h-12" />
+    </AppLayout>
+  );
+}

--- a/front/pages/w/[wId]/developers/providers.tsx
+++ b/front/pages/w/[wId]/developers/providers.tsx
@@ -6,10 +6,9 @@ import React from "react";
 
 import { subNavigationAdmin } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
+import config from "@app/lib/api/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { Providers } from "@app/pages/w/[wId]/a";
-
-const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
@@ -17,10 +16,10 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   user: UserType;
   gaTrackingId: string;
 }>(async (context, auth) => {
-  const owner = auth.workspace();
-  const subscription = auth.subscription();
-  const user = auth.user();
-  if (!owner || !auth.isAdmin() || !subscription || !user) {
+  const owner = auth.getNonNullableWorkspace();
+  const subscription = auth.getNonNullableSubscription();
+  const user = auth.getNonNullableUser();
+  if (!auth.isAdmin()) {
     return {
       notFound: true,
     };
@@ -30,7 +29,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     props: {
       owner,
       subscription,
-      gaTrackingId: GA_TRACKING_ID,
+      gaTrackingId: config.getGaTrackingId(),
       user,
     },
   };


### PR DESCRIPTION
## Description

If Vault is activated, we're adding 2 pages on the admin menu to manage Providers & API Keys. 
They will be manageable by admins only, while before it was accessible for Builders.
The API routes to CRUD those resources have been edited to restrict to admin if Vault feature is activated. 

<kbd>
<img width="393" alt="Screenshot 2024-08-30 at 11 01 00" src="https://github.com/user-attachments/assets/fdcbefd5-b4ad-492d-bc16-419966af8ebf">
</kbd>


## Risk

Can be rolled back. 

## Deploy Plan

Deploy.
