### PR TITLE
Delete configurations pointing to ds views on delete

### DIFF
--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -96,7 +96,6 @@ export class AgentTablesQueryConfigurationTable extends Model<
   declare tableId: string;
 
   declare dataSourceId: ForeignKey<DataSource["id"]> | null;
-
   declare dataSourceViewId: ForeignKey<DataSourceViewModel["id"]>;
   declare tablesQueryConfigurationId: ForeignKey<
     AgentTablesQueryConfiguration["id"]

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -20,6 +20,8 @@ import { Op } from "sequelize";
 import { getDataSourceViewUsage } from "@app/lib/api/agent_data_sources";
 import type { Authenticator } from "@app/lib/auth";
 import { isFolder, isWebsite } from "@app/lib/data_sources";
+import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
+import { AgentTablesQueryConfigurationTable } from "@app/lib/models/assistant/actions/tables_query";
 import { User } from "@app/lib/models/user";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { ResourceWithVault } from "@app/lib/resources/resource_with_vault";
@@ -342,6 +344,19 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
     transaction?: Transaction
   ): Promise<Result<undefined, Error>> {
     try {
+      // Delete agent configurations elements pointing to this data source view.
+      await AgentDataSourceConfiguration.destroy({
+        where: {
+          dataSourceViewId: this.id,
+        },
+        transaction,
+      });
+      await AgentTablesQueryConfigurationTable.destroy({
+        where: {
+          dataSourceViewId: this.id,
+        },
+      });
+
       await this.model.destroy({
         where: {
           workspaceId: auth.getNonNullableWorkspace().id,


### PR DESCRIPTION
## Description

Context: https://app.datadoghq.eu/logs?query=%22Unhandled%20activity%20error%22%20service%3Afront-worker%20env%3Aprod%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&index=%2A&messageDisplay=inline&refresh_mode=sliding&source=monitor_notif&storage=hot&stream_sort=desc&viz=stream&from_ts=1726568920185&to_ts=1726572520185&live=true

scrubbing workspace failing because we attempt to delete the ds view before the ds or the ds view does not delete the agent configurations elements pointing to it (the ds does)

We used to CASCADE.

## Risk

N/A

## Deploy Plan

- deploy `front`