### PR TITLE
[front] chore: Move connection management when private vault is not available

### DIFF
--- a/front/components/vaults/VaultSideBarMenu.tsx
+++ b/front/components/vaults/VaultSideBarMenu.tsx
@@ -15,6 +15,7 @@ import type {
   LightWorkspaceType,
   VaultKind,
   VaultType,
+  WorkspaceType,
 } from "@dust-tt/types";
 import { assertNever, DATA_SOURCE_VIEW_CATEGORIES } from "@dust-tt/types";
 import { groupBy, uniqBy } from "lodash";
@@ -35,7 +36,7 @@ import { getVaultIcon, getVaultName } from "@app/lib/vaults";
 
 interface VaultSideBarMenuProps {
   isPrivateVaultsEnabled: boolean;
-  owner: LightWorkspaceType;
+  owner: WorkspaceType;
   isAdmin: boolean;
   setShowVaultCreationModal: (show: boolean) => void;
 }
@@ -87,6 +88,24 @@ export default function VaultSideBarMenu({
 
   if (isVaultsAsAdminLoading || isVaultsAsUserLoading || !vaultsAsUser) {
     return <></>;
+  }
+
+  if (!owner.flags.includes("private_data_vaults_feature")) {
+    return (
+      <div className="flex h-0 min-h-full w-full overflow-y-auto">
+        <div className="flex w-full flex-col px-2 pt-4">
+          <Item.List>
+            <div>
+              {renderVaultItems(
+                vaults.filter((v) => v.kind === "global"),
+                vaultsAsUser,
+                owner
+              )}
+            </div>
+          </Item.List>
+        </div>
+      </div>
+    );
   }
 
   // Group by kind and sort.


### PR DESCRIPTION
fixes : https://github.com/dust-tt/dust/issues/7358

## Description

Enable connection management in company data / connected data when private vaults feature is not enabled. Also remove unused information from sidebar menu.

<img width="1345" alt="Screenshot 2024-09-13 at 15 19 49" src="https://github.com/user-attachments/assets/cb5da91f-b47e-4fda-ab2d-bf5b56763bd0">
<img width="1345" alt="Screenshot 2024-09-13 at 15 19 56" src="https://github.com/user-attachments/assets/0e0ee4e1-1bc4-4bf7-8725-901fa939e3ad">
<img width="1375" alt="Screenshot 2024-09-13 at 15 20 32" src="https://github.com/user-attachments/assets/a1df855a-3d70-4fe8-b139-e06647ac0cfa">
<img width="1362" alt="Screenshot 2024-09-13 at 15 20 41" src="https://github.com/user-attachments/assets/f7d76d1d-7468-4ca1-823e-af02902dba21">
<img width="1370" alt="Screenshot 2024-09-13 at 15 21 06" src="https://github.com/user-attachments/assets/27568cd7-bdc7-45e4-b881-c5fe2a9eb9dd">




## Risk

Only affects UI if "vault" is enabled and "private vault" disabled

## Deploy Plan

deploy front
