### PR TITLE
[Sparkle] Breadcrumbs fixes

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.216",
+  "version": "0.2.217",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.216",
+      "version": "0.2.217",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.216",
+  "version": "0.2.217",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/Breadcrumbs.tsx
+++ b/sparkle/src/components/Breadcrumbs.tsx
@@ -1,7 +1,7 @@
 import type { ComponentType } from "react";
 import React from "react";
 
-import { noHrefLink, SparkleContextLinkType } from "@sparkle/context";
+import { SparkleContextLinkType } from "@sparkle/context";
 import {
   ChevronRightIcon,
   DropdownMenu,
@@ -32,12 +32,15 @@ type BreadcrumbsAccumulator = {
 export function Breadcrumbs({ items }: BreadcrumbProps) {
   const { components } = React.useContext(SparkleContext);
 
+  const Link: SparkleContextLinkType = components.link;
+
   const { itemsShown, itemsHidden } = items.reduce(
     (acc: BreadcrumbsAccumulator, item, index) => {
       if (items.length <= 5 || index < 2 || index >= items.length - 2) {
         acc.itemsShown.push(item);
       } else if (index === 2) {
         acc.itemsShown.push({ label: ELLIPSIS_STRING });
+        acc.itemsHidden.push(item);
       } else {
         acc.itemsHidden.push(item);
       }
@@ -57,26 +60,44 @@ export function Breadcrumbs({ items }: BreadcrumbProps) {
             <Icon visual={item.icon} className="s-text-brand" />
             {item.label === ELLIPSIS_STRING ? (
               <DropdownMenu>
-                <DropdownMenu.Button>${ELLIPSIS_STRING}</DropdownMenu.Button>
+                <DropdownMenu.Button>{ELLIPSIS_STRING}</DropdownMenu.Button>
                 <DropdownMenu.Items origin="topLeft">
                   {itemsHidden.map((item, index) => (
-                    <DropdownMenu.Item
-                      key={`breadcrumbs-hidden-${index}`}
-                      icon={item.icon}
-                      label={item.label}
+                    <Link
+                      href={item.href || "#"}
+                      className={"s-text-element-700"}
                     >
-                      {getLinkForItem(item, false, components.link)}
-                    </DropdownMenu.Item>
+                      <DropdownMenu.Item
+                        key={`breadcrumbs-hidden-${index}`}
+                        icon={item.icon}
+                        label={item.label}
+                      >
+                        {truncateWithTooltip(
+                          item.label,
+                          LABEL_TRUNCATE_LENGTH_MIDDLE
+                        )}
+                      </DropdownMenu.Item>
+                    </Link>
                   ))}
                 </DropdownMenu.Items>
               </DropdownMenu>
             ) : (
               <div>
-                {getLinkForItem(
-                  item,
-                  index === itemsShown.length - 1,
-                  components.link
-                )}
+                <Link
+                  href={item.href || "#"}
+                  className={
+                    index === items.length - 1
+                      ? "s-text-element-900"
+                      : "s-text-element-700"
+                  }
+                >
+                  {index === items.length - 1
+                    ? truncateWithTooltip(item.label, LABEL_TRUNCATE_LENGTH_END)
+                    : truncateWithTooltip(
+                        item.label,
+                        LABEL_TRUNCATE_LENGTH_MIDDLE
+                      )}
+                </Link>
               </div>
             )}
             {index === itemsShown.length - 1 ? null : (
@@ -86,25 +107,6 @@ export function Breadcrumbs({ items }: BreadcrumbProps) {
         );
       })}
     </div>
-  );
-}
-
-function getLinkForItem(
-  item: BreadcrumbItem,
-  isLast: boolean,
-  link: SparkleContextLinkType
-) {
-  const Link: SparkleContextLinkType = item.href ? link : noHrefLink;
-
-  return (
-    <Link
-      href={item.href || "#"}
-      className={isLast ? "s-text-element-900" : "s-text-element-700"}
-    >
-      {isLast
-        ? truncateWithTooltip(item.label, LABEL_TRUNCATE_LENGTH_END)
-        : truncateWithTooltip(item.label, LABEL_TRUNCATE_LENGTH_MIDDLE)}
-    </Link>
   );
 }
 

--- a/sparkle/src/components/Breadcrumbs.tsx
+++ b/sparkle/src/components/Breadcrumbs.tsx
@@ -63,21 +63,17 @@ export function Breadcrumbs({ items }: BreadcrumbProps) {
                 <DropdownMenu.Button>{ELLIPSIS_STRING}</DropdownMenu.Button>
                 <DropdownMenu.Items origin="topLeft">
                   {itemsHidden.map((item, index) => (
-                    <Link
+                    <DropdownMenu.Item
+                      icon={item.icon}
+                      label={item.label}
                       href={item.href || "#"}
-                      className={"s-text-element-700"}
+                      key={`breadcrumbs-hidden-${index}`}
                     >
-                      <DropdownMenu.Item
-                        key={`breadcrumbs-hidden-${index}`}
-                        icon={item.icon}
-                        label={item.label}
-                      >
-                        {truncateWithTooltip(
-                          item.label,
-                          LABEL_TRUNCATE_LENGTH_MIDDLE
-                        )}
-                      </DropdownMenu.Item>
-                    </Link>
+                      {truncateWithTooltip(
+                        item.label,
+                        LABEL_TRUNCATE_LENGTH_MIDDLE
+                      )}
+                    </DropdownMenu.Item>
                   ))}
                 </DropdownMenu.Items>
               </DropdownMenu>

--- a/sparkle/src/stories/Breadcrumbs.stories.tsx
+++ b/sparkle/src/stories/Breadcrumbs.stories.tsx
@@ -36,7 +36,7 @@ export const BreadcrumbsExample = () => {
       icon: CompanyIcon,
     },
     { label: "My Vault", href: "#" },
-    { label: "Data Sources" },
+    { label: "Data Sources", href: ".." },
     { label: "Folder1", href: "#", icon: FolderIcon },
     { label: "With ellipsis", href: "#" },
   ];


### PR DESCRIPTION
Description
---
3 fixes:
- wrong "dollar" in ellipsis;
- click on dropdown menu items didn't go through;
- dropdown menu missed the 3rd item.

#### Before
![image](https://github.com/user-attachments/assets/b5ff392a-db97-4d42-add2-cd7d27f1a17e)

#### After
![image](https://github.com/user-attachments/assets/4414d340-7849-4947-8d6c-f36b95a4d8ee)


Risks
---
na

Deploy
---
Publish sparkle
