### PR TITLE
Flav/sparkle button margins

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.232",
+  "version": "0.2.233",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.232",
+      "version": "0.2.233",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.232",
+  "version": "0.2.233",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -161,7 +161,7 @@ const transitionClasses =
   "s-transition-all s-ease-out s-duration-200 s-cursor-pointer";
 
 const magnifyingClasses =
-  "hover:s-scale-105 hover:s-drop-shadow-md active:s-scale-100 active:s-drop-shadow-none";
+  "hover:s-scale-105 hover:s-drop-shadow-md active:s-scale-100 active:s-drop-shadow-none s-m-1";
 
 export function Button({
   variant = "primary",

--- a/sparkle/src/stories/Button.stories.tsx
+++ b/sparkle/src/stories/Button.stories.tsx
@@ -295,6 +295,33 @@ export const ButtonExamples = () => (
         disabled
       />
     </div>
+    <div className="s-flex s-items-center s-gap-4">
+      <div className="s-border-2 s-border-red-500">
+        <Button
+          variant="primary"
+          size="xs"
+          label="Within a div"
+          icon={Cog6ToothIcon}
+        />
+      </div>
+      <div className="s-border-2 s-border-red-500">
+        <Button
+          variant="primary"
+          size="sm"
+          label="Within a div"
+          icon={Cog6ToothIcon}
+        />
+      </div>
+
+      <div className="s-border-2 s-border-red-500">
+        <Button
+          variant="primary"
+          size="lg"
+          label="Within a div"
+          icon={Cog6ToothIcon}
+        />
+      </div>
+    </div>
   </div>
 );
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The button component features a magnifying hover effect that typically requires a margin. Instead of incorporating the margin directly into the component, different call sites have been adding it individually. This PR moves this logic to the button itself.
 
<img width="628" alt="image" src="https://github.com/user-attachments/assets/12aaad23-82db-42fb-bcc5-a736d4ec3078">

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
