### PR TITLE
enh: attempr to recuce notion worker memory usage

### DIFF
--- a/connectors/src/connectors/notion/temporal/worker.ts
+++ b/connectors/src/connectors/notion/temporal/worker.ts
@@ -18,6 +18,7 @@ export async function runNotionWorker() {
     reuseV8Context: true,
     namespace,
     maxConcurrentActivityTaskExecutions: 8,
+    maxCachedWorkflows: 200,
     interceptors: {
       activityInbound: [
         (ctx: Context) => {

--- a/k8s/configmaps/connectors-worker-specific-configmap.yaml
+++ b/k8s/configmaps/connectors-worker-specific-configmap.yaml
@@ -5,7 +5,7 @@ metadata:
 data:
   DD_ENV: "prod"
   DD_SERVICE: "connectors-worker"
-  NODE_OPTIONS: "-r dd-trace/init --max-old-space-size=3276"
+  NODE_OPTIONS: "-r dd-trace/init --max-old-space-size=3000"
   DD_LOGS_INJECTION: "true"
   DD_RUNTIME_METRICS_ENABLED: "true"
   NODE_ENV: "production"


### PR DESCRIPTION
## Description

- attempt to reduce the number of cached workflows per notion worker (we have lots of workflows, some of which can get pretty big)
- attempt to reduce a bit the max old space size so temporal doesn't use every single byte available

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
