### PR TITLE
Fix Website without connector panic log + Bring back sync chip for Websites

### DIFF
--- a/front/pages/w/[wId]/builder/data-sources/[dsId]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[dsId]/index.tsx
@@ -109,6 +109,21 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     );
     if (connectorRes.isOk()) {
       connector = connectorRes.value;
+    } else {
+      const error = connectorRes.error;
+      if (error.type === "connector_not_found") {
+        logger.error(
+          {
+            panic: true, // This is a panic because we want to fix the data. This should never happen.
+            workspaceId: owner.sId,
+            connectorId: dataSource.connectorId,
+            dataSourceId: dataSource.sId,
+            connectorProvider: dataSource.connectorProvider,
+          },
+          "Connector not found while we still have a data source."
+        );
+      }
+      throw error;
     }
   }
 


### PR DESCRIPTION
## Description

It's unclear to me why we were loading all connectors from the websites list. 
I removed it and removed the panic log checking for dangling websites, that was wrongly raising when we were deleting a website. 

Instead, I removed the panic log on the detail view. 
If there's an error when trying to fetch the connector, then we panic if not found, and raise a raw error: 


<img width="1351" alt="Screenshot 2024-09-19 at 13 34 11" src="https://github.com/user-attachments/assets/9d6a89f1-cd46-4cce-9f66-ecb3f9c63983">


It should never happen but if it does we want the user to get an error. 


## Risk

Can be rolled back. 

## Deploy Plan

Deploy front

