### PR TITLE
[Production check] Paginate long scrub query

### DIFF
--- a/front/lib/production_checks/checks/scrub_deleted_core_document_versions.ts
+++ b/front/lib/production_checks/checks/scrub_deleted_core_document_versions.ts
@@ -39,7 +39,7 @@ export const scrubDeletedCoreDocumentVersionsCheck: CheckFunction = async (
   do {
     // paginate by id
     const deletedDocumentsData = await coreReplica.query(
-      `SELECT * FROM data_sources_documents WHERE status = 'deleted' AND id = ${pageId} ORDER BY id LIMIT 1000`
+      `SELECT * FROM data_sources_documents WHERE status = 'deleted' AND id > ${pageId} ORDER BY id LIMIT 1000`
     );
 
     const deletedDocuments = deletedDocumentsData[0] as {

--- a/front/lib/production_checks/checks/scrub_deleted_core_document_versions.ts
+++ b/front/lib/production_checks/checks/scrub_deleted_core_document_versions.ts
@@ -33,66 +33,77 @@ export const scrubDeletedCoreDocumentVersionsCheck: CheckFunction = async (
 
   const storage = new Storage({ keyFilename: SERVICE_ACCOUNT });
 
-  const deletedDocumentsData = await coreReplica.query(
-    `SELECT * FROM data_sources_documents WHERE status = 'deleted'`
-  );
+  let pageId = 0;
+  let totalDeletedCount = 0;
 
-  const deletedDocuments = deletedDocumentsData[0] as {
-    id: number;
-    created: number;
-    data_source: number;
-    document_id: string;
-    hash: string;
-    timestamp: number;
-  }[];
-
-  logger.info(
-    {
-      documentCount: deletedDocuments.length,
-    },
-    "Found deleted core documents to scrub"
-  );
-
-  const chunks = [];
-  for (let i = 0; i < deletedDocuments.length; i += 32) {
-    chunks.push(deletedDocuments.slice(i, i + 32));
-  }
-
-  const seen: Set<string> = new Set();
-  let deletedCount = 0;
-
-  for (let i = 0; i < chunks.length; i++) {
-    heartbeat();
-    const chunk = chunks[i];
-    await Promise.all(
-      chunk.map((d) => {
-        return (async () => {
-          const done = await scrubDocument({
-            logger,
-            seen,
-            storage,
-            data_source: d.data_source,
-            document_id: d.document_id,
-            created: d.created,
-            hash: d.hash,
-          });
-          if (done) {
-            deletedCount++;
-          }
-        })();
-      })
+  do {
+    // paginate by id
+    const deletedDocumentsData = await coreReplica.query(
+      `SELECT * FROM data_sources_documents WHERE status = 'deleted' AND id = ${pageId} ORDER BY id LIMIT 1000`
     );
-  }
 
-  logger.info(
-    {
-      deletedCount,
-    },
-    "Done scrubbing deleted core document versions"
-  );
+    const deletedDocuments = deletedDocumentsData[0] as {
+      id: number;
+      created: number;
+      data_source: number;
+      document_id: string;
+      hash: string;
+      timestamp: number;
+    }[];
+
+    logger.info(
+      {
+        documentCount: deletedDocuments.length,
+      },
+      "Found a page of deleted core documents to scrub"
+    );
+
+    const chunks = [];
+    for (let i = 0; i < deletedDocuments.length; i += 32) {
+      chunks.push(deletedDocuments.slice(i, i + 32));
+    }
+
+    const seen: Set<string> = new Set();
+    let deletedCount = 0;
+
+    for (let i = 0; i < chunks.length; i++) {
+      heartbeat();
+      const chunk = chunks[i];
+      await Promise.all(
+        chunk.map((d) => {
+          return (async () => {
+            const done = await scrubDocument({
+              logger,
+              seen,
+              storage,
+              data_source: d.data_source,
+              document_id: d.document_id,
+              created: d.created,
+              hash: d.hash,
+            });
+            if (done) {
+              deletedCount++;
+            }
+          })();
+        })
+      );
+    }
+
+    logger.info(
+      {
+        deletedCount,
+      },
+      "Done scrubbing deleted core document versions for this page"
+    );
+    totalDeletedCount += deletedCount;
+    pageId =
+      deletedDocuments.length > 0
+        ? deletedDocuments[deletedDocuments.length - 1].id
+        : -1;
+  } while (pageId !== -1);
 
   reportSuccess({
-    deletedCount,
+    totalDeletedCount,
   });
 };
 


### PR DESCRIPTION
Description
---
Prospectively fixes https://github.com/dust-tt/tasks/issues/1293

Best reviewed with [hide whitespace](https://github.com/dust-tt/dust/pull/7288/files?diff=split&w=1)

We are having an SQL database error (see issue for description)

The likely cause is a long `SELECT * FROM data_sources_documents WHERE status = 'deleted'` (production check), currently 162K rows. Paginating will hopefully solve the issue.

Risks
---
NA

Deploy
---
front
