### PR TITLE
Add classname to identify expanded or collapsed nodes

### DIFF
--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.221",
+  "version": "0.2.222",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Tree.tsx
+++ b/sparkle/src/components/Tree.tsx
@@ -138,6 +138,8 @@ Tree.Item = function ({
     isNavigatableSelected: "s-border-structure-200 s-bg-white",
   };
 
+  const isExpanded = childrenToRender && !effectiveCollapsed;
+
   return (
     <>
       <div
@@ -157,17 +159,15 @@ Tree.Item = function ({
             ? isSelected
               ? treeItemStyleClasses.isNavigatableSelected
               : treeItemStyleClasses.isNavigatableUnselected
-            : ""
+            : "",
+          isExpanded ? "is-expanded" : "is-collapsed",
+          type
         )}
         onClick={onItemClick ? onItemClick : undefined}
       >
         {type === "node" && (
           <IconButton
-            icon={
-              childrenToRender && !effectiveCollapsed
-                ? ArrowDownSIcon
-                : ArrowRightSIcon
-            }
+            icon={isExpanded ? ArrowDownSIcon : ArrowRightSIcon}
             size="xs"
             variant="secondary"
             onClick={(e) => {


### PR DESCRIPTION
## Description

Add some classnames to identify Tree.Item that are expanded or collapsed and their type.
Needed when we want ot use CSS selector to get only the last nodes of a tree.

## Risk

None

## Deploy Plan

Publish Sparkle