### PR TITLE
Don't crash website list page

### DIFF
--- a/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
@@ -37,7 +37,7 @@ import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import logger from "@app/logger/logger";
 
 type DataSourceWithConnector = DataSourceType & {
-  connector: ConnectorType;
+  connector: ConnectorType | null;
 };
 
 type Info = {
@@ -108,7 +108,11 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
         },
         "Connector not found"
       );
-      throw new Error("Connector not found");
+      // Not super clean but at least we don't crash the page.
+      return {
+        ...ds,
+        connector: null,
+      };
     }
     return {
       ...ds,


### PR DESCRIPTION
## Description

Websites deleted yesterday afternoon were only partially deleted because of an error in the data source delete code (will provide links).

This means we still have the data source in local but nothing left on connectors. 
This results in us throwing and displaying a raw 500 on the website list. 

We will need to properly manually delete those dangling data sources but immediate fix is to not display a 500. 
With this the errored website is displayed as a Folder and can be delete. 


## Risk

/

## Deploy Plan

Deploy front. 
