### PR TITLE
[Agent permissions] Fix: forbid access to unowned personal agents

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -627,11 +627,18 @@ export async function getAgentConfigurations<V extends "light" | "full">({
     }),
   ]);
 
-  // Filter out agents that the user does not have access to
-  // user should be in all groups that are in the agent's groupIds
   const allowedAgentConfigurations = allAgentConfigurations
     .flat()
-    .filter((a) => auth.canRead(Authenticator.aclsFromGroupIds(a.groupIds)));
+    // Filter out agents that the user does not have access to
+    // user should be in all groups that are in the agent's groupIds
+    .filter((a) => auth.canRead(Authenticator.aclsFromGroupIds(a.groupIds)))
+    // do not show personal agents unless the user is the author
+    .filter((a) => {
+      if (a.scope === "private") {
+        return a.versionAuthorId === auth.user()?.id;
+      }
+      return true;
+    });
 
   return applySortAndLimit(allowedAgentConfigurations.flat());
 }


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/1221

Previously, one could access personal agents when knowing its sId, e.g. via the API v1 conversation creation route.

This raises a product question, confirmation to be done in the issue.

Risk
---
Some users might have gotten used to access their personal agents via API v1 => this access will now fail.

Deploy
---
front
