### PR TITLE
[Vaults] fix: remove the empty system menu for users & builders

### DIFF
--- a/front/components/vaults/VaultSideBarMenu.tsx
+++ b/front/components/vaults/VaultSideBarMenu.tsx
@@ -50,7 +50,8 @@ export default function VaultSideBarMenu({
   const sortedGroupedVaults = VAULTS_SORT_ORDER.map((kind) => ({
     kind,
     vaults: groupedVaults[kind] || [],
-  }));
+    // remove the empty system menu for users & builders
+  })).filter(({ vaults, kind }) => !(kind === "system" && vaults.length === 0));
 
   return (
     <div className="flex h-0 min-h-full w-full overflow-y-auto">


### PR DESCRIPTION
Description
---
Remove the empty system menu for users & builders:
![image](https://github.com/user-attachments/assets/d1abd0da-5966-4edb-8e26-c0e6f822b6e8)

Risks
---
na

Deploy
---
front
