### PR TITLE
[front] - fix(connection-management): empty managed data source

### DIFF
--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -14,7 +14,6 @@ import type {
   ConnectorType,
   DataSourceType,
   LightWorkspaceType,
-  PlanType,
   UpdateConnectorRequestBody,
   WorkspaceType,
 } from "@dust-tt/types";
@@ -29,6 +28,7 @@ import { setupConnection } from "@app/components/vaults/AddConnectionMenu";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { getDataSourceName } from "@app/lib/data_sources";
 import { useUser } from "@app/lib/swr/user";
+import { useWorkspaceActiveSubscription } from "@app/lib/swr/workspaces";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 
 import { PermissionTree } from "./ConnectorPermissionsTree";
@@ -327,7 +327,6 @@ export function ConnectorPermissionsModal({
   dataSource,
   isOpen,
   onClose,
-  plan,
   readOnly,
   isAdmin,
   onManageButtonClick,
@@ -337,7 +336,6 @@ export function ConnectorPermissionsModal({
   dataSource: DataSourceType;
   isOpen: boolean;
   onClose: (save: boolean) => void;
-  plan: PlanType;
   readOnly: boolean;
   isAdmin: boolean;
   onManageButtonClick?: () => void;
@@ -349,6 +347,10 @@ export function ConnectorPermissionsModal({
   const [modalToShow, setModalToShow] = useState<
     "edition" | "selection" | null
   >(null);
+  const { activeSubscription } = useWorkspaceActiveSubscription({
+    workspaceId: owner.sId,
+  });
+  const plan = activeSubscription ? activeSubscription.plan : null;
 
   const [saving, setSaving] = useState(false);
   const sendNotification = useContext(SendNotificationsContext);
@@ -477,7 +479,7 @@ export function ConnectorPermissionsModal({
               }}
             />
           </div>
-          {OptionsComponent && (
+          {OptionsComponent && plan && (
             <>
               <div className="p-1 text-xl font-bold">Connector options</div>
 

--- a/front/components/DataSourceViewResourceSelectorTree.tsx
+++ b/front/components/DataSourceViewResourceSelectorTree.tsx
@@ -241,7 +241,7 @@ function DataSourceViewResourceSelectorChildren({
                   label="Add Data"
                   icon={PlusIcon}
                   onClick={() => {
-                    setShowConnectorPermissionsModal(true)
+                    setShowConnectorPermissionsModal(true);
                   }}
                 />
                 <ConnectorPermissionsModal

--- a/front/components/DataSourceViewResourceSelectorTree.tsx
+++ b/front/components/DataSourceViewResourceSelectorTree.tsx
@@ -22,7 +22,6 @@ import { InfiniteScroll } from "@app/components/InfiniteScroll";
 import { getVisualForContentNode } from "@app/lib/content_nodes";
 import { useConnector } from "@app/lib/swr/connectors";
 import { useDataSourceViewContentNodesWithInfiniteScroll } from "@app/lib/swr/data_source_views";
-import { useWorkspaceActiveSubscription } from "@app/lib/swr/workspaces";
 import { classNames } from "@app/lib/utils";
 
 interface DataSourceViewResourceSelectorTreeBaseProps {
@@ -107,9 +106,6 @@ function DataSourceViewResourceSelectorChildren({
   const { connector } = useConnector({
     workspaceId: owner.sId,
     dataSourceId: dataSourceView.dataSource.sId,
-  });
-  const { activeSubscription } = useWorkspaceActiveSubscription({
-    workspaceId: owner.sId,
   });
 
   useEffect(() => {
@@ -235,7 +231,7 @@ function DataSourceViewResourceSelectorChildren({
         {dataSourceView.category === "managed" && nodes.length === 0 && (
           <div className="flex w-full flex-col items-center gap-2 rounded-lg border bg-structure-50 py-2">
             <span className="text-element-700">The Vault is empty!</span>
-            {owner.role === "admin" && connector && activeSubscription ? (
+            {owner.role === "admin" && connector ? (
               <>
                 <Button
                   label="Add Data"
@@ -252,7 +248,6 @@ function DataSourceViewResourceSelectorChildren({
                   onClose={() => {
                     setShowConnectorPermissionsModal(false);
                   }}
-                  plan={activeSubscription.plan}
                   readOnly={false}
                   isAdmin={owner.role === "admin"}
                 />

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -42,7 +42,9 @@ export const getAccessibleSourcesAndApps = async (auth: Authenticator) => {
   ).filter((vault) => !vault.isSystem() && vault.canRead(auth));
 
   const [dsViews, allDustApps] = await Promise.all([
-    DataSourceViewResource.listByVaults(auth, accessibleVaults),
+    DataSourceViewResource.listByVaults(auth, accessibleVaults, {
+      includeEditedBy: true,
+    }),
     AppResource.listByWorkspace(auth),
   ]);
 

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -10,8 +10,8 @@ import type {
   DataSourceViewSelectionConfiguration,
   DataSourceViewSelectionConfigurations,
   DataSourceViewType,
-  LightWorkspaceType,
   VaultType,
+  WorkspaceType,
 } from "@dust-tt/types";
 import { defaultSelectionConfiguration } from "@dust-tt/types";
 import _ from "lodash";
@@ -39,7 +39,7 @@ const MIN_DATA_SOURCES_PER_KIND_TO_GROUP = 3;
 const ONLY_ONE_VAULT_PER_SELECTION = true;
 
 interface DataSourceViewsSelectorProps {
-  owner: LightWorkspaceType;
+  owner: WorkspaceType;
   dataSourceViews: DataSourceViewType[];
   allowedVaults?: VaultType[];
   selectionConfigurations: DataSourceViewSelectionConfigurations;
@@ -218,7 +218,7 @@ export function DataSourceViewsSelector({
 }
 
 interface DataSourceViewSelectorProps {
-  owner: LightWorkspaceType;
+  owner: WorkspaceType;
   selectionConfiguration: DataSourceViewSelectionConfiguration;
   setSelectionConfigurations: Dispatch<
     SetStateAction<DataSourceViewSelectionConfigurations>

--- a/front/components/vaults/VaultDataSourceViewContentList.tsx
+++ b/front/components/vaults/VaultDataSourceViewContentList.tsx
@@ -426,7 +426,6 @@ export const VaultDataSourceViewContentList = ({
                     void mutateContentNodes();
                   }
                 }}
-                plan={plan}
                 readOnly={false}
                 isAdmin={isAdmin}
                 onManageButtonClick={() => {

--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -518,7 +518,6 @@ export const VaultResourcesList = ({
             onClose={() => {
               setShowConnectorPermissionsModal(false);
             }}
-            plan={plan}
             readOnly={false}
             isAdmin={isAdmin}
           />

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -92,7 +92,7 @@ export function useWorkspaceActiveSubscription({
     const activeSubscriptions = data.subscriptions.filter(
       (sub) => sub.status === "active"
     );
-    return activeSubscriptions[0] || null;
+    return activeSubscriptions.length ? activeSubscriptions[0] : null;
   }, [data]);
 
   return {

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -71,3 +71,33 @@ export function useWorkspaceEnterpriseConnection({
     mutateEnterpriseConnection: mutate,
   };
 }
+
+export function useWorkspaceActiveSubscription({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const workspaceSubscriptionsFetcher: Fetcher<GetSubscriptionsResponseBody> =
+    fetcher;
+
+  const { data, error } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/subscriptions`,
+    workspaceSubscriptionsFetcher
+  );
+
+  const activeSubscription = useMemo(() => {
+    if (!data) {
+      return null;
+    }
+    const activeSubscriptions = data.subscriptions.filter(
+      (sub) => sub.status === "active"
+    );
+    return activeSubscriptions[0] || null;
+  }, [data]);
+
+  return {
+    activeSubscription,
+    isActiveSubscriptionLoading: !error && !data,
+    isActiveSubscriptionError: error,
+  };
+}

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "front",
       "dependencies": {
         "@amplitude/ampli": "^1.35.0",
         "@amplitude/analytics-browser": "^2.5.2",

--- a/front/pages/w/[wId]/builder/data-sources/[dsId]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[dsId]/index.tsx
@@ -1260,7 +1260,6 @@ function ManagedDataSourceView({
           dataSource={dataSource}
           isOpen={showPermissionModal}
           onClose={() => setShowPermissionModal(false)}
-          plan={plan}
           readOnly={false}
           isAdmin={isAdmin}
         />

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -334,7 +334,6 @@ export default function DataSourcesView({
             }}
             isAdmin={isAdmin}
             readOnly={readOnly}
-            plan={plan}
           />
         )}
       </Page.Vertical>


### PR DESCRIPTION
## Description

This PR addresses the issue of empty managed data sources in the `DataSourceViewResourceSelectorTree` component. It implements an improved UI for displaying an empty state when a managed data source has no content, and provides options for administrators to add data or for non-admin users to request access.

**References:**
- https://github.com/dust-tt/tasks/issues/1340

## Risk

Low, mainly UI changes

## Deploy Plan

Deploy `front`