### PR TITLE
fix: setupWitSuffix for managed data sources is broken

### DIFF
--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -32,6 +32,7 @@ import { ConnectorPermissionsModal } from "@app/components/ConnectorPermissionsM
 import ConnectorSyncingChip from "@app/components/data_source/DataSourceSyncChip";
 import { DeleteStaticDataSourceDialog } from "@app/components/data_source/DeleteStaticDataSourceDialog";
 import { RequestDataSourceModal } from "@app/components/data_source/RequestDataSourceModal";
+import type { DataSourceIntegration } from "@app/components/vaults/AddConnectionMenu";
 import { AddConnectionMenu } from "@app/components/vaults/AddConnectionMenu";
 import { EditVaultManagedDataSourcesViews } from "@app/components/vaults/EditVaultManagedDatasourcesViews";
 import { EditVaultStaticDatasourcesViews } from "@app/components/vaults/EditVaultStaticDatasourcesViews";
@@ -73,6 +74,7 @@ type VaultResourcesListProps = {
   systemVault: VaultType;
   category: Exclude<DataSourceViewCategory, "apps">;
   onSelect: (sId: string) => void;
+  integrations: DataSourceIntegration[];
 };
 
 const getTableColumns = ({
@@ -210,6 +212,7 @@ export const VaultResourcesList = ({
   systemVault,
   category,
   onSelect,
+  integrations,
 }: VaultResourcesListProps) => {
   const [dataSourceSearch, setDataSourceSearch] = useState<string>("");
   const [showConnectorPermissionsModal, setShowConnectorPermissionsModal] =
@@ -394,6 +397,7 @@ export const VaultResourcesList = ({
                   }
                   setIsNewConnectorLoading(false);
                 }}
+                integrations={integrations}
               />
             )}
 

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -31,6 +31,7 @@ import ConnectorSyncingChip from "@app/components/data_source/DataSourceSyncChip
 import { RequestDataSourceModal } from "@app/components/data_source/RequestDataSourceModal";
 import { subNavigationBuild } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
+import type { DataSourceIntegration } from "@app/components/vaults/AddConnectionMenu";
 import { AddConnectionMenu } from "@app/components/vaults/AddConnectionMenu";
 import config from "@app/lib/api/config";
 import {
@@ -54,11 +55,6 @@ type DataSourceWithConnectorAndUsageType =
   DataSourceWithConnectorDetailsType & {
     usage: number | null;
   };
-
-type DataSourceIntegration = {
-  connectorProvider: ConnectorProvider;
-  setupWithSuffix: string | null;
-};
 
 type RowData = {
   isAdmin: boolean;
@@ -279,6 +275,7 @@ export default function DataSourcesView({
             <AddConnectionMenu
               owner={owner}
               plan={plan}
+              integrations={integrations}
               existingDataSources={managedDataSources}
               dustClientFacingUrl={dustClientFacingUrl}
               setIsProviderLoading={(provider, isLoading) =>

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -51,7 +51,7 @@ const REDIRECT_TO_EDIT_PERMISSIONS = [
   "intercom",
 ];
 
-type DataSourceWithConnectorAndUsageType =
+export type DataSourceWithConnectorAndUsageType =
   DataSourceWithConnectorDetailsType & {
     usage: number | null;
   };


### PR DESCRIPTION
## Description

The `setupWitSuffix` feature, which allows setting up a second managed data source for a specific provider, is currently broken.

This fixes it.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
