### PR TITLE
Poké: Allow updating member roles

### DIFF
--- a/front/components/poke/members/columns.tsx
+++ b/front/components/poke/members/columns.tsx
@@ -1,5 +1,6 @@
 import { IconButton, TrashIcon } from "@dust-tt/sparkle";
-import type { RoleType } from "@dust-tt/types";
+import type { ActiveRoleType, RoleType } from "@dust-tt/types";
+import { ACTIVE_ROLES } from "@dust-tt/types";
 import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
 import type { ColumnDef } from "@tanstack/react-table";
 
@@ -16,8 +17,13 @@ export type MemberDisplayType = {
 
 export function makeColumnsForMembers({
   onRevokeMember,
+  onUpdateMemberRole,
 }: {
   onRevokeMember: (m: MemberDisplayType) => Promise<void>;
+  onUpdateMemberRole: (
+    m: MemberDisplayType,
+    role: ActiveRoleType
+  ) => Promise<void>;
 }): ColumnDef<MemberDisplayType>[] {
   return [
     {
@@ -93,6 +99,27 @@ export function makeColumnsForMembers({
       },
       filterFn: (row, id, value) => {
         return value.includes(row.getValue(id));
+      },
+      cell: ({ row }) => {
+        const member = row.original;
+        return (
+          <select
+            className="rounded-lg border border-gray-300 bg-gray-50 text-sm text-gray-900"
+            value={member.role}
+            onChange={async (e) => {
+              await onUpdateMemberRole(
+                member,
+                e.target.value as ActiveRoleType
+              );
+            }}
+          >
+            {ACTIVE_ROLES.map((role) => (
+              <option key={role} value={role}>
+                {role}
+              </option>
+            ))}
+          </select>
+        );
       },
     },
     {

--- a/front/components/poke/members/table.tsx
+++ b/front/components/poke/members/table.tsx
@@ -1,4 +1,8 @@
-import type { UserTypeWithWorkspaces, WorkspaceType } from "@dust-tt/types";
+import type {
+  RoleType,
+  UserTypeWithWorkspaces,
+  WorkspaceType,
+} from "@dust-tt/types";
 import type { UserType } from "@dust-tt/types";
 import { MEMBERSHIP_ROLE_TYPES } from "@dust-tt/types";
 import { useRouter } from "next/router";
@@ -61,6 +65,36 @@ export function MembersDataTable({
     }
   };
 
+  const onUpdateMemberRole = async (m: MemberDisplayType, role: RoleType) => {
+    if (
+      !window.confirm(
+        `Are you sure you want to update role of ${m.email} to ${role}?`
+      )
+    ) {
+      return;
+    }
+
+    try {
+      const r = await fetch(`/api/poke/workspaces/${owner.sId}/roles`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          userId: m.sId,
+          role,
+        }),
+      });
+      if (!r.ok) {
+        throw new Error("Failed to update user role.");
+      }
+      router.reload();
+    } catch (e) {
+      console.error(e);
+      window.alert(`An error occurred while updating the user role: ${e}`);
+    }
+  };
+
   return (
     <>
       <div className="border-material-200 my-4 flex w-full flex-col rounded-lg border p-4">
@@ -69,7 +103,10 @@ export function MembersDataTable({
           <InviteMemberDialog owner={owner} user={user} />
         </div>
         <PokeDataTable
-          columns={makeColumnsForMembers({ onRevokeMember })}
+          columns={makeColumnsForMembers({
+            onRevokeMember,
+            onUpdateMemberRole,
+          })}
           data={prepareMembersForDisplay(members)}
           facets={[
             {

--- a/front/pages/api/poke/workspaces/[wId]/roles.ts
+++ b/front/pages/api/poke/workspaces/[wId]/roles.ts
@@ -1,0 +1,130 @@
+import type { WithAPIErrorResponse } from "@dust-tt/types";
+import { ActiveRoleSchema, assertNever } from "@dust-tt/types";
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getUserForWorkspace } from "@app/lib/api/user";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
+import { Authenticator, getSession } from "@app/lib/auth";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { ServerSideTracking } from "@app/lib/tracking/server";
+import { apiError } from "@app/logger/withlogging";
+
+export type PostRoleUserResponseBody = {
+  success: true;
+};
+
+const PostRoleUserRequestBody = t.type({
+  userId: t.string,
+  role: ActiveRoleSchema,
+});
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PostRoleUserResponseBody>>
+): Promise<void> {
+  const session = await getSession(req, res);
+  const auth = await Authenticator.fromSuperUserSession(
+    session,
+    req.query.wId as string
+  );
+  const owner = auth.getNonNullableWorkspace();
+
+  if (!auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "user_not_found",
+        message: "Could not find the user.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST":
+      const bodyValidation = PostRoleUserRequestBody.decode(req.body);
+      if (isLeft(bodyValidation)) {
+        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `The request body is invalid: ${pathError}`,
+          },
+        });
+      }
+      const { userId, role } = bodyValidation.right;
+
+      const user = await getUserForWorkspace(auth, { userId });
+      if (!user) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "user_not_found",
+            message: "Could not find the user.",
+          },
+        });
+      }
+
+      const updateRes = await MembershipResource.updateMembershipRole({
+        user,
+        workspace: owner,
+        newRole: role,
+        // We allow to re-activate a terminated membership when updating the role here.
+        allowTerminated: true,
+      });
+
+      if (updateRes.isErr()) {
+        switch (updateRes.error.type) {
+          case "not_found":
+            return apiError(req, res, {
+              status_code: 404,
+              api_error: {
+                type: "workspace_user_not_found",
+                message: "Could not find the membership.",
+              },
+            });
+          case "membership_already_terminated":
+            // This cannot happen because we allow updating terminated memberships
+            // by setting `allowTerminated` to true.
+            throw new Error("Unreachable.");
+          case "already_on_role":
+            // Should not happen, but we ignore.
+            break;
+          case "last_admin":
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: "Cannot remove the last admin of a workspace.",
+              },
+            });
+          default:
+            assertNever(updateRes.error.type);
+        }
+      }
+
+      if (updateRes.isOk()) {
+        void ServerSideTracking.trackUpdateMembershipRole({
+          user: user.toJSON(),
+          workspace: owner,
+          previousRole: updateRes.value.previousRole,
+          role: updateRes.value.newRole,
+        });
+      }
+      return res.status(200).json({ success: true });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthentication(handler);


### PR DESCRIPTION
## Description

Allow to change a member role from Poké. 
Not using a PokeSelect because I needed something very basic. 
If you select another role you get an alert asking you to confirm, and if you confirm it updates the role and reload the page (same behavior as for revoking a member). 

<kbd>
<img width="1885" alt="Screenshot 2024-09-11 at 11 42 33" src="https://github.com/user-attachments/assets/bdc8831f-209e-40a7-a917-60dde1251175">
</kbd>

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
