### PR TITLE
Remove cycles batch I

### DIFF
--- a/front/.eslintrc.js
+++ b/front/.eslintrc.js
@@ -7,6 +7,7 @@ module.exports = {
   ],
   plugins: ["import", "simple-import-sort"],
   rules: {
+    "import/no-cycle": "error",
     /**
     "@typescript-eslint/naming-convention": [
       "error",

--- a/front/.eslintrc.js
+++ b/front/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
   ],
   plugins: ["import", "simple-import-sort"],
   rules: {
-    "import/no-cycle": "error",
+    "import/no-cycle": "warn",
     /**
     "@typescript-eslint/naming-convention": [
       "error",

--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -53,7 +53,10 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
       const { systemGroup, globalGroup } =
         await GroupResource.makeDefaultsForWorkspace(lightWorkspace);
 
-      await VaultResource.makeDefaultsForWorkspace(lightWorkspace, {
+      const auth = await Authenticator.internalAdminForWorkspace(
+        lightWorkspace.sId
+      );
+      await VaultResource.makeDefaultsForWorkspace(auth, {
         systemGroup,
         globalGroup,
       });

--- a/front/components/app/RootLayout.tsx
+++ b/front/components/app/RootLayout.tsx
@@ -5,8 +5,8 @@ import type { MouseEvent } from "react";
 import type { UrlObject } from "url";
 
 import { ConfirmPopupArea } from "@app/components/Confirm";
-import { SidebarProvider } from "@app/components/sparkle/AppLayout";
 import { NotificationArea } from "@app/components/sparkle/Notification";
+import { SidebarProvider } from "@app/components/sparkle/SidebarContext";
 
 function NextLinkWrapper({
   href,

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -11,7 +11,7 @@ import { useRouter } from "next/router";
 import React, { useContext } from "react";
 
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
-import { SidebarContext } from "@app/components/sparkle/AppLayout";
+import { SidebarContext } from "@app/components/sparkle/SidebarContext";
 import { classNames } from "@app/lib/utils";
 
 type AssistantSidebarMenuProps = {

--- a/front/components/data_source/RequestDataSourceModal.tsx
+++ b/front/components/data_source/RequestDataSourceModal.tsx
@@ -11,9 +11,8 @@ import { useContext, useEffect, useState } from "react";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import {
   getConnectorProviderLogoWithFallback,
-  getDataSourceName,
 } from "@app/lib/connector_providers";
-import { isManaged } from "@app/lib/data_sources";
+import { getDataSourceName, isManaged } from "@app/lib/data_sources";
 import { sendRequestDataSourceEmail } from "@app/lib/email";
 import logger from "@app/logger/logger";
 

--- a/front/components/data_source/RequestDataSourceModal.tsx
+++ b/front/components/data_source/RequestDataSourceModal.tsx
@@ -9,9 +9,7 @@ import type { DataSourceType, LightWorkspaceType } from "@dust-tt/types";
 import { useContext, useEffect, useState } from "react";
 
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
-import {
-  getConnectorProviderLogoWithFallback,
-} from "@app/lib/connector_providers";
+import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { getDataSourceName, isManaged } from "@app/lib/data_sources";
 import { sendRequestDataSourceEmail } from "@app/lib/email";
 import logger from "@app/logger/logger";

--- a/front/components/navigation/Navigation.tsx
+++ b/front/components/navigation/Navigation.tsx
@@ -9,7 +9,7 @@ import {
   NavigationSidebar,
   ToggleNavigationSidebarButton,
 } from "@app/components/navigation/NavigationSidebar";
-import { SidebarContext } from "@app/components/sparkle/AppLayout";
+import { SidebarContext } from "@app/components/sparkle/SidebarContext";
 import { classNames } from "@app/lib/utils";
 
 interface NavigationProps {

--- a/front/components/sparkle/AppLayout.tsx
+++ b/front/components/sparkle/AppLayout.tsx
@@ -4,7 +4,7 @@ import Head from "next/head";
 import type { NextRouter } from "next/router";
 import { useRouter } from "next/router";
 import Script from "next/script";
-import React, { Fragment, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { HelpAndQuickGuideWrapper } from "@app/components/assistant/conversation/HelpAndQuickGuideWrapper";
@@ -19,30 +19,6 @@ import { classNames } from "@app/lib/utils";
  * IncidentBanner component at bottom of the page)
  */
 const SHOW_INCIDENT_BANNER = false;
-
-export const SidebarContext = React.createContext<{
-  sidebarOpen: boolean;
-  setSidebarOpen: (value: boolean) => void;
-}>({
-  sidebarOpen: false,
-  setSidebarOpen: (value) => {
-    throw new Error("SidebarContext not initialized: " + value);
-  },
-});
-
-export const SidebarProvider = ({
-  children,
-}: {
-  children: React.ReactNode;
-}) => {
-  const [sidebarOpen, setSidebarOpen] = useState(false);
-
-  return (
-    <SidebarContext.Provider value={{ sidebarOpen, setSidebarOpen }}>
-      {children}
-    </SidebarContext.Provider>
-  );
-};
 
 // This function is used to navigate back to the previous page (eg modal like page close) and
 // fallback to the landing if we linked directly to that modal.

--- a/front/components/sparkle/SidebarContext.tsx
+++ b/front/components/sparkle/SidebarContext.tsx
@@ -1,0 +1,25 @@
+import React, { useState } from "react";
+
+export const SidebarContext = React.createContext<{
+  sidebarOpen: boolean;
+  setSidebarOpen: (value: boolean) => void;
+}>({
+  sidebarOpen: false,
+  setSidebarOpen: (value) => {
+    throw new Error("SidebarContext not initialized: " + value);
+  },
+});
+
+export const SidebarProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  return (
+    <SidebarContext.Provider value={{ sidebarOpen, setSidebarOpen }}>
+      {children}
+    </SidebarContext.Provider>
+  );
+};

