### PR TITLE
Route to validate user existence in workspace.

### DIFF
--- a/front/pages/api/v1/w/[wId]/members/validate.ts
+++ b/front/pages/api/v1/w/[wId]/members/validate.ts
@@ -28,9 +28,21 @@ async function handler(
         activeOnly: true,
       });
 
-      return res
-        .status(200)
-        .json({ valid: allMembers.some((member) => member.email === email) });
+      if (!email) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Email is required.",
+          },
+        });
+      }
+
+      return res.status(200).json({
+        valid: allMembers.some(
+          (member) => member.email.toLowerCase() === email.toLowerCase()
+        ),
+      });
 
     default:
       return apiError(req, res, {

--- a/front/pages/api/v1/w/[wId]/members/validate.ts
+++ b/front/pages/api/v1/w/[wId]/members/validate.ts
@@ -8,7 +8,6 @@ import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
-import { renderLightWorkspaceType } from "@app/lib/workspace";
 import { apiError } from "@app/logger/withlogging";
 
 export type ValidateMemberResponseBody = {
@@ -20,7 +19,7 @@ export type ValidateMemberResponseBody = {
  * Validates an email corresponds to an active member in a specific workspace. For Dust managed apps only - undocumented.
  */
 
-export const validateEmailSchema = t.type({
+export const PostValidateMemberRequestBodySchema = t.type({
   email: t.string,
 });
 
@@ -29,7 +28,7 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<ValidateMemberResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
-  const bodyValidation = validateEmailSchema.decode(req.body);
+  const bodyValidation = PostValidateMemberRequestBodySchema.decode(req.body);
 
   if (isLeft(bodyValidation)) {
     const pathError = reporter.formatValidationErrors(bodyValidation.left);
@@ -49,9 +48,7 @@ async function handler(
     case "POST":
       const user = await UserResource.fetchByEmail(email);
 
-      const workspace = renderLightWorkspaceType({
-        workspace: auth.getNonNullableWorkspace(),
-      });
+      const workspace = auth.getNonNullableWorkspace();
 
       if (!user) {
         return res.status(200).json({

--- a/front/pages/api/v1/w/[wId]/members/validate.ts
+++ b/front/pages/api/v1/w/[wId]/members/validate.ts
@@ -1,0 +1,46 @@
+import type { WithAPIErrorResponse } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getMembers } from "@app/lib/api/workspace";
+import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+
+export type ValidateMemberResponseBody = {
+  valid: boolean;
+};
+
+/**
+ * @ignoreswagger
+ * Validates an email corresponds to an active member in a specific workspace. For Dust managed apps only - undocumented.
+ */
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<ValidateMemberResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  const { email } = req.body;
+
+  switch (req.method) {
+    case "POST":
+      const { members: allMembers } = await getMembers(auth, {
+        activeOnly: true,
+      });
+
+      return res
+        .status(200)
+        .json({ valid: allMembers.some((member) => member.email === email) });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withPublicAPIAuthentication(handler);


### PR DESCRIPTION
## Description

- This PR adds a route to validate if a user is an active member of a workspace, based on their email 
- This is necessary if we want to explore Dust-managed apps in pure-player marketplaces (Zendesk, Salesforce, etc)

**Current state**: customers can build on the API without us knowing what they do. It is cumbersome for them and we can't track what's happening

**Wanted state**: The goal is for us to build apps we feel customer demand on (zendesk, salesforce, etc), but still keep our current pricing model by making sure users have a Dust account when using the apps. This demand will be _partly_ solved by the browser extension, but it's harder to make a team install one by one a browser extension that just enable a new feature in a SaaS for your entire team.

This PR enables all of these 'marketplace apps' for which we manage the code to be able to validate that the user is an active workspace member before offering the service through the app.

Caveats: 
- This will not allow system accounts to use the extensions or might lead to email mismatches.

## Risk

Data leak (validate if a user exists) - the attacker would need an API key for that, and this is a very low risk endpoint compared to being able to query assistants.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
