### PR TITLE
[front] fix: show spinner in infinite scroll while revalidating

### DIFF
--- a/front/components/InfiniteScroll.tsx
+++ b/front/components/InfiniteScroll.tsx
@@ -26,8 +26,8 @@ export const InfiniteScroll = ({
 
   return (
     <>
-      {hasMore && !isValidating && <div ref={ref}>{children}</div>}
-      {isValidating && !isLoading && <div>load</div>}
+      {hasMore && !isValidating && <div ref={ref} />}
+      {isValidating && !isLoading && children}
     </>
   );
 };


### PR DESCRIPTION
## Description

Show spinner if isValidating && !isLoading (when loading more entries)

Fixes https://github.com/dust-tt/tasks/issues/1343

## Risk

## Deploy Plan

deploy front
