### PR TITLE
[@typescript-eslint/strict-boolean-expressions] First pass of easy fixes

### DIFF
--- a/front/.eslintrc.js
+++ b/front/.eslintrc.js
@@ -18,6 +18,17 @@ module.exports = {
     */
     curly: ["error", "all"],
     "react/no-unescaped-entities": 0,
+    // "@typescript-eslint/strict-boolean-expressions": [
+    //   "error",
+    //   {
+    //     allowNullableBoolean: true,
+    //     allowNullableString: true,
+    //     allowNullableObject: true,
+    //     allowNullableNumber: true,
+    //     allowNullableEnum: true,
+    //     allowAny: true,
+    //   },
+    // ],
     "@typescript-eslint/consistent-type-imports": "error",
     "import/consistent-type-specifier-style": ["error", "prefer-top-level"],
     "@typescript-eslint/no-explicit-any": 0,

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -172,7 +172,7 @@ export function ViewDataSourceTable({
                     <PokeTableRow>
                       <PokeTableCell>Last sync success</PokeTableCell>
                       <PokeTableCell>
-                        {connector?.lastSyncSuccessfulTime ? (
+                        {connector.lastSyncSuccessfulTime ? (
                           <span className="font-bold text-green-600">
                             {timeAgoFrom(connector?.lastSyncSuccessfulTime, {
                               useLongFormat: true,

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -92,7 +92,7 @@ export async function renderConversationForModelMultiActions({
 
       for (const action of actions) {
         const stepIndex = action.step;
-        steps[stepIndex] = steps[stepIndex] || emptyStep();
+        steps[stepIndex] = stepIndex in steps ? steps[stepIndex] : emptyStep();
         steps[stepIndex].actions.push({
           call: action.renderForFunctionCall(),
           result: action.renderForMultiActionsModel(),
@@ -100,7 +100,8 @@ export async function renderConversationForModelMultiActions({
       }
 
       for (const content of m.rawContents) {
-        steps[content.step] = steps[content.step] || emptyStep();
+        steps[content.step] =
+          content.step in steps ? steps[content.step] : emptyStep();
         if (content.content.trim()) {
           steps[content.step].contents.push(content.content);
         }
@@ -121,18 +122,6 @@ export async function renderConversationForModelMultiActions({
       } else {
         // In regular mode, we render all steps.
         for (const step of steps) {
-          if (!step) {
-            logger.error(
-              {
-                workspaceId: conversation.owner.sId,
-                conversationId: conversation.sId,
-                agentMessageId: m.sId,
-                panic: true,
-              },
-              "Unexpected state, agent message step is empty"
-            );
-            continue;
-          }
           if (!step.actions.length && !step.contents.length) {
             logger.error(
               {
@@ -305,7 +294,7 @@ export async function renderConversationForModelMultiActions({
   for (let i = selected.length - 1; i >= 0; i--) {
     const cfMessage = selected[i];
     if (isContentFragmentMessageTypeModel(cfMessage)) {
-      const userMessage = selected[i + 1];
+      const userMessage = i + 1 in selected ? selected[i + 1] : null;
       if (!userMessage || userMessage.role !== "user") {
         logger.error(
           {

--- a/front/lib/config.ts
+++ b/front/lib/config.ts
@@ -8,86 +8,70 @@ export function extractConfig(spec: SpecificationType): BlockRunConfig {
       case "llm":
         c[spec[i].name] = {
           type: "llm",
-          provider_id: spec[i].config ? spec[i].config.provider_id : "",
-          model_id: spec[i].config ? spec[i].config.model_id : "",
-          use_cache: spec[i].config
+          provider_id: spec[i].config.provider_id || "",
+          model_id: spec[i].config.model_id || "",
+          use_cache: spec[i].config.use_cache
             ? spec[i].config.use_cache
-              ? spec[i].config.use_cache
-              : false
             : false,
         };
         break;
       case "chat":
         c[spec[i].name] = {
           type: "chat",
-          provider_id: spec[i].config ? spec[i].config.provider_id : "",
-          model_id: spec[i].config ? spec[i].config.model_id : "",
-          function_call: spec[i].config
+          provider_id: spec[i].config.provider_id || "",
+          model_id: spec[i].config.model_id || "",
+          function_call: spec[i].config.function_call
             ? spec[i].config.function_call
-              ? spec[i].config.function_call
-              : null
             : null,
-          use_cache: spec[i].config
+          use_cache: spec[i].config.use_cache
             ? spec[i].config.use_cache
-              ? spec[i].config.use_cache
-              : false
             : false,
         };
         break;
       case "input":
         c[spec[i].name] = {
           type: "input",
-          dataset: spec[i].config ? spec[i].config.dataset : "",
+          dataset: spec[i].config.dataset || "",
         };
         break;
       case "data_source":
-        const top_k = parseInt(spec[i].config ? spec[i].config.top_k : "");
+        const top_k = parseInt(spec[i].config.top_k || "");
         c[spec[i].name] = {
           type: "data_source",
-          data_sources: spec[i].config ? spec[i].config.data_sources : [],
+          data_sources: spec[i].config.data_sources || [],
           top_k: isNaN(top_k) ? 8 : top_k,
-          filter: spec[i].config ? spec[i].config.filter : null,
-          use_cache: spec[i].config
+          filter: spec[i].config.filter || null,
+          use_cache: spec[i].config.use_cache
             ? spec[i].config.use_cache
-              ? spec[i].config.use_cache
-              : false
             : false,
         };
         break;
       case "search":
         c[spec[i].name] = {
           type: "search",
-          provider_id: spec[i].config ? spec[i].config.provider_id : "",
-          use_cache: spec[i].config
+          provider_id: spec[i].config.provider_id || "",
+          use_cache: spec[i].config.use_cache
             ? spec[i].config.use_cache
-              ? spec[i].config.use_cache
-              : false
             : false,
         };
         break;
       case "curl":
         c[spec[i].name] = {
           type: "curl",
-          use_cache: spec[i].config
+          use_cache: spec[i].config.use_cache
             ? spec[i].config.use_cache
-              ? spec[i].config.use_cache
-              : false
             : false,
         };
         break;
       case "browser":
         c[spec[i].name] = {
           type: "browser",
-          provider_id: spec[i].config ? spec[i].config.provider_id : "",
-          use_cache: spec[i].config
+          provider_id: spec[i].config.provider_id || "",
+          use_cache: spec[i].config.use_cache
             ? spec[i].config.use_cache
-              ? spec[i].config.use_cache
-              : false
             : false,
-          error_as_output: spec[i].config
+          error_as_output: spec[i].config.error_as_output
             ? spec[i].config.error_as_output
-              ? spec[i].config.error_as_output
-              : false
             : false,
         };
         break;

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -478,7 +478,7 @@ export async function getPerSeatSubscriptionPricing(
   if (
     !item.quantity ||
     !recurring ||
-    (metadata && metadata[REPORT_USAGE_METADATA_KEY] !== "PER_SEAT")
+    metadata[REPORT_USAGE_METADATA_KEY] !== "PER_SEAT"
   ) {
     return null;
   }

--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -485,5 +485,5 @@ export async function checkWorkspaceActivity(workspace: Workspace) {
     where: { workspaceId: workspace.id, updatedAt: { [Op.gte]: sevenDaysAgo } },
   });
 
-  return hasDataSource || hasCreatedAssistant || hasRecentConversation;
+  return !!hasDataSource || !!hasCreatedAssistant || !!hasRecentConversation;
 }

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -414,7 +414,8 @@ async function handler(
 
   if (targetWorkspace) {
     // For users joining a workspace from trying to access a conversation, we redirect to this conversation after signing in.
-    if (req.query.join === "true" && req.query.cId) {
+    const { cid: cId } = req.query;
+    if (req.query.join === "true" && typeof cId === "string") {
       res.redirect(`/w/${targetWorkspace.sId}/welcome?cId=${req.query.cId}`);
       return;
     }

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -280,7 +280,7 @@ async function handleRegularSignupFlow(
     });
 
     return new Ok({ flow: null, workspace });
-  } else if (targetWorkspaceId && !canJoinTargetWorkspace) {
+  } else if (targetWorkspaceId && !joinTargetWorkspaceAllowed) {
     return new Err(
       new AuthFlowError(
         "invalid_domain",

--- a/front/pages/api/poke/templates/[tId].ts
+++ b/front/pages/api/poke/templates/[tId].ts
@@ -43,7 +43,7 @@ async function handler(
   }
 
   const { tId: templateId } = req.query;
-  if (!templateId || typeof templateId !== "string") {
+  if (typeof templateId !== "string") {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/index.ts
@@ -38,7 +38,7 @@ async function handler(
   switch (req.method) {
     case "DELETE":
       const { wId } = req.query;
-      if (!wId || typeof wId !== "string") {
+      if (typeof wId !== "string") {
         return apiError(req, res, {
           status_code: 400,
           api_error: {

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/restore.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/restore.ts
@@ -38,7 +38,7 @@ async function handler(
   switch (req.method) {
     case "POST":
       const { wId } = req.query;
-      if (!wId || typeof wId !== "string") {
+      if (typeof wId !== "string") {
         return apiError(req, res, {
           status_code: 400,
           api_error: {

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/index.ts
@@ -31,7 +31,7 @@ async function handler(
   }
 
   const { cId } = req.query;
-  if (!cId || typeof cId !== "string") {
+  if (typeof cId !== "string") {
     return apiError(req, res, {
       status_code: 400,
       api_error: {

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/documents/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/documents/index.ts
@@ -58,10 +58,14 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const limit = req.query.limit ? parseInt(req.query.limit as string) : 10;
-      const offset = req.query.offset
-        ? parseInt(req.query.offset as string)
-        : 0;
+      const limit =
+        typeof req.query.limit === "string"
+          ? parseInt(req.query.limit as string)
+          : 10;
+      const offset =
+        typeof req.query.offset === "string"
+          ? parseInt(req.query.offset as string)
+          : 0;
 
       const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
       const documents = await coreAPI.getDataSourceDocuments(

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/index.ts
@@ -33,7 +33,7 @@ async function handler(
   switch (req.method) {
     case "DELETE":
       const { wId } = req.query;
-      if (!wId || typeof wId !== "string") {
+      if (typeof wId !== "string") {
         return apiError(req, res, {
           status_code: 400,
           api_error: {

--- a/front/pages/api/poke/workspaces/[wId]/upgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade.ts
@@ -34,7 +34,7 @@ async function handler(
   switch (req.method) {
     case "POST":
       const planCode = req.query.planCode;
-      if (!planCode || typeof planCode !== "string") {
+      if (typeof planCode !== "string") {
         return apiError(req, res, {
           status_code: 400,
           api_error: {

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -86,9 +86,10 @@ async function handler(
   switch (req.method) {
     case "GET":
       let listUpgraded: boolean | undefined;
-      const searchTerm = req.query.search
-        ? decodeURIComponent(req.query.search as string).trim()
-        : undefined;
+      const searchTerm =
+        typeof req.query.search === "string"
+          ? decodeURIComponent(req.query.search).trim()
+          : undefined;
       let limit: number = 0;
       let originalLimit: number = 0;
       const order: Order = [["createdAt", "DESC"]];

--- a/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
@@ -47,27 +47,24 @@ function extractUsageFromExecutions(
   traces: TraceType[][],
   usages: RunUsageType[]
 ) {
-  if (block) {
-    traces.forEach((tracesInner) => {
-      tracesInner.forEach((trace) => {
-        if (trace?.meta) {
-          const { token_usage } = trace.meta as {
-            token_usage: { prompt_tokens: number; completion_tokens: number };
-          };
-          if (token_usage) {
-            const promptTokens = token_usage.prompt_tokens;
-            const completionTokens = token_usage.completion_tokens;
-            usages.push({
-              providerId: block.provider_id,
-              modelId: block.model_id,
-              promptTokens,
-              completionTokens,
-            });
-          }
-        }
-      });
+  traces.forEach((tracesInner) => {
+    tracesInner.forEach((trace) => {
+      if (trace?.meta) {
+        const { token_usage } = trace.meta as {
+          token_usage: { prompt_tokens: number; completion_tokens: number };
+        };
+
+        const promptTokens = token_usage.prompt_tokens;
+        const completionTokens = token_usage.completion_tokens;
+        usages.push({
+          providerId: block.provider_id,
+          modelId: block.model_id,
+          promptTokens,
+          completionTokens,
+        });
+      }
     });
-  }
+  });
 }
 
 /**
@@ -214,7 +211,8 @@ async function handler(
 
   // This variable is used in the context of the DustAppRun action to use the workspace credentials
   // instead of our managed credentials when running an app with a system API key.
-  const useWorkspaceCredentials = !!req.query["use_workspace_credentials"];
+  const useWorkspaceCredentials =
+    typeof req.query.use_workspace_credentials === "string" ? true : false;
   const coreAPI = new CoreAPI(apiConfig.getCoreAPIConfig(), logger);
   const runFlavor: RunFlavor = req.body.stream
     ? "streaming"

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
@@ -66,7 +66,7 @@ async function handler(
 
   const { workspaceAuth } = await Authenticator.fromKey(keyRes.value, wId);
 
-  if (!workspaceAuth || !workspaceAuth.isBuilder()) {
+  if (!workspaceAuth.isBuilder()) {
     return apiError(req, res, {
       status_code: 401,
       api_error: {

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations/search.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations/search.ts
@@ -79,7 +79,7 @@ async function handler(
 
   const { workspaceAuth } = await Authenticator.fromKey(keyRes.value, wId);
 
-  if (!workspaceAuth || !workspaceAuth.isBuilder()) {
+  if (!workspaceAuth.isBuilder()) {
     return apiError(req, res, {
       status_code: 401,
       api_error: {

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
@@ -164,7 +164,8 @@ async function handler(
     });
   }
 
-  const lastEventId = req.query.lastEventId || null;
+  const lastEventId =
+    typeof req.query.lastEventId === "string" ? req.query.lastEventId : null;
   if (lastEventId && typeof lastEventId !== "string") {
     return apiError(req, res, {
       status_code: 400,

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/index.ts
@@ -107,10 +107,10 @@ async function handler(
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
   switch (req.method) {
     case "GET":
-      const limit = req.query.limit ? parseInt(req.query.limit as string) : 10;
-      const offset = req.query.offset
-        ? parseInt(req.query.offset as string)
-        : 0;
+      const limit =
+        typeof req.query.limit === "string" ? parseInt(req.query.limit) : 10;
+      const offset =
+        typeof req.query.offset === "string" ? parseInt(req.query.offset) : 0;
 
       const documents = await coreAPI.getDataSourceDocuments(
         {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/search.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/search.ts
@@ -215,10 +215,10 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      if (req.query.tags_in && typeof req.query.tags_in === "string") {
+      if (typeof req.query.tags_in === "string") {
         req.query.tags_in = [req.query.tags_in];
       }
-      if (req.query.tags_not && typeof req.query.tags_not === "string") {
+      if (typeof req.query.tags_not === "string") {
         req.query.tags_not = [req.query.tags_not];
       }
 

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
@@ -137,7 +137,7 @@ async function handler(
   }
 
   const tableId = req.query.tId;
-  if (!tableId || typeof tableId !== "string") {
+  if (typeof tableId !== "string") {
     return apiError(req, res, {
       status_code: 400,
       api_error: {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/[rId].ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/[rId].ts
@@ -142,7 +142,7 @@ async function handler(
   }
 
   const tableId = req.query.tId;
-  if (!tableId || typeof tableId !== "string") {
+  if (typeof tableId !== "string") {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -153,7 +153,7 @@ async function handler(
   }
 
   const rowId = req.query.rId;
-  if (!rowId || typeof rowId !== "string") {
+  if (typeof rowId !== "string") {
     return apiError(req, res, {
       status_code: 400,
       api_error: {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/index.ts
@@ -230,7 +230,7 @@ async function handler(
   }
 
   const tableId = req.query.tId;
-  if (!tableId || typeof tableId !== "string") {
+  if (typeof tableId !== "string") {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -242,10 +242,10 @@ async function handler(
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
   switch (req.method) {
     case "GET":
-      const limit = req.query.limit ? parseInt(req.query.limit as string) : 10;
-      const offset = req.query.offset
-        ? parseInt(req.query.offset as string)
-        : 0;
+      const limit =
+        typeof req.query.limit === "string" ? parseInt(req.query.limit) : 10;
+      const offset =
+        typeof req.query.offset === "string" ? parseInt(req.query.offset) : 0;
 
       const listRes = await coreAPI.getTableRows({
         projectId: dataSource.dustAPIProjectId,


### PR DESCRIPTION
## Description



The goal is to enable an eslint rule that will error on unnecessary check for always truly/falsy variables.
Some bugs can be avoided by such warnings from the linter, as displayed in this PR (search for `joinTargetWorkspaceAllowed`) or [this](https://github.com/dust-tt/dust/pull/7133) one.

This is a first pass of easy fixes, and there is another one (or two) coming before we can actually enable this rule.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
