### PR TITLE
[sparkle] - feature: update `TextArea` component with adjustable row …

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.231",
+  "version": "0.2.232",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.231",
+      "version": "0.2.232",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.231",
+  "version": "0.2.232",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/TextArea.tsx
+++ b/sparkle/src/components/TextArea.tsx
@@ -9,6 +9,7 @@ type TextAreaProps = {
   error?: string | null;
   showErrorLabel?: boolean;
   className?: string;
+  rows?: number;
 };
 
 export function TextArea({
@@ -18,6 +19,7 @@ export function TextArea({
   error,
   showErrorLabel = false,
   className,
+  rows = 10
 }: TextAreaProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -30,9 +32,10 @@ export function TextArea({
   return (
     <div className="s-flex s-flex-col s-gap-1 s-p-px">
       <textarea
+        rows={rows}
         ref={textareaRef}
         className={classNames(
-          "overflow-y-auto s-block s-min-h-60 s-w-full s-min-w-0 s-rounded-xl s-text-sm s-placeholder-element-700 s-transition-all s-duration-200 s-scrollbar-hide",
+          "overflow-y-auto s-block s-w-full s-min-w-0 s-rounded-xl s-text-sm s-placeholder-element-700 s-transition-all s-duration-200 s-scrollbar-hide",
           !error
             ? "s-border-structure-100 focus:s-border-action-300 focus:s-ring-action-300"
             : "s-border-red-500 focus:s-border-red-500 focus:s-ring-red-500",

--- a/sparkle/src/stories/TextArea.stories.tsx
+++ b/sparkle/src/stories/TextArea.stories.tsx
@@ -26,6 +26,7 @@ export const TextAreaExample = () => {
           onChange={(v) =>
             setTextValues([v, textValues[1], textValues[2], textValues[3]])
           }
+          rows={2}
         />
         <TextArea
           placeholder="placeholder"


### PR DESCRIPTION
## Description

This PR aims at modifying the `TextArea` sparkle component to pass it a number of rows. This aims to be used to tackle the following task: https://github.com/dust-tt/tasks/issues/1273.

Note: the default number of rows was set to be close to the previous min height that was set.

**References:**
- https://github.com/dust-tt/tasks/issues/1273

## Risk

None

## Deploy Plan

Deploy `sparkle`