### PR TITLE
[Global Agents] Return global agent with missing datasource

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -222,9 +222,7 @@ async function fetchGlobalAgentConfigurationForView(
   const allGlobalAgents = await getGlobalAgents(auth, globalAgentIdsToFetch);
   const matchingGlobalAgents = allGlobalAgents.filter(
     (a) =>
-      (!agentPrefix ||
-        a.name.toLowerCase().startsWith(agentPrefix.toLowerCase())) &&
-      !(a.status === "disabled_missing_datasource")
+      !agentPrefix || a.name.toLowerCase().startsWith(agentPrefix.toLowerCase())
   );
 
   if (


### PR DESCRIPTION
Description
---
Earlier, we had decided to hide agents that could not be used due to a missing datasource.

Now, we retired "connected" agents, so the only remaining agent through this code path is `@dust`

This raised an issue because enabling / disabling dust and changing data it accesses is done via the "Manage" button that is only shown on the `dust` line of the `default` tab of the assistant listing
![image](https://github.com/user-attachments/assets/172ff563-5dde-41fd-9393-5019d37a57c7)

If a user disables all datasources, the dust assistant becomes invisible, and can't be reenabled. Former conversations with it fail, etc. This happened e.g. [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1725534664636849)

This PR lets `@dust` show as a disabled agent when it has no datasources, which fixes the issue (the manage button reappears, people can reactivate, etc.)

Risk
---
na, worst case is some agents with a disabled toggle show up which is really not very scary

Deploy
---
front
