### PR TITLE
Fix member list search not working yet with pagination

### DIFF
--- a/front/pages/api/w/[wId]/members/index.ts
+++ b/front/pages/api/w/[wId]/members/index.ts
@@ -10,7 +10,7 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
-const DEFAULT_PAGE_LIMIT = 50;
+const DEFAULT_PAGE_LIMIT = 1500;
 
 export type GetMembersResponseBody = {
   members: UserTypeWithWorkspaces[];


### PR DESCRIPTION
## Description

Last week pagination was added to the /members endpoint: https://github.com/dust-tt/dust/pull/7206
=> Problem is the searchbar does not work yet with pagination so big workspace could only search in members from the first page. 

This ugly quick fix sets the pagination to 1500.
The PR with the real fix to allow search with pagination is in progress, on @JulesBelveze 's plate. 

## Risk

Load a lot of data but that's what we were doing before. 
This endpoint is currently used only on the admin member list page. 

## Deploy Plan

Deploy front. 
