### PR TITLE
Make site work without env or db

### DIFF
--- a/front/pages/index.tsx
+++ b/front/pages/index.tsx
@@ -1,17 +1,13 @@
 import type { ReactElement } from "react";
 import React from "react";
 
-import { BlogSection } from "@app/components/home/content/Product/BlogSection";
-import { FutureSection } from "@app/components/home/content/Product/FutureSection";
-import { IntroSection } from "@app/components/home/content/Product/IntroSection";
-import { TeamSection } from "@app/components/home/content/Product/TeamSection";
-import { VerticalSection } from "@app/components/home/content/Product/VerticalSection";
 import type { LandingLayoutProps } from "@app/components/home/LandingLayout";
 import LandingLayout from "@app/components/home/LandingLayout";
 import config from "@app/lib/api/config";
 import { getSession } from "@app/lib/auth";
 import { getUserFromSession } from "@app/lib/iam/session";
 import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";
+import { Landing } from "@app/pages/site";
 
 export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
   requireUserPrivilege: "none",
@@ -55,15 +51,7 @@ export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
 });
 
 export default function Home() {
-  return (
-    <>
-      <IntroSection />
-      <TeamSection />
-      <FutureSection />
-      <BlogSection />
-      <VerticalSection />
-    </>
-  );
+  return <Landing />;
 }
 
 Home.getLayout = (page: ReactElement, pageProps: LandingLayoutProps) => {

--- a/front/pages/pricing.tsx
+++ b/front/pages/pricing.tsx
@@ -13,21 +13,15 @@ import {
 import { PricePlans } from "@app/components/plans/PlansTables";
 import { SubscriptionContactUsDrawer } from "@app/components/SubscriptionContactUsDrawer";
 import config from "@app/lib/api/config";
-import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";
 
-export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
-  requireUserPrivilege: "none",
-})<{
-  gaTrackingId: string;
-  shape: number;
-}>(async () => {
+export async function getServerSideProps() {
   return {
     props: {
       gaTrackingId: config.getGaTrackingId(),
       shape: getParticleShapeIndexByName(shapeNames.bigSphere),
     },
   };
-});
+}
 
 export default function Pricing() {
   const [showContactUsDrawer, setShowContactUsDrawer] =

--- a/front/pages/security.tsx
+++ b/front/pages/security.tsx
@@ -14,22 +14,16 @@ import {
   shapeNames,
 } from "@app/components/home/Particles";
 import config from "@app/lib/api/config";
-import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";
 import { classNames } from "@app/lib/utils";
 
-export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
-  requireUserPrivilege: "none",
-})<{
-  gaTrackingId: string;
-  shape: number;
-}>(async () => {
+export async function getServerSideProps() {
   return {
     props: {
       gaTrackingId: config.getGaTrackingId(),
       shape: getParticleShapeIndexByName(shapeNames.icosahedron),
     },
   };
-});
+}
 
 export default function Security() {
   return (

--- a/front/pages/site.tsx
+++ b/front/pages/site.tsx
@@ -1,0 +1,40 @@
+import type { ReactElement } from "react";
+import React from "react";
+
+import { BlogSection } from "@app/components/home/content/Product/BlogSection";
+import { FutureSection } from "@app/components/home/content/Product/FutureSection";
+import { IntroSection } from "@app/components/home/content/Product/IntroSection";
+import { TeamSection } from "@app/components/home/content/Product/TeamSection";
+import { VerticalSection } from "@app/components/home/content/Product/VerticalSection";
+import type { LandingLayoutProps } from "@app/components/home/LandingLayout";
+import LandingLayout from "@app/components/home/LandingLayout";
+import config from "@app/lib/api/config";
+
+export async function getServerSideProps() {
+  return {
+    props: {
+      gaTrackingId: config.getGaTrackingId(),
+      shape: 0,
+    },
+  };
+}
+
+export function Landing() {
+  return (
+    <>
+      <IntroSection />
+      <TeamSection />
+      <FutureSection />
+      <BlogSection />
+      <VerticalSection />
+    </>
+  );
+}
+
+export default function Home() {
+  return <Landing />;
+}
+
+Home.getLayout = (page: ReactElement, pageProps: LandingLayoutProps) => {
+  return <LandingLayout pageProps={pageProps}>{page}</LandingLayout>;
+};

--- a/front/pages/solutions/customer-support.tsx
+++ b/front/pages/solutions/customer-support.tsx
@@ -14,21 +14,15 @@ import {
 import type { SolutionSectionAssistantBlockProps } from "@app/components/home/SolutionSection";
 import { SolutionSection } from "@app/components/home/SolutionSection";
 import config from "@app/lib/api/config";
-import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";
 
-export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
-  requireUserPrivilege: "none",
-})<{
-  gaTrackingId: string;
-  shape: number;
-}>(async () => {
+export async function getServerSideProps() {
   return {
     props: {
       gaTrackingId: config.getGaTrackingId(),
       shape: getParticleShapeIndexByName(shapeNames.octahedron),
     },
   };
-});
+}
 
 interface pageSettingsProps {
   uptitle: string;

--- a/front/pages/solutions/data-analytics.tsx
+++ b/front/pages/solutions/data-analytics.tsx
@@ -14,21 +14,15 @@ import {
 import type { SolutionSectionAssistantBlockProps } from "@app/components/home/SolutionSection";
 import { SolutionSection } from "@app/components/home/SolutionSection";
 import config from "@app/lib/api/config";
-import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";
 
-export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
-  requireUserPrivilege: "none",
-})<{
-  gaTrackingId: string;
-  shape: number;
-}>(async () => {
+export async function getServerSideProps() {
   return {
     props: {
       gaTrackingId: config.getGaTrackingId(),
       shape: getParticleShapeIndexByName(shapeNames.wave),
     },
   };
-});
+}
 
 interface pageSettingsProps {
   uptitle: string;

--- a/front/pages/solutions/dust-platform.tsx
+++ b/front/pages/solutions/dust-platform.tsx
@@ -13,22 +13,16 @@ import {
   shapeNames,
 } from "@app/components/home/Particles";
 import config from "@app/lib/api/config";
-import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";
 import { classNames } from "@app/lib/utils";
 
-export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
-  requireUserPrivilege: "none",
-})<{
-  gaTrackingId: string;
-  shape: number;
-}>(async () => {
+export async function getServerSideProps() {
   return {
     props: {
       gaTrackingId: config.getGaTrackingId(),
       shape: getParticleShapeIndexByName(shapeNames.galaxy),
     },
   };
-});
+}
 
 export default function DustPlatform() {
   return (

--- a/front/pages/solutions/engineering.tsx
+++ b/front/pages/solutions/engineering.tsx
@@ -14,21 +14,15 @@ import {
 import type { SolutionSectionAssistantBlockProps } from "@app/components/home/SolutionSection";
 import { SolutionSection } from "@app/components/home/SolutionSection";
 import config from "@app/lib/api/config";
-import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";
 
-export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
-  requireUserPrivilege: "none",
-})<{
-  gaTrackingId: string;
-  shape: number;
-}>(async () => {
+export async function getServerSideProps() {
   return {
     props: {
       gaTrackingId: config.getGaTrackingId(),
       shape: getParticleShapeIndexByName(shapeNames.cube),
     },
   };
-});
+}
 
 interface pageSettingsProps {
   uptitle: string;

--- a/front/pages/solutions/knowledge.tsx
+++ b/front/pages/solutions/knowledge.tsx
@@ -14,21 +14,15 @@ import {
 import type { SolutionSectionAssistantBlockProps } from "@app/components/home/SolutionSection";
 import { SolutionSection } from "@app/components/home/SolutionSection";
 import config from "@app/lib/api/config";
-import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";
 
-export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
-  requireUserPrivilege: "none",
-})<{
-  gaTrackingId: string;
-  shape: number;
-}>(async () => {
+export async function getServerSideProps() {
   return {
     props: {
       gaTrackingId: config.getGaTrackingId(),
       shape: getParticleShapeIndexByName(shapeNames.torus),
     },
   };
-});
+}
 
 interface pageSettingsProps {
   uptitle: React.ReactNode;

--- a/front/pages/solutions/marketing.tsx
+++ b/front/pages/solutions/marketing.tsx
@@ -14,21 +14,15 @@ import {
 import type { SolutionSectionAssistantBlockProps } from "@app/components/home/SolutionSection";
 import { SolutionSection } from "@app/components/home/SolutionSection";
 import config from "@app/lib/api/config";
-import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";
 
-export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
-  requireUserPrivilege: "none",
-})<{
-  gaTrackingId: string;
-  shape: number;
-}>(async () => {
+export async function getServerSideProps() {
   return {
     props: {
       gaTrackingId: config.getGaTrackingId(),
       shape: getParticleShapeIndexByName(shapeNames.pyramid),
     },
   };
-});
+}
 
 interface pageSettingsProps {
   uptitle: string;

--- a/front/pages/solutions/recruiting-people.tsx
+++ b/front/pages/solutions/recruiting-people.tsx
@@ -14,21 +14,15 @@ import {
 import type { SolutionSectionAssistantBlockProps } from "@app/components/home/SolutionSection";
 import { SolutionSection } from "@app/components/home/SolutionSection";
 import config from "@app/lib/api/config";
-import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";
 
-export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
-  requireUserPrivilege: "none",
-})<{
-  gaTrackingId: string;
-  shape: number;
-}>(async () => {
+export async function getServerSideProps() {
   return {
     props: {
       gaTrackingId: config.getGaTrackingId(),
       shape: getParticleShapeIndexByName(shapeNames.torus),
     },
   };
-});
+}
 
 interface pageSettingsProps {
   uptitle: React.ReactNode;

--- a/front/pages/solutions/sales.tsx
+++ b/front/pages/solutions/sales.tsx
@@ -14,21 +14,15 @@ import {
 import type { SolutionSectionAssistantBlockProps } from "@app/components/home/SolutionSection";
 import { SolutionSection } from "@app/components/home/SolutionSection";
 import config from "@app/lib/api/config";
-import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";
 
-export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
-  requireUserPrivilege: "none",
-})<{
-  gaTrackingId: string;
-  shape: number;
-}>(async () => {
+export async function getServerSideProps() {
   return {
     props: {
       gaTrackingId: config.getGaTrackingId(),
       shape: getParticleShapeIndexByName(shapeNames.bigSphere),
     },
   };
-});
+}
 
 interface pageSettingsProps {
   uptitle: string;


### PR DESCRIPTION
## Description

This PR creates a new /site route that does not attempt auto-redirect and hence does not need to getSession to display the website. It also removes the use of `makeGetServerSidePropsRequirementsWrapper` in the site public pages.

## Risk

N/A

## Deploy Plan

- deploy `front`