### PR TITLE
[front] fix: Simplify content-nodes api

### DIFF
--- a/front/components/ConnectorPermissionsTree.tsx
+++ b/front/components/ConnectorPermissionsTree.tsx
@@ -165,8 +165,7 @@ export function DataSourceViewPermissionTreeChildren({
   const { nodes, isNodesLoading, isNodesError } = useDataSourceViewContentNodes(
     {
       dataSourceView,
-      includeChildren: true,
-      internalIds: parentId ? [parentId] : undefined,
+      parentId: parentId ?? undefined,
       owner,
       viewType,
     }

--- a/front/components/DataSourceViewResourceSelectorTree.tsx
+++ b/front/components/DataSourceViewResourceSelectorTree.tsx
@@ -84,7 +84,7 @@ function DataSourceViewResourceSelectorChildren({
     {
       dataSourceView: dataSourceView,
       owner,
-      parentId: parentId ?? undefined,
+      parentId,
       viewType,
     }
   );

--- a/front/components/DataSourceViewResourceSelectorTree.tsx
+++ b/front/components/DataSourceViewResourceSelectorTree.tsx
@@ -84,8 +84,7 @@ function DataSourceViewResourceSelectorChildren({
     {
       dataSourceView: dataSourceView,
       owner,
-      internalIds: parentId ? [parentId] : undefined,
-      includeChildren: true,
+      parentId: parentId ?? undefined,
       viewType,
     }
   );

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -486,7 +486,6 @@ function DataSourceViewSelectedNodes({
     dataSourceView,
     internalIds: dataSourceConfiguration.filter.parents?.in ?? undefined,
     viewType,
-    includeChildren: false,
   });
 
   return (

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -217,7 +217,6 @@ async function renderDataSourcesConfigurations(
       const contentNodesRes = await getContentNodesForDataSourceView(
         dataSourceView,
         {
-          includeChildren: false,
           internalIds: sr.resources,
           viewType: "documents",
         }
@@ -292,7 +291,6 @@ async function renderTableDataSourcesConfigurations(
         const contentNodesRes = await getContentNodesForDataSourceView(
           dataSourceView,
           {
-            includeChildren: false,
             internalIds: sr.resources,
             // We only want to fetch tables from the core API.
             onlyCoreAPI: true,

--- a/front/components/vaults/VaultDataSourceViewContentList.tsx
+++ b/front/components/vaults/VaultDataSourceViewContentList.tsx
@@ -168,7 +168,7 @@ export const VaultDataSourceViewContentList = ({
   } = useDataSourceViewContentNodes({
     dataSourceView,
     owner,
-    parentId: parentId ?? undefined,
+    parentId,
     pagination,
     viewType: isValidContentNodesViewType(viewType) ? viewType : "documents",
   });

--- a/front/components/vaults/VaultDataSourceViewContentList.tsx
+++ b/front/components/vaults/VaultDataSourceViewContentList.tsx
@@ -168,8 +168,7 @@ export const VaultDataSourceViewContentList = ({
   } = useDataSourceViewContentNodes({
     dataSourceView,
     owner,
-    internalIds: parentId ? [parentId] : undefined,
-    includeChildren: true,
+    parentId: parentId ?? undefined,
     pagination,
     viewType: isValidContentNodesViewType(viewType) ? viewType : "documents",
   });

--- a/front/components/vaults/VaultLayout.tsx
+++ b/front/components/vaults/VaultLayout.tsx
@@ -102,14 +102,12 @@ function VaultBreadCrumbs({
     nodes: [currentFolder],
   } = useDataSourceViewContentNodes({
     owner,
-    dataSourceView,
+    dataSourceView: parentId ? dataSourceView : undefined,
     internalIds: parentId ? [parentId] : [],
-    includeChildren: false,
   });
 
   const { nodes: folders } = useDataSourceViewContentNodes({
-    dataSourceView,
-    includeChildren: false,
+    dataSourceView: currentFolder ? dataSourceView : undefined,
     internalIds: currentFolder?.parentInternalIds ?? [],
     owner,
   });

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -58,8 +58,8 @@ export function filterAndCropContentNodesByView(
 
 // If `internalIds` is not provided, it means that the request is for all the content nodes in the view.
 interface GetContentNodesForDataSourceViewParams {
-  includeChildren: boolean;
   internalIds?: string[];
+  parentId?: string;
   pagination?: OffsetPaginationParams;
   viewType: ContentNodesViewType;
   // If onlyCoreAPI is true, the function will only use the Core API to fetch the content nodes.
@@ -82,8 +82,8 @@ const paginate = (
 export async function getContentNodesForManagedDataSourceView(
   dataSourceView: DataSourceViewResource | DataSourceViewType,
   {
-    includeChildren,
     internalIds,
+    parentId,
     pagination,
     viewType,
   }: GetContentNodesForDataSourceViewParams
@@ -100,21 +100,19 @@ export async function getContentNodesForManagedDataSourceView(
     "Connector ID is required for managed data sources."
   );
 
-  // Determine if child nodes should be fetched:
-  // - Fetch children if 'includeChildren' is true and 'internalIds' are provided,
-  //   signifying a request for specific node children.
-  // - Fetch children if the 'parentsIn' field is not specified in the current view,
-  //   indicating that the view does not have predefined parent nodes.
-  // In cases where these conditions are not met, the logic defaults to fetching root nodes.
-  if ((includeChildren && internalIds) || !dataSourceView.parentsIn) {
-    const [parentInternalId] = internalIds || [];
+  // If no internalIds nor parentIds are provided, get the root nodes of the data source view.
+  if (!internalIds && !parentId && dataSourceView.parentsIn) {
+    internalIds = dataSourceView.parentsIn;
+  }
 
+  // If no internalIds are provided, fetch the children of the parent node, or root nodes of data source.
+  if (!internalIds) {
     const connectorsRes = await connectorsAPI.getConnectorPermissions({
       connectorId: dataSource.connectorId,
       filterPermission: "read",
       includeParents: true,
       // Passing an undefined parentInternalId will fetch the root nodes.
-      parentId: parentInternalId ?? undefined,
+      parentId,
       viewType,
     });
 
@@ -135,7 +133,7 @@ export async function getContentNodesForManagedDataSourceView(
     const connectorsRes = await connectorsAPI.getContentNodes({
       connectorId: dataSource.connectorId,
       includeParents: true,
-      internalIds: internalIds ?? dataSourceView.parentsIn ?? [],
+      internalIds: internalIds,
       viewType,
     });
     if (connectorsRes.isErr()) {

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -133,7 +133,7 @@ export async function getContentNodesForManagedDataSourceView(
     const connectorsRes = await connectorsAPI.getContentNodes({
       connectorId: dataSource.connectorId,
       includeParents: true,
-      internalIds: internalIds,
+      internalIds,
       viewType,
     });
     if (connectorsRes.isErr()) {

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -69,7 +69,6 @@ export function useMultipleDataSourceViewsContentNodes({
       const body = JSON.stringify({
         internalIds,
         viewType,
-        includeChildren: false,
       });
       const options = {
         method: "POST",
@@ -106,14 +105,14 @@ export function useDataSourceViewContentNodes({
   owner,
   dataSourceView,
   internalIds,
-  includeChildren,
+  parentId,
   pagination,
   viewType = "documents",
 }: {
   owner: LightWorkspaceType;
   dataSourceView?: DataSourceViewType;
   internalIds?: string[];
-  includeChildren: boolean;
+  parentId?: string;
   pagination?: PaginationState;
   viewType?: ContentNodesViewType;
 }): {
@@ -132,7 +131,7 @@ export function useDataSourceViewContentNodes({
 
   const body = JSON.stringify({
     internalIds,
-    includeChildren,
+    parentId,
     viewType,
   });
 
@@ -148,7 +147,7 @@ export function useDataSourceViewContentNodes({
       return undefined;
     }
 
-    return postFetcher([url, { internalIds, includeChildren, viewType }]);
+    return postFetcher([url, { internalIds, parentId, viewType }]);
   });
 
   return {

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/content-nodes.ts
@@ -18,8 +18,8 @@ import { apiError } from "@app/logger/withlogging";
 const DEFAULT_LIMIT = 500;
 
 const GetContentNodesOrChildrenRequestBody = t.type({
-  includeChildren: t.boolean,
   internalIds: t.union([t.array(t.union([t.string, t.null])), t.undefined]),
+  parentId: t.union([t.string, t.undefined]),
   viewType: ContentNodesViewTypeCodec,
 });
 
@@ -87,15 +87,14 @@ async function handler(
     });
   }
 
-  const { includeChildren, internalIds, viewType } = bodyValidation.right;
+  const { internalIds, parentId, viewType } = bodyValidation.right;
 
-  if (includeChildren && internalIds && internalIds.length > 1) {
+  if (parentId && internalIds) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message:
-          "When fetching children, only one internal id should be provided.",
+        message: "Cannot fetch with parentId and internalIds at the same time.",
       },
     });
   }
@@ -117,8 +116,8 @@ async function handler(
   const contentNodesRes = await getContentNodesForDataSourceView(
     dataSourceView,
     {
-      includeChildren: includeChildren === true,
       internalIds: internalIds ? removeNulls(internalIds) : undefined,
+      parentId: parentId ?? undefined,
       pagination: paginationRes.value,
       viewType,
     }

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/content-nodes.ts
@@ -117,7 +117,7 @@ async function handler(
     dataSourceView,
     {
       internalIds: internalIds ? removeNulls(internalIds) : undefined,
-      parentId: parentId ?? undefined,
+      parentId,
       pagination: paginationRes.value,
       viewType,
     }

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/tables/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/tables/index.ts
@@ -70,7 +70,6 @@ async function handler(
       const contentNodes = await getContentNodesForDataSourceView(
         dataSourceView,
         {
-          includeChildren: false,
           viewType: "tables",
           // Use core api as ww want a flat list of all tables, even for managed datasources.
           onlyCoreAPI: true,


### PR DESCRIPTION
fixes: https://github.com/dust-tt/dust/issues/7407

## Description

Instead of confusing includeChildren parameter, use 2 separate parameters depending on how you want to fetch content-nodes : 
- internalIds : you'll get the node with these ids
- parentId: you'll get the children of the specified node id

## Risk

Check all places where content-nodes endpoint is used

## Deploy Plan

deploy `front`