### PR TITLE
Pagination and width

### DIFF
--- a/front/components/sparkle/AppLayout.tsx
+++ b/front/components/sparkle/AppLayout.tsx
@@ -165,7 +165,7 @@ export default function AppLayout({
             <div
               className={classNames(
                 "flex h-[calc(100%-5rem)] w-full flex-col",
-                isWideMode ? "items-center" : "max-w-4xl px-6"
+                isWideMode ? "items-center" : "max-w-4xl"
               )}
             >
               {loaded && children}

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -76,6 +76,7 @@ export async function getContentNodesForManagedDataSourceView(
   {
     includeChildren,
     internalIds,
+    pagination,
     viewType,
   }: GetContentNodesForDataSourceViewParams
 ): Promise<Result<GetContentNodesForDataSourceViewResult, Error>> {
@@ -118,7 +119,12 @@ export async function getContentNodesForManagedDataSourceView(
     }
 
     return new Ok({
-      nodes: connectorsRes.value.resources,
+      nodes: pagination
+        ? connectorsRes.value.resources.slice(
+            pagination?.offset,
+            pagination?.offset + pagination?.limit
+          )
+        : connectorsRes.value.resources,
       // Connectors API does not support pagination yet, so the total is the length of the nodes.
       total: connectorsRes.value.resources.length,
     });
@@ -136,9 +142,13 @@ export async function getContentNodesForManagedDataSourceView(
         )
       );
     }
-
     return new Ok({
-      nodes: connectorsRes.value.nodes,
+      nodes: pagination
+        ? connectorsRes.value.nodes.slice(
+            pagination?.offset,
+            pagination?.offset + pagination?.limit
+          )
+        : connectorsRes.value.nodes,
       // Connectors API does not support pagination yet, so the total is the length of the nodes.
       total: connectorsRes.value.nodes.length,
     });

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -76,7 +76,7 @@ const paginate = (
   pagination?: OffsetPaginationParams
 ) =>
   pagination
-    ? nodes.slice(pagination?.offset, pagination?.offset + pagination?.limit)
+    ? nodes.slice(pagination.offset, pagination.offset + pagination.limit)
     : nodes;
 
 export async function getContentNodesForManagedDataSourceView(

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -71,6 +71,14 @@ interface GetContentNodesForDataSourceViewResult {
   total: number;
 }
 
+const paginate = (
+  nodes: DataSourceViewContentNode[],
+  pagination?: OffsetPaginationParams
+) =>
+  pagination
+    ? nodes.slice(pagination?.offset, pagination?.offset + pagination?.limit)
+    : nodes;
+
 export async function getContentNodesForManagedDataSourceView(
   dataSourceView: DataSourceViewResource | DataSourceViewType,
   {
@@ -119,12 +127,7 @@ export async function getContentNodesForManagedDataSourceView(
     }
 
     return new Ok({
-      nodes: pagination
-        ? connectorsRes.value.resources.slice(
-            pagination?.offset,
-            pagination?.offset + pagination?.limit
-          )
-        : connectorsRes.value.resources,
+      nodes: paginate(connectorsRes.value.resources, pagination),
       // Connectors API does not support pagination yet, so the total is the length of the nodes.
       total: connectorsRes.value.resources.length,
     });
@@ -143,12 +146,7 @@ export async function getContentNodesForManagedDataSourceView(
       );
     }
     return new Ok({
-      nodes: pagination
-        ? connectorsRes.value.nodes.slice(
-            pagination?.offset,
-            pagination?.offset + pagination?.limit
-          )
-        : connectorsRes.value.nodes,
+      nodes: paginate(connectorsRes.value.nodes, pagination),
       // Connectors API does not support pagination yet, so the total is the length of the nodes.
       total: connectorsRes.value.nodes.length,
     });


### PR DESCRIPTION
## Description

2 different fixes related to tables : 
- pagination for content-nodes : even if not supported by connectors, we expect the result to handle offset/limit. This has a side-effect on tables - table switches to client-side pagination, as it sees the total matches the number of nodes, but it reset pagination every time we try to switch page, because it sees a different rows array. even if the nodes inside are the same, the array is different, and tanstack tables auto reset pagination when the rows are changed and pagination is client side.
- remove the padding inside AppLayout  - in wide mode appLayout width is set to max-w-4xl , and the same class is used in many places in components used inside, as we expect the available size to be max-w-4xl - which is not the case if we have a padding, and make the components sometime overflow the applayout size. Visible in tables where the text is too long


Visible in https://dust.tt/w/0ec9852c2f/vaults/vlt_z2c3w2KRm0Oy/categories/managed/data_source_views/dsv_SmIOsM1AqQum?parentId=0ALcjGNU347hKUk9PVA#?tablePageIndex=1&tablePageSize=25

## Risk

was AppLayout padding used ?

## Deploy Plan

deploy `front`