### PR TITLE
[front] fix: dust-apps migration : bypass permission 

### DIFF
--- a/front/migrations/20240910_app_data_sources.ts
+++ b/front/migrations/20240910_app_data_sources.ts
@@ -101,7 +101,11 @@ async function migrateApps(
       const replacer = (obj: any, key: string) => {
         const value = obj[key];
         if (!isResourceSId("data_source_view", value)) {
-          obj[key] = dataSourceViews[value]?.sId;
+          if (dataSourceViews[value]?.sId) {
+            obj[key] = dataSourceViews[value]?.sId;
+          } else {
+            logger.warn({}, `Cannot find datasource ${value} in ${vault.name}`);
+          }
         }
       };
 

--- a/front/migrations/20240910_app_data_sources.ts
+++ b/front/migrations/20240910_app_data_sources.ts
@@ -143,7 +143,11 @@ async function migrateApps(
             logger.info(`Migrating ${app.name}).`);
 
             if (execute) {
-              await app.updateState(auth, state);
+              await AppResource.model.update(state, {
+                where: {
+                  id: app.id,
+                },
+              });
             }
           }
         }


### PR DESCRIPTION
## Description

The internalAdmin created for the script is not part of teh "public dust apps" groups, so cannot write. Use sequelize directly to bypass permission. 
Also add a check if datasource view is not found for the specific vault.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

run script

