### PR TITLE
fix: always go to documents viewType for managed DS view

### DIFF
--- a/front/components/vaults/VaultDataSourceViewContentList.tsx
+++ b/front/components/vaults/VaultDataSourceViewContentList.tsx
@@ -225,7 +225,14 @@ export const VaultDataSourceViewContentList = ({
       viewType: "tables",
     });
 
+  const isDataSourceManaged = isManaged(dataSourceView.dataSource);
+
   useEffect(() => {
+    if (isDataSourceManaged) {
+      handleViewTypeChange("documents");
+      return;
+    }
+
     if (viewType !== undefined) {
       return;
     }
@@ -243,6 +250,7 @@ export const VaultDataSourceViewContentList = ({
     viewType,
     isDocumentsLoading,
     isTablesLoading,
+    isDataSourceManaged,
   ]);
 
   const rows: RowData[] = useMemo(


### PR DESCRIPTION
## Description

no view type disables the query. For managed data sources we always use the `documents` view type. 
Currently, the ds view spins in the void for managed data sources as all queries are disabled.

## Risk

N/A

## Deploy Plan

N/A