### PR TITLE
Fetch GaTrackingId through config object

### DIFF
--- a/front/pages/login-error.tsx
+++ b/front/pages/login-error.tsx
@@ -8,9 +8,8 @@ import {
 import type { InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 
+import config from "@app/lib/api/config";
 import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";
-
-const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
   requireUserPrivilege: "none",
@@ -22,7 +21,7 @@ export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
   return {
     props: {
       domain: (context.query.domain as string) ?? null,
-      gaTrackingId: GA_TRACKING_ID,
+      gaTrackingId: config.getGaTrackingId(),
       reason: (context.query.reason as string) ?? null,
     },
   };

--- a/front/pages/w/[wId]/a/[aId]/clone.tsx
+++ b/front/pages/w/[wId]/a/[aId]/clone.tsx
@@ -21,12 +21,11 @@ import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import WorkspacePicker from "@app/components/WorkspacePicker";
 import { getApp } from "@app/lib/api/app";
+import config from "@app/lib/api/config";
 import { getUserFromSession } from "@app/lib/iam/session";
 import { withDefaultUserAuthRequirementsNoWorkspaceCheck } from "@app/lib/iam/session";
 import { classNames } from "@app/lib/utils";
 import { getDustAppsListUrl } from "@app/lib/vault_rollout";
-
-const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps =
   withDefaultUserAuthRequirementsNoWorkspaceCheck<{
@@ -72,7 +71,7 @@ export const getServerSideProps =
         subscription,
         app,
         dustAppsListUrl,
-        gaTrackingId: GA_TRACKING_ID,
+        gaTrackingId: config.getGaTrackingId(),
       },
     };
   });

--- a/front/pages/w/[wId]/a/[aId]/datasets/[name]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/[name]/index.tsx
@@ -17,12 +17,11 @@ import {
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { getApp } from "@app/lib/api/app";
+import config from "@app/lib/api/config";
 import { getDatasetHash, getDatasetSchema } from "@app/lib/api/datasets";
 import { useRegisterUnloadHandlers } from "@app/lib/front";
 import { withDefaultUserAuthRequirementsNoWorkspaceCheck } from "@app/lib/iam/session";
 import { getDustAppsListUrl } from "@app/lib/vault_rollout";
-
-const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps =
   withDefaultUserAuthRequirementsNoWorkspaceCheck<{
@@ -79,7 +78,7 @@ export const getServerSideProps =
         dataset,
         schema,
         dustAppsListUrl,
-        gaTrackingId: GA_TRACKING_ID,
+        gaTrackingId: config.getGaTrackingId(),
       },
     };
   });

--- a/front/pages/w/[wId]/a/[aId]/datasets/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/index.tsx
@@ -16,12 +16,11 @@ import {
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { getApp } from "@app/lib/api/app";
+import config from "@app/lib/api/config";
 import { getDatasets } from "@app/lib/api/datasets";
 import { withDefaultUserAuthRequirementsNoWorkspaceCheck } from "@app/lib/iam/session";
 import { classNames } from "@app/lib/utils";
 import { getDustAppsListUrl } from "@app/lib/vault_rollout";
-
-const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps =
   withDefaultUserAuthRequirementsNoWorkspaceCheck<{
@@ -63,7 +62,7 @@ export const getServerSideProps =
         app,
         datasets,
         dustAppsListUrl,
-        gaTrackingId: GA_TRACKING_ID,
+        gaTrackingId: config.getGaTrackingId(),
       },
     };
   });

--- a/front/pages/w/[wId]/a/[aId]/datasets/new.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/new.tsx
@@ -17,12 +17,11 @@ import {
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { getApp } from "@app/lib/api/app";
+import config from "@app/lib/api/config";
 import { getDatasets } from "@app/lib/api/datasets";
 import { useRegisterUnloadHandlers } from "@app/lib/front";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { getDustAppsListUrl } from "@app/lib/vault_rollout";
-
-const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
@@ -59,7 +58,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       app,
       datasets,
       dustAppsListUrl,
-      gaTrackingId: GA_TRACKING_ID,
+      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });

--- a/front/pages/w/[wId]/a/[aId]/runs/[runId]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/runs/[runId]/index.tsx
@@ -17,11 +17,10 @@ import {
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { getApp } from "@app/lib/api/app";
+import config from "@app/lib/api/config";
 import { getRun } from "@app/lib/api/run";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { getDustAppsListUrl } from "@app/lib/vault_rollout";
-
-const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
@@ -70,7 +69,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       spec,
       run,
       dustAppsListUrl,
-      gaTrackingId: GA_TRACKING_ID,
+      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });

