### PR TITLE
github connector update should launch full sync workflow

### DIFF
--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -100,6 +100,11 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
       }
 
       await c.update({ connectionId });
+
+      await launchGithubFullSyncWorkflow({
+        connectorId: this.connectorId,
+        syncCodeOnly: false,
+      });
     }
 
     return new Ok(c.id.toString());


### PR DESCRIPTION
## Description

When updating the connectionId of github we might have changed the selection of repositories so we should launch a fullSyncWorkflow. The `launchGithubFullSyncWorkflow` checks for the existence of a running workflow.

This might mean that we haven't launched syncs for some connectors. Might be worth relaunching a full sync for non failed connectors?

## Risk

Low

## Deploy Plan

- deploy `connectors`