### PR TITLE
migration to experiment with notion gc check

### DIFF
--- a/front/migrations/20240830_check_no_undeleted_documents.ts
+++ b/front/migrations/20240830_check_no_undeleted_documents.ts
@@ -1,0 +1,140 @@
+import { QueryTypes } from "sequelize";
+
+import {
+  getConnectorReplicaDbConnection,
+  getCoreReplicaDbConnection,
+} from "@app/lib/production_checks/utils";
+import { getFrontReplicaDbConnection } from "@app/lib/resources/storage";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+
+type DataSource = {
+  id: number;
+  connectorId: string;
+  dustAPIProjectId: number;
+  name: string;
+};
+
+async function checkCoreDeleted(
+  {
+    dataSource,
+    knownDocumentIds,
+  }: { dataSource: DataSource; knownDocumentIds: Set<string> },
+  logger: Logger
+) {
+  const coreReplica = getCoreReplicaDbConnection();
+  const coreDataSource: { id: number }[] = await coreReplica.query(
+    `SELECT id FROM data_sources WHERE "project" = :dustAPIProjectId AND data_source_id = :dataSourceId LIMIT 1`,
+    {
+      replacements: {
+        dustAPIProjectId: dataSource.dustAPIProjectId,
+        dataSourceId: dataSource.name,
+      },
+      type: QueryTypes.SELECT,
+    }
+  );
+
+  const coreDocuments: { id: number; document_id: string }[] =
+    await coreReplica.query(
+      "SELECT id, document_id FROM data_sources_documents WHERE data_source = :dataSourceId AND status = 'latest'",
+      {
+        replacements: {
+          dataSourceId: coreDataSource[0].id,
+        },
+        type: QueryTypes.SELECT,
+      }
+    );
+
+  logger.info(
+    {
+      coreDocumentsCount: coreDocuments.length,
+      knownDocumentsCount: knownDocumentIds.size,
+      dataSourceId: dataSource.id,
+    },
+    `Garbage collect check`
+  );
+
+  const notDeleted = coreDocuments.filter((d) => {
+    !knownDocumentIds.has(d.document_id);
+  });
+  if (notDeleted.length > 0) {
+    logger.error(
+      {
+        notDeleted,
+        connectorId: dataSource.connectorId,
+        dataSourceId: dataSource.id,
+      },
+      `Found undeleted documents GoogleDrive`
+    );
+  }
+}
+
+async function checkGoogleDriveDeleted(logger: Logger) {
+  const connectorsReplica = getConnectorReplicaDbConnection();
+  const frontReplica = getFrontReplicaDbConnection();
+
+  const gDriveDataSources: DataSource[] = await frontReplica.query(
+    `SELECT id, "connectorId", "dustAPIProjectId", "name" FROM data_sources WHERE "connectorProvider" = 'google_drive'`,
+    { type: QueryTypes.SELECT }
+  );
+
+  for (const ds of gDriveDataSources) {
+    // Retrieve a batch of 1024 documents from the
+
+    const connectorDocuments: { id: number; dustFileId: string }[] =
+      await connectorsReplica.query(
+        'SELECT id, "dustFileId" FROM google_drive_files WHERE "connectorId" = :connectorId AND "mimeType" <> \'application/vnd.google-apps.folder\'',
+        {
+          replacements: {
+            connectorId: ds.connectorId,
+          },
+          type: QueryTypes.SELECT,
+        }
+      );
+    const knownDocumentIds = new Set(
+      connectorDocuments.map((d) => d.dustFileId)
+    );
+
+    await checkCoreDeleted({ dataSource: ds, knownDocumentIds }, logger);
+  }
+}
+
+async function checkNotionDeleted(logger: Logger) {
+  const connectorsReplica = getConnectorReplicaDbConnection();
+  const frontReplica = getFrontReplicaDbConnection();
+
+  const notionDataSources: {
+    id: number;
+    connectorId: string;
+    dustAPIProjectId: number;
+    name: string;
+  }[] = await frontReplica.query(
+    `SELECT id, "connectorId", "dustAPIProjectId", "name" FROM data_sources WHERE "connectorProvider" = 'notion'`,
+    { type: QueryTypes.SELECT }
+  );
+
+  for (const ds of notionDataSources) {
+    // Retrieve a batch of 1024 documents from the
+
+    const connectorDocuments: { id: number; notionPageId: string }[] =
+      await connectorsReplica.query(
+        'SELECT id, "notionPageId" FROM notion_pages WHERE "connectorId" = :connectorId',
+        {
+          replacements: {
+            connectorId: ds.connectorId,
+          },
+          type: QueryTypes.SELECT,
+        }
+      );
+    const knownDocumentIds = new Set(
+      connectorDocuments.map((d) => `notion-${d.notionPageId}`)
+    );
+
+    await checkCoreDeleted({ dataSource: ds, knownDocumentIds }, logger);
+  }
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  await checkGoogleDriveDeleted(logger);
+  await checkNotionDeleted(logger);
+});


### PR DESCRIPTION
## Description

Goal is to have a base migration file to experiment with the resources required to check that we don't have un-deleted Notion documents (to extend and improve the check we have today for google drive only).

Contrarily to the existing check we only use secondary replicas here instead of core API which removes any potential impact on production. See: https://github.com/dust-tt/dust/blob/main/front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts

Assuming this runs properly in production I'll work toward improving and extending the existing check + adding other platforms.

Context: https://github.com/dust-tt/tasks/issues/1026

## Risk

N/A

## Deploy Plan

- deploy `prodbox` 