--- a/front/pages/w/[wId]/a/[aId]/runs/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/runs/index.tsx
@@ -15,12 +15,11 @@ import {
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { getApp } from "@app/lib/api/app";
+import config from "@app/lib/api/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useRuns } from "@app/lib/swr";
 import { classNames, timeAgoFrom } from "@app/lib/utils";
 import { getDustAppsListUrl } from "@app/lib/vault_rollout";
-
-const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
@@ -63,7 +62,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       app,
       wIdTarget,
       dustAppsListUrl,
-      gaTrackingId: GA_TRACKING_ID,
+      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });

--- a/front/pages/w/[wId]/a/[aId]/settings.tsx
+++ b/front/pages/w/[wId]/a/[aId]/settings.tsx
@@ -17,11 +17,10 @@ import {
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { getApp } from "@app/lib/api/app";
+import config from "@app/lib/api/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { classNames, MODELS_STRING_MAX_LENGTH } from "@app/lib/utils";
 import { getDustAppsListUrl } from "@app/lib/vault_rollout";
-
-const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
@@ -63,7 +62,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       subscription,
       app,
       dustAppsListUrl,
-      gaTrackingId: GA_TRACKING_ID,
+      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });

--- a/front/pages/w/[wId]/a/[aId]/specification.tsx
+++ b/front/pages/w/[wId]/a/[aId]/specification.tsx
@@ -17,8 +17,6 @@ import { dumpSpecification } from "@app/lib/specification";
 import { getDustAppsListUrl } from "@app/lib/vault_rollout";
 import logger from "@app/logger/logger";
 
-const { GA_TRACKING_ID = "" } = process.env;
-
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
@@ -77,7 +75,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       app,
       specification: spec,
       dustAppsListUrl,
-      gaTrackingId: GA_TRACKING_ID,
+      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });

--- a/front/pages/w/[wId]/a/index.tsx
+++ b/front/pages/w/[wId]/a/index.tsx
@@ -38,6 +38,7 @@ import SerperSetup from "@app/components/providers/SerperSetup";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { getApps } from "@app/lib/api/app";
+import config from "@app/lib/api/config";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import {
@@ -47,8 +48,6 @@ import {
 } from "@app/lib/providers";
 import { useDustAppSecrets, useKeys, useProviders } from "@app/lib/swr";
 import { classNames, timeAgoFrom } from "@app/lib/utils";
-
-const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
@@ -75,7 +74,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       groups,
       subscription,
       apps,
-      gaTrackingId: GA_TRACKING_ID,
+      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });

--- a/front/pages/w/[wId]/a/new.tsx
+++ b/front/pages/w/[wId]/a/new.tsx
@@ -10,11 +10,10 @@ import React, { useCallback, useEffect, useState } from "react";
 
 import { subNavigationBuild } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
+import config from "@app/lib/api/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { classNames, MODELS_STRING_MAX_LENGTH } from "@app/lib/utils";
 import { getDustAppsListUrl } from "@app/lib/vault_rollout";
-
-const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
@@ -38,7 +37,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       owner,
       subscription,
       dustAppsListUrl,
-      gaTrackingId: GA_TRACKING_ID,
+      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });

--- a/front/pages/w/[wId]/builder/assistants/dust.tsx
+++ b/front/pages/w/[wId]/builder/assistants/dust.tsx
@@ -22,12 +22,11 @@ import { subNavigationBuild } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
+import config from "@app/lib/api/config";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useAgentConfigurations, useDataSources } from "@app/lib/swr";
-
-const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
@@ -47,7 +46,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     props: {
       owner,
       subscription,
-      gaTrackingId: GA_TRACKING_ID,
+      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -31,11 +31,10 @@ import { SCOPE_INFO } from "@app/components/assistant_builder/Sharing";
 import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
 import { subNavigationBuild } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
+import config from "@app/lib/api/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useAgentConfigurations } from "@app/lib/swr";
 import { classNames, subFilter } from "@app/lib/utils";
-
-const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
@@ -61,7 +60,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       owner,
       tabScope,
       subscription,
-      gaTrackingId: GA_TRACKING_ID,
+      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });

--- a/front/pages/w/[wId]/builder/data-sources/[name]/edit-public-url.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/edit-public-url.tsx
@@ -14,8 +14,6 @@ import { getDataSource, getDataSources } from "@app/lib/api/data_sources";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import logger from "@app/logger/logger";
 
-const { GA_TRACKING_ID = "" } = process.env;
-
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
@@ -74,7 +72,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       dataSource,
       webCrawlerConfiguration: connectorRes.value
         .configuration as WebCrawlerConfigurationType,
