### PR TITLE
AppResource: use canRead to take into account public vault

### DIFF
--- a/front/lib/resources/app_resource.ts
+++ b/front/lib/resources/app_resource.ts
@@ -51,9 +51,7 @@ export class AppResource extends ResourceWithVault<App> {
       ...options,
     });
 
-    return apps.filter(
-      (app) => auth.isAdmin() || auth.hasPermission([app.vault.acl()], "read")
-    );
+    return apps.filter((app) => auth.isAdmin() || app.canRead(auth));
   }
 
   // fetchByIds filters out private apps if the auth is not a user on the workspace. This will be


### PR DESCRIPTION
## Description

hasPermissions does not take into account public vault logic. Use canRead instead.

Context: https://dust4ai.slack.com/archives/C05B529FHV1/p1725898862337069

## Risk

High

## Deploy Plan

- deploy `front`