### PR TITLE
[Notion Sync] Fix: resume GC workflow even if main workflow running

### DIFF
--- a/connectors/src/connectors/notion/temporal/client.ts
+++ b/connectors/src/connectors/notion/temporal/client.ts
@@ -48,33 +48,31 @@ export async function launchNotionSyncWorkflow(
       },
       "launchNotionSyncWorkflow: Notion sync workflow already running."
     );
-    return;
-  }
-
-  await client.workflow.start(notionSyncWorkflow, {
-    args: [
-      {
-        connectorId,
-        startFromTs,
-        forceResync,
-        garbageCollectionMode: "never",
+  } else {
+    await client.workflow.start(notionSyncWorkflow, {
+      args: [
+        {
+          connectorId,
+          startFromTs,
+          forceResync,
+          garbageCollectionMode: "never",
+        },
+      ],
+      taskQueue: QUEUE_NAME,
+      workflowId: getNotionWorkflowId(connectorId, "never"),
+      searchAttributes: {
+        connectorId: [connectorId],
       },
-    ],
-    taskQueue: QUEUE_NAME,
-    workflowId: getNotionWorkflowId(connectorId, "never"),
-    searchAttributes: {
-      connectorId: [connectorId],
-    },
-    memo: {
-      connectorId,
-    },
-  });
+      memo: {
+        connectorId,
+      },
+    });
 
-  logger.info(
-    { workspaceId: dataSourceConfig.workspaceId },
-    "launchNotionSyncWorkflow: Started Notion sync workflow."
-  );
-
+    logger.info(
+      { workspaceId: dataSourceConfig.workspaceId },
+      "launchNotionSyncWorkflow: Started Notion sync workflow."
+    );
+  }
   await launchNotionGarbageCollectorWorkflow(connectorId);
 }
 


### PR DESCRIPTION
Description
---
When running `launchNotionSyncWorkflow`, the main workflow and the GC workflow are restarted.

Previously, if the main workflow was already running, launching the GC was skipped (even if the GC had been stopped)

This PR makes sure both workflows are always restarted when requested

Risk
---
na

Deploy
---
connectors
