### PR TITLE
[front] - refacto(env): DUST_CLIENT_FACING_URL as next

### DIFF
--- a/.github/workflows/deploy-alerting-temporal.yml
+++ b/.github/workflows/deploy-alerting-temporal.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build.sh alerting-temporal ./Dockerfile ./alerting/temporal/
+          ./k8s/cloud-build.sh --image-name=alerting-temporal --dockerfile-path=./Dockerfile --working-dir=./alerting/temporal/
 
       - name: Deploy the image on Kubernetes
         run: |

--- a/.github/workflows/deploy-and-test-front-qa.yml
+++ b/.github/workflows/deploy-and-test-front-qa.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build.sh front ./front/Dockerfile https://front-qa.dust.tt/ ./
+          ./k8s/cloud-build.sh --image-name=front --dockerfile-path=./front/Dockerfile --working-dir=./
 
       - name: Deploy the image on Kubernetes
         run: |

--- a/.github/workflows/deploy-and-test-front-qa.yml
+++ b/.github/workflows/deploy-and-test-front-qa.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build.sh front ./front/Dockerfile ./
+          ./k8s/cloud-build.sh front ./front/Dockerfile https://front-qa.dust.tt/ ./
 
       - name: Deploy the image on Kubernetes
         run: |

--- a/.github/workflows/deploy-connectors.yml
+++ b/.github/workflows/deploy-connectors.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build.sh connectors ./connectors/Dockerfile ./
+          ./k8s/cloud-build.sh --image-name=connectors --dockerfile-path=./connectors/Dockerfile --working-dir=./
 
       - name: Deploy the image on Kubernetes
         run: |

--- a/.github/workflows/deploy-core.yml
+++ b/.github/workflows/deploy-core.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build.sh core ./Dockerfile ./core/
+          ./k8s/cloud-build.sh --image-name=core --dockerfile-path=./Dockerfile --working-dir=./core/
 
       - name: Deploy the image on Kubernetes
         run: |

--- a/.github/workflows/deploy-front-edge.yml
+++ b/.github/workflows/deploy-front-edge.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build.sh front ./front/Dockerfile ./ https://front-edge.dust.tt/
+          ./k8s/cloud-build.sh --image-name=front --dockerfile-path=./front/Dockerfile --working-dir=./ --dust-client-facing-url=https://front-edge.dust.tt
 
       - name: Deploy the image on Kubernetes
         run: |

--- a/.github/workflows/deploy-front-edge.yml
+++ b/.github/workflows/deploy-front-edge.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build.sh front ./front/Dockerfile ./
+          ./k8s/cloud-build.sh front ./front/Dockerfile ./ https://front-edge.dust.tt/
 
       - name: Deploy the image on Kubernetes
         run: |

--- a/.github/workflows/deploy-front.yml
+++ b/.github/workflows/deploy-front.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build.sh front ./front/Dockerfile ./ https://dust.tt/
+          ./k8s/cloud-build.sh --image-name=front --dockerfile-path=./front/Dockerfile --working-dir=./ --dust-client-facing-url=https://dust.tt
 
       - name: Deploy the image on Kubernetes
         run: |

--- a/.github/workflows/deploy-front.yml
+++ b/.github/workflows/deploy-front.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build.sh front ./front/Dockerfile ./
+          ./k8s/cloud-build.sh front ./front/Dockerfile ./ https://dust.tt/
 
       - name: Deploy the image on Kubernetes
         run: |

--- a/.github/workflows/deploy-oauth.yml
+++ b/.github/workflows/deploy-oauth.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build.sh oauth ./oauth.Dockerfile ./core/
+          ./k8s/cloud-build.sh --image-name=oauth --dockerfile-path=./oauth.Dockerfile --working-dir=./core/
 
       - name: Deploy the image on Kubernetes
         run: |

--- a/.github/workflows/deploy-prodbox.yml
+++ b/.github/workflows/deploy-prodbox.yml
@@ -45,6 +45,7 @@ jobs:
         run: |
           chmod +x ./k8s/cloud-build.sh
           ./k8s/cloud-build.sh prodbox ./prodbox.Dockerfile ./ .gcloudignore-prodbox
