### PR TITLE
Feature flag Private vaults

### DIFF
--- a/front/components/vaults/VaultLayout.tsx
+++ b/front/components/vaults/VaultLayout.tsx
@@ -49,6 +49,10 @@ export function VaultLayout({
     parentId,
   } = pageProps;
 
+  const isPrivateVaultsEnabled = owner.flags.includes(
+    "private_data_vaults_feature"
+  );
+
   return (
     <RootLayout>
       <AppLayout
@@ -59,6 +63,7 @@ export function VaultLayout({
           <VaultSideBarMenu
             owner={owner}
             isAdmin={isAdmin}
+            isPrivateVaultsEnabled={isPrivateVaultsEnabled}
             setShowVaultCreationModal={setShowVaultCreationModal}
           />
         }
@@ -71,7 +76,7 @@ export function VaultLayout({
           parentId={parentId ?? undefined}
         />
         {children}
-        {isAdmin && (
+        {isAdmin && isPrivateVaultsEnabled && (
           <CreateVaultModal
             owner={owner}
             isOpen={showVaultCreationModal}

--- a/front/components/vaults/VaultSideBarMenu.tsx
+++ b/front/components/vaults/VaultSideBarMenu.tsx
@@ -34,6 +34,7 @@ import {
 import { getVaultIcon, getVaultName } from "@app/lib/vaults";
 
 interface VaultSideBarMenuProps {
+  isPrivateVaultsEnabled: boolean;
   owner: LightWorkspaceType;
   isAdmin: boolean;
   setShowVaultCreationModal: (show: boolean) => void;
@@ -47,6 +48,7 @@ const VAULTS_SORT_ORDER: VaultKind[] = [
 ];
 
 export default function VaultSideBarMenu({
+  isPrivateVaultsEnabled,
   owner,
   isAdmin,
   setShowVaultCreationModal,
@@ -102,6 +104,9 @@ export default function VaultSideBarMenu({
           {sortedGroupedVaults.map(({ kind, vaults }, index) => {
             // Public vaults are created manually by us to hold public dust apps - other workspaces can't create them, so we do not show the section at all if there are no vaults.
             if (kind === "public" && !vaults.length) {
+              return null;
+            }
+            if (kind === "regular" && !isPrivateVaultsEnabled) {
               return null;
             }
 

--- a/types/src/shared/feature_flags.ts
+++ b/types/src/shared/feature_flags.ts
@@ -5,6 +5,7 @@ export const WHITELISTABLE_FEATURES = [
   "labs_transcripts_datasource",
   "document_tracker",
   "data_vaults_feature",
+  "private_data_vaults_feature",
 ] as const;
 export type WhitelistableFeature = (typeof WHITELISTABLE_FEATURES)[number];
 export function isWhitelistableFeature(


### PR DESCRIPTION
## Description

Our feature flag `data_vaults_feature` is to be release first. It contains all the new screens in vault, and is aka "Connection Management". 

This PR introduces a new feature flag `private_data_vaults_feature` which hold the ability to create a private vault (regular kind).

To do so we set all rights to false on a regular vaults if the feature is not activated + a couple of test in the UI to not render the Create Vault modal & the label "Private". 

<kbd>
<img width="930" alt="Screenshot 2024-09-09 at 17 54 16" src="https://github.com/user-attachments/assets/1d88e8ed-c185-4dd3-a197-5314939c4ef9">
</kbd>

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
Activate the flag for Dust workspace. 