### PR TITLE
Bring back Build menu event when Vault is activated

### DIFF
--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -120,7 +120,7 @@ export const getTopNavigationTabs = (owner: WorkspaceType) => {
       ),
   });
 
-  if (isBuilder(owner) && !owner.flags.includes("data_vaults_feature")) {
+  if (isBuilder(owner)) {
     nav.push({
       id: "assistants",
       label: "Build",


### PR DESCRIPTION
## Description

https://dust4ai.slack.com/archives/C07L7A5K2NM/p1725535450162839

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
