### PR TITLE
Group datasources when there are too many

### DIFF
--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -4,7 +4,7 @@ import type {
   WorkspaceType,
 } from "@dust-tt/types";
 import type { SetStateAction } from "react";
-import { useContext, useState } from "react";
+import { useCallback, useContext, useState } from "react";
 
 import { AssistantBuilderContext } from "@app/components/assistant_builder/AssistantBuilderContext";
 import { useNavigationLock } from "@app/components/assistant_builder/useNavigationLock";
@@ -38,6 +38,14 @@ export default function AssistantBuilderDataSourceModal({
     validation: "primaryWarning",
   });
 
+  const setSelectionConfigurationsCallback = useCallback(
+    () => (func: SetStateAction<DataSourceViewSelectionConfigurations>) => {
+      setHasChanged(true);
+      setSelectionConfigurations(func);
+    },
+    [setSelectionConfigurations]
+  );
+
   return (
     <Modal
       isOpen={isOpen}
@@ -58,12 +66,7 @@ export default function AssistantBuilderDataSourceModal({
           owner={owner}
           dataSourceViews={dataSourceViews}
           selectionConfigurations={selectionConfigurations}
-          setSelectionConfigurations={(
-            func: SetStateAction<DataSourceViewSelectionConfigurations>
-          ) => {
-            setHasChanged(true);
-            setSelectionConfigurations(func);
-          }}
+          setSelectionConfigurations={setSelectionConfigurationsCallback}
         />
       </div>
     </Modal>

--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -3,14 +3,12 @@ import type {
   DataSourceViewSelectionConfigurations,
   WorkspaceType,
 } from "@dust-tt/types";
-import { defaultSelectionConfiguration } from "@dust-tt/types";
 import type { SetStateAction } from "react";
 import { useContext, useState } from "react";
 
 import { AssistantBuilderContext } from "@app/components/assistant_builder/AssistantBuilderContext";
 import { useNavigationLock } from "@app/components/assistant_builder/useNavigationLock";
-import { DataSourceViewSelector } from "@app/components/data_source_view/DataSourceViewSelector";
-import { orderDatasourceViewByImportance } from "@app/lib/assistant";
+import { DataSourceViewsSelector } from "@app/components/data_source_view/DataSourceViewSelector";
 
 export default function AssistantBuilderDataSourceModal({
   isOpen,
@@ -56,24 +54,17 @@ export default function AssistantBuilderDataSourceModal({
       title="Manage data sources selection"
     >
       <div className="w-full pt-12">
-        {orderDatasourceViewByImportance(dataSourceViews).map(
-          (dataSourceView) => (
-            <DataSourceViewSelector
-              key={dataSourceView.sId}
-              owner={owner}
-              selectionConfiguration={
-                selectionConfigurations[dataSourceView.sId] ??
-                defaultSelectionConfiguration(dataSourceView)
-              }
-              setSelectionConfigurations={(
-                func: SetStateAction<DataSourceViewSelectionConfigurations>
-              ) => {
-                setHasChanged(true);
-                setSelectionConfigurations(func);
-              }}
-            />
-          )
-        )}
+        <DataSourceViewsSelector
+          owner={owner}
+          dataSourceViews={dataSourceViews}
+          selectionConfigurations={selectionConfigurations}
+          setSelectionConfigurations={(
+            func: SetStateAction<DataSourceViewSelectionConfigurations>
+          ) => {
+            setHasChanged(true);
+            setSelectionConfigurations(func);
+          }}
+        />
       </div>
     </Modal>
   );

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -1,7 +1,13 @@
-import { FolderIcon, Tree } from "@dust-tt/sparkle";
+import {
+  CloudArrowLeftRightIcon,
+  FolderIcon,
+  GlobeAltIcon,
+  Tree,
+} from "@dust-tt/sparkle";
 import type {
   DataSourceViewSelectionConfiguration,
   DataSourceViewSelectionConfigurations,
+  DataSourceViewType,
   WorkspaceType,
 } from "@dust-tt/types";
 import { defaultSelectionConfiguration } from "@dust-tt/types";
@@ -11,16 +17,146 @@ import { useMemo } from "react";
 
 import DataSourceResourceSelectorTree from "@app/components/DataSourceResourceSelectorTree";
 import { useParentResourcesById } from "@app/hooks/useParentResourcesById";
+import { orderDatasourceViewByImportance } from "@app/lib/assistant";
 import {
   CONNECTOR_CONFIGURATIONS,
   getConnectorProviderLogoWithFallback,
 } from "@app/lib/connector_providers";
-import { getDisplayNameForDataSource, isFolder } from "@app/lib/data_sources";
+import {
+  getDisplayNameForDataSource,
+  isFolder,
+  isManaged,
+  isWebsite,
+} from "@app/lib/data_sources";
 
-export function DataSourceViewSelector({
+const MIN_TOTAL_DATA_SOURCES_TO_GROUP = 12;
+const MIN_DATA_SOURCES_PER_KIND_TO_GROUP = 3;
+
+type DataSourceViewsSelectorProps = {
+  owner: WorkspaceType;
+  dataSourceViews: DataSourceViewType[];
+  selectionConfigurations: DataSourceViewSelectionConfigurations;
+  setSelectionConfigurations: Dispatch<
+    SetStateAction<DataSourceViewSelectionConfigurations>
+  >;
+};
+
+export function DataSourceViewsSelector({
+  owner,
+  dataSourceViews,
+  selectionConfigurations,
+  setSelectionConfigurations,
+}: DataSourceViewsSelectorProps) {
+  const applyGrouping =
+    dataSourceViews.length >= MIN_TOTAL_DATA_SOURCES_TO_GROUP;
+
+  const groupManaged =
+    applyGrouping &&
+    dataSourceViews.filter((dsv) => isManaged(dsv.dataSource)).length >=
+      MIN_DATA_SOURCES_PER_KIND_TO_GROUP;
+
+  const groupFolders =
+    applyGrouping &&
+    dataSourceViews.filter((dsv) => isFolder(dsv.dataSource)).length >=
+      MIN_DATA_SOURCES_PER_KIND_TO_GROUP;
+
+  const groupWebsites =
+    applyGrouping &&
+    dataSourceViews.filter((dsv) => isWebsite(dsv.dataSource)).length >=
+      MIN_DATA_SOURCES_PER_KIND_TO_GROUP;
+
+  return (
+    <Tree isLoading={false}>
+      {groupManaged && (
+        <Tree.Item
+          key="connected"
+          label="Connected Data"
+          visual={CloudArrowLeftRightIcon}
+          type="node"
+        >
+          {orderDatasourceViewByImportance(dataSourceViews)
+            .filter((dsv) => isManaged(dsv.dataSource))
+            .map((dataSourceView) => (
+              <DataSourceViewSelector
+                key={dataSourceView.sId}
+                owner={owner}
+                selectionConfiguration={
+                  selectionConfigurations[dataSourceView.sId] ??
+                  defaultSelectionConfiguration(dataSourceView)
+                }
+                setSelectionConfigurations={setSelectionConfigurations}
+              />
+            ))}
+        </Tree.Item>
+      )}
+
+      {orderDatasourceViewByImportance(
+        dataSourceViews.filter(
+          (dsv) =>
+            (!groupFolders && isFolder(dsv.dataSource)) ||
+            (!groupWebsites && isWebsite(dsv.dataSource)) ||
+            (!groupManaged && isManaged(dsv.dataSource))
+        )
+      ).map((dataSourceView) => (
+        <DataSourceViewSelector
+          key={dataSourceView.sId}
+          owner={owner}
+          selectionConfiguration={
+            selectionConfigurations[dataSourceView.sId] ??
+            defaultSelectionConfiguration(dataSourceView)
+          }
+          setSelectionConfigurations={setSelectionConfigurations}
+        />
+      ))}
+
+      {groupFolders && (
+        <Tree.Item key="folders" label="Files" visual={FolderIcon} type="node">
+          {dataSourceViews
+            .filter((dsv) => isFolder(dsv.dataSource))
+            .map((dataSourceView) => (
+              <DataSourceViewSelector
+                key={dataSourceView.sId}
+                owner={owner}
+                selectionConfiguration={
+                  selectionConfigurations[dataSourceView.sId] ??
+                  defaultSelectionConfiguration(dataSourceView)
+                }
+                setSelectionConfigurations={setSelectionConfigurations}
+              />
+            ))}
+        </Tree.Item>
+      )}
+
+      {groupWebsites && (
+        <Tree.Item
+          key="websites"
+          label="Websites"
+          visual={GlobeAltIcon}
+          type="node"
+        >
+          {dataSourceViews
+            .filter((dsv) => isWebsite(dsv.dataSource))
+            .map((dataSourceView) => (
+              <DataSourceViewSelector
+                key={dataSourceView.sId}
+                owner={owner}
+                selectionConfiguration={
+                  selectionConfigurations[dataSourceView.sId] ??
+                  defaultSelectionConfiguration(dataSourceView)
+                }
+                setSelectionConfigurations={setSelectionConfigurations}
+              />
+            ))}
+        </Tree.Item>
+      )}
+    </Tree>
+  );
+}
+
+function DataSourceViewSelector({
   owner,
   selectionConfiguration,
-  setSelectionConfigurations: setSelectedNodes,
+  setSelectionConfigurations,
 }: {
   owner: WorkspaceType;
   selectionConfiguration: DataSourceViewSelectionConfiguration;
@@ -66,24 +202,26 @@ export function DataSourceViewSelector({
       setParentsById({});
 
       // Setting selectedResources
-      setSelectedNodes((prevState: DataSourceViewSelectionConfigurations) => {
-        if (!checked) {
-          // Nothing is selected at all, remove from the list
-          return _.omit(prevState, dataSourceView.sId);
+      setSelectionConfigurations(
+        (prevState: DataSourceViewSelectionConfigurations) => {
+          if (!checked) {
+            // Nothing is selected at all, remove from the list
+            return _.omit(prevState, dataSourceView.sId);
+          }
+
+          const config =
+            prevState[dataSourceView.sId] ??
+            defaultSelectionConfiguration(dataSourceView);
+
+          config.isSelectAll = checked;
+          config.selectedResources = [];
+
+          // Return a new object to trigger a re-render
+          return { ...prevState, [dataSourceView.sId]: config };
         }
-
-        const config =
-          prevState[dataSourceView.sId] ??
-          defaultSelectionConfiguration(dataSourceView);
-
-        config.isSelectAll = checked;
-        config.selectedResources = [];
-
-        // Return a new object to trigger a re-render
-        return { ...prevState, [dataSourceView.sId]: config };
-      });
+      );
     };
-  }, [dataSourceView, setParentsById, setSelectedNodes]);
+  }, [dataSourceView, setParentsById, setSelectionConfigurations]);
 
   return (
     <Tree.Item
@@ -115,7 +253,7 @@ export function DataSourceViewSelector({
           });
 
           // Setting selectedResources
-          setSelectedNodes(
+          setSelectionConfigurations(
             (prevState: DataSourceViewSelectionConfigurations) => {
               const config =
                 prevState[dataSourceView.sId] ??

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -47,6 +47,9 @@ export function DataSourceViewsSelector({
   selectionConfigurations,
   setSelectionConfigurations,
 }: DataSourceViewsSelectorProps) {
+  // Apply grouping if there are many data sources, and there are enough of each kind
+  // So we don't show a long list of data sources to the user
+
   const applyGrouping =
     dataSourceViews.length >= MIN_TOTAL_DATA_SOURCES_TO_GROUP;
 
@@ -65,6 +68,11 @@ export function DataSourceViewsSelector({
     dataSourceViews.filter((dsv) => isWebsite(dsv.dataSource)).length >=
       MIN_DATA_SOURCES_PER_KIND_TO_GROUP;
 
+  const orderDatasourceViews = useMemo(
+    () => orderDatasourceViewByImportance(dataSourceViews),
+    [dataSourceViews]
+  );
+
   return (
     <Tree isLoading={false}>
       {groupManaged && (
@@ -74,7 +82,7 @@ export function DataSourceViewsSelector({
           visual={CloudArrowLeftRightIcon}
           type="node"
         >
-          {orderDatasourceViewByImportance(dataSourceViews)
+          {orderDatasourceViews
             .filter((dsv) => isManaged(dsv.dataSource))
             .map((dataSourceView) => (
               <DataSourceViewSelector
@@ -90,24 +98,24 @@ export function DataSourceViewsSelector({
         </Tree.Item>
       )}
 
-      {orderDatasourceViewByImportance(
-        dataSourceViews.filter(
+      {orderDatasourceViews
+        .filter(
           (dsv) =>
             (!groupFolders && isFolder(dsv.dataSource)) ||
             (!groupWebsites && isWebsite(dsv.dataSource)) ||
             (!groupManaged && isManaged(dsv.dataSource))
         )
-      ).map((dataSourceView) => (
-        <DataSourceViewSelector
-          key={dataSourceView.sId}
-          owner={owner}
-          selectionConfiguration={
-            selectionConfigurations[dataSourceView.sId] ??
-            defaultSelectionConfiguration(dataSourceView)
-          }
-          setSelectionConfigurations={setSelectionConfigurations}
-        />
-      ))}
+        .map((dataSourceView) => (
+          <DataSourceViewSelector
+            key={dataSourceView.sId}
+            owner={owner}
+            selectionConfiguration={
+              selectionConfigurations[dataSourceView.sId] ??
+              defaultSelectionConfiguration(dataSourceView)
+            }
+            setSelectionConfigurations={setSelectionConfigurations}
+          />
+        ))}
 
       {groupFolders && (
         <Tree.Item key="folders" label="Files" visual={FolderIcon} type="node">

--- a/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
+++ b/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
@@ -6,7 +6,7 @@ import type {
   WorkspaceType,
 } from "@dust-tt/types";
 import type { SetStateAction } from "react";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { DataSourceViewsSelector } from "@app/components/data_source_view/DataSourceViewSelector";
 import { useMultipleDataSourceViewsContentNodes } from "@app/lib/swr";
@@ -82,6 +82,14 @@ export default function VaultManagedDataSourcesViewsModal({
     }
   }, [initialConfigurations, systemVaultDataSourceViews]);
 
+  const setSelectionConfigurationsCallback = useCallback(
+    () => (func: SetStateAction<DataSourceViewSelectionConfigurations>) => {
+      setHasChanged(true);
+      setSelectionConfigurations(func);
+    },
+    [setSelectionConfigurations]
+  );
+
   return (
     <Modal
       isOpen={isOpen}
@@ -102,12 +110,7 @@ export default function VaultManagedDataSourcesViewsModal({
             dataSourceViews={systemVaultDataSourceViews}
             owner={owner}
             selectionConfigurations={selectionConfigurations}
-            setSelectionConfigurations={(
-              func: SetStateAction<DataSourceViewSelectionConfigurations>
-            ) => {
-              setHasChanged(true);
-              setSelectionConfigurations(func);
-            }}
+            setSelectionConfigurations={setSelectionConfigurationsCallback}
           />
         </div>
       </div>

--- a/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
+++ b/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
@@ -1,15 +1,14 @@
-import { Modal, Tree } from "@dust-tt/sparkle";
+import { Modal } from "@dust-tt/sparkle";
 import type {
   DataSourceViewSelectionConfigurations,
   DataSourceViewType,
   VaultType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { defaultSelectionConfiguration } from "@dust-tt/types";
 import type { SetStateAction } from "react";
 import { useEffect, useMemo, useState } from "react";
 
-import { DataSourceViewSelector } from "@app/components/data_source_view/DataSourceViewSelector";
+import { DataSourceViewsSelector } from "@app/components/data_source_view/DataSourceViewSelector";
 import { useMultipleDataSourceViewsContentNodes } from "@app/lib/swr";
 
 export default function VaultManagedDataSourcesViewsModal({
@@ -99,26 +98,17 @@ export default function VaultManagedDataSourcesViewsModal({
     >
       <div className="w-full pt-12">
         <div className="overflow-x-auto">
-          <Tree isLoading={false}>
-            {systemVaultDataSourceViews.map((dataSourceView) => {
-              return (
-                <DataSourceViewSelector
-                  key={dataSourceView.sId}
-                  owner={owner}
-                  selectionConfiguration={
-                    selectionConfigurations[dataSourceView.sId] ??
-                    defaultSelectionConfiguration(dataSourceView)
-                  }
-                  setSelectionConfigurations={(
-                    func: SetStateAction<DataSourceViewSelectionConfigurations>
-                  ) => {
-                    setHasChanged(true);
-                    setSelectionConfigurations(func);
-                  }}
-                />
-              );
-            })}
-          </Tree>
+          <DataSourceViewsSelector
+            dataSourceViews={systemVaultDataSourceViews}
+            owner={owner}
+            selectionConfigurations={selectionConfigurations}
+            setSelectionConfigurations={(
+              func: SetStateAction<DataSourceViewSelectionConfigurations>
+            ) => {
+              setHasChanged(true);
+              setSelectionConfigurations(func);
+            }}
+          />
         </div>
       </div>
     </Modal>


### PR DESCRIPTION
## Description

Avoid listing a bazillions items to pick from when the user has many datasources.

## Risk

None

## Deploy Plan

Deploy `front`