### PR TITLE
[Vaults] Filter assistants based on user's vaults/permissions

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -627,7 +627,14 @@ export async function getAgentConfigurations<V extends "light" | "full">({
     }),
   ]);
 
-  return applySortAndLimit(allAgentConfigurations.flat());
+  // Filter out agents that the user does not have access to
+  // user should be in all groups that are in the agent's groupIds
+  const userGroups = auth.groups().map((g) => g.sId);
+  const allowedAgentConfigurations = allAgentConfigurations
+    .flat()
+    .filter((a) => a.groupIds.every((id) => userGroups.includes(id)));
+
+  return applySortAndLimit(allowedAgentConfigurations.flat());
 }
 
 async function getConversationMentions(

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -52,7 +52,7 @@ import {
 } from "@app/lib/api/assistant/global_agents";
 import { agentConfigurationWasUpdatedBy } from "@app/lib/api/assistant/recent_authors";
 import { compareAgentsForSort } from "@app/lib/assistant";
-import type { Authenticator } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import { getPublicUploadBucket } from "@app/lib/file_storage";
 import { AgentBrowseConfiguration } from "@app/lib/models/assistant/actions/browse";
 import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
@@ -629,10 +629,9 @@ export async function getAgentConfigurations<V extends "light" | "full">({
 
   // Filter out agents that the user does not have access to
   // user should be in all groups that are in the agent's groupIds
-  const userGroups = auth.groups().map((g) => g.sId);
   const allowedAgentConfigurations = allAgentConfigurations
     .flat()
-    .filter((a) => a.groupIds.every((id) => userGroups.includes(id)));
+    .filter((a) => auth.canRead([Authenticator.aclFromGroupIds(a.groupIds)]));
 
   return applySortAndLimit(allowedAgentConfigurations.flat());
 }

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -631,7 +631,7 @@ export async function getAgentConfigurations<V extends "light" | "full">({
   // user should be in all groups that are in the agent's groupIds
   const allowedAgentConfigurations = allAgentConfigurations
     .flat()
-    .filter((a) => auth.canRead([Authenticator.aclFromGroupIds(a.groupIds)]));
+    .filter((a) => auth.canRead(Authenticator.aclsFromGroupIds(a.groupIds)));
 
   return applySortAndLimit(allowedAgentConfigurations.flat());
 }

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -91,6 +91,23 @@ export class Authenticator {
     this._key = key;
   }
 
+  static aclFromGroupIds(groupIds: string[]): ACLType {
+    const getIdFromSIdOrThrow = (groupId: string) => {
+      const id = getResourceIdFromSId(groupId);
+      if (!id) {
+        throw new Error(`Unexpected: Could not find id for group ${groupId}`);
+      }
+      return id;
+    };
+
+    return {
+      aclEntries: groupIds.map((groupId) => ({
+        groupId: getIdFromSIdOrThrow(groupId),
+        permissions: ["read", "write"],
+      })),
+    };
+  }
+
   /**
    * Get a an Authenticator for the target workspace associated with the authentified user from the
    * Auth0 session.

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -684,9 +684,11 @@ export class Authenticator {
   }
 
   hasPermission(acls: ACLType[], permission: Permission): boolean {
-    // Does the user belongs to a group which has the required permission on all ACLs ?
-    return this.groups().some((group) =>
-      acls.every((acl) => groupHasPermission(acl, permission, group.id))
+    // For each acl, does the user belongs to a group that has the permission?
+    return acls.every((acl) =>
+      this.groups().some((group) =>
+        groupHasPermission(acl, permission, group.id)
+      )
     );
   }
 

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -91,7 +91,7 @@ export class Authenticator {
     this._key = key;
   }
 
-  static aclFromGroupIds(groupIds: string[]): ACLType {
+  static aclsFromGroupIds(groupIds: string[]): ACLType[] {
     const getIdFromSIdOrThrow = (groupId: string) => {
       const id = getResourceIdFromSId(groupId);
       if (!id) {
@@ -100,12 +100,14 @@ export class Authenticator {
       return id;
     };
 
-    return {
-      aclEntries: groupIds.map((groupId) => ({
-        groupId: getIdFromSIdOrThrow(groupId),
-        permissions: ["read", "write"],
-      })),
-    };
+    return groupIds.map((groupId) => ({
+      aclEntries: [
+        {
+          groupId: getIdFromSIdOrThrow(groupId),
+          permissions: ["read", "write"],
+        },
+      ],
+    }));
   }
 
   /**

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -40,6 +40,7 @@ import { GroupResource } from "@app/lib/resources/group_resource";
 import type { KeyAuthType } from "@app/lib/resources/key_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";

--- a/front/migrations/20240906_2_backfill_agents_groupIds.ts
+++ b/front/migrations/20240906_2_backfill_agents_groupIds.ts
@@ -1,0 +1,163 @@
+import assert from "assert";
+
+import { Authenticator } from "@app/lib/auth";
+import { Workspace } from "@app/lib/models/workspace";
+import { App } from "@app/lib/resources/storage/models/apps";
+import { VaultResource } from "@app/lib/resources/vault_resource";
+import { makeScript } from "@app/scripts/helpers";
+import { AgentConfiguration } from "@app/lib/models/assistant/agent";
+import { Sequelize } from "sequelize";
+import _ from "lodash";
+import {
+  getAgentConfiguration,
+  getAgentConfigurations,
+} from "@app/lib/api/assistant/configuration";
+import { Logger } from "pino";
+import {
+  PostOrPatchAgentConfigurationRequestBody,
+  removeNulls,
+} from "@dust-tt/types";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+
+makeScript({}, async ({ execute }, logger) => {
+  // All workspaces that have at least one agent
+  const workspaceIds = await getDistinctWorkspaceIds();
+
+  const workspaceChunks = _.chunk(workspaceIds, 8);
+
+  for (const workspaceChunk of workspaceChunks) {
+    await Promise.all(
+      workspaceChunk.map((id) => updateAgentsForWorkspace(id, execute, logger))
+    );
+  }
+});
+
+async function getDistinctWorkspaceIds(): Promise<number[]> {
+  const workspaceIds = await AgentConfiguration.findAll({
+    attributes: [
+      [Sequelize.fn("DISTINCT", Sequelize.col("workspaceId")), "workspaceId"],
+    ],
+    raw: true,
+  });
+
+  return workspaceIds.map((entry) => entry.workspaceId);
+}
+
+async function updateAgentsForWorkspace(
+  workspaceId: number,
+  execute: boolean,
+  logger: Logger
+) {
+  const allAgents = await AgentConfiguration.findAll({
+    attributes: ["sId", "groupIds"],
+    where: { workspaceId, status: "active" },
+  });
+
+  // no need to update agents that already have groupIds
+  const agents = allAgents.filter(
+    (agent) => !agent.groupIds || agent.groupIds.length === 0
+  );
+
+  logger.info(
+    { workspaceId, count: agents.length },
+    "Updating agents for workspace"
+  );
+
+  const agentChunks = _.chunk(agents, 16);
+
+  // get workspace sid
+  const workspace = await Workspace.findByPk(workspaceId);
+
+  if (!workspace) {
+    logger.error(
+      {
+        workspaceId,
+      },
+      "Unexpected: Workspace not found"
+    );
+    return;
+  }
+
+  for (const agentChunk of agentChunks) {
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    await Promise.all(
+      agentChunk.map((agent) => updateAgent(auth, agent, execute, logger))
+    );
+  }
+}
+
+async function updateAgent(
+  auth: Authenticator,
+  agent: AgentConfiguration,
+  execute: boolean,
+  logger: Logger
+) {
+  const assistant = await getAgentConfiguration(auth, agent.sId);
+  if (!assistant) {
+    logger.error(
+      {
+        agentId: agent.sId,
+      },
+      "Unexpected: Agent not found"
+    );
+    return;
+  }
+
+  const dataSourceViewIds = getDataSourceViewIdsFromActions(assistant.actions);
+
+  const groupIds = (
+    await DataSourceViewResource.fetchByIds(auth, dataSourceViewIds)
+  )
+    .map((view) => view.acl().aclEntries.map((entry) => entry.groupId))
+    .flat();
+
+  if (execute) {
+    await AgentConfiguration.update(
+      { groupIds },
+      { where: { sId: agent.sId } }
+    );
+    logger.info(
+      {
+        agentId: agent.sId,
+        execute,
+      },
+      "Updated agent"
+    );
+  } else {
+    logger.info(
+      {
+        agentId: agent.sId,
+        execute,
+      },
+      "Would have updated agent"
+    );
+  }
+}
+
+function getDataSourceViewIdsFromActions(
+  actions: PostOrPatchAgentConfigurationRequestBody["assistant"]["actions"]
+): string[] {
+  const relevantActions = actions.filter(
+    (action) =>
+      action.type === "retrieval_configuration" ||
+      action.type === "process_configuration" ||
+      action.type === "tables_query_configuration"
+  );
+
+  return removeNulls(
+    relevantActions.flatMap((action) => {
+      if (
+        action.type === "retrieval_configuration" ||
+        action.type === "process_configuration"
+      ) {
+        return action.dataSources.map(
+          (dataSource) => dataSource.dataSourceViewId
+        );
+      } else if (action.type === "tables_query_configuration") {
+        return action.tables.map((table) => table.dataSourceViewId);
+      }
+      return [];
+    })
+  );
+}

--- a/front/migrations/20240906_2_backfill_agents_groupIds.ts
+++ b/front/migrations/20240906_2_backfill_agents_groupIds.ts
@@ -1,23 +1,15 @@
-import assert from "assert";
-
-import { Authenticator } from "@app/lib/auth";
-import { Workspace } from "@app/lib/models/workspace";
-import { App } from "@app/lib/resources/storage/models/apps";
-import { VaultResource } from "@app/lib/resources/vault_resource";
-import { makeScript } from "@app/scripts/helpers";
-import { AgentConfiguration } from "@app/lib/models/assistant/agent";
-import { Sequelize } from "sequelize";
+import type { PostOrPatchAgentConfigurationRequestBody } from "@dust-tt/types";
+import { removeNulls } from "@dust-tt/types";
 import _ from "lodash";
-import {
-  getAgentConfiguration,
-  getAgentConfigurations,
-} from "@app/lib/api/assistant/configuration";
-import { Logger } from "pino";
-import {
-  PostOrPatchAgentConfigurationRequestBody,
-  removeNulls,
-} from "@dust-tt/types";
+import type { Logger } from "pino";
+import { Sequelize } from "sequelize";
+
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
+import { Authenticator } from "@app/lib/auth";
+import { AgentConfiguration } from "@app/lib/models/assistant/agent";
+import { Workspace } from "@app/lib/models/workspace";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { makeScript } from "@app/scripts/helpers";
 
 makeScript({}, async ({ execute }, logger) => {
   // All workspaces that have at least one agent

--- a/front/migrations/20240906_2_backfill_agents_groupIds.ts
+++ b/front/migrations/20240906_2_backfill_agents_groupIds.ts
@@ -1,7 +1,7 @@
 import type { PostOrPatchAgentConfigurationRequestBody } from "@dust-tt/types";
 import { removeNulls } from "@dust-tt/types";
 import _ from "lodash";
-import type { Logger } from "pino";
+import type { Logger } from "@app/logger/logger";
 import { Sequelize } from "sequelize";
 
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
@@ -10,6 +10,7 @@ import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { Workspace } from "@app/lib/models/workspace";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { makeScript } from "@app/scripts/helpers";
+import { getDataSourceViewIdsFromActions } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 
 makeScript({}, async ({ execute }, logger) => {
   // All workspaces that have at least one agent
@@ -125,31 +126,4 @@ async function updateAgent(
       "Would have updated agent"
     );
   }
-}
-
-function getDataSourceViewIdsFromActions(
-  actions: PostOrPatchAgentConfigurationRequestBody["assistant"]["actions"]
-): string[] {
-  const relevantActions = actions.filter(
-    (action) =>
-      action.type === "retrieval_configuration" ||
-      action.type === "process_configuration" ||
-      action.type === "tables_query_configuration"
-  );
-
-  return removeNulls(
-    relevantActions.flatMap((action) => {
-      if (
-        action.type === "retrieval_configuration" ||
-        action.type === "process_configuration"
-      ) {
-        return action.dataSources.map(
-          (dataSource) => dataSource.dataSourceViewId
-        );
-      } else if (action.type === "tables_query_configuration") {
-        return action.tables.map((table) => table.dataSourceViewId);
-      }
-      return [];
-    })
-  );
 }

--- a/front/migrations/20240906_2_backfill_agents_groupIds.ts
+++ b/front/migrations/20240906_2_backfill_agents_groupIds.ts
@@ -1,7 +1,4 @@
-import type { PostOrPatchAgentConfigurationRequestBody } from "@dust-tt/types";
-import { removeNulls } from "@dust-tt/types";
 import _ from "lodash";
-import type { Logger } from "@app/logger/logger";
 import { Sequelize } from "sequelize";
 
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
@@ -9,8 +6,9 @@ import { Authenticator } from "@app/lib/auth";
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { Workspace } from "@app/lib/models/workspace";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
-import { makeScript } from "@app/scripts/helpers";
+import type { Logger } from "@app/logger/logger";
 import { getDataSourceViewIdsFromActions } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
+import { makeScript } from "@app/scripts/helpers";
 
 makeScript({}, async ({ execute }, logger) => {
   // All workspaces that have at least one agent

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -446,7 +446,7 @@ export async function createOrUpgradeAgentConfiguration({
   return new Ok(agentConfiguration);
 }
 
-function getDataSourceViewIdsFromActions(
+export function getDataSourceViewIdsFromActions(
   actions: PostOrPatchAgentConfigurationRequestBody["assistant"]["actions"]
 ): string[] {
   const relevantActions = actions.filter(


### PR DESCRIPTION
Description
---
Fixes #6763

Following #7078 that introduced `groupIds` in assistants, we can now filter assistants according to their vault restrictions for each user
We also add a backfill for groupIds

Risks
---
Breaking the list of assistants users can see. The risk is more on wrong permission side, since empty groupId = allowed to see.

Mitigation: local tests

Deploy
---
Front
run migration
