### PR TITLE
Fix 500 webcrawler

### DIFF
--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -149,7 +149,14 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
         },
       });
       if (!parent) {
-        return new Err(new Error("Parent not found"));
+        logger.error(
+          {
+            connectorId: connector.id,
+            parentInternalId,
+          },
+          "Webcrawler: Parent not found"
+        );
+        return new Ok([]);
       }
       parentUrl = parent.url;
     }


### PR DESCRIPTION
## Description

Issue: https://github.com/dust-tt/tasks/issues/1314
Webcrawler fails when a parent is not found, we could return empty nodes instead (seems that what we do for other connectors)

## Risk

Can be rolled back. 

## Deploy Plan

Deploy connector. 
