### PR TITLE
Add: copy buttons for id and sid in poke workspace page

### DIFF
--- a/front/components/misc/ContentBlockWrapper.tsx
+++ b/front/components/misc/ContentBlockWrapper.tsx
@@ -4,8 +4,9 @@ import {
   ClipboardIcon,
   IconButton,
 } from "@dust-tt/sparkle";
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 
+import { useCopyToClipboard } from "@app/hooks/useCopyToClipboard";
 import { classNames } from "@app/lib/utils";
 
 type SupportedContentType = "application/json" | "text/csv";
@@ -117,32 +118,4 @@ export function ContentBlockWrapper({
       </div>
     </div>
   );
-}
-
-function useCopyToClipboard(
-  resetInterval = 2000
-): [isCopied: boolean, copy: (d: ClipboardItem) => Promise<boolean>] {
-  const [isCopied, setCopied] = useState(false);
-
-  const copy = useCallback(
-    async (d: ClipboardItem) => {
-      if (!navigator?.clipboard) {
-        console.warn("Clipboard not supported");
-        return false;
-      }
-      try {
-        await navigator.clipboard.write([d]);
-        setCopied(true);
-        setTimeout(() => setCopied(false), resetInterval);
-        return true;
-      } catch (error) {
-        console.warn("Copy failed", error);
-        setCopied(false);
-        return false;
-      }
-    },
-    [resetInterval]
-  );
-
-  return [isCopied, copy];
 }

--- a/front/components/poke/workspace/table.tsx
+++ b/front/components/poke/workspace/table.tsx
@@ -1,4 +1,6 @@
+import { Button, ClipboardCheckIcon, ClipboardIcon } from "@dust-tt/sparkle";
 import type { WorkspaceDomain, WorkspaceType } from "@dust-tt/types";
