### PR TITLE
Flav/agent tables query data source id wave 1

### DIFF
--- a/front/lib/api/assistant/configuration/table_query.ts
+++ b/front/lib/api/assistant/configuration/table_query.ts
@@ -148,7 +148,7 @@ export async function createTableDataSourceConfiguration(
 
       await AgentTablesQueryConfigurationTable.create(
         {
-          // TODO(DATA_SOURCE_ID) Remove once fully migrated over to `dataSourceIdNew`.
+          // TODO(DATASOURCE_ID) Remove once fully migrated over to `dataSourceIdNew`.
           dataSourceId: dataSource.name,
 
           dataSourceIdNew: dataSource.id,

--- a/front/lib/api/assistant/configuration/table_query.ts
+++ b/front/lib/api/assistant/configuration/table_query.ts
@@ -148,8 +148,10 @@ export async function createTableDataSourceConfiguration(
 
       await AgentTablesQueryConfigurationTable.create(
         {
-          // TODO(GROUPS_INFRA) Use ModelId for dataSourceId.
+          // TODO(DATA_SOURCE_ID) Remove once fully migrated over to `dataSourceIdNew`.
           dataSourceId: dataSource.name,
+
+          dataSourceIdNew: dataSource.id,
           dataSourceViewId: dataSourceView.id,
           dataSourceWorkspaceId: tc.workspaceId,
           tableId: tc.tableId,

--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -170,12 +170,12 @@ AgentTablesQueryConfigurationTable.belongsTo(AgentTablesQueryConfiguration, {
 // TODO(DATA_SOURCE_ID) Enforce once fully migrated.
 // Config <> Data source.
 DataSource.hasMany(AgentTablesQueryConfigurationTable, {
-  foreignKey: { allowNull: true },
+  foreignKey: { allowNull: true, name: "dataSourceIdNew" },
   onDelete: "RESTRICT",
 });
 AgentTablesQueryConfigurationTable.belongsTo(DataSource, {
   as: "dataSource",
-  foreignKey: { allowNull: true },
+  foreignKey: { allowNull: true, name: "dataSourceIdNew" },
 });
 
 // Config <> Data source view.

--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -9,7 +9,9 @@ import { DataTypes, Model } from "sequelize";
 
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { AgentMessage } from "@app/lib/models/assistant/conversation";
+import type { Workspace } from "@app/lib/models/workspace";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataSource } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 
 export class AgentTablesQueryConfiguration extends Model<
@@ -91,9 +93,13 @@ export class AgentTablesQueryConfigurationTable extends Model<
   declare updatedAt: CreationOptional<Date>;
 
   declare dataSourceWorkspaceId: string;
+
   // TODO:(GROUPS_INFRA): `dataSourceId` should be a foreign key to `DataSource` model.
+  // TODO(DATA_SOURCE_ID) Remove once fully migrated over to `dataSourceIdNew`.
   declare dataSourceId: string;
   declare tableId: string;
+
+  declare dataSourceIdNew: ForeignKey<DataSource["id"]>;
 
   declare dataSourceViewId: ForeignKey<DataSourceViewModel["id"]>;
   declare tablesQueryConfigurationId: ForeignKey<
@@ -159,6 +165,17 @@ AgentTablesQueryConfiguration.hasMany(AgentTablesQueryConfigurationTable, {
 AgentTablesQueryConfigurationTable.belongsTo(AgentTablesQueryConfiguration, {
   foreignKey: { name: "tablesQueryConfigurationId", allowNull: false },
   onDelete: "CASCADE",
+});
+
+// TODO(DATA_SOURCE_ID) Enforce once fully migrated.
+// Config <> Data source.
+DataSource.hasMany(AgentTablesQueryConfigurationTable, {
+  foreignKey: { allowNull: true },
+  onDelete: "RESTRICT",
+});
+AgentTablesQueryConfigurationTable.belongsTo(DataSource, {
+  as: "dataSourceView",
+  foreignKey: { allowNull: true },
 });
 
 // Config <> Data source view.

--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -9,7 +9,6 @@ import { DataTypes, Model } from "sequelize";
 
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { AgentMessage } from "@app/lib/models/assistant/conversation";
-import type { Workspace } from "@app/lib/models/workspace";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataSource } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
@@ -99,7 +98,7 @@ export class AgentTablesQueryConfigurationTable extends Model<
   declare dataSourceId: string;
   declare tableId: string;
 
-  declare dataSourceIdNew: ForeignKey<DataSource["id"]>;
+  declare dataSourceIdNew: ForeignKey<DataSource["id"]> | null;
 
   declare dataSourceViewId: ForeignKey<DataSourceViewModel["id"]>;
   declare tablesQueryConfigurationId: ForeignKey<

--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -174,7 +174,7 @@ DataSource.hasMany(AgentTablesQueryConfigurationTable, {
   onDelete: "RESTRICT",
 });
 AgentTablesQueryConfigurationTable.belongsTo(DataSource, {
-  as: "dataSourceView",
+  as: "dataSource",
   foreignKey: { allowNull: true },
 });
 

--- a/front/migrations/20240916_backfill_ds_in_agent_table_query_configurations.ts
+++ b/front/migrations/20240916_backfill_ds_in_agent_table_query_configurations.ts
@@ -57,17 +57,20 @@ async function backfillDataSourceIdInAgentTableQueryConfigurationForWorkspace(
   }
 
   for (const ds of dataSources) {
-    const dataSourceView = dataSourceViews.find(
+    const dataSourceViewsForDataSource = dataSourceViews.filter(
       (dsv) => dsv.dataSourceId === ds.id
     );
     assert(
-      dataSourceView,
-      `Data source view not found for data source ${ds.id}.`
+      dataSourceViewsForDataSource.length === 1,
+      `Error while fetching data source view for data source ${ds.id} // Found ${dataSourceViewsForDataSource.length} data source views.`
     );
 
     await AgentTablesQueryConfigurationTable.update(
       // Upsert both `dataSourceIdNew` and `dataSourceViewId` to ensure consistency.
-      { dataSourceIdNew: ds.id, dataSourceViewId: dataSourceView.id },
+      {
+        dataSourceIdNew: ds.id,
+        dataSourceViewId: dataSourceViewsForDataSource[0].id,
+      },
       {
         where: {
           // /!\ `dataSourceId` is the data source's name, not the id.

--- a/front/migrations/20240916_backfill_ds_in_agent_table_query_configurations.ts
+++ b/front/migrations/20240916_backfill_ds_in_agent_table_query_configurations.ts
@@ -1,0 +1,84 @@
+import type { LightWorkspaceType } from "@dust-tt/types";
+import { Op } from "sequelize";
+
+import { Authenticator } from "@app/lib/auth";
+import { AgentTablesQueryConfigurationTable } from "@app/lib/models/assistant/actions/tables_query";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import type { Logger } from "@app/logger/logger";
+import { makeScript, runOnAllWorkspaces } from "@app/scripts/helpers";
+
+async function backfillDataSourceIdInAgentTableQueryConfigurationForWorkspace(
+  workspace: LightWorkspaceType,
+  logger: Logger,
+  execute: boolean
+) {
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+  // List workspace data sources.
+  const dataSources = await DataSourceResource.listByWorkspace(auth);
+
+  logger.info(
+    `Found ${dataSources.length} data sources for workspace(${workspace.sId}).`
+  );
+
+  // Count agent tables query configurations that uses those data sources and have no dataSourceIdNew.
+  const agentTablesQueryConfigurationsCount =
+    await AgentTablesQueryConfigurationTable.count({
+      where: {
+        // /!\ `dataSourceId` is the data source's name, not the id.
+        dataSourceId: dataSources.map((ds) => ds.name),
+        dataSourceIdNew: {
+          [Op.is]: null,
+        },
+        // Given that the name isn't unique we need to count per workspace.
+        dataSourceWorkspaceId: workspace.sId,
+      },
+    });
+
+  logger.info(
+    `About to update ${agentTablesQueryConfigurationsCount} agent tables query configurations for workspace(${workspace.sId}).`
+  );
+
+  if (!execute) {
+    return;
+  }
+
+  for (const ds of dataSources) {
+    await AgentTablesQueryConfigurationTable.update(
+      { dataSourceIdNew: ds.id },
+      {
+        where: {
+          // /!\ `dataSourceId` is the data source's name, not the id.
+          dataSourceId: ds.name,
+          dataSourceIdNew: {
+            [Op.is]: null,
+          },
+          // Given that the name isn't unique we need precise the workspace.
+          dataSourceWorkspaceId: workspace.sId,
+        },
+      }
+    );
+
+    logger.info(
+      `Updated agent tables query configuration for data source ${ds.id}.`
+    );
+  }
+
+  logger.info(
+    `Updated all agent tables query configurations for workspace(${workspace.sId}).`
+  );
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  return runOnAllWorkspaces(async (workspace) => {
+    await backfillDataSourceIdInAgentTableQueryConfigurationForWorkspace(
+      workspace,
+      logger,
+      execute
+    );
+
+    logger.info(
+      `Finished backfilling "dataSourceIdNew" for workspace(${workspace.sId}).`
+    );
+  });
+});

--- a/front/migrations/20240916_backfill_ds_in_agent_table_query_configurations.ts
+++ b/front/migrations/20240916_backfill_ds_in_agent_table_query_configurations.ts
@@ -65,11 +65,9 @@ async function backfillDataSourceIdInAgentTableQueryConfigurationForWorkspace(
       `Error while fetching data source view for data source ${ds.id} // Found ${dataSourceViewsForDataSource.length} data source views.`
     );
 
-    await AgentTablesQueryConfigurationTable.update(
-      // Upsert both `dataSourceIdNew` and `dataSourceViewId` to ensure consistency.
+    const [, affectedRows] = await AgentTablesQueryConfigurationTable.update(
       {
         dataSourceIdNew: ds.id,
-        dataSourceViewId: dataSourceViewsForDataSource[0].id,
       },
       {
         where: {
@@ -81,8 +79,32 @@ async function backfillDataSourceIdInAgentTableQueryConfigurationForWorkspace(
           // Given that the name isn't unique we need to precise the workspace.
           dataSourceWorkspaceId: workspace.sId,
         },
+        returning: true,
       }
     );
+
+    if (affectedRows && affectedRows.length > 0) {
+      const [r] = affectedRows;
+
+      // If the dataSourceViewId is not the one we expect, update it.
+      if (r.dataSourceViewId !== dataSourceViewsForDataSource[0].id) {
+        logger.error(
+          `Error while updating agent tables query configuration for data source ${ds.id}
+          // Expected dataSourceViewId to be ${dataSourceViewsForDataSource[0].id} but got ${r.dataSourceViewId}.`
+        );
+
+        await AgentTablesQueryConfigurationTable.update(
+          {
+            dataSourceViewId: dataSourceViewsForDataSource[0].id,
+          },
+          {
+            where: {
+              id: r.id,
+            },
+          }
+        );
+      }
+    }
 
     logger.info(
       `Updated agent tables query configuration for data source ${ds.id}.`

--- a/front/migrations/db/migration_80.sql
+++ b/front/migrations/db/migration_80.sql
@@ -1,0 +1,2 @@
+-- Migration created on Sep 15, 2024
+ALTER TABLE "agent_tables_query_configuration_tables" ADD FOREIGN KEY ("dataSourceId") REFERENCES "data_sources" ("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/front/migrations/db/migration_80.sql
+++ b/front/migrations/db/migration_80.sql
@@ -1,2 +1,2 @@
 -- Migration created on Sep 15, 2024
-ALTER TABLE "agent_tables_query_configuration_tables" ADD FOREIGN KEY ("dataSourceId") REFERENCES "data_sources" ("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "public"."agent_tables_query_configuration_tables" ADD COLUMN "dataSourceIdNew" INTEGER REFERENCES "data_sources" ("id") ON DELETE RESTRICT ON UPDATE CASCADE;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Following last week's incident, this PR addresses the task of changing the `dataSourceId` in the `AgentTablesQueryConfigurationTable` model from a public string, which currently represents the data source name and **is not unique** per workspace, to a proper foreign key within the database.

This change needs to be implemented in several incremental steps:
- Introduce a new column to store the new foreign key (name: `dataSourceIdNew`), begin writing to it, and backfill the data (this PR).
- Ensure the code no longer relies on the previous column by removing any read operations from it, and then delete the old column.
- Since renaming could disrupt production, create a new column as a duplicate of `dataSourceIdNew`, backfill it during the migration, and deploy code that will both write to and read from it.

⚠️ while writing this new migration I realized that we did not properly backfilled the views at first, since we relied on the data source name which isn't unique across workspaces. This PR bundles a fix within the new migration.

https://github.com/dust-tt/dust/blob/ab92d9f752ed0cfa22c50e9a3ce05bc0197c3d0c/front/migrations/20240902_backfill_views_in_agent_table_query_configurations.ts#L68-L76

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
This PR is pretty low risk as this new field is not yet used.

## Deploy Plan

- Apply the migration
- Deploy Front
- Backfill the new column
