### PR TITLE
[Poke] Fix: auth issue in invitations endpoint

### DIFF
--- a/front/pages/api/poke/workspaces/[wId]/invitations.ts
+++ b/front/pages/api/poke/workspaces/[wId]/invitations.ts
@@ -157,7 +157,7 @@ async function handler(
         });
       }
 
-      await updateInvitationStatusAndRole(auth, {
+      await updateInvitationStatusAndRole(workspaceAdminAuth, {
         invitation,
         status: "revoked",
         role: invitation.initialRole,


### PR DESCRIPTION
Description
---
Follows #7352 . Fixes `Unhandled internal server error: Error: Unauthorized attempt to update invitation status.`

(wrong auth object passed to update function)

Risks
---
na

Deploy
---
front