+          ./k8s/cloud-build.sh --image-name=prodbox --dockerfile-path=./prodbox.Dockerfile --working-dir=./ --gcloud-ignore-file=.gcloudignore-prodbox
 
       - name: Deploy the image on Kubernetes
         run: |

--- a/.github/workflows/deploy-viz.yml
+++ b/.github/workflows/deploy-viz.yml
@@ -44,6 +44,7 @@ jobs:
         run: |
           chmod +x ./k8s/cloud-build.sh
           ./k8s/cloud-build.sh viz ./viz/Dockerfile ./
+          ./k8s/cloud-build.sh --image-name=viz --dockerfile-path=./viz/Dockerfile --working-dir=./
 
       - name: Deploy the image on Kubernetes
         run: |

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -21,6 +21,7 @@ ARG NEXT_PUBLIC_VIZ_URL
 ENV NEXT_PUBLIC_COMMIT_HASH=$COMMIT_HASH
 ENV NEXT_PUBLIC_VIZ_URL=$NEXT_PUBLIC_VIZ_URL
 ENV NEXT_PUBLIC_GA_TRACKING_ID=$NEXT_PUBLIC_GA_TRACKING_ID
+ENV NEXT_PUBLIC_DUST_CLIENT_FACING_URL=$NEXT_PUBLIC_DUST_CLIENT_FACING_URL
 
 # fake database URIs are needed because Sequelize will throw if the `url` parameter
 # is undefined, and `next build` imports the `models.ts` file while "Collecting page data"

--- a/front/admin/init_dust_apps.ts
+++ b/front/admin/init_dust_apps.ts
@@ -1,13 +1,8 @@
-import { WhitelistableFeature } from "@dust-tt/types";
-
 import { Authenticator } from "@app/lib/auth";
 import { FeatureFlag } from "@app/lib/models/feature_flag";
 import { User } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
