### PR TITLE
Pass workspaceId as metadata.user_id to Anthropic

### DIFF
--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -699,11 +699,16 @@ struct StreamMessageDelta {
 pub struct AnthropicLLM {
     id: String,
     api_key: Option<String>,
+    user_id: Option<String>,
 }
 
 impl AnthropicLLM {
     pub fn new(id: String) -> Self {
-        Self { id, api_key: None }
+        Self {
+            id,
+            api_key: None,
+            user_id: None,
+        }
     }
 
     fn messages_uri(&self) -> Result<Uri> {
@@ -1488,6 +1493,12 @@ impl LLM for AnthropicLLM {
                     "Credentials or environment variable `ANTHROPIC_API_KEY` is not set."
                 ))?,
             },
+        }
+        match credentials.get("DUST_WORKSPACE_ID") {
+            Some(workspace_id) => {
+                self.user_id = Some(workspace_id.clone());
+            }
+            None => (),
         }
         Ok(())
     }

--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -761,6 +761,12 @@ impl AnthropicLLM {
             },
         });
 
+        if let Some(user_id) = self.user_id.as_ref() {
+            body["metadata"] = json!({
+                "user_id": user_id,
+            });
+        }
+
         if system.is_some() {
             body["system"] = json!(system);
         }
@@ -862,6 +868,12 @@ impl AnthropicLLM {
             },
             "stream": true,
         });
+
+        if let Some(user_id) = self.user_id.as_ref() {
+            body["metadata"] = json!({
+                "user_id": user_id,
+            });
+        }
 
         if system.is_some() {
             body["system"] = json!(system);


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/1344

Pass the workspace ID as metadata.user_id to Anthropic so that they feel comfortable enabling zero data retention for us.

## Risk

None - tested locally e2e

## Deploy Plan

- deploy `core`