### PR TITLE
Render table markdown: Fix citation in render + copy to clipboard

### DIFF
--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -547,7 +547,7 @@ function TableDataBlock({ children }: { children: React.ReactNode }) {
           return <React.Fragment key={i}>{child}</React.Fragment>;
         })
       ) : (
-        <> {children}</>
+        <>{children}</>
       )}
     </td>
   );

--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -480,9 +480,17 @@ function TableBlock({ children }: { children: React.ReactNode }) {
       .join("")}</tr></thead>`;
     const headPlain = headCells.join("\t");
 
-    const bodyRows = bodyNode.props.children.map((r: any) =>
-      r.props.children.map((c: any) => getNodeText(c))
+    const bodyRows = bodyNode.props.children.map((row: any) =>
+      row.props.children.map((cell: any) => {
+        const children = cell.props.children;
+        return (Array.isArray(children) ? children : [children])
+          .map((child: any) =>
+            child.type?.name === "CiteBlock" ? "" : getNodeText(child)
+          )
+          .join("");
+      })
     );
+
     const bodyHtml = `<tbody>${bodyRows
       .map((row: any) => {
         return `<tr>${row
@@ -536,10 +544,10 @@ function TableDataBlock({ children }: { children: React.ReactNode }) {
           if (child === "<br>") {
             return <br key={i} />;
           }
-          return <React.Fragment key={i}>{getNodeText(child)}</React.Fragment>;
+          return <React.Fragment key={i}>{child}</React.Fragment>;
         })
       ) : (
-        <> {getNodeText(children)}</>
+        <> {children}</>
       )}
     </td>
   );


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/1316

Fixes citations on table in markdown: 
<kbd>
<img width="916" alt="Screenshot 2024-09-15 at 20 13 54" src="https://github.com/user-attachments/assets/c90f1e36-95f4-4d03-ac17-2fcdaf459ac3">
</kbd>

It also does not render citations when we copy the content of the table. From the screenshot, clicking extract this content: 
```
<html><head></head><body>
Rank | Cat Breed | Description
-- | -- | --
1 | Ragdoll | Known for their large size, blue eyes, and color point coats
2 | Maine Coon | Large, gentle giants with long fur and tufted ears
3 | Exotic | Short-haired version of the Persian with a flat face
4 | Persian | Long-haired cats with round faces and short muzzles
5 | Devon Rex | Playful cats with large ears and wavy coats

</body></html>
```

Which is: 


## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
