### PR TITLE
[Connectors] /content-nodes enpoint returns in same order as input 

### DIFF
--- a/connectors/src/api/get_content_nodes.ts
+++ b/connectors/src/api/get_content_nodes.ts
@@ -1,10 +1,10 @@
-import {
-  removeNulls,
-  type ContentNode,
-  type ContentNodeWithParentIds,
-  type Result,
-  type WithConnectorsAPIErrorReponse,
+import type {
+  ContentNode,
+  ContentNodeWithParentIds,
+  Result,
+  WithConnectorsAPIErrorReponse,
 } from "@dust-tt/types";
+import { removeNulls } from "@dust-tt/types";
 import type { Request, Response } from "express";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";


### PR DESCRIPTION
Description
---
Previously, endpoint returned content nodes in an undefined order.

An upcoming breadcrumbs PR needs the content nodes in the same order
as the provided internalIds array. Other consumers might need the
same; furthermore, it seems reasonable to expect it from the endpoint.

Risk
---
na

Deploy
---
front
