### PR TITLE
feat: move registry dust apps to public vault

### DIFF
--- a/front/migrations/20240906_registry_apps_to_public_vault.ts
+++ b/front/migrations/20240906_registry_apps_to_public_vault.ts
@@ -42,7 +42,7 @@ makeScript({}, async ({ execute }, logger) => {
         {
           where: {
             sId: appId,
-            workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
+            workspaceId: dustAppsWorkspace.id,
           },
         }
       );

--- a/front/migrations/20240906_registry_apps_to_public_vault.ts
+++ b/front/migrations/20240906_registry_apps_to_public_vault.ts
@@ -1,0 +1,61 @@
+import { Workspace } from "@app/lib/models/workspace";
+import {
+  DustProdActionRegistry,
+  PRODUCTION_DUST_APPS_WORKSPACE_ID,
+} from "@app/lib/registry";
+import { App } from "@app/lib/resources/storage/models/apps";
+import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
+import { makeScript } from "@app/scripts/helpers";
+
+const PUBLIC_VAULT_SQID = "vlt_rICtlrSEpWqX";
+
+makeScript({}, async ({ execute }, logger) => {
+  const vaultId = getResourceIdFromSId(PUBLIC_VAULT_SQID);
+  const dustAppsWorkspace = await Workspace.findOne({
+    where: { sId: PRODUCTION_DUST_APPS_WORKSPACE_ID },
+  });
+  if (!dustAppsWorkspace) {
+    throw new Error(
+      `Could not find workspace with sId ${PRODUCTION_DUST_APPS_WORKSPACE_ID}`
+    );
+  }
+  if (!vaultId) {
+    throw new Error(`Could not find vault with SQID ${PUBLIC_VAULT_SQID}`);
+  }
+
+  for (const [
+    appName,
+    {
+      app: { appId },
+    },
+  ] of Object.entries(DustProdActionRegistry)) {
+    console.log(
+      execute ? "" : "[DRY RUN] ",
+      `Updating app ${appName} (sId=${appId}) in ${dustAppsWorkspace.name} workspace ` +
+        `(sId=${dustAppsWorkspace.sId}) with vaultId ${vaultId}`
+    );
+    if (execute) {
+      await App.update(
+        {
+          vaultId,
+        },
+        {
+          where: {
+            sId: appId,
+            workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
+          },
+        }
+      );
+      logger.info(
+        {
+          appName,
+          appId,
+          workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
+          vaultId,
+          execute,
+        },
+        "Updated app"
+      );
+    }
+  }
+});


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/dust/issues/7151

add a migration script to iterate over prod dust apps registry and set their vault ID to the public vault ID.

## Risk

N/A (vaults unchecked for now)

## Deploy Plan

run the script on prodbox