### PR TITLE
upsert_queue and post_upsert_hook move to dataSourceId

### DIFF
--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -427,7 +427,6 @@ export async function upsertTable({
       upsertTable: {
         workspaceId: auth.getNonNullableWorkspace().sId,
         dataSourceId: dataSource.sId,
-        dataSourceName: dataSource.name,
         tableId: nonNullTableId,
         tableName: name,
         tableDescription: description,

--- a/front/lib/documents_post_process_hooks/hooks/data_source_helpers.ts
+++ b/front/lib/documents_post_process_hooks/hooks/data_source_helpers.ts
@@ -114,7 +114,7 @@ export async function getDocumentDiff({
 
 export async function getDatasource(
   auth: Authenticator,
-  dataSourceName: string
+  dataSourceId: string
 ): Promise<DataSourceResource> {
   const owner = auth.getNonNullableWorkspace();
   const workspace = await Workspace.findOne({
@@ -127,13 +127,13 @@ export async function getDatasource(
   }
   const dataSource = await DataSourceResource.fetchByNameOrId(
     auth,
-    dataSourceName,
+    dataSourceId,
     // TOOD(DATASOURCE_SID): clean-up
     { origin: "post_upsert_hook_helper" }
   );
   if (!dataSource) {
     throw new Error(
-      `Could not find data source with name ${dataSourceName} and workspace ${owner.sId}`
+      `Could not find data source with name ${dataSourceId} and workspace ${owner.sId}`
     );
   }
   return dataSource;

--- a/front/lib/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
+++ b/front/lib/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
@@ -47,7 +47,7 @@ export async function shouldDocumentTrackerSuggestChangesRun(
   const {
     upsertContext,
     auth,
-    dataSourceName,
+    dataSourceId,
     documentId,
     dataSourceConnectorProvider,
   } = params;
@@ -67,7 +67,7 @@ export async function shouldDocumentTrackerSuggestChangesRun(
 
   const localLogger = logger.child({
     workspaceId: owner.sId,
-    dataSourceName,
+    dataSourceId,
     documentId,
   });
 
@@ -85,7 +85,7 @@ export async function shouldDocumentTrackerSuggestChangesRun(
     }
   }
 
-  const dataSource = await getDatasource(auth, dataSourceName);
+  const dataSource = await getDatasource(auth, dataSourceId);
 
   const docIsTracked = !!(await TrackedDocument.count({
     where: {
@@ -136,7 +136,7 @@ export async function shouldDocumentTrackerSuggestChangesRun(
 
 export async function documentTrackerSuggestChangesOnUpsert({
   auth,
-  dataSourceName,
+  dataSourceId,
   documentId,
   documentHash,
   documentSourceUrl,
@@ -148,7 +148,7 @@ export async function documentTrackerSuggestChangesOnUpsert({
 
   const localLogger = logger.child({
     workspaceId: owner.sId,
-    dataSourceName,
+    dataSourceId,
     documentId,
     documentHash,
   });
@@ -163,7 +163,7 @@ export async function documentTrackerSuggestChangesOnUpsert({
     "Running document_tracker_suggest_changes post upsert hook."
   );
 
-  const dataSource = await getDatasource(auth, dataSourceName);
+  const dataSource = await getDatasource(auth, dataSourceId);
   const isDocTracked = !!(await TrackedDocument.count({
     where: {
       dataSourceId: dataSource.id,

--- a/front/lib/documents_post_process_hooks/hooks/document_tracker/update_tracked_documents/lib.ts
+++ b/front/lib/documents_post_process_hooks/hooks/document_tracker/update_tracked_documents/lib.ts
@@ -18,7 +18,7 @@ const logger = mainLogger.child({
 export async function shouldDocumentTrackerUpdateTrackedDocumentsRun(
   params: DocumentsPostProcessHookFilterParams
 ): Promise<boolean> {
-  const { auth, dataSourceName, documentId, verb } = params;
+  const { auth, dataSourceId, documentId, verb } = params;
   const owner = auth.workspace();
 
   if (!owner) {
@@ -30,7 +30,7 @@ export async function shouldDocumentTrackerUpdateTrackedDocumentsRun(
 
   const localLogger = logger.child({
     workspaceId: owner.sId,
-    dataSourceName,
+    dataSourceId,
     documentId,
   });
 
@@ -38,7 +38,7 @@ export async function shouldDocumentTrackerUpdateTrackedDocumentsRun(
     return false;
   }
 
-  const dataSource = await getDatasource(auth, dataSourceName);
+  const dataSource = await getDatasource(auth, dataSourceId);
 
   if (
     verb === "upsert" &&
@@ -75,7 +75,7 @@ export async function shouldDocumentTrackerUpdateTrackedDocumentsRun(
 
 export async function documentTrackerUpdateTrackedDocumentsOnUpsert({
   auth,
-  dataSourceName,
+  dataSourceId,
   documentId,
   documentText,
 }: DocumentsPostProcessHookOnUpsertParams): Promise<void> {
@@ -86,13 +86,13 @@ export async function documentTrackerUpdateTrackedDocumentsOnUpsert({
   logger.info(
     {
       workspaceId: owner.sId,
-      dataSourceName,
+      dataSourceId,
       documentId,
     },
     "Running document_tracker_update_tracked_documents post upsert hook."
   );
 
-  const dataSource = await getDatasource(auth, dataSourceName);
+  const dataSource = await getDatasource(auth, dataSourceId);
   if (
     TRACKABLE_CONNECTOR_TYPES.includes(
       dataSource.connectorProvider as ConnectorProvider
@@ -105,7 +105,7 @@ export async function documentTrackerUpdateTrackedDocumentsOnUpsert({
 
 export async function documentTrackerUpdateTrackedDocumentsOnDelete({
   auth,
-  dataSourceName,
+  dataSourceId,
   documentId,
 }: DocumentsPostProcessHookOnDeleteParams): Promise<void> {
   const owner = auth.workspace();
@@ -116,13 +116,13 @@ export async function documentTrackerUpdateTrackedDocumentsOnDelete({
   logger.info(
     {
       workspaceId: owner.sId,
-      dataSourceName,
+      dataSourceId,
       documentId,
     },
     "Running document_tracker_update_tracked_documents onDelete."
   );
 
-  const dataSource = await getDatasource(auth, dataSourceName);
+  const dataSource = await getDatasource(auth, dataSourceId);
 
   await TrackedDocument.destroy({
     where: {

--- a/front/lib/documents_post_process_hooks/hooks/index.ts
+++ b/front/lib/documents_post_process_hooks/hooks/index.ts
@@ -19,7 +19,7 @@ export type DocumentsPostProcessHookVerb = "upsert" | "delete";
 
 export type DocumentsPostProcessHookOnUpsertParams = {
   auth: Authenticator;
-  dataSourceName: string;
+  dataSourceId: string;
   documentId: string;
   documentSourceUrl?: string;
   documentText: string;
@@ -30,7 +30,7 @@ export type DocumentsPostProcessHookOnUpsertParams = {
 
 export type DocumentsPostProcessHookOnDeleteParams = {
   auth: Authenticator;
-  dataSourceName: string;
+  dataSourceId: string;
   documentId: string;
   dataSourceConnectorProvider: ConnectorProvider | null;
 };

--- a/front/lib/upsert_queue.ts
+++ b/front/lib/upsert_queue.ts
@@ -31,8 +31,7 @@ const { DUST_UPSERT_QUEUE_BUCKET, SERVICE_ACCOUNT } = process.env;
 
 export const EnqueueUpsertDocument = t.type({
   workspaceId: t.string,
-  dataSourceId: t.union([t.string, t.null, t.undefined]),
-  dataSourceName: t.string,
+  dataSourceId: t.string,
   documentId: t.string,
   tags: t.union([t.array(t.string), t.null]),
   parents: t.union([t.array(t.string), t.null]),
@@ -44,8 +43,7 @@ export const EnqueueUpsertDocument = t.type({
 
 export const EnqueueUpsertTable = t.type({
   workspaceId: t.string,
-  dataSourceId: t.union([t.string, t.null, t.undefined]),
-  dataSourceName: t.string,
+  dataSourceId: t.string,
   tableId: t.string,
   tableName: t.string,
   tableDescription: t.string,
@@ -71,7 +69,7 @@ export async function enqueueUpsertDocument({
     {
       upsertQueueId,
       workspaceId: upsertDocument.workspaceId,
-      dataSourceName: upsertDocument.dataSourceName,
+      dataSourceId: upsertDocument.dataSourceId,
       documentId: upsertDocument.documentId,
       enqueueTimestamp: Date.now(),
     },
@@ -96,7 +94,7 @@ export async function enqueueUpsertTable({
     {
       upsertQueueId,
       workspaceId: upsertTable.workspaceId,
-      dataSourceName: upsertTable.dataSourceName,
+      dataSourceId: upsertTable.dataSourceId,
       documentId: upsertTable.tableId,
       enqueueTimestamp: Date.now(),
     },
@@ -145,7 +143,7 @@ async function enqueueUpsert({
 
     const launchRes = await launchWorkflowFn({
       workspaceId: upsertItem.workspaceId,
-      dataSourceName: upsertItem.dataSourceName,
+      dataSourceId: upsertItem.dataSourceId,
       upsertQueueId,
       enqueueTimestamp: now,
     });
@@ -188,7 +186,7 @@ export async function runPostUpsertHooks({
 
   const postUpsertHooksToRun = await getDocumentsPostUpsertHooksToRun({
     auth,
-    dataSourceName: dataSource.name,
+    dataSourceId: dataSource.sId,
     documentId: documentId,
     documentText: fullText,
     documentHash: document.hash,
@@ -200,8 +198,8 @@ export async function runPostUpsertHooks({
   // TODO: parallel.
   for (const { type: hookType, debounceMs } of postUpsertHooksToRun) {
     await launchRunPostUpsertHooksWorkflow(
-      dataSource.name,
       workspaceId,
+      dataSource.sId,
       documentId,
       document.hash,
       dataSource.connectorProvider || null,

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -416,7 +416,6 @@ async function handler(
           upsertDocument: {
             workspaceId: owner.sId,
             dataSourceId: dataSource.sId,
-            dataSourceName: dataSource.name,
             documentId: req.query.documentId as string,
             tags: bodyValidation.right.tags || [],
             parents: bodyValidation.right.parents || [],
@@ -540,7 +539,7 @@ async function handler(
 
       const postDeleteHooksToRun = await getDocumentsPostDeleteHooksToRun({
         auth: await Authenticator.internalBuilderForWorkspace(owner.sId),
-        dataSourceName: dataSource.name,
+        dataSourceId: dataSource.sId,
         documentId: req.query.documentId as string,
         dataSourceConnectorProvider: dataSource.connectorProvider || null,
       });
@@ -548,8 +547,8 @@ async function handler(
       // TODO: parallel.
       for (const { type: hookType } of postDeleteHooksToRun) {
         await launchRunPostDeleteHooksWorkflow(
-          dataSource.name,
           owner.sId,
+          dataSource.sId,
           req.query.documentId as string,
           dataSource.connectorProvider || null,
           hookType

--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
@@ -180,7 +180,6 @@ export async function handlePostTableCsvUpsertRequest(
       upsertTable: {
         workspaceId: owner.sId,
         dataSourceId: dataSource.sId,
-        dataSourceName: dataSource.name,
         tableId,
         tableName: name,
         tableDescription: description,

--- a/front/scripts/replay-upsert-document-queue-tasks.ts
+++ b/front/scripts/replay-upsert-document-queue-tasks.ts
@@ -52,10 +52,10 @@ makeScript(
         }
       }
 
-      const { workspaceId, dataSourceName, upsertQueueId, enqueueTimestamp } =
+      const { workspaceId, dataSourceId, upsertQueueId, enqueueTimestamp } =
         task;
 
-      const workflowId = `upsert-queue-document-${workspaceId}-${dataSourceName}-${upsertQueueId}`;
+      const workflowId = `upsert-queue-document-${workspaceId}-${dataSourceId}-${upsertQueueId}`;
 
       logger.info(
         { workspaceId, workflowId },
@@ -72,7 +72,7 @@ makeScript(
       // The, we restart the workflow.
       await launchUpsertDocumentWorkflow({
         workspaceId,
-        dataSourceName,
+        dataSourceId,
         upsertQueueId,
         enqueueTimestamp,
       });

--- a/front/temporal/documents_post_process_hooks/client.ts
+++ b/front/temporal/documents_post_process_hooks/client.ts
@@ -11,8 +11,8 @@ import {
 const QUEUE_NAME = "post-upsert-hooks-queue"; // TODO: rename to post-process-hooks-queue
 
 export async function launchRunPostUpsertHooksWorkflow(
-  dataSourceName: string,
   workspaceId: string,
+  dataSourceId: string,
   documentId: string,
   documentHash: string,
   dataSourceConnectorProvider: ConnectorProvider | null,
@@ -23,7 +23,7 @@ export async function launchRunPostUpsertHooksWorkflow(
 
   await client.workflow.signalWithStart(runPostUpsertHooksWorkflow, {
     args: [
-      dataSourceName,
+      dataSourceId,
       workspaceId,
       documentId,
       documentHash,
@@ -32,15 +32,15 @@ export async function launchRunPostUpsertHooksWorkflow(
       debounceMs,
     ],
     taskQueue: QUEUE_NAME,
-    workflowId: `workflow-run-post-upsert-hooks-${hookType}-${workspaceId}-${dataSourceName}-${documentId}`,
+    workflowId: `workflow-run-post-upsert-hooks-${hookType}-${workspaceId}-${dataSourceId}-${documentId}`,
     signal: newUpsertSignal,
     signalArgs: undefined,
   });
 }
 
 export async function launchRunPostDeleteHooksWorkflow(
-  dataSourceName: string,
   workspaceId: string,
+  dataSourceId: string,
   documentId: string,
   dataSourceConnectorProvider: ConnectorProvider | null,
   hookType: DocumentsPostProcessHookType
@@ -49,13 +49,13 @@ export async function launchRunPostDeleteHooksWorkflow(
 
   await client.workflow.start(runPostDeleteHoosWorkflow, {
     args: [
-      dataSourceName,
+      dataSourceId,
       workspaceId,
       documentId,
       dataSourceConnectorProvider,
       hookType,
     ],
     taskQueue: QUEUE_NAME,
-    workflowId: `workflow-run-post-delete-hooks-${hookType}-${workspaceId}-${dataSourceName}-${documentId}`,
+    workflowId: `workflow-run-post-delete-hooks-${hookType}-${workspaceId}-${dataSourceId}-${documentId}`,
   });
 }

--- a/front/temporal/documents_post_process_hooks/workflows.ts
+++ b/front/temporal/documents_post_process_hooks/workflows.ts
@@ -12,8 +12,8 @@ const { runPostUpsertHookActivity, runPostDeleteHookActivity } =
   });
 
 export async function runPostUpsertHooksWorkflow(
-  dataSourceName: string,
   workspaceId: string,
+  dataSourceId: string,
   documentId: string,
   documentHash: string,
   dataSourceConnectorProvider: ConnectorProvider | null,
@@ -35,8 +35,8 @@ export async function runPostUpsertHooksWorkflow(
     }
 
     await runPostUpsertHookActivity(
-      dataSourceName,
       workspaceId,
+      dataSourceId,
       documentId,
       documentHash,
       dataSourceConnectorProvider,
@@ -46,15 +46,15 @@ export async function runPostUpsertHooksWorkflow(
 }
 
 export async function runPostDeleteHoosWorkflow(
-  dataSourceName: string,
   workspaceId: string,
+  dataSourceId: string,
   documentId: string,
   dataSourceConnectorProvider: ConnectorProvider | null,
   hookType: DocumentsPostProcessHookType
 ) {
   await runPostDeleteHookActivity(
-    dataSourceName,
     workspaceId,
+    dataSourceId,
     documentId,
     dataSourceConnectorProvider,
     hookType

--- a/front/temporal/upsert_queue/activities.ts
+++ b/front/temporal/upsert_queue/activities.ts
@@ -49,7 +49,7 @@ export async function upsertDocumentActivity(
   const logger = mainLogger.child({
     upsertQueueId,
     workspaceId: upsertQueueItem.workspaceId,
-    dataSourceName: upsertQueueItem.dataSourceName,
+    dataSourceId: upsertQueueItem.dataSourceId,
     documentId: upsertQueueItem.documentId,
   });
 

--- a/front/temporal/upsert_queue/activities.ts
+++ b/front/temporal/upsert_queue/activities.ts
@@ -57,7 +57,7 @@ export async function upsertDocumentActivity(
     upsertQueueItem.workspaceId
   );
 
-  const dataSource = await getDataSource(auth, upsertQueueItem.dataSourceName);
+  const dataSource = await getDataSource(auth, upsertQueueItem.dataSourceId);
 
   if (!dataSource) {
     // If the data source was not found, we simply give up and remove the item from the queue as it
@@ -182,7 +182,7 @@ export async function upsertTableActivity(
   const logger = mainLogger.child({
     upsertQueueId,
     workspaceId: upsertQueueItem.workspaceId,
-    dataSourceName: upsertQueueItem.dataSourceName,
+    dataSourceId: upsertQueueItem.dataSourceId,
     tableId: upsertQueueItem.tableId,
   });
 
@@ -201,7 +201,7 @@ export async function upsertTableActivity(
     return;
   }
 
-  const dataSource = await getDataSource(auth, upsertQueueItem.dataSourceName);
+  const dataSource = await getDataSource(auth, upsertQueueItem.dataSourceId);
 
   if (!dataSource) {
     // If the data source was not found, we simply give up and remove the item from the queue as it

--- a/front/temporal/upsert_queue/client.ts
+++ b/front/temporal/upsert_queue/client.ts
@@ -9,18 +9,18 @@ import { upsertDocumentWorkflow, upsertTableWorkflow } from "./workflows";
 
 export async function launchUpsertDocumentWorkflow({
   workspaceId,
-  dataSourceName,
+  dataSourceId,
   upsertQueueId,
   enqueueTimestamp,
 }: {
   workspaceId: string;
-  dataSourceName: string;
+  dataSourceId: string;
   upsertQueueId: string;
   enqueueTimestamp: number;
 }): Promise<Result<string, Error>> {
   const client = await getTemporalClient();
 
-  const workflowId = `upsert-queue-document-${workspaceId}-${dataSourceName}-${upsertQueueId}`;
+  const workflowId = `upsert-queue-document-${workspaceId}-${dataSourceId}-${upsertQueueId}`;
 
   try {
     await client.workflow.start(upsertDocumentWorkflow, {
@@ -29,7 +29,7 @@ export async function launchUpsertDocumentWorkflow({
       workflowId: workflowId,
       memo: {
         workspaceId,
-        dataSourceName,
+        dataSourceId,
         upsertQueueId,
       },
     });
@@ -54,18 +54,18 @@ export async function launchUpsertDocumentWorkflow({
 
 export async function launchUpsertTableWorkflow({
   workspaceId,
-  dataSourceName,
+  dataSourceId,
   upsertQueueId,
   enqueueTimestamp,
 }: {
   workspaceId: string;
-  dataSourceName: string;
+  dataSourceId: string;
   upsertQueueId: string;
   enqueueTimestamp: number;
 }): Promise<Result<string, Error>> {
   const client = await getTemporalClient();
 
-  const workflowId = `upsert-queue-table-${workspaceId}-${dataSourceName}-${upsertQueueId}`;
+  const workflowId = `upsert-queue-table-${workspaceId}-${dataSourceId}-${upsertQueueId}`;
 
   try {
     await client.workflow.start(upsertTableWorkflow, {
@@ -74,7 +74,7 @@ export async function launchUpsertTableWorkflow({
       workflowId: workflowId,
       memo: {
         workspaceId,
-        dataSourceName,
+        dataSourceId,
         upsertQueueId,
       },
     });


### PR DESCRIPTION
## Description

Move to use dataSource.sId in the upsert queue and post upsert hooks

## Risk

upsert-queue: risk is potential upsert delays but well tested
post-upsert-queue: no risk other than internal failures (some workflow may fail due to change of arg name)

## Deploy Plan

- deploy `front`