### PR TITLE
Enforce `dataSourceViewId` existence on `agent_tables_query_configuration_tables`

### DIFF
--- a/front/lib/api/assistant/configuration/table_query.ts
+++ b/front/lib/api/assistant/configuration/table_query.ts
@@ -79,12 +79,10 @@ export async function fetchTableQueryActionConfigurations({
         tablesQueryConfigTables.map((table) => {
           const { dataSourceView } = table;
 
-          const dataSourceViewId = dataSourceView
-            ? DataSourceViewResource.modelIdToSId({
-                id: dataSourceView.id,
-                workspaceId: dataSourceView.workspaceId,
-              })
-            : null;
+          const dataSourceViewId = DataSourceViewResource.modelIdToSId({
+            id: dataSourceView.id,
+            workspaceId: dataSourceView.workspaceId,
+          });
 
           return {
             dataSourceId: table.dataSourceId,

--- a/front/lib/client/tables_query.ts
+++ b/front/lib/client/tables_query.ts
@@ -1,7 +1,0 @@
-import type { TablesQueryConfigurationType } from "@dust-tt/types";
-
-export function tableKey(
-  table: TablesQueryConfigurationType["tables"][number]
-) {
-  return `${table.workspaceId}/${table.dataSourceId}/${table.tableId}`;
-}

--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -95,7 +95,7 @@ export class AgentTablesQueryConfigurationTable extends Model<
   declare dataSourceId: string;
   declare tableId: string;
 
-  declare dataSourceViewId: ForeignKey<DataSourceViewModel["id"]> | null;
+  declare dataSourceViewId: ForeignKey<DataSourceViewModel["id"]>;
   declare tablesQueryConfigurationId: ForeignKey<
     AgentTablesQueryConfiguration["id"]
   >;
@@ -166,10 +166,9 @@ DataSourceViewModel.hasMany(AgentTablesQueryConfigurationTable, {
   foreignKey: { allowNull: true },
   onDelete: "RESTRICT",
 });
-// TODO(GROUPS_INFRA): This should be a required relationship.
 AgentTablesQueryConfigurationTable.belongsTo(DataSourceViewModel, {
   as: "dataSourceView",
-  foreignKey: { allowNull: true },
+  foreignKey: { allowNull: false },
 });
 
 export class AgentTablesQueryAction extends Model<

--- a/front/migrations/20240902_backfill_views_in_agent_table_query_configurations.ts
+++ b/front/migrations/20240902_backfill_views_in_agent_table_query_configurations.ts
@@ -37,6 +37,7 @@ async function backfillViewsInAgentTableQueryConfigurationForWorkspace(
   // Count agent tables query configurations that uses those data sources and have no dataSourceViewId.
   const agenTablesQueryConfigurationsCount =
     await AgentTablesQueryConfigurationTable.count({
+      // @ts-expect-error `dataSourceViewId` was nullable at some point.
       where: {
         // /!\ `dataSourceId` is the data source's name, not the id.
         dataSourceId: dataSources.map((ds) => ds.name),

--- a/front/migrations/20240902_backfill_views_in_agent_table_query_configurations.ts
+++ b/front/migrations/20240902_backfill_views_in_agent_table_query_configurations.ts
@@ -1,5 +1,6 @@
 import type { LightWorkspaceType } from "@dust-tt/types";
 import assert from "assert";
+import type { GroupedCountResultItem } from "sequelize";
 import { Op } from "sequelize";
 
 import { Authenticator } from "@app/lib/auth";
@@ -35,7 +36,7 @@ async function backfillViewsInAgentTableQueryConfigurationForWorkspace(
     );
 
   // Count agent tables query configurations that uses those data sources and have no dataSourceViewId.
-  const agenTablesQueryConfigurationsCount =
+  const agenTablesQueryConfigurationsCount: GroupedCountResultItem[] =
     await AgentTablesQueryConfigurationTable.count({
       // @ts-expect-error `dataSourceViewId` was nullable at some point.
       where: {

--- a/front/migrations/20240902_backfill_views_in_agent_table_query_configurations.ts
+++ b/front/migrations/20240902_backfill_views_in_agent_table_query_configurations.ts
@@ -36,7 +36,7 @@ async function backfillViewsInAgentTableQueryConfigurationForWorkspace(
     );
 
   // Count agent tables query configurations that uses those data sources and have no dataSourceViewId.
-  const agenTablesQueryConfigurationsCount: GroupedCountResultItem[] =
+  const agentTablesQueryConfigurationsCount: GroupedCountResultItem[] =
     await AgentTablesQueryConfigurationTable.count({
       // @ts-expect-error `dataSourceViewId` was nullable at some point.
       where: {
@@ -49,7 +49,7 @@ async function backfillViewsInAgentTableQueryConfigurationForWorkspace(
     });
 
   logger.info(
-    `About to update ${agenTablesQueryConfigurationsCount} agent tables query configurations for workspace(${workspace.sId}).`
+    `About to update ${agentTablesQueryConfigurationsCount} agent tables query configurations for workspace(${workspace.sId}).`
   );
 
   if (!execute) {

--- a/front/migrations/db/migration_72.sql
+++ b/front/migrations/db/migration_72.sql
@@ -1,0 +1,5 @@
+-- Migration created on Sep 03, 2024
+ALTER TABLE agent_tables_query_configuration_tables
+ALTER COLUMN "dataSourceViewId"
+SET
+  NOT NULL;

--- a/front/migrations/db/migration_73.sql
+++ b/front/migrations/db/migration_73.sql
@@ -1,0 +1,5 @@
+-- Migration created on Sep 03, 2024
+ALTER TABLE agent_tables_query_configuration_tables
+ALTER COLUMN "dataSourceViewId"
+SET
+  NOT NULL;

--- a/front/migrations/db/migration_73.sql
+++ b/front/migrations/db/migration_73.sql
@@ -1,5 +1,29 @@
 -- Migration created on Sep 03, 2024
-ALTER TABLE agent_tables_query_configuration_tables
-ALTER COLUMN "dataSourceViewId"
-SET
-  NOT NULL;
+-- -- This migration is dependant on a backfill script
+-- -- The backfill script is: 20240902_backfill_views_in_agent_table_query_configurations
+-- -- run psql with --set=backfilled=1 argument if you have rune the script.
+
+CREATE OR REPLACE FUNCTION perform_migration(backfilled boolean DEFAULT false)
+RETURNS VARCHAR AS $$
+BEGIN
+    IF NOT backfilled THEN
+        RAISE NOTICE 'The backfill script: 20240902_backfill_views_in_agent_table_query_configurations is required before applying this migation. If you already did it, run psql with --set=backfilled=1 argument.';
+    END IF;
+
+    ALTER TABLE agent_tables_query_configuration_tables
+    ALTER COLUMN "dataSourceViewId"
+    SET
+      NOT NULL;
+
+    RETURN 'success';
+END;
+$$ LANGUAGE plpgsql;
+
+\if :{?backfilled}
+   SELECT perform_migration(:'backfilled'::boolean);
+\else
+    \echo '!! Migration was NOT applied !!'
+    \echo 'The backfill script: 20240902_backfill_views_in_agent_table_query_configurations is required before applying this migation. If you already did it, run psql with --set=backfilled=1 argument.'
+\endif
+
+DROP FUNCTION perform_migration(boolean);

--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -51,7 +51,6 @@ import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import config from "@app/lib/api/config";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { handleFileUploadToText } from "@app/lib/client/handle_file_upload";
-import { tableKey } from "@app/lib/client/tables_query";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { getDisplayNameForDocument, isWebsite } from "@app/lib/data_sources";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
@@ -601,14 +600,9 @@ function DatasourceTablesTabView({
 
         <div className="py-8">
           <ContextItem.List>
-            {tables.map((t) => (
+            {tables.map((t, index) => (
               <ContextItem
-                key={tableKey({
-                  workspaceId: owner.sId,
-                  tableId: t.table_id,
-                  dataSourceId: dataSource.name,
-                  dataSourceViewId: undefined,
-                })}
+                key={index}
                 title={`${t.name} (${t.data_source_id})`}
                 visual={
                   <ContextItem.Visual

--- a/types/src/front/api_handlers/internal/agent_configuration.ts
+++ b/types/src/front/api_handlers/internal/agent_configuration.ts
@@ -88,8 +88,7 @@ const TablesQueryActionConfigurationSchema = t.type({
   tables: t.array(
     t.type({
       dataSourceId: t.string,
-      // TODO(GROUPS_INFRA) Make `dataSourceViewId` required.
-      dataSourceViewId: t.union([t.string, t.undefined, t.null]),
+      dataSourceViewId: t.string,
       tableId: t.string,
       workspaceId: t.string,
     })

--- a/types/src/front/assistant/actions/tables_query.ts
+++ b/types/src/front/assistant/actions/tables_query.ts
@@ -13,8 +13,7 @@ export type TablesQueryConfigurationType = {
 
 export type TableDataSourceConfiguration = {
   dataSourceId: string;
-  // TODO(GROUPS_INFRA) Make `dataSourceViewId` required.
-  dataSourceViewId: string | null | undefined;
+  dataSourceViewId: string;
   tableId: string;
   workspaceId: string;
 };


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Enforce `dataSourceViewId` existence on `agent_tables_query_configuration_tables`. All views have properly been backfilled.

```
dust-front=> SELECT COUNT(*) FROM agent_tables_query_configuration_tables WHERE "dataSourceViewId" IS NULL;
 count
-------
     0
(1 row)
``` 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
This PR requires running a SQL migration to change `dataSourceViewId` to not nullable.

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
