### PR TITLE
Fix handling of CSV as pages in Notion

### DIFF
--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -942,12 +942,13 @@ export async function retrieveDatabaseChildrenResultPage({
   }
 }
 
-// This function is used to create a text representation of a notion database properties.
-// We use it to render databases inline (in the Notion Page document on Dust), and to create
-// structured Tables on Dust (we use the CSV format).
-// The function accepts a `dustIdColumn` array which must have the same length as the `pagesProperties`. This
-// array is used to add a column to the CSV that contains the Dust ID of the page (__dust_id). This is useful
-// to uniquely identify the notion page in the CSV.
+// This function is used to create a text representation of a notion database properties.  We use it
+// to render databases inline (in the Notion Page document on Dust), and to create structured Tables
+// on Dust (we use the CSV format).
+// The function accepts a `dustIdColumn` array which must have the same length as the
+// `pagesProperties`. This array is used to add a column to the CSV that contains the Dust ID of the
+// page (__dust_id). This is useful to uniquely identify the notion page in the CSV.
+// The function returns the CSV as well as the original (non sanitized, non slugified) headers.
 export async function renderDatabaseFromPages({
   databaseTitle,
   pagesProperties,
@@ -960,9 +961,12 @@ export async function renderDatabaseFromPages({
   dustIdColumn?: string[];
   rowBoundary?: string;
   cellSeparator?: string;
-}) {
+}): Promise<{
+  originalHeader: string[];
+  csv: string;
+}> {
   if (!pagesProperties.length || !pagesProperties[0]) {
-    return "";
+    return { csv: "", originalHeader: [] };
   }
 
   if (dustIdColumn && dustIdColumn.length !== pagesProperties.length) {
@@ -1040,7 +1044,7 @@ export async function renderDatabaseFromPages({
     csv = `${databaseTitle}\n${csv}`;
   }
 
-  return csv;
+  return { csv, originalHeader: header };
 }
 
 export async function getUserName(

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -2554,7 +2554,7 @@ export async function upsertDatabaseStructuredDataFromCache({
       cellSeparator: ",",
       rowBoundary: "",
     });
-  //const csvHeader = csvForDocument.split("\n")[0];
+  const csvHeader = headerForDocument.join(",");
   const csvRows = csvForDocument.split("\n").slice(1).join("\n");
   if (csvForDocument.length > MAX_DOCUMENT_TXT_LEN) {
     localLogger.info(
@@ -2567,7 +2567,7 @@ export async function upsertDatabaseStructuredDataFromCache({
     );
   } else {
     localLogger.info("Upserting Notion Database as Document.");
-    const prefix = `${databaseName}\n${headerForDocument}\n`;
+    const prefix = `${databaseName}\n${csvHeader}\n`;
     const prefixSection = await renderPrefixSection({
       dataSourceConfig,
       prefix,

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1817,7 +1817,7 @@ export async function renderAndUpsertPageFromCache({
         const { tableId, tableName, tableDescription } =
           getTableInfoFromDatabase(parentDb);
         const rowId = `notion-${pageId}`;
-        const csv = await renderDatabaseFromPages({
+        const { csv } = await renderDatabaseFromPages({
           databaseTitle: null,
           pagesProperties: [
             JSON.parse(
@@ -2512,7 +2512,7 @@ export async function upsertDatabaseStructuredDataFromCache({
     );
   }
 
-  const csv = await renderDatabaseFromPages({
+  const { csv } = await renderDatabaseFromPages({
     databaseTitle: null,
     pagesProperties,
     dustIdColumn,
@@ -2547,13 +2547,14 @@ export async function upsertDatabaseStructuredDataFromCache({
     parents,
   });
   // Same as above, but without the `dustId` column
-  const csvForDocument = await renderDatabaseFromPages({
-    databaseTitle: null,
-    pagesProperties,
-    cellSeparator: ",",
-    rowBoundary: "",
-  });
-  const csvHeader = csvForDocument.split("\n")[0];
+  const { csv: csvForDocument, originalHeader: headerForDocument } =
+    await renderDatabaseFromPages({
+      databaseTitle: null,
+      pagesProperties,
+      cellSeparator: ",",
+      rowBoundary: "",
+    });
+  //const csvHeader = csvForDocument.split("\n")[0];
   const csvRows = csvForDocument.split("\n").slice(1).join("\n");
   if (csvForDocument.length > MAX_DOCUMENT_TXT_LEN) {
     localLogger.info(
@@ -2566,7 +2567,7 @@ export async function upsertDatabaseStructuredDataFromCache({
     );
   } else {
     localLogger.info("Upserting Notion Database as Document.");
-    const prefix = `${databaseName}\n${csvHeader}\n`;
+    const prefix = `${databaseName}\n${headerForDocument}\n`;
     const prefixSection = await renderPrefixSection({
       dataSourceConfig,
       prefix,

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -2566,7 +2566,7 @@ export async function upsertDatabaseStructuredDataFromCache({
     );
   } else {
     localLogger.info("Upserting Notion Database as Document.");
-    const prefix = `${databaseName}\n${csvHeader}`;
+    const prefix = `${databaseName}\n${csvHeader}\n`;
     const prefixSection = await renderPrefixSection({
       dataSourceConfig,
       prefix,


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/1290

- Fixes the rendering of the section when inserting a database as page in Notion
- Uses the non sanitized header when doing so to prevent replacing accents or other special characters in the document format.

Will test locally before merging:
- [ ] use the small db I created to reproduce and sync it locally
- [ ] check the content of the document locally

## Risk

Low after local testing

## Deploy Plan

- deploy `connectors`