### PR TITLE
[front] - fix(vault): allow to edit vault's name

### DIFF
--- a/front/components/vaults/CreateOrEditVaultModal.tsx
+++ b/front/components/vaults/CreateOrEditVaultModal.tsx
@@ -195,7 +195,7 @@ export function CreateOrEditVaultModal({
     setIsSaving(true);
 
     if (selectedMembers.length > 0 && vault) {
-      await doUpdate(vault, selectedMembers);
+      await doUpdate(vault, selectedMembers, vaultName);
     } else if (!vault) {
       const createdVault = await doCreate(vaultName, selectedMembers);
       if (createdVault) {
@@ -247,10 +247,8 @@ export function CreateOrEditVaultModal({
               placeholder="Vault's name"
               value={vaultName}
               name="vaultName"
-              className={vault ? "text-gray-300 hover:cursor-not-allowed" : ""}
               size="sm"
               onChange={(value) => setVaultName(value)}
-              disabled={!!vault}
             />
             {!vault && (
               <div className="flex gap-1 text-xs text-element-700">

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -1,4 +1,5 @@
 import type { ACLType, ModelId, Result, VaultType } from "@dust-tt/types";
+import { Err } from "@dust-tt/types";
 import { assertNever, Ok } from "@dust-tt/types";
 import assert from "assert";
 import type {
@@ -271,6 +272,27 @@ export class VaultResource extends BaseResource<VaultModel> {
         },
       },
     });
+  }
+
+  async updateName(
+    auth: Authenticator,
+    newName: string
+  ): Promise<Result<undefined, Error>> {
+    if (!auth.isAdmin()) {
+      return new Err(new Error("Only admins can update vault names."));
+    }
+
+    const nameAvailable = await VaultResource.isNameAvailable(auth, newName);
+    if (!nameAvailable) {
+      return new Err(new Error("This vault name is already used."));
+    }
+
+    try {
+      await this.update({ name: newName });
+      return new Ok(undefined);
+    } catch (error) {
+      return new Err(error as Error);
+    }
   }
 
   acl(): ACLType {

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -287,12 +287,8 @@ export class VaultResource extends BaseResource<VaultModel> {
       return new Err(new Error("This vault name is already used."));
     }
 
-    try {
-      await this.update({ name: newName });
-      return new Ok(undefined);
-    } catch (error) {
-      return new Err(error as Error);
-    }
+    await this.update({ name: newName });
+    return new Ok(undefined);
   }
 
   acl(): ACLType {

--- a/front/pages/api/w/[wId]/vaults/[vId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/index.ts
@@ -117,7 +117,7 @@ async function handler(
         });
       }
 
-      const { content } = bodyValidation.right;
+      const { content, name } = bodyValidation.right;
 
       if (content) {
         const currentViews = await DataSourceViewResource.listByVault(
@@ -164,6 +164,9 @@ async function handler(
             await view.delete(auth);
           }
         }
+      }
+      if (name) {
+        await vault.updateName(auth, name);
       }
       return res.status(200).json({ vault: vault.toJSON() });
     }

--- a/types/src/front/api_handlers/public/vaults.ts
+++ b/types/src/front/api_handlers/public/vaults.ts
@@ -34,6 +34,7 @@ export type PostVaultRequestBodyType = t.TypeOf<
 >;
 
 export const PatchVaultRequestBodySchema = t.type({
+  name: t.union([t.string, t.undefined]),
   memberIds: t.union([t.array(t.string), t.undefined]),
   content: t.union([t.array(ContentSchema), t.undefined]),
 });


### PR DESCRIPTION
## Description

This PR allows editing the name of existing vaults. Previously, vault names were immutable after creation. The change enables users to update vault names.

To do so, it modifies the `/vaults/[vId]/` endpoint to accept a "name" parameter in the PATCH method.

**References:**
- https://github.com/dust-tt/tasks/issues/1338

## Risk

Medium, should be backward compatible but still touches endpoints.

## Deploy Plan

Deploy `front`
