### PR TITLE
Fix: maximum call stack

### DIFF
--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1063,12 +1063,7 @@ async function findResourcesNotSeenInGarbageCollectionRun(
     return { pageIdsSeenInRun, databaseIdsSeenInRun };
   })();
 
-  const pagesNotSeenInGarbageCollectionRun: Array<{
-    lastSeenTs: Date;
-    resourceType: "page";
-    resourceId: string;
-  }> = [];
-  const pages = (
+  const pagesNotSeenInGarbageCollectionRun = (
     await NotionPage.findAll({
       where: {
         connectorId,
@@ -1086,14 +1081,7 @@ async function findResourcesNotSeenInGarbageCollectionRun(
       resourceType: "page" as const,
     }));
 
-  pagesNotSeenInGarbageCollectionRun.push(...pages);
-
-  const databasesNotSeenInGarbageCollectionRun: Array<{
-    lastSeenTs: Date;
-    resourceType: "database";
-    resourceId: string;
-  }> = [];
-  const databases = (
+  const databasesNotSeenInGarbageCollectionRun = (
     await NotionDatabase.findAll({
       where: {
         connectorId,
@@ -1110,8 +1098,6 @@ async function findResourcesNotSeenInGarbageCollectionRun(
       resourceId: p.notionDatabaseId,
       resourceType: "database" as const,
     }));
-
-  databasesNotSeenInGarbageCollectionRun.push(...databases);
 
   const allResourcesNotSeenInGarbageCollectionRun = [
     ...pagesNotSeenInGarbageCollectionRun,


### PR DESCRIPTION
## Description

TIL: if you use the spread operator with a function (such as `push(...something)`) you can exhaust the call stack limits as they are passed as arguments using the call stack ([stack overflow](https://stackoverflow.com/questions/63705432/maximum-call-stack-size-exceeded-when-using-the-dots-operator))

I easily reproduced using my browser console.

## Risk

None

## Deploy Plan

Deploy `connectors`