### PR TITLE
Use right auth permission to list agent configurations from Slack

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -314,7 +314,14 @@ async function botAnswerMessage(
     );
   }
 
-  const agentConfigurationsRes = await dustAPI.getAgentConfigurations();
+  const userEmailHeader =
+    slackChatBotMessage.slackEmail !== "unknown"
+      ? slackChatBotMessage.slackEmail
+      : undefined;
+
+  const agentConfigurationsRes = await dustAPI.getAgentConfigurations({
+    userEmailHeader,
+  });
   if (agentConfigurationsRes.isErr()) {
     return new Err(new Error(agentConfigurationsRes.error.message));
   }
@@ -444,10 +451,7 @@ async function botAnswerMessage(
     const mesasgeRes = await dustAPI.postUserMessage({
       conversationId: lastSlackChatBotMessage.conversationId,
       message: messageReqBody,
-      userEmailHeader:
-        slackChatBotMessage.slackEmail !== "unknown"
-          ? slackChatBotMessage.slackEmail
-          : undefined,
+      userEmailHeader,
     });
     if (mesasgeRes.isErr()) {
       return new Err(new Error(mesasgeRes.error.message));
@@ -455,6 +459,7 @@ async function botAnswerMessage(
     userMessage = mesasgeRes.value;
     const conversationRes = await dustAPI.getConversation({
       conversationId: lastSlackChatBotMessage.conversationId,
+      // TODO(VAULTS_INFRA) Add support for userEmailHeader and group
     });
     if (conversationRes.isErr()) {
       return new Err(new Error(conversationRes.error.message));
@@ -466,10 +471,7 @@ async function botAnswerMessage(
       visibility: "unlisted",
       message: messageReqBody,
       contentFragment: buildContentFragmentRes.value || undefined,
-      userEmailHeader:
-        slackChatBotMessage.slackEmail !== "unknown"
-          ? slackChatBotMessage.slackEmail
-          : undefined,
+      userEmailHeader,
     });
     if (convRes.isErr()) {
       return new Err(new Error(convRes.error.message));

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -4,6 +4,7 @@ import type {
   WithAPIErrorResponse,
 } from "@dust-tt/types";
 import {
+  DustUserEmailHeader,
   isEmptyString,
   PublicPostMessagesRequestBodySchema,
 } from "@dust-tt/types";
@@ -141,7 +142,7 @@ async function handler(
       // /!\ This is reserved for internal use!
       // If the header "x-api-user-email" is present and valid,
       // associate the message with the provided user email if it belongs to the same workspace.
-      const userEmailFromHeader = req.headers["x-api-user-email"];
+      const userEmailFromHeader = req.headers[DustUserEmailHeader];
       if (typeof userEmailFromHeader === "string") {
         workspaceAuth =
           (await workspaceAuth.exchangeSystemKeyForUserAuthByEmail(

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -5,6 +5,7 @@ import type {
   WithAPIErrorResponse,
 } from "@dust-tt/types";
 import {
+  DustUserEmailHeader,
   isEmptyString,
   PublicPostConversationsRequestBodySchema,
 } from "@dust-tt/types";
@@ -183,7 +184,7 @@ async function handler(
       // /!\ This is reserved for internal use!
       // If the header "x-api-user-email" is present and valid,
       // associate the message with the provided user email if it belongs to the same workspace.
-      const userEmailFromHeader = req.headers["x-api-user-email"];
+      const userEmailFromHeader = req.headers[DustUserEmailHeader];
       if (typeof userEmailFromHeader === "string") {
         workspaceAuth =
           (await workspaceAuth.exchangeSystemKeyForUserAuthByEmail(

--- a/types/src/front/lib/dust_api.ts
+++ b/types/src/front/lib/dust_api.ts
@@ -142,6 +142,7 @@ export type DustAPICredentials = {
 };
 
 export const DustGroupIdsHeader = "X-Dust-Group-Ids";
+export const DustUserEmailHeader = "x-api-user-email";
 
 type PublicPostContentFragmentRequestBody = t.TypeOf<
   typeof PublicPostContentFragmentRequestBodySchema
@@ -482,17 +483,29 @@ export class DustAPI {
     return new Ok(r.value.data_sources);
   }
 
-  async getAgentConfigurations(): Promise<
-    DustAPIResponse<LightAgentConfigurationType[]>
-  > {
+  async getAgentConfigurations({
+    userEmailHeader,
+  }: {
+    userEmailHeader?: string;
+  } = {}): Promise<DustAPIResponse<LightAgentConfigurationType[]>> {
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this._credentials.apiKey}`,
+      "Content-Type": "application/json",
+    };
+
+    if (userEmailHeader) {
+      headers[DustUserEmailHeader] = userEmailHeader;
+    }
+
+    if (this._credentials.groupIds) {
+      headers[DustGroupIdsHeader] = this._credentials.groupIds.join(",");
+    }
+
     const res = await this._fetchWithError(
       `${this.apiUrl()}/api/v1/w/${this.workspaceId()}/assistant/agent_configurations`,
       {
         method: "GET",
-        headers: {
-          Authorization: `Bearer ${this._credentials.apiKey}`,
-          "Content-Type": "application/json",
-        },
+        headers,
       }
     );
 
@@ -557,7 +570,7 @@ export class DustAPI {
     };
 
     if (userEmailHeader) {
-      headers["x-api-user-email"] = userEmailHeader;
+      headers[DustUserEmailHeader] = userEmailHeader;
     }
     if (this._credentials.groupIds) {
       headers[DustGroupIdsHeader] = this._credentials.groupIds.join(",");
@@ -596,7 +609,7 @@ export class DustAPI {
     };
 
     if (userEmailHeader) {
-      headers["x-api-user-email"] = userEmailHeader;
+      headers[DustUserEmailHeader] = userEmailHeader;
     }
     if (this._credentials.groupIds) {
       headers[DustGroupIdsHeader] = this._credentials.groupIds.join(",");


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See thread [here](https://dust4ai.slack.com/archives/C05B529FHV1/p1725975160481399).

Since https://github.com/dust-tt/dust/pull/7185 we now filters out assistant based on the vaults/groups they used. We oversaw the slack part, where we first need to list the agent configurations to find the closest one to the user's input.

This endpoint was neither handling the user email header not the group ids.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Tested locally.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
