### PR TITLE
Fix: infinite loop in events

### DIFF
--- a/front/hooks/useEventSource.ts
+++ b/front/hooks/useEventSource.ts
@@ -162,7 +162,7 @@ export function useEventSource(
   }, [buildURL, onEventCallback, uniqueId, sourceManager]);
 
   useEffect(() => {
-    if (!isReadyToConsumeStream) {
+    if (!isReadyToConsumeStream || isError) {
       return;
     }
 
@@ -181,6 +181,7 @@ export function useEventSource(
     reconnectCounter,
     sourceManager,
     uniqueId,
+    isError,
   ]);
 
   return { isError };


### PR DESCRIPTION
## Description

The anti-loop prevention didn't work at all, once the 10 attempts tried, it would loop infinitely (repro locally before/after).

## Risk

None

## Deploy Plan

Deploy `front`