### PR TITLE
[k8s] - fix: correct substitution variable prefix in cloud-build script

### DIFF
--- a/k8s/cloud-build.sh
+++ b/k8s/cloud-build.sh
@@ -60,7 +60,7 @@ echo "current working directory is $(pwd)"
 # prepare substitutions
 SUBSTITUTIONS="SHORT_SHA=$(git rev-parse --short HEAD),_IMAGE_NAME=$IMAGE_NAME,_DOCKERFILE_PATH=$DOCKERFILE_PATH"
 if [ -n "$DUST_CLIENT_FACING_URL" ]; then
-    SUBSTITUTIONS="$SUBSTITUTIONS,DUST_CLIENT_FACING_URL=$DUST_CLIENT_FACING_URL"
+    SUBSTITUTIONS="$SUBSTITUTIONS,_DUST_CLIENT_FACING_URL=$DUST_CLIENT_FACING_URL"
 fi
 
 # start the build and get its id


### PR DESCRIPTION
## Description

This PR aims at fixing the substitutions variables in the gcloud build submit command

**References:**
- https://github.com/dust-tt/dust/actions/runs/10936264302/job/30359570760

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
