### PR TITLE
Github: fix error handling

### DIFF
--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -128,10 +128,6 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         return new Err(new Error("Connector state not found"));
       }
 
-      if (!connectorState.webhooksEnabledAt) {
-        return new Err(new Error("Connector is already stopped"));
-      }
-
       await connectorState.update({
         webhooksEnabledAt: null,
       });

--- a/connectors/src/lib/oauth.ts
+++ b/connectors/src/lib/oauth.ts
@@ -40,6 +40,7 @@ export async function getOAuthConnectionAccessTokenWithThrow({
 
     if (
       tokRes.error.code === "token_revoked_error" ||
+      tokRes.error.code === "connection_not_found" ||
       isMicrosoftApplicationDisabledError(tokRes.error, provider)
     ) {
       throw new ExternalOAuthTokenError(new Error(tokRes.error.message));

--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -145,7 +145,10 @@ export class ActivityInboundLogInterceptor
             await connectorManager.stop();
           } else {
             this.logger.error(
-              `Connector manager not found for connector ${connector.id}`
+              {
+                connectorId: connector.id,
+              },
+              `Connector manager not found for connector`
             );
           }
         }


### PR DESCRIPTION
## Description

We restarted github conectors and the oauth related errors are mishandled.

- We add support for the `connection_not_found` error to trigger an `ExternalOAuthTokenError`
- We let the connector stop workflows even if `webhooksEnabledAt` is already null

This should help with the errors we see. Context: https://dust4ai.slack.com/archives/C05F84CFP0E/p1725978319667649

## Risk

Low

## Deploy Plan

- deploy `connectors`