### PR TITLE
[SEO] Don't let bot crawl front-edge/front-qa (duplicate content bad for SEO)

### DIFF
--- a/front/pages/_document.tsx
+++ b/front/pages/_document.tsx
@@ -1,5 +1,7 @@
 import Document, { Head, Html, Main, NextScript } from "next/document";
 
+const { ENABLE_BOT_CRAWLING } = process.env;
+
 class MyDocument extends Document {
   render() {
     return (
@@ -11,6 +13,9 @@ class MyDocument extends Document {
             href="https://fonts.gstatic.com"
             crossOrigin="anonymous"
           />
+          {ENABLE_BOT_CRAWLING !== "front" && (
+            <meta name="robots" content="noindex" />
+          )}
           <link href="https://use.typekit.net/jnb2umy.css" rel="stylesheet" />
         </Head>
         <body>

--- a/front/pages/_document.tsx
+++ b/front/pages/_document.tsx
@@ -13,7 +13,7 @@ class MyDocument extends Document {
             href="https://fonts.gstatic.com"
             crossOrigin="anonymous"
           />
-          {ENABLE_BOT_CRAWLING !== "front" && (
+          {ENABLE_BOT_CRAWLING !== "true" && (
             <meta name="robots" content="noindex" />
           )}
           <link href="https://use.typekit.net/jnb2umy.css" rel="stylesheet" />

--- a/k8s/configmaps/front-configmap.yaml
+++ b/k8s/configmaps/front-configmap.yaml
@@ -9,3 +9,4 @@ data:
   DD_LOGS_INJECTION: "true"
   DD_RUNTIME_METRICS_ENABLED: "true"
   NODE_ENV: "production"
+  ENABLE_BOT_CRAWLING: "true"


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/1280 (go there for context)

Risks
---
Not that I can see

Deploy
---
Apply infra
Front
Front-qa
Front-edge
