### PR TITLE
Use Authenticator's groups in doc tracker

### DIFF
--- a/front/lib/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
+++ b/front/lib/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
@@ -233,7 +233,7 @@ export async function documentTrackerSuggestChangesOnUpsert({
     "Calling doc tracker retrieval action."
   );
   const retrievalResult = await callDocTrackerRetrievalAction(
-    owner,
+    auth,
     diffText,
     targetDocumentTokens
   );
@@ -276,7 +276,7 @@ export async function documentTrackerSuggestChangesOnUpsert({
   localLogger.info({ score }, "Calling doc tracker suggest changes action.");
 
   const suggestChangesResult = await callDocTrackerSuggestChangesAction(
-    owner,
+    auth,
     diffText,
     top1.chunks.map((c) => c.text).join("\n-------\n")
   );


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of https://github.com/dust-tt/dust/pull/7035.

Looking at the recent logs, it looks like only doc tracker remains without the right permissions to access data from a data source view. This PR. ensures it uses the builder's authenticator permissions (the global group).

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Worst case it breaks doc tracker. Pretty low risk. Safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
