### PR TITLE
[front] - refacto(members): workspace members

### DIFF
--- a/front/components/members/EditInvitationModal.tsx
+++ b/front/components/members/EditInvitationModal.tsx
@@ -1,0 +1,114 @@
+import {
+  Button,
+  ElementModal,
+  MovingMailIcon,
+  Page,
+  XMarkIcon,
+} from "@dust-tt/sparkle";
+import type {
+  ActiveRoleType,
+  MembershipInvitationType,
+  WorkspaceType,
+} from "@dust-tt/types";
+import { useContext, useState } from "react";
+
+import { ConfirmContext } from "@app/components/Confirm";
+import { ROLES_DATA } from "@app/components/members/Roles";
+import { RoleDropDown } from "@app/components/members/RolesDropDown";
+import { SendNotificationsContext } from "@app/components/sparkle/Notification";
+import { sendInvitations, updateInvitation } from "@app/lib/invitations";
+
+export function EditInvitationModal({
+  owner,
+  invitation,
+  onClose,
+}: {
+  owner: WorkspaceType;
+  invitation: MembershipInvitationType;
+  onClose: () => void;
+}) {
+  const [selectedRole, setSelectedRole] = useState<ActiveRoleType>(
+    invitation.initialRole
+  );
+  const sendNotification = useContext(SendNotificationsContext);
+  const confirm = useContext(ConfirmContext);
+
+  return (
+    <ElementModal
+      title="Edit invitation"
+      openOnElement={invitation}
+      onClose={() => {
+        onClose();
+        setSelectedRole(invitation.initialRole);
+      }}
+      hasChanged={selectedRole !== invitation.initialRole}
+      variant="side-sm"
+      onSave={async (closeModalFn) => {
+        await updateInvitation({
+          owner,
+          invitation,
+          newRole: selectedRole,
+          sendNotification,
+          confirm,
+        });
+        closeModalFn();
+      }}
+      saveLabel="Update role"
+    >
+      <Page variant="modal">
+        <Page.Layout direction="vertical">
+          <Page.Layout direction="horizontal" sizing="grow" gap="sm">
+            <Page.H variant="h6">{invitation.inviteEmail}</Page.H>
+          </Page.Layout>
+          <div className="grow font-normal text-element-700">
+            Invitation sent on{" "}
+            {new Date(invitation.createdAt).toLocaleDateString()}
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="font-semibold text-element-900">Role:</div>
+            <RoleDropDown
+              selectedRole={selectedRole}
+              onChange={setSelectedRole}
+            />
+          </div>
+          <div className="grow font-normal text-element-700">
+            The role defines the rights of a member fo the workspace.{" "}
+            {ROLES_DATA[invitation.initialRole].description}
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              className="mt-4"
+              variant="primary"
+              label="Send invitation again"
+              icon={MovingMailIcon}
+              onClick={async () => {
+                await sendInvitations({
+                  owner,
+                  emails: [invitation.inviteEmail],
+                  invitationRole: selectedRole,
+                  sendNotification,
+                  isNewInvitation: false,
+                });
+              }}
+            />
+            <Button
+              className="mt-4"
+              variant="primaryWarning"
+              label="Revoke invitation"
+              icon={XMarkIcon}
+              disabled={owner.ssoEnforced}
+              onClick={async () => {
+                await updateInvitation({
+                  invitation,
+                  owner,
+                  sendNotification,
+                  confirm,
+                });
+              }}
+            />
+          </div>
+        </Page.Layout>
+      </Page>
+    </ElementModal>
+  );
+}

--- a/front/components/members/InvitationModal.tsx
+++ b/front/components/members/InvitationModal.tsx
@@ -1,37 +1,23 @@
-import {
-  Button,
-  ContentMessage,
-  ElementModal,
-  Modal,
-  MovingMailIcon,
-  Page,
-  TextArea,
-  XMarkIcon,
-} from "@dust-tt/sparkle";
+import { ContentMessage, Modal, TextArea } from "@dust-tt/sparkle";
 import type {
   ActiveRoleType,
-  MembershipInvitationType,
-  RoleType,
   SubscriptionPerSeatPricing,
   WorkspaceType,
 } from "@dust-tt/types";
 import { useContext, useEffect, useState } from "react";
 import { mutate } from "swr";
 
-import type { ConfirmDataType } from "@app/components/Confirm";
 import { ConfirmContext } from "@app/components/Confirm";
 import { displayRole, ROLES_DATA } from "@app/components/members/Roles";
 import { RoleDropDown } from "@app/components/members/RolesDropDown";
-import type { NotificationType } from "@app/components/sparkle/Notification";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { handleMembersRoleChange } from "@app/lib/client/members";
 import { getPriceAsString } from "@app/lib/client/subscription";
-import { MAX_UNCONSUMED_INVITATIONS_PER_WORKSPACE_PER_DAY } from "@app/lib/invitations";
+import {
+  MAX_UNCONSUMED_INVITATIONS_PER_WORKSPACE_PER_DAY,
+  sendInvitations,
+} from "@app/lib/invitations";
 import { isEmailValid } from "@app/lib/utils";
