### PR TITLE
fix: do not hide system vault if private vaults is disabled

### DIFF
--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -372,8 +372,7 @@ export const VaultResourcesList = ({
       }
     }
   };
-  const connectionManagementVisible =
-    isSystemVault || !owner.flags.includes("private_data_vaults_feature");
+
   return (
     <>
       <div
@@ -395,64 +394,53 @@ export const VaultResourcesList = ({
             }}
           />
         )}
-        {connectionManagementVisible && category === "managed" && (
+        {isSystemVault && category === "managed" && (
           <div className="flex items-center justify-center text-sm font-normal text-element-700">
-            {isAdmin && (
-              <AddConnectionMenu
-                owner={owner}
-                plan={plan}
-                existingDataSources={
-                  vaultDataSourceViews
-                    .filter((dsView) => isManaged(dsView.dataSource))
-                    .map(
-                      (v) => v.dataSource
-                    ) as DataSourceWithConnectorDetailsType[]
-                  // We need to filter and then cast because useVaultDataSourceViewsWithDetails can return dataSources with connectorProvider as null
-                }
-                setIsProviderLoading={(provider, isLoading) => {
-                  setIsNewConnectorLoading(isLoading);
-                  setIsLoadingByProvider((prev) => ({
-                    ...prev,
-                    [provider]: isLoading,
-                  }));
-                }}
-                onCreated={async (dataSource) => {
-                  const updateDataSourceViews =
-                    await mutateVaultDataSourceViews();
-                  if (
-                    dataSource.connectorProvider &&
-                    REDIRECT_TO_EDIT_PERMISSIONS.includes(
-                      dataSource.connectorProvider
-                    )
-                  ) {
-                    if (updateDataSourceViews) {
-                      const view = updateDataSourceViews.dataSourceViews.find(
-                        (v: DataSourceViewType) =>
-                          v.dataSource.sId === dataSource.sId
-                      );
-                      if (view) {
-                        setSelectedDataSourceView(view);
-                        setShowConnectorPermissionsModal(true);
-                      }
+            <AddConnectionMenu
+              owner={owner}
+              plan={plan}
+              existingDataSources={
+                vaultDataSourceViews
+                  .filter((dsView) => isManaged(dsView.dataSource))
+                  .map(
+                    (v) => v.dataSource
+                  ) as DataSourceWithConnectorDetailsType[]
+                // We need to filter and then cast because useVaultDataSourceViewsWithDetails can return dataSources with connectorProvider as null
+              }
+              setIsProviderLoading={(provider, isLoading) => {
+                setIsNewConnectorLoading(isLoading);
+                setIsLoadingByProvider((prev) => ({
+                  ...prev,
+                  [provider]: isLoading,
+                }));
+              }}
+              onCreated={async (dataSource) => {
+                const updateDataSourceViews =
+                  await mutateVaultDataSourceViews();
+                if (
+                  dataSource.connectorProvider &&
+                  REDIRECT_TO_EDIT_PERMISSIONS.includes(
+                    dataSource.connectorProvider
+                  )
+                ) {
+                  if (updateDataSourceViews) {
+                    const view = updateDataSourceViews.dataSourceViews.find(
+                      (v: DataSourceViewType) =>
+                        v.dataSource.sId === dataSource.sId
+                    );
+                    if (view) {
+                      setSelectedDataSourceView(view);
+                      setShowConnectorPermissionsModal(true);
                     }
                   }
-                  setIsNewConnectorLoading(false);
-                }}
-                integrations={integrations}
-              />
-            )}
-
-            {!isAdmin && (
-              <RequestDataSourceModal
-                dataSources={vaultDataSourceViews.map(
-                  (view) => view.dataSource
-                )}
-                owner={owner}
-              />
-            )}
+                }
+                setIsNewConnectorLoading(false);
+              }}
+              integrations={integrations}
+            />
           </div>
         )}
-        {!connectionManagementVisible && isManagedCategory && (
+        {!isSystemVault && isManagedCategory && (
           <EditVaultManagedDataSourcesViews
             owner={owner}
             vault={vault}

--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -39,7 +39,6 @@ import * as React from "react";
 import { ConnectorPermissionsModal } from "@app/components/ConnectorPermissionsModal";
 import ConnectorSyncingChip from "@app/components/data_source/DataSourceSyncChip";
 import { DeleteStaticDataSourceDialog } from "@app/components/data_source/DeleteStaticDataSourceDialog";
-import { RequestDataSourceModal } from "@app/components/data_source/RequestDataSourceModal";
 import type { DataSourceIntegration } from "@app/components/vaults/AddConnectionMenu";
 import { AddConnectionMenu } from "@app/components/vaults/AddConnectionMenu";
 import { EditVaultManagedDataSourcesViews } from "@app/components/vaults/EditVaultManagedDatasourcesViews";

--- a/front/components/vaults/VaultSideBarMenu.tsx
+++ b/front/components/vaults/VaultSideBarMenu.tsx
@@ -15,7 +15,6 @@ import type {
   LightWorkspaceType,
   VaultKind,
   VaultType,
-  WorkspaceType,
 } from "@dust-tt/types";
 import { assertNever, DATA_SOURCE_VIEW_CATEGORIES } from "@dust-tt/types";
 import { groupBy, sortBy, uniqBy } from "lodash";
@@ -36,7 +35,7 @@ import { getVaultIcon, getVaultName } from "@app/lib/vaults";
 
 interface VaultSideBarMenuProps {
   isPrivateVaultsEnabled: boolean;
-  owner: WorkspaceType;
+  owner: LightWorkspaceType;
   isAdmin: boolean;
   setShowVaultCreationModal: (show: boolean) => void;
 }
@@ -88,24 +87,6 @@ export default function VaultSideBarMenu({
 
   if (isVaultsAsAdminLoading || isVaultsAsUserLoading || !vaultsAsUser) {
     return <></>;
-  }
-
-  if (!owner.flags.includes("private_data_vaults_feature")) {
-    return (
-      <div className="flex h-0 min-h-full w-full overflow-y-auto">
-        <div className="flex w-full flex-col px-2 pt-4">
-          <Item.List>
-            <div>
-              {renderVaultItems(
-                vaults.filter((v) => v.kind === "global"),
-                vaultsAsUser,
-                owner
-              )}
-            </div>
-          </Item.List>
-        </div>
-      </div>
-    );
   }
 
   // Group by kind and sort.

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -4,7 +4,9 @@ export const PRODUCTION_DUST_API = "https://dust.tt";
 
 const config = {
   getClientFacingUrl: (): string => {
-    return EnvironmentConfig.getEnvVariable("DUST_CLIENT_FACING_URL");
+    return EnvironmentConfig.getEnvVariable(
+      "NEXT_PUBLIC_DUST_CLIENT_FACING_URL"
+    );
   },
   getAuth0TenantUrl: (): string => {
     return EnvironmentConfig.getEnvVariable("AUTH0_TENANT_DOMAIN_URL");

--- a/front/pages/w/[wId]/vaults/[vaultId]/categories/[category]/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/categories/[category]/index.tsx
@@ -65,7 +65,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
 
   const integrations: DataSourceIntegration[] = [];
 
-  if (["system", "global"].includes(vault.kind)) {
+  if (vault.kind === "system") {
     let setupWithSuffix: {
       connector: ConnectorProvider;
       suffix: string;


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/dust/issues/7534

maintaining the 2 code paths is tedious and error prone (we had 2 separate bugs preventing proper connection management when vaults are enabled but private vaults are disabled)

this removes the logic that hides the system vault.

## Risk

N/A

## Deploy Plan

N/A