### PR TITLE
Continued move to dustAPIDataSourceId

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -423,7 +423,7 @@ const dataSource = async (command: string, args: parseArgs.ParsedArgs) => {
       }
       const delRes = await coreAPI.deleteDataSourceDocument({
         projectId: dataSource.dustAPIProjectId,
-        dataSourceName: dataSource.name,
+        dataSourceId: dataSource.dustAPIDataSourceId,
         documentId: args.documentId,
       });
       if (delRes.isErr()) {

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -200,7 +200,7 @@ export async function buildInitialActions({
 
           const coreAPITable = await coreAPI.getTable({
             projectId: dataSourceView.dataSource.dustAPIProjectId,
-            dataSourceName: dataSourceView.dataSource.name,
+            dataSourceId: dataSourceView.dataSource.dustAPIDataSourceId,
             tableId: t.tableId,
           });
 

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -160,7 +160,7 @@ export async function getContentNodesForStaticDataSourceView(
     return new Ok(documentsAsContentNodes);
   } else {
     const tablesRes = await coreAPI.getTables({
-      dataSourceName: dataSource.name,
+      dataSourceId: dataSource.dustAPIDataSourceId,
       projectId: dataSource.dustAPIProjectId,
       viewFilter: dataSourceView.toViewFilter(),
     });

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -3,6 +3,7 @@ import type {
   CoreAPIRow,
   CoreAPIRowValue,
   CoreAPITable,
+  DataSourceType,
   Result,
   WorkspaceType,
 } from "@dust-tt/types";
@@ -58,26 +59,26 @@ export type TableOperationError =
 
 export async function deleteTable({
   owner,
-  projectId,
-  dataSourceName,
+  dataSource,
   tableId,
 }: {
   owner: WorkspaceType;
-  projectId: string;
-  dataSourceName: string;
+  dataSource: DataSourceType;
   tableId: string;
 }): Promise<Result<null, TableOperationError>> {
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 
   const deleteRes = await coreAPI.deleteTable({
-    projectId,
-    dataSourceName,
+    projectId: dataSource.dustAPIProjectId,
+    dataSourceId: dataSource.dustAPIDataSourceId,
     tableId,
   });
   if (deleteRes.isErr()) {
     logger.error(
       {
-        dataSourceName,
+        projectId: dataSource.dustAPIProjectId,
+        dataSourceId: dataSource.dustAPIDataSourceId,
+        dataSourceName: dataSource.name,
         workspaceId: owner.id,
         error: deleteRes.error,
       },
@@ -101,7 +102,8 @@ export async function deleteTable({
   await AgentTablesQueryConfigurationTable.destroy({
     where: {
       dataSourceWorkspaceId: owner.sId,
-      dataSourceId: dataSourceName,
+      // TODO(DATASOURCE_SID); state storing the datasource name
+      dataSourceId: dataSource.name,
       tableId,
     },
   });
@@ -111,8 +113,7 @@ export async function deleteTable({
 
 export async function upsertTableFromCsv({
   auth,
-  projectId,
-  dataSourceName,
+  dataSource,
   tableName,
   tableDescription,
   tableId,
@@ -123,8 +124,7 @@ export async function upsertTableFromCsv({
   truncate,
 }: {
   auth: Authenticator;
-  projectId: string;
-  dataSourceName: string;
+  dataSource: DataSourceType;
   tableName: string;
   tableDescription: string;
   tableId: string;
@@ -166,10 +166,11 @@ export async function upsertTableFromCsv({
       logger.error(
         {
           ...errorDetails,
-          dataSourceName,
+          projectId: dataSource.dustAPIProjectId,
+          dataSourceId: dataSource.dustAPIDataSourceId,
+          dataSourceName: dataSource.name,
           tableName,
           tableId,
-          projectId,
         },
         "CSV parsing error."
       );
@@ -190,10 +191,11 @@ export async function upsertTableFromCsv({
     logger.error(
       {
         ...errorDetails,
-        dataSourceName,
+        projectId: dataSource.dustAPIProjectId,
+        dataSourceId: dataSource.dustAPIDataSourceId,
+        dataSourceName: dataSource.name,
         tableName,
         tableId,
-        projectId,
       },
       "CSV input validation error: too many rows."
     );
@@ -202,8 +204,8 @@ export async function upsertTableFromCsv({
 
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
   const tableRes = await coreAPI.upsertTable({
-    projectId,
-    dataSourceName,
+    projectId: dataSource.dustAPIProjectId,
+    dataSourceId: dataSource.dustAPIDataSourceId,
     tableId,
     name: tableName,
     description: tableDescription,
@@ -221,11 +223,12 @@ export async function upsertTableFromCsv({
     logger.error(
       {
         ...errorDetails,
-        dataSourceName,
+        projectId: dataSource.dustAPIProjectId,
+        dataSourceId: dataSource.dustAPIDataSourceId,
+        dataSourceName: dataSource.name,
         workspaceId: owner.id,
         tableId,
         tableName,
-        projectId,
       },
       "Error upserting table in CoreAPI."
     );
@@ -234,8 +237,8 @@ export async function upsertTableFromCsv({
 
   if (csvRows) {
     const rowsRes = await coreAPI.upsertTableRows({
-      projectId,
-      dataSourceName,
+      projectId: dataSource.dustAPIProjectId,
+      dataSourceId: dataSource.dustAPIDataSourceId,
       tableId,
       rows: csvRows,
       truncate,
@@ -250,18 +253,19 @@ export async function upsertTableFromCsv({
       logger.error(
         {
           ...errorDetails,
-          dataSourceName,
+          projectId: dataSource.dustAPIProjectId,
+          dataSourceId: dataSource.dustAPIDataSourceId,
+          dataSourceName: dataSource.name,
           workspaceId: owner.id,
           tableId,
           tableName,
-          projectId,
         },
         "Error upserting rows in CoreAPI."
       );
 
       const delRes = await coreAPI.deleteTable({
-        projectId,
-        dataSourceName,
+        projectId: dataSource.dustAPIProjectId,
+        dataSourceId: dataSource.dustAPIDataSourceId,
         tableId,
       });
 
@@ -270,11 +274,12 @@ export async function upsertTableFromCsv({
           {
             type: "internal_server_error",
             coreAPIError: delRes.error,
-            dataSourceName,
+            projectId: dataSource.dustAPIProjectId,
+            dataSourceId: dataSource.dustAPIDataSourceId,
+            dataSourceName: dataSource.name,
             workspaceId: owner.id,
             tableId,
             tableName,
-            projectId,
           },
           "Failed to delete table after failed row upsert."
         );

--- a/front/lib/document_tracker.ts
+++ b/front/lib/document_tracker.ts
@@ -176,14 +176,14 @@ export async function updateTrackedDocuments(
   if (hasExistingTrackedDocs && !hasRemainingTrackedDocs) {
     await coreAPI.updateDataSourceDocumentTags({
       projectId: dataSource.dustAPIProjectId,
-      dataSourceName: dataSource.name,
+      dataSourceId: dataSource.dustAPIDataSourceId,
       removeTags: ["__DUST_TRACKED"],
       documentId,
     });
   } else if (!hasExistingTrackedDocs && hasRemainingTrackedDocs) {
     await coreAPI.updateDataSourceDocumentTags({
       projectId: dataSource.dustAPIProjectId,
-      dataSourceName: dataSource.name,
+      dataSourceId: dataSource.dustAPIDataSourceId,
       addTags: ["__DUST_TRACKED"],
       documentId,
     });

--- a/front/lib/documents_post_process_hooks/hooks/data_source_helpers.ts
+++ b/front/lib/documents_post_process_hooks/hooks/data_source_helpers.ts
@@ -26,7 +26,7 @@ export async function getPreviousDocumentVersion({
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
   const versions = await coreAPI.getDataSourceDocumentVersions({
     projectId: dataSource.dustAPIProjectId,
-    dataSourceName: dataSource.name,
+    dataSourceId: dataSource.dustAPIDataSourceId,
     documentId: documentId,
     limit: 1,
     offset: 1,

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -452,7 +452,7 @@ async function handler(
         // Create document with the Dust internal API.
         const upsertRes = await coreAPI.upsertDataSourceDocument({
           projectId: dataSource.dustAPIProjectId,
-          dataSourceName: dataSource.name,
+          dataSourceId: dataSource.dustAPIDataSourceId,
           documentId: req.query.documentId as string,
           tags: bodyValidation.right.tags || [],
           parents: bodyValidation.right.parents || [],
@@ -516,7 +516,7 @@ async function handler(
 
       const delRes = await coreAPI.deleteDataSourceDocument({
         projectId: dataSource.dustAPIProjectId,
-        dataSourceName: dataSource.name,
+        dataSourceId: dataSource.dustAPIDataSourceId,
         documentId: req.query.documentId as string,
       });
 

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/parents.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/parents.ts
@@ -125,7 +125,7 @@ async function handler(
       const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
       const updateRes = await coreAPI.updateDataSourceDocumentParents({
         projectId: dataSource.dustAPIProjectId,
-        dataSourceName: dataSource.name,
+        dataSourceId: dataSource.dustAPIDataSourceId,
         documentId: req.query.documentId as string,
         parents: req.body.parents,
       });

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
@@ -152,7 +152,7 @@ async function handler(
       const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
       const tableRes = await coreAPI.getTable({
         projectId: dataSource.dustAPIProjectId,
-        dataSourceName: dataSource.name,
+        dataSourceId: dataSource.dustAPIDataSourceId,
         tableId,
       });
       if (tableRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/parents.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/parents.ts
@@ -82,7 +82,7 @@ async function handler(
       const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
       const updateRes = await coreAPI.updateTableParents({
         projectId: dataSource.dustAPIProjectId,
-        dataSourceName: dataSource.name,
+        dataSourceId: dataSource.dustAPIDataSourceId,
         tableId: req.query.tId as string,
         parents,
       });

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/[rId].ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/[rId].ts
@@ -169,7 +169,7 @@ async function handler(
     case "GET":
       const rowRes = await coreAPI.getTableRow({
         projectId: dataSource.dustAPIProjectId,
-        dataSourceName: dataSource.name,
+        dataSourceId: dataSource.dustAPIDataSourceId,
         tableId,
         rowId,
       });

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/[rId].ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/[rId].ts
@@ -201,7 +201,7 @@ async function handler(
     case "DELETE":
       const deleteRes = await coreAPI.deleteTableRow({
         projectId: dataSource.dustAPIProjectId,
-        dataSourceName: dataSource.name,
+        dataSourceId: dataSource.dustAPIDataSourceId,
         tableId,
         rowId,
       });

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/index.ts
@@ -346,7 +346,7 @@ async function handler(
       // Upsert is succesful, retrieve the updated table.
       const tableRes = await coreAPI.getTable({
         projectId: dataSource.dustAPIProjectId,
-        dataSourceName: dataSource.name,
+        dataSourceId: dataSource.dustAPIDataSourceId,
         tableId,
       });
       if (tableRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/index.ts
@@ -317,7 +317,7 @@ async function handler(
       });
       const upsertRes = await coreAPI.upsertTableRows({
         projectId: dataSource.dustAPIProjectId,
-        dataSourceName: dataSource.name,
+        dataSourceId: dataSource.dustAPIDataSourceId,
         tableId: tableId,
         rows: rowsToUpsert,
         truncate,

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/index.ts
@@ -249,7 +249,7 @@ async function handler(
 
       const listRes = await coreAPI.getTableRows({
         projectId: dataSource.dustAPIProjectId,
-        dataSourceName: dataSource.name,
+        dataSourceId: dataSource.dustAPIDataSourceId,
         tableId,
         offset,
         limit,

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/index.ts
@@ -265,7 +265,7 @@ async function handler(
 
       const upsertRes = await coreAPI.upsertTable({
         projectId: dataSource.dustAPIProjectId,
-        dataSourceName: dataSource.name,
+        dataSourceId: dataSource.dustAPIDataSourceId,
         tableId,
         name,
         description,

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/index.ts
@@ -168,7 +168,7 @@ async function handler(
     case "GET":
       const tablesRes = await coreAPI.getTables({
         projectId: dataSource.dustAPIProjectId,
-        dataSourceName: dataSource.name,
+        dataSourceId: dataSource.dustAPIDataSourceId,
       });
 
       if (tablesRes.isErr()) {
@@ -230,7 +230,7 @@ async function handler(
 
       const tRes = await coreAPI.getTables({
         projectId: dataSource.dustAPIProjectId,
-        dataSourceName: dataSource.name,
+        dataSourceId: dataSource.dustAPIDataSourceId,
       });
 
       if (tRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tokenize.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tokenize.ts
@@ -84,7 +84,7 @@ async function handler(
       const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
       const coreTokenizeRes = await coreAPI.dataSourceTokenize({
         projectId: dataSource.dustAPIProjectId,
-        dataSourceName: dataSource.name,
+        dataSourceId: dataSource.dustAPIDataSourceId,
         text,
       });
       if (coreTokenizeRes.isErr()) {

--- a/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -207,7 +207,7 @@ async function handler(
       // Create document with the Dust internal API.
       const upsertRes = await coreAPI.upsertDataSourceDocument({
         projectId: dataSource.dustAPIProjectId,
-        dataSourceName: dataSource.name,
+        dataSourceId: dataSource.dustAPIDataSourceId,
         documentId: req.query.documentId as string,
         tags,
         parents: bodyValidation.right.parents || [],
@@ -283,7 +283,7 @@ async function handler(
 
       const deleteRes = await coreAPI.deleteDataSourceDocument({
         projectId: dataSource.dustAPIProjectId,
-        dataSourceName: dataSource.name,
+        dataSourceId: dataSource.dustAPIDataSourceId,
         documentId: req.query.documentId as string,
       });
 

--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
@@ -134,8 +134,7 @@ export async function handleDeleteTableByIdRequest(
 ) {
   const delRes = await deleteTable({
     owner,
-    projectId: dataSource.dustAPIProjectId,
-    dataSourceName: dataSource.name,
+    dataSource,
     tableId,
   });
 

--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
@@ -63,7 +63,7 @@ async function handler(
       const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
       const tableRes = await coreAPI.getTable({
         projectId: dataSource.dustAPIProjectId,
-        dataSourceName: dataSource.name,
+        dataSourceId: dataSource.dustAPIDataSourceId,
         tableId,
       });
       if (tableRes.isErr()) {

--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
@@ -215,8 +215,7 @@ export async function handlePostTableCsvUpsertRequest(
 
   const tableRes = await upsertTableFromCsv({
     auth,
-    projectId: dataSource.dustAPIProjectId,
-    dataSourceName,
+    dataSource,
     tableId,
     tableName: name,
     tableDescription: description,

--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/index.ts
@@ -56,7 +56,7 @@ async function handler(
       const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
       const tablesRes = await coreAPI.getTables({
         projectId: dataSource.dustAPIProjectId,
-        dataSourceName: dataSource.name,
+        dataSourceId: dataSource.dustAPIDataSourceId,
       });
       if (tablesRes.isErr()) {
         logger.error(

--- a/front/temporal/upsert_queue/activities.ts
+++ b/front/temporal/upsert_queue/activities.ts
@@ -86,7 +86,7 @@ export async function upsertDocumentActivity(
   // Create document with the Dust internal API.
   const upsertRes = await coreAPI.upsertDataSourceDocument({
     projectId: dataSource.dustAPIProjectId,
-    dataSourceName: dataSource.name,
+    dataSourceId: dataSource.dustAPIDataSourceId,
     documentId: upsertQueueItem.documentId,
     tags: upsertQueueItem.tags || [],
     parents: upsertQueueItem.parents || [],

--- a/front/temporal/upsert_queue/activities.ts
+++ b/front/temporal/upsert_queue/activities.ts
@@ -224,8 +224,7 @@ export async function upsertTableActivity(
 
   const tableRes = await upsertTableFromCsv({
     auth,
-    projectId: dataSource.dustAPIProjectId,
-    dataSourceName: dataSource.name,
+    dataSource,
     tableName: upsertQueueItem.tableName,
     tableDescription: upsertQueueItem.tableDescription,
     tableId: upsertQueueItem.tableId,

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -805,7 +805,7 @@ export class CoreAPI {
 
   async upsertDataSourceDocument({
     projectId,
-    dataSourceName,
+    dataSourceId,
     documentId,
     timestamp,
     tags,
@@ -816,7 +816,7 @@ export class CoreAPI {
     lightDocumentOutput = false,
   }: {
     projectId: string;
-    dataSourceName: string;
+    dataSourceId: string;
     documentId: string;
     timestamp?: number | null;
     tags: string[];
@@ -837,7 +837,7 @@ export class CoreAPI {
   > {
     const response = await this._fetchWithError(
       `${this._url}/projects/${projectId}/data_sources/${encodeURIComponent(
-        dataSourceName
+        dataSourceId
       )}/documents`,
       {
         method: "POST",
@@ -862,13 +862,13 @@ export class CoreAPI {
 
   async updateDataSourceDocumentTags({
     projectId,
-    dataSourceName,
+    dataSourceId,
     documentId,
     addTags,
     removeTags,
   }: {
     projectId: string;
-    dataSourceName: string;
+    dataSourceId: string;
     documentId: string;
     addTags?: string[];
     removeTags?: string[];
@@ -881,7 +881,7 @@ export class CoreAPI {
       `${this._url}/projects/${encodeURIComponent(
         projectId
       )}/data_sources/${encodeURIComponent(
-        dataSourceName
+        dataSourceId
       )}/documents/${encodeURIComponent(documentId)}/tags`,
       {
         method: "PATCH",
@@ -900,12 +900,12 @@ export class CoreAPI {
 
   async updateDataSourceDocumentParents({
     projectId,
-    dataSourceName,
+    dataSourceId,
     documentId,
     parents,
   }: {
     projectId: string;
-    dataSourceName: string;
+    dataSourceId: string;
     documentId: string;
     parents: string[];
   }): Promise<
@@ -917,7 +917,7 @@ export class CoreAPI {
       `${this._url}/projects/${encodeURIComponent(
         projectId
       )}/data_sources/${encodeURIComponent(
-        dataSourceName
+        dataSourceId
       )}/documents/${encodeURIComponent(documentId)}/parents`,
       {
         method: "PATCH",
@@ -935,18 +935,18 @@ export class CoreAPI {
 
   async deleteDataSourceDocument({
     projectId,
-    dataSourceName,
+    dataSourceId,
     documentId,
   }: {
     projectId: string;
-    dataSourceName: string;
+    dataSourceId: string;
     documentId: string;
   }): Promise<CoreAPIResponse<{ data_source: CoreAPIDataSource }>> {
     const response = await this._fetchWithError(
       `${this._url}/projects/${encodeURIComponent(
         projectId
       )}/data_sources/${encodeURIComponent(
-        dataSourceName
+        dataSourceId
       )}/documents/${encodeURIComponent(documentId)}`,
       {
         method: "DELETE",

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -1155,12 +1155,12 @@ export class CoreAPI {
 
   async updateTableParents({
     projectId,
-    dataSourceName,
+    dataSourceId,
     tableId,
     parents,
   }: {
     projectId: string;
-    dataSourceName: string;
+    dataSourceId: string;
     tableId: string;
     parents: string[];
   }): Promise<CoreAPIResponse<{ success: true }>> {
@@ -1168,7 +1168,7 @@ export class CoreAPI {
       `${this._url}/projects/${encodeURIComponent(
         projectId
       )}/data_sources/${encodeURIComponent(
-        dataSourceName
+        dataSourceId
       )}/tables/${encodeURIComponent(tableId)}/parents`,
       {
         method: "PATCH",

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -1252,14 +1252,14 @@ export class CoreAPI {
 
   async getTableRows({
     projectId,
-    dataSourceName,
+    dataSourceId,
     tableId,
     limit,
     offset,
     filter,
   }: {
     projectId: string;
-    dataSourceName: string;
+    dataSourceId: string;
     tableId: string;
     limit: number;
     offset: number;
@@ -1279,7 +1279,7 @@ export class CoreAPI {
       `${this._url}/projects/${encodeURIComponent(
         projectId
       )}/data_sources/${encodeURIComponent(
-        dataSourceName
+        dataSourceId
       )}/tables/${encodeURIComponent(
         tableId
       )}/rows?limit=${limit}&offset=${offset}${qs}`,

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -1220,13 +1220,13 @@ export class CoreAPI {
 
   async getTableRow({
     projectId,
-    dataSourceName,
+    dataSourceId,
     tableId,
     rowId,
     filter,
   }: {
     projectId: string;
-    dataSourceName: string;
+    dataSourceId: string;
     tableId: string;
     rowId: string;
     filter?: CoreAPISearchFilter | null;
@@ -1238,7 +1238,7 @@ export class CoreAPI {
       `${this._url}/projects/${encodeURIComponent(
         projectId
       )}/data_sources/${encodeURIComponent(
-        dataSourceName
+        dataSourceId
       )}/tables/${encodeURIComponent(tableId)}/rows/${encodeURIComponent(
         rowId
       )}${qs}`,

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -1076,18 +1076,18 @@ export class CoreAPI {
 
   async getTable({
     projectId,
-    dataSourceName,
+    dataSourceId,
     tableId,
   }: {
     projectId: string;
-    dataSourceName: string;
+    dataSourceId: string;
     tableId: string;
   }): Promise<CoreAPIResponse<{ table: CoreAPITable }>> {
     const response = await this._fetchWithError(
       `${this._url}/projects/${encodeURIComponent(
         projectId
       )}/data_sources/${encodeURIComponent(
-        dataSourceName
+        dataSourceId
       )}/tables/${encodeURIComponent(tableId)}`,
       {
         method: "GET",

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -1293,12 +1293,12 @@ export class CoreAPI {
 
   async deleteTableRow({
     projectId,
-    dataSourceName,
+    dataSourceId,
     tableId,
     rowId,
   }: {
     projectId: string;
-    dataSourceName: string;
+    dataSourceId: string;
     tableId: string;
     rowId: string;
   }): Promise<CoreAPIResponse<{ success: true }>> {
@@ -1306,7 +1306,7 @@ export class CoreAPI {
       `${this._url}/projects/${encodeURIComponent(
         projectId
       )}/data_sources/${encodeURIComponent(
-        dataSourceName
+        dataSourceId
       )}/tables/${encodeURIComponent(tableId)}/rows/${encodeURIComponent(
         rowId
       )}`,

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -1034,7 +1034,7 @@ export class CoreAPI {
 
   async upsertTable({
     projectId,
-    dataSourceName,
+    dataSourceId,
     tableId,
     name,
     description,
@@ -1043,7 +1043,7 @@ export class CoreAPI {
     parents,
   }: {
     projectId: string;
-    dataSourceName: string;
+    dataSourceId: string;
     tableId: string;
     name: string;
     description: string;
@@ -1054,7 +1054,7 @@ export class CoreAPI {
     const response = await this._fetchWithError(
       `${this._url}/projects/${encodeURIComponent(
         projectId
-      )}/data_sources/${encodeURIComponent(dataSourceName)}/tables`,
+      )}/data_sources/${encodeURIComponent(dataSourceId)}/tables`,
       {
         method: "POST",
         headers: {
@@ -1132,18 +1132,18 @@ export class CoreAPI {
 
   async deleteTable({
     projectId,
-    dataSourceName,
+    dataSourceId,
     tableId,
   }: {
     projectId: string;
-    dataSourceName: string;
+    dataSourceId: string;
     tableId: string;
   }): Promise<CoreAPIResponse<{ success: true }>> {
     const response = await this._fetchWithError(
       `${this._url}/projects/${encodeURIComponent(
         projectId
       )}/data_sources/${encodeURIComponent(
-        dataSourceName
+        dataSourceId
       )}/tables/${encodeURIComponent(tableId)}`,
       {
         method: "DELETE",
@@ -1186,13 +1186,13 @@ export class CoreAPI {
 
   async upsertTableRows({
     projectId,
-    dataSourceName,
+    dataSourceId,
     tableId,
     rows,
     truncate,
   }: {
     projectId: string;
-    dataSourceName: string;
+    dataSourceId: string;
     tableId: string;
     rows: CoreAPIRow[];
     truncate?: boolean;
@@ -1201,7 +1201,7 @@ export class CoreAPI {
       `${this._url}/projects/${encodeURIComponent(
         projectId
       )}/data_sources/${encodeURIComponent(
-        dataSourceName
+        dataSourceId
       )}/tables/${encodeURIComponent(tableId)}/rows`,
       {
         method: "POST",

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -1098,11 +1098,11 @@ export class CoreAPI {
   }
 
   async getTables({
-    dataSourceName,
+    dataSourceId,
     projectId,
     viewFilter,
   }: {
-    dataSourceName: string;
+    dataSourceId: string;
     projectId: string;
     viewFilter?: CoreAPISearchFilter | null;
   }): Promise<
@@ -1120,7 +1120,7 @@ export class CoreAPI {
       `${this._url}/projects/${encodeURIComponent(
         projectId
       )}/data_sources/${encodeURIComponent(
-        dataSourceName
+        dataSourceId
       )}/tables?${queryParams.toString()}`,
       {
         method: "GET",

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -1011,16 +1011,16 @@ export class CoreAPI {
   async dataSourceTokenize({
     text,
     projectId,
-    dataSourceName,
+    dataSourceId,
   }: {
     text: string;
     projectId: string;
-    dataSourceName: string;
+    dataSourceId: string;
   }): Promise<CoreAPIResponse<{ tokens: CoreAPITokenType[] }>> {
     const response = await this._fetchWithError(
       `${this._url}/projects/${encodeURIComponent(
         projectId
-      )}/data_sources/${encodeURIComponent(dataSourceName)}/tokenize`,
+      )}/data_sources/${encodeURIComponent(dataSourceId)}/tokenize`,
       {
         method: "POST",
         headers: {

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -758,14 +758,14 @@ export class CoreAPI {
 
   async getDataSourceDocumentVersions({
     projectId,
-    dataSourceName,
+    dataSourceId,
     documentId,
     latest_hash,
     limit = 10,
     offset = 0,
   }: {
     projectId: string;
-    dataSourceName: string;
+    dataSourceId: string;
     documentId: string;
     limit: number;
     offset: number;
@@ -791,7 +791,7 @@ export class CoreAPI {
       `${this._url}/projects/${encodeURIComponent(
         projectId
       )}/data_sources/${encodeURIComponent(
-        dataSourceName
+        dataSourceId
       )}/documents/${encodeURIComponent(
         documentId
       )}/versions?${params.toString()}`,


### PR DESCRIPTION
## Description

Context:
- https://github.com/dust-tt/dust/issues/7052
- https://www.notion.so/dust-tt/Design-Doc-Data-sources-sId-refactor-55a4dee1fb6f40309674ec262ddf964d

Follow-up to: 
- https://github.com/dust-tt/dust/pull/7057
- https://github.com/dust-tt/dust/pull/7066

This PR: covers all remaining `CoreAPI` endpoints.

Note on `AgentTablesQueryConfigurationTable` this one currently has a string dataSourceId which points to dataSource name. We'll want to move to storing a foreign key instead here (in a subsequent PR). cc @flvndvd 

The logs encountered that were logging dataSource name as dataSourceId are now logging dataSourceName and dataSourceId (the core Id). As we transition to having an sId on data sources we'll move to logging `dataSourceId: dataSource.sId` instead.

r? @PopDaph 

## Risk

Low: the database is properly backfilled and today dataSource.name = dataSource.dustAPIDataSourceId.

```
dust-front=> SELECT COUNT(*) FROM data_sources WHERE "name" <> "dustAPIDataSourceId";
 count 
-------
     0
```

## Deploy Plan

- deploy `front`