### PR TITLE
Fix slack sharing tree selection

### DIFF
--- a/front/components/assistant_builder/Sharing.tsx
+++ b/front/components/assistant_builder/Sharing.tsx
@@ -166,114 +166,123 @@ export function SharingButton({
         />
       )}
       <DropdownMenu>
-        <DropdownMenu.Button>
-          <Button
-            size="sm"
-            label="Sharing"
-            icon={ArrowUpOnSquareIcon}
-            variant="tertiary"
-            type="menu"
-          />
-        </DropdownMenu.Button>
-        <DropdownMenu.Items width={300} overflow="visible">
-          <div className="flex flex-col gap-y-2 py-1">
-            <div className="flex flex-col gap-y-3">
-              <SharingDropdown
-                owner={owner}
-                agentConfiguration={agentConfiguration}
-                initialScope={initialScope}
-                newScope={newScope}
-                setNewScope={setNewScope}
+        {({ close }) => (
+          <>
+            <DropdownMenu.Button>
+              <Button
+                size="sm"
+                label="Sharing"
+                icon={ArrowUpOnSquareIcon}
+                variant="tertiary"
+                type="menu"
               />
-              <div className="text-sm text-element-700">
-                <div>
-                  {SCOPE_INFO[newScope].text}{" "}
-                  {agentUsage && newScope !== "private" ? usageText : null}
+            </DropdownMenu.Button>
+            <DropdownMenu.Items width={300} overflow="visible">
+              <div className="flex flex-col gap-y-2 py-1">
+                <div className="flex flex-col gap-y-3">
+                  <SharingDropdown
+                    owner={owner}
+                    agentConfiguration={agentConfiguration}
+                    initialScope={initialScope}
+                    newScope={newScope}
+                    setNewScope={setNewScope}
+                  />
+                  <div className="text-sm text-element-700">
+                    <div>
+                      {SCOPE_INFO[newScope].text}{" "}
+                      {agentUsage && newScope !== "private" ? usageText : null}
+                    </div>
+                  </div>
                 </div>
-              </div>
-            </div>
-            {showSlackIntegration && (
-              <>
-                <Page.Separator />
-                <div className="flex flex-row justify-between">
-                  <div>
-                    <div className="text-base font-bold text-element-800">
-                      Slack integration
-                    </div>
-                    <div className="text-sm text-element-700">
-                      {slackChannelSelected.length === 0 ? (
-                        <>
-                          Set as default assistant for specific&nbsp;channels.
-                        </>
-                      ) : (
-                        <>
-                          Default assistant for{" "}
-                          {slackChannelSelected
-                            .map((c) => c.slackChannelName)
-                            .join(", ")}
-                        </>
-                      )}
-                    </div>
+                {showSlackIntegration && (
+                  <>
+                    <Page.Separator />
+                    <div className="flex flex-row justify-between">
+                      <div>
+                        <div className="text-base font-bold text-element-800">
+                          Slack integration
+                        </div>
+                        <div className="text-sm text-element-700">
+                          {slackChannelSelected.length === 0 ? (
+                            <>
+                              Set as default assistant for
+                              specific&nbsp;channels.
+                            </>
+                          ) : (
+                            <>
+                              Default assistant for{" "}
+                              {slackChannelSelected
+                                .map((c) => c.slackChannelName)
+                                .join(", ")}
+                            </>
+                          )}
+                        </div>
 
-                    {slackChannelSelected.length > 0 && (
-                      <div className="pt-3">
-                        <Button
-                          size="xs"
-                          variant="secondary"
-                          label="Manage channels"
-                          onClick={() => setSlackDrawerOpened(true)}
+                        {slackChannelSelected.length > 0 && (
+                          <div className="pt-3">
+                            <Button
+                              size="xs"
+                              variant="secondary"
+                              label="Manage channels"
+                              onClick={() => {
+                                close();
+                                setSlackDrawerOpened(true);
+                              }}
+                            />
+                          </div>
+                        )}
+                      </div>
+                      <div className="pt-4">
+                        <SliderToggle
+                          selected={slackChannelSelected.length > 0}
+                          // If not admins, but there are channels selected, prevent from removing.
+                          disabled={slackChannelSelected.length > 0 && !isAdmin}
+                          onClick={() => {
+                            if (slackChannelSelected.length > 0) {
+                              setNewLinkedSlackChannels([]);
+                            } else {
+                              close();
+                              setSlackDrawerOpened(true);
+                            }
+                          }}
                         />
                       </div>
-                    )}
-                  </div>
-                  <div className="pt-4">
-                    <SliderToggle
-                      selected={slackChannelSelected.length > 0}
-                      // If not admins, but there are channels selected, prevent from removing.
-                      disabled={slackChannelSelected.length > 0 && !isAdmin}
-                      onClick={() => {
-                        if (slackChannelSelected.length > 0) {
-                          setNewLinkedSlackChannels([]);
-                        } else {
-                          setSlackDrawerOpened(true);
-                        }
-                      }}
-                    />
-                  </div>
-                </div>
-              </>
-            )}
-            {agentConfigurationId && (
-              <>
-                <Page.Separator />
-                <div className="flex w-full flex-row">
-                  <div className="grow">
-                    <div className="text-base font-bold text-element-800">
-                      Link
                     </div>
-                    <div className="text-sm text-element-700">
-                      Shareable direct&nbsp;URL
+                  </>
+                )}
+                {agentConfigurationId && (
+                  <>
+                    <Page.Separator />
+                    <div className="flex w-full flex-row">
+                      <div className="grow">
+                        <div className="text-base font-bold text-element-800">
+                          Link
+                        </div>
+                        <div className="text-sm text-element-700">
+                          Shareable direct&nbsp;URL
+                        </div>
+                      </div>
+                      <div className="pt-4 text-right">
+                        <Button
+                          size="sm"
+                          label={copyLinkSuccess ? "Copied!" : "Copy link"}
+                          variant="secondary"
+                          onClick={async () => {
+                            await navigator.clipboard.writeText(shareLink);
+                            setCopyLinkSuccess(true);
+                            setTimeout(() => {
+                              setCopyLinkSuccess(false);
+                            }, 1000);
+                          }}
+                        />
+                      </div>
                     </div>
-                  </div>
-                  <div className="pt-4 text-right">
-                    <Button
-                      size="sm"
-                      label={copyLinkSuccess ? "Copied!" : "Copy link"}
-                      variant="secondary"
-                      onClick={async () => {
-                        await navigator.clipboard.writeText(shareLink);
-                        setCopyLinkSuccess(true);
-                        setTimeout(() => {
-                          setCopyLinkSuccess(false);
-                        }, 1000);
-                      }}
-                    />
-                  </div>
-                </div>
-              </>
-            )}
-          </div>
-        </DropdownMenu.Items>
+                  </>
+                )}
+              </div>
+            </DropdownMenu.Items>
+          </>
+        )}
       </DropdownMenu>
     </>
   );

--- a/front/components/assistant_builder/SlackIntegration.tsx
+++ b/front/components/assistant_builder/SlackIntegration.tsx
@@ -52,7 +52,12 @@ export function SlackIntegration({
 
       setNewSelection((prevSelection) => {
         if (!prevSelection) {
-          return [];
+          return [
+            {
+              slackChannelId: internalId,
+              slackChannelName: title,
+            },
+          ];
         }
 
         // Create a copy of the previous selection.


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes https://github.com/dust-tt/tasks/issues/1224.

The problem lies in our `DropdownMenu` implementation, which struggles with managing complex layouts. When using a switch, the menu doesn't close even though the action is executed. In our situation, the modal was opening, but we needed an initial click to close the menu before we could interact with the modal.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
