### PR TITLE
Fix: Non Dust workspace members can still query the Dust Slack bot.

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -200,7 +200,7 @@ async function botAnswerMessage(
       },
       slackConfig.whitelistedDomains
     );
-    if (!hasChatbotAccess) {
+    if (!hasChatbotAccess.authorized) {
       return new Ok(undefined);
     }
   }


### PR DESCRIPTION
## Description

Fix: Non Dust workspace members can still query the Dust Slack bot.

The bug was introduced by this PR:
https://github.com/dust-tt/dust/pull/7070

This is not a privacy / security issue, as this restriction exists only for pricing reasons.

In today's world, we consider that a full member of a Slack workspace has access to the Dust bot regardless of their Dust membership, from a security standpoint. A good example of that is the whitelisting of a Slack workflow, which can be triggered by any Slack member, and can potentially talk to the Dust bot of the Slack workspace.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
