### PR TITLE
[front] fix: Hide builder tab

### DIFF
--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -122,7 +122,7 @@ export const getTopNavigationTabs = (owner: WorkspaceType) => {
       ].includes(currentRoute),
   });
 
-  if (isBuilder(owner)) {
+  if (isBuilder(owner) && !owner.flags.includes("data_vaults_feature")) {
     nav.push({
       id: "assistants",
       label: "Build",


### PR DESCRIPTION
fixes: https://github.com/dust-tt/dust/issues/7356

## Description

Hide builder tab if new connection management ui is enabled

## Risk

none

## Deploy Plan


deploy front