### PR TITLE
[front] - refacto(hooks): members hooks

### DIFF
--- a/front/components/members/InvitationModal.tsx
+++ b/front/components/members/InvitationModal.tsx
@@ -11,7 +11,7 @@ import { ConfirmContext } from "@app/components/Confirm";
 import { displayRole, ROLES_DATA } from "@app/components/members/Roles";
 import { RoleDropDown } from "@app/components/members/RolesDropDown";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
-import { handleMembersRoleChange } from "@app/lib/client/members";
+import { useHandleMembersRoleChange } from "@app/hooks/useHandleMembersRoleChange";
 import { getPriceAsString } from "@app/lib/client/subscription";
 import {
   MAX_UNCONSUMED_INVITATIONS_PER_WORKSPACE_PER_DAY,
@@ -39,6 +39,7 @@ export function InviteEmailModal({
   const sendNotification = useContext(SendNotificationsContext);
   const confirm = useContext(ConfirmContext);
   const [invitationRole, setInvitationRole] = useState<ActiveRoleType>("user");
+  const handleMembersRoleChange = useHandleMembersRoleChange({ owner });
 
   function getEmailsList(): string[] | null {
     const inviteEmailsList = inviteEmails
@@ -153,7 +154,6 @@ export function InviteEmailModal({
         await handleMembersRoleChange({
           members: activeDifferentRole,
           role: invitationRole,
-          sendNotification,
         });
         await mutate(`/api/w/${owner.sId}/members`);
       }

--- a/front/components/members/InvitationModal.tsx
+++ b/front/components/members/InvitationModal.tsx
@@ -11,7 +11,7 @@ import { ConfirmContext } from "@app/components/Confirm";
 import { displayRole, ROLES_DATA } from "@app/components/members/Roles";
 import { RoleDropDown } from "@app/components/members/RolesDropDown";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
-import { useHandleMembersRoleChange } from "@app/hooks/useHandleMembersRoleChange";
+import { useChangeMembersRoles } from "@app/hooks/useChangeMembersRoles";
 import { getPriceAsString } from "@app/lib/client/subscription";
 import {
   MAX_UNCONSUMED_INVITATIONS_PER_WORKSPACE_PER_DAY,
@@ -39,7 +39,7 @@ export function InviteEmailModal({
   const sendNotification = useContext(SendNotificationsContext);
   const confirm = useContext(ConfirmContext);
   const [invitationRole, setInvitationRole] = useState<ActiveRoleType>("user");
-  const handleMembersRoleChange = useHandleMembersRoleChange({ owner });
+  const handleMembersRoleChange = useChangeMembersRoles({ owner });
 
   function getEmailsList(): string[] | null {
     const inviteEmailsList = inviteEmails

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -17,7 +17,7 @@ import React, { useMemo, useState } from "react";
 
 import { displayRole, ROLES_DATA } from "@app/components/members/Roles";
 import { ChangeMemberModal } from "@app/components/workspace/ChangeMemberModal";
-import { useSearchMembers } from "@app/lib/swr/user";
+import { useSearchMembers } from "@app/lib/swr/memberships";
 import { classNames } from "@app/lib/utils";
 
 type RowData = {

--- a/front/components/vaults/CreateOrEditVaultModal.tsx
+++ b/front/components/vaults/CreateOrEditVaultModal.tsx
@@ -24,7 +24,7 @@ import React, {
 
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { ConfirmDeleteVaultDialog } from "@app/components/vaults/ConfirmDeleteVaultDialog";
-import { useSearchMembers } from "@app/lib/swr/user";
+import { useSearchMembers } from "@app/lib/swr/memberships";
 import {
   useCreateVault,
   useDeleteVault,

--- a/front/hooks/useChangeMembersRoles.ts
+++ b/front/hooks/useChangeMembersRoles.ts
@@ -6,7 +6,7 @@ import type {
 import { useCallback, useContext } from "react";
 
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
-import { useMembers } from "@app/lib/swr/memberships";
+import { useMembers, useSearchMembers } from "@app/lib/swr/memberships";
 
 type HandleMembersRoleChangeParams = {
   members: UserTypeWithWorkspaces[];
@@ -21,6 +21,18 @@ export function useChangeMembersRoles({
   const sendNotification = useContext(SendNotificationsContext);
   const { mutateMembers } = useMembers({
     workspaceId: owner.sId,
+    disabled: true,
+  });
+
+  // mock parameters for useSearchMembers
+  const mockParameters = {
+    pageIndex: 0,
+    pageSize: 0,
+    searchTerm: "",
+    workspaceId: owner.sId,
+  };
+  const { mutateMembers: mutateSearchMembers } = useSearchMembers({
+    ...mockParameters,
     disabled: true,
   });
 
@@ -66,6 +78,7 @@ export function useChangeMembersRoles({
           });
 
           await mutateMembers();
+          await mutateSearchMembers();
           return true;
         }
       } catch (error) {
@@ -78,7 +91,7 @@ export function useChangeMembersRoles({
         return false;
       }
     },
-    [owner.sId, sendNotification, mutateMembers]
+    [owner.sId, sendNotification, mutateMembers, mutateSearchMembers]
   );
 
   return handleMembersRoleChange;

--- a/front/hooks/useHandleMembersRoleChange.ts
+++ b/front/hooks/useHandleMembersRoleChange.ts
@@ -1,0 +1,84 @@
+import type {
+  LightWorkspaceType,
+  RoleType,
+  UserTypeWithWorkspaces,
+} from "@dust-tt/types";
+import { useCallback, useContext } from "react";
+import { useSWRConfig } from "swr";
+
+import { SendNotificationsContext } from "@app/components/sparkle/Notification";
+
+type HandleMembersRoleChangeParams = {
+  members: UserTypeWithWorkspaces[];
+  role: RoleType;
+};
+
+export function useHandleMembersRoleChange({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const sendNotification = useContext(SendNotificationsContext);
+  const { mutate } = useSWRConfig();
+
+  const handleMembersRoleChange = useCallback(
+    async ({
+      members,
+      role,
+    }: HandleMembersRoleChangeParams): Promise<boolean> => {
+      if (members.length === 0) {
+        return false;
+      }
+
+      const promises = members.map((member) =>
+        fetch(`/api/w/${owner.sId}/members/${member.sId}`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            role: role === "none" ? "revoked" : role,
+          }),
+        })
+      );
+
+      try {
+        const results = await Promise.all(promises);
+        const errors = results.filter((res) => !res.ok);
+
+        if (errors.length > 0) {
+          sendNotification({
+            type: "error",
+            title: "Update failed",
+            description: `Failed to update members role for ${
+              errors.length
+            } member(s) (${members.length - errors.length} succeeded).`,
+          });
+          return false;
+        } else {
+          sendNotification({
+            type: "success",
+            title: "Role updated",
+            description: `Role updated to ${role} for ${members.length} member(s).`,
+          });
+
+          // Mutate the members data to trigger a revalidation
+          await mutate(`/api/w/${owner.sId}/members`);
+          return true;
+        }
+      } catch (error) {
+        console.error("Error updating member roles:", error);
+        sendNotification({
+          type: "error",
+          title: "Update failed",
+          description:
+            "An unexpected error occurred while updating member roles.",
+        });
+        return false;
+      }
+    },
+    [owner.sId, sendNotification, mutate]
+  );
+
+  return handleMembersRoleChange;
+}

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -41,6 +41,37 @@ export function useMembers({
   };
 }
 
+export function useAdmins(owner: LightWorkspaceType) {
+  const membersFetcher: Fetcher<GetMembersResponseBody> = fetcher;
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/w/${owner.sId}/members?role=admin`,
+    membersFetcher
+  );
+
+  return {
+    admins: useMemo(() => (data ? data.members : []), [data]),
+    isAdminsLoading: !error && !data,
+    iAdminsError: error,
+    mutateMembers: mutate,
+  };
+}
+
+export function useWorkspaceInvitations(owner: LightWorkspaceType) {
+  const workspaceInvitationsFetcher: Fetcher<GetWorkspaceInvitationsResponseBody> =
+    fetcher;
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/w/${owner.sId}/invitations`,
+    workspaceInvitationsFetcher
+  );
+
+  return {
+    invitations: useMemo(() => (data ? data.invitations : []), [data]),
+    isInvitationsLoading: !error && !data,
+    isInvitationsError: error,
+    mutateInvitations: mutate,
+  };
+}
+
 export function useSearchMembers({
   workspaceId,
   searchTerm,
@@ -87,36 +118,5 @@ export function useSearchMembers({
     isLoading: !error && !data,
     isError: !!error,
     mutateMembers: mutate,
-  };
-}
-
-export function useAdmins(owner: LightWorkspaceType) {
-  const membersFetcher: Fetcher<GetMembersResponseBody> = fetcher;
-  const { data, error, mutate } = useSWRWithDefaults(
-    `/api/w/${owner.sId}/members?role=admin`,
-    membersFetcher
-  );
-
-  return {
-    admins: useMemo(() => (data ? data.members : []), [data]),
-    isAdminsLoading: !error && !data,
-    iAdminsError: error,
-    mutateMembers: mutate,
-  };
-}
-
-export function useWorkspaceInvitations(owner: LightWorkspaceType) {
-  const workspaceInvitationsFetcher: Fetcher<GetWorkspaceInvitationsResponseBody> =
-    fetcher;
-  const { data, error, mutate } = useSWRWithDefaults(
-    `/api/w/${owner.sId}/invitations`,
-    workspaceInvitationsFetcher
-  );
-
-  return {
-    invitations: useMemo(() => (data ? data.invitations : []), [data]),
-    isInvitationsLoading: !error && !data,
-    isInvitationsError: error,
-    mutateInvitations: mutate,
   };
 }

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -1,6 +1,6 @@
 import type { LightWorkspaceType } from "@dust-tt/types";
 import type { PaginationState } from "@tanstack/react-table";
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { Fetcher } from "swr";
 
 import {
@@ -8,8 +8,10 @@ import {
   fetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
+import { debounce } from "@app/lib/utils/debounce";
 import type { GetWorkspaceInvitationsResponseBody } from "@app/pages/api/w/[wId]/invitations";
 import type { GetMembersResponseBody } from "@app/pages/api/w/[wId]/members";
+import type { SearchMembersResponseBody } from "@app/pages/api/w/[wId]/members/search";
 
 export function useMembers({
   workspaceId,
@@ -36,6 +38,55 @@ export function useMembers({
     isMembersError: error,
     mutateMembers: mutate,
     total: data ? data.total : 0,
+  };
+}
+
+export function useSearchMembers({
+  workspaceId,
+  searchTerm,
+  pageIndex,
+  pageSize,
+  disabled,
+}: {
+  workspaceId: string;
+  searchTerm: string;
+  pageIndex: number;
+  pageSize: number;
+  disabled?: boolean;
+}) {
+  const searchMembersFetcher: Fetcher<SearchMembersResponseBody> = fetcher;
+  const debounceHandle = useRef<NodeJS.Timeout | undefined>(undefined);
+  const [debouncedSearchTerm, setDebouncedSearchTerm] = useState(searchTerm);
+
+  useEffect(() => {
+    const debouncedSearch = () => {
+      setDebouncedSearchTerm(searchTerm);
+    };
+
+    debounce(debounceHandle, debouncedSearch, 300);
+  }, [searchTerm]);
+
+  const searchParams = new URLSearchParams({
+    searchTerm: debouncedSearchTerm,
+    orderBy: "name",
+    lastValue: (pageIndex * pageSize).toString(),
+  });
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/members/search?${searchParams.toString()}`,
+    searchMembersFetcher,
+    {
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      disabled,
+    }
+  );
+  return {
+    members: useMemo(() => (data ? data.members : []), [data]),
+    totalMembersCount: data?.total ?? 0,
+    isLoading: !error && !data,
+    isError: !!error,
+    mutateMembers: mutate,
   };
 }
 

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -1,11 +1,8 @@
-import { useEffect, useMemo, useRef, useState } from "react";
 import type { Fetcher } from "swr";
 
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import { debounce } from "@app/lib/utils/debounce";
 import type { GetUserResponseBody } from "@app/pages/api/user";
 import type { GetUserMetadataResponseBody } from "@app/pages/api/user/metadata/[key]";
-import type { SearchMembersResponseBody } from "@app/pages/api/w/[wId]/members/search";
 
 export function useUser() {
   const userFetcher: Fetcher<GetUserResponseBody> = fetcher;
@@ -31,54 +28,5 @@ export function useUserMetadata(key: string) {
     isMetadataLoading: !error && !data,
     isMetadataError: error,
     mutateMetadata: mutate,
-  };
-}
-
-export function useSearchMembers({
-  workspaceId,
-  searchTerm,
-  pageIndex,
-  pageSize,
-  disabled,
-}: {
-  workspaceId: string;
-  searchTerm: string;
-  pageIndex: number;
-  pageSize: number;
-  disabled?: boolean;
-}) {
-  const searchMembersFetcher: Fetcher<SearchMembersResponseBody> = fetcher;
-  const debounceHandle = useRef<NodeJS.Timeout | undefined>(undefined);
-  const [debouncedSearchTerm, setDebouncedSearchTerm] = useState(searchTerm);
-
-  useEffect(() => {
-    const debouncedSearch = () => {
-      setDebouncedSearchTerm(searchTerm);
-    };
-
-    debounce(debounceHandle, debouncedSearch, 300);
-  }, [searchTerm]);
-
-  const searchParams = new URLSearchParams({
-    searchTerm: debouncedSearchTerm,
-    orderBy: "name",
-    lastValue: (pageIndex * pageSize).toString(),
-  });
-
-  const { data, error, mutate } = useSWRWithDefaults(
-    `/api/w/${workspaceId}/members/search?${searchParams.toString()}`,
-    searchMembersFetcher,
-    {
-      revalidateOnFocus: false,
-      revalidateOnReconnect: false,
-      disabled,
-    }
-  );
-  return {
-    members: useMemo(() => (data ? data.members : []), [data]),
-    totalMembersCount: data?.total ?? 0,
-    isLoading: !error && !data,
-    isError: !!error,
-    mutateMembers: mutate,
   };
 }


### PR DESCRIPTION
## Description

This PR refactors the members hooks in `front`, specifically moving the `useSearchMembers` hook from the `user.ts` file to the `memberships.ts` file. The changes aim to improve code organization and consistency by placing member-related hooks in a more appropriate location.

The main changes include:
- Moving the `useSearchMembers` hook from `lib/swr/user.ts` to `lib/swr/memberships.ts`.
- Updating import statements in affected components to use the new location of the `useSearchMembers` hook.
- Minor adjustments to the `useHandleMembersRoleChange` hook for better consistency and reusability.

## Risk

Low. The refactoring primarily involves moving existing code to a more appropriate location.

## Deploy Plan

Deploy `front`
