### PR TITLE
[front] chore: text and icon styles

### DIFF
--- a/front/components/vaults/VaultCategoriesList.tsx
+++ b/front/components/vaults/VaultCategoriesList.tsx
@@ -70,8 +70,8 @@ const getTableColumns = () => {
       accessorKey: "name",
       cell: (info: Info) => (
         <DataTable.CellContent icon={info.row.original.icon}>
-          <span className="font-bold">{info.row.original.name}</span> (
-          {info.row.original.count} items)
+          <span>{info.row.original.name}</span> ({info.row.original.count}{" "}
+          items)
         </DataTable.CellContent>
       ),
     },

--- a/front/components/vaults/VaultDataSourceViewContentList.tsx
+++ b/front/components/vaults/VaultDataSourceViewContentList.tsx
@@ -64,7 +64,7 @@ const getTableColumns = (): ColumnDef<RowData, string>[] => {
       sortingFn: "text", // built-in sorting function case-insensitive
       cell: (info: CellContext<RowData, unknown>) => (
         <DataTable.CellContent icon={info.row.original.icon}>
-          <span className="font-bold">{info.row.original.title}</span>
+          <span>{info.row.original.title}</span>
         </DataTable.CellContent>
       ),
     },

--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -87,7 +87,7 @@ const getTableColumns = ({
     sortingFn: "text", // built-in sorting function case-insensitive
     cell: (info: CellContext<RowData, string>) => (
       <DataTable.CellContent icon={info.row.original.icon}>
-        <span className="font-bold"> {info.getValue()}</span>
+        <span>{info.getValue()}</span>
       </DataTable.CellContent>
     ),
   };

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,7 @@
         "@amplitude/analytics-browser": "^2.5.2",
         "@amplitude/analytics-node": "^1.3.5",
         "@auth0/nextjs-auth0": "^3.5.0",
-        "@dust-tt/sparkle": "^0.2.232",
+        "@dust-tt/sparkle": "^0.2.233",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -10736,9 +10736,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.232",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.232.tgz",
-      "integrity": "sha512-TmS4n2YO72gwcfcbm2Z/YvjZUk5XfK8vxm8Tw0hUnhbFqQorsBtx0ECDvaPIHTCTOIDY8vCGYx9Jfjfyi1SNpA==",
+      "version": "0.2.233",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.233.tgz",
+      "integrity": "sha512-HFB1E9LcSKwtT/dbHVljBa5VsOT5sP890yJwNCH1jJEfiFkWLWxgSZbgL8u3sQ658loXzGTlmb0v0UzEK3K00Q==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
     "@amplitude/analytics-browser": "^2.5.2",
     "@amplitude/analytics-node": "^1.3.5",
     "@auth0/nextjs-auth0": "^3.5.0",
-    "@dust-tt/sparkle": "^0.2.232",
+    "@dust-tt/sparkle": "^0.2.233",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/1257

## Description

switch table and tree icon to text-element-800, text in tables to regular

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
deploy front
