### PR TITLE
poke: data source [name] -> [dsId]

### DIFF
--- a/front/components/poke/data_sources/columns.tsx
+++ b/front/components/poke/data_sources/columns.tsx
@@ -10,6 +10,7 @@ import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 export type DataSources = {
   connectorProvider: string | null;
   id: number;
+  sId: string;
   name: string;
   editedBy: string | undefined;
   editedAt: number | undefined;
@@ -22,23 +23,23 @@ export function makeColumnsForDataSources(
 ): ColumnDef<DataSources>[] {
   return [
     {
-      accessorKey: "id",
+      accessorKey: "sId",
       cell: ({ row }) => {
-        const name: string = row.getValue("name");
+        const sId: string = row.getValue("sId");
 
         return (
           <Link
             className="font-bold hover:underline"
-            href={`/poke/${owner.sId}/data_sources/${name}`}
+            href={`/poke/${owner.sId}/data_sources/${sId}`}
           >
-            {name}
+            {sId}
           </Link>
         );
       },
       header: ({ column }) => {
         return (
           <div className="flex space-x-2">
-            <p>Id</p>
+            <p>sId</p>
             <IconButton
               variant="tertiary"
               icon={ArrowsUpDownIcon}

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -38,7 +38,7 @@ export const MANAGED_DS_DELETABLE_AS_BUILDER: ConnectorProvider[] = [
 
 export async function getDataSource(
   auth: Authenticator,
-  name: string,
+  nameOrId: string,
   { includeEditedBy }: { includeEditedBy: boolean } = {
     includeEditedBy: false,
   }
@@ -52,7 +52,7 @@ export async function getDataSource(
     return null;
   }
 
-  const dataSource = await DataSourceResource.fetchByNameOrId(auth, name, {
+  const dataSource = await DataSourceResource.fetchByNameOrId(auth, nameOrId, {
     includeEditedBy,
     // TODO(DATASOURCE_SID): clean-up
     origin: "lib_api_get_data_source",

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -71,14 +71,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
     };
   }
 
-  const dataSourceName = context.params?.name;
-  if (!dataSourceName || typeof dataSourceName !== "string") {
-    return {
-      notFound: true,
-    };
-  }
-
-  const dataSource = await getDataSource(auth, dataSourceName, {
+  const dataSource = await getDataSource(auth, context.params?.dsId as string, {
     includeEditedBy: true,
   });
   if (!dataSource) {
@@ -90,7 +83,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
   const coreDataSourceRes = await coreAPI.getDataSource({
     projectId: dataSource.dustAPIProjectId,
-    dataSourceId: dataSource.name,
+    dataSourceId: dataSource.dustAPIDataSourceId,
   });
 
   if (coreDataSourceRes.isErr()) {
@@ -305,7 +298,7 @@ const DataSourcePage = ({
     ) {
       window.open(
         `/poke/${owner.sId}/data_sources/${
-          dataSource.name
+          dataSource.sId
         }/view?documentId=${encodeURIComponent(documentId)}`
       );
     }

--- a/front/pages/poke/[wId]/data_sources/[dsId]/search.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/search.tsx
@@ -24,7 +24,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
     };
   }
 
-  const dataSource = await getDataSource(auth, context.params?.name as string);
+  const dataSource = await getDataSource(auth, context.params?.dsId as string);
   if (!dataSource) {
     return {
       notFound: true,

--- a/front/pages/poke/[wId]/data_sources/[dsId]/view.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/view.tsx
@@ -13,14 +13,7 @@ import logger from "@app/logger/logger";
 export const getServerSideProps = withSuperUserAuthRequirements<{
   document: CoreAPIDocument;
 }>(async (context, auth) => {
-  const dataSourceName = context.params?.name;
-  if (!dataSourceName || typeof dataSourceName !== "string") {
-    return {
-      notFound: true,
-    };
-  }
-
-  const dataSource = await getDataSource(auth, dataSourceName);
+  const dataSource = await getDataSource(auth, context.params?.dsId as string);
   if (!dataSource) {
     return {
       notFound: true,


### PR DESCRIPTION
## Description

Move poke to using DataSource.sId in routes vs [name]

![Screenshot from 2024-09-04 14-29-45](https://github.com/user-attachments/assets/a0842635-a161-4a05-acc3-d10cf48af116)
![Screenshot from 2024-09-04 14-29-35](https://github.com/user-attachments/assets/fb3e2e09-9312-433e-8915-60244f274523)


## Risk

N/A poke

## Deploy Plan

- deploy `front`