### PR TITLE
[Microsoft] Cast application disabled as externaloauthtokenerror

### DIFF
--- a/connectors/src/lib/error.ts
+++ b/connectors/src/lib/error.ts
@@ -1,6 +1,10 @@
 // JS cannot give you any guarantee about the shape of an error you `catch`
 
-import type { APIError, ConnectorProvider } from "@dust-tt/types";
+import type {
+  APIError,
+  ConnectorProvider,
+  OAuthAPIError,
+} from "@dust-tt/types";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function errorFromAny(e: any): Error {
@@ -59,7 +63,8 @@ export interface NotFoundError extends HTTPError {
   statusCode: 404;
 }
 
-// This error is thrown when we are dealing with a revoked OAuth token.
+// This error is thrown when we are dealing with a revoked OAuth token, or more
+// generally Oauth issues due to a revoked access
 export class ExternalOAuthTokenError extends Error {
   constructor(readonly innerError?: Error) {
     super(innerError?.message);
@@ -69,4 +74,15 @@ export class ExternalOAuthTokenError extends Error {
 
 export function isNotFoundError(err: unknown): err is NotFoundError {
   return err instanceof HTTPError && err.statusCode === 404;
+}
+
+export function isMicrosoftApplicationDisabledError(
+  error: OAuthAPIError,
+  provider: string
+): boolean {
+  return (
+    error.code === "provider_access_token_refresh_error" &&
+    provider === "microsoft" &&
+    /Application.*is disabled/.test(error.message)
+  );
 }

--- a/connectors/src/lib/oauth.ts
+++ b/connectors/src/lib/oauth.ts
@@ -3,7 +3,10 @@ import { getOAuthConnectionAccessToken } from "@dust-tt/types";
 import type { LoggerInterface } from "@dust-tt/types/dist/shared/logger";
 
 import { apiConfig } from "@connectors/lib/api/config";
-import { ExternalOAuthTokenError } from "@connectors/lib/error";
+import {
+  ExternalOAuthTokenError,
+  isMicrosoftApplicationDisabledError,
+} from "@connectors/lib/error";
 
 // Most connectors are built on the assumption that errors are thrown with special handling of
 // selected errors such as ExternalOauthTokenError. This function is used to retrieve an OAuth
@@ -35,8 +38,11 @@ export async function getOAuthConnectionAccessTokenWithThrow({
       "Error retrieving access token"
     );
 
-    if (tokRes.error.code === "token_revoked_error") {
-      throw new ExternalOAuthTokenError();
+    if (
+      tokRes.error.code === "token_revoked_error" ||
+      isMicrosoftApplicationDisabledError(tokRes.error, provider)
+    ) {
+      throw new ExternalOAuthTokenError(new Error(tokRes.error.message));
     } else {
       throw new Error(`Error retrieving access token from ${provider}`);
     }

--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -130,19 +130,23 @@ export class ActivityInboundLogInterceptor
 
           const connector = await ConnectorResource.fetchById(connectorId);
 
-          if (connector) {
-            const connectorManager = getConnectorManager({
-              connectorId: connector.id,
-              connectorProvider: connector.type,
-            });
+          if (!connector) {
+            throw new Error(
+              `Unexpected: Connector with id ${connectorId} not found in the database.`
+            );
+          }
 
-            if (connectorManager) {
-              await connectorManager.stop();
-            } else {
-              this.logger.error(
-                `Connector manager not found for connector ${connector.id}`
-              );
-            }
+          const connectorManager = getConnectorManager({
+            connectorId: connector.id,
+            connectorProvider: connector.type,
+          });
+
+          if (connectorManager) {
+            await connectorManager.stop();
+          } else {
+            this.logger.error(
+              `Connector manager not found for connector ${connector.id}`
+            );
           }
         }
       }


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/1228

A particular microsoft oauth error indicates the user revoked access. We cast this as an `ExternalOauthToken` error so the workflow is automatically stopped

In a follow-up, we send an email to warn users

Risk
---
na

Deploy
---
connectors
