### PR TITLE
[Notion] Fix cases of getParents infinite loop

### DIFF
--- a/connectors/migrations/20240802_table_parents.ts
+++ b/connectors/migrations/20240802_table_parents.ts
@@ -170,7 +170,7 @@ export async function notionTables(
     const parents = await getNotionParents(
       connectorId as number,
       notionDatabaseId as string,
-      new Set<string>(),
+      [],
       memo
     );
 

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -604,12 +604,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
     const memo = memoizationKey || uuidv4();
 
     try {
-      const parents = await getParents(
-        this.connectorId,
-        internalId,
-        new Set<string>(),
-        memo
-      );
+      const parents = await getParents(this.connectorId, internalId, [], memo);
 
       return new Ok(parents);
     } catch (e) {

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1792,7 +1792,7 @@ export async function renderAndUpsertPageFromCache({
         const parents = await getParents(
           connector.id,
           parentDb.notionDatabaseId,
-          new Set<string>(),
+          [],
           runTimestamp.toString()
         );
 
@@ -1980,7 +1980,7 @@ export async function renderAndUpsertPageFromCache({
     const parents = await getParents(
       connectorId,
       pageId,
-      new Set<string>(),
+      [],
       runTimestamp.toString()
     );
 
@@ -2449,7 +2449,7 @@ export async function upsertDatabaseStructuredDataFromCache({
   const parents = await getParents(
     connector.id,
     databaseId,
-    new Set<string>(),
+    [],
     runTimestamp.toString()
   );
 


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/1252

When we get into an infinite loop, we now return a best-effort parent set rather than breaking.

Details here: https://github.com/dust-tt/tasks/issues/1252#issuecomment-2346475582

Note: turns `seen` from a set to an array, to preserve parents order. This is fine from a complexity pov since while set inclusion is O(1) for large sets, the small number here (most likely 1 to 20 elements max) makes arrays at least as efficient

Risks
---
A bit less aware of some pages that become less available in notion. IMO fine because:
1- very edgy case, currently 3 times a year
2- that solves itself in many cases
3- we still have the log

Deploy
---
Connectors
