### PR TITLE
No root page for system vault, redirect to managed

### DIFF
--- a/front/pages/api/w/[wId]/groups/[gId]/index.ts
+++ b/front/pages/api/w/[wId]/groups/[gId]/index.ts
@@ -71,12 +71,12 @@ async function handler(
           },
         });
       }
-      if (groupRes.value.kind === "system") {
+      if (groupRes.value.isSystem()) {
         return apiError(req, res, {
-          status_code: 400,
+          status_code: 403,
           api_error: {
             type: "invalid_request_error",
-            message: "Can administrate the system group.",
+            message: "System group can't be updated.",
           },
         });
       }

--- a/front/pages/api/w/[wId]/groups/[gId]/index.ts
+++ b/front/pages/api/w/[wId]/groups/[gId]/index.ts
@@ -71,6 +71,15 @@ async function handler(
           },
         });
       }
+      if (groupRes.value.kind === "system") {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Can administrate the system group.",
+          },
+        });
+      }
       const bodyValidation = PatchGroupRequestBodySchema.decode(req.body);
 
       if (isLeft(bodyValidation)) {

--- a/front/pages/w/[wId]/vaults/[vaultId]/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/index.tsx
@@ -43,7 +43,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     };
   }
   // No root page for System vaults since it contains only managed data sources.
-  if (vault.kind === "system") {
+  if (vault.isSystem()) {
     return {
       redirect: {
         destination: `/w/${owner.sId}/vaults/${vault.sId}/categories/managed`,

--- a/front/pages/w/[wId]/vaults/[vaultId]/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/index.tsx
@@ -42,6 +42,16 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
       notFound: true,
     };
   }
+  // No root page for System vaults since it contains only managed data sources.
+  if (vault.kind === "system") {
+    return {
+      redirect: {
+        destination: `/w/${owner.sId}/vaults/${vault.sId}/categories/managed`,
+        permanent: false,
+      },
+    };
+  }
+
   const isAdmin = auth.isAdmin();
 
   return {


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/1283

We don't want to allow users to land on the root of the system vault, since this screen has no point as the system vault contains only managed data sources and member management is not allowed:
- We redirect to the managed category.
- We block the patch route (ceinture & bretelles).

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
