### PR TITLE
Add vault selector on Dust App action in Assistant Builder

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -54,6 +54,7 @@ import { AssistantBuilderContext } from "@app/components/assistant_builder/Assis
 import { isLegacyAssistantBuilderConfiguration } from "@app/components/assistant_builder/legacy_agent";
 import type {
   AssistantBuilderActionConfiguration,
+  AssistantBuilderActionConfigurationWithId,
   AssistantBuilderPendingAction,
   AssistantBuilderProcessConfiguration,
   AssistantBuilderRetrievalConfiguration,
@@ -113,16 +114,12 @@ export function hasActionError(
   }
 }
 
-type VaultIdToActions = Record<string, AssistantBuilderActionConfiguration[]>;
+type VaultIdToActions = Record<
+  string,
+  AssistantBuilderActionConfigurationWithId[]
+>;
 
-export default function ActionsScreen({
-  owner,
-  builderState,
-  setBuilderState,
-  setEdited,
-  setAction,
-  pendingAction,
-}: {
+interface ActionScreenProps {
   owner: WorkspaceType;
   builderState: AssistantBuilderState;
   setBuilderState: (
@@ -131,7 +128,16 @@ export default function ActionsScreen({
   setEdited: (edited: boolean) => void;
   setAction: (action: AssistantBuilderSetActionType) => void;
   pendingAction: AssistantBuilderPendingAction;
-}) {
+}
+
+export default function ActionsScreen({
+  owner,
+  builderState,
+  setBuilderState,
+  setEdited,
+  setAction,
+  pendingAction,
+}: ActionScreenProps) {
   const { vaults } = useContext(AssistantBuilderContext);
 
   const configurableActions = builderState.actions.filter(
@@ -142,7 +148,7 @@ export default function ActionsScreen({
 
   const vaultIdToActions = useMemo(() => {
     return configurableActions.reduce<
-      Record<string, AssistantBuilderActionConfiguration[]>
+      Record<string, AssistantBuilderActionConfigurationWithId[]>
     >((acc, action) => {
       const addActionToVault = (vaultId?: string) => {
         if (vaultId) {
@@ -216,6 +222,7 @@ export default function ActionsScreen({
                 // There is no way (that I could find) to make typescript understand that
                 // type and configuration are compatible.
                 configuration: getNewActionConfig(action.configuration) as any,
+                id: action.id,
               }
             : action
         ),
@@ -436,9 +443,9 @@ export default function ActionsScreen({
 type NewActionModalProps = {
   isOpen: boolean;
   builderState: AssistantBuilderState;
-  initialAction: AssistantBuilderActionConfiguration | null;
+  initialAction: AssistantBuilderActionConfigurationWithId | null;
   vaultsUsedInActions: VaultIdToActions;
-  onSave: (newAction: AssistantBuilderActionConfiguration) => void;
+  onSave: (newAction: AssistantBuilderActionConfigurationWithId) => void;
   onClose: () => void;
   updateAction: (args: {
     actionName: string;
@@ -460,8 +467,9 @@ function NewActionModal({
   setEdited,
   builderState,
 }: NewActionModalProps) {
-  const [newAction, setNewAction] =
-    useState<AssistantBuilderActionConfiguration | null>(null);
+  const [newAction, setNewAction] = useState<
+    (AssistantBuilderActionConfiguration & { id: string }) | null
+  >(null);
 
   const [showInvalidActionError, setShowInvalidActionError] = useState<
     string | null
@@ -636,22 +644,22 @@ function ActionCard({
   );
 }
 
-type ActionConfigEditorProps = {
+interface ActionConfigEditorProps {
   owner: WorkspaceType;
-  action: AssistantBuilderActionConfiguration;
+  action: AssistantBuilderActionConfigurationWithId;
   vaultsUsedInActions: VaultIdToActions;
   instructions: string | null;
   updateAction: (args: {
     actionName: string;
     actionDescription: string;
     getNewActionConfig: (
-      old: AssistantBuilderActionConfiguration["configuration"]
-    ) => AssistantBuilderActionConfiguration["configuration"];
+      old: AssistantBuilderActionConfigurationWithId["configuration"]
+    ) => AssistantBuilderActionConfigurationWithId["configuration"];
   }) => void;
   setEdited: (edited: boolean) => void;
   description: string;
   onDescriptionChange: (v: string) => void;
-};
+}
 
 function ActionConfigEditor({
   owner,
@@ -665,16 +673,22 @@ function ActionConfigEditor({
 }: ActionConfigEditorProps) {
   const { vaults } = useContext(AssistantBuilderContext);
 
-  // Only allow one vault across all actions
+  // Only allow one vault across all actions.
   const allowedVaults = useMemo(() => {
     const isVaultUsedInOtherActions = (vault: VaultType) => {
       const actionsUsingVault = vaultsUsedInActions[vault.sId] ?? [];
-      return actionsUsingVault.some((a) => a !== action);
+
+      return actionsUsingVault.some((a) => {
+        // We use the id to compare actions, as the configuration can change.
+        return a.id !== action.id;
+      });
     };
+
     const usedVaultsInOtherActions = vaults.filter(isVaultUsedInOtherActions);
     if (usedVaultsInOtherActions.length === 0) {
       return vaults;
     }
+
     return vaults.filter((vault) =>
       usedVaultsInOtherActions.some((v) => v.sId === vault.sId)
     );
@@ -691,6 +705,7 @@ function ActionConfigEditor({
           setEdited={setEdited}
         />
       );
+
     case "RETRIEVAL_SEARCH":
       return (
         <ActionRetrievalSearch
@@ -708,6 +723,7 @@ function ActionConfigEditor({
           setEdited={setEdited}
         />
       );
+
     case "RETRIEVAL_EXHAUSTIVE":
       return (
         <ActionRetrievalExhaustive
@@ -725,6 +741,7 @@ function ActionConfigEditor({
           setEdited={setEdited}
         />
       );
+
     case "PROCESS":
       return (
         <ActionProcess
@@ -745,6 +762,7 @@ function ActionConfigEditor({
           onDescriptionChange={onDescriptionChange}
         />
       );
+
     case "TABLES_QUERY":
       return (
         <ActionTablesQuery
@@ -762,15 +780,17 @@ function ActionConfigEditor({
           setEdited={setEdited}
         />
       );
+
     case "WEB_NAVIGATION":
       return <ActionWebNavigation />;
+
     default:
       assertNever(action);
   }
 }
 
 interface ActionEditorProps {
-  action: AssistantBuilderActionConfiguration;
+  action: AssistantBuilderActionConfigurationWithId;
   vaultsUsedInActions: VaultIdToActions;
   showInvalidActionNameError: string | null;
   showInvalidActionDescError: string | null;
@@ -988,11 +1008,11 @@ function AdvancedSettings({
   );
 }
 
-function AddAction({
-  onAddAction,
-}: {
-  onAddAction: (action: AssistantBuilderActionConfiguration) => void;
-}) {
+interface AddActionProps {
+  onAddAction: (action: AssistantBuilderActionConfigurationWithId) => void;
+}
+
+function AddAction({ onAddAction }: AddActionProps) {
   return (
     <DropdownMenu>
       <DropdownMenu.Button>

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -21,6 +21,7 @@ import {
   isBuilder,
   SUPPORTED_MODEL_CONFIGS,
 } from "@dust-tt/types";
+import { uniqueId } from "lodash";
 import { useRouter } from "next/router";
 import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import React from "react";
@@ -118,7 +119,10 @@ export default function AssistantBuilder({
           generationSettings: initialBuilderState.generationSettings ?? {
             ...getDefaultAssistantState().generationSettings,
           },
-          actions: initialBuilderState.actions,
+          actions: initialBuilderState.actions.map((action) => ({
+            id: uniqueId(),
+            ...action,
+          })),
           maxStepsPerRun:
             initialBuilderState.maxStepsPerRun ??
             getDefaultAssistantState().maxStepsPerRun,

--- a/front/components/assistant_builder/AssistantBuilderDustAppModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDustAppModal.tsx
@@ -68,8 +68,6 @@ function PickDustApp({
     (app) => !app.description || app.description.length === 0
   );
 
-  // TODO: Refresh vault when removing the dust apps.
-
   return (
     <Transition show={show} className="mx-auto max-w-6xl">
       <Page>

--- a/front/components/assistant_builder/AssistantBuilderDustAppModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDustAppModal.tsx
@@ -1,18 +1,26 @@
 import { CommandLineIcon, Item, Modal, Page } from "@dust-tt/sparkle";
-import type { AppType } from "@dust-tt/types";
+import type { AppType, LightWorkspaceType, VaultType } from "@dust-tt/types";
 import { Transition } from "@headlessui/react";
 
-export default function AssistantBuilderDustAppModal({
-  isOpen,
-  setOpen,
-  dustApps,
-  onSave,
-}: {
-  isOpen: boolean;
-  setOpen: (isOpen: boolean) => void;
+import { VaultSelector } from "@app/components/assistant_builder/vaults/VaultSelector";
+
+interface AssistantBuilderDustAppModalProps {
+  allowedVaults: VaultType[];
   dustApps: AppType[];
+  isOpen: boolean;
   onSave: (app: AppType) => void;
-}) {
+  owner: LightWorkspaceType;
+  setOpen: (isOpen: boolean) => void;
+}
+
+export default function AssistantBuilderDustAppModal({
+  allowedVaults,
+  dustApps,
+  isOpen,
+  onSave,
+  owner,
+  setOpen,
+}: AssistantBuilderDustAppModalProps) {
   const onClose = () => {
     setOpen(false);
   };
@@ -27,6 +35,8 @@ export default function AssistantBuilderDustAppModal({
     >
       <div className="w-full pt-12">
         <PickDustApp
+          allowedVaults={allowedVaults}
+          owner={owner}
           show={true}
           dustApps={dustApps}
           onPick={(app) => {
@@ -39,18 +49,27 @@ export default function AssistantBuilderDustAppModal({
   );
 }
 
+interface PickDustAppProps {
+  allowedVaults: VaultType[];
+  dustApps: AppType[];
+  onPick: (app: AppType) => void;
+  owner: LightWorkspaceType;
+  show: boolean;
+}
+
 function PickDustApp({
+  owner,
+  allowedVaults,
   dustApps,
   show,
   onPick,
-}: {
-  dustApps: AppType[];
-  show: boolean;
-  onPick: (app: AppType) => void;
-}) {
+}: PickDustAppProps) {
   const hasSomeUnselectableApps = dustApps.some(
     (app) => !app.description || app.description.length === 0
   );
+
+  // TODO: Refresh vault when removing the dust apps.
+
   return (
     <Transition show={show} className="mx-auto max-w-6xl">
       <Page>
@@ -61,17 +80,36 @@ function PickDustApp({
             App selectable, edit it and add a description.
           </Page.P>
         )}
-        {dustApps.map((app) => (
-          <Item.Navigation
-            label={app.name}
-            icon={CommandLineIcon}
-            disabled={!app.description || app.description.length === 0}
-            key={app.sId}
-            onClick={() => {
-              onPick(app);
-            }}
-          />
-        ))}
+        <VaultSelector
+          owner={owner}
+          allowedVaults={allowedVaults}
+          defaultVault={allowedVaults[0].sId}
+          renderChildren={(vault) => {
+            const allowedDustApps = vault
+              ? dustApps.filter((app) => app.vault.sId === vault.sId)
+              : dustApps;
+
+            if (allowedDustApps.length === 0) {
+              return <>No Dust Apps available.</>;
+            }
+
+            return (
+              <>
+                {allowedDustApps.map((app) => (
+                  <Item.Navigation
+                    label={app.name}
+                    icon={CommandLineIcon}
+                    disabled={!app.description || app.description.length === 0}
+                    key={app.sId}
+                    onClick={() => {
+                      onPick(app);
+                    }}
+                  />
+                ))}
+              </>
+            );
+          }}
+        />
       </Page>
     </Transition>
   );

--- a/front/components/assistant_builder/AssistantBuilderDustAppModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDustAppModal.tsx
@@ -30,7 +30,7 @@ export default function AssistantBuilderDustAppModal({
       isOpen={isOpen}
       onClose={onClose}
       hasChanged={false}
-      variant="full-screen"
+      variant="side-md"
       title="Select Dust App"
     >
       <div className="w-full pt-12">

--- a/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
+++ b/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
@@ -39,6 +39,19 @@ import { useUser } from "@app/lib/swr/user";
 import { classNames } from "@app/lib/utils";
 import type { FetchAssistantTemplateResponse } from "@app/pages/api/w/[wId]/assistant/builder/templates/[tId]";
 
+interface AssistantBuilderRightPanelProps {
+  screen: BuilderScreen;
+  template: FetchAssistantTemplateResponse | null;
+  removeTemplate: () => Promise<void>;
+  resetToTemplateInstructions: () => Promise<void>;
+  resetToTemplateActions: () => Promise<void>;
+  owner: WorkspaceType;
+  rightPanelStatus: AssistantBuilderRightPanelStatus;
+  openRightPanelTab: (tabName: AssistantBuilderRightPanelTab) => void;
+  builderState: AssistantBuilderState;
+  setAction: (action: AssistantBuilderSetActionType) => void;
+}
+
 export default function AssistantBuilderRightPanel({
   screen,
   template,
@@ -50,18 +63,7 @@ export default function AssistantBuilderRightPanel({
   openRightPanelTab,
   builderState,
   setAction,
-}: {
-  screen: BuilderScreen;
-  template: FetchAssistantTemplateResponse | null;
-  removeTemplate: () => Promise<void>;
-  resetToTemplateInstructions: () => Promise<void>;
-  resetToTemplateActions: () => Promise<void>;
-  owner: WorkspaceType;
-  rightPanelStatus: AssistantBuilderRightPanelStatus;
-  openRightPanelTab: (tabName: AssistantBuilderRightPanelTab) => void;
-  builderState: AssistantBuilderState;
-  setAction: (action: AssistantBuilderSetActionType) => void;
-}) {
+}: AssistantBuilderRightPanelProps) {
   const tabsConfig = useMemo(
     () => [
       {

--- a/front/components/assistant_builder/actions/DustAppRunAction.tsx
+++ b/front/components/assistant_builder/actions/DustAppRunAction.tsx
@@ -1,5 +1,9 @@
 import { ContentMessage } from "@dust-tt/sparkle";
-import type { WorkspaceType } from "@dust-tt/types";
+import type {
+  LightWorkspaceType,
+  VaultType,
+  WorkspaceType,
+} from "@dust-tt/types";
 import { assertNever, slugify } from "@dust-tt/types";
 import { useContext, useState } from "react";
 
@@ -23,14 +27,11 @@ export function isActionDustAppRunValid(
     : "Please select a Dust App.";
 }
 
-export function ActionDustAppRun({
-  owner,
-  action,
-  updateAction,
-  setEdited,
-}: {
-  owner: WorkspaceType;
+interface ActionDustAppRunProps {
   action: AssistantBuilderActionConfiguration;
+  allowedVaults: VaultType[];
+  owner: LightWorkspaceType;
+  setEdited: (edited: boolean) => void;
   updateAction: (args: {
     actionName: string;
     actionDescription: string;
@@ -38,8 +39,15 @@ export function ActionDustAppRun({
       old: AssistantBuilderActionConfiguration["configuration"]
     ) => AssistantBuilderActionConfiguration["configuration"];
   }) => void;
-  setEdited: (edited: boolean) => void;
-}) {
+}
+
+export function ActionDustAppRun({
+  action,
+  allowedVaults,
+  owner,
+  setEdited,
+  updateAction,
+}: ActionDustAppRunProps) {
   const { dustApps } = useContext(AssistantBuilderContext);
   const [showDustAppsModal, setShowDustAppsModal] = useState(false);
 
@@ -66,6 +74,8 @@ export function ActionDustAppRun({
   return (
     <>
       <AssistantBuilderDustAppModal
+        allowedVaults={allowedVaults}
+        owner={owner}
         isOpen={showDustAppsModal}
         setOpen={(isOpen) => {
           setShowDustAppsModal(isOpen);

--- a/front/components/assistant_builder/actions/DustAppRunAction.tsx
+++ b/front/components/assistant_builder/actions/DustAppRunAction.tsx
@@ -1,9 +1,5 @@
 import { ContentMessage } from "@dust-tt/sparkle";
-import type {
-  LightWorkspaceType,
-  VaultType,
-  WorkspaceType,
-} from "@dust-tt/types";
+import type { LightWorkspaceType, VaultType } from "@dust-tt/types";
 import { assertNever, slugify } from "@dust-tt/types";
 import { useContext, useState } from "react";
 
@@ -53,6 +49,7 @@ export function ActionDustAppRun({
 
   const deleteDustApp = () => {
     setEdited(true);
+
     updateAction({
       actionName:
         ASSISTANT_BUILDER_DUST_APP_RUN_ACTION_CONFIGURATION_DEFAULT_NAME,

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -14,6 +14,7 @@ import {
   assertNever,
   CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG,
 } from "@dust-tt/types";
+import { uniqueId } from "lodash";
 
 import {
   DEFAULT_PROCESS_ACTION_NAME,
@@ -103,6 +104,11 @@ export type AssistantBuilderActionConfiguration = (
   noConfigurationRequired?: boolean;
 };
 
+export type AssistantBuilderActionConfigurationWithId =
+  AssistantBuilderActionConfiguration & {
+    id: string;
+  };
+
 export type TemplateActionType = Omit<
   AssistantBuilderActionConfiguration,
   "configuration"
@@ -115,11 +121,11 @@ export type AssistantBuilderActionType =
 
 export type AssistantBuilderSetActionType =
   | {
-      action: AssistantBuilderActionConfiguration;
+      action: AssistantBuilderActionConfigurationWithId;
       type: "insert" | "edit" | "pending";
     }
   | {
-      action: AssistantBuilderActionConfiguration;
+      action: AssistantBuilderActionConfigurationWithId;
       type: "pending";
     }
   | {
@@ -128,7 +134,7 @@ export type AssistantBuilderSetActionType =
 
 export type AssistantBuilderPendingAction =
   | {
-      action: AssistantBuilderActionConfiguration;
+      action: AssistantBuilderActionConfigurationWithId;
       previousActionName: string | null;
     }
   | {
@@ -145,7 +151,7 @@ export type AssistantBuilderState = {
     modelSettings: SupportedModel;
     temperature: number;
   };
-  actions: Array<AssistantBuilderActionConfiguration>;
+  actions: Array<AssistantBuilderActionConfigurationWithId>;
   maxStepsPerRun: number | null;
   visualizationEnabled: boolean;
   templateId: string | null;
@@ -274,25 +280,36 @@ export function getDefaultWebsearchActionConfiguration(): AssistantBuilderAction
 
 export function getDefaultActionConfiguration(
   actionType: AssistantBuilderActionType | null
-): AssistantBuilderActionConfiguration | null {
-  switch (actionType) {
-    case null:
-      return null;
-    case "RETRIEVAL_SEARCH":
-      return getDefaultRetrievalSearchActionConfiguration();
-    case "RETRIEVAL_EXHAUSTIVE":
-      return getDefaultRetrievalExhaustiveActionConfiguration();
-    case "DUST_APP_RUN":
-      return getDefaultDustAppRunActionConfiguration();
-    case "TABLES_QUERY":
-      return getDefaultTablesQueryActionConfiguration();
-    case "PROCESS":
-      return getDefaultProcessActionConfiguration();
-    case "WEB_NAVIGATION":
-      return getDefaultWebsearchActionConfiguration();
-    default:
-      assertNever(actionType);
+): AssistantBuilderActionConfigurationWithId | null {
+  const config = (() => {
+    switch (actionType) {
+      case null:
+        return null;
+      case "RETRIEVAL_SEARCH":
+        return getDefaultRetrievalSearchActionConfiguration();
+      case "RETRIEVAL_EXHAUSTIVE":
+        return getDefaultRetrievalExhaustiveActionConfiguration();
+      case "DUST_APP_RUN":
+        return getDefaultDustAppRunActionConfiguration();
+      case "TABLES_QUERY":
+        return getDefaultTablesQueryActionConfiguration();
+      case "PROCESS":
+        return getDefaultProcessActionConfiguration();
+      case "WEB_NAVIGATION":
+        return getDefaultWebsearchActionConfiguration();
+      default:
+        assertNever(actionType);
+    }
+  })();
+
+  if (config) {
+    return {
+      id: uniqueId(),
+      ...config,
+    };
   }
+
+  return null;
 }
 
 export const BUILDER_FLOWS = [

--- a/front/components/assistant_builder/vaults/VaultSelector.tsx
+++ b/front/components/assistant_builder/vaults/VaultSelector.tsx
@@ -1,4 +1,4 @@
-import { Chip, Icon, RadioButton, Spinner } from "@dust-tt/sparkle";
+import { Chip, Icon, Page, RadioButton, Spinner } from "@dust-tt/sparkle";
 import type { LightWorkspaceType, VaultType } from "@dust-tt/types";
 import { useState } from "react";
 
@@ -41,53 +41,51 @@ export function VaultSelector({
 
             return (
               <div key={vault.sId}>
-                <div className="h-px w-full bg-structure-200" />
-                <div className="py-2">
-                  <RadioButton
-                    name={`Vault ${vault.name}`}
-                    choices={[
-                      {
-                        label: (
-                          <>
-                            <Icon
-                              visual={getVaultIcon(vault)}
-                              size="md"
-                              className="ml-3 mr-2 inline-block flex-shrink-0 align-middle text-brand"
-                            />
-                            <span
-                              className={classNames(
-                                "text-element-900",
-                                "align-middle",
-                                !isDisabled ? "font-bold" : "italic"
-                              )}
-                            >
-                              {getVaultName(vault)}
-                              {isDisabled && (
-                                <Chip
-                                  size="xs"
-                                  className="ml-2"
-                                  label="Disabled: only one vault allowed per assistant"
-                                  color="warning"
-                                />
-                              )}
-                            </span>
-                          </>
-                        ),
-                        value: vault.sId,
-                        disabled: isDisabled,
-                      },
-                    ]}
-                    value={selectedVault}
-                    onChange={() => setSelectedVault(vault.sId)}
-                  />
-                </div>
+                <Page.Separator />
+                <RadioButton
+                  name={`Vault ${vault.name}`}
+                  choices={[
+                    {
+                      label: (
+                        <>
+                          <Icon
+                            visual={getVaultIcon(vault)}
+                            size="md"
+                            className="ml-3 mr-2 inline-block flex-shrink-0 align-middle text-brand"
+                          />
+                          <span
+                            className={classNames(
+                              "text-element-900",
+                              "align-middle",
+                              !isDisabled ? "font-bold" : "italic"
+                            )}
+                          >
+                            {getVaultName(vault)}
+                            {isDisabled && (
+                              <Chip
+                                size="xs"
+                                className="ml-2"
+                                label="Disabled: only one vault allowed per assistant"
+                                color="warning"
+                              />
+                            )}
+                          </span>
+                        </>
+                      ),
+                      value: vault.sId,
+                      disabled: isDisabled,
+                    },
+                  ]}
+                  value={selectedVault}
+                  onChange={() => setSelectedVault(vault.sId)}
+                />
                 {selectedVault === vault.sId && (
-                  <div className="mb-2">{renderChildren(selectedVaultObj)}</div>
+                  <div className="m-2">{renderChildren(selectedVaultObj)}</div>
                 )}
               </div>
             );
           })}
-      <div className="h-px w-full bg-structure-200" />
+      <Page.Separator />
     </div>
   );
 }

--- a/front/components/assistant_builder/vaults/VaultSelector.tsx
+++ b/front/components/assistant_builder/vaults/VaultSelector.tsx
@@ -1,0 +1,114 @@
+import { Chip, Icon, RadioButton, Spinner } from "@dust-tt/sparkle";
+import type {
+  DataSourceViewType,
+  LightWorkspaceType,
+  VaultType,
+} from "@dust-tt/types";
+import { groupBy } from "lodash";
+import { useMemo, useState } from "react";
+
+import { useVaults } from "@app/lib/swr/vaults";
+import { classNames } from "@app/lib/utils";
+import { getVaultIcon, getVaultName } from "@app/lib/vaults";
+
+interface VaultSelctorProps {
+  owner: LightWorkspaceType;
+  dataSourceViews: DataSourceViewType[];
+  allowedVaults?: VaultType[];
+  defaultVault: string;
+  renderChildren: (dataSourceViews: DataSourceViewType[]) => React.ReactNode;
+}
+
+export function VaultSelector({
+  owner,
+  dataSourceViews,
+  allowedVaults,
+  defaultVault,
+  renderChildren,
+}: VaultSelctorProps) {
+  const dataSourceViewsByVaultId = useMemo(
+    () => groupBy(dataSourceViews, (dsv) => dsv.vaultId),
+    [dataSourceViews]
+  );
+
+  const { vaults, isVaultsError, isVaultsLoading } = useVaults({
+    workspaceId: owner.sId,
+  });
+
+  const [selectedVault, setSelectedVault] = useState<string>(defaultVault);
+
+  if (isVaultsLoading || isVaultsError) {
+    return <Spinner />;
+  }
+
+  if (Object.keys(dataSourceViewsByVaultId).length === 1) {
+    return renderChildren(dataSourceViews);
+  } else {
+    return (
+      <div>
+        <div className="h-px w-full bg-structure-200" />
+        {Object.keys(dataSourceViewsByVaultId).map((vaultId) => {
+          const vault = vaults.find((v) => v.sId === vaultId);
+          if (!vault) {
+            // Should never happen
+            return null;
+          }
+          const disabled = !(allowedVaults
+            ? allowedVaults.find((v) => v.sId === vaultId)
+            : false);
+          return (
+            <>
+              <div key={vaultId} className="py-2">
+                <RadioButton
+                  name={`Vault ${vaultId}`}
+                  choices={[
+                    {
+                      label: (
+                        <>
+                          <Icon
+                            visual={getVaultIcon(vault)}
+                            size="md"
+                            className="ml-3 mr-2 inline-block flex-shrink-0 align-middle text-brand"
+                          />
+                          <span
+                            className={classNames(
+                              "text-element-900",
+                              "align-middle",
+                              !disabled ? "font-bold" : "italic"
+                            )}
+                          >
+                            {getVaultName(vault)}{" "}
+                            {disabled && (
+                              <Chip
+                                key="xs-warning"
+                                size="xs"
+                                className="ml-2"
+                                label="Disabled: only one vault allowed per assistant"
+                                color="warning"
+                              />
+                            )}
+                          </span>
+                        </>
+                      ),
+                      value: vaultId,
+                      disabled: disabled,
+                    },
+                  ]}
+                  value={selectedVault}
+                  onChange={() => setSelectedVault(vaultId)}
+                />
+              </div>
+              {selectedVault === vaultId && (
+                <div className="mb-2">
+                  {renderChildren(dataSourceViewsByVaultId[vaultId])}
+                </div>
+              )}
+
+              <div className="h-px w-full bg-structure-200" />
+            </>
+          );
+        })}
+      </div>
+    );
+  }
+}

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -95,18 +95,27 @@ export function DataSourceViewsSelector({
     return (
       <VaultSelector
         owner={owner}
-        dataSourceViews={dataSourceViews}
         allowedVaults={allowedVaults}
         defaultVault={defaultVault}
-        renderChildren={(dataSourceViews) => (
-          <DataSourceViewsSelector
-            owner={owner}
-            dataSourceViews={dataSourceViews}
-            selectionConfigurations={selectionConfigurations}
-            setSelectionConfigurations={setSelectionConfigurations}
-            viewType={viewType}
-          />
-        )}
+        renderChildren={(vault) => {
+          const dataSourceViewsForVault = vault
+            ? dataSourceViews.filter((dsv) => dsv.vaultId === vault.sId)
+            : dataSourceViews;
+
+          if (dataSourceViewsForVault.length === 0) {
+            return <>No data source in this vault.</>;
+          }
+
+          return (
+            <DataSourceViewsSelector
+              owner={owner}
+              dataSourceViews={dataSourceViewsForVault}
+              selectionConfigurations={selectionConfigurations}
+              setSelectionConfigurations={setSelectionConfigurations}
+              viewType={viewType}
+            />
+          );
+        }}
       />
     );
   } else {

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -1,11 +1,7 @@
 import {
-  Chip,
   CloudArrowLeftRightIcon,
   FolderIcon,
   GlobeAltIcon,
-  Icon,
-  RadioButton,
-  Spinner,
   Tree,
 } from "@dust-tt/sparkle";
 import type {
@@ -20,8 +16,9 @@ import type {
 import { defaultSelectionConfiguration } from "@dust-tt/types";
 import _ from "lodash";
 import type { Dispatch, SetStateAction } from "react";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 
+import { VaultSelector } from "@app/components/assistant_builder/vaults/VaultSelector";
 import DataSourceViewResourceSelectorTree from "@app/components/DataSourceViewResourceSelectorTree";
 import { useParentResourcesById } from "@app/hooks/useParentResourcesById";
 import { orderDatasourceViewByImportance } from "@app/lib/assistant";
@@ -36,9 +33,6 @@ import {
   isManaged,
   isWebsite,
 } from "@app/lib/data_sources";
-import { useVaults } from "@app/lib/swr/vaults";
-import { classNames } from "@app/lib/utils";
-import { getVaultIcon, getVaultName } from "@app/lib/vaults";
 
 const MIN_TOTAL_DATA_SOURCES_TO_GROUP = 12;
 const MIN_DATA_SOURCES_PER_KIND_TO_GROUP = 3;
@@ -55,120 +49,6 @@ interface DataSourceViewsSelectorProps {
   viewType: ContentNodesViewType;
 }
 
-function VaultSelector({
-  owner,
-  dataSourceViews,
-  allowedVaults,
-  selectionConfigurations,
-  setSelectionConfigurations,
-  viewType,
-}: DataSourceViewsSelectorProps) {
-  const dataSourceViewsByVaultId = useMemo(
-    () => _.groupBy(dataSourceViews, (dsv) => dsv.vaultId),
-    [dataSourceViews]
-  );
-
-  const { vaults, isVaultsError, isVaultsLoading } = useVaults({
-    workspaceId: owner.sId,
-  });
-
-  const [selectedVault, setSelectedVault] = useState<string>(() => {
-    const firstKey = Object.keys(selectionConfigurations)[0] ?? null;
-    return firstKey
-      ? selectionConfigurations[firstKey]?.dataSourceView?.vaultId ?? ""
-      : "";
-  });
-
-  if (isVaultsLoading || isVaultsError) {
-    return <Spinner />;
-  }
-
-  if (Object.keys(dataSourceViewsByVaultId).length === 1) {
-    return (
-      <DataSourceViewsSelector
-        owner={owner}
-        dataSourceViews={dataSourceViews}
-        selectionConfigurations={selectionConfigurations}
-        setSelectionConfigurations={setSelectionConfigurations}
-        viewType={viewType}
-      />
-    );
-  } else {
-    return (
-      <div>
-        <div className="h-px w-full bg-structure-200" />
-        {Object.keys(dataSourceViewsByVaultId).map((vaultId) => {
-          const vault = vaults.find((v) => v.sId === vaultId);
-          if (!vault) {
-            // Should never happen
-            return null;
-          }
-          const disabled = !(allowedVaults
-            ? allowedVaults.find((v) => v.sId === vaultId)
-            : false);
-          return (
-            <>
-              <div key={vaultId} className="py-2">
-                <RadioButton
-                  name={`Vault ${vaultId}`}
-                  choices={[
-                    {
-                      label: (
-                        <>
-                          <Icon
-                            visual={getVaultIcon(vault)}
-                            size="md"
-                            className="ml-3 mr-2 inline-block flex-shrink-0 align-middle text-brand"
-                          />
-                          <span
-                            className={classNames(
-                              "text-element-900",
-                              "align-middle",
-                              !disabled ? "font-bold" : "italic"
-                            )}
-                          >
-                            {getVaultName(vault)}{" "}
-                            {disabled && (
-                              <Chip
-                                key="xs-warning"
-                                size="xs"
-                                className="ml-2"
-                                label="Disabled: only one vault allowed per assistant"
-                                color="warning"
-                              />
-                            )}
-                          </span>
-                        </>
-                      ),
-                      value: vaultId,
-                      disabled: disabled,
-                    },
-                  ]}
-                  value={selectedVault}
-                  onChange={() => setSelectedVault(vaultId)}
-                />
-              </div>
-              {selectedVault === vaultId && (
-                <div className="mb-2">
-                  <DataSourceViewsSelector
-                    owner={owner}
-                    dataSourceViews={dataSourceViewsByVaultId[selectedVault]}
-                    selectionConfigurations={selectionConfigurations}
-                    setSelectionConfigurations={setSelectionConfigurations}
-                    viewType={viewType}
-                  />
-                </div>
-              )}
-
-              <div className="h-px w-full bg-structure-200" />
-            </>
-          );
-        })}
-      </div>
-    );
-  }
-}
-
 export function DataSourceViewsSelector({
   owner,
   dataSourceViews,
@@ -179,7 +59,6 @@ export function DataSourceViewsSelector({
 }: DataSourceViewsSelectorProps) {
   // Apply grouping if there are many data sources, and there are enough of each kind
   // So we don't show a long list of data sources to the user
-
   const nbOfVaults = _.uniqBy(dataSourceViews, (dsv) => dsv.vaultId).length;
 
   const applyGrouping =
@@ -205,15 +84,29 @@ export function DataSourceViewsSelector({
     [dataSourceViews]
   );
 
+  const defaultVault = useMemo(() => {
+    const firstKey = Object.keys(selectionConfigurations)[0] ?? null;
+    return firstKey
+      ? selectionConfigurations[firstKey]?.dataSourceView?.vaultId ?? ""
+      : "";
+  }, [selectionConfigurations]);
+
   if (nbOfVaults > 1) {
     return (
       <VaultSelector
         owner={owner}
         dataSourceViews={dataSourceViews}
         allowedVaults={allowedVaults}
-        selectionConfigurations={selectionConfigurations}
-        setSelectionConfigurations={setSelectionConfigurations}
-        viewType={viewType}
+        defaultVault={defaultVault}
+        renderChildren={(dataSourceViews) => (
+          <DataSourceViewsSelector
+            owner={owner}
+            dataSourceViews={dataSourceViews}
+            selectionConfigurations={selectionConfigurations}
+            setSelectionConfigurations={setSelectionConfigurations}
+            viewType={viewType}
+          />
+        )}
       />
     );
   } else {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR separates the <VaultSelector /> component to enable its use for both wrapping data source view-related actions and Dust apps. The aim is to enforce consistent restrictions at the Dust App level, meaning that if the vault engineering is used by a search action, adding a Dust App action will also need to operate on the engineering vault.

The main changes include always displaying all the vaults, regardless of whether they have Dust apps available or data sources. We will inform the user if those vaults are empty.

The current structure of the assistant builder is quite nested, and with many different implementations of actions, I decided to introduce a unique ID for each action. This ID exists temporarily in the UI and is used to compare actions, as other attributes, including the name, are subject to change. It's essential to reliably identify the action being edited to ensure that the vaults used are updated appropriately when a single action is modified.

This vault logic is still hidden if the workspace does not have any vaults other than the global one.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
