### PR TITLE
[sparkle] - fix(TextArea): shrinking behaviour

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.236",
+  "version": "0.2.237",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.236",
+      "version": "0.2.237",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.236",
+  "version": "0.2.237",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/TextArea.tsx
+++ b/sparkle/src/components/TextArea.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useRef } from "react";
 
 import { classNames } from "@sparkle/lib/utils";
 
@@ -9,7 +9,7 @@ type TextAreaProps = {
   error?: string | null;
   showErrorLabel?: boolean;
   className?: string;
-  rows?: number;
+  minRows?: number;
 };
 
 export function TextArea({
@@ -19,21 +19,14 @@ export function TextArea({
   error,
   showErrorLabel = false,
   className,
-  rows = 10
+  minRows = 10
 }: TextAreaProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  useEffect(() => {
-    const textarea = textareaRef.current;
-    if (textarea) {
-      textarea.style.height = 'auto'; // Reset height
-      textarea.style.height = `${textarea.scrollHeight}px`; // Set to scroll height
-    }
-  }, [value]); // Re-run when value changes
   return (
     <div className="s-flex s-flex-col s-gap-1 s-p-px">
       <textarea
-        rows={rows}
+        rows={minRows}
         ref={textareaRef}
         className={classNames(
           "overflow-y-auto s-block s-w-full s-min-w-0 s-rounded-xl s-text-sm s-placeholder-element-700 s-transition-all s-duration-200 s-scrollbar-hide",
@@ -47,15 +40,6 @@ export function TextArea({
         placeholder={placeholder}
         value={value ?? ""}
         onChange={(e) => {
-          const newValue = e.target.value;
-          const textAreaComponent = textareaRef.current;
-          if (
-            textAreaComponent &&
-            value?.length &&
-            newValue.length < value.length
-          ) {
-            textAreaComponent.style.height = "auto"; // Reset height to recalculate
-          }
           onChange(e.target.value);
         }}
       />

--- a/sparkle/src/stories/TextArea.stories.tsx
+++ b/sparkle/src/stories/TextArea.stories.tsx
@@ -26,7 +26,7 @@ export const TextAreaExample = () => {
           onChange={(v) =>
             setTextValues([v, textValues[1], textValues[2], textValues[3]])
           }
-          rows={2}
+          minRows={2}
         />
         <TextArea
           placeholder="placeholder"


### PR DESCRIPTION
## Description

This PR streamline TextArea component and remove dynamic height changes

 - Removed useEffect dependency on value for dynamic height calculation
 - Replaced `rows` prop with `minRows` to better reflect its usage

## Risk

None

## Deploy Plan

Deploy `sparkle`