### PR TITLE
Fix Vault's permissions

### DIFF
--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -406,12 +406,6 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
     return getDataSourceViewUsage({ auth, dataSourceView: this.toJSON() });
   };
 
-  // Permissions.
-
-  canRead(auth: Authenticator) {
-    return this.vault.canRead(auth);
-  }
-
   // Serialization.
 
   toJSON(): DataSourceViewType {

--- a/front/lib/resources/resource_with_vault.ts
+++ b/front/lib/resources/resource_with_vault.ts
@@ -107,7 +107,21 @@ export abstract class ResourceWithVault<
     });
   }
 
+  // Permissions.
+
   acl() {
     return this.vault.acl();
+  }
+
+  canList(auth: Authenticator) {
+    return this.vault.canList(auth);
+  }
+
+  canRead(auth: Authenticator) {
+    return this.vault.canRead(auth);
+  }
+
+  canWrite(auth: Authenticator) {
+    return this.vault.canWrite(auth);
   }
 }

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -161,9 +161,7 @@ export class VaultResource extends BaseResource<VaultModel> {
   ): Promise<VaultResource[]> {
     const vaults = await this.baseFetch(auth);
     return vaults.filter(
-      (vault) =>
-        (auth.isAdmin() && adminsBypassACL) ||
-        auth.hasPermission([vault.acl()], "read")
+      (vault) => (auth.isAdmin() && adminsBypassACL) || vault.canRead(auth)
     );
   }
 
