### PR TITLE
[eslint-no-unnecessary-condition] First pass of easy fixes.

### DIFF
--- a/front/.eslintrc.js
+++ b/front/.eslintrc.js
@@ -17,6 +17,7 @@ module.exports = {
     ],
     */
     curly: ["error", "all"],
+    // "@typescript-eslint/no-unnecessary-condition": "error",
     "react/no-unescaped-entities": 0,
     "@typescript-eslint/consistent-type-imports": "error",
     "import/consistent-type-specifier-style": ["error", "prefer-top-level"],

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -111,9 +111,9 @@ export function ViewDataSourceTable({
                     <PokeTableRow>
                       <PokeTableCell>Paused at</PokeTableCell>
                       <PokeTableCell>
-                        {connector?.pausedAt ? (
+                        {connector.pausedAt ? (
                           <span className="font-bold text-green-600">
-                            {timeAgoFrom(connector?.pausedAt, {
+                            {timeAgoFrom(connector.pausedAt, {
                               useLongFormat: true,
                             })}
                           </span>
@@ -125,8 +125,8 @@ export function ViewDataSourceTable({
                     <PokeTableRow>
                       <PokeTableCell>Last sync start</PokeTableCell>
                       <PokeTableCell>
-                        {connector?.lastSyncStartTime ? (
-                          timeAgoFrom(connector?.lastSyncStartTime, {
+                        {connector.lastSyncStartTime ? (
+                          timeAgoFrom(connector.lastSyncStartTime, {
                             useLongFormat: true,
                           })
                         ) : (
@@ -139,8 +139,8 @@ export function ViewDataSourceTable({
                     <PokeTableRow>
                       <PokeTableCell>Last sync finish</PokeTableCell>
                       <PokeTableCell>
-                        {connector?.lastSyncFinishTime ? (
-                          timeAgoFrom(connector?.lastSyncFinishTime, {
+                        {connector.lastSyncFinishTime ? (
+                          timeAgoFrom(connector.lastSyncFinishTime, {
                             useLongFormat: true,
                           })
                         ) : (
@@ -153,9 +153,9 @@ export function ViewDataSourceTable({
                     <PokeTableRow>
                       <PokeTableCell>Last sync status</PokeTableCell>
                       <PokeTableCell>
-                        {connector?.lastSyncStatus ? (
+                        {connector.lastSyncStatus ? (
                           <span className="font-bold">
-                            {connector?.lastSyncStatus}
+                            {connector.lastSyncStatus}
                             {connector.lastSyncStatus === "failed" && (
                               <span className="text-warning-500">
                                 &nbsp;{connector.errorType}
@@ -172,9 +172,9 @@ export function ViewDataSourceTable({
                     <PokeTableRow>
                       <PokeTableCell>Last sync success</PokeTableCell>
                       <PokeTableCell>
-                        {connector?.lastSyncSuccessfulTime ? (
+                        {connector.lastSyncSuccessfulTime ? (
                           <span className="font-bold text-green-600">
-                            {timeAgoFrom(connector?.lastSyncSuccessfulTime, {
+                            {timeAgoFrom(connector.lastSyncSuccessfulTime, {
                               useLongFormat: true,
                             })}
                           </span>

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -514,7 +514,7 @@ async function fetchWorkspaceAgentConfigurationsForView(
     agentConfigurationType.userListStatus = agentUserListStatus({
       agentConfiguration: agentConfigurationType,
       listStatusOverride:
-        agentUserRelations[agent.sId]?.listStatusOverride ?? null,
+        agentUserRelations[agent.sId].listStatusOverride ?? null,
     });
 
     agentConfigurationTypes.push(agentConfigurationType);
@@ -1296,7 +1296,7 @@ async function _createAgentDataSourcesConfigData(
       const dataSourcesWithViews: DataSourceWithView[] = uniqueDataSources.map(
         (ds) => ({
           ds,
-          view: dataSourceViewMap[ds.id] ?? null,
+          view: dataSourceViewMap[ds.id],
         })
       );
 

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -357,13 +357,8 @@ export async function rowsFromCsv(
 
     for (const [i, h] of header.entries()) {
       const col = record[i];
-      if (col === undefined) {
-        return new Err({
-          type: "invalid_record_length",
-          message: `Invalid record length at row ${i} (expected ${header.length} columns, got ${record.length})).`,
-        });
-      }
-      if (!valuesByCol[h]) {
+
+      if (!(h in valuesByCol)) {
         valuesByCol[h] = [col];
       } else {
         (valuesByCol[h] as string[]).push(col);
@@ -464,9 +459,9 @@ export async function rowsFromCsv(
   for (let i = 0; i < nbRows; i++) {
     const record = header.reduce(
       (acc, h) => {
-        const parsedValues = parsedValuesByCol[h];
-        acc[h] =
-          parsedValues && parsedValues[i] !== undefined ? parsedValues[i] : "";
+        const parsedValues =
+          h in parsedValuesByCol ? parsedValuesByCol[h] : undefined;
+        acc[h] = parsedValues ? parsedValues[i] : "";
         return acc;
       },
       {} as Record<string, CoreAPIRowValue>

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -206,7 +206,7 @@ export class Authenticator {
           return (
             await FeatureFlag.findAll({
               where: {
-                workspaceId: workspace?.id,
+                workspaceId: workspace.id,
               },
             })
           ).map((flag) => flag.name);
@@ -419,7 +419,7 @@ export class Authenticator {
         return (
           await FeatureFlag.findAll({
             where: {
-              workspaceId: workspace?.id,
+              workspaceId: workspace.id,
             },
           })
         ).map((flag) => flag.name);
@@ -429,7 +429,7 @@ export class Authenticator {
     return new Authenticator({
       workspace,
       role: "builder",
-      groups: globalGroup ? [globalGroup] : [],
+      groups: [globalGroup],
       subscription,
       flags,
     });
@@ -461,7 +461,7 @@ export class Authenticator {
         return (
           await FeatureFlag.findAll({
             where: {
-              workspaceId: workspace?.id,
+              workspaceId: workspace.id,
             },
           })
         ).map((flag) => flag.name);
@@ -471,7 +471,7 @@ export class Authenticator {
     return new Authenticator({
       workspace,
       role: "admin",
-      groups: globalGroup ? [globalGroup] : [],
+      groups: [globalGroup],
       subscription,
       flags,
     });

--- a/front/lib/config.ts
+++ b/front/lib/config.ts
@@ -8,99 +8,85 @@ export function extractConfig(spec: SpecificationType): BlockRunConfig {
       case "llm":
         c[spec[i].name] = {
           type: "llm",
-          provider_id: spec[i].config ? spec[i].config.provider_id : "",
-          model_id: spec[i].config ? spec[i].config.model_id : "",
-          use_cache: spec[i].config
+          provider_id: spec[i].config.provider_id || "",
+          model_id: spec[i].config.model_id || "",
+          use_cache: spec[i].config.use_cache
             ? spec[i].config.use_cache
-              ? spec[i].config.use_cache
-              : false
             : false,
         };
         break;
       case "chat":
         c[spec[i].name] = {
           type: "chat",
-          provider_id: spec[i].config ? spec[i].config.provider_id : "",
-          model_id: spec[i].config ? spec[i].config.model_id : "",
-          function_call: spec[i].config
+          provider_id: spec[i].config.provider_id || "",
+          model_id: spec[i].config.model_id || "",
+          function_call: spec[i].config.function_call
             ? spec[i].config.function_call
-              ? spec[i].config.function_call
-              : null
             : null,
-          use_cache: spec[i].config
+
+          use_cache: spec[i].config.use_cache
             ? spec[i].config.use_cache
-              ? spec[i].config.use_cache
-              : false
             : false,
         };
         break;
       case "input":
         c[spec[i].name] = {
           type: "input",
-          dataset: spec[i].config ? spec[i].config.dataset : "",
+          dataset: spec[i].config.dataset || "",
         };
         break;
       case "data_source":
-        const top_k = parseInt(spec[i].config ? spec[i].config.top_k : "");
+        const top_k = parseInt(spec[i].config.top_k || "");
         c[spec[i].name] = {
           type: "data_source",
-          data_sources: spec[i].config ? spec[i].config.data_sources : [],
+          data_sources: spec[i].config.data_sources || [],
           top_k: isNaN(top_k) ? 8 : top_k,
-          filter: spec[i].config ? spec[i].config.filter : null,
-          use_cache: spec[i].config
+          filter: spec[i].config.filter || null,
+          use_cache: spec[i].config.use_cache
             ? spec[i].config.use_cache
-              ? spec[i].config.use_cache
-              : false
             : false,
         };
         break;
       case "search":
         c[spec[i].name] = {
           type: "search",
-          provider_id: spec[i].config ? spec[i].config.provider_id : "",
-          use_cache: spec[i].config
+          provider_id: spec[i].config.provider_id || "",
+          use_cache: spec[i].config.use_cache
             ? spec[i].config.use_cache
-              ? spec[i].config.use_cache
-              : false
             : false,
         };
         break;
       case "curl":
         c[spec[i].name] = {
           type: "curl",
-          use_cache: spec[i].config
+          use_cache: spec[i].config.use_cache
             ? spec[i].config.use_cache
-              ? spec[i].config.use_cache
-              : false
             : false,
         };
         break;
       case "browser":
         c[spec[i].name] = {
           type: "browser",
-          provider_id: spec[i].config ? spec[i].config.provider_id : "",
-          use_cache: spec[i].config
+          provider_id: spec[i].config.provider_id || "",
+          use_cache: spec[i].config.use_cache
             ? spec[i].config.use_cache
-              ? spec[i].config.use_cache
-              : false
             : false,
-          error_as_output: spec[i].config
+
+          error_as_output: spec[i].config.error_as_output
             ? spec[i].config.error_as_output
-              ? spec[i].config.error_as_output
-              : false
             : false,
         };
         break;
       case "database_schema":
         c[spec[i].name] = {
           type: "database_schema",
-          tables: spec[i].config?.tables,
+          tables: spec[i].config.tables,
         };
         break;
       case "database":
         c[spec[i].name] = {
           type: "database",
-          tables: spec[i].config?.tables,
+          tables: spec[i].config.tables,
         };
         break;
       case "data":

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -38,11 +38,7 @@ async function getDefautPriceFromMetadata(
   const stripe = getStripeClient();
   const prices = await stripe.prices.list({ product: productId, active: true });
   for (const price of prices.data) {
-    if (
-      price.metadata &&
-      key in price.metadata &&
-      price.metadata[key] === "true"
-    ) {
+    if (key in price.metadata && price.metadata[key] === "true") {
       return price.id;
     }
   }
@@ -353,7 +349,7 @@ export function isEnterpriseSubscription(
 
   return activeItems.every((item) => {
     const isRecurring = Boolean(item.price.recurring);
-    const reportUsage = item.price.metadata?.REPORT_USAGE;
+    const reportUsage = item.price.metadata.REPORT_USAGE;
 
     return isRecurring && isEnterpriseReportUsage(reportUsage);
   });
@@ -378,7 +374,7 @@ export function assertStripeSubscriptionItemIsValid({
     });
   }
 
-  const reportUsage = item.price.metadata?.REPORT_USAGE;
+  const reportUsage = item.price.metadata.REPORT_USAGE;
 
   if (!item.price.recurring && reportUsage) {
     return new Err({
@@ -417,7 +413,7 @@ export function assertStripeSubscriptionItemIsValid({
     }
 
     if (item.price.recurring.usage_type === "metered") {
-      if (!isMauReportUsage(item.price.metadata?.REPORT_USAGE)) {
+      if (!isMauReportUsage(item.price.metadata.REPORT_USAGE)) {
         return new Err({
           invalidity_message: `Subscription recurring price has usage_type 'metered' but no valid REPORT_USAGE metadata. REPORT_USAGE should be MAU_{number} (e.g. MAU_1, MAU_5, MAU_10). Got ${reportUsage}`,
         });

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -86,7 +86,7 @@ export function renderSubscriptionFromModels({
     trialing: activeSubscription?.trialing === true,
     sId: activeSubscription?.sId || null,
     stripeSubscriptionId: activeSubscription?.stripeSubscriptionId || null,
-    startDate: activeSubscription?.startDate?.getTime() || null,
+    startDate: activeSubscription?.startDate.getTime() || null,
     endDate: activeSubscription?.endDate?.getTime() || null,
     paymentFailingSince:
       activeSubscription?.paymentFailingSince?.getTime() || null,
@@ -133,7 +133,7 @@ export const internalSubscribeWorkspaceToFreeNoPlan = async ({
     });
 
     // Notify Stripe that we ended the subscription if the subscription was a paid one
-    if (activeSubscription?.stripeSubscriptionId) {
+    if (activeSubscription.stripeSubscriptionId) {
       await cancelSubscriptionImmediately({
         stripeSubscriptionId: activeSubscription.stripeSubscriptionId,
       });
@@ -459,14 +459,8 @@ export async function getPerSeatSubscriptionPricing(
   }
 
   const { items } = stripeSubscription;
-  if (!items) {
-    return null;
-  }
 
   const [item] = items.data;
-  if (!item || !item.price) {
-    return null;
-  }
 
   const { unit_amount: unitAmount, currency, recurring, metadata } = item.price;
 
@@ -478,7 +472,7 @@ export async function getPerSeatSubscriptionPricing(
   if (
     !item.quantity ||
     !recurring ||
-    (metadata && metadata[REPORT_USAGE_METADATA_KEY] !== "PER_SEAT")
+    metadata[REPORT_USAGE_METADATA_KEY] !== "PER_SEAT"
   ) {
     return null;
   }

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -280,7 +280,7 @@ async function handleRegularSignupFlow(
     });
 
     return new Ok({ flow: null, workspace });
-  } else if (targetWorkspaceId && !canJoinTargetWorkspace) {
+  } else if (targetWorkspaceId && !joinTargetWorkspaceAllowed) {
     return new Err(
       new AuthFlowError(
         "invalid_domain",

--- a/front/pages/api/poke/templates/[tId].ts
+++ b/front/pages/api/poke/templates/[tId].ts
@@ -121,7 +121,7 @@ async function handler(
         });
       }
 
-      await existingTemplate?.update({
+      await existingTemplate.update({
         backgroundColor: body.backgroundColor,
         description: body.description ?? null,
         emoji: body.emoji,
@@ -137,7 +137,7 @@ async function handler(
         presetInstructions: body.presetInstructions ?? null,
         presetModelId: model.modelId,
         presetProviderId: model.providerId,
-        presetTemperature: body.presetTemperature ?? null,
+        presetTemperature: body.presetTemperature,
         tags: body.tags,
         visibility: body.visibility,
       });

--- a/front/pages/api/poke/templates/index.ts
+++ b/front/pages/api/poke/templates/index.ts
@@ -103,7 +103,7 @@ async function handler(
         presetInstructions: body.presetInstructions ?? null,
         presetModelId: model.modelId,
         presetProviderId: model.providerId,
-        presetTemperature: body.presetTemperature ?? null,
+        presetTemperature: body.presetTemperature,
         sId: generateLegacyModelSId(),
         tags: body.tags,
         visibility: body.visibility,

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/index.ts
@@ -68,7 +68,7 @@ async function handler(
         auth,
         agentsGetView: viewParam,
         variant: "light",
-        sort: viewParam === "archived" ? "updatedAt" : undefined,
+        sort: "updatedAt",
       });
 
       return res.status(200).json({

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -100,8 +100,8 @@ async function handler(
           const session = event.data.object as Stripe.Checkout.Session;
           const workspaceId = session.client_reference_id;
           const stripeSubscriptionId = session.subscription;
-          const planCode = session?.metadata?.planCode || null;
-          const userId = session?.metadata?.userId || null;
+          const planCode = session.metadata?.planCode || null;
+          const userId = session.metadata?.userId || null;
 
           if (session.status === "open" || session.status === "expired") {
             // Open: The checkout session is still in progress. Payment processing has not started.

--- a/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
@@ -47,27 +47,23 @@ function extractUsageFromExecutions(
   traces: TraceType[][],
   usages: RunUsageType[]
 ) {
-  if (block) {
-    traces.forEach((tracesInner) => {
-      tracesInner.forEach((trace) => {
-        if (trace?.meta) {
-          const { token_usage } = trace.meta as {
-            token_usage: { prompt_tokens: number; completion_tokens: number };
-          };
-          if (token_usage) {
-            const promptTokens = token_usage.prompt_tokens;
-            const completionTokens = token_usage.completion_tokens;
-            usages.push({
-              providerId: block.provider_id,
-              modelId: block.model_id,
-              promptTokens,
-              completionTokens,
-            });
-          }
-        }
-      });
+  traces.forEach((tracesInner) => {
+    tracesInner.forEach((trace) => {
+      if (trace.meta) {
+        const { token_usage } = trace.meta as {
+          token_usage: { prompt_tokens: number; completion_tokens: number };
+        };
+        const promptTokens = token_usage.prompt_tokens;
+        const completionTokens = token_usage.completion_tokens;
+        usages.push({
+          providerId: block.provider_id,
+          modelId: block.model_id,
+          promptTokens,
+          completionTokens,
+        });
+      }
     });
-  }
+  });
 }
 
 /**

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
@@ -66,7 +66,7 @@ async function handler(
 
   const { workspaceAuth } = await Authenticator.fromKey(keyRes.value, wId);
 
-  if (!workspaceAuth || !workspaceAuth.isBuilder()) {
+  if (!workspaceAuth.isBuilder()) {
     return apiError(req, res, {
       status_code: 401,
       api_error: {

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations/search.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations/search.ts
@@ -79,7 +79,7 @@ async function handler(
 
   const { workspaceAuth } = await Authenticator.fromKey(keyRes.value, wId);
 
-  if (!workspaceAuth || !workspaceAuth.isBuilder()) {
+  if (!workspaceAuth.isBuilder()) {
     return apiError(req, res, {
       status_code: 401,
       api_error: {

--- a/front/pages/api/w/[wId]/apps/[aId]/datasets/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/datasets/index.ts
@@ -105,12 +105,9 @@ async function handler(
         attributes: ["name"],
       });
 
-      let exists = false;
-      existing.forEach((e) => {
-        if (e.name == bodyValidation.right.dataset.name) {
-          exists = true;
-        }
-      });
+      const exists = existing.some(
+        (e) => e.name === bodyValidation.right.dataset.name
+      );
       if (exists) {
         return apiError(req, res, {
           status_code: 400,


### PR DESCRIPTION
## Description



The goal is to enable an eslint rule that will error on unnecessary check for always truly/falsy variables.
Some bugs can be avoided by such warnings from the linter, as displayed in this PR (search for `joinTargetWorkspaceAllowed`) or [this](https://github.com/dust-tt/dust/pull/7133) one.

This is a first pass of easy fixes, and there is another one (or two) coming before we can actually enable this rule.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
