### PR TITLE
Add: distinguish vaults visible as admin vs visible as members

### DIFF
--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -428,7 +428,7 @@ function DataSourceViewsSection({
 
           return (
             <Tree.Item
-              key={dsConfig.dataSourceId}
+              key={dsConfig.dataSourceViewId}
               type={
                 canBeExpanded(viewType, dataSourceView?.dataSource)
                   ? "node"

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -37,9 +37,9 @@ import { DataSourceViewResource } from "@app/lib/resources/data_source_view_reso
 import { VaultResource } from "@app/lib/resources/vault_resource";
 
 export const getAccessibleSourcesAndApps = async (auth: Authenticator) => {
-  const accessibleVaults = [
-    ...(await VaultResource.listWorkspaceVaults(auth)),
-  ].filter((vault) => !vault.isSystem());
+  const accessibleVaults = (
+    await VaultResource.listWorkspaceVaults(auth)
+  ).filter((vault) => !vault.isSystem());
 
   const [dsViews, allDustApps] = await Promise.all([
     DataSourceViewResource.listByVaults(auth, accessibleVaults),

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -38,7 +38,7 @@ import { VaultResource } from "@app/lib/resources/vault_resource";
 
 export const getAccessibleSourcesAndApps = async (auth: Authenticator) => {
   const accessibleVaults = [
-    ...(await VaultResource.listWorkspaceVaults(auth, false)),
+    ...(await VaultResource.listWorkspaceVaults(auth)),
   ].filter((vault) => !vault.isSystem());
 
   const [dsViews, allDustApps] = await Promise.all([

--- a/front/components/vaults/VaultLayout.tsx
+++ b/front/components/vaults/VaultLayout.tsx
@@ -73,11 +73,13 @@ export function VaultLayout({
           parentId={parentId ?? undefined}
         />
         {children}
-        <CreateVaultModal
-          owner={owner}
-          isOpen={showVaultCreationModal}
-          onClose={() => setShowVaultCreationModal(false)}
-        />
+        {isAdmin && (
+          <CreateVaultModal
+            owner={owner}
+            isOpen={showVaultCreationModal}
+            onClose={() => setShowVaultCreationModal(false)}
+          />
+        )}
       </AppLayout>
     </RootLayout>
   );

--- a/front/components/vaults/VaultMembers.tsx
+++ b/front/components/vaults/VaultMembers.tsx
@@ -6,7 +6,7 @@ import { useContext, useState } from "react";
 
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { ManageMembersModal } from "@app/components/vaults/ManageMembersModal";
-import { useVaultInfo } from "@app/lib/swr/vaults";
+import { useVaultInfo, useVaults } from "@app/lib/swr/vaults";
 import { classNames, removeDiacritics } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 
@@ -56,6 +56,11 @@ export const VaultMembers = ({ owner, isAdmin, vault }: VaultMembersProps) => {
   const [addMemberModalOpen, setAddMemberModalOpen] = useState(false);
   const sendNotification = useContext(SendNotificationsContext);
 
+  const { mutate } = useVaults({
+    workspaceId: owner.sId,
+    disabled: true,
+  });
+
   const { vaultInfo, isVaultInfoLoading, mutateVaultInfo } = useVaultInfo({
     workspaceId: owner.sId,
     vaultId: vault.sId,
@@ -101,6 +106,7 @@ export const VaultMembers = ({ owner, isAdmin, vault }: VaultMembersProps) => {
       });
 
       await mutateVaultInfo();
+      await mutate();
     }
   };
 

--- a/front/components/vaults/VaultSideBarMenu.tsx
+++ b/front/components/vaults/VaultSideBarMenu.tsx
@@ -20,7 +20,7 @@ import { assertNever, DATA_SOURCE_VIEW_CATEGORIES } from "@dust-tt/types";
 import { groupBy } from "lodash";
 import { useRouter } from "next/router";
 import type { ComponentType, ReactElement } from "react";
-import { Fragment, useEffect, useState } from "react";
+import { Fragment, useCallback, useEffect, useState } from "react";
 
 import {
   getConnectorProviderLogoWithFallback,
@@ -31,6 +31,7 @@ import {
   useVaultDataSourceViews,
   useVaultInfo,
   useVaults,
+  useVaultsAsAdmin,
 } from "@app/lib/swr/vaults";
 import { getVaultIcon, getVaultName } from "@app/lib/vaults";
 
@@ -52,9 +53,33 @@ export default function VaultSideBarMenu({
   isAdmin,
   setShowVaultCreationModal,
 }: VaultSideBarMenuProps) {
-  const { vaults, isVaultsLoading } = useVaults({ workspaceId: owner.sId });
+  const { vaults, isVaultsLoading } = useVaultsAsAdmin({
+    workspaceId: owner.sId,
+  });
 
-  if (!vaults || isVaultsLoading) {
+  const { vaults: vaultsAsUser, isVaultsLoading: isVaultsAsUserLoading } =
+    useVaults({
+      workspaceId: owner.sId,
+    });
+
+  // Vaults that are in the vaultsAsUser list should be displayed first, use the name as a tiebreaker.
+  const compareVaults = useCallback(
+    (v1: VaultType, v2: VaultType) => {
+      const v1IsMember = !!vaultsAsUser?.find((v) => v.sId === v1.sId);
+      const v2IsMember = !!vaultsAsUser?.find((v) => v.sId === v2.sId);
+
+      if (v1IsMember && !v2IsMember) {
+        return -1;
+      } else if (!v1IsMember && v2IsMember) {
+        return 1;
+      } else {
+        return v1.name.localeCompare(v2.name);
+      }
+    },
+    [vaultsAsUser]
+  );
+
+  if (!vaults || !vaultsAsUser || isVaultsLoading || isVaultsAsUserLoading) {
     return <></>;
   }
 
@@ -96,7 +121,11 @@ export default function VaultSideBarMenu({
                     />
                   )}
                 </div>
-                {renderVaultItems(vaults, owner)}
+                {renderVaultItems(
+                  vaults.toSorted(compareVaults),
+                  vaultsAsUser,
+                  owner
+                )}
               </Fragment>
             );
           })}
@@ -107,16 +136,25 @@ export default function VaultSideBarMenu({
 }
 
 // Function to render vault items.
-const renderVaultItems = (vaults: VaultType[], owner: LightWorkspaceType) =>
-  vaults.map((vault) => (
+const renderVaultItems = (
+  vaults: VaultType[],
+  vaultsAsUser: VaultType[],
+  owner: LightWorkspaceType
+) => {
+  return vaults.map((vault) => (
     <Fragment key={`vault-${vault.sId}`}>
       {vault.kind === "system" ? (
         <SystemVaultMenu owner={owner} vault={vault} />
       ) : (
-        <VaultMenu owner={owner} vault={vault} />
+        <VaultMenu
+          owner={owner}
+          vault={vault}
+          isMember={!!vaultsAsUser.find((v) => v.sId === vault.sId)}
+        />
       )}
     </Fragment>
   ));
+};
 
 const getSectionLabel = (kind: VaultKind) => {
   switch (kind) {
@@ -245,13 +283,15 @@ const SystemVaultItem = ({
 const VaultMenu = ({
   owner,
   vault,
+  isMember,
 }: {
   owner: LightWorkspaceType;
   vault: VaultType;
+  isMember: boolean;
 }) => {
   return (
     <Tree variant="navigator">
-      <VaultMenuItem owner={owner} vault={vault} />
+      <VaultMenuItem owner={owner} vault={vault} isMember={isMember} />
     </Tree>
   );
 };
@@ -259,9 +299,11 @@ const VaultMenu = ({
 const VaultMenuItem = ({
   owner,
   vault,
+  isMember,
 }: {
   owner: LightWorkspaceType;
   vault: VaultType;
+  isMember: boolean;
 }) => {
   const router = useRouter();
 
@@ -291,7 +333,7 @@ const VaultMenuItem = ({
       isSelected={router.asPath === vaultPath}
       onChevronClick={() => setIsExpanded(!isExpanded)}
       visual={getVaultIcon(vault)}
-      tailwindIconTextColor="text-brand"
+      tailwindIconTextColor={isMember ? "text-success-500" : "text-warning-400"}
       size="md"
       areActionsFading={false}
     >

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -165,10 +165,11 @@ export class VaultResource extends BaseResource<VaultModel> {
   static async listWorkspaceVaultsAsAdmin(
     auth: Authenticator
   ): Promise<VaultResource[]> {
-    const vaults = await this.baseFetch(auth);
-    return vaults.filter(
-      (vault) => auth.isAdmin() || auth.hasPermission([vault.acl()], "read")
-    );
+    if (!auth.isAdmin()) {
+      return [];
+    }
+
+    return this.baseFetch(auth);
   }
 
   static async listWorkspaceDefaultVaults(auth: Authenticator) {

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -156,14 +156,18 @@ export class VaultResource extends BaseResource<VaultModel> {
   }
 
   static async listWorkspaceVaults(
-    auth: Authenticator,
-    adminsBypassACL: boolean = true
+    auth: Authenticator
+  ): Promise<VaultResource[]> {
+    const vaults = await this.baseFetch(auth);
+    return vaults.filter((vault) => auth.hasPermission([vault.acl()], "read"));
+  }
+
+  static async listWorkspaceVaultsAsAdmin(
+    auth: Authenticator
   ): Promise<VaultResource[]> {
     const vaults = await this.baseFetch(auth);
     return vaults.filter(
-      (vault) =>
-        (auth.isAdmin() && adminsBypassACL) ||
-        auth.hasPermission([vault.acl()], "read")
+      (vault) => auth.isAdmin() || auth.hasPermission([vault.acl()], "read")
     );
   }
 

--- a/front/lib/swr/swr.ts
+++ b/front/lib/swr/swr.ts
@@ -3,11 +3,6 @@ import useSWR, { useSWRConfig } from "swr";
 
 import { COMMIT_HASH } from "@app/lib/commit-hash";
 
-export const SWR_KEYS = {
-  vaults: (workspaceId: string) => `/api/w/${workspaceId}/vaults`,
-  conversations: (workspaceId: string) => `/api/w/${workspaceId}/conversations`,
-};
-
 const DEFAULT_SWR_CONFIG: SWRConfiguration = {
   errorRetryCount: 16,
 };

--- a/front/lib/swr/vaults.ts
+++ b/front/lib/swr/vaults.ts
@@ -23,7 +23,7 @@ export function useVaults({
   );
 
   return {
-    vaults: data ? data.vaults : [],
+    vaults: useMemo(() => (data ? data.vaults : []), [data]),
     isVaultsLoading: !error && !data && !disabled,
     isVaultsError: error,
     mutate,
@@ -46,7 +46,7 @@ export function useVaultsAsAdmin({
   );
 
   return {
-    vaults: data ? data.vaults : [],
+    vaults: useMemo(() => (data ? data.vaults : []), [data]),
     isVaultsLoading: !error && !data && !disabled,
     isVaultsError: error,
     mutate,

--- a/front/lib/swr/vaults.ts
+++ b/front/lib/swr/vaults.ts
@@ -2,23 +2,54 @@ import type { DataSourceViewCategory } from "@dust-tt/types";
 import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
-import { fetcher, SWR_KEYS, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetVaultsResponseBody } from "@app/pages/api/w/[wId]/vaults";
 import type { GetVaultResponseBody } from "@app/pages/api/w/[wId]/vaults/[vId]";
 import type { GetVaultDataSourceViewsResponseBody } from "@app/pages/api/w/[wId]/vaults/[vId]/data_source_views";
 
-export function useVaults({ workspaceId }: { workspaceId: string }) {
+export function useVaults({
+  workspaceId,
+  disabled,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
   const vaultsFetcher: Fetcher<GetVaultsResponseBody> = fetcher;
 
-  const { data, error } = useSWRWithDefaults(
-    SWR_KEYS.vaults(workspaceId),
-    vaultsFetcher
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/vaults`,
+    vaultsFetcher,
+    { disabled }
   );
 
   return {
     vaults: data ? data.vaults : null,
     isVaultsLoading: !error && !data,
     isVaultsError: error,
+    mutate,
+  };
+}
+
+export function useVaultsAsAdmin({
+  workspaceId,
+  disabled,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
+  const vaultsFetcher: Fetcher<GetVaultsResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/vaults?role=admin`,
+    vaultsFetcher,
+    { disabled }
+  );
+
+  return {
+    vaults: data ? data.vaults : null,
+    isVaultsLoading: !error && !data,
+    isVaultsError: error,
+    mutate,
   };
 }
 

--- a/front/lib/swr/vaults.ts
+++ b/front/lib/swr/vaults.ts
@@ -23,8 +23,8 @@ export function useVaults({
   );
 
   return {
-    vaults: data ? data.vaults : null,
-    isVaultsLoading: !error && !data,
+    vaults: data ? data.vaults : [],
+    isVaultsLoading: !error && !data && !disabled,
     isVaultsError: error,
     mutate,
   };
@@ -46,8 +46,8 @@ export function useVaultsAsAdmin({
   );
 
   return {
-    vaults: data ? data.vaults : null,
-    isVaultsLoading: !error && !data,
+    vaults: data ? data.vaults : [],
+    isVaultsLoading: !error && !data && !disabled,
     isVaultsError: error,
     mutate,
   };

--- a/front/pages/api/w/[wId]/vaults/index.ts
+++ b/front/pages/api/w/[wId]/vaults/index.ts
@@ -46,6 +46,16 @@ async function handler(
       let vaults: VaultResource[] = [];
 
       if (role && role === "admin") {
+        if (!auth.isAdmin()) {
+          return apiError(req, res, {
+            status_code: 403,
+            api_error: {
+              type: "workspace_auth_error",
+              message:
+                "Only users that are `admins` can see all vaults in the workspace.",
+            },
+          });
+        }
         vaults = await VaultResource.listWorkspaceVaultsAsAdmin(auth);
       } else {
         vaults = await VaultResource.listWorkspaceVaults(auth);

--- a/front/pages/api/w/[wId]/vaults/index.ts
+++ b/front/pages/api/w/[wId]/vaults/index.ts
@@ -31,7 +31,25 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const vaults = await VaultResource.listWorkspaceVaults(auth);
+      const { role } = req.query;
+
+      if (role && typeof role !== "string") {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Invalid request query parameters.",
+          },
+        });
+      }
+
+      let vaults: VaultResource[] = [];
+
+      if (role && role === "admin") {
+        vaults = await VaultResource.listWorkspaceVaultsAsAdmin(auth);
+      } else {
+        vaults = await VaultResource.listWorkspaceVaults(auth);
+      }
 
       return res.status(200).json({
         vaults: vaults.map((vault) => vault.toJSON()),

--- a/front/pages/w/[wId]/data-sources/vaults/[vaultId]/index.tsx
+++ b/front/pages/w/[wId]/data-sources/vaults/[vaultId]/index.tsx
@@ -1,5 +1,11 @@
-import { Page, PuzzleIcon, Tab, UserGroupIcon } from "@dust-tt/sparkle";
-import type { VaultType } from "@dust-tt/types";
+import {
+  Chip,
+  InformationCircleIcon,
+  Page,
+  PuzzleIcon,
+  Tab,
+  UserGroupIcon,
+} from "@dust-tt/sparkle";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import type { ReactElement } from "react";
@@ -15,10 +21,7 @@ import { VaultResource } from "@app/lib/resources/vault_resource";
 import { getVaultIcon, getVaultName } from "@app/lib/vaults";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<
-  VaultLayoutProps & {
-    isAdmin: boolean;
-    vault: VaultType;
-  }
+  VaultLayoutProps & { isMember: boolean }
 >(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
   const subscription = auth.subscription();
@@ -39,20 +42,23 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     };
   }
   const isAdmin = auth.isAdmin();
+  const isMember = vault.canRead(auth);
 
   return {
     props: {
       gaTrackingId: config.getGaTrackingId(),
       isAdmin,
+      isMember,
       owner,
       subscription,
       vault: vault.toJSON(),
     },
   };
 });
-
+//
 export default function Vault({
   isAdmin,
+  isMember,
   owner,
   vault,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
@@ -65,6 +71,14 @@ export default function Vault({
         icon={getVaultIcon(vault)}
         description="Manage connections to your products and the real-time data feeds Dust has access to."
       />
+      {!isMember && (
+        <Chip
+          color="warning"
+          label="You are not a member of this vault."
+          size="sm"
+          icon={InformationCircleIcon}
+        />
+      )}
 
       {vault.kind !== "global" && isAdmin && (
         <div className="w-[320px]">

--- a/front/pages/w/[wId]/data-sources/vaults/[vaultId]/index.tsx
+++ b/front/pages/w/[wId]/data-sources/vaults/[vaultId]/index.tsx
@@ -55,7 +55,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     },
   };
 });
-//
+
 export default function Vault({
   isAdmin,
   owner,


### PR DESCRIPTION
## Description

Distinguish the vaults accessible as members and the one you can see because you are an admin.


https://github.com/user-attachments/assets/4179cd6a-2bd5-4466-a764-1cc71593eb0c



## Risk

None

## Deploy Plan

Deploy `front`