### PR TITLE
Fix v2 ContentItem of document in document list

### DIFF
--- a/front/components/vaults/ContentActions.tsx
+++ b/front/components/vaults/ContentActions.tsx
@@ -162,11 +162,8 @@ export const getMenuItems = (
   }
 
   // Edit & Delete
-  if (
-    canWriteInVault &&
-    (isFolder(dataSourceView.dataSource) ||
-      isWebsite(dataSourceView.dataSource))
-  ) {
+  // We can edit/delete the documents on on Folders
+  if (canWriteInVault && isFolder(dataSourceView.dataSource)) {
     actions.push({
       label: "Edit",
       icon: PencilSquareIcon,
@@ -202,9 +199,10 @@ const makeViewSourceUrlContentAction = (
   dataSourceView: DataSourceViewType
 ) => {
   const dataSource = dataSourceView.dataSource;
-  const label = isFolder(dataSource)
-    ? "View associated URL"
-    : `View in ${capitalize(getDataSourceName(dataSource))}`;
+  const label =
+    isFolder(dataSource) || isWebsite(dataSource)
+      ? "View associated URL"
+      : `View in ${capitalize(getDataSourceName(dataSource))}`;
 
   return {
     label,

--- a/front/components/vaults/ContentActions.tsx
+++ b/front/components/vaults/ContentActions.tsx
@@ -147,7 +147,7 @@ export const getMenuItems = (
 ): ContentActionsMenu => {
   const actions: ContentActionsMenu = [];
 
-  // View in source
+  // View in source:
   // We have a source for all types of docs excepts folder docs unless manually set by the user.
   if (
     canReadInVault &&
@@ -156,13 +156,13 @@ export const getMenuItems = (
     actions.push(makeViewSourceUrlContentAction(contentNode, dataSourceView));
   }
 
-  // View raw content in modal
+  // View raw content in modal.
   if (canReadInVault && contentNode.type === "file") {
     actions.push(makeViewRawContentAction(contentNode, contentActionsRef));
   }
 
-  // Edit & Delete
-  // We can edit/delete the documents on on Folders
+  // Edit & Delete:
+  // We can edit/delete the documents in a Folder only.
   if (canWriteInVault && isFolder(dataSourceView.dataSource)) {
     actions.push({
       label: "Edit",


### PR DESCRIPTION
## Description

This code is the code of the ContentItem used in DataSourceContentList -> listing the content of a datasource.
2 fixes: 
- The edit/delete buttons in a document list should be only for folders (we cannot edit the page of a website). 
- The label of the link for a website should also be "View associated url". We keep "View in [datasourceName]" only for connected ds.

<kbd>
<img width="961" alt="Screenshot 2024-09-09 at 14 32 47" src="https://github.com/user-attachments/assets/240c4408-9e0a-4d97-8d8c-447cebdbeae7">
</kbd>

## Risk

/

## Deploy Plan

Deploy front.