### PR TITLE
Content Action buttons fixes

### DIFF
--- a/front/components/vaults/ContentActions.tsx
+++ b/front/components/vaults/ContentActions.tsx
@@ -129,7 +129,11 @@ export const getMenuItems = (
   const actions: ContentActionsMenu = [];
 
   // View in source
-  if (canReadInVault) {
+  // We have a source for all types of docs excepts folder docs unless manually set by the user.
+  if (
+    canReadInVault &&
+    (!isFolder(dataSourceView.dataSource) || contentNode.sourceUrl)
+  ) {
     actions.push(makeViewSourceUrlContentAction(contentNode, dataSourceView));
   }
 
@@ -140,8 +144,9 @@ export const getMenuItems = (
 
   // Edit & Delete
   if (
-    (canWriteInVault && isFolder(dataSourceView.dataSource)) ||
-    isWebsite(dataSourceView.dataSource)
+    canWriteInVault &&
+    (isFolder(dataSourceView.dataSource) ||
+      isWebsite(dataSourceView.dataSource))
   ) {
     actions.push({
       label: "Edit",
@@ -177,8 +182,13 @@ const makeViewSourceUrlContentAction = (
   contentNode: LightContentNode,
   dataSourceView: DataSourceViewType
 ) => {
+  const dataSource = dataSourceView.dataSource;
+  const label = isFolder(dataSource)
+    ? "View associated URL"
+    : `View in ${capitalize(getDataSourceName(dataSource))}`;
+
   return {
-    label: `View in ${capitalize(getDataSourceName(dataSourceView.dataSource))}`,
+    label,
     icon: ExternalLinkIcon,
     link: contentNode.sourceUrl
       ? { href: contentNode.sourceUrl, target: "_blank" }


### PR DESCRIPTION
## Description

- Don't display the "View in [ds]" link unless there is a sourceUrl. 
- For Folders, "View in [ds]" does not make sense -> replace by "View associated URL".
- Fix wrong parenthesis in condition to display edit/delete buttons. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
