### PR TITLE
Upg: spread confluence workflows and rebalance notion workers

### DIFF
--- a/connectors/src/connectors/confluence/temporal/client.ts
+++ b/connectors/src/connectors/confluence/temporal/client.ts
@@ -50,6 +50,8 @@ export async function launchConfluenceSyncWorkflow(
 
   const workflowId = makeConfluenceSyncWorkflowId(connector.id);
 
+  const minute = connector.id % 60; // Spread workflows across the hour.
+
   // When the workflow is inactive, we omit passing spaceIds as they are only used to signal modifications within a currently active full sync workflow.
   try {
     await client.workflow.signalWithStart(confluenceSyncWorkflow, {
@@ -68,7 +70,7 @@ export async function launchConfluenceSyncWorkflow(
       memo: {
         connectorId,
       },
-      cronSchedule: "0 * * * *", // Every hour.
+      cronSchedule: `${minute} * * * *`, // Every hour at minute `minute`.
     });
   } catch (err) {
     return new Err(err as Error);

--- a/k8s/deployments/connectors-worker-notion-deployment.yaml
+++ b/k8s/deployments/connectors-worker-notion-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: connectors-worker-notion-deployment
 spec:
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
       app: connectors-worker

--- a/k8s/deployments/connectors-worker-notion-gc-deployment.yaml
+++ b/k8s/deployments/connectors-worker-notion-gc-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: connectors-worker-notion-gc-deployment
 spec:
-  replicas: 2
+  replicas: 3
   selector:
     matchLabels:
       app: connectors-worker


### PR DESCRIPTION
## Description

Spread confluence workflows over the hour and not have all of them starts at once to avoid this pattern: 
<img width="734" alt="image" src="https://github.com/user-attachments/assets/b5c3274d-7efa-46cf-96ff-e1d0a34c0141">

Rebalance notion workers between sync & gc (gc is much heavier).

## Risk

Let's make sure notion sync worker are okay during burst of activity (when a new big sync comes for example).

## Deploy Plan

Deploy `connectors`