### PR TITLE
[front] fix: Set config to dsv id when selecting data source

### DIFF
--- a/front/components/data_source/DataSourcePicker.tsx
+++ b/front/components/data_source/DataSourcePicker.tsx
@@ -68,18 +68,6 @@ export default function DataSourcePicker({
       if (!selectedDataSourceView) {
         // If the selected data source view is not found in the list, reset the config
         onDataSourcesUpdate([]);
-      } else if (
-        currentDataSources[0].data_source_id !==
-        selectedDataSourceView.dataSource.name
-      ) {
-        // If the selected data source view is found in the list, but the id is not the dataSource name, update the config
-        // Switch back to datasource view id when core is fixed
-        onDataSourcesUpdate([
-          {
-            workspace_id: owner.sId,
-            data_source_id: selectedDataSourceView.dataSource.name,
-          },
-        ]);
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -177,7 +165,7 @@ export default function DataSourcePicker({
                         onDataSourcesUpdate([
                           {
                             workspace_id: owner.sId,
-                            data_source_id: dsv.dataSource.name,
+                            data_source_id: dsv.sId,
                           },
                         ]);
                         setSearchFilter("");


### PR DESCRIPTION
## Description

Restore the change to put dsvId in app config, now correctly supported by core.

I removed the effect that automatically reset to dsvId as it resets the table, when we have a table a picker. We'll rather run the migration here : https://github.com/dust-tt/dust/pull/7258

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
