### PR TITLE
More use of dataSource.sId

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -252,11 +252,6 @@ export default function AssistantBuilder({
       builderState.instructions.trim().length / 4 >
         modelConfig.contextSize * 0.9
     ) {
-      console.log(
-        `csize ${builderState.instructions.trim().length / 4} and limit ${
-          modelConfig.contextSize * 0.9
-        }`
-      );
       localInstructionError = `Instructions may exceed context size window.`;
     }
 

--- a/front/components/data_source/DocumentOrTableUploadOrEditModal.tsx
+++ b/front/components/data_source/DocumentOrTableUploadOrEditModal.tsx
@@ -144,14 +144,7 @@ export function DocumentOrTableUploadOrEditModal({
         sourceUrl: document.source_url ?? "",
       }));
     }
-  }, [
-    isTable,
-    initialId,
-    table,
-    owner.sId,
-    dataSourceView.dataSource.name,
-    document,
-  ]);
+  }, [isTable, initialId, table, owner.sId, document]);
 
   const isLoading = isTableLoading || isDocumentLoading;
   const isError = isDocumentError || isTableError;
@@ -189,7 +182,7 @@ export function DocumentOrTableUploadOrEditModal({
         throw new Error("File too large");
       }
 
-      const base = `/api/w/${owner.sId}/vaults/${dataSourceView.vaultId}/data_sources/${dataSourceView.dataSource.name}/tables`;
+      const base = `/api/w/${owner.sId}/vaults/${dataSourceView.vaultId}/data_sources/${dataSourceView.dataSource.sId}/tables`;
       const endpoint = initialId ? `${base}/${initialId}` : base;
 
       const body = JSON.stringify({
@@ -233,7 +226,7 @@ export function DocumentOrTableUploadOrEditModal({
   const handleDocumentUpload = async (document: TableOrDocument) => {
     setUploading(true);
     try {
-      const base = `/api/w/${owner.sId}/vaults/${dataSourceView.vaultId}/data_sources/${dataSourceView.dataSource.name}/documents`;
+      const base = `/api/w/${owner.sId}/vaults/${dataSourceView.vaultId}/data_sources/${dataSourceView.dataSource.sId}/documents`;
       const endpoint = initialId
         ? `${base}/${encodeURIComponent(document.name)}`
         : base;

--- a/front/components/data_source/MultipleDocumentsUpload.tsx
+++ b/front/components/data_source/MultipleDocumentsUpload.tsx
@@ -70,7 +70,7 @@ export const MultipleDocumentsUpload = ({
     try {
       const res = await fetch(
         `/api/w/${owner.sId}/vaults/${dataSourceView.vaultId}/data_sources/${
-          dataSourceView.dataSource.name
+          dataSourceView.dataSource.sId
         }/documents`,
         {
           method: "POST",

--- a/front/lib/documents_post_process_hooks/hooks/data_source_helpers.ts
+++ b/front/lib/documents_post_process_hooks/hooks/data_source_helpers.ts
@@ -9,20 +9,17 @@ import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import logger from "@app/logger/logger";
 
 export async function getPreviousDocumentVersion({
-  auth,
-  dataSourceName,
+  dataSource,
   documentId,
   documentHash,
 }: {
-  auth: Authenticator;
-  dataSourceName: string;
+  dataSource: DataSourceResource;
   documentId: string;
   documentHash?: string | null; // if null, will get the penultimate version
 }): Promise<{
   hash: string;
   created: number;
 } | null> {
-  const dataSource = await getDatasource(auth, dataSourceName);
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
   const versions = await coreAPI.getDataSourceDocumentVersions({
     projectId: dataSource.dustAPIProjectId,
@@ -42,22 +39,18 @@ export async function getPreviousDocumentVersion({
 }
 
 export async function getDiffBetweenDocumentVersions({
-  auth,
-  dataSourceName,
+  dataSource,
   documentId,
   hash1,
   hash2,
 }: {
-  auth: Authenticator;
-  dataSourceName: string;
+  dataSource: DataSourceResource;
   documentId: string;
   // if null, will diff from an empty string
   hash1?: string | null;
   // if null, will get the latest version
   hash2?: string | null;
 }): Promise<Diff[]> {
-  const dataSource = await getDatasource(auth, dataSourceName);
-
   async function getDocumentText(hash?: string | null): Promise<string> {
     const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
     const res = await coreAPI.getDataSourceDocument({
@@ -81,21 +74,18 @@ export async function getDiffBetweenDocumentVersions({
 }
 
 // returns the diff between tthe version right before the provided hash
-// and the current version of the document
+// and the current version of he document
 export async function getDocumentDiff({
-  auth,
-  dataSourceName,
+  dataSource,
   documentId,
   hash,
 }: {
-  auth: Authenticator;
-  dataSourceName: string;
+  dataSource: DataSourceResource;
   documentId: string;
   hash: string;
 }): Promise<Diff[]> {
   const previousVersion = await getPreviousDocumentVersion({
-    auth,
-    dataSourceName,
+    dataSource,
     documentId,
     documentHash: hash,
   });
@@ -104,8 +94,7 @@ export async function getDocumentDiff({
   const hash1 = previousVersion ? previousVersion.hash : null;
 
   return getDiffBetweenDocumentVersions({
-    auth,
-    dataSourceName,
+    dataSource,
     documentId,
     hash1,
     hash2: null, // compare against the latest version

--- a/front/lib/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
+++ b/front/lib/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
@@ -178,8 +178,7 @@ export async function documentTrackerSuggestChangesOnUpsert({
     return;
   }
   const documentDiff = await getDocumentDiff({
-    auth,
-    dataSourceName: dataSource.name,
+    dataSource,
     documentId,
     hash: documentHash,
   });


### PR DESCRIPTION
## Description

Move to using more dataSource.sId in place of dataSource.name. Cleans up a bit doc tracker while doing so.

## Risk

Low

## Deploy Plan

- deploy `front`