### PR TITLE
[Vaults] Breadcrumbs display full parent hierarchy

### DIFF
--- a/connectors/src/api/get_content_nodes.ts
+++ b/connectors/src/api/get_content_nodes.ts
@@ -1,10 +1,10 @@
-import {
-  removeNulls,
-  type ContentNode,
-  type ContentNodeWithParentIds,
-  type Result,
-  type WithConnectorsAPIErrorReponse,
+import type {
+  ContentNode,
+  ContentNodeWithParentIds,
+  Result,
+  WithConnectorsAPIErrorReponse,
 } from "@dust-tt/types";
+import { removeNulls } from "@dust-tt/types";
 import type { Request, Response } from "express";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";

--- a/front/components/vaults/VaultLayout.tsx
+++ b/front/components/vaults/VaultLayout.tsx
@@ -125,7 +125,18 @@ function VaultBreadCrumbs({
       href: `/w/${owner.sId}/data-sources/vaults/${vault.sId}/categories/${category}`,
     },
   ];
+
   if (dataSourceView) {
+    if (category === "managed") {
+      // Remove the "Connected data" from breadcrumbs to avoid hiding the actual
+      // managed connection name
+
+      // Showing the actual managed connection name (e.g. microsoft, slack...) is
+      // more important and implies clearly that we are dealing with connected
+      // data
+      items.pop();
+    }
+
     items.push({
       icon: getConnectorProviderLogoWithFallback(
         dataSourceView.dataSource.connectorProvider,

--- a/front/components/vaults/VaultLayout.tsx
+++ b/front/components/vaults/VaultLayout.tsx
@@ -111,15 +111,15 @@ function VaultBreadCrumbs({
     internalIds: currentFolder?.parentInternalIds || [],
   });
 
-  if (!category) {
-    return null;
-  }
-
   const items: {
     label: string;
     icon?: ComponentType;
     href?: string;
   }[] = useMemo(() => {
+    if (!category) {
+      return [];
+    }
+
     const items = [
       {
         icon: vault.kind === "global" ? CompanyIcon : LockIcon,
@@ -163,6 +163,10 @@ function VaultBreadCrumbs({
     }
     return items;
   }, [owner, vault, category, dataSourceView, folders]);
+
+  if (items.length === 0) {
+    return null;
+  }
 
   return (
     <div className="pb-8">

--- a/front/components/vaults/VaultLayout.tsx
+++ b/front/components/vaults/VaultLayout.tsx
@@ -12,7 +12,7 @@ import type {
   WorkspaceType,
 } from "@dust-tt/types";
 import type { ComponentType } from "react";
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 
 import RootLayout from "@app/components/app/RootLayout";
 import AppLayout from "@app/components/sparkle/AppLayout";
@@ -97,13 +97,19 @@ function VaultBreadCrumbs({
   dataSourceView?: DataSourceViewType;
   parentId?: string;
 }) {
-  const { nodes } = useDataSourceViewContentNodes({
+  const {
+    nodes: [currentFolder],
+  } = useDataSourceViewContentNodes({
     owner,
     dataSourceView,
     internalIds: parentId ? [parentId] : [],
   });
 
-  const { title: folderName, parentInternalId } = nodes[0] || {};
+  const { nodes: folders } = useDataSourceViewContentNodes({
+    owner,
+    dataSourceView,
+    internalIds: currentFolder?.parentInternalIds || [],
+  });
 
   if (!category) {
     return null;
@@ -113,52 +119,50 @@ function VaultBreadCrumbs({
     label: string;
     icon?: ComponentType;
     href?: string;
-  }[] = [
-    {
-      icon: vault.kind === "global" ? CompanyIcon : LockIcon,
-      label: vault.name,
-      href: `/w/${owner.sId}/data-sources/vaults/${vault.sId}`,
-    },
-    {
-      icon: CATEGORY_DETAILS[category].icon,
-      label: CATEGORY_DETAILS[category].label,
-      href: `/w/${owner.sId}/data-sources/vaults/${vault.sId}/categories/${category}`,
-    },
-  ];
+  }[] = useMemo(() => {
+    const items = [
+      {
+        icon: vault.kind === "global" ? CompanyIcon : LockIcon,
+        label: vault.kind === "global" ? "Company Data" : vault.name,
+        href: `/w/${owner.sId}/data-sources/vaults/${vault.sId}`,
+      },
+      {
+        icon: CATEGORY_DETAILS[category].icon,
+        label: CATEGORY_DETAILS[category].label,
+        href: `/w/${owner.sId}/data-sources/vaults/${vault.sId}/categories/${category}`,
+      },
+    ];
 
-  if (dataSourceView) {
-    if (category === "managed") {
-      // Remove the "Connected data" from breadcrumbs to avoid hiding the actual
-      // managed connection name
+    if (dataSourceView) {
+      if (category === "managed") {
+        // Remove the "Connected data" from breadcrumbs to avoid hiding the actual
+        // managed connection name
 
-      // Showing the actual managed connection name (e.g. microsoft, slack...) is
-      // more important and implies clearly that we are dealing with connected
-      // data
-      items.pop();
-    }
+        // Showing the actual managed connection name (e.g. microsoft, slack...) is
+        // more important and implies clearly that we are dealing with connected
+        // data
+        items.pop();
+      }
 
-    items.push({
-      icon: getConnectorProviderLogoWithFallback(
-        dataSourceView.dataSource.connectorProvider,
-        FolderIcon
-      ),
-      label: getDataSourceNameFromView(dataSourceView),
-      href: `/w/${owner.sId}/data-sources/vaults/${vault.sId}/categories/${category}/data_source_views/${dataSourceView.sId}`,
-    });
+      items.push({
+        icon: getConnectorProviderLogoWithFallback(
+          dataSourceView.dataSource.connectorProvider,
+          FolderIcon
+        ),
+        label: getDataSourceNameFromView(dataSourceView),
+        href: `/w/${owner.sId}/data-sources/vaults/${vault.sId}/categories/${category}/data_source_views/${dataSourceView.sId}`,
+      });
 
-    if (folderName) {
-      if (parentInternalId) {
+      for (const node of [...folders].reverse()) {
         items.push({
-          label: "...",
-          href: `/w/${owner.sId}/data-sources/vaults/${vault.sId}/categories/${category}/data_source_views/${dataSourceView.sId}?parentId=${parentInternalId}`,
+          label: node.title,
+          href: `/w/${owner.sId}/data-sources/vaults/${vault.sId}/categories/${category}/data_source_views/${dataSourceView.sId}?parentId=${node.internalId}`,
+          icon: FolderIcon,
         });
       }
-      items.push({
-        label: folderName,
-        icon: FolderIcon,
-      });
     }
-  }
+    return items;
+  }, [owner, vault, category, dataSourceView, folders]);
 
   return (
     <div className="pb-8">

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,7 @@
         "@amplitude/analytics-browser": "^2.5.2",
         "@amplitude/analytics-node": "^1.3.5",
         "@auth0/nextjs-auth0": "^3.5.0",
-        "@dust-tt/sparkle": "^0.2.216",
+        "@dust-tt/sparkle": "^0.2.217",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -10735,9 +10735,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.216",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.216.tgz",
-      "integrity": "sha512-/dh+mH6tkG7Z7UPlEh4HFD+TJI44O0yEuhw+QKw/hfLqrMvl4jAtMk5Di/GFwBJ0goSeoyMU979rU9ANqED2sA==",
+      "version": "0.2.217",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.217.tgz",
+      "integrity": "sha512-TANtB3/WxkrBPWRq5KWT2jce/xspTWpO1ARxmkGelD57xWSy6pcrLvrBw61QZnZPasUTUWPI1UwhVD7Vmvq4uQ==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,7 @@
         "@amplitude/analytics-browser": "^2.5.2",
         "@amplitude/analytics-node": "^1.3.5",
         "@auth0/nextjs-auth0": "^3.5.0",
-        "@dust-tt/sparkle": "^0.2.214",
+        "@dust-tt/sparkle": "^0.2.216",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -10735,9 +10735,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.214",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.214.tgz",
-      "integrity": "sha512-tiAtg/9eo08e2m5nNaa8KaQZTnzfPKHawVRrkeflblulHVaWnxa11ZWcwUIMX6U4w8MLQnt0mE3D+CiiKXaVqw==",
+      "version": "0.2.216",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.216.tgz",
+      "integrity": "sha512-/dh+mH6tkG7Z7UPlEh4HFD+TJI44O0yEuhw+QKw/hfLqrMvl4jAtMk5Di/GFwBJ0goSeoyMU979rU9ANqED2sA==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
     "@amplitude/analytics-browser": "^2.5.2",
     "@amplitude/analytics-node": "^1.3.5",
     "@auth0/nextjs-auth0": "^3.5.0",
-    "@dust-tt/sparkle": "^0.2.216",
+    "@dust-tt/sparkle": "^0.2.217",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
     "@amplitude/analytics-browser": "^2.5.2",
     "@amplitude/analytics-node": "^1.3.5",
     "@auth0/nextjs-auth0": "^3.5.0",
-    "@dust-tt/sparkle": "^0.2.214",
+    "@dust-tt/sparkle": "^0.2.216",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",


### PR DESCRIPTION
## Description
Fixes #6906
![Screenshot from 2024-08-31 18-26-29](https://github.com/user-attachments/assets/69453d5c-b453-4915-b1d4-b49762e0bfb3)

## Risk
Requires 2 swr calls (get parent ids, & get related content nodes) => might slow down a bit. Likely acceptable, keeping an eye.
Blast radius: pages where breadcrumbs are displayed

## Deploy
front

