### PR TITLE
[Websearch] Invite model to search on specific websites via action description

### DIFF
--- a/front/lib/api/assistant/actions/websearch.ts
+++ b/front/lib/api/assistant/actions/websearch.ts
@@ -104,13 +104,12 @@ export class WebsearchConfigurationServerRunner extends BaseActionConfigurationS
     return new Ok({
       name,
       description:
-        description ||
-        "Perform a google search and return the top results. Optionally, can restrict the search a specific site.",
+        description || "Perform a google search and return the top results.",
       inputs: [
         {
           name: "query",
           description:
-            "The query used to perform the google search. If it is needed to restrict the search to a specific site, the query should end with `site:SITE_NAME`.",
+            "The query used to perform the google search. If requested by the user, use the google syntax `site:` to restrict the the search to a particular website or domain.",
           type: "string",
         },
       ],

--- a/front/lib/api/assistant/actions/websearch.ts
+++ b/front/lib/api/assistant/actions/websearch.ts
@@ -104,11 +104,13 @@ export class WebsearchConfigurationServerRunner extends BaseActionConfigurationS
     return new Ok({
       name,
       description:
-        description || "Perform a web search and return the top results.",
+        description ||
+        "Perform a google search and return the top results. Optionally, can restrict the search a specific site.",
       inputs: [
         {
           name: "query",
-          description: "The query used to perform the web search.",
+          description:
+            "The query used to perform the google search. If it is needed to restrict the search to a specific site, the query should end with `site:SITE_NAME`.",
           type: "string",
         },
       ],


### PR DESCRIPTION
Description
---
Follows some of our users' struggles to have their assistants retrieve data from specific websites, see [thread](https://dust4ai.slack.com/archives/C066R3PMUAU/p1724767101223409). Following an IRL discussion cc @Duncid @Yutcam we tried to see how to fix this. 

This PR is a solution. Tweaks the description of action so the models naturally use `site:xxxx.com` when users request searching a specific website. Seems to work well, see example below
![image](https://github.com/user-attachments/assets/1d1583c5-5f5e-4952-b045-7cb300c06159)
![image](https://github.com/user-attachments/assets/2bba93d8-06cd-40e7-b3f4-9cf93c6e10f7)

Risks
---
Might affect websearch behaviour in general, but given the change it should only be for the better

Deploy
---
front
