### PR TITLE
Use key auth object on conversation's related public endpoints

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -865,7 +865,10 @@ export async function* postUserMessage(
 
   // TODO(2024-08-30 flav) Remove once debugging is done.
   const groups = auth.groups();
-  if (groups.length === 1 && groups[0].kind === "system") {
+  if (
+    groups.length === 0 ||
+    (groups.length === 1 && groups[0].kind === "system")
+  ) {
     logger.info(
       {
         agentMessages: {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
In our quest to enforce strict permission checks during registry lookups, there are still some requests that lack the correct permissions. This pull request updates the conversation-related endpoints of the public API to use the key authenticator. 

The logic can be a bit complex, but here's a breakdown:
The `Authenticator.fromKey` method generates two `Authenticator` objects:
- one representing the current workspace ID from the URL (`workspaceAuth`)
- and another representing the key permissions (`keyAuth`). With the recent introduction of groups, `workspaceAuth` does not contain any groups.

All groups are embedded within `keyAuth`. We need to use `workspaceAuth` to verify that the key has access to the current workspace (`/w/[wId]/`). Once this access is confirmed for those endpoints, we should leverage the groups contained in `keyAuth`.

I'm considering a more explicit pattern for the Authenticator to make this clearer. In the meantime, this approach should work and ensure the proper use of groups.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
