### PR TITLE
[front] Fixed table/docs switch

### DIFF
--- a/front/components/vaults/VaultDataSourceViewContentList.tsx
+++ b/front/components/vaults/VaultDataSourceViewContentList.tsx
@@ -129,22 +129,24 @@ function useStaticDataSourceViewHasContent({
   viewType: ContentNodesViewType;
 }) {
   // We don't do the call if the dataSourceView is managed.
-  const { isNodesLoading, nodes } = useDataSourceViewContentNodes({
-    dataSourceView: isManaged(dataSourceView.dataSource)
-      ? undefined
-      : dataSourceView,
-    owner,
-    internalIds: parentId ? [parentId] : undefined,
-    pagination: {
-      pageIndex: 0,
-      pageSize: 1,
-    },
-    viewType,
-  });
+  const { isNodesLoading, nodes, isNodesValidating } =
+    useDataSourceViewContentNodes({
+      dataSourceView: isManaged(dataSourceView.dataSource)
+        ? undefined
+        : dataSourceView,
+      owner,
+      internalIds: parentId ? [parentId] : undefined,
+      pagination: {
+        pageIndex: 0,
+        pageSize: 1,
+      },
+      viewType,
+    });
 
   return {
     hasContent: isManaged(dataSourceView.dataSource) ? true : !!nodes?.length,
     isLoading: isManaged(dataSourceView.dataSource) ? false : isNodesLoading,
+    isNodesValidating,
   };
 }
 
@@ -210,14 +212,14 @@ export const VaultDataSourceViewContentList = ({
     viewType: isValidContentNodesViewType(viewType) ? viewType : undefined,
   });
 
-  const { hasContent: hasDocuments, isLoading: isDocumentsLoading } =
+  const { hasContent: hasDocuments, isNodesValidating: isDocumentsValidating } =
     useStaticDataSourceViewHasContent({
       owner,
       dataSourceView,
       parentId,
       viewType: "documents",
     });
-  const { hasContent: hasTables, isLoading: isTablesLoading } =
+  const { hasContent: hasTables, isNodesValidating: isTablesValidating } =
     useStaticDataSourceViewHasContent({
       owner,
       dataSourceView,
@@ -226,22 +228,24 @@ export const VaultDataSourceViewContentList = ({
     });
 
   useEffect(() => {
-    // If the view only has content in one of the two views, we switch to that view.
-    // if both view have content, or neither views have content, we default to documents.
-    if (hasTables === true && hasDocuments === false) {
-      handleViewTypeChange("tables");
-    } else if (hasTables === false && hasDocuments === true) {
-      handleViewTypeChange("documents");
-    } else if (!viewType) {
-      handleViewTypeChange("documents");
+    if (!isTablesValidating && !isDocumentsValidating) {
+      // If the view only has content in one of the two views, we switch to that view.
+      // if both view have content, or neither views have content, we default to documents.
+      if (hasTables === true && hasDocuments === false) {
+        handleViewTypeChange("tables");
+      } else if (hasTables === false && hasDocuments === true) {
+        handleViewTypeChange("documents");
+      } else if (!viewType) {
+        handleViewTypeChange("documents");
+      }
     }
   }, [
     hasDocuments,
     hasTables,
     handleViewTypeChange,
     viewType,
-    isDocumentsLoading,
-    isTablesLoading,
+    isTablesValidating,
+    isDocumentsValidating,
   ]);
 
   const rows: RowData[] = useMemo(

--- a/front/components/vaults/VaultDataSourceViewContentList.tsx
+++ b/front/components/vaults/VaultDataSourceViewContentList.tsx
@@ -225,15 +225,22 @@ export const VaultDataSourceViewContentList = ({
       viewType: "tables",
     });
 
+  console.log("VaultDataSourceViewContentList.tsx", {
+    hasDocuments,
+    hasTables,
+    viewType,
+    isDocumentsLoading,
+    isTablesLoading,
+  });
+
   useEffect(() => {
-    if (viewType !== undefined) {
-      return;
-    }
     // If the view only has content in one of the two views, we switch to that view.
     // if both view have content, or neither views have content, we default to documents.
     if (hasTables === true && hasDocuments === false) {
       handleViewTypeChange("tables");
     } else if (hasTables === false && hasDocuments === true) {
+      handleViewTypeChange("documents");
+    } else if (!viewType) {
       handleViewTypeChange("documents");
     }
   }, [

--- a/front/components/vaults/VaultDataSourceViewContentList.tsx
+++ b/front/components/vaults/VaultDataSourceViewContentList.tsx
@@ -225,14 +225,6 @@ export const VaultDataSourceViewContentList = ({
       viewType: "tables",
     });
 
-  console.log("VaultDataSourceViewContentList.tsx", {
-    hasDocuments,
-    hasTables,
-    viewType,
-    isDocumentsLoading,
-    isTablesLoading,
-  });
-
   useEffect(() => {
     // If the view only has content in one of the two views, we switch to that view.
     // if both view have content, or neither views have content, we default to documents.

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -120,6 +120,7 @@ export function useDataSourceViewContentNodes({
 }): {
   isNodesError: boolean;
   isNodesLoading: boolean;
+  isNodesValidating: boolean;
   mutate: KeyedMutator<GetDataSourceViewContentNodes>;
   mutateRegardlessOfQueryParams: KeyedMutator<GetDataSourceViewContentNodes>;
   nodes: GetDataSourceViewContentNodes["nodes"];
@@ -145,7 +146,7 @@ export function useDataSourceViewContentNodes({
     }); // Serialize with body to ensure uniqueness.
   }, [url, body]);
 
-  const { data, error, mutate, mutateRegardlessOfQueryParams } =
+  const { data, error, mutate, isValidating, mutateRegardlessOfQueryParams } =
     useSWRWithDefaults(
       fetchKey,
       async () => {
@@ -163,6 +164,7 @@ export function useDataSourceViewContentNodes({
   return {
     isNodesError: !!error,
     isNodesLoading: !error && !data,
+    isNodesValidating: isValidating,
     mutate,
     mutateRegardlessOfQueryParams,
     nodes: useMemo(() => (data ? data.nodes : []), [data]),


### PR DESCRIPTION
## Description

fix 2 issues :

- If folder is empty and no viewType is selected, loader stays infinitely
- If a viewType was previoulsy selected but doesn't match the current content, we cant switch

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
