### PR TITLE
Fix: list correctly admined only vs normal vaults.

### DIFF
--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -159,14 +159,9 @@ export class VaultResource extends BaseResource<VaultModel> {
     return vaults.filter((vault) => vault.canList(auth));
   }
 
-  static async listWorkspaceVaultsAsAdmin(
-    auth: Authenticator
-  ): Promise<VaultResource[]> {
-    if (!auth.isAdmin()) {
-      return [];
-    }
-
-    return this.baseFetch(auth);
+  static async listWorkspaceVaultsAsMember(auth: Authenticator) {
+    const vaults = await this.baseFetch(auth);
+    return vaults.filter((vault) => vault.canList(auth) && vault.canRead(auth));
   }
 
   static async listWorkspaceDefaultVaults(auth: Authenticator) {

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -161,6 +161,7 @@ export class VaultResource extends BaseResource<VaultModel> {
 
   static async listWorkspaceVaultsAsMember(auth: Authenticator) {
     const vaults = await this.baseFetch(auth);
+    // using canRead() as we know that only members can read vaults (but admins can list them)
     return vaults.filter((vault) => vault.canList(auth) && vault.canRead(auth));
   }
 

--- a/front/pages/api/w/[wId]/vaults/index.ts
+++ b/front/pages/api/w/[wId]/vaults/index.ts
@@ -56,9 +56,9 @@ async function handler(
             },
           });
         }
-        vaults = await VaultResource.listWorkspaceVaultsAsAdmin(auth);
-      } else {
         vaults = await VaultResource.listWorkspaceVaults(auth);
+      } else {
+        vaults = await VaultResource.listWorkspaceVaultsAsMember(auth);
       }
 
       return res.status(200).json({

--- a/front/pages/w/[wId]/vaults/[vaultId]/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/index.tsx
@@ -9,7 +9,7 @@ import {
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import type { ReactElement } from "react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import { VaultCategoriesList } from "@app/components/vaults/VaultCategoriesList";
 import type { VaultLayoutProps } from "@app/components/vaults/VaultLayout";
@@ -69,7 +69,10 @@ export default function Vault({
 
   const router = useRouter();
   const [currentTab, setCurrentTab] = useState("resources");
-  const isMember = vaultInfo?.members?.some((m) => m.sId === userId);
+  const isMember = useMemo(
+    () => vaultInfo?.members?.some((m) => m.sId === userId),
+    [userId, vaultInfo?.members]
+  );
 
   return (
     <Page.Vertical gap="xl" align="stretch">
@@ -78,7 +81,7 @@ export default function Vault({
         icon={getVaultIcon(vault)}
         description="Manage connections to your products and the real-time data feeds Dust has access to."
       />
-      {!isMember && (
+      {vaultInfo && !isMember && (
         <Chip
           color="warning"
           label="You are not a member of this vault."


### PR DESCRIPTION
## Description

Fix the list of admined vs normal vaults due to the bug introduced by `canList()`.

## Risk

None

## Deploy Plan

Deploy `front`