### PR TITLE
`dustAPIDataSourceId` not null + batch one of using it

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -413,7 +413,7 @@ const dataSource = async (command: string, args: parseArgs.ParsedArgs) => {
       const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
       const getRes = await coreAPI.getDataSourceDocument({
         projectId: dataSource.dustAPIProjectId,
-        dataSourceName: dataSource.name,
+        dataSourceId: dataSource.dustAPIDataSourceId,
         documentId: args.documentId,
       });
       if (getRes.isErr()) {

--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -320,7 +320,7 @@ const dataSource = async (command: string, args: parseArgs.ParsedArgs) => {
 
       const coreDeleteRes = await coreAPI.deleteDataSource({
         projectId: dataSource.dustAPIProjectId,
-        dataSourceName: dataSource.name,
+        dataSourceId: dataSource.name,
       });
       if (coreDeleteRes.isErr()) {
         throw new Error(coreDeleteRes.error.message);

--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -320,7 +320,7 @@ const dataSource = async (command: string, args: parseArgs.ParsedArgs) => {
 
       const coreDeleteRes = await coreAPI.deleteDataSource({
         projectId: dataSource.dustAPIProjectId,
-        dataSourceId: dataSource.name,
+        dataSourceId: dataSource.dustAPIDataSourceId,
       });
       if (coreDeleteRes.isErr()) {
         throw new Error(coreDeleteRes.error.message);

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -131,7 +131,7 @@ export async function getContentNodesForStaticDataSourceView(
 
   if (viewType === "documents") {
     const documentsRes = await coreAPI.getDataSourceDocuments({
-      dataSourceName: dataSource.name,
+      dataSourceId: dataSource.dustAPIDataSourceId,
       limit,
       offset,
       projectId: dataSource.dustAPIProjectId,

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -132,7 +132,7 @@ export async function deleteDataSource(
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
   const coreDeleteRes = await coreAPI.deleteDataSource({
     projectId: dustAPIProjectId,
-    dataSourceId: dataSource.name,
+    dataSourceId: dataSource.dustAPIDataSourceId,
   });
   if (coreDeleteRes.isErr()) {
     // Same as above we proceed with the deletion if the data source is not found in core. Otherwise

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -132,7 +132,7 @@ export async function deleteDataSource(
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
   const coreDeleteRes = await coreAPI.deleteDataSource({
     projectId: dustAPIProjectId,
-    dataSourceName: dataSource.name,
+    dataSourceId: dataSource.name,
   });
   if (coreDeleteRes.isErr()) {
     // Same as above we proceed with the deletion if the data source is not found in core. Otherwise

--- a/front/lib/documents_post_process_hooks/hooks/data_source_helpers.ts
+++ b/front/lib/documents_post_process_hooks/hooks/data_source_helpers.ts
@@ -62,7 +62,7 @@ export async function getDiffBetweenDocumentVersions({
     const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
     const res = await coreAPI.getDataSourceDocument({
       projectId: dataSource.dustAPIProjectId,
-      dataSourceName: dataSource.name,
+      dataSourceId: dataSource.dustAPIDataSourceId,
       documentId: documentId,
       versionHash: hash,
     });

--- a/front/lib/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
+++ b/front/lib/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
@@ -372,7 +372,7 @@ export async function documentTrackerSuggestChangesOnUpsert({
 
   const incomingDocument = await coreAPI.getDataSourceDocument({
     projectId: dataSource.dustAPIProjectId,
-    dataSourceName: dataSource.name,
+    dataSourceId: dataSource.dustAPIDataSourceId,
     documentId,
   });
   if (incomingDocument.isErr()) {

--- a/front/lib/models/data_source.ts
+++ b/front/lib/models/data_source.ts
@@ -29,7 +29,7 @@ export class DataSource extends Model<
   declare description: string | null;
   declare assistantDefaultSelected: boolean;
   declare dustAPIProjectId: string;
-  declare dustAPIDataSourceId: string | null;
+  declare dustAPIDataSourceId: string;
   declare connectorId: string | null;
   declare connectorProvider: ConnectorProvider | null;
   declare workspaceId: ForeignKey<Workspace["id"]>;
@@ -81,7 +81,7 @@ DataSource.init(
     },
     dustAPIDataSourceId: {
       type: DataTypes.STRING,
-      allowNull: true,
+      allowNull: false,
     },
     connectorId: {
       type: DataTypes.STRING,

--- a/front/migrations/20230522_slack_doc_rename_incident.ts
+++ b/front/migrations/20230522_slack_doc_rename_incident.ts
@@ -29,7 +29,7 @@ async function main() {
         const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
         const dds = await coreAPI.deleteDataSource({
           projectId: ds.dustAPIProjectId,
-          dataSourceId: ds.name,
+          dataSourceId: ds.dustAPIDataSourceId,
         });
 
         if (dds.isErr()) {

--- a/front/migrations/20230522_slack_doc_rename_incident.ts
+++ b/front/migrations/20230522_slack_doc_rename_incident.ts
@@ -29,7 +29,7 @@ async function main() {
         const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
         const dds = await coreAPI.deleteDataSource({
           projectId: ds.dustAPIProjectId,
-          dataSourceName: ds.name,
+          dataSourceId: ds.name,
         });
 
         if (dds.isErr()) {

--- a/front/migrations/20230803_wipe_gdrive_connectors.ts
+++ b/front/migrations/20230803_wipe_gdrive_connectors.ts
@@ -39,7 +39,7 @@ async function main() {
     const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
     await coreAPI.deleteDataSource({
       projectId: d.dustAPIProjectId,
-      dataSourceName: d.name,
+      dataSourceId: d.name,
     });
     console.log(`creating data source ${d.name} in core`);
     await coreAPI.createDataSource({

--- a/front/migrations/20230803_wipe_gdrive_connectors.ts
+++ b/front/migrations/20230803_wipe_gdrive_connectors.ts
@@ -39,7 +39,7 @@ async function main() {
     const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
     await coreAPI.deleteDataSource({
       projectId: d.dustAPIProjectId,
-      dataSourceId: d.name,
+      dataSourceId: d.dustAPIDataSourceId,
     });
     console.log(`creating data source ${d.name} in core`);
     await coreAPI.createDataSource({

--- a/front/migrations/20231107_empty_data_sources.ts
+++ b/front/migrations/20231107_empty_data_sources.ts
@@ -65,7 +65,7 @@ async function main() {
         const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
         const coreDeleteRes = await coreAPI.deleteDataSource({
           projectId: dustAPIProjectId,
-          dataSourceId: ds.name,
+          dataSourceId: ds.dustAPIDataSourceId,
         });
         if (coreDeleteRes.isErr()) {
           console.log("[x] Error deleting CoreAPI data source", ds);

--- a/front/migrations/20231107_empty_data_sources.ts
+++ b/front/migrations/20231107_empty_data_sources.ts
@@ -65,7 +65,7 @@ async function main() {
         const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
         const coreDeleteRes = await coreAPI.deleteDataSource({
           projectId: dustAPIProjectId,
-          dataSourceName: ds.name,
+          dataSourceId: ds.name,
         });
         if (coreDeleteRes.isErr()) {
           console.log("[x] Error deleting CoreAPI data source", ds);

--- a/front/migrations/20240524_clean_up_orphaned_core_data_sources.ts
+++ b/front/migrations/20240524_clean_up_orphaned_core_data_sources.ts
@@ -15,7 +15,7 @@ makeScript({}, async ({ execute }) => {
       const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
       const coreDeleteRes = await coreAPI.deleteDataSource({
         projectId: project,
-        dataSourceName: data_source_id,
+        dataSourceId: data_source_id,
       });
       if (coreDeleteRes.isErr()) {
         console.log("ERROR:" + coreDeleteRes.error);

--- a/front/migrations/db/migration_70.sql
+++ b/front/migrations/db/migration_70.sql
@@ -1,0 +1,2 @@
+-- Migration created on Sep 02, 2024
+ALTER TABLE "data_sources" ALTER COLUMN "dustAPIDataSourceId" SET NOT NULL;

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/documents/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/documents/index.ts
@@ -66,7 +66,7 @@ async function handler(
       const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
       const documents = await coreAPI.getDataSourceDocuments({
         projectId: dataSource.dustAPIProjectId,
-        dataSourceName: dataSource.name,
+        dataSourceId: dataSource.dustAPIDataSourceId,
         limit,
         offset,
       });

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -251,7 +251,7 @@ async function handler(
     case "GET":
       const docRes = await coreAPI.getDataSourceDocument({
         projectId: dataSource.dustAPIProjectId,
-        dataSourceName: dataSource.name,
+        dataSourceId: dataSource.dustAPIDataSourceId,
         documentId: req.query.documentId as string,
       });
 

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -361,7 +361,7 @@ async function handler(
       if (plan.limits.dataSources.documents.count != -1) {
         const documents = await coreAPI.getDataSourceDocuments({
           projectId: dataSource.dustAPIProjectId,
-          dataSourceName: dataSource.name,
+          dataSourceId: dataSource.dustAPIDataSourceId,
           limit: 1,
           offset: 0,
         });

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/index.ts
@@ -114,7 +114,7 @@ async function handler(
 
       const documents = await coreAPI.getDataSourceDocuments({
         projectId: dataSource.dustAPIProjectId,
-        dataSourceName: dataSource.name,
+        dataSourceId: dataSource.dustAPIDataSourceId,
         limit,
         offset,
       });

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/search.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/search.ts
@@ -241,7 +241,7 @@ async function handler(
       const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
       const data = await coreAPI.searchDataSource(
         dataSource.dustAPIProjectId,
-        dataSource.name,
+        dataSource.dustAPIDataSourceId,
         {
           query: query.query,
           topK: query.top_k,

--- a/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -152,7 +152,7 @@ async function handler(
       if (plan.limits.dataSources.documents.count != -1) {
         const documents = await coreAPI.getDataSourceDocuments({
           projectId: dataSource.dustAPIProjectId,
-          dataSourceName: dataSource.name,
+          dataSourceId: dataSource.dustAPIDataSourceId,
           limit: 1,
           offset: 0,
         });

--- a/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -238,7 +238,7 @@ async function handler(
     case "GET":
       const document = await coreAPI.getDataSourceDocument({
         projectId: dataSource.dustAPIProjectId,
-        dataSourceName: dataSource.name,
+        dataSourceId: dataSource.dustAPIDataSourceId,
         documentId: req.query.documentId as string,
       });
 

--- a/front/pages/api/w/[wId]/data_sources/[name]/documents/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/documents/index.ts
@@ -41,7 +41,7 @@ async function handler(
       const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
       const documents = await coreAPI.getDataSourceDocuments({
         projectId: dataSource.dustAPIProjectId,
-        dataSourceName: dataSource.name,
+        dataSourceId: dataSource.dustAPIDataSourceId,
         limit,
         offset,
       });

--- a/front/pages/api/w/[wId]/data_sources/[name]/search.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/search.ts
@@ -119,7 +119,7 @@ export async function handleSearchDataSource({
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
   const data = await coreAPI.searchDataSource(
     dataSource.dustAPIProjectId,
-    dataSource.name,
+    dataSource.dustAPIDataSourceId,
     {
       query: searchQuery.query,
       topK: searchQuery.top_k,

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -353,7 +353,7 @@ async function handler(
         await dataSource.delete(auth);
         const deleteRes = await coreAPI.deleteDataSource({
           projectId: dustProject.value.project.project_id.toString(),
-          dataSourceName: dustDataSource.value.data_source.data_source_id,
+          dataSourceId: dustDataSource.value.data_source.data_source_id,
         });
         if (deleteRes.isErr()) {
           logger.error(

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/documents/[documentId]/index.ts
@@ -61,7 +61,7 @@ async function handler(
   switch (req.method) {
     case "GET":
       const document = await coreAPI.getDataSourceDocument({
-        dataSourceName: dataSourceView.dataSource.name,
+        dataSourceId: dataSourceView.dataSource.dustAPIDataSourceId,
         documentId,
         projectId: dataSourceView.dataSource.dustAPIProjectId,
         viewFilter: dataSourceView.toViewFilter(),

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/index.ts
@@ -440,7 +440,7 @@ const handleDataSourceWithProvider = async ({
     await dataSource.delete(auth);
     const deleteRes = await coreAPI.deleteDataSource({
       projectId: dustProject.value.project.project_id.toString(),
-      dataSourceName: dustDataSource.value.data_source.data_source_id,
+      dataSourceId: dustDataSource.value.data_source.data_source_id,
     });
     if (deleteRes.isErr()) {
       logger.error(

--- a/front/pages/poke/[wId]/data_sources/[name]/view.tsx
+++ b/front/pages/poke/[wId]/data_sources/[name]/view.tsx
@@ -30,7 +30,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
   const document = await coreAPI.getDataSourceDocument({
     projectId: dataSource.dustAPIProjectId,
-    dataSourceName: dataSource.name,
+    dataSourceId: dataSource.dustAPIDataSourceId,
     documentId: context.query.documentId as string,
   });
 

--- a/front/temporal/documents_post_process_hooks/activities.ts
+++ b/front/temporal/documents_post_process_hooks/activities.ts
@@ -142,8 +142,8 @@ async function getDataSourceDocument({
   }
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
   const docText = await coreAPI.getDataSourceDocument({
-    projectId: dataSource?.dustAPIProjectId,
-    dataSourceName: dataSourceName,
+    projectId: dataSource.dustAPIProjectId,
+    dataSourceId: dataSource.dustAPIDataSourceId,
     documentId,
   });
   if (docText.isErr()) {

--- a/types/src/front/data_source.ts
+++ b/types/src/front/data_source.ts
@@ -67,7 +67,7 @@ export type DataSourceType = {
   description: string | null;
   assistantDefaultSelected: boolean;
   dustAPIProjectId: string;
-  dustAPIDataSourceId: string | null;
+  dustAPIDataSourceId: string;
   connectorId: string | null;
   connectorProvider: ConnectorProvider | null;
   editedByUser?: EditedByUser | null;

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -713,13 +713,13 @@ export class CoreAPI {
   }
 
   async getDataSourceDocument({
-    dataSourceName,
+    dataSourceId,
     documentId,
     projectId,
     versionHash,
     viewFilter,
   }: {
-    dataSourceName: string;
+    dataSourceId: string;
     documentId: string;
     projectId: string;
     versionHash?: string | null;
@@ -746,7 +746,7 @@ export class CoreAPI {
       `${this._url}/projects/${encodeURIComponent(
         projectId
       )}/data_sources/${encodeURIComponent(
-        dataSourceName
+        dataSourceId
       )}/documents/${encodeURIComponent(documentId)}${qs ? `?${qs}` : ""}`,
       {
         method: "GET",

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -671,13 +671,13 @@ export class CoreAPI {
   }
 
   async getDataSourceDocuments({
-    dataSourceName,
+    dataSourceId,
     limit,
     offset,
     projectId,
     viewFilter,
   }: {
-    dataSourceName: string;
+    dataSourceId: string;
     limit: number;
     offset: number;
     projectId: string;
@@ -703,7 +703,7 @@ export class CoreAPI {
       `${this._url}/projects/${encodeURIComponent(
         projectId
       )}/data_sources/${encodeURIComponent(
-        dataSourceName
+        dataSourceId
       )}/documents?${queryParams.toString()}`,
       {
         method: "GET",

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -618,15 +618,15 @@ export class CoreAPI {
 
   async deleteDataSource({
     projectId,
-    dataSourceName,
+    dataSourceId,
   }: {
     projectId: string;
-    dataSourceName: string;
+    dataSourceId: string;
   }): Promise<CoreAPIResponse<{ data_source: CoreAPIDataSource }>> {
     const response = await this._fetchWithError(
       `${this._url}/projects/${encodeURIComponent(
         projectId
-      )}/data_sources/${encodeURIComponent(dataSourceName)}`,
+      )}/data_sources/${encodeURIComponent(dataSourceId)}`,
       {
         method: "DELETE",
       }

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -637,7 +637,7 @@ export class CoreAPI {
 
   async searchDataSource(
     projectId: string,
-    dataSourceName: string,
+    dataSourceId: string,
     payload: {
       query: string;
       topK: number;
@@ -650,7 +650,7 @@ export class CoreAPI {
     const response = await this._fetchWithError(
       `${this._url}/projects/${encodeURIComponent(
         projectId
-      )}/data_sources/${encodeURIComponent(dataSourceName)}/search`,
+      )}/data_sources/${encodeURIComponent(dataSourceId)}/search`,
       {
         method: "POST",
         headers: {


### PR DESCRIPTION
## Description

Context:
- https://github.com/dust-tt/dust/issues/7052
- https://www.notion.so/dust-tt/Design-Doc-Data-sources-sId-refactor-55a4dee1fb6f40309674ec262ddf964d\

Follow-up to: https://github.com/dust-tt/dust/pull/7057

After adding `dustAPIDataSourceId` on `front` `DataSource` and backfilling it. We now enforce it's not null and start using it.

This PR: covers a first batch of `CoreAPI` endpoints:
- deleteDataSource
- searchDataSource
- getDataSourceDocuments
- getDataSourceDocument

## Risk

Tested in dev. Low.

## Deploy Plan

- deploy `front`
- run migration (not needed to run before deploy, can be run at any time)