-import type {
-  PostInvitationRequestBody,
-  PostInvitationResponseBody,
-} from "@app/pages/api/w/[wId]/invitations";
 
 export function InviteEmailModal({
   showModal,
@@ -247,101 +233,6 @@ export function InviteEmailModal({
   );
 }
 
-export function EditInvitationModal({
-  owner,
-  invitation,
-  onClose,
-}: {
-  owner: WorkspaceType;
-  invitation: MembershipInvitationType;
-  onClose: () => void;
-}) {
-  const [selectedRole, setSelectedRole] = useState<ActiveRoleType>(
-    invitation.initialRole
-  );
-  const sendNotification = useContext(SendNotificationsContext);
-  const confirm = useContext(ConfirmContext);
-
-  return (
-    <ElementModal
-      title="Edit invitation"
-      openOnElement={invitation}
-      onClose={() => {
-        onClose();
-        setSelectedRole(invitation.initialRole);
-      }}
-      hasChanged={selectedRole !== invitation.initialRole}
-      variant="side-sm"
-      onSave={async (closeModalFn) => {
-        await updateInvitation({
-          owner,
-          invitation,
-          newRole: selectedRole,
-          sendNotification,
-          confirm,
-        });
-        closeModalFn();
-      }}
-      saveLabel="Update role"
-    >
-      <Page variant="modal">
-        <Page.Layout direction="vertical">
-          <Page.Layout direction="horizontal" sizing="grow" gap="sm">
-            <Page.H variant="h6">{invitation.inviteEmail}</Page.H>
-          </Page.Layout>
-          <div className="grow font-normal text-element-700">
-            Invitation sent on{" "}
-            {new Date(invitation.createdAt).toLocaleDateString()}
-          </div>
-          <div className="flex items-center gap-2">
-            <div className="font-semibold text-element-900">Role:</div>
-            <RoleDropDown
-              selectedRole={selectedRole}
-              onChange={setSelectedRole}
-            />
-          </div>
-          <div className="grow font-normal text-element-700">
-            The role defines the rights of a member fo the workspace.{" "}
-            {ROLES_DATA[invitation.initialRole].description}
-          </div>
-          <div className="flex items-center gap-2">
-            <Button
-              className="mt-4"
-              variant="primary"
-              label="Send invitation again"
-              icon={MovingMailIcon}
-              onClick={async () => {
-                await sendInvitations({
-                  owner,
-                  emails: [invitation.inviteEmail],
-                  invitationRole: selectedRole,
-                  sendNotification,
-                  isNewInvitation: false,
-                });
-              }}
-            />
-            <Button
-              className="mt-4"
-              variant="primaryWarning"
-              label="Revoke invitation"
-              icon={XMarkIcon}
-              disabled={owner.ssoEnforced}
-              onClick={async () => {
-                await updateInvitation({
-                  invitation,
-                  owner,
-                  sendNotification,
-                  confirm,
-                });
-              }}
-            />
-          </div>
-        </Page.Layout>
-      </Page>
-    </ElementModal>
-  );
-}
-
 function ProPlanBillingNotice({
   perSeatPricing,
 }: {
@@ -367,139 +258,4 @@ function ProPlanBillingNotice({
       </p>
     </ContentMessage>
   );
-}
-
-async function sendInvitations({
-  owner,
-  emails,
-  invitationRole,
-  sendNotification,
-  isNewInvitation,
-}: {
-  owner: WorkspaceType;
-  emails: string[];
-  invitationRole: ActiveRoleType;
-  sendNotification: any;
-  isNewInvitation: boolean;
-}) {
-  const body: PostInvitationRequestBody = emails.map((email) => ({
-    email,
-    role: invitationRole,
-  }));
-
-  const res = await fetch(`/api/w/${owner.sId}/invitations`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(body),
-  });
-
-  if (!res.ok) {
-    let data: any = {};
-    try {
-      data = await res.json();
-    } catch (e) {
-      // ignore
-    }
-    if (data?.error?.type === "invitation_already_sent_recently") {
-      sendNotification({
-        type: "error",
-        title: emails.length === 1 ? "Invite failed" : "Invites failed",
-        description:
-          (emails.length === 1 ? "This user has" : "These users have") +
-          " already been invited in the last 24 hours. Please wait before sending another invite.",
-      });
-    }
-
-    sendNotification({
-      type: "error",
-      title: "Invite failed",
-      description:
-        "Failed to invite new members to workspace: " + res.statusText,
-    });
-  } else {
-    const result: PostInvitationResponseBody = await res.json();
-    const failures = result.filter((r) => !r.success);
-
-    if (failures.length > 0) {
-      sendNotification({
-        type: "error",
-        title: "Some invites failed",
-        description:
-          result[0].error_message ||
-          `Failed to invite ${failures} new member(s) to workspace.`,
-      });
-    } else {
-      sendNotification({
-        type: "success",
-        title: "Invites sent",
-        description: isNewInvitation
-          ? `${emails.length} new invites sent.`
-          : `Sent ${emails.length} invites again.`,
-      });
-    }
-  }
-}
-
-async function updateInvitation({
-  owner,
-  invitation,
-  newRole,
-  sendNotification,
-  confirm,
-}: {
-  owner: WorkspaceType;
-  invitation: MembershipInvitationType;
-  newRole?: RoleType; // Optional parameter for role change
-  sendNotification: (notificationData: NotificationType) => void;
-  confirm?: (confirmData: ConfirmDataType) => Promise<boolean>;
-}) {
-  if (!newRole && confirm) {
-    const confirmation = await confirm({
-      title: "Revoke invitation",
-      message: `Are you sure you want to revoke the invitation for ${invitation.inviteEmail}?`,
-      validateLabel: "Yes, revoke",
-      validateVariant: "primaryWarning",
-    });
-    if (!confirmation) {
-      return;
-    }
-  }
-
-  const body = {
-    status: newRole ? invitation.status : "revoked",
-    initialRole: newRole ?? invitation.initialRole,
-  };
-
-  const res = await fetch(`/api/w/${owner.sId}/invitations/${invitation.sId}`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(body),
-  });
-
-  if (!res.ok) {
-    const error: { error: { message: string } } = await res.json();
-    const message = newRole
-      ? error.error.message
-      : "Failed to update member's invitation.";
-    sendNotification({
-      type: "error",
-      title: `${newRole ? "Role Update Failed" : "Revoke Failed"}`,
-      description: message,
-    });
-    return;
-  }
-
-  const successMessage = newRole
-    ? `Invitation updated to ${newRole}`
-    : "Invitation revoked";
-  sendNotification({
-    type: "success",
-    title: `${newRole ? "Role updated" : "Invitation Revoked"}`,
-    description: `${successMessage} for ${invitation.inviteEmail}.`,
-  });
-  await mutate(`/api/w/${owner.sId}/invitations`);
 }

--- a/front/components/members/InvitationModal.tsx
+++ b/front/components/members/InvitationModal.tsx
@@ -88,14 +88,19 @@ export function InviteEmailModal({
 
     const invitesByCase = {
       activeSameRole: existingMembers.filter(
-        (m) => m && m.role === invitationRole
+        (m) => m && m.workspaces[0].role === invitationRole
       ),
       activeDifferentRole: existingMembers.filter(
-        (m) => m && m.role !== invitationRole && m.role !== "none"
+        (m) =>
+          m &&
+          m.workspaces[0].role !== invitationRole &&
+          m.workspaces[0].role !== "none"
       ),
       notInWorkspace: inviteEmailsList.filter(
-        (_, index) =>
-          !existingMembers[index] || existingMembers[index].role === "none"
+        (m) =>
+          existingMembers.find((x) => x.email === m) ||
+          existingMembers.find((x) => x.email === m).workspaces[0].role ===
+            "none"
       ),
     };
 

--- a/front/components/members/InvitationModal.tsx
+++ b/front/components/members/InvitationModal.tsx
@@ -98,8 +98,8 @@ export function InviteEmailModal({
       ),
       notInWorkspace: inviteEmailsList.filter(
         (m) =>
-          existingMembers.find((x) => x.email === m) ||
-          existingMembers.find((x) => x.email === m).workspaces[0].role ===
+          !existingMembers.find((x) => x.email === m) ||
+          existingMembers.find((x) => x.email === m)?.workspaces[0].role ===
             "none"
       ),
     };

--- a/front/components/members/InvitationsList.tsx
+++ b/front/components/members/InvitationsList.tsx
@@ -1,10 +1,22 @@
-import { Avatar, ChevronRightIcon, Chip, Icon, Page } from "@dust-tt/sparkle";
+import {
+  Avatar,
+  ChevronRightIcon,
+  Chip,
+  DataTable,
+  Icon,
+  Page,
+} from "@dust-tt/sparkle";
 import type { MembershipInvitationType, WorkspaceType } from "@dust-tt/types";
-import { useState } from "react";
+import type { CellContext } from "@tanstack/react-table";
+import React, { useMemo, useState } from "react";
 
 import { EditInvitationModal } from "@app/components/members/EditInvitationModal";
 import { displayRole, ROLES_DATA } from "@app/components/members/Roles";
 import { useWorkspaceInvitations } from "@app/lib/swr/memberships";
+
+type RowData = MembershipInvitationType & {
+  onClick: () => void;
+};
 
 export function InvitationsList({
   owner,
@@ -16,14 +28,68 @@ export function InvitationsList({
   const { invitations, isInvitationsLoading } = useWorkspaceInvitations(owner);
   const [selectedInvite, setSelectedInvite] =
     useState<MembershipInvitationType | null>(null);
-  const filteredInvitations = invitations
-    .sort((a, b) => a.inviteEmail.localeCompare(b.inviteEmail))
-    .filter((i) => i.status === "pending")
-    .filter(
-      (i) =>
-        !searchText ||
-        i.inviteEmail.toLowerCase().includes(searchText.toLowerCase())
-    );
+
+  const filteredInvitations = useMemo(
+    () =>
+      invitations
+        .sort((a, b) => a.inviteEmail.localeCompare(b.inviteEmail))
+        .filter((i) => i.status === "pending")
+        .filter(
+          (i) =>
+            !searchText ||
+            i.inviteEmail.toLowerCase().includes(searchText.toLowerCase())
+        ),
+    [invitations, searchText]
+  );
+
+  const rows = useMemo(
+    () =>
+      filteredInvitations.map((invitation) => ({
+        ...invitation,
+        onClick: () => setSelectedInvite(invitation),
+      })),
+    [filteredInvitations]
+  );
+
+  const columns = [
+    {
+      id: "inviteEmail",
+      cell: (info: CellContext<RowData, string>) => (
+        <DataTable.CellContent>
+          <span>{info.row.original.inviteEmail}</span>
+        </DataTable.CellContent>
+      ),
+      meta: {
+        width: "46rem",
+      },
+    },
+    {
+      id: "initialRole",
+      cell: (info: CellContext<RowData, string>) => (
+        <DataTable.CellContent>
+          <Chip
+            size="xs"
+            color={ROLES_DATA[info.row.original.initialRole]["color"]}
+            className="capitalize"
+          >
+            {displayRole(info.row.original.initialRole)}
+          </Chip>
+        </DataTable.CellContent>
+      ),
+      meta: {
+        width: "6rem",
+      },
+    },
+    {
+      id: "action",
+      cell: () => (
+        <DataTable.CellContent>
+          <Icon visual={ChevronRightIcon} className="text-element-600" />
+        </DataTable.CellContent>
+      ),
+    },
+  ];
+
   return (
     <>
       {selectedInvite && (
@@ -36,41 +102,9 @@ export function InvitationsList({
       {filteredInvitations.length > 0 && (
         <Page.H variant="h5">Invitations</Page.H>
       )}
-      <div className="s-w-full">
-        {!isInvitationsLoading &&
-          filteredInvitations.length > 0 &&
-          filteredInvitations.map((invitation: MembershipInvitationType) => (
-            <div
-              key={`invitation-${invitation.id}`}
-              className="transition-color flex cursor-pointer items-center justify-center gap-3 border-t border-structure-200 p-2 text-xs duration-200 hover:bg-action-50 sm:text-sm"
-              onClick={() => setSelectedInvite(invitation)}
-            >
-              <div className="hidden sm:block">
-                <Avatar size="sm" className={invitation.sId} />
-              </div>
-              <div className="flex grow flex-col gap-1 sm:flex-row sm:gap-3">
-                <div className="grow font-normal text-element-700">
-                  {invitation.inviteEmail}
-                </div>
-                <div>
-                  <Chip
-                    size="xs"
-                    color={ROLES_DATA[invitation.initialRole]["color"]}
-                    className="capitalize"
-                  >
-                    {displayRole(invitation.initialRole)}
-                  </Chip>
-                </div>
-                <div className="hidden sm:block">
-                  <Icon
-                    visual={ChevronRightIcon}
-                    className="text-element-600"
-                  />
-                </div>
-              </div>
-            </div>
-          ))}
-        {isInvitationsLoading && (
+
+      {isInvitationsLoading ? (
+        <div className="flex flex-col gap-2">
           <div className="flex animate-pulse cursor-pointer items-center justify-center gap-3 border-t border-structure-200 bg-structure-50 py-2 text-xs sm:text-sm">
             <div className="hidden sm:block">
               <Avatar size="xs" />
@@ -88,8 +122,12 @@ export function InvitationsList({
               <ChevronRightIcon />
             </div>
           </div>
-        )}
-      </div>
+        </div>
+      ) : (
+        filteredInvitations.length > 0 && (
+          <DataTable data={rows} columns={columns} />
+        )
+      )}
     </>
   );
 }

--- a/front/components/members/InvitationsList.tsx
+++ b/front/components/members/InvitationsList.tsx
@@ -2,7 +2,7 @@ import { Avatar, ChevronRightIcon, Chip, Icon, Page } from "@dust-tt/sparkle";
 import type { MembershipInvitationType, WorkspaceType } from "@dust-tt/types";
 import { useState } from "react";
 
-import { EditInvitationModal } from "@app/components/members/InvitationModal";
+import { EditInvitationModal } from "@app/components/members/EditInvitationModal";
 import { displayRole, ROLES_DATA } from "@app/components/members/Roles";
 import { useWorkspaceInvitations } from "@app/lib/swr/memberships";
 

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -7,7 +7,7 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import type {
-  ActiveRoleType,
+  RoleType,
   UserTypeWithWorkspaces,
   WorkspaceType,
 } from "@dust-tt/types";
@@ -15,7 +15,7 @@ import type { CellContext, PaginationState } from "@tanstack/react-table";
 import _ from "lodash";
 import React, { useMemo, useState } from "react";
 
-import { ROLES_DATA } from "@app/components/members/Roles";
+import { displayRole, ROLES_DATA } from "@app/components/members/Roles";
 import { ChangeMemberModal } from "@app/components/workspace/ChangeMemberModal";
 import { useSearchMembers } from "@app/lib/swr/user";
 import { classNames } from "@app/lib/utils";
@@ -25,7 +25,7 @@ type RowData = {
   name: string;
   userId: string;
   email: string;
-  role: ActiveRoleType;
+  role: RoleType;
   onClick: () => void;
 };
 
@@ -40,7 +40,7 @@ function getTableRows(
     name: user.fullName,
     userId: user.sId,
     email: user.email ?? "",
-    role: user.workspaces[0].role as ActiveRoleType,
+    role: user.workspaces[0].role,
     onClick: () => onClick(user),
   }));
 }
@@ -89,8 +89,12 @@ export function MembersList({
       cell: (info: Info) => (
         <DataTable.CellContent>
           <Chip
-            label={_.capitalize(info.row.original.role)}
-            color={ROLES_DATA[info.row.original.role]["color"]}
+            label={_.capitalize(displayRole(info.row.original.role))}
+            color={
+              info.row.original.role !== "none"
+                ? ROLES_DATA[info.row.original.role]["color"]
+                : undefined
+            }
           />
         </DataTable.CellContent>
       ),

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -1,11 +1,9 @@
 import {
-  Button,
   ChevronRightIcon,
   Chip,
   DataTable,
   Icon,
-  PlusIcon,
-  Searchbar,
+  Page,
   Spinner,
 } from "@dust-tt/sparkle";
 import type {
@@ -50,13 +48,12 @@ function getTableRows(
 export function MembersList({
   owner,
   currentUserId,
-  onInviteClick,
+  searchText,
 }: {
   owner: WorkspaceType;
   currentUserId: string;
-  onInviteClick: () => void;
+  searchText: string;
 }) {
-  const [searchText, setSearchText] = useState("");
   const [pagination, setPagination] = React.useState<PaginationState>({
     pageIndex: 0,
     pageSize: 25,
@@ -73,7 +70,6 @@ export function MembersList({
   const columns = [
     {
       id: "name",
-      accessorKey: "name",
       cell: (info: Info) => (
         <DataTable.CellContent
           avatarUrl={info.row.original.icon}
@@ -122,21 +118,7 @@ export function MembersList({
 
   return (
     <div className="flex flex-col gap-2">
-      <div className="flex flex-row gap-2">
-        <Searchbar
-          placeholder="Search members (email)"
-          value={searchText}
-          name="search"
-          onChange={(s) => {
-            setSearchText(s);
-          }}
-        />
-        <Button
-          label="Invite members"
-          icon={PlusIcon}
-          onClick={onInviteClick}
-        />
-      </div>
+      <Page.H variant="h5">Members</Page.H>
       {isLoading ? (
         <div className="flex items-center justify-center py-8">
           <Spinner size="lg" />

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -95,7 +95,7 @@ export function MembersList({
         </DataTable.CellContent>
       ),
       meta: {
-        width: "5rem",
+        width: "6rem",
       },
     },
     {

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -29,7 +29,7 @@ type RowData = {
   onClick: () => void;
 };
 
-type Info = CellContext<RowData, unknown>;
+type Info = CellContext<RowData, string>;
 
 function getTableRows(
   allUsers: UserTypeWithWorkspaces[],

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -119,11 +119,9 @@ export function MembersList({
   ];
 
   const rows = useMemo(() => {
-    const filteredMembers = members.filter(
-      (m) => m.workspaces[0].role !== "none"
-    );
+    console.log(">>>>> members", members)
     return getTableRows(
-      filteredMembers,
+      members,
       (user: UserTypeWithWorkspaces | null) => {
         setSelectedMember(user);
       }

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -121,8 +121,6 @@ export function MembersList({
   ];
 
   const rows = useMemo(() => {
-    console.log(">>>>> members", members);
-    console.log(">>>>> allMembers", allMembers);
     return getTableRows(members, (user: UserTypeWithWorkspaces | null) => {
       setSelectedMember(user);
     });

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -80,6 +80,9 @@ export function MembersList({
         </DataTable.CellContent>
       ),
       enableSorting: false,
+      meta: {
+        width: "46rem",
+      },
     },
     {
       id: "role",
@@ -91,6 +94,9 @@ export function MembersList({
           />
         </DataTable.CellContent>
       ),
+      meta: {
+        width: "5rem",
+      },
     },
     {
       id: "open",

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -118,13 +118,17 @@ export function MembersList({
     },
   ];
 
-  const rows = useMemo(
-    () =>
-      getTableRows(members, (user: UserTypeWithWorkspaces | null) => {
+  const rows = useMemo(() => {
+    const filteredMembers = members.filter(
+      (m) => m.workspaces[0].role !== "none"
+    );
+    return getTableRows(
+      filteredMembers,
+      (user: UserTypeWithWorkspaces | null) => {
         setSelectedMember(user);
-      }),
-    [members]
-  );
+      }
+    );
+  }, [members]);
 
   return (
     <div className="flex flex-col gap-2">

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -17,7 +17,6 @@ import React, { useMemo, useState } from "react";
 
 import { displayRole, ROLES_DATA } from "@app/components/members/Roles";
 import { ChangeMemberModal } from "@app/components/workspace/ChangeMemberModal";
-import { useMembers } from "@app/lib/swr/memberships";
 import { useSearchMembers } from "@app/lib/swr/user";
 import { classNames } from "@app/lib/utils";
 
@@ -67,7 +66,6 @@ export function MembersList({
     pagination.pageIndex,
     pagination.pageSize
   );
-  const { members: allMembers } = useMembers(owner);
 
   const columns = [
     {
@@ -121,10 +119,16 @@ export function MembersList({
   ];
 
   const rows = useMemo(() => {
-    return getTableRows(members, (user: UserTypeWithWorkspaces | null) => {
-      setSelectedMember(user);
-    });
-  }, [allMembers, members]);
+    const filteredMembers = members.filter(
+      (m) => m.workspaces[0].role !== "none"
+    );
+    return getTableRows(
+      filteredMembers,
+      (user: UserTypeWithWorkspaces | null) => {
+        setSelectedMember(user);
+      }
+    );
+  }, [members]);
 
   return (
     <div className="flex flex-col gap-2">

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -17,6 +17,7 @@ import React, { useMemo, useState } from "react";
 
 import { displayRole, ROLES_DATA } from "@app/components/members/Roles";
 import { ChangeMemberModal } from "@app/components/workspace/ChangeMemberModal";
+import { useMembers } from "@app/lib/swr/memberships";
 import { useSearchMembers } from "@app/lib/swr/user";
 import { classNames } from "@app/lib/utils";
 
@@ -66,6 +67,7 @@ export function MembersList({
     pagination.pageIndex,
     pagination.pageSize
   );
+  const { members: allMembers } = useMembers(owner);
 
   const columns = [
     {
@@ -119,14 +121,12 @@ export function MembersList({
   ];
 
   const rows = useMemo(() => {
-    console.log(">>>>> members", members)
-    return getTableRows(
-      members,
-      (user: UserTypeWithWorkspaces | null) => {
-        setSelectedMember(user);
-      }
-    );
-  }, [members]);
+    console.log(">>>>> members", members);
+    console.log(">>>>> allMembers", allMembers);
+    return getTableRows(members, (user: UserTypeWithWorkspaces | null) => {
+      setSelectedMember(user);
+    });
+  }, [allMembers, members]);
 
   return (
     <div className="flex flex-col gap-2">

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -28,7 +28,7 @@ type RowData = {
   userId: string;
   email: string;
   role: ActiveRoleType;
-  onClick: () => void
+  onClick: () => void;
 };
 
 type Info = CellContext<RowData, unknown>;
@@ -36,14 +36,14 @@ type Info = CellContext<RowData, unknown>;
 function getTableRows(
   allUsers: UserTypeWithWorkspaces[],
   onClick: (user: UserTypeWithWorkspaces) => void
-) : RowData[] {
+): RowData[] {
   return allUsers.map((user) => ({
     icon: user.image ?? "",
     name: user.fullName,
     userId: user.sId,
     email: user.email ?? "",
     role: user.workspaces[0].role as ActiveRoleType,
-    onClick: () => onClick(user)
+    onClick: () => onClick(user),
   }));
 }
 
@@ -61,7 +61,8 @@ export function MembersList({
     pageIndex: 0,
     pageSize: 25,
   });
-  const [selectedMember, setSelectedMember] = useState<UserTypeWithWorkspaces | null>(null)
+  const [selectedMember, setSelectedMember] =
+    useState<UserTypeWithWorkspaces | null>(null);
   const { members, totalMembersCount, isLoading } = useSearchMembers(
     owner.sId,
     searchText,
@@ -112,10 +113,10 @@ export function MembersList({
   ];
 
   const rows = useMemo(
-    () => getTableRows(
-      members,
-      (user: UserTypeWithWorkspaces | null) => {setSelectedMember(user)}
-    ),
+    () =>
+      getTableRows(members, (user: UserTypeWithWorkspaces | null) => {
+        setSelectedMember(user);
+      }),
     [members]
   );
 
@@ -127,7 +128,7 @@ export function MembersList({
           value={searchText}
           name="search"
           onChange={(s) => {
-            setSearchText(s)
+            setSearchText(s);
           }}
         />
         <Button

--- a/front/components/vaults/CreateOrEditVaultModal.tsx
+++ b/front/components/vaults/CreateOrEditVaultModal.tsx
@@ -96,6 +96,8 @@ export function CreateOrEditVaultModal({
     pagination.pageSize
   );
 
+  console.log(members);
+
   const getTableColumns = useCallback(() => {
     return [
       {

--- a/front/components/vaults/CreateOrEditVaultModal.tsx
+++ b/front/components/vaults/CreateOrEditVaultModal.tsx
@@ -96,8 +96,6 @@ export function CreateOrEditVaultModal({
     pagination.pageSize
   );
 
-  console.log(members);
-
   const getTableColumns = useCallback(() => {
     return [
       {

--- a/front/components/workspace/ChangeMemberModal.tsx
+++ b/front/components/workspace/ChangeMemberModal.tsx
@@ -1,0 +1,133 @@
+import { Avatar, Button, Dialog, ElementModal, Page } from "@dust-tt/sparkle";
+import type {
+  ActiveRoleType,
+  UserTypeWithWorkspaces,
+  WorkspaceType,
+} from "@dust-tt/types";
+import { isActiveRoleType } from "@dust-tt/types";
+import React, { useContext, useState } from "react";
+import { useSWRConfig } from "swr";
+
+import { ROLES_DATA } from "@app/components/members/Roles";
+import { RoleDropDown } from "@app/components/members/RolesDropDown";
+import { SendNotificationsContext } from "@app/components/sparkle/Notification";
+import { handleMembersRoleChange } from "@app/lib/client/members";
+
+export function ChangeMemberModal({
+  onClose,
+  member,
+  owner,
+}: {
+  onClose: () => void;
+  member: UserTypeWithWorkspaces | null;
+  owner: WorkspaceType;
+}) {
+  const { role = null } = member?.workspaces[0] ?? {};
+
+  const { mutate } = useSWRConfig();
+  const sendNotification = useContext(SendNotificationsContext);
+  const [revokeMemberModalOpen, setRevokeMemberModalOpen] = useState(false);
+  const [selectedRole, setSelectedRole] = useState<ActiveRoleType | null>(
+    role !== "none" ? role : null
+  );
+  const [isSaving, setIsSaving] = useState(false);
+
+  if (!member || !role || !isActiveRoleType(role)) {
+    return null;
+  }
+
+  return (
+    <ElementModal
+      openOnElement={member}
+      onClose={() => {
+        onClose();
+        setSelectedRole(null);
+        setIsSaving(false);
+      }}
+      isSaving={isSaving}
+      hasChanged={selectedRole !== member.workspaces[0].role}
+      title={member.fullName || "Unreachable"}
+      variant="side-sm"
+      onSave={async (closeModalFn: () => void) => {
+        if (!selectedRole) {
+          return;
+        }
+        setIsSaving(true);
+        await handleMembersRoleChange({
+          members: [member],
+          role: selectedRole,
+          sendNotification,
+        });
+        await mutate(`/api/w/${owner.sId}/members`);
+        closeModalFn();
+      }}
+      saveLabel="Update role"
+    >
+      <Page variant="modal">
+        <div className="mt-6 flex flex-col gap-9 text-sm text-element-700">
+          <div className="flex items-center gap-4">
+            <Avatar size="lg" visual={member.image} name={member.fullName} />
+            <div className="flex grow flex-col">
+              <div className="font-semibold text-element-900">
+                {member.fullName}
+              </div>
+              <div className="font-normal">{member.email}</div>
+            </div>
+          </div>
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center gap-2">
+              <div className="font-bold text-element-900">Role:</div>
+              <RoleDropDown
+                selectedRole={selectedRole || role}
+                onChange={setSelectedRole}
+              />
+            </div>
+            <Page.P>
+              The role defines the rights of a member of the workspace.{" "}
+              {ROLES_DATA[role]["description"]}
+            </Page.P>
+          </div>
+          <div className="flex flex-none flex-col gap-2">
+            <div className="flex-none">
+              <Button
+                variant="primaryWarning"
+                label="Revoke member access"
+                size="sm"
+                onClick={() => setRevokeMemberModalOpen(true)}
+              />
+            </div>
+            <Page.P>
+              Deleting a member will remove them from the workspace. They will
+              be able to rejoin if they have an invitation link.
+            </Page.P>
+          </div>
+        </div>
+      </Page>
+      <Dialog
+        isOpen={revokeMemberModalOpen}
+        title="Revoke member access"
+        onValidate={async () => {
+          await handleMembersRoleChange({
+            members: [member],
+            role: "none",
+            sendNotification,
+          });
+          await mutate(`/api/w/${owner.sId}/members`);
+          setRevokeMemberModalOpen(false);
+          onClose();
+        }}
+        validateLabel="Yes, revoke"
+        validateVariant="primaryWarning"
+        onCancel={() => {
+          setRevokeMemberModalOpen(false);
+        }}
+        isSaving={isSaving}
+      >
+        <div>
+          Revoke access for user{" "}
+          <span className="font-bold">{member.fullName}</span>?
+        </div>
+      </Dialog>
+    </ElementModal>
+  );
+}

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -198,8 +198,10 @@ export async function searchMembers(
     paginationParams
   );
 
-  const userIds = users.map((u) => u.id);
-  const memberships = await MembershipResource.fetchByUserIds(userIds);
+  const { memberships } = await MembershipResource.getActiveMemberships({
+    users,
+    workspace: owner,
+  });
 
   const usersWithWorkspaces = users.map((u) => {
     const membership = memberships.find(

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -202,7 +202,9 @@ export async function searchMembers(
   const memberships = await MembershipResource.fetchByUserIds(userIds);
 
   const usersWithWorkspaces = users.map((u) => {
-    const membership = memberships.find((m) => m.userId === u.id);
+    const membership = memberships.find(
+      (m) => m.userId === u.id && m.workspaceId === owner.id
+    );
     const role =
       membership && !membership.isRevoked()
         ? ACTIVE_ROLES.includes(membership.role)

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -1,15 +1,14 @@
-import {
-  ACTIVE_ROLES,
+import type {
   LightWorkspaceType,
   MembershipRoleType,
   RoleType,
   SubscriptionType,
-  UserType,
   UserTypeWithWorkspaces,
   WorkspaceDomain,
   WorkspaceSegmentationType,
   WorkspaceType,
 } from "@dust-tt/types";
+import { ACTIVE_ROLES } from "@dust-tt/types";
 
 import type { PaginationParams } from "@app/lib/api/pagination";
 import type { Authenticator } from "@app/lib/auth";
@@ -208,8 +207,8 @@ export async function searchMembers(
       membership && !membership.isRevoked()
         ? ACTIVE_ROLES.includes(membership.role)
           ? membership.role
-          : "none" as RoleType
-        : "none" as RoleType;
+          : ("none" as RoleType)
+        : ("none" as RoleType);
 
     return {
       ...u.toJSON(),

--- a/front/lib/invitations.ts
+++ b/front/lib/invitations.ts
@@ -1,2 +1,152 @@
 // Maxmimum allowed number of unconsumed invitations per workspace per day.
+import type {
+  ActiveRoleType,
+  MembershipInvitationType,
+  RoleType,
+  WorkspaceType,
+} from "@dust-tt/types";
+import { mutate } from "swr";
+
+import type { ConfirmDataType } from "@app/components/Confirm";
+import type { NotificationType } from "@app/components/sparkle/Notification";
+import type {
+  PostInvitationRequestBody,
+  PostInvitationResponseBody,
+} from "@app/pages/api/w/[wId]/invitations";
+
 export const MAX_UNCONSUMED_INVITATIONS_PER_WORKSPACE_PER_DAY = 50;
+
+export async function updateInvitation({
+  owner,
+  invitation,
+  newRole,
+  sendNotification,
+  confirm,
+}: {
+  owner: WorkspaceType;
+  invitation: MembershipInvitationType;
+  newRole?: RoleType; // Optional parameter for role change
+  sendNotification: (notificationData: NotificationType) => void;
+  confirm?: (confirmData: ConfirmDataType) => Promise<boolean>;
+}) {
+  if (!newRole && confirm) {
+    const confirmation = await confirm({
+      title: "Revoke invitation",
+      message: `Are you sure you want to revoke the invitation for ${invitation.inviteEmail}?`,
+      validateLabel: "Yes, revoke",
+      validateVariant: "primaryWarning",
+    });
+    if (!confirmation) {
+      return;
+    }
+  }
+
+  const body = {
+    status: newRole ? invitation.status : "revoked",
+    initialRole: newRole ?? invitation.initialRole,
+  };
+
+  const res = await fetch(`/api/w/${owner.sId}/invitations/${invitation.sId}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const error: { error: { message: string } } = await res.json();
+    const message = newRole
+      ? error.error.message
+      : "Failed to update member's invitation.";
+    sendNotification({
+      type: "error",
+      title: `${newRole ? "Role Update Failed" : "Revoke Failed"}`,
+      description: message,
+    });
+    return;
+  }
+
+  const successMessage = newRole
+    ? `Invitation updated to ${newRole}`
+    : "Invitation revoked";
+  sendNotification({
+    type: "success",
+    title: `${newRole ? "Role updated" : "Invitation Revoked"}`,
+    description: `${successMessage} for ${invitation.inviteEmail}.`,
+  });
+  await mutate(`/api/w/${owner.sId}/invitations`);
+}
+
+export async function sendInvitations({
+  owner,
+  emails,
+  invitationRole,
+  sendNotification,
+  isNewInvitation,
+}: {
+  owner: WorkspaceType;
+  emails: string[];
+  invitationRole: ActiveRoleType;
+  sendNotification: any;
+  isNewInvitation: boolean;
+}) {
+  const body: PostInvitationRequestBody = emails.map((email) => ({
+    email,
+    role: invitationRole,
+  }));
+
+  const res = await fetch(`/api/w/${owner.sId}/invitations`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    let data: any = {};
+    try {
+      data = await res.json();
+    } catch (e) {
+      // ignore
+    }
+    if (data?.error?.type === "invitation_already_sent_recently") {
+      sendNotification({
+        type: "error",
+        title: emails.length === 1 ? "Invite failed" : "Invites failed",
+        description:
+          (emails.length === 1 ? "This user has" : "These users have") +
+          " already been invited in the last 24 hours. Please wait before sending another invite.",
+      });
+    }
+
+    sendNotification({
+      type: "error",
+      title: "Invite failed",
+      description:
+        "Failed to invite new members to workspace: " + res.statusText,
+    });
+  } else {
+    const result: PostInvitationResponseBody = await res.json();
+    const failures = result.filter((r) => !r.success);
+
+    if (failures.length > 0) {
+      sendNotification({
+        type: "error",
+        title: "Some invites failed",
+        description:
+          result[0].error_message ||
+          `Failed to invite ${failures} new member(s) to workspace.`,
+      });
+    } else {
+      sendNotification({
+        type: "success",
+        title: "Invites sent",
+        description: isNewInvitation
+          ? `${emails.length} new invites sent.`
+          : `Sent ${emails.length} invites again.`,
+      });
+    }
+  }
+}

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -19,7 +19,6 @@ import { Op } from "sequelize";
 import type { PaginationParams } from "@app/lib/api/pagination";
 import type { Authenticator } from "@app/lib/auth";
 import { canForceUserRole } from "@app/lib/development";
-import { User } from "@app/lib/models/user";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { MembershipModel } from "@app/lib/resources/storage/models/membership";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -1,6 +1,7 @@
 import type {
   LightWorkspaceType,
   MembershipRoleType,
+  ModelId,
   RequireAtLeastOne,
   Result,
 } from "@dust-tt/types";
@@ -18,6 +19,7 @@ import { Op } from "sequelize";
 import type { PaginationParams } from "@app/lib/api/pagination";
 import type { Authenticator } from "@app/lib/auth";
 import { canForceUserRole } from "@app/lib/development";
+import { User } from "@app/lib/models/user";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { MembershipModel } from "@app/lib/resources/storage/models/membership";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
@@ -354,6 +356,19 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     );
 
     return new MembershipResource(MembershipModel, newMembership.get());
+  }
+
+  static async fetchByUserIds(
+    userIds: ModelId[]
+  ): Promise<MembershipResource[]> {
+    const membershipModels = await MembershipModel.findAll({
+      where: {
+        userId: userIds,
+      },
+    });
+    return membershipModels.map(
+      (m) => new MembershipResource(MembershipModel, m.get())
+    );
   }
 
   /**

--- a/front/pages/api/w/[wId]/members/search.ts
+++ b/front/pages/api/w/[wId]/members/search.ts
@@ -51,7 +51,7 @@ async function handler(
       const paginationRes = getPaginationParams(req, {
         defaultLimit: DEFAULT_PAGE_LIMIT,
         defaultOrderColumn: orderBy || "name",
-        defaultOrderDirection: "desc",
+        defaultOrderDirection: "asc",
         supportedOrderColumn: ["name"],
       });
 

--- a/front/pages/api/w/[wId]/members/search.ts
+++ b/front/pages/api/w/[wId]/members/search.ts
@@ -1,4 +1,7 @@
-import type { UserType, WithAPIErrorResponse } from "@dust-tt/types";
+import type {
+  UserTypeWithWorkspaces,
+  WithAPIErrorResponse,
+} from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getPaginationParams } from "@app/lib/api/pagination";
@@ -10,7 +13,7 @@ import { apiError } from "@app/logger/withlogging";
 const DEFAULT_PAGE_LIMIT = 25;
 
 export type SearchMembersResponseBody = {
-  members: UserType[];
+  members: UserTypeWithWorkspaces[];
   total: number;
 };
 

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -1,4 +1,11 @@
-import { Button, Dialog, Page, Popup } from "@dust-tt/sparkle";
+import {
+  Button,
+  Dialog,
+  Page,
+  PlusIcon,
+  Popup,
+  Searchbar,
+} from "@dust-tt/sparkle";
 import type { UserType, WorkspaceDomain, WorkspaceType } from "@dust-tt/types";
 import type {
   PlanType,
@@ -13,6 +20,7 @@ import React, { useContext, useMemo, useState } from "react";
 import type { WorkspaceLimit } from "@app/components/app/ReachedLimitPopup";
 import { ReachedLimitPopup } from "@app/components/app/ReachedLimitPopup";
 import { InviteEmailModal } from "@app/components/members/InvitationModal";
+import { InvitationsList } from "@app/components/members/InvitationsList";
 import { MembersList } from "@app/components/members/MembersList";
 import { subNavigationAdmin } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
@@ -87,6 +95,7 @@ export default function WorkspaceAdmin({
   workspaceHasAvailableSeats,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
+  const [searchTerm, setSearchTerm] = useState("");
   const [showNoInviteLinkPopup, setShowNoInviteLinkPopup] = useState(false);
   const [isActivateAutoJoinOpened, setIsActivateAutoJoinOpened] =
     useState(false);
@@ -203,12 +212,27 @@ export default function WorkspaceAdmin({
           plan={plan}
           strategyDetails={enterpriseConnectionStrategyDetails}
         />
+        <div className="flex flex-row gap-2">
+          <Searchbar
+            placeholder="Search members (email)"
+            value={searchTerm}
+            name="search"
+            onChange={(s) => {
+              setSearchTerm(s);
+            }}
+          />
+          <Button
+            label="Invite members"
+            icon={PlusIcon}
+            onClick={onInviteClick}
+          />
+        </div>
+        <InvitationsList owner={owner} searchText={searchTerm} />
         <MembersList
           currentUserId={user.sId}
           owner={owner}
-          onInviteClick={onInviteClick}
+          searchText={searchTerm}
         />
-
         <InviteEmailModal
           showModal={inviteEmailModalOpen}
           onClose={() => {

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -1,39 +1,19 @@
-import {
-  Avatar,
-  Button,
-  Dialog,
-  ElementModal,
-  Page,
-  PlusIcon,
-  Popup,
-  Searchbar,
-} from "@dust-tt/sparkle";
-import type {
-  ActiveRoleType,
-  UserType,
-  UserTypeWithWorkspaces,
-  WorkspaceDomain,
-  WorkspaceType,
-} from "@dust-tt/types";
+import { Button, Dialog, Page, Popup } from "@dust-tt/sparkle";
+import type { UserType, WorkspaceDomain, WorkspaceType } from "@dust-tt/types";
 import type {
   PlanType,
   SubscriptionPerSeatPricing,
   SubscriptionType,
 } from "@dust-tt/types";
-import { isActiveRoleType } from "@dust-tt/types";
 import { UsersIcon } from "@heroicons/react/20/solid";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
-import { useContext, useMemo, useState } from "react";
-import { useSWRConfig } from "swr";
+import React, { useContext, useMemo, useState } from "react";
 
 import type { WorkspaceLimit } from "@app/components/app/ReachedLimitPopup";
 import { ReachedLimitPopup } from "@app/components/app/ReachedLimitPopup";
 import { InviteEmailModal } from "@app/components/members/InvitationModal";
-import { InvitationsList } from "@app/components/members/InvitationsList";
 import { MembersList } from "@app/components/members/MembersList";
-import { ROLES_DATA } from "@app/components/members/Roles";
-import { RoleDropDown } from "@app/components/members/RolesDropDown";
 import { subNavigationAdmin } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
@@ -45,11 +25,9 @@ import {
   checkWorkspaceSeatAvailabilityUsingAuth,
   getWorkspaceVerifiedDomain,
 } from "@app/lib/api/workspace";
-import { handleMembersRoleChange } from "@app/lib/client/members";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { getPerSeatSubscriptionPricing } from "@app/lib/plans/subscription";
-import { useMembers } from "@app/lib/swr/memberships";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   user: UserType;
@@ -112,9 +90,40 @@ export default function WorkspaceAdmin({
   const [showNoInviteLinkPopup, setShowNoInviteLinkPopup] = useState(false);
   const [isActivateAutoJoinOpened, setIsActivateAutoJoinOpened] =
     useState(false);
+  const [inviteEmailModalOpen, setInviteEmailModalOpen] = useState(false);
+  const [inviteBlockedPopupReason, setInviteBlockedPopupReason] =
+    useState<WorkspaceLimit | null>(null);
 
   const { domain = "", domainAutoJoinEnabled = false } =
     workspaceVerifiedDomain ?? {};
+
+  const onInviteClick = () => {
+    if (!isUpgraded(plan)) {
+      setInviteBlockedPopupReason("cant_invite_free_plan");
+    } else if (subscription.paymentFailingSince) {
+      setInviteBlockedPopupReason("cant_invite_payment_failure");
+    } else if (!workspaceHasAvailableSeats) {
+      setInviteBlockedPopupReason("cant_invite_no_seats_available");
+    } else {
+      setInviteEmailModalOpen(true);
+    }
+  };
+
+  const popup = useMemo(() => {
+    if (!inviteBlockedPopupReason) {
+      return <></>;
+    }
+
+    return (
+      <ReachedLimitPopup
+        isOpened={!!inviteBlockedPopupReason}
+        onClose={() => setInviteBlockedPopupReason(null)}
+        subscription={subscription}
+        owner={owner}
+        code={inviteBlockedPopupReason}
+      />
+    );
+  }, [inviteBlockedPopupReason, owner, subscription]);
 
   return (
     <AppLayout
@@ -194,112 +203,25 @@ export default function WorkspaceAdmin({
           plan={plan}
           strategyDetails={enterpriseConnectionStrategyDetails}
         />
-        <MemberList perSeatPricing={perSeatPricing} />
-      </Page.Vertical>
-    </AppLayout>
-  );
-
-  function MemberList({
-    perSeatPricing,
-  }: {
-    perSeatPricing: SubscriptionPerSeatPricing | null;
-  }) {
-    const [inviteBlockedPopupReason, setInviteBlockedPopupReason] =
-      useState<WorkspaceLimit | null>(null);
-
-    const [searchText, setSearchText] = useState("");
-    const { members, isMembersLoading } = useMembers(owner);
-
-    const [inviteEmailModalOpen, setInviteEmailModalOpen] = useState(false);
-
-    const [changeRoleMember, setChangeRoleMember] =
-      useState<UserTypeWithWorkspaces | null>(null);
-
-    const popup = useMemo(() => {
-      if (!inviteBlockedPopupReason) {
-        return <></>;
-      }
-
-      return (
-        <ReachedLimitPopup
-          isOpened={!!inviteBlockedPopupReason}
-          onClose={() => setInviteBlockedPopupReason(null)}
-          subscription={subscription}
+        <MembersList
+          currentUserId={user.sId}
           owner={owner}
-          code={inviteBlockedPopupReason}
+          onInviteClick={onInviteClick}
         />
-      );
-    }, [inviteBlockedPopupReason, setInviteBlockedPopupReason]);
-    return (
-      <>
+
         <InviteEmailModal
           showModal={inviteEmailModalOpen}
           onClose={() => {
             setInviteEmailModalOpen(false);
           }}
           owner={owner}
-          prefillText={searchText}
-          members={members}
+          prefillText={""}
           perSeatPricing={perSeatPricing}
         />
-        <ChangeMemberModal
-          owner={owner}
-          member={changeRoleMember}
-          onClose={() => setChangeRoleMember(null)}
-        />
-        <Page.Vertical gap="sm" align="stretch">
-          <Page.H variant="h5">Member list</Page.H>
-          <div className="flex flex-col items-stretch gap-2 sm:flex-row">
-            <div className="flex-grow">
-              <Searchbar
-                placeholder="Search members"
-                onChange={setSearchText}
-                value={searchText}
-                name={""}
-              />
-            </div>
-            <div className="relative flex-none">
-              <Button
-                variant="primary"
-                label="Invite members"
-                size="sm"
-                icon={PlusIcon}
-                onClick={() => {
-                  if (!isUpgraded(plan)) {
-                    setInviteBlockedPopupReason("cant_invite_free_plan");
-                  } else if (subscription.paymentFailingSince) {
-                    setInviteBlockedPopupReason("cant_invite_payment_failure");
-                  } else if (!workspaceHasAvailableSeats) {
-                    setInviteBlockedPopupReason(
-                      "cant_invite_no_seats_available"
-                    );
-                  } else {
-                    setInviteEmailModalOpen(true);
-                  }
-                }}
-              />
-              {popup}
-            </div>
-          </div>
-          <div className="s-w-full">
-            <div className="space-y-2 pt-4">
-              <InvitationsList owner={owner} searchText={searchText} />
-            </div>
-            <div className="space-y-2 pb-3 pt-4">
-              <Page.H variant="h5">Members</Page.H>
-              <MembersList
-                users={members}
-                currentUserId={user.id}
-                isMembersLoading={isMembersLoading}
-                onClickEvent={(role) => setChangeRoleMember(role)}
-                searchText={searchText}
-              />
-            </div>
-          </div>
-        </Page.Vertical>
-      </>
-    );
-  }
+        {popup}
+      </Page.Vertical>
+    </AppLayout>
+  );
 }
 
 function DomainAutoJoinModal({
@@ -370,124 +292,5 @@ function DomainAutoJoinModal({
     >
       <div>{description}</div>
     </Dialog>
-  );
-}
-
-function ChangeMemberModal({
-  onClose,
-  member,
-  owner,
-}: {
-  onClose: () => void;
-  member: UserTypeWithWorkspaces | null;
-  owner: WorkspaceType;
-}) {
-  const { role = null } = member?.workspaces[0] ?? {};
-
-  const { mutate } = useSWRConfig();
-  const sendNotification = useContext(SendNotificationsContext);
-  const [revokeMemberModalOpen, setRevokeMemberModalOpen] = useState(false);
-  const [selectedRole, setSelectedRole] = useState<ActiveRoleType | null>(
-    role !== "none" ? role : null
-  );
-  const [isSaving, setIsSaving] = useState(false);
-
-  if (!member || !role || !isActiveRoleType(role)) {
-    return null;
-  }
-
-  return (
-    <ElementModal
-      openOnElement={member}
-      onClose={() => {
-        onClose();
-        setSelectedRole(null);
-        setIsSaving(false);
-      }}
-      isSaving={isSaving}
-      hasChanged={selectedRole !== member.workspaces[0].role}
-      title={member.fullName || "Unreachable"}
-      variant="side-sm"
-      onSave={async (closeModalFn: () => void) => {
-        if (!selectedRole) {
-          return;
-        }
-        setIsSaving(true);
-        await handleMembersRoleChange({
-          members: [member],
-          role: selectedRole,
-          sendNotification,
-        });
-        await mutate(`/api/w/${owner.sId}/members`);
-        closeModalFn();
-      }}
-      saveLabel="Update role"
-    >
-      <Page variant="modal">
-        <div className="mt-6 flex flex-col gap-9 text-sm text-element-700">
-          <div className="flex items-center gap-4">
-            <Avatar size="lg" visual={member.image} name={member.fullName} />
-            <div className="flex grow flex-col">
-              <div className="font-semibold text-element-900">
-                {member.fullName}
-              </div>
-              <div className="font-normal">{member.email}</div>
-            </div>
-          </div>
-          <div className="flex flex-col gap-2">
-            <div className="flex items-center gap-2">
-              <div className="font-bold text-element-900">Role:</div>
-              <RoleDropDown
-                selectedRole={selectedRole || role}
-                onChange={setSelectedRole}
-              />
-            </div>
-            <Page.P>
-              The role defines the rights of a member of the workspace.{" "}
-              {ROLES_DATA[role]["description"]}
-            </Page.P>
-          </div>
-          <div className="flex flex-none flex-col gap-2">
-            <div className="flex-none">
-              <Button
-                variant="primaryWarning"
-                label="Revoke member access"
-                size="sm"
-                onClick={() => setRevokeMemberModalOpen(true)}
-              />
-            </div>
-            <Page.P>
-              Deleting a member will remove them from the workspace. They will
-              be able to rejoin if they have an invitation link.
-            </Page.P>
-          </div>
-        </div>
-      </Page>
-      <Dialog
-        isOpen={revokeMemberModalOpen}
-        title="Revoke member access"
-        onValidate={async () => {
-          await handleMembersRoleChange({
-            members: [member],
-            role: "none",
-            sendNotification,
-          });
-          await mutate(`/api/w/${owner.sId}/members`);
-          setRevokeMemberModalOpen(false);
-          onClose();
-        }}
-        validateLabel="Yes, revoke"
-        validateVariant="primaryWarning"
-        onCancel={() => {
-          setRevokeMemberModalOpen(false);
-        }}
-        isSaving={isSaving}
-      >
-        <div>
-          Revoke access for user{" "}
-          <span className="font-bold">{member.fullName}</span>?
-        </div>
-      </Dialog>
-    </ElementModal>
   );
 }


### PR DESCRIPTION
## Description

This PR refactors the workspace members management interface, improving the user experience and performance. It introduces a new search endpoint for members, implements server-side pagination, and updates the UI components to use the latest Sparkle DataTable. The changes aim to streamline the process of managing workspace members, invitations, and roles.


## Risk

Medium. While the changes are significant, they primarily affect the front-end and API interactions for member management.

## Deploy Plan

- Deploy to `front-edge`
- Deploy to `front`