### PR TITLE
enh: change notion sync worker configs

### DIFF
--- a/connectors/src/connectors/notion/temporal/worker.ts
+++ b/connectors/src/connectors/notion/temporal/worker.ts
@@ -20,7 +20,7 @@ export async function runNotionWorker() {
     connection,
     reuseV8Context: true,
     namespace,
-    maxConcurrentActivityTaskExecutions: 8,
+    maxConcurrentActivityTaskExecutions: 16,
     maxCachedWorkflows: 200,
     interceptors: {
       activityInbound: [
@@ -44,7 +44,7 @@ export async function runNotionGarbageCollectWorker() {
     connection,
     reuseV8Context: true,
     namespace,
-    maxConcurrentActivityTaskExecutions: 8,
+    maxConcurrentActivityTaskExecutions: 3,
     maxCachedWorkflows: 200,
     interceptors: {
       activityInbound: [

--- a/k8s/deployments/connectors-worker-notion-gc-deployment.yaml
+++ b/k8s/deployments/connectors-worker-notion-gc-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: connectors-worker-notion-gc-deployment
 spec:
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
       app: connectors-worker


### PR DESCRIPTION
## Description

- reduce number of notion GC workers (3 -> 2)
- reduce concurrent activities per GC worker (8 -> 3)
- increase concurrent activities per notion sync worker (8 -> 16)

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
