### PR TITLE
enh: use front-edge v1 as prod api from front-edge

### DIFF
--- a/k8s/deployments/front-edge-deployment.yaml
+++ b/k8s/deployments/front-edge-deployment.yaml
@@ -47,6 +47,9 @@ spec:
               value: https://front-edge.dust.tt
             - name: DUST_CLIENT_FACING_URL
               value: https://front-edge.dust.tt
+            # Make public prod API point to front-edge instead of front
+            - name: DUST_PROD_API
+              value: https://front-edge.dust.tt
 
             - name: DD_AGENT_HOST
               valueFrom:


### PR DESCRIPTION
## Description

Testing on front-edge can be deceptive, because the "public api" used is still actual prod instead of being front-edge's v1 api
## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
