### PR TITLE
More precise check of sId to prevent collision

### DIFF
--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -108,7 +108,7 @@ export function isResourceSId(
   resourceName: ResourceNameType,
   sId: string
 ): boolean {
-  return sId.startsWith(RESOURCES_PREFIX[resourceName]);
+  return sId.startsWith(`${RESOURCES_PREFIX[resourceName]}_`);
 }
 
 // Legacy behavior.


### PR DESCRIPTION
## Description

We check that it starts with the prefix and `_` to avoid collision with legacy ids.

## Risk

N/A

## Deploy Plan

- deploy `front`