### PR TITLE
[Breadcrumbs] Fix: do not display "System" vault for connected data management

### DIFF
--- a/front/components/vaults/VaultLayout.tsx
+++ b/front/components/vaults/VaultLayout.tsx
@@ -132,8 +132,16 @@ function VaultBreadCrumbs({
       },
     ];
 
+    if (vault.kind === "system") {
+      // For system vault, we don't want the first breadcrumb to show, since
+      // it's only used to manage "connected data" already. Otherwise it would
+      // expose a useless link, and name would be redundant with the "Connected
+      // data" label
+      items.shift();
+    }
+
     if (dataSourceView) {
-      if (category === "managed") {
+      if (category === "managed" && vault.kind !== "system") {
         // Remove the "Connected data" from breadcrumbs to avoid hiding the actual
         // managed connection name
 


### PR DESCRIPTION
## Description
Partly fixes https://github.com/dust-tt/tasks/issues/1236
Adapts the breadcrumbs to "Connection management" by removing the "System" first crumb

Rationale:       
// For system vault, we don't want the first breadcrumb to show, since
// it's only used to manage "connected data" already. Otherwise it would
// expose a useless link, and name would be redundant with the "Connected
// data" label

Plus, it makes the icons match

From here:
![image](https://github.com/user-attachments/assets/20d1dcf8-267a-40b5-b442-a69b59f97336)

To there:
![image](https://github.com/user-attachments/assets/310a57e1-9936-4c99-8c4d-ff18b999715f)


## Risk
na

## Deploy Plan
front
