### PR TITLE
Return DataSourceResource instead of DataSourceType in getDataSource

### DIFF
--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -26,7 +26,7 @@ export async function getDataSource(
   { includeEditedBy }: { includeEditedBy: boolean } = {
     includeEditedBy: false,
   }
-): Promise<DataSourceType | null> {
+): Promise<DataSourceResource | null> {
   const owner = auth.workspace();
 
   // This condition is critical it checks that we can identify the workspace and that the current
@@ -46,7 +46,7 @@ export async function getDataSource(
     return null;
   }
 
-  return dataSource.toJSON();
+  return dataSource;
 }
 
 export async function getDataSources(

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -3,7 +3,6 @@ import type {
   CoreAPIRow,
   CoreAPIRowValue,
   CoreAPITable,
-  DataSourceType,
   Result,
   WorkspaceType,
 } from "@dust-tt/types";
@@ -16,6 +15,8 @@ import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentTablesQueryConfigurationTable } from "@app/lib/models/assistant/actions/tables_query";
 import logger from "@app/logger/logger";
+
+import type { DataSourceResource } from "../resources/data_source_resource";
 
 type CsvParsingError = {
   type:
@@ -63,7 +64,7 @@ export async function deleteTable({
   tableId,
 }: {
   owner: WorkspaceType;
-  dataSource: DataSourceType;
+  dataSource: DataSourceResource;
   tableId: string;
 }): Promise<Result<null, TableOperationError>> {
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
@@ -124,7 +125,7 @@ export async function upsertTableFromCsv({
   truncate,
 }: {
   auth: Authenticator;
-  dataSource: DataSourceType;
+  dataSource: DataSourceResource;
   tableName: string;
   tableDescription: string;
   tableId: string;

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -392,6 +392,7 @@ export class DataSourceResource extends ResourceWithVault<DataSource> {
   toJSON(): DataSourceType {
     return {
       id: this.id,
+      sId: this.sId,
       createdAt: this.createdAt.getTime(),
       name: this.name,
       description: this.description,

--- a/front/lib/upsert_queue.ts
+++ b/front/lib/upsert_queue.ts
@@ -1,7 +1,6 @@
 import type {
   CoreAPIDocument,
   CoreAPILightDocument,
-  DataSourceType,
   Result,
   UpsertContext,
 } from "@dust-tt/types";
@@ -25,6 +24,8 @@ import {
   launchUpsertDocumentWorkflow,
   launchUpsertTableWorkflow,
 } from "@app/temporal/upsert_queue/client";
+
+import type { DataSourceResource } from "./resources/data_source_resource";
 
 const { DUST_UPSERT_QUEUE_BUCKET, SERVICE_ACCOUNT } = process.env;
 
@@ -174,7 +175,7 @@ export async function runPostUpsertHooks({
   upsertContext,
 }: {
   workspaceId: string;
-  dataSource: DataSourceType;
+  dataSource: DataSourceResource;
   documentId: string;
   section: t.TypeOf<typeof FrontDataSourceDocumentSection>;
   document: CoreAPILightDocument | CoreAPIDocument;

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/managed/permissions.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/managed/permissions.ts
@@ -58,7 +58,7 @@ async function handler(
       return getManagedDataSourcePermissionsHandler(
         auth,
         // To make typescript happy.
-        { ...dataSource, connectorId: dataSource.connectorId },
+        { ...dataSource.toJSON(), connectorId: dataSource.connectorId },
         req,
         res
       );

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -477,7 +477,7 @@ async function handler(
 
         res.status(200).json({
           document: upsertRes.value.document,
-          data_source: dataSource,
+          data_source: dataSource.toJSON(),
         });
 
         await runPostUpsertHooks({

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
@@ -86,7 +86,7 @@ async function handler(
       return getManagedDataSourcePermissionsHandler(
         auth,
         // To make typescript happy.
-        { ...dataSource, connectorId: dataSource.connectorId },
+        { ...dataSource.toJSON(), connectorId: dataSource.connectorId },
         req,
         res
       );

--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
@@ -1,6 +1,5 @@
 import type {
   CoreAPITable,
-  DataSourceType,
   WithAPIErrorResponse,
   WorkspaceType,
 } from "@dust-tt/types";
@@ -12,6 +11,7 @@ import { getDataSource } from "@app/lib/api/data_sources";
 import { deleteTable } from "@app/lib/api/tables";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import type { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 
@@ -128,7 +128,7 @@ export async function handleDeleteTableByIdRequest(
     tableId,
   }: {
     owner: WorkspaceType;
-    dataSource: DataSourceType;
+    dataSource: DataSourceResource;
     tableId: string;
   }
 ) {

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -10,7 +10,7 @@ import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import config from "@app/lib/api/config";
-import { getDataSource, getDataSources } from "@app/lib/api/data_sources";
+import { getDataSources } from "@app/lib/api/data_sources";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
@@ -211,16 +211,13 @@ async function handler(
         ds
       );
 
-      const dataSourceType = await getDataSource(auth, ds.name);
-      if (dataSourceType) {
-        void ServerSideTracking.trackDataSourceCreated({
-          user,
-          workspace: owner,
-          dataSource: dataSourceType,
-        });
-      }
-
       res.status(201).json({
+        dataSource: ds.toJSON(),
+      });
+
+      void ServerSideTracking.trackDataSourceCreated({
+        user,
+        workspace: owner,
         dataSource: ds.toJSON(),
       });
       return;

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -20,7 +20,6 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import config from "@app/lib/api/config";
-import { getDataSource } from "@app/lib/api/data_sources";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getOrCreateSystemApiKey } from "@app/lib/auth";
@@ -389,19 +388,18 @@ async function handler(
       await dataSource.update({
         connectorId: connectorsRes.value.id,
       });
-      const dataSourceType = await getDataSource(auth, dataSource.name);
-      if (dataSourceType) {
-        void ServerSideTracking.trackDataSourceCreated({
-          dataSource: dataSourceType,
-          user,
-          workspace: owner,
-        });
-      }
 
-      return res.status(201).json({
+      res.status(201).json({
         dataSource: dataSource.toJSON(),
         connector: connectorsRes.value,
       });
+
+      void ServerSideTracking.trackDataSourceCreated({
+        dataSource: dataSource.toJSON(),
+        user,
+        workspace: owner,
+      });
+      return;
 
     default:
       return apiError(req, res, {

--- a/front/pages/poke/[wId]/data_sources/[name]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[name]/index.tsx
@@ -244,7 +244,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   return {
     props: {
       owner,
-      dataSource,
+      dataSource: dataSource.toJSON(),
       coreDataSource: coreDataSourceRes.value.data_source,
       connector,
       features,

--- a/front/pages/poke/[wId]/data_sources/[name]/search.tsx
+++ b/front/pages/poke/[wId]/data_sources/[name]/search.tsx
@@ -34,7 +34,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   return {
     props: {
       owner,
-      dataSource,
+      dataSource: dataSource.toJSON(),
     },
   };
 });

--- a/front/pages/w/[wId]/builder/data-sources/[name]/edit-public-url.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/edit-public-url.tsx
@@ -8,7 +8,6 @@ import { ConnectorsAPI } from "@dust-tt/types";
 import type { InferGetServerSidePropsType } from "next";
 
 import WebsiteConfiguration from "@app/components/data_source/WebsiteConfiguration";
-import { getDataSourceUsage } from "@app/lib/api/agent_data_sources";
 import config from "@app/lib/api/config";
 import { getDataSource, getDataSources } from "@app/lib/api/data_sources";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
@@ -57,7 +56,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     new ConnectorsAPI(config.getConnectorsAPIConfig(), logger).getConnector(
       dataSource.connectorId
     ),
-    getDataSourceUsage({ auth, dataSource }),
+    dataSource.getUsagesByAgents(auth),
   ]);
 
   if (connectorRes.isErr()) {
@@ -69,7 +68,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       owner,
       subscription,
       dataSources,
-      dataSource,
+      dataSource: dataSource.toJSON(),
       webCrawlerConfiguration: connectorRes.value
         .configuration as WebCrawlerConfigurationType,
       gaTrackingId: config.getGaTrackingId(),

--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -129,7 +129,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       readOnly,
       isAdmin,
       isBuilder,
-      dataSource,
+      dataSource: dataSource.toJSON(),
       connector,
       standardView,
       dustClientFacingUrl: config.getClientFacingUrl(),

--- a/front/pages/w/[wId]/builder/data-sources/[name]/search.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/search.tsx
@@ -44,7 +44,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     props: {
       owner,
       subscription,
-      dataSource,
+      dataSource: dataSource.toJSON(),
       gaTrackingId: config.getGaTrackingId(),
     },
   };

--- a/front/pages/w/[wId]/builder/data-sources/[name]/settings.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/settings.tsx
@@ -16,7 +16,6 @@ import { DeleteDataSourceDialog } from "@app/components/data_source/DeleteDataSo
 import { subNavigationBuild } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleSaveCancelTitle } from "@app/components/sparkle/AppLayoutTitle";
-import { getDataSourceUsage } from "@app/lib/api/agent_data_sources";
 import config from "@app/lib/api/config";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
@@ -49,15 +48,13 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       notFound: true,
     };
   }
-  const dataSourceUsageRes = await getDataSourceUsage({
-    auth,
-    dataSource,
-  });
+  const dataSourceUsageRes = await dataSource.getUsagesByAgents(auth);
+
   return {
     props: {
       owner,
       subscription,
-      dataSource,
+      dataSource: dataSource.toJSON(),
       gaTrackingId: config.getGaTrackingId(),
       dataSourceUsage: dataSourceUsageRes.isOk() ? dataSourceUsageRes.value : 0,
     },

--- a/front/pages/w/[wId]/builder/data-sources/[name]/tables/upsert.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/tables/upsert.tsx
@@ -51,7 +51,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   }
 
   const dataSource = await getDataSource(auth, context.params?.name as string);
-
   if (!dataSource) {
     return {
       notFound: true,
@@ -66,7 +65,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       owner,
       subscription,
       readOnly,
-      dataSource,
+      dataSource: dataSource.toJSON(),
       loadTableId: (context.query.tableId || null) as string | null,
       gaTrackingId: config.getGaTrackingId(),
     },

--- a/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
@@ -64,7 +64,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       plan,
       subscription,
       readOnly,
-      dataSource,
+      dataSource: dataSource.toJSON(),
       loadDocumentId: (context.query.documentId || null) as string | null,
       gaTrackingId: config.getGaTrackingId(),
     },

--- a/types/src/front/data_source.ts
+++ b/types/src/front/data_source.ts
@@ -61,6 +61,7 @@ export type EditedByUser = {
 
 export type DataSourceType = {
   id: ModelId;
+  sId: string;
   createdAt: number;
   name: string;
   description: string | null;


### PR DESCRIPTION
## Description

Reintroduce .sId on DataSourceType
Return DataSourceResource instead of DataSourceType in getDataSource

## Risk

Low. mostly type-protected refactor.

## Deploy Plan

- deploy `front`