### PR TITLE
[sparkle] - feat(DataTable): add sorting function

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.217",
+  "version": "0.2.218",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.217",
+      "version": "0.2.218",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.217",
+  "version": "0.2.218",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -4,7 +4,7 @@ import {
   flexRender,
   getCoreRowModel,
   getFilteredRowModel,
-  getSortedRowModel,
+  getSortedRowModel, SortingFn,
   type SortingState,
   useReactTable,
 } from "@tanstack/react-table";
@@ -35,6 +35,7 @@ interface DataTableProps<TData extends TBaseData> {
   filterColumn?: string;
   initialColumnOrder?: SortingState;
   columnsBreakpoints?: ColumnBreakpoint;
+  sortingFn?: SortingFn<TData>
 }
 
 function shouldRenderColumn(

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -55,6 +55,20 @@ export const DataTableExample = () => {
       ],
     },
     {
+      name: "design",
+      usedBy: 3,
+      addedBy: "User21",
+      lastUpdated: "2023-07-09",
+      size: "64kb",
+      icon: FolderIcon,
+      moreMenuItems: [
+        {
+          label: "Edit",
+          onClick: () => console.log("Edit"),
+        },
+      ],
+    },
+    {
       name: "Development",
       usedBy: 5,
       addedBy: "User3",
@@ -81,6 +95,7 @@ export const DataTableExample = () => {
     {
       accessorKey: "name",
       header: "Name",
+      sortingFn: "text",
       cell: (info) => (
         <DataTable.CellContent
           avatarUrl={info.row.original.avatarUrl}


### PR DESCRIPTION
## Description

This PR aims at updating the sparkle `DataTable` component to accept a `sortingFn` parameter. 

The main reason for this change is the following: the default sorting function is case sensitive which doesn't make sense in most of our cases.

## Risk

Limited

## Deploy Plan

- Deploy `sparkle`
