### PR TITLE
[front] fix: update test and comment

### DIFF
--- a/front/components/data_source/DataSourcePicker.tsx
+++ b/front/components/data_source/DataSourcePicker.tsx
@@ -69,9 +69,11 @@ export default function DataSourcePicker({
         // If the selected data source view is not found in the list, reset the config
         onDataSourcesUpdate([]);
       } else if (
-        selectedDataSourceView.sId !== selectedDataSourceView.dataSource.name
+        currentDataSources[0].data_source_id !==
+        selectedDataSourceView.dataSource.name
       ) {
-        // If the selected data source view is found in the list, but the id is not the dsv sId (so dataSource name), update the config
+        // If the selected data source view is found in the list, but the id is not the dataSource name, update the config
+        // Switch back to datasource view id when core is fixed
         onDataSourcesUpdate([
           {
             workspace_id: owner.sId,


### PR DESCRIPTION
## Description

temporary fix the datasource name / dsv id test so that the block store datasource name and don't reset table on every load

## Risk

none

## Deploy Plan

front
