### PR TITLE
Sparkle Datatable: Add option to add tooltip on Avatar

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.223",
+  "version": "0.2.224",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.223",
+      "version": "0.2.224",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.223",
+  "version": "0.2.224",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -18,6 +18,7 @@ import {
 } from "@sparkle/components/DropdownMenu";
 import { IconButton } from "@sparkle/components/IconButton";
 import { ArrowDownIcon, ArrowUpIcon, MoreIcon } from "@sparkle/icons";
+import { Tooltip } from "@sparkle/index_with_tw_base";
 import { classNames } from "@sparkle/lib/utils";
 
 import { Icon } from "./Icon";
@@ -301,6 +302,7 @@ DataTable.Cell = function Cell({ children, className, ...props }: CellProps) {
 
 interface CellContentProps extends React.TdHTMLAttributes<HTMLDivElement> {
   avatarUrl?: string;
+  avatarTooltipLabel?: string;
   icon?: React.ComponentType<{ className?: string }>;
   iconClassName?: string;
   roundedAvatar?: boolean;
@@ -312,6 +314,7 @@ DataTable.CellContent = function CellContent({
   children,
   className,
   avatarUrl,
+  avatarTooltipLabel,
   roundedAvatar,
   icon,
   iconClassName,
@@ -323,7 +326,17 @@ DataTable.CellContent = function CellContent({
       className={classNames("s-flex s-items-center s-py-2", className || "")}
       {...props}
     >
-      {avatarUrl && (
+      {avatarUrl && avatarTooltipLabel && (
+        <Tooltip label={avatarTooltipLabel} position="above">
+          <Avatar
+            visual={avatarUrl}
+            size="xs"
+            className="s-mr-2"
+            isRounded={roundedAvatar ?? false}
+          />
+        </Tooltip>
+      )}
+      {avatarUrl && !avatarTooltipLabel && (
         <Avatar
           visual={avatarUrl}
           size="xs"

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -21,6 +21,7 @@ type Data = {
   lastUpdated: string;
   size: string;
   avatarUrl?: string;
+  avatarTooltipLabel?: string;
   icon?: React.ComponentType<{ className?: string }>;
   onClick?: () => void;
   moreMenuItems?: DropdownItemProps[];
@@ -29,6 +30,17 @@ type Data = {
 
 export const DataTableExample = () => {
   const data: Data[] = [
+    {
+      name: "Soupinou with tooltip on avatar",
+      usedBy: 100,
+      addedBy: "User1",
+      lastUpdated: "July 8, 2023",
+      size: "32kb",
+      avatarUrl: "https://avatars.githubusercontent.com/u/138893015?s=200&v=4",
+      avatarTooltipLabel: "Meow",
+      roundedAvatar: true,
+      onClick: () => console.log("hehe"),
+    },
     {
       name: "Marketing",
       description: "(23 items)",
@@ -100,6 +112,7 @@ export const DataTableExample = () => {
       cell: (info) => (
         <DataTable.CellContent
           avatarUrl={info.row.original.avatarUrl}
+          avatarTooltipLabel={info.row.original.avatarTooltipLabel}
           icon={info.row.original.icon}
           description={info.row.original.description}
           roundedAvatar={info.row.original.roundedAvatar}


### PR DESCRIPTION
## Description

On Vaults we want to be able to display a tooltip on all "Manage by" columns to display the name of the person managing the data. This requires a Sparkle update. 

<kbd>
<img width="914" alt="Screenshot 2024-09-06 at 10 53 36" src="https://github.com/user-attachments/assets/c0707fe6-1fcc-409f-b301-a3a76d3501c0">
</kbd>

## Risk

/ 

## Deploy Plan

Deploy Sparkle, then use in front. 
