### PR TITLE
[sparkle] - chore(Input): disabled input

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.242",
+  "version": "0.2.243",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.242",
+      "version": "0.2.243",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.242",
+  "version": "0.2.243",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Input.tsx
+++ b/sparkle/src/components/Input.tsx
@@ -50,8 +50,8 @@ export function Input({
         id={name}
         className={classNames(
           "s-w-full s-border-0 s-outline-none s-ring-1 focus:s-outline-none focus:s-ring-2",
-          "s-bg-structure-50 s-text-element-900 s-placeholder-element-700",
-          "dark:s-bg-structure-50-dark dark:s-text-element-800-dark dark:s-placeholder-element-700-dark",
+          "s-bg-structure-50s-placeholder-element-700",
+          "dark:s-bg-structure-50-dark dark:s-placeholder-element-700-dark",
           sizeInputClasses[size],
           "s-transition-all s-duration-300 s-ease-out",
           className ?? "",
@@ -63,7 +63,10 @@ export function Input({
             : classNames(
                 "s-ring-warning-200 focus:s-ring-warning-300",
                 "dark:s-ring-warning-200-dark dark:focus:s-ring-warning-300-dark"
-              )
+              ),
+          disabled
+            ? "s-text-element-500 hover:s-cursor-not-allowed"
+            : "s-text-element-900 dark:s-text-element-800-dark"
         )}
         placeholder={placeholder}
         value={value ?? ""}

--- a/sparkle/src/components/Input.tsx
+++ b/sparkle/src/components/Input.tsx
@@ -50,7 +50,7 @@ export function Input({
         id={name}
         className={classNames(
           "s-w-full s-border-0 s-outline-none s-ring-1 focus:s-outline-none focus:s-ring-2",
-          "s-bg-structure-50s-placeholder-element-700",
+          "s-bg-structure-50 s-placeholder-element-700",
           "dark:s-bg-structure-50-dark dark:s-placeholder-element-700-dark",
           sizeInputClasses[size],
           "s-transition-all s-duration-300 s-ease-out",


### PR DESCRIPTION
## Description

This PR adjusts styling in `Input` component to conditionally apply `cursor-not-allowed` and text color classes when disabled

**References:**
- https://github.com/dust-tt/tasks/issues/1349

## Risk

N/A

## Deploy Plan

Deploy `sparkle`