### PR TITLE
Upg: sort dust apps in assistant builder and add button to go edit directly

### DIFF
--- a/front/components/assistant_builder/AssistantBuilderDustAppModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDustAppModal.tsx
@@ -1,6 +1,7 @@
 import { CommandLineIcon, Item, Modal, Page } from "@dust-tt/sparkle";
 import type { AppType, LightWorkspaceType, VaultType } from "@dust-tt/types";
 import { Transition } from "@headlessui/react";
+import { sortBy } from "lodash";
 
 import { VaultSelector } from "@app/components/assistant_builder/vaults/VaultSelector";
 
@@ -70,7 +71,7 @@ function PickDustApp({
 
   return (
     <Transition show={show} className="mx-auto max-w-6xl">
-      <Page>
+      <Page variant="modal">
         <Page.Header title="Select Dust App" icon={CommandLineIcon} />
         {hasSomeUnselectableApps && (
           <Page.P>
@@ -93,17 +94,25 @@ function PickDustApp({
 
             return (
               <>
-                {allowedDustApps.map((app) => (
-                  <Item.Navigation
-                    label={app.name}
-                    icon={CommandLineIcon}
-                    disabled={!app.description || app.description.length === 0}
-                    key={app.sId}
-                    onClick={() => {
-                      onPick(app);
-                    }}
-                  />
-                ))}
+                {sortBy(
+                  allowedDustApps,
+                  (a) => !a.description || a.description.length === 0,
+                  "name"
+                ).map((app) => {
+                  const disabled =
+                    !app.description || app.description.length === 0;
+                  return (
+                    <Item.Navigation
+                      label={app.name + (disabled ? " (No description)" : "")}
+                      icon={CommandLineIcon}
+                      disabled={disabled}
+                      key={app.sId}
+                      onClick={() => {
+                        onPick(app);
+                      }}
+                    />
+                  );
+                })}
               </>
             );
           }}

--- a/front/components/assistant_builder/DustAppSelectionSection.tsx
+++ b/front/components/assistant_builder/DustAppSelectionSection.tsx
@@ -2,26 +2,34 @@ import {
   Button,
   CommandLineIcon,
   ContextItem,
+  PencilSquareIcon,
   TrashIcon,
 } from "@dust-tt/sparkle";
+import type { LightWorkspaceType } from "@dust-tt/types";
 import { Transition } from "@headlessui/react";
+import { useRouter } from "next/router";
 
 import type { AssistantBuilderDustAppConfiguration } from "@app/components/assistant_builder/types";
 import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
 
 export default function DustAppSelectionSection({
+  owner,
   show,
   dustAppConfiguration,
   openDustAppModal,
   onDelete,
   canSelectDustApp,
 }: {
+  owner: LightWorkspaceType;
   show: boolean;
   dustAppConfiguration: AssistantBuilderDustAppConfiguration;
   openDustAppModal: () => void;
   onDelete?: (sId: string) => void;
   canSelectDustApp: boolean;
 }) {
+  const router = useRouter();
+
+  const appPath = `/w/${owner.sId}/vaults/${dustAppConfiguration.app?.vault.sId}/apps/${dustAppConfiguration.app?.sId}`;
   return (
     <Transition
       show={show}
@@ -55,6 +63,13 @@ export default function DustAppSelectionSection({
               visual={<ContextItem.Visual visual={CommandLineIcon} />}
               action={
                 <Button.List>
+                  <Button
+                    icon={PencilSquareIcon}
+                    variant="secondary"
+                    label="Edit"
+                    labelVisible={false}
+                    onClick={() => router.push(appPath)}
+                  />
                   <Button
                     icon={TrashIcon}
                     variant="secondaryWarning"

--- a/front/components/assistant_builder/actions/DustAppRunAction.tsx
+++ b/front/components/assistant_builder/actions/DustAppRunAction.tsx
@@ -143,6 +143,7 @@ export function ActionDustAppRun({
             application's input block dataset schema.
           </div>
           <DustAppSelectionSection
+            owner={owner}
             show={true}
             dustAppConfiguration={
               action.configuration as AssistantBuilderDustAppConfiguration

--- a/front/components/vaults/VaultAppsList.tsx
+++ b/front/components/vaults/VaultAppsList.tsx
@@ -9,6 +9,7 @@ import {
 } from "@dust-tt/sparkle";
 import type { ConnectorType, VaultType, WorkspaceType } from "@dust-tt/types";
 import type { CellContext } from "@tanstack/react-table";
+import { sortBy } from "lodash";
 import type { ComponentType } from "react";
 import { useRef } from "react";
 import { useState } from "react";
@@ -69,7 +70,7 @@ export const VaultAppsList = ({
 
   const rows: RowData[] = React.useMemo(
     () =>
-      apps?.map((app) => ({
+      sortBy(apps, "name").map((app) => ({
         sId: app.sId,
         category: "apps",
         name: app.name,

--- a/front/components/vaults/VaultSideBarMenu.tsx
+++ b/front/components/vaults/VaultSideBarMenu.tsx
@@ -579,7 +579,6 @@ const VaultAppSubMenu = ({
 
   const { isAppsLoading, apps } = useApps({
     owner,
-    disabled: !isExpanded,
     vault,
   });
 
@@ -593,6 +592,7 @@ const VaultAppSubMenu = ({
       onChevronClick={() => setIsExpanded(!isExpanded)}
       visual={categoryDetails.icon}
       areActionsFading={false}
+      type={isAppsLoading || apps.length > 0 ? "node" : "leaf"}
     >
       {isExpanded && (
         <Tree isLoading={isAppsLoading}>


### PR DESCRIPTION
## Description

- Missed some place where apps where listed => adding sort.
- In assistant builder, first list apps that are usable, then the disabled ones.
- Add edit button.
- In vault side menu, hide "chevron" if no apps (like other kinds of sources).

<img width="771" alt="image" src="https://github.com/user-attachments/assets/9e4e0ddc-85f0-4d29-b84a-ab884a6672a7">


## Risk

None

## Deploy Plan

Deploy `front`