### PR TITLE
Dust has access to all ds + one action per managed ds

### DIFF
--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -46,6 +46,7 @@ import { SharingDropdown } from "@app/components/assistant_builder/Sharing";
 import { DataSourceViewPermissionTreeChildren } from "@app/components/ConnectorPermissionsTree";
 import DataSourceViewDocumentModal from "@app/components/DataSourceViewDocumentModal";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
+import { GLOBAL_AGENTS_SID } from "@app/lib/assistant";
 import { updateAgentScope } from "@app/lib/client/dust_api";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { getVisualForContentNode } from "@app/lib/content_nodes";
@@ -235,14 +236,19 @@ export function AssistantDetails({
     );
 
   const ActionsSection = ({
+    isDustGlobalAgent,
     actions,
   }: {
+    isDustGlobalAgent: boolean;
     actions: AgentConfigurationType["actions"];
   }) => {
     const [retrievalActions, otherActions] = useMemo(() => {
       return actions.reduce(
         ([dataSources, otherActions], a) => {
-          if (isRetrievalConfiguration(a)) {
+          if (
+            isRetrievalConfiguration(a) &&
+            (!isDustGlobalAgent || !a.name.startsWith("hidden_dust_search_"))
+          ) {
             dataSources.push(a);
           } else {
             otherActions.push(a);
@@ -254,7 +260,7 @@ export function AssistantDetails({
           [] as AgentActionConfigurationType[],
         ]
       );
-    }, [actions]);
+    }, [isDustGlobalAgent, actions]);
 
     return (
       !!actions.length && (
@@ -330,7 +336,10 @@ export function AssistantDetails({
     >
       <div className="flex flex-col gap-5 pt-6 text-sm text-element-700">
         <DescriptionSection />
-        <ActionsSection actions={agentConfiguration?.actions ?? []} />
+        <ActionsSection
+          isDustGlobalAgent={agentConfiguration.sId === GLOBAL_AGENTS_SID.DUST}
+          actions={agentConfiguration?.actions ?? []}
+        />
         <InstructionsSection />
       </div>
     </ElementModal>

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -245,6 +245,9 @@ export function AssistantDetails({
     const [retrievalActions, otherActions] = useMemo(() => {
       return actions.reduce(
         ([dataSources, otherActions], a) => {
+          // Since Dust is configured with one search for all, plus individual searches for each managed data source,
+          // we hide these additional searches from the user in the UI to avoid displaying the same data source twice.
+          // We use the `hidden_dust_search_` prefix to identify these additional searches.
           if (
             isRetrievalConfiguration(a) &&
             (!isDustGlobalAgent || !a.name.startsWith("hidden_dust_search_"))

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -903,14 +903,15 @@ function _getDustGlobalAgent(
     };
   }
 
-  let instructions = `The assistant answers with precision and brevity. It produces short and straight to the point answers. The assistant should not provide additional information or content that the user did not ask for. When possible, the assistant should answer using a single sentence.
-# When the user asks a questions to the assistant, the assistant should analyze the situation as follows.
-1. If the user's question requires information that is likely private or internal to the company (and therefore unlikely to be found on the public internet or within the assistant's own knowledge), the assistant should search in the company's internal data sources to answer the question. It's important to not pick a restrictive timeframe unless it's explicitly requested or obviously needed.
-2. If the users's question requires information that is recent and likely to be found on the public internet, the assistant should use the internet to answer the question. That means performing a websearch and potentially browse some webpages.
-3. If it is not obvious whether the information would be included in the internal company data sources or on the public internet, the assistant should both search the internal company data sources and the public internet before answering the user's question.
-4. If the user's query require neither internal company data or recent public knowledge, the assistant is allowed to answer without using any tool.
-The assistant always respects the mardown format and generates spaces to nest content.`;
+  const instructions = `The assistant answers with precision and brevity. It produces short and straight to the point answers. The assistant should not provide additional information or content that the user did not ask for. When possible, the assistant should answer using a single sentence.
+    # When the user asks a questions to the assistant, the assistant should analyze the situation as follows.
+    1. If the user's question requires information that is likely private or internal to the company (and therefore unlikely to be found on the public internet or within the assistant's own knowledge), the assistant should search in the company's internal data sources to answer the question. Searching in all datasources is the default behavior unless the user has specified the location in which case it is better to search only on the specific data source. It's important to not pick a restrictive timeframe unless it's explicitly requested or obviously needed.
+    2. If the users's question requires information that is recent and likely to be found on the public internet, the assistant should use the internet to answer the question. That means performing a websearch and potentially browse some webpages.
+    3. If it is not obvious whether the information would be included in the internal company data sources or on the public internet, the assistant should both search the internal company data sources and the public internet before answering the user's question.
+    4. If the user's query require neither internal company data or recent public knowledge, the assistant is allowed to answer without using any tool.
+    The assistant always respects the mardown format and generates spaces to nest content.`;
 
+  // We push one action with all data sources
   const actions: AgentActionConfigurationType[] = [
     {
       id: -1,
@@ -930,46 +931,36 @@ The assistant always respects the mardown format and generates spaces to nest co
     },
   ];
 
-  if (owner.flags.includes("dust_splitted_ds_flag")) {
-    // Note: if we want to ungate this, we should make sure to provide a better design in the Assitant detail modal.
-    // The instructions have been edited only to add "Searching in all datasources is the default behavior unless the user has specified the location in which case it is better to search only on the specific data source."
-    instructions = `The assistant answers with precision and brevity. It produces short and straight to the point answers. The assistant should not provide additional information or content that the user did not ask for. When possible, the assistant should answer using a single sentence.
-    # When the user asks a questions to the assistant, the assistant should analyze the situation as follows.
-    1. If the user's question requires information that is likely private or internal to the company (and therefore unlikely to be found on the public internet or within the assistant's own knowledge), the assistant should search in the company's internal data sources to answer the question. Searching in all datasources is the default behavior unless the user has specified the location in which case it is better to search only on the specific data source. It's important to not pick a restrictive timeframe unless it's explicitly requested or obviously needed.
-    2. If the users's question requires information that is recent and likely to be found on the public internet, the assistant should use the internet to answer the question. That means performing a websearch and potentially browse some webpages.
-    3. If it is not obvious whether the information would be included in the internal company data sources or on the public internet, the assistant should both search the internal company data sources and the public internet before answering the user's question.
-    4. If the user's query require neither internal company data or recent public knowledge, the assistant is allowed to answer without using any tool.
-    The assistant always respects the mardown format and generates spaces to nest content.`;
-
-    dataSourceViews.forEach((dsView) => {
-      if (
-        dsView.dataSource.connectorProvider &&
-        dsView.dataSource.connectorProvider !== "webcrawler"
-      ) {
-        actions.push({
-          id: -1,
-          sId:
-            GLOBAL_AGENTS_SID.DUST +
-            "-datasource-action-" +
-            dsView.dataSource.name,
-          type: "retrieval_configuration",
-          query: "auto",
-          relativeTimeFrame: "auto",
-          topK: "auto",
-          dataSources: [
-            {
-              dataSourceId: dsView.dataSource.name,
-              dataSourceViewId: dsView.sId,
-              workspaceId: preFetchedDataSources.workspaceId,
-              filter: { parents: null },
-            },
-          ],
-          name: "search_" + dsView.dataSource.name,
-          description: `The user's ${dsView.dataSource.connectorProvider} data source.`,
-        });
-      }
-    });
-  }
+  // Then we push one action per managed data source to have better results when users ask "search in <data_source>"
+  // Hack: We prefix the action names with "hidden_" to hide it from the user in the UI otherwise data sources are displayed twice.
+  dataSourceViews.forEach((dsView) => {
+    if (
+      dsView.dataSource.connectorProvider &&
+      dsView.dataSource.connectorProvider !== "webcrawler"
+    ) {
+      actions.push({
+        id: -1,
+        sId:
+          GLOBAL_AGENTS_SID.DUST +
+          "-datasource-action-" +
+          dsView.dataSource.name,
+        type: "retrieval_configuration",
+        query: "auto",
+        relativeTimeFrame: "auto",
+        topK: "auto",
+        dataSources: [
+          {
+            dataSourceId: dsView.dataSource.name,
+            dataSourceViewId: dsView.sId,
+            workspaceId: preFetchedDataSources.workspaceId,
+            filter: { parents: null },
+          },
+        ],
+        name: "hidden_dust_search_" + dsView.dataSource.name,
+        description: `The user's ${dsView.dataSource.connectorProvider} data source.`,
+      });
+    }
+  });
 
   actions.push({
     id: -1,

--- a/types/src/shared/feature_flags.ts
+++ b/types/src/shared/feature_flags.ts
@@ -4,7 +4,6 @@ export const WHITELISTABLE_FEATURES = [
   "labs_transcripts",
   "labs_transcripts_datasource",
   "document_tracker",
-  "dust_splitted_ds_flag",
   "data_vaults_feature",
 ] as const;
 export type WhitelistableFeature = (typeof WHITELISTABLE_FEATURES)[number];


### PR DESCRIPTION
## Description

We did an experiment a few weeks ago to experiment a change on @dust global assistant. Instead of having only one search action with all data sources, it also has access to one search action per managed data source. 

Goal was to improve results when asking "search for Soupinou on Slack".
We weren't sure it would work well or not. 
We had this activated on our workspace for 2 months & no one complained about Dust so let's try to roll it out. 
I'll make a product announcement so that everyone is aware of it, in case we get complains. 

This PR: 
- Removes the feature flag that we had for the experiment. 
- Adds a ugly hack so that we don't display twice the data sources on the Assistant Detail modal. I went with an easy & quick way to do it but if you have in mind something more elegant it is very welcome!


Review with hidden whitespaces simplifies the diff a lot: https://github.com/dust-tt/dust/pull/7107/files?diff=split&w=1

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front.