@@ -290,8 +288,10 @@ export class VaultResource extends BaseResource<VaultModel> {
     switch (this.kind) {
       case "system":
         return auth.isAdmin() && auth.canWrite([this.acl()]);
+
       case "global":
         return auth.isBuilder() && auth.canWrite([this.acl()]);
+
       case "regular":
       case "public":
         return auth.canWrite([this.acl()]);
@@ -303,16 +303,31 @@ export class VaultResource extends BaseResource<VaultModel> {
 
   canRead(auth: Authenticator) {
     switch (this.kind) {
-      case "system":
-        return auth.isAdmin() && auth.canRead([this.acl()]);
       case "global":
       case "regular":
+      case "system":
         return auth.canRead([this.acl()]);
+
       case "public":
         return true;
+
       default:
         assertNever(this.kind);
     }
+  }
+
+  canList(auth: Authenticator) {
+    // Admins can list all vaults.
+    if (auth.isAdmin()) {
+      return true;
+    }
+
+    // Public vaults can be listed by anyone.
+    if (this.isPublic()) {
+      return true;
+    }
+
+    return auth.canRead([this.acl()]);
   }
 
   isGlobal() {

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -184,7 +184,7 @@ async function handler(
         vault = await VaultResource.fetchWorkspaceGlobalVault(auth);
       }
 
-      if (!auth.hasPermission([vault.acl()], "write")) {
+      if (!vault.canWrite(auth)) {
         return apiError(req, res, {
           status_code: 403,
           api_error: {

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/content-nodes.ts
@@ -53,7 +53,7 @@ async function handler(
   if (
     !dataSourceView ||
     vId !== dataSourceView.vault.sId ||
-    !dataSourceView.canRead(auth)
+    !dataSourceView.canList(auth)
   ) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/documents/[documentId]/index.ts
@@ -41,13 +41,8 @@ async function handler(
   }
 
   const dataSourceView = await DataSourceViewResource.fetchById(auth, dsvId);
-  // TODO(GROUPS_INFRA) Move to DataSourceViewResource.fetchById once it handles permission.
-  const hasAccessToDataSourceView =
-    auth.isAdmin() ||
-    (dataSourceView &&
-      auth.hasPermission([dataSourceView.vault.acl()], "read"));
 
-  if (!dataSourceView || !hasAccessToDataSourceView) {
+  if (!dataSourceView || !dataSourceView.canRead(auth)) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.ts
@@ -26,8 +26,7 @@ async function handler(
   if (
     !dataSourceView ||
     req.query.vId !== dataSourceView.vault.sId ||
-    (!auth.isAdmin() &&
-      !auth.hasPermission([dataSourceView.vault.acl()], "read"))
+    !dataSourceView.canList(auth)
   ) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/tables/[tableId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/tables/[tableId]/index.ts
@@ -41,7 +41,7 @@ async function handler(
   }
 
   const dataSourceView = await DataSourceViewResource.fetchById(auth, dsvId);
-  if (!dataSourceView || !dataSourceView.canList(auth)) {
+  if (!dataSourceView || !dataSourceView.canRead(auth)) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/tables/[tableId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/tables/[tableId]/index.ts
@@ -41,13 +41,7 @@ async function handler(
   }
 
   const dataSourceView = await DataSourceViewResource.fetchById(auth, dsvId);
-  // TODO(GROUPS_INFRA) Move to DataSourceViewResource.fetchById once it handles permission.
-  const hasAccessToDataSourceView =
-    auth.isAdmin() ||
-    (dataSourceView &&
-      auth.hasPermission([dataSourceView.vault.acl()], "read"));
-
-  if (!dataSourceView || !hasAccessToDataSourceView) {
+  if (!dataSourceView || !dataSourceView.canList(auth)) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/index.ts
@@ -40,10 +40,7 @@ async function handler(
 ): Promise<void> {
   const vault = await VaultResource.fetchById(auth, req.query.vId as string);
 
-  if (
-    !vault ||
-    (!auth.isAdmin() && !auth.hasPermission([vault.acl()], "read"))
-  ) {
+  if (!vault || !vault.canList(auth)) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/[dsId]/configuration.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/[dsId]/configuration.ts
@@ -70,7 +70,7 @@ async function handler(
     });
   }
 
-  if (!auth.hasPermission([dataSource.acl()], "read")) {
+  if (!dataSource.canRead(auth)) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {
@@ -118,7 +118,7 @@ async function handler(
       });
 
     case "PATCH":
-      if (!auth.hasPermission([dataSource.acl()], "write")) {
+      if (!dataSource.canWrite(auth)) {
         return apiError(req, res, {
           status_code: 403,
           api_error: {
@@ -129,6 +129,7 @@ async function handler(
         });
       }
 
+      // TODO(VAULTS_INFRA) Do we need this?
       if (!auth.isBuilder()) {
         return apiError(req, res, {
           status_code: 403,

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/[dsId]/configuration.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/[dsId]/configuration.ts
@@ -129,7 +129,6 @@ async function handler(
         });
       }
 
-      // TODO(VAULTS_INFRA) Do we need this?
       if (!auth.isBuilder()) {
         return apiError(req, res, {
           status_code: 403,

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/[dsId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/[dsId]/index.ts
@@ -63,7 +63,7 @@ async function handler(
       },
     });
   }
-  if (!auth.hasPermission([vault.acl()], "write")) {
+  if (!vault.canWrite(auth)) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/index.ts
@@ -132,7 +132,8 @@ async function handler(
         },
       });
     }
-    if (!auth.hasPermission([vault.acl()], "write")) {
+
+    if (!vault.canWrite(auth)) {
       return apiError(req, res, {
         status_code: 403,
         api_error: {

--- a/front/pages/api/w/[wId]/vaults/[vId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/index.ts
@@ -39,11 +39,7 @@ async function handler(
 ): Promise<void> {
   const vault = await VaultResource.fetchById(auth, req.query.vId as string);
 
-  // Check if the user has access to the vault - either they are an admin or they have read access
-  if (
-    !vault ||
-    (!auth.isAdmin() && !auth.hasPermission([vault.acl()], "read"))
-  ) {
+  if (!vault || !vault.canList(auth)) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
+++ b/front/pages/w/[wId]/data-sources/vaults/[vaultId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
@@ -59,10 +59,11 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     auth,
     dataSourceViewId
   );
+
   if (
     !dataSourceView ||
     dataSourceView.vault.sId !== vaultId ||
-    !dataSourceView.canRead(auth)
+    !dataSourceView.canList(auth)
   ) {
     return {
       notFound: true,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR refactors the permission system related to vaults. The aim is to keep permission logic contained within the resource itself. To achieve this, we've introduced three permission helper methods available for all resources associated with a vault:
- `canRead`: Determines if the content of a resource can be read (e.g., accessing the content of a document from within a view).
- `canList`: Determines if the contents of a resource can be listed (e.g., listing all data source views within a vault).
- `canWrite`: Determines if a resource can be modified.

We should consistently use these helper methods for managing permissions.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
