### PR TITLE
Use proper image prefix when building

### DIFF
--- a/.github/workflows/deploy-and-test-front-qa.yml
+++ b/.github/workflows/deploy-and-test-front-qa.yml
@@ -15,6 +15,7 @@ concurrency:
 
 env:
   GCLOUD_PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
+  IMAGE_NAME: front-qa
 
 jobs:
   build-and-deploy:
@@ -50,12 +51,12 @@ jobs:
       - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build.sh --image-name=front-qa --dockerfile-path=./front/Dockerfile --working-dir=./
+          ./k8s/cloud-build.sh --image-name=$IMAGE_NAME --dockerfile-path=./front/Dockerfile --working-dir=./
 
       - name: Deploy the image on Kubernetes
         run: |
           chmod +x ./k8s/deploy-image.sh
-          ./k8s/deploy-image.sh gcr.io/$GCLOUD_PROJECT_ID/front-image:${{ steps.short_sha.outputs.short_sha }} front-qa-deployment
+          ./k8s/deploy-image.sh gcr.io/$GCLOUD_PROJECT_ID/$IMAGE_NAME:${{ steps.short_sha.outputs.short_sha }} front-qa-deployment
 
       - name: Wait for rollout to complete
         run: kubectl rollout status deployment/front-qa-deployment --timeout=10m

--- a/.github/workflows/deploy-and-test-front-qa.yml
+++ b/.github/workflows/deploy-and-test-front-qa.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build.sh --image-name=front --dockerfile-path=./front/Dockerfile --working-dir=./
+          ./k8s/cloud-build.sh --image-name=front-qa --dockerfile-path=./front/Dockerfile --working-dir=./
 
       - name: Deploy the image on Kubernetes
         run: |

--- a/.github/workflows/deploy-front-edge.yml
+++ b/.github/workflows/deploy-front-edge.yml
@@ -9,6 +9,7 @@ concurrency:
 
 env:
   GCLOUD_PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
+  IMAGE_NAME: front-edge
 
 jobs:
   build-and-deploy:
@@ -41,12 +42,12 @@ jobs:
       - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build.sh --image-name=front-edge --dockerfile-path=./front/Dockerfile --working-dir=./
+          ./k8s/cloud-build.sh --image-name=$IMAGE_NAME --dockerfile-path=./front/Dockerfile --working-dir=./
 
       - name: Deploy the image on Kubernetes
         run: |
           chmod +x ./k8s/deploy-image.sh
-          ./k8s/deploy-image.sh gcr.io/$GCLOUD_PROJECT_ID/front-image:${{ steps.short_sha.outputs.short_sha }} front-edge-deployment
+          ./k8s/deploy-image.sh gcr.io/$GCLOUD_PROJECT_ID/$IMAGE_NAME:${{ steps.short_sha.outputs.short_sha }} front-edge-deployment
 
       - name: Wait for rollout to complete
         run: kubectl rollout status deployment/front-edge-deployment --timeout=10m

--- a/.github/workflows/deploy-front-edge.yml
+++ b/.github/workflows/deploy-front-edge.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build.sh --image-name=front --dockerfile-path=./front/Dockerfile --working-dir=./
+          ./k8s/cloud-build.sh --image-name=front-edge --dockerfile-path=./front/Dockerfile --working-dir=./
 
       - name: Deploy the image on Kubernetes
         run: |

--- a/k8s/deployments/front-edge-deployment.yaml
+++ b/k8s/deployments/front-edge-deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: web
-          image: gcr.io/or1g1n-186209/front-image:latest
+          image: gcr.io/or1g1n-186209/front-edge-image:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 3000

--- a/k8s/deployments/front-qa-deployment.yaml
+++ b/k8s/deployments/front-qa-deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: web
-          image: gcr.io/or1g1n-186209/front-image:latest
+          image: gcr.io/or1g1n-186209/front-qa-image:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 3000


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR resolves an issue where the same prefix was used across `front-qa`, `front-edge`, and `front` deployments. When building and deploying for a specific commit, deploying `front-qa` first and then `front` would result in the `front` deployment using the public environment variables of `front-qa`.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
