### PR TITLE
Fix: show manage button when no private vaults, show sync status for websites

### DIFF
--- a/front/lib/vaults.ts
+++ b/front/lib/vaults.ts
@@ -1,5 +1,5 @@
 import { CompanyIcon, LockIcon, PlanetIcon } from "@dust-tt/sparkle";
-import type { VaultType } from "@dust-tt/types";
+import type { VaultType, WorkspaceType } from "@dust-tt/types";
 import type React from "react";
 
 export function getVaultIcon(
@@ -17,3 +17,11 @@ export function getVaultIcon(
 export const getVaultName = (vault: VaultType) => {
   return vault.kind === "global" ? "Company Data" : vault.name;
 };
+
+export const showConnexionsManagement = (
+  owner: WorkspaceType,
+  vault: VaultType
+) =>
+  vault.kind === "system" ||
+  (vault.kind === "global" &&
+    !owner.flags.includes("private_data_vaults_feature"));

--- a/front/pages/w/[wId]/vaults/[vaultId]/categories/[category]/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/categories/[category]/index.tsx
@@ -27,6 +27,7 @@ import {
 import { isManaged } from "@app/lib/data_sources";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { VaultResource } from "@app/lib/resources/vault_resource";
+import { showConnexionsManagement } from "@app/lib/vaults";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<
   VaultLayoutProps & {
@@ -65,7 +66,8 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
 
   const integrations: DataSourceIntegration[] = [];
 
-  if (["system", "global"].includes(vault.kind)) {
+  // We need to fetch the integrations if we are showing the connection management
+  if (showConnexionsManagement(owner, vault.toJSON())) {
     let setupWithSuffix: {
       connector: ConnectorProvider;
       suffix: string;


### PR DESCRIPTION
## Description

Fix 2 bugs:
- Show manage / view buttons for managed datasources correctly depending on the feature flags
- Show last sync status for website.

Tested locally with: flag on|off X admin|builder|user

## Risk

None

## Deploy Plan

Deploy `front`
