### PR TITLE
Fix: validate only assistant builder when edited.

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -267,8 +267,10 @@ export default function AssistantBuilder({
   }, [builderState, owner, initialBuilderState?.handle]);
 
   useEffect(() => {
-    void formValidation();
-  }, [formValidation]);
+    if (edited) {
+      void formValidation();
+    }
+  }, [edited, formValidation]);
 
   const setAction = useCallback(
     (p: AssistantBuilderSetActionType) => {

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -198,7 +198,7 @@ export default function CreateAssistant({
         }
         agentConfigurationId={null}
         isAdmin={isAdmin}
-        defaultIsEdited={true}
+        defaultIsEdited={false}
         baseUrl={baseUrl}
         defaultTemplate={assistantTemplate}
       />


### PR DESCRIPTION
## Description

Avoid showing errors until you have edited the form.

## Risk

None

## Deploy Plan

Deploy `front`