### PR TITLE
DataSourceResource fetchByNameOrId

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -269,7 +269,12 @@ const dataSource = async (command: string, args: parseArgs.ParsedArgs) => {
 
       const auth = await Authenticator.internalAdminForWorkspace(args.wId);
 
-      const dataSource = await DataSourceResource.fetchByName(auth, args.name);
+      const dataSource = await DataSourceResource.fetchByNameOrId(
+        auth,
+        args.name,
+        // TODO(DATASOURCE_SID): Clean-up
+        { origin: "cli_delete" }
+      );
       if (!dataSource) {
         throw new Error(
           `DataSource not found: wId='${args.wId}' name='${args.name}'`
@@ -380,7 +385,14 @@ const dataSource = async (command: string, args: parseArgs.ParsedArgs) => {
 
       const auth = await Authenticator.internalAdminForWorkspace(args.wId);
 
-      const dataSource = await DataSourceResource.fetchByName(auth, args.name);
+      const dataSource = await DataSourceResource.fetchByNameOrId(
+        auth,
+        args.name,
+        {
+          // TODO(DATASOURCE_SID): Clean-up
+          origin: "cli_delete_document",
+        }
+      );
       if (!dataSource) {
         throw new Error(
           `DataSource not found: wId='${args.wId}' name='${args.name}'`

--- a/front/components/vaults/VaultWebsiteModal.tsx
+++ b/front/components/vaults/VaultWebsiteModal.tsx
@@ -93,7 +93,8 @@ export default function VaultWebsiteModal({
     null
   );
 
-  const dataSourceId = dataSourceView ? dataSourceView.dataSource.name : null;
+  // TODO(DATASOURCE_SID): Move to dataSourceId = ... dataSourceView.dataSource.sId
+  const dsName = dataSourceView ? dataSourceView.dataSource.name : null;
   const defaultDataSourceName = dataSourceView
     ? dataSourceView.dataSource.name
     : "";
@@ -159,7 +160,11 @@ export default function VaultWebsiteModal({
 
     // Validate Name
     const nameExists = dataSources.some(
-      (d) => d.name === dataSourceName && d.name !== dataSourceId
+      // TODO(DATASOURCE_SID): This line was kind of buggy because dataSourceId and sId was name but
+      // dataSourceId was not defined when it mattered (creation) and this not used during patching.
+      // (currently replacing back to .name the real real value for now showing that the line makes
+      // no sense). Will move to sId in subsequent PR.
+      (d) => d.name === dataSourceName && d.name !== dsName
     );
     const dataSourceNameRes = isDataSourceNameValid(dataSourceName);
     if (nameExists) {
@@ -173,7 +178,7 @@ export default function VaultWebsiteModal({
     setDataSourceUrlError(urlError);
     setDataSourceNameError(nameError);
     return !urlError && !nameError;
-  }, [dataSourceName, dataSourceId, dataSources, dataSourceUrl]);
+  }, [dataSourceName, dsName, dataSources, dataSourceUrl]);
 
   useEffect(() => {
     if (isSubmitted) {
@@ -247,7 +252,7 @@ export default function VaultWebsiteModal({
       }
     } else if (dataSourceView) {
       const res = await fetch(
-        `/api/w/${owner.sId}/vaults/${vault.sId}/data_sources/${dataSourceId}/configuration`,
+        `/api/w/${owner.sId}/vaults/${vault.sId}/data_sources/${dsName}/configuration`,
         {
           method: "PATCH",
           headers: {
@@ -295,12 +300,12 @@ export default function VaultWebsiteModal({
   };
 
   const handleDelete = async () => {
-    if (!dataSourceId) {
+    if (!dsName) {
       return;
     }
     setIsSaving(true);
     const res = await fetch(
-      `/api/w/${owner.sId}/vaults/${vault.sId}/data_sources/${dataSourceId}`,
+      `/api/w/${owner.sId}/vaults/${vault.sId}/data_sources/${dsName}`,
       {
         method: "DELETE",
       }
@@ -589,7 +594,7 @@ export default function VaultWebsiteModal({
                     setAdvancedSettingsOpened(true);
                   }}
                 ></Button>
-                {webCrawlerConfiguration && dataSourceId && (
+                {webCrawlerConfiguration && dsName && (
                   <>
                     <Button
                       variant="secondaryWarning"

--- a/front/lib/api/assistant/configuration/table_query.ts
+++ b/front/lib/api/assistant/configuration/table_query.ts
@@ -107,6 +107,8 @@ export async function createTableDataSourceConfiguration(
   const [globalVault, dataSources] = await Promise.all([
     // TODO(GROUPS_INFRA): Remove fetching global vault once the UI passes the data source view.
     VaultResource.fetchWorkspaceGlobalVault(auth),
+    // TODO(DATASOURCE_SID): remove fetch by names in favor of fetchByModelIds once the
+    // configuration is migrated to it.
     DataSourceResource.fetchByNames(
       // We can use `auth` because we limit to one workspace.
       auth,

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -36,8 +36,10 @@ export async function getDataSource(
     return null;
   }
 
-  const dataSource = await DataSourceResource.fetchByName(auth, name, {
+  const dataSource = await DataSourceResource.fetchByNameOrId(auth, name, {
     includeEditedBy,
+    // TODO(DATASOURCE_SID): clean-up
+    origin: "lib_api_get_data_source",
   });
 
   if (!dataSource) {
@@ -86,7 +88,14 @@ export async function deleteDataSource(
     });
   }
 
-  const dataSource = await DataSourceResource.fetchByName(auth, dataSourceName);
+  const dataSource = await DataSourceResource.fetchByNameOrId(
+    auth,
+    dataSourceName,
+    {
+      // TODO(DATASOURCE_SID): clean-up
+      origin: "lib_api_delete_data_source",
+    }
+  );
 
   if (!dataSource) {
     return new Err({

--- a/front/lib/documents_post_process_hooks/hooks/data_source_helpers.ts
+++ b/front/lib/documents_post_process_hooks/hooks/data_source_helpers.ts
@@ -125,7 +125,12 @@ export async function getDatasource(
   if (!workspace) {
     throw new Error(`Could not find workspace ${owner.sId}`);
   }
-  const dataSource = await DataSourceResource.fetchByName(auth, dataSourceName);
+  const dataSource = await DataSourceResource.fetchByNameOrId(
+    auth,
+    dataSourceName,
+    // TOOD(DATASOURCE_SID): clean-up
+    { origin: "post_upsert_hook_helper" }
+  );
   if (!dataSource) {
     throw new Error(
       `Could not find data source with name ${dataSourceName} and workspace ${owner.sId}`

--- a/front/lib/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
+++ b/front/lib/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
@@ -304,7 +304,17 @@ export async function documentTrackerSuggestChangesOnUpsert({
     "Match found."
   );
 
-  const matchedDs = await DataSourceResource.fetchByName(auth, matchedDsName);
+  const matchedDs = await DataSourceResource.fetchByNameOrId(
+    auth,
+    matchedDsName,
+    // TODO(DATASOURCE_SID): clean-up we have an assumption here that core.data_source_id is
+    // retrievable in front. Here as name, in the future as sId. This should be a fetch by
+    // dustAPIDataSourceId but we need the project_id as well in the response which is not
+    // desirable.
+    {
+      origin: "document_tracker",
+    }
+  );
   if (!matchedDs) {
     throw new Error(
       `Could not find data source with name ${matchedDsName} and workspace ${owner.sId}`

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -36,7 +36,17 @@ export type FetchDataSourceOrigin =
   | "post_upsert_hook_helper"
   | "post_upsert_hook_activities"
   | "lib_api_get_data_source"
-  | "lib_api_delete_data_source";
+  | "lib_api_delete_data_source"
+  | "cli_delete"
+  | "cli_delete_document"
+  | "vault_patch_content"
+  | "data_source_view_create"
+  | "poke_data_source_config"
+  | "registry_lookup"
+  | "data_source_get_or_post"
+  | "data_source_managed_update"
+  | "vault_data_source_config"
+  | "vault_patch_or_delete_data_source";
 
 export type FetchDataSourceOptions = {
   includeEditedBy?: boolean;
@@ -191,30 +201,6 @@ export class DataSourceResource extends ResourceWithVault<DataSource> {
       );
       return dataSources[0];
     }
-  }
-
-  static async fetchById(
-    auth: Authenticator,
-    id: string,
-    options?: FetchDataSourceOptions
-  ): Promise<DataSourceResource | null> {
-    // Preparing the introduction of datasource sIds - fetchById for now points to fetchByName
-    const dataSource = await this.fetchByName(auth, id, options);
-
-    return dataSource ?? null;
-  }
-
-  static async fetchByName(
-    auth: Authenticator,
-    name: string,
-    options?: Omit<FetchDataSourceOptions, "limit" | "order">
-  ): Promise<DataSourceResource | null> {
-    const dataSources = await this.fetchByNames(auth, [name], options);
-    if (dataSources.length === 0) {
-      return null;
-    }
-
-    return dataSources[0];
   }
 
   // TODO(DATASOURCE_SID): remove

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -226,8 +226,8 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
       "limit" | "order"
     >
   ) {
-    const fileModelId = getResourceIdFromSId(id);
-    if (!fileModelId) {
+    const dataSourceViewModelId = getResourceIdFromSId(id);
+    if (!dataSourceViewModelId) {
       return null;
     }
 
@@ -236,7 +236,7 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
       fetchDataSourceViewOptions,
       {
         where: {
-          id: fileModelId,
+          id: dataSourceViewModelId,
         },
       }
     );

--- a/front/lib/resources/labs_transcripts_resource.ts
+++ b/front/lib/resources/labs_transcripts_resource.ts
@@ -146,7 +146,12 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
       return;
     }
 
-    const dataSource = await DataSourceResource.fetchById(auth, dataSourceId);
+    const dataSource = await DataSourceResource.fetchByNameOrId(
+      auth,
+      dataSourceId,
+      // TODO(DATASOURCE_SID): clean-up
+      { origin: "labs_transcripts_resource" }
+    );
 
     if (!dataSource || this.dataSourceId === dataSource.id) {
       return;

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/config.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/config.ts
@@ -59,9 +59,11 @@ async function handler(
       }
       const { configKey, configValue } = req.body;
 
-      const dataSource = await DataSourceResource.fetchByName(
+      const dataSource = await DataSourceResource.fetchByNameOrId(
         auth,
-        req.query.name as string
+        req.query.name as string,
+        // TODO(DATASOURCE_SID): Clean-up and rename parameter [dsId]
+        { origin: "poke_data_source_config" }
       );
 
       if (!dataSource) {

--- a/front/pages/api/registry/[type]/lookup.ts
+++ b/front/pages/api/registry/[type]/lookup.ts
@@ -258,7 +258,12 @@ async function handleDataSource(
   dataSourceId: string,
   dustOrigin: string | null
 ): Promise<Result<LookupDataSourceResponseBody, Error>> {
-  const dataSource = await DataSourceResource.fetchByName(auth, dataSourceId);
+  const dataSource = await DataSourceResource.fetchByNameOrId(
+    auth,
+    dataSourceId,
+    // TODO(DATASOURCE_SID): Clean-up
+    { origin: "registry_lookup" }
+  );
   if (!dataSource) {
     return new Err(new Error("Data source not found."));
   }

--- a/front/pages/api/w/[wId]/data_sources/[name]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/index.ts
@@ -31,7 +31,12 @@ async function handler(
     });
   }
 
-  const dataSource = await DataSourceResource.fetchByName(auth, req.query.name);
+  const dataSource = await DataSourceResource.fetchByNameOrId(
+    auth,
+    req.query.name,
+    // TODO(DATASOURCE_SID): Clean-up and rename parameter as [dsId]
+    { origin: "data_source_get_or_post" }
+  );
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/update.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/update.ts
@@ -43,9 +43,11 @@ async function handler(
   const user = auth.getNonNullableUser();
 
   // fetchByName enforces through auth the authorization (workspace here mainly).
-  const dataSource = await DataSourceResource.fetchByName(
+  const dataSource = await DataSourceResource.fetchByNameOrId(
     auth,
-    req.query.name as string
+    req.query.name as string,
+    // TOOD(DATASOURCE_SID): Clean-up and rename param as [dsId]
+    { origin: "data_source_managed_update" }
   );
   if (!dataSource) {
     return apiError(req, res, {

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/index.ts
@@ -124,7 +124,10 @@ async function handler(
       const { name, parentsIn } = bodyValidation.right;
 
       // Create a new view
-      const dataSource = await DataSourceResource.fetchByName(auth, name);
+      const dataSource = await DataSourceResource.fetchByNameOrId(auth, name, {
+        // TODO(DATASOURCE_SID): Clean-up
+        origin: "data_source_view_create",
+      });
       if (!dataSource) {
         return apiError(req, res, {
           status_code: 400,

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/[dsId]/configuration.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/[dsId]/configuration.ts
@@ -54,7 +54,12 @@ async function handler(
     });
   }
 
-  const dataSource = await DataSourceResource.fetchById(auth, req.query.dsId);
+  const dataSource = await DataSourceResource.fetchByNameOrId(
+    auth,
+    req.query.dsId,
+    // TODO(DATASOURCE_SID): Clean-up
+    { origin: "vault_data_source_config" }
+  );
   if (!dataSource || dataSource.vault.sId !== req.query.vId) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/[dsId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/[dsId]/index.ts
@@ -103,7 +103,12 @@ async function handler(
       },
     });
   }
-  const dataSource = await DataSourceResource.fetchById(auth, req.query.dsId);
+  const dataSource = await DataSourceResource.fetchByNameOrId(
+    auth,
+    req.query.dsId,
+    // TODO(DATASOURCE_SID): Clean-up
+    { origin: "vault_patch_or_delete_data_source" }
+  );
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/vaults/[vId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/index.ts
@@ -149,9 +149,11 @@ async function handler(
             await view.setEditedBy(auth);
           } else {
             // Create a new view
-            const dataSource = await DataSourceResource.fetchByName(
+            const dataSource = await DataSourceResource.fetchByNameOrId(
               auth,
-              dataSourceConfig.dataSource
+              dataSourceConfig.dataSource,
+              // TODO(DATASOURCE_SID): Clean-up
+              { origin: "vault_patch_content" }
             );
             if (dataSource) {
               await DataSourceViewResource.createViewInVaultFromDataSource(

--- a/front/temporal/documents_post_process_hooks/activities.ts
+++ b/front/temporal/documents_post_process_hooks/activities.ts
@@ -135,7 +135,12 @@ async function getDataSourceDocument({
   }
 
   const auth = await Authenticator.internalBuilderForWorkspace(workspaceId);
-  const dataSource = await DataSourceResource.fetchByName(auth, dataSourceName);
+  const dataSource = await DataSourceResource.fetchByNameOrId(
+    auth,
+    dataSourceName,
+    // TODO(DATASOURCE_SID): clean-up
+    { origin: "post_upsert_hook_activities" }
+  );
 
   if (!dataSource) {
     return new Err(new Error(`Could not find data source ${dataSourceName}`));

--- a/types/src/front/api_handlers/public/vaults.ts
+++ b/types/src/front/api_handlers/public/vaults.ts
@@ -3,11 +3,13 @@ import * as t from "io-ts";
 import { ContentNodeType } from "../../lib/connectors_api";
 
 export const ContentSchema = t.type({
+  // TODO(DATASOURCE_SID): rename to `dataSourceId`
   dataSource: t.string,
   parentsIn: t.union([t.array(t.string), t.null]),
 });
 
 export const PostDataSourceViewSchema = t.type({
+  // TODO(DATASOURCE_SID): rename to `dataSourceId`
   name: t.string,
   parentsIn: t.union([t.array(t.string), t.null]),
 });


### PR DESCRIPTION
## Description

- Replace `fetchByName` and `fetchById` by `fetchByNameOrId` with verbose logging to track all usage using an `origin` parameter.
- Remove `sId` from DataSourceType to be in a state of total explicitness of places where we use `name`
- Audited all uses of the raw DataSource model (mostly used as include in other queries)

Follow-up work wil consists in removing all uses of `name` in favor of `sId`

## Risk

Medium. Tested critical pathes (classical views) in dev:
- Dust app search
- Creating a data source adding a doc
- Creating a managed data source with initial syncing

## Deploy Plan

- deploy `front`

r? @flvndvd 