### PR TITLE
Render citations in table v2

### DIFF
--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -480,8 +480,15 @@ function TableBlock({ children }: { children: React.ReactNode }) {
       .join("")}</tr></thead>`;
     const headPlain = headCells.join("\t");
 
-    const bodyRows = bodyNode.props.children.map((r: any) =>
-      r.props.children.map((c: any) => getNodeText(c))
+    const bodyRows = bodyNode.props.children.map((row: any) =>
+      row.props.children.map((cell: any) => {
+        const children = cell.props.children;
+        return (Array.isArray(children) ? children : [children])
+          .map((child: any) =>
+            child?.type?.name === "CiteBlock" ? "" : getNodeText(child)
+          )
+          .join("");
+      })
     );
     const bodyHtml = `<tbody>${bodyRows
       .map((row: any) => {
@@ -536,10 +543,10 @@ function TableDataBlock({ children }: { children: React.ReactNode }) {
           if (child === "<br>") {
             return <br key={i} />;
           }
-          return <React.Fragment key={i}>{getNodeText(child)}</React.Fragment>;
+          return <React.Fragment key={i}>{child}</React.Fragment>;
         })
       ) : (
-        <> {getNodeText(children)}</>
+        <>{children}</>
       )}
     </td>
   );


### PR DESCRIPTION
## Description

Initially here: https://github.com/dust-tt/dust/pull/7396/files
Had to be rolled back because of this error: 

```
framework-8d83868bf6469d6b.js:1 TypeError: Cannot read properties of undefined (reading 'type')
```

From line: 
```
return "CiteBlock" === (null === (t = e.type) || void 0 === t ? void 0 : t.name) ? "" : J(e)`
```

So instead of `child.type?.name` I'm now specifying `child?.type?.name`.


Confirmed working on front edge, pinging an Assistant that would fail before: https://front-edge.dust.tt/w/0ec9852c2f/assistant/vRN3Icdbt4

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
