### PR TITLE
fix: don't backfill groups on draft agents

### DIFF
--- a/front/migrations/20240912_backfill_agent_group_ids_dust_apps.ts
+++ b/front/migrations/20240912_backfill_agent_group_ids_dust_apps.ts
@@ -1,4 +1,5 @@
 import { groupBy, keyBy, mapValues, uniq } from "lodash";
+import { Op } from "sequelize";
 
 import { AgentDustAppRunConfiguration } from "@app/lib/models/assistant/actions/dust_app_run";
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
@@ -39,6 +40,9 @@ makeScript({}, async ({ execute }, logger) => {
       id: uniq(
         allDustAppRunConfigs.map((config) => config.agentConfigurationId)
       ),
+      status: {
+        [Op.not]: "draft",
+      },
     },
   });
 


### PR DESCRIPTION
## Description

We have never backfilled group ids on draft assistants so better not do it here.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
