### PR TITLE
`dataSource.name` -> `dataSource.sId` batch I

### DIFF
--- a/front/components/ManagedDataSourceDocumentModal.tsx
+++ b/front/components/ManagedDataSourceDocumentModal.tsx
@@ -23,9 +23,7 @@ export default function ManagedDataSourceDocumentModal({
     if (documentId && dataSource) {
       setDownloading(true);
       fetch(
-        `/api/w/${owner.sId}/data_sources/${encodeURIComponent(
-          dataSource.name
-        )}/documents/${encodeURIComponent(documentId)}`
+        `/api/w/${owner.sId}/data_sources/${dataSource.sId}/documents/${encodeURIComponent(documentId)}`
       )
         .then(async (res) => {
           if (res.ok) {

--- a/front/components/data_source/WebsiteConfiguration.tsx
+++ b/front/components/data_source/WebsiteConfiguration.tsx
@@ -196,9 +196,7 @@ export default function WebsiteConfiguration({
       }
     } else if (dataSource) {
       const res = await fetch(
-        `/api/w/${owner.sId}/data_sources/${encodeURIComponent(
-          dataSource.name
-        )}/configuration`,
+        `/api/w/${owner.sId}/data_sources/${dataSource.sId}/configuration`,
         {
           method: "PATCH",
           headers: {

--- a/front/components/poke/data_sources/columns.tsx
+++ b/front/components/poke/data_sources/columns.tsx
@@ -107,7 +107,7 @@ export function makeColumnsForDataSources(
               await deleteDataSource(
                 owner,
                 agentConfigurations,
-                dataSource.name,
+                dataSource.sId,
                 reload
               );
             }}
@@ -121,16 +121,16 @@ export function makeColumnsForDataSources(
 async function deleteDataSource(
   owner: WorkspaceType,
   agentConfigurations: AgentConfigurationType[],
-  dataSourceName: string,
+  dataSourceId: string,
   reload: () => void
 ) {
   const agents = agentConfigurations.filter((agt) =>
     agt.actions.some(
       (a) =>
         ((isRetrievalConfiguration(a) || isProcessConfiguration(a)) &&
-          a.dataSources.some((ds) => ds.dataSourceId === dataSourceName)) ||
+          a.dataSources.some((ds) => ds.dataSourceId === dataSourceId)) ||
         (isTablesQueryConfiguration(a) &&
-          a.tables.some((t) => t.dataSourceId === dataSourceName))
+          a.tables.some((t) => t.dataSourceId === dataSourceId))
     )
   );
 
@@ -143,7 +143,7 @@ async function deleteDataSource(
   }
   if (
     !window.confirm(
-      `Are you sure you want to delete the ${dataSourceName} data source? There is no going back.`
+      `Are you sure you want to delete the ${dataSourceId} data source? There is no going back.`
     )
   ) {
     return;
@@ -155,9 +155,7 @@ async function deleteDataSource(
 
   try {
     const r = await fetch(
-      `/api/poke/workspaces/${owner.sId}/data_sources/${encodeURIComponent(
-        dataSourceName
-      )}`,
+      `/api/poke/workspaces/${owner.sId}/data_sources/${dataSourceId}`,
       {
         method: "DELETE",
         headers: {

--- a/front/lib/swr/connectors.ts
+++ b/front/lib/swr/connectors.ts
@@ -30,9 +30,7 @@ export function useConnectorPermissions({
   const permissionsFetcher: Fetcher<GetDataSourcePermissionsResponseBody> =
     fetcher;
 
-  let url = `/api/w/${owner.sId}/data_sources/${encodeURIComponent(
-    dataSource.name
-  )}/managed/permissions?viewType=${viewType}`;
+  let url = `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/permissions?viewType=${viewType}`;
   if (parentId) {
     url += `&parentId=${parentId}`;
   }
@@ -63,9 +61,7 @@ export function useConnectorConfig({
   const configFetcher: Fetcher<GetOrPostManagedDataSourceConfigResponseBody> =
     fetcher;
 
-  const url = `/api/w/${owner.sId}/data_sources/${encodeURIComponent(
-    dataSource.name
-  )}/managed/config/${configKey}`;
+  const url = `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/${configKey}`;
 
   const { data, error, mutate } = useSWRWithDefaults(url, configFetcher);
 

--- a/front/lib/swr/data_sources.ts
+++ b/front/lib/swr/data_sources.ts
@@ -1,4 +1,4 @@
-import type { LightWorkspaceType } from "@dust-tt/types";
+import type { DataSourceType, LightWorkspaceType } from "@dust-tt/types";
 import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
@@ -30,15 +30,13 @@ export function useDataSources(
 
 export function useDataSourceDocuments(
   owner: LightWorkspaceType,
-  dataSource: { name: string },
+  dataSource: DataSourceType,
   limit: number,
   offset: number
 ) {
   const documentsFetcher: Fetcher<GetDocumentsResponseBody> = fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
-    `/api/w/${owner.sId}/data_sources/${
-      dataSource.name
-    }/documents?limit=${limit}&offset=${offset}`,
+    `/api/w/${owner.sId}/data_sources/${dataSource.sId}/documents?limit=${limit}&offset=${offset}`,
     documentsFetcher
   );
 
@@ -54,18 +52,18 @@ export function useDataSourceDocuments(
 //TODO(GROUPS_INFRA) Deprecated, remove once all usages are removed.
 export function useDataSourceTable({
   workspaceId,
-  dataSourceName,
+  dataSource,
   tableId,
 }: {
   workspaceId: string;
-  dataSourceName: string;
+  dataSource: DataSourceType;
   tableId: string | null;
 }) {
   const tableFetcher: Fetcher<GetTableResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
     tableId
-      ? `/api/w/${workspaceId}/data_sources/${dataSourceName}/tables/${tableId}`
+      ? `/api/w/${workspaceId}/data_sources/${dataSource.sId}/tables/${tableId}`
       : null,
     tableFetcher
   );
@@ -81,16 +79,16 @@ export function useDataSourceTable({
 //TODO(GROUPS_INFRA) Deprecated, remove once all usages are removed.
 export function useDataSourceTables({
   workspaceId,
-  dataSourceName,
+  dataSource,
 }: {
   workspaceId: string;
-  dataSourceName: string | undefined;
+  dataSource: DataSourceType | undefined;
 }) {
   const tablesFetcher: Fetcher<ListTablesResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
-    dataSourceName
-      ? `/api/w/${workspaceId}/data_sources/${dataSourceName}/tables`
+    dataSource
+      ? `/api/w/${workspaceId}/data_sources/${dataSource.sId}/tables`
       : null,
     tablesFetcher
   );

--- a/front/migrations/20240830_check_no_undeleted_documents.ts
+++ b/front/migrations/20240830_check_no_undeleted_documents.ts
@@ -36,6 +36,7 @@ async function checkCoreDeleted(
 
   const coreDocuments: { id: number; document_id: string }[] =
     await coreReplica.query(
+      // Note this query won't be valid anymore
       "SELECT id, document_id FROM data_sources_documents WHERE data_source = :dataSourceId AND status = 'latest'",
       {
         replacements: {

--- a/front/pages/api/v1/w/[wId]/data_sources/[dsId]/tables/[tId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[dsId]/tables/[tId]/index.ts
@@ -151,7 +151,7 @@ async function handler(
         }
         logger.error(
           {
-            dataSourcename: dataSource.name,
+            dataSourceId: dataSource.sId,
             workspaceId: owner.id,
             error: tableRes.error,
           },

--- a/front/pages/api/v1/w/[wId]/data_sources/[dsId]/tables/[tId]/rows/[rId].ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[dsId]/tables/[tId]/rows/[rId].ts
@@ -154,7 +154,7 @@ async function handler(
       if (rowRes.isErr()) {
         logger.error(
           {
-            dataSourceName: dataSource.name,
+            dataSourceId: dataSource.sId,
             workspaceId: owner.id,
             tableId: tId,
             rowId: rId,
@@ -195,7 +195,7 @@ async function handler(
         }
         logger.error(
           {
-            dataSourceName: dataSource.name,
+            dataSourceId: dataSource.sId,
             workspaceId: owner.id,
             tableId: tId,
             rowId: rId,

--- a/front/pages/api/v1/w/[wId]/data_sources/[dsId]/tables/[tId]/rows/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[dsId]/tables/[tId]/rows/index.ts
@@ -243,7 +243,7 @@ async function handler(
       if (listRes.isErr()) {
         logger.error(
           {
-            dataSourceName: dataSource.name,
+            dataSourceId: dataSource.sId,
             workspaceId: owner.id,
             tableId: tId,
             error: listRes.error,
@@ -311,7 +311,7 @@ async function handler(
       if (upsertRes.isErr()) {
         logger.error(
           {
-            dataSourceName: dataSource.name,
+            dataSourceId: dataSource.sId,
             workspaceId: owner.id,
             tableId: tId,
             error: upsertRes.error,
@@ -337,7 +337,7 @@ async function handler(
       if (tableRes.isErr()) {
         logger.error(
           {
-            dataSourcename: dataSource.name,
+            dataSourceId: dataSource.sId,
             workspaceId: owner.id,
             error: tableRes.error,
           },

--- a/front/pages/api/v1/w/[wId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[dsId]/tables/index.ts
@@ -169,8 +169,8 @@ async function handler(
       if (tablesRes.isErr()) {
         logger.error(
           {
-            dataSourcename: dataSource.name,
             workspaceId: owner.id,
+            dataSourceId: dataSource.sId,
             error: tablesRes.error,
           },
           "Failed to get tables."
@@ -231,7 +231,7 @@ async function handler(
       if (tRes.isErr()) {
         logger.error(
           {
-            dataSourcename: dataSource.name,
+            dataSourceId: dataSource.sId,
             workspaceId: owner.id,
             error: tRes.error,
           },
@@ -272,7 +272,7 @@ async function handler(
       if (upsertRes.isErr()) {
         logger.error(
           {
-            dataSourceName: dataSource.name,
+            dataSourceId: dataSource.sId,
             workspaceId: owner.id,
             databaseName: name,
             tableId,

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/tables/[tId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/tables/[tId]/index.ts
@@ -59,7 +59,7 @@ async function handler(
       if (tableRes.isErr()) {
         logger.error(
           {
-            dataSourcename: dataSource.name,
+            dataSourceId: dataSource.sId,
             workspaceId: owner.id,
             error: tableRes.error,
           },

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/tables/index.ts
@@ -67,7 +67,7 @@ async function handler(
       if (tablesRes.isErr()) {
         logger.error(
           {
-            dataSourcename: dataSource.name,
+            dataSourceId: dataSource.sId,
             workspaceId: owner.id,
             error: tablesRes.error,
           },

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -350,7 +350,7 @@ const DataSourcePage = ({
                 title="Slackbot enabled?"
                 owner={owner}
                 features={features}
-                dataSource={dataSource.name}
+                dataSource={dataSource}
                 configKey="botEnabled"
                 featureKey="slackBotEnabled"
               />

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -376,7 +376,7 @@ const DataSourcePage = ({
                 title="PDF syncing enabled?"
                 owner={owner}
                 features={features}
-                dataSource={dataSource.name}
+                dataSource={dataSource}
                 configKey="pdfEnabled"
                 featureKey="googleDrivePdfEnabled"
               />
@@ -384,7 +384,7 @@ const DataSourcePage = ({
                 title="CSV syncing enabled?"
                 owner={owner}
                 features={features}
-                dataSource={dataSource.name}
+                dataSource={dataSource}
                 configKey="csvEnabled"
                 featureKey="googleDriveCsvEnabled"
               />
@@ -393,7 +393,7 @@ const DataSourcePage = ({
                 title="Large Files enabled?"
                 owner={owner}
                 features={features}
-                dataSource={dataSource.name}
+                dataSource={dataSource}
                 configKey="largeFilesEnabled"
                 featureKey="googleDriveLargeFilesEnabled"
               />
@@ -405,7 +405,7 @@ const DataSourcePage = ({
                 title="Pdf syncing enabled?"
                 owner={owner}
                 features={features}
-                dataSource={dataSource.name}
+                dataSource={dataSource}
                 configKey="pdfEnabled"
                 featureKey="microsoftPdfEnabled"
               />
@@ -413,7 +413,7 @@ const DataSourcePage = ({
                 title="CSV syncing enabled?"
                 owner={owner}
                 features={features}
-                dataSource={dataSource.name}
+                dataSource={dataSource}
                 configKey="csvEnabled"
                 featureKey="microsoftCsvEnabled"
               />
@@ -421,7 +421,7 @@ const DataSourcePage = ({
                 title="Large Files enabled?"
                 owner={owner}
                 features={features}
-                dataSource={dataSource.name}
+                dataSource={dataSource}
                 configKey="largeFilesEnabled"
                 featureKey="microsoftLargeFilesEnabled"
               />
@@ -432,7 +432,7 @@ const DataSourcePage = ({
               title="Code sync enabled?"
               owner={owner}
               features={features}
-              dataSource={dataSource.name}
+              dataSource={dataSource}
               configKey="codeSyncEnabled"
               featureKey="githubCodeSyncEnabled"
             />
@@ -781,14 +781,14 @@ const ConfigToggle = ({
   features: FeaturesType;
   featureKey: keyof FeaturesType;
   configKey: string;
-  dataSource: string;
+  dataSource: DataSourceType;
 }) => {
   const router = useRouter();
 
   const { isSubmitting, submit: onToggle } = useSubmitFunction(async () => {
     try {
       const r = await fetch(
-        `/api/poke/workspaces/${owner.sId}/data_sources/${dataSource}/config`,
+        `/api/poke/workspaces/${owner.sId}/data_sources/${dataSource.sId}/config`,
         {
           method: "POST",
           headers: {

--- a/front/pages/poke/[wId]/data_sources/[dsId]/search.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/search.tsx
@@ -123,9 +123,7 @@ export default function DataSourceView({
       )
     ) {
       window.open(
-        `/poke/${owner.sId}/data_sources/${
-          dataSource.name
-        }/view?documentId=${encodeURIComponent(documentId)}`
+        `/poke/${owner.sId}/data_sources/${dataSource.sId}/view?documentId=${encodeURIComponent(documentId)}`
       );
     }
   };

--- a/front/pages/w/[wId]/builder/data-sources/[dsId]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[dsId]/index.tsx
@@ -561,7 +561,7 @@ function DatasourceTablesTabView({
 }) {
   const { tables } = useDataSourceTables({
     workspaceId: owner.sId,
-    dataSourceName: dataSource.name,
+    dataSource,
   });
 
   return (

--- a/front/pages/w/[wId]/builder/data-sources/[dsId]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[dsId]/index.tsx
@@ -196,7 +196,7 @@ function StandardDataSourceView({
                   icon: Cog6ToothIcon,
                   onClick: () => {
                     void router.push(
-                      `/w/${owner.sId}/builder/data-sources/${dataSource.name}/settings`
+                      `/w/${owner.sId}/builder/data-sources/${dataSource.sId}/settings`
                     );
                   },
                 }
@@ -282,7 +282,7 @@ function DatasourceDocumentsTabView({
     try {
       const res = await fetch(
         `/api/w/${owner.sId}/data_sources/${
-          dataSource.name
+          dataSource.sId
         }/documents/${encodeURIComponent(documentId)}`,
         {
           method: "POST",
@@ -483,7 +483,7 @@ function DatasourceDocumentsTabView({
                     setShowDocumentsLimitPopup(true);
                   } else {
                     void router.push(
-                      `/w/${owner.sId}/builder/data-sources/${dataSource.name}/upsert`
+                      `/w/${owner.sId}/builder/data-sources/${dataSource.sId}/upsert`
                     );
                   }
                 }}
@@ -516,7 +516,7 @@ function DatasourceDocumentsTabView({
                     onClick={() => {
                       void router.push(
                         `/w/${owner.sId}/builder/data-sources/${
-                          dataSource.name
+                          dataSource.sId
                         }/upsert?documentId=${encodeURIComponent(
                           d.document_id
                         )}`
@@ -587,7 +587,7 @@ function DatasourceTablesTabView({
                   label="Add table"
                   onClick={() => {
                     void router.push(
-                      `/w/${owner.sId}/builder/data-sources/${dataSource.name}/tables/upsert`
+                      `/w/${owner.sId}/builder/data-sources/${dataSource.sId}/tables/upsert`
                     );
                   }}
                 />
@@ -619,7 +619,7 @@ function DatasourceTablesTabView({
                       onClick={() => {
                         void router.push(
                           `/w/${owner.sId}/builder/data-sources/${
-                            dataSource.name
+                            dataSource.sId
                           }/tables/upsert?tableId=${encodeURIComponent(
                             t.table_id
                           )}`
@@ -677,7 +677,7 @@ function SlackBotEnableView({
   const handleSetBotEnabled = async (botEnabled: boolean) => {
     setLoading(true);
     const res = await fetch(
-      `/api/w/${owner.sId}/data_sources/${dataSource.name}/managed/config/botEnabled`,
+      `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/botEnabled`,
       {
         headers: {
           "Content-Type": "application/json",
@@ -771,7 +771,7 @@ function GithubCodeEnableView({
   const handleSetCodeSyncEnabled = async (codeSyncEnabled: boolean) => {
     setLoading(true);
     const res = await fetch(
-      `/api/w/${owner.sId}/data_sources/${dataSource.name}/managed/config/codeSyncEnabled`,
+      `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/codeSyncEnabled`,
       {
         headers: {
           "Content-Type": "application/json",
@@ -849,7 +849,7 @@ function IntercomConfigView({
   const handleSetNewConfig = async (configValue: boolean) => {
     setLoading(true);
     const res = await fetch(
-      `/api/w/${owner.sId}/data_sources/${dataSource.name}/managed/config/${configKey}`,
+      `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/${configKey}`,
       {
         headers: {
           "Content-Type": "application/json",
@@ -1008,20 +1008,20 @@ function ManagedDataSourceView({
       // To prevent it from reopening on page refresh,
       // we remove the flag from the URL and then display the modal.
       router
-        .push(`/w/${owner.sId}/builder/data-sources/${dataSource.name}`)
+        .push(`/w/${owner.sId}/builder/data-sources/${dataSource.sId}`)
         .then(() => {
           setShowPermissionModal(true);
         })
         .catch(console.error);
     }
-  }, [dataSource.name, owner.sId, router]);
+  }, [dataSource.sId, owner.sId, router]);
 
   const updateConnectorConnectionId = async (
     newConnectionId: string,
     provider: string
   ) => {
     const res = await fetch(
-      `/api/w/${owner.sId}/data_sources/${dataSource.name}/managed/update`,
+      `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/update`,
       {
         method: "POST",
         headers: {
@@ -1140,9 +1140,7 @@ function ManagedDataSourceView({
           {isBuilder && displayWebcrawlerSettingsButton ? (
             <Link
               className="ml-auto"
-              href={`/w/${owner.sId}/builder/data-sources/${encodeURIComponent(
-                dataSource.name
-              )}/edit-public-url`}
+              href={`/w/${owner.sId}/builder/data-sources/${dataSource.sId}/edit-public-url`}
             >
               <Button
                 label="Settings"

--- a/front/pages/w/[wId]/builder/data-sources/[dsId]/search.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[dsId]/search.tsx
@@ -103,7 +103,7 @@ export default function DataSourceView({
       searchParams.append("full_text", "false");
 
       const searchRes = await fetch(
-        `/api/w/${owner.sId}/data_sources/${dataSource.name}/search?` +
+        `/api/w/${owner.sId}/data_sources/${dataSource.sId}/search?` +
           searchParams.toString(),
         {
           method: "GET",
@@ -130,7 +130,7 @@ export default function DataSourceView({
     return () => {
       isCancelled = true;
     };
-  }, [dataSource.name, owner.sId, searchQuery]);
+  }, [dataSource.sId, owner.sId, searchQuery]);
 
   return (
     <AppLayout
@@ -147,7 +147,7 @@ export default function DataSourceView({
           title="Search Data Source"
           onClose={() => {
             void router.push(
-              `/w/${owner.sId}/builder/data-sources/${dataSource.name}`
+              `/w/${owner.sId}/builder/data-sources/${dataSource.sId}`
             );
           }}
         />
@@ -187,7 +187,7 @@ export default function DataSourceView({
                           <div className="flex">
                             <Link
                               href={`/w/${owner.sId}/builder/data-sources/${
-                                dataSource.name
+                                dataSource.sId
                               }/upsert?documentId=${encodeURIComponent(
                                 d.document_id
                               )}`}

--- a/front/pages/w/[wId]/builder/data-sources/[dsId]/tables/upsert.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[dsId]/tables/upsert.tsx
@@ -104,7 +104,7 @@ export default function TableUpsert({
 
   const { table } = useDataSourceTable({
     workspaceId: owner.sId,
-    dataSourceName: dataSource.name,
+    dataSource,
     tableId: loadTableId,
   });
 

--- a/front/pages/w/[wId]/builder/data-sources/[dsId]/upsert.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[dsId]/upsert.tsx
@@ -107,7 +107,7 @@ export default function DatasourceUpsert({
       setDisabled(true);
       fetch(
         `/api/w/${owner.sId}/data_sources/${
-          dataSource.name
+          dataSource.sId
         }/documents/${encodeURIComponent(loadDocumentId)}`
       )
         .then(async (res) => {
@@ -122,7 +122,7 @@ export default function DatasourceUpsert({
         })
         .catch((e) => console.error(e));
     }
-  }, [dataSource.name, loadDocumentId, owner.sId]);
+  }, [dataSource.sId, loadDocumentId, owner.sId]);
 
   const router = useRouter();
 
@@ -146,9 +146,7 @@ export default function DatasourceUpsert({
     };
 
     const res = await fetch(
-      `/api/w/${owner.sId}/data_sources/${
-        dataSource.name
-      }/documents/${encodeURIComponent(documentId)}`,
+      `/api/w/${owner.sId}/data_sources/${dataSource.sId}/documents/${encodeURIComponent(documentId)}`,
       {
         method: "POST",
         headers: {
@@ -160,7 +158,7 @@ export default function DatasourceUpsert({
 
     if (res.ok) {
       await router.push(
-        `/w/${owner.sId}/builder/data-sources/${dataSource.name}`
+        `/w/${owner.sId}/builder/data-sources/${dataSource.sId}`
       );
     } else {
       let errMsg = "";
@@ -199,7 +197,7 @@ export default function DatasourceUpsert({
   const handleDelete = async () => {
     const res = await fetch(
       `/api/w/${owner.sId}/data_sources/${
-        dataSource.name
+        dataSource.sId
       }/documents/${encodeURIComponent(documentId)}`,
       {
         method: "DELETE",
@@ -210,9 +208,7 @@ export default function DatasourceUpsert({
       alert("There was an error deleting the document.");
       return;
     }
-    await router.push(
-      `/w/${owner.sId}/builder/data-sources/${dataSource.name}`
-    );
+    await router.push(`/w/${owner.sId}/builder/data-sources/${dataSource.sId}`);
   };
 
   return (
@@ -228,7 +224,7 @@ export default function DatasourceUpsert({
           title={loadDocumentId ? "Edit document" : "Add a new document"}
           onCancel={() => {
             void router.push(
-              `/w/${owner.sId}/builder/data-sources/${dataSource.name}`
+              `/w/${owner.sId}/builder/data-sources/${dataSource.sId}`
             );
           }}
           onSave={

--- a/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
@@ -105,8 +105,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
           panic: true, // This is a panic because we want to fix the data. This should never happen.
           workspaceId: owner.sId,
           connectorId: ds.connectorId,
-          dataSourceName: ds.name,
-          dataSourceId: ds.id,
+          dataSourceId: ds.sId,
           connectorProvider: ds.connectorProvider,
         },
         "Connector not found while we still have a data source."

--- a/front/poke/swr.ts
+++ b/front/poke/swr.ts
@@ -1,4 +1,8 @@
-import type { ConversationType, LightWorkspaceType } from "@dust-tt/types";
+import type {
+  ConversationType,
+  DataSourceType,
+  LightWorkspaceType,
+} from "@dust-tt/types";
 import { useMemo } from "react";
 import type { Fetcher } from "swr";
 import useSWR from "swr";
@@ -75,15 +79,13 @@ export function useConversation({
 
 export function useDocuments(
   owner: LightWorkspaceType,
-  dataSource: { name: string },
+  dataSource: DataSourceType,
   limit: number,
   offset: number
 ) {
   const documentsFetcher: Fetcher<GetDocumentsResponseBody> = fetcher;
   const { data, error, mutate } = useSWR(
-    `/api/poke/workspaces/${owner.sId}/data_sources/${encodeURIComponent(
-      dataSource.name
-    )}/documents?limit=${limit}&offset=${offset}`,
+    `/api/poke/workspaces/${owner.sId}/data_sources/${dataSource.sId}/documents?limit=${limit}&offset=${offset}`,
     documentsFetcher
   );
 


### PR DESCRIPTION
## Description

Move from using dataSource.name to dataSource.sId in a first batch of places (routes have already been all updated)

## Risk

Could break some part of the product but all routes support both name and sId

## Deploy Plan

- deploy `front`