### PR TITLE
Rework top menu for vault

### DIFF
--- a/front/components/assistant/AssistantBrowser.tsx
+++ b/front/components/assistant/AssistantBrowser.tsx
@@ -26,6 +26,7 @@ import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/
 
 interface AssistantListProps {
   owner: WorkspaceType;
+  isBuilder: boolean;
   agents: LightAgentConfigurationType[];
   loadingStatus: "loading" | "finished";
   handleAssistantClick: (agent: LightAgentConfigurationType) => void;
@@ -46,6 +47,7 @@ type TabId = (typeof ALL_AGENTS_TABS)[number]["id"];
 
 export function AssistantBrowser({
   owner,
+  isBuilder,
   agents,
   loadingStatus,
   handleAssistantClick,
@@ -133,7 +135,7 @@ export function AssistantBrowser({
                 <Button
                   variant="primary"
                   icon={PlusIcon}
-                  label="Create an Assistant"
+                  label="Create"
                   size="sm"
                 />
               </div>
@@ -141,7 +143,7 @@ export function AssistantBrowser({
                 <Button
                   variant="primary"
                   icon={PlusIcon}
-                  label="Create an Assistant"
+                  label="Create"
                   labelVisible={false}
                   size="sm"
                   className="sm:hidden"
@@ -149,6 +151,18 @@ export function AssistantBrowser({
               </div>
             </Link>
           </Tooltip>
+          {isBuilder && (
+            <Tooltip label="Manage assistants">
+              <Link href={`/w/${owner.sId}/builder/assistants/`}>
+                <Button
+                  variant="primary"
+                  icon={RobotIcon}
+                  label="Manage"
+                  size="sm"
+                />
+              </Link>
+            </Tooltip>
+          )}
         </Button.List>
       </div>
 

--- a/front/components/assistant/conversation/AssistantBrowserContainer.tsx
+++ b/front/components/assistant/conversation/AssistantBrowserContainer.tsx
@@ -12,12 +12,14 @@ import { classNames } from "@app/lib/utils";
 interface AssistantBrowserContainerProps {
   onAgentConfigurationClick: (agentId: string) => void;
   owner: WorkspaceType;
+  isBuilder: boolean;
   setAssistantToMention: (agent: LightAgentConfigurationType) => void;
 }
 
 export function AssistantBrowserContainer({
   onAgentConfigurationClick,
   owner,
+  isBuilder,
   setAssistantToMention,
 }: AssistantBrowserContainerProps) {
   const { agentConfigurations, isLoading, mutateAgentConfigurations } =
@@ -68,6 +70,7 @@ export function AssistantBrowserContainer({
       </div>
       <AssistantBrowser
         owner={owner}
+        isBuilder={isBuilder}
         agents={agentConfigurations}
         loadingStatus={isLoading ? "loading" : "finished"}
         handleAssistantClick={handleAssistantClick}

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -41,6 +41,7 @@ interface ConversationContainerProps {
   owner: WorkspaceType;
   subscription: SubscriptionType;
   user: UserType;
+  isBuilder: boolean;
   agentIdToMention: string | null;
 }
 
@@ -49,6 +50,7 @@ export function ConversationContainer({
   owner,
   subscription,
   user,
+  isBuilder,
   agentIdToMention,
 }: ConversationContainerProps) {
   const [activeConversationId, setActiveConversationId] =
@@ -316,6 +318,7 @@ export function ConversationContainer({
             assistantToMention.current = assistant;
           }}
           owner={owner}
+          isBuilder={isBuilder}
         />
       </Transition>
 

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -120,7 +120,7 @@ export const getTopNavigationTabs = (owner: WorkspaceType) => {
       ),
   });
 
-  if (isBuilder(owner)) {
+  if (isBuilder(owner) && !owner.flags.includes("data_vaults_feature")) {
     nav.push({
       id: "assistants",
       label: "Build",

--- a/front/pages/w/[wId]/assistant/[cId]/index.tsx
+++ b/front/pages/w/[wId]/assistant/[cId]/index.tsx
@@ -17,6 +17,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     // Here, override conversationId.
     conversationId: string | null;
     user: UserType;
+    isBuilder: boolean;
   }
 >(async (context, auth) => {
   const owner = auth.workspace();
@@ -48,6 +49,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
   return {
     props: {
       user,
+      isBuilder: auth.isBuilder(),
       owner,
       subscription,
       baseUrl: config.getClientFacingUrl(),
@@ -62,6 +64,7 @@ export default function AssistantConversation({
   owner,
   subscription,
   user,
+  isBuilder,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [conversationKey, setConversationKey] = useState<string | null>(null);
   const [agentIdToMention, setAgentIdToMention] = useState<string | null>(null);
@@ -123,6 +126,7 @@ export default function AssistantConversation({
       owner={owner}
       subscription={subscription}
       user={user}
+      isBuilder={isBuilder}
       agentIdToMention={agentIdToMention}
     />
   );


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/1215 (Figma screenshot in card).
- Add a new button "Manage Assistant" on the Chat home page: we display it for all builder (no matter if vault activated or not). 
- Display either "Build" or "Datasource" menu depending on wether the Vault feature is activated. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
