### PR TITLE
[front] - migration: backfill missing editedByUserId

### DIFF
--- a/front/migrations/20240912_backfill_editedbyuser_id.ts
+++ b/front/migrations/20240912_backfill_editedbyuser_id.ts
@@ -13,7 +13,9 @@ makeScript({}, async ({ execute }, logger) => {
       editedByUserId: {
         [Op.is]: undefined,
       },
-      connectorProvider: "google_drive"
+      connectorProvider: {
+        [Op.not]: undefined
+      }
     }
   });
 

--- a/front/migrations/20240912_backfill_editedbyuser_id.ts
+++ b/front/migrations/20240912_backfill_editedbyuser_id.ts
@@ -14,58 +14,65 @@ makeScript({}, async ({ execute }, logger) => {
         [Op.is]: undefined,
       },
       connectorProvider: {
-        [Op.not]: undefined
-      }
-    }
+        [Op.not]: undefined,
+      },
+    },
   });
 
   for (const ds of dataSources) {
     const workspace = await Workspace.findOne({
       where: {
-        id: ds.workspaceId
-      }
-    })
+        id: ds.workspaceId,
+      },
+    });
     assert(workspace, `Failed to find workspace for dataSource ${ds.id}`);
 
     const oldestAdminMembership = await MembershipModel.findOne({
       where: {
         workspaceId: workspace.id,
         role: "admin",
-        endAt: null
+        endAt: null,
       },
       order: [["startAt", "ASC"]],
-      include: [{
-        model: User,
-        attributes: ["id", "username", "email"]
-      }]
+      include: [
+        {
+          model: User,
+          attributes: ["id", "username", "email"],
+        },
+      ],
     });
 
     if (!oldestAdminMembership) {
-      logger.error({
-        workspaceId: workspace.id
-      },
+      logger.error(
+        {
+          workspaceId: workspace.id,
+        },
         "Workspace has no admin"
-        )
-      return
+      );
+      return;
     }
 
     if (execute) {
       await ds.update({
-        editedByUserId: oldestAdminMembership.userId
-      })
-      logger.info({
-        workspaceId: workspace.id,
-        dataSourceId: ds.id,
-        editedByUserId: oldestAdminMembership.userId
-      },
-        "Updated data source")
-    } else {
-      logger.info({
+        editedByUserId: oldestAdminMembership.userId,
+      });
+      logger.info(
+        {
           workspaceId: workspace.id,
           dataSourceId: ds.id,
-          editedByUserId: oldestAdminMembership.userId
+          editedByUserId: oldestAdminMembership.userId,
         },
-        "Would have updated data source")
+        "Updated data source"
+      );
+    } else {
+      logger.info(
+        {
+          workspaceId: workspace.id,
+          dataSourceId: ds.id,
+          editedByUserId: oldestAdminMembership.userId,
+        },
+        "Would have updated data source"
+      );
     }
   }
 });

--- a/front/migrations/20240912_backfill_editedbyuser_id.ts
+++ b/front/migrations/20240912_backfill_editedbyuser_id.ts
@@ -1,0 +1,69 @@
+import assert from "assert";
+import { Op } from "sequelize";
+
+import { User } from "@app/lib/models/user";
+import { Workspace } from "@app/lib/models/workspace";
+import { DataSource } from "@app/lib/resources/storage/models/data_source";
+import { MembershipModel } from "@app/lib/resources/storage/models/membership";
+import { makeScript } from "@app/scripts/helpers";
+
+makeScript({}, async ({ execute }, logger) => {
+  const dataSources = await DataSource.findAll({
+    where: {
+      editedByUserId: {
+        [Op.is]: undefined,
+      },
+      connectorProvider: "google_drive"
+    }
+  });
+
+  for (const ds of dataSources) {
+    const workspace = await Workspace.findOne({
+      where: {
+        id: ds.workspaceId
+      }
+    })
+    assert(workspace, `Failed to find workspace for dataSource ${ds.id}`);
+
+    const oldestAdminMembership = await MembershipModel.findOne({
+      where: {
+        workspaceId: workspace.id,
+        role: "admin",
+        endAt: null
+      },
+      order: [["startAt", "ASC"]],
+      include: [{
+        model: User,
+        attributes: ["id", "username", "email"]
+      }]
+    });
+
+    if (!oldestAdminMembership) {
+      logger.error({
+        workspaceId: workspace.id
+      },
+        "Workspace has no admin"
+        )
+      return
+    }
+
+    if (execute) {
+      await ds.update({
+        editedByUserId: oldestAdminMembership.userId
+      })
+      logger.info({
+        workspaceId: workspace.id,
+        dataSourceId: ds.id,
+        editedByUserId: oldestAdminMembership.userId
+      },
+        "Updated data source")
+    } else {
+      logger.info({
+          workspaceId: workspace.id,
+          dataSourceId: ds.id,
+          editedByUserId: oldestAdminMembership.userId
+        },
+        "Would have updated data source")
+    }
+  }
+});


### PR DESCRIPTION
## Description

This PR aims at providing a migration script to backfill the `editedByUserId` column of the `data_sources` table with the oldest admin of the workspace.

**References:**
 - https://github.com/dust-tt/tasks/issues/1309

## Risk

Touches database

## Deploy Plan