### PR TITLE
[k8s] - fix(CI): include client-facing URL in cloudbuild

### DIFF
--- a/.github/workflows/deploy-alerting-temporal.yml
+++ b/.github/workflows/deploy-alerting-temporal.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build.sh --image-name=alerting-temporal --dockerfile-path=./Dockerfile --working-dir=./alerting/temporal/
+          ./k8s/cloud-build.sh --image-name=alerting-temporal --dockerfile-path=./Dockerfile --working-dir=./alerting/temporal/ --dust-client-facing-url=https://dust.tt
 
       - name: Deploy the image on Kubernetes
         run: |

--- a/.github/workflows/deploy-connectors.yml
+++ b/.github/workflows/deploy-connectors.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build.sh --image-name=connectors --dockerfile-path=./connectors/Dockerfile --working-dir=./
+          ./k8s/cloud-build.sh --image-name=connectors --dockerfile-path=./connectors/Dockerfile --working-dir=./ --dust-client-facing-url=https://dust.tt
 
       - name: Deploy the image on Kubernetes
         run: |

--- a/.github/workflows/deploy-core.yml
+++ b/.github/workflows/deploy-core.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build.sh --image-name=core --dockerfile-path=./Dockerfile --working-dir=./core/
+          ./k8s/cloud-build.sh --image-name=core --dockerfile-path=./Dockerfile --working-dir=./core/ --dust-client-facing-url=https://dust.tt
 
       - name: Deploy the image on Kubernetes
         run: |

--- a/.github/workflows/deploy-oauth.yml
+++ b/.github/workflows/deploy-oauth.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build.sh --image-name=oauth --dockerfile-path=./oauth.Dockerfile --working-dir=./core/
+          ./k8s/cloud-build.sh --image-name=oauth --dockerfile-path=./oauth.Dockerfile --working-dir=./core/ --dust-client-facing-url=https://dust.tt
 
       - name: Deploy the image on Kubernetes
         run: |

--- a/.github/workflows/deploy-prodbox.yml
+++ b/.github/workflows/deploy-prodbox.yml
@@ -44,8 +44,7 @@ jobs:
       - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build.sh prodbox ./prodbox.Dockerfile ./ .gcloudignore-prodbox
-          ./k8s/cloud-build.sh --image-name=prodbox --dockerfile-path=./prodbox.Dockerfile --working-dir=./ --gcloud-ignore-file=.gcloudignore-prodbox
+          ./k8s/cloud-build.sh --image-name=prodbox --dockerfile-path=./prodbox.Dockerfile --working-dir=./ --gcloud-ignore-file=.gcloudignore-prodbox --dust-client-facing-url=https://dust.tt
 
       - name: Deploy the image on Kubernetes
         run: |

--- a/.github/workflows/deploy-viz.yml
+++ b/.github/workflows/deploy-viz.yml
@@ -43,8 +43,7 @@ jobs:
       - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build.sh viz ./viz/Dockerfile ./
-          ./k8s/cloud-build.sh --image-name=viz --dockerfile-path=./viz/Dockerfile --working-dir=./
+          ./k8s/cloud-build.sh --image-name=viz --dockerfile-path=./viz/Dockerfile --working-dir=./ --dust-client-facing-url=https://dust.tt
 
       - name: Deploy the image on Kubernetes
         run: |

--- a/k8s/cloudbuild.yaml
+++ b/k8s/cloudbuild.yaml
@@ -18,7 +18,7 @@ steps:
       - --build-arg
       - NEXT_PUBLIC_GA_TRACKING_ID=G-K9HQ2LE04G
       - --build-arg
-      - NEXT_PUBLIC_DUST_CLIENT_FACING_URL=${_DUST_CLIENT_FACING_URL:-}
+      - NEXT_PUBLIC_DUST_CLIENT_FACING_URL=${_DUST_CLIENT_FACING_URL}
       - .
     secretEnv:
       - "DEPOT_TOKEN"


### PR DESCRIPTION
## Description

This PR aims at always passing the `--dust-client-facing-url` args to the `cloud-build.sh` script.

## Risk


## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
