### PR TITLE
[front/api] - feat(workspace): add pagination to `getMembers` function

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -229,7 +229,7 @@ const user = async (command: string, args: parseArgs.ParsedArgs) => {
       console.log(`  name: ${u.name}`);
       console.log(`  email: ${u.email}`);
 
-      const memberships = await MembershipResource.getLatestMemberships({
+      const { memberships } = await MembershipResource.getLatestMemberships({
         users: [u],
       });
 

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -170,9 +170,8 @@ async function warnPostDeletion(
   switch (dataSourceProvider) {
     case "github":
       // get admin emails
-      const adminEmails = (await getMembers(auth, { roles: ["admin"] })).map(
-        (u) => u.email
-      );
+      const { members } = await getMembers(auth, { roles: ["admin"] });
+      const adminEmails = members.map((u) => u.email);
       // send email to admins
       for (const email of adminEmails) {
         await sendGithubDeletionEmail(email);

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -366,7 +366,9 @@ export async function handleMembershipInvitations(
     });
   }
 
-  const existingMembers = await getMembers(auth, { activeOnly: true });
+  const { members: existingMembers } = await getMembers(auth, {
+    activeOnly: true,
+  });
   const unconsumedInvitations =
     await getRecentPendingAndRevokedInvitations(auth);
   if (

--- a/front/lib/api/user.ts
+++ b/front/lib/api/user.ts
@@ -116,11 +116,11 @@ export async function fetchRevokedWorkspace(
     return new Err(new Error(message));
   }
 
-  const memberships = await MembershipResource.getLatestMemberships({
+  const { memberships, total } = await MembershipResource.getLatestMemberships({
     users: [u],
   });
 
-  if (!memberships.length) {
+  if (total === 0) {
     const message = "Unreachable: user has no memberships.";
     logger.error({ userId: user.id }, message);
     return new Err(new Error(message));

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -137,7 +137,7 @@ export async function getMembers(
     return [];
   }
 
-  const memberships = activeOnly
+  const { memberships } = activeOnly
     ? await MembershipResource.getActiveMemberships({
         workspace: owner,
         roles,

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -9,6 +9,7 @@ import type {
   WorkspaceType,
 } from "@dust-tt/types";
 
+import type { PaginationParams } from "@app/lib/api/pagination";
 import type { Authenticator } from "@app/lib/auth";
 import { Workspace, WorkspaceHasDomain } from "@app/lib/models/workspace";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
@@ -117,6 +118,7 @@ export async function setInternalWorkspaceSegmentation(
  * their own workspaces).
  * @param auth Authenticator
  * @param role RoleType optional filter on role
+ * @param paginationParams PaginationParams optional pagination parameters
  * @returns UserType[] members of the workspace
  */
 export async function getMembers(
@@ -127,7 +129,8 @@ export async function getMembers(
   }: {
     roles?: MembershipRoleType[];
     activeOnly?: boolean;
-  } = {}
+  } = {},
+  paginationParams?: PaginationParams
 ): Promise<UserTypeWithWorkspaces[]> {
   const owner = auth.workspace();
   if (!owner) {
@@ -138,10 +141,12 @@ export async function getMembers(
     ? await MembershipResource.getActiveMemberships({
         workspace: owner,
         roles,
+        paginationParams,
       })
     : await MembershipResource.getLatestMemberships({
         workspace: owner,
         roles,
+        paginationParams,
       });
 
   const users = await UserResource.fetchByModelIds(

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -504,13 +504,14 @@ export class Authenticator {
     }
 
     // Verify that one of the user has an active membership in the specified workspace.
-    const activeMemberships = await MembershipResource.getActiveMemberships({
-      users,
-      workspace: owner,
-    });
+    const { memberships: activeMemberships, total } =
+      await MembershipResource.getActiveMemberships({
+        users,
+        workspace: owner,
+      });
     // If none of the user has an active membership in the workspace,
     // simply ignore and return null.
-    if (activeMemberships.length === 0) {
+    if (total === 0) {
       return null;
     }
 

--- a/front/lib/document_tracker.ts
+++ b/front/lib/document_tracker.ts
@@ -100,7 +100,7 @@ export async function updateTrackedDocuments(
     : [];
 
   // restrict to users in the workspace
-  const memberships = await MembershipResource.getActiveMemberships({
+  const { memberships } = await MembershipResource.getActiveMemberships({
     workspace: owner,
   });
   const userIdsInWorkspace = new Set(

--- a/front/lib/iam/session.ts
+++ b/front/lib/iam/session.ts
@@ -36,7 +36,7 @@ export async function getUserFromSession(
     return null;
   }
 
-  const memberships = await MembershipResource.getActiveMemberships({
+  const { memberships } = await MembershipResource.getActiveMemberships({
     users: [user],
   });
   const workspaces = await Workspace.findAll({

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -377,9 +377,10 @@ export class GroupResource extends BaseResource<GroupModel> {
     // The global group does not have a DB entry for each workspace member.
     // TODO(GROUPS_INFRA): Remove this once we consolidate memberships with group memberships.
     if (this.isGlobal()) {
-      memberships = await MembershipResource.getActiveMemberships({
+      const { memberships: m } = await MembershipResource.getActiveMemberships({
         workspace: auth.getNonNullableWorkspace(),
       });
+      memberships = m;
     } else {
       memberships = await GroupMembershipModel.findAll({
         where: {

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -419,10 +419,11 @@ export class GroupResource extends BaseResource<GroupModel> {
         )
       );
     }
-    const workspaceMemberships = await MembershipResource.getActiveMemberships({
-      users: userResources,
-      workspace: owner,
-    });
+    const { memberships: workspaceMemberships } =
+      await MembershipResource.getActiveMemberships({
+        users: userResources,
+        workspace: owner,
+      });
 
     if (
       new Set(workspaceMemberships.map((m) => m.userId)).size !== userIds.length
@@ -508,12 +509,12 @@ export class GroupResource extends BaseResource<GroupModel> {
         )
       );
     }
-    const workspaceMemberships = await MembershipResource.getActiveMemberships({
+    const { total } = await MembershipResource.getActiveMemberships({
       users: userResources,
       workspace: owner,
     });
 
-    if (workspaceMemberships.length !== userIds.length) {
+    if (total !== userIds.length) {
       return new Err(
         new DustError(
           "user_not_member",

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -1,12 +1,23 @@
 import type { LightWorkspaceType } from "@dust-tt/types";
+import type { PaginationState } from "@tanstack/react-table";
 import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import {
+  appendPaginationParams,
+  fetcher,
+  useSWRWithDefaults,
+} from "@app/lib/swr/swr";
 import type { GetWorkspaceInvitationsResponseBody } from "@app/pages/api/w/[wId]/invitations";
 import type { GetMembersResponseBody } from "@app/pages/api/w/[wId]/members";
 
-export function useMembers(owner: LightWorkspaceType) {
+export function useMembers(
+  owner: LightWorkspaceType,
+  pagination?: PaginationState
+) {
+  const params = new URLSearchParams();
+  appendPaginationParams(params, pagination);
+
   const membersFetcher: Fetcher<GetMembersResponseBody> = fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
     `/api/w/${owner.sId}/members`,
@@ -18,6 +29,7 @@ export function useMembers(owner: LightWorkspaceType) {
     isMembersLoading: !error && !data,
     isMembersError: error,
     mutateMembers: mutate,
+    total: data ? data.total : 0,
   };
 }
 

--- a/front/lib/tracking/customerio/server.ts
+++ b/front/lib/tracking/customerio/server.ts
@@ -141,9 +141,10 @@ export class CustomerioServerSideTracking {
       return;
     }
 
-    const userMemberships = await MembershipResource.getLatestMemberships({
-      users: [u],
-    });
+    const { memberships: userMemberships } =
+      await MembershipResource.getLatestMemberships({
+        users: [u],
+      });
 
     const workspaces = _.keyBy(
       await Workspace.findAll({

--- a/front/migrations/20240513_backfill_customerio_delete_free_test.ts
+++ b/front/migrations/20240513_backfill_customerio_delete_free_test.ts
@@ -23,11 +23,11 @@ const backfillCustomerIo = async (execute: boolean) => {
         i + 1
       }/${chunks.length})`
     );
-    const membershipsByUserId = _.groupBy(
-      await MembershipResource.getLatestMemberships({
-        users: c.map((u) => u.toJSON()),
-      }),
-      (m) => m.userId.toString()
+    const { memberships } = await MembershipResource.getLatestMemberships({
+      users: c.map((u) => u.toJSON()),
+    });
+    const membershipsByUserId = _.groupBy(memberships, (m) =>
+      m.userId.toString()
     );
 
     const workspaceIds = Object.values(membershipsByUserId)

--- a/front/migrations/20240513_backfill_customerio_membership_timestamps.ts
+++ b/front/migrations/20240513_backfill_customerio_membership_timestamps.ts
@@ -59,9 +59,10 @@ const backfillCustomerIo = async (execute: boolean) => {
       continue;
     }
 
-    const workspaceMemberships = await MembershipResource.getLatestMemberships({
-      workspace: renderLightWorkspaceType({ workspace }),
-    });
+    const { memberships: workspaceMemberships } =
+      await MembershipResource.getLatestMemberships({
+        workspace: renderLightWorkspaceType({ workspace }),
+      });
     const userIds = workspaceMemberships.map((m) => m.userId);
     const users = await UserResource.fetchByModelIds(userIds);
 

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -153,7 +153,7 @@ async function handleEnterpriseSignUpFlow(
   workspace: Workspace | null;
 }> {
   // Combine queries to optimize database calls.
-  const [activeMemberships, workspace] = await Promise.all([
+  const [{ total }, workspace] = await Promise.all([
     MembershipResource.getActiveMemberships({
       users: [user],
     }),
@@ -165,7 +165,7 @@ async function handleEnterpriseSignUpFlow(
   ]);
 
   // Early return if user is already a member of a workspace.
-  if (activeMemberships.length !== 0) {
+  if (total !== 0) {
     return { flow: null, workspace: null };
   }
 
@@ -220,12 +220,13 @@ async function handleRegularSignupFlow(
     AuthFlowError | SSOEnforcedError
   >
 > {
-  const activeMemberships = await MembershipResource.getActiveMemberships({
-    users: [user],
-  });
+  const { memberships: activeMemberships, total } =
+    await MembershipResource.getActiveMemberships({
+      users: [user],
+    });
 
   // Return early if the user is already a member of a workspace and is not attempting to join another one.
-  if (activeMemberships.length !== 0 && !targetWorkspaceId) {
+  if (total !== 0 && !targetWorkspaceId) {
     return new Ok({
       flow: null,
       workspace: null,

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -181,10 +181,11 @@ async function handler(
           // We can have 2 users with the same email if a Google user and a Github user have the same email.
           const users = await UserResource.listByEmail(searchTerm);
           if (users.length) {
-            const memberships = await MembershipResource.getLatestMemberships({
-              users,
-            });
-            if (memberships.length) {
+            const { memberships, total } =
+              await MembershipResource.getLatestMemberships({
+                users,
+              });
+            if (total > 0) {
               conditions.push({
                 id: {
                   [Op.in]: memberships.map((m) => m.workspaceId),
@@ -296,12 +297,13 @@ async function handler(
             const dataSources = await DataSourceResource.listByWorkspace(auth);
             const dataSourcesCount = dataSources.length;
 
-            const admins = await MembershipResource.getActiveMemberships({
-              workspace: lightWorkspace,
-              roles: ["admin" as MembershipRoleType],
-            });
+            const { memberships: admins, total } =
+              await MembershipResource.getActiveMemberships({
+                workspace: lightWorkspace,
+                roles: ["admin" as MembershipRoleType],
+              });
 
-            const firstAdmin = admins.length
+            const firstAdmin = total
               ? await UserResource.fetchByModelId(
                   admins.sort(
                     (a, b) => a.createdAt.getTime() - b.createdAt.getTime()

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -357,9 +357,8 @@ async function handler(
               "Couldn't get owner or subscription from `auth`."
             );
           }
-          const adminEmails = (
-            await getMembers(auth, { roles: ["admin"] })
-          ).map((u) => u.email);
+          const { members } = await getMembers(auth, { roles: ["admin"] });
+          const adminEmails = members.map((u) => u.email);
           const customerEmail = invoice.customer_email;
           if (customerEmail && !adminEmails.includes(customerEmail)) {
             adminEmails.push(customerEmail);
@@ -487,9 +486,8 @@ async function handler(
             }
 
             // then email admins
-            const adminEmails = (
-              await getMembers(auth, { roles: ["admin"] })
-            ).map((u) => u.email);
+            const { members } = await getMembers(auth, { roles: ["admin"] });
+            const adminEmails = members.map((u) => u.email);
             if (adminEmails.length === 0) {
               return apiError(req, res, {
                 status_code: 500,

--- a/front/pages/api/v1/w/[wId]/members/emails.ts
+++ b/front/pages/api/v1/w/[wId]/members/emails.ts
@@ -43,7 +43,7 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const allMembers = await getMembers(workspaceAuth, {
+      const { members: allMembers } = await getMembers(workspaceAuth, {
         activeOnly: !!activeOnly,
       });
 

--- a/front/pages/api/w/[wId]/members/index.ts
+++ b/front/pages/api/w/[wId]/members/index.ts
@@ -11,6 +11,8 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
+const DEFAULT_PAGE_LIMIT = 50;
+
 export type GetMembersResponseBody = {
   members: UserTypeWithWorkspaces[];
   paginationParams: PaginationParams;
@@ -24,7 +26,7 @@ async function handler(
   switch (req.method) {
     case "GET":
       const paginationRes = getPaginationParams(req, {
-        defaultLimit: 1,
+        defaultLimit: DEFAULT_PAGE_LIMIT,
         defaultOrderColumn: "createdAt",
         defaultOrderDirection: "desc",
         supportedOrderColumn: ["createdAt"],

--- a/front/pages/api/w/[wId]/members/index.ts
+++ b/front/pages/api/w/[wId]/members/index.ts
@@ -4,7 +4,6 @@ import type {
 } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import type { PaginationParams } from "@app/lib/api/pagination";
 import { getPaginationParams } from "@app/lib/api/pagination";
 import { getMembers } from "@app/lib/api/workspace";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
@@ -15,7 +14,7 @@ const DEFAULT_PAGE_LIMIT = 50;
 
 export type GetMembersResponseBody = {
   members: UserTypeWithWorkspaces[];
-  paginationParams: PaginationParams;
+  total: number;
 };
 
 async function handler(
@@ -45,7 +44,7 @@ async function handler(
       const paginationParams = paginationRes.value;
 
       if (auth.isBuilder() && req.query.role && req.query.role === "admin") {
-        const members = await getMembers(
+        const { members, total } = await getMembers(
           auth,
           {
             roles: ["admin"],
@@ -54,11 +53,7 @@ async function handler(
         );
         res.status(200).json({
           members,
-          paginationParams: {
-            limit: paginationParams.limit,
-            orderColumn: paginationParams.orderColumn,
-            orderDirection: paginationParams.orderDirection,
-          },
+          total,
         });
         return;
       }
@@ -74,15 +69,11 @@ async function handler(
         });
       }
 
-      const members = await getMembers(auth, {}, paginationParams);
+      const { members, total } = await getMembers(auth, {}, paginationParams);
 
       res.status(200).json({
         members,
-        paginationParams: {
-          limit: paginationParams.limit,
-          orderColumn: paginationParams.orderColumn,
-          orderDirection: paginationParams.orderDirection,
-        },
+        total,
       });
       return;
 

--- a/front/pages/poke/[wId]/memberships.tsx
+++ b/front/pages/poke/[wId]/memberships.tsx
@@ -29,7 +29,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
     };
   }
 
-  const [members, pendingInvitations] = await Promise.all([
+  const [{ members }, pendingInvitations] = await Promise.all([
     getMembers(auth),
     getPendingInvitations(auth),
   ]);

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -510,7 +510,7 @@ export async function deleteMembersActivity({
       transaction: t,
     });
 
-    const memberships = await MembershipResource.getLatestMemberships({
+    const { memberships } = await MembershipResource.getLatestMemberships({
       workspace,
       transaction: t,
     });
@@ -518,12 +518,11 @@ export async function deleteMembersActivity({
     for (const membership of memberships) {
       const user = await UserResource.fetchByModelId(membership.userId, t);
       if (user) {
-        const membershipsOfUser = await MembershipResource.getLatestMemberships(
-          {
+        const { memberships: membershipsOfUser } =
+          await MembershipResource.getLatestMemberships({
             users: [user],
             transaction: t,
-          }
-        );
+          });
 
         // If the user we're removing the membership of only has one membership, we delete the user.
         if (membershipsOfUser.length === 1) {

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -186,22 +186,26 @@ async function cleanupCustomerio(auth: Authenticator) {
   }
 
   // Fetch all the memberships for the workspace.
-  const workspaceMemberships = await MembershipResource.getLatestMemberships({
-    workspace: w,
-  });
+  const { memberships: workspaceMemberships } =
+    await MembershipResource.getLatestMemberships({
+      workspace: w,
+    });
 
   // Fetch all the users in the workspace.
   const userIds = workspaceMemberships.map((m) => m.userId);
   const users = await UserResource.fetchByModelIds(userIds);
 
   // For each user, fetch all their memberships.
-  const allMembershipsByUserId = _.groupBy(
-    userIds.length
-      ? await MembershipResource.getLatestMemberships({
-          users,
-        })
-      : [],
-    (m) => m.userId.toString()
+  let latestMemberships: MembershipResource[] = [];
+  if (userIds.length) {
+    const { memberships } = await MembershipResource.getLatestMemberships({
+      users,
+    });
+    latestMemberships = memberships;
+  }
+
+  const allMembershipsByUserId = _.groupBy(latestMemberships, (m) =>
+    m.userId.toString()
   );
 
   // For every membership, fetch the workspace.

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -46,7 +46,7 @@ export async function sendDataDeletionEmail({
     if (!ws) {
       throw new Error("No workspace found");
     }
-    const admins = await getMembers(auth, { roles: ["admin"] });
+    const { members: admins } = await getMembers(auth, { roles: ["admin"] });
     for (const a of admins) {
       await sendAdminDataDeletionEmail({
         email: a.email,


### PR DESCRIPTION
## Description

This PR adds pagination functionality to the `getMembers` function in the workspace API. It modifies the `MembershipResource` class to support pagination parameters and updates the `/api/w/[wId]/members` endpoint to handle pagination requests.

**References:**
- https://github.com/dust-tt/dust/issues/7201

## Risk

Non negligible as it might affect an endpoint's behaviour

## Deploy Plan

Deploy `front`
