### PR TITLE
Builder: fiter by vaults with read access

### DIFF
--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -39,7 +39,7 @@ import logger from "@app/logger/logger";
 export const getAccessibleSourcesAndApps = async (auth: Authenticator) => {
   const accessibleVaults = (
     await VaultResource.listWorkspaceVaults(auth)
-  ).filter((vault) => !vault.isSystem());
+  ).filter((vault) => !vault.isSystem() && vault.canRead(auth));
 
   const [dsViews, allDustApps] = await Promise.all([
     DataSourceViewResource.listByVaults(auth, accessibleVaults),


### PR DESCRIPTION
## Description
 
Fixes:https://github.com/dust-tt/tasks/issues/1335

=> In the builder when we fetch the list of vault we want only the vault for which we have read permission. 
=> Cause a blank screen when you're in no vault 😄 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 