### PR TITLE
Add public API wrapper

### DIFF
--- a/front/lib/api/wrappers.ts
+++ b/front/lib/api/wrappers.ts
@@ -143,7 +143,7 @@ export function withSessionAuthenticationForWorkspace<T>(
  * @param opts
  * @returns
  */
-export function withPublicApiAuthentication<T, U extends boolean>(
+export function withPublicAPIAuthentication<T, U extends boolean>(
   handler: (
     req: NextApiRequest,
     res: NextApiResponse<WithAPIErrorResponse<T>>,
@@ -209,10 +209,12 @@ export function withPublicApiAuthentication<T, U extends boolean>(
         });
       }
 
-      // /!\ This is reserved for internal use!
-      // If the header "x-api-user-email" is present and valid,
-      // exchange the workspace auth for a user auth.
-      // This only works if the user is a member of the workspace.
+      // NOTE: This section is for internal use only!
+      // If the "x-api-user-email" header is present and contains a valid email address, attempt
+      // to exchange the current workspace authentication for user authentication.
+      // This operation is only performed if:
+      // 1. The user associated with the email is a member of the current workspace.
+      // 2. The system key is being used for authentication.
       const userEmailFromHeader = req.headers[DustUserEmailHeader];
       if (
         typeof userEmailFromHeader === "string" &&

--- a/front/lib/api/wrappers.ts
+++ b/front/lib/api/wrappers.ts
@@ -198,7 +198,8 @@ export function withPublicAPIAuthentication<T, U extends boolean>(
         });
       }
 
-      // Authenticator created from the a key has the builder role if the key is associated with the workspace.
+      // Authenticator created from the a key has the builder role if the key is associated with
+      // the workspace.
       if (!workspaceAuth.isBuilder() && !allowUserOutsideCurrentWorkspace) {
         return apiError(req, res, {
           status_code: 401,

--- a/front/lib/api/wrappers.ts
+++ b/front/lib/api/wrappers.ts
@@ -1,8 +1,10 @@
 import type { WithAPIErrorResponse } from "@dust-tt/types";
+import { DustUserEmailHeader } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { Authenticator } from "@app/lib/auth";
+import { Authenticator, getAPIKey } from "@app/lib/auth";
 import { getSession } from "@app/lib/auth";
+import { getGroupIdsFromHeaders } from "@app/lib/http_api/group_header";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
@@ -126,5 +128,114 @@ export function withSessionAuthenticationForWorkspace<T>(
       return handler(req, res, auth, session);
     },
     opts
+  );
+}
+
+/**
+ * This function is a wrapper for Public API routes that require authentication for a workspace.
+ * It must be used on all routes that require workspace authentication (prefix: /v1/w/[wId/]).
+ *
+ * opts.allowUserOutsideCurrentWorkspace allows the handler to be called even if the key is not a
+ * associated with the workspace. This is useful for routes that share data across workspaces (eg apps
+ * runs).
+ *
+ * @param handler
+ * @param opts
+ * @returns
+ */
+export function withPublicApiAuthentication<T, U extends boolean>(
+  handler: (
+    req: NextApiRequest,
+    res: NextApiResponse<WithAPIErrorResponse<T>>,
+    auth: Authenticator,
+    keyAuth: U extends true ? Authenticator : null
+  ) => Promise<void> | void,
+  opts: {
+    isStreaming?: boolean;
+    allowUserOutsideCurrentWorkspace?: U;
+  } = {}
+) {
+  const { allowUserOutsideCurrentWorkspace, isStreaming } = opts;
+
+  return withLogging(
+    async (
+      req: NextApiRequest,
+      res: NextApiResponse<WithAPIErrorResponse<T>>
+    ) => {
+      const { wId } = req.query;
+      if (typeof wId !== "string" || !wId) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "workspace_not_found",
+            message: "The workspace was not found.",
+          },
+        });
+      }
+
+      const keyRes = await getAPIKey(req);
+      if (keyRes.isErr()) {
+        return apiError(req, res, keyRes.error);
+      }
+
+      const keyAndWorkspaceAuth = await Authenticator.fromKey(
+        keyRes.value,
+        wId,
+        getGroupIdsFromHeaders(req.headers)
+      );
+      const { keyAuth } = keyAndWorkspaceAuth;
+      let { workspaceAuth } = keyAndWorkspaceAuth;
+
+      const owner = workspaceAuth.workspace();
+      const plan = workspaceAuth.plan();
+      if (!owner || !plan) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "workspace_not_found",
+            message: "The workspace was not found.",
+          },
+        });
+      }
+
+      // Authenticator created from the a key has the builder role if the key is associated with the workspace.
+      if (!workspaceAuth.isBuilder() && !allowUserOutsideCurrentWorkspace) {
+        return apiError(req, res, {
+          status_code: 401,
+          api_error: {
+            type: "workspace_auth_error",
+            message: "Only users of the workspace can access this route.",
+          },
+        });
+      }
+
+      // /!\ This is reserved for internal use!
+      // If the header "x-api-user-email" is present and valid,
+      // exchange the workspace auth for a user auth.
+      // This only works if the user is a member of the workspace.
+      const userEmailFromHeader = req.headers[DustUserEmailHeader];
+      if (
+        typeof userEmailFromHeader === "string" &&
+        !allowUserOutsideCurrentWorkspace
+      ) {
+        workspaceAuth =
+          (await workspaceAuth.exchangeSystemKeyForUserAuthByEmail(
+            workspaceAuth,
+            {
+              userEmail: userEmailFromHeader,
+            }
+          )) ?? workspaceAuth;
+      }
+
+      return handler(
+        req,
+        res,
+        workspaceAuth,
+        (opts.allowUserOutsideCurrentWorkspace
+          ? keyAuth
+          : null) as U extends true ? Authenticator : null
+      );
+    },
+    isStreaming
   );
 }

