### PR TITLE
fix: go back to correct dust apps list URL on dust app close

### DIFF
--- a/front/lib/vault_rollout.ts
+++ b/front/lib/vault_rollout.ts
@@ -3,7 +3,7 @@ import { VaultResource } from "@app/lib/resources/vault_resource";
 
 export const getDustAppsListUrl = async (
   auth: Authenticator,
-  vaultId?: string
+  vaultId: string
 ): Promise<string> => {
   const owner = auth.getNonNullableWorkspace();
 

--- a/front/lib/vault_rollout.ts
+++ b/front/lib/vault_rollout.ts
@@ -2,7 +2,8 @@ import type { Authenticator } from "@app/lib/auth";
 import { VaultResource } from "@app/lib/resources/vault_resource";
 
 export const getDustAppsListUrl = async (
-  auth: Authenticator
+  auth: Authenticator,
+  vaultId?: string
 ): Promise<string> => {
   const owner = auth.getNonNullableWorkspace();
 
@@ -12,9 +13,14 @@ export const getDustAppsListUrl = async (
     return defaultUrl;
   }
 
-  const vault = await VaultResource.fetchWorkspaceGlobalVault(auth);
-  if (!vault) {
-    return defaultUrl;
+  let vaultIdForUrl = vaultId;
+  if (!vaultIdForUrl) {
+    const vault = await VaultResource.fetchWorkspaceGlobalVault(auth);
+    if (!vault) {
+      return defaultUrl;
+    }
+    vaultIdForUrl = vault.sId;
   }
-  return `/w/${owner.sId}/vaults/${vault.sId}/categories/apps`;
+
+  return `/w/${owner.sId}/vaults/${vaultIdForUrl}/categories/apps`;
 };

--- a/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/datasets/[name]/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/datasets/[name]/index.tsx
@@ -42,7 +42,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
 
   const readOnly = !auth.isBuilder();
 
-  const { aId } = context.params;
+  const { aId, vaultId } = context.params;
   if (typeof aId !== "string") {
     return {
       notFound: true,
@@ -70,7 +70,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   }
 
   const schema = await getDatasetSchema(auth, app, dataset.name);
-  const dustAppsListUrl = await getDustAppsListUrl(auth);
+  const dustAppsListUrl = await getDustAppsListUrl(auth, vaultId);
 
   return {
     props: {

--- a/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/datasets/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/datasets/index.tsx
@@ -48,7 +48,10 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   }
 
   const datasets = await getDatasets(auth, app.toJSON());
-  const dustAppsListUrl = await getDustAppsListUrl(auth);
+  const dustAppsListUrl = await getDustAppsListUrl(
+    auth,
+    context.params.vaultId
+  );
 
   return {
     props: {

--- a/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/datasets/new.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/datasets/new.tsx
@@ -47,7 +47,10 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   }
 
   const datasets = await getDatasets(auth, app.toJSON());
-  const dustAppsListUrl = await getDustAppsListUrl(auth);
+  const dustAppsListUrl = await getDustAppsListUrl(
+    auth,
+    context.params.vaultId
+  );
 
   return {
     props: {

--- a/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/index.tsx
@@ -64,7 +64,10 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
-  const dustAppsListUrl = await getDustAppsListUrl(auth);
+  const dustAppsListUrl = await getDustAppsListUrl(
+    auth,
+    context.params.vaultId
+  );
 
   return {
     props: {

--- a/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/runs/[runId]/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/runs/[runId]/index.tsx
@@ -56,7 +56,10 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   }
   const { run, spec } = r;
 
-  const dustAppsListUrl = await getDustAppsListUrl(auth);
+  const dustAppsListUrl = await getDustAppsListUrl(
+    auth,
+    context.params.vaultId
+  );
 
   return {
     props: {

--- a/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/runs/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/runs/index.tsx
@@ -49,7 +49,11 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   // `wIdTarget` is used to change the workspace owning the runs of the apps we're looking at.
   // Mostly useful for debugging as an example our use of `dust-apps` as `dust`.
   const wIdTarget = (context.query?.wIdTarget as string) || null;
-  const dustAppsListUrl = await getDustAppsListUrl(auth);
+
+  const dustAppsListUrl = await getDustAppsListUrl(
+    auth,
+    context.params.vaultId
+  );
 
   return {
     props: {

--- a/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/settings.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/settings.tsx
@@ -52,7 +52,10 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
-  const dustAppsListUrl = await getDustAppsListUrl(auth);
+  const dustAppsListUrl = await getDustAppsListUrl(
+    auth,
+    context.params.vaultId
+  );
 
   return {
     props: {

--- a/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/specification.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/specification.tsx
@@ -64,7 +64,10 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     latestDatasets
   );
 
-  const dustAppsListUrl = await getDustAppsListUrl(auth);
+  const dustAppsListUrl = await getDustAppsListUrl(
+    auth,
+    context.params.vaultId
+  );
 
   return {
     props: {

--- a/front/pages/w/[wId]/vaults/[vaultId]/apps/new.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/apps/new.tsx
@@ -41,7 +41,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
-  const dustAppsListUrl = await getDustAppsListUrl(auth);
+  const dustAppsListUrl = await getDustAppsListUrl(auth, vault.sId);
 
   return {
     props: {


### PR DESCRIPTION
## Description

`getDustAppsListUrl` was added as we are in a transition state between `build` tab and `datasource` tab, so depending on if you have the vault flag enabled, when closing a dust app you are not going back to the same place.

Now that dust apps are inside of vaults, for flagged-in workspaces we need to go back to the correct vault.


## Risk

N/A

## Deploy Plan

N/A