-      gaTrackingId: GA_TRACKING_ID,
+      gaTrackingId: config.getGaTrackingId(),
       dataSourceUsage: dataSourceUsageRes.isOk() ? dataSourceUsageRes.value : 0,
     },
   };

--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -62,8 +62,6 @@ import logger from "@app/logger/logger";
 
 import { setupConnection } from "../managed";
 
-const { GA_TRACKING_ID = "" } = process.env;
-
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
@@ -133,7 +131,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       connector,
       standardView,
       dustClientFacingUrl: config.getClientFacingUrl(),
-      gaTrackingId: GA_TRACKING_ID,
+      gaTrackingId: config.getGaTrackingId(),
       user,
     },
   };

--- a/front/pages/w/[wId]/builder/data-sources/[name]/search.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/search.tsx
@@ -12,12 +12,11 @@ import { useEffect, useState } from "react";
 import { subNavigationBuild } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
+import config from "@app/lib/api/config";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { getDisplayNameForDocument } from "@app/lib/data_sources";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { classNames, timeAgoFrom } from "@app/lib/utils";
-
-const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
@@ -46,7 +45,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       owner,
       subscription,
       dataSource,
-      gaTrackingId: GA_TRACKING_ID,
+      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });

--- a/front/pages/w/[wId]/builder/data-sources/[name]/settings.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/settings.tsx
@@ -17,11 +17,10 @@ import { subNavigationBuild } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleSaveCancelTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { getDataSourceUsage } from "@app/lib/api/agent_data_sources";
+import config from "@app/lib/api/config";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { classNames } from "@app/lib/utils";
-
-const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
@@ -59,7 +58,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       owner,
       subscription,
       dataSource,
-      gaTrackingId: GA_TRACKING_ID,
+      gaTrackingId: config.getGaTrackingId(),
       dataSourceUsage: dataSourceUsageRes.isOk() ? dataSourceUsageRes.value : 0,
     },
   };

--- a/front/pages/w/[wId]/builder/data-sources/[name]/tables/upsert.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/tables/upsert.tsx
@@ -24,14 +24,13 @@ import { subNavigationBuild } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleSaveCancelTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
+import config from "@app/lib/api/config";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { handleFileUploadToText } from "@app/lib/client/handle_file_upload";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useTable } from "@app/lib/swr";
 import { classNames } from "@app/lib/utils";
 import type { UpsertTableFromCsvRequestBody } from "@app/pages/api/w/[wId]/data_sources/[name]/tables/csv";
-
-const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
@@ -69,7 +68,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       readOnly,
       dataSource,
       loadTableId: (context.query.tableId || null) as string | null,
-      gaTrackingId: GA_TRACKING_ID,
+      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });

--- a/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
@@ -23,12 +23,11 @@ import { subNavigationBuild } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleSaveCancelTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
+import config from "@app/lib/api/config";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { handleFileUploadToText } from "@app/lib/client/handle_file_upload";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { classNames } from "@app/lib/utils";
-
-const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
@@ -67,7 +66,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       readOnly,
       dataSource,
       loadDocumentId: (context.query.documentId || null) as string | null,
-      gaTrackingId: GA_TRACKING_ID,
+      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -49,8 +49,6 @@ import { isManaged } from "@app/lib/data_sources";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { classNames } from "@app/lib/utils";
 
-const { GA_TRACKING_ID = "" } = process.env;
-
 type DataSourceWithConnectorAndUsageType =
   DataSourceWithConnectorDetailsType & {
     usage: number | null;
@@ -203,7 +201,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       managedDataSources,
       integrations,
       plan,
-      gaTrackingId: GA_TRACKING_ID,
+      gaTrackingId: config.getGaTrackingId(),
       dustClientFacingUrl: config.getClientFacingUrl(),
     },
   };

--- a/front/pages/w/[wId]/builder/data-sources/new-public-url.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/new-public-url.tsx
@@ -6,10 +6,9 @@ import type {
 import type { InferGetServerSidePropsType } from "next";
 
 import WebsiteConfiguration from "@app/components/data_source/WebsiteConfiguration";
+import config from "@app/lib/api/config";
 import { getDataSources } from "@app/lib/api/data_sources";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
-
-const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
@@ -33,7 +32,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       owner,
       subscription,
       dataSources,
-      gaTrackingId: GA_TRACKING_ID,
+      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });

--- a/front/pages/w/[wId]/builder/data-sources/new.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/new.tsx
@@ -11,11 +11,10 @@ import { useCallback, useEffect, useState } from "react";
 import { subNavigationBuild } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleSaveCancelTitle } from "@app/components/sparkle/AppLayoutTitle";
