### PR TITLE
Actions button in vaults respect the expected rights

### DIFF
--- a/front/components/vaults/EditVaultStaticDatasourcesViews.tsx
+++ b/front/components/vaults/EditVaultStaticDatasourcesViews.tsx
@@ -1,4 +1,4 @@
-import { Button, PlusIcon, Popup } from "@dust-tt/sparkle";
+import { Button, PlusIcon, Popup, Tooltip } from "@dust-tt/sparkle";
 import type {
   DataSourceType,
   DataSourceViewWithConnectorType,
@@ -16,6 +16,7 @@ import { useDataSourceViewConnectorConfiguration } from "@app/lib/swr/data_sourc
 
 interface EditVaultStaticDatasourcesViewsProps {
   owner: WorkspaceType;
+  canWriteInVault: boolean;
   isOpen: boolean;
   setOpen: (isOpen: boolean) => void;
   plan: PlanType;
@@ -28,6 +29,7 @@ interface EditVaultStaticDatasourcesViewsProps {
 
 export function EditVaultStaticDatasourcesViews({
   owner,
+  canWriteInVault,
   plan,
   vault,
   isOpen,
@@ -98,11 +100,30 @@ export function EditVaultStaticDatasourcesViews({
           }
         />
       ) : null}
-      <Button
-        label={category === "folder" ? "Add folder" : "Add website"}
-        onClick={checkLimitsAndOpenModal}
-        icon={PlusIcon}
-      />
+      {canWriteInVault ? (
+        <Button
+          label={`Add ${category}`}
+          onClick={checkLimitsAndOpenModal}
+          icon={PlusIcon}
+          disabled={!canWriteInVault}
+        />
+      ) : (
+        <Tooltip
+          label={
+            vault.kind === "global"
+              ? `Only builders of the workspace can add a ${category} in the Company data Vault.`
+              : `Only members of the vault can add a ${category}.`
+          }
+          position="above"
+        >
+          <Button
+            label={`Add ${category}`}
+            onClick={checkLimitsAndOpenModal}
+            icon={PlusIcon}
+            disabled={!canWriteInVault}
+          />
+        </Tooltip>
+      )}
     </>
   );
 }

--- a/front/components/vaults/FoldersHeaderMenu.tsx
+++ b/front/components/vaults/FoldersHeaderMenu.tsx
@@ -19,7 +19,7 @@ import { useDataSources } from "@app/lib/swr/data_sources";
 type FoldersHeaderMenuProps = {
   owner: WorkspaceType;
   vault: VaultType;
-  canWrite: boolean;
+  canWriteInVault: boolean;
   folder: DataSourceType;
   contentActionsRef: RefObject<ContentActionsRef>;
 };
@@ -27,16 +27,16 @@ type FoldersHeaderMenuProps = {
 export const FoldersHeaderMenu = ({
   owner,
   vault,
-  canWrite,
+  canWriteInVault,
   folder,
   contentActionsRef,
 }: FoldersHeaderMenuProps) => {
   return (
     <>
-      {canWrite ? (
+      {canWriteInVault ? (
         <AddDataDropDownButton
           contentActionsRef={contentActionsRef}
-          canWrite={canWrite}
+          canWriteInVault={canWriteInVault}
         />
       ) : (
         <Tooltip
@@ -49,16 +49,16 @@ export const FoldersHeaderMenu = ({
         >
           <AddDataDropDownButton
             contentActionsRef={contentActionsRef}
-            canWrite={canWrite}
+            canWriteInVault={canWriteInVault}
           />
         </Tooltip>
       )}
-      {canWrite ? (
+      {canWriteInVault ? (
         <EditFolderButton
           owner={owner}
           vault={vault}
           folder={folder}
-          canWrite={canWrite}
+          canWriteInVault={canWriteInVault}
         />
       ) : (
         <Tooltip
@@ -73,7 +73,7 @@ export const FoldersHeaderMenu = ({
             owner={owner}
             vault={vault}
             folder={folder}
-            canWrite={canWrite}
+            canWriteInVault={canWriteInVault}
           />
         </Tooltip>
       )}
@@ -83,10 +83,10 @@ export const FoldersHeaderMenu = ({
 
 const AddDataDropDownButton = ({
   contentActionsRef,
-  canWrite,
+  canWriteInVault,
 }: {
   contentActionsRef: RefObject<ContentActionsRef>;
-  canWrite: boolean;
+  canWriteInVault: boolean;
 }) => {
   return (
     <DropdownMenu>
@@ -97,7 +97,7 @@ const AddDataDropDownButton = ({
           icon={PlusIcon}
           variant="primary"
           type="menu"
-          disabled={!canWrite}
+          disabled={!canWriteInVault}
         />
       </DropdownMenu.Button>
 
@@ -132,12 +132,12 @@ const EditFolderButton = ({
   owner,
   vault,
   folder,
-  canWrite,
+  canWriteInVault,
 }: {
   owner: WorkspaceType;
   vault: VaultType;
   folder: DataSourceType;
-  canWrite: boolean;
+  canWriteInVault: boolean;
 }) => {
   const { dataSources } = useDataSources(owner);
   const [showEditFolderModal, setShowEditFolderModal] = useState(false);
@@ -161,7 +161,7 @@ const EditFolderButton = ({
         onClick={() => {
           setShowEditFolderModal(true);
         }}
-        disabled={!canWrite}
+        disabled={!canWriteInVault}
       />
     </>
   );

--- a/front/components/vaults/FoldersHeaderMenu.tsx
+++ b/front/components/vaults/FoldersHeaderMenu.tsx
@@ -81,13 +81,15 @@ export const FoldersHeaderMenu = ({
   );
 };
 
+type AddDataDropDrownButtonProps = {
+  contentActionsRef: RefObject<ContentActionsRef>;
+  canWriteInVault: boolean;
+};
+
 const AddDataDropDownButton = ({
   contentActionsRef,
   canWriteInVault,
-}: {
-  contentActionsRef: RefObject<ContentActionsRef>;
-  canWriteInVault: boolean;
-}) => {
+}: AddDataDropDrownButtonProps) => {
   return (
     <DropdownMenu>
       <DropdownMenu.Button>
@@ -128,17 +130,19 @@ const AddDataDropDownButton = ({
   );
 };
 
+type EditFolderButtonProps = {
+  owner: WorkspaceType;
+  vault: VaultType;
+  folder: DataSourceType;
+  canWriteInVault: boolean;
+};
+
 const EditFolderButton = ({
   owner,
   vault,
   folder,
   canWriteInVault,
-}: {
-  owner: WorkspaceType;
-  vault: VaultType;
-  folder: DataSourceType;
-  canWriteInVault: boolean;
-}) => {
+}: EditFolderButtonProps) => {
   const { dataSources } = useDataSources(owner);
   const [showEditFolderModal, setShowEditFolderModal] = useState(false);
   return (

--- a/front/components/vaults/VaultDataSourceViewContentList.tsx
+++ b/front/components/vaults/VaultDataSourceViewContentList.tsx
@@ -45,7 +45,7 @@ type VaultDataSourceViewContentListProps = {
   vault: VaultType;
   dataSourceView: DataSourceViewType;
   plan: PlanType;
-  isAdmin: boolean;
+  canWrite: boolean;
   onSelect: (parentId: string) => void;
   owner: WorkspaceType;
   parentId?: string;
@@ -72,7 +72,7 @@ export const VaultDataSourceViewContentList = ({
   vault,
   dataSourceView,
   plan,
-  isAdmin,
+  canWrite,
   onSelect,
   parentId,
 }: VaultDataSourceViewContentListProps) => {
@@ -143,7 +143,7 @@ export const VaultDataSourceViewContentList = ({
       <div
         className={classNames(
           "flex gap-2",
-          rows.length === 0 && isAdmin
+          rows.length === 0
             ? "h-36 w-full max-w-4xl items-center justify-center rounded-lg border bg-structure-50"
             : ""
         )}
@@ -186,6 +186,7 @@ export const VaultDataSourceViewContentList = ({
             <FoldersHeaderMenu
               owner={owner}
               vault={vault}
+              canWrite={canWrite}
               folder={dataSourceView.dataSource}
               contentActionsRef={contentActionsRef}
             />
@@ -195,6 +196,7 @@ export const VaultDataSourceViewContentList = ({
           <WebsitesHeaderMenu
             owner={owner}
             vault={vault}
+            canWrite={canWrite}
             dataSourceView={dataSourceView}
           />
         )}

--- a/front/components/vaults/VaultDataSourceViewContentList.tsx
+++ b/front/components/vaults/VaultDataSourceViewContentList.tsx
@@ -45,7 +45,7 @@ type VaultDataSourceViewContentListProps = {
   vault: VaultType;
   dataSourceView: DataSourceViewType;
   plan: PlanType;
-  canWrite: boolean;
+  canWriteInVault: boolean;
   onSelect: (parentId: string) => void;
   owner: WorkspaceType;
   parentId?: string;
@@ -72,7 +72,7 @@ export const VaultDataSourceViewContentList = ({
   vault,
   dataSourceView,
   plan,
-  canWrite,
+  canWriteInVault,
   onSelect,
   parentId,
 }: VaultDataSourceViewContentListProps) => {
@@ -186,7 +186,7 @@ export const VaultDataSourceViewContentList = ({
             <FoldersHeaderMenu
               owner={owner}
               vault={vault}
-              canWrite={canWrite}
+              canWriteInVault={canWriteInVault}
               folder={dataSourceView.dataSource}
               contentActionsRef={contentActionsRef}
             />
@@ -196,7 +196,7 @@ export const VaultDataSourceViewContentList = ({
           <WebsitesHeaderMenu
             owner={owner}
             vault={vault}
-            canWrite={canWrite}
+            canWriteInVault={canWriteInVault}
             dataSourceView={dataSourceView}
           />
         )}

--- a/front/components/vaults/VaultLayout.tsx
+++ b/front/components/vaults/VaultLayout.tsx
@@ -28,6 +28,7 @@ import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 export interface VaultLayoutProps {
   gaTrackingId: string;
   owner: WorkspaceType;
+  isAdmin: boolean;
   subscription: SubscriptionType;
   vault: VaultType;
   category?: DataSourceViewCategory;
@@ -46,6 +47,7 @@ export function VaultLayout({
   const {
     gaTrackingId,
     owner,
+    isAdmin,
     subscription,
     vault,
     category,
@@ -62,6 +64,7 @@ export function VaultLayout({
         navChildren={
           <VaultSideBarMenu
             owner={owner}
+            isAdmin={isAdmin}
             setShowVaultCreationModal={setShowVaultCreationModal}
           />
         }

--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -58,6 +58,7 @@ type VaultResourcesListProps = {
   owner: WorkspaceType;
   plan: PlanType;
   isAdmin: boolean;
+  canWriteInVault: boolean;
   vault: VaultType;
   systemVault: VaultType;
   category: DataSourceViewCategory;
@@ -173,6 +174,7 @@ export const VaultResourcesList = ({
   owner,
   plan,
   isAdmin,
+  canWriteInVault,
   dustClientFacingUrl,
   vault,
   systemVault,
@@ -296,7 +298,7 @@ export const VaultResourcesList = ({
       <div
         className={classNames(
           "flex gap-2",
-          rows.length === 0 && isAdmin
+          rows.length === 0
             ? "h-36 w-full max-w-4xl items-center justify-center rounded-lg border bg-structure-50"
             : ""
         )}
@@ -345,6 +347,7 @@ export const VaultResourcesList = ({
               setOpen={setShowFolderOrWebsiteModal}
               owner={owner}
               vault={vault}
+              canWriteInVault={canWriteInVault}
               dataSources={dataSources}
               dataSourceView={selectedDataSourceView}
               plan={plan}
@@ -364,7 +367,7 @@ export const VaultResourcesList = ({
           </>
         )}
       </div>
-      {rows.length > 0 ? (
+      {rows.length > 0 && (
         <DataTable
           data={rows}
           columns={getTableColumns({ isManaged, isSystemVault })}
@@ -372,12 +375,6 @@ export const VaultResourcesList = ({
           filterColumn="name"
           initialColumnOrder={[{ desc: false, id: "name" }]}
         />
-      ) : !isAdmin ? (
-        <div className="flex items-center justify-center text-sm font-normal text-element-700">
-          No available connection
-        </div>
-      ) : (
-        <></>
       )}
     </>
   );

--- a/front/components/vaults/VaultSideBarMenu.tsx
+++ b/front/components/vaults/VaultSideBarMenu.tsx
@@ -34,6 +34,7 @@ import {
 
 interface VaultSideBarMenuProps {
   owner: LightWorkspaceType;
+  isAdmin: boolean;
   setShowVaultCreationModal: (show: boolean) => void;
 }
 
@@ -41,6 +42,7 @@ const VAULTS_SORT_ORDER: VaultKind[] = ["system", "global", "regular"];
 
 export default function VaultSideBarMenu({
   owner,
+  isAdmin,
   setShowVaultCreationModal,
 }: VaultSideBarMenuProps) {
   const { vaults, isVaultsLoading } = useVaults({ workspaceId: owner.sId });
@@ -68,12 +70,12 @@ export default function VaultSideBarMenu({
               <Fragment key={`vault-section-${index}`}>
                 <div className="flex items-center justify-between">
                   <Item.SectionHeader label={sectionLabel} />
-                  {sectionLabel === "PRIVATE" && (
+                  {sectionLabel === "PRIVATE" && isAdmin && (
                     <Button
                       className="mt-4"
                       size="xs"
                       variant="tertiary"
-                      label="Create Vault "
+                      label="Create Vault"
                       icon={LockIcon}
                       onClick={() => setShowVaultCreationModal(true)}
                     />

--- a/front/components/vaults/WebsitesHeaderMenu.tsx
+++ b/front/components/vaults/WebsitesHeaderMenu.tsx
@@ -15,12 +15,14 @@ import { useDataSources } from "@app/lib/swr/data_sources";
 type WebsitesHeaderMenuProps = {
   owner: WorkspaceType;
   vault: VaultType;
+  canWrite: boolean;
   dataSourceView: DataSourceViewType;
 };
 
 export const WebsitesHeaderMenu = ({
   owner,
   vault,
+  canWrite,
   dataSourceView,
 }: WebsitesHeaderMenuProps) => {
   const [showEditWebsiteModal, setShowEditWebsiteModal] = useState(false);
@@ -57,6 +59,7 @@ export const WebsitesHeaderMenu = ({
         onClick={() => {
           setShowEditWebsiteModal(true);
         }}
+        disabled={!canWrite}
       />
     </>
   );

--- a/front/components/vaults/WebsitesHeaderMenu.tsx
+++ b/front/components/vaults/WebsitesHeaderMenu.tsx
@@ -15,14 +15,14 @@ import { useDataSources } from "@app/lib/swr/data_sources";
 type WebsitesHeaderMenuProps = {
   owner: WorkspaceType;
   vault: VaultType;
-  canWrite: boolean;
+  canWriteInVault: boolean;
   dataSourceView: DataSourceViewType;
 };
 
 export const WebsitesHeaderMenu = ({
   owner,
   vault,
-  canWrite,
+  canWriteInVault,
   dataSourceView,
 }: WebsitesHeaderMenuProps) => {
   const [showEditWebsiteModal, setShowEditWebsiteModal] = useState(false);
@@ -59,7 +59,7 @@ export const WebsitesHeaderMenu = ({
         onClick={() => {
           setShowEditWebsiteModal(true);
         }}
-        disabled={!canWrite}
+        disabled={!canWriteInVault}
       />
     </>
   );

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -379,10 +379,7 @@ export class DataSourceResource extends ResourceWithVault<DataSource> {
   }
 
   canWrite(auth: Authenticator) {
-    if (this.vault.isRegular()) {
-      return auth.canWrite([this.vault.acl()]);
-    }
-    return auth.isBuilder() && auth.canWrite([this.vault.acl()]);
+    return auth.canWrite([this.vault.acl()]);
   }
 
   // sId logic.

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -375,11 +375,11 @@ export class DataSourceResource extends ResourceWithVault<DataSource> {
   // Permissions.
 
   canRead(auth: Authenticator) {
-    return auth.canRead([this.vault.acl()]);
+    return this.vault.canRead(auth);
   }
 
   canWrite(auth: Authenticator) {
-    return auth.canWrite([this.vault.acl()]);
+    return this.vault.canWrite(auth);
   }
 
   // sId logic.

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -379,6 +379,9 @@ export class DataSourceResource extends ResourceWithVault<DataSource> {
   }
 
   canWrite(auth: Authenticator) {
+    if (this.vault.isRegular()) {
+      return auth.canWrite([this.vault.acl()]);
+    }
     return auth.isBuilder() && auth.canWrite([this.vault.acl()]);
   }
 

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -409,7 +409,7 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
   // Permissions.
 
   canRead(auth: Authenticator) {
-    return auth.isAdmin() || auth.canRead([this.vault.acl()]);
+    return this.vault.canRead(auth);
   }
 
   // Serialization.

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -283,12 +283,27 @@ export class VaultResource extends BaseResource<VaultModel> {
     };
   }
 
+  canWrite(auth: Authenticator) {
+    if (this.isRegular()) {
+      return auth.canWrite([this.acl()]);
+    }
+    return auth.isBuilder() && auth.canWrite([this.acl()]);
+  }
+
+  canRead(auth: Authenticator) {
+    return auth.canRead([this.acl()]);
+  }
+
   isGlobal() {
     return this.kind === "global";
   }
 
   isSystem() {
     return this.kind === "system";
+  }
+
+  isRegular() {
+    return this.kind === "regular";
   }
 
   toJSON(): VaultType {

--- a/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
+++ b/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
@@ -23,6 +23,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     dataSource: DataSourceType;
     dataSourceView: DataSourceViewType;
     isAdmin: boolean;
+    canWrite: boolean;
     parentId?: string;
     plan: PlanType;
   }
@@ -67,6 +68,9 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     };
   }
 
+  const vault = dataSourceView.vault;
+  const canWrite = vault.canWrite(auth);
+
   return {
     props: {
       category: context.query.category as DataSourceViewCategory,
@@ -74,12 +78,13 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
       dataSourceView: dataSourceView.toJSON(),
       gaTrackingId: config.getGaTrackingId(),
       isAdmin,
+      canWrite,
       owner,
       // undefined is not allowed in the JSON response
       ...(parentId && { parentId }),
       plan,
       subscription,
-      vault: dataSourceView.vault.toJSON(),
+      vault: vault.toJSON(),
     },
   };
 });
@@ -88,7 +93,7 @@ export default function Vault({
   vault,
   category,
   dataSourceView,
-  isAdmin,
+  canWrite,
   owner,
   parentId,
   plan,
@@ -100,7 +105,7 @@ export default function Vault({
         owner={owner}
         vault={vault}
         plan={plan}
-        isAdmin={isAdmin}
+        canWrite={canWrite}
         parentId={parentId}
         dataSourceView={dataSourceView}
         onSelect={(parentId) => {

--- a/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
+++ b/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
@@ -23,7 +23,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     dataSource: DataSourceType;
     dataSourceView: DataSourceViewType;
     isAdmin: boolean;
-    canWrite: boolean;
+    canWriteInVault: boolean;
     parentId?: string;
     plan: PlanType;
   }
@@ -69,7 +69,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
   }
 
   const vault = dataSourceView.vault;
-  const canWrite = vault.canWrite(auth);
+  const canWriteInVault = vault.canWrite(auth);
 
   return {
     props: {
@@ -78,7 +78,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
       dataSourceView: dataSourceView.toJSON(),
       gaTrackingId: config.getGaTrackingId(),
       isAdmin,
-      canWrite,
+      canWriteInVault,
       owner,
       // undefined is not allowed in the JSON response
       ...(parentId && { parentId }),
@@ -93,7 +93,7 @@ export default function Vault({
   vault,
   category,
   dataSourceView,
-  canWrite,
+  canWriteInVault,
   owner,
   parentId,
   plan,
@@ -105,7 +105,7 @@ export default function Vault({
         owner={owner}
         vault={vault}
         plan={plan}
-        canWrite={canWrite}
+        canWriteInVault={canWriteInVault}
         parentId={parentId}
         dataSourceView={dataSourceView}
         onSelect={(parentId) => {

--- a/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/index.tsx
+++ b/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/index.tsx
@@ -22,6 +22,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     dustClientFacingUrl: string;
     isAdmin: boolean;
     isBuilder: boolean;
+    canWrite: boolean;
     vault: VaultType;
     systemVault: VaultType;
     plan: PlanType;
@@ -49,6 +50,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
   }
   const isAdmin = auth.isAdmin();
   const isBuilder = auth.isBuilder();
+  const canWrite = vault.canWrite(auth);
 
   return {
     props: {
@@ -57,6 +59,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
       gaTrackingId: config.getGaTrackingId(),
       isAdmin,
       isBuilder,
+      canWrite,
       owner,
       plan,
       subscription,
@@ -71,6 +74,7 @@ export default function Vault({
   dustClientFacingUrl,
   isAdmin,
   isBuilder,
+  canWrite,
   owner,
   plan,
   vault,
@@ -95,6 +99,7 @@ export default function Vault({
           vault={vault}
           systemVault={systemVault}
           isAdmin={isAdmin}
+          canWrite={canWrite}
           category={category}
           onSelect={(sId) => {
             void router.push(

--- a/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/index.tsx
+++ b/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/index.tsx
@@ -22,7 +22,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     dustClientFacingUrl: string;
     isAdmin: boolean;
     isBuilder: boolean;
-    canWrite: boolean;
+    canWriteInVault: boolean;
     vault: VaultType;
     systemVault: VaultType;
     plan: PlanType;
@@ -50,7 +50,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
   }
   const isAdmin = auth.isAdmin();
   const isBuilder = auth.isBuilder();
-  const canWrite = vault.canWrite(auth);
+  const canWriteInVault = vault.canWrite(auth);
 
   return {
     props: {
@@ -59,7 +59,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
       gaTrackingId: config.getGaTrackingId(),
       isAdmin,
       isBuilder,
-      canWrite,
+      canWriteInVault,
       owner,
       plan,
       subscription,
@@ -74,7 +74,7 @@ export default function Vault({
   dustClientFacingUrl,
   isAdmin,
   isBuilder,
-  canWrite,
+  canWriteInVault,
   owner,
   plan,
   vault,
@@ -99,7 +99,7 @@ export default function Vault({
           vault={vault}
           systemVault={systemVault}
           isAdmin={isAdmin}
-          canWrite={canWrite}
+          canWriteInVault={canWriteInVault}
           category={category}
           onSelect={(sId) => {
             void router.push(


### PR DESCRIPTION
## Description

- [x] Only admins can see the button "Create Vault".
- [x] Only admins can manage Connected Data in Vaults, users in group have the request button.
- [x] Regular vault: Only users from vault can add/edit/remove websites / folder / data in folder. Admins have the buttons disabled with a tooltip explaining that they need to be in the Vault to manage data. 
- [x] Global vault: Builders can manage the data. 

Notes: 
- When user has no right to manage data, the button is disabled with a tooltip explaining why. Code is not perfect, ideally it could be an option of the button to specify a tooltip to display if the button is disable (code would be easier to read). I initially wanted to do it but we already have a "disabledTooltip" attributes on buttons that is used for something else. So I decided to submit as is to unblock and will discuss how to improve Button component separately. 
- I'll review all wordings with Ed tomorrow. 
- I did not touch the member parts only for admins, will do in the next PR. 

## Risk

Since we decided that users of Vault can create data (website/folder) in Vaults, I edited the canWrite of a data source to remove the check on Builder if we're on a regular vault (we still want builders only on the global vault). 

Can be rolled back. 

## Deploy Plan

Deploy front. 
