### PR TITLE
fix: mutate all content nodes after upload

### DIFF
--- a/front/components/vaults/VaultDataSourceViewContentList.tsx
+++ b/front/components/vaults/VaultDataSourceViewContentList.tsx
@@ -199,7 +199,7 @@ export const VaultDataSourceViewContentList = ({
 
   const {
     isNodesLoading,
-    mutateDataSourceViewContentNodesRegardlessOfQueryParams: mutateContentNodes,
+    mutateRegardlessOfQueryParams: mutateContentNodes,
     nodes,
     totalNodesCount,
   } = useDataSourceViewContentNodes({

--- a/front/components/vaults/VaultDataSourceViewContentList.tsx
+++ b/front/components/vaults/VaultDataSourceViewContentList.tsx
@@ -185,7 +185,7 @@ export const VaultDataSourceViewContentList = ({
   });
 
   const handleViewTypeChange = useCallback(
-    (newViewType: ContentNodesViewType) => {
+    (newViewType?: ContentNodesViewType) => {
       if (newViewType !== viewType) {
         setPagination(
           { pageIndex: 0, pageSize: pagination.pageSize },
@@ -199,7 +199,7 @@ export const VaultDataSourceViewContentList = ({
 
   const {
     isNodesLoading,
-    mutateDataSourceViewContentNodes,
+    mutateDataSourceViewContentNodesRegardlessOfQueryParams: mutateContentNodes,
     nodes,
     totalNodesCount,
   } = useDataSourceViewContentNodes({
@@ -226,14 +226,14 @@ export const VaultDataSourceViewContentList = ({
     });
 
   useEffect(() => {
+    if (viewType !== undefined) {
+      return;
+    }
     // If the view only has content in one of the two views, we switch to that view.
     // if both view have content, or neither views have content, we default to documents.
     if (hasTables === true && hasDocuments === false) {
       handleViewTypeChange("tables");
-    } else if (
-      (hasTables === false && hasDocuments === true) ||
-      (viewType === undefined && !(isDocumentsLoading || isTablesLoading))
-    ) {
+    } else if (hasTables === false && hasDocuments === true) {
       handleViewTypeChange("documents");
     }
   }, [
@@ -407,7 +407,7 @@ export const VaultDataSourceViewContentList = ({
                 onClose={(save) => {
                   setShowConnectorPermissionsModal(false);
                   if (save) {
-                    void mutateDataSourceViewContentNodes();
+                    void mutateContentNodes();
                   }
                 }}
                 plan={plan}
@@ -444,12 +444,15 @@ export const VaultDataSourceViewContentList = ({
         owner={owner}
         plan={plan}
         onSave={async (action?: ContentActionKey) => {
-          if (action === "DocumentUploadOrEdit") {
+          await mutateContentNodes();
+          if (
+            action === "DocumentUploadOrEdit" ||
+            action === "MultipleDocumentsUpload"
+          ) {
             handleViewTypeChange("documents");
           } else if (action === "TableUploadOrEdit") {
             handleViewTypeChange("tables");
           }
-          await mutateDataSourceViewContentNodes();
         }}
       />
     </>

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -120,8 +120,8 @@ export function useDataSourceViewContentNodes({
 }): {
   isNodesError: boolean;
   isNodesLoading: boolean;
-  mutateDataSourceViewContentNodes: KeyedMutator<GetDataSourceViewContentNodes>;
-  mutateDataSourceViewContentNodesRegardlessOfQueryParams: KeyedMutator<GetDataSourceViewContentNodes>;
+  mutate: KeyedMutator<GetDataSourceViewContentNodes>;
+  mutateRegardlessOfQueryParams: KeyedMutator<GetDataSourceViewContentNodes>;
   nodes: GetDataSourceViewContentNodes["nodes"];
   totalNodesCount: number;
 } {
@@ -163,9 +163,8 @@ export function useDataSourceViewContentNodes({
   return {
     isNodesError: !!error,
     isNodesLoading: !error && !data,
-    mutateDataSourceViewContentNodes: mutate,
-    mutateDataSourceViewContentNodesRegardlessOfQueryParams:
-      mutateRegardlessOfQueryParams,
+    mutate,
+    mutateRegardlessOfQueryParams,
     nodes: useMemo(() => (data ? data.nodes : []), [data]),
     totalNodesCount: data ? data.total : 0,
   };

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -108,6 +108,7 @@ export function useDataSourceViewContentNodes({
   parentId,
   pagination,
   viewType,
+  disabled = false,
 }: {
   owner: LightWorkspaceType;
   dataSourceView?: DataSourceViewType;
@@ -115,20 +116,21 @@ export function useDataSourceViewContentNodes({
   parentId?: string;
   pagination?: PaginationState;
   viewType?: ContentNodesViewType;
+  disabled?: boolean;
 }): {
   isNodesError: boolean;
   isNodesLoading: boolean;
   mutateDataSourceViewContentNodes: KeyedMutator<GetDataSourceViewContentNodes>;
+  mutateDataSourceViewContentNodesRegardlessOfQueryParams: KeyedMutator<GetDataSourceViewContentNodes>;
   nodes: GetDataSourceViewContentNodes["nodes"];
   totalNodesCount: number;
 } {
   const params = new URLSearchParams();
   appendPaginationParams(params, pagination);
 
-  const url =
-    dataSourceView && viewType
-      ? `/api/w/${owner.sId}/vaults/${dataSourceView.vaultId}/data_source_views/${dataSourceView.sId}/content-nodes?${params}`
-      : null;
+  const url = dataSourceView
+    ? `/api/w/${owner.sId}/vaults/${dataSourceView.vaultId}/data_source_views/${dataSourceView.sId}/content-nodes?${params}`
+    : null;
 
   const body = JSON.stringify({
     internalIds,
@@ -143,18 +145,27 @@ export function useDataSourceViewContentNodes({
     }); // Serialize with body to ensure uniqueness.
   }, [url, body]);
 
-  const { data, error, mutate } = useSWRWithDefaults(fetchKey, async () => {
-    if (!url) {
-      return undefined;
-    }
+  const { data, error, mutate, mutateRegardlessOfQueryParams } =
+    useSWRWithDefaults(
+      fetchKey,
+      async () => {
+        if (!url) {
+          return undefined;
+        }
 
-    return postFetcher([url, { internalIds, parentId, viewType }]);
-  });
+        return postFetcher([url, { internalIds, parentId, viewType }]);
+      },
+      {
+        disabled: disabled || !viewType,
+      }
+    );
 
   return {
     isNodesError: !!error,
     isNodesLoading: !error && !data,
     mutateDataSourceViewContentNodes: mutate,
+    mutateDataSourceViewContentNodesRegardlessOfQueryParams:
+      mutateRegardlessOfQueryParams,
     nodes: useMemo(() => (data ? data.nodes : []), [data]),
     totalNodesCount: data ? data.total : 0,
   };


### PR DESCRIPTION
## Description

- when we upload a document in a folder that has only tables (or the opposite), we need the viewType to be switched
- when we upload a document or a table (or multiple tables), we need to properly mutate all content-nodes keys (regardless of query params) so the correct list is shown

## Risk

N/A

## Deploy Plan

N/A