### PR TITLE
[Microsoft] Fix: skip malformed tables

### DIFF
--- a/connectors/src/lib/error.ts
+++ b/connectors/src/lib/error.ts
@@ -86,3 +86,11 @@ export function isMicrosoftApplicationDisabledError(
     /Application.*is disabled/.test(error.message)
   );
 }
+
+// Error for invalid rows when upserting table
+export class InvalidRowsRequestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidRowsRequestError";
+  }
+}

--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
@@ -169,7 +169,7 @@ export async function handlePostTableCsvUpsertRequest(
     if (csvRowsRes?.isErr()) {
       return apiError(req, res, {
         api_error: {
-          type: "invalid_request_error",
+          type: "invalid_rows_request_error",
           message: `Failed to parse CSV: ${csvRowsRes.error.message}`,
         },
         status_code: 400,

--- a/types/src/front/lib/error.ts
+++ b/types/src/front/lib/error.ts
@@ -12,6 +12,7 @@ export type APIErrorType =
   | "invalid_api_key_error"
   | "internal_server_error"
   | "invalid_request_error"
+  | "invalid_rows_request_error"
   | "user_not_found"
   | "data_source_error"
   | "data_source_not_found"


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/1262

When rows are malformed we currently raise an error.

We should instead skip the table---the error is very often due to the user being editing the table (so it's fixed by them later on), and anyways we cannot do anything but skip whether they fix or not

We of course leave a log

Risks
---
Missing indefinitely some spreadsheets, and users don't understand why Mitigation: log, + we do the same on gdrive already & never had any complaint

Deploy
---
front
connectors
