### PR TITLE
Ability to edit Folder in vault

### DIFF
--- a/front/components/vaults/EditVaultStaticDatasourcesViews.tsx
+++ b/front/components/vaults/EditVaultStaticDatasourcesViews.tsx
@@ -8,8 +8,8 @@ import type {
 import { useRouter } from "next/router";
 import React, { useCallback, useState } from "react";
 
-import VaultCreateFolderModal from "@app/components/vaults/VaultCreateFolderModal";
 import VaultCreateWebsiteModal from "@app/components/vaults/VaultCreateWebsiteModal";
+import VaultUpsertFolderModal from "@app/components/vaults/VaultUpsertFolderModal";
 
 export function EditVaultStaticDataSourcesViews({
   owner,
@@ -59,7 +59,7 @@ export function EditVaultStaticDataSourcesViews({
         }}
         className="absolute bottom-8 right-0"
       />
-      <VaultCreateFolderModal
+      <VaultUpsertFolderModal
         isOpen={showAddFolderModal}
         setOpen={(isOpen) => {
           setShowAddFolderModal(isOpen);
@@ -67,6 +67,7 @@ export function EditVaultStaticDataSourcesViews({
         owner={owner}
         vault={vault}
         dataSources={dataSources}
+        folder={null} // null for a folder creation.
       />
       <VaultCreateWebsiteModal
         isOpen={showAddWebsiteModal}

--- a/front/components/vaults/EditVaultStaticDatasourcesViews.tsx
+++ b/front/components/vaults/EditVaultStaticDatasourcesViews.tsx
@@ -9,7 +9,7 @@ import { useRouter } from "next/router";
 import React, { useCallback, useState } from "react";
 
 import VaultCreateWebsiteModal from "@app/components/vaults/VaultCreateWebsiteModal";
-import VaultUpsertFolderModal from "@app/components/vaults/VaultUpsertFolderModal";
+import VaultFolderModal from "@app/components/vaults/VaultUpsertFolderModal";
 
 export function EditVaultStaticDataSourcesViews({
   owner,
@@ -59,7 +59,7 @@ export function EditVaultStaticDataSourcesViews({
         }}
         className="absolute bottom-8 right-0"
       />
-      <VaultUpsertFolderModal
+      <VaultFolderModal
         isOpen={showAddFolderModal}
         setOpen={(isOpen) => {
           setShowAddFolderModal(isOpen);

--- a/front/components/vaults/FoldersHeaderMenu.tsx
+++ b/front/components/vaults/FoldersHeaderMenu.tsx
@@ -1,57 +1,95 @@
 import {
   Button,
   CloudArrowUpIcon,
+  Cog6ToothIcon,
   DocumentTextIcon,
   DropdownMenu,
   PlusIcon,
   TableIcon,
 } from "@dust-tt/sparkle";
+import type { DataSourceType, VaultType, WorkspaceType } from "@dust-tt/types";
 import type { RefObject } from "react";
+import { useState } from "react";
 
 import type { ContentActionsRef } from "@app/components/vaults/ContentActions";
+import VaultUpsertFolderModal from "@app/components/vaults/VaultUpsertFolderModal";
+import { useDataSources } from "@app/lib/swr";
 
 type FoldersHeaderMenuProps = {
+  owner: WorkspaceType;
+  vault: VaultType;
+  folder: DataSourceType;
   contentActionsRef: RefObject<ContentActionsRef>;
 };
 
 export const FoldersHeaderMenu = ({
+  owner,
+  vault,
+  folder,
   contentActionsRef,
 }: FoldersHeaderMenuProps) => {
-  return (
-    <DropdownMenu>
-      <DropdownMenu.Button>
-        <Button
-          size="sm"
-          label="Add data"
-          icon={PlusIcon}
-          variant="primary"
-          type="menu"
-        />
-      </DropdownMenu.Button>
+  const [showEditFolderModal, setShowEditFolderModal] = useState(false);
 
-      <DropdownMenu.Items width={300}>
-        <DropdownMenu.Item
-          icon={DocumentTextIcon}
-          onClick={() => {
-            contentActionsRef.current?.callAction("DocumentUploadOrEditModal");
-          }}
-          label="Create a document"
-        />
-        <DropdownMenu.Item
-          icon={TableIcon}
-          onClick={() => {
-            contentActionsRef.current?.callAction("TableUploadOrEditModal");
-          }}
-          label="Create a table"
-        />
-        <DropdownMenu.Item
-          icon={CloudArrowUpIcon}
-          onClick={() => {
-            contentActionsRef.current?.callAction("MultipleDocumentsUpload");
-          }}
-          label="Upload multiple files"
-        />
-      </DropdownMenu.Items>
-    </DropdownMenu>
+  const { dataSources } = useDataSources(owner);
+
+  return (
+    <>
+      <VaultUpsertFolderModal
+        isOpen={showEditFolderModal}
+        setOpen={(isOpen) => {
+          setShowEditFolderModal(isOpen);
+        }}
+        owner={owner}
+        vault={vault}
+        dataSources={dataSources}
+        folder={folder}
+      />
+      <DropdownMenu>
+        <DropdownMenu.Button>
+          <Button
+            size="sm"
+            label="Add data"
+            icon={PlusIcon}
+            variant="primary"
+            type="menu"
+          />
+        </DropdownMenu.Button>
+
+        <DropdownMenu.Items width={300}>
+          <DropdownMenu.Item
+            icon={DocumentTextIcon}
+            onClick={() => {
+              contentActionsRef.current?.callAction(
+                "DocumentUploadOrEditModal"
+              );
+            }}
+            label="Create a document"
+          />
+          <DropdownMenu.Item
+            icon={TableIcon}
+            onClick={() => {
+              contentActionsRef.current?.callAction("TableUploadOrEditModal");
+            }}
+            label="Create a table"
+          />
+          <DropdownMenu.Item
+            icon={CloudArrowUpIcon}
+            onClick={() => {
+              contentActionsRef.current?.callAction("MultipleDocumentsUpload");
+            }}
+            label="Upload multiple files"
+          />
+        </DropdownMenu.Items>
+      </DropdownMenu>
+      <Button
+        size="sm"
+        label="Edit folder"
+        icon={Cog6ToothIcon}
+        variant="primary"
+        onClick={() => {
+          setShowEditFolderModal(true);
+        }}
+      />
+    </>
   );
 };

--- a/front/components/vaults/FoldersHeaderMenu.tsx
+++ b/front/components/vaults/FoldersHeaderMenu.tsx
@@ -12,7 +12,7 @@ import type { RefObject } from "react";
 import { useState } from "react";
 
 import type { ContentActionsRef } from "@app/components/vaults/ContentActions";
-import VaultUpsertFolderModal from "@app/components/vaults/VaultUpsertFolderModal";
+import VaultFolderModal from "@app/components/vaults/VaultUpsertFolderModal";
 import { useDataSources } from "@app/lib/swr";
 
 type FoldersHeaderMenuProps = {
@@ -34,7 +34,7 @@ export const FoldersHeaderMenu = ({
 
   return (
     <>
-      <VaultUpsertFolderModal
+      <VaultFolderModal
         isOpen={showEditFolderModal}
         setOpen={(isOpen) => {
           setShowEditFolderModal(isOpen);

--- a/front/components/vaults/VaultDataSourceViewContentList.tsx
+++ b/front/components/vaults/VaultDataSourceViewContentList.tsx
@@ -2,6 +2,7 @@ import { DataTable, Searchbar, Spinner } from "@dust-tt/sparkle";
 import type {
   DataSourceViewType,
   PlanType,
+  VaultType,
   WorkspaceType,
 } from "@dust-tt/types";
 import type { CellContext } from "@tanstack/react-table";
@@ -28,6 +29,7 @@ type RowData = {
 };
 
 type VaultDataSourceViewContentListProps = {
+  vault: VaultType;
   dataSourceView: DataSourceViewType;
   plan: PlanType;
   isAdmin: boolean;
@@ -52,11 +54,12 @@ const getTableColumns = () => {
 };
 
 export const VaultDataSourceViewContentList = ({
+  owner,
+  vault,
   dataSourceView,
   plan,
   isAdmin,
   onSelect,
-  owner,
   parentId,
 }: VaultDataSourceViewContentListProps) => {
   const [dataSourceSearch, setDataSourceSearch] = useState<string>("");
@@ -118,7 +121,12 @@ export const VaultDataSourceViewContentList = ({
           </>
         )}
         {isFolder(dataSourceView.dataSource) && (
-          <FoldersHeaderMenu contentActionsRef={contentActionsRef} />
+          <FoldersHeaderMenu
+            owner={owner}
+            vault={vault}
+            folder={dataSourceView.dataSource}
+            contentActionsRef={contentActionsRef}
+          />
         )}
       </div>
       {rows.length > 0 && (

--- a/front/components/vaults/VaultUpsertFolderModal.tsx
+++ b/front/components/vaults/VaultUpsertFolderModal.tsx
@@ -36,9 +36,12 @@ export default function VaultUpsertFolderModal({
   const router = useRouter();
   const sendNotification = useContext(SendNotificationsContext);
 
-  const [name, setName] = useState<string | null>(folder?.name ?? null);
+  const defaultName = folder?.name ?? null;
+  const defaultDescription = folder?.description ?? null;
+
+  const [name, setName] = useState<string | null>(defaultName);
   const [description, setDescription] = useState<string | null>(
-    folder?.description ?? null
+    defaultDescription
   );
 
   const [errors, setErrors] = useState<{
@@ -64,7 +67,7 @@ export default function VaultUpsertFolderModal({
       }
     );
     if (res.ok) {
-      setOpen(false);
+      onClose();
       const response: PostVaultDataSourceResponseBody = await res.json();
       const { dataSourceView } = response;
       await router.push(
@@ -99,7 +102,7 @@ export default function VaultUpsertFolderModal({
       }
     );
     if (res.ok) {
-      setOpen(false);
+      onClose();
       sendNotification({
         type: "success",
         title: "Successfully updated folder",
@@ -149,6 +152,12 @@ export default function VaultUpsertFolderModal({
     }
   };
 
+  const onClose = () => {
+    setOpen(false);
+    setName(defaultName);
+    setDescription(defaultDescription);
+  };
+
   const hasChanged =
     folder === null
       ? name !== null || description !== null
@@ -157,9 +166,7 @@ export default function VaultUpsertFolderModal({
   return (
     <Modal
       isOpen={isOpen}
-      onClose={() => {
-        setOpen(false);
-      }}
+      onClose={onClose}
       onSave={onSave}
       hasChanged={hasChanged}
       variant="side-sm"
@@ -188,7 +195,7 @@ export default function VaultUpsertFolderModal({
                 <ExclamationCircleStrokeIcon />{" "}
                 {folder === null
                   ? "Folder name must be unique and not use spaces."
-                  : "Folder name change not allowed."}
+                  : "Folder name cannot be changed."}
               </p>
             </div>
 

--- a/front/components/vaults/VaultUpsertFolderModal.tsx
+++ b/front/components/vaults/VaultUpsertFolderModal.tsx
@@ -18,7 +18,7 @@ import { useContext, useState } from "react";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import type { PostVaultDataSourceResponseBody } from "@app/pages/api/w/[wId]/vaults/[vId]/data_sources";
 
-export default function VaultUpsertFolderModal({
+export default function VaultFolderModal({
   isOpen,
   setOpen,
   owner,

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/[dsId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/[dsId]/index.ts
@@ -1,4 +1,7 @@
-import type { WithAPIErrorResponse } from "@dust-tt/types";
+import type { DataSourceType, WithAPIErrorResponse } from "@dust-tt/types";
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
@@ -11,9 +14,19 @@ import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { VaultResource } from "@app/lib/resources/vault_resource";
 import { apiError } from "@app/logger/withlogging";
 
+const PatchDataSourceWithoutProviderRequestBodySchema = t.type({
+  description: t.string,
+});
+
+export type PatchVaultDataSourceResponseBody = {
+  dataSource: DataSourceType;
+};
+
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<void>>,
+  res: NextApiResponse<
+    WithAPIErrorResponse<PatchVaultDataSourceResponseBody | void>
+  >,
   auth: Authenticator
 ): Promise<void> {
   const owner = auth.workspace();
@@ -102,6 +115,40 @@ async function handler(
   }
 
   switch (req.method) {
+    case "PATCH": {
+      if (dataSource.connectorId) {
+        // Not implemented yet, next PR will allow patching a website.
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Managed data sources cannot be updated.",
+          },
+        });
+      }
+
+      const bodyValidation =
+        PatchDataSourceWithoutProviderRequestBodySchema.decode(req.body);
+      if (isLeft(bodyValidation)) {
+        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body to patch a static data source: ${pathError}`,
+          },
+        });
+      }
+      const { description } = bodyValidation.right;
+
+      await dataSource.update({
+        description,
+      });
+
+      return res.status(200).json({
+        dataSource: dataSource.toJSON(),
+      });
+    }
     case "DELETE": {
       if (
         dataSource.connectorId &&
@@ -137,7 +184,8 @@ async function handler(
         status_code: 405,
         api_error: {
           type: "method_not_supported_error",
-          message: "The method passed is not supported DELETE is expected.",
+          message:
+            "The method passed is not supported, PATCH or DELETE is expected.",
         },
       });
   }

--- a/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
+++ b/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
@@ -85,6 +85,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
 });
 
 export default function Vault({
+  vault,
   category,
   dataSourceView,
   isAdmin,
@@ -97,6 +98,7 @@ export default function Vault({
     <Page.Vertical gap="xl" align="stretch">
       <VaultDataSourceViewContentList
         owner={owner}
+        vault={vault}
         plan={plan}
         isAdmin={isAdmin}
         parentId={parentId}


### PR DESCRIPTION
## Description

Ability to edit a Folder in vault. We can not edit the name in the folder, only its description (was already the case before Vault). 

- Adds a patch route on `front/pages/api/w/[wId]/vaults/[vId]/data_sources/[dsId]/index.ts`.
- Adds a button "Edit" on the Folder header menu. 
- Rename and update the Folder modal to handle update. 

Empty folder: 
<kbd>
<img width="1007" alt="Screenshot 2024-09-02 at 12 05 02" src="https://github.com/user-attachments/assets/8617a769-89e2-4147-99a1-847a4a23b6ad">
</kbd>

Folder with docs: 
<kbd>
<img width="966" alt="Screenshot 2024-09-02 at 12 05 29" src="https://github.com/user-attachments/assets/5465d2c1-306e-441a-979a-6806a05c8017">
</kbd>

Next step: 
- Add a delete button on this modal to allow deleting a folder. 
- Fix permissions -> today the create/edit buttons are displayed for admin role. 

## Risk

/ 
Can be rolled back. 

## Deploy Plan

Deploy front. 
