### PR TITLE
[k8s] - fix: change shebang to use bash in cloud-build script

### DIFF
--- a/k8s/cloud-build.sh
+++ b/k8s/cloud-build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 set -x
 


### PR DESCRIPTION
## Description

This PR aims at changing the `cloud-build.sh` shebang from `/bin/sh` to `/bin/bash`.

**References:**
- https://github.com/dust-tt/dust/actions/runs/10936069120/job/30358984923#step:8:33

## Risk

N/A

## Deploy Plan

N/A