### PR TITLE
use internalAdminForWorkspace to list vault resources

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -129,7 +129,7 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
           throw new Error(`Workspace not found: wId='${args.wId}'`);
         }
 
-        const auth = await Authenticator.internalBuilderForWorkspace(w.sId);
+        const auth = await Authenticator.internalAdminForWorkspace(w.sId);
         const dataSources = await getDataSources(auth);
         const connectorIds = removeNulls(dataSources.map((d) => d.connectorId));
         const connectorsAPI = new ConnectorsAPI(
@@ -169,7 +169,7 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
         }
         console.log(`Unpausing connectors for workspace: wId=${w.sId}`);
 
-        const auth = await Authenticator.internalBuilderForWorkspace(w.sId);
+        const auth = await Authenticator.internalAdminForWorkspace(w.sId);
         const dataSources = await getDataSources(auth);
         const connectorIds = removeNulls(dataSources.map((d) => d.connectorId));
         const connectorsAPI = new ConnectorsAPI(

--- a/front/lib/upsert_queue.ts
+++ b/front/lib/upsert_queue.ts
@@ -182,7 +182,7 @@ export async function runPostUpsertHooks({
   upsertContext?: UpsertContext;
 }) {
   const fullText = sectionFullText(section);
-  const auth = await Authenticator.internalBuilderForWorkspace(workspaceId);
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
 
   const postUpsertHooksToRun = await getDocumentsPostUpsertHooksToRun({
     auth,

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -291,9 +291,7 @@ async function handler(
               defaultEmbeddingProvider: ws.defaultEmbeddingProvider,
             };
 
-            const auth = await Authenticator.internalBuilderForWorkspace(
-              ws.sId
-            );
+            const auth = await Authenticator.internalAdminForWorkspace(ws.sId);
             const dataSources = await DataSourceResource.listByWorkspace(auth);
             const dataSourcesCount = dataSources.length;
 

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -241,7 +241,7 @@ async function handler(
               });
             }
             await unpauseAllConnectorsAndCancelScrub(
-              await Authenticator.internalBuilderForWorkspace(workspace.sId)
+              await Authenticator.internalAdminForWorkspace(workspace.sId)
             );
             return res.status(200).json({ success: true });
           } catch (error) {
@@ -448,7 +448,7 @@ async function handler(
               // If the subscription is reactivated, we unset the requestCancelAt date.
               requestCancelAt: endDate ? now : null,
             });
-            const auth = await Authenticator.internalBuilderForWorkspace(
+            const auth = await Authenticator.internalAdminForWorkspace(
               subscription.workspace.sId
             );
             if (!endDate) {

--- a/front/pages/api/v1/w/[wId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -524,7 +524,7 @@ async function handler(
       });
 
       const postDeleteHooksToRun = await getDocumentsPostDeleteHooksToRun({
-        auth: await Authenticator.internalBuilderForWorkspace(owner.sId),
+        auth: await Authenticator.internalAdminForWorkspace(owner.sId),
         dataSourceId: dataSource.sId,
         documentId: req.query.documentId as string,
         dataSourceConnectorProvider: dataSource.connectorProvider || null,

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -102,7 +102,7 @@ export async function isWorkflowDeletableActivity({
 }: {
   workspaceId: string;
 }) {
-  const auth = await Authenticator.internalBuilderForWorkspace(workspaceId);
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
   const workspace = auth.workspace();
   if (!workspace) {
     return false;
@@ -132,7 +132,7 @@ export async function deleteConversationsActivity({
 }: {
   workspaceId: string;
 }) {
-  const auth = await Authenticator.internalBuilderForWorkspace(workspaceId);
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
   const workspace = auth.workspace();
 
   if (!workspace) {
@@ -268,7 +268,7 @@ export async function deleteAgentsActivity({
 }: {
   workspaceId: string;
 }) {
-  const auth = await Authenticator.internalBuilderForWorkspace(workspaceId);
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
   const workspace = auth.workspace();
 
   if (!workspace) {
@@ -379,7 +379,7 @@ export async function deleteAppsActivity({
   workspaceId: string;
 }) {
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-  const auth = await Authenticator.internalBuilderForWorkspace(workspaceId);
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
   const workspace = auth.workspace();
 
   if (!workspace) {
@@ -420,7 +420,7 @@ export async function deleteRunOnDustAppsActivity({
   workspaceId: string;
 }) {
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-  const auth = await Authenticator.internalBuilderForWorkspace(workspaceId);
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
   const workspace = auth.workspace();
 
   if (!workspace) {
@@ -463,7 +463,7 @@ export async function deleteMembersActivity({
 }: {
   workspaceId: string;
 }) {
-  const auth = await Authenticator.internalBuilderForWorkspace(workspaceId);
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
   const workspace = auth.workspace();
 
   if (!workspace) {
@@ -521,7 +521,7 @@ export async function deleteWorkspaceActivity({
 }: {
   workspaceId: string;
 }) {
-  const auth = await Authenticator.internalBuilderForWorkspace(workspaceId);
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
   const workspace = auth.workspace();
 
   if (!workspace) {

--- a/front/temporal/documents_post_process_hooks/activities.ts
+++ b/front/temporal/documents_post_process_hooks/activities.ts
@@ -66,7 +66,7 @@ export async function runPostUpsertHookActivity(
   }
 
   await hook.onUpsert({
-    auth: await Authenticator.internalBuilderForWorkspace(workspaceId),
+    auth: await Authenticator.internalAdminForWorkspace(workspaceId),
     dataSourceId,
     documentId,
     documentText,
@@ -106,7 +106,7 @@ export async function runPostDeleteHookActivity(
   }
 
   await hook.onDelete({
-    auth: await Authenticator.internalBuilderForWorkspace(workspaceId),
+    auth: await Authenticator.internalAdminForWorkspace(workspaceId),
     dataSourceId,
     documentId,
     dataSourceConnectorProvider,
@@ -134,7 +134,7 @@ async function getDataSourceDocument({
     return new Err(new Error(`Could not find workspace ${workspaceId}`));
   }
 
-  const auth = await Authenticator.internalBuilderForWorkspace(workspaceId);
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
   const dataSource = await DataSourceResource.fetchByNameOrId(
     auth,
     dataSourceId,

--- a/front/temporal/labs/activities.ts
+++ b/front/temporal/labs/activities.ts
@@ -61,7 +61,7 @@ export async function retrieveNewTranscriptsActivity(
     );
   }
 
-  const auth = await Authenticator.internalBuilderForWorkspace(workspace.sId);
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
   if (!auth.workspace()) {
     await stopRetrieveTranscriptsWorkflow(transcriptsConfiguration);

--- a/front/temporal/upsert_queue/activities.ts
+++ b/front/temporal/upsert_queue/activities.ts
@@ -53,7 +53,7 @@ export async function upsertDocumentActivity(
     documentId: upsertQueueItem.documentId,
   });
 
-  const auth = await Authenticator.internalBuilderForWorkspace(
+  const auth = await Authenticator.internalAdminForWorkspace(
     upsertQueueItem.workspaceId
   );
 
@@ -190,7 +190,7 @@ export async function upsertTableActivity(
     tableId: upsertQueueItem.tableId,
   });
 
-  const auth = await Authenticator.internalBuilderForWorkspace(
+  const auth = await Authenticator.internalAdminForWorkspace(
     upsertQueueItem.workspaceId
   );
 


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/1106 

## Description

Replace internalBuilderForWorkspace by internalAdminForWorkspace where we need to list datasources and/or their content. Builder has no permission to list content and will be rejected once we'll enable permission check on resources.

Most of the calls replaced need the auth for getting dataSources and must not be filtered. 
Delete/scrub activities need to get all datasources/views/apps available.
In `front/temporal/documents_post_process_hooks/activities.ts` and `front/temporal/upsert_queue/activities.ts`, in addition to getting the datasources, the activities are actually reading/writing into the document by calling core, but no permission check is done here. I don't think we need to add more permission checks here (and extend the auth with required groups) - they are done before creating the activities.

## Risk

none

## Deploy Plan

deploy `front`
