### PR TITLE
[sparkle] - feat(DataTable): pass `SortingState` to `DataTable`.

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.240",
+  "version": "0.2.241",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.240",
+      "version": "0.2.241",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.240",
+  "version": "0.2.241",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -92,7 +92,7 @@ export function DataTable<TData extends TBaseData>({
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
 
   const isServerSidePagination = !!totalRowCount && totalRowCount > data.length;
-  const isClientSideSortingEnabled = !isServerSideSorting && !pagination;
+  const isClientSideSortingEnabled = !isServerSideSorting && !isServerSidePagination;
 
   const onPaginationChange =
     pagination && setPagination

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -90,7 +90,7 @@ export function DataTable<TData extends TBaseData>({
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
 
   const isServerSidePagination = !!totalRowCount && totalRowCount > data.length;
-  const isClientSideSorting = !!sorting && !!setSorting;
+  const isServerSideSorting = !!sorting && !!setSorting;
   const onPaginationChange =
     pagination && setPagination
       ? (updater: Updater<PaginationState>) => {
@@ -114,12 +114,12 @@ export function DataTable<TData extends TBaseData>({
     columns,
     rowCount: totalRowCount,
     manualPagination: isServerSidePagination,
-    manualSorting: isClientSideSorting && !isServerSidePagination,
-    ...(isClientSideSorting && {
+    manualSorting: isServerSideSorting,
+    ...(isServerSideSorting && {
       onSortingChange: onSortingChange,
     }),
     getCoreRowModel: getCoreRowModel(),
-    ...(!isClientSideSorting && {
+    ...(!isServerSideSorting && {
       getSortedRowModel: getSortedRowModel(),
     }),
     getFilteredRowModel: getFilteredRowModel(),
@@ -127,7 +127,7 @@ export function DataTable<TData extends TBaseData>({
     onColumnFiltersChange: setColumnFilters,
     state: {
       columnFilters,
-      ...(isClientSideSorting && {
+      ...(isServerSideSorting && {
         sorting,
       }),
       pagination,

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -59,6 +59,7 @@ interface DataTableProps<TData extends TBaseData> {
   columnsBreakpoints?: ColumnBreakpoint;
   sorting?: SortingState;
   setSorting?: (sorting: SortingState) => void;
+  isServerSideSorting?: boolean;
 }
 
 function shouldRenderColumn(
@@ -84,13 +85,13 @@ export function DataTable<TData extends TBaseData>({
   setPagination,
   sorting,
   setSorting,
+  isServerSideSorting = false,
 }: DataTableProps<TData>) {
   const windowSize = useWindowSize();
 
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
 
   const isServerSidePagination = !!totalRowCount && totalRowCount > data.length;
-  const isServerSideSorting = !!sorting && !!setSorting;
   const isClientSideSortingEnabled = !isServerSideSorting && !pagination;
 
   const onPaginationChange =

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -90,6 +90,7 @@ export function DataTable<TData extends TBaseData>({
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
 
   const isServerSidePagination = !!totalRowCount && totalRowCount > data.length;
+  const isClientSideSorting = !!sorting && !!setSorting;
   const onPaginationChange =
     pagination && setPagination
       ? (updater: Updater<PaginationState>) => {
@@ -113,22 +114,29 @@ export function DataTable<TData extends TBaseData>({
     columns,
     rowCount: totalRowCount,
     manualPagination: isServerSidePagination,
-    onSortingChange: onSortingChange,
+    manualSorting: isClientSideSorting && !isServerSidePagination,
+    ...(isClientSideSorting && {
+      onSortingChange: onSortingChange,
+    }),
     getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: sorting ? getSortedRowModel() : undefined,
+    ...(!isClientSideSorting && {
+      getSortedRowModel: getSortedRowModel(),
+    }),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: pagination ? getPaginationRowModel() : undefined,
     onColumnFiltersChange: setColumnFilters,
     state: {
       columnFilters,
-      sorting,
+      ...(isClientSideSorting && {
+        sorting,
+      }),
       pagination,
     },
     initialState: {
       pagination,
       sorting,
     },
-    onPaginationChange: onPaginationChange,
+    onPaginationChange,
   });
 
   useEffect(() => {

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -91,6 +91,8 @@ export function DataTable<TData extends TBaseData>({
 
   const isServerSidePagination = !!totalRowCount && totalRowCount > data.length;
   const isServerSideSorting = !!sorting && !!setSorting;
+  const isClientSideSortingEnabled = !isServerSideSorting && !pagination;
+
   const onPaginationChange =
     pagination && setPagination
       ? (updater: Updater<PaginationState>) => {
@@ -121,6 +123,7 @@ export function DataTable<TData extends TBaseData>({
     getCoreRowModel: getCoreRowModel(),
     ...(!isServerSideSorting && {
       getSortedRowModel: getSortedRowModel(),
+      enableSorting: isClientSideSortingEnabled,
     }),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: pagination ? getPaginationRowModel() : undefined,

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -206,6 +206,32 @@ export const DataTableExample = () => {
   );
 };
 
+export const DataTableClientSideSortingExample = () => {
+  const [sorting, setSorting] = React.useState<SortingState>([{ id: "name", desc: true }])
+  const [filter, setFilter] = React.useState<string>("");
+  
+  return (
+    <div className="s-w-full s-max-w-4xl s-overflow-x-auto">
+      <Input
+        name="filter"
+        placeholder="Filter"
+        value={filter}
+        onChange={(v) => setFilter(v)}
+      />
+      <DataTable
+        className="s-w-full s-max-w-4xl s-overflow-x-auto"
+        data={data}
+        filter={filter}
+        filterColumn="name"
+        columns={columns}
+        columnsBreakpoints={{ lastUpdated: "sm" }}
+        sorting={sorting}
+        setSorting={setSorting}
+      />
+    </div>
+  );
+};
+
 export const DataTablePaginatedExample = () => {
   const [pagination, setPagination] = React.useState<PaginationState>({
     pageIndex: 0,
@@ -279,6 +305,7 @@ export const DataTablePaginatedServerSideExample = () => {
         sorting={sorting}
         setSorting={setSorting}
         columnsBreakpoints={{ lastUpdated: "sm" }}
+        isServerSideSorting={true}
       />
     </div>
   );

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -267,7 +267,7 @@ export const DataTablePaginatedServerSideExample = () => {
     <div className="s-w-full s-max-w-4xl s-overflow-x-auto">
       <Input
         name="filter"
-        placeholder="Filte r"
+        placeholder="Filter"
         value={filter}
         onChange={(v) => setFilter(v)}
       />
@@ -281,7 +281,7 @@ export const DataTablePaginatedServerSideExample = () => {
         setPagination={setPagination}
         columns={columns}
         sorting={sorting}
-        setSorting={(sorting) => setSorting(sorting)}
+        setSorting={setSorting}
         columnsBreakpoints={{ lastUpdated: "sm" }}
       />
     </div>

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -262,7 +262,7 @@ export const DataTablePaginatedServerSideExample = () => {
       (pagination.pageIndex + 1) * pagination.pageSize
     );
   }, [data, pagination, sorting]);
-
+  console.log(sorting)
   return (
     <div className="s-w-full s-max-w-4xl s-overflow-x-auto">
       <Input

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -211,7 +211,6 @@ export const DataTablePaginatedExample = () => {
     pageIndex: 0,
     pageSize: 2,
   });
-  const [sorting, setSorting] = React.useState<SortingState>([{ id: "name", desc: true }])
   const [filter, setFilter] = React.useState<string>("");
 
   return (
@@ -230,8 +229,6 @@ export const DataTablePaginatedExample = () => {
         pagination={pagination}
         setPagination={setPagination}
         columns={columns}
-        sorting={sorting}
-        setSorting={setSorting}
         columnsBreakpoints={{ lastUpdated: "sm" }}
       />
     </div>
@@ -262,7 +259,6 @@ export const DataTablePaginatedServerSideExample = () => {
       (pagination.pageIndex + 1) * pagination.pageSize
     );
   }, [data, pagination, sorting]);
-  console.log(sorting)
   return (
     <div className="s-w-full s-max-w-4xl s-overflow-x-auto">
       <Input

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta } from "@storybook/react";
-import { ColumnDef, PaginationState } from "@tanstack/react-table";
+import { ColumnDef, PaginationState, SortingState } from "@tanstack/react-table";
 import React, { useMemo } from "react";
 
 import { DropdownItemProps } from "@sparkle/components/DropdownMenu";
@@ -211,6 +211,7 @@ export const DataTablePaginatedExample = () => {
     pageIndex: 0,
     pageSize: 2,
   });
+  const [sorting, setSorting] = React.useState<SortingState>([{ id: "name", desc: true }])
   const [filter, setFilter] = React.useState<string>("");
 
   return (
@@ -229,7 +230,8 @@ export const DataTablePaginatedExample = () => {
         pagination={pagination}
         setPagination={setPagination}
         columns={columns}
-        initialColumnOrder={[{ id: "name", desc: false }]}
+        sorting={sorting}
+        setSorting={setSorting}
         columnsBreakpoints={{ lastUpdated: "sm" }}
       />
     </div>
@@ -241,19 +243,31 @@ export const DataTablePaginatedServerSideExample = () => {
     pageIndex: 0,
     pageSize: 2,
   });
+  const [sorting, setSorting] = React.useState<SortingState>([{ id: "name", desc: true }])
   const [filter, setFilter] = React.useState<string>("");
   const rows = useMemo(() => {
+    if (sorting.length > 0) {
+      const order = sorting[0].desc ? -1: 1;
+      return data.sort(
+        (a: Data, b: Data) => {
+          return a.name.toLowerCase().localeCompare(b.name.toLowerCase()) * order
+        }
+      ).slice(
+        pagination.pageIndex * pagination.pageSize,
+        (pagination.pageIndex + 1) * pagination.pageSize
+      );
+    }
     return data.slice(
       pagination.pageIndex * pagination.pageSize,
       (pagination.pageIndex + 1) * pagination.pageSize
     );
-  }, [data, pagination]);
+  }, [data, pagination, sorting]);
 
   return (
     <div className="s-w-full s-max-w-4xl s-overflow-x-auto">
       <Input
         name="filter"
-        placeholder="Filter"
+        placeholder="Filte r"
         value={filter}
         onChange={(v) => setFilter(v)}
       />
@@ -266,7 +280,8 @@ export const DataTablePaginatedServerSideExample = () => {
         pagination={pagination}
         setPagination={setPagination}
         columns={columns}
-        initialColumnOrder={[{ id: "name", desc: false }]}
+        sorting={sorting}
+        setSorting={(sorting) => setSorting(sorting)}
         columnsBreakpoints={{ lastUpdated: "sm" }}
       />
     </div>

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -209,7 +209,7 @@ export const DataTableExample = () => {
 export const DataTableClientSideSortingExample = () => {
   const [sorting, setSorting] = React.useState<SortingState>([{ id: "name", desc: true }])
   const [filter, setFilter] = React.useState<string>("");
-  
+
   return (
     <div className="s-w-full s-max-w-4xl s-overflow-x-auto">
       <Input


### PR DESCRIPTION
## Description

This PR enhances the `DataTable` component in sparkle by adding support for external sorting state management. 

It allows passing `sorting` and `setSorting` props to the component, enabling manual control of the sorting functionality. This change improves flexibility, particularly for server-side sorting scenarios.

**References:**
- https://github.com/dust-tt/dust/issues/7314

## Risk

Moderated, when bumping sparkle version in front we need to pay special attention to instances passing `sortingFn`, as it's no longer accepted.

## Deploy Plan

Deploy `sparkle`