### PR TITLE
Fix: delete dialog will fetch usage on it's own.

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -7,6 +7,7 @@ import {
   Item,
   ListCheckIcon,
   MoreIcon,
+  PlusIcon,
   RobotIcon,
   TrashIcon,
   XMarkIcon,
@@ -134,7 +135,7 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
   return (
     <>
       <Dialog
-        title="Clear conversations history"
+        title="Clear conversation history"
         isOpen={showDeleteDialog === "all"}
         onCancel={() => setShowDeleteDialog(null)}
         onValidate={deleteAll}
@@ -217,14 +218,24 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
                       labelVisible={false}
                     />
                   </DropdownMenu.Button>
-                  <DropdownMenu.Items width={260}>
+                  <DropdownMenu.Items width={250}>
                     {isBuilder(owner) && (
-                      <DropdownMenu.Item
-                        label="Manage assistants"
-                        link={{ href: `/w/${owner.sId}/builder/assistants` }}
-                        icon={RobotIcon}
-                      />
+                      <>
+                        <DropdownMenu.Item
+                          label="Create new assistant"
+                          link={{
+                            href: `/w/${owner.sId}/builder/assistants/create`,
+                          }}
+                          icon={PlusIcon}
+                        />
+                        <DropdownMenu.Item
+                          label="Manage assistants"
+                          link={{ href: `/w/${owner.sId}/builder/assistants` }}
+                          icon={RobotIcon}
+                        />
+                      </>
                     )}
+
                     <DropdownMenu.Item
                       label="Edit conversations"
                       onClick={toggleMutliSelect}
@@ -232,7 +243,7 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
                       disabled={conversations.length === 0}
                     />
                     <DropdownMenu.Item
-                      label="Clear conversations history"
+                      label="Clear conversation history"
                       onClick={() => setShowDeleteDialog("all")}
                       icon={TrashIcon}
                       disabled={conversations.length === 0}

--- a/front/components/data_source/DeleteStaticDataSourceDialog.tsx
+++ b/front/components/data_source/DeleteStaticDataSourceDialog.tsx
@@ -1,28 +1,30 @@
 import { Dialog } from "@dust-tt/sparkle";
-import type {
-  DataSourceType,
-  DataSourceWithAgentsUsageType,
-} from "@dust-tt/types";
-import { useState } from "react";
+import type { DataSourceType, LightWorkspaceType } from "@dust-tt/types";
+import { useMemo, useState } from "react";
 
 import { getDataSourceName, isManaged } from "@app/lib/data_sources";
+import { useDataSourceUsage } from "@app/lib/swr/data_sources";
 
 interface DeleteStaticDataSourceDialogProps {
+  owner: LightWorkspaceType;
   dataSource: DataSourceType;
   handleDelete: () => void;
-  dataSourceUsage?: DataSourceWithAgentsUsageType;
   isOpen: boolean;
   onClose: () => void;
 }
 
 export function DeleteStaticDataSourceDialog({
+  owner,
   dataSource,
   handleDelete,
-  dataSourceUsage,
   isOpen,
   onClose,
 }: DeleteStaticDataSourceDialogProps) {
   const [isLoading, setIsLoading] = useState(false);
+  const { usage, isUsageLoading, isUsageError } = useDataSourceUsage({
+    owner,
+    dataSource,
+  });
 
   const onDelete = async () => {
     setIsLoading(true);
@@ -34,19 +36,28 @@ export function DeleteStaticDataSourceDialog({
     ? dataSource.name
     : getDataSourceName(dataSource);
 
-  const message =
-    dataSourceUsage === undefined
-      ? `Are you sure you want to permanently delete ${name}?`
-      : dataSourceUsage.count > 0
-        ? `${dataSourceUsage.count} assistants currently use "${name}": ${dataSourceUsage.agentNames.join(", ")}.`
-        : `No assistants are using "${name}".`;
+  const message = useMemo(() => {
+    if (isUsageLoading) {
+      return "Checking usage...";
+    }
+    if (isUsageError) {
+      return "Failed to check usage.";
+    }
+    if (!usage) {
+      return "No usage data available.";
+    }
+    if (usage.count > 0) {
+      return `${usage.count} assistants currently use "${name}": ${usage.agentNames.join(", ")}.`;
+    }
+    return `No assistants are using "${name}".`;
+  }, [isUsageLoading, isUsageError, usage, name]);
 
   return (
     <Dialog
       isOpen={isOpen}
       title={`Removing ${name}`}
       onValidate={onDelete}
-      isSaving={isLoading}
+      isSaving={isLoading || isUsageLoading}
       onCancel={onClose}
       validateVariant="primaryWarning"
     >

--- a/front/components/data_source/WebsiteConfiguration.tsx
+++ b/front/components/data_source/WebsiteConfiguration.tsx
@@ -12,7 +12,6 @@ import {
 import type {
   CrawlingFrequency,
   DataSourceType,
-  DataSourceWithAgentsUsageType,
   DepthOption,
   SubscriptionType,
   UpdateConnectorConfigurationType,
@@ -44,14 +43,12 @@ export default function WebsiteConfiguration({
   dataSources,
   dataSource,
   webCrawlerConfiguration,
-  dataSourceUsage,
 }: {
   owner: WorkspaceType;
   subscription: SubscriptionType;
   dataSources: DataSourceType[];
   webCrawlerConfiguration: WebCrawlerConfigurationType | null;
   dataSource: DataSourceType | null;
-  dataSourceUsage?: DataSourceWithAgentsUsageType;
 }) {
   const [isSaving, setIsSaving] = useState(false);
   const [isSubmitted, setIsSubmitted] = useState(false);
@@ -530,11 +527,11 @@ export default function WebsiteConfiguration({
               />
               {dataSource && (
                 <DeleteStaticDataSourceDialog
+                  owner={owner}
                   dataSource={dataSource}
                   handleDelete={handleDelete}
                   isOpen={isDeleteModalOpen}
                   onClose={() => setIsDeleteModalOpen(false)}
-                  dataSourceUsage={dataSourceUsage}
                 />
               )}
             </div>

--- a/front/components/vaults/VaultFolderModal.tsx
+++ b/front/components/vaults/VaultFolderModal.tsx
@@ -172,6 +172,7 @@ export default function VaultFolderModal({
               <>
                 <Page.Separator />
                 <DeleteStaticDataSourceDialog
+                  owner={owner}
                   dataSource={folder}
                   handleDelete={onDeleteFolder}
                   isOpen={showDeleteConfirmDialog}

--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -479,6 +479,7 @@ export const VaultResourcesList = ({
             />
             {selectedDataSourceView && (
               <DeleteStaticDataSourceDialog
+                owner={owner}
                 dataSource={selectedDataSourceView.dataSource}
                 handleDelete={onDeleteFolderOrWebsite}
                 isOpen={showDeleteConfirmDialog}

--- a/front/components/vaults/VaultWebsiteModal.tsx
+++ b/front/components/vaults/VaultWebsiteModal.tsx
@@ -619,6 +619,7 @@ export default function VaultWebsiteModal({
                     />
                     {dataSourceView && (
                       <DeleteStaticDataSourceDialog
+                        owner={owner}
                         dataSource={dataSourceView.dataSource}
                         handleDelete={handleDelete}
                         isOpen={isDeleteModalOpen}

--- a/front/lib/swr/data_sources.ts
+++ b/front/lib/swr/data_sources.ts
@@ -7,6 +7,7 @@ import type { GetDataSourcesResponseBody } from "@app/pages/api/w/[wId]/data_sou
 import type { GetDocumentsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[dsId]/documents";
 import type { ListTablesResponseBody } from "@app/pages/api/w/[wId]/data_sources/[dsId]/tables";
 import type { GetTableResponseBody } from "@app/pages/api/w/[wId]/data_sources/[dsId]/tables/[tId]";
+import type { GetDataSourceUsageResponseBody } from "@app/pages/api/w/[wId]/data_sources/[dsId]/usage";
 
 export function useDataSources(
   owner: LightWorkspaceType,
@@ -98,5 +99,26 @@ export function useDataSourceTables({
     isTablesLoading: !error && !data,
     isTablesError: error,
     mutateTables: mutate,
+  };
+}
+
+export function useDataSourceUsage({
+  owner,
+  dataSource,
+}: {
+  owner: LightWorkspaceType;
+  dataSource: DataSourceType;
+}) {
+  const usageFetcher: Fetcher<GetDataSourceUsageResponseBody> = fetcher;
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/w/${owner.sId}/data_sources/${dataSource.sId}/usage`,
+    usageFetcher
+  );
+
+  return {
+    usage: useMemo(() => (data ? data.usage : null), [data]),
+    isUsageLoading: !error && !data,
+    isUsageError: error,
+    mutate,
   };
 }

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/usage.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/usage.ts
@@ -1,0 +1,80 @@
+import type {
+  DataSourceWithAgentsUsageType,
+  WithAPIErrorResponse,
+} from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getDataSourceUsage } from "@app/lib/api/agent_data_sources";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { apiError } from "@app/logger/withlogging";
+
+export type GetDataSourceUsageResponseBody = {
+  usage: DataSourceWithAgentsUsageType;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<GetDataSourceUsageResponseBody | void>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  const { dsId } = req.query;
+  if (typeof dsId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid path parameters.",
+      },
+    });
+  }
+
+  const dataSource = await DataSourceResource.fetchByNameOrId(
+    auth,
+    dsId,
+    // TODO(DATASOURCE_SID): Clean-up and rename parameter as [dsId]
+    { origin: "data_source_get_or_post" }
+  );
+
+  if (!dataSource) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "The data source you requested was not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const usage = await getDataSourceUsage({ auth, dataSource });
+      if (usage.isOk()) {
+        return res.status(200).json({
+          usage: usage.value,
+        });
+      } else {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to get data source usage.",
+          },
+        });
+      }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/w/[wId]/builder/data-sources/[dsId]/edit-public-url.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[dsId]/edit-public-url.tsx
@@ -1,6 +1,5 @@
 import type {
   DataSourceType,
-  DataSourceWithAgentsUsageType,
   SubscriptionType,
   WebCrawlerConfigurationType,
   WorkspaceType,
@@ -21,7 +20,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   dataSources: DataSourceType[];
   dataSource: DataSourceType;
   webCrawlerConfiguration: WebCrawlerConfigurationType;
-  dataSourceUsage: DataSourceWithAgentsUsageType;
 }>(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
   const subscription = auth.getNonNullableSubscription();
@@ -62,12 +60,10 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
-  const [connectorRes, dataSourceUsageRes] = await Promise.all([
-    new ConnectorsAPI(config.getConnectorsAPIConfig(), logger).getConnector(
-      dataSource.connectorId
-    ),
-    dataSource.getUsagesByAgents(auth),
-  ]);
+  const connectorRes = await new ConnectorsAPI(
+    config.getConnectorsAPIConfig(),
+    logger
+  ).getConnector(dataSource.connectorId);
 
   if (connectorRes.isErr()) {
     throw new Error(connectorRes.error.message);
@@ -81,9 +77,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       dataSource: dataSource.toJSON(),
       webCrawlerConfiguration: connectorRes.value
         .configuration as WebCrawlerConfigurationType,
-      dataSourceUsage: dataSourceUsageRes.isOk()
-        ? dataSourceUsageRes.value
-        : { count: 0, agentNames: [] },
     },
   };
 });
@@ -94,7 +87,6 @@ export default function DataSourceNew({
   dataSources,
   dataSource,
   webCrawlerConfiguration,
-  dataSourceUsage,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   return (
     <WebsiteConfiguration
@@ -103,7 +95,6 @@ export default function DataSourceNew({
       dataSources={dataSources}
       webCrawlerConfiguration={webCrawlerConfiguration}
       dataSource={dataSource}
-      dataSourceUsage={dataSourceUsage}
     />
   );
 }

--- a/front/pages/w/[wId]/builder/data-sources/[dsId]/settings.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[dsId]/settings.tsx
@@ -2,7 +2,6 @@ import { Button, TrashIcon } from "@dust-tt/sparkle";
 import type {
   APIError,
   DataSourceType,
-  DataSourceWithAgentsUsageType,
   SubscriptionType,
   WorkspaceType,
 } from "@dust-tt/types";
@@ -26,7 +25,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   subscription: SubscriptionType;
   dataSource: DataSourceType;
   fetchConnectorError?: boolean;
-  dataSourceUsage: DataSourceWithAgentsUsageType;
 }>(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
   const subscription = auth.getNonNullableSubscription();
@@ -58,16 +56,11 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
-  const dataSourceUsageRes = await dataSource.getUsagesByAgents(auth);
-
   return {
     props: {
       owner,
       subscription,
       dataSource: dataSource.toJSON(),
-      dataSourceUsage: dataSourceUsageRes.isOk()
-        ? dataSourceUsageRes.value
-        : { count: 0, agentNames: [] },
     },
   };
 });
@@ -76,7 +69,6 @@ export default function DataSourceSettings({
   owner,
   subscription,
   dataSource,
-  dataSourceUsage,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
 
@@ -118,7 +110,6 @@ export default function DataSourceSettings({
         description: string;
         assistantDefaultSelected: boolean;
       }) => handleUpdate(settings)}
-      dataSourceUsage={dataSourceUsage}
     />
   );
 }
@@ -128,7 +119,6 @@ function StandardDataSourceSettings({
   subscription,
   dataSource,
   handleUpdate,
-  dataSourceUsage,
 }: {
   owner: WorkspaceType;
   subscription: SubscriptionType;
@@ -137,7 +127,6 @@ function StandardDataSourceSettings({
     description: string;
     assistantDefaultSelected: boolean;
   }) => Promise<void>;
-  dataSourceUsage: DataSourceWithAgentsUsageType;
 }) {
   const { mutate } = useSWRConfig();
 
@@ -290,11 +279,11 @@ function StandardDataSourceSettings({
               }}
             />
             <DeleteStaticDataSourceDialog
+              owner={owner}
               dataSource={dataSource}
               handleDelete={handleDelete}
               isOpen={isDeleteModalOpen}
               onClose={() => setIsDeleteModalOpen(false)}
-              dataSourceUsage={dataSourceUsage}
             />
           </div>
         </div>


### PR DESCRIPTION
## Description

Fix hard to see situations (because of optional arg) when usage was not available to the delete popup by adding an endpoint to get usage, an hook, and use it directly in the component.
This will even make it easier if we need to introduce usages computation caching for list views later.

## Risk

None

## Deploy Plan

Deploy `front`