### PR TITLE
Upg: immediately remove the conversation for the list when deleted to avoid UI glitch

### DIFF
--- a/front/components/assistant/conversation/ConversationLayout.tsx
+++ b/front/components/assistant/conversation/ConversationLayout.tsx
@@ -1,8 +1,4 @@
-import type {
-  ConversationType,
-  SubscriptionType,
-  WorkspaceType,
-} from "@dust-tt/types";
+import type { SubscriptionType, WorkspaceType } from "@dust-tt/types";
 import { useRouter } from "next/router";
 import React, { useCallback, useContext, useEffect, useState } from "react";
 
@@ -118,8 +114,7 @@ export default function ConversationLayout({
           ...prevState,
           conversations:
             prevState?.conversations.filter(
-              (conversation: ConversationType) =>
-                conversation.sId !== conversationId
+              (conversation) => conversation.sId !== conversationId
             ) ?? [],
         };
       });

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -29,7 +29,7 @@ export function ConversationTitle({
   owner: WorkspaceType;
   conversation: ConversationType;
   shareLink: string;
-  onDelete?: () => void;
+  onDelete?: (conversationId: string) => void;
 }) {
   const { mutate } = useSWRConfig();
 
@@ -86,7 +86,7 @@ export function ConversationTitle({
           onClose={() => setShowDeleteDialog(false)}
           onDelete={() => {
             setShowDeleteDialog(false);
-            onDelete();
+            onDelete(conversation.sId);
           }}
         />
       )}

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1,5 +1,8 @@
 import { Button, ChatBubbleBottomCenterPlusIcon, Item } from "@dust-tt/sparkle";
-import type { ConversationWithoutContentType } from "@dust-tt/types";
+import type {
+  ConversationType,
+  ConversationWithoutContentType,
+} from "@dust-tt/types";
 import type { WorkspaceType } from "@dust-tt/types";
 import { isOnlyUser } from "@dust-tt/types";
 import moment from "moment";
@@ -9,16 +12,21 @@ import React, { useContext } from "react";
 
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { SidebarContext } from "@app/components/sparkle/AppLayout";
-import { useConversations } from "@app/lib/swr";
 import { classNames } from "@app/lib/utils";
 
-export function AssistantSidebarMenu({ owner }: { owner: WorkspaceType }) {
+type AssistantSidebarMenuProps = {
+  owner: WorkspaceType;
+  conversations: ConversationType[];
+  isConversationsError: boolean;
+};
+
+export function AssistantSidebarMenu({
+  owner,
+  conversations,
+  isConversationsError,
+}: AssistantSidebarMenuProps) {
   const router = useRouter();
   const { setSidebarOpen } = useContext(SidebarContext);
-  const { conversations, isConversationsLoading, isConversationsError } =
-    useConversations({
-      workspaceId: owner.sId,
-    });
 
   const groupConversationsByDate = (
     conversations: ConversationWithoutContentType[]
@@ -58,10 +66,9 @@ export function AssistantSidebarMenu({ owner }: { owner: WorkspaceType }) {
     return groups;
   };
 
-  const conversationsByDate =
-    !isConversationsLoading && conversations.length
-      ? groupConversationsByDate(conversations)
-      : {};
+  const conversationsByDate = conversations.length
+    ? groupConversationsByDate(conversations)
+    : {};
 
   const { setAnimate } = useContext(InputBarContext);
 

--- a/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
+++ b/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
@@ -31,6 +31,7 @@ import type { LabsTranscriptsConfigurationResource } from "@app/lib/resources/la
 import { VaultResource } from "@app/lib/resources/vault_resource";
 import {
   useAgentConfigurations,
+  useConversations,
   useLabsTranscriptsConfiguration,
 } from "@app/lib/swr";
 import type { PatchTranscriptsConfiguration } from "@app/pages/api/w/[wId]/labs/transcripts/[tId]";
@@ -110,6 +111,10 @@ export default function LabsTranscriptsIndex({
     isTranscriptsConfigurationLoading,
     mutateTranscriptsConfiguration,
   } = useLabsTranscriptsConfiguration({ workspaceId: owner.sId });
+
+  const { conversations, isConversationsError } = useConversations({
+    workspaceId: owner.sId,
+  });
 
   const [transcriptsConfigurationState, setTranscriptsConfigurationState] =
     useState<{
@@ -454,7 +459,13 @@ export default function LabsTranscriptsIndex({
       owner={owner}
       gaTrackingId={gaTrackingId}
       pageTitle="Dust - Transcripts processing"
-      navChildren={<AssistantSidebarMenu owner={owner} />}
+      navChildren={
+        <AssistantSidebarMenu
+          owner={owner}
+          conversations={conversations}
+          isConversationsError={isConversationsError}
+        />
+      }
     >
       <Dialog
         isOpen={isDeleteProviderDialogOpened}


### PR DESCRIPTION
## Description

Deleting a conversation was not immediately reflected in the UI because we had to wait for swr to refresh the list.
Fixed by moving the conversations list one layer up and immediately mutating the conversations list when a conversation is deleted.

## Risk

None

## Deploy Plan

Deploy `front`