### PR TITLE
Add log to understand why some AgentTablesQueryConfigurationTable disappear

### DIFF
--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -157,11 +157,13 @@ AgentTablesQueryConfigurationTable.init(
 AgentTablesQueryConfigurationTable.addHook(
   "beforeDestroy",
   async (instance: AgentTablesQueryConfigurationTable) => {
+    const stackTrace = new Error().stack;
     logger.error(
       {
         tableId: instance.tableId,
         dataSourceId: instance.dataSourceId,
         dataSourceWorkspaceId: instance.dataSourceWorkspaceId,
+        stackTrace,
       },
       "[AgentTablesQueryConfigurationTable deleted] Source = Hook from model."
     );

--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -11,6 +11,7 @@ import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { AgentMessage } from "@app/lib/models/assistant/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
+import logger from "@app/logger/logger";
 
 export class AgentTablesQueryConfiguration extends Model<
   InferAttributes<AgentTablesQueryConfiguration>,
@@ -149,6 +150,21 @@ AgentTablesQueryConfigurationTable.init(
       },
     ],
     sequelize: frontSequelize,
+  }
+);
+
+// todo(@daph): Remove this once we have understood why some AgentTablesQueryConfigurationTable disappear.
+AgentTablesQueryConfigurationTable.addHook(
+  "beforeDestroy",
+  async (instance: AgentTablesQueryConfigurationTable) => {
+    logger.error(
+      {
+        tableId: instance.tableId,
+        dataSourceId: instance.dataSourceId,
+        dataSourceWorkspaceId: instance.dataSourceWorkspaceId,
+      },
+      "[AgentTablesQueryConfigurationTable deleted] Source = Hook from model."
+    );
   }
 );
 

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -304,6 +304,31 @@ export class DataSourceResource extends ResourceWithVault<DataSource> {
       transaction,
     });
 
+    // todo(@daph): Remove this once we have understood why some AgentTablesQueryConfigurationTable disappear.
+    const relatedAgentTablesQueryConfigurationTables =
+      await AgentTablesQueryConfigurationTable.findAll({
+        where: {
+          dataSourceId: this.name,
+        },
+      });
+    if (relatedAgentTablesQueryConfigurationTables.length > 0) {
+      logger.error(
+        {
+          panic: true,
+          dataSourceId: this.name,
+          workspaceId: this.workspaceId,
+          sId: this.sId,
+          configIds: relatedAgentTablesQueryConfigurationTables.map(
+            (t) => t.tablesQueryConfigurationId
+          ),
+          configTableIds: relatedAgentTablesQueryConfigurationTables.map(
+            (t) => t.tableId
+          ),
+        },
+        "[AgentTablesQueryConfigurationTable deleted]. Source = Data source deleted."
+      );
+    }
+
     // TODO(DATASOURCE_SID): state storing the datasource name.
     await AgentTablesQueryConfigurationTable.destroy({
       where: {


### PR DESCRIPTION
## Description

Task: https://github.com/dust-tt/tasks/issues/1295

Turns out this https://github.com/dust-tt/dust/pull/7256 was not enough and some users still report a lost configuration. 
This is super weird since we removed the destroy, so to confirm data is deleted I'm adding some logs that are meant to stay here temporarily. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
