### PR TITLE
fix: allow creating connections from global vault

### DIFF
--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -275,7 +275,7 @@ export default function DataSourcesView({
             </div>
           )}
 
-          {isAdmin && integrations.length > 0 && (
+          {isAdmin && integrations.length && (
             <AddConnectionMenu
               owner={owner}
               plan={plan}

--- a/front/pages/w/[wId]/vaults/[vaultId]/categories/[category]/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/categories/[category]/index.tsx
@@ -63,10 +63,9 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
   const isBuilder = auth.isBuilder();
   const canWriteInVault = vault.canWrite(auth);
 
-  const isSystemVault = vault.kind === "system";
   const integrations: DataSourceIntegration[] = [];
 
-  if (isSystemVault) {
+  if (["system", "global"].includes(vault.kind)) {
     let setupWithSuffix: {
       connector: ConnectorProvider;
       suffix: string;


### PR DESCRIPTION
## Description

With the data vaults feature flag, we don't render the system vault. Because of that, an admin cannot create a new connection (since this is only available in the system vault).

This commit fixes it by allowing creating connections from the global vault.

fixes https://github.com/dust-tt/tasks/issues/1348

## Risk

N/A 

## Deploy Plan

N/A