### PR TITLE
connector: remove all occurrences of dataSourceName in favor of dataSourceId

### DIFF
--- a/connectors/src/api/create_connector.ts
+++ b/connectors/src/api/create_connector.ts
@@ -54,7 +54,6 @@ const _createConnectorAPIHandler = async (
     const {
       workspaceId,
       workspaceAPIKey,
-      dataSourceName,
       dataSourceId,
       connectionId,
       configuration,
@@ -83,7 +82,6 @@ const _createConnectorAPIHandler = async (
             dataSourceConfig: {
               workspaceId,
               dataSourceId,
-              dataSourceName,
               workspaceAPIKey,
             },
             connectionId,
@@ -114,7 +112,6 @@ const _createConnectorAPIHandler = async (
               workspaceId,
               workspaceAPIKey,
               dataSourceId,
-              dataSourceName,
             },
             connectionId,
           },
@@ -135,7 +132,6 @@ const _createConnectorAPIHandler = async (
               workspaceId,
               workspaceAPIKey,
               dataSourceId,
-              dataSourceName,
             },
             connectionId,
             configuration: null,

--- a/connectors/src/api/webhooks/webhook_intercom.ts
+++ b/connectors/src/api/webhooks/webhook_intercom.ts
@@ -142,7 +142,7 @@ const _webhookIntercomAPIHandler = async (
     workspaceId: dataSourceConfig.workspaceId,
     connectorId,
     provider: "intercom",
-    dataSourceName: dataSourceConfig.dataSourceName,
+    dataSourceId: dataSourceConfig.dataSourceId,
     intercomWorkspaceId,
     conversationId: conversation.id,
   };
@@ -238,7 +238,7 @@ const _webhookIntercomUninstallAPIHandler = async (
     workspaceId: dataSourceConfig.workspaceId,
     connectorId: connector.id,
     provider: "intercom",
-    dataSourceName: dataSourceConfig.dataSourceName,
+    dataSourceId: dataSourceConfig.dataSourceId,
     intercomWorkspaceId,
   };
 

--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -91,7 +91,6 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
           workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
           workspaceId: dataSourceConfig.workspaceId,
           dataSourceId: dataSourceConfig.dataSourceId,
-          dataSourceName: dataSourceConfig.dataSourceName,
         },
         confluenceConfigurationBlob
       );

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -231,7 +231,7 @@ export async function confluenceCheckAndUpsertPageActivity({
 
   const loggerArgs = {
     connectorId,
-    dataSourceName: dataSourceConfig.dataSourceName,
+    dataSourceId: dataSourceConfig.dataSourceId,
     pageId,
     spaceId,
     workspaceId: dataSourceConfig.workspaceId,

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -55,7 +55,6 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
           workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
           workspaceId: dataSourceConfig.workspaceId,
           dataSourceId: dataSourceConfig.dataSourceId,
-          dataSourceName: dataSourceConfig.dataSourceName,
         },
         githubConfigurationBlob
       );

--- a/connectors/src/connectors/github/lib/cli.ts
+++ b/connectors/src/connectors/github/lib/cli.ts
@@ -28,8 +28,8 @@ export const github = async ({
       if (!args.wId) {
         throw new Error("Missing --wId argument");
       }
-      if (!args.dataSourceName) {
-        throw new Error("Missing --dataSourceName argument");
+      if (!args.dsId) {
+        throw new Error("Missing --dsId argument");
       }
       if (!args.owner) {
         throw new Error("Missing --owner argument");
@@ -40,7 +40,7 @@ export const github = async ({
 
       const connector = await ConnectorResource.findByDataSource({
         workspaceId: `${args.wId}`,
-        dataSourceName: args.dataSourceName,
+        dataSourceId: args.dsId,
       });
       if (!connector) {
         throw new Error(
@@ -73,8 +73,8 @@ export const github = async ({
       if (!args.wId) {
         throw new Error("Missing --wId argument");
       }
-      if (!args.dataSourceName) {
-        throw new Error("Missing --dataSourceName argument");
+      if (!args.dsId) {
+        throw new Error("Missing --dsId argument");
       }
       if (!args.enable) {
         throw new Error("Missing --enable (true/false) argument");
@@ -87,7 +87,7 @@ export const github = async ({
 
       const connector = await ConnectorResource.findByDataSource({
         workspaceId: `${args.wId}`,
-        dataSourceName: args.dataSourceName,
+        dataSourceId: args.dsId,
       });
       if (!connector) {
         throw new Error(
@@ -123,8 +123,8 @@ export const github = async ({
       if (!args.wId) {
         throw new Error("Missing --wId argument");
       }
-      if (!args.dataSourceName) {
-        throw new Error("Missing --dataSourceName argument");
+      if (!args.dsId) {
+        throw new Error("Missing --dsId argument");
       }
       if (!args.repoLogin) {
         throw new Error("Missing --repoLogin argument");
@@ -140,8 +140,8 @@ export const github = async ({
       }
 
       const connector = await ConnectorResource.findByDataSource({
-        workspaceId: args.wId,
-        dataSourceName: args.dataSourceName,
+        workspaceId: `${args.wId}`,
+        dataSourceId: args.dsId,
       });
       if (!connector) {
         throw new Error(
@@ -163,16 +163,16 @@ export const github = async ({
       if (!args.wId) {
         throw new Error("Missing --wId argument");
       }
-      if (!args.dataSourceName) {
-        throw new Error("Missing --dataSourceName argument");
+      if (!args.dsId) {
+        throw new Error("Missing --dsId argument");
       }
       if (!args.repoId) {
         throw new Error("Missing --repoId argument");
       }
 
       const connector = await ConnectorResource.findByDataSource({
-        workspaceId: args.wId,
-        dataSourceName: args.dataSourceName,
+        workspaceId: `${args.wId}`,
+        dataSourceId: args.dsId,
       });
       if (!connector) {
         throw new Error(

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -1238,7 +1238,7 @@ export async function githubCodeSyncDailyCronActivity({
   await client.workflow.signalWithStart("githubCodeSyncWorkflow", {
     args: [dataSourceConfig, connectorId, repoName, repoId, repoLogin],
     taskQueue: QUEUE_NAME,
-    workflowId: getCodeSyncWorkflowId(dataSourceConfig, repoId),
+    workflowId: getCodeSyncWorkflowId(connectorId, repoId),
     searchAttributes: {
       connectorId: [connectorId],
     },

--- a/connectors/src/connectors/github/temporal/utils.ts
+++ b/connectors/src/connectors/github/temporal/utils.ts
@@ -3,25 +3,25 @@ import type { ModelId } from "@dust-tt/types";
 import type { DataSourceInfo } from "@connectors/types/data_source_config";
 
 export function getFullSyncWorkflowId(dataSourceInfo: DataSourceInfo) {
-  return `workflow-github-full-sync-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceName}`;
+  return `workflow-github-full-sync-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceId}`;
 }
 
 export function getReposSyncWorkflowId(dataSourceInfo: DataSourceInfo) {
-  return `workflow-github-repos-sync-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceName}`;
+  return `workflow-github-repos-sync-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceId}`;
 }
 
 export function getCodeSyncWorkflowId(
   dataSourceInfo: DataSourceInfo,
   repoId: number
 ) {
-  return `workflow-github-code-sync-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceName}-${repoId}`;
+  return `workflow-github-code-sync-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceId}-${repoId}`;
 }
 
 export function getCodeSyncDailyCronWorkflowId(
   dataSourceInfo: DataSourceInfo,
   repoId: number
 ) {
-  return `workflow-github-code-sync-daily-cron-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceName}-${repoId}`;
+  return `workflow-github-code-sync-daily-cron-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceId}-${repoId}`;
 }
 
 export function getIssueSyncWorkflowId(
@@ -29,7 +29,7 @@ export function getIssueSyncWorkflowId(
   repoId: number,
   issueNumber: number
 ) {
-  return `workflow-github-issue-sync-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceName}-${repoId}-${issueNumber}`;
+  return `workflow-github-issue-sync-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceId}-${repoId}-${issueNumber}`;
 }
 
 export function getDiscussionSyncWorkflowId(
@@ -38,7 +38,7 @@ export function getDiscussionSyncWorkflowId(
   repoId: number,
   discussionNumber: number
 ) {
-  return `workflow-github-discussion-sync-${connectorId}-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceName}-${repoId}-${discussionNumber}`;
+  return `workflow-github-discussion-sync-${connectorId}-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceId}-${repoId}-${discussionNumber}`;
 }
 
 export function getIssueGarbageCollectWorkflowId(
@@ -46,7 +46,7 @@ export function getIssueGarbageCollectWorkflowId(
   repoId: number,
   issueNumber: number
 ) {
-  return `workflow-github-issue-garbage-collect-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceName}-${repoId}-${issueNumber}`;
+  return `workflow-github-issue-garbage-collect-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceId}-${repoId}-${issueNumber}`;
 }
 
 export function getDiscussionGarbageCollectWorkflowId(
@@ -55,12 +55,12 @@ export function getDiscussionGarbageCollectWorkflowId(
   repoId: number,
   issueNumber: number
 ) {
-  return `workflow-github-discussion-garbage-collect-${connectorId}-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceName}-${repoId}-${issueNumber}`;
+  return `workflow-github-discussion-garbage-collect-${connectorId}-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceId}-${repoId}-${issueNumber}`;
 }
 
 export function getRepoGarbageCollectWorkflowId(
   dataSourceInfo: DataSourceInfo,
   repoId: number
 ) {
-  return `workflow-github-repo-garbage-collect-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceName}-${repoId}`;
+  return `workflow-github-repo-garbage-collect-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceId}-${repoId}`;
 }

--- a/connectors/src/connectors/github/temporal/utils.ts
+++ b/connectors/src/connectors/github/temporal/utils.ts
@@ -1,22 +1,22 @@
 import type { ModelId } from "@dust-tt/types";
 
 export function getFullSyncWorkflowId(connectorId: ModelId) {
-  return `workflow-github-full-sync-${connectorId}`;
+  return `workflow-github-${connectorId}-full-sync`;
 }
 
 export function getReposSyncWorkflowId(connectorId: ModelId) {
-  return `workflow-github-repos-sync-${connectorId}`;
+  return `workflow-github-${connectorId}-repos-sync`;
 }
 
 export function getCodeSyncWorkflowId(connectorId: ModelId, repoId: number) {
-  return `workflow-github-code-sync-${connectorId}-${repoId}`;
+  return `workflow-github-${connectorId}-code-sync-${repoId}`;
 }
 
 export function getCodeSyncDailyCronWorkflowId(
   connectorId: ModelId,
   repoId: number
 ) {
-  return `workflow-github-code-sync-daily-cron-${connectorId}-${repoId}`;
+  return `workflow-github-${connectorId}-code-sync-daily-cron-${repoId}`;
 }
 
 export function getIssueSyncWorkflowId(
@@ -24,7 +24,7 @@ export function getIssueSyncWorkflowId(
   repoId: number,
   issueNumber: number
 ) {
-  return `workflow-github-issue-sync-${connectorId}-${repoId}-${issueNumber}`;
+  return `workflow-github-${connectorId}-issue-sync-${repoId}-${issueNumber}`;
 }
 
 export function getDiscussionSyncWorkflowId(
@@ -32,7 +32,7 @@ export function getDiscussionSyncWorkflowId(
   repoId: number,
   discussionNumber: number
 ) {
-  return `workflow-github-discussion-sync-${connectorId}-${repoId}-${discussionNumber}`;
+  return `workflow-github-${connectorId}-discussion-sync-${repoId}-${discussionNumber}`;
 }
 
 export function getIssueGarbageCollectWorkflowId(
@@ -40,7 +40,7 @@ export function getIssueGarbageCollectWorkflowId(
   repoId: number,
   issueNumber: number
 ) {
-  return `workflow-github-issue-garbage-collect-${connectorId}-${repoId}-${issueNumber}`;
+  return `workflow-github-${connectorId}-issue-garbage-collect-${repoId}-${issueNumber}`;
 }
 
 export function getDiscussionGarbageCollectWorkflowId(
@@ -48,12 +48,12 @@ export function getDiscussionGarbageCollectWorkflowId(
   repoId: number,
   issueNumber: number
 ) {
-  return `workflow-github-discussion-garbage-collect-${connectorId}-${repoId}-${issueNumber}`;
+  return `workflow-github-${connectorId}-discussion-garbage-collect-${repoId}-${issueNumber}`;
 }
 
 export function getRepoGarbageCollectWorkflowId(
   connectorId: ModelId,
   repoId: number
 ) {
-  return `workflow-github-repo-garbage-collect-${connectorId}-${repoId}`;
+  return `workflow-github-${connectorId}-repo-garbage-collect-${repoId}`;
 }

--- a/connectors/src/connectors/github/temporal/utils.ts
+++ b/connectors/src/connectors/github/temporal/utils.ts
@@ -1,66 +1,59 @@
 import type { ModelId } from "@dust-tt/types";
 
-import type { DataSourceInfo } from "@connectors/types/data_source_config";
-
-export function getFullSyncWorkflowId(dataSourceInfo: DataSourceInfo) {
-  return `workflow-github-full-sync-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceId}`;
+export function getFullSyncWorkflowId(connectorId: ModelId) {
+  return `workflow-github-full-sync-${connectorId}`;
 }
 
-export function getReposSyncWorkflowId(dataSourceInfo: DataSourceInfo) {
-  return `workflow-github-repos-sync-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceId}`;
+export function getReposSyncWorkflowId(connectorId: ModelId) {
+  return `workflow-github-repos-sync-${connectorId}`;
 }
 
-export function getCodeSyncWorkflowId(
-  dataSourceInfo: DataSourceInfo,
-  repoId: number
-) {
-  return `workflow-github-code-sync-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceId}-${repoId}`;
+export function getCodeSyncWorkflowId(connectorId: ModelId, repoId: number) {
+  return `workflow-github-code-sync-${connectorId}-${repoId}`;
 }
 
 export function getCodeSyncDailyCronWorkflowId(
-  dataSourceInfo: DataSourceInfo,
+  connectorId: ModelId,
   repoId: number
 ) {
-  return `workflow-github-code-sync-daily-cron-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceId}-${repoId}`;
+  return `workflow-github-code-sync-daily-cron-${connectorId}-${repoId}`;
 }
 
 export function getIssueSyncWorkflowId(
-  dataSourceInfo: DataSourceInfo,
+  connectorId: ModelId,
   repoId: number,
   issueNumber: number
 ) {
-  return `workflow-github-issue-sync-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceId}-${repoId}-${issueNumber}`;
+  return `workflow-github-issue-sync-${connectorId}-${repoId}-${issueNumber}`;
 }
 
 export function getDiscussionSyncWorkflowId(
   connectorId: ModelId,
-  dataSourceInfo: DataSourceInfo,
   repoId: number,
   discussionNumber: number
 ) {
-  return `workflow-github-discussion-sync-${connectorId}-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceId}-${repoId}-${discussionNumber}`;
+  return `workflow-github-discussion-sync-${connectorId}-${repoId}-${discussionNumber}`;
 }
 
 export function getIssueGarbageCollectWorkflowId(
-  dataSourceInfo: DataSourceInfo,
+  connectorId: ModelId,
   repoId: number,
   issueNumber: number
 ) {
-  return `workflow-github-issue-garbage-collect-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceId}-${repoId}-${issueNumber}`;
+  return `workflow-github-issue-garbage-collect-${connectorId}-${repoId}-${issueNumber}`;
 }
 
 export function getDiscussionGarbageCollectWorkflowId(
   connectorId: ModelId,
-  dataSourceInfo: DataSourceInfo,
   repoId: number,
   issueNumber: number
 ) {
-  return `workflow-github-discussion-garbage-collect-${connectorId}-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceId}-${repoId}-${issueNumber}`;
+  return `workflow-github-discussion-garbage-collect-${connectorId}-${repoId}-${issueNumber}`;
 }
 
 export function getRepoGarbageCollectWorkflowId(
-  dataSourceInfo: DataSourceInfo,
+  connectorId: ModelId,
   repoId: number
 ) {
-  return `workflow-github-repo-garbage-collect-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceId}-${repoId}`;
+  return `workflow-github-repo-garbage-collect-${connectorId}-${repoId}`;
 }

--- a/connectors/src/connectors/github/temporal/workflows.ts
+++ b/connectors/src/connectors/github/temporal/workflows.ts
@@ -68,7 +68,7 @@ export async function githubFullSyncWorkflow(
   await githubSaveStartSyncActivity(dataSourceConfig);
   const loggerArgs = {
     connectorId,
-    dataSourceName: dataSourceConfig.dataSourceName,
+    dataSourceId: dataSourceConfig.dataSourceId,
     workspaceId: dataSourceConfig.workspaceId,
     syncCodeOnly: syncCodeOnly.toString(),
   };
@@ -181,7 +181,7 @@ export async function githubRepoIssuesSyncWorkflow({
   pageNumber: number;
 }): Promise<boolean> {
   const loggerArgs = {
-    dataSourceName: dataSourceConfig.dataSourceName,
+    dataSourceId: dataSourceConfig.dataSourceId,
     workspaceId: dataSourceConfig.workspaceId,
     connectorId,
     repoName,
@@ -243,7 +243,7 @@ export async function githubRepoDiscussionsSyncWorkflow({
   nextCursor: string | null;
 }): Promise<string | null> {
   const loggerArgs = {
-    dataSourceName: dataSourceConfig.dataSourceName,
+    dataSourceId: dataSourceConfig.dataSourceId,
     workspaceId: dataSourceConfig.workspaceId,
     connectorId,
     repoName,
@@ -306,7 +306,7 @@ export async function githubRepoSyncWorkflow({
   forceCodeResync?: boolean;
 }) {
   const loggerArgs = {
-    dataSourceName: dataSourceConfig.dataSourceName,
+    dataSourceId: dataSourceConfig.dataSourceId,
     workspaceId: dataSourceConfig.workspaceId,
     connectorId,
     repoName,
@@ -404,7 +404,7 @@ export async function githubCodeSyncWorkflow(
   repoLogin: string
 ) {
   const loggerArgs = {
-    dataSourceName: dataSourceConfig.dataSourceName,
+    dataSourceId: dataSourceConfig.dataSourceId,
     workspaceId: dataSourceConfig.workspaceId,
     connectorId,
     repoName,
@@ -469,7 +469,7 @@ export async function githubIssueSyncWorkflow(
   issueNumber: number
 ) {
   const loggerArgs = {
-    dataSourceName: dataSourceConfig.dataSourceName,
+    dataSourceId: dataSourceConfig.dataSourceId,
     workspaceId: dataSourceConfig.workspaceId,
     connectorId,
     repoName,
@@ -513,7 +513,7 @@ export async function githubDiscussionSyncWorkflow(
   discussionNumber: number
 ) {
   const loggerArgs = {
-    dataSourceName: dataSourceConfig.dataSourceName,
+    dataSourceId: dataSourceConfig.dataSourceId,
     workspaceId: dataSourceConfig.workspaceId,
     connectorId,
     repoName,
@@ -557,7 +557,7 @@ export async function githubIssueGarbageCollectWorkflow(
   issueNumber: number
 ) {
   const loggerArgs = {
-    dataSourceName: dataSourceConfig.dataSourceName,
+    dataSourceId: dataSourceConfig.dataSourceId,
     workspaceId: dataSourceConfig.workspaceId,
     connectorId,
     issueNumber,
@@ -580,7 +580,7 @@ export async function githubDiscussionGarbageCollectWorkflow(
   discussionNumber: number
 ) {
   const loggerArgs = {
-    dataSourceName: dataSourceConfig.dataSourceName,
+    dataSourceId: dataSourceConfig.dataSourceId,
     workspaceId: dataSourceConfig.workspaceId,
     connectorId,
     discussionNumber,
@@ -602,7 +602,7 @@ export async function githubRepoGarbageCollectWorkflow(
   repoId: string
 ) {
   const loggerArgs = {
-    dataSourceName: dataSourceConfig.dataSourceName,
+    dataSourceId: dataSourceConfig.dataSourceId,
     workspaceId: dataSourceConfig.workspaceId,
     connectorId,
   };

--- a/connectors/src/connectors/github/temporal/workflows.ts
+++ b/connectors/src/connectors/github/temporal/workflows.ts
@@ -90,7 +90,7 @@ export async function githubFullSyncWorkflow(
     pageNumber += 1;
 
     for (const repo of resultsPage) {
-      const fullSyncWorkflowId = getFullSyncWorkflowId(dataSourceConfig);
+      const fullSyncWorkflowId = getFullSyncWorkflowId(connectorId);
       const childWorkflowId = `${fullSyncWorkflowId}-repo-${repo.id}-syncCodeOnly-${syncCodeOnly}`;
       promises.push(
         queue.add(() =>
@@ -134,7 +134,7 @@ export async function githubReposSyncWorkflow(
   const promises: Promise<void>[] = [];
 
   for (const repo of repos) {
-    const reposSyncWorkflowId = getReposSyncWorkflowId(dataSourceConfig);
+    const reposSyncWorkflowId = getReposSyncWorkflowId(connectorId);
     const childWorkflowId = `${reposSyncWorkflowId}-repo-${repo.id}`;
     promises.push(
       queue.add(() =>
@@ -319,8 +319,8 @@ export async function githubRepoSyncWorkflow({
     for (;;) {
       const childWorkflowId = `${
         isFullSync
-          ? getFullSyncWorkflowId(dataSourceConfig)
-          : getReposSyncWorkflowId(dataSourceConfig)
+          ? getFullSyncWorkflowId(connectorId)
+          : getReposSyncWorkflowId(connectorId)
       }-repo-${repoId}-issues-page-${pageNumber}`;
 
       const shouldContinue = await executeChild(githubRepoIssuesSyncWorkflow, {
@@ -353,8 +353,8 @@ export async function githubRepoSyncWorkflow({
     for (;;) {
       const childWorkflowId = `${
         isFullSync
-          ? getFullSyncWorkflowId(dataSourceConfig)
-          : getReposSyncWorkflowId(dataSourceConfig)
+          ? getFullSyncWorkflowId(connectorId)
+          : getReposSyncWorkflowId(connectorId)
       }-repo-${repoId}-issues-page-${cursorIteration}`;
 
       nextCursor = await executeChild(githubRepoDiscussionsSyncWorkflow, {

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -127,7 +127,6 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
         workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
         workspaceId: dataSourceConfig.workspaceId,
         dataSourceId: dataSourceConfig.dataSourceId,
-        dataSourceName: dataSourceConfig.dataSourceName,
       },
       googleDriveConfigurationBlob
     );

--- a/connectors/src/connectors/google_drive/lib/cli.ts
+++ b/connectors/src/connectors/google_drive/lib/cli.ts
@@ -87,14 +87,14 @@ export const google_drive = async ({
       if (!args.wId) {
         throw new Error("Missing --wId argument");
       }
-      if (!args.dataSourceName) {
-        throw new Error("Missing --dataSourceName argument");
+      if (!args.dsId) {
+        throw new Error("Missing --dsId argument");
       }
 
       const connector = await ConnectorModel.findOne({
         where: {
           workspaceId: `${args.wId}`,
-          dataSourceName: args.dataSourceName,
+          dataSourceId: args.dsId,
           type: "google_drive",
         },
       });
@@ -130,8 +130,8 @@ export const google_drive = async ({
       if (!args.wId) {
         throw new Error("Missing --wId argument");
       }
-      if (!args.dataSourceName) {
-        throw new Error("Missing --dataSourceName argument");
+      if (!args.dsId) {
+        throw new Error("Missing --dsId argument");
       }
       if (!args.fileId) {
         throw new Error("Missing --fileId argument");
@@ -140,7 +140,7 @@ export const google_drive = async ({
       const connector = await ConnectorModel.findOne({
         where: {
           workspaceId: `${args.wId}`,
-          dataSourceName: args.dataSourceName,
+          dataSourceId: args.dsId,
         },
       });
       if (!connector) {

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -159,7 +159,7 @@ export async function syncFiles(
   logger.info(
     {
       connectorId,
-      dataSourceName: dataSourceConfig.dataSourceName,
+      dataSourceId: dataSourceConfig.dataSourceId,
     },
     `[SyncFiles] Start sync.`
   );
@@ -244,7 +244,7 @@ export async function syncFiles(
   logger.info(
     {
       connectorId,
-      dataSourceName: dataSourceConfig.dataSourceName,
+      dataSourceId: dataSourceConfig.dataSourceId,
       folderId: driveFolderId,
       count: filesToSync.length,
     },
@@ -276,7 +276,7 @@ export async function syncFiles(
   logger.info(
     {
       connectorId,
-      dataSourceName: dataSourceConfig.dataSourceName,
+      dataSourceId: dataSourceConfig.dataSourceId,
       folderId: driveFolderId,
       count,
     },

--- a/connectors/src/connectors/google_drive/temporal/file.ts
+++ b/connectors/src/connectors/google_drive/temporal/file.ts
@@ -170,6 +170,7 @@ async function handleFileExport(
       maxDocumentLen,
       localLogger,
       dataSourceConfig,
+      provider: "google_drive",
       connectorId,
       parents: [file.id, ...parents],
     });
@@ -219,7 +220,7 @@ export async function syncOneFile(
       const localLogger = logger.child({
         provider: "google_drive",
         workspaceId: dataSourceConfig.workspaceId,
-        dataSourceName: dataSourceConfig.dataSourceName,
+        dataSourceId: dataSourceConfig.dataSourceId,
         connectorId,
         documentId,
         fileId: file.id,

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -91,7 +91,6 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
           workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
           workspaceId: dataSourceConfig.workspaceId,
           dataSourceId: dataSourceConfig.dataSourceId,
-          dataSourceName: dataSourceConfig.dataSourceName,
         },
         intercomConfigurationBlob
       );
@@ -263,7 +262,7 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
       logger.error(
         {
           workspaceId: dataSourceConfig.workspaceId,
-          dataSourceName: dataSourceConfig.dataSourceName,
+          dataSourceId: dataSourceConfig.dataSourceId,
           error: e,
         },
         "Error launching Intercom sync workflow."

--- a/connectors/src/connectors/intercom/temporal/activities.ts
+++ b/connectors/src/connectors/intercom/temporal/activities.ts
@@ -118,7 +118,7 @@ export async function syncHelpCenterOnlyActivity({
     workspaceId: dataSourceConfig.workspaceId,
     connectorId,
     provider: "intercom",
-    dataSourceName: dataSourceConfig.dataSourceName,
+    dataSourceId: dataSourceConfig.dataSourceId,
   };
 
   const helpCenterOnDb = await IntercomHelpCenter.findOne({
@@ -238,7 +238,7 @@ export async function syncLevel1CollectionWithChildrenActivity({
     workspaceId: dataSourceConfig.workspaceId,
     connectorId,
     provider: "intercom",
-    dataSourceName: dataSourceConfig.dataSourceName,
+    dataSourceId: dataSourceConfig.dataSourceId,
   };
 
   const intercomWorkspace = await IntercomWorkspace.findOne({
@@ -342,7 +342,7 @@ export async function syncArticleBatchActivity({
     workspaceId: dataSourceConfig.workspaceId,
     connectorId,
     provider: "intercom",
-    dataSourceName: dataSourceConfig.dataSourceName,
+    dataSourceId: dataSourceConfig.dataSourceId,
   };
 
   const intercomWorkspace = await IntercomWorkspace.findOne({
@@ -440,7 +440,7 @@ export async function syncTeamOnlyActivity({
     workspaceId: dataSourceConfig.workspaceId,
     connectorId,
     provider: "intercom",
-    dataSourceName: dataSourceConfig.dataSourceName,
+    dataSourceId: dataSourceConfig.dataSourceId,
   };
 
   const teamOnDB = await IntercomTeam.findOne({
@@ -557,7 +557,7 @@ export async function syncConversationBatchActivity({
     workspaceId: dataSourceConfig.workspaceId,
     connectorId,
     provider: "intercom",
-    dataSourceName: dataSourceConfig.dataSourceName,
+    dataSourceId: dataSourceConfig.dataSourceId,
     teamId: teamId ?? null,
   };
 

--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -91,7 +91,6 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
         workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
         workspaceId: dataSourceConfig.workspaceId,
         dataSourceId: dataSourceConfig.dataSourceId,
-        dataSourceName: dataSourceConfig.dataSourceName,
       },
       microsoftConfigurationBlob
     );

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -375,7 +375,7 @@ export async function syncFiles({
   logger.info(
     {
       connectorId,
-      dataSourceName: dataSourceConfig.dataSourceName,
+      dataSourceId: dataSourceConfig.dataSourceId,
       parent,
       count,
     },

--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -178,12 +178,13 @@ export async function syncOneFile({
     ];
 
     result = await handleCsvFile({
-      dataSourceConfig,
       data,
       tableId: documentId,
       fileName: file.name || "",
       localLogger,
       maxDocumentLen,
+      dataSourceConfig,
+      provider: "microsoft",
       connectorId,
       parents,
     });

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -83,7 +83,6 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
           workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
           workspaceId: dataSourceConfig.workspaceId,
           dataSourceId: dataSourceConfig.dataSourceId,
-          dataSourceName: dataSourceConfig.dataSourceName,
         },
         {}
       );
@@ -98,7 +97,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
       logger.error(
         {
           workspaceId: dataSourceConfig.workspaceId,
-          dataSourceName: dataSourceConfig.dataSourceName,
+          dataSourceId: dataSourceConfig.dataSourceId,
           error: e,
         },
         "Error launching notion sync workflow."
@@ -183,7 +182,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
         logger.error(
           {
             workspaceId: dataSourceConfig.workspaceId,
-            dataSourceName: dataSourceConfig.dataSourceName,
+            dataSourceId: dataSourceConfig.dataSourceId,
             error: e,
           },
           "Error launching notion sync workflow post update."
@@ -254,7 +253,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
       logger.error(
         {
           workspaceId: dataSourceConfig.workspaceId,
-          dataSourceName: dataSourceConfig.dataSourceName,
+          dataSourceId: dataSourceConfig.dataSourceId,
           error: e,
         },
         "Error launching notion sync workflow."
@@ -367,7 +366,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
         {
           connectorId: this.connectorId,
           workspaceId: connector.workspaceId,
-          dataSourceName: connector.dataSourceName,
+          dataSourceId: connector.dataSourceId,
           e,
         },
         "Error stopping notion sync workflow."
@@ -390,7 +389,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
         {
           connectorId: this.connectorId,
           workspaceId: connector.workspaceId,
-          dataSourceName: connector.dataSourceName,
+          dataSourceId: connector.dataSourceId,
           error: e,
         },
         "Error launching notion sync workflow."

--- a/connectors/src/connectors/notion/lib/cli.ts
+++ b/connectors/src/connectors/notion/lib/cli.ts
@@ -227,8 +227,8 @@ export const notion = async ({
       if (!args.wId) {
         throw new Error("Missing --wId argument");
       }
-      if (!args.dataSourceName) {
-        throw new Error("Missing --dataSourceName argument");
+      if (!args.dsId) {
+        throw new Error("Missing --dsId argument");
       }
       if (!args.pageId) {
         throw new Error("Missing --pageId argument");
@@ -239,7 +239,7 @@ export const notion = async ({
         where: {
           type: "notion",
           workspaceId: `${args.wId}`,
-          dataSourceName: args.dataSourceName,
+          dataSourceId: args.dsId,
         },
       });
       if (!connector) {
@@ -290,8 +290,8 @@ export const notion = async ({
       if (!args.wId) {
         throw new Error("Missing --wId argument");
       }
-      if (!args.dataSourceName) {
-        throw new Error("Missing --dataSourceName argument");
+      if (!args.dsId) {
+        throw new Error("Missing --dsId argument");
       }
       if (!args.databaseId) {
         throw new Error("Missing --databaseId argument");
@@ -302,7 +302,7 @@ export const notion = async ({
         where: {
           type: "notion",
           workspaceId: `${args.wId}`,
-          dataSourceName: args.dataSourceName,
+          dataSourceId: args.dsId,
         },
       });
 
@@ -372,6 +372,9 @@ export const notion = async ({
       if (!args.wId) {
         throw new Error("Missing --wId argument");
       }
+      if (!args.dsId) {
+        throw new Error("Missing --dsId argument");
+      }
       if (!args.pageId) {
         throw new Error("Missing --pageId argument");
       }
@@ -380,7 +383,7 @@ export const notion = async ({
         where: {
           type: "notion",
           workspaceId: `${args.wId}`,
-          dataSourceName: "managed-notion",
+          dataSourceId: args.dsId,
         },
       });
       if (!connector) {
@@ -429,6 +432,9 @@ export const notion = async ({
       if (!args.wId) {
         throw new Error("Missing --wId argument");
       }
+      if (!args.dsId) {
+        throw new Error("Missing --dsId argument");
+      }
       if (!args.databaseId) {
         throw new Error("Missing --databaseId argument");
       }
@@ -437,7 +443,7 @@ export const notion = async ({
         where: {
           type: "notion",
           workspaceId: `${args.wId}`,
-          dataSourceName: "managed-notion",
+          dataSourceId: args.dsId,
         },
       });
       if (!connector) {
@@ -484,14 +490,14 @@ export const notion = async ({
     }
 
     case "search-pages": {
-      const { query, wId } = args;
+      const { query, wId, dsId } = args;
 
       if (!query) {
         throw new Error("Missing --query argument");
       }
 
       const connector = await getConnectorOrThrow({
-        connectorType: "notion",
+        dataSourceId: dsId,
         workspaceId: wId,
       });
 
@@ -505,14 +511,14 @@ export const notion = async ({
     }
 
     case "check-url": {
-      const { url, wId } = args;
+      const { url, wId, dsId } = args;
 
       if (!url) {
         throw new Error("Missing --url argument");
       }
 
       const connector = await getConnectorOrThrow({
-        connectorType: "notion",
+        dataSourceId: dsId,
         workspaceId: wId,
       });
 
@@ -526,14 +532,14 @@ export const notion = async ({
     }
 
     case "find-url": {
-      const { url, wId } = args;
+      const { url, wId, dsId } = args;
 
       if (!url) {
         throw new Error("Missing --url argument");
       }
 
       const connector = await getConnectorOrThrow({
-        connectorType: "notion",
+        dataSourceId: dsId,
         workspaceId: wId,
       });
 
@@ -546,10 +552,10 @@ export const notion = async ({
     }
 
     case "me": {
-      const { wId } = args;
+      const { wId, dsId } = args;
 
       const connector = await getConnectorOrThrow({
-        connectorType: "notion",
+        dataSourceId: dsId,
         workspaceId: wId,
       });
 

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -139,7 +139,7 @@ export async function fetchDatabaseChildPages({
   const localLoggerArgs = {
     ...loggerArgs,
     databaseId,
-    dataSourceName: connector.dataSourceName,
+    dataSourceId: connector.dataSourceId,
     workspaceId: connector.workspaceId,
   };
   const localLogger = logger.child(localLoggerArgs);
@@ -288,7 +288,7 @@ export async function getPagesAndDatabasesToSync({
   const localLogger = logger.child({
     ...loggerArgs,
     connectorId: connector.id,
-    dataSourceName: connector.dataSourceName,
+    dataSourceId: connector.dataSourceId,
     workspaceId: connector.workspaceId,
   });
 
@@ -314,7 +314,7 @@ export async function getPagesAndDatabasesToSync({
       cursors,
       {
         ...loggerArgs,
-        dataSourceName: connector.dataSourceName,
+        dataSourceId: connector.dataSourceId,
         workspaceId: connector.workspaceId,
       },
       skippedDatabaseIds
@@ -492,7 +492,7 @@ export async function upsertDatabaseInConnectorsDb(
       loggerArgs: {
         ...loggerArgs,
         workspaceId: connector.workspaceId,
-        dataSourceName: connector.dataSourceName,
+        dataSourceId: connector.dataSourceId,
       },
     });
 
@@ -651,7 +651,7 @@ export async function garbageCollectorMarkAsSeen({
   }
 
   const localLogger = logger.child({
-    dataSourceName: connector.dataSourceName,
+    dataSourceId: connector.dataSourceId,
     workspaceId: connector.workspaceId,
   });
 
@@ -809,7 +809,7 @@ export async function garbageCollect({
 
   const localLogger = logger.child({
     connectorId: connector.id,
-    dataSourceName: connector.dataSourceName,
+    dataSourceId: connector.dataSourceId,
     workspaceId: connector.workspaceId,
   });
 
@@ -1037,7 +1037,7 @@ export async function deletePageOrDatabaseIfArchived({
     ...loggerArgs,
     objectId,
     objectType,
-    dataSourceName: connector.dataSourceName,
+    dataSourceId: connector.dataSourceId,
     workspaceId: connector.workspaceId,
   });
 
@@ -1214,7 +1214,7 @@ export async function updateParentsFields(connectorId: ModelId) {
 
   const localLogger = logger.child({
     workspaceId: connector.workspaceId,
-    dataSourceName: connector.dataSourceName,
+    dataSourceId: connector.dataSourceId,
   });
 
   const notionPageIds = (
@@ -1286,7 +1286,7 @@ export async function cachePage({
   let localLogger = logger.child({
     ...loggerArgs,
     pageId,
-    dataSourceName: connector.dataSourceName,
+    dataSourceId: connector.dataSourceId,
     workspaceId: connector.workspaceId,
   });
 
@@ -1430,7 +1430,7 @@ export async function cacheBlockChildren({
     pageId,
     blockId,
     currentIndexInParent,
-    dataSourceName: connector.dataSourceName,
+    dataSourceId: connector.dataSourceId,
     workspaceId: connector.workspaceId,
   });
 
@@ -1549,7 +1549,7 @@ async function cacheDatabaseChildPages({
   const localLogger = logger.child({
     ...loggerArgs,
     workspaceId: connector.workspaceId,
-    dataSourceName: connector.dataSourceName,
+    dataSourceId: connector.dataSourceId,
   });
 
   const notionDatabaseModel = await NotionDatabase.findOne({
@@ -1783,7 +1783,7 @@ export async function renderAndUpsertPageFromCache({
   const localLogger = logger.child({
     ...loggerArgs,
     pageId,
-    dataSourceName: connector.dataSourceName,
+    dataSourceId: connector.dataSourceId,
     workspaceId: connector.workspaceId,
   });
 
@@ -1980,7 +1980,7 @@ export async function renderAndUpsertPageFromCache({
     loggerArgs: {
       ...loggerArgs,
       workspaceId: connector.workspaceId,
-      dataSourceName: connector.dataSourceName,
+      dataSourceId: connector.dataSourceId,
     },
   });
 
@@ -2171,7 +2171,7 @@ export async function clearWorkflowCache({
 
   const localLogger = logger.child({
     workspaceId: connector.workspaceId,
-    dataSourceName: connector.dataSourceName,
+    dataSourceId: connector.dataSourceId,
   });
 
   localLogger.info("notionClearConnectorCacheActivity: Clearing cache.");
@@ -2209,7 +2209,7 @@ export async function getDiscoveredResourcesFromCache({
 
   const localLogger = logger.child({
     workspaceId: connector.workspaceId,
-    dataSourceName: connector.dataSourceName,
+    dataSourceId: connector.dataSourceId,
   });
 
   localLogger.info(
@@ -2458,7 +2458,7 @@ export async function upsertDatabaseStructuredDataFromCache({
   const localLogger = logger.child({
     ...loggerArgs,
     workspaceId: connector.workspaceId,
-    dataSourceName: connector.dataSourceName,
+    dataSourceId: connector.dataSourceId,
     databaseId,
   });
 

--- a/connectors/src/connectors/shared/file.ts
+++ b/connectors/src/connectors/shared/file.ts
@@ -1,9 +1,11 @@
 import type {
+  ConnectorProvider,
   CoreAPIDataSourceDocumentSection,
   ModelId,
   Result,
 } from "@dust-tt/types";
 import {
+  CONNECTOR_TYPE_TO_NAME,
   Err,
   isTextExtractionSupportedContentType,
   Ok,
@@ -16,11 +18,6 @@ import { apiConfig } from "@connectors/lib/api/config";
 import { upsertTableFromCsv } from "@connectors/lib/data_sources";
 import type { Logger } from "@connectors/logger/logger";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
-
-const dataSourceNameToConnectorName: { [key: string]: string } = {
-  "managed-microsoft": "Microsoft",
-  "managed-google_drive": "Google Drive",
-};
 
 export function handleTextFile(
   data: ArrayBuffer,
@@ -43,6 +40,7 @@ export async function handleCsvFile({
   maxDocumentLen,
   localLogger,
   dataSourceConfig,
+  provider,
   connectorId,
   parents,
 }: {
@@ -52,6 +50,7 @@ export async function handleCsvFile({
   maxDocumentLen: number;
   localLogger: Logger;
   dataSourceConfig: DataSourceConfig;
+  provider: ConnectorProvider;
   connectorId: ModelId;
   parents: string[];
 }): Promise<Result<null, Error>> {
@@ -62,7 +61,7 @@ export async function handleCsvFile({
 
   const tableCsv = Buffer.from(data).toString("utf-8").trim();
   const tableName = slugify(fileName.substring(0, 32));
-  const tableDescription = `Structured data from ${dataSourceNameToConnectorName[dataSourceConfig.dataSourceName]} (${fileName})`;
+  const tableDescription = `Structured data from ${CONNECTOR_TYPE_TO_NAME[provider]} (${fileName})`;
 
   try {
     const stringifiedContent = await parseAndStringifyCsv(tableCsv);

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -70,7 +70,6 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
         workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
         workspaceId: dataSourceConfig.workspaceId,
         dataSourceId: dataSourceConfig.dataSourceId,
-        dataSourceName: dataSourceConfig.dataSourceName,
       },
       {
         slackTeamId: teamInfo.team.id,

--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -74,7 +74,6 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
         workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
         workspaceId: dataSourceConfig.workspaceId,
         dataSourceId: dataSourceConfig.dataSourceId,
-        dataSourceName: dataSourceConfig.dataSourceName,
       },
       webCrawlerConfigurationBlob
     );

--- a/connectors/src/lib/api/data_source_config.ts
+++ b/connectors/src/lib/api/data_source_config.ts
@@ -11,7 +11,6 @@ export function dataSourceConfigFromConnector(
 ): DataSourceConfig {
   return {
     workspaceAPIKey: connector.workspaceAPIKey,
-    dataSourceName: connector.dataSourceName,
     dataSourceId: connector.dataSourceId,
     workspaceId: connector.workspaceId,
   };
@@ -22,7 +21,6 @@ export function dataSourceInfoFromConnector(
   connector: ConnectorResource | ConnectorModel
 ): DataSourceInfo {
   return {
-    dataSourceName: connector.dataSourceName,
     dataSourceId: connector.dataSourceId,
     workspaceId: connector.workspaceId,
   };

--- a/connectors/src/lib/cli.ts
+++ b/connectors/src/lib/cli.ts
@@ -57,25 +57,27 @@ export async function runCommand(adminCommand: AdminCommandType) {
 }
 
 export async function getConnectorOrThrow({
-  connectorType,
   workspaceId,
+  dataSourceId,
 }: {
-  connectorType: string;
   workspaceId: string | undefined;
+  dataSourceId: string | undefined;
 }): Promise<ConnectorModel> {
   if (!workspaceId) {
     throw new Error("Missing workspace ID (wId)");
   }
+  if (!dataSourceId) {
+    throw new Error("Missing dataSource ID (dsId)");
+  }
   const connector = await ConnectorModel.findOne({
     where: {
-      type: connectorType,
       workspaceId: workspaceId,
-      dataSourceName: "managed-" + connectorType,
+      dataSourceId: dataSourceId,
     },
   });
   if (!connector) {
     throw new Error(
-      `No connector found for ${connectorType} workspace with ID ${workspaceId}`
+      `No connector found for ${dataSourceId} workspace with ID ${workspaceId}`
     );
   }
   return connector;
@@ -98,6 +100,9 @@ export const connectors = async ({
   if (!args.wId) {
     throw new Error("Missing --wId argument");
   }
+  if (!args.dsId) {
+    throw new Error("Missing --dsId argument");
+  }
   if (!args.dataSourceName) {
     throw new Error("Missing --dataSourceName argument");
   }
@@ -107,7 +112,7 @@ export const connectors = async ({
   const connector = await ConnectorModel.findOne({
     where: {
       workspaceId: `${args.wId}`,
-      dataSourceName: args.dataSourceName,
+      dataSourceId: args.dsId,
     },
   });
 
@@ -233,7 +238,7 @@ export const batch = async ({
           }).sync({ fromTs })
         );
         logger.info(
-          `[Admin] Triggered for connector id:${connector.id} - ${connector.type} - workspace:${connector.workspaceId} - dataSource:${connector.dataSourceName} - fromTs:${fromTs}`
+          `[Admin] Triggered for connector id:${connector.id} - ${connector.type} - workspace:${connector.workspaceId} - dataSource:${connector.dataSourceId} - fromTs:${fromTs}`
         );
       }
       return { success: true };

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -99,11 +99,11 @@ async function _upsertToDatasource({
         documentUrl,
         documentLength: sectionFullText(documentContent).length,
         workspaceId: dataSourceConfig.workspaceId,
-        dataSourceName: dataSourceConfig.dataSourceName,
+        dataSourceId: dataSourceConfig.dataSourceId,
         parents,
       });
       const statsDTags = [
-        `data_source_name:${dataSourceConfig.dataSourceName}`,
+        `data_source_Id:${dataSourceConfig.dataSourceId}`,
         `workspace_id:${dataSourceConfig.workspaceId}`,
       ];
 
@@ -116,8 +116,9 @@ async function _upsertToDatasource({
 
       const now = new Date();
 
-      const urlSafeName = encodeURIComponent(dataSourceConfig.dataSourceName);
-      const endpoint = `${DUST_FRONT_API}/api/v1/w/${dataSourceConfig.workspaceId}/data_sources/${urlSafeName}/documents/${documentId}`;
+      const endpoint =
+        `${DUST_FRONT_API}/api/v1/w/${dataSourceConfig.workspaceId}` +
+        `/data_sources/${dataSourceConfig.dataSourceId}/documents/${documentId}`;
       const dustRequestPayload: PostDataSourceDocumentRequestBody = {
         text: null,
         section: documentContent,
@@ -213,8 +214,9 @@ export async function deleteFromDataSource(
 ) {
   const localLogger = logger.child({ ...loggerArgs, documentId });
 
-  const urlSafeName = encodeURIComponent(dataSourceConfig.dataSourceName);
-  const endpoint = `${DUST_FRONT_API}/api/v1/w/${dataSourceConfig.workspaceId}/data_sources/${urlSafeName}/documents/${documentId}`;
+  const endpoint =
+    `${DUST_FRONT_API}/api/v1/w/${dataSourceConfig.workspaceId}` +
+    `/data_sources/${dataSourceConfig.dataSourceId}/documents/${documentId}`;
   const dustRequestConfig: AxiosRequestConfig = {
     headers: {
       Authorization: `Bearer ${dataSourceConfig.workspaceAPIKey}`,
@@ -300,8 +302,9 @@ async function _updateDocumentOrTableParentsField({
     tableOrDocument === "document"
       ? logger.child({ ...loggerArgs, documentId: id })
       : logger.child({ ...loggerArgs, tableId: id });
-  const urlSafeName = encodeURIComponent(dataSourceConfig.dataSourceName);
-  const endpoint = `${DUST_FRONT_API}/api/v1/w/${dataSourceConfig.workspaceId}/data_sources/${urlSafeName}/${tableOrDocument}s/${id}/parents`;
+  const endpoint =
+    `${DUST_FRONT_API}/api/v1/w/${dataSourceConfig.workspaceId}` +
+    `/data_sources/${dataSourceConfig.dataSourceId}/${tableOrDocument}s/${id}/parents`;
   const dustRequestConfig: AxiosRequestConfig = {
     headers: {
       Authorization: `Bearer ${dataSourceConfig.workspaceAPIKey}`,
@@ -404,14 +407,14 @@ async function tokenize(text: string, ds: DataSourceConfig) {
     logger,
     { useLocalInDev: true }
   );
-  const tokensRes = await dustAPI.tokenize(text, ds.dataSourceName);
+  const tokensRes = await dustAPI.tokenize(text, ds.dataSourceId);
   if (tokensRes.isErr()) {
     logger.error(
       { error: tokensRes.error },
-      `Error tokenizing text for ${ds.dataSourceName}`
+      `Error tokenizing text for ${ds.dataSourceId}`
     );
     throw new DustConnectorWorkflowError(
-      `Error tokenizing text for ${ds.dataSourceName}`,
+      `Error tokenizing text for ${ds.dataSourceId}`,
       "transient_upstream_activity_error",
       tokensRes.error
     );
@@ -569,7 +572,7 @@ export async function upsertTableFromCsv({
 }) {
   const localLogger = logger.child({ ...loggerArgs, tableId, tableName });
   const statsDTags = [
-    `data_source_name:${dataSourceConfig.dataSourceName}`,
+    `data_source_id:${dataSourceConfig.dataSourceId}`,
     `workspace_id:${dataSourceConfig.workspaceId}`,
   ];
 
@@ -582,8 +585,9 @@ export async function upsertTableFromCsv({
 
   const now = new Date();
 
-  const urlSafeName = encodeURIComponent(dataSourceConfig.dataSourceName);
-  const endpoint = `${DUST_FRONT_API}/api/v1/w/${dataSourceConfig.workspaceId}/data_sources/${urlSafeName}/tables/csv`;
+  const endpoint =
+    `${DUST_FRONT_API}/api/v1/w/${dataSourceConfig.workspaceId}` +
+    `/data_sources/${dataSourceConfig.dataSourceId}/tables/csv`;
   const dustRequestPayload = {
     name: tableName,
     parents,
@@ -709,7 +713,7 @@ export async function deleteTableRow({
     rowId,
   });
   const statsDTags = [
-    `data_source_name:${dataSourceConfig.dataSourceName}`,
+    `data_source_id:${dataSourceConfig.dataSourceId}`,
     `workspace_id:${dataSourceConfig.workspaceId}`,
   ];
 
@@ -722,8 +726,9 @@ export async function deleteTableRow({
 
   const now = new Date();
 
-  const urlSafeName = encodeURIComponent(dataSourceConfig.dataSourceName);
-  const endpoint = `${DUST_FRONT_API}/api/v1/w/${dataSourceConfig.workspaceId}/data_sources/${urlSafeName}/tables/${tableId}/rows/${rowId}`;
+  const endpoint =
+    `${DUST_FRONT_API}/api/v1/w/${dataSourceConfig.workspaceId}` +
+    `/data_sources/${dataSourceConfig.dataSourceId}/tables/${tableId}/rows/${rowId}`;
   const dustRequestConfig: AxiosRequestConfig = {
     headers: {
       Authorization: `Bearer ${dataSourceConfig.workspaceAPIKey}`,
@@ -801,8 +806,9 @@ export async function getTable({
     tableId,
   });
 
-  const urlSafeName = encodeURIComponent(dataSourceConfig.dataSourceName);
-  const endpoint = `${DUST_FRONT_API}/api/v1/w/${dataSourceConfig.workspaceId}/data_sources/${urlSafeName}/tables/${tableId}`;
+  const endpoint =
+    `${DUST_FRONT_API}/api/v1/w/${dataSourceConfig.workspaceId}` +
+    `/data_sources/${dataSourceConfig.dataSourceId}/tables/${tableId}`;
   const dustRequestConfig: AxiosRequestConfig = {
     headers: {
       Authorization: `Bearer ${dataSourceConfig.workspaceAPIKey}`,
@@ -839,7 +845,7 @@ export async function deleteTable({
     tableId,
   });
   const statsDTags = [
-    `data_source_name:${dataSourceConfig.dataSourceName}`,
+    `data_source_id:${dataSourceConfig.dataSourceId}`,
     `workspace_id:${dataSourceConfig.workspaceId}`,
   ];
 
@@ -852,8 +858,9 @@ export async function deleteTable({
 
   const now = new Date();
 
-  const urlSafeName = encodeURIComponent(dataSourceConfig.dataSourceName);
-  const endpoint = `${DUST_FRONT_API}/api/v1/w/${dataSourceConfig.workspaceId}/data_sources/${urlSafeName}/tables/${tableId}`;
+  const endpoint =
+    `${DUST_FRONT_API}/api/v1/w/${dataSourceConfig.workspaceId}` +
+    `/data_sources/${dataSourceConfig.dataSourceId}/tables/${tableId}`;
   const dustRequestConfig: AxiosRequestConfig = {
     headers: {
       Authorization: `Bearer ${dataSourceConfig.workspaceAPIKey}`,

--- a/connectors/src/lib/databases.ts
+++ b/connectors/src/lib/databases.ts
@@ -17,11 +17,11 @@ type CreateDatabaseParams = {
 };
 
 async function _createDatabase({
-  dataSourceConfig: { workspaceAPIKey, workspaceId, dataSourceName },
+  dataSourceConfig: { workspaceAPIKey, workspaceId, dataSourceId },
   databaseName,
 }: CreateDatabaseParams): Promise<string> {
   const res = await fetch(
-    `${DUST_FRONT_API}/api/v1/w/${workspaceId}/data_sources/${dataSourceName}/databases`,
+    `${DUST_FRONT_API}/api/v1/w/${workspaceId}/data_sources/${dataSourceId}/databases`,
     {
       method: "POST",
       headers: {
@@ -33,7 +33,7 @@ async function _createDatabase({
   );
   if (!res.ok) {
     throw new Error(
-      `Failed to create database ${databaseName} in data source ${dataSourceName}: ${res.status} ${res.statusText}`
+      `Failed to create database ${databaseName} in data source ${dataSourceId}: ${res.status} ${res.statusText}`
     );
   }
   const body = await res.json();
@@ -48,13 +48,13 @@ type UpsertTableParams = {
 };
 
 async function _upsertTable({
-  dataSourceConfig: { workspaceAPIKey, workspaceId, dataSourceName },
+  dataSourceConfig: { workspaceAPIKey, workspaceId, dataSourceId },
   databaseId,
   name,
   description,
 }: UpsertTableParams): Promise<string> {
   const res = await fetch(
-    `${DUST_FRONT_API}/api/v1/w/${workspaceId}/data_sources/${dataSourceName}/databases/${databaseId}/tables`,
+    `${DUST_FRONT_API}/api/v1/w/${workspaceId}/data_sources/${dataSourceId}/databases/${databaseId}/tables`,
     {
       method: "POST",
       headers: {
@@ -66,7 +66,7 @@ async function _upsertTable({
   );
   if (!res.ok) {
     throw new Error(
-      `Failed to upsert table ${name} in database ${databaseId} in data source ${dataSourceName}: ${res.status} ${res.statusText}`
+      `Failed to upsert table ${name} in database ${databaseId} in data source ${dataSourceId}: ${res.status} ${res.statusText}`
     );
   }
   const body = await res.json();
@@ -85,14 +85,14 @@ type UpsertRowsParams = {
 };
 
 async function _upsertRows({
-  dataSourceConfig: { workspaceAPIKey, workspaceId, dataSourceName },
+  dataSourceConfig: { workspaceAPIKey, workspaceId, dataSourceId },
   databaseId,
   tableId,
   rows,
   truncate,
 }: UpsertRowsParams): Promise<void> {
   const res = await fetch(
-    `${DUST_FRONT_API}/api/v1/w/${workspaceId}/data_sources/${dataSourceName}/databases/${databaseId}/tables/${tableId}/rows`,
+    `${DUST_FRONT_API}/api/v1/w/${workspaceId}/data_sources/${dataSourceId}/databases/${databaseId}/tables/${tableId}/rows`,
     {
       method: "POST",
       headers: {
@@ -104,7 +104,7 @@ async function _upsertRows({
   );
   if (!res.ok) {
     throw new Error(
-      `Failed to upsert rows in table ${tableId} in database ${databaseId} in data source ${dataSourceName}: ${res.status} ${res.statusText}`
+      `Failed to upsert rows in table ${tableId} in database ${databaseId} in data source ${dataSourceId}: ${res.status} ${res.statusText}`
     );
   }
 }

--- a/connectors/src/resources/connector_resource.ts
+++ b/connectors/src/resources/connector_resource.ts
@@ -116,11 +116,11 @@ export class ConnectorResource extends BaseResource<ConnectorModel> {
 
   static async findByDataSource(dataSource: {
     workspaceId: string;
-    dataSourceName: string;
+    dataSourceId: string;
   }) {
     const where: WhereOptions<ConnectorModel> = {
       workspaceId: dataSource.workspaceId,
-      dataSourceName: dataSource.dataSourceName,
+      dataSourceId: dataSource.dataSourceId,
     };
 
     const blob = await ConnectorResource.model.findOne({
@@ -206,7 +206,7 @@ export class ConnectorResource extends BaseResource<ConnectorModel> {
       type: this.type,
       connectionId: this.connectionId,
       workspaceId: this.workspaceId,
-      dataSourceName: this.dataSourceName,
+      dataSourceId: this.dataSourceId,
       lastSyncStatus: this.lastSyncStatus,
       lastSyncStartTime: this.lastSyncStartTime?.getTime(),
       lastSyncFinishTime: this.lastSyncFinishTime?.getTime(),

--- a/connectors/src/resources/storage/models/connector_model.ts
+++ b/connectors/src/resources/storage/models/connector_model.ts
@@ -24,8 +24,7 @@ export class ConnectorModel extends Model<
 
   declare workspaceAPIKey: string;
   declare workspaceId: string;
-  declare dataSourceId: string | null;
-  declare dataSourceName: string;
+  declare dataSourceId: string;
 
   declare lastSyncStatus?: ConnectorSyncStatus;
   declare errorType: ConnectorErrorType | null;
@@ -69,10 +68,6 @@ ConnectorModel.init(
       allowNull: false,
     },
     workspaceId: {
-      type: DataTypes.STRING,
-      allowNull: false,
-    },
-    dataSourceName: {
       type: DataTypes.STRING,
       allowNull: false,
     },

--- a/connectors/src/types/data_source_config.ts
+++ b/connectors/src/types/data_source_config.ts
@@ -1,8 +1,7 @@
 export type DataSourceConfig = {
   workspaceAPIKey: string;
   workspaceId: string;
-  dataSourceId: string | null;
-  dataSourceName: string;
+  dataSourceId: string;
 };
 
 export type DataSourceInfo = Omit<DataSourceConfig, "workspaceAPIKey">;

--- a/front/components/data_source/DataSourceSyncChip.tsx
+++ b/front/components/data_source/DataSourceSyncChip.tsx
@@ -8,11 +8,11 @@ import { timeAgoFrom } from "@app/lib/utils";
 
 export default function ConnectorSyncingChip({
   workspaceId,
-  dataSourceName,
+  dataSourceId,
   initialState,
 }: {
   workspaceId: string;
-  dataSourceName: string;
+  dataSourceId: string;
   initialState: ConnectorType;
 }) {
   const {
@@ -20,8 +20,8 @@ export default function ConnectorSyncingChip({
     isConnectorLoading,
     isConnectorError,
   } = useConnector({
-    workspaceId: workspaceId,
-    dataSourceName: dataSourceName,
+    workspaceId,
+    dataSourceId,
   });
 
   const connector = refreshedConnector || initialState;

--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -111,9 +111,7 @@ const getTableColumns = ({
                   info.row.original.dataSourceView.dataSource.connector
                 }
                 workspaceId={info.row.original.workspaceId}
-                dataSourceName={
-                  info.row.original.dataSourceView.dataSource.name
-                }
+                dataSourceId={info.row.original.dataSourceView.dataSource.sId}
               />
             )}
         </>

--- a/front/lib/production_checks/checks/check_notion_active_workflows.ts
+++ b/front/lib/production_checks/checks/check_notion_active_workflows.ts
@@ -9,7 +9,7 @@ import { withRetries } from "@app/lib/utils/retries";
 
 interface NotionConnector {
   id: number;
-  dataSourceName: string;
+  dataSourceId: string;
   workspaceId: string;
   pausedAt: Date | null;
 }
@@ -18,7 +18,7 @@ async function listAllNotionConnectors() {
   const connectorsReplica = getConnectorReplicaDbConnection();
 
   const notionConnectors: NotionConnector[] = await connectorsReplica.query(
-    `SELECT id, "dataSourceName", "workspaceId", "pausedAt" FROM connectors WHERE "type" = 'notion' and  "errorType" IS NULL`,
+    `SELECT id, "dataSourceId", "workspaceId", "pausedAt" FROM connectors WHERE "type" = 'notion' and  "errorType" IS NULL`,
     {
       type: QueryTypes.SELECT,
     }

--- a/front/lib/production_checks/checks/check_notion_active_workflows.ts
+++ b/front/lib/production_checks/checks/check_notion_active_workflows.ts
@@ -35,10 +35,10 @@ async function getDescriptionsAndHistories({
   notionConnector: NotionConnector;
 }) {
   const incrementalSyncHandle: WorkflowHandle = client.workflow.getHandle(
-    getNotionWorkflowId(notionConnector, "never")
+    getNotionWorkflowId(notionConnector.id, "never")
   );
   const garbageCollectorHandle: WorkflowHandle = client.workflow.getHandle(
-    getNotionWorkflowId(notionConnector, "always")
+    getNotionWorkflowId(notionConnector.id, "always")
   );
 
   const descriptions = await Promise.all([

--- a/front/lib/swr/connectors.ts
+++ b/front/lib/swr/connectors.ts
@@ -80,14 +80,14 @@ export function useConnectorConfig({
 
 export function useConnector({
   workspaceId,
-  dataSourceName,
+  dataSourceId,
 }: {
   workspaceId: string;
-  dataSourceName: string;
+  dataSourceId: string;
 }) {
   const configFetcher: Fetcher<GetConnectorResponseBody> = fetcher;
 
-  const url = `/api/w/${workspaceId}/data_sources/${dataSourceName}/connector`;
+  const url = `/api/w/${workspaceId}/data_sources/${dataSourceId}/connector`;
 
   const { data, error, mutate } = useSWRWithDefaults(url, configFetcher, {
     refreshInterval: (connectorResBody) => {

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -338,7 +338,6 @@ async function handler(
         workspaceId: owner.sId,
         workspaceAPIKey: systemAPIKeyRes.value.secret,
         dataSourceId: dataSource.sId,
-        dataSourceName: dataSource.name,
         connectionId: connectionId || "none",
         configuration,
       });

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/index.ts
@@ -426,7 +426,6 @@ const handleDataSourceWithProvider = async ({
     workspaceId: owner.sId,
     workspaceAPIKey: systemAPIKeyRes.value.secret,
     dataSourceId: dataSource.sId,
-    dataSourceName: dataSource.name,
     connectionId: connectionId ?? "none",
     configuration,
   });

--- a/front/pages/poke/connectors/[connectorId]/index.tsx
+++ b/front/pages/poke/connectors/[connectorId]/index.tsx
@@ -30,7 +30,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<object>(
 
     return {
       redirect: {
-        destination: `/poke/${connector.workspaceId}/data_sources/${connector.dataSourceName}`,
+        destination: `/poke/${connector.workspaceId}/data_sources/${connector.dataSourceId}`,
         permanent: false,
       },
     };

--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -1187,7 +1187,7 @@ function ManagedDataSourceView({
           <ConnectorSyncingChip
             initialState={connector}
             workspaceId={connector.workspaceId}
-            dataSourceName={connector.dataSourceName}
+            dataSourceId={connector.dataSourceId}
           />
         </div>
 

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -391,7 +391,7 @@ function getTableColumns() {
                   <ConnectorSyncingChip
                     initialState={managedDataSource.connector}
                     workspaceId={info.row.original.workspaceId}
-                    dataSourceName={managedDataSource.name}
+                    dataSourceId={managedDataSource.sId}
                   />
                 )
               );

--- a/types/src/connectors/api_handlers/create_connector.ts
+++ b/types/src/connectors/api_handlers/create_connector.ts
@@ -4,7 +4,6 @@ import { ConnectorConfigurationTypeSchema } from "./connector_configuration";
 
 export const ConnectorCreateRequestBodySchema = t.type({
   workspaceAPIKey: t.string,
-  dataSourceName: t.string,
   dataSourceId: t.string,
   workspaceId: t.string,
   connectionId: t.string,

--- a/types/src/connectors/notion.ts
+++ b/types/src/connectors/notion.ts
@@ -11,14 +11,14 @@ export type PropertyTypes = PageObjectProperties[PropertyKeys]["type"];
 export type NotionGarbageCollectionMode = "always" | "never";
 
 export function getNotionWorkflowId(
-  dataSourceInfo: { workspaceId: string; dataSourceName: string },
+  dataSourceInfo: { workspaceId: string; dataSourceId: string },
   gargbageCollectionMode: NotionGarbageCollectionMode
 ) {
   let wfName = "workflow-notion";
   if (gargbageCollectionMode === "always") {
     wfName += "-garbage-collector";
   }
-  return `${wfName}-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceName}`;
+  return `${wfName}-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceId}`;
 }
 
 // Extractor types

--- a/types/src/connectors/notion.ts
+++ b/types/src/connectors/notion.ts
@@ -4,6 +4,8 @@ import type {
 } from "@notionhq/client/build/src/api-endpoints";
 import * as t from "io-ts";
 
+import { ModelId } from "../shared/model_id";
+
 // notion SDK types
 export type PageObjectProperties = PageObjectResponse["properties"];
 export type PropertyKeys = keyof PageObjectProperties;
@@ -11,14 +13,14 @@ export type PropertyTypes = PageObjectProperties[PropertyKeys]["type"];
 export type NotionGarbageCollectionMode = "always" | "never";
 
 export function getNotionWorkflowId(
-  dataSourceInfo: { workspaceId: string; dataSourceId: string },
+  connectorId: ModelId,
   gargbageCollectionMode: NotionGarbageCollectionMode
 ) {
   let wfName = "workflow-notion";
   if (gargbageCollectionMode === "always") {
     wfName += "-garbage-collector";
   }
-  return `${wfName}-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceId}`;
+  return `${wfName}-${connectorId}`;
 }
 
 // Extractor types

--- a/types/src/connectors/notion.ts
+++ b/types/src/connectors/notion.ts
@@ -16,11 +16,11 @@ export function getNotionWorkflowId(
   connectorId: ModelId,
   gargbageCollectionMode: NotionGarbageCollectionMode
 ) {
-  let wfName = "workflow-notion";
+  let wfName = `workflow-notion-${connectorId}`;
   if (gargbageCollectionMode === "always") {
     wfName += "-garbage-collector";
   }
-  return `${wfName}-${connectorId}`;
+  return wfName;
 }
 
 // Extractor types

--- a/types/src/front/data_source.ts
+++ b/types/src/front/data_source.ts
@@ -14,6 +14,17 @@ export const CONNECTOR_PROVIDERS = [
   "webcrawler",
 ] as const;
 
+export const CONNECTOR_TYPE_TO_NAME: Record<ConnectorProvider, string> = {
+  confluence: "Confluence",
+  github: "GitHub",
+  google_drive: "Google Drive",
+  intercom: "Intercom",
+  notion: "Notion",
+  slack: "Slack",
+  microsoft: "Microsoft",
+  webcrawler: "Website",
+};
+
 export const CONNECTOR_TYPE_TO_MISMATCH_ERROR: Record<
   ConnectorProvider,
   string

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -29,7 +29,7 @@ export type ConnectorType = {
   id: string;
   type: ConnectorProvider;
   workspaceId: string;
-  dataSourceName: string;
+  dataSourceId: string;
   connectionId: string;
 
   lastSyncStatus?: ConnectorSyncStatus;
@@ -140,7 +140,6 @@ export class ConnectorsAPI {
     workspaceId,
     workspaceAPIKey,
     dataSourceId,
-    dataSourceName,
     connectionId,
     configuration,
   }: {
@@ -148,7 +147,6 @@ export class ConnectorsAPI {
     workspaceId: string;
     workspaceAPIKey: string;
     dataSourceId: string;
-    dataSourceName: string;
     connectionId: string;
     configuration: ConnectorConfiguration;
   }): Promise<ConnectorsAPIResponse<ConnectorType>> {
@@ -160,7 +158,6 @@ export class ConnectorsAPI {
         body: JSON.stringify({
           workspaceId,
           workspaceAPIKey,
-          dataSourceName,
           dataSourceId,
           connectionId,
           configuration,

--- a/types/src/front/lib/dust_api.ts
+++ b/types/src/front/lib/dust_api.ts
@@ -767,10 +767,9 @@ export class DustAPI {
 
   async tokenize(
     text: string,
-    dataSourceName: string
+    dataSourceId: string
   ): Promise<DustAPIResponse<CoreAPITokenType[]>> {
-    const urlSafeName = encodeURIComponent(dataSourceName);
-    const endpoint = `${this.apiUrl()}/api/v1/w/${this.workspaceId()}/data_sources/${urlSafeName}/tokenize`;
+    const endpoint = `${this.apiUrl()}/api/v1/w/${this.workspaceId()}/data_sources/${dataSourceId}/tokenize`;
 
     const res = await this._fetchWithError(endpoint, {
       method: "POST",


### PR DESCRIPTION
## Description

- Remove dataSourceName from DB
- Use dataSourceId everywhere
- Small side-effects in front and types

Note on workflowIds: github and notion workflow ids used to rely on dataSourceName (bad idea).

This PR changes that logic.

For GitHub, workflows are not long-lived so this should have not impact.
For Notion, we will want to stop all notion workflows, deploy and then restart all notion workflows
Other providers didn't rely on dataSourceName in their workflow name or arguments.

Will drop the column in a subsequent PR

## Risk

Connectors might be impacted but this is code only until we nuke the column so easy to revert.

## Deploy Plan

- stop all notion connectors
- deploy `connectors` 
- deploy `front` (ship syncing widget might be a bit unhappy in the interim but that's fine)
- start all notion connectors
- check notion workflows are happy
- check github workflows are happy