--- a/front/components/vaults/ContentActions.tsx
+++ b/front/components/vaults/ContentActions.tsx
@@ -19,8 +19,7 @@ import { DocumentOrTableDeleteDialog } from "@app/components/data_source/Documen
 import { DocumentOrTableUploadOrEditModal } from "@app/components/data_source/DocumentOrTableUploadOrEditModal";
 import { MultipleDocumentsUpload } from "@app/components/data_source/MultipleDocumentsUpload";
 import DataSourceViewDocumentModal from "@app/components/DataSourceViewDocumentModal";
-import { getDataSourceName } from "@app/lib/connector_providers";
-import { isFolder, isWebsite } from "@app/lib/data_sources";
+import { getDataSourceName, isFolder, isWebsite } from "@app/lib/data_sources";
 
 export type ContentActionKey =
   | "DocumentUploadOrEdit"

--- a/front/components/vaults/VaultLayout.tsx
+++ b/front/components/vaults/VaultLayout.tsx
@@ -14,10 +14,8 @@ import AppLayout from "@app/components/sparkle/AppLayout";
 import { CreateVaultModal } from "@app/components/vaults/CreateVaultModal";
 import { CATEGORY_DETAILS } from "@app/components/vaults/VaultCategoriesList";
 import VaultSideBarMenu from "@app/components/vaults/VaultSideBarMenu";
-import {
-  getConnectorProviderLogoWithFallback,
-  getDataSourceNameFromView,
-} from "@app/lib/connector_providers";
+import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
+import { getDataSourceNameFromView } from "@app/lib/data_sources";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import { getVaultIcon } from "@app/lib/vaults";
 

--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -45,10 +45,8 @@ import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { AddConnectionMenu } from "@app/components/vaults/AddConnectionMenu";
 import { EditVaultManagedDataSourcesViews } from "@app/components/vaults/EditVaultManagedDatasourcesViews";
 import { EditVaultStaticDatasourcesViews } from "@app/components/vaults/EditVaultStaticDatasourcesViews";
-import {
-  getConnectorProviderLogoWithFallback,
-  getDataSourceNameFromView,
-} from "@app/lib/connector_providers";
+import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
+import { getDataSourceNameFromView } from "@app/lib/data_sources";
 import { useDataSources } from "@app/lib/swr/data_sources";
 import { useVaultDataSourceViews } from "@app/lib/swr/vaults";
 import { classNames } from "@app/lib/utils";

--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -42,7 +42,10 @@ import { DataSourceEditionModal } from "@app/components/data_source/DataSourceEd
 import ConnectorSyncingChip from "@app/components/data_source/DataSourceSyncChip";
 import { DeleteStaticDataSourceDialog } from "@app/components/data_source/DeleteStaticDataSourceDialog";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
-import { AddConnectionMenu } from "@app/components/vaults/AddConnectionMenu";
+import {
+  AddConnectionMenu,
+  setupConnection,
+} from "@app/components/vaults/AddConnectionMenu";
 import { EditVaultManagedDataSourcesViews } from "@app/components/vaults/EditVaultManagedDatasourcesViews";
 import { EditVaultStaticDatasourcesViews } from "@app/components/vaults/EditVaultStaticDatasourcesViews";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
@@ -50,7 +53,6 @@ import { getDataSourceNameFromView } from "@app/lib/data_sources";
 import { useDataSources } from "@app/lib/swr/data_sources";
 import { useVaultDataSourceViews } from "@app/lib/swr/vaults";
 import { classNames } from "@app/lib/utils";
