### PR TITLE
[Vaults] Add groupIds column to agent_configurations

### DIFF
--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -176,6 +176,7 @@ function _getHelperGlobalAgent({
     maxStepsPerRun: 0,
     visualizationEnabled: false,
     templateId: null,
+    groupIds: [],
   };
 }
 
@@ -207,6 +208,7 @@ function _getGPT35TurboGlobalAgent({
     maxStepsPerRun: 0,
     visualizationEnabled: false,
     templateId: null,
+    groupIds: [],
   };
 }
 function _getGPT4GlobalAgent({
@@ -247,6 +249,7 @@ function _getGPT4GlobalAgent({
     maxStepsPerRun: 0,
     visualizationEnabled: false,
     templateId: null,
+    groupIds: [],
   };
 }
 
@@ -278,6 +281,7 @@ function _getClaudeInstantGlobalAgent({
     maxStepsPerRun: 0,
     visualizationEnabled: false,
     templateId: null,
+    groupIds: [],
   };
 }
 
@@ -316,6 +320,7 @@ function _getClaude2GlobalAgent({
     maxStepsPerRun: 0,
     visualizationEnabled: false,
     templateId: null,
+    groupIds: [],
   };
 }
 
@@ -348,6 +353,7 @@ function _getClaude3HaikuGlobalAgent({
     maxStepsPerRun: 0,
     visualizationEnabled: false,
     templateId: null,
+    groupIds: [],
   };
 }
 
@@ -385,6 +391,7 @@ function _getClaude3OpusGlobalAgent({
     maxStepsPerRun: 0,
     visualizationEnabled: false,
     templateId: null,
+    groupIds: [],
   };
 }
 
@@ -423,6 +430,7 @@ function _getClaude3GlobalAgent({
     maxStepsPerRun: 0,
     visualizationEnabled: false,
     templateId: null,
+    groupIds: [],
   };
 }
 
@@ -460,6 +468,7 @@ function _getMistralLargeGlobalAgent({
     maxStepsPerRun: 0,
     visualizationEnabled: false,
     templateId: null,
+    groupIds: [],
   };
 }
 
@@ -497,6 +506,7 @@ function _getMistralMediumGlobalAgent({
     maxStepsPerRun: 0,
     visualizationEnabled: false,
     templateId: null,
+    groupIds: [],
   };
 }
 
@@ -528,6 +538,7 @@ function _getMistralSmallGlobalAgent({
     maxStepsPerRun: 0,
     visualizationEnabled: false,
     templateId: null,
+    groupIds: [],
   };
 }
 
@@ -564,6 +575,7 @@ function _getGeminiProGlobalAgent({
     maxStepsPerRun: 0,
     visualizationEnabled: false,
     templateId: null,
+    groupIds: [],
   };
 }
 
@@ -630,6 +642,7 @@ function _getManagedDataSourceAgent(
       maxStepsPerRun: 0,
       visualizationEnabled: false,
       templateId: null,
+      groupIds: [],
     };
   }
 
@@ -656,6 +669,7 @@ function _getManagedDataSourceAgent(
       maxStepsPerRun: 0,
       visualizationEnabled: false,
       templateId: null,
+      groupIds: [],
     };
   }
 
@@ -694,6 +708,7 @@ function _getManagedDataSourceAgent(
     maxStepsPerRun: 1,
     visualizationEnabled: false,
     templateId: null,
+    groupIds: [],
   };
 }
 
@@ -874,6 +889,7 @@ function _getDustGlobalAgent(
       maxStepsPerRun: 0,
       visualizationEnabled: false,
       templateId: null,
+      groupIds: [],
     };
   }
 
@@ -900,6 +916,7 @@ function _getDustGlobalAgent(
       maxStepsPerRun: 0,
       visualizationEnabled: false,
       templateId: null,
+      groupIds: [],
     };
   }
 
@@ -1000,6 +1017,7 @@ function _getDustGlobalAgent(
     maxStepsPerRun: 3,
     visualizationEnabled: false,
     templateId: null,
+    groupIds: [],
   };
 }
 

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -137,6 +137,7 @@ AgentConfiguration.init(
     groupIds: {
       type: DataTypes.ARRAY(DataTypes.INTEGER),
       allowNull: false,
+      defaultValue: [],
     },
   },
   {

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -55,6 +55,8 @@ export class AgentConfiguration extends Model<
 
   declare templateId: ForeignKey<TemplateModel["id"]> | null;
 
+  declare groupIds: number[];
+
   declare author: NonAttribute<User>;
 }
 
