### PR TITLE
Upg: show usage by agents in all screens. Opt: improve performance of usage query. Fix: handle all cases of usages (table, process, retrieval).

### DIFF
--- a/front/components/data_source/DeleteStaticDataSourceDialog.tsx
+++ b/front/components/data_source/DeleteStaticDataSourceDialog.tsx
@@ -54,7 +54,7 @@ export function DeleteStaticDataSourceDialog({
         {message}
         <br />
         <br />
-        <b>Are you sure you want to remove&nbsp;?</b>
+        <b>Are you sure you want to remove ?</b>
       </div>
     </Dialog>
   );

--- a/front/components/data_source/DeleteStaticDataSourceDialog.tsx
+++ b/front/components/data_source/DeleteStaticDataSourceDialog.tsx
@@ -38,8 +38,8 @@ export function DeleteStaticDataSourceDialog({
     dataSourceUsage === undefined
       ? `Are you sure you want to permanently delete ${name}?`
       : dataSourceUsage.count > 0
-        ? `${dataSourceUsage} assistants currently use ${name}: ${dataSourceUsage.agentNames.join(", ")}. Are you sure you want to remove?`
-        : `No assistants are using ${name}. Confirm permanent deletion?`;
+        ? `${dataSourceUsage.count} assistants currently use "${name}": ${dataSourceUsage.agentNames.join(", ")}.`
+        : `No assistants are using "${name}".`;
 
   return (
     <Dialog
@@ -50,7 +50,12 @@ export function DeleteStaticDataSourceDialog({
       onCancel={onClose}
       validateVariant="primaryWarning"
     >
-      <div>{message}</div>
+      <div>
+        {message}
+        <br />
+        <br />
+        <b>Are you sure you want to remove&nbsp;?</b>
+      </div>
     </Dialog>
   );
 }

--- a/front/components/data_source/DeleteStaticDataSourceDialog.tsx
+++ b/front/components/data_source/DeleteStaticDataSourceDialog.tsx
@@ -1,5 +1,8 @@
 import { Dialog } from "@dust-tt/sparkle";
-import type { DataSourceType, DataSourceUsageType } from "@dust-tt/types";
+import type {
+  DataSourceType,
+  DataSourceWithAgentsUsageType,
+} from "@dust-tt/types";
 import { useState } from "react";
 
 import { getDataSourceName, isManaged } from "@app/lib/data_sources";
@@ -7,7 +10,7 @@ import { getDataSourceName, isManaged } from "@app/lib/data_sources";
 interface DeleteStaticDataSourceDialogProps {
   dataSource: DataSourceType;
   handleDelete: () => void;
-  dataSourceUsage?: DataSourceUsageType;
+  dataSourceUsage?: DataSourceWithAgentsUsageType;
   isOpen: boolean;
   onClose: () => void;
 }

--- a/front/components/data_source/DeleteStaticDataSourceDialog.tsx
+++ b/front/components/data_source/DeleteStaticDataSourceDialog.tsx
@@ -1,5 +1,5 @@
 import { Dialog } from "@dust-tt/sparkle";
-import type { DataSourceType } from "@dust-tt/types";
+import type { DataSourceType, DataSourceUsageType } from "@dust-tt/types";
 import { useState } from "react";
 
 import { getDataSourceName, isManaged } from "@app/lib/data_sources";
@@ -7,7 +7,7 @@ import { getDataSourceName, isManaged } from "@app/lib/data_sources";
 interface DeleteStaticDataSourceDialogProps {
   dataSource: DataSourceType;
   handleDelete: () => void;
-  dataSourceUsage?: number;
+  dataSourceUsage?: DataSourceUsageType;
   isOpen: boolean;
   onClose: () => void;
 }
@@ -34,8 +34,8 @@ export function DeleteStaticDataSourceDialog({
   const message =
     dataSourceUsage === undefined
       ? `Are you sure you want to permanently delete ${name}?`
-      : dataSourceUsage > 0
-        ? `${dataSourceUsage} assistants currently use ${name}. Are you sure you want to remove?`
+      : dataSourceUsage.count > 0
+        ? `${dataSourceUsage} assistants currently use ${name}: ${dataSourceUsage.agentNames.join(", ")}. Are you sure you want to remove?`
         : `No assistants are using ${name}. Confirm permanent deletion?`;
 
   return (

--- a/front/components/data_source/WebsiteConfiguration.tsx
+++ b/front/components/data_source/WebsiteConfiguration.tsx
@@ -12,6 +12,7 @@ import {
 import type {
   CrawlingFrequency,
   DataSourceType,
+  DataSourceUsageType,
   DepthOption,
   SubscriptionType,
   UpdateConnectorConfigurationType,
@@ -50,7 +51,7 @@ export default function WebsiteConfiguration({
   dataSources: DataSourceType[];
   webCrawlerConfiguration: WebCrawlerConfigurationType | null;
   dataSource: DataSourceType | null;
-  dataSourceUsage?: number;
+  dataSourceUsage?: DataSourceUsageType;
 }) {
   const [isSaving, setIsSaving] = useState(false);
   const [isSubmitted, setIsSubmitted] = useState(false);
@@ -535,7 +536,7 @@ export default function WebsiteConfiguration({
                   handleDelete={handleDelete}
                   isOpen={isDeleteModalOpen}
                   onClose={() => setIsDeleteModalOpen(false)}
-                  dataSourceUsage={dataSourceUsage ?? 0}
+                  dataSourceUsage={dataSourceUsage}
                 />
               )}
             </div>

--- a/front/components/data_source/WebsiteConfiguration.tsx
+++ b/front/components/data_source/WebsiteConfiguration.tsx
@@ -12,7 +12,7 @@ import {
 import type {
   CrawlingFrequency,
   DataSourceType,
-  DataSourceUsageType,
+  DataSourceWithAgentsUsageType,
   DepthOption,
   SubscriptionType,
   UpdateConnectorConfigurationType,
@@ -51,7 +51,7 @@ export default function WebsiteConfiguration({
   dataSources: DataSourceType[];
   webCrawlerConfiguration: WebCrawlerConfigurationType | null;
   dataSource: DataSourceType | null;
-  dataSourceUsage?: DataSourceUsageType;
+  dataSourceUsage?: DataSourceWithAgentsUsageType;
 }) {
   const [isSaving, setIsSaving] = useState(false);
   const [isSubmitted, setIsSubmitted] = useState(false);

--- a/front/components/vaults/ConfirmDeleteVaultDialog.tsx
+++ b/front/components/vaults/ConfirmDeleteVaultDialog.tsx
@@ -8,6 +8,7 @@ interface ConfirmDeleteVaultDialogProps {
   handleDelete: () => void;
   dataSourceUsage?: number;
   isOpen: boolean;
+  isDeleting: boolean;
   onClose: () => void;
 }
 
@@ -16,13 +17,9 @@ export function ConfirmDeleteVaultDialog({
   handleDelete,
   dataSourceUsage,
   isOpen,
+  isDeleting,
   onClose,
 }: ConfirmDeleteVaultDialogProps) {
-  const onDelete = async () => {
-    void handleDelete();
-    onClose();
-  };
-
   const message =
     dataSourceUsage === undefined
       ? `Are you sure you want to permanently delete vault ${getVaultName(vault)}?`
@@ -34,9 +31,10 @@ export function ConfirmDeleteVaultDialog({
     <Dialog
       isOpen={isOpen}
       title={`Deleting ${getVaultName(vault)}`}
-      onValidate={onDelete}
+      onValidate={handleDelete}
       onCancel={onClose}
       validateVariant="primaryWarning"
+      isSaving={isDeleting}
     >
       <div>{message}</div>
     </Dialog>

--- a/front/components/vaults/CreateOrEditVaultModal.tsx
+++ b/front/components/vaults/CreateOrEditVaultModal.tsx
@@ -76,6 +76,7 @@ export function CreateOrEditVaultModal({
   });
   const sendNotifications = useContext(SendNotificationsContext);
   const [showDeleteConfirmDialog, setShowDeleteConfirmDialog] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
   const doCreate = useCreateVault({ owner });
   const doUpdate = useUpdateVault({ owner });
   const doDelete = useDeleteVault({ owner });
@@ -217,10 +218,16 @@ export function CreateOrEditVaultModal({
 
   const onDelete = useCallback(async () => {
     if (!vault) {
+      setShowDeleteConfirmDialog(false);
       return;
     }
 
+    setIsDeleting(true);
+
     const res = await doDelete(vault);
+    setIsDeleting(false);
+    setShowDeleteConfirmDialog(false);
+
     if (res) {
       onClose();
       await router.push(`/w/${owner.sId}/vaults`);
@@ -293,6 +300,7 @@ export function CreateOrEditVaultModal({
                 vault={vault}
                 handleDelete={onDelete}
                 isOpen={showDeleteConfirmDialog}
+                isDeleting={isDeleting}
                 onClose={() => setShowDeleteConfirmDialog(false)}
               />
               <div className="flex w-full justify-end">

--- a/front/components/vaults/CreateOrEditVaultModal.tsx
+++ b/front/components/vaults/CreateOrEditVaultModal.tsx
@@ -300,6 +300,7 @@ export function CreateOrEditVaultModal({
                   size="sm"
                   label="Delete Vault"
                   variant="primaryWarning"
+                  className="mr-2"
                   onClick={() => setShowDeleteConfirmDialog(true)}
                 />
               </div>

--- a/front/components/vaults/EditVaultStaticDatasourcesViews.tsx
+++ b/front/components/vaults/EditVaultStaticDatasourcesViews.tsx
@@ -1,7 +1,7 @@
 import { Button, PlusIcon, Popup, Tooltip } from "@dust-tt/sparkle";
 import type {
   DataSourceType,
-  DataSourceViewWithConnectorType,
+  DataSourceViewType,
   PlanType,
   VaultType,
   WorkspaceType,
@@ -22,7 +22,7 @@ interface EditVaultStaticDatasourcesViewsProps {
   plan: PlanType;
   vault: VaultType;
   dataSources: DataSourceType[];
-  dataSourceView: DataSourceViewWithConnectorType | null;
+  dataSourceView: DataSourceViewType | null;
   category: "folder" | "website";
   onClose: () => void;
 }

--- a/front/components/vaults/VaultCategoriesList.tsx
+++ b/front/components/vaults/VaultCategoriesList.tsx
@@ -81,6 +81,7 @@ const getTableColumns = () => {
     },
     {
       header: "Used by",
+      accessorFn: (row: RowData) => row.usage.count,
       meta: {
         width: "6rem",
       },

--- a/front/components/vaults/VaultCategoriesList.tsx
+++ b/front/components/vaults/VaultCategoriesList.tsx
@@ -11,7 +11,7 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import type {
-  DataSourceUsageType,
+  DataSourceWithAgentsUsageType,
   VaultType,
   WorkspaceType,
 } from "@dust-tt/types";
@@ -27,7 +27,7 @@ type RowData = {
   category: string;
   name: string;
   icon: ComponentType;
-  usage: DataSourceUsageType;
+  usage: DataSourceWithAgentsUsageType;
   count: number;
   onClick?: () => void;
 };
@@ -81,7 +81,6 @@ const getTableColumns = () => {
     },
     {
       header: "Used by",
-      accessorKey: "usage",
       meta: {
         width: "6rem",
       },

--- a/front/components/vaults/VaultCategoriesList.tsx
+++ b/front/components/vaults/VaultCategoriesList.tsx
@@ -10,7 +10,11 @@ import {
   Searchbar,
   Spinner,
 } from "@dust-tt/sparkle";
-import type { VaultType, WorkspaceType } from "@dust-tt/types";
+import type {
+  DataSourceUsageType,
+  VaultType,
+  WorkspaceType,
+} from "@dust-tt/types";
 import { DATA_SOURCE_VIEW_CATEGORIES, removeNulls } from "@dust-tt/types";
 import type { CellContext } from "@tanstack/react-table";
 import type { ComponentType } from "react";
@@ -23,7 +27,7 @@ type RowData = {
   category: string;
   name: string;
   icon: ComponentType;
-  usage: number;
+  usage: DataSourceUsageType;
   count: number;
   onClick?: () => void;
 };
@@ -84,8 +88,11 @@ const getTableColumns = () => {
       cell: (info: Info) => (
         <>
           {info.row.original.usage ? (
-            <DataTable.CellContent icon={RobotIcon}>
-              {info.row.original.usage}
+            <DataTable.CellContent
+              icon={RobotIcon}
+              title={`Used by ${info.row.original.usage.agentNames.join(", ")}`}
+            >
+              {info.row.original.usage.count}
             </DataTable.CellContent>
           ) : null}
         </>

--- a/front/components/vaults/VaultDataSourceViewContentList.tsx
+++ b/front/components/vaults/VaultDataSourceViewContentList.tsx
@@ -95,7 +95,7 @@ const getTableColumns = (showVaultUsage: boolean): ColumnDef<RowData>[] => {
             ? info
                 .getValue()
                 .map((v) => v.name)
-                .join(",")
+                .join(", ")
             : "-"}
         </DataTable.CellContent>
       ),

--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -14,10 +14,10 @@ import {
 } from "@dust-tt/sparkle";
 import type {
   ConnectorProvider,
-  DataSourceUsageType,
   DataSourceViewCategory,
   DataSourceViewsWithDetails,
   DataSourceViewType,
+  DataSourceWithAgentsUsageType,
   DataSourceWithConnectorDetailsType,
   PlanType,
   VaultType,
@@ -132,7 +132,6 @@ const getTableColumns = ({
   const usedByColumn = {
     header: "Used by",
     id: "usedBy",
-    accessorFn: (row: RowData) => row.dataSourceView.usage,
     sortingFn: (rowA: Row<RowData>, rowB: Row<RowData>) => {
       return (
         (rowA.original.dataSourceView.usage?.count ?? 0) -
@@ -142,7 +141,7 @@ const getTableColumns = ({
     meta: {
       width: "6rem",
     },
-    cell: (info: CellContext<RowData, DataSourceUsageType>) => (
+    cell: (info: CellContext<RowData, DataSourceWithAgentsUsageType>) => (
       <>
         {info.row.original.dataSourceView.usage ? (
           <DataTable.CellContent

--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -27,7 +27,6 @@ import { isWebsiteOrFolderCategory } from "@dust-tt/types";
 import type {
   CellContext,
   ColumnDef,
-  Row,
   SortingState,
 } from "@tanstack/react-table";
 import { useRouter } from "next/router";
@@ -133,12 +132,6 @@ const getTableColumns = ({
     header: "Used by",
     accessorFn: (row: RowData) => row.dataSourceView.usage?.count ?? 0,
     id: "usedBy",
-    sortingFn: (rowA: Row<RowData>, rowB: Row<RowData>) => {
-      return (
-        (rowA.original.dataSourceView.usage?.count ?? 0) -
-        (rowB.original.dataSourceView.usage?.count ?? 0)
-      );
-    },
     meta: {
       width: "6rem",
     },

--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -131,6 +131,7 @@ const getTableColumns = ({
 
   const usedByColumn = {
     header: "Used by",
+    accessorFn: (row: RowData) => row.dataSourceView.usage?.count ?? 0,
     id: "usedBy",
     sortingFn: (rowA: Row<RowData>, rowB: Row<RowData>) => {
       return (

--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -45,7 +45,7 @@ import { AddConnectionMenu } from "@app/components/vaults/AddConnectionMenu";
 import { EditVaultManagedDataSourcesViews } from "@app/components/vaults/EditVaultManagedDatasourcesViews";
 import { EditVaultStaticDatasourcesViews } from "@app/components/vaults/EditVaultStaticDatasourcesViews";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
-import { getDataSourceNameFromView } from "@app/lib/data_sources";
+import { getDataSourceNameFromView, isManaged } from "@app/lib/data_sources";
 import { useDataSources } from "@app/lib/swr/data_sources";
 import {
   useDeleteFolderOrWebsite,
@@ -268,7 +268,7 @@ export const VaultResourcesList = ({
   const searchBarRef = useRef<HTMLInputElement>(null);
 
   const isSystemVault = systemVault.sId === vault.sId;
-  const isManaged = category === "managed";
+  const isManagedCategory = category === "managed";
   const isWebsiteOrFolder = isWebsiteOrFolderCategory(category);
 
   const [isLoadingByProvider, setIsLoadingByProvider] = useState<
@@ -403,9 +403,7 @@ export const VaultResourcesList = ({
                 plan={plan}
                 existingDataSources={
                   vaultDataSourceViews
-                    .filter(
-                      (dsView) => dsView.dataSource.connectorProvider !== null
-                    )
+                    .filter((dsView) => isManaged(dsView.dataSource))
                     .map(
                       (v) => v.dataSource
                     ) as DataSourceWithConnectorDetailsType[]
@@ -454,7 +452,7 @@ export const VaultResourcesList = ({
             )}
           </div>
         )}
-        {!connectionManagementVisible && isManaged && (
+        {!connectionManagementVisible && isManagedCategory && (
           <EditVaultManagedDataSourcesViews
             owner={owner}
             vault={vault}
@@ -493,7 +491,10 @@ export const VaultResourcesList = ({
       {rows.length > 0 && (
         <DataTable
           data={rows}
-          columns={getTableColumns({ isManaged, isSystemVault })}
+          columns={getTableColumns({
+            isManaged: isManagedCategory,
+            isSystemVault,
+          })}
           filter={dataSourceSearch}
           filterColumn="name"
           sorting={sorting}

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -24,6 +24,10 @@ import type { DataSourceViewResource } from "@app/lib/resources/data_source_view
 import { DataSource } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 
+// To use in case of heavy db load emergency with theses usages queries
+// If it is a problem, let's add caching
+const DISABLE_QUERIES = false;
+
 export type DataSourcesUsageByAgent = Record<
   ModelId,
   DataSourceWithAgentsUsageType | null
@@ -44,6 +48,11 @@ export async function getDataSourceViewsUsageByCategory({
   if (!owner || !auth.isUser()) {
     return {};
   }
+
+  if (DISABLE_QUERIES) {
+    return {};
+  }
+
   let connectorProvider: WhereAttributeHashValue<ConnectorProvider | null> =
     null;
 
@@ -277,6 +286,11 @@ export async function getDataSourcesUsageByCategory({
   if (!owner || !auth.isUser()) {
     return {};
   }
+
+  if (DISABLE_QUERIES) {
+    return {};
+  }
+
   let connectorProvider: WhereAttributeHashValue<ConnectorProvider | null> =
     null;
   if (category === "folder") {
@@ -476,6 +490,10 @@ export async function getDataSourceUsage({
     return new Err(new Error("Unexpected `auth` without `workspace`."));
   }
 
+  if (DISABLE_QUERIES) {
+    new Ok({ count: 0, agentNames: [] });
+  }
+
   const res = (await Promise.all([
     AgentDataSourceConfiguration.findOne({
       raw: true,
@@ -619,6 +637,10 @@ export async function getDataSourceViewUsage({
   // be possible to access data sources without being authenticated.
   if (!owner || !auth.isUser()) {
     return new Err(new Error("Unexpected `auth` without `workspace`."));
+  }
+
+  if (DISABLE_QUERIES) {
+    new Ok({ count: 0, agentNames: [] });
   }
 
   const res = (await Promise.all([

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -1,29 +1,40 @@
 import type {
   ConnectorProvider,
-  DataSourceType,
-  DataSourceViewType,
+  DataSourceUsageType,
+  DataSourceViewCategory,
   ModelId,
   Result,
 } from "@dust-tt/types";
-import { Err, Ok } from "@dust-tt/types";
-import { Sequelize } from "sequelize";
+import { assertNever, Err, Ok } from "@dust-tt/types";
+import { uniq } from "lodash";
+import type { WhereAttributeHashValue } from "sequelize";
+import { Op, Sequelize } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
 import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
+import { AgentProcessConfiguration } from "@app/lib/models/assistant/actions/process";
 import { AgentRetrievalConfiguration } from "@app/lib/models/assistant/actions/retrieval";
+import {
+  AgentTablesQueryConfiguration,
+  AgentTablesQueryConfigurationTable,
+} from "@app/lib/models/assistant/actions/tables_query";
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
+import type { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { DataSource } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 
-export type DataSourcesUsageByAgent = Record<ModelId, number>;
+export type DataSourcesUsageByAgent = Record<
+  ModelId,
+  DataSourceUsageType | null
+>;
 
-// TODO(GROUPS_INFRA) Add support for views here.
-export async function getDataSourcesUsageByAgents({
+export async function getDataSourceViewsUsageByCategory({
   auth,
-  providerFilter,
+  category,
 }: {
   auth: Authenticator;
-  providerFilter: ConnectorProvider | null;
+  category: DataSourceViewCategory;
 }): Promise<DataSourcesUsageByAgent> {
   const owner = auth.workspace();
 
@@ -33,12 +44,281 @@ export async function getDataSourcesUsageByAgents({
   if (!owner || !auth.isUser()) {
     return {};
   }
+  let connectorProvider: WhereAttributeHashValue<ConnectorProvider | null> =
+    null;
 
-  const agentDataSourceConfigurations =
-    await AgentDataSourceConfiguration.findAll({
+  switch (category) {
+    case "folder":
+      connectorProvider = null;
+      break;
+    case "website":
+      connectorProvider = "webcrawler";
+      break;
+    case "managed":
+      const managedConnectorProvider: ConnectorProvider[] = [
+        "confluence",
+        "github",
+        "google_drive",
+        "intercom",
+        "notion",
+        "slack",
+        "microsoft",
+      ];
+      connectorProvider = {
+        [Op.in]: managedConnectorProvider,
+      };
+      break;
+    case "apps":
+      return {};
+    default:
+      assertNever(category);
+      break;
+  }
+
+  const res = (await Promise.all([
+    AgentDataSourceConfiguration.findAll({
+      raw: true,
+      group: ["dataSourceView.id"],
+      attributes: [
+        [Sequelize.col("dataSourceView.id"), "dataSourceViewId"],
+        [
+          Sequelize.fn(
+            "array_agg",
+            Sequelize.col(
+              "agent_retrieval_configuration->agent_configuration.name"
+            )
+          ),
+          "names",
+        ],
+        [Sequelize.fn("count", Sequelize.col("*")), "count"],
+      ],
+      include: [
+        {
+          model: DataSourceViewModel,
+          as: "dataSourceView",
+          attributes: [],
+          required: true,
+          include: [
+            {
+              model: DataSource,
+              as: "dataSourceForView",
+              attributes: [],
+              required: true,
+              where: {
+                connectorProvider: connectorProvider,
+              },
+            },
+          ],
+        },
+        {
+          model: AgentRetrievalConfiguration,
+          as: "agent_retrieval_configuration",
+          attributes: [],
+          required: true,
+          include: [
+            {
+              model: AgentConfiguration,
+              as: "agent_configuration",
+              attributes: [],
+              required: true,
+              where: {
+                status: "active",
+                workspaceId: owner.id,
+              },
+            },
+          ],
+        },
+      ],
+    }),
+    AgentDataSourceConfiguration.findAll({
+      raw: true,
+      group: ["dataSourceView.id"],
+      attributes: [
+        [Sequelize.col("dataSourceView.id"), "dataSourceViewId"],
+        [
+          Sequelize.fn(
+            "array_agg",
+            Sequelize.col(
+              "agent_process_configuration->agent_configuration.name"
+            )
+          ),
+          "names",
+        ],
+        [Sequelize.fn("count", Sequelize.col("*")), "count"],
+      ],
+      include: [
+        {
+          model: DataSourceViewModel,
+          as: "dataSourceView",
+          attributes: [],
+          required: true,
+          include: [
+            {
+              model: DataSource,
+              as: "dataSourceForView",
+              attributes: [],
+              required: true,
+              where: {
+                connectorProvider: connectorProvider,
+              },
+            },
+          ],
+        },
+        {
+          model: AgentProcessConfiguration,
+          as: "agent_process_configuration",
+          attributes: [],
+          required: true,
+          include: [
+            {
+              model: AgentConfiguration,
+              as: "agent_configuration",
+              attributes: [],
+              required: true,
+              where: {
+                status: "active",
+                workspaceId: owner.id,
+              },
+            },
+          ],
+        },
+      ],
+    }),
+    AgentTablesQueryConfigurationTable.findAll({
+      raw: true,
+      group: ["dataSourceView.id"],
+      attributes: [
+        [Sequelize.col("dataSourceView.id"), "dataSourceViewId"],
+        [
+          Sequelize.fn(
+            "array_agg",
+            Sequelize.col(
+              "agent_tables_query_configuration->agent_configuration.name"
+            )
+          ),
+          "names",
+        ],
+        [Sequelize.fn("count", Sequelize.col("*")), "count"],
+      ],
+      include: [
+        {
+          model: DataSourceViewModel,
+          as: "dataSourceView",
+          attributes: [],
+          required: true,
+          include: [
+            {
+              model: DataSource,
+              as: "dataSourceForView",
+              attributes: [],
+              required: true,
+              where: {
+                connectorProvider: connectorProvider,
+              },
+            },
+          ],
+        },
+        {
+          model: AgentTablesQueryConfiguration,
+          as: "agent_tables_query_configuration",
+          attributes: [],
+          required: true,
+          include: [
+            {
+              model: AgentConfiguration,
+              as: "agent_configuration",
+              attributes: [],
+              required: true,
+              where: {
+                status: "active",
+                workspaceId: owner.id,
+              },
+            },
+          ],
+        },
+      ],
+    }),
+  ])) as unknown as {
+    dataSourceViewId: ModelId;
+    names: string[];
+    count: string;
+  }[][];
+
+  return res.flat().reduce<DataSourcesUsageByAgent>((acc, dsViewConfig) => {
+    let usage = acc[dsViewConfig.dataSourceViewId];
+
+    if (!usage) {
+      usage = {
+        count: 0,
+        agentNames: [],
+      };
+    }
+
+    usage.count += parseInt(dsViewConfig.count);
+    usage.agentNames = usage.agentNames
+      .concat(dsViewConfig.names)
+      .filter((t) => t && t.length > 0);
+    usage.agentNames = uniq(usage.agentNames);
+
+    acc[dsViewConfig.dataSourceViewId] = usage;
+
+    return acc;
+  }, {});
+}
+
+export async function getDataSourcesUsageByCategory({
+  auth,
+  category,
+}: {
+  auth: Authenticator;
+  category: DataSourceViewCategory;
+}): Promise<DataSourcesUsageByAgent> {
+  const owner = auth.workspace();
+
+  // This condition is critical it checks that we can identify the workspace and that the current
+  // auth is a user for this workspace. Checking `auth.isUser()` is critical as it would otherwise
+  // be possible to access data sources without being authenticated.
+  if (!owner || !auth.isUser()) {
+    return {};
+  }
+  let connectorProvider: WhereAttributeHashValue<ConnectorProvider | null> =
+    null;
+  if (category === "folder") {
+    connectorProvider = null;
+  } else if (category === "website") {
+    connectorProvider = "webcrawler";
+  } else if (category === "managed") {
+    const managedConnectorProvider: ConnectorProvider[] = [
+      "confluence",
+      "github",
+      "google_drive",
+      "intercom",
+      "notion",
+      "slack",
+      "microsoft",
+    ];
+
+    connectorProvider = {
+      [Op.in]: managedConnectorProvider,
+    };
+  }
+
+  const res = (await Promise.all([
+    AgentDataSourceConfiguration.findAll({
+      raw: true,
+      group: ["dataSource.id"],
       attributes: [
         [Sequelize.col("dataSource.id"), "dataSourceId"],
-        [Sequelize.fn("COUNT", Sequelize.col("dataSource.id")), "count"],
+        [
+          Sequelize.fn(
+            "array_agg",
+            Sequelize.col(
+              "agent_retrieval_configuration->agent_configuration.name"
+            )
+          ),
+          "names",
+        ],
+        [Sequelize.fn("count", Sequelize.col("*")), "count"],
       ],
       include: [
         {
@@ -47,8 +327,7 @@ export async function getDataSourcesUsageByAgents({
           attributes: [],
           required: true,
           where: {
-            workspaceId: owner.id,
-            connectorProvider: providerFilter,
+            connectorProvider: connectorProvider,
           },
         },
         {
@@ -64,23 +343,129 @@ export async function getDataSourcesUsageByAgents({
               required: true,
               where: {
                 status: "active",
+                workspaceId: owner.id,
               },
             },
           ],
         },
       ],
-      group: ["dataSource.id"],
+    }),
+    AgentDataSourceConfiguration.findAll({
       raw: true,
-    });
-  return agentDataSourceConfigurations.reduce<DataSourcesUsageByAgent>(
-    (acc, dsConfig) => {
-      acc[dsConfig.dataSourceId] = (
-        dsConfig as unknown as { count: number }
-      ).count;
-      return acc;
-    },
-    {}
-  );
+      group: ["dataSource.id"],
+      attributes: [
+        [Sequelize.col("dataSource.id"), "dataSourceId"],
+        [
+          Sequelize.fn(
+            "array_agg",
+            Sequelize.col(
+              "agent_process_configuration->agent_configuration.name"
+            )
+          ),
+          "names",
+        ],
+        [Sequelize.fn("count", Sequelize.col("*")), "count"],
+      ],
+      include: [
+        {
+          model: DataSource,
+          as: "dataSource",
+          attributes: [],
+          required: true,
+          where: {
+            connectorProvider: connectorProvider,
+          },
+        },
+        {
+          model: AgentProcessConfiguration,
+          as: "agent_process_configuration",
+          attributes: [],
+          required: true,
+          include: [
+            {
+              model: AgentConfiguration,
+              as: "agent_configuration",
+              attributes: [],
+              required: true,
+              where: {
+                status: "active",
+                workspaceId: owner.id,
+              },
+            },
+          ],
+        },
+      ],
+    }),
+    AgentTablesQueryConfigurationTable.findAll({
+      raw: true,
+      group: ["dataSource.id"],
+      attributes: [
+        [Sequelize.col("dataSource.id"), "dataSourceId"],
+        [
+          Sequelize.fn(
+            "array_agg",
+            Sequelize.col(
+              "agent_tables_query_configuration->agent_configuration.name"
+            )
+          ),
+          "names",
+        ],
+        [Sequelize.fn("count", Sequelize.col("*")), "count"],
+      ],
+      include: [
+        {
+          model: DataSource,
+          as: "dataSource",
+          attributes: [],
+          required: true,
+          where: {
+            connectorProvider: connectorProvider,
+          },
+        },
+        {
+          model: AgentTablesQueryConfiguration,
+          as: "agent_tables_query_configuration",
+          attributes: [],
+          required: true,
+          include: [
+            {
+              model: AgentConfiguration,
+              as: "agent_configuration",
+              attributes: [],
+              required: true,
+              where: {
+                status: "active",
+                workspaceId: owner.id,
+              },
+            },
+          ],
+        },
+      ],
+    }),
+  ])) as unknown as {
+    dataSourceId: ModelId;
+    names: string[];
+    count: string;
+  }[][];
+
+  return res.flat().reduce<DataSourcesUsageByAgent>((acc, dsConfig) => {
+    let usage = acc[dsConfig.dataSourceId];
+    if (!usage) {
+      usage = {
+        count: 0,
+        agentNames: [],
+      };
+    }
+
+    usage.count += parseInt(dsConfig.count);
+    usage.agentNames = usage.agentNames
+      .concat(dsConfig.names)
+      .filter((t) => t && t.length > 0);
+    usage.agentNames = uniq(usage.agentNames);
+
+    acc[dsConfig.dataSourceId] = usage;
+    return acc;
+  }, {});
 }
 
 export async function getDataSourceUsage({
@@ -88,8 +473,8 @@ export async function getDataSourceUsage({
   dataSource,
 }: {
   auth: Authenticator;
-  dataSource: DataSourceType;
-}): Promise<Result<number, Error>> {
+  dataSource: DataSourceResource;
+}): Promise<Result<DataSourceUsageType, Error>> {
   const owner = auth.workspace();
 
   // This condition is critical it checks that we can identify the workspace and that the current
@@ -99,20 +484,25 @@ export async function getDataSourceUsage({
     return new Err(new Error("Unexpected `auth` without `workspace`."));
   }
 
-  return new Ok(
-    await AgentDataSourceConfiguration.count({
+  const res = (await Promise.all([
+    AgentDataSourceConfiguration.findOne({
+      raw: true,
+      attributes: [
+        [
+          Sequelize.fn(
+            "array_agg",
+            Sequelize.col(
+              "agent_retrieval_configuration->agent_configuration.name"
+            )
+          ),
+          "names",
+        ],
+        [Sequelize.fn("count", Sequelize.col("*")), "count"],
+      ],
       where: {
         dataSourceId: dataSource.id,
       },
       include: [
-        {
-          model: DataSource,
-          as: "dataSource",
-          where: {
-            workspaceId: owner.id,
-          },
-          attributes: [],
-        },
         {
           model: AgentRetrievalConfiguration,
           as: "agent_retrieval_configuration",
@@ -126,13 +516,100 @@ export async function getDataSourceUsage({
               required: true,
               where: {
                 status: "active",
+                workspaceId: owner.id,
               },
             },
           ],
         },
       ],
-    })
-  );
+    }),
+    AgentDataSourceConfiguration.findOne({
+      raw: true,
+      attributes: [
+        [
+          Sequelize.fn(
+            "array_agg",
+            Sequelize.col(
+              "agent_process_configuration->agent_configuration.name"
+            )
+          ),
+          "names",
+        ],
+        [Sequelize.fn("count", Sequelize.col("*")), "count"],
+      ],
+      where: {
+        dataSourceId: dataSource.id,
+      },
+      include: [
+        {
+          model: AgentProcessConfiguration,
+          as: "agent_process_configuration",
+          attributes: [],
+          required: true,
+          include: [
+            {
+              model: AgentConfiguration,
+              as: "agent_configuration",
+              attributes: [],
+              required: true,
+              where: {
+                status: "active",
+                workspaceId: owner.id,
+              },
+            },
+          ],
+        },
+      ],
+    }),
+    AgentTablesQueryConfigurationTable.findOne({
+      raw: true,
+      attributes: [
+        [
+          Sequelize.fn(
+            "array_agg",
+            Sequelize.col(
+              "agent_tables_query_configuration->agent_configuration.name"
+            )
+          ),
+          "names",
+        ],
+        [Sequelize.fn("count", Sequelize.col("*")), "count"],
+      ],
+      where: {
+        dataSourceId: dataSource.id,
+      },
+      include: [
+        {
+          model: AgentTablesQueryConfiguration,
+          as: "agent_tables_query_configuration",
+          attributes: [],
+          required: true,
+          include: [
+            {
+              model: AgentConfiguration,
+              as: "agent_configuration",
+              attributes: [],
+              required: true,
+              where: {
+                status: "active",
+                workspaceId: owner.id,
+              },
+            },
+          ],
+        },
+      ],
+    }),
+  ])) as unknown as { names: string[]; count: string }[] | null;
+
+  if (!res) {
+    return new Ok({ count: 0, agentNames: [] });
+  } else {
+    const count = res.reduce((acc, r) => acc + parseInt(r.count), 0);
+    const agentNames = res
+      .reduce<string[]>((acc, r) => acc.concat(r.names), [])
+      .filter((t) => t && t.length > 0);
+    return new Ok({ count, agentNames });
+  }
 }
 
 export async function getDataSourceViewUsage({
@@ -140,8 +617,8 @@ export async function getDataSourceViewUsage({
   dataSourceView,
 }: {
   auth: Authenticator;
-  dataSourceView: DataSourceViewType;
-}): Promise<Result<number, Error>> {
+  dataSourceView: DataSourceViewResource;
+}): Promise<Result<DataSourceUsageType, Error>> {
   const owner = auth.workspace();
 
   // This condition is critical it checks that we can identify the workspace and that the current
@@ -151,20 +628,25 @@ export async function getDataSourceViewUsage({
     return new Err(new Error("Unexpected `auth` without `workspace`."));
   }
 
-  return new Ok(
-    await AgentDataSourceConfiguration.count({
+  const res = (await Promise.all([
+    AgentDataSourceConfiguration.findOne({
+      raw: true,
+      attributes: [
+        [
+          Sequelize.fn(
+            "array_agg",
+            Sequelize.col(
+              "agent_retrieval_configuration->agent_configuration.name"
+            )
+          ),
+          "names",
+        ],
+        [Sequelize.fn("count", Sequelize.col("*")), "count"],
+      ],
       where: {
         dataSourceViewId: dataSourceView.id,
       },
       include: [
-        {
-          model: DataSourceViewModel,
-          as: "dataSourceView",
-          where: {
-            workspaceId: owner.id,
-          },
-          attributes: [],
-        },
         {
           model: AgentRetrievalConfiguration,
           as: "agent_retrieval_configuration",
@@ -178,11 +660,98 @@ export async function getDataSourceViewUsage({
               required: true,
               where: {
                 status: "active",
+                workspaceId: owner.id,
               },
             },
           ],
         },
       ],
-    })
-  );
+    }),
+    AgentDataSourceConfiguration.findOne({
+      raw: true,
+      attributes: [
+        [
+          Sequelize.fn(
+            "array_agg",
+            Sequelize.col(
+              "agent_process_configuration->agent_configuration.name"
+            )
+          ),
+          "names",
+        ],
+        [Sequelize.fn("count", Sequelize.col("*")), "count"],
+      ],
+      where: {
+        dataSourceViewId: dataSourceView.id,
+      },
+      include: [
+        {
+          model: AgentProcessConfiguration,
+          as: "agent_process_configuration",
+          attributes: [],
+          required: true,
+          include: [
+            {
+              model: AgentConfiguration,
+              as: "agent_configuration",
+              attributes: [],
+              required: true,
+              where: {
+                status: "active",
+                workspaceId: owner.id,
+              },
+            },
+          ],
+        },
+      ],
+    }),
+    AgentTablesQueryConfigurationTable.findOne({
+      raw: true,
+      attributes: [
+        [
+          Sequelize.fn(
+            "array_agg",
+            Sequelize.col(
+              "agent_tables_query_configuration->agent_configuration.name"
+            )
+          ),
+          "names",
+        ],
+        [Sequelize.fn("count", Sequelize.col("*")), "count"],
+      ],
+      where: {
+        dataSourceViewId: dataSourceView.id,
+      },
+      include: [
+        {
+          model: AgentTablesQueryConfiguration,
+          as: "agent_tables_query_configuration",
+          attributes: [],
+          required: true,
+          include: [
+            {
+              model: AgentConfiguration,
+              as: "agent_configuration",
+              attributes: [],
+              required: true,
+              where: {
+                status: "active",
+                workspaceId: owner.id,
+              },
+            },
+          ],
+        },
+      ],
+    }),
+  ])) as unknown as { names: string[]; count: string }[] | null;
+
+  if (!res) {
+    return new Ok({ count: 0, agentNames: [] });
+  } else {
+    const count = res.reduce((acc, r) => acc + parseInt(r.count), 0);
+    const agentNames = res
+      .reduce<string[]>((acc, r) => acc.concat(r.names), [])
+      .filter((t) => t && t.length > 0);
+    return new Ok({ count, agentNames });
+  }
 }

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -1,7 +1,7 @@
 import type {
   ConnectorProvider,
-  DataSourceUsageType,
   DataSourceViewCategory,
+  DataSourceWithAgentsUsageType,
   ModelId,
   Result,
 } from "@dust-tt/types";
@@ -26,7 +26,7 @@ import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_sour
 
 export type DataSourcesUsageByAgent = Record<
   ModelId,
-  DataSourceUsageType | null
+  DataSourceWithAgentsUsageType | null
 >;
 
 export async function getDataSourceViewsUsageByCategory({
@@ -466,7 +466,7 @@ export async function getDataSourceUsage({
 }: {
   auth: Authenticator;
   dataSource: DataSourceResource;
-}): Promise<Result<DataSourceUsageType, Error>> {
+}): Promise<Result<DataSourceWithAgentsUsageType, Error>> {
   const owner = auth.workspace();
 
   // This condition is critical it checks that we can identify the workspace and that the current
@@ -611,7 +611,7 @@ export async function getDataSourceViewUsage({
 }: {
   auth: Authenticator;
   dataSourceView: DataSourceViewResource;
-}): Promise<Result<DataSourceUsageType, Error>> {
+}): Promise<Result<DataSourceWithAgentsUsageType, Error>> {
   const owner = auth.workspace();
 
   // This condition is critical it checks that we can identify the workspace and that the current

--- a/front/lib/api/vaults.ts
+++ b/front/lib/api/vaults.ts
@@ -1,4 +1,4 @@
-import type { DataSourceUsageType } from "@dust-tt/types";
+import type { DataSourceWithAgentsUsageType } from "@dust-tt/types";
 import { uniq } from "lodash";
 
 import type { Authenticator } from "@app/lib/auth";
@@ -19,7 +19,7 @@ export const deleteVault = async (
 
   const dataSourceViews = await DataSourceViewResource.listByVault(auth, vault);
 
-  const usages: DataSourceUsageType[] = [];
+  const usages: DataSourceWithAgentsUsageType[] = [];
   for (const view of dataSourceViews) {
     const usage = await view.getUsagesByAgents(auth);
     if (usage.isErr()) {

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -418,7 +418,7 @@ export class DataSourceResource extends ResourceWithVault<DataSource> {
   }
 
   getUsagesByAgents(auth: Authenticator) {
-    return getDataSourceUsage({ auth, dataSource: this.toJSON() });
+    return getDataSourceUsage({ auth, dataSource: this });
   }
 
   // Permissions.

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -422,7 +422,7 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
   }
 
   getUsagesByAgents = async (auth: Authenticator) => {
-    return getDataSourceViewUsage({ auth, dataSourceView: this.toJSON() });
+    return getDataSourceViewUsage({ auth, dataSourceView: this });
   };
 
   // Serialization.
@@ -437,7 +437,6 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
       parentsIn: this.parentsIn,
       sId: this.sId,
       updatedAt: this.updatedAt.getTime(),
-      usage: 0,
       vaultId: this.vault.sId,
       ...this.makeEditedBy(this.editedByUser, this.editedAt),
     };

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.ts
@@ -102,12 +102,14 @@ async function handler(
       }
 
       const usageRes = await dataSourceView.getUsagesByAgents(auth);
-      if (usageRes.isErr() || usageRes.value > 0) {
+      if (usageRes.isErr() || usageRes.value.count > 0) {
         return apiError(req, res, {
           status_code: 401,
           api_error: {
             type: "data_source_error",
-            message: "The data source view is in use and cannot be deleted.",
+            message: usageRes.isOk()
+              ? `The data source view is in use by ${usageRes.value.agentNames.join(", ")} and cannot be deleted.`
+              : "The data source view is in use and cannot be deleted.",
           },
         });
       }

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/index.ts
@@ -1,6 +1,7 @@
 import type {
+  DataSourceViewCategory,
+  DataSourceViewsWithDetails,
   DataSourceViewType,
-  DataSourceViewWithConnectorType,
   WithAPIErrorResponse,
 } from "@dust-tt/types";
 import { PostDataSourceViewSchema } from "@dust-tt/types";
@@ -8,6 +9,11 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { DataSourcesUsageByAgent } from "@app/lib/api/agent_data_sources";
+import {
+  getDataSourcesUsageByCategory,
+  getDataSourceViewsUsageByCategory,
+} from "@app/lib/api/agent_data_sources";
 import { augmentDataSourceWithConnectorDetails } from "@app/lib/api/data_sources";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -18,10 +24,10 @@ import { VaultResource } from "@app/lib/resources/vault_resource";
 import { apiError } from "@app/logger/withlogging";
 
 export type GetVaultDataSourceViewsResponseBody<
-  IncludeConnectorDetails extends boolean = boolean,
+  IncludeDetails extends boolean = boolean,
 > = {
-  dataSourceViews: IncludeConnectorDetails extends true
-    ? DataSourceViewWithConnectorType[]
+  dataSourceViews: IncludeDetails extends true
+    ? DataSourceViewsWithDetails[]
     : DataSourceViewType[];
 };
 
@@ -54,7 +60,7 @@ async function handler(
     case "GET": {
       const category =
         req.query.category && typeof req.query.category === "string"
-          ? req.query.category
+          ? (req.query.category as DataSourceViewCategory)
           : null;
 
       const dataSourceViews = (
@@ -65,31 +71,81 @@ async function handler(
         .map((ds) => ds.toJSON())
         .filter((d) => !category || d.category === category);
 
-      if (req.query.includeConnectorDetails) {
-        const enhancedDataSourceViews = await Promise.all(
-          dataSourceViews.map(async (dataSourceView) => {
-            const dataSource = dataSourceView.dataSource;
-            if (!isManaged(dataSource)) {
-              return dataSourceView;
-            }
-            const augmentedDataSource =
-              await augmentDataSourceWithConnectorDetails(dataSource);
-            return {
-              ...dataSourceView,
-              dataSource: augmentedDataSource,
-            };
-          })
-        );
+      if (!req.query.withDetails) {
+        return res.status(200).json({
+          dataSourceViews,
+        });
+      } else {
+        if (!category) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: "Cannot get details without specifying a category.",
+            },
+          });
+        }
+
+        let usages: DataSourcesUsageByAgent = {};
+
+        if (vault.isSystem()) {
+          // In case of system vault, we want to reflect the usage by datasources themselves so we get usage accross all vaults
+          const usagesByDataSources = await getDataSourcesUsageByCategory({
+            auth,
+            category,
+          });
+
+          // Then we remap to the dataSourceViews of the system vaults
+          dataSourceViews.forEach((dsView) => {
+            usages[dsView.id] = usagesByDataSources[dsView.dataSource.id];
+          });
+        } else {
+          // Directly take the usage by dataSourceViews
+          usages = await getDataSourceViewsUsageByCategory({
+            auth,
+            category,
+          });
+        }
+
+        const enhancedDataSourceViews: GetVaultDataSourceViewsResponseBody<true>["dataSourceViews"] =
+          await Promise.all(
+            dataSourceViews.map(async (dataSourceView) => {
+              const dataSource = dataSourceView.dataSource;
+
+              if (!isManaged(dataSource)) {
+                return {
+                  ...dataSourceView,
+                  dataSource: {
+                    ...dataSource,
+                    // As it's not managed, we don't have any connector details
+                    connectorDetails: { connector: null, connectorId: null },
+                    connector: null,
+                    fetchConnectorError: false,
+                    fetchConnectorErrorMessage: null,
+                  },
+                  usage: usages[dataSourceView.id] || {
+                    count: 0,
+                    agentNames: [],
+                  },
+                };
+              }
+
+              const augmentedDataSource =
+                await augmentDataSourceWithConnectorDetails(dataSource);
+              return {
+                ...dataSourceView,
+                dataSource: augmentedDataSource,
+                usage: usages[dataSourceView.id] || {
+                  count: 0,
+                  agentNames: [],
+                },
+              };
+            })
+          );
         return res.status(200).json({
           dataSourceViews: enhancedDataSourceViews,
         });
       }
-
-      return res.status(200).json({
-        dataSourceViews: dataSourceViews.filter(
-          (d) => !category || d.category === category
-        ),
-      });
     }
 
     case "POST": {

--- a/front/pages/api/w/[wId]/vaults/[vId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/index.ts
@@ -1,5 +1,5 @@
 import type {
-  DataSourceUsageType,
+  DataSourceWithAgentsUsageType,
   UserType,
   VaultType,
   WithAPIErrorResponse,
@@ -24,7 +24,7 @@ import { VaultResource } from "@app/lib/resources/vault_resource";
 import { apiError } from "@app/logger/withlogging";
 
 export type VaultCategoryInfo = {
-  usage: DataSourceUsageType;
+  usage: DataSourceWithAgentsUsageType;
   count: number;
 };
 

--- a/front/pages/api/w/[wId]/vaults/[vId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/index.ts
@@ -1,12 +1,19 @@
-import type { UserType, VaultType, WithAPIErrorResponse } from "@dust-tt/types";
+import type {
+  DataSourceUsageType,
+  UserType,
+  VaultType,
+  WithAPIErrorResponse,
+} from "@dust-tt/types";
 import {
   DATA_SOURCE_VIEW_CATEGORIES,
   PatchVaultRequestBodySchema,
 } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
+import { uniq } from "lodash";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { getDataSourceViewsUsageByCategory } from "@app/lib/api/agent_data_sources";
 import { deleteVault } from "@app/lib/api/vaults";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -17,7 +24,7 @@ import { VaultResource } from "@app/lib/resources/vault_resource";
 import { apiError } from "@app/logger/withlogging";
 
 export type VaultCategoryInfo = {
-  usage: number;
+  usage: DataSourceUsageType;
   count: number;
 };
 
@@ -57,22 +64,45 @@ async function handler(
         auth,
         vault
       );
-      const serializedDatasourceViews = dataSourceViews.map((view) =>
-        view.toJSON()
-      );
       const apps = await AppResource.listByVault(auth, vault);
 
       const categories: { [key: string]: VaultCategoryInfo } = {};
       for (const category of DATA_SOURCE_VIEW_CATEGORIES) {
         categories[category] = {
           count: 0,
-          usage: 0,
+          usage: {
+            count: 0,
+            agentNames: [],
+          },
         };
-      }
 
-      for (const dataSource of serializedDatasourceViews) {
-        categories[dataSource.category].count += 1;
-        categories[dataSource.category].usage += dataSource.usage;
+        const dataSourceViewsInCategory = dataSourceViews.filter(
+          (view) => view.toJSON().category === category
+        );
+
+        // As the usage call is expensive, we only call it if there are views in the category
+        if (dataSourceViewsInCategory.length > 0) {
+          const usages = await getDataSourceViewsUsageByCategory({
+            auth,
+            category,
+          });
+
+          for (const dsView of dataSourceViewsInCategory) {
+            categories[category].count += 1;
+
+            const usage = usages[dsView.id];
+
+            if (usage) {
+              categories[category].usage.agentNames = categories[
+                category
+              ].usage.agentNames.concat(usage.agentNames);
+              categories[category].usage.agentNames = uniq(
+                categories[category].usage.agentNames
+              );
+              categories[category].usage.count += usage.count;
+            }
+          }
+        }
       }
 
       categories["apps"].count = apps.length;
@@ -184,7 +214,17 @@ async function handler(
         });
       }
 
-      await deleteVault(auth, vault);
+      try {
+        await deleteVault(auth, vault);
+      } catch (e: any) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: e.message ?? "The vault cannot be deleted.",
+          },
+        });
+      }
 
       return res.status(200).json({ vault: vault.toJSON() });
     }

--- a/front/pages/w/[wId]/builder/data-sources/[dsId]/edit-public-url.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[dsId]/edit-public-url.tsx
@@ -1,6 +1,6 @@
 import type {
   DataSourceType,
-  DataSourceUsageType,
+  DataSourceWithAgentsUsageType,
   SubscriptionType,
   WebCrawlerConfigurationType,
   WorkspaceType,
@@ -21,7 +21,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   dataSources: DataSourceType[];
   dataSource: DataSourceType;
   webCrawlerConfiguration: WebCrawlerConfigurationType;
-  dataSourceUsage: DataSourceUsageType;
+  dataSourceUsage: DataSourceWithAgentsUsageType;
 }>(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
   const subscription = auth.getNonNullableSubscription();

--- a/front/pages/w/[wId]/builder/data-sources/[dsId]/edit-public-url.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[dsId]/edit-public-url.tsx
@@ -1,5 +1,6 @@
 import type {
   DataSourceType,
+  DataSourceUsageType,
   SubscriptionType,
   WebCrawlerConfigurationType,
   WorkspaceType,
@@ -20,7 +21,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   dataSources: DataSourceType[];
   dataSource: DataSourceType;
   webCrawlerConfiguration: WebCrawlerConfigurationType;
-  dataSourceUsage: number;
+  dataSourceUsage: DataSourceUsageType;
 }>(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
   const subscription = auth.getNonNullableSubscription();
@@ -80,7 +81,9 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       dataSource: dataSource.toJSON(),
       webCrawlerConfiguration: connectorRes.value
         .configuration as WebCrawlerConfigurationType,
-      dataSourceUsage: dataSourceUsageRes.isOk() ? dataSourceUsageRes.value : 0,
+      dataSourceUsage: dataSourceUsageRes.isOk()
+        ? dataSourceUsageRes.value
+        : { count: 0, agentNames: [] },
     },
   };
 });

--- a/front/pages/w/[wId]/builder/data-sources/[dsId]/settings.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[dsId]/settings.tsx
@@ -2,7 +2,7 @@ import { Button, TrashIcon } from "@dust-tt/sparkle";
 import type {
   APIError,
   DataSourceType,
-  DataSourceUsageType,
+  DataSourceWithAgentsUsageType,
   SubscriptionType,
   WorkspaceType,
 } from "@dust-tt/types";
@@ -26,7 +26,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   subscription: SubscriptionType;
   dataSource: DataSourceType;
   fetchConnectorError?: boolean;
-  dataSourceUsage: DataSourceUsageType;
+  dataSourceUsage: DataSourceWithAgentsUsageType;
 }>(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
   const subscription = auth.getNonNullableSubscription();
@@ -137,7 +137,7 @@ function StandardDataSourceSettings({
     description: string;
     assistantDefaultSelected: boolean;
   }) => Promise<void>;
-  dataSourceUsage: DataSourceUsageType;
+  dataSourceUsage: DataSourceWithAgentsUsageType;
 }) {
   const { mutate } = useSWRConfig();
 

--- a/front/pages/w/[wId]/builder/data-sources/[dsId]/settings.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[dsId]/settings.tsx
@@ -2,6 +2,7 @@ import { Button, TrashIcon } from "@dust-tt/sparkle";
 import type {
   APIError,
   DataSourceType,
+  DataSourceUsageType,
   SubscriptionType,
   WorkspaceType,
 } from "@dust-tt/types";
@@ -25,7 +26,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   subscription: SubscriptionType;
   dataSource: DataSourceType;
   fetchConnectorError?: boolean;
-  dataSourceUsage: number;
+  dataSourceUsage: DataSourceUsageType;
 }>(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
   const subscription = auth.getNonNullableSubscription();
@@ -64,7 +65,9 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       owner,
       subscription,
       dataSource: dataSource.toJSON(),
-      dataSourceUsage: dataSourceUsageRes.isOk() ? dataSourceUsageRes.value : 0,
+      dataSourceUsage: dataSourceUsageRes.isOk()
+        ? dataSourceUsageRes.value
+        : { count: 0, agentNames: [] },
     },
   };
 });
@@ -134,7 +137,7 @@ function StandardDataSourceSettings({
     description: string;
     assistantDefaultSelected: boolean;
   }) => Promise<void>;
-  dataSourceUsage: number;
+  dataSourceUsage: DataSourceUsageType;
 }) {
   const { mutate } = useSWRConfig();
 

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -10,7 +10,7 @@ import {
 } from "@dust-tt/sparkle";
 import type {
   ConnectorProvider,
-  DataSourceUsageType,
+  DataSourceWithAgentsUsageType,
   DataSourceWithConnectorDetailsType,
   PlanType,
   SubscriptionType,
@@ -54,7 +54,7 @@ const REDIRECT_TO_EDIT_PERMISSIONS = [
 
 export type DataSourceWithConnectorAndUsageType =
   DataSourceWithConnectorDetailsType & {
-    usage: DataSourceUsageType | null;
+    usage: DataSourceWithAgentsUsageType | null;
   };
 
 type RowData = {
@@ -368,7 +368,7 @@ function getTableColumns() {
           (rowB.original.managedDataSource.usage?.count ?? 0)
         );
       },
-      cell: (info: CellContext<RowData, DataSourceUsageType>) => (
+      cell: (info: CellContext<RowData, DataSourceWithAgentsUsageType>) => (
         <>
           {info.getValue() ? (
             <DataTable.CellContent

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -22,7 +22,7 @@ import {
   isConnectorProvider,
   removeNulls,
 } from "@dust-tt/types";
-import type { CellContext, Row } from "@tanstack/react-table";
+import type { CellContext } from "@tanstack/react-table";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -358,24 +358,19 @@ function getTableColumns() {
     {
       header: "Used by",
       id: "usedBy",
-      accessorKey: "managedDataSource.usage",
+      accessorFn: (row: RowData) => row.managedDataSource.usage?.count ?? 0,
       meta: {
         width: "6rem",
       },
-      sortingFn: (rowA: Row<RowData>, rowB: Row<RowData>) => {
-        return (
-          (rowA.original.managedDataSource.usage?.count ?? 0) -
-          (rowB.original.managedDataSource.usage?.count ?? 0)
-        );
-      },
+
       cell: (info: CellContext<RowData, DataSourceWithAgentsUsageType>) => (
         <>
           {info.getValue() ? (
             <DataTable.CellContent
               icon={RobotIcon}
-              title={`Used by ${info.getValue().agentNames.join(", ")}`}
+              title={`Used by ${info.row.original.managedDataSource.usage?.agentNames.join(", ")}`}
             >
-              {info.getValue().count}
+              {info.row.original.managedDataSource.usage?.count}
             </DataTable.CellContent>
           ) : null}
         </>

--- a/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
@@ -281,6 +281,7 @@ function getTableColumns() {
     {
       header: "Used by",
       id: "usedBy",
+      accessorFn: (row: RowData) => row.usage.count,
       meta: {
         width: "6rem",
       },

--- a/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
@@ -19,7 +19,7 @@ import type {
 } from "@dust-tt/types";
 import { removeNulls, truncate } from "@dust-tt/types";
 import { ConnectorsAPI } from "@dust-tt/types";
-import type { Row, SortingState } from "@tanstack/react-table";
+import type { SortingState } from "@tanstack/react-table";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import type { ComponentType } from "react";
@@ -284,11 +284,6 @@ function getTableColumns() {
       accessorFn: (row: RowData) => row.usage.count,
       meta: {
         width: "6rem",
-      },
-      sortingFn: (rowA: Row<RowData>, rowB: Row<RowData>) => {
-        return (
-          (rowA.original.usage.count ?? 0) - (rowB.original.usage.count ?? 0)
-        );
       },
       cell: (info: Info) => (
         <>

--- a/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
@@ -12,7 +12,7 @@ import { GlobeAltIcon } from "@dust-tt/sparkle";
 import type {
   ConnectorType,
   DataSourceType,
-  DataSourceUsageType,
+  DataSourceWithAgentsUsageType,
   PlanType,
   SubscriptionType,
   WorkspaceType,
@@ -44,7 +44,7 @@ type DataSourceWithConnector = DataSourceType & {
 
 type RowData = DataSourceType & {
   icon: ComponentType;
-  usage: DataSourceUsageType;
+  usage: DataSourceWithAgentsUsageType;
 };
 
 type Info = {
@@ -281,7 +281,6 @@ function getTableColumns() {
     {
       header: "Used by",
       id: "usedBy",
-      accessorKey: "managedDataSource.usage",
       meta: {
         width: "6rem",
       },

--- a/front/pages/w/[wId]/builder/data-sources/static.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/static.tsx
@@ -11,7 +11,7 @@ import {
 } from "@dust-tt/sparkle";
 import type {
   DataSourceType,
-  DataSourceUsageType,
+  DataSourceWithAgentsUsageType,
   PlanType,
   SubscriptionType,
   WorkspaceType,
@@ -201,7 +201,7 @@ export default function DataSourcesView({
 
 type RowData = DataSourceType & {
   icon: ComponentType;
-  usage: DataSourceUsageType;
+  usage: DataSourceWithAgentsUsageType;
 };
 
 function getTableColumns() {
@@ -227,7 +227,6 @@ function getTableColumns() {
     },
     {
       header: "Used by",
-      accessorKey: "usage",
       id: "usage",
       meta: {
         width: "6rem",

--- a/front/pages/w/[wId]/builder/data-sources/static.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/static.tsx
@@ -17,7 +17,7 @@ import type {
   WorkspaceType,
 } from "@dust-tt/types";
 import { truncate } from "@dust-tt/types";
-import type { Row, SortingState } from "@tanstack/react-table";
+import type { SortingState } from "@tanstack/react-table";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import type { ComponentType } from "react";
@@ -231,11 +231,6 @@ function getTableColumns() {
       id: "usage",
       meta: {
         width: "6rem",
-      },
-      sortingFn: (rowA: Row<RowData>, rowB: Row<RowData>) => {
-        return (
-          (rowA.original.usage.count ?? 0) - (rowB.original.usage.count ?? 0)
-        );
       },
       cell: (info: Info) => (
         <DataTable.CellContent

--- a/front/pages/w/[wId]/builder/data-sources/static.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/static.tsx
@@ -227,6 +227,7 @@ function getTableColumns() {
     },
     {
       header: "Used by",
+      accessorFn: (row: RowData) => row.usage.count,
       id: "usage",
       meta: {
         width: "6rem",

--- a/front/pages/w/[wId]/vaults/[vaultId]/categories/[category]/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/categories/[category]/index.tsx
@@ -2,6 +2,7 @@ import { CloudArrowLeftRightIcon, Page } from "@dust-tt/sparkle";
 import type {
   ConnectorProvider,
   DataSourceViewCategory,
+  DataSourceWithConnectorDetailsType,
   PlanType,
   VaultType,
 } from "@dust-tt/types";
@@ -26,7 +27,6 @@ import {
 import { isManaged } from "@app/lib/data_sources";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { VaultResource } from "@app/lib/resources/vault_resource";
-import type { DataSourceWithConnectorAndUsageType } from "@app/pages/w/[wId]/builder/data-sources/managed";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<
   VaultLayoutProps & {
@@ -87,7 +87,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
       includeEditedBy: true,
     });
 
-    const managedDataSources: DataSourceWithConnectorAndUsageType[] =
+    const managedDataSources: DataSourceWithConnectorDetailsType[] =
       removeNulls(
         await Promise.all(
           allDataSources.map(async (managedDataSource) => {
@@ -98,11 +98,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
             const augmentedDataSource =
               await augmentDataSourceWithConnectorDetails(ds);
 
-            const usageRes = await managedDataSource.getUsagesByAgents(auth);
-            return {
-              ...augmentedDataSource,
-              usage: usageRes.isOk() ? usageRes.value : 0,
-            };
+            return augmentedDataSource;
           })
         )
       );

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -1,5 +1,9 @@
 import type { Meta } from "@storybook/react";
-import { ColumnDef, PaginationState, SortingState } from "@tanstack/react-table";
+import {
+  ColumnDef,
+  PaginationState,
+  SortingState,
+} from "@tanstack/react-table";
 import React, { useMemo } from "react";
 
 import { DropdownItemProps } from "@sparkle/components/DropdownMenu";
@@ -207,7 +211,9 @@ export const DataTableExample = () => {
 };
 
 export const DataTableClientSideSortingExample = () => {
-  const [sorting, setSorting] = React.useState<SortingState>([{ id: "name", desc: true }])
+  const [sorting, setSorting] = React.useState<SortingState>([
+    { id: "name", desc: true },
+  ]);
   const [filter, setFilter] = React.useState<string>("");
 
   return (
@@ -266,19 +272,23 @@ export const DataTablePaginatedServerSideExample = () => {
     pageIndex: 0,
     pageSize: 2,
   });
-  const [sorting, setSorting] = React.useState<SortingState>([{ id: "name", desc: true }])
+  const [sorting, setSorting] = React.useState<SortingState>([
+    { id: "name", desc: true },
+  ]);
   const [filter, setFilter] = React.useState<string>("");
   const rows = useMemo(() => {
     if (sorting.length > 0) {
-      const order = sorting[0].desc ? -1: 1;
-      return data.sort(
-        (a: Data, b: Data) => {
-          return a.name.toLowerCase().localeCompare(b.name.toLowerCase()) * order
-        }
-      ).slice(
-        pagination.pageIndex * pagination.pageSize,
-        (pagination.pageIndex + 1) * pagination.pageSize
-      );
+      const order = sorting[0].desc ? -1 : 1;
+      return data
+        .sort((a: Data, b: Data) => {
+          return (
+            a.name.toLowerCase().localeCompare(b.name.toLowerCase()) * order
+          );
+        })
+        .slice(
+          pagination.pageIndex * pagination.pageSize,
+          (pagination.pageIndex + 1) * pagination.pageSize
+        );
     }
     return data.slice(
       pagination.pageIndex * pagination.pageSize,

--- a/types/src/front/data_source.ts
+++ b/types/src/front/data_source.ts
@@ -96,6 +96,11 @@ export type DataSourceWithConnectorDetailsType = DataSourceType &
     fetchConnectorErrorMessage: string | null;
   };
 
+export type DataSourceUsageType = {
+  count: number;
+  agentNames: string[];
+};
+
 export function isDataSourceNameValid(name: string): Result<void, string> {
   const trimmed = name.trim();
   if (trimmed.length === 0) {

--- a/types/src/front/data_source.ts
+++ b/types/src/front/data_source.ts
@@ -89,14 +89,17 @@ export type WithConnector = {
   connectorId: string;
 };
 
-export type DataSourceWithConnectorDetailsType = DataSourceType &
-  WithConnector & {
-    connector: ConnectorType | null;
-    fetchConnectorError: boolean;
-    fetchConnectorErrorMessage: string | null;
-  };
+export type ConnectorStatusDetails = {
+  connector: ConnectorType | null;
+  fetchConnectorError: boolean;
+  fetchConnectorErrorMessage: string | null;
+};
 
-export type DataSourceUsageType = {
+export type DataSourceWithConnectorDetailsType = DataSourceType &
+  WithConnector &
+  ConnectorStatusDetails;
+
+export type DataSourceWithAgentsUsageType = {
   count: number;
   agentNames: string[];
 };

--- a/types/src/front/data_source_view.ts
+++ b/types/src/front/data_source_view.ts
@@ -2,10 +2,10 @@ import { ModelId } from "../shared/model_id";
 import { DataSourceViewCategory } from "./api_handlers/public/vaults";
 import {
   DataSourceType,
-  DataSourceWithConnectorDetailsType,
+  DataSourceUsageType,
   EditedByUser,
 } from "./data_source";
-import { BaseContentNode } from "./lib/connectors_api";
+import { BaseContentNode, ConnectorType } from "./lib/connectors_api";
 
 export interface DataSourceViewType {
   category: DataSourceViewCategory;
@@ -17,13 +17,16 @@ export interface DataSourceViewType {
   parentsIn: string[] | null;
   sId: string;
   updatedAt: number;
-  // TODO(GROUPS_INFRA) Add support for usage.
-  usage: number;
   vaultId: string;
 }
 
-export type DataSourceViewWithConnectorType = DataSourceViewType & {
-  dataSource: DataSourceWithConnectorDetailsType;
+export type DataSourceViewsWithDetails = DataSourceViewType & {
+  dataSource: DataSourceType & {
+    connector: ConnectorType | null;
+    fetchConnectorError: boolean;
+    fetchConnectorErrorMessage: string | null;
+  };
+  usage: DataSourceUsageType;
 };
 
 export type DataSourceViewContentNode = BaseContentNode & {

--- a/types/src/front/data_source_view.ts
+++ b/types/src/front/data_source_view.ts
@@ -1,11 +1,12 @@
 import { ModelId } from "../shared/model_id";
 import { DataSourceViewCategory } from "./api_handlers/public/vaults";
 import {
+  ConnectorStatusDetails,
   DataSourceType,
-  DataSourceUsageType,
+  DataSourceWithAgentsUsageType,
   EditedByUser,
 } from "./data_source";
-import { BaseContentNode, ConnectorType } from "./lib/connectors_api";
+import { BaseContentNode } from "./lib/connectors_api";
 
 export interface DataSourceViewType {
   category: DataSourceViewCategory;
@@ -21,12 +22,8 @@ export interface DataSourceViewType {
 }
 
 export type DataSourceViewsWithDetails = DataSourceViewType & {
-  dataSource: DataSourceType & {
-    connector: ConnectorType | null;
-    fetchConnectorError: boolean;
-    fetchConnectorErrorMessage: string | null;
-  };
-  usage: DataSourceUsageType;
+  dataSource: DataSourceType & ConnectorStatusDetails;
+  usage: DataSourceWithAgentsUsageType;
 };
 
 export type DataSourceViewContentNode = BaseContentNode & {


### PR DESCRIPTION
## Description

- Update usage queries to make them faster and retrieve the assistants names.
- Add Used By columns and fix sorting.
- Split `useVaultDataSourceViews` in 2 hooks, one without details, the other one with details to leverage typing correctly.

## Risk

Queries might not be fast enough (but it seems fine from my testing in prod with our largest customer).

## Deploy Plan

Deploy `front`