### PR TITLE
[front] fix: Remove breadcrumb at system root level

### DIFF
--- a/front/components/vaults/VaultLayout.tsx
+++ b/front/components/vaults/VaultLayout.tsx
@@ -137,6 +137,10 @@ function VaultBreadCrumbs({
     ];
 
     if (vault.kind === "system") {
+      if (!dataSourceView) {
+        return [];
+      }
+
       // For system vault, we don't want the first breadcrumb to show, since
       // it's only used to manage "connected data" already. Otherwise it would
       // expose a useless link, and name would be redundant with the "Connected

--- a/front/pages/w/[wId]/vaults/[vaultId]/categories/[category]/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/categories/[category]/index.tsx
@@ -1,4 +1,4 @@
-import { Page } from "@dust-tt/sparkle";
+import { CloudArrowLeftRightIcon, Page } from "@dust-tt/sparkle";
 import type {
   DataSourceViewCategory,
   PlanType,
@@ -80,6 +80,12 @@ export default function Vault({
   const router = useRouter();
   return (
     <Page.Vertical gap="xl" align="stretch">
+      {vault.kind === "system" && (
+        <Page.Header
+          title={"Connection Management"}
+          icon={CloudArrowLeftRightIcon}
+        />
+      )}
       {category === "apps" ? (
         <VaultAppsList
           owner={owner}


### PR DESCRIPTION
fixes: https://github.com/dust-tt/dust/issues/7359

## Description

Disabled breadrumb in connection management root level. Use page title instead.

<img width="905" alt="Screenshot 2024-09-13 at 17 18 11" src="https://github.com/user-attachments/assets/ac811f65-2056-46df-8997-0f8ddcf728a7">


## Risk

none

## Deploy Plan

deploy front
