### PR TITLE
[front] Fixed table upsert

### DIFF
--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -9,7 +9,6 @@ import type {
 import {
   CoreAPI,
   Err,
-  getSanitizedHeaders,
   getSmallWhitelistedModel,
   guessDelimiter,
   Ok,

--- a/types/src/shared/utils/structured_data.ts
+++ b/types/src/shared/utils/structured_data.ts
@@ -1,8 +1,6 @@
 import { parse } from "csv-parse";
 import { stringify } from "csv-stringify";
 
-import { slugify } from "./string_utils";
-
 export class InvalidStructuredDataHeaderError extends Error {}
 class ParsingCsvError extends Error {}
 

--- a/types/src/shared/utils/structured_data.ts
+++ b/types/src/shared/utils/structured_data.ts
@@ -23,9 +23,8 @@ export function getSanitizedHeaders(rawHeaders: string[]) {
       }
 
       if (!conflictResolved) {
-        throw new InvalidStructuredDataHeaderError(
-          `Failed to generate unique slugified name for header "${curr}" after multiple attempts.`
-        );
+        // Ignore this header, push empty value
+        acc.push("");
       }
     }
     return acc;

--- a/types/src/shared/utils/structured_data.ts
+++ b/types/src/shared/utils/structured_data.ts
@@ -6,31 +6,6 @@ import { slugify } from "./string_utils";
 export class InvalidStructuredDataHeaderError extends Error {}
 class ParsingCsvError extends Error {}
 
-export function getSanitizedHeaders(rawHeaders: string[]) {
-  return rawHeaders.reduce<string[]>((acc, curr) => {
-    const slugifiedName = slugify(curr);
-
-    if (!acc.includes(slugifiedName) || !slugifiedName.length) {
-      acc.push(slugifiedName);
-    } else {
-      let conflictResolved = false;
-      for (let i = 2; i < 64; i++) {
-        if (!acc.includes(slugify(`${slugifiedName}_${i}`))) {
-          acc.push(slugify(`${slugifiedName}_${i}`));
-          conflictResolved = true;
-          break;
-        }
-      }
-
-      if (!conflictResolved) {
-        // Ignore this header, push empty value
-        acc.push("");
-      }
-    }
-    return acc;
-  }, []);
-}
-
 export async function guessDelimiter(csv: string): Promise<string | undefined> {
   // Detect the delimiter: try to parse the first 2 lines with different delimiters,
   // keep the one that works for both lines and has the most columns.


### PR DESCRIPTION
## Description

If a table has a lot of identical headers, our sanitizedHeader method crashes after 64 repetitions. Fixed by ignoring the repeetition after 64 but not crash - columns will be excluded from the table.

Moved the method getSanitizedHeaders into tables as it's used only there and behaviour changed (can return empty header to be ignored)

## Risk


## Deploy Plan

deploy front
