### PR TITLE
[Manage Assistants] Fix: usage sort broken for shared/default tabs

### DIFF
--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -80,12 +80,11 @@ export default function WorkspaceAssistants({
   const includes: ("authors" | "usage")[] = (() => {
     switch (tabScope) {
       case "published":
-        return ["authors"];
+        return ["authors", "usage"];
       case "private":
+      case "global":
       case "workspace":
         return ["usage"];
-      case "global":
-        return [];
       default:
         assertNever(tabScope);
     }


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/1286

We did not return usage for published or global
agents. Likely because it was not needed when the page was made (there was no sort button) and then not updated when the sort button was added

Risk
---
Since the cause of not returning usage is not certain, a little risk, but blast radius is very low. We already did return usage for company & personal assistants without issues.

Deploy
---
front