### PR TITLE
:wave: gaTrackingId

### DIFF
--- a/front/components/assistant/conversation/ConversationLayout.tsx
+++ b/front/components/assistant/conversation/ConversationLayout.tsx
@@ -28,8 +28,7 @@ export default function ConversationLayout({
   children: React.ReactNode;
   pageProps: ConversationLayoutProps;
 }) {
-  const { baseUrl, conversationId, owner, subscription } =
-    pageProps;
+  const { baseUrl, conversationId, owner, subscription } = pageProps;
 
   const router = useRouter();
   const sendNotification = useContext(SendNotificationsContext);

--- a/front/components/assistant/conversation/ConversationLayout.tsx
+++ b/front/components/assistant/conversation/ConversationLayout.tsx
@@ -17,7 +17,6 @@ import { useConversation, useConversations } from "@app/lib/swr/conversations";
 export interface ConversationLayoutProps {
   baseUrl: string;
   conversationId: string | null;
-  gaTrackingId: string;
   owner: WorkspaceType;
   subscription: SubscriptionType;
 }
@@ -29,7 +28,7 @@ export default function ConversationLayout({
   children: React.ReactNode;
   pageProps: ConversationLayoutProps;
 }) {
-  const { baseUrl, conversationId, gaTrackingId, owner, subscription } =
+  const { baseUrl, conversationId, owner, subscription } =
     pageProps;
 
   const router = useRouter();
@@ -136,7 +135,6 @@ export default function ConversationLayout({
               ? `Dust - ${conversation?.title}`
               : `Dust - New Conversation`
           }
-          gaTrackingId={gaTrackingId}
           titleChildren={
             // TODO: Improve so we don't re-render everytime.
             conversation && (

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -71,7 +71,6 @@ export default function AssistantBuilder({
   owner,
   subscription,
   plan,
-  gaTrackingId,
   initialBuilderState,
   agentConfigurationId,
   flow,
@@ -402,7 +401,6 @@ export default function AssistantBuilder({
         hideSidebar
         isWideMode
         owner={owner}
-        gaTrackingId={gaTrackingId}
         subNavigation={subNavigationBuild({
           owner,
           current: "workspace_assistants",

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -307,7 +307,6 @@ export type AssistantBuilderProps = {
   defaultIsEdited?: boolean;
   defaultTemplate: FetchAssistantTemplateResponse | null;
   flow: BuilderFlow;
-  gaTrackingId: string;
   initialBuilderState: AssistantBuilderInitialState | null;
   isAdmin: boolean;
   owner: WorkspaceType;

--- a/front/components/data_source/WebsiteConfiguration.tsx
+++ b/front/components/data_source/WebsiteConfiguration.tsx
@@ -42,7 +42,6 @@ export default function WebsiteConfiguration({
   subscription,
   dataSources,
   dataSource,
-  gaTrackingId,
   webCrawlerConfiguration,
   dataSourceUsage,
 }: {
@@ -51,7 +50,6 @@ export default function WebsiteConfiguration({
   dataSources: DataSourceType[];
   webCrawlerConfiguration: WebCrawlerConfigurationType | null;
   dataSource: DataSourceType | null;
-  gaTrackingId: string;
   dataSourceUsage?: number;
 }) {
   const [isSaving, setIsSaving] = useState(false);
@@ -264,7 +262,6 @@ export default function WebsiteConfiguration({
     <AppLayout
       subscription={subscription}
       owner={owner}
-      gaTrackingId={gaTrackingId}
       subNavigation={subNavigationBuild({
         owner,
         current: "data_sources_static",

--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -37,10 +37,7 @@ export default function LandingLayout({
   children: React.ReactNode;
   pageProps: LandingLayoutProps;
 }) {
-  const {
-    postLoginReturnToUrl = "/api/login",
-    shape,
-  } = pageProps;
+  const { postLoginReturnToUrl = "/api/login", shape } = pageProps;
 
   const router = useRouter();
   const [currentShape, setCurrentShape] = useState(shape);

--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -27,7 +27,6 @@ import { classNames } from "@app/lib/utils";
 
 export interface LandingLayoutProps {
   shape: number;
-  gaTrackingId: string;
   postLoginReturnToUrl?: string;
 }
 
@@ -39,7 +38,6 @@ export default function LandingLayout({
   pageProps: LandingLayoutProps;
 }) {
   const {
-    gaTrackingId,
     postLoginReturnToUrl = "/api/login",
     shape,
   } = pageProps;
@@ -157,7 +155,7 @@ export default function LandingLayout({
         {hasAcceptedCookies && (
           <>
             <Script
-              src={`https://www.googletagmanager.com/gtag/js?id=${gaTrackingId}`}
+              src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GA_TRACKING_ID}`}
               strategy="afterInteractive"
             />
             <Script id="google-analytics" strategy="afterInteractive">
@@ -166,7 +164,7 @@ export default function LandingLayout({
              function gtag(){window.dataLayer.push(arguments);}
              gtag('js', new Date());
 
-             gtag('config', '${gaTrackingId}');
+             gtag('config', '${process.env.NEXT_PUBLIC_GA_TRACKING_ID}');
             `}
             </Script>
           </>

--- a/front/components/sparkle/AppLayout.tsx
+++ b/front/components/sparkle/AppLayout.tsx
@@ -43,7 +43,6 @@ export default function AppLayout({
   hideSidebar = false,
   subNavigation,
   pageTitle,
-  gaTrackingId,
   navChildren,
   titleChildren,
   children,
@@ -54,7 +53,6 @@ export default function AppLayout({
   hideSidebar?: boolean;
   subNavigation?: SidebarNavigation[] | null;
   pageTitle?: string;
-  gaTrackingId: string;
   navChildren?: React.ReactNode;
   titleChildren?: React.ReactNode;
   children: React.ReactNode;
@@ -182,7 +180,7 @@ export default function AppLayout({
       )}
       <>
         <Script
-          src={`https://www.googletagmanager.com/gtag/js?id=${gaTrackingId}`}
+          src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GA_TRACKING_ID}`}
           strategy="afterInteractive"
         />
         <Script id="google-analytics" strategy="afterInteractive">
@@ -191,7 +189,7 @@ export default function AppLayout({
           function gtag(){window.dataLayer.push(arguments);}
           gtag('js', new Date());
 
-          gtag('config', '${gaTrackingId}');
+          gtag('config', '${process.env.NEXT_PUBLIC_GA_TRACKING_ID}');
           `}
         </Script>
       </>

--- a/front/components/sparkle/OnboardingLayout.tsx
+++ b/front/components/sparkle/OnboardingLayout.tsx
@@ -6,13 +6,11 @@ import React from "react";
 
 export default function OnboardingLayout({
   owner,
-  gaTrackingId,
   headerTitle,
   headerRightActions,
   children,
 }: {
   owner: LightWorkspaceType;
-  gaTrackingId: string;
   headerTitle: string;
   headerRightActions: React.ReactNode;
   children: React.ReactNode;
@@ -78,7 +76,7 @@ export default function OnboardingLayout({
       </Page>
 
       <Script
-        src={`https://www.googletagmanager.com/gtag/js?id=${gaTrackingId}`}
+        src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GA_TRACKING_ID}`}
         strategy="afterInteractive"
       />
       <Script id="google-analytics" strategy="afterInteractive">
@@ -86,7 +84,7 @@ export default function OnboardingLayout({
             window.dataLayer = window.dataLayer || [];
             function gtag(){window.dataLayer.push(arguments);}
             gtag('js', new Date());
-            gtag('config', '${gaTrackingId}');
+            gtag('config', '${process.env.NEXT_PUBLIC_GA_TRACKING_ID}');
           `}
       </Script>
     </>

--- a/front/components/vaults/VaultLayout.tsx
+++ b/front/components/vaults/VaultLayout.tsx
@@ -20,7 +20,6 @@ import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import { getVaultIcon } from "@app/lib/vaults";
 
 export interface VaultLayoutProps {
-  gaTrackingId: string;
   owner: WorkspaceType;
   isAdmin: boolean;
   subscription: SubscriptionType;
@@ -39,7 +38,6 @@ export function VaultLayout({
 }) {
   const [showVaultCreationModal, setShowVaultCreationModal] = useState(false);
   const {
-    gaTrackingId,
     owner,
     isAdmin,
     subscription,
@@ -58,7 +56,6 @@ export function VaultLayout({
       <AppLayout
         subscription={subscription}
         owner={owner}
-        gaTrackingId={gaTrackingId}
         navChildren={
           <VaultSideBarMenu
             owner={owner}

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -46,9 +46,6 @@ const config = {
   getServiceAccount: (): string => {
     return EnvironmentConfig.getEnvVariable("SERVICE_ACCOUNT");
   },
-  getGaTrackingId: (): string => {
-    return EnvironmentConfig.getEnvVariable("GA_TRACKING_ID");
-  },
   getCustomerIoSiteId: (): string => {
     return EnvironmentConfig.getEnvVariable("CUSTOMERIO_SITE_ID");
   },

--- a/front/pages/index.tsx
+++ b/front/pages/index.tsx
@@ -3,7 +3,6 @@ import React from "react";
 
 import type { LandingLayoutProps } from "@app/components/home/LandingLayout";
 import LandingLayout from "@app/components/home/LandingLayout";
-import config from "@app/lib/api/config";
 import { getSession } from "@app/lib/auth";
 import { getUserFromSession } from "@app/lib/iam/session";
 import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";
@@ -12,7 +11,6 @@ import { Landing } from "@app/pages/site";
 export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
   requireUserPrivilege: "none",
 })<{
-  gaTrackingId: string;
   postLoginReturnToUrl: string;
 }>(async (context) => {
   // Fetch session explicitly as this page redirects logged in users to our home page.
@@ -43,7 +41,6 @@ export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
 
   return {
     props: {
-      gaTrackingId: config.getGaTrackingId(),
       postLoginReturnToUrl: postLoginCallbackUrl,
       shape: 0,
     },

--- a/front/pages/login-error.tsx
+++ b/front/pages/login-error.tsx
@@ -8,20 +8,17 @@ import {
 import type { InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 
-import config from "@app/lib/api/config";
 import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";
 
 export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
   requireUserPrivilege: "none",
 })<{
   domain: string | null;
-  gaTrackingId: string;
   reason: string | null;
 }>(async (context) => {
   return {
     props: {
       domain: (context.query.domain as string) ?? null,
-      gaTrackingId: config.getGaTrackingId(),
       reason: (context.query.reason as string) ?? null,
     },
   };

--- a/front/pages/pricing.tsx
+++ b/front/pages/pricing.tsx
@@ -12,12 +12,10 @@ import {
 } from "@app/components/home/Particles";
 import { PricePlans } from "@app/components/plans/PlansTables";
 import { SubscriptionContactUsDrawer } from "@app/components/SubscriptionContactUsDrawer";
-import config from "@app/lib/api/config";
 
 export async function getServerSideProps() {
   return {
     props: {
-      gaTrackingId: config.getGaTrackingId(),
       shape: getParticleShapeIndexByName(shapeNames.bigSphere),
     },
   };

--- a/front/pages/security.tsx
+++ b/front/pages/security.tsx
@@ -13,13 +13,11 @@ import {
   getParticleShapeIndexByName,
   shapeNames,
 } from "@app/components/home/Particles";
-import config from "@app/lib/api/config";
 import { classNames } from "@app/lib/utils";
 
 export async function getServerSideProps() {
   return {
     props: {
-      gaTrackingId: config.getGaTrackingId(),
       shape: getParticleShapeIndexByName(shapeNames.icosahedron),
     },
   };

--- a/front/pages/site.tsx
+++ b/front/pages/site.tsx
@@ -8,12 +8,10 @@ import { TeamSection } from "@app/components/home/content/Product/TeamSection";
 import { VerticalSection } from "@app/components/home/content/Product/VerticalSection";
 import type { LandingLayoutProps } from "@app/components/home/LandingLayout";
 import LandingLayout from "@app/components/home/LandingLayout";
-import config from "@app/lib/api/config";
 
 export async function getServerSideProps() {
   return {
     props: {
-      gaTrackingId: config.getGaTrackingId(),
       shape: 0,
     },
   };

--- a/front/pages/solutions/customer-support.tsx
+++ b/front/pages/solutions/customer-support.tsx
@@ -13,12 +13,10 @@ import {
 } from "@app/components/home/Particles";
 import type { SolutionSectionAssistantBlockProps } from "@app/components/home/SolutionSection";
 import { SolutionSection } from "@app/components/home/SolutionSection";
-import config from "@app/lib/api/config";
 
 export async function getServerSideProps() {
   return {
     props: {
-      gaTrackingId: config.getGaTrackingId(),
       shape: getParticleShapeIndexByName(shapeNames.octahedron),
     },
   };

--- a/front/pages/solutions/data-analytics.tsx
+++ b/front/pages/solutions/data-analytics.tsx
@@ -13,12 +13,10 @@ import {
 } from "@app/components/home/Particles";
 import type { SolutionSectionAssistantBlockProps } from "@app/components/home/SolutionSection";
 import { SolutionSection } from "@app/components/home/SolutionSection";
-import config from "@app/lib/api/config";
 
 export async function getServerSideProps() {
   return {
     props: {
-      gaTrackingId: config.getGaTrackingId(),
       shape: getParticleShapeIndexByName(shapeNames.wave),
     },
   };

--- a/front/pages/solutions/dust-platform.tsx
+++ b/front/pages/solutions/dust-platform.tsx
@@ -12,13 +12,11 @@ import {
   getParticleShapeIndexByName,
   shapeNames,
 } from "@app/components/home/Particles";
-import config from "@app/lib/api/config";
 import { classNames } from "@app/lib/utils";
 
 export async function getServerSideProps() {
   return {
     props: {
-      gaTrackingId: config.getGaTrackingId(),
       shape: getParticleShapeIndexByName(shapeNames.galaxy),
     },
   };

--- a/front/pages/solutions/engineering.tsx
+++ b/front/pages/solutions/engineering.tsx
@@ -13,12 +13,10 @@ import {
 } from "@app/components/home/Particles";
 import type { SolutionSectionAssistantBlockProps } from "@app/components/home/SolutionSection";
 import { SolutionSection } from "@app/components/home/SolutionSection";
-import config from "@app/lib/api/config";
 
 export async function getServerSideProps() {
   return {
     props: {
-      gaTrackingId: config.getGaTrackingId(),
       shape: getParticleShapeIndexByName(shapeNames.cube),
     },
   };

--- a/front/pages/solutions/knowledge.tsx
+++ b/front/pages/solutions/knowledge.tsx
@@ -13,12 +13,10 @@ import {
 } from "@app/components/home/Particles";
 import type { SolutionSectionAssistantBlockProps } from "@app/components/home/SolutionSection";
 import { SolutionSection } from "@app/components/home/SolutionSection";
-import config from "@app/lib/api/config";
 
 export async function getServerSideProps() {
   return {
     props: {
-      gaTrackingId: config.getGaTrackingId(),
       shape: getParticleShapeIndexByName(shapeNames.torus),
     },
   };

--- a/front/pages/solutions/marketing.tsx
+++ b/front/pages/solutions/marketing.tsx
@@ -13,12 +13,10 @@ import {
 } from "@app/components/home/Particles";
 import type { SolutionSectionAssistantBlockProps } from "@app/components/home/SolutionSection";
 import { SolutionSection } from "@app/components/home/SolutionSection";
-import config from "@app/lib/api/config";
 
 export async function getServerSideProps() {
   return {
     props: {
-      gaTrackingId: config.getGaTrackingId(),
       shape: getParticleShapeIndexByName(shapeNames.pyramid),
     },
   };

--- a/front/pages/solutions/recruiting-people.tsx
+++ b/front/pages/solutions/recruiting-people.tsx
@@ -13,12 +13,10 @@ import {
 } from "@app/components/home/Particles";
 import type { SolutionSectionAssistantBlockProps } from "@app/components/home/SolutionSection";
 import { SolutionSection } from "@app/components/home/SolutionSection";
-import config from "@app/lib/api/config";
 
 export async function getServerSideProps() {
   return {
     props: {
-      gaTrackingId: config.getGaTrackingId(),
       shape: getParticleShapeIndexByName(shapeNames.torus),
     },
   };

--- a/front/pages/solutions/sales.tsx
+++ b/front/pages/solutions/sales.tsx
@@ -13,12 +13,10 @@ import {
 } from "@app/components/home/Particles";
 import type { SolutionSectionAssistantBlockProps } from "@app/components/home/SolutionSection";
 import { SolutionSection } from "@app/components/home/SolutionSection";
-import config from "@app/lib/api/config";
 
 export async function getServerSideProps() {
   return {
     props: {
-      gaTrackingId: config.getGaTrackingId(),
       shape: getParticleShapeIndexByName(shapeNames.bigSphere),
     },
   };

--- a/front/pages/w/[wId]/assistant/[cId]/index.tsx
+++ b/front/pages/w/[wId]/assistant/[cId]/index.tsx
@@ -53,7 +53,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
       owner,
       subscription,
       baseUrl: config.getClientFacingUrl(),
-      gaTrackingId: config.getGaTrackingId(),
       conversationId: getValidConversationId(cId),
     },
   };

--- a/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
+++ b/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
@@ -46,7 +46,6 @@ const defaultTranscriptConfigurationState = {
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
-  gaTrackingId: string;
   dustClientFacingUrl: string;
   dataSourcesViews: DataSourceViewType[];
 }>(async (_context, auth) => {
@@ -80,7 +79,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     props: {
       owner,
       subscription,
-      gaTrackingId: apiConfig.getGaTrackingId(),
       dustClientFacingUrl: apiConfig.getClientFacingUrl(),
       dataSourcesViews,
     },
@@ -90,7 +88,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
 export default function LabsTranscriptsIndex({
   owner,
   subscription,
-  gaTrackingId,
   dustClientFacingUrl,
   dataSourcesViews,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
@@ -455,7 +452,6 @@ export default function LabsTranscriptsIndex({
     <AppLayout
       subscription={subscription}
       owner={owner}
-      gaTrackingId={gaTrackingId}
       pageTitle="Dust - Transcripts processing"
       navChildren={
         <AssistantSidebarMenu

--- a/front/pages/w/[wId]/assistants/index.tsx
+++ b/front/pages/w/[wId]/assistants/index.tsx
@@ -4,7 +4,6 @@ import type { InferGetServerSidePropsType } from "next";
 import * as React from "react";
 
 import { SCOPE_INFO } from "@app/components/assistant_builder/Sharing";
-import config from "@app/lib/api/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import WorkspaceAssistants from "@app/pages/w/[wId]/builder/assistants";
 
@@ -16,7 +15,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   tabScope: AgentConfigurationScope;
-  gaTrackingId: string;
 }>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
@@ -36,7 +34,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       owner,
       tabScope,
       subscription,
-      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });
@@ -45,14 +42,12 @@ export default function ManageAssistants({
   owner,
   tabScope,
   subscription,
-  gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   return (
     <WorkspaceAssistants
       owner={owner}
       tabScope={tabScope}
       subscription={subscription}
-      gaTrackingId={gaTrackingId}
       loadFromChatMenu={true}
     />
   );

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -33,7 +33,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   dataSourceViews: DataSourceViewType[];
   dustApps: AppType[];
   flow: BuilderFlow;
-  gaTrackingId: string;
   isAdmin: boolean;
   owner: WorkspaceType;
   plan: PlanType;
@@ -92,7 +91,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       dataSourceViews: dataSourceViews.map((v) => v.toJSON()),
       dustApps: dustApps.map((a) => a.toJSON()),
       flow,
-      gaTrackingId: config.getGaTrackingId(),
       isAdmin: auth.isAdmin(),
       owner,
       plan,
@@ -110,7 +108,6 @@ export default function EditAssistant({
   dataSourceViews,
   dustApps,
   flow,
-  gaTrackingId,
   isAdmin,
   owner,
   plan,
@@ -136,7 +133,6 @@ export default function EditAssistant({
         owner={owner}
         subscription={subscription}
         plan={plan}
-        gaTrackingId={gaTrackingId}
         flow={flow}
         initialBuilderState={{
           scope: agentConfiguration.scope,

--- a/front/pages/w/[wId]/builder/assistants/create.tsx
+++ b/front/pages/w/[wId]/builder/assistants/create.tsx
@@ -26,13 +26,11 @@ import type { BuilderFlow } from "@app/components/assistant_builder/types";
 import { BUILDER_FLOWS } from "@app/components/assistant_builder/types";
 import AppLayout, { appLayoutBack } from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
-import config from "@app/lib/api/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useAssistantTemplates } from "@app/lib/swr/assistants";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   flow: BuilderFlow;
-  gaTrackingId: string;
   owner: WorkspaceType;
   subscription: SubscriptionType;
   templateTagsMapping: TemplateTagsType;
@@ -56,7 +54,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     props: {
       owner,
       subscription,
-      gaTrackingId: config.getGaTrackingId(),
       flow,
       templateTagsMapping: TEMPLATES_TAGS_CONFIG,
     },
@@ -65,7 +62,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
 
 export default function CreateAssistant({
   flow,
-  gaTrackingId,
   owner,
   subscription,
   templateTagsMapping,
@@ -194,7 +190,6 @@ export default function CreateAssistant({
       subscription={subscription}
       hideSidebar
       owner={owner}
-      gaTrackingId={gaTrackingId}
       titleChildren={
         <AppLayoutSimpleCloseTitle
           title={"Create an Assistant"}

--- a/front/pages/w/[wId]/builder/assistants/dust.tsx
+++ b/front/pages/w/[wId]/builder/assistants/dust.tsx
@@ -148,7 +148,6 @@ export default function EditDustAssistant({
       subscription={subscription}
       hideSidebar
       owner={owner}
-      gaTrackingId={gaTrackingId}
       subNavigation={subNavigationBuild({
         owner,
         current: "workspace_assistants",

--- a/front/pages/w/[wId]/builder/assistants/dust.tsx
+++ b/front/pages/w/[wId]/builder/assistants/dust.tsx
@@ -22,7 +22,6 @@ import { subNavigationBuild } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
-import config from "@app/lib/api/config";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
@@ -32,7 +31,6 @@ import { useDataSources } from "@app/lib/swr/data_sources";
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
-  gaTrackingId: string;
 }>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
@@ -47,7 +45,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     props: {
       owner,
       subscription,
-      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });
@@ -55,7 +52,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
 export default function EditDustAssistant({
   owner,
   subscription,
-  gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
   const sendNotification = useContext(SendNotificationsContext);

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -32,7 +32,6 @@ import { SCOPE_INFO } from "@app/components/assistant_builder/Sharing";
 import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
 import { subNavigationBuild } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
-import config from "@app/lib/api/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import { useConversations } from "@app/lib/swr/conversations";
@@ -43,7 +42,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   subscription: SubscriptionType;
   tabScope: AgentConfigurationScope;
   loadFromChatMenu: boolean;
-  gaTrackingId: string;
 }>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
@@ -64,7 +62,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       tabScope,
       subscription,
       loadFromChatMenu: false,
-      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });
@@ -74,7 +71,6 @@ export default function WorkspaceAssistants({
   tabScope,
   subscription,
   loadFromChatMenu,
-  gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [assistantSearch, setAssistantSearch] = useState<string>("");
   const [orderBy, setOrderBy] = useState<SearchOrderType>("name");
@@ -243,7 +239,6 @@ export default function WorkspaceAssistants({
     <AppLayout
       subscription={subscription}
       owner={owner}
-      gaTrackingId={gaTrackingId}
       subNavigation={subNavigation}
       navChildren={navChildren}
     >

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -44,7 +44,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   plan: PlanType;
-  gaTrackingId: string;
   vaults: VaultType[];
   dataSourceViews: DataSourceViewType[];
   dustApps: AppType[];
@@ -121,7 +120,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       dataSourceViews: dataSourceViews.map((v) => v.toJSON()),
       dustApps: dustApps.map((a) => a.toJSON()),
       flow,
-      gaTrackingId: config.getGaTrackingId(),
       isAdmin: auth.isAdmin(),
       owner,
       plan,
@@ -140,7 +138,6 @@ export default function CreateAssistant({
   dataSourceViews,
   dustApps,
   flow,
-  gaTrackingId,
   isAdmin,
   owner,
   plan,
@@ -170,7 +167,6 @@ export default function CreateAssistant({
         owner={owner}
         subscription={subscription}
         plan={plan}
-        gaTrackingId={gaTrackingId}
         flow={flow}
         initialBuilderState={
           agentConfiguration

--- a/front/pages/w/[wId]/builder/data-sources/[name]/edit-public-url.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/edit-public-url.tsx
@@ -19,7 +19,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   dataSources: DataSourceType[];
   dataSource: DataSourceType;
   webCrawlerConfiguration: WebCrawlerConfigurationType;
-  gaTrackingId: string;
   dataSourceUsage: number;
 }>(async (context, auth) => {
   const owner = auth.workspace();
@@ -71,7 +70,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       dataSource: dataSource.toJSON(),
       webCrawlerConfiguration: connectorRes.value
         .configuration as WebCrawlerConfigurationType,
-      gaTrackingId: config.getGaTrackingId(),
       dataSourceUsage: dataSourceUsageRes.isOk() ? dataSourceUsageRes.value : 0,
     },
   };
@@ -82,7 +80,6 @@ export default function DataSourceNew({
   subscription,
   dataSources,
   dataSource,
-  gaTrackingId,
   webCrawlerConfiguration,
   dataSourceUsage,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
@@ -91,7 +88,6 @@ export default function DataSourceNew({
       owner={owner}
       subscription={subscription}
       dataSources={dataSources}
-      gaTrackingId={gaTrackingId}
       webCrawlerConfiguration={webCrawlerConfiguration}
       dataSource={dataSource}
       dataSourceUsage={dataSourceUsage}

--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -74,7 +74,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   connector: ConnectorType | null;
   standardView: boolean;
   dustClientFacingUrl: string;
-  gaTrackingId: string;
   user: UserType;
 }>(async (context, auth) => {
   const owner = auth.workspace();
@@ -132,7 +131,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       connector,
       standardView,
       dustClientFacingUrl: config.getClientFacingUrl(),
-      gaTrackingId: config.getGaTrackingId(),
       user,
     },
   };
@@ -1288,7 +1286,6 @@ export default function DataSourceView({
   connector,
   standardView,
   dustClientFacingUrl,
-  gaTrackingId,
   user,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
@@ -1297,7 +1294,6 @@ export default function DataSourceView({
     <AppLayout
       subscription={subscription}
       owner={owner}
-      gaTrackingId={gaTrackingId}
       subNavigation={subNavigationBuild({
         owner,
         current: dataSource.connectorId

--- a/front/pages/w/[wId]/builder/data-sources/[name]/search.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/search.tsx
@@ -12,7 +12,6 @@ import { useEffect, useState } from "react";
 import { subNavigationBuild } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
-import config from "@app/lib/api/config";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { getDisplayNameForDocument } from "@app/lib/data_sources";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
@@ -22,7 +21,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   dataSource: DataSourceType;
-  gaTrackingId: string;
 }>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
@@ -45,7 +43,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       owner,
       subscription,
       dataSource: dataSource.toJSON(),
-      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });
@@ -54,7 +51,6 @@ export default function DataSourceView({
   owner,
   subscription,
   dataSource,
-  gaTrackingId: gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [searchQuery, setSearchQuery] = useState("");
   const [documents, setDocuments] = useState<DocumentType[]>([]);
@@ -130,7 +126,6 @@ export default function DataSourceView({
     <AppLayout
       subscription={subscription}
       owner={owner}
-      gaTrackingId={gaTrackingId}
       subNavigation={subNavigationBuild({
         owner,
         current: dataSource.connectorId

--- a/front/pages/w/[wId]/builder/data-sources/[name]/settings.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/settings.tsx
@@ -16,7 +16,6 @@ import { DeleteStaticDataSourceDialog } from "@app/components/data_source/Delete
 import { subNavigationBuild } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleSaveCancelTitle } from "@app/components/sparkle/AppLayoutTitle";
-import config from "@app/lib/api/config";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { classNames } from "@app/lib/utils";
@@ -26,7 +25,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   subscription: SubscriptionType;
   dataSource: DataSourceType;
   fetchConnectorError?: boolean;
-  gaTrackingId: string;
   dataSourceUsage: number;
 }>(async (context, auth) => {
   const owner = auth.workspace();
@@ -55,7 +53,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       owner,
       subscription,
       dataSource: dataSource.toJSON(),
-      gaTrackingId: config.getGaTrackingId(),
       dataSourceUsage: dataSourceUsageRes.isOk() ? dataSourceUsageRes.value : 0,
     },
   };
@@ -65,7 +62,6 @@ export default function DataSourceSettings({
   owner,
   subscription,
   dataSource,
-  gaTrackingId,
   dataSourceUsage,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
@@ -108,7 +104,6 @@ export default function DataSourceSettings({
         description: string;
         assistantDefaultSelected: boolean;
       }) => handleUpdate(settings)}
-      gaTrackingId={gaTrackingId}
       dataSourceUsage={dataSourceUsage}
     />
   );
@@ -119,7 +114,6 @@ function StandardDataSourceSettings({
   subscription,
   dataSource,
   handleUpdate,
-  gaTrackingId,
   dataSourceUsage,
 }: {
   owner: WorkspaceType;
@@ -129,7 +123,6 @@ function StandardDataSourceSettings({
     description: string;
     assistantDefaultSelected: boolean;
   }) => Promise<void>;
-  gaTrackingId: string;
   dataSourceUsage: number;
 }) {
   const { mutate } = useSWRConfig();
@@ -180,7 +173,6 @@ function StandardDataSourceSettings({
     <AppLayout
       subscription={subscription}
       owner={owner}
-      gaTrackingId={gaTrackingId}
       subNavigation={subNavigationBuild({
         owner,
         current: "data_sources_static",

--- a/front/pages/w/[wId]/builder/data-sources/[name]/tables/upsert.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/tables/upsert.tsx
@@ -24,7 +24,6 @@ import { subNavigationBuild } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleSaveCancelTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
-import config from "@app/lib/api/config";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { handleFileUploadToText } from "@app/lib/client/handle_file_upload";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
@@ -38,7 +37,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   readOnly: boolean;
   dataSource: DataSourceType;
   loadTableId: string | null;
-  gaTrackingId: string;
 }>(async (context, auth) => {
   const owner = auth.workspace();
   const plan = auth.plan();
@@ -67,7 +65,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       readOnly,
       dataSource: dataSource.toJSON(),
       loadTableId: (context.query.tableId || null) as string | null,
-      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });
@@ -78,7 +75,6 @@ export default function TableUpsert({
   readOnly,
   dataSource,
   loadTableId,
-  gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
   const { mutate } = useSWRConfig();
@@ -291,7 +287,6 @@ export default function TableUpsert({
     <AppLayout
       subscription={subscription}
       owner={owner}
-      gaTrackingId={gaTrackingId}
       subNavigation={subNavigationBuild({
         owner,
         current: "data_sources_static",

--- a/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
@@ -23,7 +23,6 @@ import { subNavigationBuild } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleSaveCancelTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
-import config from "@app/lib/api/config";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { handleFileUploadToText } from "@app/lib/client/handle_file_upload";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
@@ -36,7 +35,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   readOnly: boolean;
   dataSource: DataSourceType;
   loadDocumentId: string | null;
-  gaTrackingId: string;
 }>(async (context, auth) => {
   const owner = auth.workspace();
   const plan = auth.plan();
@@ -66,7 +64,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       readOnly,
       dataSource: dataSource.toJSON(),
       loadDocumentId: (context.query.documentId || null) as string | null,
-      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });
@@ -78,7 +75,6 @@ export default function DatasourceUpsert({
   readOnly,
   dataSource,
   loadDocumentId,
-  gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -219,7 +215,6 @@ export default function DatasourceUpsert({
     <AppLayout
       subscription={subscription}
       owner={owner}
-      gaTrackingId={gaTrackingId}
       subNavigation={subNavigationBuild({
         owner,
         current: "data_sources_static",

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -88,7 +88,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   integrations: DataSourceIntegration[];
   managedDataSources: DataSourceWithConnectorAndUsageType[];
   plan: PlanType;
-  gaTrackingId: string;
   dustClientFacingUrl: string;
   user: UserType;
 }>(async (context, auth) => {
@@ -169,7 +168,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       managedDataSources,
       integrations,
       plan,
-      gaTrackingId: config.getGaTrackingId(),
       dustClientFacingUrl: config.getClientFacingUrl(),
       user,
     },
@@ -184,7 +182,6 @@ export default function DataSourcesView({
   managedDataSources,
   integrations,
   plan,
-  gaTrackingId,
   dustClientFacingUrl,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [isLoadingByProvider, setIsLoadingByProvider] = useState(
@@ -239,7 +236,6 @@ export default function DataSourcesView({
     <AppLayout
       subscription={subscription}
       owner={owner}
-      gaTrackingId={gaTrackingId}
       subNavigation={subNavigationBuild({
         owner,
         current: "data_sources_managed",

--- a/front/pages/w/[wId]/builder/data-sources/new-public-url.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/new-public-url.tsx
@@ -6,7 +6,6 @@ import type {
 import type { InferGetServerSidePropsType } from "next";
 
 import WebsiteConfiguration from "@app/components/data_source/WebsiteConfiguration";
-import config from "@app/lib/api/config";
 import { getDataSources } from "@app/lib/api/data_sources";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 
@@ -14,7 +13,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   dataSources: DataSourceType[];
-  gaTrackingId: string;
 }>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
@@ -32,7 +30,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       owner,
       subscription,
       dataSources: dataSources.map((ds) => ds.toJSON()),
-      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });
@@ -41,14 +38,12 @@ export default function DataSourceNew({
   owner,
   subscription,
   dataSources,
-  gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   return (
     <WebsiteConfiguration
       owner={owner}
       subscription={subscription}
       dataSources={dataSources}
-      gaTrackingId={gaTrackingId}
       webCrawlerConfiguration={null}
       dataSource={null}
     />

--- a/front/pages/w/[wId]/builder/data-sources/new.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/new.tsx
@@ -11,7 +11,6 @@ import { useCallback, useEffect, useState } from "react";
 import { subNavigationBuild } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleSaveCancelTitle } from "@app/components/sparkle/AppLayoutTitle";
-import config from "@app/lib/api/config";
 import { getDataSources } from "@app/lib/api/data_sources";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { classNames } from "@app/lib/utils";
@@ -20,7 +19,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   dataSources: DataSourceType[];
-  gaTrackingId: string;
 }>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
@@ -38,7 +36,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       owner,
       subscription,
       dataSources: dataSources.map((ds) => ds.toJSON()),
-      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });
@@ -47,7 +44,6 @@ export default function DataSourceNew({
   owner,
   subscription,
   dataSources,
-  gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [isSaving, setIsSaving] = useState(false);
   const [isEdited, setIsEdited] = useState(false);
@@ -119,7 +115,6 @@ export default function DataSourceNew({
     <AppLayout
       subscription={subscription}
       owner={owner}
-      gaTrackingId={gaTrackingId}
       subNavigation={subNavigationBuild({
         owner,
         current: "data_sources_static",

--- a/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
@@ -55,7 +55,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   plan: PlanType;
   readOnly: boolean;
   dataSources: DataSourceWithConnector[];
-  gaTrackingId: string;
   dataSourcesUsage: DataSourcesUsageByAgent;
 }>(async (context, auth) => {
   const owner = auth.workspace();
@@ -124,7 +123,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       plan,
       readOnly,
       dataSources,
-      gaTrackingId: config.getGaTrackingId(),
       dataSourcesUsage,
     },
   };
@@ -136,7 +134,6 @@ export default function DataSourcesView({
   plan,
   readOnly,
   dataSources,
-  gaTrackingId,
   dataSourcesUsage,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
@@ -175,7 +172,6 @@ export default function DataSourcesView({
     <AppLayout
       subscription={subscription}
       owner={owner}
-      gaTrackingId={gaTrackingId}
       subNavigation={subNavigationBuild({
         owner,
         current: "data_sources_url",

--- a/front/pages/w/[wId]/builder/data-sources/static.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/static.tsx
@@ -27,7 +27,6 @@ import { subNavigationBuild } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import type { DataSourcesUsageByAgent } from "@app/lib/api/agent_data_sources";
 import { getDataSourcesUsageByAgents } from "@app/lib/api/agent_data_sources";
-import config from "@app/lib/api/config";
 import { getDataSources } from "@app/lib/api/data_sources";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
@@ -38,7 +37,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   plan: PlanType;
   readOnly: boolean;
   dataSources: DataSourceType[];
-  gaTrackingId: string;
   dataSourcesUsage: DataSourcesUsageByAgent;
 }>(async (context, auth) => {
   const owner = auth.workspace();
@@ -66,7 +64,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       plan,
       readOnly,
       dataSources: dataSources.map((ds) => ds.toJSON()),
-      gaTrackingId: config.getGaTrackingId(),
       dataSourcesUsage,
     },
   };
@@ -78,7 +75,6 @@ export default function DataSourcesView({
   plan,
   readOnly,
   dataSources,
-  gaTrackingId,
   dataSourcesUsage,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
@@ -117,7 +113,6 @@ export default function DataSourcesView({
     <AppLayout
       subscription={subscription}
       owner={owner}
-      gaTrackingId={gaTrackingId}
       subNavigation={subNavigationBuild({
         owner,
         current: "data_sources_static",

--- a/front/pages/w/[wId]/congratulations.tsx
+++ b/front/pages/w/[wId]/congratulations.tsx
@@ -10,13 +10,11 @@ import { useRouter } from "next/router";
 import { useRef } from "react";
 
 import OnboardingLayout from "@app/components/sparkle/OnboardingLayout";
-import config from "@app/lib/api/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   conversationId: string | null;
-  gaTrackingId: string;
 }>(async (context, auth) => {
   const owner = auth.workspace();
   const user = auth.user();
@@ -39,7 +37,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     props: {
       owner,
       conversationId,
-      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });
@@ -47,7 +44,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
 export default function Congratulations({
   owner,
   conversationId,
-  gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
   const referentRef = useRef<HTMLDivElement>(null);
@@ -62,7 +58,6 @@ export default function Congratulations({
     <div className="h-full" ref={referentRef}>
       <OnboardingLayout
         owner={owner}
-        gaTrackingId={gaTrackingId}
         headerTitle="Joining Dust"
         headerRightActions={<></>}
       >

--- a/front/pages/w/[wId]/developers/api-keys.tsx
+++ b/front/pages/w/[wId]/developers/api-keys.tsx
@@ -6,7 +6,6 @@ import React from "react";
 
 import { subNavigationAdmin } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
-import config from "@app/lib/api/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { APIKeys } from "@app/pages/w/[wId]/vaults/[vaultId]/apps";
 
@@ -15,7 +14,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   subscription: SubscriptionType;
   groups: GroupType[];
   user: UserType;
-  gaTrackingId: string;
 }>(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
   const subscription = auth.getNonNullableSubscription();
@@ -26,14 +24,11 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
-  const groups = await auth.groups();
-
   return {
     props: {
       owner,
-      groups,
+      groups: auth.groups(),
       subscription,
-      gaTrackingId: config.getGaTrackingId(),
       user,
     },
   };
@@ -43,13 +38,11 @@ export default function APIKeysPage({
   owner,
   subscription,
   groups,
-  gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   return (
     <AppLayout
       subscription={subscription}
       owner={owner}
-      gaTrackingId={gaTrackingId}
       subNavigation={subNavigationAdmin({ owner, current: "api_keys" })}
     >
       <Page.Vertical gap="xl" align="stretch">

--- a/front/pages/w/[wId]/developers/providers.tsx
+++ b/front/pages/w/[wId]/developers/providers.tsx
@@ -6,7 +6,6 @@ import React from "react";
 
 import { subNavigationAdmin } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
-import config from "@app/lib/api/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { Providers } from "@app/pages/w/[wId]/vaults/[vaultId]/apps";
 
@@ -14,7 +13,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   user: UserType;
-  gaTrackingId: string;
 }>(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
   const subscription = auth.getNonNullableSubscription();
@@ -29,7 +27,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     props: {
       owner,
       subscription,
-      gaTrackingId: config.getGaTrackingId(),
       user,
     },
   };
@@ -38,13 +35,11 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
 export default function ProvidersPage({
   owner,
   subscription,
-  gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   return (
     <AppLayout
       subscription={subscription}
       owner={owner}
-      gaTrackingId={gaTrackingId}
       subNavigation={subNavigationAdmin({ owner, current: "providers" })}
     >
       <Page.Vertical gap="xl" align="stretch">

--- a/front/pages/w/[wId]/join.tsx
+++ b/front/pages/w/[wId]/join.tsx
@@ -40,7 +40,6 @@ export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
   requireUserPrivilege: "none",
 })<{
   baseUrl: string;
-  gaTrackingId: string;
   invitationEmail: string | null;
   onboardingType: OnboardingType;
   signUpCallbackUrl: string;
@@ -124,7 +123,6 @@ export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
   return {
     props: {
       baseUrl: config.getClientFacingUrl(),
-      gaTrackingId: config.getGaTrackingId(),
       invitationEmail,
       onboardingType,
       signUpCallbackUrl,
@@ -134,7 +132,6 @@ export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
 });
 
 export default function Join({
-  gaTrackingId,
   invitationEmail,
   onboardingType,
   signUpCallbackUrl,
@@ -149,7 +146,6 @@ export default function Join({
   return (
     <OnboardingLayout
       owner={workspace}
-      gaTrackingId={gaTrackingId}
       headerTitle="Welcome to Dust"
       headerRightActions={
         <Button

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -58,7 +58,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   perSeatPricing: SubscriptionPerSeatPricing | null;
   enterpriseConnectionStrategyDetails: EnterpriseConnectionStrategyDetails;
   plan: PlanType;
-  gaTrackingId: string;
   workspaceHasAvailableSeats: boolean;
   workspaceVerifiedDomain: WorkspaceDomain | null;
 }>(async (context, auth) => {
@@ -93,7 +92,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       perSeatPricing,
       enterpriseConnectionStrategyDetails,
       plan,
-      gaTrackingId: config.getGaTrackingId(),
       workspaceHasAvailableSeats,
       workspaceVerifiedDomain,
     },
@@ -107,7 +105,6 @@ export default function WorkspaceAdmin({
   perSeatPricing,
   enterpriseConnectionStrategyDetails,
   plan,
-  gaTrackingId,
   workspaceVerifiedDomain,
   workspaceHasAvailableSeats,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
@@ -123,7 +120,6 @@ export default function WorkspaceAdmin({
     <AppLayout
       subscription={subscription}
       owner={owner}
-      gaTrackingId={gaTrackingId}
       subNavigation={subNavigationAdmin({ owner, current: "members" })}
     >
       <Page.Vertical gap="xl" align="stretch">

--- a/front/pages/w/[wId]/subscribe.tsx
+++ b/front/pages/w/[wId]/subscribe.tsx
@@ -9,7 +9,6 @@ import { ProPlansTable } from "@app/components/plans/ProPlansTable";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { UserMenu } from "@app/components/UserMenu";
 import WorkspacePicker from "@app/components/WorkspacePicker";
-import config from "@app/lib/api/config";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { withDefaultUserAuthPaywallWhitelisted } from "@app/lib/iam/session";
 import { useUser } from "@app/lib/swr/user";
@@ -19,7 +18,6 @@ import { ClientSideTracking } from "@app/lib/tracking/client";
 export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
   owner: WorkspaceType;
   isAdmin: boolean;
-  gaTrackingId: string;
 }>(async (context, auth) => {
   const owner = auth.workspace();
   if (!owner || !auth.isUser()) {
@@ -32,7 +30,6 @@ export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
     props: {
       owner,
       isAdmin: auth.isAdmin(),
-      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -26,7 +26,6 @@ import { PricePlans } from "@app/components/plans/PlansTables";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { SubscriptionContactUsDrawer } from "@app/components/SubscriptionContactUsDrawer";
-import config from "@app/lib/api/config";
 import { getPriceAsString } from "@app/lib/client/subscription";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
@@ -45,7 +44,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   subscription: SubscriptionType;
   user: UserType;
   trialDaysRemaining: number | null;
-  gaTrackingId: string;
   workspaceSeats: number;
   perSeatPricing: SubscriptionPerSeatPricing | null;
 }>(async (context, auth) => {
@@ -85,7 +83,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       owner,
       subscription,
       trialDaysRemaining,
-      gaTrackingId: config.getGaTrackingId(),
       user,
       workspaceSeats,
       perSeatPricing,
@@ -98,7 +95,6 @@ export default function Subscription({
   user,
   subscription,
   trialDaysRemaining,
-  gaTrackingId,
   workspaceSeats,
   perSeatPricing,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
@@ -282,7 +278,6 @@ export default function Subscription({
     <AppLayout
       subscription={subscription}
       owner={owner}
-      gaTrackingId={gaTrackingId}
       subNavigation={subNavigationAdmin({ owner, current: "subscription" })}
     >
       {perSeatPricing && (

--- a/front/pages/w/[wId]/subscription/payment_processing.tsx
+++ b/front/pages/w/[wId]/subscription/payment_processing.tsx
@@ -5,7 +5,6 @@ import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import React, { useEffect } from "react";
 
-import config from "@app/lib/api/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { getStripeSubscription } from "@app/lib/plans/stripe";
 
@@ -39,7 +38,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     props: {
       owner,
       subscription,
-      gaTrackingId: config.getGaTrackingId(),
       user,
     },
   };

--- a/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/datasets/[name]/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/datasets/[name]/index.tsx
@@ -16,7 +16,6 @@ import {
 } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
-import config from "@app/lib/api/config";
 import { getDatasetHash, getDatasetSchema } from "@app/lib/api/datasets";
 import { useRegisterUnloadHandlers } from "@app/lib/front";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
@@ -31,7 +30,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   dataset: DatasetType;
   schema: DatasetSchema | null;
   dustAppsListUrl: string;
-  gaTrackingId: string;
 }>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
@@ -83,7 +81,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       dataset,
       schema,
       dustAppsListUrl,
-      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });
@@ -96,7 +93,6 @@ export default function ViewDatasetView({
   dataset,
   schema,
   dustAppsListUrl,
-  gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
 
@@ -176,7 +172,6 @@ export default function ViewDatasetView({
     <AppLayout
       subscription={subscription}
       owner={owner}
-      gaTrackingId={gaTrackingId}
       subNavigation={subNavigationBuild({
         owner,
         current: "developers",

--- a/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/datasets/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/datasets/index.tsx
@@ -15,7 +15,6 @@ import {
 } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
-import config from "@app/lib/api/config";
 import { getDatasets } from "@app/lib/api/datasets";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { AppResource } from "@app/lib/resources/app_resource";
@@ -29,7 +28,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   app: AppType;
   datasets: DatasetType[];
   dustAppsListUrl: string;
-  gaTrackingId: string;
 }>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
@@ -60,7 +58,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       app: app.toJSON(),
       datasets,
       dustAppsListUrl,
-      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });
@@ -72,7 +69,6 @@ export default function DatasetsView({
   app,
   datasets,
   dustAppsListUrl,
-  gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
   const confirm = useContext(ConfirmContext);
@@ -104,7 +100,6 @@ export default function DatasetsView({
     <AppLayout
       subscription={subscription}
       owner={owner}
-      gaTrackingId={gaTrackingId}
       subNavigation={subNavigationBuild({
         owner,
         current: "developers",

--- a/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/datasets/new.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/datasets/new.tsx
@@ -16,7 +16,6 @@ import {
 } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
-import config from "@app/lib/api/config";
 import { getDatasets } from "@app/lib/api/datasets";
 import { useRegisterUnloadHandlers } from "@app/lib/front";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
@@ -29,7 +28,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   app: AppType;
   datasets: DatasetType[];
   dustAppsListUrl: string;
-  gaTrackingId: string;
 }>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
@@ -58,7 +56,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       app: app.toJSON(),
       datasets,
       dustAppsListUrl,
-      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });
@@ -69,7 +66,6 @@ export default function NewDatasetView({
   app,
   datasets,
   dustAppsListUrl,
-  gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
 
@@ -136,7 +132,6 @@ export default function NewDatasetView({
     <AppLayout
       subscription={subscription}
       owner={owner}
-      gaTrackingId={gaTrackingId}
       subNavigation={subNavigationBuild({
         owner,
         current: "developers",

--- a/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/index.tsx
@@ -44,7 +44,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   url: string;
   dustAppsListUrl: string;
   app: AppType;
-  gaTrackingId: string;
 }>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
@@ -75,7 +74,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       url: config.getClientFacingUrl(),
       dustAppsListUrl,
       app: app.toJSON(),
-      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });
@@ -141,7 +139,6 @@ export default function AppView({
   app,
   url,
   dustAppsListUrl,
-  gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const { mutate } = useSWRConfig();
 
@@ -315,7 +312,6 @@ export default function AppView({
       subscription={subscription}
       hideSidebar
       owner={owner}
-      gaTrackingId={gaTrackingId}
       subNavigation={subNavigationBuild({
         owner,
         current: "developers",

--- a/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/runs/[runId]/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/runs/[runId]/index.tsx
@@ -16,7 +16,6 @@ import {
 } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
-import config from "@app/lib/api/config";
 import { getRun } from "@app/lib/api/run";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { AppResource } from "@app/lib/resources/app_resource";
@@ -30,7 +29,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   run: RunType;
   spec: SpecificationType;
   dustAppsListUrl: string;
-  gaTrackingId: string;
 }>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
@@ -69,7 +67,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       spec,
       run,
       dustAppsListUrl,
-      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });
@@ -82,7 +79,6 @@ export default function AppRun({
   spec,
   run,
   dustAppsListUrl,
-  gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [savedRunId, setSavedRunId] = useState<string | null | undefined>(
     app.savedRun
@@ -150,7 +146,6 @@ export default function AppRun({
     <AppLayout
       subscription={subscription}
       owner={owner}
-      gaTrackingId={gaTrackingId}
       subNavigation={subNavigationBuild({
         owner,
         current: "developers",

--- a/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/runs/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/runs/index.tsx
@@ -14,7 +14,6 @@ import {
 } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
-import config from "@app/lib/api/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { useRuns } from "@app/lib/swr/apps";
@@ -28,7 +27,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   app: AppType;
   wIdTarget: string | null;
   dustAppsListUrl: string;
-  gaTrackingId: string;
 }>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
@@ -61,7 +59,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       app: app.toJSON(),
       wIdTarget,
       dustAppsListUrl,
-      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });
@@ -89,7 +86,6 @@ export default function RunsView({
   app,
   wIdTarget,
   dustAppsListUrl,
-  gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [runType, setRunType] = useState(
     (wIdTarget ? "deploy" : "local") as RunRunType
@@ -128,7 +124,6 @@ export default function RunsView({
     <AppLayout
       subscription={subscription}
       owner={owner}
-      gaTrackingId={gaTrackingId}
       subNavigation={subNavigationBuild({
         owner,
         current: "developers",

--- a/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/settings.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/settings.tsx
@@ -16,7 +16,6 @@ import {
 } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
-import config from "@app/lib/api/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { classNames, MODELS_STRING_MAX_LENGTH } from "@app/lib/utils";
@@ -27,7 +26,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   subscription: SubscriptionType;
   app: AppType;
   dustAppsListUrl: string;
-  gaTrackingId: string;
 }>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
@@ -62,7 +60,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       subscription,
       app: app.toJSON(),
       dustAppsListUrl,
-      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });
@@ -72,7 +69,6 @@ export default function SettingsView({
   subscription,
   app,
   dustAppsListUrl,
-  gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [disable, setDisabled] = useState(true);
 
@@ -172,7 +168,6 @@ export default function SettingsView({
     <AppLayout
       subscription={subscription}
       owner={owner}
-      gaTrackingId={gaTrackingId}
       subNavigation={subNavigationBuild({
         owner,
         current: "developers",

--- a/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/specification.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/specification.tsx
@@ -24,7 +24,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   app: AppType;
   specification: string;
   dustAppsListUrl: string;
-  gaTrackingId: string;
 }>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
@@ -75,7 +74,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       app: app.toJSON(),
       specification: spec,
       dustAppsListUrl,
-      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });
@@ -86,7 +84,6 @@ export default function Specification({
   app,
   specification,
   dustAppsListUrl,
-  gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
 
@@ -94,7 +91,6 @@ export default function Specification({
     <AppLayout
       subscription={subscription}
       owner={owner}
-      gaTrackingId={gaTrackingId}
       subNavigation={subNavigationBuild({
         owner,
         current: "developers",

--- a/front/pages/w/[wId]/vaults/[vaultId]/apps/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/apps/index.tsx
@@ -37,7 +37,6 @@ import SerpAPISetup from "@app/components/providers/SerpAPISetup";
 import SerperSetup from "@app/components/providers/SerperSetup";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
-import config from "@app/lib/api/config";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import {
@@ -54,7 +53,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   groups: GroupType[];
   subscription: SubscriptionType;
   apps: AppType[];
-  gaTrackingId: string;
   vaultId: string;
 }>(async (context, auth) => {
   const owner = auth.workspace();
@@ -76,7 +74,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
         app.toJSON()
       ),
       vaultId: context.params?.vaultId as string,
-      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });
@@ -776,7 +773,6 @@ export default function Developers({
   groups,
   subscription,
   apps,
-  gaTrackingId,
   vaultId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [currentTab, setCurrentTab] = useState("apps");
@@ -796,7 +792,6 @@ export default function Developers({
     <AppLayout
       subscription={subscription}
       owner={owner}
-      gaTrackingId={gaTrackingId}
       subNavigation={subNavigationBuild({
         owner,
         current: "developers",

--- a/front/pages/w/[wId]/vaults/[vaultId]/apps/new.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/apps/new.tsx
@@ -10,7 +10,6 @@ import React, { useCallback, useEffect, useState } from "react";
 
 import { subNavigationBuild } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
-import config from "@app/lib/api/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { VaultResource } from "@app/lib/resources/vault_resource";
 import { classNames, MODELS_STRING_MAX_LENGTH } from "@app/lib/utils";
@@ -20,7 +19,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   dustAppsListUrl: string;
-  gaTrackingId: string;
   vault: VaultType;
 }>(async (context, auth) => {
   const owner = auth.workspace();
@@ -50,7 +48,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       owner,
       subscription,
       dustAppsListUrl,
-      gaTrackingId: config.getGaTrackingId(),
       vault: vault.toJSON(),
     },
   };
@@ -60,7 +57,6 @@ export default function NewApp({
   owner,
   subscription,
   dustAppsListUrl,
-  gaTrackingId,
   vault,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [disable, setDisabled] = useState(true);
@@ -122,7 +118,6 @@ export default function NewApp({
     <AppLayout
       subscription={subscription}
       owner={owner}
-      gaTrackingId={gaTrackingId}
       subNavigation={subNavigationBuild({ owner, current: "developers" })}
     >
       <div className="flex flex-col">

--- a/front/pages/w/[wId]/vaults/[vaultId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
@@ -98,7 +98,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
       category: context.query.category as DataSourceViewCategory,
       dataSource: dataSourceView.dataSource.toJSON(),
       dataSourceView: dataSourceView.toJSON(),
-      gaTrackingId: config.getGaTrackingId(),
       isAdmin,
       canWriteInVault,
       canReadInVault,

--- a/front/pages/w/[wId]/vaults/[vaultId]/categories/[category]/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/categories/[category]/index.tsx
@@ -55,7 +55,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     props: {
       category: context.query.category as DataSourceViewCategory,
       dustClientFacingUrl: config.getClientFacingUrl(),
-      gaTrackingId: config.getGaTrackingId(),
       isAdmin,
       isBuilder,
       canWriteInVault,

--- a/front/pages/w/[wId]/vaults/[vaultId]/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/index.tsx
@@ -8,7 +8,6 @@ import { CreateOrEditVaultModal } from "@app/components/vaults/CreateOrEditVault
 import { VaultCategoriesList } from "@app/components/vaults/VaultCategoriesList";
 import type { VaultLayoutProps } from "@app/components/vaults/VaultLayout";
 import { VaultLayout } from "@app/components/vaults/VaultLayout";
-import config from "@app/lib/api/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { VaultResource } from "@app/lib/resources/vault_resource";
 import { useVaultInfo } from "@app/lib/swr/vaults";
@@ -49,7 +48,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
 
   return {
     props: {
-      gaTrackingId: config.getGaTrackingId(),
       isAdmin,
       owner,
       subscription,

--- a/front/pages/w/[wId]/welcome.tsx
+++ b/front/pages/w/[wId]/welcome.tsx
@@ -23,7 +23,6 @@ export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
   defaultExpertise: string;
   defaultAdminInterest: string;
   conversationId: string | null;
-  gaTrackingId: string;
   baseUrl: string;
 }>(async (context, auth) => {
   const owner = auth.workspace();
@@ -57,7 +56,6 @@ export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
       defaultAdminInterest: adminInterest?.value || "",
       conversationId,
       baseUrl: config.getClientFacingUrl(),
-      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });
@@ -69,7 +67,6 @@ export default function Welcome({
   defaultExpertise,
   defaultAdminInterest,
   conversationId,
-  gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
   const [firstName, setFirstName] = useState<string>(user.firstName);
@@ -124,7 +121,6 @@ export default function Welcome({
   return (
     <OnboardingLayout
       owner={owner}
-      gaTrackingId={gaTrackingId}
       headerTitle="Joining Dust"
       headerRightActions={
         <Button

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -9,13 +9,11 @@ import AppLayout from "@app/components/sparkle/AppLayout";
 import { ActivityReport } from "@app/components/workspace/ActivityReport";
 import { QuickInsights } from "@app/components/workspace/Analytics";
 import { ProviderManagementModal } from "@app/components/workspace/ProviderManagementModal";
-import config from "@app/lib/api/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
-  gaTrackingId: string;
 }>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
@@ -29,7 +27,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     props: {
       owner,
       subscription,
-      gaTrackingId: config.getGaTrackingId(),
     },
   };
 });
@@ -37,7 +34,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
 export default function WorkspaceAdmin({
   owner,
   subscription,
-  gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [disable, setDisabled] = useState(true);
   const [updating, setUpdating] = useState(false);
@@ -186,7 +182,6 @@ export default function WorkspaceAdmin({
       <AppLayout
         subscription={subscription}
         owner={owner}
-        gaTrackingId={gaTrackingId}
         subNavigation={subNavigationAdmin({ owner, current: "workspace" })}
       >
         <Page.Vertical align="stretch" gap="xl">


### PR DESCRIPTION
## Description

Use `NEXT_PUBLIC_GA_TRACKING_ID` directly from client-side when needed and stop passing `gaTrackingId` everywhere.

See: https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables#bundling-environment-variables-for-the-browser

## Risk

N/A

## Deploy Plan

- set `NEXT_PUBLIC_GA_TRACKING_ID` in front secrets
- deploy `front`
- update dev setup doc