### PR TITLE
[Front] Infra: raise replicas from 6 to 8

### DIFF
--- a/k8s/deployments/front-deployment.yaml
+++ b/k8s/deployments/front-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: front-deployment
 spec:
-  replicas: 6
+  replicas: 8
   selector:
     matchLabels:
       app: front


### PR DESCRIPTION
Description
---
We are getting a few CPU high alerts on front deployments. It's not that much higher than before, and it's been a while since we scaled so seems fair to bump since we grew a bit :)

If CPU high reproduces, this will be a tell. Keeping an eye on it this week

Risks
---
na

Deploy
---
front
