### PR TITLE
Assistant details uses DataSourceView for tables

### DIFF
--- a/front/components/assistant_builder/DataSourceSelectionSection.tsx
+++ b/front/components/assistant_builder/DataSourceSelectionSection.tsx
@@ -21,7 +21,10 @@ import ManagedDataSourceDocumentModal from "@app/components/ManagedDataSourceDoc
 import { orderDatasourceViewSelectionConfigurationByImportance } from "@app/lib/assistant";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { getVisualForContentNode } from "@app/lib/content_nodes";
-import { getDisplayNameForDataSource } from "@app/lib/data_sources";
+import {
+  canBeExpanded,
+  getDisplayNameForDataSource,
+} from "@app/lib/data_sources";
 import { classNames } from "@app/lib/utils";
 
 interface DataSourceSelectionSectionProps {
@@ -45,7 +48,6 @@ export default function DataSourceSelectionSection({
     useState<DataSourceViewType | null>(null);
 
   const canAddDataSource = dataSourceViews.length > 0;
-  const isTableView = viewType === "tables";
 
   return (
     <>
@@ -96,14 +98,14 @@ export default function DataSourceSelectionSection({
                 FolderIcon
               );
 
-              // Folders are always displayed as leaf items, except for table items.
-              const isLeafItem =
-                !dsConfig.dataSourceView.dataSource.connectorId && !isTableView;
-
               return (
                 <Tree.Item
                   key={dsConfig.dataSourceView.sId}
-                  type={isLeafItem ? "leaf" : "node"}
+                  type={
+                    canBeExpanded(viewType, dsConfig.dataSourceView.dataSource)
+                      ? "node"
+                      : "leaf"
+                  } // todo make useConnectorPermissions hook work for non managed ds (Folders)
                   label={getDisplayNameForDataSource(
                     dsConfig.dataSourceView.dataSource
                   )}

--- a/front/components/data_source/DocumentOrTableUploadOrEditModal.tsx
+++ b/front/components/data_source/DocumentOrTableUploadOrEditModal.tsx
@@ -101,8 +101,8 @@ export function DocumentOrTableUploadOrEditModal({
   const initialId = contentNode?.internalId;
 
   const { table, isTableError, isTableLoading } = useTable({
-    workspaceId: owner.sId,
-    dataSourceView: dataSourceView,
+    owner,
+    dataSourceView,
     tableId: isTable ? initialId ?? null : null,
   });
 

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -24,6 +24,7 @@ import {
   getConnectorProviderLogoWithFallback,
 } from "@app/lib/connector_providers";
 import {
+  canBeExpanded,
   getDisplayNameForDataSource,
   isFolder,
   isManaged,
@@ -241,10 +242,6 @@ function DataSourceViewSelector({
 
   const isTableView = viewType === "tables";
 
-  // Folders with viewType "documents" are always considered leaf items.
-  // For viewType "tables", folders are not leaf items because users need to select a specific table.
-  const isLeafItem = isFolder(dataSourceView.dataSource) && !isTableView;
-
   // Show the checkbox by default. Hide it only for tables where no child items are partially checked.
   const hideCheckbox = isTableView && !isPartiallyChecked;
 
@@ -253,7 +250,9 @@ function DataSourceViewSelector({
       key={dataSourceView.dataSource.name}
       label={getDisplayNameForDataSource(dataSourceView.dataSource)}
       visual={LogoComponent}
-      type={isLeafItem ? "leaf" : "node"}
+      type={
+        canBeExpanded(viewType, dataSourceView.dataSource) ? "node" : "leaf"
+      }
       checkbox={
         hideCheckbox
           ? undefined

--- a/front/components/tables/TablePicker.tsx
+++ b/front/components/tables/TablePicker.tsx
@@ -5,7 +5,7 @@ import { Menu } from "@headlessui/react";
 import { ChevronDownIcon } from "@heroicons/react/20/solid";
 import { useEffect, useState } from "react";
 
-import { useTables } from "@app/lib/swr/tables";
+import { useDataSourceTables } from "@app/lib/swr/data_sources";
 import { classNames } from "@app/lib/utils";
 
 export default function TablePicker({
@@ -28,7 +28,7 @@ export default function TablePicker({
   void dataSource;
 
   // TODO(GROUPS_INFRA): Use data source views to get tables.
-  const { tables } = useTables({
+  const { tables } = useDataSourceTables({
     workspaceId: dataSource.workspace_id,
     dataSourceName: dataSource.data_source_id,
   });

--- a/front/lib/data_sources.ts
+++ b/front/lib/data_sources.ts
@@ -1,5 +1,6 @@
 import type {
   ConnectorProvider,
+  ContentNodesViewType,
   CoreAPIDocument,
   DataSourceType,
   WithConnector,
@@ -71,4 +72,16 @@ export function supportsStructuredData(ds: DataSource): boolean {
       (ds.connectorProvider &&
         STRUCTURED_DATA_SOURCES.includes(ds.connectorProvider))
   );
+}
+
+export function canBeExpanded(
+  viewType: ContentNodesViewType,
+  ds?: DataSource
+): boolean {
+  if (!ds) {
+    return false;
+  }
+  // Folders with viewType "documents" are always considered leaf items.
+  // For viewType "tables", folders are not leaf items because users need to select a specific table.
+  return !isFolder(ds) || viewType === "tables";
 }

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -45,6 +45,7 @@ export function useDataSourceViews(
     mutateDataSourceViews: mutate,
   };
 }
+
 export function useMultipleDataSourceViewsContentNodes({
   dataSourceViewsAndInternalIds,
   owner,

--- a/front/lib/swr/data_sources.ts
+++ b/front/lib/swr/data_sources.ts
@@ -5,6 +5,7 @@ import type { Fetcher } from "swr";
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetDataSourcesResponseBody } from "@app/pages/api/w/[wId]/data_sources";
 import type { GetDocumentsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/documents";
+import type { GetTableResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/tables/[tId]";
 
 export function useDataSources(
   owner: LightWorkspaceType,
@@ -25,7 +26,7 @@ export function useDataSources(
   };
 }
 
-export function useDocuments(
+export function useDataSourceDocuments(
   owner: LightWorkspaceType,
   dataSource: { name: string },
   limit: number,
@@ -45,5 +46,32 @@ export function useDocuments(
     isDocumentsLoading: !error && !data,
     isDocumentsError: error,
     mutateDocuments: mutate,
+  };
+}
+
+//TODO(GROUPS_INFRA) Deprecated, remove once all usages are removed.
+export function useDataSourceTable({
+  workspaceId,
+  dataSourceName,
+  tableId,
+}: {
+  workspaceId: string;
+  dataSourceName: string;
+  tableId: string | null;
+}) {
+  const tableFetcher: Fetcher<GetTableResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    tableId
+      ? `/api/w/${workspaceId}/data_sources/${dataSourceName}/tables/${tableId}`
+      : null,
+    tableFetcher
+  );
+
+  return {
+    table: data ? data.table : null,
+    isTableLoading: !error && !data,
+    isTableError: error,
+    mutateTable: mutate,
   };
 }

--- a/front/lib/swr/data_sources.ts
+++ b/front/lib/swr/data_sources.ts
@@ -5,6 +5,7 @@ import type { Fetcher } from "swr";
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetDataSourcesResponseBody } from "@app/pages/api/w/[wId]/data_sources";
 import type { GetDocumentsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/documents";
+import type { ListTablesResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/tables";
 import type { GetTableResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/tables/[tId]";
 
 export function useDataSources(
@@ -73,5 +74,30 @@ export function useDataSourceTable({
     isTableLoading: !error && !data,
     isTableError: error,
     mutateTable: mutate,
+  };
+}
+
+//TODO(GROUPS_INFRA) Deprecated, remove once all usages are removed.
+export function useDataSourceTables({
+  workspaceId,
+  dataSourceName,
+}: {
+  workspaceId: string;
+  dataSourceName: string;
+}) {
+  const tablesFetcher: Fetcher<ListTablesResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    dataSourceName
+      ? `/api/w/${workspaceId}/data_sources/${dataSourceName}/tables`
+      : null,
+    tablesFetcher
+  );
+
+  return {
+    tables: useMemo(() => (data ? data.tables : []), [data]),
+    isTablesLoading: !error && !data,
+    isTablesError: error,
+    mutateTables: mutate,
   };
 }

--- a/front/lib/swr/tables.ts
+++ b/front/lib/swr/tables.ts
@@ -33,26 +33,15 @@ export function useTables({
 export function useTable({
   workspaceId,
   dataSourceView,
-  dataSourceName,
   tableId,
-}:
-  | {
-      workspaceId: string;
-      dataSourceView: DataSourceViewType;
-      dataSourceName?: undefined;
-      tableId: string | null;
-    }
-  | {
-      workspaceId: string;
-      dataSourceView?: undefined;
-      dataSourceName: string;
-      tableId: string | null;
-    }) {
+}: {
+  workspaceId: string;
+  dataSourceView: DataSourceViewType;
+  tableId: string | null;
+}) {
   const tableFetcher: Fetcher<GetTableResponseBody> = fetcher;
 
-  const endpoint = dataSourceView
-    ? `/api/w/${workspaceId}/vaults/${dataSourceView.vaultId}/data_source_views/${dataSourceView.sId}/tables/${tableId}`
-    : `/api/w/${workspaceId}/data_sources/${dataSourceName}/tables/${tableId}`;
+  const endpoint = `/api/w/${workspaceId}/vaults/${dataSourceView.vaultId}/data_source_views/${dataSourceView.sId}/tables/${tableId}`;
   const { data, error, mutate } = useSWRWithDefaults(
     tableId ? endpoint : null,
     tableFetcher

--- a/front/lib/swr/tables.ts
+++ b/front/lib/swr/tables.ts
@@ -1,47 +1,21 @@
-import type { DataSourceViewType } from "@dust-tt/types";
-import { useMemo } from "react";
+import type { DataSourceViewType, LightWorkspaceType } from "@dust-tt/types";
 import type { Fetcher } from "swr";
 
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { ListTablesResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/tables";
 import type { GetTableResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/tables/[tId]";
 
-export function useTables({
-  workspaceId,
-  dataSourceName,
-}: {
-  workspaceId: string;
-  dataSourceName: string;
-}) {
-  const tablesFetcher: Fetcher<ListTablesResponseBody> = fetcher;
-
-  const { data, error, mutate } = useSWRWithDefaults(
-    dataSourceName
-      ? `/api/w/${workspaceId}/data_sources/${dataSourceName}/tables`
-      : null,
-    tablesFetcher
-  );
-
-  return {
-    tables: useMemo(() => (data ? data.tables : []), [data]),
-    isTablesLoading: !error && !data,
-    isTablesError: error,
-    mutateTables: mutate,
-  };
-}
-
 export function useTable({
-  workspaceId,
+  owner,
   dataSourceView,
   tableId,
 }: {
-  workspaceId: string;
+  owner: LightWorkspaceType;
   dataSourceView: DataSourceViewType;
   tableId: string | null;
 }) {
   const tableFetcher: Fetcher<GetTableResponseBody> = fetcher;
 
-  const endpoint = `/api/w/${workspaceId}/vaults/${dataSourceView.vaultId}/data_source_views/${dataSourceView.sId}/tables/${tableId}`;
+  const endpoint = `/api/w/${owner.sId}/vaults/${dataSourceView.vaultId}/data_source_views/${dataSourceView.sId}/tables/${tableId}`;
   const { data, error, mutate } = useSWRWithDefaults(
     tableId ? endpoint : null,
     tableFetcher

--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -55,8 +55,10 @@ import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { getDisplayNameForDocument, isWebsite } from "@app/lib/data_sources";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useConnectorConfig } from "@app/lib/swr/connectors";
-import { useDataSourceDocuments } from "@app/lib/swr/data_sources";
-import { useTables } from "@app/lib/swr/tables";
+import {
+  useDataSourceDocuments,
+  useDataSourceTables,
+} from "@app/lib/swr/data_sources";
 import { ClientSideTracking } from "@app/lib/tracking/client";
 import { timeAgoFrom } from "@app/lib/utils";
 import logger from "@app/logger/logger";
@@ -561,7 +563,7 @@ function DatasourceTablesTabView({
   dataSource: DataSourceType;
   router: ReturnType<typeof useRouter>;
 }) {
-  const { tables } = useTables({
+  const { tables } = useDataSourceTables({
     workspaceId: owner.sId,
     dataSourceName: dataSource.name,
   });

--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -55,7 +55,7 @@ import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { getDisplayNameForDocument, isWebsite } from "@app/lib/data_sources";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useConnectorConfig } from "@app/lib/swr/connectors";
-import { useDocuments } from "@app/lib/swr/data_sources";
+import { useDataSourceDocuments } from "@app/lib/swr/data_sources";
 import { useTables } from "@app/lib/swr/tables";
 import { ClientSideTracking } from "@app/lib/tracking/client";
 import { timeAgoFrom } from "@app/lib/utils";
@@ -251,7 +251,7 @@ function DatasourceDocumentsTabView({
     isDocumentsLoading,
     isDocumentsError,
     mutateDocuments,
-  } = useDocuments(owner, dataSource, limit, offset);
+  } = useDataSourceDocuments(owner, dataSource, limit, offset);
   const [showDocumentsLimitPopup, setShowDocumentsLimitPopup] = useState(false);
 
   const [displayNameByDocId, setDisplayNameByDocId] = useState<

--- a/front/pages/w/[wId]/builder/data-sources/[name]/tables/upsert.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/tables/upsert.tsx
@@ -28,7 +28,7 @@ import config from "@app/lib/api/config";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { handleFileUploadToText } from "@app/lib/client/handle_file_upload";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
-import { useTable } from "@app/lib/swr/tables";
+import { useDataSourceTable } from "@app/lib/swr/data_sources";
 import { classNames } from "@app/lib/utils";
 import type { UpsertTableFromCsvRequestBody } from "@app/pages/api/w/[wId]/data_sources/[name]/tables/csv";
 
@@ -97,7 +97,7 @@ export default function TableUpsert({
   const [upserting, setUpserting] = useState(false);
   const [isBigFile, setIsBigFile] = useState(false);
 
-  const { table } = useTable({
+  const { table } = useDataSourceTable({
     workspaceId: owner.sId,
     dataSourceName: dataSource.name,
     tableId: loadTableId,


### PR DESCRIPTION
## Description

Update AssistantDetails to use the same component to render all datasource.

<img width="449" alt="image" src="https://github.com/user-attachments/assets/3f8ff0ba-3358-4f6d-aa8c-648e37d47234">

## Risk

Worst case : we are missing some datasources.

## Deploy Plan

Deploy `front`