### PR TITLE
feat: Add "public" as a new vault kind

### DIFF
--- a/front/components/vaults/VaultSideBarMenu.tsx
+++ b/front/components/vaults/VaultSideBarMenu.tsx
@@ -114,6 +114,9 @@ const getSectionLabel = (kind: VaultKind) => {
     case "system":
       return "SYSTEM";
 
+    case "public":
+      return "PUBLIC";
+
     default:
       assertNever(kind);
   }

--- a/front/components/vaults/VaultSideBarMenu.tsx
+++ b/front/components/vaults/VaultSideBarMenu.tsx
@@ -2,7 +2,6 @@ import {
   Button,
   CloudArrowLeftRightIcon,
   CommandLineIcon,
-  CompanyIcon,
   FolderIcon,
   GlobeAltIcon,
   Item,
@@ -22,6 +21,7 @@ import { useRouter } from "next/router";
 import type { ComponentType, ReactElement } from "react";
 import { Fragment, useEffect, useState } from "react";
 
+import { getVaultIcon } from "@app/lib/client/vaults";
 import {
   getConnectorProviderLogoWithFallback,
   getDataSourceNameFromView,
@@ -38,7 +38,12 @@ interface VaultSideBarMenuProps {
   setShowVaultCreationModal: (show: boolean) => void;
 }
 
-const VAULTS_SORT_ORDER: VaultKind[] = ["system", "global", "regular"];
+const VAULTS_SORT_ORDER: VaultKind[] = [
+  "system",
+  "global",
+  "regular",
+  "public",
+];
 
 export default function VaultSideBarMenu({
   owner,
@@ -261,7 +266,7 @@ const VaultMenuItem = ({
       onItemClick={() => router.push(vaultPath)}
       isSelected={router.asPath === vaultPath}
       onChevronClick={() => setIsExpanded(!isExpanded)}
-      visual={vault.kind === "global" ? CompanyIcon : LockIcon}
+      visual={getVaultIcon(vault.kind)}
       tailwindIconTextColor="text-brand"
       size="md"
       areActionsFading={false}

--- a/front/lib/client/vaults.ts
+++ b/front/lib/client/vaults.ts
@@ -1,0 +1,15 @@
+import { CompanyIcon, LockIcon, PlanetIcon } from "@dust-tt/sparkle";
+import type { VaultKind } from "@dust-tt/types";
+import type React from "react";
+
+export function getVaultIcon(
+  kind: VaultKind
+): (props: React.SVGProps<SVGSVGElement>) => React.ReactElement {
+  if (kind === "global") {
+    return CompanyIcon;
+  }
+  if (kind === "public") {
+    return PlanetIcon;
+  }
+  return LockIcon;
+}

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -288,9 +288,9 @@ export class VaultResource extends BaseResource<VaultModel> {
       case "system":
         return auth.isAdmin() && auth.canWrite([this.acl()]);
       case "global":
-      case "public":
         return auth.isBuilder() && auth.canWrite([this.acl()]);
       case "regular":
+      case "public":
         return auth.canWrite([this.acl()]);
 
       default:

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -288,9 +288,11 @@ export class VaultResource extends BaseResource<VaultModel> {
       case "system":
         return auth.isAdmin() && auth.canWrite([this.acl()]);
       case "global":
+      case "public":
         return auth.isBuilder() && auth.canWrite([this.acl()]);
       case "regular":
         return auth.canWrite([this.acl()]);
+
       default:
         assertNever(this.kind);
     }
@@ -303,6 +305,8 @@ export class VaultResource extends BaseResource<VaultModel> {
       case "global":
       case "regular":
         return auth.canRead([this.acl()]);
+      case "public":
+        return true;
       default:
         assertNever(this.kind);
     }
@@ -318,6 +322,10 @@ export class VaultResource extends BaseResource<VaultModel> {
 
   isRegular() {
     return this.kind === "regular";
+  }
+
+  isPublic() {
+    return this.kind === "public";
   }
 
   toJSON(): VaultType {

--- a/front/pages/w/[wId]/data-sources/vaults/[vaultId]/index.tsx
+++ b/front/pages/w/[wId]/data-sources/vaults/[vaultId]/index.tsx
@@ -1,11 +1,4 @@
-import {
-  LockIcon,
-  Page,
-  PlanetIcon,
-  PuzzleIcon,
-  Tab,
-  UserGroupIcon,
-} from "@dust-tt/sparkle";
+import { Page, PuzzleIcon, Tab, UserGroupIcon } from "@dust-tt/sparkle";
 import type { VaultType } from "@dust-tt/types";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
@@ -17,6 +10,7 @@ import type { VaultLayoutProps } from "@app/components/vaults/VaultLayout";
 import { VaultLayout } from "@app/components/vaults/VaultLayout";
 import { VaultMembers } from "@app/components/vaults/VaultMembers";
 import config from "@app/lib/api/config";
+import { getVaultIcon } from "@app/lib/client/vaults";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { VaultResource } from "@app/lib/resources/vault_resource";
 
@@ -68,7 +62,7 @@ export default function Vault({
     <Page.Vertical gap="xl" align="stretch">
       <Page.Header
         title={vault.kind === "global" ? "Company Data" : vault.name}
-        icon={vault.kind === "global" ? PlanetIcon : LockIcon}
+        icon={getVaultIcon(vault.kind)}
         description="Manage connections to your products and the real-time data feeds Dust has access to."
       />
 

--- a/types/src/front/vault.ts
+++ b/types/src/front/vault.ts
@@ -1,4 +1,4 @@
-const VAULT_KINDS = ["regular", "global", "system"] as const;
+const VAULT_KINDS = ["regular", "global", "system", "public"] as const;
 export type VaultKind = (typeof VAULT_KINDS)[number];
 
 export type VaultType = {


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/dust/issues/7150

Adds the "public" vault kind. Resources in public vaults can be read by anyone (including users that are not part of the workspace), and can be written to by `builders` that are also member of the vault (this is an assumption I made, maybe we actually want to treat them similar to a regular vault instead ?)

This also includes a small refactoring for vault icons: the "planet" icon is used for public vaults, the "company" icon for the global vault and the regular vault use the "lock" icon (moved that to a helper)


## Risk

Shouldn't affect anyone, since there is no way to create a public vault (only way currently is to manually run a SQL query)

## Deploy Plan

N/A