### PR TITLE
Fix: opt-in for mutate all swr hooks regardless of query params

### DIFF
--- a/front/components/assistant/conversation/AssistantBrowserContainer.tsx
+++ b/front/components/assistant/conversation/AssistantBrowserContainer.tsx
@@ -22,10 +22,13 @@ export function AssistantBrowserContainer({
   isBuilder,
   setAssistantToMention,
 }: AssistantBrowserContainerProps) {
-  const { agentConfigurations, isLoading, mutateAgentConfigurations } =
-    useProgressiveAgentConfigurations({
-      workspaceId: owner.sId,
-    });
+  const {
+    agentConfigurations,
+    isLoading,
+    mutateRegardlessOfQueryParams: mutateAgentConfigurations,
+  } = useProgressiveAgentConfigurations({
+    workspaceId: owner.sId,
+  });
 
   const handleAssistantClick = useCallback(
     // On click, scroll to the input bar and set the selected assistant.

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -60,13 +60,17 @@ export function MembersList({
   });
   const [selectedMember, setSelectedMember] =
     useState<UserTypeWithWorkspaces | null>(null);
-  const { members, totalMembersCount, isLoading, mutateMembers } =
-    useSearchMembers({
-      workspaceId: owner.sId,
-      searchTerm: searchText,
-      pageIndex: pagination.pageIndex,
-      pageSize: pagination.pageSize,
-    });
+  const {
+    members,
+    totalMembersCount,
+    isLoading,
+    mutateRegardlessOfQueryParams: mutateMembers,
+  } = useSearchMembers({
+    workspaceId: owner.sId,
+    searchTerm: searchText,
+    pageIndex: pagination.pageIndex,
+    pageSize: pagination.pageSize,
+  });
   const columns = [
     {
       id: "name",

--- a/front/components/vaults/EditVaultManagedDatasourcesViews.tsx
+++ b/front/components/vaults/EditVaultManagedDatasourcesViews.tsx
@@ -35,7 +35,7 @@ export function EditVaultManagedDataSourcesViews({
   const {
     vaultDataSourceViews,
     isVaultDataSourceViewsLoading,
-    mutateVaultDataSourceViews,
+    mutateRegardlessOfQueryParams: mutateVaultDataSourceViews,
   } = useVaultDataSourceViews({
     workspaceId: owner.sId,
     vaultId: vault.sId,

--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -250,7 +250,7 @@ export const VaultResourcesList = ({
   const {
     vaultDataSourceViews,
     isVaultDataSourceViewsLoading,
-    mutateVaultDataSourceViews,
+    mutateRegardlessOfQueryParams: mutateVaultDataSourceViews,
   } = useVaultDataSourceViews({
     workspaceId: owner.sId,
     vaultId: vault.sId,

--- a/front/components/vaults/VaultWebsiteModal.tsx
+++ b/front/components/vaults/VaultWebsiteModal.tsx
@@ -141,11 +141,12 @@ export default function VaultWebsiteModal({
   const [advancedSettingsOpened, setAdvancedSettingsOpened] = useState(false);
   const [headers, setHeaders] = useState<{ key: string; value: string }[]>([]);
 
-  const { mutateVaultDataSourceViews } = useVaultDataSourceViews({
-    workspaceId: owner.sId,
-    vaultId: vault.sId,
-    category: WEBSITE_CAT,
-  });
+  const { mutateRegardlessOfQueryParams: mutateVaultDataSourceViews } =
+    useVaultDataSourceViews({
+      workspaceId: owner.sId,
+      vaultId: vault.sId,
+      category: WEBSITE_CAT,
+    });
 
   const frequencyDisplayText: Record<CrawlingFrequency, string> = {
     never: "Never",
@@ -255,7 +256,7 @@ export default function VaultWebsiteModal({
           type: "success",
           description: "The website has been successfully created.",
         });
-        await mutateVaultDataSourceViews();
+        void mutateVaultDataSourceViews();
         setIsSaving(false);
         const response: PostVaultDataSourceResponseBody = await res.json();
         const { dataSourceView } = response;
@@ -333,7 +334,7 @@ export default function VaultWebsiteModal({
     );
     setIsSaving(false);
     if (res.ok) {
-      await mutateVaultDataSourceViews();
+      void mutateVaultDataSourceViews();
       await router.push(
         `/w/${owner.sId}/vaults/${vault.sId}/categories/${WEBSITE_CAT}`
       );

--- a/front/hooks/useChangeMembersRoles.ts
+++ b/front/hooks/useChangeMembersRoles.ts
@@ -19,7 +19,7 @@ export function useChangeMembersRoles({
   owner: LightWorkspaceType;
 }) {
   const sendNotification = useContext(SendNotificationsContext);
-  const { mutateMembers } = useMembers({
+  const { mutateRegardlessOfQueryParams: mutateMembers } = useMembers({
     workspaceId: owner.sId,
     disabled: true,
   });
@@ -31,10 +31,11 @@ export function useChangeMembersRoles({
     searchTerm: "",
     workspaceId: owner.sId,
   };
-  const { mutateMembers: mutateSearchMembers } = useSearchMembers({
-    ...mockParameters,
-    disabled: true,
-  });
+  const { mutateRegardlessOfQueryParams: mutateSearchMembers } =
+    useSearchMembers({
+      ...mockParameters,
+      disabled: true,
+    });
 
   const handleMembersRoleChange = useCallback(
     async ({

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -112,13 +112,14 @@ export function useAgentConfigurations({
   }
 
   const queryString = getQueryString();
-  const { data, error, mutate } = useSWRWithDefaults(
-    agentsGetView
-      ? `/api/w/${workspaceId}/assistant/agent_configurations?${queryString}`
-      : null,
-    agentConfigurationsFetcher,
-    { disabled }
-  );
+  const { data, error, mutate, mutateRegardlessOfQueryParams } =
+    useSWRWithDefaults(
+      agentsGetView
+        ? `/api/w/${workspaceId}/assistant/agent_configurations?${queryString}`
+        : null,
+      agentConfigurationsFetcher,
+      { disabled }
+    );
 
   return {
     agentConfigurations: useMemo(
@@ -127,7 +128,8 @@ export function useAgentConfigurations({
     ),
     isAgentConfigurationsLoading: !error && !data,
     isAgentConfigurationsError: error,
-    mutateAgentConfigurations: mutate,
+    mutate,
+    mutateRegardlessOfQueryParams,
   };
 }
 
@@ -149,7 +151,8 @@ export function useProgressiveAgentConfigurations({
   const {
     agentConfigurations: agentConfigurationsWithAuthors,
     isAgentConfigurationsLoading: isAgentConfigurationsWithAuthorsLoading,
-    mutateAgentConfigurations,
+    mutate,
+    mutateRegardlessOfQueryParams,
   } = useAgentConfigurations({
     workspaceId,
     agentsGetView: "assistants-search",
@@ -166,7 +169,8 @@ export function useProgressiveAgentConfigurations({
   return {
     agentConfigurations,
     isLoading,
-    mutateAgentConfigurations,
+    mutate,
+    mutateRegardlessOfQueryParams,
   };
 }
 
@@ -261,11 +265,12 @@ export function useDeleteAgentConfiguration({
   agentConfiguration: LightAgentConfigurationType;
 }) {
   const sendNotification = useContext(SendNotificationsContext);
-  const { mutateAgentConfigurations } = useAgentConfigurations({
-    workspaceId: owner.sId,
-    agentsGetView: "list", // Anything would work
-    disabled: true, // We only use the hook to mutate the cache
-  });
+  const { mutateRegardlessOfQueryParams: mutateAgentConfigurations } =
+    useAgentConfigurations({
+      workspaceId: owner.sId,
+      agentsGetView: "list", // Anything would work
+      disabled: true, // We only use the hook to mutate the cache
+    });
 
   const { mutateAgentConfiguration } = useAgentConfiguration({
     workspaceId: owner.sId,

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -26,17 +26,17 @@ export function useMembers({
   appendPaginationParams(params, pagination);
 
   const membersFetcher: Fetcher<GetMembersResponseBody> = fetcher;
-  const { data, error, mutate } = useSWRWithDefaults(
-    `/api/w/${workspaceId}/members`,
-    membersFetcher,
-    { disabled }
-  );
+  const { data, error, mutate, mutateRegardlessOfQueryParams } =
+    useSWRWithDefaults(`/api/w/${workspaceId}/members`, membersFetcher, {
+      disabled,
+    });
 
   return {
     members: useMemo(() => (data ? data.members : []), [data]),
     isMembersLoading: !error && !data,
     isMembersError: error,
-    mutateMembers: mutate,
+    mutate,
+    mutateRegardlessOfQueryParams,
     total: data ? data.total : 0,
   };
 }
@@ -103,20 +103,22 @@ export function useSearchMembers({
     lastValue: (pageIndex * pageSize).toString(),
   });
 
-  const { data, error, mutate } = useSWRWithDefaults(
-    `/api/w/${workspaceId}/members/search?${searchParams.toString()}`,
-    searchMembersFetcher,
-    {
-      revalidateOnFocus: false,
-      revalidateOnReconnect: false,
-      disabled,
-    }
-  );
+  const { data, error, mutate, mutateRegardlessOfQueryParams } =
+    useSWRWithDefaults(
+      `/api/w/${workspaceId}/members/search?${searchParams.toString()}`,
+      searchMembersFetcher,
+      {
+        revalidateOnFocus: false,
+        revalidateOnReconnect: false,
+        disabled,
+      }
+    );
   return {
     members: useMemo(() => (data ? data.members : []), [data]),
     totalMembersCount: data?.total ?? 0,
     isLoading: !error && !data,
     isError: !!error,
-    mutateMembers: mutate,
+    mutate,
+    mutateRegardlessOfQueryParams,
   };
 }

--- a/front/lib/swr/swr.ts
+++ b/front/lib/swr/swr.ts
@@ -12,7 +12,9 @@ const DEFAULT_SWR_CONFIG: SWRConfiguration = {
 export function useSWRWithDefaults<TKey extends Key, TData>(
   key: TKey,
   fetcher: Fetcher<TData, TKey> | null,
-  config?: SWRConfiguration & { disabled?: boolean }
+  config?: SWRConfiguration & {
+    disabled?: boolean;
+  }
 ) {
   const { mutate: globalMutate, cache } = useSWRConfig();
 
@@ -58,11 +60,15 @@ export function useSWRWithDefaults<TKey extends Key, TData>(
   );
 
   const myMutateWhenDisabled = useCallback(() => {
+    return globalMutate(key);
+  }, [key, globalMutate]);
+
+  const myMutateWhenDisabledRegardlessOfQueryParams = useCallback(() => {
     mutateKeysWithSameUrl(key);
     return globalMutate(key);
   }, [key, mutateKeysWithSameUrl, globalMutate]);
 
-  const myMutate: typeof result.mutate = useCallback(
+  const myMutateRegardlessOfQueryParams: typeof result.mutate = useCallback(
     (...args) => {
       mutateKeysWithSameUrl(key);
       return result.mutate(...args);
@@ -76,11 +82,13 @@ export function useSWRWithDefaults<TKey extends Key, TData>(
     return {
       ...result,
       mutate: myMutateWhenDisabled,
+      mutateRegardlessOfQueryParams:
+        myMutateWhenDisabledRegardlessOfQueryParams,
     };
   } else {
     return {
       ...result,
-      mutate: myMutate,
+      mutateRegardlessOfQueryParams: myMutateRegardlessOfQueryParams,
     };
   }
 }

--- a/front/lib/swr/vaults.ts
+++ b/front/lib/swr/vaults.ts
@@ -129,11 +129,12 @@ export function useVaultDataSourceViews<
     queryParams.set("includeEditedBy", "true");
   }
 
-  const { data, error, mutate } = useSWRWithDefaults(
-    `/api/w/${workspaceId}/vaults/${vaultId}/data_source_views?${queryParams.toString()}`,
-    vaultsDataSourceViewsFetcher,
-    { disabled }
-  );
+  const { data, error, mutate, mutateRegardlessOfQueryParams } =
+    useSWRWithDefaults(
+      `/api/w/${workspaceId}/vaults/${vaultId}/data_source_views?${queryParams.toString()}`,
+      vaultsDataSourceViewsFetcher,
+      { disabled }
+    );
 
   const vaultDataSourceViews = useMemo(() => {
     return (data?.dataSourceViews ??
@@ -142,7 +143,8 @@ export function useVaultDataSourceViews<
 
   return {
     vaultDataSourceViews,
-    mutateVaultDataSourceViews: mutate,
+    mutate,
+    mutateRegardlessOfQueryParams,
     isVaultDataSourceViewsLoading: !error && !data,
     isVaultDataSourceViewsError: error,
   };
@@ -157,12 +159,13 @@ export function useCreateFolder({
   vaultId: string;
 }) {
   const sendNotification = useContext(SendNotificationsContext);
-  const { mutateVaultDataSourceViews } = useVaultDataSourceViews({
-    workspaceId: owner.sId,
-    vaultId: vaultId,
-    category: "folder",
-    disabled: true, // Needed just to mutate
-  });
+  const { mutateRegardlessOfQueryParams: mutateVaultDataSourceViews } =
+    useVaultDataSourceViews({
+      workspaceId: owner.sId,
+      vaultId: vaultId,
+      category: "folder",
+      disabled: true, // Needed just to mutate
+    });
 
   // TODO(GROUPS_INFRA) - Ideally, it should be a DataSourceViewType
   const doCreate = async (name: string | null, description: string | null) => {
@@ -215,12 +218,13 @@ export function useUpdateFolder({
   vaultId: string;
 }) {
   const sendNotification = useContext(SendNotificationsContext);
-  const { mutateVaultDataSourceViews } = useVaultDataSourceViews({
-    workspaceId: owner.sId,
-    vaultId: vaultId,
-    category: "folder",
-    disabled: true, // Needed just to mutate
-  });
+  const { mutateRegardlessOfQueryParams: mutateVaultDataSourceViews } =
+    useVaultDataSourceViews({
+      workspaceId: owner.sId,
+      vaultId: vaultId,
+      category: "folder",
+      disabled: true, // Needed just to mutate
+    });
 
   // TODO(GROUPS_INFRA) - Ideally, it should be a DataSourceViewType
   const doUpdate = async (
@@ -275,12 +279,13 @@ export function useDeleteFolderOrWebsite({
   category: Exclude<DataSourceViewCategory, "apps">;
 }) {
   const sendNotification = useContext(SendNotificationsContext);
-  const { mutateVaultDataSourceViews } = useVaultDataSourceViews({
-    workspaceId: owner.sId,
-    vaultId: vaultId,
-    category: category,
-    disabled: true, // Needed just to mutate
-  });
+  const { mutateRegardlessOfQueryParams: mutateVaultDataSourceViews } =
+    useVaultDataSourceViews({
+      workspaceId: owner.sId,
+      vaultId: vaultId,
+      category: category,
+      disabled: true, // Needed just to mutate
+    });
 
   // TODO(GROUPS_INFRA) - Ideally, it should be a DataSourceViewType
   const doDelete = async (dataSource: DataSourceType | null) => {

--- a/front/pages/w/[wId]/builder/assistants/dust.tsx
+++ b/front/pages/w/[wId]/builder/assistants/dust.tsx
@@ -56,11 +56,13 @@ export default function EditDustAssistant({
   const router = useRouter();
   const sendNotification = useContext(SendNotificationsContext);
 
-  const { agentConfigurations, mutateAgentConfigurations } =
-    useAgentConfigurations({
-      workspaceId: owner.sId,
-      agentsGetView: "global",
-    });
+  const {
+    agentConfigurations,
+    mutateRegardlessOfQueryParams: mutateAgentConfigurations,
+  } = useAgentConfigurations({
+    workspaceId: owner.sId,
+    agentsGetView: "global",
+  });
   const { dataSources, mutateDataSources } = useDataSources(owner);
 
   const sortedDatasources = dataSources.sort((a, b) => {

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -95,7 +95,7 @@ export default function WorkspaceAssistants({
   // user searches: search across all agents
   const {
     agentConfigurations,
-    mutateAgentConfigurations,
+    mutateRegardlessOfQueryParams: mutateAgentConfigurations,
     isAgentConfigurationsLoading,
   } = useAgentConfigurations({
     workspaceId: owner.sId,


### PR DESCRIPTION
## Description

Ask the dev to explictely pick the non-classic mutation that mutate all keys sharing the same url regardless of the query params.

## Risk

Regarding amount of re-render / refretch : less than what we already have.
Hopefully, I didn't miss any that could re-introduce bug where things do not update automatically.

## Deploy Plan

Deploy `front`