### PR TITLE
[front] - refactor: update icon for 'Add Connections' button

### DIFF
--- a/front/components/vaults/AddConnectionMenu.tsx
+++ b/front/components/vaults/AddConnectionMenu.tsx
@@ -1,4 +1,9 @@
-import { Button, Dialog, DropdownMenu, PlusIcon } from "@dust-tt/sparkle";
+import {
+  Button,
+  CloudArrowLeftRightIcon,
+  Dialog,
+  DropdownMenu,
+} from "@dust-tt/sparkle";
 import type {
   ConnectorProvider,
   ConnectorType,
@@ -267,7 +272,7 @@ export const AddConnectionMenu = ({
             <Button
               label="Add Connections"
               variant="primary"
-              icon={PlusIcon}
+              icon={CloudArrowLeftRightIcon}
               size="sm"
             />
           </DropdownMenu.Button>


### PR DESCRIPTION
## Description

This PR aims at changing the "Add Connections" button icon to be aligned with the Figma.

**References:**
- https://github.com/dust-tt/tasks/issues/1288

## Risk

None

## Deploy Plan

Deploy `front`