### PR TITLE
[Login] Fix invitation failure when emails are lowercase/uppercase

### DIFF
--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -47,7 +47,7 @@ async function handleMembershipInvite(
     AuthFlowError | SSOEnforcedError
   >
 > {
-  if (membershipInvite.inviteEmail !== user.email) {
+  if (membershipInvite.inviteEmail.toLowerCase() !== user.email.toLowerCase()) {
     return new Err(
       new AuthFlowError(
         "invitation_token_email_mismatch",


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/1260

Some emails are stored with some uppercase chars in our DB, which is legit as user entry; while the invitation email may have been entered without uppercase, and vice versa.

When using invitation link with email with different case than session-provided email, we get the failure described in the issue

Risks
---
na

Deploy
---
front
