### PR TITLE
We don't want Visualization spinner to go over the input bar

### DIFF
--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -153,7 +153,7 @@ export function VisualizationActionIframe({
   return (
     <div className="relative flex flex-col">
       {showSpinner && (
-        <div className="absolute inset-0 z-50 flex items-center justify-center bg-white">
+        <div className="absolute inset-0 flex items-center justify-center bg-white">
           <Spinner size="xl" />
         </div>
       )}


### PR DESCRIPTION
## Description

Task: [Data viz] Viz <Spinner> stays above text input [#1226](https://github.com/dust-tt/tasks/issues/1226)

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 