### PR TITLE
Temporary hack content-nodes listing

### DIFF
--- a/connectors/src/lib/api/content_nodes.ts
+++ b/connectors/src/lib/api/content_nodes.ts
@@ -30,7 +30,7 @@ export async function getParentIdsForContentNodes(
   const parentsResults = await concurrentExecutor(
     internalIds,
     (internalId) => connectorManager.retrieveContentNodeParents({ internalId }),
-    { concurrency: 10 }
+    { concurrency: 30 }
   );
 
   const nodes: ContentNodeParentIdsBlob[] = [];

--- a/front/components/poke/data_source_views/table.tsx
+++ b/front/components/poke/data_source_views/table.tsx
@@ -40,6 +40,7 @@ export function DataSourceViewsDataTable({
         <PokeDataTable
           columns={makeColumnsForDataSourceViews()}
           data={prepareDataSourceViewsForDisplay(owner, data)}
+          defaultFilterColumn="dataSourceName"
         />
       )}
     </PokeDataTableConditionalFetch>

--- a/front/components/poke/data_source_views/view.tsx
+++ b/front/components/poke/data_source_views/view.tsx
@@ -43,6 +43,10 @@ export function ViewDataSourceViewTable({
                 <PokeTableCell>{dataSourceView.kind}</PokeTableCell>
               </PokeTableRow>
               <PokeTableRow>
+                <PokeTableHead>Vault</PokeTableHead>
+                <PokeTableCell>{dataSourceView.vaultId}</PokeTableCell>
+              </PokeTableRow>
+              <PokeTableRow>
                 <PokeTableHead>Data source</PokeTableHead>
                 <PokeTableCellWithLink
                   href={`/poke/${owner.sId}/data_sources/${dataSourceView.dataSource.sId}`}

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -178,7 +178,7 @@ export function useDataSourceViewContentNodesWithInfiniteScroll({
   dataSourceView,
   internalIds,
   parentId,
-  pageSize = 50,
+  pageSize = 500,
   viewType,
 }: {
   owner: LightWorkspaceType;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See https://github.com/dust-tt/tasks/issues/1343.

We noticed that it was really slow to list a long list of content nodes from the Assistant Builder, after investigating the original issue comes from the need to fetch all the parents of all those nodes to apply data source view restriction (x2 the original behavior). This has been heavily deteriorated by the recent pagination work, which only applies at Front's API level and not connector meaning that when the UI asks for 50 nodes, we fetch **ALL** the nodes in connectors with their parents before cropping only to a subset representing the current page. Given that the default page size is currently 50, it takes several minuted to load the long list of content nodes.

⚠️ This PR is a temporary hack and the real solution lies in the proper implementation of the pagination on the connector side, which will require some more work since each connector does its own logic.

Temporarily we bump the page size from 50 to 500 (max page size supported on the API's side) and we also increase concurrency of the parent computation steps.  

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
