### PR TITLE
[Infra] Front deployment horizontalization

### DIFF
--- a/k8s/deployments/front-deployment.yaml
+++ b/k8s/deployments/front-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: front-deployment
 spec:
-  replicas: 8
+  replicas: 12
   selector:
     matchLabels:
       app: front
@@ -60,12 +60,12 @@ spec:
 
           resources:
             requests:
-              cpu: 2000m
-              memory: 2.5Gi
+              cpu: 1250m
+              memory: 1.5Gi
 
             limits:
-              cpu: 2000m
-              memory: 2.5Gi
+              cpu: 1250m
+              memory: 1.5Gi
 
       volumes:
         - name: cert-volume


### PR DESCRIPTION
Description
---
Increase number of pods, decrease per-pod capacity
- since node is single threaded, no need to have more than 1 core per pod;
- memory was underused, reduced it per pod.

This should lower cost per pod and increase total capacity

Note: put 1250m and not 1000m because in some cases surges go over the thread limit (e.g. node takes 100% + system takes a few cycles)

Related [thread](https://dust4ai.slack.com/archives/C05F84CFP0E/p1725960639602569)

Risk
---
Will keep an eye on impact on front latencies & total usage

Deploy
---
front
