### PR TITLE
Notion workers are too busy

### DIFF
--- a/connectors/src/connectors/notion/temporal/worker.ts
+++ b/connectors/src/connectors/notion/temporal/worker.ts
@@ -17,7 +17,7 @@ export async function runNotionWorker() {
     connection,
     reuseV8Context: true,
     namespace,
-    maxConcurrentActivityTaskExecutions: 16,
+    maxConcurrentActivityTaskExecutions: 8,
     interceptors: {
       activityInbound: [
         (ctx: Context) => {

--- a/k8s/deployments/connectors-worker-notion-deployment.yaml
+++ b/k8s/deployments/connectors-worker-notion-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: connectors-worker-notion-deployment
 spec:
-  replicas: 3
+  replicas: 6
   selector:
     matchLabels:
       app: connectors-worker


### PR DESCRIPTION
## Description

Notion workers are too busy, which blocks the pods.
We tried restarting the worker but did not last long. 

From what I understand we changed something related to GC which explains that there is a lot of load: 

<img width="445" alt="Screenshot 2024-09-11 at 16 06 48" src="https://github.com/user-attachments/assets/eb1f3e28-fdf3-4e72-81fa-b7df529723f8">


We're doubling the number of pods (to handle the load) and reducing the mx number of concurrent activities (to avoid hitting too much memory). 


## Risk

/

## Deploy Plan

- Apply infra
- Deploy connectors. 
