### PR TITLE
[front] - fix(UI): decrease folder description TextArea

### DIFF
--- a/front/components/vaults/VaultFolderModal.tsx
+++ b/front/components/vaults/VaultFolderModal.tsx
@@ -264,6 +264,7 @@ export default function VaultFolderModal({
                 }}
                 error={errors.description}
                 showErrorLabel
+                rows={2}
               />
             </div>
 

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,7 @@
         "@amplitude/analytics-browser": "^2.5.2",
         "@amplitude/analytics-node": "^1.3.5",
         "@auth0/nextjs-auth0": "^3.5.0",
-        "@dust-tt/sparkle": "^0.2.231",
+        "@dust-tt/sparkle": "^0.2.232",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -10736,9 +10736,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.231",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.231.tgz",
-      "integrity": "sha512-bGKdWewUcEiC3ie1/Iu5i/2SJFtQuC5Yj7z+N7vlulgWcAuLhhmTf3PAJ8ovDUAYKJC/9XxLDlEQDLjsQv28iQ==",
+      "version": "0.2.232",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.232.tgz",
+      "integrity": "sha512-TmS4n2YO72gwcfcbm2Z/YvjZUk5XfK8vxm8Tw0hUnhbFqQorsBtx0ECDvaPIHTCTOIDY8vCGYx9Jfjfyi1SNpA==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
     "@amplitude/analytics-browser": "^2.5.2",
     "@amplitude/analytics-node": "^1.3.5",
     "@auth0/nextjs-auth0": "^3.5.0",
-    "@dust-tt/sparkle": "^0.2.231",
+    "@dust-tt/sparkle": "^0.2.232",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",


### PR DESCRIPTION
## Description

This PR aims at using the latest `sparkle` version to decrease the folder description TextArea size by setting a number of rows.

**References:**
- https://github.com/dust-tt/tasks/issues/1273

## Risk

None

## Deploy Plan

Deploy `front`