### PR TITLE
Always include the current node internal id in parent hierarchy

### DIFF
--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -651,6 +651,8 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
     internalId: string;
     memoizationKey?: string;
   }): Promise<Result<string[], Error>> {
+    const baseParents: string[] = [internalId];
+
     const connector = await ConnectorResource.fetchById(this.connectorId);
     if (!connector) {
       return new Err(
@@ -666,9 +668,9 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
           internalId,
           repoId
         );
-        return new Ok(parents);
+        return new Ok([...baseParents, ...parents]);
       } else {
-        return new Ok([`${repoId}`]);
+        return new Ok([...baseParents, `${repoId}`]);
       }
     } else {
       const repoId = parseInt(internalId.split("-")[0] || "", 10);
@@ -676,9 +678,9 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         internalId.endsWith("-issues") ||
         internalId.endsWith("-discussions")
       ) {
-        return new Ok([`${repoId}`]);
+        return new Ok([...baseParents, `${repoId}`]);
       }
-      return new Ok([]);
+      return new Ok(baseParents);
     }
   }
 

--- a/connectors/src/connectors/interface.ts
+++ b/connectors/src/connectors/interface.ts
@@ -55,6 +55,10 @@ export abstract class BaseConnectorManager<T extends ConnectorConfiguration> {
     viewType: ContentNodesViewType;
   }): Promise<Result<ContentNode[], Error>>;
 
+  /**
+   * Retrieves the parent IDs of a content node in hierarchical order.
+   * The first ID is the internal ID of the content node itself.
+   */
   abstract retrieveContentNodeParents(params: {
     internalId: string;
     memoizationKey?: string;

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -573,9 +573,12 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
     return new Ok(contentNodes);
   }
 
-  async retrieveContentNodeParents(): Promise<Result<string[], Error>> {
-    // Slack is flat.
-    return new Ok([]);
+  async retrieveContentNodeParents({
+    internalId,
+  }: {
+    internalId: string;
+  }): Promise<Result<string[], Error>> {
+    return new Ok([internalId]);
   }
 
   async setConfigurationKey({

--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -299,7 +299,7 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
     internalId: string;
     memoizationKey?: string;
   }): Promise<Result<string[], Error>> {
-    const parents: string[] = [];
+    const parents: string[] = [internalId];
     let parentUrl: string | null = null;
 
     // First we get the Page or Folder for which we want to retrieve the parents

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -265,6 +265,8 @@ export async function getContentNodesForDataSourceView(
     contentNodesResult = contentNodesRes.value;
   }
 
+  console.log("contentNodesResult", contentNodesResult.nodes);
+
   const contentNodesInView = filterAndCropContentNodesByView(
     dataSourceView,
     contentNodesResult.nodes

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -265,8 +265,6 @@ export async function getContentNodesForDataSourceView(
     contentNodesResult = contentNodesRes.value;
   }
 
-  console.log("contentNodesResult", contentNodesResult.nodes);
-
   const contentNodesInView = filterAndCropContentNodesByView(
     dataSourceView,
     contentNodesResult.nodes


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The `filterAndCropContentNodesByView` function is designed to enforce data source view permissions. It assumes that the current node's internal ID is always the first element in the parents array. This assumption holds true in all cases except for GitHub and Slack.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
