### PR TITLE
enh: prevent deleting ds / dsview if there are still agent dsconfigs

### DIFF
--- a/front/components/poke/data_sources/columns.tsx
+++ b/front/components/poke/data_sources/columns.tsx
@@ -1,6 +1,10 @@
 import { IconButton, TrashIcon } from "@dust-tt/sparkle";
 import type { AgentConfigurationType, WorkspaceType } from "@dust-tt/types";
-import { isRetrievalConfiguration } from "@dust-tt/types";
+import {
+  isProcessConfiguration,
+  isRetrievalConfiguration,
+  isTablesQueryConfiguration,
+} from "@dust-tt/types";
 import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
 import type { ColumnDef } from "@tanstack/react-table";
 import Link from "next/link";
@@ -120,17 +124,20 @@ async function deleteDataSource(
   dataSourceName: string,
   reload: () => void
 ) {
-  const retrievalAgents = agentConfigurations.filter((agt) =>
+  const agents = agentConfigurations.filter((agt) =>
     agt.actions.some(
       (a) =>
-        isRetrievalConfiguration(a) &&
-        a.dataSources.some((ds) => ds.dataSourceId === dataSourceName)
+        ((isRetrievalConfiguration(a) || isProcessConfiguration(a)) &&
+          a.dataSources.some((ds) => ds.dataSourceId === dataSourceName)) ||
+        (isTablesQueryConfiguration(a) &&
+          a.tables.some((t) => t.dataSourceId === dataSourceName))
     )
   );
-  if (retrievalAgents.length > 0) {
+
+  if (agents.length > 0) {
     window.alert(
       "Please archive agents using this data source first: " +
-        retrievalAgents.map((a) => a.name).join(", ")
+        agents.map((a) => a.name).join(", ")
     );
     return;
   }

--- a/front/lib/models/assistant/actions/data_sources.ts
+++ b/front/lib/models/assistant/actions/data_sources.ts
@@ -111,7 +111,7 @@ AgentDataSourceConfiguration.belongsTo(AgentProcessConfiguration, {
 DataSource.hasMany(AgentDataSourceConfiguration, {
   as: "dataSource",
   foreignKey: { name: "dataSourceId", allowNull: false },
-  onDelete: "CASCADE",
+  onDelete: "RESTRICT",
 });
 AgentDataSourceConfiguration.belongsTo(DataSource, {
   as: "dataSource",
@@ -122,7 +122,7 @@ AgentDataSourceConfiguration.belongsTo(DataSource, {
 DataSourceViewModel.hasMany(AgentDataSourceConfiguration, {
   as: "dataSourceView",
   foreignKey: { allowNull: true },
-  onDelete: "CASCADE",
+  onDelete: "RESTRICT",
 });
 // TODO(GROUPS_INFRA): This should be a required relationship.
 AgentDataSourceConfiguration.belongsTo(DataSourceViewModel, {

--- a/front/migrations/db/migration_79.sql
+++ b/front/migrations/db/migration_79.sql
@@ -1,0 +1,10 @@
+-- Migration created on Sep 12, 2024
+ALTER TABLE
+    "agent_data_source_configurations"
+ADD
+    FOREIGN KEY ("dataSourceId") REFERENCES "data_sources" ("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE
+    "agent_data_source_configurations"
+ADD
+    FOREIGN KEY ("dataSourceViewId") REFERENCES "data_source_views" ("id") ON DELETE RESTRICT ON UPDATE CASCADE;


### PR DESCRIPTION
## Description

Step 1 for https://github.com/dust-tt/dust/issues/7303

- prevent deleting a `DataSource` or a `DataSourceView` if there are still `AgentDataSourceConfiguration` tied to them
- improve the Poke check to prevent deleting a Datasource that is still used by an assistant (check was only checking retrieval, we'll now reject based on process and tables query as well)

Next step: prevent deleting data sources if there's still a tables query config using one of its tables. Requires making datasourceId a real FK.

## Risk



## Deploy Plan

deploy then run migration