-import {
-  internalSubscribeWorkspaceToFreePlan,
-  pokeUpgradeWorkspaceToPlan,
-} from "@app/lib/plans/subscription";
+import { internalSubscribeWorkspaceToFreePlan } from "@app/lib/plans/subscription";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -51,7 +51,6 @@ interface DataSourceManagementModalProps {
 
 interface DataSourceEditionModalProps {
   dataSource: DataSourceType;
-  dustClientFacingUrl: string;
   isOpen: boolean;
   onClose: () => void;
   onEditPermissionsClick: () => void;
@@ -62,13 +61,11 @@ export async function handleUpdatePermissions(
   connector: ConnectorType,
   dataSource: DataSourceType,
   owner: LightWorkspaceType,
-  dustClientFacingUrl: string,
   sendNotification: (notification: NotificationType) => void
 ) {
   const provider = connector.type;
 
   const connectionIdRes = await setupConnection({
-    dustClientFacingUrl,
     owner,
     provider,
   });
@@ -333,7 +330,6 @@ export function ConnectorPermissionsModal({
   plan,
   readOnly,
   isAdmin,
-  dustClientFacingUrl,
   onManageButtonClick,
 }: {
   owner: WorkspaceType;
@@ -342,7 +338,6 @@ export function ConnectorPermissionsModal({
   isOpen: boolean;
   onClose: (save: boolean) => void;
   plan: PlanType;
-  dustClientFacingUrl: string;
   readOnly: boolean;
   isAdmin: boolean;
   onManageButtonClick?: () => void;
@@ -532,11 +527,9 @@ export function ConnectorPermissionsModal({
             connector,
             dataSource,
             owner,
-            dustClientFacingUrl,
             sendNotification
           );
         }}
-        dustClientFacingUrl={dustClientFacingUrl}
       />
     </>
   );

--- a/front/components/data_source/DataSourceEditionModal.tsx
+++ b/front/components/data_source/DataSourceEditionModal.tsx
@@ -45,7 +45,6 @@ function DataSourceManagementModal({
 
 interface DataSourceEditionModalProps {
   dataSource: DataSourceType;
-  dustClientFacingUrl: string;
   isOpen: boolean;
   onClose: () => void;
   onEditPermissionsClick: () => void;

--- a/front/components/vaults/AddConnectionMenu.tsx
+++ b/front/components/vaults/AddConnectionMenu.tsx
@@ -60,7 +60,7 @@ export async function setupConnection({
   if (isOAuthProvider(provider)) {
     // OAuth flow
     const cRes = await setupOAuthConnection({
-      dustClientFacingUrl: `${process.env.DUST_CLIENT_FACING_URL}`,
+      dustClientFacingUrl: `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}`,
       owner,
       provider,
       useCase: "connection",

--- a/front/components/vaults/AddConnectionMenu.tsx
+++ b/front/components/vaults/AddConnectionMenu.tsx
@@ -43,18 +43,15 @@ type AddConnectionMenuProps = {
   owner: WorkspaceType;
   plan: PlanType;
   existingDataSources: DataSourceWithConnectorDetailsType[];
-  dustClientFacingUrl: string;
   setIsProviderLoading: (provider: ConnectorProvider, value: boolean) => void;
   onCreated(dataSource: DataSourceType): void;
   integrations: DataSourceIntegration[];
 };
 
 export async function setupConnection({
-  dustClientFacingUrl,
   owner,
   provider,
 }: {
-  dustClientFacingUrl: string;
   owner: LightWorkspaceType;
   provider: ConnectorProvider;
 }): Promise<Result<string, Error>> {
@@ -63,7 +60,7 @@ export async function setupConnection({
   if (isOAuthProvider(provider)) {
     // OAuth flow
     const cRes = await setupOAuthConnection({
-      dustClientFacingUrl,
+      dustClientFacingUrl: `${process.env.DUST_CLIENT_FACING_URL}`,
       owner,
       provider,
       useCase: "connection",
@@ -83,7 +80,6 @@ export const AddConnectionMenu = ({
   owner,
   plan,
   existingDataSources,
-  dustClientFacingUrl,
   setIsProviderLoading,
   onCreated,
   integrations,
@@ -117,7 +113,6 @@ export const AddConnectionMenu = ({
   ) => {
     try {
       const connectionIdRes = await setupConnection({
-        dustClientFacingUrl,
         owner,
         provider,
       });

--- a/front/components/vaults/VaultDataSourceViewContentList.tsx
+++ b/front/components/vaults/VaultDataSourceViewContentList.tsx
@@ -59,7 +59,6 @@ type VaultDataSourceViewContentListProps = {
   owner: WorkspaceType;
   parentId?: string;
   isAdmin: boolean;
-  dustClientFacingUrl: string;
   connector: ConnectorType | null;
 };
 
@@ -158,7 +157,6 @@ export const VaultDataSourceViewContentList = ({
   onSelect,
   parentId,
   isAdmin,
-  dustClientFacingUrl,
   connector,
 }: VaultDataSourceViewContentListProps) => {
   const [dataSourceSearch, setDataSourceSearch] = useState<string>("");
@@ -413,7 +411,6 @@ export const VaultDataSourceViewContentList = ({
                 plan={plan}
                 readOnly={false}
                 isAdmin={isAdmin}
-                dustClientFacingUrl={dustClientFacingUrl}
                 onManageButtonClick={() => {
                   setShowConnectorPermissionsModal(true);
                 }}

--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -65,7 +65,6 @@ type RowData = {
 };
 
 type VaultResourcesListProps = {
-  dustClientFacingUrl: string;
   owner: WorkspaceType;
   plan: PlanType;
   isAdmin: boolean;
@@ -209,7 +208,6 @@ export const VaultResourcesList = ({
   plan,
   isAdmin,
   canWriteInVault,
-  dustClientFacingUrl,
   vault,
   systemVault,
   category,
@@ -365,7 +363,6 @@ export const VaultResourcesList = ({
             {isAdmin && (
               <AddConnectionMenu
                 owner={owner}
-                dustClientFacingUrl={dustClientFacingUrl}
                 plan={plan}
                 existingDataSources={vaultDataSourceViews.map(
                   (v) => v.dataSource
@@ -477,7 +474,6 @@ export const VaultResourcesList = ({
             plan={plan}
             readOnly={false}
             isAdmin={isAdmin}
-            dustClientFacingUrl={dustClientFacingUrl}
           />
         )}
     </>

--- a/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
+++ b/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
@@ -24,7 +24,6 @@ import { AssistantPicker } from "@app/components/assistant/AssistantPicker";
 import { AssistantSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
-import apiConfig from "@app/lib/api/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import type { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
@@ -46,7 +45,6 @@ const defaultTranscriptConfigurationState = {
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
-  dustClientFacingUrl: string;
   dataSourcesViews: DataSourceViewType[];
 }>(async (_context, auth) => {
   const owner = auth.workspace();
@@ -79,7 +77,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     props: {
       owner,
       subscription,
-      dustClientFacingUrl: apiConfig.getClientFacingUrl(),
       dataSourcesViews,
     },
   };
@@ -88,7 +85,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
 export default function LabsTranscriptsIndex({
   owner,
   subscription,
-  dustClientFacingUrl,
   dataSourcesViews,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const sendNotification = useContext(SendNotificationsContext);
@@ -337,7 +333,7 @@ export default function LabsTranscriptsIndex({
     }
 
     const cRes = await setupOAuthConnection({
-      dustClientFacingUrl,
+      dustClientFacingUrl: `${process.env.DUST_CLIENT_FACING_URL}`,
       owner,
       provider: "google_drive",
       useCase: "labs_transcripts",
@@ -391,7 +387,7 @@ export default function LabsTranscriptsIndex({
         return;
       } else {
         const cRes = await setupOAuthConnection({
-          dustClientFacingUrl,
+          dustClientFacingUrl: `${process.env.DUST_CLIENT_FACING_URL}`,
           owner,
           provider: "gong",
           useCase: "connection",

--- a/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
+++ b/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
@@ -333,7 +333,7 @@ export default function LabsTranscriptsIndex({
     }
 
     const cRes = await setupOAuthConnection({
-      dustClientFacingUrl: `${process.env.DUST_CLIENT_FACING_URL}`,
+      dustClientFacingUrl: `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}`,
       owner,
       provider: "google_drive",
       useCase: "labs_transcripts",
@@ -387,7 +387,7 @@ export default function LabsTranscriptsIndex({
         return;
       } else {
         const cRes = await setupOAuthConnection({
-          dustClientFacingUrl: `${process.env.DUST_CLIENT_FACING_URL}`,
+          dustClientFacingUrl: `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}`,
           owner,
           provider: "gong",
           useCase: "connection",

--- a/front/pages/w/[wId]/builder/data-sources/[dsId]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[dsId]/index.tsx
@@ -73,7 +73,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   dataSource: DataSourceType;
   connector: ConnectorType | null;
   standardView: boolean;
-  dustClientFacingUrl: string;
   user: UserType;
 }>(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
@@ -132,7 +131,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       dataSource: dataSource.toJSON(),
       connector,
       standardView,
-      dustClientFacingUrl: config.getClientFacingUrl(),
       user,
     },
   };
@@ -980,7 +978,6 @@ function ManagedDataSourceView({
   isBuilder,
   dataSource,
   connector,
-  dustClientFacingUrl,
   plan,
 }: {
   owner: WorkspaceType;
@@ -989,7 +986,6 @@ function ManagedDataSourceView({
   isBuilder: boolean;
   dataSource: DataSourceType;
   connector: ConnectorType;
-  dustClientFacingUrl: string;
   plan: PlanType;
 }) {
   const router = useRouter();
@@ -1077,7 +1073,6 @@ function ManagedDataSourceView({
     const provider = connector.type;
 
     const connectionIdRes = await setupConnection({
-      dustClientFacingUrl,
       owner,
       provider,
     });
@@ -1270,7 +1265,6 @@ function ManagedDataSourceView({
           plan={plan}
           readOnly={false}
           isAdmin={isAdmin}
-          dustClientFacingUrl={dustClientFacingUrl}
         />
       </div>
     </>
@@ -1287,7 +1281,6 @@ export default function DataSourceView({
   dataSource,
   connector,
   standardView,
-  dustClientFacingUrl,
   user,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
@@ -1333,7 +1326,6 @@ export default function DataSourceView({
             isBuilder,
             dataSource,
             connector,
-            dustClientFacingUrl,
             plan,
             user,
           }}

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -33,7 +33,6 @@ import { subNavigationBuild } from "@app/components/navigation/config";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import type { DataSourceIntegration } from "@app/components/vaults/AddConnectionMenu";
 import { AddConnectionMenu } from "@app/components/vaults/AddConnectionMenu";
-import config from "@app/lib/api/config";
 import {
   augmentDataSourceWithConnectorDetails,
   getDataSources,
@@ -84,7 +83,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   integrations: DataSourceIntegration[];
   managedDataSources: DataSourceWithConnectorAndUsageType[];
   plan: PlanType;
-  dustClientFacingUrl: string;
   user: UserType;
 }>(async (context, auth) => {
   const owner = auth.workspace();
@@ -164,7 +162,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       managedDataSources,
       integrations,
       plan,
-      dustClientFacingUrl: config.getClientFacingUrl(),
       user,
     },
   };
@@ -178,7 +175,6 @@ export default function DataSourcesView({
   managedDataSources,
   integrations,
   plan,
-  dustClientFacingUrl,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [isLoadingByProvider, setIsLoadingByProvider] = useState(
     {} as Record<ConnectorProvider, boolean>
@@ -277,7 +273,6 @@ export default function DataSourcesView({
               plan={plan}
               integrations={integrations}
               existingDataSources={managedDataSources}
-              dustClientFacingUrl={dustClientFacingUrl}
               setIsProviderLoading={(provider, isLoading) =>
                 setIsLoadingByProvider((prev) => ({
                   ...prev,
@@ -332,7 +327,6 @@ export default function DataSourcesView({
             isAdmin={isAdmin}
             readOnly={readOnly}
             plan={plan}
-            dustClientFacingUrl={dustClientFacingUrl}
           />
         )}
       </Page.Vertical>

--- a/front/pages/w/[wId]/vaults/[vaultId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
@@ -16,7 +16,6 @@ import { VaultDataSourceViewContentList } from "@app/components/vaults/VaultData
 import type { VaultLayoutProps } from "@app/components/vaults/VaultLayout";
 import { VaultLayout } from "@app/components/vaults/VaultLayout";
 import config from "@app/lib/api/config";
-import apiConfig from "@app/lib/api/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import logger from "@app/logger/logger";
@@ -30,7 +29,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     canReadInVault: boolean;
     parentId?: string;
     plan: PlanType;
-    dustClientFacingUrl: string;
     connector: ConnectorType | null;
   }
 >(async (context, auth) => {
@@ -108,7 +106,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
       plan,
       subscription,
       vault: vault.toJSON(),
-      dustClientFacingUrl: apiConfig.getClientFacingUrl(),
       connector,
     },
   };
@@ -124,7 +121,6 @@ export default function Vault({
   parentId,
   plan,
   isAdmin,
-  dustClientFacingUrl,
   connector,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
@@ -144,7 +140,6 @@ export default function Vault({
           );
         }}
         isAdmin={isAdmin}
-        dustClientFacingUrl={dustClientFacingUrl}
         connector={connector}
       />
     </Page.Vertical>

--- a/front/pages/w/[wId]/vaults/[vaultId]/categories/[category]/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/categories/[category]/index.tsx
@@ -19,7 +19,6 @@ import { VaultAppsList } from "@app/components/vaults/VaultAppsList";
 import type { VaultLayoutProps } from "@app/components/vaults/VaultLayout";
 import { VaultLayout } from "@app/components/vaults/VaultLayout";
 import { VaultResourcesList } from "@app/components/vaults/VaultResourcesList";
-import config from "@app/lib/api/config";
 import {
   augmentDataSourceWithConnectorDetails,
   getDataSources,
@@ -32,7 +31,6 @@ import type { DataSourceWithConnectorAndUsageType } from "@app/pages/w/[wId]/bui
 export const getServerSideProps = withDefaultUserAuthRequirements<
   VaultLayoutProps & {
     category: DataSourceViewCategory;
-    dustClientFacingUrl: string;
     isAdmin: boolean;
     canWriteInVault: boolean;
     vault: VaultType;
@@ -129,7 +127,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
   return {
     props: {
       category: context.query.category as DataSourceViewCategory,
-      dustClientFacingUrl: config.getClientFacingUrl(),
       isAdmin,
       isBuilder,
       canWriteInVault,
@@ -145,7 +142,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
 
 export default function Vault({
   category,
-  dustClientFacingUrl,
   isAdmin,
   canWriteInVault,
   owner,
@@ -174,7 +170,6 @@ export default function Vault({
         />
       ) : (
         <VaultResourcesList
-          dustClientFacingUrl={dustClientFacingUrl}
           owner={owner}
           plan={plan}
           vault={vault}

--- a/k8s/cloud-build.sh
+++ b/k8s/cloud-build.sh
@@ -7,7 +7,7 @@ set -x
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
 WORKING_DIR="${3}"
-GCLOUD_IGNORE_FILE="${4}"
+GCLOUD_IGNORE_FILE="${5}"
 
 if [ -n "$GCLOUD_IGNORE_FILE" ]; then
     GCLOUD_IGNORE_FILE_ARG="--ignore-file=$GCLOUD_IGNORE_FILE"
@@ -24,4 +24,4 @@ echo "Current working directory is $(pwd)"
 
 # Start the build and get its ID
 echo "Starting build..."
-BUILD_ID=$(gcloud builds submit --quiet --config "${SCRIPT_DIR}/cloudbuild.yaml" ${GCLOUD_IGNORE_FILE_ARG} --substitutions=SHORT_SHA=$(git rev-parse --short HEAD),_IMAGE_NAME=$1,_DOCKERFILE_PATH=$2 --format='value(id)' .)
+BUILD_ID=$(gcloud builds submit --quiet --config "${SCRIPT_DIR}/cloudbuild.yaml" ${GCLOUD_IGNORE_FILE_ARG} --substitutions=SHORT_SHA=$(git rev-parse --short HEAD),_IMAGE_NAME=$1,_DOCKERFILE_PATH=$2,DUST_CLIENT_FACING_URL=$4 --format='value(id)' .)

--- a/k8s/cloud-build.sh
+++ b/k8s/cloud-build.sh
@@ -60,7 +60,7 @@ echo "current working directory is $(pwd)"
 # prepare substitutions
 SUBSTITUTIONS="SHORT_SHA=$(git rev-parse --short HEAD),_IMAGE_NAME=$IMAGE_NAME,_DOCKERFILE_PATH=$DOCKERFILE_PATH"
 if [ -n "$DUST_CLIENT_FACING_URL" ]; then
-    SUBSTITUTIONS="$SUBSTITUTIONS,_DUST_CLIENT_FACING_URL=$DUST_CLIENT_FACING_URL"
+    SUBSTITUTIONS="$SUBSTITUTIONS,DUST_CLIENT_FACING_URL=$DUST_CLIENT_FACING_URL"
 fi
 
 # start the build and get its id

--- a/k8s/cloud-build.sh
+++ b/k8s/cloud-build.sh
@@ -1,27 +1,68 @@
 #!/bin/sh
-# first arg : name of image to build
-# second arg: path to the Dockerfile, relative to the resolved WORKING_DIR.
-# thid arg : path to the docker build context.
 set -e
 set -x
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
-WORKING_DIR="${3}"
-GCLOUD_IGNORE_FILE="${5}"
+
+# default values
+WORKING_DIR=""
+GCLOUD_IGNORE_FILE=""
+IMAGE_NAME=""
+DOCKERFILE_PATH=""
+DUST_CLIENT_FACING_URL=""
+
+# parse command-line arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --working-dir=*)
+      WORKING_DIR="${1#*=}"
+      shift
+      ;;
+    --gcloud-ignore-file=*)
+      GCLOUD_IGNORE_FILE="${1#*=}"
+      shift
+      ;;
+    --image-name=*)
+      IMAGE_NAME="${1#*=}"
+      shift
+      ;;
+    --dockerfile-path=*)
+      DOCKERFILE_PATH="${1#*=}"
+      shift
+      ;;
+    --dust-client-facing-url=*)
+      DUST_CLIENT_FACING_URL="${1#*=}"
+      shift
+      ;;
+    *)
+      echo "unknown argument: $1"
+      exit 1
+      ;;
+  esac
+done
+
+# check required arguments
+if [ -z "$WORKING_DIR" ] || [ -z "$IMAGE_NAME" ] || [ -z "$DOCKERFILE_PATH" ]; then
+  echo "error: --working-dir, --image-name, and --dockerfile-path are required"
+  exit 1
+fi
 
 if [ -n "$GCLOUD_IGNORE_FILE" ]; then
     GCLOUD_IGNORE_FILE_ARG="--ignore-file=$GCLOUD_IGNORE_FILE"
 fi
 
-
-
-
-# Change the current working directory to the directory in which to build the image
+# change the current working directory to the directory in which to build the image
 cd "$WORKING_DIR"
 
-# Check the current working directory
-echo "Current working directory is $(pwd)"
+# check the current working directory
+echo "current working directory is $(pwd)"
 
-# Start the build and get its ID
-echo "Starting build..."
-BUILD_ID=$(gcloud builds submit --quiet --config "${SCRIPT_DIR}/cloudbuild.yaml" ${GCLOUD_IGNORE_FILE_ARG} --substitutions=SHORT_SHA=$(git rev-parse --short HEAD),_IMAGE_NAME=$1,_DOCKERFILE_PATH=$2,DUST_CLIENT_FACING_URL=$4 --format='value(id)' .)
+# prepare substitutions
+SUBSTITUTIONS="SHORT_SHA=$(git rev-parse --short HEAD),_IMAGE_NAME=$IMAGE_NAME,_DOCKERFILE_PATH=$DOCKERFILE_PATH"
+if [ -n "$DUST_CLIENT_FACING_URL" ]; then
+    SUBSTITUTIONS="$SUBSTITUTIONS,_DUST_CLIENT_FACING_URL=$DUST_CLIENT_FACING_URL"
+fi
+
+# start the build and get its id
+echo "starting build..."
+BUILD_ID=$(gcloud builds submit --quiet --config "${SCRIPT_DIR}/cloudbuild.yaml" ${GCLOUD_IGNORE_FILE_ARG} --substitutions=$SUBSTITUTIONS --format='value(id)' .)

--- a/k8s/cloudbuild.yaml
+++ b/k8s/cloudbuild.yaml
@@ -17,6 +17,8 @@ steps:
       - NEXT_PUBLIC_VIZ_URL=https://viz.dust.tt
       - --build-arg
       - NEXT_PUBLIC_GA_TRACKING_ID=G-K9HQ2LE04G
+      - --build-arg
+      - NEXT_PUBLIC_DUST_CLIENT_FACING_URL=https://dust.tt
       - .
     secretEnv:
       - "DEPOT_TOKEN"

--- a/k8s/cloudbuild.yaml
+++ b/k8s/cloudbuild.yaml
@@ -18,7 +18,7 @@ steps:
       - --build-arg
       - NEXT_PUBLIC_GA_TRACKING_ID=G-K9HQ2LE04G
       - --build-arg
-      - NEXT_PUBLIC_DUST_CLIENT_FACING_URL=https://dust.tt
+      - NEXT_PUBLIC_DUST_CLIENT_FACING_URL=$DUST_CLIENT_FACING_URL
       - .
     secretEnv:
       - "DEPOT_TOKEN"

--- a/k8s/deployments/front-edge-deployment.yaml
+++ b/k8s/deployments/front-edge-deployment.yaml
@@ -45,8 +45,6 @@ spec:
               value: "-r dd-trace/init"
             - name: AUTH0_BASE_URL
               value: https://front-edge.dust.tt
-            - name: DUST_CLIENT_FACING_URL
-              value: https://front-edge.dust.tt
             # Make public prod API point to front-edge instead of front
             - name: DUST_PROD_API
               value: https://front-edge.dust.tt

--- a/k8s/deployments/front-qa-deployment.yaml
+++ b/k8s/deployments/front-qa-deployment.yaml
@@ -45,8 +45,6 @@ spec:
               value: "-r dd-trace/init"
             - name: AUTH0_BASE_URL
               value: https://front-qa.dust.tt
-            - name: DUST_CLIENT_FACING_URL
-              value: https://front-qa.dust.tt
 
             - name: DD_AGENT_HOST
               valueFrom:


### PR DESCRIPTION
## Description

Use `NEXT_PUBLIC_DUST_CLIENT_FACING_URL` directly from front to avoid drilling down `dustClientFacingUrl` variable.

## Risk

None, if rollout is properly done

## Deploy Plan

- [x] Set `DUST_CLIENT_FACING_URL` in front k8s secrets
- [ ] Apply `infra`
- [ ] Deploy & test `front-edge`
- [ ] Deploy `front`
- [ ] Update dev setup