+import { useCallback, useState } from "react";
 
 import {
   PokeTable,
@@ -6,6 +8,33 @@ import {
   PokeTableCell,
   PokeTableRow,
 } from "@app/components/poke/shadcn/ui/table";
+
+export function useCopyToClipboard(
+  resetInterval = 2000
+): [isCopied: boolean, copy: (d: ClipboardItem) => Promise<boolean>] {
+  const [isCopied, setCopied] = useState(false);
+
+  const copy = useCallback(
+    async (d: ClipboardItem) => {
+      if (!navigator?.clipboard) {
+        console.warn("Clipboard not supported");
+        return false;
+      }
+      try {
+        await navigator.clipboard.write([d]);
+        setCopied(true);
+        setTimeout(() => setCopied(false), resetInterval);
+        return true;
+      } catch (error) {
+        setCopied(false);
+        return false;
+      }
+    },
+    [resetInterval]
+  );
+
+  return [isCopied, copy];
+}
 
 export function WorkspaceInfoTable({
   owner,
@@ -16,6 +45,9 @@ export function WorkspaceInfoTable({
   workspaceVerifiedDomain: WorkspaceDomain | null;
   worspaceCreationDay: string;
 }) {
+  const [isCopiedId, copyToClipboardId] = useCopyToClipboard();
+  const [isCopiedSid, copyToClipboardSid] = useCopyToClipboard();
+
   return (
     <div className="flex justify-between gap-3 pt-4">
       <div className="border-material-200 my-4 flex flex-grow flex-col rounded-lg border p-4">
@@ -25,15 +57,69 @@ export function WorkspaceInfoTable({
         <PokeTable>
           <PokeTableBody>
             <PokeTableRow>
-              <PokeTableCell>Workspace creation</PokeTableCell>
+              <PokeTableCell>Id</PokeTableCell>
+              <PokeTableCell>
+                {owner.id}
+                &nbsp;
+                <Button
+                  size="xs"
+                  variant="secondary"
+                  onClick={useCallback(
+                    async (e: any) => {
+                      e.preventDefault();
+                      await copyToClipboardId(
+                        new ClipboardItem({
+                          "text/plain": new Blob([`${owner.id}`], {
+                            type: "text/plain",
+                          }),
+                        })
+                      );
+                    },
+                    [copyToClipboardId, owner.id]
+                  )}
+                  label="Copy"
+                  labelVisible={false}
+                  icon={isCopiedId ? ClipboardCheckIcon : ClipboardIcon}
+                />
+              </PokeTableCell>
+            </PokeTableRow>
+            <PokeTableRow>
+              <PokeTableCell>sId</PokeTableCell>
+              <PokeTableCell>
+                {owner.sId}
+                &nbsp;
+                <Button
+                  size="xs"
+                  variant="secondary"
+                  onClick={useCallback(
+                    async (e: any) => {
+                      e.preventDefault();
+                      await copyToClipboardSid(
+                        new ClipboardItem({
+                          "text/plain": new Blob([owner.sId], {
+                            type: "text/plain",
+                          }),
+                        })
+                      );
+                    },
+                    [copyToClipboardSid, owner.sId]
+                  )}
+                  label="Copy"
+                  labelVisible={false}
+                  icon={isCopiedSid ? ClipboardCheckIcon : ClipboardIcon}
+                />
+              </PokeTableCell>
+            </PokeTableRow>
+            <PokeTableRow>
+              <PokeTableCell>Creation</PokeTableCell>
               <PokeTableCell>{worspaceCreationDay}</PokeTableCell>
             </PokeTableRow>
             <PokeTableRow>
-              <PokeTableCell>SSO Enforced</PokeTableCell>
+              <PokeTableCell>SSO</PokeTableCell>
               <PokeTableCell>{owner.ssoEnforced ? "✅" : "❌"}</PokeTableCell>
             </PokeTableRow>
             <PokeTableRow>
-              <PokeTableCell>Auto Join Enabled</PokeTableCell>
+              <PokeTableCell>Auto Join</PokeTableCell>
               <PokeTableCell>
                 {workspaceVerifiedDomain?.domainAutoJoinEnabled ? "✅" : "❌"}
               </PokeTableCell>

--- a/front/components/poke/workspace/table.tsx
+++ b/front/components/poke/workspace/table.tsx
@@ -1,6 +1,6 @@
 import { Button, ClipboardCheckIcon, ClipboardIcon } from "@dust-tt/sparkle";
 import type { WorkspaceDomain, WorkspaceType } from "@dust-tt/types";
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 
 import {
   PokeTable,
@@ -8,33 +8,7 @@ import {
   PokeTableCell,
   PokeTableRow,
 } from "@app/components/poke/shadcn/ui/table";
-
-export function useCopyToClipboard(
-  resetInterval = 2000
-): [isCopied: boolean, copy: (d: ClipboardItem) => Promise<boolean>] {
-  const [isCopied, setCopied] = useState(false);
-
-  const copy = useCallback(
-    async (d: ClipboardItem) => {
-      if (!navigator?.clipboard) {
-        console.warn("Clipboard not supported");
-        return false;
-      }
-      try {
-        await navigator.clipboard.write([d]);
-        setCopied(true);
-        setTimeout(() => setCopied(false), resetInterval);
-        return true;
-      } catch (error) {
-        setCopied(false);
-        return false;
-      }
-    },
-    [resetInterval]
-  );
-
-  return [isCopied, copy];
-}
+import { useCopyToClipboard } from "@app/hooks/useCopyToClipboard";
 
 export function WorkspaceInfoTable({
   owner,
@@ -67,13 +41,7 @@ export function WorkspaceInfoTable({
                   onClick={useCallback(
                     async (e: any) => {
                       e.preventDefault();
-                      await copyToClipboardId(
-                        new ClipboardItem({
-                          "text/plain": new Blob([`${owner.id}`], {
-                            type: "text/plain",
-                          }),
-                        })
-                      );
+                      await copyToClipboardId(owner.id);
                     },
                     [copyToClipboardId, owner.id]
                   )}
@@ -94,13 +62,7 @@ export function WorkspaceInfoTable({
                   onClick={useCallback(
                     async (e: any) => {
                       e.preventDefault();
-                      await copyToClipboardSid(
-                        new ClipboardItem({
-                          "text/plain": new Blob([owner.sId], {
-                            type: "text/plain",
-                          }),
-                        })
-                      );
+                      await copyToClipboardSid(owner.sId);
                     },
                     [copyToClipboardSid, owner.sId]
                   )}
@@ -115,7 +77,7 @@ export function WorkspaceInfoTable({
               <PokeTableCell>{worspaceCreationDay}</PokeTableCell>
             </PokeTableRow>
             <PokeTableRow>
-              <PokeTableCell>SSO</PokeTableCell>
+              <PokeTableCell>SSO Enforced</PokeTableCell>
               <PokeTableCell>{owner.ssoEnforced ? "✅" : "❌"}</PokeTableCell>
             </PokeTableRow>
             <PokeTableRow>

--- a/front/hooks/useCopyToClipboard.ts
+++ b/front/hooks/useCopyToClipboard.ts
@@ -1,0 +1,39 @@
+import { useCallback, useState } from "react";
+
+export function useCopyToClipboard(
+  resetInterval: number = 2000
+): [
+  isCopied: boolean,
+  copy: (d: ClipboardItem | string | number) => Promise<boolean>,
+] {
+  const [isCopied, setCopied] = useState(false);
+
+  const copy = useCallback(
+    async (d: ClipboardItem | string | number) => {
+      if (!navigator?.clipboard) {
+        console.warn("Clipboard not supported");
+        return false;
+      }
+      try {
+        const item: ClipboardItem =
+          typeof d === "string" || typeof d === "number"
+            ? new ClipboardItem({
+                "text/plain": new Blob([`${d}`], { type: "text/plain" }),
+              })
+            : d;
+
+        await navigator.clipboard.write([item]);
+        setCopied(true);
+        setTimeout(() => setCopied(false), resetInterval);
+        return true;
+      } catch (error) {
+        console.warn("Copy failed", error);
+        setCopied(false);
+        return false;
+      }
+    },
+    [resetInterval]
+  );
+
+  return [isCopied, copy];
+}


### PR DESCRIPTION
## Description

Add id and sid in the workspace poke page with copy to clipboard buttons as a convenience.

<img width="353" alt="image" src="https://github.com/user-attachments/assets/218ed212-fe02-458b-b81d-73f131829e9c">


## Risk

None

## Deploy Plan

Deploy `front`