### PR TITLE
[front] - feat(members): search members endpoint

### DIFF
--- a/front/components/vaults/CreateOrEditVaultModal.tsx
+++ b/front/components/vaults/CreateOrEditVaultModal.tsx
@@ -63,10 +63,8 @@ export function CreateOrEditVaultModal({
     vault?.name ?? null
   );
   const [selectedMembers, setSelectedMembers] = useState<string[]>([]);
-  // const [members, setMembers] = useState<UserType[]>([]);
   const [searchTerm, setSearchTerm] = useState<string>("");
   const [isSaving, setIsSaving] = useState(false);
-  // const [isLoading, setIsLoading] = useState(false);
   const [pagination, setPagination] = React.useState<PaginationState>({
     pageIndex: 0,
     pageSize: 25,

--- a/front/components/vaults/CreateOrEditVaultModal.tsx
+++ b/front/components/vaults/CreateOrEditVaultModal.tsx
@@ -94,7 +94,7 @@ export function CreateOrEditVaultModal({
     }
   }, [vaultMembers]);
 
-  const { members, membersCount, isLoading } = useSearchMembers(
+  const { members, totalMembersCount, isLoading } = useSearchMembers(
     owner.sId,
     searchTerm,
     pagination.pageIndex,
@@ -294,7 +294,7 @@ export function CreateOrEditVaultModal({
                   columns={columns}
                   pagination={pagination}
                   setPagination={setPagination}
-                  totalRowCount={membersCount}
+                  totalRowCount={totalMembersCount}
                 />
               </div>
             )}

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -191,7 +191,7 @@ export async function searchMembers(
   }
 
   const { users, total } = await UserResource.searchUsers(
-    owner.sId,
+    owner.id,
     {
       searchTerm: options.searchTerm,
     },

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -181,7 +181,7 @@ export async function getMembers(
 export async function searchMembers(
   auth: Authenticator,
   options: {
-    searchTerm?: string;
+    email?: string;
   },
   paginationParams: PaginationParams
 ): Promise<{ members: UserType[]; total: number }> {
@@ -190,27 +190,16 @@ export async function searchMembers(
     return { members: [], total: 0 };
   }
 
-  const { users, total } = await UserResource.searchUsers(
+  const { users, total } = await UserResource.listUsersWithEmailPredicat(
     owner.id,
     {
-      searchTerm: options.searchTerm,
+      email: options.email,
     },
     paginationParams
   );
 
   const usersJson = users.map((u) => {
-    return {
-      fullName: u.name,
-      image: u.imageUrl,
-      createdAt: u.createdAt.getTime(),
-      sId: u.sId,
-      id: u.id,
-      provider: u.provider,
-      username: u.username,
-      email: u.email,
-      firstName: u.firstName,
-      lastName: u.lastName,
-    };
+    return u.toJSON();
   });
   return { members: usersJson, total };
 }

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -198,10 +198,7 @@ export async function searchMembers(
     paginationParams
   );
 
-  const usersJson = users.map((u) => {
-    return u.toJSON();
-  });
-  return { members: usersJson, total };
+  return { members: users.map((u) => u.toJSON()), total };
 }
 
 export async function getMembersCount(

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -3,6 +3,7 @@ import type {
   MembershipRoleType,
   RoleType,
   SubscriptionType,
+  UserType,
   UserTypeWithWorkspaces,
   WorkspaceDomain,
   WorkspaceSegmentationType,
@@ -175,6 +176,43 @@ export async function getMembers(
   });
 
   return { members: usersWithWorkspaces, total };
+}
+
+export async function searchMembers(
+  auth: Authenticator,
+  options: {
+    searchTerm?: string;
+  },
+  paginationParams: PaginationParams
+): Promise<{ members: UserType[]; total: number }> {
+  const owner = auth.workspace();
+  if (!owner) {
+    return { members: [], total: 0 };
+  }
+
+  const { users, total } = await UserResource.searchUsers(
+    owner.sId,
+    {
+      searchTerm: options.searchTerm,
+    },
+    paginationParams
+  );
+
+  const usersJson = users.map((u) => {
+    return {
+      fullName: u.name,
+      image: u.imageUrl,
+      createdAt: u.createdAt.getTime(),
+      sId: u.sId,
+      id: u.id,
+      provider: u.provider,
+      username: u.username,
+      email: u.email,
+      firstName: u.firstName,
+      lastName: u.lastName,
+    };
+  });
+  return { members: usersJson, total };
 }
 
 export async function getMembersCount(

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -146,7 +146,7 @@ export class UserResource extends BaseResource<User> {
   }
 
   static async searchUsers(
-    workspaceId: string,
+    workspaceId: number,
     options: {
       searchTerm?: string;
     },

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -145,17 +145,17 @@ export class UserResource extends BaseResource<User> {
     return user ? new UserResource(User, user.get()) : null;
   }
 
-  static async searchUsers(
+  static async listUsersWithEmailPredicat(
     workspaceId: number,
     options: {
-      searchTerm?: string;
+      email?: string;
     },
     paginationParams: PaginationParams
-  ): Promise<{ users: User[]; total: number }> {
+  ): Promise<{ users: UserResource[]; total: number }> {
     const userWhereClause: any = {};
-    if (options.searchTerm) {
+    if (options.email) {
       userWhereClause.email = {
-        [Op.iLike]: `%${options.searchTerm}%`,
+        [Op.iLike]: `%${options.email}%`,
       };
     }
 
@@ -178,7 +178,10 @@ export class UserResource extends BaseResource<User> {
       offset: paginationParams.lastValue,
     });
 
-    return { users, total: count };
+    return {
+      users: users.map((u) => new UserResource(User, u.get())),
+      total: count,
+    };
   }
 
   async updateAuth0Sub(sub: string): Promise<void> {

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { Fetcher } from "swr";
 
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
@@ -67,8 +67,8 @@ export function useSearchMembers(
     }
   );
   return {
-    members: data?.members ?? [],
-    membersCount: data?.total ?? 0,
+    members: useMemo(() => (data ? data.members : []), [data]),
+    totalMembersCount: data?.total ?? 0,
     isLoading: !error && !data,
     isError: !!error,
     mutateMembers: mutate,

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -1,8 +1,11 @@
+import { useEffect, useRef, useState } from "react";
 import type { Fetcher } from "swr";
 
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { debounce } from "@app/lib/utils/debounce";
 import type { GetUserResponseBody } from "@app/pages/api/user";
 import type { GetUserMetadataResponseBody } from "@app/pages/api/user/metadata/[key]";
+import type { SearchMembersResponseBody } from "@app/pages/api/w/[wId]/members/search";
 
 export function useUser() {
   const userFetcher: Fetcher<GetUserResponseBody> = fetcher;
@@ -28,5 +31,46 @@ export function useUserMetadata(key: string) {
     isMetadataLoading: !error && !data,
     isMetadataError: error,
     mutateMetadata: mutate,
+  };
+}
+
+export function useSearchMembers(
+  workspaceId: string,
+  searchTerm: string,
+  pageIndex: number,
+  pageSize: number
+) {
+  const searchMembersFetcher: Fetcher<SearchMembersResponseBody> = fetcher;
+  const debounceHandle = useRef<NodeJS.Timeout | undefined>(undefined);
+  const [debouncedSearchTerm, setDebouncedSearchTerm] = useState(searchTerm);
+
+  useEffect(() => {
+    const debouncedSearch = () => {
+      setDebouncedSearchTerm(searchTerm);
+    };
+
+    debounce(debounceHandle, debouncedSearch, 300);
+  }, [searchTerm]);
+
+  const searchParams = new URLSearchParams({
+    searchTerm: debouncedSearchTerm,
+    orderBy: "name",
+    lastValue: (pageIndex * pageSize).toString(),
+  });
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/members/search?${searchParams.toString()}`,
+    searchMembersFetcher,
+    {
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+    }
+  );
+  return {
+    members: data?.members ?? [],
+    membersCount: data?.total ?? 0,
+    isLoading: !error && !data,
+    isError: !!error,
+    mutateMembers: mutate,
   };
 }

--- a/front/pages/api/w/[wId]/members/search.ts
+++ b/front/pages/api/w/[wId]/members/search.ts
@@ -7,7 +7,7 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
-const DEFAULT_PAGE_LIMIT = 20;
+const DEFAULT_PAGE_LIMIT = 25;
 
 export type SearchMembersResponseBody = {
   members: UserType[];
@@ -49,7 +49,7 @@ async function handler(
         defaultLimit: DEFAULT_PAGE_LIMIT,
         defaultOrderColumn: orderBy || "name",
         defaultOrderDirection: "desc",
-        supportedOrderColumn: ["createdAt", "email", "fullName"],
+        supportedOrderColumn: ["createdAt", "email", "name"],
       });
 
       if (paginationRes.isErr()) {

--- a/front/pages/api/w/[wId]/members/search.ts
+++ b/front/pages/api/w/[wId]/members/search.ts
@@ -1,0 +1,92 @@
+import type { UserType, WithAPIErrorResponse } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getPaginationParams } from "@app/lib/api/pagination";
+import { searchMembers } from "@app/lib/api/workspace";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+
+const DEFAULT_PAGE_LIMIT = 20;
+
+export type SearchMembersResponseBody = {
+  members: UserType[];
+  total: number;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<SearchMembersResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can search memberships.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const { searchTerm, orderBy } = req.query;
+
+      if (typeof searchTerm !== "string" || typeof orderBy !== "string") {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "Invalid query parameters. Both 'searchTerm' and 'orderBy' must be strings.",
+          },
+        });
+      }
+
+      const paginationRes = getPaginationParams(req, {
+        defaultLimit: DEFAULT_PAGE_LIMIT,
+        defaultOrderColumn: orderBy || "name",
+        defaultOrderDirection: "desc",
+        supportedOrderColumn: ["createdAt", "email", "fullName"],
+      });
+
+      if (paginationRes.isErr()) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: paginationRes.error.message,
+          },
+        });
+      }
+
+      const paginationParams = paginationRes.value;
+
+      const { members, total } = await searchMembers(
+        auth,
+        {
+          searchTerm,
+        },
+        paginationParams
+      );
+
+      res.status(200).json({
+        members,
+        total,
+      });
+      return;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/members/search.ts
+++ b/front/pages/api/w/[wId]/members/search.ts
@@ -49,7 +49,7 @@ async function handler(
         defaultLimit: DEFAULT_PAGE_LIMIT,
         defaultOrderColumn: orderBy || "name",
         defaultOrderDirection: "desc",
-        supportedOrderColumn: ["createdAt", "email", "name"],
+        supportedOrderColumn: ["name"],
       });
 
       if (paginationRes.isErr()) {
@@ -67,7 +67,7 @@ async function handler(
       const { members, total } = await searchMembers(
         auth,
         {
-          searchTerm,
+          email: searchTerm,
         },
         paginationParams
       );


### PR DESCRIPTION
## Description

This PR implements pagination search for the member list in the `CreateOrEditVaultModal` component.

It introduces a new `/search` endpoint for members, which allows for efficient server-side pagination and filtering of workspace members. The changes improve performance and user experience when creating or editing vaults, especially for workspaces with a large number of members.

**References:**
- https://github.com/dust-tt/tasks/issues/1284

## Risk

Minor as it is only used in vaults

## Deploy Plan

- Deploy `front-edge`
- Deploy `front`