@@ -130,6 +132,10 @@ AgentConfiguration.init(
     },
     pictureUrl: {
       type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    groupIds: {
+      type: DataTypes.ARRAY(DataTypes.INTEGER),
       allowNull: false,
     },
   },

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -243,15 +243,19 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
       "limit" | "order"
     >
   ) {
-    const fileModelIds = removeNulls(ids.map(getResourceIdFromSId));
+    const dataSourceViewModelIds = removeNulls(ids.map(getResourceIdFromSId));
 
-    const dataSource = await this.baseFetch(auth, fetchDataSourceViewOptions, {
-      where: {
-        id: fileModelIds,
-      },
-    });
+    const dataSourceViews = await this.baseFetch(
+      auth,
+      fetchDataSourceViewOptions,
+      {
+        where: {
+          id: dataSourceViewModelIds,
+        },
+      }
+    );
 
-    return dataSource ?? null;
+    return dataSourceViews ?? null;
   }
 
   // Updating.

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -226,20 +226,30 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
       "limit" | "order"
     >
   ) {
-    const dataSourceViewModelId = getResourceIdFromSId(id);
-    if (!dataSourceViewModelId) {
-      return null;
-    }
-
-    const [dataSource] = await this.baseFetch(
+    const [dataSourceView] = await DataSourceViewResource.fetchByIds(
       auth,
-      fetchDataSourceViewOptions,
-      {
-        where: {
-          id: dataSourceViewModelId,
-        },
-      }
+      [id],
+      fetchDataSourceViewOptions
     );
+
+    return dataSourceView ?? null;
+  }
+
+  static async fetchByIds(
+    auth: Authenticator,
+    ids: string[],
+    fetchDataSourceViewOptions?: Omit<
+      FetchDataSourceViewOptions,
+      "limit" | "order"
+    >
+  ) {
+    const fileModelIds = removeNulls(ids.map(getResourceIdFromSId));
+
+    const dataSource = await this.baseFetch(auth, fetchDataSourceViewOptions, {
+      where: {
+        id: fileModelIds,
+      },
+    });
 
     return dataSource ?? null;
   }

--- a/front/migrations/db/migration_71.sql
+++ b/front/migrations/db/migration_71.sql
@@ -1,0 +1,2 @@
+-- Migration created on Sep 03, 2024
+ALTER TABLE "public"."agent_configurations" ADD COLUMN "groupIds" INTEGER[] NOT NULL DEFAULT ARRAY[]::INTEGER[];

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -295,7 +295,7 @@ export async function createOrUpgradeAgentConfiguration({
     model: assistant.model,
     agentConfigurationId,
     templateId: assistant.templateId ?? null,
-    dataSourceViewIds: getDsvIdsFromActions(actions),
+    dataSourceViewIds: getDataSourceViewIdsFromActions(actions),
   });
 
   if (agentConfigurationRes.isErr()) {
@@ -446,7 +446,7 @@ export async function createOrUpgradeAgentConfiguration({
   return new Ok(agentConfiguration);
 }
 
-function getDsvIdsFromActions(
+function getDataSourceViewIdsFromActions(
   actions: PostOrPatchAgentConfigurationRequestBody["assistant"]["actions"]
 ): string[] {
   const relevantActions = actions.filter(
@@ -458,11 +458,10 @@ function getDsvIdsFromActions(
 
   return removeNulls(
     relevantActions.flatMap((action) => {
-      if (action.type === "retrieval_configuration") {
-        return action.dataSources.map(
-          (dataSource) => dataSource.dataSourceViewId
-        );
-      } else if (action.type === "process_configuration") {
+      if (
+        action.type === "retrieval_configuration" ||
+        action.type === "process_configuration"
+      ) {
         return action.dataSources.map(
           (dataSource) => dataSource.dataSourceViewId
         );

--- a/types/src/front/api_handlers/internal/agent_configuration.ts
+++ b/types/src/front/api_handlers/internal/agent_configuration.ts
@@ -86,11 +86,20 @@ const DustAppRunActionConfigurationSchema = t.type({
 const TablesQueryActionConfigurationSchema = t.type({
   type: t.literal("tables_query_configuration"),
   tables: t.array(
-    t.type({
-      dataSourceId: t.string,
-      tableId: t.string,
-      workspaceId: t.string,
-    })
+    // TODO(GROUPS_INFRA) Make `dataSourceViewId` required.
+    t.union([
+      t.type({
+        dataSourceId: t.string,
+        dataSourceViewId: t.string,
+        tableId: t.string,
+        workspaceId: t.string,
+      }),
+      t.type({
+        dataSourceId: t.string,
+        tableId: t.string,
+        workspaceId: t.string,
+      }),
+    ])
   ),
 });
 

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -177,6 +177,10 @@ export type LightAgentConfigurationType = {
   visualizationEnabled: boolean;
 
   templateId: string | null;
+
+  // group restrictions: if empty, no restrictions, otherwise only users who belong to all the
+  // groups can see the agent
+  groupIds: string[];
 };
 
 export type AgentConfigurationType = LightAgentConfigurationType & {


### PR DESCRIPTION
Description
---
Part of #6763  ,  listing only agents the user has access to, by checking the groupIds columns of agents.

The plan is that user should be in the intersection of all groupIds here to see the agent. If groupIds is empty then agent is accessible, e.g. if the agent has no search / table query action then it's not restricted to anybody.

This PR adds the `groupIds` column and properly computes it on agent creation / edition.

Risk
---
Usual risks from migrations. Here we add a column.

## Deploy Plan
- run migration
- deploy front