### PR TITLE
Small fixes sidebar for Vaults

### DIFF
--- a/front/components/vaults/VaultSideBarMenu.tsx
+++ b/front/components/vaults/VaultSideBarMenu.tsx
@@ -142,6 +142,7 @@ const SystemVaultMenu = ({
           owner={owner}
           vault={vault}
           visual={item.visual}
+          tailwindIconTextColor={item.tailwindIconTextColor}
         />
       ))}
     </Tree>
@@ -156,12 +157,14 @@ const SystemVaultItem = ({
   owner,
   vault,
   visual,
+  tailwindIconTextColor,
 }: {
   category: DataSourceViewCategory;
   label: string;
   owner: LightWorkspaceType;
   vault: VaultType;
   visual: IconType;
+  tailwindIconTextColor: string;
 }) => {
   const router = useRouter();
 
@@ -193,6 +196,7 @@ const SystemVaultItem = ({
       visual={visual}
       size="md"
       areActionsFading={false}
+      tailwindIconTextColor={tailwindIconTextColor}
     >
       {isExpanded && (
         <Tree isLoading={isVaultDataSourceViewsLoading}>
@@ -275,28 +279,23 @@ const DATA_SOURCE_OR_VIEW_SUB_ITEMS: {
       className?: string;
     }>;
     label: string;
-    tailwindIconTextColor: "text-element-700";
   };
 } = {
   managed: {
     icon: CloudArrowLeftRightIcon,
     label: "Connected Data",
-    tailwindIconTextColor: "text-element-700",
   },
   folder: {
     icon: FolderIcon,
-    label: "Files",
-    tailwindIconTextColor: "text-element-700",
+    label: "Folders",
   },
   website: {
     icon: GlobeAltIcon,
     label: "Websites",
-    tailwindIconTextColor: "text-element-700",
   },
   apps: {
     icon: CommandLineIcon,
     label: "Apps",
-    tailwindIconTextColor: "text-element-700",
   },
 };
 
@@ -329,7 +328,6 @@ const VaultDataSourceViewItem = ({
       onItemClick={() => router.push(dataSourceViewPath)}
       label={getDataSourceNameFromView(item)}
       visual={LogoComponent}
-      tailwindIconTextColor="text-element-700"
       areActionsFading={false}
     />
   );


### PR DESCRIPTION
## Description

Small fixes on the sidebar:
- Connection Management icon should be green.
- Rename "Files" to "Folders".
- Keep only one shade of grey on the Tree view. 

Before on the left, after on the right

<img width="338" alt="Screenshot 2024-09-03 at 16 51 15" src="https://github.com/user-attachments/assets/acfc9dd8-0478-43c2-ba20-250a870c8ffc">

<img width="369" alt="Screenshot 2024-09-03 at 16 51 03" src="https://github.com/user-attachments/assets/1defdb3b-414f-4c38-aa94-4b965e256c0e">



## Risk

/ 

## Deploy Plan

Deploy front. 
