### PR TITLE
getCitations: refactor to remove cycles

### DIFF
--- a/front/lib/api/assistant/actions/browse.ts
+++ b/front/lib/api/assistant/actions/browse.ts
@@ -111,11 +111,6 @@ export class BrowseConfigurationServerRunner extends BaseActionConfigurationServ
     });
   }
 
-  // Browse does not use citations.
-  getCitationsCount(): number {
-    return 0;
-  }
-
   // This method is in charge of running the browse and creating an AgentBrowseAction object in
   // the database. It does not create any generic model related to the conversation. It is possible
   // for an AgentBrowseAction to be stored (once the query params are infered) but for its execution

--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -178,11 +178,6 @@ export class DustAppRunConfigurationServerRunner extends BaseActionConfiguration
     });
   }
 
-  // DustAppRun does not use citations.
-  getCitationsCount(): number {
-    return 0;
-  }
-
   // This method is in charge of running a dust app and creating an AgentDustAppRunAction object in
   // the database. It does not create any generic model related to the conversation. It is possible
   // for an AgentDustAppRunAction to be stored (once the params are infered) but for the dust app run

--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -142,11 +142,6 @@ export class ProcessConfigurationServerRunner extends BaseActionConfigurationSer
     return new Ok(spec);
   }
 
-  // Process does not use citations.
-  getCitationsCount(): number {
-    return 0;
-  }
-
   // This method is in charge of running the retrieval and creating an AgentProcessAction object in
   // the database. It does not create any generic model related to the conversation. It is possible
   // for an AgentProcessAction to be stored (once the query params are infered) but for its execution

--- a/front/lib/api/assistant/actions/runners.ts
+++ b/front/lib/api/assistant/actions/runners.ts
@@ -80,7 +80,7 @@ export const ACTION_TYPE_TO_CONFIGURATION_SERVER_RUNNER: {
   retrieval_configuration: RetrievalConfigurationServerRunner,
 } as const;
 