--- a/front/lib/http_api/group_header.ts
+++ b/front/lib/http_api/group_header.ts
@@ -4,7 +4,7 @@ export function getGroupIdsFromHeaders(
   headers: Record<string, string | string[] | undefined>
 ): string[] | undefined {
   const groupIds = headers[DustGroupIdsHeader.toLowerCase()];
-  if (typeof groupIds === "string") {
+  if (typeof groupIds === "string" && groupIds.trim().length > 0) {
     return groupIds.split(",").map((id) => id.trim());
   } else {
     undefined;

--- a/front/pages/api/v1/w/[wId]/apps/[aId]/runs/[runId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/[aId]/runs/[runId]/index.ts
@@ -3,7 +3,7 @@ import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import apiConfig from "@app/lib/api/config";
-import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { AppResource } from "@app/lib/resources/app_resource";
 import logger from "@app/logger/logger";
@@ -147,4 +147,4 @@ async function handler(
   }
 }
 
-export default withPublicApiAuthentication(handler);
+export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
@@ -19,14 +19,14 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import apiConfig from "@app/lib/api/config";
 import { getDustAppSecrets } from "@app/lib/api/dust_app_secrets";
-import { Authenticator, getAPIKey } from "@app/lib/auth";
-import { getGroupIdsFromHeaders } from "@app/lib/http_api/group_header";
+import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { AppResource } from "@app/lib/resources/app_resource";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { Provider } from "@app/lib/resources/storage/models/apps";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type PostRunResponseBody = {
   run: RunType;
@@ -168,38 +168,20 @@ function extractUsageFromExecutions(
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<PostRunResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PostRunResponseBody>>,
+  auth: Authenticator,
+  keyAuth: Authenticator
 ): Promise<void> {
-  const keyRes = await getAPIKey(req);
-  if (keyRes.isErr()) {
-    return apiError(req, res, keyRes.error);
-  }
-
-  const { keyAuth, workspaceAuth } = await Authenticator.fromKey(
-    keyRes.value,
-    req.query.wId as string,
-    getGroupIdsFromHeaders(req.headers)
-  );
-
-  const owner = workspaceAuth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace was not found.",
-      },
-    });
-  }
+  const keyWorkspaceId = keyAuth.getNonNullableWorkspace().id;
 
   const [app, providers, secrets] = await Promise.all([
-    AppResource.fetchById(workspaceAuth, req.query.aId as string),
+    AppResource.fetchById(auth, req.query.aId as string),
     Provider.findAll({
       where: {
-        workspaceId: keyRes.value.workspaceId,
+        workspaceId: keyWorkspaceId,
       },
     }),
-    getDustAppSecrets(workspaceAuth, true),
+    getDustAppSecrets(auth, true),
   ]);
 
   if (!app) {
@@ -211,6 +193,8 @@ async function handler(
       },
     });
   }
+
+  const owner = auth.getNonNullableWorkspace();
 
   // This variable is used in the context of the DustAppRun action to use the workspace credentials
   // instead of our managed credentials when running an app with a system API key.
@@ -252,14 +236,14 @@ async function handler(
       }
 
       let credentials: CredentialsType | null = null;
