### PR TITLE
connector: accept dataSourceId (sId) at creation, migration to backfill

### DIFF
--- a/connectors/migrations/20240828_microsoft_refill_parents_field.ts
+++ b/connectors/migrations/20240828_microsoft_refill_parents_field.ts
@@ -2,6 +2,7 @@ import { makeScript } from "scripts/helpers";
 import { Op } from "sequelize";
 
 import { getParents } from "@connectors/connectors/microsoft/temporal/file";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { updateDocumentParentsField } from "@connectors/lib/data_sources";
 import { MicrosoftNodeModel } from "@connectors/lib/models/microsoft";
@@ -76,11 +77,7 @@ async function updateParentsFieldForConnector(
         }
 
         return updateDocumentParentsField({
-          dataSourceConfig: {
-            dataSourceName: connector.dataSourceName,
-            workspaceId: connector.workspaceId,
-            workspaceAPIKey: connector.workspaceAPIKey,
-          },
+          dataSourceConfig: dataSourceConfigFromConnector(connector),
           documentId: node.internalId,
           parents,
         });

--- a/connectors/migrations/db/migration_13.sql
+++ b/connectors/migrations/db/migration_13.sql
@@ -1,0 +1,3 @@
+-- Migration created on Sep 04, 2024
+ALTER TABLE "public"."connectors" ADD COLUMN "dataSourceId" VARCHAR(255);
+[16:16:27.965] INFO (2766662): Done;

--- a/connectors/migrations/db/migration_13.sql
+++ b/connectors/migrations/db/migration_13.sql
@@ -1,3 +1,2 @@
 -- Migration created on Sep 04, 2024
 ALTER TABLE "public"."connectors" ADD COLUMN "dataSourceId" VARCHAR(255);
-[16:16:27.965] INFO (2766662): Done;

--- a/connectors/src/api/create_connector.ts
+++ b/connectors/src/api/create_connector.ts
@@ -52,9 +52,10 @@ const _createConnectorAPIHandler = async (
     }
 
     const {
+      workspaceId,
       workspaceAPIKey,
       dataSourceName,
-      workspaceId,
+      dataSourceId,
       connectionId,
       configuration,
     } = bodyValidation.right;
