### PR TITLE
[Production check] Core scrub workflow: mark stale 'deleted' rows as …

### DIFF
--- a/core/src/stores/migrations/20240918_ds_docs_deleted_index.sql
+++ b/core/src/stores/migrations/20240918_ds_docs_deleted_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_status_deleted ON data_sources_documents (id) WHERE status = 'deleted';


### PR DESCRIPTION
…'soft-hard-deleted'

Description
---
Partly adresses https://github.com/dust-tt/tasks/issues/1293

We plan to remove 'deleted' rows previously kept when there's a more recent active version of a document; we strongly suspect keeping those 'deleted' rows have no value while there are lots of them in the database.

After a little digging, I suspect most of those rows correspond to add/remove operations on connections. E.g. user removes a folder / a channel, then adds it back. Could also be some erase-rewrite operations in connectors activities

We want to be able to roll back though, as a precaution, so:
- we will mark all those rows as 'soft-hard-deleted' as status instead of 'deleted'
- we will add a partial index on status 'deleted' so the select query of scrub is fast, which is the main point of the issue-- as recommended by [@q and @gpt4](https://dust.tt/w/0ec9852c2f/assistant/UFg7YYGXuO)
- if, after a week, everything's fine, we'll follow-up with a PR to remove 'soft-hard-deleted' rows and delete the rows directly instead of marking them in the code.

Additionally, this PR moves pagination back to 1000 (previous move to 100 had no effect, likely counter-productive)

Risk
---
Mentioned above, with the rollback feature.

Deploy
---
- front
- run production check to mark rows 'soft-hard-deleted'
- add the deleted index