-      if (keyRes.value.isSystem && !useWorkspaceCredentials) {
+      if (auth.isSystemKey() && !useWorkspaceCredentials) {
         // Dust managed credentials: system API key (packaged apps).
         credentials = dustManagedCredentials();
       } else {
         credentials = credentialsFromProviders(providers);
       }
 
-      if (!keyRes.value.isSystem) {
+      if (!auth.isSystemKey()) {
         const remaining = await rateLimiter({
           key: `app_run:w:${owner.sId}:a:${app.sId}`,
           maxPerTimeframe: 10000,
@@ -426,7 +410,7 @@ async function handler(
         dustRunId,
         appId: app.id,
         runType: "deploy",
-        workspaceId: keyRes.value.workspaceId,
+        workspaceId: keyWorkspaceId,
       });
 
       await run.recordRunUsage(usages);
@@ -500,4 +484,6 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withPublicApiAuthentication(handler, {
+  allowUserOutsideCurrentWorkspace: true,
+});

--- a/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
@@ -19,7 +19,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import apiConfig from "@app/lib/api/config";
 import { getDustAppSecrets } from "@app/lib/api/dust_app_secrets";
-import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { AppResource } from "@app/lib/resources/app_resource";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
@@ -484,6 +484,6 @@ async function handler(
   }
 }
 
-export default withPublicApiAuthentication(handler, {
+export default withPublicAPIAuthentication(handler, {
   allowUserOutsideCurrentWorkspace: true,
 });

--- a/front/pages/api/v1/w/[wId]/apps/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/index.ts
@@ -1,7 +1,7 @@
 import type { AppType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { apiError } from "@app/logger/withlogging";
@@ -104,4 +104,4 @@ async function handler(
   }
 }
 
-export default withPublicApiAuthentication(handler);
+export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
@@ -2,8 +2,9 @@ import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
-import { Authenticator, getAPIKey } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
 import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 
 /**
@@ -46,40 +47,15 @@ import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetAgentConfigurationsResponseBody>>
+  res: NextApiResponse<
+    WithAPIErrorResponse<GetAgentConfigurationsResponseBody>
+  >,
+  auth: Authenticator
 ): Promise<void> {
-  const keyRes = await getAPIKey(req);
-  if (keyRes.isErr()) {
-    return apiError(req, res, keyRes.error);
-  }
-
-  const { wId } = req.query;
-  if (typeof wId !== "string") {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Workspace ID not found",
-      },
-    });
-  }
-
-  const { workspaceAuth } = await Authenticator.fromKey(keyRes.value, wId);
-
-  if (!workspaceAuth || !workspaceAuth.isBuilder()) {
-    return apiError(req, res, {
-      status_code: 401,
-      api_error: {
-        type: "workspace_not_found",
-        message: "Workspace not found",
-      },
-    });
-  }
-
   switch (req.method) {
     case "GET": {
       const agentConfigurations = await getAgentConfigurations({
-        auth: workspaceAuth,
+        auth,
         agentsGetView: "all",
         variant: "light",
       });
@@ -98,4 +74,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withPublicApiAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
@@ -2,7 +2,7 @@ import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
-import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
@@ -74,4 +74,4 @@ async function handler(
   }
 }
 
-export default withPublicApiAuthentication(handler);
+export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations/search.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations/search.ts
@@ -2,9 +2,10 @@ import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { searchAgentConfigurationsByName } from "@app/lib/api/assistant/configuration";
-import { Authenticator, getAPIKey } from "@app/lib/auth";
+import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import type { AgentConfiguration } from "@app/lib/models/assistant/agent";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 /**
  * @swagger
@@ -59,38 +60,14 @@ type GetAgentConfigurationsResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetAgentConfigurationsResponseBody>>
+  res: NextApiResponse<
+    WithAPIErrorResponse<GetAgentConfigurationsResponseBody>
+  >,
+  auth: Authenticator
 ): Promise<void> {
-  const keyRes = await getAPIKey(req);
-  if (keyRes.isErr()) {
-    return apiError(req, res, keyRes.error);
-  }
-
-  const { wId, q } = req.query;
-  if (typeof wId !== "string") {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Workspace ID not found",
-      },
-    });
-  }
-
-  const { workspaceAuth } = await Authenticator.fromKey(keyRes.value, wId);
-
-  if (!workspaceAuth || !workspaceAuth.isBuilder()) {
-    return apiError(req, res, {
-      status_code: 401,
-      api_error: {
-        type: "workspace_not_found",
-        message: "Workspace not found",
-      },
-    });
-  }
-
   switch (req.method) {
     case "GET": {
+      const { q } = req.query;
       if (typeof q !== "string") {
         return apiError(req, res, {
           status_code: 400,
@@ -102,7 +79,7 @@ async function handler(
       }
 
       const agentConfigurations = await searchAgentConfigurationsByName(
-        workspaceAuth,
+        auth,
         q
       );
       return res.status(200).json({
@@ -120,4 +97,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withPublicApiAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations/search.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations/search.ts
@@ -2,7 +2,7 @@ import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { searchAgentConfigurationsByName } from "@app/lib/api/assistant/configuration";
-import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import type { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { apiError } from "@app/logger/withlogging";
@@ -97,4 +97,4 @@ async function handler(
   }
 }
 
-export default withPublicApiAuthentication(handler);
+export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -10,7 +10,7 @@ import {
   normalizeContentFragmentType,
   postNewContentFragment,
 } from "@app/lib/api/assistant/conversation";
-import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
@@ -163,4 +163,4 @@ async function handler(
   }
 }
 
-export default withPublicApiAuthentication(handler);
+export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -3,7 +3,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
 import { getConversationEvents } from "@app/lib/api/assistant/pubsub";
-import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
@@ -104,4 +104,4 @@ async function handler(
   }
 }
 
-export default withPublicApiAuthentication(handler, { isStreaming: true });
+export default withPublicAPIAuthentication(handler, { isStreaming: true });

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -2,7 +2,7 @@ import type { ConversationType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
-import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
@@ -94,4 +94,4 @@ async function handler(
   }
 }
 
-export default withPublicApiAuthentication(handler);
+export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -2,8 +2,9 @@ import type { ConversationType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
-import { Authenticator, getAPIKey } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
 
 /**
  * @swagger
@@ -49,35 +50,23 @@ import { apiError, withLogging } from "@app/logger/withlogging";
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<{ conversation: ConversationType }>>
+  res: NextApiResponse<
+    WithAPIErrorResponse<{ conversation: ConversationType }>
+  >,
+  auth: Authenticator
 ): Promise<void> {
-  const keyRes = await getAPIKey(req);
-  if (keyRes.isErr()) {
-    return apiError(req, res, keyRes.error);
-  }
-
-  const { keyAuth, workspaceAuth } = await Authenticator.fromKey(
-    keyRes.value,
-    req.query.wId as string
-  );
-
-  if (
-    !workspaceAuth.isBuilder() ||
-    keyAuth.getNonNullableWorkspace().sId !== req.query.wId
-  ) {
+  const { cId } = req.query;
+  if (typeof cId !== "string") {
     return apiError(req, res, {
-      status_code: 400,
+      status_code: 404,
       api_error: {
-        type: "invalid_request_error",
-        message: "The Assistant API is only available on your own workspace.",
+        type: "conversation_not_found",
+        message: "Conversation not found.",
       },
     });
   }
 
-  const conversation = await getConversation(
-    workspaceAuth,
-    req.query.cId as string
-  );
+  const conversation = await getConversation(auth, cId);
   if (!conversation) {
     return apiError(req, res, {
       status_code: 404,
@@ -105,4 +94,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withPublicApiAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
@@ -6,7 +6,7 @@ import {
   getConversationWithoutContent,
 } from "@app/lib/api/assistant/conversation";
 import { getMessagesEvents } from "@app/lib/api/assistant/pubsub";
-import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
@@ -175,4 +175,4 @@ async function handler(
   }
 }
 
-export default withPublicApiAuthentication(handler, { isStreaming: true });
+export default withPublicAPIAuthentication(handler, { isStreaming: true });

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
@@ -6,8 +6,9 @@ import {
   getConversationWithoutContent,
 } from "@app/lib/api/assistant/conversation";
 import { getMessagesEvents } from "@app/lib/api/assistant/pubsub";
-import { Authenticator, getAPIKey } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
 
 /**
  * @swagger
@@ -76,47 +77,31 @@ import { apiError, withLogging } from "@app/logger/withlogging";
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<void>>
+  res: NextApiResponse<WithAPIErrorResponse<void>>,
+  auth: Authenticator
 ): Promise<void> {
-  const keyRes = await getAPIKey(req);
-  if (keyRes.isErr()) {
-    return apiError(req, res, keyRes.error);
-  }
-
-  const { keyAuth, workspaceAuth } = await Authenticator.fromKey(
-    keyRes.value,
-    req.query.wId as string
-  );
-
-  if (
-    !workspaceAuth.isBuilder() ||
-    keyAuth.getNonNullableWorkspace().sId !== req.query.wId
-  ) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "The Assistant API is only available on your own workspace.",
-      },
-    });
-  }
-
-  const owner = workspaceAuth.workspace();
-  if (!owner) {
+  const { cId, mId } = req.query;
+  if (typeof cId !== "string") {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you're trying to modify was not found.",
+        type: "conversation_not_found",
+        message: "Conversation not found.",
       },
     });
   }
 
-  const conversation = await getConversationWithoutContent(
-    workspaceAuth,
-    req.query.cId as string
-  );
+  if (typeof mId !== "string") {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "message_not_found",
+        message: "Message not found.",
+      },
+    });
+  }
 
+  const conversation = await getConversationWithoutContent(auth, cId);
   if (!conversation) {
     return apiError(req, res, {
       status_code: 404,
@@ -127,24 +112,7 @@ async function handler(
     });
   }
 
-  if (!(typeof req.query.mId === "string")) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid query parameters, `cId` (string) is required.",
-      },
-    });
-  }
-
-  const messageId = req.query.mId;
-
-  const messageType = await getConversationMessageType(
-    workspaceAuth,
-    conversation,
-    messageId
-  );
-
+  const messageType = await getConversationMessageType(auth, conversation, mId);
   if (!messageType) {
     return apiError(req, res, {
       status_code: 404,
@@ -178,7 +146,7 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const eventStream = getMessagesEvents(messageId, lastEventId);
+      const eventStream = getMessagesEvents(mId, lastEventId);
 
       res.writeHead(200, {
         "Content-Type": "text/event-stream",
@@ -207,4 +175,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler, true);
+export default withPublicApiAuthentication(handler, { isStreaming: true });

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -13,7 +13,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
 import { postUserMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
-import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
@@ -155,4 +155,4 @@ async function handler(
   }
 }
 
-export default withPublicApiAuthentication(handler);
+export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -4,7 +4,6 @@ import type {
   WithAPIErrorResponse,
 } from "@dust-tt/types";
 import {
-  DustUserEmailHeader,
   isEmptyString,
   PublicPostMessagesRequestBodySchema,
 } from "@dust-tt/types";
@@ -14,9 +13,9 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
 import { postUserMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
-import { Authenticator, getAPIKey } from "@app/lib/auth";
-import { getGroupIdsFromHeaders } from "@app/lib/http_api/group_header";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
 
 export type PostMessagesResponseBody = {
   message: UserMessageType;
@@ -69,38 +68,21 @@ export type PostMessagesResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<PostMessagesResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PostMessagesResponseBody>>,
+  auth: Authenticator
 ): Promise<void> {
-  const keyRes = await getAPIKey(req);
-  if (keyRes.isErr()) {
-    return apiError(req, res, keyRes.error);
-  }
-
-  const authenticator = await Authenticator.fromKey(
-    keyRes.value,
-    req.query.wId as string,
-    getGroupIdsFromHeaders(req.headers)
-  );
-  let { workspaceAuth } = authenticator;
-  const { keyAuth } = authenticator;
-
-  if (
-    !workspaceAuth.isBuilder() ||
-    keyAuth.getNonNullableWorkspace().sId !== req.query.wId
-  ) {
+  const { cId } = req.query;
+  if (typeof cId !== "string") {
     return apiError(req, res, {
-      status_code: 400,
+      status_code: 404,
       api_error: {
-        type: "invalid_request_error",
-        message: "The Assistant API is only available on your own workspace.",
+        type: "conversation_not_found",
+        message: "Conversation not found.",
       },
     });
   }
 
-  const conversation = await getConversation(
-    workspaceAuth,
-    req.query.cId as string
-  );
+  const conversation = await getConversation(auth, cId);
   if (!conversation) {
     return apiError(req, res, {
       status_code: 404,
@@ -139,22 +121,8 @@ async function handler(
         });
       }
 
-      // /!\ This is reserved for internal use!
-      // If the header "x-api-user-email" is present and valid,
-      // associate the message with the provided user email if it belongs to the same workspace.
-      const userEmailFromHeader = req.headers[DustUserEmailHeader];
-      if (typeof userEmailFromHeader === "string") {
-        workspaceAuth =
-          (await workspaceAuth.exchangeSystemKeyForUserAuthByEmail(
-            workspaceAuth,
-            {
-              userEmail: userEmailFromHeader,
-            }
-          )) ?? workspaceAuth;
-      }
-
       const messageRes = await postUserMessageWithPubSub(
-        workspaceAuth,
+        auth,
         {
           conversation,
           content,
@@ -187,4 +155,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withPublicApiAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -19,7 +19,7 @@ import {
   postNewContentFragment,
 } from "@app/lib/api/assistant/conversation";
 import { postUserMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
-import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
@@ -256,4 +256,4 @@ async function handler(
   }
 }
 
-export default withPublicApiAuthentication(handler);
+export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -5,7 +5,6 @@ import type {
   WithAPIErrorResponse,
 } from "@dust-tt/types";
 import {
-  DustUserEmailHeader,
   isEmptyString,
   PublicPostConversationsRequestBodySchema,
 } from "@dust-tt/types";
@@ -20,9 +19,9 @@ import {
   postNewContentFragment,
 } from "@app/lib/api/assistant/conversation";
 import { postUserMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
-import { Authenticator, getAPIKey } from "@app/lib/auth";
-import { getGroupIdsFromHeaders } from "@app/lib/http_api/group_header";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
 
 export type PostConversationsResponseBody = {
   conversation: ConversationType;
@@ -92,45 +91,9 @@ export type PostConversationsResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<PostConversationsResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PostConversationsResponseBody>>,
+  auth: Authenticator
 ): Promise<void> {
-  const keyRes = await getAPIKey(req);
-  if (keyRes.isErr()) {
-    return apiError(req, res, keyRes.error);
-  }
-
-  const authenticator = await Authenticator.fromKey(
-    keyRes.value,
-    req.query.wId as string,
-    getGroupIdsFromHeaders(req.headers)
-  );
-  let { workspaceAuth } = authenticator;
-  const { keyAuth } = authenticator;
-
-  if (
-    !workspaceAuth.isBuilder() ||
-    keyAuth.getNonNullableWorkspace().sId !== req.query.wId
-  ) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "The Assistant API is only available on your own workspace.",
-      },
-    });
-  }
-
-  const owner = workspaceAuth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you're trying to access was not found",
-      },
-    });
-  }
-
   switch (req.method) {
     case "POST":
       const bodyValidation = PublicPostConversationsRequestBodySchema.decode(
@@ -181,21 +144,7 @@ async function handler(
         }
       }
 
-      // /!\ This is reserved for internal use!
-      // If the header "x-api-user-email" is present and valid,
-      // associate the message with the provided user email if it belongs to the same workspace.
-      const userEmailFromHeader = req.headers[DustUserEmailHeader];
-      if (typeof userEmailFromHeader === "string") {
-        workspaceAuth =
-          (await workspaceAuth.exchangeSystemKeyForUserAuthByEmail(
-            workspaceAuth,
-            {
-              userEmail: userEmailFromHeader,
-            }
-          )) ?? workspaceAuth;
-      }
-
-      let conversation = await createConversation(workspaceAuth, {
+      let conversation = await createConversation(auth, {
         title,
         visibility,
       });
@@ -210,7 +159,7 @@ async function handler(
         });
 
         const cfRes = await postNewContentFragment(
-          workspaceAuth,
+          auth,
           conversation,
           {
             ...contentFragment,
@@ -236,7 +185,7 @@ async function handler(
 
         newContentFragment = cfRes.value;
         const updatedConversation = await getConversation(
-          workspaceAuth,
+          auth,
           conversation.sId
         );
         if (updatedConversation) {
@@ -250,7 +199,7 @@ async function handler(
         // PostUserMessageWithPubSub returns swiftly since it only waits for the
         // initial message creation event (or error)
         const messageRes = await postUserMessageWithPubSub(
-          workspaceAuth,
+          auth,
           {
             conversation,
             content: message.content,
@@ -280,7 +229,7 @@ async function handler(
         // created as well, so pulling the conversation again will allow to have an up to date view
         // of the conversation with agent messages included so that the user of the API can start
         // streaming events from these agent messages directly.
-        const updated = await getConversation(workspaceAuth, conversation.sId);
+        const updated = await getConversation(auth, conversation.sId);
 
         if (!updated) {
           throw `Conversation unexpectedly not found after creation: ${conversation.sId}`;
@@ -307,4 +256,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withPublicApiAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -234,8 +234,8 @@ async function handler(
     });
   }
 
-  const owner = await auth.getNonNullableWorkspace();
-  const plan = await auth.getNonNullablePlan();
+  const owner = auth.getNonNullableWorkspace();
+  const plan = auth.getNonNullablePlan();
 
   const coreAPI = new CoreAPI(apiConfig.getCoreAPIConfig(), logger);
   switch (req.method) {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -17,7 +17,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import apiConfig from "@app/lib/api/config";
 import { getDataSource } from "@app/lib/api/data_sources";
-import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator } from "@app/lib/auth";
 import { getDocumentsPostDeleteHooksToRun } from "@app/lib/documents_post_process_hooks/hooks";
 import {
@@ -550,4 +550,4 @@ async function handler(
   }
 }
 
-export default withPublicApiAuthentication(handler);
+export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -17,7 +17,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import apiConfig from "@app/lib/api/config";
 import { getDataSource } from "@app/lib/api/data_sources";
-import { Authenticator, getAPIKey } from "@app/lib/auth";
+import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import { Authenticator } from "@app/lib/auth";
 import { getDocumentsPostDeleteHooksToRun } from "@app/lib/documents_post_process_hooks/hooks";
 import {
   enqueueUpsertDocument,
@@ -25,7 +26,7 @@ import {
 } from "@app/lib/upsert_queue";
 import { validateUrl } from "@app/lib/utils";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 import { launchRunPostDeleteHooksWorkflow } from "@app/temporal/documents_post_process_hooks/client";
 
 export const config = {
@@ -208,20 +209,11 @@ async function handler(
       | DeleteDocumentResponseBody
       | UpsertDocumentResponseBody
     >
-  >
+  >,
+  auth: Authenticator
 ): Promise<void> {
-  const keyRes = await getAPIKey(req);
-  if (keyRes.isErr()) {
-    return apiError(req, res, keyRes.error);
-  }
-  const { workspaceAuth } = await Authenticator.fromKey(
-    keyRes.value,
-    req.query.wId as string
-  );
-
-  const owner = workspaceAuth.workspace();
-  const plan = workspaceAuth.plan();
-  if (!owner || !plan || !workspaceAuth.isBuilder()) {
+  const { name } = req.query;
+  if (typeof name !== "string") {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -231,11 +223,7 @@ async function handler(
     });
   }
 
-  const dataSource = await getDataSource(
-    workspaceAuth,
-    req.query.name as string
-  );
-
+  const dataSource = await getDataSource(auth, name);
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 404,
@@ -245,6 +233,9 @@ async function handler(
       },
     });
   }
+
+  const owner = await auth.getNonNullableWorkspace();
+  const plan = await auth.getNonNullablePlan();
 
   const coreAPI = new CoreAPI(apiConfig.getCoreAPIConfig(), logger);
   switch (req.method) {
@@ -272,7 +263,7 @@ async function handler(
       return;
 
     case "POST":
-      if (dataSource.connectorId && !keyRes.value.isSystem) {
+      if (dataSource.connectorId && !auth.isSystemKey()) {
         return apiError(req, res, {
           status_code: 403,
           api_error: {
@@ -282,7 +273,7 @@ async function handler(
         });
       }
 
-      if (!keyRes.value.isSystem) {
+      if (!auth.isSystemKey()) {
         const remaining = await rateLimiter({
           key: `upsert-document-w-${owner.sId}`,
           maxPerTimeframe: 120,
@@ -494,18 +485,7 @@ async function handler(
       }
 
     case "DELETE":
-      if (!workspaceAuth.isBuilder()) {
-        return apiError(req, res, {
-          status_code: 403,
-          api_error: {
-            type: "data_source_auth_error",
-            message:
-              "You can only alter the data souces of the workspaces for which you are a builder.",
-          },
-        });
-      }
-
-      if (dataSource.connectorId && !keyRes.value.isSystem) {
+      if (dataSource.connectorId && !auth.isSystemKey()) {
         return apiError(req, res, {
           status_code: 403,
           api_error: {
@@ -570,4 +550,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withPublicApiAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/parents.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/parents.ts
@@ -4,9 +4,10 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import config from "@app/lib/api/config";
 import { getDataSource } from "@app/lib/api/data_sources";
-import { Authenticator, getAPIKey } from "@app/lib/auth";
+import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type PostParentsResponseBody = {
   updated: true;
@@ -70,19 +71,11 @@ export type PostParentsResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<PostParentsResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PostParentsResponseBody>>,
+  auth: Authenticator
 ): Promise<void> {
-  const keyRes = await getAPIKey(req);
-  if (keyRes.isErr()) {
-    return apiError(req, res, keyRes.error);
-  }
-  const { workspaceAuth } = await Authenticator.fromKey(
-    keyRes.value,
-    req.query.wId as string
-  );
-
-  const owner = workspaceAuth.workspace();
-  if (!owner || !workspaceAuth.isBuilder()) {
+  const { name } = req.query;
+  if (typeof name !== "string") {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -92,11 +85,7 @@ async function handler(
     });
   }
 
-  const dataSource = await getDataSource(
-    workspaceAuth,
-    req.query.name as string
-  );
-
+  const dataSource = await getDataSource(auth, name);
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 404,
@@ -155,4 +144,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withPublicApiAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/parents.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/parents.ts
@@ -4,7 +4,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import config from "@app/lib/api/config";
 import { getDataSource } from "@app/lib/api/data_sources";
-import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -144,4 +144,4 @@ async function handler(
   }
 }
 
-export default withPublicApiAuthentication(handler);
+export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/index.ts
@@ -4,9 +4,10 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import config from "@app/lib/api/config";
 import { getDataSource } from "@app/lib/api/data_sources";
-import { Authenticator, getAPIKey } from "@app/lib/auth";
+import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type GetDocumentsResponseBody = {
   documents: Array<DocumentType>;
@@ -68,18 +69,11 @@ export type GetDocumentsResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetDocumentsResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetDocumentsResponseBody>>,
+  auth: Authenticator
 ): Promise<void> {
-  const keyRes = await getAPIKey(req);
-  if (keyRes.isErr()) {
-    return apiError(req, res, keyRes.error);
-  }
-  const { workspaceAuth } = await Authenticator.fromKey(
-    keyRes.value,
-    req.query.wId as string
-  );
-
-  if (!workspaceAuth.isBuilder()) {
+  const { name } = req.query;
+  if (typeof name !== "string") {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -89,11 +83,7 @@ async function handler(
     });
   }
 
-  const dataSource = await getDataSource(
-    workspaceAuth,
-    req.query.name as string
-  );
-
+  const dataSource = await getDataSource(auth, req.query.name as string);
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 404,
@@ -147,4 +137,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withPublicApiAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/index.ts
@@ -4,7 +4,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import config from "@app/lib/api/config";
 import { getDataSource } from "@app/lib/api/data_sources";
-import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -137,4 +137,4 @@ async function handler(
   }
 }
 
-export default withPublicApiAuthentication(handler);
+export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/search.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/search.ts
@@ -6,7 +6,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import config from "@app/lib/api/config";
 import { getDataSource } from "@app/lib/api/data_sources";
-import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { parse_payload } from "@app/lib/http_utils";
 import logger from "@app/logger/logger";
@@ -283,4 +283,4 @@ async function handler(
   }
 }
 
-export default withPublicApiAuthentication(handler);
+export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
@@ -4,7 +4,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import config from "@app/lib/api/config";
 import { getDataSource } from "@app/lib/api/data_sources";
-import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -205,4 +205,4 @@ async function handler(
   }
 }
 
-export default withPublicApiAuthentication(handler);
+export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
@@ -4,9 +4,10 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import config from "@app/lib/api/config";
 import { getDataSource } from "@app/lib/api/data_sources";
-import { Authenticator, getAPIKey } from "@app/lib/auth";
+import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 import { handleDeleteTableByIdRequest } from "@app/pages/api/w/[wId]/data_sources/[name]/tables/[tId]";
 
 export type GetTableResponseBody = {
@@ -98,21 +99,13 @@ export type GetTableResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetTableResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetTableResponseBody>>,
+  auth: Authenticator
 ): Promise<void> {
-  const keyRes = await getAPIKey(req);
-  if (keyRes.isErr()) {
-    return apiError(req, res, keyRes.error);
-  }
+  const owner = auth.getNonNullableWorkspace();
 
-  const { workspaceAuth } = await Authenticator.fromKey(
-    keyRes.value,
-    req.query.wId as string
-  );
-
-  const owner = workspaceAuth.workspace();
-  const plan = workspaceAuth.plan();
-  if (!owner || !plan || !workspaceAuth.isBuilder()) {
+  const { name } = req.query;
+  if (typeof name !== "string") {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -122,10 +115,7 @@ async function handler(
     });
   }
 
-  const dataSource = await getDataSource(
-    workspaceAuth,
-    req.query.name as string
-  );
+  const dataSource = await getDataSource(auth, name);
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 404,
@@ -215,4 +205,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withPublicApiAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/parents.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/parents.ts
@@ -7,7 +7,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import config from "@app/lib/api/config";
 import { getDataSource } from "@app/lib/api/data_sources";
-import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -110,4 +110,4 @@ async function handler(
   }
 }
 
-export default withPublicApiAuthentication(handler);
+export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/parents.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/parents.ts
@@ -7,9 +7,10 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import config from "@app/lib/api/config";
 import { getDataSource } from "@app/lib/api/data_sources";
-import { Authenticator, getAPIKey } from "@app/lib/auth";
+import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 const ParentsBodySchema = t.type({
   parents: t.array(t.string),
@@ -26,20 +27,10 @@ export type PostParentsResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<PostParentsResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<PostParentsResponseBody>>,
+  auth: Authenticator
 ): Promise<void> {
-  const keyRes = await getAPIKey(req);
-  if (keyRes.isErr()) {
-    return apiError(req, res, keyRes.error);
-  }
-  const { workspaceAuth } = await Authenticator.fromKey(
-    keyRes.value,
-    req.query.wId as string
-  );
-
-  const owner = workspaceAuth.workspace();
-  const isSystemKey = keyRes.value.isSystem;
-  if (!owner || !workspaceAuth.isBuilder() || !isSystemKey) {
+  if (!auth.isSystemKey()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -49,11 +40,18 @@ async function handler(
     });
   }
 
-  const dataSource = await getDataSource(
-    workspaceAuth,
-    req.query.name as string
-  );
+  const { name } = req.query;
+  if (typeof name !== "string") {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "The data source you requested was not found.",
+      },
+    });
+  }
 
+  const dataSource = await getDataSource(auth, name);
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 404,
@@ -112,4 +110,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withPublicApiAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/[rId].ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/[rId].ts
@@ -4,7 +4,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import config from "@app/lib/api/config";
 import { getDataSource } from "@app/lib/api/data_sources";
-import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -240,4 +240,4 @@ async function handler(
   }
 }
 
-export default withPublicApiAuthentication(handler);
+export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/[rId].ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/[rId].ts
@@ -4,9 +4,10 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import config from "@app/lib/api/config";
 import { getDataSource } from "@app/lib/api/data_sources";
-import { Authenticator, getAPIKey } from "@app/lib/auth";
+import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 type GetTableRowsResponseBody = {
   row: CoreAPIRow;
@@ -103,21 +104,11 @@ async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
     WithAPIErrorResponse<GetTableRowsResponseBody | { success: boolean }>
-  >
+  >,
+  auth: Authenticator
 ): Promise<void> {
-  const keyRes = await getAPIKey(req);
-  if (keyRes.isErr()) {
-    return apiError(req, res, keyRes.error);
-  }
-
-  const { workspaceAuth } = await Authenticator.fromKey(
-    keyRes.value,
-    req.query.wId as string
-  );
-
-  const owner = workspaceAuth.workspace();
-  const plan = workspaceAuth.plan();
-  if (!owner || !plan || !workspaceAuth.isBuilder()) {
+  const { name } = req.query;
+  if (typeof name !== "string") {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -127,10 +118,9 @@ async function handler(
     });
   }
 
-  const dataSource = await getDataSource(
-    workspaceAuth,
-    req.query.name as string
-  );
+  const owner = auth.getNonNullableWorkspace();
+
+  const dataSource = await getDataSource(auth, name);
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 404,
@@ -250,4 +240,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withPublicApiAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/index.ts
@@ -11,7 +11,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import config from "@app/lib/api/config";
 import { getDataSource } from "@app/lib/api/data_sources";
-import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -379,4 +379,4 @@ async function handler(
   }
 }
 
-export default withPublicApiAuthentication(handler);
+export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/csv.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/csv.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import { handlePostTableCsvUpsertRequest } from "@app/pages/api/w/[wId]/data_sources/[name]/tables/csv";
@@ -48,4 +48,4 @@ async function handler(
   }
 }
 
-export default withPublicApiAuthentication(handler);
+export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/csv.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/csv.ts
@@ -1,7 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { Authenticator, getAPIKey } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
 import { handlePostTableCsvUpsertRequest } from "@app/pages/api/w/[wId]/data_sources/[name]/tables/csv";
 
 export const config = {
@@ -19,22 +20,10 @@ export const config = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse
+  res: NextApiResponse,
+  auth: Authenticator
 ): Promise<void> {
-  const keyRes = await getAPIKey(req);
-  if (keyRes.isErr()) {
-    return apiError(req, res, keyRes.error);
-  }
-
-  const { workspaceAuth } = await Authenticator.fromKey(
-    keyRes.value,
-    req.query.wId as string
-  );
-
-  const owner = workspaceAuth.workspace();
-  const plan = workspaceAuth.plan();
-  const isSystemKey = keyRes.value.isSystem;
-  if (!owner || !plan || !workspaceAuth.isBuilder() || !isSystemKey) {
+  if (!auth.isSystemKey()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -46,7 +35,7 @@ async function handler(
 
   switch (req.method) {
     case "POST":
-      return handlePostTableCsvUpsertRequest(workspaceAuth, req, res);
+      return handlePostTableCsvUpsertRequest(auth, req, res);
 
     default:
       return apiError(req, res, {
@@ -59,4 +48,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withPublicApiAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/index.ts
@@ -7,7 +7,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import config from "@app/lib/api/config";
 import { getDataSource } from "@app/lib/api/data_sources";
-import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { generateLegacyModelSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
@@ -309,4 +309,4 @@ async function handler(
   }
 }
 
-export default withPublicApiAuthentication(handler);
+export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/index.ts
@@ -7,10 +7,11 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import config from "@app/lib/api/config";
 import { getDataSource } from "@app/lib/api/data_sources";
-import { Authenticator, getAPIKey } from "@app/lib/auth";
+import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { generateLegacyModelSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 
 export type ListTablesResponseBody = {
   tables: {
@@ -124,21 +125,11 @@ async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
     WithAPIErrorResponse<ListTablesResponseBody | UpsertTableResponseBody>
-  >
+  >,
+  auth: Authenticator
 ): Promise<void> {
-  const keyRes = await getAPIKey(req);
-  if (keyRes.isErr()) {
-    return apiError(req, res, keyRes.error);
-  }
-
-  const { workspaceAuth } = await Authenticator.fromKey(
-    keyRes.value,
-    req.query.wId as string
-  );
-
-  const owner = workspaceAuth.workspace();
-  const plan = workspaceAuth.plan();
-  if (!owner || !plan || !workspaceAuth.isBuilder()) {
+  const { name } = req.query;
+  if (typeof name !== "string") {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -148,10 +139,9 @@ async function handler(
     });
   }
 
-  const dataSource = await getDataSource(
-    workspaceAuth,
-    req.query.name as string
-  );
+  const owner = auth.getNonNullableWorkspace();
+
+  const dataSource = await getDataSource(auth, name);
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 404,
@@ -319,4 +309,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withPublicApiAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tokenize.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tokenize.ts
@@ -7,7 +7,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import config from "@app/lib/api/config";
 import { getDataSource } from "@app/lib/api/data_sources";
-import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -105,4 +105,4 @@ async function handler(
   }
 }
 
-export default withPublicApiAuthentication(handler);
+export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/index.ts
@@ -2,8 +2,9 @@ import type { DataSourceType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSources } from "@app/lib/api/data_sources";
-import { Authenticator, getAPIKey } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
 
 export type GetDataSourcesResponseBody = {
   data_sources: Array<DataSourceType>;
@@ -46,28 +47,10 @@ export type GetDataSourcesResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetDataSourcesResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<GetDataSourcesResponseBody>>,
+  auth: Authenticator
 ): Promise<void> {
-  const keyRes = await getAPIKey(req);
-  if (keyRes.isErr()) {
-    return apiError(req, res, keyRes.error);
-  }
-  const { workspaceAuth } = await Authenticator.fromKey(
-    keyRes.value,
-    req.query.wId as string
-  );
-
-  if (!workspaceAuth.isBuilder()) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you requested was not found.",
-      },
-    });
-  }
-
-  const dataSources = await getDataSources(workspaceAuth);
+  const dataSources = await getDataSources(auth);
 
   switch (req.method) {
     case "GET":
@@ -87,4 +70,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withPublicApiAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/index.ts
@@ -2,7 +2,7 @@ import type { DataSourceType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSources } from "@app/lib/api/data_sources";
-import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
@@ -70,4 +70,4 @@ async function handler(
   }
 }
 
-export default withPublicApiAuthentication(handler);
+export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/feature_flags.ts
+++ b/front/pages/api/v1/w/[wId]/feature_flags.ts
@@ -4,7 +4,7 @@ import type {
 } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
@@ -48,4 +48,4 @@ async function handler(
   }
 }
 
-export default withPublicApiAuthentication(handler);
+export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/members/emails.ts
+++ b/front/pages/api/v1/w/[wId]/members/emails.ts
@@ -2,8 +2,9 @@ import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getMembers } from "@app/lib/api/workspace";
-import { Authenticator, getAPIKey } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
 
 export type ListMemberEmailsResponseBody = {
   emails: string[];
@@ -16,20 +17,10 @@ export type ListMemberEmailsResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<ListMemberEmailsResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<ListMemberEmailsResponseBody>>,
+  auth: Authenticator
 ): Promise<void> {
-  const keyRes = await getAPIKey(req);
-  if (keyRes.isErr()) {
-    return apiError(req, res, keyRes.error);
-  }
-  const { workspaceAuth } = await Authenticator.fromKey(
-    keyRes.value,
-    req.query.wId as string
-  );
-
-  const owner = workspaceAuth.workspace();
-  const isSystemKey = keyRes.value.isSystem;
-  if (!owner || !isSystemKey || !workspaceAuth.isBuilder()) {
+  if (!auth.isSystemKey()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -43,7 +34,7 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const { members: allMembers } = await getMembers(workspaceAuth, {
+      const { members: allMembers } = await getMembers(auth, {
         activeOnly: !!activeOnly,
       });
 
@@ -60,4 +51,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withPublicApiAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/members/emails.ts
+++ b/front/pages/api/v1/w/[wId]/members/emails.ts
@@ -2,7 +2,7 @@ import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getMembers } from "@app/lib/api/workspace";
-import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
@@ -51,4 +51,4 @@ async function handler(
   }
 }
 
-export default withPublicApiAuthentication(handler);
+export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/usage.ts
+++ b/front/pages/api/v1/w/[wId]/usage.ts
@@ -3,7 +3,7 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { unsafeGetUsageData } from "@app/lib/workspace_usage";
 import { apiError } from "@app/logger/withlogging";
@@ -80,4 +80,4 @@ async function handler(
   }
 }
 
-export default withPublicApiAuthentication(handler);
+export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/verified_domains.ts
+++ b/front/pages/api/v1/w/[wId]/verified_domains.ts
@@ -2,7 +2,7 @@ import type { WithAPIErrorResponse, WorkspaceDomain } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getWorkspaceVerifiedDomain } from "@app/lib/api/workspace";
-import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
@@ -51,4 +51,4 @@ async function handler(
   }
 }
 
-export default withPublicApiAuthentication(handler);
+export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/verified_domains.ts
+++ b/front/pages/api/v1/w/[wId]/verified_domains.ts
@@ -2,8 +2,9 @@ import type { WithAPIErrorResponse, WorkspaceDomain } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getWorkspaceVerifiedDomain } from "@app/lib/api/workspace";
-import { Authenticator, getAPIKey } from "@app/lib/auth";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
 
 export type ListMemberEmailsResponseBody = {
   verified_domains: WorkspaceDomain[];
@@ -16,20 +17,10 @@ export type ListMemberEmailsResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<ListMemberEmailsResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<ListMemberEmailsResponseBody>>,
+  auth: Authenticator
 ): Promise<void> {
-  const keyRes = await getAPIKey(req);
-  if (keyRes.isErr()) {
-    return apiError(req, res, keyRes.error);
-  }
-  const { workspaceAuth } = await Authenticator.fromKey(
-    keyRes.value,
-    req.query.wId as string
-  );
-
-  const owner = workspaceAuth.workspace();
-  const isSystemKey = keyRes.value.isSystem;
-  if (!owner || !isSystemKey || !workspaceAuth.isBuilder()) {
+  if (!auth.isSystemKey()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -41,7 +32,9 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const verifiedDomain = await getWorkspaceVerifiedDomain(owner);
+      const verifiedDomain = await getWorkspaceVerifiedDomain(
+        auth.getNonNullableWorkspace()
+      );
 
       return res
         .status(200)
@@ -58,4 +51,4 @@ async function handler(
   }
 }
 
-export default withLogging(handler);
+export default withPublicApiAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/v1/w/[wId]/workspace-usage.ts
@@ -6,7 +6,7 @@ import * as reporter from "io-ts-reporters";
 import JSZip from "jszip";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import {
   getAssistantsUsageData,
@@ -251,4 +251,4 @@ async function fetchUsageData({
   }
 }
 
-export default withPublicApiAuthentication(handler);
+export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/v1/w/[wId]/workspace-usage.ts
@@ -6,14 +6,15 @@ import * as reporter from "io-ts-reporters";
 import JSZip from "jszip";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { Authenticator, getAPIKey } from "@app/lib/auth";
+import { withPublicApiAuthentication } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import {
   getAssistantsUsageData,
   getBuildersUsageData,
   getMessageUsageData,
   getUserUsageData,
 } from "@app/lib/workspace_usage";
-import { apiError, withLogging } from "@app/logger/withlogging";
+import { apiError } from "@app/logger/withlogging";
 import { getSupportedUsageTablesCodec } from "@app/pages/api/w/[wId]/workspace-usage";
 
 export const usageTables = [
@@ -118,28 +119,10 @@ const GetWorkspaceUsageSchema = t.union([
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse
+  res: NextApiResponse,
+  auth: Authenticator
 ): Promise<void> {
-  const keyRes = await getAPIKey(req);
-  if (keyRes.isErr()) {
-    return apiError(req, res, keyRes.error);
-  }
-  const { workspaceAuth } = await Authenticator.fromKey(
-    keyRes.value,
-    req.query.wId as string
-  );
-
-  const owner = workspaceAuth.workspace();
-  if (!owner || !workspaceAuth.isBuilder()) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace was not found.",
-      },
-    });
-  }
-
+  const owner = auth.getNonNullableWorkspace();
   if (!owner.flags.includes("usage_data_api")) {
     return apiError(req, res, {
       status_code: 403,
@@ -268,4 +251,4 @@ async function fetchUsageData({
   }
 }
 
-export default withLogging(handler);
+export default withPublicApiAuthentication(handler);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -8,7 +8,6 @@ import type {
 } from "@dust-tt/types";
 import {
   assertNever,
-  DustUserEmailHeader,
   Err,
   GetAgentConfigurationsQuerySchema,
   Ok,
@@ -51,25 +50,12 @@ async function handler(
       | void
     >
   >,
-  baseAuth: Authenticator
+  auth: Authenticator
 ): Promise<void> {
-  const owner = baseAuth.getNonNullableWorkspace();
-
-  let auth = baseAuth;
+  const owner = auth.getNonNullableWorkspace();
 
   switch (req.method) {
     case "GET":
-      // /!\ This is reserved for internal use!
-      // If the header "x-api-user-email" is present and valid,
-      // associate the message with the provided user email if it belongs to the same workspace.
-      const userEmailFromHeader = req.headers[DustUserEmailHeader];
-      if (typeof userEmailFromHeader === "string") {
-        auth =
-          (await auth.exchangeSystemKeyForUserAuthByEmail(auth, {
-            userEmail: userEmailFromHeader,
-          })) ?? auth;
-      }
-
       // extract the view from the query parameters
       const queryValidation = GetAgentConfigurationsQuerySchema.decode({
         ...req.query,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR introduces a new wrapper, `withPublicApiAuthentication`, for the public API endpoints. This wrapper centralizes authentication for the public API in a single location. It's essential for the vault initiative because it allows us to manage group access for Slack users and workflows without spreading this logic across multiple endpoints. This will make things easier to control.

The wrapper is designed to default to the key's workspace, meaning it will return a 401 error if an endpoint is accessed that the current key doesn't have permission for. However, this behavior can be modified using the `allowUserOutsideCurrentWorkspace` option. Currently, the only use of this modified behavior is for the public endpoint that runs a Dust app on a workspace different than the one of the key's workspace.

Additionally, system keys have the ability to modify the groups associated with the authentication. They can use values from either the group IDs header or the user email header to make these adjustments.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Pretty risky. Worst case most of Dust will be impacted (tokenization, data sources, runs, ...). Safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
