### PR TITLE
Fix table query configuration deleted

### DIFF
--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -308,7 +308,8 @@ export class DataSourceResource extends ResourceWithVault<DataSource> {
     const relatedAgentTablesQueryConfigurationTables =
       await AgentTablesQueryConfigurationTable.findAll({
         where: {
-          dataSourceId: this.name,
+          dataSourceWorkspaceId: auth.getNonNullableWorkspace().sId,
+          dataSourceId: this.id,
         },
       });
     if (relatedAgentTablesQueryConfigurationTables.length > 0) {
@@ -332,7 +333,8 @@ export class DataSourceResource extends ResourceWithVault<DataSource> {
     // TODO(DATASOURCE_SID): state storing the datasource name.
     await AgentTablesQueryConfigurationTable.destroy({
       where: {
-        dataSourceId: this.name,
+        dataSourceWorkspaceId: auth.getNonNullableWorkspace().sId,
+        dataSourceId: this.id,
       },
     });
 


### PR DESCRIPTION
## Description

Fixes for incident https://dust4ai.slack.com/archives/C05B529FHV1/p1726140546083079

We were deleting the AgentTablesQueryConfigurationTable using the name of the datasource. Since all managed-ds have the same name, if we were scrubbing a workspace with a manage-google_drive we would delete all the AgentTablesQueryConfigurationTable linked to a Google Drive ds. 

## Risk

/

## Deploy Plan

Deploy front. 
