### PR TITLE
Apply DataSourceView permissions when fetching Assistant builder actions

### DIFF
--- a/front/components/assistant_builder/shared.ts
+++ b/front/components/assistant_builder/shared.ts
@@ -1,16 +1,12 @@
 import type {
-  CoreAPITable,
   DataSourceType,
-  DataSourceViewType,
   LightContentNode,
   TimeframeUnit,
 } from "@dust-tt/types";
 import type { ConnectorProvider } from "@dust-tt/types";
 import {
-  getGoogleSheetContentNodeInternalIdFromTableId,
   getGoogleSheetTableIdFromContentNodeInternalId,
   getMicrosoftSheetContentNodeInternalIdFromTableId,
-  getNotionDatabaseContentNodeInternalIdFromTableId,
   getNotionDatabaseTableIdFromContentNodeInternalId,
   isGoogleSheetContentNodeInternalId,
 } from "@dust-tt/types";
@@ -310,34 +306,6 @@ export function getTableIdForContentNode(
     // For static tables, the tableId is the contentNode internalId.
     case null:
       return contentNode.internalId;
-
-    default:
-      throw new Error(
-        `Provider ${dataSource.connectorProvider} is not supported`
-      );
-  }
-}
-
-export function getContentNodeInternalIdFromTableId(
-  dataSourceView: DataSourceViewType,
-  table: CoreAPITable
-): string {
-  const { dataSource } = dataSourceView;
-  const { table_id: tableId } = table;
-
-  switch (dataSource.connectorProvider) {
-    case "google_drive":
-      return getGoogleSheetContentNodeInternalIdFromTableId(tableId);
-
-    case "notion":
-      return getNotionDatabaseContentNodeInternalIdFromTableId(tableId);
-
-    case "microsoft":
-      return getMicrosoftSheetContentNodeInternalIdFromTableId(tableId);
-
-    // For static tables, the contentNode internalId is the tableId.
-    case null:
-      return tableId;
 
     default:
       throw new Error(

--- a/front/components/assistant_builder/shared.ts
+++ b/front/components/assistant_builder/shared.ts
@@ -295,7 +295,7 @@ export function getTableIdForContentNode(
     case "google_drive":
       if (!isGoogleSheetContentNodeInternalId(contentNode.internalId)) {
         throw new Error(
-          `Googgle Drive ContentNode internalId ${contentNode.internalId} is not a Google Sheet internal ID`
+          `Google Drive ContentNode internalId ${contentNode.internalId} is not a Google Sheet internal ID`
         );
       }
       return getGoogleSheetTableIdFromContentNodeInternalId(

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -1,0 +1,36 @@
+import type { CoreAPITable } from "@dust-tt/types";
+import {
+  getGoogleSheetContentNodeInternalIdFromTableId,
+  getMicrosoftSheetContentNodeInternalIdFromTableId,
+  getNotionDatabaseContentNodeInternalIdFromTableId,
+} from "@dust-tt/types";
+
+import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+
+export function getContentNodeInternalIdFromTableId(
+  dataSourceView: DataSourceViewResource,
+  table: CoreAPITable
+): string {
+  const { dataSource } = dataSourceView;
+  const { table_id: tableId } = table;
+
+  switch (dataSource.connectorProvider) {
+    case "google_drive":
+      return getGoogleSheetContentNodeInternalIdFromTableId(tableId);
+
+    case "notion":
+      return getNotionDatabaseContentNodeInternalIdFromTableId(tableId);
+
+    case "microsoft":
+      return getMicrosoftSheetContentNodeInternalIdFromTableId(tableId);
+
+    // For static tables, the contentNode internalId is the tableId.
+    case null:
+      return tableId;
+
+    default:
+      throw new Error(
+        `Provider ${dataSource.connectorProvider} is not supported`
+      );
+  }
+}

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -9,6 +9,7 @@ import { ConnectorsAPI, CoreAPI, Err, Ok, removeNulls } from "@dust-tt/types";
 import assert from "assert";
 
 import config from "@app/lib/api/config";
+import { getContentNodeInternalIdFromTableId } from "@app/lib/api/content_nodes";
 import type { OffsetPaginationParams } from "@app/lib/api/pagination";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import logger from "@app/logger/logger";
@@ -212,10 +213,10 @@ export async function getContentNodesForStaticDataSourceView(
       tablesRes.value.tables.map((table) => ({
         dustDocumentId: table.table_id,
         expandable: false,
-        internalId: table.table_id,
+        internalId: getContentNodeInternalIdFromTableId(dataSourceView, table),
         lastUpdatedAt: table.timestamp,
         parentInternalId: null,
-        parentInternalIds: [],
+        parentInternalIds: table.parents,
         permission: "read",
         preventSelection: false,
         sourceUrl: null,

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -61,6 +61,8 @@ interface GetContentNodesForDataSourceViewParams {
   internalIds?: string[];
   pagination?: OffsetPaginationParams;
   viewType: ContentNodesViewType;
+  // If onlyCoreAPI is true, the function will only use the Core API to fetch the content nodes.
+  onlyCoreAPI?: boolean;
 }
 
 interface GetContentNodesForDataSourceViewResult {
@@ -234,9 +236,11 @@ export async function getContentNodesForDataSourceView(
 ): Promise<
   Result<GetContentNodesForDataSourceViewResult, Error | CoreAPIError>
 > {
+  const { onlyCoreAPI = false } = params;
+
   let contentNodesResult: GetContentNodesForDataSourceViewResult;
 
-  if (dataSourceView.dataSource.connectorId) {
+  if (dataSourceView.dataSource.connectorId && !onlyCoreAPI) {
     const contentNodesRes = await getContentNodesForManagedDataSourceView(
       dataSourceView,
       params

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -89,8 +89,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       actions,
       agentConfiguration: configuration,
       baseUrl: config.getClientFacingUrl(),
-      vaults,
-      dataSourceViews,
+      dataSourceViews: dataSourceViews.map((v) => v.toJSON()),
       dustApps,
       flow,
       gaTrackingId: config.getGaTrackingId(),
@@ -98,6 +97,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       owner,
       plan,
       subscription,
+      vaults: vaults.map((v) => v.toJSON()),
     },
   };
 });

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -118,8 +118,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       actions,
       agentConfiguration: configuration,
       baseUrl: config.getClientFacingUrl(),
-      vaults,
-      dataSourceViews,
+      dataSourceViews: dataSourceViews.map((v) => v.toJSON()),
       dustApps,
       flow,
       gaTrackingId: config.getGaTrackingId(),
@@ -128,6 +127,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       plan,
       subscription,
       templateId,
+      vaults: vaults.map((v) => v.toJSON()),
     },
   };
 });


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes https://github.com/dust-tt/dust/issues/7081.

It uses the helper functions to retrieve content nodes during the server-side rendering of actions in the Assistant Builder. The aim is to ensure that all calls pass through this function, as it honors the data source view permissions. This PR introduces a minor change: tables are saved in Query tables actions with their prefix. This prefix is applied when saving a table to core, and interestingly, only Notion appears to save in this manner.

To avoid introducing any changes, this PR includes an `onlyCoreAPI` boolean that targets only the core API while still honoring view permissions. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Worst case, it breaks SSR of query tables.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
