### PR TITLE
Bump content fragment size limit to 128kb in the API

### DIFF
--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -114,13 +114,13 @@ async function handler(
       const { right: contentFragmentBody } = bodyValidation;
       const { content, contentType } = contentFragmentBody;
 
-      if (content.length === 0 || content.length > 64 * 1024) {
+      if (content.length === 0 || content.length > 128 * 1024) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
             message:
-              "The content must be a non-empty string of less than 64kb.",
+              "The content must be a non-empty string of less than 128kb.",
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -131,14 +131,14 @@ async function handler(
       if (contentFragment) {
         if (
           contentFragment.content.length === 0 ||
-          contentFragment.content.length > 64 * 1024
+          contentFragment.content.length > 128 * 1024
         ) {
           return apiError(req, res, {
             status_code: 400,
             api_error: {
               type: "invalid_request_error",
               message:
-                "The content must be a non-empty string of less than 64kb.",
+                "The content must be a non-empty string of less than 128kb.",
             },
           });
         }


### PR DESCRIPTION
## Description

Bump content fragment size limit to 128kb in the API

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
