### PR TITLE
Allow radio button label to use anything

### DIFF
--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.220",
+  "version": "0.2.221",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/RadioButton.tsx
+++ b/sparkle/src/components/RadioButton.tsx
@@ -11,7 +11,7 @@ export type RadioButtonProps = {
 };
 
 export type RadioButtonChoice = {
-  label: string;
+  label: React.JSX.Element | string;
   value: string;
   disabled: boolean;
 };

--- a/sparkle/src/stories/RadioButton.stories.tsx
+++ b/sparkle/src/stories/RadioButton.stories.tsx
@@ -2,7 +2,7 @@ import { Meta } from "@storybook/react";
 import React from "react";
 
 import { RadioButton } from "@sparkle/components/RadioButton";
-import { LockIcon, PauseIcon, PlayIcon, StopIcon } from "@sparkle/icons";
+import { PauseIcon, PlayIcon, StopIcon } from "@sparkle/icons";
 
 const meta = {
   title: "Primitives/RadioButton",

--- a/sparkle/src/stories/RadioButton.stories.tsx
+++ b/sparkle/src/stories/RadioButton.stories.tsx
@@ -2,6 +2,7 @@ import { Meta } from "@storybook/react";
 import React from "react";
 
 import { RadioButton } from "@sparkle/components/RadioButton";
+import { LockIcon, PauseIcon, PlayIcon, StopIcon } from "@sparkle/icons";
 
 const meta = {
   title: "Primitives/RadioButton",
@@ -20,18 +21,30 @@ export const RadioButtonExamples = () => {
         name="test1"
         choices={[
           {
-            label: "yes",
-            value: "yes",
+            label: (
+              <>
+                <PauseIcon style={{ display: "inline" }} /> pause
+              </>
+            ),
+            value: "pause",
             disabled: false,
           },
           {
-            label: "no",
-            value: "no",
+            label: (
+              <>
+                <PlayIcon style={{ display: "inline" }} /> play
+              </>
+            ),
+            value: "play",
             disabled: false,
           },
           {
-            label: "maybe",
-            value: "maybe",
+            label: (
+              <>
+                <StopIcon style={{ display: "inline" }} /> stop
+              </>
+            ),
+            value: "stop",
             disabled: true,
           },
         ]}


### PR DESCRIPTION
## Description

Allow sparkle radio button to use any jsx element as labels.

<img width="379" alt="image" src="https://github.com/user-attachments/assets/37ce71f0-b4cd-4fb8-9e1a-90a0e85ff0ea">


## Risk

None

## Deploy Plan

Publish the updated package, update version in main.