### PR TITLE
[front] chore: Add vault columns in connection management

### DIFF
--- a/front/components/vaults/VaultDataSourceViewContentList.tsx
+++ b/front/components/vaults/VaultDataSourceViewContentList.tsx
@@ -37,8 +37,8 @@ import {
   useDataSourceViewContentNodes,
   useDataSourceViews,
 } from "@app/lib/swr/data_source_views";
-import { classNames, formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { useVaults } from "@app/lib/swr/vaults";
+import { classNames, formatTimestampToFriendlyDate } from "@app/lib/utils";
 
 type RowData = DataSourceViewContentNode & {
   icon: React.ComponentType;
@@ -79,10 +79,12 @@ const getTableColumns = (showVaultUsage: boolean): ColumnDef<RowData>[] => {
       accessorKey: "vaults",
       cell: (info: CellContext<RowData, VaultType[]>) => (
         <DataTable.CellContent>
-          {info
-            .getValue()
-            .map((v) => v.name)
-            .join(",")}
+          {info.getValue().length > 0
+            ? info
+                .getValue()
+                .map((v) => v.name)
+                .join(",")
+            : "-"}
         </DataTable.CellContent>
       ),
     });
@@ -92,19 +94,13 @@ const getTableColumns = (showVaultUsage: boolean): ColumnDef<RowData>[] => {
     header: "Last updated",
     accessorKey: "lastUpdatedAt",
     id: "lastUpdatedAt",
-    cell: (info: CellContext<RowData, number>) => {
-      const lastUpdatedAt = info.getValue();
-
-      if (!lastUpdatedAt) {
-        return <DataTable.CellContent>-</DataTable.CellContent>;
-      }
-
-      return (
-        <DataTable.CellContent>
-          {formatTimestampToFriendlyDate(lastUpdatedAt, "short")}
-        </DataTable.CellContent>
-      );
-    },
+    cell: (info: CellContext<RowData, number>) => (
+      <DataTable.CellContent>
+        {info.getValue()
+          ? formatTimestampToFriendlyDate(info.getValue(), "short")
+          : "-"}
+      </DataTable.CellContent>
+    ),
   });
 
   return columns;

--- a/front/components/vaults/VaultDataSourceViewContentList.tsx
+++ b/front/components/vaults/VaultDataSourceViewContentList.tsx
@@ -33,8 +33,12 @@ import { FoldersHeaderMenu } from "@app/components/vaults/FoldersHeaderMenu";
 import { WebsitesHeaderMenu } from "@app/components/vaults/WebsitesHeaderMenu";
 import { getVisualForContentNode } from "@app/lib/content_nodes";
 import { isFolder, isManaged, isWebsite } from "@app/lib/data_sources";
-import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
+import {
+  useDataSourceViewContentNodes,
+  useDataSourceViews,
+} from "@app/lib/swr/data_source_views";
 import { classNames, formatTimestampToFriendlyDate } from "@app/lib/utils";
