### PR TITLE
Display name of EditedBy user on tooltip in vault resource list

### DIFF
--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -112,15 +112,18 @@ const getTableColumns = ({
         ? row.dataSourceView.dataSource.editedByUser?.imageUrl
         : row.dataSourceView.editedByUser?.imageUrl) ?? "",
     id: "managedBy",
-    cell: (info: CellContext<RowData, string>) => (
-      <DataTable.CellContent
-        avatarUrl={info.getValue()}
-        avatarTooltipLabel={
-          info.row.original.dataSourceView.editedByUser?.fullName ?? undefined
-        }
-        roundedAvatar={true}
-      />
-    ),
+    cell: (info: CellContext<RowData, string>) => {
+      const dsv = info.row.original.dataSourceView;
+      const editedByUser =
+        dsv.kind === "default" ? dsv.dataSource.editedByUser : dsv.editedByUser;
+      return (
+        <DataTable.CellContent
+          avatarUrl={info.getValue()}
+          avatarTooltipLabel={editedByUser?.fullName ?? undefined}
+          roundedAvatar={true}
+        />
+      );
+    },
   };
 
   const lastSyncedColumn = {

--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -113,7 +113,13 @@ const getTableColumns = ({
         : row.dataSourceView.editedByUser?.imageUrl) ?? "",
     id: "managedBy",
     cell: (info: CellContext<RowData, string>) => (
-      <DataTable.CellContent avatarUrl={info.getValue()} roundedAvatar={true} />
+      <DataTable.CellContent
+        avatarUrl={info.getValue()}
+        avatarTooltipLabel={
+          info.row.original.dataSourceView.editedByUser?.fullName ?? undefined
+        }
+        roundedAvatar={true}
+      />
     ),
   };
 


### PR DESCRIPTION
## Description

Adds a tooltip on the "Managed By" column in Vault resource list. 
We want to display the name of the person managing the resource. 

<kbd>
<img width="976" alt="Screenshot 2024-09-06 at 15 52 45" src="https://github.com/user-attachments/assets/251aa5f9-025b-4607-85d4-a67e100c8095">
</kbd>

## Risk

Can be rolled back.

## Deploy Plan

Deploy front. 
