### PR TITLE
Add poke endpoint for data source view content nodes

### DIFF
--- a/front/components/DataSourceViewResourceSelectorTree.tsx
+++ b/front/components/DataSourceViewResourceSelectorTree.tsx
@@ -21,7 +21,7 @@ import DataSourceViewDocumentModal from "@app/components/DataSourceViewDocumentM
 import { InfiniteScroll } from "@app/components/InfiniteScroll";
 import { getVisualForContentNode } from "@app/lib/content_nodes";
 import { useConnector } from "@app/lib/swr/connectors";
-import { useDataSourceViewContentNodesWithInfiniteScroll } from "@app/lib/swr/data_source_views";
+import type { useDataSourceViewContentNodesWithInfiniteScroll } from "@app/lib/swr/data_source_views";
 import { classNames } from "@app/lib/utils";
 
 interface DataSourceViewResourceSelectorTreeBaseProps {
@@ -37,6 +37,7 @@ interface DataSourceViewResourceSelectorTreeBaseProps {
   selectedParents?: string[];
   selectedResourceIds: string[];
   showExpand: boolean;
+  useDataSourceViewContentNodes: typeof useDataSourceViewContentNodesWithInfiniteScroll;
   viewType?: ContentNodesViewType;
 }
 
@@ -49,6 +50,7 @@ export default function DataSourceViewResourceSelectorTree({
   selectedParents = [],
   selectedResourceIds,
   onSelectChange,
+  useDataSourceViewContentNodes,
   viewType = "documents",
 }: DataSourceViewResourceSelectorTreeBaseProps) {
   return (
@@ -65,6 +67,7 @@ export default function DataSourceViewResourceSelectorTree({
         onSelectChange={(resource, parents, selected) => {
           onSelectChange(resource, parents, selected);
         }}
+        useDataSourceViewContentNodes={useDataSourceViewContentNodes}
         viewType={viewType}
       />
     </div>
@@ -89,6 +92,7 @@ function DataSourceViewResourceSelectorChildren({
   selectedParents,
   selectedResourceIds,
   showExpand,
+  useDataSourceViewContentNodes,
   viewType = "documents",
 }: DataSourceResourceSelectorChildrenProps) {
   const {
@@ -98,7 +102,7 @@ function DataSourceViewResourceSelectorChildren({
     nextPage,
     hasMore,
     isNodesValidating,
-  } = useDataSourceViewContentNodesWithInfiniteScroll({
+  } = useDataSourceViewContentNodes({
     dataSourceView: dataSourceView,
     owner,
     parentId,
@@ -110,6 +114,7 @@ function DataSourceViewResourceSelectorChildren({
   const { connector } = useConnector({
     workspaceId: owner.sId,
     dataSourceId: dataSourceView.dataSource.sId,
+    disabled: readonly,
   });
 
   useEffect(() => {
@@ -196,6 +201,7 @@ function DataSourceViewResourceSelectorChildren({
                   readonly={readonly}
                   parents={[...parents, r.internalId]}
                   parentIsSelected={parentIsSelected || isSelected}
+                  useDataSourceViewContentNodes={useDataSourceViewContentNodes}
                   viewType={viewType}
                 />
               )}

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -33,6 +33,7 @@ import {
   isManaged,
   isWebsite,
 } from "@app/lib/data_sources";
+import { useDataSourceViewContentNodesWithInfiniteScroll } from "@app/lib/swr/data_source_views";
 
 const MIN_TOTAL_DATA_SOURCES_TO_GROUP = 12;
 const MIN_DATA_SOURCES_PER_KIND_TO_GROUP = 3;
@@ -224,6 +225,7 @@ interface DataSourceViewSelectorProps {
   setSelectionConfigurations: Dispatch<
     SetStateAction<DataSourceViewSelectionConfigurations>
   >;
+  useDataSourceViewContentNodes?: typeof useDataSourceViewContentNodesWithInfiniteScroll;
   viewType: ContentNodesViewType;
 }
 
@@ -232,6 +234,7 @@ export function DataSourceViewSelector({
   readonly = false,
   selectionConfiguration,
   setSelectionConfigurations,
+  useDataSourceViewContentNodes = useDataSourceViewContentNodesWithInfiniteScroll,
   viewType,
 }: DataSourceViewSelectorProps) {
   const dataSourceView = selectionConfiguration.dataSourceView;
@@ -405,6 +408,7 @@ export function DataSourceViewSelector({
         selectedParents={selectedParents}
         selectedResourceIds={internalIds}
         showExpand={config?.isNested ?? true}
+        useDataSourceViewContentNodes={useDataSourceViewContentNodes}
         viewType={viewType}
       />
     </Tree.Item>

--- a/front/lib/swr/connectors.ts
+++ b/front/lib/swr/connectors.ts
@@ -74,11 +74,13 @@ export function useConnectorConfig({
 }
 
 export function useConnector({
-  workspaceId,
   dataSourceId,
+  disabled,
+  workspaceId,
 }: {
-  workspaceId: string;
   dataSourceId: string;
+  disabled?: boolean;
+  workspaceId: string;
 }) {
   const configFetcher: Fetcher<GetConnectorResponseBody> = fetcher;
 
@@ -105,6 +107,7 @@ export function useConnector({
 
       return 0;
     },
+    disabled,
   });
 
   return {

--- a/front/pages/api/poke/workspaces/[wId]/data_source_views/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_source_views/index.ts
@@ -16,10 +16,18 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<PokeListDataSourceViews>>,
   session: SessionWithUser
 ): Promise<void> {
-  const auth = await Authenticator.fromSuperUserSession(
-    session,
-    req.query.wId as string
-  );
+  const { wId } = req.query;
+  if (typeof wId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace you're trying to modify was not found.",
+      },
+    });
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
 
   const owner = auth.workspace();
 

--- a/front/pages/api/poke/workspaces/[wId]/vaults/[vId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/poke/workspaces/[wId]/vaults/[vId]/data_source_views/[dsvId]/content-nodes.ts
@@ -1,0 +1,164 @@
+import type {
+  DataSourceViewContentNode,
+  WithAPIErrorResponse,
+} from "@dust-tt/types";
+import { ContentNodesViewTypeCodec, removeNulls } from "@dust-tt/types";
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getContentNodesForDataSourceView } from "@app/lib/api/data_source_view";
+import { getOffsetPaginationParams } from "@app/lib/api/pagination";
+import { withSessionAuthentication } from "@app/lib/api/wrappers";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { apiError } from "@app/logger/withlogging";
+
+const DEFAULT_LIMIT = 500;
+
+const GetContentNodesOrChildrenRequestBody = t.type({
+  internalIds: t.union([t.array(t.union([t.string, t.null])), t.undefined]),
+  parentId: t.union([t.string, t.undefined]),
+  viewType: ContentNodesViewTypeCodec,
+});
+
+export type PokeGetDataSourceViewContentNodes = {
+  nodes: DataSourceViewContentNode[];
+  total: number;
+};
+
+// This endpoints serves two purposes:
+// 1. Fetch content nodes for a given data source view.
+// 2. Fetch children of a given content node.
+// It always apply the data source view filter to the content nodes.
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PokeGetDataSourceViewContentNodes>>,
+  session: SessionWithUser
+): Promise<void> {
+  const { wId } = req.query;
+  if (typeof wId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace you're trying to modify was not found.",
+      },
+    });
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
+
+  const owner = auth.workspace();
+  if (!owner || !auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_view_not_found",
+        message: "Could not find the data source view.",
+      },
+    });
+  }
+
+  const { dsvId, vId } = req.query;
+  if (typeof dsvId !== "string" || typeof vId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid path parameters.",
+      },
+    });
+  }
+
+  const dataSourceView = await DataSourceViewResource.fetchById(auth, dsvId);
+
+  if (
+    !dataSourceView ||
+    vId !== dataSourceView.vault.sId ||
+    !dataSourceView.canList(auth)
+  ) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_view_not_found",
+        message: "The data source view you requested was not found.",
+      },
+    });
+  }
+
+  if (req.method !== "POST") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, POST is expected.",
+      },
+    });
+  }
+
+  const bodyValidation = GetContentNodesOrChildrenRequestBody.decode(req.body);
+  if (isLeft(bodyValidation)) {
+    const pathError = reporter.formatValidationErrors(bodyValidation.left);
+
+    return apiError(req, res, {
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid request body: ${pathError}`,
+      },
+      status_code: 400,
+    });
+  }
+
+  const { internalIds, parentId, viewType } = bodyValidation.right;
+
+  if (parentId && internalIds) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Cannot fetch with parentId and internalIds at the same time.",
+      },
+    });
+  }
+
+  const paginationRes = getOffsetPaginationParams(req, {
+    defaultLimit: DEFAULT_LIMIT,
+    defaultOffset: 0,
+  });
+  if (paginationRes.isErr()) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_pagination_parameters",
+        message: "Invalid pagination parameters",
+      },
+    });
+  }
+
+  const contentNodesRes = await getContentNodesForDataSourceView(
+    dataSourceView,
+    {
+      internalIds: internalIds ? removeNulls(internalIds) : undefined,
+      parentId,
+      pagination: paginationRes.value,
+      viewType,
+    }
+  );
+
+  if (contentNodesRes.isErr()) {
+    return apiError(req, res, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: contentNodesRes.error.message,
+      },
+    });
+  }
+
+  return res.status(200).json(contentNodesRes.value);
+}
+
+export default withSessionAuthentication(handler);

--- a/front/pages/poke/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.tsx
+++ b/front/pages/poke/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.tsx
@@ -9,6 +9,7 @@ import { ViewDataSourceViewTable } from "@app/components/poke/data_source_views/
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import PokeLayout from "@app/pages/poke/PokeLayout";
+import { usePokeDataSourceViewContentNodesWithInfiniteScroll } from "@app/poke/swr/data_source_views";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
   dataSourceView: DataSourceViewType;
@@ -53,6 +54,9 @@ export default function DataSourceViewPage({
           readonly
           selectionConfiguration={defaultSelectionConfiguration(dataSourceView)}
           setSelectionConfigurations={() => {}}
+          useDataSourceViewContentNodes={
+            usePokeDataSourceViewContentNodesWithInfiniteScroll
+          }
           viewType="documents"
         />
       </div>

--- a/front/poke/swr/data_source_views.ts
+++ b/front/poke/swr/data_source_views.ts
@@ -1,8 +1,20 @@
+import type {
+  ContentNodesViewType,
+  DataSourceViewType,
+  LightWorkspaceType,
+} from "@dust-tt/types";
 import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import {
+  appendPaginationParams,
+  fetcher,
+  postFetcher,
+  useSWRInfiniteWithDefaults,
+  useSWRWithDefaults,
+} from "@app/lib/swr/swr";
 import type { PokeListDataSourceViews } from "@app/pages/api/poke/workspaces/[wId]/data_source_views";
+import type { PokeGetDataSourceViewContentNodes } from "@app/pages/api/poke/workspaces/[wId]/data_source_views/[dsvId]/content-nodes";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 
 export function usePokeDataSourceViews({
@@ -21,5 +33,92 @@ export function usePokeDataSourceViews({
     isLoading: !error && !data,
     isError: error,
     mutateDocuments: mutate,
+  };
+}
+
+interface DataSourceViewContentNodesWithInfiniteScrollProps {
+  dataSourceView?: DataSourceViewType;
+  internalIds?: string[];
+  owner: LightWorkspaceType;
+  pageSize?: number;
+  parentId?: string;
+  viewType?: ContentNodesViewType;
+}
+
+export function usePokeDataSourceViewContentNodesWithInfiniteScroll({
+  owner,
+  dataSourceView,
+  internalIds,
+  parentId,
+  pageSize = 50,
+  viewType,
+}: DataSourceViewContentNodesWithInfiniteScrollProps): {
+  isNodesError: boolean;
+  isNodesLoading: boolean;
+  isNodesValidating: boolean;
+  nodes: PokeGetDataSourceViewContentNodes["nodes"];
+  totalNodesCount: number;
+  hasMore: boolean;
+  nextPage: () => Promise<void>;
+} {
+  const url =
+    dataSourceView && viewType
+      ? `/api/poke/workspaces/${owner.sId}/vaults/${dataSourceView.vaultId}/data_source_views/${dataSourceView.sId}/content-nodes`
+      : null;
+
+  const body = {
+    internalIds,
+    parentId,
+    viewType,
+  };
+
+  const fetcher: Fetcher<PokeGetDataSourceViewContentNodes, [string, object]> =
+    postFetcher;
+
+  const { data, error, setSize, size, isValidating } =
+    useSWRInfiniteWithDefaults(
+      (index) => {
+        if (!url) {
+          // No URL, return an empty array to skip the fetch
+          return null;
+        }
+
+        // Append the pagination params to the URL
+        const params = new URLSearchParams();
+        appendPaginationParams(params, {
+          pageIndex: index,
+          pageSize,
+        });
+
+        return JSON.stringify([url + "?" + params.toString(), body]);
+      },
+      async (fetchKey) => {
+        if (!fetchKey) {
+          return undefined;
+        }
+
+        // Get the URL and body from the fetchKey
+        const params = JSON.parse(fetchKey);
+
+        return fetcher(params);
+      },
+      {
+        revalidateFirstPage: false,
+      }
+    );
+
+  return {
+    isNodesError: !!error,
+    isNodesLoading: !error && !data,
+    isNodesValidating: isValidating,
+    nodes: useMemo(
+      () => (data ? data.flatMap((d) => (d ? d.nodes : [])) : []),
+      [data]
+    ),
+    totalNodesCount: data?.[0] ? data[0].total : 0,
+    hasMore: size * pageSize < (data?.[0] ? data[0].total : 0),
+    nextPage: async () => {
+      await setSize((size) => size + 1);
+    },
   };
 }

--- a/front/poke/swr/data_source_views.ts
+++ b/front/poke/swr/data_source_views.ts
@@ -14,7 +14,7 @@ import {
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import type { PokeListDataSourceViews } from "@app/pages/api/poke/workspaces/[wId]/data_source_views";
-import type { PokeGetDataSourceViewContentNodes } from "@app/pages/api/poke/workspaces/[wId]/data_source_views/[dsvId]/content-nodes";
+import type { PokeGetDataSourceViewContentNodes } from "@app/pages/api/poke/workspaces/[wId]/vaults/[vId]/data_source_views/[dsvId]/content-nodes";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 
 export function usePokeDataSourceViews({


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR is a continuation of https://github.com/dust-tt/dust/pull/7551 and introduces the `/content-nodes` endpoint, dedicated to Poke. This endpoint is necessary for the Tree displayed in the data source view UI in Poke and is specifically designed for Dust Super admins.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
