### PR TITLE
Upgrade ephemeral storage for notion workers

### DIFF
--- a/k8s/deployments/connectors-worker-notion-deployment.yaml
+++ b/k8s/deployments/connectors-worker-notion-deployment.yaml
@@ -45,10 +45,12 @@ spec:
             requests:
               cpu: 2000m
               memory: 4Gi
+              ephemeral-storage: 4Gi
 
             limits:
               cpu: 2000m
               memory: 4Gi
+              ephemeral-storage: 4Gi
 
       volumes:
         - name: cert-volume

--- a/k8s/deployments/connectors-worker-notion-gc-deployment.yaml
+++ b/k8s/deployments/connectors-worker-notion-gc-deployment.yaml
@@ -45,10 +45,12 @@ spec:
             requests:
               cpu: 2000m
               memory: 4Gi
+              ephemeral-storage: 4Gi
 
             limits:
               cpu: 2000m
               memory: 4Gi
+              ephemeral-storage: 4Gi
 
       volumes:
         - name: cert-volume


### PR DESCRIPTION
## Description

Trying for fix pods being evicted
Last events of an evicted pod:
```
Events:
  Type     Reason     Age   From                                   Message
  ----     ------     ----  ----                                   -------
  Normal   Scheduled  23m   gke.io/optimize-utilization-scheduler  Successfully assigned default/connectors-worker-notion-deployment-55bc557b49-f6gww to gk3-dust-kube-pool-3-24ebe5e6-2vph
  Normal   Pulling    23m   kubelet                                Pulling image "gcr.io/or1g1n-186209/connectors-image:c089bdb"
  Normal   Pulled     23m   kubelet                                Successfully pulled image "gcr.io/or1g1n-186209/connectors-image:c089bdb" in 221ms (221ms including waiting)
  Normal   Created    23m   kubelet                                Created container web
  Normal   Started    23m   kubelet                                Started container web
  Warning  Evicted    12m   kubelet                                Pod ephemeral local storage usage exceeds the total limit of containers 1Gi.
  Normal   Killing    12m   kubelet                                Stopping container web
```

## Risk

None in particular.

## Deploy Plan

Apply `infra`