### PR TITLE
Use proper Dust api headers for Slack

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -52,7 +52,7 @@ import {
 } from "@app/lib/api/assistant/global_agents";
 import { agentConfigurationWasUpdatedBy } from "@app/lib/api/assistant/recent_authors";
 import { compareAgentsForSort } from "@app/lib/assistant";
-import type { Authenticator } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import { getPublicUploadBucket } from "@app/lib/file_storage";
 import { AgentBrowseConfiguration } from "@app/lib/models/assistant/actions/browse";
 import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
@@ -627,14 +627,13 @@ export async function getAgentConfigurations<V extends "light" | "full">({
     }),
   ]);
 
-  // Rolled back:
   // Filter out agents that the user does not have access to
   // user should be in all groups that are in the agent's groupIds
-  // const allowedAgentConfigurations = allAgentConfigurations
-  //   .flat()
-  //   .filter((a) => auth.canRead(Authenticator.aclsFromGroupIds(a.groupIds)));
-  // return applySortAndLimit(allowedAgentConfigurations.flat());
-  return applySortAndLimit(allAgentConfigurations.flat());
+  const allowedAgentConfigurations = allAgentConfigurations
+    .flat()
+    .filter((a) => auth.canRead(Authenticator.aclsFromGroupIds(a.groupIds)));
+
+  return applySortAndLimit(allowedAgentConfigurations.flat());
 }
 
 async function getConversationMentions(

--- a/types/src/front/lib/dust_api.ts
+++ b/types/src/front/lib/dust_api.ts
@@ -580,6 +580,7 @@ export class DustAPI {
     if (this._credentials.userEmail) {
       headers[DustUserEmailHeader] = this._credentials.userEmail;
     }
+
     if (this._credentials.groupIds) {
       headers[DustGroupIdsHeader] = this._credentials.groupIds.join(",");
     }
@@ -667,7 +668,7 @@ export class DustAPI {
       }/messages/${message.sId}/events`,
       {
         method: "GET",
-        headers: headers,
+        headers,
       }
     );
 
@@ -791,10 +792,7 @@ export class DustAPI {
       `${this.apiUrl()}/api/v1/w/${this.workspaceId()}/assistant/conversations/${conversationId}`,
       {
         method: "GET",
-        headers: {
-          Authorization: `Bearer ${this._credentials.apiKey}`,
-          "Content-Type": "application/json",
-        },
+        headers,
       }
     );
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR reinstates the filtering of assistants based on the authenticator's permissions, which was previously reverted. Initially, we encountered two issues:
1. We were unable to list the appropriate assistants because the email/group header was missing. So all assistants with a tool associated with a vault were missing.
2. Even after resolving the first issue, we couldn't retrieve the conversation because `getConversation` relies on `getAgentConfiguration`, which applies the filter.

In https://github.com/dust-tt/dust/pull/7266, we introduced a more robust solution to manage these two different headers in our Public API. This PR simply uses those headers in various places when responding to a Slack message.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Successfully tested locally, eveything works end to end! Safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
Deploy `connectors` then `front`.
