### PR TITLE
Flav/tables dsv wave 3

### DIFF
--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -137,6 +137,7 @@ export function ConnectorPermissionsModal({
                   }));
                 }}
                 showExpand={CONNECTOR_CONFIGURATIONS[connector.type]?.isNested}
+                // List only document-type items when displaying permissions for a data source.
                 viewType="documents"
               />
             </div>

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -137,6 +137,7 @@ export function ConnectorPermissionsModal({
                   }));
                 }}
                 showExpand={CONNECTOR_CONFIGURATIONS[connector.type]?.isNested}
+                viewType="documents"
               />
             </div>
           </Page.Vertical>

--- a/front/components/ConnectorPermissionsTree.tsx
+++ b/front/components/ConnectorPermissionsTree.tsx
@@ -11,6 +11,7 @@ import {
 import type {
   BaseContentNode,
   ConnectorProvider,
+  ContentNodesViewType,
   DataSourceType,
   DataSourceViewType,
   LightWorkspaceType,
@@ -76,6 +77,7 @@ type DataSourcePermissionTreeChildrenProps = PermissionTreeChildrenBaseProps & {
   dataSource: DataSourceType;
   permissionFilter?: ConnectorPermission;
   useConnectorPermissionsHook: typeof useConnectorPermissions;
+  viewType: ContentNodesViewType;
 };
 
 export function DataSourcePermissionTreeChildren({
@@ -85,14 +87,16 @@ export function DataSourcePermissionTreeChildren({
   parentId,
   permissionFilter,
   useConnectorPermissionsHook,
+  viewType,
   ...props
 }: DataSourcePermissionTreeChildrenProps) {
   const { resources, isResourcesLoading, isResourcesError } =
     useConnectorPermissionsHook({
-      owner,
       dataSource,
-      parentId,
       filterPermission: permissionFilter || null,
+      owner,
+      parentId,
+      viewType,
     });
 
   // For data source permissions, we rely on the permission field to determine if a node is checked.
@@ -131,6 +135,7 @@ export function DataSourcePermissionTreeChildren({
           parentIsSelected={isParentNodeSelected}
           permissionFilter={permissionFilter}
           useConnectorPermissionsHook={useConnectorPermissionsHook}
+          viewType={viewType}
           {...props}
           // Disable search for children.
           isSearchEnabled={false}
@@ -145,20 +150,23 @@ type DataSourceViewPermissionTreeChildrenProps =
   PermissionTreeChildrenBaseProps & {
     dataSourceView: DataSourceViewType;
     permissionFilter?: ConnectorPermission;
+    viewType: ContentNodesViewType;
   };
 
 export function DataSourceViewPermissionTreeChildren({
   dataSourceView,
   owner,
   parentId,
+  viewType,
   ...props
 }: DataSourceViewPermissionTreeChildrenProps) {
   const { nodes, isNodesLoading, isNodesError } = useDataSourceViewContentNodes(
     {
-      owner,
       dataSourceView,
-      internalIds: parentId ? [parentId] : [],
       includeChildren: true,
+      internalIds: parentId ? [parentId] : [],
+      owner,
+      viewType,
     }
   );
 
@@ -185,6 +193,7 @@ export function DataSourceViewPermissionTreeChildren({
           owner={owner}
           parentId={node.internalId}
           parentIsSelected={isParentNodeSelected}
+          viewType={viewType}
           {...props}
           // Disable search for children.
           isSearchEnabled={false}
@@ -414,23 +423,27 @@ function PermissionTreeChildren({
   );
 }
 
-export function PermissionTree({
-  owner,
-  dataSource,
-  permissionFilter,
-  canUpdatePermissions,
-  onPermissionUpdate,
-  showExpand,
-  isSearchEnabled,
-}: {
-  owner: LightWorkspaceType;
-  dataSource: DataSourceType;
-  permissionFilter?: ConnectorPermission;
+interface PermissionTreenProps {
   canUpdatePermissions?: boolean;
-  onPermissionUpdate?: onPermissionUpdateType;
-  showExpand?: boolean;
+  dataSource: DataSourceType;
   isSearchEnabled: boolean;
-}) {
+  onPermissionUpdate?: onPermissionUpdateType;
+  owner: LightWorkspaceType;
+  permissionFilter?: ConnectorPermission;
+  showExpand?: boolean;
+  viewType: ContentNodesViewType;
+}
+
+export function PermissionTree({
+  canUpdatePermissions,
+  dataSource,
+  isSearchEnabled,
+  onPermissionUpdate,
+  owner,
+  permissionFilter,
+  showExpand,
+  viewType,
+}: PermissionTreenProps) {
   const [documentToDisplay, setDocumentToDisplay] = useState<string | null>(
     null
   );
@@ -464,6 +477,7 @@ export function PermissionTree({
           }}
           useConnectorPermissionsHook={useConnectorPermissions}
           isSearchEnabled={isSearchEnabled}
+          viewType={viewType}
         />
       </div>
     </>

--- a/front/components/ConnectorPermissionsTree.tsx
+++ b/front/components/ConnectorPermissionsTree.tsx
@@ -423,7 +423,7 @@ function PermissionTreeChildren({
   );
 }
 
-interface PermissionTreenProps {
+interface PermissionTreeProps {
   canUpdatePermissions?: boolean;
   dataSource: DataSourceType;
   isSearchEnabled: boolean;
@@ -443,7 +443,7 @@ export function PermissionTree({
   permissionFilter,
   showExpand,
   viewType,
-}: PermissionTreenProps) {
+}: PermissionTreeProps) {
   const [documentToDisplay, setDocumentToDisplay] = useState<string | null>(
     null
   );

--- a/front/components/DataSourceViewResourceSelectorTree.tsx
+++ b/front/components/DataSourceViewResourceSelectorTree.tsx
@@ -6,8 +6,8 @@ import {
 } from "@dust-tt/sparkle";
 import type {
   ContentNodesViewType,
+  DataSourceViewContentNode,
   DataSourceViewType,
-  LightContentNode,
   LightWorkspaceType,
 } from "@dust-tt/types";
 import { useEffect, useState } from "react";
@@ -17,7 +17,22 @@ import { getVisualForContentNode } from "@app/lib/content_nodes";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import { classNames } from "@app/lib/utils";
 
-export default function DataSourceResourceSelectorTree({
+interface DataSourceViewResourceSelectorTreeBaseProps {
+  dataSourceView: DataSourceViewType;
+  onSelectChange: (
+    resource: DataSourceViewContentNode,
+    parents: string[],
+    selected: boolean
+  ) => void;
+  owner: LightWorkspaceType;
+  parentIsSelected?: boolean;
+  selectedParents?: string[];
+  selectedResourceIds: string[];
+  showExpand: boolean;
+  viewType?: ContentNodesViewType;
+}
+
+export default function DataSourceViewResourceSelectorTree({
   owner,
   dataSourceView,
   showExpand, //if not, it's flat
@@ -26,23 +41,10 @@ export default function DataSourceResourceSelectorTree({
   selectedResourceIds,
   onSelectChange,
   viewType = "documents",
-}: {
-  owner: LightWorkspaceType;
-  dataSourceView: DataSourceViewType;
-  showExpand: boolean;
-  parentIsSelected?: boolean;
-  selectedParents?: string[];
-  selectedResourceIds: string[];
-  onSelectChange: (
-    resource: LightContentNode,
-    parents: string[],
-    selected: boolean
-  ) => void;
-  viewType?: ContentNodesViewType;
-}) {
+}: DataSourceViewResourceSelectorTreeBaseProps) {
   return (
     <div className="overflow-x-auto">
-      <DataSourceResourceSelectorChildren
+      <DataSourceViewResourceSelectorChildren
         owner={owner}
         dataSourceView={dataSourceView}
         showExpand={showExpand}
@@ -59,33 +61,25 @@ export default function DataSourceResourceSelectorTree({
   );
 }
 
-function DataSourceResourceSelectorChildren({
-  owner,
+type DataSourceResourceSelectorChildrenProps =
+  DataSourceViewResourceSelectorTreeBaseProps & {
+    parentId?: string;
+    parents: string[];
+    selectedParents: string[];
+  };
+
+function DataSourceViewResourceSelectorChildren({
   dataSourceView,
-  parentId,
-  parents,
-  parentIsSelected,
-  selectedParents,
-  showExpand,
-  selectedResourceIds,
   onSelectChange,
+  owner,
+  parentId,
+  parentIsSelected,
+  parents,
+  selectedParents,
+  selectedResourceIds,
+  showExpand,
   viewType = "documents",
-}: {
-  owner: LightWorkspaceType;
-  dataSourceView: DataSourceViewType;
-  parentId?: string;
-  parents: string[];
-  parentIsSelected?: boolean;
-  selectedParents: string[];
-  showExpand: boolean;
-  selectedResourceIds: string[];
-  onSelectChange: (
-    resource: LightContentNode,
-    parents: string[],
-    selected: boolean
-  ) => void;
-  viewType: ContentNodesViewType;
-}) {
+}: DataSourceResourceSelectorChildrenProps) {
   const { nodes, isNodesLoading, isNodesError } = useDataSourceViewContentNodes(
     {
       dataSourceView: dataSourceView,
@@ -171,7 +165,7 @@ function DataSourceResourceSelectorChildren({
                   : undefined
               }
               renderTreeItems={() => (
-                <DataSourceResourceSelectorChildren
+                <DataSourceViewResourceSelectorChildren
                   owner={owner}
                   dataSourceView={dataSourceView}
                   parentId={r.internalId}

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -408,6 +408,7 @@ function DataSourceViewsSection({
                     setDocumentToDisplay(documentId);
                   }}
                   isSearchEnabled={false}
+                  viewType="documents"
                 />
               )}
               {dataSourceView && !isAllSelected && (
@@ -499,6 +500,7 @@ function DataSourceViewSelectedNodes({
               setDocumentToDisplay(documentId);
             }}
             isSearchEnabled={false}
+            viewType="documents"
           />
         </Tree.Item>
       ))}

--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -63,10 +63,11 @@ export default function AssistantBuilderDataSourceModal({
     >
       <div className="w-full pt-12">
         <DataSourceViewsSelector
-          owner={owner}
           dataSourceViews={dataSourceViews}
+          owner={owner}
           selectionConfigurations={selectionConfigurations}
           setSelectionConfigurations={setSelectionConfigurationsCallback}
+          viewType="documents"
         />
       </div>
     </Modal>

--- a/front/components/assistant_builder/DataSourceSelectionSection.tsx
+++ b/front/components/assistant_builder/DataSourceSelectionSection.tsx
@@ -7,9 +7,10 @@ import {
   Tree,
 } from "@dust-tt/sparkle";
 import type {
+  ContentNodesViewType,
   DataSourceViewSelectionConfigurations,
   DataSourceViewType,
-  WorkspaceType,
+  LightWorkspaceType,
 } from "@dust-tt/types";
 import { useContext, useState } from "react";
 
@@ -23,16 +24,19 @@ import { getVisualForContentNode } from "@app/lib/content_nodes";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import { classNames } from "@app/lib/utils";
 
-export default function DataSourceSelectionSection({
-  owner,
-  dataSourceConfigurations,
-  openDataSourceModal,
-}: {
-  owner: WorkspaceType;
+interface DataSourceSelectionSectionProps {
   dataSourceConfigurations: DataSourceViewSelectionConfigurations;
   openDataSourceModal: () => void;
-  onDelete?: (name: string) => void;
-}) {
+  owner: LightWorkspaceType;
+  viewType: ContentNodesViewType;
+}
+
+export default function DataSourceSelectionSection({
+  dataSourceConfigurations,
+  openDataSourceModal,
+  owner,
+  viewType,
+}: DataSourceSelectionSectionProps) {
   const { dataSourceViews } = useContext(AssistantBuilderContext);
   const [documentToDisplay, setDocumentToDisplay] = useState<string | null>(
     null
@@ -90,6 +94,7 @@ export default function DataSourceSelectionSection({
                 dsConfig.dataSourceView.dataSource.connectorProvider,
                 FolderIcon
               );
+
               return (
                 <Tree.Item
                   key={dsConfig.dataSourceView.sId}
@@ -115,6 +120,7 @@ export default function DataSourceSelectionSection({
                         setDocumentToDisplay(documentId);
                       }}
                       isSearchEnabled={false}
+                      viewType={viewType}
                     />
                   )}
                   {dsConfig.selectedResources.map((node) => {
@@ -175,6 +181,7 @@ export default function DataSourceSelectionSection({
                             setDocumentToDisplay(documentId);
                           }}
                           isSearchEnabled={false}
+                          viewType={viewType}
                         />
                       </Tree.Item>
                     );

--- a/front/components/assistant_builder/PickTablesManaged.tsx
+++ b/front/components/assistant_builder/PickTablesManaged.tsx
@@ -7,7 +7,7 @@ import type {
 import { Transition } from "@headlessui/react";
 import * as React from "react";
 
-import DataSourceResourceSelectorTree from "@app/components/DataSourceResourceSelectorTree";
+import DataSourceViewResourceSelectorTree from "@app/components/DataSourceViewResourceSelectorTree";
 
 export const PickTablesManaged = ({
   owner,
@@ -33,7 +33,7 @@ export const PickTablesManaged = ({
     <Transition show className="mx-auto max-w-6xl">
       <Page>
         <Page.Header title="Select a Table" icon={ServerIcon} />
-        <DataSourceResourceSelectorTree
+        <DataSourceViewResourceSelectorTree
           owner={owner}
           dataSourceView={dataSourceView}
           showExpand={true}

--- a/front/components/assistant_builder/SlackIntegration.tsx
+++ b/front/components/assistant_builder/SlackIntegration.tsx
@@ -91,6 +91,7 @@ export function SlackIntegration({
       isSearchEnabled={false}
       customIsNodeChecked={customIsNodeChecked}
       useConnectorPermissionsHook={useConnectorPermissions}
+      viewType="documents"
     />
   );
 }

--- a/front/components/assistant_builder/actions/ProcessAction.tsx
+++ b/front/components/assistant_builder/actions/ProcessAction.tsx
@@ -301,22 +301,6 @@ export function ActionProcess({
     return null;
   }
 
-  const deleteDataSource = (name: string) => {
-    updateAction((previousAction) => {
-      if (previousAction.dataSourceConfigurations[name]) {
-        setEdited(true);
-      }
-      const dataSourceConfigurations = {
-        ...previousAction.dataSourceConfigurations,
-      };
-      delete dataSourceConfigurations[name];
-      return {
-        ...previousAction,
-        dataSourceConfigurations,
-      };
-    });
-  };
-
   const foldersOnly =
     Object.keys(actionConfiguration.dataSourceConfigurations).every(
       (k) =>
@@ -415,7 +399,7 @@ export function ActionProcess({
         openDataSourceModal={() => {
           setShowDataSourcesModal(true);
         }}
-        onDelete={deleteDataSource}
+        viewType="documents"
       />
 
       {(foldersOnly ||

--- a/front/components/assistant_builder/actions/RetrievalAction.tsx
+++ b/front/components/assistant_builder/actions/RetrievalAction.tsx
@@ -12,34 +12,6 @@ import type {
 } from "@app/components/assistant_builder/types";
 import { classNames } from "@app/lib/utils";
 
-const deleteDataSource = ({
-  name,
-  updateAction,
-  setEdited,
-}: {
-  name: string;
-  updateAction: (
-    setNewAction: (
-      previousAction: AssistantBuilderRetrievalConfiguration
-    ) => AssistantBuilderRetrievalConfiguration
-  ) => void;
-  setEdited: (edited: boolean) => void;
-}) => {
-  updateAction((previousAction) => {
-    if (previousAction.dataSourceConfigurations[name]) {
-      setEdited(true);
-    }
-    const newDataSourceConfigurations = {
-      ...previousAction.dataSourceConfigurations,
-    };
-    delete newDataSourceConfigurations[name];
-    return {
-      ...previousAction,
-      dataSourceConfigurations: newDataSourceConfigurations,
-    };
-  });
-};
-
 export function hasErrorActionRetrievalSearch(
   action: AssistantBuilderActionConfiguration
 ): string | null {
@@ -98,13 +70,7 @@ export function ActionRetrievalSearch({
         openDataSourceModal={() => {
           setShowDataSourcesModal(true);
         }}
-        onDelete={(name) => {
-          deleteDataSource({
-            name,
-            updateAction,
-            setEdited,
-          });
-        }}
+        viewType={"documents"}
       />
     </>
   );
@@ -178,13 +144,7 @@ export function ActionRetrievalExhaustive({
         openDataSourceModal={() => {
           setShowDataSourcesModal(true);
         }}
-        onDelete={(name) => {
-          deleteDataSource({
-            name,
-            updateAction,
-            setEdited,
-          });
-        }}
+        viewType={"documents"}
       />
       <div className={"flex flex-row items-center gap-4 pb-4"}>
         <div className="text-sm font-semibold text-element-900">

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -5,10 +5,11 @@ import {
   Tree,
 } from "@dust-tt/sparkle";
 import type {
+  ContentNodesViewType,
   DataSourceViewSelectionConfiguration,
   DataSourceViewSelectionConfigurations,
   DataSourceViewType,
-  WorkspaceType,
+  LightWorkspaceType,
 } from "@dust-tt/types";
 import { defaultSelectionConfiguration } from "@dust-tt/types";
 import _ from "lodash";
@@ -32,20 +33,22 @@ import {
 const MIN_TOTAL_DATA_SOURCES_TO_GROUP = 12;
 const MIN_DATA_SOURCES_PER_KIND_TO_GROUP = 3;
 
-type DataSourceViewsSelectorProps = {
-  owner: WorkspaceType;
+interface DataSourceViewsSelectorProps {
+  owner: LightWorkspaceType;
   dataSourceViews: DataSourceViewType[];
   selectionConfigurations: DataSourceViewSelectionConfigurations;
   setSelectionConfigurations: Dispatch<
     SetStateAction<DataSourceViewSelectionConfigurations>
   >;
-};
+  viewType: ContentNodesViewType;
+}
 
 export function DataSourceViewsSelector({
   owner,
   dataSourceViews,
   selectionConfigurations,
   setSelectionConfigurations,
+  viewType,
 }: DataSourceViewsSelectorProps) {
   // Apply grouping if there are many data sources, and there are enough of each kind
   // So we don't show a long list of data sources to the user
@@ -93,6 +96,7 @@ export function DataSourceViewsSelector({
                   defaultSelectionConfiguration(dataSourceView)
                 }
                 setSelectionConfigurations={setSelectionConfigurations}
+                viewType={viewType}
               />
             ))}
         </Tree.Item>
@@ -114,6 +118,7 @@ export function DataSourceViewsSelector({
               defaultSelectionConfiguration(dataSourceView)
             }
             setSelectionConfigurations={setSelectionConfigurations}
+            viewType={viewType}
           />
         ))}
 
@@ -130,6 +135,7 @@ export function DataSourceViewsSelector({
                   defaultSelectionConfiguration(dataSourceView)
                 }
                 setSelectionConfigurations={setSelectionConfigurations}
+                viewType={viewType}
               />
             ))}
         </Tree.Item>
@@ -153,6 +159,7 @@ export function DataSourceViewsSelector({
                   defaultSelectionConfiguration(dataSourceView)
                 }
                 setSelectionConfigurations={setSelectionConfigurations}
+                viewType={viewType}
               />
             ))}
         </Tree.Item>
@@ -161,17 +168,21 @@ export function DataSourceViewsSelector({
   );
 }
 
-function DataSourceViewSelector({
-  owner,
-  selectionConfiguration,
-  setSelectionConfigurations,
-}: {
-  owner: WorkspaceType;
+interface DataSourceViewSelectorProps {
+  owner: LightWorkspaceType;
   selectionConfiguration: DataSourceViewSelectionConfiguration;
   setSelectionConfigurations: Dispatch<
     SetStateAction<DataSourceViewSelectionConfigurations>
   >;
-}) {
+  viewType: ContentNodesViewType;
+}
+
+function DataSourceViewSelector({
+  owner,
+  selectionConfiguration,
+  setSelectionConfigurations,
+  viewType,
+}: DataSourceViewSelectorProps) {
   const dataSourceView = selectionConfiguration.dataSourceView;
   const config = dataSourceView.dataSource.connectorProvider
     ? CONNECTOR_CONFIGURATIONS[dataSourceView.dataSource.connectorProvider]
@@ -231,16 +242,29 @@ function DataSourceViewSelector({
     };
   }, [dataSourceView, setParentsById, setSelectionConfigurations]);
 
+  const isTableView = viewType === "tables";
+
+  // Folders with viewType "documents" are always considered leaf items.
+  // For viewType "tables", folders are not leaf items because users need to select a specific table.
+  const isLeafItem = isFolder(dataSourceView.dataSource) && !isTableView;
+
+  // Show the checkbox by default. Hide it only for tables where no child items are partially checked.
+  const hideCheckbox = isTableView && !isPartiallyChecked;
+
   return (
     <Tree.Item
       key={dataSourceView.dataSource.name}
       label={getDisplayNameForDataSource(dataSourceView.dataSource)}
       visual={LogoComponent}
-      type={isFolder(dataSourceView.dataSource) ? "leaf" : "node"}
-      checkbox={{
-        checked: checkedStatus,
-        onChange: onToggleSelectAll,
-      }}
+      type={isLeafItem ? "leaf" : "node"}
+      checkbox={
+        hideCheckbox
+          ? undefined
+          : {
+              checked: checkedStatus,
+              onChange: onToggleSelectAll,
+            }
+      }
     >
       <DataSourceResourceSelectorTree
         owner={owner}
@@ -294,6 +318,7 @@ function DataSourceViewSelector({
           );
         }}
         parentIsSelected={selectionConfiguration.isSelectAll}
+        viewType={viewType}
       />
     </Tree.Item>
   );

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -16,7 +16,7 @@ import _ from "lodash";
 import type { Dispatch, SetStateAction } from "react";
 import { useMemo } from "react";
 
-import DataSourceResourceSelectorTree from "@app/components/DataSourceResourceSelectorTree";
+import DataSourceViewResourceSelectorTree from "@app/components/DataSourceViewResourceSelectorTree";
 import { useParentResourcesById } from "@app/hooks/useParentResourcesById";
 import { orderDatasourceViewByImportance } from "@app/lib/assistant";
 import {
@@ -196,11 +196,8 @@ function DataSourceViewSelector({
     (r) => r.internalId
   );
 
-  // TODO(GROUPS_INFRA): useParentResourcesById should use views not data sources.
   const { parentsById, setParentsById } = useParentResourcesById({
-    owner,
-    dataSource: dataSourceView.dataSource,
-    internalIds,
+    selectedResources: selectionConfiguration.selectedResources,
   });
 
   const selectedParents = [
@@ -266,7 +263,7 @@ function DataSourceViewSelector({
             }
       }
     >
-      <DataSourceResourceSelectorTree
+      <DataSourceViewResourceSelectorTree
         owner={owner}
         dataSourceView={dataSourceView}
         showExpand={config?.isNested ?? true}

--- a/front/components/poke/PokeConnectorPermissionsTree.tsx
+++ b/front/components/poke/PokeConnectorPermissionsTree.tsx
@@ -35,6 +35,7 @@ export function PokePermissionTree({
         displayDocumentSource={displayDocumentSource}
         useConnectorPermissionsHook={usePokeConnectorPermissions}
         isSearchEnabled={false}
+        viewType="documents"
       />
     </div>
   );

--- a/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
+++ b/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
@@ -112,6 +112,7 @@ export default function VaultManagedDataSourcesViewsModal({
             owner={owner}
             selectionConfigurations={selectionConfigurations}
             setSelectionConfigurations={setSelectionConfigurationsCallback}
+            viewType="documents"
           />
         </div>
       </div>

--- a/front/hooks/useParentResourcesById.ts
+++ b/front/hooks/useParentResourcesById.ts
@@ -1,78 +1,26 @@
-import type { DataSourceType, LightWorkspaceType } from "@dust-tt/types";
-import { useCallback, useEffect, useState } from "react";
-
-import type { GetContentNodeParentsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/parents";
+import type { DataSourceViewContentNode } from "@dust-tt/types";
+import { useEffect, useState } from "react";
 
 export function useParentResourcesById({
-  owner,
-  dataSource,
-  internalIds,
+  selectedResources,
 }: {
-  owner: LightWorkspaceType;
-  dataSource: DataSourceType | null;
-  internalIds: string[];
+  selectedResources: DataSourceViewContentNode[];
 }) {
   const [parentsById, setParentsById] = useState<Record<string, Set<string>>>(
     {}
   );
-  const [parentsAreLoading, setParentsAreLoading] = useState(false);
-  const [parentsAreError, setParentsAreError] = useState(false);
-
-  const fetchParents = useCallback(async () => {
-    setParentsAreLoading(true);
-    try {
-      const res = await fetch(
-        `/api/w/${owner.sId}/data_sources/${encodeURIComponent(
-          dataSource?.name ?? ""
-        )}/managed/parents`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            internalIds,
-          }),
-        }
-      );
-      if (!res.ok) {
-        throw new Error("Failed to fetch parents");
-      }
-      const json: GetContentNodeParentsResponseBody = await res.json();
-
-      setParentsById(
-        json.nodes.reduce(
-          (acc, r) => {
-            acc[r.internalId] = new Set(r.parents);
-            return acc;
-          },
-          {} as Record<string, Set<string>>
-        )
-      );
-    } catch (e) {
-      setParentsAreError(true);
-    } finally {
-      setParentsAreLoading(false);
-    }
-  }, [owner, dataSource?.name, internalIds]);
-
-  const hasParentsById = Object.keys(parentsById || {}).length > 0;
-  const hasSelectedResources = internalIds.length > 0;
 
   useEffect(() => {
-    if (parentsAreLoading || parentsAreError) {
-      return;
-    }
-    if (!hasParentsById && hasSelectedResources) {
-      fetchParents().catch(console.error);
-    }
-  }, [
-    hasParentsById,
-    hasSelectedResources,
-    fetchParents,
-    parentsAreLoading,
-    parentsAreError,
-  ]);
+    const newParentsById: Record<string, Set<string>> = {};
+    selectedResources.forEach((resource) => {
+      if (resource.parentInternalIds) {
+        newParentsById[resource.internalId] = new Set(
+          resource.parentInternalIds
+        );
+      }
+    });
+    setParentsById(newParentsById);
+  }, [selectedResources]);
 
-  return { parentsById, setParentsById, parentsAreLoading, parentsAreError };
+  return { parentsById, setParentsById };
 }

--- a/front/lib/swr/connectors.ts
+++ b/front/lib/swr/connectors.ts
@@ -12,14 +12,13 @@ import type { GetConnectorResponseBody } from "@app/pages/api/w/[wId]/data_sourc
 import type { GetOrPostManagedDataSourceConfigResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/config/[key]";
 import type { GetDataSourcePermissionsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/permissions";
 
-// TODO(GROUPS_INFRA: Refactor to use the vaults/data_source_views endpoint)
 export function useConnectorPermissions({
   owner,
   dataSource,
   parentId,
   filterPermission,
   disabled,
-  viewType = "documents",
+  viewType,
 }: {
   owner: LightWorkspaceType;
   dataSource: DataSourceType;

--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -1287,6 +1287,7 @@ function ManagedDataSourceView({
               dataSource={dataSource}
               permissionFilter="read"
               showExpand={CONNECTOR_CONFIGURATIONS[connectorProvider]?.isNested}
+              viewType="documents"
             />
           </div>
         </div>

--- a/types/src/front/data_source_view.ts
+++ b/types/src/front/data_source_view.ts
@@ -29,9 +29,13 @@ export type DataSourceViewWithConnectorType = DataSourceViewType & {
   dataSource: DataSourceWithConnectorDetailsType;
 };
 
+export type DataSourceViewContentNode = BaseContentNode & {
+  parentInternalIds: string[] | null;
+};
+
 export type DataSourceViewSelectionConfiguration = {
   dataSourceView: DataSourceViewType;
-  selectedResources: LightContentNode[];
+  selectedResources: DataSourceViewContentNode[];
   isSelectAll: boolean;
 };
 
@@ -52,7 +56,3 @@ export type DataSourceViewSelectionConfigurations = Record<
 
 const DATA_SOURCE_VIEW_KINDS = ["default", "custom"] as const;
 export type DataSourceViewKind = (typeof DATA_SOURCE_VIEW_KINDS)[number];
-
-export type DataSourceViewContentNode = BaseContentNode & {
-  parentInternalIds: string[] | null;
-};

--- a/types/src/front/data_source_view.ts
+++ b/types/src/front/data_source_view.ts
@@ -1,8 +1,5 @@
 import { ModelId } from "../shared/model_id";
-import {
-  DataSourceViewCategory,
-  LightContentNode,
-} from "./api_handlers/public/vaults";
+import { DataSourceViewCategory } from "./api_handlers/public/vaults";
 import {
   DataSourceType,
   DataSourceWithConnectorDetailsType,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Extracted from https://github.com/dust-tt/dust/pull/7094.

The primary objective of the mentioned PR is to standardize the UI by using a single set of components, regardless of whether it's for a table or a document. Ultimately, the intent remains the same: allowing users to select a node in a tree. This PR enhances the existing tree components to manage both documents and tables. There are minor variations in how tree items are displayed depending on the view type. Additionally, I eliminated the extra calls to fetch parent nodes in the tree, as these are now included with the content nodes. This approach was necessary since the previous endpoint only worked with managed data sources and was malfunctioning anyway.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Worst case it breaks the way we display the tree in both Assistant Builder and data source management.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
