### PR TITLE
Add: dropdown menu in assistant browser

### DIFF
--- a/front/components/assistant/AssistantBrowser.tsx
+++ b/front/components/assistant/AssistantBrowser.tsx
@@ -217,6 +217,7 @@ export function AssistantBrowser({
               onClick={() => handleAssistantClick(agent)}
               actionElement={
                 <>
+                  {/* TODO: get rid of the ugly hack */}
                   {/* Theses 2 divs are an ugly hack to align the button while making the dropdown menu visible above the container, it has the size of the button hardcoded -- Let's fix it asap */}
                   <div style={{ width: "56px" }}></div>{" "}
                   <div className="absolute">

--- a/front/components/assistant/AssistantBrowser.tsx
+++ b/front/components/assistant/AssistantBrowser.tsx
@@ -17,10 +17,11 @@ import type {
   WorkspaceType,
 } from "@dust-tt/types";
 import Link from "next/link";
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import type { KeyedMutator } from "swr";
 
 import { AssistantDetails } from "@app/components/assistant/AssistantDetails";
+import { AssistantDetailsDropdownMenu } from "@app/components/assistant/AssistantDetailsDropdownMenu";
 import { subFilter } from "@app/lib/utils";
 import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 
@@ -93,9 +94,24 @@ export function AssistantBrowser({
   const visibleTabs = useMemo(() => {
     return ALL_AGENTS_TABS.filter((tab) => agentsByTab[tab.id].length > 0);
   }, [agentsByTab]);
-  const [selectedTab, setSelectedTab] = useState<TabId | null>(
-    visibleTabs[0]?.id || null
-  );
+
+  // check the query string for the tab to show, the query param to look for is called "defaultTab"
+  // if it's not found, show the first tab with agents
+  const defaultTab = useMemo(() => {
+    const queryParams = new URLSearchParams(window.location.search);
+    const defaultTab = queryParams.get("defaultTab") as TabId | null;
+    return visibleTabs.find((tab) => tab.id === defaultTab)
+      ? defaultTab
+      : visibleTabs[0]?.id;
+  }, [visibleTabs]);
+
+  const [selectedTab, setSelectedTab] = useState<TabId | null>(defaultTab);
+
+  useEffect(() => {
+    if (!selectedTab && defaultTab) {
+      setSelectedTab(defaultTab);
+    }
+  }, [defaultTab, selectedTab]);
 
   const displayedTab =
     assistantSearch.trim() !== "" // If search is active, show all agents
@@ -189,7 +205,7 @@ export function AssistantBrowser({
       )}
 
       {displayedTab && (
-        <div className="grid w-full grid-cols-1 gap-2 px-4 md:grid-cols-3">
+        <div className="relative grid w-full grid-cols-1 gap-2 px-4 md:grid-cols-3">
           {agentsByTab[displayedTab].map((agent) => (
             <AssistantPreview
               key={agent.sId}
@@ -199,7 +215,23 @@ export function AssistantBrowser({
               description={agent.description}
               variant="minimal"
               onClick={() => handleAssistantClick(agent)}
-              onActionClick={() => setAssistantIdToShow(agent.sId)}
+              actionElement={
+                <>
+                  {/* Theses 2 divs are an ugly hack to align the button while making the dropdown menu visible above the container, it has the size of the button hardcoded -- Let's fix it asap */}
+                  <div style={{ width: "56px" }}></div>{" "}
+                  <div className="absolute">
+                    <AssistantDetailsDropdownMenu
+                      agentConfigurationId={agent.sId}
+                      owner={owner}
+                      variant="button"
+                      showAssistantDetails={() =>
+                        setAssistantIdToShow(agent.sId)
+                      }
+                      canDelete
+                    />
+                  </div>
+                </>
+              }
             />
           ))}
         </div>

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -178,10 +178,7 @@ export function AssistantDetails({
               agentConfigurationId={agentConfiguration.sId}
               owner={owner}
               variant="button"
-              onAgentDeletion={() => {
-                void mutateCurrentAgentConfiguration();
-                void mutateAgentConfigurations?.();
-              }}
+              canDelete
             />
           </div>
         )}

--- a/front/components/assistant/AssistantDetailsDropdownMenu.tsx
+++ b/front/components/assistant/AssistantDetailsDropdownMenu.tsx
@@ -57,11 +57,11 @@ export function AssistantDetailsDropdownMenu({
   const [showDeletionModal, setShowDeletionModal] =
     useState<LightAgentConfigurationType | null>(null);
 
-  if (!agentConfiguration || !user) {
-    return <></>;
-  }
-
-  if (agentConfiguration.status === "archived") {
+  if (
+    !agentConfiguration ||
+    agentConfiguration.status === "archived" ||
+    !user
+  ) {
     return <></>;
   }
 
@@ -143,6 +143,7 @@ export function AssistantDetailsDropdownMenu({
         {({ close }) => (
           <>
             <DropdownMenu.Button>{dropdownButton}</DropdownMenu.Button>
+            {/* TODO: get rid of the hardcoded value */}
             <DropdownMenu.Items width={230}>
               <DropdownMenu.Item
                 label="Start new conversation"

--- a/front/components/assistant/AssistantDetailsDropdownMenu.tsx
+++ b/front/components/assistant/AssistantDetailsDropdownMenu.tsx
@@ -3,6 +3,7 @@ import {
   ChatBubbleBottomCenterTextIcon,
   ClipboardIcon,
   DropdownMenu,
+  EyeIcon,
   Icon,
   ListAddIcon,
   ListRemoveIcon,
@@ -28,7 +29,8 @@ interface AssistantDetailsDropdownMenuProps {
   agentConfigurationId: string;
   owner: WorkspaceType;
   variant?: "button" | "plain";
-  onAgentDeletion?: () => void;
+  canDelete?: boolean;
+  showAssistantDetails?: () => void;
   showAddRemoveToList?: boolean;
 }
 
@@ -39,7 +41,8 @@ export function AssistantDetailsDropdownMenu({
   agentConfigurationId,
   owner,
   variant = "plain",
-  onAgentDeletion,
+  canDelete,
+  showAssistantDetails,
   showAddRemoveToList = false,
 }: AssistantDetailsDropdownMenuProps) {
   const [isUpdatingList, setIsUpdatingList] = useState(false);
@@ -67,7 +70,7 @@ export function AssistantDetailsDropdownMenu({
   const isGlobalAgent = agentConfiguration.scope === "global";
 
   const isInList = agentConfiguration.userListStatus === "in-list";
-  const canDelete = onAgentDeletion && (isBuilder(owner) || !isAgentWorkspace);
+  const allowDeletion = canDelete && (isBuilder(owner) || !isAgentWorkspace);
 
   const updateAgentUserList = async (listStatus: AgentUserListStatus) => {
     setIsUpdatingList(true);
@@ -126,81 +129,109 @@ export function AssistantDetailsDropdownMenu({
 
   return (
     <>
-      {canDelete && showDeletionModal && (
+      {allowDeletion && showDeletionModal && (
         <DeleteAssistantDialog
           owner={owner}
-          agentConfigurationId={showDeletionModal.sId}
+          agentConfiguration={showDeletionModal}
           show={!!showDeletionModal}
           onClose={() => setShowDeletionModal(null)}
-          onDelete={onAgentDeletion}
           isPrivateAssistant={showDeletionModal.scope === "private"}
         />
       )}
 
       <DropdownMenu className="text-element-700">
-        <DropdownMenu.Button>{dropdownButton}</DropdownMenu.Button>
-        <DropdownMenu.Items width={220}>
-          <DropdownMenu.Item
-            label="Start conversation"
-            link={{
-              href: `/w/${owner.sId}/assistant/new?assistant=${agentConfiguration.sId}`,
-            }}
-            icon={ChatBubbleBottomCenterTextIcon}
-          />
-          {!isGlobalAgent && (
-            <>
-              <DropdownMenu.SectionHeader label="Edition" />
-
-              {/* Should use the router to have a better navigation experience */}
-              {(isBuilder(owner) || !isAgentWorkspace) && (
-                <DropdownMenu.Item
-                  label="Edit"
-                  link={{
-                    href: `/w/${owner.sId}/builder/assistants/${
-                      agentConfiguration.sId
-                    }?flow=${
-                      isAgentWorkspace
-                        ? "workspace_assistants"
-                        : "personal_assistants"
-                    }`,
-                  }}
-                  icon={PencilSquareIcon}
-                />
-              )}
+        {({ close }) => (
+          <>
+            <DropdownMenu.Button>{dropdownButton}</DropdownMenu.Button>
+            <DropdownMenu.Items width={230}>
               <DropdownMenu.Item
-                label="Duplicate (New)"
+                label="Start new conversation"
                 link={{
-                  href: `/w/${owner.sId}/builder/assistants/new?flow=personal_assistants&duplicate=${agentConfiguration.sId}`,
+                  href: `/w/${owner.sId}/assistant/new?assistant=${agentConfiguration.sId}`,
                 }}
-                icon={ClipboardIcon}
+                icon={ChatBubbleBottomCenterTextIcon}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  close();
+                }}
               />
-              {canDelete && (
+              {showAssistantDetails && (
                 <DropdownMenu.Item
-                  label="Delete"
-                  icon={TrashIcon}
-                  variant="warning"
-                  onClick={() => setShowDeletionModal(agentConfiguration)}
+                  label={`More about @${agentConfiguration.name}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    close();
+                    showAssistantDetails();
+                  }}
+                  icon={EyeIcon}
                 />
               )}
-
-              {isAgentPublished && showAddRemoveToList && (
+              {!isGlobalAgent && (
                 <>
-                  <DropdownMenu.SectionHeader label="MY ASSISTANTS" />
+                  <DropdownMenu.SectionHeader label="Edition" />
+
+                  {/* Should use the router to have a better navigation experience */}
+                  {(isBuilder(owner) || !isAgentWorkspace) && (
+                    <DropdownMenu.Item
+                      label="Edit"
+                      link={{
+                        href: `/w/${owner.sId}/builder/assistants/${
+                          agentConfiguration.sId
+                        }?flow=${
+                          isAgentWorkspace
+                            ? "workspace_assistants"
+                            : "personal_assistants"
+                        }`,
+                      }}
+                      icon={PencilSquareIcon}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        close();
+                      }}
+                    />
+                  )}
                   <DropdownMenu.Item
-                    label={isInList ? "Remove from my list" : "Add to my list"}
-                    disabled={isUpdatingList}
-                    onClick={() => {
-                      void updateAgentUserList(
-                        isInList ? "not-in-list" : "in-list"
-                      );
+                    label="Duplicate (New)"
+                    link={{
+                      href: `/w/${owner.sId}/builder/assistants/new?flow=personal_assistants&duplicate=${agentConfiguration.sId}`,
                     }}
-                    icon={isInList ? ListRemoveIcon : ListAddIcon}
+                    icon={ClipboardIcon}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      close();
+                    }}
                   />
+                  {canDelete && (
+                    <DropdownMenu.Item
+                      label="Delete"
+                      icon={TrashIcon}
+                      variant="warning"
+                      onClick={() => setShowDeletionModal(agentConfiguration)}
+                    />
+                  )}
+
+                  {isAgentPublished && showAddRemoveToList && (
+                    <>
+                      <DropdownMenu.SectionHeader label="MY ASSISTANTS" />
+                      <DropdownMenu.Item
+                        label={
+                          isInList ? "Remove from my list" : "Add to my list"
+                        }
+                        disabled={isUpdatingList}
+                        onClick={() => {
+                          void updateAgentUserList(
+                            isInList ? "not-in-list" : "in-list"
+                          );
+                        }}
+                        icon={isInList ? ListRemoveIcon : ListAddIcon}
+                      />
+                    </>
+                  )}
                 </>
               )}
-            </>
-          )}
-        </DropdownMenu.Items>
+            </DropdownMenu.Items>
+          </>
+        )}
       </DropdownMenu>
     </>
   );

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -338,7 +338,9 @@ export default function AssistantBuilder({
 
         // Redirect to the assistant list once saved.
         if (flow === "personal_assistants") {
-          await router.push(`/w/${owner.sId}/assistant/new`);
+          await router.push(
+            `/w/${owner.sId}/assistant/new?defaultTab=personal`
+          );
         } else {
           await router.push(`/w/${owner.sId}/builder/assistants`);
         }

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,7 @@
         "@amplitude/analytics-browser": "^2.5.2",
         "@amplitude/analytics-node": "^1.3.5",
         "@auth0/nextjs-auth0": "^3.5.0",
-        "@dust-tt/sparkle": "^0.2.238",
+        "@dust-tt/sparkle": "^0.2.239",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -10737,9 +10737,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.238",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.238.tgz",
-      "integrity": "sha512-LOKHl/Z2Kg49NxbJ+JJPJbFFde5MuGmZmLMuF21j9E6K9UZ6y821n6ETMUl583tRMv9Od/Ycs3Bb2WxtDNLrFg==",
+      "version": "0.2.239",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.239.tgz",
+      "integrity": "sha512-Sn0Hp6EodSG4zVAY3gtUt7/HiDqgg7uSCUaylh1XqTBEIGvZKP1umwFhX9f2txsgw86MMO6SZURTmHyr1M+Tfw==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
     "@amplitude/analytics-browser": "^2.5.2",
     "@amplitude/analytics-node": "^1.3.5",
     "@auth0/nextjs-auth0": "^3.5.0",
-    "@dust-tt/sparkle": "^0.2.238",
+    "@dust-tt/sparkle": "^0.2.239",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",


### PR DESCRIPTION
## Description

Updated so that the action button in the assistant browser show the dropdown menu instead of opening the AssistantDetails.
Took the opportunity:
- Fix click-thru when selecting from the DropDown
- Refactor the deletion of assistant to a hook (and simplify a bit)
- Allow passing a default tab in the url so when you create a personal assistant, you are redirect to your personal assitants (it was annoying me)

Note: there is an ugly hack to make layout work, i spent 1h+ trying to make it work, I hope to come back and fix it later.

<img width="389" alt="image" src="https://github.com/user-attachments/assets/344f77e0-a579-4775-b77f-e9b292a94af6">


## Risk

Nothing in particular.

## Deploy Plan

Deploy `prod`