### PR TITLE
Adding attempted URL in 404

### DIFF
--- a/front/pages/404.tsx
+++ b/front/pages/404.tsx
@@ -1,7 +1,17 @@
 import { Button, LogoutIcon } from "@dust-tt/sparkle";
 import Link from "next/link";
+import { useEffect, useState } from "react";
 
 export default function Custom404() {
+  const [currentURL, setCurrentURL] = useState("");
+
+  useEffect(() => {
+    // Only set the URL on the client-side
+    if (typeof window !== "undefined") {
+      setCurrentURL(window.location.href);
+    }
+  }, []);
+
   return (
     <div className="flex h-screen items-center justify-center">
       <div className="flex flex-col gap-3 text-center">
@@ -12,9 +22,14 @@ export default function Custom404() {
           <p className="text-xl font-bold leading-7 text-slate-900">
             404: Page not found
           </p>
-          <p className="max-w-48 text-sm font-normal leading-tight text-slate-500">
+          <p className="text-sm font-normal leading-tight text-slate-500">
             Looks like this page took an unscheduled coffee break.
           </p>
+          {currentURL && (
+            <p className="mt-2 text-xs text-slate-400">
+              Attempted URL: {currentURL}
+            </p>
+          )}
         </div>
         <Link href="/">
           <Button


### PR DESCRIPTION
## Description

Adding attempted URL in 404 pages. Necessary when building external apps that hit 404s
<img width="426" alt="Screenshot 2024-09-20 at 09 33 09" src="https://github.com/user-attachments/assets/5c25c3fe-053b-4dcc-9c66-16f306ee6555">


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
