### PR TITLE
Admins only can see the Member tabs in a vault

### DIFF
--- a/front/components/vaults/VaultCategoriesList.tsx
+++ b/front/components/vaults/VaultCategoriesList.tsx
@@ -30,7 +30,6 @@ type Info = CellContext<RowData, unknown>;
 
 type VaultCategoriesListProps = {
   owner: WorkspaceType;
-  isAdmin: boolean;
   vault: VaultType;
   onSelect: (category: string) => void;
 };
@@ -91,7 +90,6 @@ const getTableColumns = () => {
 
 export const VaultCategoriesList = ({
   owner,
-  isAdmin,
   vault,
   onSelect,
 }: VaultCategoriesListProps) => {
@@ -131,7 +129,7 @@ export const VaultCategoriesList = ({
       <div
         className={classNames(
           "flex gap-2",
-          rows.length === 0 && isAdmin
+          rows.length === 0
             ? "h-36 w-full max-w-4xl items-center justify-center rounded-lg border bg-structure-50"
             : ""
         )}
@@ -147,19 +145,13 @@ export const VaultCategoriesList = ({
           />
         )}
       </div>
-      {rows.length > 0 ? (
+      {rows.length > 0 && (
         <DataTable
           data={rows}
           columns={getTableColumns()}
           filter={dataSourceSearch}
           filterColumn={"name"}
         />
-      ) : !isAdmin ? (
-        <div className="flex items-center justify-center text-sm font-normal text-element-700">
-          No available connection
-        </div>
-      ) : (
-        <></>
       )}
     </>
   );

--- a/front/pages/w/[wId]/data-sources/vaults/[vaultId]/index.tsx
+++ b/front/pages/w/[wId]/data-sources/vaults/[vaultId]/index.tsx
@@ -72,7 +72,7 @@ export default function Vault({
         description="Manage connections to your products and the real-time data feeds Dust has access to."
       />
 
-      {vault.kind !== "global" && (
+      {vault.kind !== "global" && isAdmin && (
         <div className="w-[320px]">
           <Tab
             tabs={[
@@ -101,7 +101,6 @@ export default function Vault({
         <VaultCategoriesList
           owner={owner}
           vault={vault}
-          isAdmin={isAdmin}
           onSelect={(category) => {
             void router.push(
               `/w/${owner.sId}/data-sources/vaults/${vault.sId}/categories/${category}`
@@ -109,7 +108,7 @@ export default function Vault({
           }}
         />
       )}
-      {currentTab === "members" && (
+      {currentTab === "members" && isAdmin && (
         <VaultMembers owner={owner} vault={vault} isAdmin={isAdmin} />
       )}
     </Page.Vertical>


### PR DESCRIPTION
## Description

Don't display the Resources / Members tabs in a vault if user is not admin. 

<kbd>
<img width="1037" alt="Screenshot 2024-09-05 at 16 53 19" src="https://github.com/user-attachments/assets/f172290a-0aaf-4939-90e0-576bde7ab135">
</kbd>


Also I don't think the search bar should be displayed when on the resource tab, I pinged Ed to confirm https://dust4ai.slack.com/archives/C07L7A5K2NM/p1725547476117859

## Risk

/

## Deploy Plan

Deploy front. 
