### PR TITLE
Vaults: sidebar bug + refacto useSwrDefaults disabled config param

### DIFF
--- a/front/components/vaults/VaultFolderModal.tsx
+++ b/front/components/vaults/VaultFolderModal.tsx
@@ -18,6 +18,7 @@ import { useContext, useEffect, useState } from "react";
 
 import { DeleteStaticDataSourceDialog } from "@app/components/data_source/DeleteStaticDataSourceDialog";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
+import { useVaultDataSourceViews } from "@app/lib/swr/vaults";
 import type { PostVaultDataSourceResponseBody } from "@app/pages/api/w/[wId]/vaults/[vId]/data_sources";
 
 export default function VaultFolderModal({
@@ -37,6 +38,12 @@ export default function VaultFolderModal({
 }) {
   const router = useRouter();
   const sendNotification = useContext(SendNotificationsContext);
+  const { mutateVaultDataSourceViews: mutate } = useVaultDataSourceViews({
+    workspaceId: owner.sId,
+    vaultId: vault.sId,
+    category: "folder",
+    disabled: true, // We don't need to fetch the data source views here, we want the mutate function to refresh the data elsewhere.
+  });
 
   const defaultName = folder?.name ?? null;
   const defaultDescription = folder?.description ?? null;
@@ -76,6 +83,7 @@ export default function VaultFolderModal({
       }
     );
     if (res.ok) {
+      await mutate();
       handleOnClose();
       const response: PostVaultDataSourceResponseBody = await res.json();
       const { dataSourceView } = response;
@@ -175,6 +183,7 @@ export default function VaultFolderModal({
       }
     );
     if (res.ok) {
+      await mutate();
       handleOnClose();
       await router.push(
         `/w/${owner.sId}/data-sources/vaults/${vault.sId}/categories/folder`

--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -61,7 +61,7 @@ type VaultResourcesListProps = {
   canWriteInVault: boolean;
   vault: VaultType;
   systemVault: VaultType;
-  category: DataSourceViewCategory;
+  category: Exclude<DataSourceViewCategory, "apps">;
   onSelect: (sId: string) => void;
 };
 

--- a/front/components/vaults/VaultSideBarMenu.tsx
+++ b/front/components/vaults/VaultSideBarMenu.tsx
@@ -71,6 +71,11 @@ export default function VaultSideBarMenu({
       <div className="flex w-full flex-col px-2">
         <Item.List>
           {sortedGroupedVaults.map(({ kind, vaults }, index) => {
+            // Public vaults are created manually by us to hold public dust apps - other workspaces can't create them, so we do not show the section at all if there are no vaults.
+            if (kind === "public" && !vaults.length) {
+              return null;
+            }
+
             const sectionLabel = getSectionLabel(kind);
 
             return (

--- a/front/components/vaults/VaultSideBarMenu.tsx
+++ b/front/components/vaults/VaultSideBarMenu.tsx
@@ -76,7 +76,10 @@ export default function VaultSideBarMenu({
             return (
               <Fragment key={`vault-section-${index}`}>
                 <div className="flex items-center justify-between">
-                  <Item.SectionHeader label={sectionLabel} />
+                  <Item.SectionHeader
+                    label={sectionLabel}
+                    variant="secondary"
+                  />
                   {sectionLabel === "PRIVATE" && isAdmin && (
                     <Button
                       className="mt-4"
@@ -495,7 +498,7 @@ const VaultAppSubMenu = ({
 
   const categoryDetails = DATA_SOURCE_OR_VIEW_SUB_ITEMS[category];
 
-  const { isAppsLoading, apps } = useApps(owner);
+  const { isAppsLoading, apps } = useApps(owner, !isExpanded);
 
   return (
     <Tree.Item

--- a/front/components/vaults/VaultSideBarMenu.tsx
+++ b/front/components/vaults/VaultSideBarMenu.tsx
@@ -103,7 +103,7 @@ const renderVaultItems = (vaults: VaultType[], owner: LightWorkspaceType) =>
       {vault.kind === "system" ? (
         <SystemVaultMenu owner={owner} vault={vault} />
       ) : (
-        <VaultMenuItem owner={owner} vault={vault} />
+        <VaultMenu owner={owner} vault={vault} />
       )}
     </Fragment>
   ));
@@ -231,6 +231,20 @@ const SystemVaultItem = ({
 };
 
 // Global + regular vaults.
+
+const VaultMenu = ({
+  owner,
+  vault,
+}: {
+  owner: LightWorkspaceType;
+  vault: VaultType;
+}) => {
+  return (
+    <Tree variant="navigator">
+      <VaultMenuItem owner={owner} vault={vault} />
+    </Tree>
+  );
+};
 
 const VaultMenuItem = ({
   owner,

--- a/front/components/vaults/VaultWebsiteModal.tsx
+++ b/front/components/vaults/VaultWebsiteModal.tsx
@@ -14,7 +14,6 @@ import type {
   APIError,
   CrawlingFrequency,
   DataSourceType,
-  DataSourceViewCategory,
   DataSourceViewType,
   DepthOption,
   VaultType,
@@ -45,7 +44,7 @@ import type {
   PostVaultDataSourceResponseBody,
 } from "@app/pages/api/w/[wId]/vaults/[vId]/data_sources";
 
-const WEBSITE_CAT: DataSourceViewCategory = "website";
+const WEBSITE_CAT = "website";
 
 // todo(GROUPS_INFRA): current component has been mostly copy pasted from the WebsiteConfiguration existing component
 // this should be refactored to use the new design.

--- a/front/lib/swr/apps.ts
+++ b/front/lib/swr/apps.ts
@@ -33,12 +33,15 @@ export function useApp({
   };
 }
 
-export function useApps(owner: LightWorkspaceType) {
+export function useApps(owner: LightWorkspaceType, disabled?: boolean) {
   const appsFetcher: Fetcher<GetAppsResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
     `/api/w/${owner.sId}/apps`,
-    appsFetcher
+    appsFetcher,
+    {
+      disabled,
+    }
   );
 
   return {
@@ -141,8 +144,11 @@ export function useProviders({
   const providersFetcher: Fetcher<GetProvidersResponseBody> = fetcher;
 
   const { data, error } = useSWRWithDefaults(
-    disabled ? null : `/api/w/${owner.sId}/providers`,
-    providersFetcher
+    `/api/w/${owner.sId}/providers`,
+    providersFetcher,
+    {
+      disabled,
+    }
   );
 
   return {

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -223,10 +223,11 @@ export function useSlackChannelsLinkedWithAgent({
     fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
-    dataSourceName && !disabled
-      ? `/api/w/${workspaceId}/data_sources/${dataSourceName}/managed/slack/channels_linked_with_agent`
-      : null,
-    slackChannelsLinkedWithAgentFetcher
+    `/api/w/${workspaceId}/data_sources/${dataSourceName}/managed/slack/channels_linked_with_agent`,
+    slackChannelsLinkedWithAgentFetcher,
+    {
+      disabled,
+    }
   );
 
   return {

--- a/front/lib/swr/connectors.ts
+++ b/front/lib/swr/connectors.ts
@@ -40,10 +40,9 @@ export function useConnectorPermissions({
     url += `&filterPermission=${filterPermission}`;
   }
 
-  const { data, error } = useSWRWithDefaults(
-    disabled ? null : url,
-    permissionsFetcher
-  );
+  const { data, error } = useSWRWithDefaults(url, permissionsFetcher, {
+    disabled,
+  });
 
   return {
     resources: useMemo(() => (data ? data.resources : []), [data]),

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -34,8 +34,9 @@ export function useDataSourceViews(
   const dataSourceViewsFetcher: Fetcher<GetDataSourceViewsResponseBody> =
     fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
-    disabled ? null : `/api/w/${owner.sId}/data_source_views`,
-    dataSourceViewsFetcher
+    `/api/w/${owner.sId}/data_source_views`,
+    dataSourceViewsFetcher,
+    { disabled }
   );
 
   return {

--- a/front/lib/swr/data_sources.ts
+++ b/front/lib/swr/data_sources.ts
@@ -15,8 +15,9 @@ export function useDataSources(
   const { disabled } = options;
   const dataSourcesFetcher: Fetcher<GetDataSourcesResponseBody> = fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
-    disabled ? null : `/api/w/${owner.sId}/data_sources`,
-    dataSourcesFetcher
+    `/api/w/${owner.sId}/data_sources`,
+    dataSourcesFetcher,
+    { disabled }
   );
 
   return {

--- a/front/lib/swr/datasets.ts
+++ b/front/lib/swr/datasets.ts
@@ -18,8 +18,11 @@ export function useDatasets({
   const datasetsFetcher: Fetcher<GetDatasetsResponseBody> = fetcher;
 
   const { data, error } = useSWRWithDefaults(
-    disabled ? null : `/api/w/${owner.sId}/apps/${app.sId}/datasets`,
-    datasetsFetcher
+    `/api/w/${owner.sId}/apps/${app.sId}/datasets`,
+    datasetsFetcher,
+    {
+      disabled,
+    }
   );
 
   return {

--- a/front/lib/swr/poke.ts
+++ b/front/lib/swr/poke.ts
@@ -37,10 +37,9 @@ export function usePokeConnectorPermissions({
     url += `&filterPermission=${filterPermission}`;
   }
 
-  const { data, error } = useSWRWithDefaults(
-    disabled ? null : url,
-    permissionsFetcher
-  );
+  const { data, error } = useSWRWithDefaults(url, permissionsFetcher, {
+    disabled,
+  });
 
   return {
     resources: useMemo(() => (data ? data.resources : []), [data]),
@@ -74,8 +73,11 @@ export function usePokeWorkspaces({
   }
 
   const { data, error } = useSWRWithDefaults(
-    disabled ? null : `api/poke/workspaces${query}`,
-    workspacesFetcher
+    `api/poke/workspaces${query}`,
+    workspacesFetcher,
+    {
+      disabled,
+    }
   );
 
   return {

--- a/front/lib/swr/vaults.ts
+++ b/front/lib/swr/vaults.ts
@@ -56,7 +56,7 @@ export function useVaultDataSourceViews<
   vaultId,
   workspaceId,
 }: {
-  category: DataSourceViewCategory;
+  category: Exclude<DataSourceViewCategory, "apps">;
   disabled?: boolean;
   includeConnectorDetails?: IncludeConnectorDetails;
   includeEditedBy?: boolean;

--- a/front/lib/swr/vaults.ts
+++ b/front/lib/swr/vaults.ts
@@ -34,8 +34,11 @@ export function useVaultInfo({
   const vaultsCategoriesFetcher: Fetcher<GetVaultResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
-    disabled ? null : `/api/w/${workspaceId}/vaults/${vaultId}`,
-    vaultsCategoriesFetcher
+    `/api/w/${workspaceId}/vaults/${vaultId}`,
+    vaultsCategoriesFetcher,
+    {
+      disabled,
+    }
   );
 
   return {
@@ -79,10 +82,9 @@ export function useVaultDataSourceViews<
   }
 
   const { data, error, mutate } = useSWRWithDefaults(
-    disabled
-      ? null
-      : `/api/w/${workspaceId}/vaults/${vaultId}/data_source_views?${queryParams.toString()}`,
-    vaultsDataSourceViewsFetcher
+    `/api/w/${workspaceId}/vaults/${vaultId}/data_source_views?${queryParams.toString()}`,
+    vaultsDataSourceViewsFetcher,
+    { disabled }
   );
 
   const vaultDataSourceViews = useMemo(() => {

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -36,8 +36,11 @@ export function useWorkspaceAnalytics({
   const analyticsFetcher: Fetcher<GetWorkspaceAnalyticsResponse> = fetcher;
 
   const { data, error } = useSWRWithDefaults(
-    !disabled ? `/api/w/${workspaceId}/workspace-analytics` : null,
-    analyticsFetcher
+    `/api/w/${workspaceId}/workspace-analytics`,
+    analyticsFetcher,
+    {
+      disabled,
+    }
   );
 
   return {

--- a/types/src/front/api_handlers/public/vaults.ts
+++ b/types/src/front/api_handlers/public/vaults.ts
@@ -74,11 +74,3 @@ export function isWebsiteOrFolder(
 ): category is Extract<DataSourceViewCategory, "website" | "folder"> {
   return category === "website" || category === "folder";
 }
-
-export function isDataSourceViewCategory(
-  category: string
-): category is DataSourceViewCategory {
-  return DATA_SOURCE_VIEW_CATEGORIES.includes(
-    category as DataSourceViewCategory
-  );
-}


### PR DESCRIPTION
## Description

Fix all this:
- Header in sidebar should be secondary.
- When clicking on “Apps” on the sidebar, it should display all apps in a tree (same as for Websites).
- Sidebar Trees → not the same padding between ConnectionManagement and first children (valid) versus Company data & first children).
- Adding a folder is not immediately reflected in the sidebar

Updated the `useSwrDefaults` hook to accept a `disabled` config parameter, in that case, the hook will not trigger a fetching but it will still provide a correct "mutate" function. I updated all SWR hooks to use this pattern instead.

note, i think `DataSourceViewCategory` should not have "apps" in it or be renamed (but it had side-effects so I kept it out of this PR).

https://github.com/user-attachments/assets/aae04eb6-f38c-4747-bccd-0186b868376d

## Risk

None

## Deploy Plan

Deploy `front`