### PR TITLE
Paginate data source views content nodes

### DIFF
--- a/front/components/ConnectorPermissionsTree.tsx
+++ b/front/components/ConnectorPermissionsTree.tsx
@@ -164,7 +164,7 @@ export function DataSourceViewPermissionTreeChildren({
     {
       dataSourceView,
       includeChildren: true,
-      internalIds: parentId ? [parentId] : [],
+      internalIds: parentId ? [parentId] : undefined,
       owner,
       viewType,
     }

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -488,8 +488,9 @@ function DataSourceViewSelectedNodes({
   const dataSourceViewSelectedNodes = useDataSourceViewContentNodes({
     owner,
     dataSourceView,
-    internalIds: dataSourceConfiguration.filter.parents?.in ?? [],
+    internalIds: dataSourceConfiguration.filter.parents?.in ?? undefined,
     viewType,
+    includeChildren: false,
   });
 
   return (

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -241,7 +241,7 @@ async function renderDataSourcesConfigurations(
       }
       return {
         dataSourceView,
-        selectedResources: nodesRes.value,
+        selectedResources: nodesRes.value.nodes,
         isSelectAll: sr.isSelectAll,
       };
     })

--- a/front/components/vaults/VaultDataSourceViewContentList.tsx
+++ b/front/components/vaults/VaultDataSourceViewContentList.tsx
@@ -117,7 +117,7 @@ export const VaultDataSourceViewContentList = ({
     useDataSourceViewContentNodes({
       dataSourceView,
       owner,
-      internalIds: parentId ? [parentId] : [],
+      internalIds: parentId ? [parentId] : undefined,
       includeChildren: true,
       viewType,
     });

--- a/front/components/vaults/VaultLayout.tsx
+++ b/front/components/vaults/VaultLayout.tsx
@@ -102,12 +102,14 @@ function VaultBreadCrumbs({
     owner,
     dataSourceView,
     internalIds: parentId ? [parentId] : [],
+    includeChildren: false,
   });
 
   const { nodes: folders } = useDataSourceViewContentNodes({
-    owner,
     dataSourceView,
-    internalIds: currentFolder?.parentInternalIds || [],
+    includeChildren: false,
+    internalIds: currentFolder?.parentInternalIds ?? [],
+    owner,
   });
 
   const items: {

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -58,7 +58,7 @@ export function filterAndCropContentNodesByView(
 interface GetContentNodesForDataSourceViewParams {
   includeChildren: boolean;
   internalIds: string[];
-  pagination: OffsetPaginationParams;
+  pagination?: OffsetPaginationParams;
   viewType: ContentNodesViewType;
 }
 

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -113,6 +113,7 @@ export function useDataSourceViewContentNodes({
   isNodesLoading: boolean;
   mutateDataSourceViewContentNodes: KeyedMutator<GetDataSourceViewContentNodes>;
   nodes: GetDataSourceViewContentNodes["nodes"];
+  totalNodes: number;
 } {
   const url = dataSourceView
     ? `/api/w/${owner.sId}/vaults/${dataSourceView.vaultId}/data_source_views/${dataSourceView.sId}/content-nodes`
@@ -144,6 +145,7 @@ export function useDataSourceViewContentNodes({
     isNodesLoading: !error && !data,
     mutateDataSourceViewContentNodes: mutate,
     nodes: useMemo(() => (data ? data.nodes : []), [data]),
+    totalNodes: data ? data.total : 0,
   };
 }
 

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -63,7 +63,11 @@ export function useMultipleDataSourceViewsContentNodes({
   const urlsAndOptions = dataSourceViewsAndInternalIds.map(
     ({ dataSourceView, internalIds }) => {
       const url = `/api/w/${owner.sId}/vaults/${dataSourceView.vaultId}/data_source_views/${dataSourceView.sId}/content-nodes`;
-      const body = JSON.stringify({ internalIds, viewType });
+      const body = JSON.stringify({
+        internalIds,
+        viewType,
+        includeChildren: false,
+      });
       const options = {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -105,8 +109,8 @@ export function useDataSourceViewContentNodes({
 }: {
   owner: LightWorkspaceType;
   dataSourceView?: DataSourceViewType;
-  internalIds: string[];
-  includeChildren?: boolean;
+  internalIds?: string[];
+  includeChildren: boolean;
   viewType?: ContentNodesViewType;
 }): {
   isNodesError: boolean;

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,7 @@
         "@amplitude/analytics-browser": "^2.5.2",
         "@amplitude/analytics-node": "^1.3.5",
         "@auth0/nextjs-auth0": "^3.5.0",
-        "@dust-tt/sparkle": "^0.2.227",
+        "@dust-tt/sparkle": "^0.2.228",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -10736,9 +10736,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.227",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.227.tgz",
-      "integrity": "sha512-yDoWaDLdkQ1hI8G6znkyeZaLBfYfDNv1R5LMaaVwAJG8PCgDcZqzh/JBAC1+nq2qGtoQvNQYaQfDaGOJ0CLP9g==",
+      "version": "0.2.228",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.228.tgz",
+      "integrity": "sha512-NR0+7Hkm4lgo3GwqA4yOmu3Ek3GsjTQKm9wYZ51CjbrDFB39PHKftpmWyNjIoXZPkj1cHbqteG46XNcxCT8jRQ==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
     "@amplitude/analytics-browser": "^2.5.2",
     "@amplitude/analytics-node": "^1.3.5",
     "@auth0/nextjs-auth0": "^3.5.0",
-    "@dust-tt/sparkle": "^0.2.227",
+    "@dust-tt/sparkle": "^0.2.228",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR introduces pagination for the content nodes in the data source view. Additionally, it resolves the breadcrumb issue that occurs in the static data source view when displaying the first element. The endpoint has been restructured to handle three scenarios for internal IDs:
- `undefined`: Returns all root nodes.
- `[]`: An empty array means no nodes are returned.
- `[n, n1, ...]`: Returns content nodes for the specified IDs.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
