### PR TITLE
Fix: couldn't pick a datasource because of badly setup callback

### DIFF
--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -39,7 +39,7 @@ export default function AssistantBuilderDataSourceModal({
   });
 
   const setSelectionConfigurationsCallback = useCallback(
-    () => (func: SetStateAction<DataSourceViewSelectionConfigurations>) => {
+    (func: SetStateAction<DataSourceViewSelectionConfigurations>) => {
       setHasChanged(true);
       setSelectionConfigurations(func);
     },

--- a/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
+++ b/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
@@ -83,7 +83,7 @@ export default function VaultManagedDataSourcesViewsModal({
   }, [initialConfigurations, systemVaultDataSourceViews]);
 
   const setSelectionConfigurationsCallback = useCallback(
-    () => (func: SetStateAction<DataSourceViewSelectionConfigurations>) => {
+    (func: SetStateAction<DataSourceViewSelectionConfigurations>) => {
       setHasChanged(true);
       setSelectionConfigurations(func);
     },


### PR DESCRIPTION
## Description

Fix a badly coded useCallback() that broke datasource selection.

## Risk

None

## Deploy Plan

Deploy `front`