### PR TITLE
fix: bring back notion workers max-old-space-size to original value

### DIFF
--- a/k8s/configmaps/connectors-worker-specific-configmap.yaml
+++ b/k8s/configmaps/connectors-worker-specific-configmap.yaml
@@ -5,7 +5,7 @@ metadata:
 data:
   DD_ENV: "prod"
   DD_SERVICE: "connectors-worker"
-  NODE_OPTIONS: "-r dd-trace/init --max-old-space-size=3000"
+  NODE_OPTIONS: "-r dd-trace/init --max-old-space-size=3276"
   DD_LOGS_INJECTION: "true"
   DD_RUNTIME_METRICS_ENABLED: "true"
   NODE_ENV: "production"


### PR DESCRIPTION
## Description

This value was reduced 2 days ago. We've seen some `FATAL ERROR: Ineffective mark-compacts near heap limit` since then

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
