### PR TITLE
[front] - fix(vaults): vaults navigation items padding

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.218",
+  "version": "0.2.219",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.218",
+      "version": "0.2.219",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.218",
+  "version": "0.2.219",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/Tree.tsx
+++ b/sparkle/src/components/Tree.tsx
@@ -177,7 +177,7 @@ Tree.Item = function ({
             }}
           />
         )}
-        {type === "leaf" && <div className="s-w-4"></div>}
+        {type === "leaf" && <div className="s-w-4 s-flex-shrink-0"></div>}
         {checkbox && <Checkbox {...checkbox} size="xs" />}
         <Icon
           visual={visual}

--- a/sparkle/src/stories/Tree.stories.tsx
+++ b/sparkle/src/stories/Tree.stories.tsx
@@ -254,21 +254,21 @@ export const TreeExample = () => {
             </Tree>
           </div>
         </div>
-        <div className="s-flex s-flex-col s-gap-3">
+        <div className="s-flex s-flex-col s-gap-3 s-max-w-xs">
           <div className="s-text-xl">Nav bar</div>
           <div>
             <Tree variant="navigator">
               <Tree.Item
-                label="Intercom"
+                label="Intercom  github.com-apache-incubator-devlake-tree-main-backend"
                 visual={IntercomLogo}
                 onItemClick={() => console.log("Clickable")}
                 isSelected={true}
                 size="md"
               >
                 <Tree variant="navigator" tailwindIconTextColor="s-text-brand">
-                  <Tree.Item label="item 1" visual={FolderIcon}>
+                  <Tree.Item label="item 1 with a very very very very very very very long text" visual={FolderIcon}>
                     <Tree variant="navigator">
-                      <Tree.Item label="item 1" visual={FolderIcon} />
+                      <Tree.Item label="item 1 with a very very very very very very very long text" visual={FolderIcon} type="leaf"/>
                       <Tree.Item label="item 2" visual={FolderIcon} />
                       <Tree.Item label="item 3" visual={FolderIcon} />
                     </Tree>


### PR DESCRIPTION
## Description

This PR aims at fixing the `VaultSideBarMenu` which breaks when "leaf" items have a too long name (cf. screenshot below)

<img width="339" alt="Screenshot 2024-09-02 at 17 24 17" src="https://github.com/user-attachments/assets/d1585443-a923-42c3-a393-d40ec5a1f1dd">

## Risk

Low

## Deploy Plan

Deploy `sparkle`