### PR TITLE
[front] - fix(dsv): hide facets on empty folders 

### DIFF
--- a/front/components/vaults/VaultDataSourceViewContentList.tsx
+++ b/front/components/vaults/VaultDataSourceViewContentList.tsx
@@ -277,27 +277,29 @@ export const VaultDataSourceViewContentList = ({
         )}
         {isFolder(dataSourceView.dataSource) && (
           <>
-            <DropdownMenu>
-              <DropdownMenu.Button>
-                <Button
-                  size="sm"
-                  label={viewType === "documents" ? "Documents" : "Tables"}
-                  variant="secondary"
-                  type="menu"
-                />
-              </DropdownMenu.Button>
+            {rows.length > 0 && (
+              <DropdownMenu>
+                <DropdownMenu.Button>
+                  <Button
+                    size="sm"
+                    label={viewType === "documents" ? "Documents" : "Tables"}
+                    variant="secondary"
+                    type="menu"
+                  />
+                </DropdownMenu.Button>
 
-              <DropdownMenu.Items>
-                <DropdownMenu.Item
-                  label="Documents"
-                  onClick={() => handleViewTypeChange("documents")}
-                />
-                <DropdownMenu.Item
-                  label="Tables"
-                  onClick={() => handleViewTypeChange("tables")}
-                />
-              </DropdownMenu.Items>
-            </DropdownMenu>
+                <DropdownMenu.Items>
+                  <DropdownMenu.Item
+                    label="Documents"
+                    onClick={() => handleViewTypeChange("documents")}
+                  />
+                  <DropdownMenu.Item
+                    label="Tables"
+                    onClick={() => handleViewTypeChange("tables")}
+                  />
+                </DropdownMenu.Items>
+              </DropdownMenu>
+            )}
             <FoldersHeaderMenu
               owner={owner}
               vault={vault}


### PR DESCRIPTION
## Description

This PR aims at hiding the facets dropdown when the folder is empty.

Before:
![Screenshot 2024-09-13 at 11 46 58](https://github.com/user-attachments/assets/146f8575-496e-4627-8e69-17b6e710a1c2)

After:
![Screenshot 2024-09-13 at 12 20 17](https://github.com/user-attachments/assets/37630d62-5c9f-499c-90ed-4e84b25f11ee)

**References:**
- https://github.com/dust-tt/tasks/issues/1319

## Risk

None

## Deploy Plan

Deploy `front`