### PR TITLE
[sparkle] UI polish / color adjustments

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.232",
+  "version": "0.2.233",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.232",
+      "version": "0.2.233",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.232",
+  "version": "0.2.233",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -384,7 +384,7 @@ DataTable.CellContent = function CellContent({
           visual={icon}
           size="sm"
           className={classNames(
-            "s-mr-2 s-text-element-600",
+            "s-mr-2 s-text-element-800",
             iconClassName || ""
           )}
         />

--- a/sparkle/src/components/Tree.tsx
+++ b/sparkle/src/components/Tree.tsx
@@ -94,7 +94,7 @@ Tree.Item = function ({
   type = "node",
   className = "",
   size = "sm",
-  tailwindIconTextColor = "s-text-element-600",
+  tailwindIconTextColor = "s-text-element-800",
   visual,
   checkbox,
   onChevronClick,


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/1257

## Description

switch table and tree icon to text-element-800

## Risk


## Deploy Plan

publish sparkle