### PR TITLE
Upg: use redis to store data between gc activities and workflow

### DIFF
--- a/connectors/src/connectors/notion/temporal/config.ts
+++ b/connectors/src/connectors/notion/temporal/config.ts
@@ -1,2 +1,2 @@
-export const WORKFLOW_VERSION = 38;
+export const WORKFLOW_VERSION = 39;
 export const QUEUE_NAME = `notion-queue-v${WORKFLOW_VERSION}`;


### PR DESCRIPTION
## Description

Activities results have a size limit, let's use Redis to store the data :)

## Risk

Break notion gc

## Deploy Plan

Deploy `connectors`, restart all notion workers.