### PR TITLE
[front] - enh(assistant-builder): vaults empty

### DIFF
--- a/front/components/DataSourceViewResourceSelectorTree.tsx
+++ b/front/components/DataSourceViewResourceSelectorTree.tsx
@@ -1,7 +1,9 @@
 import {
   BracesIcon,
+  Button,
   ExternalLinkIcon,
   IconButton,
+  PlusIcon,
   Tree,
 } from "@dust-tt/sparkle";
 import type {
@@ -12,6 +14,7 @@ import type {
 } from "@dust-tt/types";
 import { useEffect, useState } from "react";
 
+import { RequestDataSourceModal } from "@app/components/data_source/RequestDataSourceModal";
 import DataSourceViewDocumentModal from "@app/components/DataSourceViewDocumentModal";
 import { getVisualForContentNode } from "@app/lib/content_nodes";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
@@ -113,7 +116,6 @@ function DataSourceViewResourceSelectorChildren({
   }
 
   const isTablesView = viewType === "tables";
-
   return (
     <>
       <DataSourceViewDocumentModal
@@ -209,6 +211,19 @@ function DataSourceViewResourceSelectorChildren({
             />
           );
         })}
+        {dataSourceView.category === "managed" && nodes.length === 0 && (
+          <div className="flex w-full flex-col items-center gap-2 rounded-lg border bg-structure-50 py-2">
+            <span className="text-element-700">The Vault is empty!</span>
+            {owner.role !== "admin" ? (
+              <Button label="Add Data" icon={PlusIcon} />
+            ) : (
+              <RequestDataSourceModal
+                dataSources={[dataSourceView.dataSource]}
+                owner={owner}
+              />
+            )}
+          </div>
+        )}
       </Tree>
     </>
   );

--- a/front/components/assistant_builder/AssistantBuilderContext.tsx
+++ b/front/components/assistant_builder/AssistantBuilderContext.tsx
@@ -1,10 +1,17 @@
-import type { AppType, DataSourceViewType, VaultType } from "@dust-tt/types";
+import type {
+  AppType,
+  DataSourceViewType,
+  PlanType,
+  VaultType,
+} from "@dust-tt/types";
 import { createContext } from "react";
 
 type AssistantBuilderContextType = {
   dustApps: AppType[];
   dataSourceViews: DataSourceViewType[];
   vaults: VaultType[];
+  plan: PlanType | undefined;
+  dustClientFacingUrl: string | undefined;
 };
 
 export const AssistantBuilderContext =
@@ -12,12 +19,16 @@ export const AssistantBuilderContext =
     dustApps: [],
     dataSourceViews: [],
     vaults: [],
+    dustClientFacingUrl: undefined,
+    plan: undefined,
   });
 
 export function AssistantBuilderProvider({
   dustApps,
   dataSourceViews,
   vaults,
+  dustClientFacingUrl,
+  plan,
   children,
 }: AssistantBuilderContextType & {
   children: React.ReactNode;
@@ -28,6 +39,8 @@ export function AssistantBuilderProvider({
         dustApps,
         dataSourceViews,
         vaults,
+        dustClientFacingUrl,
+        plan,
       }}
     >
       {children}

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -42,7 +42,9 @@ export const getAccessibleSourcesAndApps = async (auth: Authenticator) => {
   ).filter((vault) => !vault.isSystem() && vault.canRead(auth));
 
   const [dsViews, allDustApps] = await Promise.all([
-    DataSourceViewResource.listByVaults(auth, accessibleVaults),
+    DataSourceViewResource.listByVaults(auth, accessibleVaults, {
+      includeEditedBy: true,
+    }),
     AppResource.listByWorkspace(auth),
   ]);
 

--- a/front/components/data_source/RequestDataSourceModal.tsx
+++ b/front/components/data_source/RequestDataSourceModal.tsx
@@ -50,7 +50,7 @@ export function RequestDataSourceModal({
   return (
     <>
       <Button
-        label="Request"
+        label="Request Data"
         icon={PlusIcon}
         onClick={() => setShowRequestDataSourceModal(true)}
       />

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -10,8 +10,8 @@ import type {
   DataSourceViewSelectionConfiguration,
   DataSourceViewSelectionConfigurations,
   DataSourceViewType,
-  LightWorkspaceType,
   VaultType,
+  WorkspaceType,
 } from "@dust-tt/types";
 import { defaultSelectionConfiguration } from "@dust-tt/types";
 import _ from "lodash";
@@ -39,7 +39,7 @@ const MIN_DATA_SOURCES_PER_KIND_TO_GROUP = 3;
 const ONLY_ONE_VAULT_PER_SELECTION = true;
 
 interface DataSourceViewsSelectorProps {
-  owner: LightWorkspaceType;
+  owner: WorkspaceType;
   dataSourceViews: DataSourceViewType[];
   allowedVaults?: VaultType[];
   selectionConfigurations: DataSourceViewSelectionConfigurations;
@@ -218,7 +218,7 @@ export function DataSourceViewsSelector({
 }
 
 interface DataSourceViewSelectorProps {
-  owner: LightWorkspaceType;
+  owner: WorkspaceType;
   selectionConfiguration: DataSourceViewSelectionConfiguration;
   setSelectionConfigurations: Dispatch<
     SetStateAction<DataSourceViewSelectionConfigurations>

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -128,6 +128,8 @@ export default function EditAssistant({
       vaults={vaults}
       dustApps={dustApps}
       dataSourceViews={dataSourceViews}
+      plan={plan}
+      dustClientFacingUrl={baseUrl}
     >
       <AssistantBuilder
         owner={owner}

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -162,6 +162,8 @@ export default function CreateAssistant({
       vaults={vaults}
       dustApps={dustApps}
       dataSourceViews={dataSourceViews}
+      dustClientFacingUrl={baseUrl}
+      plan={plan}
     >
       <AssistantBuilder
         owner={owner}


### PR DESCRIPTION
## Description

This PR aims at handling more nicely the data selection step within the assistant builder. When a managed data source is empty we display a button to enable the addition/request of data directly within the modal.

**References:**
- https://github.com/dust-tt/tasks/issues/1340

## Risk

Low

## Deploy Plan

Deploy `front`