### PR TITLE
[front] - refactor: make description folder optional

### DIFF
--- a/front/components/vaults/VaultFolderModal.tsx
+++ b/front/components/vaults/VaultFolderModal.tsx
@@ -57,10 +57,8 @@ export default function VaultFolderModal({
 
   const [errors, setErrors] = useState<{
     name: string | null;
-    description: string | null;
   }>({
     name: null,
-    description: null,
   });
 
   useEffect(() => {
@@ -138,7 +136,6 @@ export default function VaultFolderModal({
 
   const onSave = async () => {
     let nameError: string | null = null;
-    let descriptionError: string | null = null;
 
     if (!name) {
       nameError = "Name is required.";
@@ -151,14 +148,9 @@ export default function VaultFolderModal({
       nameError = "A data source with this name already exists.";
     }
 
-    if (!description || description.trim() === "") {
-      descriptionError = "Description is required.";
-    }
-
-    if (nameError || descriptionError) {
+    if (nameError) {
       setErrors({
         name: nameError,
-        description: descriptionError,
       });
       return;
     }

--- a/front/components/vaults/VaultFolderModal.tsx
+++ b/front/components/vaults/VaultFolderModal.tsx
@@ -55,11 +55,7 @@ export default function VaultFolderModal({
 
   const [showDeleteConfirmDialog, setShowDeleteConfirmDialog] = useState(false);
 
-  const [errors, setErrors] = useState<{
-    name: string | null;
-  }>({
-    name: null,
-  });
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     setName(folder ? folder.name : null);
@@ -149,9 +145,7 @@ export default function VaultFolderModal({
     }
 
     if (nameError) {
-      setErrors({
-        name: nameError,
-      });
+      setError(nameError);
       return;
     }
 
@@ -226,11 +220,8 @@ export default function VaultFolderModal({
                 value={name}
                 onChange={(value) => {
                   setName(value);
-                  if (errors.name) {
-                    setErrors({ ...errors, name: null });
-                  }
                 }}
-                error={errors.name}
+                error={error}
                 disabled={folder !== null} // We cannot change the name of a datasource
                 showErrorLabel
               />
@@ -250,11 +241,7 @@ export default function VaultFolderModal({
                 value={description}
                 onChange={(value) => {
                   setDescription(value);
-                  if (errors.description) {
-                    setErrors({ ...errors, description: null });
-                  }
                 }}
-                error={errors.description}
                 showErrorLabel
                 minRows={2}
               />

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/index.ts
@@ -67,7 +67,7 @@ export function getConnectorProviderCodec(): t.Mixed {
 
 const PostDataSourceWithoutProviderRequestBodySchema = t.type({
   name: t.string,
-  description: t.string,
+  description: t.union([t.string, t.null]),
 });
 
 const PostDataSourceRequestBodySchema = t.union([


### PR DESCRIPTION
## Description

This PR aims at making the "description" field of a folder optional. This is iso with what we currently have.

**References:**
 - https://github.com/dust-tt/dust/issues/7362

## Risk

Low

## Deploy Plan

Deploy `front`