-import { setupConnection } from "@app/pages/w/[wId]/builder/data-sources/managed";
 
 const REDIRECT_TO_EDIT_PERMISSIONS = [
   "confluence",

--- a/front/components/vaults/VaultSideBarMenu.tsx
+++ b/front/components/vaults/VaultSideBarMenu.tsx
@@ -22,10 +22,8 @@ import { useRouter } from "next/router";
 import type { ComponentType, ReactElement } from "react";
 import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
 
-import {
-  getConnectorProviderLogoWithFallback,
-  getDataSourceNameFromView,
-} from "@app/lib/connector_providers";
+import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
+import { getDataSourceNameFromView } from "@app/lib/data_sources";
 import { useApps } from "@app/lib/swr/apps";
 import {
   useVaultDataSourceViews,

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -92,6 +92,10 @@ async function getDataSourcesAndWorkspaceIdForGlobalAgents(
 }> {
   const owner = auth.getNonNullableWorkspace();
 
+  // const { VaultResource } = await import("@app/lib/resources/vault_resource");
+  // const { DataSourceViewResource } = await import(
+  //   "@app/lib/resources/data_source_view_resource"
+  // );
   const defaultVaults = [await VaultResource.fetchWorkspaceGlobalVault(auth)];
   const dataSourceViews = await DataSourceViewResource.listByVaults(
     auth,

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -92,10 +92,6 @@ async function getDataSourcesAndWorkspaceIdForGlobalAgents(
 }> {
   const owner = auth.getNonNullableWorkspace();
 
-  // const { VaultResource } = await import("@app/lib/resources/vault_resource");
-  // const { DataSourceViewResource } = await import(
-  //   "@app/lib/resources/data_source_view_resource"
-  // );
   const defaultVaults = [await VaultResource.fetchWorkspaceGlobalVault(auth)];
   const dataSourceViews = await DataSourceViewResource.listByVaults(
     auth,

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -23,23 +23,19 @@ import {
   Ok,
   WHITELISTABLE_FEATURES,
 } from "@dust-tt/types";
-import * as _ from "lodash";
 import type {
   GetServerSidePropsContext,
   NextApiRequest,
   NextApiResponse,
 } from "next";
 
+import config from "@app/lib/api/config";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { isValidSession } from "@app/lib/iam/provider";
 import { FeatureFlag } from "@app/lib/models/feature_flag";
-import { Plan, Subscription } from "@app/lib/models/plan";
 import { Workspace } from "@app/lib/models/workspace";
-import type { PlanAttributes } from "@app/lib/plans/free_plans";
-import { FREE_NO_PLAN_DATA } from "@app/lib/plans/free_plans";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
-import { renderSubscriptionFromModels } from "@app/lib/plans/subscription";
-import { getTrialVersionForPlan, isTrial } from "@app/lib/plans/trial";
+import { subscriptionForWorkspace } from "@app/lib/plans/subscription";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import type { KeyAuthType } from "@app/lib/resources/key_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
@@ -48,7 +44,6 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 
-import config from "./api/config";
 const { ACTIVATE_ALL_FEATURES_DEV = false } = process.env;
 
 const DUST_INTERNAL_EMAIL_REGEXP = /^[^@]+@dust\.tt$/;
@@ -750,100 +745,6 @@ export async function getAPIKey(
   }
 
   return new Ok(key);
-}
-
-/**
- * Construct the SubscriptionType for the provided workspace.
- * @param w WorkspaceType the workspace to get the plan for
- * @returns SubscriptionType
- */
-export async function subscriptionForWorkspace(
-  workspace: LightWorkspaceType
-): Promise<SubscriptionType> {
-  const res = await subscriptionForWorkspaces([workspace]);
-
-  const subscription = res[workspace.sId];
-  if (!subscription) {
-    throw new Error(
-      `Could not find subscription for workspace ${workspace.sId}`
-    );
-  }
-
-  return subscription;
-}
-
-/**
- * Construct the SubscriptionType for the provided workspaces.
- * @param w WorkspaceType the workspace to get the plan for
- * @returns SubscriptionType
- */
-export async function subscriptionForWorkspaces(
-  workspaces: LightWorkspaceType[]
-): Promise<{ [key: string]: SubscriptionType }> {
-  const workspaceModelBySid = _.keyBy(workspaces, "sId");
-
-  const activeSubscriptionByWorkspaceId = _.keyBy(
-    await Subscription.findAll({
-      attributes: [
-        "endDate",
-        "id",
-        "paymentFailingSince",
-        "sId",
-        "startDate",
-        "status",
-        "stripeSubscriptionId",
-        "trialing",
-        "workspaceId",
-      ],
-      where: {
-        workspaceId: Object.values(workspaceModelBySid).map((w) => w.id),
-        status: "active",
-      },
-      include: [
-        {
-          model: Plan,
-          as: "plan",
-          required: true,
-        },
-      ],
-    }),
-    "workspaceId"
-  );
-
-  const renderedSubscriptionByWorkspaceSid: Record<string, SubscriptionType> =
-    {};
-
-  for (const [sId, workspace] of Object.entries(workspaceModelBySid)) {
-    const activeSubscription =
-      activeSubscriptionByWorkspaceId[workspace.id.toString()];
-
-    // Default values when no subscription
-    let plan: PlanAttributes = FREE_NO_PLAN_DATA;
-
-    if (activeSubscription) {
-      // If the subscription is in trial, temporarily override the plan until the FREE_TEST_PLAN is phased out.
-      if (isTrial(activeSubscription)) {
-        plan = getTrialVersionForPlan(activeSubscription.plan);
-      } else if (activeSubscription.plan) {
-        plan = activeSubscription.plan;
-      } else {
-        logger.error(
-          {
-            workspaceId: sId,
-            activeSubscription,
-          },
-          "Cannot find plan for active subscription. Will use limits of FREE_TEST_PLAN instead. Please check and fix."
-        );
-      }
-    }
-
-    renderedSubscriptionByWorkspaceSid[sId] = renderSubscriptionFromModels({
-      plan,
-      activeSubscription,
-    });
-  }
-
-  return renderedSubscriptionByWorkspaceSid;
 }
 
 /**

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -11,15 +11,11 @@ import {
 } from "@dust-tt/sparkle";
 import type {
   ConnectorProvider,
-  DataSourceType,
-  DataSourceViewType,
   PlanType,
   WhitelistableFeature,
 } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
 import type { ComponentType } from "react";
-
-import { isManaged } from "@app/lib/data_sources";
 
 export type ConnectorProviderConfiguration = {
   name: string;
@@ -148,18 +144,6 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     isSearchEnabled: false,
   },
 };
-
-export function getDataSourceNameFromView(dsv: DataSourceViewType): string {
-  return getDataSourceName(dsv.dataSource);
-}
-
-export function getDataSourceName(ds: DataSourceType): string {
-  if (isManaged(ds)) {
-    return CONNECTOR_CONFIGURATIONS[ds.connectorProvider].name;
-  }
-
-  return ds.name;
-}
 
 export function getConnectorProviderLogoWithFallback(
   provider: ConnectorProvider | null,

--- a/front/lib/data_sources.ts
+++ b/front/lib/data_sources.ts
@@ -3,6 +3,7 @@ import type {
   ContentNodesViewType,
   CoreAPIDocument,
   DataSourceType,
+  DataSourceViewType,
   WithConnector,
 } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
@@ -84,4 +85,16 @@ export function canBeExpanded(
   // Folders with viewType "documents" are always considered leaf items.
   // For viewType "tables", folders are not leaf items because users need to select a specific table.
   return !isFolder(ds) || viewType === "tables";
+}
+
+export function getDataSourceNameFromView(dsv: DataSourceViewType): string {
+  return getDataSourceName(dsv.dataSource);
+}
+
+export function getDataSourceName(ds: DataSourceType): string {
+  if (isManaged(ds)) {
+    return CONNECTOR_CONFIGURATIONS[ds.connectorProvider].name;
+  }
+
+  return ds.name;
 }

--- a/front/lib/iam/errors.ts
+++ b/front/lib/iam/errors.ts
@@ -11,6 +11,7 @@ type AuthFlowErrorCodeType =
   | "invalid_invitation_token"
   | "invitation_token_email_mismatch"
   | "invalid_domain"
+  | "membership_update_error"
   | "revoked";
 
 export class AuthFlowError extends Error {

--- a/front/lib/iam/workspaces.ts
+++ b/front/lib/iam/workspaces.ts
@@ -1,5 +1,6 @@
 import { sendUserOperationMessage } from "@dust-tt/types";
 
+import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { Workspace, WorkspaceHasDomain } from "@app/lib/models/workspace";
 import { GroupResource } from "@app/lib/resources/group_resource";
@@ -44,7 +45,10 @@ export async function createWorkspaceInternal({
   const { systemGroup, globalGroup } =
     await GroupResource.makeDefaultsForWorkspace(lightWorkspace);
 
-  await VaultResource.makeDefaultsForWorkspace(lightWorkspace, {
+  const auth = await Authenticator.internalAdminForWorkspace(
+    lightWorkspace.sId
+  );
+  await VaultResource.makeDefaultsForWorkspace(auth, {
     systemGroup,
     globalGroup,
   });

--- a/front/lib/plans/renderers.ts
+++ b/front/lib/plans/renderers.ts
@@ -1,7 +1,4 @@
-import type {
-  PlanType,
-  SubscriptionType,
-} from "@dust-tt/types";
+import type { PlanType, SubscriptionType } from "@dust-tt/types";
 
 import type { Subscription } from "@app/lib/models/plan";
 import type { PlanAttributes } from "@app/lib/plans/free_plans";

--- a/front/lib/plans/renderers.ts
+++ b/front/lib/plans/renderers.ts
@@ -1,0 +1,70 @@
+import type {
+  PlanType,
+  SubscriptionType,
+} from "@dust-tt/types";
+
+import type { Subscription } from "@app/lib/models/plan";
+import type { PlanAttributes } from "@app/lib/plans/free_plans";
+
+// Helper function to render PlanType from PlanAttributes
+export function renderPlanFromModel({
+  plan,
+}: {
+  plan: PlanAttributes;
+}): PlanType {
+  return {
+    code: plan.code,
+    name: plan.name,
+    limits: {
+      assistant: {
+        isSlackBotAllowed: plan.isSlackbotAllowed,
+        maxMessages: plan.maxMessages,
+        maxMessagesTimeframe: plan.maxMessagesTimeframe,
+      },
+      connections: {
+        isConfluenceAllowed: plan.isManagedConfluenceAllowed,
+        isSlackAllowed: plan.isManagedSlackAllowed,
+        isNotionAllowed: plan.isManagedNotionAllowed,
+        isGoogleDriveAllowed: plan.isManagedGoogleDriveAllowed,
+        isGithubAllowed: plan.isManagedGithubAllowed,
+        isIntercomAllowed: plan.isManagedIntercomAllowed,
+        isWebCrawlerAllowed: plan.isManagedWebCrawlerAllowed,
+      },
+      dataSources: {
+        count: plan.maxDataSourcesCount,
+        documents: {
+          count: plan.maxDataSourcesDocumentsCount,
+          sizeMb: plan.maxDataSourcesDocumentsSizeMb,
+        },
+      },
+      users: {
+        maxUsers: plan.maxUsersInWorkspace,
+      },
+      canUseProduct: plan.canUseProduct,
+    },
+    trialPeriodDays: plan.trialPeriodDays,
+  };
+}
+
+// Helper in charge of rendering the SubscriptionType object form PlanAttributes and optionally an
+// active Subscription model.
+export function renderSubscriptionFromModels({
+  plan,
+  activeSubscription,
+}: {
+  plan: PlanAttributes;
+  activeSubscription: Subscription | null;
+}): SubscriptionType {
+  return {
+    status: activeSubscription?.status ?? "active",
+    trialing: activeSubscription?.trialing === true,
+    sId: activeSubscription?.sId || null,
+    stripeSubscriptionId: activeSubscription?.stripeSubscriptionId || null,
+    startDate: activeSubscription?.startDate?.getTime() || null,
+    endDate: activeSubscription?.endDate?.getTime() || null,
+    paymentFailingSince:
+      activeSubscription?.paymentFailingSince?.getTime() || null,
+    plan: renderPlanFromModel({ plan }),
+    requestCancelAt: activeSubscription?.requestCancelAt?.getTime() ?? null,
+  };
+}

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -444,3 +444,15 @@ export function assertStripeSubscriptionItemIsValid({
 
   return new Ok(true);
 }
+
+export async function reportActiveSeats(
+  stripeSubscriptionItem: Stripe.SubscriptionItem,
+  workspace: LightWorkspaceType
+): Promise<void> {
+  const activeSeats = await countActiveSeatsInWorkspace(workspace.sId);
+
+  await updateStripeQuantityForSubscriptionItem(
+    stripeSubscriptionItem,
+    activeSeats
+  );
+}

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -1,4 +1,9 @@
-import type { BillingPeriod, LightWorkspaceType, Result, WorkspaceType } from "@dust-tt/types";
+import type {
+  BillingPeriod,
+  LightWorkspaceType,
+  Result,
+  WorkspaceType,
+} from "@dust-tt/types";
 import type { SubscriptionType } from "@dust-tt/types";
 import { Err, isDevelopment, Ok } from "@dust-tt/types";
 import { Stripe } from "stripe";

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -1,4 +1,4 @@
-import type { BillingPeriod, Result, WorkspaceType } from "@dust-tt/types";
+import type { BillingPeriod, LightWorkspaceType, Result, WorkspaceType } from "@dust-tt/types";
 import type { SubscriptionType } from "@dust-tt/types";
 import { Err, isDevelopment, Ok } from "@dust-tt/types";
 import { Stripe } from "stripe";

--- a/front/lib/plans/usage/index.ts
+++ b/front/lib/plans/usage/index.ts
@@ -2,8 +2,8 @@ import type { LightWorkspaceType, Result } from "@dust-tt/types";
 import { assertNever, Err, Ok } from "@dust-tt/types";
 import type Stripe from "stripe";
 
+import { reportActiveSeats } from "@app/lib/plans/stripe";
 import { reportMonthlyActiveUsers } from "@app/lib/plans/usage/mau";
-import { reportActiveSeats } from "@app/lib/plans/usage/seats";
 import type {
   InvalidRecurringPriceError,
   SupportedReportUsage,

--- a/front/lib/plans/usage/seats.ts
+++ b/front/lib/plans/usage/seats.ts
@@ -1,9 +1,6 @@
-import type { LightWorkspaceType } from "@dust-tt/types";
 import { cacheWithRedis } from "@dust-tt/types";
-import type Stripe from "stripe";
 
 import { Workspace } from "@app/lib/models/workspace";
-import { updateStripeQuantityForSubscriptionItem } from "@app/lib/plans/stripe";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 
@@ -33,14 +30,3 @@ export const countActiveSeatsInWorkspaceCached = cacheWithRedis(
   60 * 10 * 1000 // 10 minutes
 );
 
-export async function reportActiveSeats(
-  stripeSubscriptionItem: Stripe.SubscriptionItem,
-  workspace: LightWorkspaceType
-): Promise<void> {
-  const activeSeats = await countActiveSeatsInWorkspace(workspace.sId);
-
-  await updateStripeQuantityForSubscriptionItem(
-    stripeSubscriptionItem,
-    activeSeats
-  );
-}

--- a/front/lib/plans/usage/seats.ts
+++ b/front/lib/plans/usage/seats.ts
@@ -29,4 +29,3 @@ export const countActiveSeatsInWorkspaceCached = cacheWithRedis(
   },
   60 * 10 * 1000 // 10 minutes
 );
-

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -435,4 +435,3 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
     };
   }
 }
-

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -435,3 +435,4 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
     };
   }
 }
+

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -247,7 +247,9 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     });
   }
 
-  // Caller of this method should call `ServerSideTracking.trackCreateMembership`.
+  /**
+   * Caller of this method should call `ServerSideTracking.trackCreateMembership`.
+   */
   static async createMembership({
     user,
     workspace,
@@ -293,7 +295,9 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     return new MembershipResource(MembershipModel, newMembership.get());
   }
 
-  // Caller of this method should call `ServerSideTracking.trackRevokeMembership`.
+  /**
+   * Caller of this method should call `ServerSideTracking.trackRevokeMembership`.
+   */
   static async revokeMembership({
     user,
     workspace,
@@ -338,7 +342,9 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     });
   }
 
-  // Caller of this method should call `ServerSideTracking.trackUpdateMembershipRole`.
+  /**
+   * Caller of this method should call `ServerSideTracking.trackUpdateMembershipRole`.
+   */
   static async updateMembershipRole({
     user,
     workspace,
@@ -415,7 +421,6 @@ export class MembershipResource extends BaseResource<MembershipModel> {
         { role: newRole },
         { where: { id: membership.id }, transaction }
       );
-      Object.assign(membership, { role: newRole });
     } else {
       // If the last membership was terminated, we create a new membership with the new role.
       await this.createMembership({

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -1,6 +1,5 @@
 import type {
   ACLType,
-  LightWorkspaceType,
   ModelId,
   Result,
   VaultType,
@@ -16,7 +15,7 @@ import type {
 } from "sequelize";
 import { Op } from "sequelize";
 
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
@@ -62,7 +61,7 @@ export class VaultResource extends BaseResource<VaultModel> {
   }
 
   static async makeDefaultsForWorkspace(
-    workspace: LightWorkspaceType,
+    auth: Authenticator,
     {
       systemGroup,
       globalGroup,
@@ -71,16 +70,14 @@ export class VaultResource extends BaseResource<VaultModel> {
       globalGroup: GroupResource;
     }
   ) {
-    const existingVaults = await this.listWorkspaceDefaultVaults(
-      await Authenticator.internalAdminForWorkspace(workspace.sId)
-    );
+    const existingVaults = await this.listWorkspaceDefaultVaults(auth);
     const systemVault =
       existingVaults.find((v) => v.kind === "system") ||
       (await VaultResource.makeNew(
         {
           name: "System",
           kind: "system",
-          workspaceId: workspace.id,
+          workspaceId: auth.getNonNullableWorkspace().id,
         },
         systemGroup
       ));
@@ -91,7 +88,7 @@ export class VaultResource extends BaseResource<VaultModel> {
         {
           name: "Workspace",
           kind: "global",
-          workspaceId: workspace.id,
+          workspaceId: auth.getNonNullableWorkspace().id,
         },
         globalGroup
       ));

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -1,3 +1,5 @@
+import assert from "node:assert";
+
 import type { ACLType, ModelId, Result, VaultType } from "@dust-tt/types";
 import { assertNever, Ok } from "@dust-tt/types";
 import type {
@@ -65,6 +67,8 @@ export class VaultResource extends BaseResource<VaultModel> {
       globalGroup: GroupResource;
     }
   ) {
+    assert(auth.isAdmin(), "Only admins can call `makeDefaultsForWorkspace`");
+
     const existingVaults = await this.listWorkspaceDefaultVaults(auth);
     const systemVault =
       existingVaults.find((v) => v.kind === "system") ||

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -1,9 +1,4 @@
-import type {
-  ACLType,
-  ModelId,
-  Result,
-  VaultType,
-} from "@dust-tt/types";
+import type { ACLType, ModelId, Result, VaultType } from "@dust-tt/types";
 import { assertNever, Ok } from "@dust-tt/types";
 import type {
   Attributes,

--- a/front/lib/tracking/customerio/server.ts
+++ b/front/lib/tracking/customerio/server.ts
@@ -7,8 +7,8 @@ import { rateLimiter } from "@dust-tt/types";
 import * as _ from "lodash";
 
 import config from "@app/lib/api/config";
-import { subscriptionForWorkspace } from "@app/lib/auth";
 import { Workspace } from "@app/lib/models/workspace";
+import { subscriptionForWorkspace } from "@app/lib/plans/subscription";
 import { countActiveSeatsInWorkspaceCached } from "@app/lib/plans/usage/seats";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";

--- a/front/lib/tracking/server.ts
+++ b/front/lib/tracking/server.ts
@@ -11,8 +11,8 @@ import type {
 } from "@dust-tt/types";
 import * as _ from "lodash";
 
-import { subscriptionForWorkspaces } from "@app/lib/auth";
 import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
+import { subscriptionForWorkspaces } from "@app/lib/plans/subscription";
 import { countActiveSeatsInWorkspaceCached } from "@app/lib/plans/usage/seats";
 import { AmplitudeServerSideTracking } from "@app/lib/tracking/amplitude/server";
 import { CustomerioServerSideTracking } from "@app/lib/tracking/customerio/server";
@@ -110,7 +110,7 @@ export class ServerSideTracking {
     }
   }
 
-  static async trackUserMessage({
+  static trackUserMessage({
     userMessage,
     workspace,
     userId,
@@ -124,7 +124,7 @@ export class ServerSideTracking {
     agentMessages: AgentMessageType[];
   }) {
     try {
-      await AmplitudeServerSideTracking.trackUserMessage({
+      AmplitudeServerSideTracking.trackUserMessage({
         userMessage,
         workspace,
         userId,
@@ -139,7 +139,7 @@ export class ServerSideTracking {
     }
   }
 
-  static async trackDataSourceCreated({
+  static trackDataSourceCreated({
     user,
     workspace,
     dataSource,
@@ -149,7 +149,7 @@ export class ServerSideTracking {
     dataSource: DataSourceType;
   }) {
     try {
-      await AmplitudeServerSideTracking.trackDataSourceCreated({
+      AmplitudeServerSideTracking.trackDataSourceCreated({
         user,
         workspace,
         dataSource,
@@ -162,7 +162,7 @@ export class ServerSideTracking {
     }
   }
 
-  static async trackDataSourceUpdated({
+  static trackDataSourceUpdated({
     user,
     workspace,
     dataSource,
@@ -172,7 +172,7 @@ export class ServerSideTracking {
     dataSource: DataSourceType;
   }) {
     try {
-      await AmplitudeServerSideTracking.trackDataSourceUpdated({
+      AmplitudeServerSideTracking.trackDataSourceUpdated({
         user,
         workspace,
         dataSource,
@@ -185,7 +185,7 @@ export class ServerSideTracking {
     }
   }
 
-  static async trackAssistantCreated({
+  static trackAssistantCreated({
     user,
     workspace,
     assistant,
@@ -195,7 +195,7 @@ export class ServerSideTracking {
     assistant: AgentConfigurationType;
   }) {
     try {
-      await AmplitudeServerSideTracking.trackAssistantCreated({
+      AmplitudeServerSideTracking.trackAssistantCreated({
         user,
         workspace,
         assistant,

--- a/front/migrations/20240513_backfill_customerio_delete_free_test.ts
+++ b/front/migrations/20240513_backfill_customerio_delete_free_test.ts
@@ -1,10 +1,10 @@
 import { removeNulls } from "@dust-tt/types";
 import * as _ from "lodash";
 
-import { subscriptionForWorkspaces } from "@app/lib/auth";
 import { User } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
 import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
+import {subscriptionForWorkspaces} from "@app/lib/plans/subscription";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { CustomerioServerSideTracking } from "@app/lib/tracking/customerio/server";

--- a/front/migrations/20240513_backfill_customerio_delete_free_test.ts
+++ b/front/migrations/20240513_backfill_customerio_delete_free_test.ts
@@ -4,7 +4,7 @@ import * as _ from "lodash";
 import { User } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
 import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
-import {subscriptionForWorkspaces} from "@app/lib/plans/subscription";
+import { subscriptionForWorkspaces } from "@app/lib/plans/subscription";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { CustomerioServerSideTracking } from "@app/lib/tracking/customerio/server";

--- a/front/migrations/20240726_vault_backfill.ts
+++ b/front/migrations/20240726_vault_backfill.ts
@@ -1,94 +1,94 @@
-import _ from "lodash";
-import { Op } from "sequelize";
-
-import { Authenticator } from "@app/lib/auth";
-import { Workspace } from "@app/lib/models/workspace";
-import { GroupResource } from "@app/lib/resources/group_resource";
-import { DataSource } from "@app/lib/resources/storage/models/data_source";
-import { VaultResource } from "@app/lib/resources/vault_resource";
-import { renderLightWorkspaceType } from "@app/lib/workspace";
-import { makeScript } from "@app/scripts/helpers";
-
-async function backfillWorkspacesGroup(execute: boolean) {
-  const workspaces = await Workspace.findAll();
-
-  const chunks = _.chunk(workspaces, 16);
-  for (const [i, c] of chunks.entries()) {
-    console.log(
-      `[execute=${execute}] Processing chunk of ${c.length} workspaces... (${
-        i + 1
-      }/${chunks.length})`
-    );
-    if (execute) {
-      await Promise.all(
-        c.map((w) =>
-          (async () => {
-            try {
-              const auth = await Authenticator.internalAdminForWorkspace(w.sId);
-              const systemGroup =
-                await GroupResource.fetchWorkspaceSystemGroup(auth);
-              const globalGroup =
-                await GroupResource.fetchWorkspaceGlobalGroup(auth);
-              if (systemGroup.isErr() || globalGroup.isErr()) {
-                throw new Error("System or global group not found.");
-              }
-              const { systemVault, globalVault } =
-                await VaultResource.makeDefaultsForWorkspace(
-                  renderLightWorkspaceType({ workspace: w }),
-                  {
-                    systemGroup: systemGroup.value,
-                    globalGroup: globalGroup.value,
-                  }
-                );
-              // Move connected (non webcrawler) to system vault
-              await DataSource.update(
-                { vaultId: systemVault.id },
-                {
-                  where: {
-                    workspaceId: w.id,
-                    connectorId: {
-                      [Op.ne]: null,
-                    },
-                    connectorProvider: {
-                      [Op.ne]: "webcrawler",
-                    },
-                  },
-                }
-              );
-              // Move non-connected to global vault
-              await DataSource.update(
-                { vaultId: globalVault.id },
-                {
-                  where: {
-                    workspaceId: w.id,
-                    connectorId: {
-                      [Op.eq]: null,
-                    },
-                  },
-                }
-              );
-              // Move webcrawler to global vault
-              await DataSource.update(
-                { vaultId: globalVault.id },
-                {
-                  where: {
-                    workspaceId: w.id,
-                    connectorProvider: "webcrawler",
-                  },
-                }
-              );
-            } catch (error) {
-              console.error(error);
-            }
-          })()
-        )
-      );
-    }
-  }
-
-  console.log(`Done.`);
-}
-
-makeScript({}, async ({ execute }) => {
-  await backfillWorkspacesGroup(execute);
-});
+// import _ from "lodash";
+// import { Op } from "sequelize";
+//
+// import { Authenticator } from "@app/lib/auth";
+// import { Workspace } from "@app/lib/models/workspace";
+// import { GroupResource } from "@app/lib/resources/group_resource";
+// import { DataSource } from "@app/lib/resources/storage/models/data_source";
+// import { VaultResource } from "@app/lib/resources/vault_resource";
+// import { renderLightWorkspaceType } from "@app/lib/workspace";
+// import { makeScript } from "@app/scripts/helpers";
+//
+// async function backfillWorkspacesGroup(execute: boolean) {
+//   const workspaces = await Workspace.findAll();
+//
+//   const chunks = _.chunk(workspaces, 16);
+//   for (const [i, c] of chunks.entries()) {
+//     console.log(
+//       `[execute=${execute}] Processing chunk of ${c.length} workspaces... (${
+//         i + 1
+//       }/${chunks.length})`
+//     );
+//     if (execute) {
+//       await Promise.all(
+//         c.map((w) =>
+//           (async () => {
+//             try {
+//               const auth = await Authenticator.internalAdminForWorkspace(w.sId);
+//               const systemGroup =
+//                 await GroupResource.fetchWorkspaceSystemGroup(auth);
+//               const globalGroup =
+//                 await GroupResource.fetchWorkspaceGlobalGroup(auth);
+//               if (systemGroup.isErr() || globalGroup.isErr()) {
+//                 throw new Error("System or global group not found.");
+//               }
+//               const { systemVault, globalVault } =
+//                 await VaultResource.makeDefaultsForWorkspace(
+//                   renderLightWorkspaceType({ workspace: w }),
+//                   {
+//                     systemGroup: systemGroup.value,
+//                     globalGroup: globalGroup.value,
+//                   }
+//                 );
+//               // Move connected (non webcrawler) to system vault
+//               await DataSource.update(
+//                 { vaultId: systemVault.id },
+//                 {
+//                   where: {
+//                     workspaceId: w.id,
+//                     connectorId: {
+//                       [Op.ne]: null,
+//                     },
+//                     connectorProvider: {
+//                       [Op.ne]: "webcrawler",
+//                     },
+//                   },
+//                 }
+//               );
+//               // Move non-connected to global vault
+//               await DataSource.update(
+//                 { vaultId: globalVault.id },
+//                 {
+//                   where: {
+//                     workspaceId: w.id,
+//                     connectorId: {
+//                       [Op.eq]: null,
+//                     },
+//                   },
+//                 }
+//               );
+//               // Move webcrawler to global vault
+//               await DataSource.update(
+//                 { vaultId: globalVault.id },
+//                 {
+//                   where: {
+//                     workspaceId: w.id,
+//                     connectorProvider: "webcrawler",
+//                   },
+//                 }
+//               );
+//             } catch (error) {
+//               console.error(error);
+//             }
+//           })()
+//         )
+//       );
+//     }
+//   }
+//
+//   console.log(`Done.`);
+// }
+//
+// makeScript({}, async ({ execute }) => {
+//   await backfillWorkspacesGroup(execute);
+// });

--- a/front/pages/api/poke/plans.ts
+++ b/front/pages/api/poke/plans.ts
@@ -7,7 +7,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { Plan } from "@app/lib/models/plan";
-import { renderPlanFromModel } from "@app/lib/plans/subscription";
+import { renderPlanFromModel } from "@app/lib/plans/renderers";
 import { apiError } from "@app/logger/withlogging";
 
 export const PlanTypeSchema = t.type({

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -22,7 +22,7 @@ import {
   isOldFreePlan,
   isProPlan,
 } from "@app/lib/plans/plan_codes";
-import { renderSubscriptionFromModels } from "@app/lib/plans/subscription";
+import { renderSubscriptionFromModels } from "@app/lib/plans/renderers";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -37,7 +37,7 @@ import { useSubmitFunction } from "@app/lib/client/utils";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { Plan, Subscription } from "@app/lib/models/plan";
 import { FREE_NO_PLAN_CODE } from "@app/lib/plans/plan_codes";
-import { renderSubscriptionFromModels } from "@app/lib/plans/subscription";
+import { renderSubscriptionFromModels } from "@app/lib/plans/renderers";
 import { DustProdActionRegistry } from "@app/lib/registry";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{

--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -48,6 +48,7 @@ import { subNavigationBuild } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
+import {setupConnection} from "@app/components/vaults/AddConnectionMenu";
 import config from "@app/lib/api/config";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { handleFileUploadToText } from "@app/lib/client/handle_file_upload";
@@ -62,8 +63,6 @@ import {
 import { ClientSideTracking } from "@app/lib/tracking/client";
 import { timeAgoFrom } from "@app/lib/utils";
 import logger from "@app/logger/logger";
-
-import { setupConnection } from "../managed";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;

--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -48,7 +48,7 @@ import { subNavigationBuild } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
-import {setupConnection} from "@app/components/vaults/AddConnectionMenu";
+import { setupConnection } from "@app/components/vaults/AddConnectionMenu";
 import config from "@app/lib/api/config";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { handleFileUploadToText } from "@app/lib/client/handle_file_upload";

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -40,7 +40,10 @@ import { RequestDataSourceModal } from "@app/components/data_source/RequestDataS
 import { subNavigationBuild } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
-import { AddConnectionMenu } from "@app/components/vaults/AddConnectionMenu";
+import {
+  AddConnectionMenu,
+  setupConnection,
+} from "@app/components/vaults/AddConnectionMenu";
 import config from "@app/lib/api/config";
 import {
   augmentDataSourceWithConnectorDetails,

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -13,9 +13,7 @@ import type {
   ConnectorType,
   DataSourceType,
   DataSourceWithConnectorDetailsType,
-  LightWorkspaceType,
   PlanType,
-  Result,
   SubscriptionType,
   UpdateConnectorRequestBody,
   UserType,
@@ -24,12 +22,8 @@ import type {
 import { CONNECTOR_TYPE_TO_MISMATCH_ERROR } from "@dust-tt/types";
 import {
   CONNECTOR_PROVIDERS,
-  Err,
   isConnectorProvider,
-  isOAuthProvider,
-  Ok,
   removeNulls,
-  setupOAuthConnection,
 } from "@dust-tt/types";
 import type { CellContext } from "@tanstack/react-table";
 import type { InferGetServerSidePropsType } from "next";
@@ -94,36 +88,6 @@ type GetTableRowParams = {
   readOnly: boolean;
   onButtonClick: (ds: DataSourceWithConnectorAndUsageType) => void;
 };
-
-export async function setupConnection({
-  dustClientFacingUrl,
-  owner,
-  provider,
-}: {
-  dustClientFacingUrl: string;
-  owner: LightWorkspaceType;
-  provider: ConnectorProvider;
-}): Promise<Result<string, Error>> {
-  let connectionId: string;
-
-  if (isOAuthProvider(provider)) {
-    // OAuth flow
-    const cRes = await setupOAuthConnection({
-      dustClientFacingUrl,
-      owner,
-      provider,
-      useCase: "connection",
-    });
-    if (!cRes.isOk()) {
-      return cRes;
-    }
-    connectionId = cRes.value.connection_id;
-  } else {
-    return new Err(new Error(`Unknown provider ${provider}`));
-  }
-
-  return new Ok(connectionId);
-}
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -13,7 +13,7 @@ import {
   getWorkspaceInfos,
   unsafeGetWorkspacesByModelId,
 } from "@app/lib/api/workspace";
-import { Authenticator, subscriptionForWorkspaces } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import { destroyConversation } from "@app/lib/conversation";
 import { sendAdminDataDeletionEmail } from "@app/lib/email";
 import { Conversation } from "@app/lib/models/assistant/conversation";
@@ -21,6 +21,7 @@ import {
   FREE_NO_PLAN_CODE,
   FREE_TEST_PLAN_CODE,
 } from "@app/lib/plans/plan_codes";
+import {subscriptionForWorkspaces} from "@app/lib/plans/subscription";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -21,7 +21,7 @@ import {
   FREE_NO_PLAN_CODE,
   FREE_TEST_PLAN_CODE,
 } from "@app/lib/plans/plan_codes";
-import {subscriptionForWorkspaces} from "@app/lib/plans/subscription";
+import { subscriptionForWorkspaces } from "@app/lib/plans/subscription";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";


### PR DESCRIPTION
## Description

Removing cycles after enabling `"import/no-cycle": "error"`.

This is a first batch of cycle removal. 

- Remove ServerSideTracking from MembershipResource, changing the return type to call it at call site.
- Remove subscription/plans rendering from their main files into a renderers file to avoid dep of auth.ts on subscriptions
- Also remove some subscriptions only methods from auth into lib/ files
- Some client-side stuff (SidebarContext and setupConnection mostly, quite trivial)

The worst is mostly about ServerSideTracking and MembershipResource

## Risk

Impacts many files so testing in dev and front-edge should minimized risk

## Deploy Plan

- deploy `front`