### PR TITLE
Revert "Trace the origin of misconfigured groups (#7004)"

### DIFF
--- a/core/src/app.rs
+++ b/core/src/app.rs
@@ -531,10 +531,9 @@ impl App {
                     Some(ref skips) => skips[input_idx],
                     None => false,
                 };
-                let project_id = project.project_id();
                 tokio::spawn(async move {
                     match skip {
-                        false => match b.execute(&name, &e, event_sender, project_id).await {
+                        false => match b.execute(&name, &e, event_sender).await {
                             Ok(v) => {
                                 let block_status = {
                                     let mut block_status = block_status.lock();

--- a/core/src/blocks/block.rs
+++ b/core/src/blocks/block.rs
@@ -155,7 +155,6 @@ pub trait Block {
         name: &str,
         env: &Env,
         event_sender: Option<UnboundedSender<Value>>,
-        project_id: i64,
     ) -> Result<BlockResult>;
 
     fn clone_box(&self) -> Box<dyn Block + Sync + Send>;

--- a/core/src/blocks/browser.rs
+++ b/core/src/blocks/browser.rs
@@ -112,7 +112,6 @@ impl Block for Browser {
         name: &str,
         env: &Env,
         _event_sender: Option<UnboundedSender<Value>>,
-        _project_id: i64,
     ) -> Result<BlockResult> {
         let config = env.config.config_for_block(name);
 

--- a/core/src/blocks/chat.rs
+++ b/core/src/blocks/chat.rs
@@ -171,7 +171,6 @@ impl Block for Chat {
         name: &str,
         env: &Env,
         event_sender: Option<UnboundedSender<Value>>,
-        _project_id: i64,
     ) -> Result<BlockResult> {
         let config = env.config.config_for_block(name);
 

--- a/core/src/blocks/code.rs
+++ b/core/src/blocks/code.rs
@@ -58,7 +58,6 @@ impl Block for Code {
         _name: &str,
         env: &Env,
         _event_sender: Option<UnboundedSender<Value>>,
-        _project_id: i64,
     ) -> Result<BlockResult> {
         // Assumes there is a _fun function defined in `source`.
         // TODO(spolu): revisit, not sure this is optimal.

--- a/core/src/blocks/curl.rs
+++ b/core/src/blocks/curl.rs
@@ -99,7 +99,6 @@ impl Block for Curl {
         name: &str,
         env: &Env,
         _event_sender: Option<UnboundedSender<Value>>,
-        _project_id: i64,
     ) -> Result<BlockResult> {
         let config = env.config.config_for_block(name);
 

--- a/core/src/blocks/data.rs
+++ b/core/src/blocks/data.rs
@@ -65,7 +65,6 @@ impl Block for Data {
         _name: &str,
         env: &Env,
         _event_sender: Option<UnboundedSender<Value>>,
-        _project_id: i64,
     ) -> Result<BlockResult> {
         match env
             .store

--- a/core/src/blocks/data_source.rs
+++ b/core/src/blocks/data_source.rs
@@ -80,14 +80,13 @@ impl DataSource {
         top_k: usize,
         filter: Option<SearchFilter>,
         target_document_tokens: Option<usize>,
-        project_id: i64,
     ) -> Result<Vec<Document>> {
         let (data_source_project, view_filter, data_source_id) =
             get_data_source_project_and_view_filter(
                 &workspace_id,
                 &data_source_or_data_source_view_id,
                 env,
-                format!("data_source_project_id_{}", project_id).as_str(),
+                "data_source",
             )
             .await?;
 
@@ -186,7 +185,6 @@ impl Block for DataSource {
         name: &str,
         env: &Env,
         _event_sender: Option<UnboundedSender<Value>>,
-        project_id: i64,
     ) -> Result<BlockResult> {
         let config = env.config.config_for_block(name);
 
@@ -332,7 +330,6 @@ impl Block for DataSource {
                 top_k,
                 filter.clone(),
                 target_document_tokens,
-                project_id,
             ));
         }
 

--- a/core/src/blocks/database.rs
+++ b/core/src/blocks/database.rs
@@ -64,7 +64,6 @@ impl Block for Database {
         name: &str,
         env: &Env,
         _event_sender: Option<UnboundedSender<Value>>,
-        project_id: i64,
     ) -> Result<BlockResult> {
         let config = env.config.config_for_block(name);
 
@@ -102,7 +101,7 @@ impl Block for Database {
         };
 
         let query = replace_variables_in_string(&self.query, "query", env)?;
-        let tables = load_tables_from_identifiers(&table_identifiers, env, project_id).await?;
+        let tables = load_tables_from_identifiers(&table_identifiers, env).await?;
 
         match query_database(&tables, env.store.clone(), &query).await {
             Ok((results, schema)) => Ok(BlockResult {

--- a/core/src/blocks/end.rs
+++ b/core/src/blocks/end.rs
@@ -45,7 +45,6 @@ impl Block for End {
         _name: &str,
         _env: &Env,
         _event_sender: Option<UnboundedSender<Value>>,
-        _project_id: i64,
     ) -> Result<BlockResult> {
         // No-op the block outputs within the while|if/end are coallesced, the output of end is
         // ignored and not stored in the environment as it has the same name as the while|if block.

--- a/core/src/blocks/input.rs
+++ b/core/src/blocks/input.rs
@@ -33,7 +33,6 @@ impl Block for Input {
         _name: &str,
         env: &Env,
         _event_sender: Option<UnboundedSender<Value>>,
-        _project_id: i64,
     ) -> Result<BlockResult> {
         match env.input.value.as_ref() {
             Some(i) => Ok(BlockResult {

--- a/core/src/blocks/llm.rs
+++ b/core/src/blocks/llm.rs
@@ -302,7 +302,6 @@ impl Block for LLM {
         name: &str,
         env: &Env,
         event_sender: Option<UnboundedSender<Value>>,
-        _project_id: i64,
     ) -> Result<BlockResult> {
         let config = env.config.config_for_block(name);
 

--- a/core/src/blocks/map.rs
+++ b/core/src/blocks/map.rs
@@ -83,7 +83,6 @@ impl Block for Map {
         _name: &str,
         env: &Env,
         _event_sender: Option<UnboundedSender<Value>>,
-        _project_id: i64,
     ) -> Result<BlockResult> {
         match env.state.get(&self.from) {
             None => Err(anyhow::anyhow!(

--- a/core/src/blocks/reduce.rs
+++ b/core/src/blocks/reduce.rs
@@ -47,7 +47,6 @@ impl Block for Reduce {
         _name: &str,
         _env: &Env,
         _event_sender: Option<UnboundedSender<Value>>,
-        _project_id: i64,
     ) -> Result<BlockResult> {
         // No-op the block outputs within the map/reduce will be coallesced, the output of reduce is
         // ignored and not stored in the environment as it has the same name as the map block.

--- a/core/src/blocks/search.rs
+++ b/core/src/blocks/search.rs
@@ -131,7 +131,6 @@ impl Block for Search {
         name: &str,
         env: &Env,
         _event_sender: Option<UnboundedSender<Value>>,
-        _project_id: i64,
     ) -> Result<BlockResult> {
         let config = env.config.config_for_block(name);
 

--- a/core/src/blocks/while.rs
+++ b/core/src/blocks/while.rs
@@ -80,7 +80,6 @@ impl Block for While {
         _name: &str,
         env: &Env,
         _event_sender: Option<UnboundedSender<Value>>,
-        _project_id: i64,
     ) -> Result<BlockResult> {
         let e = env.clone();
 


### PR DESCRIPTION
This reverts commit 691399c113fcd23c335378af85228fcbd6a64dac.

## Description

Reverting tracing in `core` that was initially added to debug requests made to our public API without the appropriate group ids.
Task is [here](https://github.com/dust-tt/tasks/issues/1210).

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
