### PR TITLE
Do not delete AgentTablesQueryConfigurationTable if table was deleted

### DIFF
--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -13,7 +13,6 @@ import { DateTime } from "luxon";
 
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentTablesQueryConfigurationTable } from "@app/lib/models/assistant/actions/tables_query";
 import logger from "@app/logger/logger";
 
 import type { DataSourceResource } from "../resources/data_source_resource";
@@ -100,14 +99,9 @@ export async function deleteTable({
       message: "Failed to delete table.",
     });
   }
-  await AgentTablesQueryConfigurationTable.destroy({
-    where: {
-      dataSourceWorkspaceId: owner.sId,
-      // TODO(DATASOURCE_SID); state storing the datasource name
-      dataSourceId: dataSource.name,
-      tableId,
-    },
-  });
+  // We do not delete the related AgentTablesQueryConfigurationTable entry if any.
+  // This is because the table might be created again with the same name and we want to keep the configuration.
+  // The Assistant Builder displays an error on the action card if it misses a table.
 
   return new Ok(null);
 }


### PR DESCRIPTION
## Description

Eng runner card: https://github.com/dust-tt/tasks/issues/1295

From what I understood: When we update a spreadsheet and the structure is invalid because a user is currently playing the data, we remove the table. The table is then re-created, potentially with the same id as before. 

Problem is when we delete the table, we also delete the associated `AgentTablesQueryConfigurationTable` objects which means all agents using this table are loosing their configuration. 

This PR removes this destroy. 
I checked and the Assistant Builder handles this case and displays an error in the action chip if invalid: 
<kbd>
<img width="1000" alt="Screenshot 2024-09-10 at 13 28 03" src="https://github.com/user-attachments/assets/26d89ef7-454f-42e8-a617-fb06effd6ef9">
</kbd>

The assistant will also properly yield an error if this happens: https://github.com/dust-tt/dust/blob/main/front/lib/api/assistant/actions/tables_query.ts#L277

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
