### PR TITLE
[Poke] Fix broken notion check/find url

### DIFF
--- a/connectors/src/connectors/notion/lib/parents.ts
+++ b/connectors/src/connectors/notion/lib/parents.ts
@@ -31,7 +31,6 @@ async function _getParents(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- used for memoization
   memoizationKey?: string
 ): Promise<string[]> {
-  logger.info({ connectorId, pageOrDbId }, "getParents");
   const parents: string[] = [pageOrDbId];
   const pageOrDb =
     (await getNotionPageFromConnectorsDb(connectorId, pageOrDbId)) ||
@@ -65,7 +64,7 @@ async function _getParents(
           {
             connectorId,
             pageOrDbId,
-            seen,
+            seen: seen.entries(),
             parentId: pageOrDb.parentId,
           },
           "getParents infinite loop"

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -365,7 +365,7 @@ const DataSourcePage = ({
             </>
           )}
           {dataSource.connectorProvider === "notion" && (
-            <NotionUrlCheckOrFind owner={owner} />
+            <NotionUrlCheckOrFind owner={owner} dsId={dataSource.sId} />
           )}
           {dataSource.connectorProvider === "google_drive" && (
             <>
@@ -543,6 +543,7 @@ const DataSourcePage = ({
 async function handleCheckOrFindNotionUrl(
   url: string,
   wId: string,
+  dsId: string,
   command: "check-url" | "find-url"
 ): Promise<NotionCheckUrlResponseType | NotionFindUrlResponseType | null> {
   const res = await fetch(`/api/poke/admin`, {
@@ -556,6 +557,7 @@ async function handleCheckOrFindNotionUrl(
       args: {
         url,
         wId,
+        dsId,
       },
     }),
   });
@@ -605,7 +607,13 @@ async function handleWhitelistBot(
   alert("Bot whitelisted successfully");
 }
 
-function NotionUrlCheckOrFind({ owner }: { owner: WorkspaceType }) {
+function NotionUrlCheckOrFind({
+  owner,
+  dsId,
+}: {
+  owner: WorkspaceType;
+  dsId: string;
+}) {
   const [notionUrl, setNotionUrl] = useState("");
   const [urlDetails, setUrlDetails] = useState<
     NotionCheckUrlResponseType | NotionFindUrlResponseType | null
@@ -635,6 +643,7 @@ function NotionUrlCheckOrFind({ owner }: { owner: WorkspaceType }) {
               await handleCheckOrFindNotionUrl(
                 notionUrl,
                 owner.sId,
+                dsId,
                 "check-url"
               )
             );
@@ -646,7 +655,12 @@ function NotionUrlCheckOrFind({ owner }: { owner: WorkspaceType }) {
           onClick={async () => {
             setCommand("find-url");
             setUrlDetails(
-              await handleCheckOrFindNotionUrl(notionUrl, owner.sId, "find-url")
+              await handleCheckOrFindNotionUrl(
+                notionUrl,
+                owner.sId,
+                dsId,
+                "find-url"
+              )
             );
           }}
         />


### PR DESCRIPTION
Description
---
Notion check/find url was broken since we now require a dsId that was not passed to arguments

Side fix: remove a useless but consuming log, and fixes another to make it more useful

Risks
---
Absolutely not tested locally because it's a pain. But trust me, it's fine :wink:

Deploy
---
Front
Connectors

