### PR TITLE
Flav/agent tables query data source id wave 3

### DIFF
--- a/front/lib/api/assistant/configuration/table_query.ts
+++ b/front/lib/api/assistant/configuration/table_query.ts
@@ -154,7 +154,7 @@ export async function createTableDataSourceConfiguration(
 
       await AgentTablesQueryConfigurationTable.create(
         {
-          dataSourceIdNew: dataSource.id,
+          dataSourceId: dataSource.id,
           dataSourceViewId: dataSourceView.id,
           dataSourceWorkspaceId: tc.workspaceId,
           tableId: tc.tableId,

--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -95,7 +95,7 @@ export class AgentTablesQueryConfigurationTable extends Model<
 
   declare tableId: string;
 
-  declare dataSourceIdNew: ForeignKey<DataSource["id"]> | null;
+  declare dataSourceId: ForeignKey<DataSource["id"]> | null;
 
   declare dataSourceViewId: ForeignKey<DataSourceViewModel["id"]>;
   declare tablesQueryConfigurationId: ForeignKey<
@@ -162,12 +162,12 @@ AgentTablesQueryConfigurationTable.belongsTo(AgentTablesQueryConfiguration, {
 
 // Config <> Data source.
 DataSource.hasMany(AgentTablesQueryConfigurationTable, {
-  foreignKey: { allowNull: false, name: "dataSourceIdNew" },
+  foreignKey: { allowNull: false, name: "dataSourceId" },
   onDelete: "RESTRICT",
 });
 AgentTablesQueryConfigurationTable.belongsTo(DataSource, {
   as: "dataSource",
-  foreignKey: { allowNull: false, name: "dataSourceIdNew" },
+  foreignKey: { allowNull: false, name: "dataSourceId" },
 });
 
 // Config <> Data source view.

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -343,7 +343,7 @@ export class DataSourceResource extends ResourceWithVault<DataSource> {
     await AgentTablesQueryConfigurationTable.destroy({
       where: {
         dataSourceWorkspaceId: auth.getNonNullableWorkspace().sId,
-        dataSourceIdNew: this.id,
+        dataSourceId: this.id,
       },
     });
 

--- a/front/migrations/20240902_backfill_views_in_agent_table_query_configurations.ts
+++ b/front/migrations/20240902_backfill_views_in_agent_table_query_configurations.ts
@@ -38,9 +38,9 @@ async function backfillViewsInAgentTableQueryConfigurationForWorkspace(
   // Count agent tables query configurations that uses those data sources and have no dataSourceViewId.
   const agentTablesQueryConfigurationsCount: GroupedCountResultItem[] =
     await AgentTablesQueryConfigurationTable.count({
+      // @ts-expect-error `dataSourceViewId` is not nullable.
       where: {
         // /!\ `dataSourceId` is the data source's name, not the id.
-        // @ts-expect-error `dataSourceId` has been removed.
         dataSourceId: dataSources.map((ds) => ds.name),
         dataSourceViewId: {
           [Op.is]: null,
@@ -70,7 +70,6 @@ async function backfillViewsInAgentTableQueryConfigurationForWorkspace(
       {
         where: {
           // /!\ `dataSourceId` is the data source's name, not the id.
-          // @ts-expect-error `dataSourceId` has been removed.
           dataSourceId: ds.name,
         },
       }

--- a/front/migrations/20240916_backfill_ds_in_agent_table_query_configurations.ts
+++ b/front/migrations/20240916_backfill_ds_in_agent_table_query_configurations.ts
@@ -40,8 +40,8 @@ async function backfillDataSourceIdInAgentTableQueryConfigurationForWorkspace(
     await AgentTablesQueryConfigurationTable.count({
       where: {
         // /!\ `dataSourceId` is the data source's name, not the id.
-        // @ts-expect-error `dataSourceId` has been removed.
         dataSourceId: dataSources.map((ds) => ds.name),
+        // @ts-expect-error `dataSourceIdNew` has been removed.
         dataSourceIdNew: {
           [Op.is]: null,
         },
@@ -69,12 +69,12 @@ async function backfillDataSourceIdInAgentTableQueryConfigurationForWorkspace(
 
     const [, affectedRows] = await AgentTablesQueryConfigurationTable.update(
       {
+        // @ts-expect-error `dataSourceIdNew` has been removed.
         dataSourceIdNew: ds.id,
       },
       {
         where: {
           // /!\ `dataSourceId` is the data source's name, not the id.
-          // @ts-expect-error `dataSourceId` has been removed.
           dataSourceId: ds.name,
           dataSourceIdNew: {
             [Op.is]: null,

--- a/front/migrations/db/migration_82.sql
+++ b/front/migrations/db/migration_82.sql
@@ -1,0 +1,7 @@
+-- Migration created on Sep 16, 2024
+ALTER TABLE "public"."agent_tables_query_configuration_tables"
+ADD COLUMN "dataSourceId" INTEGER NOT NULL REFERENCES "data_sources" ("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+UPDATE "public"."agent_tables_query_configuration_tables"
+SET
+  "dataSourceId" = "dataSourceIdNew";

--- a/front/migrations/db/migration_82.sql
+++ b/front/migrations/db/migration_82.sql
@@ -2,6 +2,10 @@
 ALTER TABLE "public"."agent_tables_query_configuration_tables"
 ADD COLUMN "dataSourceId" INTEGER REFERENCES "data_sources" ("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
+ALTER TABLE "public"."agent_tables_query_configuration_tables"
+ALTER COLUMN "dataSourceIdNew"
+DROP NOT NULL;
+
 UPDATE "public"."agent_tables_query_configuration_tables"
 SET
   "dataSourceId" = "dataSourceIdNew";

--- a/front/migrations/db/migration_82.sql
+++ b/front/migrations/db/migration_82.sql
@@ -1,6 +1,6 @@
 -- Migration created on Sep 16, 2024
 ALTER TABLE "public"."agent_tables_query_configuration_tables"
-ADD COLUMN "dataSourceId" INTEGER NOT NULL REFERENCES "data_sources" ("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ADD COLUMN "dataSourceId" INTEGER REFERENCES "data_sources" ("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 UPDATE "public"."agent_tables_query_configuration_tables"
 SET


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of https://github.com/dust-tt/dust/pull/7399.

This PR reintroduces a `dataSourceId` column in the `agent_tables_query_configuration_tables` table. The column will be filled using an SQL migration that transfers values from the temporary column. From now on, both writing and reading operations will be done on this newly added column.

While not the ideal solution, executing this change outside of peak hours is an effective shortcut.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] Apply migration
- [ ] Deploy
- [ ] Remove the temporary column `dataSourceIdNew`.

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