-export function getRunnerforActionConfiguration<K extends keyof CombinedMap>(
+export function getRunnerForActionConfiguration<K extends keyof CombinedMap>(
   actionConfiguration: {
     type: K;
   } & CombinedMap[K]["configType"]

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -158,11 +158,6 @@ export class TablesQueryConfigurationServerRunner extends BaseActionConfiguratio
     return new Ok(spec);
   }
 
-  // TablesQuery does not use citations.
-  getCitationsCount(): number {
-    return 0;
-  }
-
   async *run(
     auth: Authenticator,
     {

--- a/front/lib/api/assistant/actions/types.ts
+++ b/front/lib/api/assistant/actions/types.ts
@@ -61,15 +61,6 @@ export abstract class BaseActionConfigurationServerRunner<
     { name, description }: { name: string | null; description: string | null }
   ): Promise<Result<AgentActionSpecification, Error>>;
 
-  // Computes the max number of citation for the actions as part of this step.
-  abstract getCitationsCount({
-    agentConfiguration,
-    stepActions,
-  }: {
-    agentConfiguration: AgentConfigurationType;
-    stepActions: AgentActionConfigurationType[];
-  }): number;
-
   // Action execution.
   abstract run(
     auth: Authenticator,

--- a/front/lib/api/assistant/actions/utils.ts
+++ b/front/lib/api/assistant/actions/utils.ts
@@ -15,6 +15,7 @@ import type {
   WhitelistableFeature,
 } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
+import assert from "assert";
 
 import type { AssistantBuilderActionConfiguration } from "@app/components/assistant_builder/types";
 import { getSupportedModelConfig } from "@app/lib/assistant";
@@ -76,54 +77,146 @@ export const ACTION_SPECIFICATIONS: Record<
   },
 };
 
-export function getCitationsCount({
+/**
+ * This function computes the topK for retrieval actions. This is used by both the action (to
+ * compute the topK) and computing the citation counts for retrieval actions.
+ *
+ * We share the topK across retrieval actions from the same step. If there are multiple retrieval
+ * actions in the same step we get the maximum topK and divide it by the number of retrieval actions
+ * in the step.
+ */
+export function getRetrievalTopK({
   agentConfiguration,
   stepActions,
 }: {
   agentConfiguration: AgentConfigurationType;
   stepActions: AgentActionConfigurationType[];
 }): number {
-  const actionsWithCitations: (
-    | RetrievalConfigurationType
-    | WebsearchConfigurationType
-  )[] = [];
-  for (const a of stepActions) {
-    if (
-      a.type === "retrieval_configuration" ||
-      a.type === "websearch_configuration"
-    ) {
-      actionsWithCitations.push(a);
-    }
-  }
-  const actionsWithCitationsCount = actionsWithCitations.length;
-
-  if (actionsWithCitationsCount === 0) {
-    throw new Error("Unexpected: found 0 actions with citations");
-  }
-
   const model = getSupportedModelConfig(agentConfiguration.model);
 
-  // We find the retrieval action in the step with the highest topK.
-  const maxTopK = actionsWithCitations
-    .map((a) => {
-      if (a.type === "retrieval_configuration") {
-        if (a.topK === "auto") {
-          if (a.query === "none") {
-            return model.recommendedExhaustiveTopK;
-          } else {
-            return model.recommendedTopK;
-          }
-        } else {
-          return a.topK;
-        }
-      } else if (a.type === "websearch_configuration") {
-        return WEBSEARCH_ACTION_NUM_RESULTS;
-      } else {
-        assertNever(a);
-      }
-    })
-    .reduce((acc, topK) => Math.max(acc, topK), 0);
+  const retrievalActions = stepActions.filter(
+    (action) => action.type === "retrieval_configuration"
+  ) as RetrievalConfigurationType[];
 
-  // We split the topK evenly among all retrieval actions of the step.
-  return Math.ceil(maxTopK / actionsWithCitationsCount);
+  assert(
+    retrievalActions.length > 0,
+    "No retrieval actions found in `getRetrievalTopK`"
+  );
+
+  const topKs = retrievalActions.map((action) => {
+    if (action.topK === "auto") {
+      if (action.query === "none") {
+        return model.recommendedExhaustiveTopK;
+      } else {
+        return model.recommendedTopK;
+      }
+    } else {
+      return action.topK;
+    }
+  });
+
+  return Math.ceil(Math.max(...topKs) / retrievalActions.length);
+}
+
+/**
+ * This function computes the number of results for websearch actions. This is used by both the
+ * action (to compute the number of results) and computing the citation counts for websearch
+ * actions.
+ *
+ * We share the number of results across websearch actions from the same step. If there are multiple
+ * websearch actions in the same step we get the maximum number of results and divide it by The
+ * number of websearch actions in the step.
+ */
+export function getWebsearchNumResults({
+  stepActions,
+}: {
+  stepActions: AgentActionConfigurationType[];
+}): number {
+  const websearchActions = stepActions.filter(
+    (action) => action.type === "websearch_configuration"
+  ) as WebsearchConfigurationType[];
+
+  assert(
+    websearchActions.length > 0,
+    "No websearch actions found in `getWebsearchNumResults`"
+  );
+
+  const numResults = websearchActions.map(() => {
+    return WEBSEARCH_ACTION_NUM_RESULTS;
+  });
+
+  return Math.ceil(Math.max(...numResults) / websearchActions.length);
+}
+
+/**
+ * This function computes the number of citations per actions within one step. It is centralized
+ * here as it is used from the runners and across runners which leads to circular imports.
+ *
+ * It works as follows:
+ * - Returns 0 for actions that do not have citations.
+ * - Returns the shared topK for retrieval actions.
+ * - Returns the shared number of results for websearch actions.
+ */
+export function getCitationsCount({
+  agentConfiguration,
+  stepActions,
+  stepActionIndex,
+}: {
+  agentConfiguration: AgentConfigurationType;
+  stepActions: AgentActionConfigurationType[];
+  stepActionIndex: number;
+}): number {
+  const action = stepActions[stepActionIndex];
+
+  switch (action.type) {
+    case "retrieval_configuration":
+      return getRetrievalTopK({
+        agentConfiguration,
+        stepActions,
+      });
+    case "websearch_configuration":
+      return getWebsearchNumResults({
+        stepActions,
+      });
+    case "tables_query_configuration":
+    case "dust_app_run_configuration":
+    case "process_configuration":
+    case "browse_configuration":
+      return 0;
+    default:
+      assertNever(action);
+  }
+}
+
+/**
+ * This is shared across action runners and used to compute the local step refsOffset (the current
+ * refsOffset for the assistant actions up to the current step (`refsOffset`) to which we add the
+ * actions that comes before the current action in the current step).
+ *
+ * @param agentConfiguration The agent configuration.
+ * @param stepActionIndex The index of the current action in the current step.
+ * @param stepActions The actions in the current step.
+ * @param refsOffset The current refsOffset up to the current step.
+ * @returns The updated refsOffset for the action at stepActionIndex.
+ */
+export function actionRefsOffset({
+  agentConfiguration,
+  stepActionIndex,
+  stepActions,
+  refsOffset,
+}: {
+  agentConfiguration: AgentConfigurationType;
+  stepActionIndex: number;
+  stepActions: AgentActionConfigurationType[];
+  refsOffset: number;
+}): number {
+  for (let i = 0; i < stepActionIndex; i++) {
+    refsOffset += getCitationsCount({
+      agentConfiguration,
+      stepActions,
+      stepActionIndex: i,
+    });
+  }
+
+  return refsOffset;
 }

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -30,7 +30,7 @@ import {
 } from "@dust-tt/types";
 
 import { runActionStreamed } from "@app/lib/actions/server";
-import { getRunnerforActionConfiguration } from "@app/lib/api/assistant/actions/runners";
+import { getRunnerForActionConfiguration } from "@app/lib/api/assistant/actions/runners";
 import {
   AgentMessageContentParser,
   getDelimitersConfiguration,
@@ -46,6 +46,8 @@ import type { Authenticator } from "@app/lib/auth";
 import { AgentMessageContent } from "@app/lib/models/assistant/agent_message_content";
 import { cloneBaseConfig, DustProdActionRegistry } from "@app/lib/registry";
 import logger from "@app/logger/logger";
+
+import { getCitationsCount } from "./actions/utils";
 
 const CANCELLATION_CHECK_INTERVAL = 500;
 const MAX_ACTIONS_PER_STEP = 16;
@@ -215,14 +217,13 @@ async function* runMultiActionsAgentLoop(
           }
 
           // After we are done running actions we update the inter step refsOffset.
-          event.actions.forEach(({ action }) => {
-            citationsRefsOffset += getRunnerforActionConfiguration(
-              action
-            ).getCitationsCount({
+          for (let j = 0; j < event.actions.length; j++) {
+            citationsRefsOffset += getCitationsCount({
               agentConfiguration: configuration,
               stepActions: event.actions.map((a) => a.action),
+              stepActionIndex: j,
             });
-          });
+          }
 
           break;
 
@@ -392,7 +393,7 @@ export async function* runMultiActionsAgent(
 
   const specifications: AgentActionSpecification[] = [];
   for (const a of availableActions) {
-    const specRes = await getRunnerforActionConfiguration(a).buildSpecification(
+    const specRes = await getRunnerForActionConfiguration(a).buildSpecification(
       auth,
       {
         name: a.name,
@@ -799,7 +800,7 @@ async function* runAction(
   const now = Date.now();
 
   if (isRetrievalConfiguration(actionConfiguration)) {
-    const eventStream = getRunnerforActionConfiguration(
+    const eventStream = getRunnerForActionConfiguration(
       actionConfiguration
     ).run(
       auth,
@@ -876,7 +877,7 @@ async function* runAction(
       return;
     }
 
-    const eventStream = getRunnerforActionConfiguration(
+    const eventStream = getRunnerForActionConfiguration(
       actionConfiguration
     ).run(
       auth,
@@ -932,7 +933,7 @@ async function* runAction(
       }
     }
   } else if (isTablesQueryConfiguration(actionConfiguration)) {
-    const eventStream = getRunnerforActionConfiguration(
+    const eventStream = getRunnerForActionConfiguration(
       actionConfiguration
     ).run(auth, {
       agentConfiguration: configuration,
@@ -979,7 +980,7 @@ async function* runAction(
       }
     }
   } else if (isProcessConfiguration(actionConfiguration)) {
-    const eventStream = getRunnerforActionConfiguration(
+    const eventStream = getRunnerForActionConfiguration(
       actionConfiguration
     ).run(auth, {
       agentConfiguration: configuration,
@@ -1027,7 +1028,7 @@ async function* runAction(
       }
     }
   } else if (isWebsearchConfiguration(actionConfiguration)) {
-    const eventStream = getRunnerforActionConfiguration(
+    const eventStream = getRunnerForActionConfiguration(
       actionConfiguration
     ).run(
       auth,
@@ -1082,7 +1083,7 @@ async function* runAction(
       }
     }
   } else if (isBrowseConfiguration(actionConfiguration)) {
-    const eventStream = getRunnerforActionConfiguration(
+    const eventStream = getRunnerForActionConfiguration(
       actionConfiguration
     ).run(auth, {
       agentConfiguration: configuration,


### PR DESCRIPTION
## Description

We had an import cycle runner.rs (`getRunnerforActionConfiguration`) => retrieval/search.ts (runner.getCitations).

This PR removes citation calculation from the runners (as we need to compute citations across runners leading to an import cycle if we keep it on the runner).

Doing so we clarify with comments what we are doing and also fix the behavior a bit (we were sharing across retrieval and websearch actions (from one step) their topK/numResults). Instead we share topK for retrieval and numResults for websearch independently which is more principled.

## Risk

Low

## Deploy Plan

- deploy `front`