### PR TITLE
Support o1

### DIFF
--- a/core/src/providers/azure_openai.rs
+++ b/core/src/providers/azure_openai.rs
@@ -471,7 +471,7 @@ impl LLM for AzureOpenAILLM {
             .map(OpenAITool::try_from)
             .collect::<Result<Vec<OpenAITool>, _>>()?;
 
-        let openai_messages = to_openai_messages(messages)?;
+        let openai_messages = to_openai_messages(messages, &self.model_id.clone().unwrap())?;
 
         let (c, request_id) = match event_sender {
             Some(_) => {

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -2098,7 +2098,7 @@ impl LLM for OpenAILLM {
                             },
                         }));
                         // Add a small delay to simulate real-time streaming.
-                        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                        tokio::time::sleep(std::time::Duration::from_millis(30)).await;
                     }
                 }
             }

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -1707,10 +1707,15 @@ impl OpenAILLM {
 
 pub fn to_openai_messages(
     messages: &Vec<ChatMessage>,
+    model_id: &str,
 ) -> Result<Vec<OpenAIChatMessage>, anyhow::Error> {
     messages
         .iter()
-        .map(|m| OpenAIChatMessage::try_from(m))
+        .filter_map(|m| match m {
+            // [o1-preview] Hack for OpenAI `o1-*` models to exclude system messages.
+            ChatMessage::System(_) if model_id.starts_with("o1-") => None,
+            _ => Some(OpenAIChatMessage::try_from(m)),
+        })
         .collect::<Result<Vec<_>>>()
 }
 
@@ -1780,101 +1785,100 @@ impl LLM for OpenAILLM {
             }
         }
 
