### PR TITLE
[k8s] - fix: update environment variable interpolation in build config

### DIFF
--- a/k8s/cloudbuild.yaml
+++ b/k8s/cloudbuild.yaml
@@ -18,7 +18,7 @@ steps:
       - --build-arg
       - NEXT_PUBLIC_GA_TRACKING_ID=G-K9HQ2LE04G
       - --build-arg
-      - NEXT_PUBLIC_DUST_CLIENT_FACING_URL=$DUST_CLIENT_FACING_URL
+      - NEXT_PUBLIC_DUST_CLIENT_FACING_URL=${_DUST_CLIENT_FACING_URL}
       - .
     secretEnv:
       - "DEPOT_TOKEN"


### PR DESCRIPTION
## Description

Correct the interpolation syntax for the `DUST_CLIENT_FACING_URL` environment variable to properly reference its value during the build process

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
