### PR TITLE
Assistant Builder tree displays only first 100 content-nodes (no pagination)

### DIFF
--- a/front/lib/api/pagination.ts
+++ b/front/lib/api/pagination.ts
@@ -34,7 +34,7 @@ function getOrderColumnCodec(supportedOrderColumns: string[]): t.Mixed {
   ]);
 }
 
-const LimitCodec = createRangeCodec(0, 100);
+const LimitCodec = createRangeCodec(0, 500);
 
 const PaginationParamsCodec = (supportedOrderColumns: string[]) =>
   t.type({

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/content-nodes.ts
@@ -15,7 +15,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { apiError } from "@app/logger/withlogging";
 
-const DEFAULT_LIMIT = 100;
+const DEFAULT_LIMIT = 500;
 
 const GetContentNodesOrChildrenRequestBody = t.type({
   includeChildren: t.boolean,


### PR DESCRIPTION
## Description

Eng runner card: https://github.com/dust-tt/tasks/issues/1329

Pagination of the content-nodes routes was introduced in here: https://github.com/dust-tt/dust/pull/7011/files#diff-725d9bf34333d2099c3967150ac43ffadb4fb51f27d2381ec8c4fdd4d63122e7 with a default value to 100.

All routes from vaults are properly using the pagination mechanism, but nothing was done on the AssistantBuilder (tree compontent). 

Hotfix is to increase the number of default pagination, real fix will be to handle pagination from the Tree Component. 

## Risk

Can be rolled back; 

## Deploy Plan

Deploy front. 
