### PR TITLE
feat: store dust app vaults group IDs on agents

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -727,8 +727,7 @@ export async function createAgentConfiguration(
     model,
     agentConfigurationId,
     templateId,
-    // datasource view ids used by the agent, to be used for permissions check
-    dataSourceViewIds,
+    groupIds,
   }: {
     name: string;
     description: string;
@@ -741,7 +740,7 @@ export async function createAgentConfiguration(
     model: AgentModelConfigurationType;
     agentConfigurationId?: string;
     templateId: string | null;
-    dataSourceViewIds: string[];
+    groupIds: number[];
   }
 ): Promise<Result<LightAgentConfigurationType, Error>> {
   const owner = auth.workspace();
@@ -766,12 +765,6 @@ export async function createAgentConfiguration(
 
   let version = 0;
   let listStatusOverride: AgentUserListStatus | null = null;
-
-  const groupIds = (
-    await DataSourceViewResource.fetchByIds(auth, dataSourceViewIds)
-  )
-    .map((view) => view.acl().aclEntries.map((entry) => entry.groupId))
-    .flat();
 
   try {
     let template: TemplateResource | null = null;

--- a/front/migrations/20240912_backfill_agent_group_ids_dust_apps.ts
+++ b/front/migrations/20240912_backfill_agent_group_ids_dust_apps.ts
@@ -1,0 +1,73 @@
+import { groupBy, keyBy, mapValues, uniq } from "lodash";
+
+import { AgentDustAppRunConfiguration } from "@app/lib/models/assistant/actions/dust_app_run";
+import { AgentConfiguration } from "@app/lib/models/assistant/agent";
+import { App } from "@app/lib/resources/storage/models/apps";
+import { GroupVaultModel } from "@app/lib/resources/storage/models/group_vaults";
+import { VaultModel } from "@app/lib/resources/storage/models/vaults";
+import { makeScript } from "@app/scripts/helpers";
+
+makeScript({}, async ({ execute }, logger) => {
+  const allDustAppRunConfigs = await AgentDustAppRunConfiguration.findAll();
+  const allDustAppModels = await App.findAll({
+    where: {
+      sId: allDustAppRunConfigs.map((config) => config.appId),
+    },
+  });
+  const allDustAppVaults = await VaultModel.findAll({
+    where: {
+      id: allDustAppModels.map((app) => app.vaultId),
+    },
+  });
+  const groupVaults = await GroupVaultModel.findAll({
+    where: {
+      vaultId: allDustAppVaults.map((vault) => vault.id),
+    },
+  });
+  const groupIdsByVaultId = mapValues(
+    groupBy(groupVaults, "vaultId"),
+    (groupVaults) => groupVaults.map((groupVault) => groupVault.groupId).flat()
+  );
+  const dustAppIdsByAgentConfigId = mapValues(
+    groupBy(allDustAppRunConfigs, "agentConfigurationId"),
+    (configs) => configs.map((config) => config.appId)
+  );
+  const appByDustAppId = keyBy(allDustAppModels, "sId");
+
+  const affectedAgents = await AgentConfiguration.findAll({
+    where: {
+      id: allDustAppRunConfigs.map((config) => config.agentConfigurationId),
+    },
+  });
+
+  for (const agent of affectedAgents) {
+    const dustAppIds = dustAppIdsByAgentConfigId[agent.id];
+    const vaultIds = uniq(
+      dustAppIds.map((dustAppId) => appByDustAppId[dustAppId].vaultId)
+    );
+    const groupIds = uniq([
+      ...vaultIds.map((vaultId) => groupIdsByVaultId[vaultId]).flat(),
+      ...agent.groupIds,
+    ]);
+    const newGroupIds = groupIds.filter(
+      (groupId) => !agent.groupIds.includes(groupId)
+    );
+
+    if (newGroupIds.length) {
+      console.log(
+        !execute ? "[DRY RUN] " : "",
+        `Backfilling agent ${agent.sId} with new group ids: ${newGroupIds.join(", ")}`
+      );
+
+      if (execute) {
+        logger.info(
+          { agentId: agent.sId, newGroupIds, prevGroupIds: agent.groupIds },
+          `Backfilling agent group IDs`
+        );
+        await agent.update({
+          groupIds,
+        });
+      }
+    }
+  }
+});

--- a/front/migrations/20240912_backfill_agent_group_ids_dust_apps.ts
+++ b/front/migrations/20240912_backfill_agent_group_ids_dust_apps.ts
@@ -26,7 +26,7 @@ makeScript({}, async ({ execute }, logger) => {
   });
   const groupIdsByVaultId = mapValues(
     groupBy(groupVaults, "vaultId"),
-    (groupVaults) => groupVaults.map((groupVault) => groupVault.groupId).flat()
+    (groupVaults) => groupVaults.map((groupVault) => groupVault.groupId)
   );
   const dustAppIdsByAgentConfigId = mapValues(
     groupBy(allDustAppRunConfigs, "agentConfigurationId"),
@@ -36,7 +36,9 @@ makeScript({}, async ({ execute }, logger) => {
 
   const affectedAgents = await AgentConfiguration.findAll({
     where: {
-      id: allDustAppRunConfigs.map((config) => config.agentConfigurationId),
+      id: uniq(
+        allDustAppRunConfigs.map((config) => config.agentConfigurationId)
+      ),
     },
   });
 


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/dust/issues/7324

When an agent config has dust app actions, we need to add the group ids from the dust apps' vaults on the agent config.

Currently we block using more than one vault on an agent, so I believe we don't need the backfill. Still including a backfill script, in case we have a few.

## Risk

N/A

## Deploy Plan

Deploy then run backfill (although it's likely useless)