### PR TITLE
Add pagination support in core for both documents and tables.

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1725,13 +1725,13 @@ async fn data_sources_documents_list(
         .list_data_source_documents(
             &project,
             &data_source_id,
-            limit_offset,
             &match view_filter {
                 Some(filter) => Some(filter.postprocess_for_data_source(&data_source_id)),
                 None => None,
             },
-            true, // remove system tags
             &document_ids,
+            limit_offset,
+            true, // remove system tags
         )
         .await
     {

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -1733,7 +1733,7 @@ impl DataSource {
 
         // Delete tables (concurrently).
         let (tables, total) = store
-            .list_tables(&self.project, &self.data_source_id, None)
+            .list_tables(&self.project, &self.data_source_id, &None, &None, None)
             .await?;
         try_join_all(
             tables

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -1741,10 +1741,10 @@ impl Store for PostgresStore {
         &self,
         project: &Project,
         data_source_id: &str,
-        limit_offset: Option<(usize, usize)>,
         view_filter: &Option<SearchFilter>,
-        remove_system_tags: bool,
         document_ids: &Option<Vec<String>>,
+        limit_offset: Option<(usize, usize)>,
+        remove_system_tags: bool,
     ) -> Result<(Vec<Document>, usize)> {
         let project_id = project.project_id();
         let data_source_id = data_source_id.to_string();

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -161,10 +161,10 @@ pub trait Store {
         &self,
         project: &Project,
         data_source_id: &str,
-        limit_offset: Option<(usize, usize)>,
         view_filter: &Option<SearchFilter>,
-        remove_system_tags: bool,
         document_ids: &Option<Vec<String>>,
+        limit_offset: Option<(usize, usize)>,
+        remove_system_tags: bool,
     ) -> Result<(Vec<Document>, usize)>;
     async fn delete_data_source_document(
         &self,

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -164,6 +164,7 @@ pub trait Store {
         limit_offset: Option<(usize, usize)>,
         view_filter: &Option<SearchFilter>,
         remove_system_tags: bool,
+        document_ids: &Option<Vec<String>>,
     ) -> Result<(Vec<Document>, usize)>;
     async fn delete_data_source_document(
         &self,
@@ -229,6 +230,8 @@ pub trait Store {
         &self,
         project: &Project,
         data_source_id: &str,
+        view_filter: &Option<SearchFilter>,
+        table_ids: &Option<Vec<String>>,
         limit_offset: Option<(usize, usize)>,
     ) -> Result<(Vec<Table>, usize)>;
     async fn delete_table(

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -132,13 +132,15 @@ export async function getContentNodesForStaticDataSourceView(
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 
   if (viewType === "documents") {
-    const documentsRes = await coreAPI.getDataSourceDocuments({
-      dataSourceId: dataSource.dustAPIDataSourceId,
-      documentIds: internalIds,
-      pagination,
-      projectId: dataSource.dustAPIProjectId,
-      viewFilter: dataSourceView.toViewFilter(),
-    });
+    const documentsRes = await coreAPI.getDataSourceDocuments(
+      {
+        dataSourceId: dataSource.dustAPIDataSourceId,
+        documentIds: internalIds,
+        projectId: dataSource.dustAPIProjectId,
+        viewFilter: dataSourceView.toViewFilter(),
+      },
+      pagination
+    );
 
     if (documentsRes.isErr()) {
       return documentsRes;
@@ -161,13 +163,15 @@ export async function getContentNodesForStaticDataSourceView(
 
     return new Ok(documentsAsContentNodes);
   } else {
-    const tablesRes = await coreAPI.getTables({
-      dataSourceId: dataSource.dustAPIDataSourceId,
-      pagination,
-      projectId: dataSource.dustAPIProjectId,
-      tableIds: internalIds,
-      viewFilter: dataSourceView.toViewFilter(),
-    });
+    const tablesRes = await coreAPI.getTables(
+      {
+        dataSourceId: dataSource.dustAPIDataSourceId,
+        projectId: dataSource.dustAPIProjectId,
+        tableIds: internalIds,
+        viewFilter: dataSourceView.toViewFilter(),
+      },
+      pagination
+    );
 
     if (tablesRes.isErr()) {
       return tablesRes;

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -9,6 +9,7 @@ import { ConnectorsAPI, CoreAPI, Err, Ok, removeNulls } from "@dust-tt/types";
 import assert from "assert";
 
 import config from "@app/lib/api/config";
+import type { OffsetPaginationParams } from "@app/lib/api/pagination";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import logger from "@app/logger/logger";
 
@@ -123,7 +124,8 @@ export async function getContentNodesForManagedDataSourceView(
 export async function getContentNodesForStaticDataSourceView(
   dataSourceView: DataSourceViewResource,
   viewType: ContentNodesViewType,
-  { limit, offset }: { limit: number; offset: number }
+  internalIds: string[],
+  pagination?: OffsetPaginationParams
 ): Promise<Result<DataSourceViewContentNode[], Error | CoreAPIError>> {
   const { dataSource } = dataSourceView;
 
@@ -132,8 +134,8 @@ export async function getContentNodesForStaticDataSourceView(
   if (viewType === "documents") {
     const documentsRes = await coreAPI.getDataSourceDocuments({
       dataSourceId: dataSource.dustAPIDataSourceId,
-      limit,
-      offset,
+      documentIds: internalIds,
+      pagination,
       projectId: dataSource.dustAPIProjectId,
       viewFilter: dataSourceView.toViewFilter(),
     });
@@ -161,7 +163,9 @@ export async function getContentNodesForStaticDataSourceView(
   } else {
     const tablesRes = await coreAPI.getTables({
       dataSourceId: dataSource.dustAPIDataSourceId,
+      pagination,
       projectId: dataSource.dustAPIProjectId,
+      tableIds: internalIds,
       viewFilter: dataSourceView.toViewFilter(),
     });
 

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -310,12 +310,13 @@ export async function upsertDocument({
   // the `getDataSourceDocuments` query involves a SELECT COUNT(*) in the DB that is not
   // optimized, so we avoid it for large workspaces if we know we're unlimited anyway
   if (plan.limits.dataSources.documents.count !== -1) {
-    const documents = await coreAPI.getDataSourceDocuments({
-      projectId: dataSource.dustAPIProjectId,
-      dataSourceId: dataSource.dustAPIDataSourceId,
-      limit: 1,
-      offset: 0,
-    });
+    const documents = await coreAPI.getDataSourceDocuments(
+      {
+        projectId: dataSource.dustAPIProjectId,
+        dataSourceId: dataSource.dustAPIDataSourceId,
+      },
+      { limit: 1, offset: 0 }
+    );
     if (documents.isErr()) {
       return new Err(
         new DustError(

--- a/front/lib/api/pagination.ts
+++ b/front/lib/api/pagination.ts
@@ -91,7 +91,7 @@ const OffsetPaginationParamsCodec = t.type({
   offset: t.number,
 });
 
-interface OffsetPaginationParams {
+export interface OffsetPaginationParams {
   limit: number;
   offset: number;
 }

--- a/front/lib/data_sources.ts
+++ b/front/lib/data_sources.ts
@@ -1,6 +1,5 @@
 import type {
   ConnectorProvider,
-  ContentNodesViewType,
   CoreAPIDocument,
   DataSourceType,
   WithConnector,

--- a/front/lib/data_sources.ts
+++ b/front/lib/data_sources.ts
@@ -1,5 +1,6 @@
 import type {
   ConnectorProvider,
+  ContentNodesViewType,
   CoreAPIDocument,
   DataSourceType,
   WithConnector,

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/documents/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/documents/index.ts
@@ -64,12 +64,16 @@ async function handler(
         : 0;
 
       const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-      const documents = await coreAPI.getDataSourceDocuments({
-        projectId: dataSource.dustAPIProjectId,
-        dataSourceId: dataSource.dustAPIDataSourceId,
-        limit,
-        offset,
-      });
+      const documents = await coreAPI.getDataSourceDocuments(
+        {
+          projectId: dataSource.dustAPIProjectId,
+          dataSourceId: dataSource.dustAPIDataSourceId,
+        },
+        {
+          limit,
+          offset,
+        }
+      );
 
       if (documents.isErr()) {
         return apiError(req, res, {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -359,12 +359,13 @@ async function handler(
       // the `getDataSourceDocuments` query involves a SELECT COUNT(*) in the DB that is not
       // optimized, so we avoid it for large workspaces if we know we're unlimited anyway
       if (plan.limits.dataSources.documents.count != -1) {
-        const documents = await coreAPI.getDataSourceDocuments({
-          projectId: dataSource.dustAPIProjectId,
-          dataSourceId: dataSource.dustAPIDataSourceId,
-          limit: 1,
-          offset: 0,
-        });
+        const documents = await coreAPI.getDataSourceDocuments(
+          {
+            projectId: dataSource.dustAPIProjectId,
+            dataSourceId: dataSource.dustAPIDataSourceId,
+          },
+          { limit: 1, offset: 0 }
+        );
 
         if (documents.isErr()) {
           return apiError(req, res, {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/index.ts
@@ -112,12 +112,13 @@ async function handler(
         ? parseInt(req.query.offset as string)
         : 0;
 
-      const documents = await coreAPI.getDataSourceDocuments({
-        projectId: dataSource.dustAPIProjectId,
-        dataSourceId: dataSource.dustAPIDataSourceId,
-        limit,
-        offset,
-      });
+      const documents = await coreAPI.getDataSourceDocuments(
+        {
+          projectId: dataSource.dustAPIProjectId,
+          dataSourceId: dataSource.dustAPIDataSourceId,
+        },
+        { limit, offset }
+      );
       if (documents.isErr()) {
         return apiError(req, res, {
           status_code: 400,

--- a/front/pages/api/w/[wId]/data_sources/[name]/documents/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/documents/index.ts
@@ -39,12 +39,13 @@ async function handler(
         : 0;
 
       const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-      const documents = await coreAPI.getDataSourceDocuments({
-        projectId: dataSource.dustAPIProjectId,
-        dataSourceId: dataSource.dustAPIDataSourceId,
-        limit,
-        offset,
-      });
+      const documents = await coreAPI.getDataSourceDocuments(
+        {
+          projectId: dataSource.dustAPIProjectId,
+          dataSourceId: dataSource.dustAPIDataSourceId,
+        },
+        { limit, offset }
+      );
 
       if (documents.isErr()) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/content-nodes.ts
@@ -174,7 +174,7 @@ async function handler(
     const contentNodesRes = await getContentNodesForStaticDataSourceView(
       dataSourceView,
       viewType,
-      internalIds,
+      removeNulls(internalIds),
       paginationRes.value
     );
 

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/content-nodes.ts
@@ -159,6 +159,7 @@ async function handler(
 
     contentNodes = contentNodesRes.value;
   } else {
+    // TODO(GROUPS_INFRA) Remove once core has pagination.
     if (internalIds.length > 0) {
       return apiError(req, res, {
         status_code: 400,
@@ -173,6 +174,7 @@ async function handler(
     const contentNodesRes = await getContentNodesForStaticDataSourceView(
       dataSourceView,
       viewType,
+      internalIds,
       paginationRes.value
     );
 

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -672,31 +672,37 @@ export class CoreAPI {
 
   async getDataSourceDocuments({
     dataSourceId,
-    limit,
-    offset,
+    documentIds,
+    pagination,
     projectId,
     viewFilter,
   }: {
     dataSourceId: string;
-    limit: number;
-    offset: number;
+    documentIds?: string[];
+    pagination?: { limit: number; offset: number };
     projectId: string;
     viewFilter?: CoreAPISearchFilter | null;
   }): Promise<
     CoreAPIResponse<{
-      offset: number;
-      limit: number;
-      total: number;
       documents: CoreAPIDocument[];
+      limit: number;
+      offset: number;
+      total: number;
     }>
   > {
-    const queryParams = new URLSearchParams({
-      limit: String(limit),
-      offset: String(offset),
-    });
+    const queryParams = new URLSearchParams();
+
+    if (pagination) {
+      queryParams.append("limit", String(pagination.limit));
+      queryParams.append("offset", String(pagination.offset));
+    }
 
     if (viewFilter) {
       queryParams.append("view_filter", JSON.stringify(viewFilter));
+    }
+
+    if (documentIds && documentIds.length > 0) {
+      queryParams.append("document_ids", JSON.stringify(documentIds));
     }
 
     const response = await this._fetchWithError(
@@ -1107,21 +1113,37 @@ export class CoreAPI {
 
   async getTables({
     dataSourceId,
+    pagination,
     projectId,
+    tableIds,
     viewFilter,
   }: {
     dataSourceId: string;
+    pagination?: { limit: number; offset: number };
     projectId: string;
+    tableIds?: string[];
     viewFilter?: CoreAPISearchFilter | null;
   }): Promise<
     CoreAPIResponse<{
+      limit: number;
+      offset: number;
       tables: CoreAPITable[];
+      total: number;
     }>
   > {
     const queryParams = new URLSearchParams();
 
     if (viewFilter) {
       queryParams.append("view_filter", JSON.stringify(viewFilter));
+    }
+
+    if (tableIds && tableIds.length > 0) {
+      queryParams.append("table_ids", JSON.stringify(tableIds));
+    }
+
+    if (pagination) {
+      queryParams.append("limit", String(pagination.limit));
+      queryParams.append("offset", String(pagination.offset));
     }
 
     const response = await this._fetchWithError(

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -670,19 +670,20 @@ export class CoreAPI {
     return this._resultFromResponse(response);
   }
 
-  async getDataSourceDocuments({
-    dataSourceId,
-    documentIds,
-    pagination,
-    projectId,
-    viewFilter,
-  }: {
-    dataSourceId: string;
-    documentIds?: string[];
-    pagination?: { limit: number; offset: number };
-    projectId: string;
-    viewFilter?: CoreAPISearchFilter | null;
-  }): Promise<
+  async getDataSourceDocuments(
+    {
+      dataSourceId,
+      documentIds,
+      projectId,
+      viewFilter,
+    }: {
+      dataSourceId: string;
+      documentIds?: string[];
+      projectId: string;
+      viewFilter?: CoreAPISearchFilter | null;
+    },
+    pagination?: { limit: number; offset: number }
+  ): Promise<
     CoreAPIResponse<{
       documents: CoreAPIDocument[];
       limit: number;
@@ -1111,19 +1112,20 @@ export class CoreAPI {
     return this._resultFromResponse(response);
   }
 
-  async getTables({
-    dataSourceId,
-    pagination,
-    projectId,
-    tableIds,
-    viewFilter,
-  }: {
-    dataSourceId: string;
-    pagination?: { limit: number; offset: number };
-    projectId: string;
-    tableIds?: string[];
-    viewFilter?: CoreAPISearchFilter | null;
-  }): Promise<
+  async getTables(
+    {
+      dataSourceId,
+      projectId,
+      tableIds,
+      viewFilter,
+    }: {
+      dataSourceId: string;
+      projectId: string;
+      tableIds?: string[];
+      viewFilter?: CoreAPISearchFilter | null;
+    },
+    pagination?: { limit: number; offset: number }
+  ): Promise<
     CoreAPIResponse<{
       limit: number;
       offset: number;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR aims to establish a uniform pagination experience across documents and tables in core. Pagination is now optional for core endpoints, the table listing logic needed a bit refactor. This change allows view filter parameters to be applied during the query instead of post-query, which would otherwise break pagination. As a result, both the list tables and documents endpoints now return pagination cursor details, including total, limit, and offset.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Worst case it breaks content node listing for static data sources. Safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
