### PR TITLE
[k8s] - fix(CI): optional build arg

### DIFF
--- a/.github/workflows/deploy-and-test-front-qa.yml
+++ b/.github/workflows/deploy-and-test-front-qa.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build.sh --image-name=front --dockerfile-path=./front/Dockerfile --working-dir=./
+          ./k8s/cloud-build.sh --image-name=front --dockerfile-path=./front/Dockerfile --working-dir=./ --dust-client-facing-url=https://front-qa.dust.tt
 
       - name: Deploy the image on Kubernetes
         run: |

--- a/k8s/cloudbuild.yaml
+++ b/k8s/cloudbuild.yaml
@@ -18,7 +18,7 @@ steps:
       - --build-arg
       - NEXT_PUBLIC_GA_TRACKING_ID=G-K9HQ2LE04G
       - --build-arg
-      - NEXT_PUBLIC_DUST_CLIENT_FACING_URL=${_DUST_CLIENT_FACING_URL}
+      - NEXT_PUBLIC_DUST_CLIENT_FACING_URL=${_DUST_CLIENT_FACING_URL:-}
       - .
     secretEnv:
       - "DEPOT_TOKEN"


### PR DESCRIPTION
## Description

The previous changes to `cloudbuild.yaml` were causing some CI to break:
 - Pass the `--dust-client-facing-url` with a QA specific URL during the front image build process
 - Make the `NEXT_PUBLIC_DUST_CLIENT_FACING_URL` build argument default to an empty value if not specified

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
