### PR TITLE
fix: add clear error if tables query action has no tables

### DIFF
--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -270,6 +270,20 @@ export class TablesQueryConfigurationServerRunner extends BaseActionConfiguratio
       table_id: t.tableId,
       data_source_id: t.dataSourceId,
     }));
+    if (tables.length === 0) {
+      yield {
+        type: "tables_query_error",
+        created: Date.now(),
+        configurationId: agentConfiguration.sId,
+        messageId: agentMessage.sId,
+        error: {
+          code: "tables_query_error",
+          message:
+            "The assistant does not have access to any tables. Please edit the assistant's Query Tables tool to add tables, or remove the tool.",
+        },
+      };
+      return;
+    }
     config.DATABASE_SCHEMA = {
       type: "database_schema",
       tables,


### PR DESCRIPTION
## Description

This should no longer happen since we automatically remove the action, but in case it does this is better than an inscrutable error.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
