### PR TITLE
chore: disable core secondary forwarding

### DIFF
--- a/k8s/configmaps/core-configmap.yaml
+++ b/k8s/configmaps/core-configmap.yaml
@@ -8,4 +8,3 @@ data:
   DD_LOGS_INJECTION: "true"
   DD_RUNTIME_METRICS_ENABLED: "true"
   CORE_SECONDARY_API: "http://core-secondary-service"
-  SECONDARY_API_FORWARDING_ENABLED: "true"


### PR DESCRIPTION
## Description

Some of the core endpoints (tables query) are being forwarded to a "secondary" deployment. This was done in order to figure out if these endpoints were responsible for the memory leak.

It appears that both deployments suffer from the same leak.

This PR disables the use of the secondary API. next PR will delete it entirely

## Risk

N/A

## Deploy Plan

First apply infra and deploy. Next get rid of the secondary API code & infra