@@ -80,8 +81,9 @@ const _createConnectorAPIHandler = async (
           params: {
             configuration: configurationRes.value,
             dataSourceConfig: {
-              dataSourceName,
               workspaceId,
+              dataSourceId,
+              dataSourceName,
               workspaceAPIKey,
             },
             connectionId,
@@ -109,9 +111,10 @@ const _createConnectorAPIHandler = async (
           params: {
             configuration: configurationRes.value,
             dataSourceConfig: {
-              dataSourceName,
               workspaceId,
               workspaceAPIKey,
+              dataSourceId,
+              dataSourceName,
             },
             connectionId,
           },
@@ -129,9 +132,10 @@ const _createConnectorAPIHandler = async (
           connectorProvider: req.params.connector_provider,
           params: {
             dataSourceConfig: {
-              dataSourceName,
               workspaceId,
               workspaceAPIKey,
+              dataSourceId,
+              dataSourceName,
             },
             connectionId,
             configuration: null,

--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -90,6 +90,7 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
           connectionId,
           workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
           workspaceId: dataSourceConfig.workspaceId,
+          dataSourceId: dataSourceConfig.dataSourceId,
           dataSourceName: dataSourceConfig.dataSourceName,
         },
         confluenceConfigurationBlob

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -508,11 +508,7 @@ export async function confluenceUpdatePagesParentIdsActivity(
       );
 
       await updateDocumentParentsField({
-        dataSourceConfig: {
-          dataSourceName: connector.dataSourceName,
-          workspaceId: connector.workspaceId,
-          workspaceAPIKey: connector.workspaceAPIKey,
-        },
+        dataSourceConfig: dataSourceConfigFromConnector(connector),
         documentId: makeConfluencePageId(page.pageId),
         parents: parentIds,
       });

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -54,6 +54,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
           connectionId,
           workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
           workspaceId: dataSourceConfig.workspaceId,
+          dataSourceId: dataSourceConfig.dataSourceId,
           dataSourceName: dataSourceConfig.dataSourceName,
         },
         githubConfigurationBlob

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -126,6 +126,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
         connectionId,
         workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
         workspaceId: dataSourceConfig.workspaceId,
+        dataSourceId: dataSourceConfig.dataSourceId,
         dataSourceName: dataSourceConfig.dataSourceName,
       },
       googleDriveConfigurationBlob

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -90,6 +90,7 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
           connectionId,
           workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
           workspaceId: dataSourceConfig.workspaceId,
+          dataSourceId: dataSourceConfig.dataSourceId,
           dataSourceName: dataSourceConfig.dataSourceName,
         },
         intercomConfigurationBlob

--- a/connectors/src/connectors/intercom/temporal/sync_conversation.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_conversation.ts
@@ -74,14 +74,7 @@ export async function deleteConversation({
     conversationId
   );
   await Promise.all([
-    deleteFromDataSource(
-      {
-        dataSourceName: dataSourceConfig.dataSourceName,
-        workspaceId: dataSourceConfig.workspaceId,
-        workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
-      },
-      dsConversationId
-    ),
+    deleteFromDataSource(dataSourceConfig, dsConversationId),
     IntercomConversation.destroy({
       where: {
         connectorId,

--- a/connectors/src/connectors/intercom/temporal/sync_help_center.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_help_center.ts
@@ -102,14 +102,7 @@ export async function deleteCollectionWithChildren({
         article.articleId
       );
       await Promise.all([
-        deleteFromDataSource(
-          {
-            dataSourceName: dataSourceConfig.dataSourceName,
-            workspaceId: dataSourceConfig.workspaceId,
-            workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
-          },
-          dsArticleId
-        ),
+        deleteFromDataSource(dataSourceConfig, dsArticleId),
         article.destroy(),
       ]);
     })

--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -90,6 +90,7 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
         connectionId,
         workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
         workspaceId: dataSourceConfig.workspaceId,
+        dataSourceId: dataSourceConfig.dataSourceId,
         dataSourceName: dataSourceConfig.dataSourceName,
       },
       microsoftConfigurationBlob

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -82,6 +82,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
           connectionId,
           workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
           workspaceId: dataSourceConfig.workspaceId,
+          dataSourceId: dataSourceConfig.dataSourceId,
           dataSourceName: dataSourceConfig.dataSourceName,
         },
         {}

--- a/connectors/src/connectors/notion/lib/parents.ts
+++ b/connectors/src/connectors/notion/lib/parents.ts
@@ -13,6 +13,7 @@ import type { NotionDatabase, NotionPage } from "@connectors/lib/models/notion";
 import { heartbeat } from "@connectors/lib/temporal";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 
 /** Compute the parents field for a notion pageOrDb See the [Design
  * Doc](https://www.notion.so/dust-tt/Engineering-e0f834b5be5a43569baaf76e9c41adf2?p=3d26536a4e0a464eae0c3f8f27a7af97&pm=s)
@@ -154,11 +155,7 @@ export async function updateAllParentsFields(
           "Updating parents field for page"
         );
         await updateDocumentParentsField({
-          dataSourceConfig: {
-            dataSourceName: connector.dataSourceName,
-            workspaceId: connector.workspaceId,
-            workspaceAPIKey: connector.workspaceAPIKey,
-          },
+          dataSourceConfig: dataSourceConfigFromConnector(connector),
           documentId: `notion-${pageId}`,
           parents,
         });

--- a/connectors/src/connectors/notion/lib/parents.ts
+++ b/connectors/src/connectors/notion/lib/parents.ts
@@ -8,12 +8,12 @@ import {
   getNotionPageFromConnectorsDb,
   getPageChildrenOf,
 } from "@connectors/connectors/notion/lib/connectors_db_helpers";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { updateDocumentParentsField } from "@connectors/lib/data_sources";
 import type { NotionDatabase, NotionPage } from "@connectors/lib/models/notion";
 import { heartbeat } from "@connectors/lib/temporal";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
-import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 
 /** Compute the parents field for a notion pageOrDb See the [Design
  * Doc](https://www.notion.so/dust-tt/Engineering-e0f834b5be5a43569baaf76e9c41adf2?p=3d26536a4e0a464eae0c3f8f27a7af97&pm=s)

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -40,7 +40,10 @@ import {
   updateAllParentsFields,
 } from "@connectors/connectors/notion/lib/parents";
 import { getTagsForPage } from "@connectors/connectors/notion/lib/tags";
-import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import {
+  dataSourceConfigFromConnector,
+  dataSourceInfoFromConnector,
+} from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import {
   deleteFromDataSource,
@@ -2081,10 +2084,7 @@ export async function renderAndUpsertPageFromCache({
     "notionRenderAndUpsertPageFromCache: Saving page in connectors DB."
   );
   await upsertNotionPageInConnectorsDb({
-    dataSourceInfo: {
-      dataSourceName: connector.dataSourceName,
-      workspaceId: connector.workspaceId,
-    },
+    dataSourceInfo: dataSourceInfoFromConnector(connector),
     notionPageId: pageId,
     lastSeenTs: runTimestamp,
     parentType,

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -69,6 +69,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
         connectionId,
         workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
         workspaceId: dataSourceConfig.workspaceId,
+        dataSourceId: dataSourceConfig.dataSourceId,
         dataSourceName: dataSourceConfig.dataSourceName,
       },
       {

--- a/connectors/src/connectors/slack/temporal/client.ts
+++ b/connectors/src/connectors/slack/temporal/client.ts
@@ -1,10 +1,10 @@
 import type { ModelId } from "@dust-tt/types";
 import { Err, Ok, removeNulls } from "@dust-tt/types";
 
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { getTemporalClient } from "@connectors/lib/temporal";
 import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
-import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
 import { getWeekStart } from "../lib/utils";
 import { getChannelsToSync } from "./activities";
@@ -39,11 +39,7 @@ export async function launchSlackSyncWorkflow(
   }
   const client = await getTemporalClient();
 
-  const dataSourceConfig: DataSourceConfig = {
-    workspaceAPIKey: connector.workspaceAPIKey,
-    workspaceId: connector.workspaceId,
-    dataSourceName: connector.dataSourceName,
-  };
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
 
   const workflowId = workspaceFullSyncWorkflowId(connectorId, fromTs);
   try {

--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -73,6 +73,7 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
         connectionId: configuration.url,
         workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
         workspaceId: dataSourceConfig.workspaceId,
+        dataSourceId: dataSourceConfig.dataSourceId,
         dataSourceName: dataSourceConfig.dataSourceName,
       },
       webCrawlerConfigurationBlob

--- a/connectors/src/lib/api/data_source_config.ts
+++ b/connectors/src/lib/api/data_source_config.ts
@@ -1,6 +1,9 @@
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
-import type { DataSourceConfig } from "@connectors/types/data_source_config";
+import type {
+  DataSourceConfig,
+  DataSourceInfo,
+} from "@connectors/types/data_source_config";
 
 export function dataSourceConfigFromConnector(
   // TODO(2024-02-14 flav) Remove ConnectorModel once fully bundled in `ConnectorResource`.
@@ -9,6 +12,18 @@ export function dataSourceConfigFromConnector(
   return {
     workspaceAPIKey: connector.workspaceAPIKey,
     dataSourceName: connector.dataSourceName,
+    dataSourceId: connector.dataSourceId,
+    workspaceId: connector.workspaceId,
+  };
+}
+
+export function dataSourceInfoFromConnector(
+  // TODO(2024-02-14 flav) Remove ConnectorModel once fully bundled in `ConnectorResource`.
+  connector: ConnectorResource | ConnectorModel
+): DataSourceInfo {
+  return {
+    dataSourceName: connector.dataSourceName,
+    dataSourceId: connector.dataSourceId,
     workspaceId: connector.workspaceId,
   };
 }

--- a/connectors/src/resources/storage/models/connector_model.ts
+++ b/connectors/src/resources/storage/models/connector_model.ts
@@ -24,6 +24,7 @@ export class ConnectorModel extends Model<
 
   declare workspaceAPIKey: string;
   declare workspaceId: string;
+  declare dataSourceId: string | null;
   declare dataSourceName: string;
 
   declare lastSyncStatus?: ConnectorSyncStatus;
@@ -74,6 +75,10 @@ ConnectorModel.init(
     dataSourceName: {
       type: DataTypes.STRING,
       allowNull: false,
+    },
+    dataSourceId: {
+      type: DataTypes.STRING,
+      allowNull: true,
     },
     lastSyncStatus: {
       type: DataTypes.STRING,

--- a/connectors/src/types/data_source_config.ts
+++ b/connectors/src/types/data_source_config.ts
@@ -1,6 +1,7 @@
 export type DataSourceConfig = {
   workspaceAPIKey: string;
   workspaceId: string;
+  dataSourceId: string | null;
   dataSourceName: string;
 };
 

--- a/front/migrations/20240904_data_source_id_to_connector.ts
+++ b/front/migrations/20240904_data_source_id_to_connector.ts
@@ -69,6 +69,7 @@ makeScript({}, async ({ execute }, logger) => {
         {
           workspaceId: c.workspaceId,
           connectorId: c.id,
+          dataSourceId: ds.sId,
           dataSourceName: ds.name,
           execute,
         },

--- a/front/migrations/20240904_data_source_id_to_connector.ts
+++ b/front/migrations/20240904_data_source_id_to_connector.ts
@@ -1,0 +1,79 @@
+import { EnvironmentConfig } from "@dust-tt/types";
+import { QueryTypes, Sequelize } from "sequelize";
+
+import { getDataSource } from "@app/lib/api/data_sources";
+import { Authenticator } from "@app/lib/auth";
+import { makeScript } from "@app/scripts/helpers";
+
+makeScript({}, async ({ execute }, logger) => {
+  const connectorDB = new Sequelize(
+    EnvironmentConfig.getEnvVariable("CONNECTORS_DATABASE_URI")
+  );
+
+  const connectors: {
+    id: number;
+    workspaceId: string;
+    dataSourceName: string;
+  }[] = await connectorDB.query(
+    `SELECT "id", "workspaceId", "dataSourceName" FROM connectors WHERE "dataSourceId" IS NULL`,
+    {
+      type: QueryTypes.SELECT,
+    }
+  );
+
+  for (const c of connectors) {
+    const auth = await Authenticator.internalAdminForWorkspace(c.workspaceId);
+    const ds = await getDataSource(auth, c.dataSourceName);
+    if (!ds) {
+      logger.error(
+        { workspaceId: c.workspaceId, dataSourceName: c.dataSourceName },
+        "Failed to retrieve data source"
+      );
+      throw new Error("Failed to retrieve data source");
+    }
+
+    if (c.dataSourceName !== ds.name) {
+      logger.error(
+        {
+          worksaceId: c.workspaceId,
+          connectorDataSourceName: c.dataSourceName,
+          dataSourceName: ds.name,
+        },
+        "Unexpected data source name mistmatch"
+      );
+      throw new Error("Unexpected data source name mistmatch");
+    }
+
+    if (execute) {
+      await connectorDB.query(
+        `UPDATE connectors SET "dataSourceId" = :dataSourceId WHERE id = :connectorId`,
+        {
+          replacements: {
+            dataSourceId: ds.sId,
+            connectorId: c.id,
+          },
+        }
+      );
+      logger.info(
+        {
+          workspaceId: c.workspaceId,
+          connectorId: c.id,
+          dataSourceId: ds.sId,
+          dataSourceName: ds.name,
+          execute,
+        },
+        "Updated connector"
+      );
+    } else {
+      logger.info(
+        {
+          workspaceId: c.workspaceId,
+          connectorId: c.id,
+          dataSourceName: ds.name,
+          execute,
+        },
+        "Would have updated connector"
+      );
+    }
+  }
+});

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -333,14 +333,15 @@ async function handler(
         logger
       );
 
-      const connectorsRes = await connectorsAPI.createConnector(
+      const connectorsRes = await connectorsAPI.createConnector({
         provider,
-        owner.sId,
-        systemAPIKeyRes.value.secret,
-        dataSourceName,
-        connectionId || "none",
-        configuration
-      );
+        workspaceId: owner.sId,
+        workspaceAPIKey: systemAPIKeyRes.value.secret,
+        dataSourceId: dataSource.sId,
+        dataSourceName: dataSource.name,
+        connectionId: connectionId || "none",
+        configuration,
+      });
 
       if (connectorsRes.isErr()) {
         logger.error(

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/index.ts
@@ -421,14 +421,15 @@ const handleDataSourceWithProvider = async ({
     logger
   );
 
-  const connectorsRes = await connectorsAPI.createConnector(
+  const connectorsRes = await connectorsAPI.createConnector({
     provider,
-    owner.sId,
-    systemAPIKeyRes.value.secret,
-    dataSourceName,
-    connectionId ?? "none",
-    configuration
-  );
+    workspaceId: owner.sId,
+    workspaceAPIKey: systemAPIKeyRes.value.secret,
+    dataSourceId: dataSource.sId,
+    dataSourceName: dataSource.name,
+    connectionId: connectionId ?? "none",
+    configuration,
+  });
 
   if (connectorsRes.isErr()) {
     logger.error(

--- a/types/src/connectors/api_handlers/create_connector.ts
+++ b/types/src/connectors/api_handlers/create_connector.ts
@@ -5,6 +5,7 @@ import { ConnectorConfigurationTypeSchema } from "./connector_configuration";
 export const ConnectorCreateRequestBodySchema = t.type({
   workspaceAPIKey: t.string,
   dataSourceName: t.string,
+  dataSourceId: t.string,
   workspaceId: t.string,
   connectionId: t.string,
   configuration: ConnectorConfigurationTypeSchema,

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -135,14 +135,23 @@ export class ConnectorsAPI {
     this._logger = logger;
   }
 
-  async createConnector(
-    provider: ConnectorProvider,
-    workspaceId: string,
-    workspaceAPIKey: string,
-    dataSourceName: string,
-    connectionId: string,
-    configuration: ConnectorConfiguration
-  ): Promise<ConnectorsAPIResponse<ConnectorType>> {
+  async createConnector({
+    provider,
+    workspaceId,
+    workspaceAPIKey,
+    dataSourceId,
+    dataSourceName,
+    connectionId,
+    configuration,
+  }: {
+    provider: ConnectorProvider;
+    workspaceId: string;
+    workspaceAPIKey: string;
+    dataSourceId: string;
+    dataSourceName: string;
+    connectionId: string;
+    configuration: ConnectorConfiguration;
+  }): Promise<ConnectorsAPIResponse<ConnectorType>> {
     const res = await this._fetchWithError(
       `${this._url}/connectors/create/${encodeURIComponent(provider)}`,
       {
@@ -152,6 +161,7 @@ export class ConnectorsAPI {
           workspaceId,
           workspaceAPIKey,
           dataSourceName,
+          dataSourceId,
           connectionId,
           configuration,
         } satisfies ConnectorCreateRequestBody),


### PR DESCRIPTION
## Description

- Accepts and starts sending from front sId at connector creation
- Update DataSourceConfig to carry it
- Migration to backfill

In subsequent PR: enforce its presence, start using it to upsert, nuke dataSourceName

## Risk

Bork connector. Easy to revert. Connector creation and migration tested in dev.

## Deploy Plan

- run SQL migration
- deploy `front` (start sending dataSourceId at creation)
- deploy `connector`
- run ts migration