### PR TITLE
Fix DatabaseError: operator does not exist: character varying = integer

### DIFF
--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -308,7 +308,7 @@ export class DataSourceResource extends ResourceWithVault<DataSource> {
     await AgentTablesQueryConfigurationTable.destroy({
       where: {
         dataSourceWorkspaceId: auth.getNonNullableWorkspace().sId,
-        dataSourceId: this.id,
+        dataSourceId: this.id.toString(),
       },
     });
 
@@ -317,7 +317,7 @@ export class DataSourceResource extends ResourceWithVault<DataSource> {
     await DataSourceViewModel.destroy({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
-        dataSourceId: this.id.toString(),
+        dataSourceId: this.id,
       },
       transaction,
     });


### PR DESCRIPTION
## Description

I'm doing too many things at the same time and fixed the wrong line on the `DatabaseError: operator does not exist: character varying = integer` error. 

=> ON AgentTablesQueryConfigurationTable, dataSourceId is a string it's not yet a relation. So it needs to be casted to string, and not for the destroy of DataSourceViewModel

## Risk

/

## Deploy Plan

Deploy front
