### PR TITLE
Upg: mutate() provided by useSWRDefaults now automatically mutate all urls regardless of query params.

### DIFF
--- a/front/components/vaults/VaultFolderModal.tsx
+++ b/front/components/vaults/VaultFolderModal.tsx
@@ -107,14 +107,16 @@ export default function VaultFolderModal({
         );
       }
     } else {
-      if (await doUpdate(folder, description)) {
+      const res = await doUpdate(folder, description);
+      if (res) {
         handleOnClose();
       }
     }
   };
 
   const onDeleteFolder = async () => {
-    if (await doDelete(folder)) {
+    const res = await doDelete(folder);
+    if (res) {
       handleOnClose();
       await router.push(
         `/w/${owner.sId}/vaults/${vault.sId}/categories/folder`

--- a/front/components/vaults/VaultFolderModal.tsx
+++ b/front/components/vaults/VaultFolderModal.tsx
@@ -6,20 +6,17 @@ import {
   Page,
   TextArea,
 } from "@dust-tt/sparkle";
-import type {
-  APIError,
-  DataSourceType,
-  VaultType,
-  WorkspaceType,
-} from "@dust-tt/types";
+import type { DataSourceType, VaultType, WorkspaceType } from "@dust-tt/types";
 import { isDataSourceNameValid } from "@dust-tt/types";
 import { useRouter } from "next/router";
-import { useContext, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { DeleteStaticDataSourceDialog } from "@app/components/data_source/DeleteStaticDataSourceDialog";
-import { SendNotificationsContext } from "@app/components/sparkle/Notification";
-import { useVaultDataSourceViews } from "@app/lib/swr/vaults";
-import type { PostVaultDataSourceResponseBody } from "@app/pages/api/w/[wId]/vaults/[vId]/data_sources";
+import {
+  useCreateFolder,
+  useDeleteFolderOrWebsite,
+  useUpdateFolder,
+} from "@app/lib/swr/vaults";
 
 export default function VaultFolderModal({
   isOpen,
@@ -36,14 +33,20 @@ export default function VaultFolderModal({
   dataSources: DataSourceType[];
   folder: DataSourceType | null;
 }) {
-  const router = useRouter();
-  const sendNotification = useContext(SendNotificationsContext);
-  const { mutateVaultDataSourceViews: mutate } = useVaultDataSourceViews({
-    workspaceId: owner.sId,
+  const doCreate = useCreateFolder({
+    owner,
+    vaultId: vault.sId,
+  });
+  const doUpdate = useUpdateFolder({
+    owner,
+    vaultId: vault.sId,
+  });
+  const doDelete = useDeleteFolderOrWebsite({
+    owner,
     vaultId: vault.sId,
     category: "folder",
-    disabled: true, // We don't need to fetch the data source views here, we want the mutate function to refresh the data elsewhere.
   });
+  const router = useRouter();
 
   const defaultName = folder?.name ?? null;
   const defaultDescription = folder?.description ?? null;
@@ -67,74 +70,6 @@ export default function VaultFolderModal({
     setName(folder ? folder.name : null);
     setDescription(folder ? folder.description : null);
   }, [folder]);
-
-  const postCreateFolder = async () => {
-    const res = await fetch(
-      `/api/w/${owner.sId}/vaults/${vault.sId}/data_sources`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          name,
-          description,
-        }),
-      }
-    );
-    if (res.ok) {
-      await mutate();
-      handleOnClose();
-      const response: PostVaultDataSourceResponseBody = await res.json();
-      const { dataSourceView } = response;
-      await router.push(
-        `/w/${owner.sId}/vaults/${vault.sId}/categories/folder/data_source_views/${dataSourceView.sId}`
-      );
-      sendNotification({
-        type: "success",
-        title: "Successfully created folder",
-        description: "Folder was successfully created.",
-      });
-    } else {
-      const err: { error: APIError } = await res.json();
-      sendNotification({
-        type: "error",
-        title: "Error creating Folder",
-        description: `Error: ${err.error.message}`,
-      });
-    }
-  };
-
-  // TODO(DATASOURCE_SID) - move to sId
-  const patchUpdateFolder = async (folderName: string) => {
-    const res = await fetch(
-      `/api/w/${owner.sId}/vaults/${vault.sId}/data_sources/${folderName}`,
-      {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          description,
-        }),
-      }
-    );
-    if (res.ok) {
-      handleOnClose();
-      sendNotification({
-        type: "success",
-        title: "Successfully updated folder",
-        description: "Folder was successfully updated.",
-      });
-    } else {
-      const err: { error: APIError } = await res.json();
-      sendNotification({
-        type: "error",
-        title: "Error updating Folder",
-        description: `Error: ${err.error.message}`,
-      });
-    }
-  };
 
   const onSave = async () => {
     let nameError: string | null = null;
@@ -164,42 +99,26 @@ export default function VaultFolderModal({
     }
 
     if (folder === null) {
-      await postCreateFolder();
+      const dataSourceView = await doCreate(name, description);
+      if (dataSourceView) {
+        handleOnClose();
+        await router.push(
+          `/w/${owner.sId}/vaults/${vault.sId}/categories/folder/data_source_views/${dataSourceView.sId}`
+        );
+      }
     } else {
-      // TODO(DATASOURCE_SID) - move to sId
-      await patchUpdateFolder(folder.name);
+      if (await doUpdate(folder, description)) {
+        handleOnClose();
+      }
     }
   };
 
   const onDeleteFolder = async () => {
-    if (folder === null) {
-      return;
-    }
-    const res = await fetch(
-      // TODO(DATASOURCE_SID) - move to sId
-      `/api/w/${owner.sId}/vaults/${vault.sId}/data_sources/${folder.name}`,
-      {
-        method: "DELETE",
-      }
-    );
-    if (res.ok) {
-      await mutate();
+    if (await doDelete(folder)) {
       handleOnClose();
       await router.push(
         `/w/${owner.sId}/vaults/${vault.sId}/categories/folder`
       );
-      sendNotification({
-        type: "success",
-        title: "Successfully deleted folder",
-        description: "Folder was successfully deleted.",
-      });
-    } else {
-      const err: { error: APIError } = await res.json();
-      sendNotification({
-        type: "error",
-        title: "Error deleting Folder",
-        description: `Error: ${err.error.message}`,
-      });
     }
   };
 

--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -12,7 +12,6 @@ import {
   usePaginationFromUrl,
 } from "@dust-tt/sparkle";
 import type {
-  APIError,
   ConnectorProvider,
   DataSourceViewCategory,
   DataSourceViewType,
@@ -25,21 +24,23 @@ import { isWebsiteOrFolderCategory } from "@dust-tt/types";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import { useRouter } from "next/router";
 import type { ComponentType } from "react";
-import { useContext, useMemo } from "react";
+import { useMemo } from "react";
 import { useRef } from "react";
 import { useState } from "react";
 
 import { ConnectorPermissionsModal } from "@app/components/ConnectorPermissionsModal";
 import ConnectorSyncingChip from "@app/components/data_source/DataSourceSyncChip";
 import { DeleteStaticDataSourceDialog } from "@app/components/data_source/DeleteStaticDataSourceDialog";
-import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { AddConnectionMenu } from "@app/components/vaults/AddConnectionMenu";
 import { EditVaultManagedDataSourcesViews } from "@app/components/vaults/EditVaultManagedDatasourcesViews";
 import { EditVaultStaticDatasourcesViews } from "@app/components/vaults/EditVaultStaticDatasourcesViews";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { getDataSourceNameFromView } from "@app/lib/data_sources";
 import { useDataSources } from "@app/lib/swr/data_sources";
-import { useVaultDataSourceViews } from "@app/lib/swr/vaults";
+import {
+  useDeleteFolderOrWebsite,
+  useVaultDataSourceViews,
+} from "@app/lib/swr/vaults";
 import { classNames } from "@app/lib/utils";
 
 const REDIRECT_TO_EDIT_PERMISSIONS = [
@@ -209,7 +210,6 @@ export const VaultResourcesList = ({
   const [isNewConnectorLoading, setIsNewConnectorLoading] = useState(false);
   const { dataSources, isDataSourcesLoading } = useDataSources(owner);
   const router = useRouter();
-  const sendNotification = useContext(SendNotificationsContext);
 
   const searchBarRef = useRef<HTMLInputElement>(null);
 
@@ -223,6 +223,12 @@ export const VaultResourcesList = ({
 
   const { pagination, setPagination } = usePaginationFromUrl({
     urlPrefix: "table",
+  });
+
+  const doDelete = useDeleteFolderOrWebsite({
+    owner,
+    vaultId: vault.sId,
+    category,
   });
 
   // DataSources Views of the current vault.
@@ -305,32 +311,14 @@ export const VaultResourcesList = ({
   }
 
   const onDeleteFolderOrWebsite = async () => {
-    if (!selectedDataSourceView) {
-      return;
-    }
-    const res = await fetch(
-      `/api/w/${owner.sId}/vaults/${vault.sId}/data_sources/${selectedDataSourceView.dataSource.name}`,
-      { method: "DELETE" }
-    );
-
-    if (res.ok) {
+    if (
+      selectedDataSourceView?.dataSource &&
+      (await doDelete(selectedDataSourceView?.dataSource))
+    ) {
       await router.push(
         `/w/${owner.sId}/vaults/${vault.sId}/categories/${selectedDataSourceView.category}`
       );
-      sendNotification({
-        type: "success",
-        title: `Successfully deleted ${selectedDataSourceView.category}`,
-        description: `${getDataSourceNameFromView(selectedDataSourceView)} was successfully deleted.`,
-      });
-    } else {
-      const err: { error: APIError } = await res.json();
-      sendNotification({
-        type: "error",
-        title: `Error deleting ${selectedDataSourceView.category}`,
-        description: `Error: ${err.error.message}`,
-      });
     }
-    return res.ok;
   };
 
   return (

--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -311,13 +311,13 @@ export const VaultResourcesList = ({
   }
 
   const onDeleteFolderOrWebsite = async () => {
-    if (
-      selectedDataSourceView?.dataSource &&
-      (await doDelete(selectedDataSourceView?.dataSource))
-    ) {
-      await router.push(
-        `/w/${owner.sId}/vaults/${vault.sId}/categories/${selectedDataSourceView.category}`
-      );
+    if (selectedDataSourceView?.dataSource) {
+      const res = await doDelete(selectedDataSourceView.dataSource);
+      if (res) {
+        await router.push(
+          `/w/${owner.sId}/vaults/${vault.sId}/categories/${selectedDataSourceView.category}`
+        );
+      }
     }
   };
 

--- a/front/components/vaults/VaultSideBarMenu.tsx
+++ b/front/components/vaults/VaultSideBarMenu.tsx
@@ -470,7 +470,6 @@ const VaultDataSourceViewSubMenu = ({
       workspaceId: owner.sId,
       vaultId: vault.sId,
       category,
-      disabled: !isExpanded,
     });
 
   return (
@@ -483,6 +482,11 @@ const VaultDataSourceViewSubMenu = ({
       onChevronClick={() => setIsExpanded(!isExpanded)}
       visual={categoryDetails.icon}
       areActionsFading={false}
+      type={
+        isVaultDataSourceViewsLoading || vaultDataSourceViews.length > 0
+          ? "node"
+          : "leaf"
+      }
     >
       {isExpanded && (
         <Tree isLoading={isVaultDataSourceViewsLoading}>

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -145,7 +145,7 @@ export function useDataSourceViewContentNodes({
 
   const { data, error, mutate } = useSWRWithDefaults(fetchKey, async () => {
     if (!url) {
-      return null;
+      return undefined;
     }
 
     return postFetcher([url, { internalIds, includeChildren, viewType }]);

--- a/front/lib/swr/swr.ts
+++ b/front/lib/swr/swr.ts
@@ -27,17 +27,28 @@ export function useSWRWithDefaults<TKey extends Key, TData>(
       // to make sure we don't cache different pages together
       // Naive way to detect url by checking for '/'
       if (typeof key === "string" && key.includes("/")) {
-        const keyWithoutQueryParams = key.split("?")[0];
+        console.log(key);
+        const urlFromKey = new URL(
+          key,
+          key.indexOf("://") == -1 ? "https://example.org/" : undefined // We need to provide a base url to make sure the URL is parsed correctly
+        );
+        const urlFromKeyWithoutQueryParams =
+          urlFromKey.origin + urlFromKey.pathname;
 
         // Cycle through all the keys in the cache that start with the same url
         // and mutate them too
         for (const k of cache.keys()) {
-          if (
-            k !== key &&
-            typeof k === "string" &&
-            k.startsWith(keyWithoutQueryParams)
-          ) {
-            void globalMutate<TData>(k);
+          if (k !== key && typeof k === "string") {
+            const urlFromK = new URL(
+              k,
+              key.indexOf("://") == -1 ? "https://example.org/" : undefined
+            );
+            const urlFromKWithoutQueryParams =
+              urlFromK.origin + urlFromK.pathname;
+
+            if (urlFromKWithoutQueryParams === urlFromKeyWithoutQueryParams) {
+              void globalMutate<TData>(k);
+            }
           }
         }
       }


### PR DESCRIPTION
## Description

### Customized `mutate()`

We had an issue where the list of data sources would not refresh automatically after adding or deleting one depending on where it was showing (sidebar menu vs resources list).

It was caused because mutate, by default, only mutate the exact same key (url) and we used the same hook but with differents query params (to show editedBy etc..) so the key differed.

To fix this, we could use & mutate all "versions" of the hooks but with 2 booleans params, it's already 4 combinations, with 3 booleans params, it's 9, and let's not talk about non boolean params. It's hard to maintain and quite verbose.

Instead, useSWRDefaults() now returns a customized mutate function that will also mutate all keys that share the same url but with different query params.

### Various improvements

- The sidebar menu will not show a "chevron" if there are no childs elements.
- Extracted functions that create / update / delete a folder into hooks, next to their fetching hooks, so they are centralized & mutate automatically (take it a suggested pattern for this kind of problems).

## Risk

Trigger too many loadings.
Break mutate() calls somehow (but type checking is a safety net).

## Deploy Plan

Deploy `front`