### PR TITLE
Add loader on Data source delete dialog to prevent multiple clicks

### DIFF
--- a/front/components/data_source/DeleteStaticDataSourceDialog.tsx
+++ b/front/components/data_source/DeleteStaticDataSourceDialog.tsx
@@ -1,5 +1,6 @@
 import { Dialog } from "@dust-tt/sparkle";
 import type { DataSourceType } from "@dust-tt/types";
+import { useState } from "react";
 
 import { getDataSourceName, isManaged } from "@app/lib/data_sources";
 
@@ -18,8 +19,12 @@ export function DeleteStaticDataSourceDialog({
   isOpen,
   onClose,
 }: DeleteStaticDataSourceDialogProps) {
+  const [isLoading, setIsLoading] = useState(false);
+
   const onDelete = async () => {
+    setIsLoading(true);
     await handleDelete();
+    setIsLoading(false);
     onClose();
   };
   const name = !isManaged(dataSource)
@@ -38,6 +43,7 @@ export function DeleteStaticDataSourceDialog({
       isOpen={isOpen}
       title={`Removing ${name}`}
       onValidate={onDelete}
+      isSaving={isLoading}
       onCancel={onClose}
       validateVariant="primaryWarning"
     >


### PR DESCRIPTION
## Description

Prevent multi-clicks on the dialog to remove a data source (folder / website). 
isSaving removes the button and displays a loader instead. 

<img width="526" alt="Screenshot 2024-09-16 at 17 22 09" src="https://github.com/user-attachments/assets/4d7ada5f-8ebc-478c-a2ad-12d6c1e369ed">

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
