### PR TITLE
Do not render dust app action if app was deleted

### DIFF
--- a/front/lib/api/assistant/configuration/dust_app_run.ts
+++ b/front/lib/api/assistant/configuration/dust_app_run.ts
@@ -47,21 +47,20 @@ export async function fetchDustAppRunActionConfigurations(
     for (const c of configs) {
       const dustApp = dustApps.find((app) => app.sId === c.appId);
 
-      if (!dustApp) {
-        // unreachable
-        throw new Error(
-          `Couldn't find dust app for dust app run configuration ${c.id}`
-        );
+      // If the dust app is not found (was deleted) we just skip the action. This is not ideal as it
+      // will change the behavior of the assistant without notice, but we don't want to crash or let
+      // the app be used if it was deleted.
+      if (dustApp) {
+        actions.push({
+          id: c.id,
+          sId: c.sId,
+          type: "dust_app_run_configuration",
+          appWorkspaceId: c.appWorkspaceId,
+          appId: c.appId,
+          name: dustApp.name,
+          description: dustApp.description,
+        });
       }
-      actions.push({
-        id: c.id,
-        sId: c.sId,
-        type: "dust_app_run_configuration",
-        appWorkspaceId: c.appWorkspaceId,
-        appId: c.appId,
-        name: dustApp.name,
-        description: dustApp.description,
-      });
     }
 
     actionsByConfigurationId.set(parseInt(agentConfigurationId, 10), actions);


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/1287

If a dust app is deleted we just don't render the action of an assistant tied to it. The assistant won't have this action and editing it will restore sanity.

Before https://github.com/dust-tt/dust/pull/7190/files#diff-35bb795c12e93ef5da811be4f91a5ae38c34a556f62be8a29e41c6e41c2ddd40L27-L33 we would keep the action around which was not great (allowing likely to run the dust app even if it had been deleted).

This fixes poke as well as assitsant builder in the case of a deleted dust app.

## Risk

Low

## Deploy Plan

- deploy `front`