### PR TITLE
Specify group id for Slack whitelisted domains.

### DIFF
--- a/connectors/src/connectors/slack/lib/cli.ts
+++ b/connectors/src/connectors/slack/lib/cli.ts
@@ -130,7 +130,16 @@ export const slack = async ({
         throw new Error("Missing --wId argument");
       }
       if (!whitelistedDomains) {
-        throw new Error("Missing --whitelistedDomains argument");
+        throw new Error(
+          "Missing --whitelistedDomains argument. Eg: --whitelistedDomains=example.com:group1,example2.com:group2"
+        );
+      }
+      for (const domain of whitelistedDomains.split(",")) {
+        if (domain.split(":").length !== 2) {
+          throw new Error(
+            `Invalid domain format: ${domain}. Eg: --whitelistedDomains=example.com:group1,example2.com:group2`
+          );
+        }
       }
 
       const connector = await ConnectorModel.findOne({

--- a/connectors/src/lib/models/slack.ts
+++ b/connectors/src/lib/models/slack.ts
@@ -20,6 +20,7 @@ export class SlackConfigurationModel extends Model<
   declare slackTeamId: string;
   declare botEnabled: boolean;
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
+  // Whitelisted domains are in the format "domain:group_id".
   declare whitelistedDomains?: readonly string[];
   declare autoReadChannelPattern?: string | null;
 }

--- a/front/migrations/20240903_backfill_slack_whitelisted_domains_groups.ts
+++ b/front/migrations/20240903_backfill_slack_whitelisted_domains_groups.ts
@@ -1,0 +1,75 @@
+import { EnvironmentConfig } from "@dust-tt/types";
+import { QueryTypes, Sequelize } from "sequelize";
+
+import { Authenticator } from "@app/lib/auth";
+import { Workspace } from "@app/lib/models/workspace";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { makeSId } from "@app/lib/resources/string_ids";
+import { makeScript } from "@app/scripts/helpers";
+
+makeScript({}, async ({ execute }, logger) => {
+  const connectorDB = new Sequelize(
+    EnvironmentConfig.getEnvVariable("CONNECTORS_DATABASE_URI")
+  );
+  const slackConfigurations: {
+    whitelistedDomains: string[];
+    workspaceid: string;
+    configurationId: number;
+  }[] = await connectorDB.query(
+    `SELECT sc.id as "configurationId", sc."whitelistedDomains" as "whitelistedDomains", c."workspaceId" as workspaceId FROM slack_configurations sc INNER JOIN connectors c ON sc."connectorId" = c.id WHERE c.type = 'slack' and sc."whitelistedDomains" IS NOT NULL`,
+    {
+      type: QueryTypes.SELECT,
+    }
+  );
+
+  for (const sc of slackConfigurations) {
+    const auth = await Authenticator.internalAdminForWorkspace(sc.workspaceid);
+    const groupRes = await GroupResource.fetchWorkspaceGlobalGroup(auth);
+    if (groupRes.isErr()) {
+      throw new Error(
+        `Failed to fetch global group for workspace ${sc.workspaceid}`
+      );
+    }
+    const workspace = await Workspace.findOne({
+      where: { sId: sc.workspaceid },
+    });
+    if (!workspace) {
+      throw new Error(`Workspace not found for workspaceId ${sc.workspaceid}`);
+    }
+
+    const groupId = makeSId("group", {
+      id: groupRes.value.id,
+      workspaceId: workspace.id,
+    });
+
+    const newDomains: string[] = [];
+
+    for (const domain of sc.whitelistedDomains) {
+      if (domain.split(":").length > 1) {
+        // domain already updated
+        continue;
+      }
+      newDomains.push(`${domain}:${groupId}`);
+    }
+
+    logger.info(
+      {
+        workspaceId: sc.workspaceid,
+        groupId: groupId,
+        newDomains: newDomains,
+      },
+      "Updating slack_configuration.whitelistedDOmain"
+    );
+    if (execute) {
+      await connectorDB.query(
+        `UPDATE slack_configurations SET "whitelistedDomains" = ARRAY[:newDomains] WHERE id = :configurationId`,
+        {
+          replacements: {
+            newDomains: newDomains,
+            configurationId: sc.configurationId,
+          },
+        }
+      );
+    }
+  }
+});


### PR DESCRIPTION
## Description
Adding support for specifying a group ID associated with a Slack whitelisted domain.

We decided to go with this dirty solution of separating the domain name and the group id with `:` character in the database, given that this is only used by one customer and will be deprecated soon by the user of vaults.


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- Deploy connectors
- Run the backfill migration of this PR. There will be a few minutes where the whitelisted domains won't work but given that it's only for one customer, I think it's acceptable. We can do it over lunch time or tonight if needed.