-        let (c, request_id) = match event_sender {
-            Some(_) => {
-                if n > 1 {
-                    return Err(anyhow!(
-                        "Generating multiple variations in streaming mode is not supported."
-                    ))?;
-                }
-                streamed_completion(
-                    self.uri()?,
-                    self.api_key.clone().unwrap(),
-                    match &extras {
-                        Some(ex) => match ex.get("openai_organization_id") {
-                            Some(Value::String(o)) => Some(o.to_string().clone()),
-                            _ => None,
-                        },
-                        None => None,
-                    },
-                    Some(self.id.clone()),
-                    prompt,
-                    max_tokens,
-                    temperature,
-                    n,
-                    match top_logprobs {
-                        Some(l) => Some(l),
-                        None => Some(0),
-                    },
-                    true,
-                    stop,
-                    match frequency_penalty {
-                        Some(f) => f,
-                        None => 0.0,
-                    },
-                    match presence_penalty {
-                        Some(p) => p,
-                        None => 0.0,
-                    },
-                    match top_p {
-                        Some(t) => t,
-                        None => 1.0,
-                    },
-                    match &extras {
-                        Some(e) => match e.get("openai_user") {
-                            Some(Value::String(u)) => Some(u.to_string()),
-                            _ => None,
-                        },
-                        None => None,
-                    },
-                    event_sender,
-                )
-                .await?
+        // [o1-preview] Hack for OpenAI `o1-*` models to not use streaming.
+        let model_is_o1 = self.id.as_str().starts_with("o1-");
+        let (c, request_id) = if !model_is_o1 && event_sender.is_some() {
+            if n > 1 {
+                return Err(anyhow!(
+                    "Generating multiple variations in streaming mode is not supported."
+                ))?;
             }
-            None => {
-                completion(
-                    self.uri()?,
-                    self.api_key.clone().unwrap(),
-                    match &extras {
-                        Some(e) => match e.get("openai_organization_id") {
-                            Some(Value::String(o)) => Some(o.to_string()),
-                            _ => None,
-                        },
-                        None => None,
+            streamed_completion(
+                self.uri()?,
+                self.api_key.clone().unwrap(),
+                match &extras {
+                    Some(ex) => match ex.get("openai_organization_id") {
+                        Some(Value::String(o)) => Some(o.to_string().clone()),
+                        _ => None,
                     },
-                    Some(self.id.clone()),
-                    prompt,
-                    max_tokens,
-                    temperature,
-                    n,
-                    match top_logprobs {
-                        Some(l) => Some(l),
-                        None => Some(0),
+                    None => None,
+                },
+                Some(self.id.clone()),
+                prompt,
+                max_tokens,
+                temperature,
+                n,
+                match top_logprobs {
+                    Some(l) => Some(l),
+                    None => Some(0),
+                },
+                true,
+                stop,
+                match frequency_penalty {
+                    Some(f) => f,
+                    None => 0.0,
+                },
+                match presence_penalty {
+                    Some(p) => p,
+                    None => 0.0,
+                },
+                match top_p {
+                    Some(t) => t,
+                    None => 1.0,
+                },
+                match &extras {
+                    Some(e) => match e.get("openai_user") {
+                        Some(Value::String(u)) => Some(u.to_string()),
+                        _ => None,
                     },
-                    true,
-                    stop,
-                    match frequency_penalty {
-                        Some(f) => f,
-                        None => 0.0,
+                    None => None,
+                },
+                event_sender,
+            )
+            .await?
+        } else {
+            completion(
+                self.uri()?,
+                self.api_key.clone().unwrap(),
+                match &extras {
+                    Some(e) => match e.get("openai_organization_id") {
+                        Some(Value::String(o)) => Some(o.to_string()),
+                        _ => None,
                     },
-                    match presence_penalty {
-                        Some(p) => p,
-                        None => 0.0,
+                    None => None,
+                },
+                Some(self.id.clone()),
+                prompt,
+                max_tokens,
+                temperature,
+                n,
+                match top_logprobs {
+                    Some(l) => Some(l),
+                    None => Some(0),
+                },
+                true,
+                stop,
+                match frequency_penalty {
+                    Some(f) => f,
+                    None => 0.0,
+                },
+                match presence_penalty {
+                    Some(p) => p,
+                    None => 0.0,
+                },
+                match top_p {
+                    Some(t) => t,
+                    None => 1.0,
+                },
+                match &extras {
+                    Some(e) => match e.get("openai_user") {
+                        Some(Value::String(u)) => Some(u.to_string()),
+                        _ => None,
                     },
-                    match top_p {
-                        Some(t) => t,
-                        None => 1.0,
-                    },
-                    match &extras {
-                        Some(e) => match e.get("openai_user") {
-                            Some(Value::String(u)) => Some(u.to_string()),
-                            _ => None,
-                        },
-                        None => None,
-                    },
-                )
-                .await?
-            }
+                    None => None,
+                },
+            )
+            .await?
         };
 
         // println!("COMPLETION: {:?}", c);
@@ -2008,71 +2012,108 @@ impl LLM for OpenAILLM {
             .map(OpenAITool::try_from)
             .collect::<Result<Vec<OpenAITool>, _>>()?;
 
-        let openai_messages = to_openai_messages(messages)?;
+        let openai_messages = to_openai_messages(messages, &self.id)?;
 
-        let (c, request_id) = match event_sender {
-            Some(_) => {
-                streamed_chat_completion(
-                    self.chat_uri()?,
-                    self.api_key.clone().unwrap(),
-                    openai_org_id,
-                    Some(self.id.clone()),
-                    &openai_messages,
-                    tools,
-                    tool_choice,
-                    temperature,
-                    match top_p {
-                        Some(t) => t,
-                        None => 1.0,
-                    },
-                    n,
-                    stop,
-                    max_tokens,
-                    match presence_penalty {
-                        Some(p) => p,
-                        None => 0.0,
-                    },
-                    match frequency_penalty {
-                        Some(f) => f,
-                        None => 0.0,
-                    },
-                    response_format,
-                    openai_user,
-                    event_sender,
-                )
-                .await?
-            }
-            None => {
-                chat_completion(
-                    self.chat_uri()?,
-                    self.api_key.clone().unwrap(),
-                    openai_org_id,
-                    Some(self.id.clone()),
-                    &openai_messages,
-                    tools,
-                    tool_choice,
-                    temperature,
-                    match top_p {
-                        Some(t) => t,
-                        None => 1.0,
-                    },
-                    n,
-                    stop,
-                    max_tokens,
-                    match presence_penalty {
-                        Some(p) => p,
-                        None => 0.0,
-                    },
-                    match frequency_penalty {
-                        Some(f) => f,
-                        None => 0.0,
-                    },
-                    response_format,
-                    openai_user,
-                )
-                .await?
-            }
+        // [o1-preview] Hack for OpenAI `o1-*` models to simulate streaming.
+        let is_streaming = event_sender.is_some();
+        let model_is_o1 = self.id.as_str().starts_with("o1-");
+
+        let (c, request_id) = if !model_is_o1 && is_streaming {
+            streamed_chat_completion(
+                self.chat_uri()?,
+                self.api_key.clone().unwrap(),
+                openai_org_id,
+                Some(self.id.clone()),
+                &openai_messages,
+                tools,
+                tool_choice,
+                temperature,
+                match top_p {
+                    Some(t) => t,
+                    None => 1.0,
+                },
+                n,
+                stop,
+                max_tokens,
+                match presence_penalty {
+                    Some(p) => p,
+                    None => 0.0,
+                },
+                match frequency_penalty {
+                    Some(f) => f,
+                    None => 0.0,
+                },
+                response_format,
+                openai_user,
+                event_sender.clone(),
+            )
+            .await?
+        } else {
+            chat_completion(
+                self.chat_uri()?,
+                self.api_key.clone().unwrap(),
+                openai_org_id,
+                Some(self.id.clone()),
+                &openai_messages,
+                tools,
+                tool_choice,
+                temperature,
+                match top_p {
+                    Some(t) => t,
+                    None => 1.0,
+                },
+                n,
+                stop,
+                max_tokens,
+                match presence_penalty {
+                    Some(p) => p,
+                    None => 0.0,
+                },
+                match frequency_penalty {
+                    Some(f) => f,
+                    None => 0.0,
+                },
+                response_format,
+                openai_user,
+            )
+            .await?
         };
+
+        // [o1-preview] Hack for OpenAI `o1-*` models to simulate streaming.
+        if model_is_o1 && is_streaming {
+            let sender = event_sender.as_ref().unwrap();
+            for choice in &c.choices {
+                if let Some(content) = &choice.message.content {
+                    // Split content into smaller chunks to simulate streaming.
+                    for chunk in content
+                        .chars()
+                        .collect::<Vec<char>>()
+                        .chunks(4)
+                        .map(|c| c.iter().collect::<String>())
+                    {
+                        let _ = sender.send(json!({
+                            "type": "tokens",
+                            "content": {
+                                "text": chunk,
+                            },
+                        }));
+                        // Add a small delay to simulate real-time streaming
+                        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                    }
+                }
+                if let Some(tool_calls) = &choice.message.tool_calls {
+                    for tool_call in tool_calls {
+                        let _ = sender.send(json!({
+                            "type": "function_call",
+                            "content": {
+                                "name": tool_call.function.name,
+                                // Include other necessary function call details
+                            },
+                        }));
+                    }
+                }
+            }
+        }
 
         assert!(c.choices.len() > 0);
 

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -2097,19 +2097,8 @@ impl LLM for OpenAILLM {
                                 "text": chunk,
                             },
                         }));
-                        // Add a small delay to simulate real-time streaming
+                        // Add a small delay to simulate real-time streaming.
                         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-                    }
-                }
-                if let Some(tool_calls) = &choice.message.tool_calls {
-                    for tool_call in tool_calls {
-                        let _ = sender.send(json!({
-                            "type": "function_call",
-                            "content": {
-                                "name": tool_call.function.name,
-                                // Include other necessary function call details
-                            },
-                        }));
                     }
                 }
             }

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -28,7 +28,8 @@ import {
   MISTRAL_LARGE_MODEL_CONFIG,
   MISTRAL_MEDIUM_MODEL_CONFIG,
   MISTRAL_SMALL_MODEL_CONFIG,
-  O1_MODEL_CONFIG,
+  O1_MINI_MODEL_CONFIG,
+  O1_PREVIEW_MODEL_CONFIG,
 } from "@dust-tt/types";
 
 import {
@@ -253,7 +254,7 @@ function _getGPT4GlobalAgent({
     groupIds: [],
   };
 }
-function _getO1GlobalAgent({
+function _getO1PreviewGlobalAgent({
   auth,
   settings,
 }: {
@@ -272,15 +273,52 @@ function _getO1GlobalAgent({
     versionCreatedAt: null,
     versionAuthorId: null,
     name: "openai-o1",
-    description: O1_MODEL_CONFIG.description,
+    description: O1_PREVIEW_MODEL_CONFIG.description,
     instructions: null,
     pictureUrl: "https://dust.tt/static/systemavatar/gpt4_avatar_full.png", // @todo: change to O1 avatar
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
     model: {
-      providerId: O1_MODEL_CONFIG.providerId,
-      modelId: O1_MODEL_CONFIG.modelId,
+      providerId: O1_PREVIEW_MODEL_CONFIG.providerId,
+      modelId: O1_PREVIEW_MODEL_CONFIG.modelId,
+      temperature: 1, // 1 is forced for O1
+    },
+    actions: [],
+    maxStepsPerRun: 0,
+    visualizationEnabled: false,
+    templateId: null,
+    groupIds: [],
+  };
+}
+function _getO1MiniGlobalAgent({
+  auth,
+  settings,
+}: {
+  auth: Authenticator;
+  settings: GlobalAgentSettings | null;
+}): AgentConfigurationType {
+  let status = settings?.status ?? "active";
+  if (!auth.isUpgraded()) {
+    status = "disabled_free_workspace";
+  }
+
+  return {
+    id: -1,
+    sId: GLOBAL_AGENTS_SID.O1_MINI,
+    version: 0,
+    versionCreatedAt: null,
+    versionAuthorId: null,
+    name: "openai-o1-mini",
+    description: O1_MINI_MODEL_CONFIG.description,
+    instructions: null,
+    pictureUrl: "https://dust.tt/static/systemavatar/gpt4_avatar_full.png", // @todo: change to O1 avatar
+    status,
+    scope: "global",
+    userListStatus: status === "active" ? "in-list" : "not-in-list",
+    model: {
+      providerId: O1_MINI_MODEL_CONFIG.providerId,
+      modelId: O1_MINI_MODEL_CONFIG.modelId,
       temperature: 1, // 1 is forced for O1
     },
     actions: [],
@@ -1084,7 +1122,10 @@ function getGlobalAgent(
       agentConfiguration = _getGPT4GlobalAgent({ auth, settings });
       break;
     case GLOBAL_AGENTS_SID.O1:
-      agentConfiguration = _getO1GlobalAgent({ auth, settings });
+      agentConfiguration = _getO1PreviewGlobalAgent({ auth, settings });
+      break;
+    case GLOBAL_AGENTS_SID.O1_MINI:
+      agentConfiguration = _getO1MiniGlobalAgent({ auth, settings });
       break;
     case GLOBAL_AGENTS_SID.CLAUDE_INSTANT:
       agentConfiguration = _getClaudeInstantGlobalAgent({ settings });
@@ -1232,6 +1273,11 @@ export async function getGlobalAgents(
   if (!owner.flags.includes("openai_o1_feature")) {
     agentsIdsToFetch = agentsIdsToFetch.filter(
       (sId) => sId !== GLOBAL_AGENTS_SID.O1
+    );
+  }
+  if (!owner.flags.includes("openai_o1_mini_feature")) {
+    agentsIdsToFetch = agentsIdsToFetch.filter(
+      (sId) => sId !== GLOBAL_AGENTS_SID.O1_MINI
     );
   }
 

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -28,6 +28,7 @@ import {
   MISTRAL_LARGE_MODEL_CONFIG,
   MISTRAL_MEDIUM_MODEL_CONFIG,
   MISTRAL_SMALL_MODEL_CONFIG,
+  O1_MODEL_CONFIG,
 } from "@dust-tt/types";
 
 import {
@@ -244,6 +245,43 @@ function _getGPT4GlobalAgent({
       providerId: GPT_4O_MODEL_CONFIG.providerId,
       modelId: GPT_4O_MODEL_CONFIG.modelId,
       temperature: 0.7,
+    },
+    actions: [],
+    maxStepsPerRun: 0,
+    visualizationEnabled: false,
+    templateId: null,
+    groupIds: [],
+  };
+}
+function _getO1GlobalAgent({
+  auth,
+  settings,
+}: {
+  auth: Authenticator;
+  settings: GlobalAgentSettings | null;
+}): AgentConfigurationType {
+  let status = settings?.status ?? "active";
+  if (!auth.isUpgraded()) {
+    status = "disabled_free_workspace";
+  }
+
+  return {
+    id: -1,
+    sId: GLOBAL_AGENTS_SID.O1,
+    version: 0,
+    versionCreatedAt: null,
+    versionAuthorId: null,
+    name: "openai-o1",
+    description: O1_MODEL_CONFIG.description,
+    instructions: null,
+    pictureUrl: "https://dust.tt/static/systemavatar/gpt4_avatar_full.png", // @todo: change to O1 avatar
+    status,
+    scope: "global",
+    userListStatus: status === "active" ? "in-list" : "not-in-list",
+    model: {
+      providerId: O1_MODEL_CONFIG.providerId,
+      modelId: O1_MODEL_CONFIG.modelId,
+      temperature: 1, // 1 is forced for O1
     },
     actions: [],
     maxStepsPerRun: 0,
@@ -1045,6 +1083,9 @@ function getGlobalAgent(
     case GLOBAL_AGENTS_SID.GPT4:
       agentConfiguration = _getGPT4GlobalAgent({ auth, settings });
       break;
+    case GLOBAL_AGENTS_SID.O1:
+      agentConfiguration = _getO1GlobalAgent({ auth, settings });
+      break;
     case GLOBAL_AGENTS_SID.CLAUDE_INSTANT:
       agentConfiguration = _getClaudeInstantGlobalAgent({ settings });
       break;
@@ -1182,11 +1223,17 @@ export async function getGlobalAgents(
   // If agentIds have been passed we fetch those. Otherwise we fetch them all, removing the retired
   // one (which will remove these models from the list of default agents in the product + list of
   // user assistants).
-  const agentsIdsToFetch =
+  let agentsIdsToFetch =
     agentIds ??
     Object.values(GLOBAL_AGENTS_SID).filter(
       (sId) => !RETIRED_GLOABL_AGENTS_SID.includes(sId)
     );
+
+  if (!owner.flags.includes("openai_o1_feature")) {
+    agentsIdsToFetch = agentsIdsToFetch.filter(
+      (sId) => sId !== GLOBAL_AGENTS_SID.O1
+    );
+  }
 
   // For now we retrieve them all
   // We will store them in the database later to allow admin enable them or not

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -47,6 +47,7 @@ export enum GLOBAL_AGENTS_SID {
   INTERCOM = "intercom",
   GPT35_TURBO = "gpt-3.5-turbo",
   GPT4 = "gpt-4",
+  O1 = "o1",
   CLAUDE_3_OPUS = "claude-3-opus",
   CLAUDE_3_SONNET = "claude-3-sonnet",
   CLAUDE_3_HAIKU = "claude-3-haiku",

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -48,6 +48,7 @@ export enum GLOBAL_AGENTS_SID {
   GPT35_TURBO = "gpt-3.5-turbo",
   GPT4 = "gpt-4",
   O1 = "o1",
+  O1_MINI = "o1-mini",
   CLAUDE_3_OPUS = "claude-3-opus",
   CLAUDE_3_SONNET = "claude-3-sonnet",
   CLAUDE_3_HAIKU = "claude-3-haiku",

--- a/front/pages/api/w/[wId]/providers/[pId]/models.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/models.ts
@@ -84,9 +84,11 @@ async function handler(
                   ) &&
                   (m.id.startsWith("text-") ||
                     m.id.startsWith("code-") ||
+                    m.id.startsWith("o1-") ||
                     m.id.startsWith("gpt-3.5-turbo") ||
                     m.id.startsWith("gpt-4")) &&
                   (!chat ||
+                    m.id.startsWith("o1-") ||
                     m.id.startsWith("gpt-3.5-turbo") ||
                     m.id.startsWith("gpt-4"))
                 );

--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -87,6 +87,7 @@ export const GPT_4_TURBO_MODEL_ID = "gpt-4-turbo" as const;
 export const GPT_4O_LEGACY_MODEL_ID = "gpt-4o" as const;
 export const GPT_4O_MODEL_ID = "gpt-4o-2024-08-06" as const;
 export const GPT_4O_MINI_MODEL_ID = "gpt-4o-mini" as const;
+export const O1_MODEL_ID = "o1-preview" as const;
 export const CLAUDE_3_OPUS_2024029_MODEL_ID = "claude-3-opus-20240229" as const;
 export const CLAUDE_3_5_SONNET_20240620_MODEL_ID =
   "claude-3-5-sonnet-20240620" as const;
@@ -108,6 +109,7 @@ export const MODEL_IDS = [
   GPT_4O_MODEL_ID,
   GPT_4O_LEGACY_MODEL_ID,
   GPT_4O_MINI_MODEL_ID,
+  O1_MODEL_ID,
   CLAUDE_3_OPUS_2024029_MODEL_ID,
   CLAUDE_3_5_SONNET_20240620_MODEL_ID,
   CLAUDE_3_HAIKU_20240307_MODEL_ID,
@@ -243,6 +245,20 @@ export const GPT_4O_MINI_MODEL_CONFIG: ModelConfigurationType = {
   isLegacy: false,
   toolUseMetaPrompt: LEGACY_OPEN_AI_TOOL_USE_META_PROMPT,
   supportsVision: true,
+};
+export const O1_MODEL_CONFIG: ModelConfigurationType = {
+  providerId: "openai",
+  modelId: O1_MODEL_ID,
+  displayName: "Open AI O1",
+  contextSize: 128_000,
+  recommendedTopK: 32,
+  recommendedExhaustiveTopK: 128, // 65_536
+  largeModel: true,
+  description:
+    "OpenAI's O1 series, trained with reinforcement learning to perform complex reasoning.",
+  shortDescription: "OpenAI's model for complex reasoning.",
+  isLegacy: false,
+  supportsVision: false,
 };
 
 const ANTHROPIC_DELIMITERS_CONFIGURATION = {
@@ -458,6 +474,7 @@ export const SUPPORTED_MODEL_CONFIGS: ModelConfigurationType[] = [
   GPT_4O_MODEL_CONFIG,
   GPT_4O_LEGACY_MODEL_CONFIG,
   GPT_4O_MINI_MODEL_CONFIG,
+  O1_MODEL_CONFIG,
   CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG,
   CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG,
   CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG,

--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -87,7 +87,8 @@ export const GPT_4_TURBO_MODEL_ID = "gpt-4-turbo" as const;
 export const GPT_4O_LEGACY_MODEL_ID = "gpt-4o" as const;
 export const GPT_4O_MODEL_ID = "gpt-4o-2024-08-06" as const;
 export const GPT_4O_MINI_MODEL_ID = "gpt-4o-mini" as const;
-export const O1_MODEL_ID = "o1-preview" as const;
+export const O1_PREVIEW_MODEL_ID = "o1-preview" as const;
+export const O1_MINI_MODEL_ID = "o1-mini" as const;
 export const CLAUDE_3_OPUS_2024029_MODEL_ID = "claude-3-opus-20240229" as const;
 export const CLAUDE_3_5_SONNET_20240620_MODEL_ID =
   "claude-3-5-sonnet-20240620" as const;
@@ -109,7 +110,8 @@ export const MODEL_IDS = [
   GPT_4O_MODEL_ID,
   GPT_4O_LEGACY_MODEL_ID,
   GPT_4O_MINI_MODEL_ID,
-  O1_MODEL_ID,
+  O1_PREVIEW_MODEL_ID,
+  O1_MINI_MODEL_ID,
   CLAUDE_3_OPUS_2024029_MODEL_ID,
   CLAUDE_3_5_SONNET_20240620_MODEL_ID,
   CLAUDE_3_HAIKU_20240307_MODEL_ID,
@@ -246,17 +248,33 @@ export const GPT_4O_MINI_MODEL_CONFIG: ModelConfigurationType = {
   toolUseMetaPrompt: LEGACY_OPEN_AI_TOOL_USE_META_PROMPT,
   supportsVision: true,
 };
-export const O1_MODEL_CONFIG: ModelConfigurationType = {
+export const O1_PREVIEW_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
-  modelId: O1_MODEL_ID,
-  displayName: "Open AI O1",
+  modelId: O1_PREVIEW_MODEL_ID,
+  displayName: "Open AI O1 Preview",
   contextSize: 128_000,
   recommendedTopK: 32,
   recommendedExhaustiveTopK: 128, // 65_536
   largeModel: true,
   description:
     "OpenAI's O1 series, trained with reinforcement learning to perform complex reasoning.",
-  shortDescription: "OpenAI's model for complex reasoning.",
+  shortDescription:
+    "OpenAI's reasoning model designed to solve hard problems across domains.",
+  isLegacy: false,
+  supportsVision: false,
+};
+export const O1_MINI_MODEL_CONFIG: ModelConfigurationType = {
+  providerId: "openai",
+  modelId: O1_MINI_MODEL_ID,
+  displayName: "Open AI O1 Mini",
+  contextSize: 128_000,
+  recommendedTopK: 32,
+  recommendedExhaustiveTopK: 128, // 65_536
+  largeModel: true,
+  description:
+    "OpenAI's O1 series, trained with reinforcement learning to perform complex reasoning.",
+  shortDescription:
+    "OpenAI's fast reasoning model particularly good at coding, math, and science.",
   isLegacy: false,
   supportsVision: false,
 };
@@ -474,7 +492,8 @@ export const SUPPORTED_MODEL_CONFIGS: ModelConfigurationType[] = [
   GPT_4O_MODEL_CONFIG,
   GPT_4O_LEGACY_MODEL_CONFIG,
   GPT_4O_MINI_MODEL_CONFIG,
-  O1_MODEL_CONFIG,
+  O1_PREVIEW_MODEL_CONFIG,
+  O1_MINI_MODEL_CONFIG,
   CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG,
   CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG,
   CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG,

--- a/types/src/shared/feature_flags.ts
+++ b/types/src/shared/feature_flags.ts
@@ -7,6 +7,7 @@ export const WHITELISTABLE_FEATURES = [
   "data_vaults_feature",
   "private_data_vaults_feature",
   "openai_o1_feature",
+  "openai_o1_mini_feature",
 ] as const;
 export type WhitelistableFeature = (typeof WHITELISTABLE_FEATURES)[number];
 export function isWhitelistableFeature(

--- a/types/src/shared/feature_flags.ts
+++ b/types/src/shared/feature_flags.ts
@@ -6,6 +6,7 @@ export const WHITELISTABLE_FEATURES = [
   "document_tracker",
   "data_vaults_feature",
   "private_data_vaults_feature",
+  "openai_o1_feature",
 ] as const;
 export type WhitelistableFeature = (typeof WHITELISTABLE_FEATURES)[number];
 export function isWhitelistableFeature(


### PR DESCRIPTION
## Description

Review with hidden whitespaces advised: https://github.com/dust-tt/dust/pull/7506/files?diff=split&w=1

### Core
Adds support for O1 in Core, with some hacks since it does not support system messages nor streaming. 
I only support it on OpenAI not azureOpenAI, but we could of course easily do it if we wanted. 
I made a few tests with a convo with both O1 and an agent with websearch and it seems to work properly.
Will make more tests on prod before checking if we need to add more hacks (since it does not support tools).

### On front
- Add a global agent `@openai-o1`, behind a flag. 
- We cannot select this model on the Assistant Builder. 
- We can select this model from a Dust app.

### Fake streaming
I'm fake streaming from Core. View XP here: https://www.loom.com/share/a32028526f124b6c97076142fefaf621
=> Actually I added a commit to stream a bit faster.

## Risk

Can be rolled back.

## Deploy Plan

Deploy Core. 
Deploy front. 