+import { useVaults } from "@app/lib/swr/vaults";
 
 type RowData = DataSourceViewContentNode & {
   icon: React.ComponentType;
@@ -55,39 +59,53 @@ type VaultDataSourceViewContentListProps = {
   connector: ConnectorType | null;
 };
 
-const getTableColumns = (): ColumnDef<RowData, string>[] => {
-  const columns: ColumnDef<RowData, string>[] = [
-    {
-      header: "Name",
-      accessorKey: "title",
-      id: "title",
-      sortingFn: "text", // built-in sorting function case-insensitive
-      cell: (info: CellContext<RowData, unknown>) => (
-        <DataTable.CellContent icon={info.row.original.icon}>
-          <span>{info.row.original.title}</span>
+const getTableColumns = (showVaultUsage: boolean): ColumnDef<RowData>[] => {
+  const columns: ColumnDef<RowData, any>[] = [];
+  columns.push({
+    header: "Name",
+    accessorKey: "title",
+    id: "title",
+    sortingFn: "text", // built-in sorting function case-insensitive
+    cell: (info: CellContext<RowData, string>) => (
+      <DataTable.CellContent icon={info.row.original.icon}>
+        <span>{info.getValue()}</span>
+      </DataTable.CellContent>
+    ),
+  });
+
+  if (showVaultUsage) {
+    columns.push({
+      header: "Available to",
+      accessorKey: "vaults",
+      cell: (info: CellContext<RowData, VaultType[]>) => (
+        <DataTable.CellContent>
+          {info
+            .getValue()
+            .map((v) => v.name)
+            .join(",")}
         </DataTable.CellContent>
       ),
-    },
-    {
-      header: "Last updated",
-      accessorKey: "lastUpdatedAt",
-      id: "lastUpdatedAt",
-      sortingFn: "text", // built-in sorting function case-insensitive
-      cell: (info: CellContext<RowData, unknown>) => {
-        const { lastUpdatedAt } = info.row.original;
+    });
+  }
 
-        if (!lastUpdatedAt) {
-          return <DataTable.CellContent>-</DataTable.CellContent>;
-        }
+  columns.push({
+    header: "Last updated",
+    accessorKey: "lastUpdatedAt",
+    id: "lastUpdatedAt",
+    cell: (info: CellContext<RowData, number>) => {
+      const lastUpdatedAt = info.getValue();
 
-        return (
-          <DataTable.CellContent>
-            {formatTimestampToFriendlyDate(lastUpdatedAt, "short")}
-          </DataTable.CellContent>
-        );
-      },
+      if (!lastUpdatedAt) {
+        return <DataTable.CellContent>-</DataTable.CellContent>;
+      }
+
+      return (
+        <DataTable.CellContent>
+          {formatTimestampToFriendlyDate(lastUpdatedAt, "short")}
+        </DataTable.CellContent>
+      );
     },
-  ];
+  });
 
   return columns;
 };
@@ -115,6 +133,16 @@ export const VaultDataSourceViewContentList = ({
   });
   const [viewType, setViewType] = useHashParam("viewType", "documents");
 
+  const showVaultUsage =
+    dataSourceView.kind === "default" && isManaged(dataSourceView.dataSource);
+  const { vaults } = useVaults({
+    workspaceId: owner.sId,
+    disabled: !showVaultUsage,
+  });
+  const { dataSourceViews } = useDataSourceViews(owner, {
+    disabled: !showVaultUsage,
+  });
+
   const handleViewTypeChange = (newViewType: ContentNodesViewType) => {
     if (newViewType !== viewType) {
       setPagination({ pageIndex: 0, pageSize: pagination.pageSize }, "replace");
@@ -141,6 +169,21 @@ export const VaultDataSourceViewContentList = ({
       nodes?.map((contentNode) => ({
         ...contentNode,
         icon: getVisualForContentNode(contentNode),
+        vaults: vaults.filter((vault) =>
+          dataSourceViews
+            .filter(
+              (dsv) =>
+                dsv.dataSource.sId === dataSourceView.dataSource.sId &&
+                dsv.kind !== "default" &&
+                contentNode.parentInternalIds &&
+                contentNode.parentInternalIds.some(
+                  (parentId) =>
+                    !dsv.parentsIn || dsv.parentsIn.includes(parentId)
+                )
+            )
+            .map((dsv) => dsv.vaultId)
+            .includes(vault.sId)
+        ),
         ...(contentNode.expandable && {
           onClick: () => {
             if (contentNode.expandable) {
@@ -156,7 +199,15 @@ export const VaultDataSourceViewContentList = ({
           contentActionsRef
         ),
       })) || [],
-    [canWriteInVault, canReadInVault, dataSourceView, nodes, onSelect]
+    [
+      canWriteInVault,
+      canReadInVault,
+      dataSourceView,
+      nodes,
+      onSelect,
+      vaults,
+      dataSourceViews,
+    ]
   );
 
   if (isNodesLoading) {
@@ -265,7 +316,7 @@ export const VaultDataSourceViewContentList = ({
       {rows.length > 0 && (
         <DataTable
           data={rows}
-          columns={getTableColumns()}
+          columns={getTableColumns(showVaultUsage)}
           filter={dataSourceSearch}
           filterColumn="title"
           initialColumnOrder={[{ desc: false, id: "title" }]}


### PR DESCRIPTION
fixes: https://github.com/dust-tt/dust/issues/7300

## Description

Add a new column in connection management that show in which vault a resource is available

<img width="936" alt="Screenshot 2024-09-11 at 18 05 57" src="https://github.com/user-attachments/assets/0ff87401-25c5-4cba-99d0-0dcde949d947">


## Risk



## Deploy Plan

deploy front