### PR TITLE
Flav/dsv retrieval document

### DIFF
--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -36,6 +36,7 @@ import {
   DustProdActionRegistry,
   PRODUCTION_DUST_WORKSPACE_ID,
 } from "@app/lib/registry";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import type { RetrievalDocumentBlob } from "@app/lib/resources/retrieval_document_resource";
 import { RetrievalDocumentResource } from "@app/lib/resources/retrieval_document_resource";
 import logger from "@app/logger/logger";
@@ -482,6 +483,7 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
     let blobs: {
       blob: RetrievalDocumentBlob;
       chunks: RetrievalDocumentChunkType[];
+      dataSourceView: DataSourceViewResource;
     }[] = [];
 
     // This is not perfect and will be erroneous in case of two data sources with the same id from
@@ -489,10 +491,30 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
     // likely want `core` to return the `workspace_id` that was used eventualy.
     // TODO(spolu): make `core` return data source workspace id.
     const dataSourcesIdToWorkspaceId: {
-      [key: string]: { workspaceId: string };
+      [key: string]: {
+        dataSourceView: DataSourceViewResource;
+        workspaceId: string;
+      };
     } = {};
+    const uniqueDataSourceViewIds = [
+      ...new Set(
+        actionConfiguration.dataSources.map((ds) => ds.dataSourceViewId)
+      ),
+    ];
+    const dataSourceViews = await DataSourceViewResource.fetchByIds(
+      auth,
+      uniqueDataSourceViewIds
+    );
+    const dataSourceViewsMap = dataSourceViews.reduce<
+      Record<string, DataSourceViewResource>
+    >((acc, dsv) => {
+      acc[dsv.sId] = dsv;
+      return acc;
+    }, {});
+
     for (const ds of actionConfiguration.dataSources) {
       dataSourcesIdToWorkspaceId[ds.dataSourceId] = {
+        dataSourceView: dataSourceViewsMap[ds.dataSourceViewId],
         workspaceId: ds.workspaceId,
       };
     }
@@ -595,6 +617,8 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
             const reference = refs[i % refs.length];
             const dsDetails = dataSourcesIdToWorkspaceId[d.data_source_id];
 
+            console.log(">> found documents:", d);
+
             return {
               blob: {
                 dataSourceWorkspaceId: dsDetails.workspaceId,
@@ -608,11 +632,14 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
                 retrievalActionId: action.id,
               },
               chunks: d.chunks,
+              dataSourceView: dsDetails.dataSourceView,
             };
           });
         }
       }
     }
+
+    console.log(">> about to create documents:", blobs);
 
     // We are done, store documents and chunks in database and yield the final events.
     const documents = await RetrievalDocumentResource.makeNewBatch(auth, blobs);
