### PR TITLE
fix: switch to tables viewType if no docs

### DIFF
--- a/front/components/vaults/VaultDataSourceViewContentList.tsx
+++ b/front/components/vaults/VaultDataSourceViewContentList.tsx
@@ -116,7 +116,7 @@ const getTableColumns = (showVaultUsage: boolean): ColumnDef<RowData>[] => {
   return columns;
 };
 
-function useViewHasContent({
+function useStaticDataSourceViewHasContent({
   owner,
   dataSourceView,
   parentId,
@@ -127,8 +127,11 @@ function useViewHasContent({
   parentId?: string;
   viewType: ContentNodesViewType;
 }) {
+  // We don't do the call if the dataSourceView is managed.
   const { isNodesLoading, nodes } = useDataSourceViewContentNodes({
-    dataSourceView,
+    dataSourceView: isManaged(dataSourceView.dataSource)
+      ? undefined
+      : dataSourceView,
     owner,
     internalIds: parentId ? [parentId] : undefined,
     pagination: {
@@ -139,8 +142,8 @@ function useViewHasContent({
   });
 
   return {
-    hasContent: !!nodes?.length,
-    isLoading: isNodesLoading,
+    hasContent: isManaged(dataSourceView.dataSource) ? true : !!nodes?.length,
+    isLoading: isManaged(dataSourceView.dataSource) ? false : isNodesLoading,
   };
 }
 
@@ -206,13 +209,13 @@ export const VaultDataSourceViewContentList = ({
     viewType: isValidContentNodesViewType(viewType) ? viewType : undefined,
   });
 
-  const { hasContent: hasDocuments } = useViewHasContent({
+  const { hasContent: hasDocuments } = useStaticDataSourceViewHasContent({
     owner,
     dataSourceView,
     parentId,
     viewType: "documents",
   });
-  const { hasContent: hasTables } = useViewHasContent({
+  const { hasContent: hasTables } = useStaticDataSourceViewHasContent({
     owner,
     dataSourceView,
     parentId,

--- a/front/components/vaults/VaultDataSourceViewContentList.tsx
+++ b/front/components/vaults/VaultDataSourceViewContentList.tsx
@@ -13,6 +13,7 @@ import type {
   ContentNodesViewType,
   DataSourceViewContentNode,
   DataSourceViewType,
+  LightWorkspaceType,
   PlanType,
   VaultType,
   WorkspaceType,
@@ -122,7 +123,7 @@ function useStaticDataSourceViewHasContent({
   parentId,
   viewType,
 }: {
-  owner: WorkspaceType;
+  owner: LightWorkspaceType;
   dataSourceView: DataSourceViewType;
   parentId?: string;
   viewType: ContentNodesViewType;

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -107,7 +107,7 @@ export function useDataSourceViewContentNodes({
   internalIds,
   parentId,
   pagination,
-  viewType = "documents",
+  viewType,
 }: {
   owner: LightWorkspaceType;
   dataSourceView?: DataSourceViewType;
@@ -125,9 +125,10 @@ export function useDataSourceViewContentNodes({
   const params = new URLSearchParams();
   appendPaginationParams(params, pagination);
 
-  const url = dataSourceView
-    ? `/api/w/${owner.sId}/vaults/${dataSourceView.vaultId}/data_source_views/${dataSourceView.sId}/content-nodes?${params}`
-    : null;
+  const url =
+    dataSourceView && viewType
+      ? `/api/w/${owner.sId}/vaults/${dataSourceView.vaultId}/data_source_views/${dataSourceView.sId}/content-nodes?${params}`
+      : null;
 
   const body = JSON.stringify({
     internalIds,


### PR DESCRIPTION
## Description

- When there is no documents in a view but there are tables, we still default to the documents view (bad xp)
- On the documents view, if empty, we don't show the dropdown to switch to tables view
- so basically, if the view only has tables, the user is stuck and cannot see them

my fix is to make a small query to check if the view has docs and tables, and based on that decide what tab to show. Only show the dropdown if useful (i.e, there's content in the view type that's not being displayed)

## Risk

Need to make 2 small queries to check if there are docs / tables. Fine for static data sources (since we have real pagination and the calls are inexpensive). Not doing for managed data sources (we don't have real pagination there + this issue doesn't really exist on managed data sources)

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
