### PR TITLE
[Vaults] Fix: filterAndCropContentNodesByView parents computation

### DIFF
--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -18,14 +18,22 @@ export function filterAndCropContentNodesByView(
       return null;
     }
 
-    // We stop at the first parent that is in the view.
+    // At the first parent that is in the view, we know the content node is in the view
     const indexToSplit = parentInternalIds.findIndex((p) =>
       dataSourceView.parentsIn?.includes(p)
     );
     const isInView = !viewHasParents || indexToSplit !== -1;
 
     if (isInView) {
-      const parentIdsInView = parentInternalIds.slice(0, indexToSplit);
+      // for parents, we include all those up to the last one in the view
+      // (or all of them if the view has no parents)
+      const lastParentInViewIndex = parentInternalIds.findLastIndex((p) =>
+        dataSourceView.parentsIn?.includes(p)
+      );
+
+      const parentIdsInView = !viewHasParents
+        ? parentInternalIds
+        : parentInternalIds.slice(0, lastParentInViewIndex + 1);
 
       return {
         ...node,

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -18,11 +18,11 @@ export function filterAndCropContentNodesByView(
       return null;
     }
 
-    // check that the node or at least a parent is in the view we know the
-    // content node is in the view
-    // for parents, we include all those up to the last one in the view
-    // (or all of them if the view has no parents)
-
+    // Ensure that the node, or at least one of its ancestors, is within the
+    // view. For parentInternalIds, include all of them  up to the highest one
+    // in the hierarchy that is in the view, (which is last index, since parents
+    // are ordered from leaf to root), or all of them  if the view is "full",
+    // that is,  parentsIn is null.
     const indexToSplit = parentInternalIds.findLastIndex((p) =>
       dataSourceView.parentsIn?.includes(p)
     );

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -18,22 +18,20 @@ export function filterAndCropContentNodesByView(
       return null;
     }
 
-    // At the first parent that is in the view, we know the content node is in the view
-    const indexToSplit = parentInternalIds.findIndex((p) =>
+    // check that the node or at least a parent is in the view we know the
+    // content node is in the view
+    // for parents, we include all those up to the last one in the view
+    // (or all of them if the view has no parents)
+
+    const indexToSplit = parentInternalIds.findLastIndex((p) =>
       dataSourceView.parentsIn?.includes(p)
     );
     const isInView = !viewHasParents || indexToSplit !== -1;
 
     if (isInView) {
-      // for parents, we include all those up to the last one in the view
-      // (or all of them if the view has no parents)
-      const lastParentInViewIndex = parentInternalIds.findLastIndex((p) =>
-        dataSourceView.parentsIn?.includes(p)
-      );
-
       const parentIdsInView = !viewHasParents
         ? parentInternalIds
-        : parentInternalIds.slice(0, lastParentInViewIndex + 1);
+        : parentInternalIds.slice(0, indexToSplit + 1);
 
       return {
         ...node,


### PR DESCRIPTION
Description
---
Former version of `filterAndCropContentNodesByView` correctly excluded nodes, but incorrectly filtered parentsInternalIds: some parents that were in the view were excluded from it

This PR fixes it

Risk
---
na

Deploy
---
front