@@ -710,6 +737,7 @@ function retrievalActionSpecification({
 // should not be used outside of api/assistant. We allow a ModelId interface here because for
 // optimization purposes to avoid duplicating DB requests while having clear action specific code.
 export async function retrievalActionTypesFromAgentMessageIds(
+  auth: Authenticator,
   agentMessageIds: ModelId[]
 ): Promise<RetrievalActionType[]> {
   const models = await AgentRetrievalAction.findAll({
@@ -727,8 +755,10 @@ export async function retrievalActionTypesFromAgentMessageIds(
 
   const actionIds = models.map((a) => a.id);
 
-  const documents =
-    await RetrievalDocumentResource.listAllForActions(actionIds);
+  const documents = await RetrievalDocumentResource.listAllForActions(
+    auth,
+    actionIds
+  );
   const documentRowsByActionId = documents.reduce<{
     [id: ModelId]: RetrievalDocumentResource[];
   }>((acc, d) => {

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -142,7 +142,8 @@ export async function batchRenderAgentMessages(
       ).filter((a) => a !== null) as LightAgentConfigurationType[];
       return agents;
     })(),
-    (async () => retrievalActionTypesFromAgentMessageIds(agentMessageIds))(),
+    (async () =>
+      retrievalActionTypesFromAgentMessageIds(auth, agentMessageIds))(),
     (async () => dustAppRunTypesFromAgentMessageIds(agentMessageIds))(),
     (async () => tableQueryTypesFromAgentMessageIds(agentMessageIds))(),
     (async () => processActionTypesFromAgentMessageIds(agentMessageIds))(),

--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -11,6 +11,7 @@ import { DataTypes, Model } from "sequelize";
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { AgentMessage } from "@app/lib/models/assistant/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 
 export class AgentRetrievalConfiguration extends Model<
   InferAttributes<AgentRetrievalConfiguration>,
@@ -269,9 +270,11 @@ export class RetrievalDocument extends Model<
   declare tags: string[];
   declare score: number | null;
 
+  declare dataSourceViewId: ForeignKey<DataSourceViewModel["id"]>;
   declare retrievalActionId: ForeignKey<AgentRetrievalAction["id"]>;
 
   declare chunks: NonAttribute<RetrievalDocumentChunk[]>;
+  declare dataSourceView: NonAttribute<DataSourceViewModel>;
 }
 
 RetrievalDocument.init(
@@ -337,6 +340,16 @@ AgentRetrievalAction.hasMany(RetrievalDocument, {
 });
 RetrievalDocument.belongsTo(AgentRetrievalAction, {
   foreignKey: { name: "retrievalActionId", allowNull: false },
+});
+
+// TODO(VAULTS_INFRA) Set to not null once backfilled.
+DataSourceViewModel.hasMany(RetrievalDocument, {
+  foreignKey: { allowNull: true },
+  onDelete: "SET NULL",
+});
+RetrievalDocument.belongsTo(DataSourceViewModel, {
+  as: "dataSourceView",
+  foreignKey: { allowNull: true },
 });
 
 export class RetrievalDocumentChunk extends Model<

--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -270,7 +270,8 @@ export class RetrievalDocument extends Model<
   declare tags: string[];
   declare score: number | null;
 
-  declare dataSourceViewId: ForeignKey<DataSourceViewModel["id"]>;
+  // TODO(VAULTS_INFRA) Make not nullable once backfilled.
+  declare dataSourceViewId: ForeignKey<DataSourceViewModel["id"]> | null;
   declare retrievalActionId: ForeignKey<AgentRetrievalAction["id"]>;
 
   declare chunks: NonAttribute<RetrievalDocumentChunk[]>;

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -14,6 +14,7 @@ import type {
   ModelStatic,
   Transaction,
 } from "sequelize";
+import { Op } from "sequelize";
 
 import { getDataSourceViewUsage } from "@app/lib/api/agent_data_sources";
 import { getDataSourceCategory } from "@app/lib/api/vaults";
@@ -257,7 +258,25 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
       fetchDataSourceViewOptions,
       {
         where: {
-          id: dataSourceViewModelIds,
+          id: {
+            [Op.in]: dataSourceViewModelIds,
+          },
+        },
+      }
+    );
+
+    return dataSourceViews ?? null;
+  }
+
+  static async fetchByModelIds(auth: Authenticator, ids: ModelId[]) {
+    const dataSourceViews = await this.baseFetch(
+      auth,
+      {},
+      {
+        where: {
+          id: {
+            [Op.in]: ids,
+          },
         },
       }
     );

--- a/front/lib/resources/retrieval_document_resource.ts
+++ b/front/lib/resources/retrieval_document_resource.ts
@@ -2,11 +2,12 @@
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 
-import type {
-  ModelId,
-  Result,
-  RetrievalDocumentChunkType,
-  RetrievalDocumentType,
+import {
+  removeNulls,
+  type ModelId,
+  type Result,
+  type RetrievalDocumentChunkType,
+  type RetrievalDocumentType,
 } from "@dust-tt/types";
 import type { Attributes, CreationAttributes, ModelStatic } from "sequelize";
 import { Op } from "sequelize";
@@ -36,7 +37,7 @@ export class RetrievalDocumentResource extends BaseResource<RetrievalDocument> {
     model: ModelStatic<RetrievalDocument>,
     blob: Attributes<RetrievalDocument>,
     readonly chunks: RetrievalDocumentChunkType[],
-    readonly dataSourceView: DataSourceViewResource
+    readonly dataSourceView?: DataSourceViewResource
   ) {
     super(RetrievalDocument, blob);
   }
@@ -114,9 +115,9 @@ export class RetrievalDocumentResource extends BaseResource<RetrievalDocument> {
       ],
     });
 
-    const uniqueDataSourceViewIds = [
+    const uniqueDataSourceViewIds = removeNulls([
       ...new Set(docs.map((d) => d.dataSourceViewId)),
-    ];
+    ]);
     const dataSourceViews = await DataSourceViewResource.fetchByModelIds(
       auth,
       uniqueDataSourceViewIds
@@ -135,7 +136,9 @@ export class RetrievalDocumentResource extends BaseResource<RetrievalDocument> {
           this.model,
           d.get(),
           d.chunks,
-          dataSourceViewsMap[d.dataSourceViewId]
+          d.dataSourceViewId
+            ? dataSourceViewsMap[d.dataSourceViewId]
+            : undefined
         )
     );
   }

--- a/front/lib/resources/retrieval_document_resource.ts
+++ b/front/lib/resources/retrieval_document_resource.ts
@@ -2,13 +2,13 @@
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 
-import {
-  removeNulls,
-  type ModelId,
-  type Result,
-  type RetrievalDocumentChunkType,
-  type RetrievalDocumentType,
+import type {
+  ModelId,
+  Result,
+  RetrievalDocumentChunkType,
+  RetrievalDocumentType,
 } from "@dust-tt/types";
+import { removeNulls } from "@dust-tt/types";
 import type { Attributes, CreationAttributes, ModelStatic } from "sequelize";
 import { Op } from "sequelize";
 

--- a/front/migrations/20240911_backfill_views_in_retrieval_documents.ts
+++ b/front/migrations/20240911_backfill_views_in_retrieval_documents.ts
@@ -1,0 +1,107 @@
+import type { LightWorkspaceType } from "@dust-tt/types";
+import { removeNulls } from "@dust-tt/types";
+import assert from "assert";
+import { pick, uniqBy } from "lodash";
+import { Op } from "sequelize";
+
+import { Authenticator } from "@app/lib/auth";
+import { RetrievalDocument } from "@app/lib/models/assistant/actions/retrieval";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { VaultResource } from "@app/lib/resources/vault_resource";
+import type { Logger } from "@app/logger/logger";
+import { makeScript, runOnAllWorkspaces } from "@app/scripts/helpers";
+
+async function backfillViewsInRetrievalDocumentsForWorkspace(
+  workspace: LightWorkspaceType,
+  logger: Logger,
+  execute: boolean
+) {
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+  // List workspace data sources.
+  const dataSources = await DataSourceResource.listByWorkspace(auth);
+
+  logger.info(
+    `Found ${dataSources.length} data sources for workspace(${workspace.sId}).`
+  );
+
+  const globalVault = await VaultResource.fetchWorkspaceGlobalVault(auth);
+
+  // Retrieve data source views for data sources.
+  const dataSourceViews =
+    await DataSourceViewResource.listForDataSourcesInVault(
+      auth,
+      dataSources,
+      globalVault
+    );
+
+  const uniqueDataSources = removeNulls(
+    dataSourceViews.map((dsv) => dsv.dataSource)
+  );
+
+  // Count retrieval documents that uses those data sources and have no dataSourceViewId.
+  const retrievalDocumentsCount = await RetrievalDocument.count({
+    where: {
+      // /!\ `dataSourceId` is the data source's name, not the id.
+      dataSourceId: {
+        [Op.in]: uniqueDataSources.map((ds) => ds.name),
+      },
+      // Scope to data sources that belong to the workspace.
+      dataSourceWorkspaceId: workspace.sId,
+      dataSourceViewId: {
+        [Op.is]: null,
+      },
+    },
+  });
+
+  logger.info(
+    `About to update ${retrievalDocumentsCount} retrieval documents for workspace(${workspace.sId}).`
+  );
+
+  if (!execute) {
+    return;
+  }
+
+  for (const ds of uniqueDataSources) {
+    const dataSourceView = dataSourceViews.find(
+      (dsv) => dsv.dataSourceId === ds.id
+    );
+    assert(
+      dataSourceView,
+      `Data source view not found for data source ${ds.id}.`
+    );
+
+    await RetrievalDocument.update(
+      { dataSourceViewId: dataSourceView.id },
+      {
+        where: {
+          // /!\ `dataSourceId` is the data source's name, not the id.
+          dataSourceId: ds.name,
+          // Scope to data sources that belong to the workspace.
+          dataSourceWorkspaceId: workspace.sId,
+        },
+      }
+    );
+
+    logger.info(
+      `Updated retrieval documents for data source ${ds.id}-${ds.name}.`
+    );
+  }
+
+  logger.info(
+    `Updated all retrieval documents for workspace(${workspace.sId}).`
+  );
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  return runOnAllWorkspaces(async (workspace) => {
+    await backfillViewsInRetrievalDocumentsForWorkspace(
+      workspace,
+      logger,
+      execute
+    );
+
+    logger.info(`Finished backfilling views for workspace(${workspace.sId}).`);
+  });
+});

--- a/front/migrations/db/migration_77.sql
+++ b/front/migrations/db/migration_77.sql
@@ -1,0 +1,2 @@
+-- Migration created on Sep 11, 2024
+ALTER TABLE "public"."retrieval_documents" ADD COLUMN "dataSourceViewId" INTEGER REFERENCES "data_source_views" ("id") ON DELETE SET NULL ON UPDATE CASCADE;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR introduces the `dataSourceViewId` column to the `retrieval_documents` table. This is necessary to generate accurate links for users to view the data used by the models. Currently, links are based on the underlying data source, but moving forward, they should reference the correct data source view. This strategy addresses the potential issue of removed or deleted data source views. The new column is initialized with `ON DELETE SET NULL`, ensuring that the row is kept even if the associated document is no longer visible to the user. This PR also includes the backfill process for all existing retrieval document rows.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
First apply the SQL migration
Then deploy front
Finally run the backfill
