### PR TITLE
Fix #2 to delete ds view

### DIFF
--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -371,11 +371,12 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
     }
   }
 
+  // This method can only be used once all agent configurations have been deleted. Otherwise use the
+  // delete method on each data source view separately.
   static async deleteAllForWorkspace(
     auth: Authenticator,
     transaction?: Transaction
   ) {
-    // TODO(GROUPS_INFRA) Delete agent_data_source_configuration and agent_tables_query_configuration.
     return this.model.destroy({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -151,10 +151,17 @@ async function archiveAssistants(auth: Authenticator) {
 }
 
 async function deleteDatasources(auth: Authenticator) {
-  const dataSources = await getDataSources(auth);
   // First, we delete all the data source views.
-  await DataSourceViewResource.deleteAllForWorkspace(auth);
+  const dataSourceViews = await DataSourceViewResource.listByWorkspace(auth);
+  for (const dataSourceView of dataSourceViews) {
+    const r = await dataSourceView.delete(auth);
+    if (r.isErr()) {
+      throw new Error(`Failed to delete data source view: ${r.error.message}`);
+    }
+  }
 
+  // Then, we delete all the data sources.
+  const dataSources = await getDataSources(auth);
   for (const dataSource of dataSources) {
     const r = await deleteDataSource(auth, dataSource);
     if (r.isErr()) {


### PR DESCRIPTION
## Description

In the scrub workspace activity we want to delete the data source view one by one to trigger the code path that cleans-up the relationship to agent configurations.

## Risk

N/A

## Deploy Plan

- deploy `front`