+import config from "@app/lib/api/config";
 import { getDataSources } from "@app/lib/api/data_sources";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { classNames } from "@app/lib/utils";
-
-const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
@@ -39,7 +38,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       owner,
       subscription,
       dataSources,
-      gaTrackingId: GA_TRACKING_ID,
+      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });

--- a/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
@@ -36,8 +36,6 @@ import { isWebsite } from "@app/lib/data_sources";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import logger from "@app/logger/logger";
 
-const { GA_TRACKING_ID = "" } = process.env;
-
 type DataSourceWithConnector = DataSourceType & {
   connector: ConnectorType;
 };
@@ -124,7 +122,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       plan,
       readOnly,
       dataSources,
-      gaTrackingId: GA_TRACKING_ID,
+      gaTrackingId: config.getGaTrackingId(),
       dataSourcesUsage,
     },
   };

--- a/front/pages/w/[wId]/builder/data-sources/static.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/static.tsx
@@ -27,11 +27,10 @@ import { subNavigationBuild } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import type { DataSourcesUsageByAgent } from "@app/lib/api/agent_data_sources";
 import { getDataSourcesUsageByAgents } from "@app/lib/api/agent_data_sources";
+import config from "@app/lib/api/config";
 import { getDataSources } from "@app/lib/api/data_sources";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
-
-const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
@@ -67,7 +66,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       plan,
       readOnly,
       dataSources,
-      gaTrackingId: GA_TRACKING_ID,
+      gaTrackingId: config.getGaTrackingId(),
       dataSourcesUsage,
     },
   };

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -51,8 +51,6 @@ import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { getPerSeatSubscriptionPricing } from "@app/lib/plans/subscription";
 import { useMembers } from "@app/lib/swr";
 
-const { GA_TRACKING_ID = "" } = process.env;
-
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   user: UserType;
   owner: WorkspaceType;
@@ -95,7 +93,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       perSeatPricing,
       enterpriseConnectionStrategyDetails,
       plan,
-      gaTrackingId: GA_TRACKING_ID,
+      gaTrackingId: config.getGaTrackingId(),
       workspaceHasAvailableSeats,
       workspaceVerifiedDomain,
     },

--- a/front/pages/w/[wId]/subscribe.tsx
+++ b/front/pages/w/[wId]/subscribe.tsx
@@ -9,12 +9,11 @@ import { ProPlansTable } from "@app/components/plans/ProPlansTable";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { UserMenu } from "@app/components/UserMenu";
 import WorkspacePicker from "@app/components/WorkspacePicker";
+import config from "@app/lib/api/config";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { withDefaultUserAuthPaywallWhitelisted } from "@app/lib/iam/session";
 import { useUser, useWorkspaceSubscriptions } from "@app/lib/swr";
 import { ClientSideTracking } from "@app/lib/tracking/client";
-
-const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
   owner: WorkspaceType;
@@ -32,7 +31,7 @@ export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
     props: {
       owner,
       isAdmin: auth.isAdmin(),
-      gaTrackingId: GA_TRACKING_ID,
+      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -26,6 +26,7 @@ import { PricePlans } from "@app/components/plans/PlansTables";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { SubscriptionContactUsDrawer } from "@app/components/SubscriptionContactUsDrawer";
+import config from "@app/lib/api/config";
 import { getPriceAsString } from "@app/lib/client/subscription";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
@@ -38,8 +39,6 @@ import { getStripeSubscription } from "@app/lib/plans/stripe";
 import { getPerSeatSubscriptionPricing } from "@app/lib/plans/subscription";
 import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
 import type { PatchSubscriptionRequestBody } from "@app/pages/api/w/[wId]/subscriptions";
-
-const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
@@ -86,7 +85,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       owner,
       subscription,
       trialDaysRemaining,
-      gaTrackingId: GA_TRACKING_ID,
+      gaTrackingId: config.getGaTrackingId(),
       user,
       workspaceSeats,
       perSeatPricing,

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -9,9 +9,8 @@ import AppLayout from "@app/components/sparkle/AppLayout";
 import { ActivityReport } from "@app/components/workspace/ActivityReport";
 import { QuickInsights } from "@app/components/workspace/Analytics";
 import { ProviderManagementModal } from "@app/components/workspace/ProviderManagementModal";
+import config from "@app/lib/api/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
-
-const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
@@ -30,7 +29,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     props: {
       owner,
       subscription,
-      gaTrackingId: GA_TRACKING_ID,
+      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });


### PR DESCRIPTION
## Description

Go through config object to get the GA tracking ID required for AppLayout. 
https://github.com/dust-tt/dust/pull/7018#discussion_r1738542771

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
