### PR TITLE
Fix remark katex outputs

### DIFF
--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -305,14 +305,14 @@ export function RenderMessageMarkdown({
     [textSize, textColor, customRenderer]
   );
 
-  const markdownPlugins = useMemo(
+  const markdownPlugins: PluggableList = useMemo(
     () => [
       remarkDirective,
       mentionDirective,
       visualizationDirective,
       citeDirective(),
       remarkGfm,
-      remarkMath,
+      [remarkMath, { singleDollarTextMath: false }],
     ],
     []
   );
@@ -336,7 +336,9 @@ export function RenderMessageMarkdown({
               linkTarget="_blank"
               components={markdownComponents}
               remarkPlugins={markdownPlugins}
-              rehypePlugins={[rehypeKatex] as PluggableList}
+              rehypePlugins={
+                [[rehypeKatex, { output: "mathml" }]] as PluggableList
+              }
             >
               {processedContent}
             </ReactMarkdown>


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/1204

Fix one issue and tweak one behavior:
- We would render both mathml and html outputs for formulas duplicating output, now renders only mathml.
- We would consider single $ as math formulas which is a bit aggressive, deactivates this

r? @PopDaph cc @flvndvd 

## Risk

N/A

## Deploy Plan

- deploy `front`