### PR TITLE
[Sparkle] Breadcrumbs: tooltip of long names should be below not above

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.215",
+  "version": "0.2.216",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.215",
+      "version": "0.2.216",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.215",
+  "version": "0.2.216",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/Breadcrumbs.tsx
+++ b/sparkle/src/components/Breadcrumbs.tsx
@@ -110,7 +110,10 @@ function getLinkForItem(
 
 function truncateWithTooltip(text: string, length: number) {
   return text.length > length ? (
-    <Tooltip label={text}>{`${text.substring(0, length - 1)}…`}</Tooltip>
+    <Tooltip
+      label={text}
+      position="below"
+    >{`${text.substring(0, length - 1)}…`}</Tooltip>
   ) : (
     text
   );


### PR DESCRIPTION
Description
---
Avoids this
![image](https://github.com/user-attachments/assets/454a8e73-4da3-468d-9099-a0e6a7f67cba)

Risk
---
na

Deploy
---
publish sparkle

