### PR TITLE
[front] - chore: retrieve light `User`

### DIFF
--- a/front/components/vaults/CreateVaultModal.tsx
+++ b/front/components/vaults/CreateVaultModal.tsx
@@ -71,7 +71,7 @@ export function CreateVaultModal({
   const router = useRouter();
   const { members, isMembersLoading } = useMembers({
     owner,
-    returnLight: true,
+    light: true,
   });
   const sendNotification = useContext(SendNotificationsContext);
 

--- a/front/components/vaults/CreateVaultModal.tsx
+++ b/front/components/vaults/CreateVaultModal.tsx
@@ -9,7 +9,10 @@ import {
   Searchbar,
   Spinner,
 } from "@dust-tt/sparkle";
-import type { LightWorkspaceType, UserType } from "@dust-tt/types";
+import type {
+  LightUserType,
+  LightWorkspaceType,
+} from "@dust-tt/types";
 import { InformationCircleIcon } from "@heroicons/react/20/solid";
 import type { CellContext } from "@tanstack/react-table";
 import { MinusIcon } from "lucide-react";
@@ -37,7 +40,7 @@ interface CreateVaultModalProps {
   onClose: () => void;
 }
 
-function getTableRows(allUsers: UserType[]): RowData[] {
+function getTableRows(allUsers: LightUserType[]): RowData[] {
   return allUsers.map((user) => ({
     icon: user.image ?? "",
     name: user.fullName,
@@ -63,7 +66,10 @@ export function CreateVaultModal({
     disabled: true, // Disable as we just want the mutation function
   });
   const router = useRouter();
-  const { members, isMembersLoading } = useMembers(owner);
+  const { members, isMembersLoading } = useMembers({
+    owner,
+    returnLight: true,
+  });
   const sendNotification = useContext(SendNotificationsContext);
 
   const getTableColumns = useCallback(() => {

--- a/front/components/vaults/CreateVaultModal.tsx
+++ b/front/components/vaults/CreateVaultModal.tsx
@@ -9,10 +9,7 @@ import {
   Searchbar,
   Spinner,
 } from "@dust-tt/sparkle";
-import type {
-  LightUserType,
-  LightWorkspaceType,
-} from "@dust-tt/types";
+import type { LightUserType, LightWorkspaceType } from "@dust-tt/types";
 import { InformationCircleIcon } from "@heroicons/react/20/solid";
 import type { CellContext } from "@tanstack/react-table";
 import { MinusIcon } from "lucide-react";

--- a/front/components/vaults/CreateVaultModal.tsx
+++ b/front/components/vaults/CreateVaultModal.tsx
@@ -31,6 +31,8 @@ type RowData = {
 
 type Info = CellContext<RowData, unknown>;
 
+const defaultPageSize = 25;
+
 interface CreateVaultModalProps {
   owner: LightWorkspaceType;
   isOpen: boolean;
@@ -54,6 +56,10 @@ export function CreateVaultModal({
   const [selectedMembers, setSelectedMembers] = useState<string[]>([]);
   const [searchTerm, setSearchTerm] = useState<string>("");
   const [isSaving, setIsSaving] = useState(false);
+  const [pagination, setPagination] = useState({
+    pageIndex: 0,
+    pageSize: defaultPageSize,
+  });
   const { mutate: mutateVaults } = useVaults({
     workspaceId: owner.sId,
     disabled: true, // Disable as we just want the mutation function
@@ -239,6 +245,8 @@ export function CreateVaultModal({
                   columns={columns}
                   filterColumn="name"
                   filter={searchTerm}
+                  pagination={pagination}
+                  setPagination={setPagination}
                 />
               </div>
             )}

--- a/front/components/vaults/ManageMembersModal.tsx
+++ b/front/components/vaults/ManageMembersModal.tsx
@@ -7,7 +7,11 @@ import {
   Searchbar,
   Spinner,
 } from "@dust-tt/sparkle";
-import type { LightWorkspaceType, UserType } from "@dust-tt/types";
+import type {
+  LightUserType,
+  LightWorkspaceType,
+  UserType,
+} from "@dust-tt/types";
 import type { CellContext, Row } from "@tanstack/react-table";
 import { MinusIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -30,7 +34,7 @@ interface ManageMembersModalProps {
   onClose: () => void;
 }
 
-function getTableRows(allUsers: UserType[]): RowData[] {
+function getTableRows(allUsers: LightUserType[]): RowData[] {
   return allUsers
     .map((user) => ({
       icon: user.image ?? "",
@@ -50,7 +54,7 @@ export function ManageMembersModal({
   const [selectedMemberIds, setSelectedMemberIds] = useState<string[]>([]);
   const [searchTerm, setSearchTerm] = useState<string>("");
   const [isSaving, setIsSaving] = useState(false);
-  const { members, isMembersLoading } = useMembers(owner);
+  const { members, isMembersLoading } = useMembers({ owner });
 
   const existingMemberIds = useMemo(
     () => existingMembers.map((m) => m.sId).sort(),

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -178,11 +178,10 @@ export async function getMembers(
 }
 
 /**
- * Returns the users members of the workspace associated with the authenticator (without listing
- * their own workspaces).
+ * Returns the users members of the workspace.
  * @param auth Authenticator
  * @param role RoleType optional filter on role
- * @returns An object containing an array of UserTypeWithWorkspaces and the total count of members.
+ * @returns An object containing an array of LightUserType and the total count of members.
  */
 export async function getMembersLight(
   auth: Authenticator,

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -1,4 +1,5 @@
 import type {
+  LightUserType,
   ModelId,
   Result,
   UserProviderType,
@@ -59,6 +60,23 @@ export class UserResource extends BaseResource<User> {
     });
 
     return users.map((user) => new UserResource(User, user.get()));
+  }
+
+  static async fetchLightUsersByModelIds(
+    ids: ModelId[]
+  ): Promise<LightUserType[]> {
+    const users = await User.findAll({
+      where: {
+        id: ids,
+      },
+      attributes: ["sId", "imageUrl", "name"],
+    });
+
+    return users.map((user) => ({
+      sId: user.sId,
+      image: user.imageUrl,
+      fullName: user.name,
+    }));
   }
 
   static async listByUsername(username: string): Promise<UserResource[]> {

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -11,23 +11,25 @@ import {
 import type { GetWorkspaceInvitationsResponseBody } from "@app/pages/api/w/[wId]/invitations";
 import type { GetMembersResponseBody } from "@app/pages/api/w/[wId]/members";
 
-export function useMembers<T extends boolean = false>({
+export function useMembers<Light extends boolean = false>({
   owner,
   pagination,
-  returnLight,
+  light,
 }: {
   owner: LightWorkspaceType;
   pagination?: PaginationState;
-  returnLight?: T;
+  light?: Light;
 }) {
-  const params = new URLSearchParams();
-  appendPaginationParams(params, pagination);
+  const queryParams = new URLSearchParams();
+  appendPaginationParams(queryParams, pagination);
 
-  const url = returnLight
-    ? `/api/w/${owner.sId}/members?light=true`
-    : `/api/w/${owner.sId}/members`;
+  if (light) {
+    queryParams.set("light", "true");
+  }
 
-  const membersFetcher: Fetcher<GetMembersResponseBody<T>> = fetcher;
+  const url = `/api/w/${owner.sId}/members${queryParams.toString()}`;
+
+  const membersFetcher: Fetcher<GetMembersResponseBody<Light>> = fetcher;
   const { data, error, mutate } = useSWRWithDefaults(url, membersFetcher);
 
   return {

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -1,8 +1,4 @@
-import type {
-  LightUserType,
-  LightWorkspaceType,
-  UserTypeWithWorkspaces,
-} from "@dust-tt/types";
+import type { LightWorkspaceType } from "@dust-tt/types";
 import type { PaginationState } from "@tanstack/react-table";
 import { useMemo } from "react";
 import type { Fetcher } from "swr";
@@ -22,7 +18,7 @@ export function useMembers<T extends boolean = false>({
 }: {
   owner: LightWorkspaceType;
   pagination?: PaginationState;
-  returnLight?: boolean;
+  returnLight?: T;
 }) {
   const params = new URLSearchParams();
   appendPaginationParams(params, pagination);
@@ -35,13 +31,7 @@ export function useMembers<T extends boolean = false>({
   const { data, error, mutate } = useSWRWithDefaults(url, membersFetcher);
 
   return {
-    members: useMemo(
-      () =>
-        (data ? data.members : []) as T extends true
-          ? LightUserType[]
-          : UserTypeWithWorkspaces[],
-      [data]
-    ),
+    members: useMemo(() => (data ? data.members : []), [data]),
     isMembersLoading: !error && !data,
     isMembersError: error,
     mutateMembers: mutate,

--- a/front/pages/api/w/[wId]/members/index.ts
+++ b/front/pages/api/w/[wId]/members/index.ts
@@ -32,7 +32,17 @@ async function handler<T extends boolean>(
         supportedOrderColumn: ["createdAt"],
       });
 
-      const returnLight = req.query.light as string;
+      const returnLight = req.query.light;
+
+      if (typeof returnLight !== "string") {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Parameter 'light' needs to be a string",
+          },
+        });
+      }
 
       if (paginationRes.isErr()) {
         return apiError(req, res, {

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -212,7 +212,7 @@ export default function WorkspaceAdmin({
       useState<WorkspaceLimit | null>(null);
 
     const [searchText, setSearchText] = useState("");
-    const { members, isMembersLoading } = useMembers(owner);
+    const { members, isMembersLoading } = useMembers({ owner });
 
     const [inviteEmailModalOpen, setInviteEmailModalOpen] = useState(false);
 

--- a/types/src/front/user.ts
+++ b/types/src/front/user.ts
@@ -63,6 +63,12 @@ export type UserType = {
   image: string | null;
 };
 
+export type LightUserType = {
+  sId: string;
+  fullName: string;
+  image: string | null;
+}
+
 export type UserTypeWithWorkspaces = UserType & {
   workspaces: LightWorkspaceType[];
 };


### PR DESCRIPTION
## Description

This PR aims at enabling to retrieve a dry version of `User`. 

This is done such that we can fetch all the users of a workspace and display them in the `VaultCreationModal`. As of now we cannot perform server-side pagination along with filtering. For this reason we want to fetch all the members of a workspace and perform the pagination/filtering on the client-side.

**References:**
- https://github.com/dust-tt/tasks/issues/1284

## Risk

Non negligible as It touches endpoints

## Deploy Plan

Deploy `front`