### PR TITLE
Remove dataSourceId from assistant builder & use dustAPIDataSourceId in actions

### DIFF
--- a/connectors/src/connectors/slack/chat/citations.ts
+++ b/connectors/src/connectors/slack/chat/citations.ts
@@ -5,8 +5,6 @@ import {
   isWebsearchActionType,
 } from "@dust-tt/types";
 
-import { makeDustAppUrl } from "@connectors/connectors/slack/chat/utils";
-
 interface SlackMessageFootnote {
   index: number;
   link: string;
@@ -30,17 +28,14 @@ export function annotateCitations(
   for (const action of actions) {
     if (action && isRetrievalActionType(action) && action.documents) {
       action.documents.forEach((d) => {
-        references[d.reference] = {
-          reference: d.reference,
-          link: d.sourceUrl
-            ? d.sourceUrl
-            : makeDustAppUrl(
-                `/w/${d.dataSourceWorkspaceId}/builder/data-sources/${
-                  d.dataSourceId
-                }/upsert?documentId=${encodeURIComponent(d.documentId)}`
-              ),
-          title: getTitleFromRetrievedDocument(d),
-        };
+        // If the document has no sourceUrl we skip the citation.
+        if (d.sourceUrl) {
+          references[d.reference] = {
+            reference: d.reference,
+            link: d.sourceUrl,
+            title: getTitleFromRetrievedDocument(d),
+          };
+        }
       });
     }
     if (action && isWebsearchActionType(action) && action.output) {

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -407,7 +407,7 @@ function DataSourceViewsSection({
             (dsv) => dsv.sId === dsConfig.dataSourceViewId
           );
 
-          // We won't throw here if dataSourceView is null to avoid carshing the UI but this is not
+          // We won't throw here if dataSourceView is null to avoid crashing the UI but this is not
           // supposed to happen as we delete the configurations when data sources are deleted.
           let dsLogo = null;
           let dataSourceName = "Deleted data source";

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -299,16 +299,15 @@ export function AssistantDetails({
                   owner={owner}
                   dataSourceViews={dataSourceViews}
                   dataSourceConfigurations={action.tables.map((t) => {
-                    // We should never have an undefined dataSourceView here as
-                    // if it's undefined, it means the dataSourceView was deleted and the configuration is invalid
-                    // But we need to handle this case to avoid crashing the UI
+                    // We should never have an undefined dataSourceView here as if it's undefined,
+                    // it means the dataSourceView was deleted and the configuration is invalid But
+                    // we need to handle this case to avoid crashing the UI
                     const dataSourceView = dataSourceViews.find(
                       (dsv) => dsv.sId == t.dataSourceViewId
                     );
 
                     return {
                       workspaceId: t.workspaceId,
-                      dataSourceId: t.dataSourceId,
                       dataSourceViewId: t.dataSourceViewId,
                       filter: {
                         parents:
@@ -408,12 +407,14 @@ function DataSourceViewsSection({
             (dsv) => dsv.sId === dsConfig.dataSourceViewId
           );
 
-          let DsLogo = null;
-          let dataSourceName = dsConfig.dataSourceId;
+          // We won't throw here if dataSourceView is null to avoid carshing the UI but this is not
+          // supposed to happen as we delete the configurations when data sources are deleted.
+          let dsLogo = null;
+          let dataSourceName = "Deleted data source";
 
           if (dataSourceView) {
             const { dataSource } = dataSourceView;
-            DsLogo = getConnectorProviderLogoWithFallback(
+            dsLogo = getConnectorProviderLogoWithFallback(
               dataSource.connectorProvider,
               FolderIcon
             );
@@ -431,7 +432,7 @@ function DataSourceViewsSection({
                   : "leaf"
               }
               label={dataSourceName}
-              visual={DsLogo ?? FolderIcon}
+              visual={dsLogo ?? FolderIcon}
               className="whitespace-nowrap"
             >
               {dataSourceView && isAllSelected && (

--- a/front/components/assistant_builder/submitAssistantBuilderForm.ts
+++ b/front/components/assistant_builder/submitAssistantBuilderForm.ts
@@ -81,7 +81,6 @@ export async function submitAssistantBuilderForm({
             dataSources: Object.values(
               a.configuration.dataSourceConfigurations
             ).map(({ dataSourceView, selectedResources, isSelectAll }) => ({
-              dataSourceId: dataSourceView.dataSource.name,
               dataSourceViewId: dataSourceView.sId,
               workspaceId: owner.sId,
               filter: {
@@ -124,7 +123,6 @@ export async function submitAssistantBuilderForm({
             tables: Object.values(a.configuration).flatMap(
               ({ dataSourceView, selectedResources }) => {
                 return selectedResources.map((resource) => ({
-                  dataSourceId: dataSourceView.dataSource.name,
                   dataSourceViewId: dataSourceView.sId,
                   workspaceId: owner.sId,
                   tableId: getTableIdForContentNode(
@@ -160,7 +158,6 @@ export async function submitAssistantBuilderForm({
             dataSources: Object.values(
               a.configuration.dataSourceConfigurations
             ).map(({ dataSourceView, selectedResources, isSelectAll }) => ({
-              dataSourceId: dataSourceView.dataSource.name,
               dataSourceViewId: dataSourceView.sId,
               workspaceId: owner.sId,
               filter: {

--- a/front/components/poke/data_sources/table.tsx
+++ b/front/components/poke/data_sources/table.tsx
@@ -1,6 +1,7 @@
 import type {
   AgentConfigurationType,
   DataSourceType,
+  DataSourceViewType,
   WorkspaceType,
 } from "@dust-tt/types";
 import { useRouter } from "next/router";
@@ -11,6 +12,7 @@ import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
 interface DataSourceDataTableProps {
   owner: WorkspaceType;
   dataSources: DataSourceType[];
+  dataSourceViews: DataSourceViewType[];
   agentConfigurations: AgentConfigurationType[];
 }
 
@@ -27,6 +29,7 @@ function prepareDataSourceForDisplay(dataSources: DataSourceType[]) {
 export function DataSourceDataTable({
   owner,
   dataSources,
+  dataSourceViews,
   agentConfigurations,
 }: DataSourceDataTableProps) {
   const router = useRouter();
@@ -38,6 +41,14 @@ export function DataSourceDataTable({
         columns={makeColumnsForDataSources(
           owner,
           agentConfigurations,
+          dataSources.map((ds) => {
+            return {
+              dataSource: ds,
+              dataSourceViews: dataSourceViews.filter(
+                (view) => view.dataSource.id === ds.id
+              ),
+            };
+          }),
           router.reload
         )}
         data={prepareDataSourceForDisplay(dataSources)}

--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -21,6 +21,7 @@ import {
   PROCESS_ACTION_TOP_K,
   renderSchemaPropertiesAsJSONSchema,
 } from "@dust-tt/types";
+import assert from "assert";
 
 import { runActionStreamed } from "@app/lib/actions/server";
 import { DEFAULT_PROCESS_ACTION_NAME } from "@app/lib/api/assistant/actions/names";
@@ -41,6 +42,7 @@ import {
   DustProdActionRegistry,
   PRODUCTION_DUST_WORKSPACE_ID,
 } from "@app/lib/registry";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import logger from "@app/logger/logger";
 
 interface ProcessActionBlob {
@@ -241,6 +243,17 @@ export class ProcessConfigurationServerRunner extends BaseActionConfigurationSer
       hasAvailableActions: false,
     });
 
+    const uniqueDataSourceViewIds = Array.from(
+      new Set(actionConfiguration.dataSources.map((ds) => ds.dataSourceViewId))
+    );
+    const dataSourceViews = await DataSourceViewResource.fetchByIds(
+      auth,
+      uniqueDataSourceViewIds
+    );
+    const dataSourceViewsMap = Object.fromEntries(
+      dataSourceViews.map((dsv) => [dsv.sId, dsv])
+    );
+
     const config = cloneBaseConfig(
       DustProdActionRegistry["assistant-v2-process"].config
     );
@@ -258,9 +271,9 @@ export class ProcessConfigurationServerRunner extends BaseActionConfigurationSer
             ? PRODUCTION_DUST_WORKSPACE_ID
             : d.workspaceId,
 
-        // Use dataSourceViewId if it exists; otherwise, use dataSourceId.
-        // Note: This value is passed to the registry for lookup.
-        data_source_id: d.dataSourceViewId ?? d.dataSourceId,
+        // Note: This value is passed to the registry for lookup. The registry will return the
+        // associated data source's dustAPIDataSourceId.
+        data_source_id: d.dataSourceViewId,
       })
     );
 
@@ -286,10 +299,16 @@ export class ProcessConfigurationServerRunner extends BaseActionConfigurationSer
           config.DATASOURCE.filter.parents.in_map = {};
         }
 
+        const dsView = dataSourceViewsMap[ds.dataSourceViewId];
+        // This should never happen since dataSourceViews are stored by id in the
+        // agent_data_source_configurations table.
+        assert(dsView, `Data source view ${ds.dataSourceViewId} not found`);
+
         // Note: We use dataSourceId here because after the registry lookup,
         // it returns either the data source itself or the data source associated with the data source view.
-        config.DATASOURCE.filter.parents.in_map[ds.dataSourceId] =
-          ds.filter.parents.in;
+        config.DATASOURCE.filter.parents.in_map[
+          dsView.dataSource.dustAPIDataSourceId
+        ] = ds.filter.parents.in;
       }
       if (ds.filter.parents?.not) {
         if (!config.DATASOURCE.filter.parents.not) {

--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -22,6 +22,7 @@ import {
   renderSchemaPropertiesAsJSONSchema,
 } from "@dust-tt/types";
 import assert from "assert";
+import _ from "lodash";
 
 import { runActionStreamed } from "@app/lib/actions/server";
 import { DEFAULT_PROCESS_ACTION_NAME } from "@app/lib/api/assistant/actions/names";
@@ -243,12 +244,9 @@ export class ProcessConfigurationServerRunner extends BaseActionConfigurationSer
       hasAvailableActions: false,
     });
 
-    const uniqueDataSourceViewIds = Array.from(
-      new Set(actionConfiguration.dataSources.map((ds) => ds.dataSourceViewId))
-    );
     const dataSourceViews = await DataSourceViewResource.fetchByIds(
       auth,
-      uniqueDataSourceViewIds
+      _.uniq(actionConfiguration.dataSources.map((ds) => ds.dataSourceViewId))
     );
     const dataSourceViewsMap = Object.fromEntries(
       dataSourceViews.map((dsv) => [dsv.sId, dsv])

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -31,6 +31,7 @@ import {
 import { getRefs } from "@app/lib/api/assistant/citations";
 import apiConfig from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
+import { getDataSourceNameFromView } from "@app/lib/data_sources";
 import { AgentRetrievalAction } from "@app/lib/models/assistant/actions/retrieval";
 import {
   cloneBaseConfig,
@@ -182,10 +183,9 @@ export class RetrievalAction extends BaseAction {
           }
         }
 
-        let dataSourceName = d.dataSourceId;
-        if (d.dataSourceId.startsWith("managed-")) {
-          dataSourceName = d.dataSourceId.substring(8);
-        }
+        const dataSourceName = d.dataSourceView
+          ? getDataSourceNameFromView(d.dataSourceView)
+          : "unknown";
 
         content += `TITLE: ${title} (data source: ${dataSourceName})\n`;
         content += `REFERENCE: ${d.reference}\n`;

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -18,6 +18,7 @@ import type { AgentActionSpecification } from "@dust-tt/types";
 import type { Result } from "@dust-tt/types";
 import { BaseAction, isDevelopment } from "@dust-tt/types";
 import { Ok } from "@dust-tt/types";
+import assert from "assert";
 
 import { runActionStreamed } from "@app/lib/actions/server";
 import { DEFAULT_RETRIEVAL_ACTION_NAME } from "@app/lib/api/assistant/actions/names";
@@ -393,6 +394,19 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
       DustProdActionRegistry["assistant-v2-retrieval"].config
     );
 
+    const uniqueDataSourceViewIds = Array.from(
+      new Set(actionConfiguration.dataSources.map((ds) => ds.dataSourceViewId))
+    );
+
+    const dataSourceViews = await DataSourceViewResource.fetchByIds(
+      auth,
+      uniqueDataSourceViewIds
+    );
+
+    const dataSourceViewsMap = Object.fromEntries(
+      dataSourceViews.map((dsv) => [dsv.sId, dsv])
+    );
+
     // Handle data sources list and parents/tags filtering.
     config.DATASOURCE.data_sources = actionConfiguration.dataSources.map(
       (d) => ({
@@ -400,9 +414,8 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
           isDevelopment() && !apiConfig.getDevelopmentDustAppsWorkspaceId()
             ? PRODUCTION_DUST_WORKSPACE_ID
             : d.workspaceId,
-        // Use dataSourceViewId if it exists; otherwise, use dataSourceId.
         // Note: This value is passed to the registry for lookup.
-        data_source_id: d.dataSourceViewId ?? d.dataSourceId,
+        data_source_id: d.dataSourceViewId,
       })
     );
 
@@ -417,10 +430,16 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
           config.DATASOURCE.filter.parents.in_map = {};
         }
 
-        // Note: We use dataSourceId here because after the registry lookup, it returns either the
-        // data source itself or the data source associated with the data source view.
-        config.DATASOURCE.filter.parents.in_map[ds.dataSourceId] =
-          ds.filter.parents.in;
+        const dsView = dataSourceViewsMap[ds.dataSourceViewId];
+        // This should never happen since dataSourceViews are stored by id in the
+        // agent_data_source_configurations table.
+        assert(dsView, `Data source view ${ds.dataSourceViewId} not found`);
+
+        // Note we use the dustAPIDataSourceId here since this is what is returned from the registry
+        // lookup.
+        config.DATASOURCE.filter.parents.in_map[
+          dsView.dataSource.dustAPIDataSourceId
+        ] = ds.filter.parents.in;
       }
       if (ds.filter.parents?.not) {
         if (!config.DATASOURCE.filter.parents.not) {
@@ -486,26 +505,13 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
       dataSourceView: DataSourceViewResource;
     }[] = [];
 
-    const uniqueDataSourceViewIds = Array.from(
-      new Set(actionConfiguration.dataSources.map((ds) => ds.dataSourceViewId))
-    );
-
-    const dataSourceViews = await DataSourceViewResource.fetchByIds(
-      auth,
-      uniqueDataSourceViewIds
-    );
-
-    const dataSourceViewsMap = Object.fromEntries(
-      dataSourceViews.map((dsv) => [dsv.sId, dsv])
-    );
-
     // This is not perfect and will be erroneous in case of two data sources with the same id from
     // two different workspaces. We don't support cross workspace data sources right now. But we'll
     // likely want `core` to return the `workspace_id` that was used eventualy.
     // TODO(spolu): make `core` return data source workspace id.
-    const dataSourcesIdToWorkspaceId = Object.fromEntries(
+    const dustAPIDataSourcesIdToDetails = Object.fromEntries(
       actionConfiguration.dataSources.map((ds) => [
-        ds.dataSourceId,
+        dataSourceViewsMap[ds.dataSourceViewId].dataSource.dustAPIDataSourceId,
         {
           dataSourceView: dataSourceViewsMap[ds.dataSourceViewId],
           workspaceId: ds.workspaceId,
@@ -609,12 +615,19 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
           // Prepare an array of document blobs and chunks to be passed to makeNewBatch.
           blobs = v.map((d, i) => {
             const reference = refs[i % refs.length];
-            const dsDetails = dataSourcesIdToWorkspaceId[d.data_source_id];
+
+            const details = dustAPIDataSourcesIdToDetails[d.data_source_id];
+            assert(details, `Data source view ${d.data_source_id} not found`);
+
+            console.log(
+              ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+            );
+            console.log(details);
 
             return {
               blob: {
-                dataSourceWorkspaceId: dsDetails.workspaceId,
-                dataSourceId: d.data_source_id,
+                dataSourceWorkspaceId: details.workspaceId,
+                dataSourceId: details.dataSourceView.sId,
                 sourceUrl: d.source_url,
                 documentId: d.document_id,
                 reference,
@@ -624,7 +637,7 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
                 retrievalActionId: action.id,
               },
               chunks: d.chunks,
-              dataSourceView: dsDetails.dataSourceView,
+              dataSourceView: details.dataSourceView,
             };
           });
         }

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -19,6 +19,7 @@ import type { Result } from "@dust-tt/types";
 import { BaseAction, isDevelopment } from "@dust-tt/types";
 import { Ok } from "@dust-tt/types";
 import assert from "assert";
+import _ from "lodash";
 
 import { runActionStreamed } from "@app/lib/actions/server";
 import { DEFAULT_RETRIEVAL_ACTION_NAME } from "@app/lib/api/assistant/actions/names";
@@ -42,7 +43,6 @@ import { DataSourceViewResource } from "@app/lib/resources/data_source_view_reso
 import type { RetrievalDocumentBlob } from "@app/lib/resources/retrieval_document_resource";
 import { RetrievalDocumentResource } from "@app/lib/resources/retrieval_document_resource";
 import logger from "@app/logger/logger";
-import _ from "lodash";
 
 /**
  * TimeFrame parsing

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -627,7 +627,7 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
             return {
               blob: {
                 dataSourceWorkspaceId: details.workspaceId,
-                dataSourceId: details.dataSourceView.sId,
+                dataSourceId: details.dataSourceView.dataSource.sId,
                 sourceUrl: d.source_url,
                 documentId: d.document_id,
                 reference,

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -42,6 +42,7 @@ import { DataSourceViewResource } from "@app/lib/resources/data_source_view_reso
 import type { RetrievalDocumentBlob } from "@app/lib/resources/retrieval_document_resource";
 import { RetrievalDocumentResource } from "@app/lib/resources/retrieval_document_resource";
 import logger from "@app/logger/logger";
+import _ from "lodash";
 
 /**
  * TimeFrame parsing
@@ -389,12 +390,9 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
 
     const now = Date.now();
 
-    const uniqueDataSourceViewIds = Array.from(
-      new Set(actionConfiguration.dataSources.map((ds) => ds.dataSourceViewId))
-    );
     const dataSourceViews = await DataSourceViewResource.fetchByIds(
       auth,
-      uniqueDataSourceViewIds
+      _.uniq(actionConfiguration.dataSources.map((ds) => ds.dataSourceViewId))
     );
     const dataSourceViewsMap = Object.fromEntries(
       dataSourceViews.map((dsv) => [dsv.sId, dsv])

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -263,7 +263,9 @@ export class TablesQueryConfigurationServerRunner extends BaseActionConfiguratio
     const tables = actionConfiguration.tables.map((t) => ({
       workspace_id: t.workspaceId,
       table_id: t.tableId,
-      data_source_id: t.dataSourceId,
+      // Note: This value is passed to the registry for lookup. The registry will return the
+      // associated data source's dustAPIDataSourceId.
+      data_source_id: t.dataSourceViewId,
     }));
     if (tables.length === 0) {
       yield {

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -1230,11 +1230,6 @@ async function _createAgentDataSourcesConfigData(
           "Can't create AgentDataSourceConfiguration for retrieval: DataSourceView not found."
         );
 
-        console.log(
-          "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
-        );
-        console.log(dataSourceView.toJSON());
-
         return AgentDataSourceConfiguration.create(
           {
             dataSourceId: dataSourceView.dataSource.id,

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -1230,16 +1230,14 @@ async function _createAgentDataSourcesConfigData(
           "Can't create AgentDataSourceConfiguration for retrieval: DataSourceView not found."
         );
 
-        const { dataSource } = dataSourceView;
-
-        assert(
-          dataSourceView.dataSource.name === dsConfig.dataSourceId,
-          "Can't create AgentDataSourceConfiguration for retrieval: data source view does not belong to the data source."
+        console.log(
+          "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
         );
+        console.log(dataSourceView.toJSON());
 
         return AgentDataSourceConfiguration.create(
           {
-            dataSourceId: dataSource.id,
+            dataSourceId: dataSourceView.dataSource.id,
             parentsIn: dsConfig.filter.parents?.in,
             parentsNotIn: dsConfig.filter.parents?.not,
             retrievalConfigurationId: retrievalConfigurationId,

--- a/front/lib/api/assistant/configuration/process.ts
+++ b/front/lib/api/assistant/configuration/process.ts
@@ -121,12 +121,11 @@ function getDataSource(
   const { dataSourceView } = dataSourceConfig;
 
   return {
+    workspaceId: dataSourceView.workspace.sId,
     dataSourceViewId: DataSourceViewResource.modelIdToSId({
       id: dataSourceView.id,
       workspaceId: dataSourceView.workspaceId,
     }),
-    dataSourceId: dataSourceView.dataSourceForView.name,
-    workspaceId: dataSourceView.workspace.sId,
     filter: {
       parents:
         dataSourceConfig.parentsIn && dataSourceConfig.parentsNotIn

--- a/front/lib/api/assistant/configuration/retrieval.ts
+++ b/front/lib/api/assistant/configuration/retrieval.ts
@@ -128,12 +128,11 @@ function getDataSource(
   const { dataSourceView } = dataSourceConfig;
 
   return {
+    workspaceId: dataSourceView.workspace.sId,
     dataSourceViewId: DataSourceViewResource.modelIdToSId({
       id: dataSourceView.id,
       workspaceId: dataSourceView.workspaceId,
     }),
-    dataSourceId: dataSourceView.dataSourceForView.name,
-    workspaceId: dataSourceView.workspace.sId,
     filter: {
       parents:
         dataSourceConfig.parentsIn && dataSourceConfig.parentsNotIn

--- a/front/lib/api/assistant/configuration/table_query.ts
+++ b/front/lib/api/assistant/configuration/table_query.ts
@@ -147,11 +147,6 @@ export async function createTableDataSourceConfiguration(
 
       const { dataSource } = dataSourceView;
 
-      assert(
-        dataSourceView.dataSource.name === tc.dataSourceId,
-        "Can't create TableDataSourceConfiguration for query tables: data source view does not belong to the data source."
-      );
-
       await AgentTablesQueryConfigurationTable.create(
         {
           dataSourceId: dataSource.id,

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -1043,9 +1043,8 @@ function _getDustGlobalAgent(
         topK: "auto",
         dataSources: [
           {
-            dataSourceId: dsView.dataSource.name,
-            dataSourceViewId: dsView.sId,
             workspaceId: preFetchedDataSources.workspaceId,
+            dataSourceViewId: dsView.sId,
             filter: { parents: null },
           },
         ],

--- a/front/lib/resources/retrieval_document_resource.ts
+++ b/front/lib/resources/retrieval_document_resource.ts
@@ -198,6 +198,7 @@ export class RetrievalDocumentResource extends BaseResource<RetrievalDocument> {
       id: this.id,
       dataSourceWorkspaceId: this.dataSourceWorkspaceId,
       dataSourceId: this.dataSourceId,
+      dataSourceView: this.dataSourceView?.toJSON() || null,
       sourceUrl: this.getSourceUrl(auth),
       documentId: this.documentId,
       reference: this.reference,

--- a/front/lib/resources/retrieval_document_resource.ts
+++ b/front/lib/resources/retrieval_document_resource.ts
@@ -196,8 +196,6 @@ export class RetrievalDocumentResource extends BaseResource<RetrievalDocument> {
   toJSON(auth: Authenticator): RetrievalDocumentType {
     return {
       id: this.id,
-      dataSourceWorkspaceId: this.dataSourceWorkspaceId,
-      dataSourceId: this.dataSourceId,
       dataSourceView: this.dataSourceView?.toJSON() || null,
       sourceUrl: this.getSourceUrl(auth),
       documentId: this.documentId,

--- a/front/pages/api/registry/[type]/lookup.ts
+++ b/front/pages/api/registry/[type]/lookup.ts
@@ -100,11 +100,11 @@ async function handler(
               },
             });
           };
+
           const {
             data_source_id: dataSourceOrDataSourceViewId,
             workspace_id: workspaceId,
           } = req.query;
-
           if (
             typeof workspaceId !== "string" ||
             typeof dataSourceOrDataSourceViewId !== "string"

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -2,6 +2,7 @@ import { Button, DropdownMenu, Modal, Spinner } from "@dust-tt/sparkle";
 import type {
   AgentConfigurationType,
   DataSourceType,
+  DataSourceViewType,
   WhitelistableFeature,
   WorkspaceDomain,
   WorkspaceSegmentationType,
@@ -40,12 +41,14 @@ import { Plan, Subscription } from "@app/lib/models/plan";
 import { FREE_NO_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { renderSubscriptionFromModels } from "@app/lib/plans/renderers";
 import { DustProdActionRegistry } from "@app/lib/registry";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
   owner: WorkspaceType;
   activeSubscription: SubscriptionType;
   subscriptions: SubscriptionType[];
   dataSources: DataSourceType[];
+  dataSourceViews: DataSourceViewType[];
   agentConfigurations: AgentConfigurationType[];
   whitelistableFeatures: WhitelistableFeature[];
   registry: typeof DustProdActionRegistry;
@@ -62,27 +65,30 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   }
 
   // TODO(2024-02-28 flav) Stop fetching agent configurations on the server side.
-  const [dataSources, agentConfigurations, subscriptionModels] =
-    await Promise.all([
-      getDataSources(auth, { includeEditedBy: true }),
-      (async () => {
-        return (
-          await getAgentConfigurations({
-            auth,
-            agentsGetView: "admin_internal",
-            variant: "full",
-          })
-        ).filter(
-          (a) =>
-            !Object.values(GLOBAL_AGENTS_SID).includes(
-              a.sId as GLOBAL_AGENTS_SID
-            )
-        );
-      })(),
-      Subscription.findAll({
-        where: { workspaceId: owner.id },
-      }),
-    ]);
+  const [
+    dataSources,
+    dataSourceViews,
+    agentConfigurations,
+    subscriptionModels,
+  ] = await Promise.all([
+    getDataSources(auth, { includeEditedBy: true }),
+    DataSourceViewResource.listByWorkspace(auth),
+    (async () => {
+      return (
+        await getAgentConfigurations({
+          auth,
+          agentsGetView: "admin_internal",
+          variant: "full",
+        })
+      ).filter(
+        (a) =>
+          !Object.values(GLOBAL_AGENTS_SID).includes(a.sId as GLOBAL_AGENTS_SID)
+      );
+    })(),
+    Subscription.findAll({
+      where: { workspaceId: owner.id },
+    }),
+  ]);
 
   const plans = keyBy(
     await Plan.findAll({
@@ -111,6 +117,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
       dataSources: orderDatasourceByImportance(
         dataSources.map((ds) => ds.toJSON())
       ),
+      dataSourceViews: dataSourceViews.map((dsv) => dsv.toJSON()),
       agentConfigurations: agentConfigurations,
       whitelistableFeatures:
         WHITELISTABLE_FEATURES as unknown as WhitelistableFeature[],
@@ -126,6 +133,7 @@ const WorkspacePage = ({
   activeSubscription,
   subscriptions,
   dataSources,
+  dataSourceViews,
   agentConfigurations,
   whitelistableFeatures,
   registry,
@@ -264,6 +272,7 @@ const WorkspacePage = ({
               <DataSourceDataTable
                 owner={owner}
                 dataSources={dataSources}
+                dataSourceViews={dataSourceViews}
                 agentConfigurations={agentConfigurations}
               />
               <DataSourceViewsDataTable owner={owner} />

--- a/types/src/front/api_handlers/internal/agent_configuration.ts
+++ b/types/src/front/api_handlers/internal/agent_configuration.ts
@@ -61,7 +61,6 @@ const RetrievalActionConfigurationSchema = t.type({
   topK: t.union([t.number, t.literal("auto")]),
   dataSources: t.array(
     t.type({
-      dataSourceId: t.string,
       dataSourceViewId: t.string,
       workspaceId: t.string,
       filter: t.type({
@@ -87,7 +86,6 @@ const TablesQueryActionConfigurationSchema = t.type({
   type: t.literal("tables_query_configuration"),
   tables: t.array(
     t.type({
-      dataSourceId: t.string,
       dataSourceViewId: t.string,
       tableId: t.string,
       workspaceId: t.string,
@@ -107,7 +105,6 @@ const ProcessActionConfigurationSchema = t.type({
   type: t.literal("process_configuration"),
   dataSources: t.array(
     t.type({
-      dataSourceId: t.string,
       dataSourceViewId: t.string,
       workspaceId: t.string,
       filter: t.type({

--- a/types/src/front/assistant/actions/retrieval.ts
+++ b/types/src/front/assistant/actions/retrieval.ts
@@ -34,7 +34,6 @@ export type DataSourceFilter = {
 
 export type DataSourceConfiguration = {
   workspaceId: string;
-  dataSourceId: string;
   dataSourceViewId: string;
   filter: DataSourceFilter;
 };

--- a/types/src/front/assistant/actions/retrieval.ts
+++ b/types/src/front/assistant/actions/retrieval.ts
@@ -6,6 +6,7 @@ import { BaseAction } from "../../../front/lib/api/assistant/actions/index";
 import { ModelId } from "../../../shared/model_id";
 import { ioTsEnum } from "../../../shared/utils/iots_utils";
 import { ConnectorProvider } from "../../data_source";
+import { DataSourceViewType } from "../../data_source_view";
 
 export const TIME_FRAME_UNITS = [
   "hour",
@@ -79,10 +80,8 @@ export interface RetrievalDocumentChunkType {
 
 export interface RetrievalDocumentType {
   chunks: RetrievalDocumentChunkType[];
-  dataSourceId: string;
-  // TODO(GROUPS_INFRA) Add support for dataSourceViewId.
-  dataSourceWorkspaceId: string;
   documentId: string;
+  dataSourceView: DataSourceViewType | null;
   id: ModelId;
   reference: string; // Short random string so that the model can refer to the document.
   score: number | null;
@@ -95,26 +94,15 @@ type ConnectorProviderDocumentType =
   | Exclude<ConnectorProvider, "webcrawler">
   | "document";
 
-const providerMap: Record<string, ConnectorProviderDocumentType> = {
-  "managed-slack": "slack",
-  "managed-notion": "notion",
-  "managed-google_drive": "google_drive",
-  "managed-github": "github",
-  "managed-confluence": "confluence",
-  "managed-microsoft": "microsoft",
-  "managed-intercom": "intercom",
-};
-
-const providerRegex = new RegExp(`^(${Object.keys(providerMap).join("|")})`);
-
 export function getProviderFromRetrievedDocument(
   document: RetrievalDocumentType
 ): ConnectorProviderDocumentType {
-  const match = document.dataSourceId.match(providerRegex);
-  if (match && match[1]) {
-    return providerMap[match[1]];
+  if (document.dataSourceView) {
+    if (document.dataSourceView.dataSource.connectorProvider === "webcrawler") {
+      return "document";
+    }
+    return document.dataSourceView.dataSource.connectorProvider || "document";
   }
-
   return "document";
 }
 
@@ -135,10 +123,6 @@ export function getTitleFromRetrievedDocument(
     if (t.startsWith("title:")) {
       return t.substring(6);
     }
-  }
-
-  if (provider === "document") {
-    return `[${document.dataSourceId}] ${document.documentId}`;
   }
 
   return document.documentId;

--- a/types/src/front/assistant/actions/tables_query.ts
+++ b/types/src/front/assistant/actions/tables_query.ts
@@ -12,7 +12,6 @@ export type TablesQueryConfigurationType = {
 };
 
 export type TableDataSourceConfiguration = {
-  dataSourceId: string;
   dataSourceViewId: string;
   tableId: string;
   workspaceId: string;

--- a/types/src/front/assistant/actions/tables_query.ts
+++ b/types/src/front/assistant/actions/tables_query.ts
@@ -12,9 +12,9 @@ export type TablesQueryConfigurationType = {
 };
 
 export type TableDataSourceConfiguration = {
+  workspaceId: string;
   dataSourceViewId: string;
   tableId: string;
-  workspaceId: string;
 };
 
 export interface TablesQueryActionType extends BaseAction {


### PR DESCRIPTION
## Description

This PR touches 2 critical paths relative to moving to dsViews and removing dataSource.name

- It removes the dataSourceId parameters from the assistant builder and agent configuration creation arguments solely relying on the dsView.
- It uses the dataSource.dustAPIDataSourceId in all interactions with `core`. The fact that it works today is because core `dustAPIDataSourceId` is the dataSourceName for now and we use dataSource.name to interact with it. If we were to start using dataSource.sId as id when creating data source in core (dustAPIDataSourceId = sId) then the current code path would break.

I double checked that AgentTablesQueryConfigurationTable is fully backfilled with dataSourceViewId
I double checked that RetrievalDocument is fully backfilled with dataSourceViewId
I double checked that AgentDataSourceConfigurations is fully backfilled with dataSourceViewId

Tests in dev:
- [x] retrieval
  - [x] create assistant
  - [x] interact with assistant
  - [x] check that citations are working with propoer logos
- [x] table query
  - [x] create assistant
  - [x] interact with assistant
- [x] extract
  - [x] create assistant
  - [x] interact with assistant
- [x] test data source deletion prevention in poke

As a follow-up we will be able to clean the AgentTablesQueryConfigurationTable RetrievalDocument and AgentDataSourceConfigurations from direct data source references

## Risk

High. Quite extensively tested in dev and front-edge + revertable safely

## Deploy Plan

- deploy `front`