### PR TITLE
[sparkle] fix: Don't set initial pagination state, always reset to first page

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.242",
+  "version": "0.2.243",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.242",
+      "version": "0.2.243",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.243",
+  "version": "0.2.244",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.243",
+      "version": "0.2.244",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.242",
+  "version": "0.2.243",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.243",
+  "version": "0.2.244",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -92,7 +92,8 @@ export function DataTable<TData extends TBaseData>({
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
 
   const isServerSidePagination = !!totalRowCount && totalRowCount > data.length;
-  const isClientSideSortingEnabled = !isServerSideSorting && !isServerSidePagination;
+  const isClientSideSortingEnabled =
+    !isServerSideSorting && !isServerSidePagination;
 
   const onPaginationChange =
     pagination && setPagination
@@ -137,7 +138,6 @@ export function DataTable<TData extends TBaseData>({
       pagination,
     },
     initialState: {
-      pagination,
       sorting,
     },
     onPaginationChange,


### PR DESCRIPTION
## Description

Datatable use this initialstate to autoreset when any param change (data, filter, ..) - it should always reset to page 0

## Risk

pagination issues ..

## Deploy Plan

sparkle