### PR TITLE
Do not raise on server-side-props-helper to prevent 500 on Assistant Builder

### DIFF
--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -34,6 +34,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { VaultResource } from "@app/lib/resources/vault_resource";
+import logger from "@app/logger/logger";
 
 export const getAccessibleSourcesAndApps = async (auth: Authenticator) => {
   const accessibleVaults = (
@@ -280,7 +281,20 @@ async function renderTableDataSourcesConfigurations(
         );
 
         if (contentNodesRes.isErr()) {
-          throw contentNodesRes.error;
+          logger.error(
+            {
+              error: contentNodesRes.error,
+              workspaceId: dataSourceView.workspaceId,
+              dataSourceViewId: sr.dataSourceViewId,
+              internalIds: sr.resources,
+            },
+            `Assistant Builder: Error fetching content nodes.`
+          );
+          return {
+            dataSourceView: serializedDataSourceView,
+            selectedResources: [],
+            isSelectAll: sr.isSelectAll,
+          };
         }
 
         return {


### PR DESCRIPTION
## Description

We don't want to raise on the assistant builder `front/components/assistant_builder/server_side_props_helpers.ts` when connector answers with an error trying to fetch data source content nodes, since this puts the Builder in 500. 

We log an error instead. 

## Risk



## Deploy Plan

Deploy front. 
