### PR TITLE
upsertQueue: move to dataSource.sId take 1

### DIFF
--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -426,7 +426,7 @@ export async function upsertTable({
     const enqueueRes = await enqueueUpsertTable({
       upsertTable: {
         workspaceId: auth.getNonNullableWorkspace().sId,
-        projectId: dataSource.dustAPIProjectId,
+        dataSourceId: dataSource.sId,
         dataSourceName: dataSource.name,
         tableId: nonNullTableId,
         tableName: name,

--- a/front/lib/upsert_queue.ts
+++ b/front/lib/upsert_queue.ts
@@ -31,6 +31,7 @@ const { DUST_UPSERT_QUEUE_BUCKET, SERVICE_ACCOUNT } = process.env;
 
 export const EnqueueUpsertDocument = t.type({
   workspaceId: t.string,
+  dataSourceId: t.union([t.string, t.null, t.undefined]),
   dataSourceName: t.string,
   documentId: t.string,
   tags: t.union([t.array(t.string), t.null]),
@@ -43,7 +44,7 @@ export const EnqueueUpsertDocument = t.type({
 
 export const EnqueueUpsertTable = t.type({
   workspaceId: t.string,
-  projectId: t.string,
+  dataSourceId: t.union([t.string, t.null, t.undefined]),
   dataSourceName: t.string,
   tableId: t.string,
   tableName: t.string,

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -415,6 +415,7 @@ async function handler(
         const enqueueRes = await enqueueUpsertDocument({
           upsertDocument: {
             workspaceId: owner.sId,
+            dataSourceId: dataSource.sId,
             dataSourceName: dataSource.name,
             documentId: req.query.documentId as string,
             tags: bodyValidation.right.tags || [],

--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
@@ -179,8 +179,8 @@ export async function handlePostTableCsvUpsertRequest(
     const enqueueRes = await enqueueUpsertTable({
       upsertTable: {
         workspaceId: owner.sId,
-        projectId: dataSource.dustAPIProjectId,
-        dataSourceName,
+        dataSourceId: dataSource.sId,
+        dataSourceName: dataSource.name,
         tableId,
         tableName: name,
         tableDescription: description,


### PR DESCRIPTION
## Description

Move the upsertQueue to using dataSource.sId

- Take1 (this): pass dataSourceId along with dataSourceName
- Take2 (subsequent PR): enforce dataSourceId, remove dataSourceName and start using dataSourceId

Goal is to push dataSourceId in the queue while consuming all old element without it to then enforce it.

Also removes projectId which has no reason to be passed here.

## Risk

Low

## Deploy Plan

- deploy `front`