### PR TITLE
[front] fix: use client side pagination when needed

### DIFF
--- a/front/components/ConnectorPermissionsTree.tsx
+++ b/front/components/ConnectorPermissionsTree.tsx
@@ -5,7 +5,6 @@ import {
   IconButton,
   ListCheckIcon,
   Searchbar,
-  Spinner,
   Tooltip,
   Tree,
 } from "@dust-tt/sparkle";
@@ -20,11 +19,10 @@ import type {
 } from "@dust-tt/types";
 import { useCallback, useState } from "react";
 
-import { InfiniteScroll } from "@app/components/InfiniteScroll";
 import ManagedDataSourceDocumentModal from "@app/components/ManagedDataSourceDocumentModal";
 import { getVisualForContentNode } from "@app/lib/content_nodes";
 import { useConnectorPermissions } from "@app/lib/swr/connectors";
-import { useDataSourceViewContentNodesWithInfiniteScroll } from "@app/lib/swr/data_source_views";
+import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import { classNames, timeAgoFrom } from "@app/lib/utils";
 
 const CONNECTOR_TYPE_TO_PERMISSIONS: Record<
@@ -164,19 +162,14 @@ export function DataSourceViewPermissionTreeChildren({
   viewType,
   ...props
 }: DataSourceViewPermissionTreeChildrenProps) {
-  const {
-    nodes,
-    isNodesLoading,
-    isNodesError,
-    nextPage,
-    hasMore,
-    isNodesValidating,
-  } = useDataSourceViewContentNodesWithInfiniteScroll({
-    dataSourceView: dataSourceView,
-    owner,
-    parentId: parentId ?? undefined,
-    viewType,
-  });
+  const { nodes, isNodesLoading, isNodesError } = useDataSourceViewContentNodes(
+    {
+      dataSourceView: dataSourceView,
+      owner,
+      parentId: parentId ?? undefined,
+      viewType,
+    }
+  );
 
   if (isNodesError) {
     return (
@@ -211,16 +204,6 @@ export function DataSourceViewPermissionTreeChildren({
         )}
         {...props}
       />
-      <InfiniteScroll
-        nextPage={nextPage}
-        hasMore={hasMore}
-        isValidating={isNodesValidating}
-        isLoading={isNodesLoading}
-      >
-        <div className="pl-5 pt-1">
-          <Spinner size="xs" variant="dark" />
-        </div>
-      </InfiniteScroll>
     </>
   );
 }

--- a/front/components/DataSourceViewResourceSelectorTree.tsx
+++ b/front/components/DataSourceViewResourceSelectorTree.tsx
@@ -4,7 +4,6 @@ import {
   ExternalLinkIcon,
   IconButton,
   PlusIcon,
-  Spinner,
   Tree,
 } from "@dust-tt/sparkle";
 import type {
@@ -18,10 +17,9 @@ import { useEffect, useState } from "react";
 import { ConnectorPermissionsModal } from "@app/components/ConnectorPermissionsModal";
 import { RequestDataSourceModal } from "@app/components/data_source/RequestDataSourceModal";
 import DataSourceViewDocumentModal from "@app/components/DataSourceViewDocumentModal";
-import { InfiniteScroll } from "@app/components/InfiniteScroll";
 import { getVisualForContentNode } from "@app/lib/content_nodes";
 import { useConnector } from "@app/lib/swr/connectors";
-import type { useDataSourceViewContentNodesWithInfiniteScroll } from "@app/lib/swr/data_source_views";
+import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import { classNames } from "@app/lib/utils";
 
 interface DataSourceViewResourceSelectorTreeBaseProps {
@@ -37,7 +35,7 @@ interface DataSourceViewResourceSelectorTreeBaseProps {
   selectedParents?: string[];
   selectedResourceIds: string[];
   showExpand: boolean;
-  useDataSourceViewContentNodes: typeof useDataSourceViewContentNodesWithInfiniteScroll;
+  useContentNodes: typeof useDataSourceViewContentNodes;
   viewType?: ContentNodesViewType;
 }
 
@@ -50,7 +48,7 @@ export default function DataSourceViewResourceSelectorTree({
   selectedParents = [],
   selectedResourceIds,
   onSelectChange,
-  useDataSourceViewContentNodes,
+  useContentNodes = useDataSourceViewContentNodes,
   viewType = "documents",
 }: DataSourceViewResourceSelectorTreeBaseProps) {
   return (
@@ -67,7 +65,7 @@ export default function DataSourceViewResourceSelectorTree({
         onSelectChange={(resource, parents, selected) => {
           onSelectChange(resource, parents, selected);
         }}
-        useDataSourceViewContentNodes={useDataSourceViewContentNodes}
+        useContentNodes={useContentNodes}
         viewType={viewType}
       />
     </div>
@@ -92,17 +90,10 @@ function DataSourceViewResourceSelectorChildren({
   selectedParents,
   selectedResourceIds,
   showExpand,
-  useDataSourceViewContentNodes,
+  useContentNodes,
   viewType = "documents",
 }: DataSourceResourceSelectorChildrenProps) {
-  const {
-    nodes,
-    isNodesLoading,
-    isNodesError,
-    nextPage,
-    hasMore,
-    isNodesValidating,
-  } = useDataSourceViewContentNodes({
+  const { nodes, isNodesLoading, isNodesError } = useContentNodes({
     dataSourceView: dataSourceView,
     owner,
     parentId,
@@ -201,7 +192,7 @@ function DataSourceViewResourceSelectorChildren({
                   readonly={readonly}
                   parents={[...parents, r.internalId]}
                   parentIsSelected={parentIsSelected || isSelected}
-                  useDataSourceViewContentNodes={useDataSourceViewContentNodes}
+                  useContentNodes={useContentNodes}
                   viewType={viewType}
                 />
               )}
@@ -275,16 +266,6 @@ function DataSourceViewResourceSelectorChildren({
             </div>
           )}
       </Tree>
-      <InfiniteScroll
-        nextPage={nextPage}
-        hasMore={hasMore}
-        isValidating={isNodesValidating}
-        isLoading={isNodesLoading}
-      >
-        <div className="pl-5 pt-1">
-          <Spinner size="xs" variant="dark" />
-        </div>
-      </InfiniteScroll>
     </>
   );
 }

--- a/front/components/DataSourceViewResourceSelectorTree.tsx
+++ b/front/components/DataSourceViewResourceSelectorTree.tsx
@@ -2,11 +2,6 @@ import {
   BracesIcon,
   ExternalLinkIcon,
   IconButton,
-<<<<<<< HEAD
-  PlusIcon,
-=======
-  Spinner,
->>>>>>> main
   Tree,
 } from "@dust-tt/sparkle";
 import type {
@@ -20,12 +15,7 @@ import { useEffect, useState } from "react";
 import { RequestOrAddDataFromDataSourceModal } from "@app/components/data_source/RequestOrAddDataFromDataSourceModal";
 import DataSourceViewDocumentModal from "@app/components/DataSourceViewDocumentModal";
 import { getVisualForContentNode } from "@app/lib/content_nodes";
-<<<<<<< HEAD
-import { useConnector } from "@app/lib/swr/connectors";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
-=======
-import type { useDataSourceViewContentNodesWithInfiniteScroll } from "@app/lib/swr/data_source_views";
->>>>>>> main
 import { classNames } from "@app/lib/utils";
 
 interface DataSourceViewResourceSelectorTreeBaseProps {

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -10,7 +10,6 @@ import {
   IconButton,
   Page,
   PlanetIcon,
-  Spinner,
   Tree,
 } from "@dust-tt/sparkle";
 import type {
@@ -43,7 +42,6 @@ import { assistantUsageMessage } from "@app/components/assistant/Usage";
 import { SharingDropdown } from "@app/components/assistant_builder/Sharing";
 import { DataSourceViewPermissionTreeChildren } from "@app/components/ConnectorPermissionsTree";
 import DataSourceViewDocumentModal from "@app/components/DataSourceViewDocumentModal";
-import { InfiniteScroll } from "@app/components/InfiniteScroll";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { GLOBAL_AGENTS_SID } from "@app/lib/assistant";
 import { updateAgentScope } from "@app/lib/client/dust_api";
@@ -56,7 +54,7 @@ import {
 } from "@app/lib/data_sources";
 import { useAgentConfiguration, useAgentUsage } from "@app/lib/swr/assistants";
 import {
-  useDataSourceViewContentNodesWithInfiniteScroll,
+  useDataSourceViewContentNodes,
   useDataSourceViews,
 } from "@app/lib/swr/data_source_views";
 import { classNames, timeAgoFrom } from "@app/lib/utils";
@@ -483,13 +481,12 @@ function DataSourceViewSelectedNodes({
   setDataSourceViewToDisplay: (dsv: DataSourceViewType) => void;
   setDocumentToDisplay: (documentId: string) => void;
 }) {
-  const { nodes, isNodesLoading, nextPage, hasMore, isNodesValidating } =
-    useDataSourceViewContentNodesWithInfiniteScroll({
-      owner,
-      dataSourceView,
-      internalIds: dataSourceConfiguration.filter.parents?.in ?? undefined,
-      viewType,
-    });
+  const { nodes } = useDataSourceViewContentNodes({
+    owner,
+    dataSourceView,
+    internalIds: dataSourceConfiguration.filter.parents?.in ?? undefined,
+    viewType,
+  });
 
   return (
     <>
@@ -548,16 +545,6 @@ function DataSourceViewSelectedNodes({
           />
         </Tree.Item>
       ))}
-      <InfiniteScroll
-        nextPage={nextPage}
-        hasMore={hasMore}
-        isValidating={isNodesValidating}
-        isLoading={isNodesLoading}
-      >
-        <div className="pl-5 pt-1">
-          <Spinner size="xs" variant="dark" />
-        </div>
-      </InfiniteScroll>
     </>
   );
 }

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -33,7 +33,7 @@ import {
   isManaged,
   isWebsite,
 } from "@app/lib/data_sources";
-import { useDataSourceViewContentNodesWithInfiniteScroll } from "@app/lib/swr/data_source_views";
+import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 
 const MIN_TOTAL_DATA_SOURCES_TO_GROUP = 12;
 const MIN_DATA_SOURCES_PER_KIND_TO_GROUP = 3;
@@ -225,7 +225,7 @@ interface DataSourceViewSelectorProps {
   setSelectionConfigurations: Dispatch<
     SetStateAction<DataSourceViewSelectionConfigurations>
   >;
-  useDataSourceViewContentNodes?: typeof useDataSourceViewContentNodesWithInfiniteScroll;
+  useContentNodes?: typeof useDataSourceViewContentNodes;
   viewType: ContentNodesViewType;
 }
 
@@ -234,7 +234,7 @@ export function DataSourceViewSelector({
   readonly = false,
   selectionConfiguration,
   setSelectionConfigurations,
-  useDataSourceViewContentNodes = useDataSourceViewContentNodesWithInfiniteScroll,
+  useContentNodes = useDataSourceViewContentNodes,
   viewType,
 }: DataSourceViewSelectorProps) {
   const dataSourceView = selectionConfiguration.dataSourceView;
@@ -408,7 +408,7 @@ export function DataSourceViewSelector({
         selectedParents={selectedParents}
         selectedResourceIds={internalIds}
         showExpand={config?.isNested ?? true}
-        useDataSourceViewContentNodes={useDataSourceViewContentNodes}
+        useContentNodes={useContentNodes}
         viewType={viewType}
       />
     </Tree.Item>

--- a/front/components/vaults/VaultDataSourceViewContentList.tsx
+++ b/front/components/vaults/VaultDataSourceViewContentList.tsx
@@ -179,7 +179,7 @@ export const VaultDataSourceViewContentList = ({
 
   const { pagination, setPagination } = usePaginationFromUrl({
     urlPrefix: "table",
-    initialPageSize: 5,
+    initialPageSize: 25,
   });
   const [viewType, setViewType] = useHashParam("viewType", "documents");
   const router = useRouter();

--- a/front/components/vaults/VaultDataSourceViewContentList.tsx
+++ b/front/components/vaults/VaultDataSourceViewContentList.tsx
@@ -25,8 +25,8 @@ import type {
   SortingState,
 } from "@tanstack/react-table";
 import { useRouter } from "next/router";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import * as React from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { ConnectorPermissionsModal } from "@app/components/ConnectorPermissionsModal";
 import { RequestDataSourceModal } from "@app/components/data_source/RequestDataSourceModal";
@@ -65,6 +65,11 @@ type VaultDataSourceViewContentListProps = {
   parentId?: string;
   isAdmin: boolean;
   connector: ConnectorType | null;
+};
+
+const columnsBreakpoints = {
+  lastUpdatedAt: "sm" as const,
+  vaults: "md" as const,
 };
 
 const getTableColumns = (showVaultUsage: boolean): ColumnDef<RowData>[] => {
@@ -169,15 +174,14 @@ export const VaultDataSourceViewContentList = ({
   const [dataSourceSearch, setDataSourceSearch] = useState<string>("");
   const [showConnectorPermissionsModal, setShowConnectorPermissionsModal] =
     useState(false);
-  const [sorting, setSorting] = React.useState<SortingState>([
-    { id: "name", desc: false },
-  ]);
+  const [sorting, setSorting] = React.useState<SortingState>([]);
   const contentActionsRef = useRef<ContentActionsRef>(null);
 
   const { pagination, setPagination } = usePaginationFromUrl({
     urlPrefix: "table",
+    initialPageSize: 5,
   });
-  const [viewType, setViewType] = useHashParam("viewType");
+  const [viewType, setViewType] = useHashParam("viewType", "documents");
   const router = useRouter();
   const showVaultUsage =
     dataSourceView.kind === "default" && isManaged(dataSourceView.dataSource);
@@ -205,6 +209,14 @@ export const VaultDataSourceViewContentList = ({
     [setPagination, setViewType, viewType, pagination.pageSize]
   );
 
+  const isServerPagination =
+    !isManaged(dataSourceView.dataSource) && !dataSourceSearch;
+
+  const columns = useMemo(
+    () => getTableColumns(showVaultUsage),
+    [showVaultUsage]
+  );
+
   const {
     isNodesLoading,
     mutateRegardlessOfQueryParams: mutateContentNodes,
@@ -214,8 +226,8 @@ export const VaultDataSourceViewContentList = ({
     dataSourceView,
     owner,
     parentId,
-    pagination,
-    viewType: isValidContentNodesViewType(viewType) ? viewType : undefined,
+    pagination: isServerPagination ? pagination : undefined,
+    viewType: isValidContentNodesViewType(viewType) ? viewType : "documents",
   });
 
   const { hasContent: hasDocuments, isNodesValidating: isDocumentsValidating } =
@@ -307,14 +319,6 @@ export const VaultDataSourceViewContentList = ({
     ]
   );
 
-  if (isNodesLoading) {
-    return (
-      <div className="mt-8 flex justify-center">
-        <Spinner />
-      </div>
-    );
-  }
-
   const emptyVaultContent =
     isManaged(dataSourceView.dataSource) && vault.kind !== "system" ? (
       isAdmin ? (
@@ -339,30 +343,35 @@ export const VaultDataSourceViewContentList = ({
       <></>
     );
 
+  const isEmpty = rows.length === 0 && !isNodesLoading;
+
   return (
     <>
       <div
         className={classNames(
           "flex gap-2",
-          rows.length === 0
+          isEmpty
             ? "h-36 w-full max-w-4xl items-center justify-center rounded-lg border bg-structure-50"
             : ""
         )}
       >
-        {rows.length > 0 ? (
+        {!isEmpty && (
           <>
             <Searchbar
               name="search"
               placeholder="Search (Name)"
               value={dataSourceSearch}
               onChange={(s) => {
+                setPagination(
+                  { pageIndex: 0, pageSize: pagination.pageSize },
+                  "replace"
+                );
                 setDataSourceSearch(s);
               }}
             />
           </>
-        ) : (
-          emptyVaultContent
         )}
+        {isEmpty && !emptyVaultContent}
         {isFolder(dataSourceView.dataSource) && (
           <>
             {((viewType === "tables" && hasDocuments) ||
@@ -435,22 +444,24 @@ export const VaultDataSourceViewContentList = ({
             </div>
           )}
       </div>
+      {isNodesLoading && (
+        <div className="mt-8 flex justify-center">
+          <Spinner />
+        </div>
+      )}
       {rows.length > 0 && (
         <DataTable
           data={rows}
-          columns={getTableColumns(showVaultUsage)}
+          columns={columns}
           filter={dataSourceSearch}
           filterColumn="title"
           className="pb-4"
           sorting={sorting}
           setSorting={setSorting}
-          totalRowCount={totalNodesCount}
+          totalRowCount={isServerPagination ? totalNodesCount : undefined}
           pagination={pagination}
           setPagination={setPagination}
-          columnsBreakpoints={{
-            lastUpdatedAt: "sm",
-            vaults: "md",
-          }}
+          columnsBreakpoints={columnsBreakpoints}
         />
       )}
       <ContentActions

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -71,22 +71,9 @@ interface GetContentNodesForDataSourceViewResult {
   total: number;
 }
 
-const paginate = (
-  nodes: DataSourceViewContentNode[],
-  pagination?: OffsetPaginationParams
-) =>
-  pagination
-    ? nodes.slice(pagination.offset, pagination.offset + pagination.limit)
-    : nodes;
-
 export async function getContentNodesForManagedDataSourceView(
   dataSourceView: DataSourceViewResource | DataSourceViewType,
-  {
-    internalIds,
-    parentId,
-    pagination,
-    viewType,
-  }: GetContentNodesForDataSourceViewParams
+  { internalIds, parentId, viewType }: GetContentNodesForDataSourceViewParams
 ): Promise<Result<GetContentNodesForDataSourceViewResult, Error>> {
   const { dataSource } = dataSourceView;
 
@@ -125,7 +112,7 @@ export async function getContentNodesForManagedDataSourceView(
     }
 
     return new Ok({
-      nodes: paginate(connectorsRes.value.resources, pagination),
+      nodes: connectorsRes.value.resources,
       // Connectors API does not support pagination yet, so the total is the length of the nodes.
       total: connectorsRes.value.resources.length,
     });
@@ -144,7 +131,7 @@ export async function getContentNodesForManagedDataSourceView(
       );
     }
     return new Ok({
-      nodes: paginate(connectorsRes.value.nodes, pagination),
+      nodes: connectorsRes.value.nodes,
       // Connectors API does not support pagination yet, so the total is the length of the nodes.
       total: connectorsRes.value.nodes.length,
     });

--- a/front/lib/api/pagination.ts
+++ b/front/lib/api/pagination.ts
@@ -96,22 +96,26 @@ export interface OffsetPaginationParams {
   offset: number;
 }
 
-interface OffsetPaginationOptions {
-  defaultLimit: number;
-  defaultOffset: 0;
-}
-
 export function getOffsetPaginationParams(
-  req: NextApiRequest,
-  defaults: OffsetPaginationOptions
-): Result<OffsetPaginationParams, InvalidPaginationParamsError> {
+  req: NextApiRequest
+): Result<OffsetPaginationParams | undefined, InvalidPaginationParamsError> {
+  const { limit, offset } = req.query;
+  if (!req.query.limit) {
+    return new Ok(undefined);
+  }
+
+  if (typeof limit !== "string" || (offset && typeof offset !== "string")) {
+    return new Err(
+      new InvalidPaginationParamsError(
+        "Invalid pagination parameters",
+        "limit and offset must be strings"
+      )
+    );
+  }
+
   const rawParams = {
-    limit: req.query.limit
-      ? parseInt(req.query.limit as string)
-      : defaults.defaultLimit,
-    offset: req.query.offset
-      ? parseInt(req.query.offset as string)
-      : defaults.defaultOffset,
+    limit: parseInt(limit),
+    offset: offset ? parseInt(offset) : 0,
   };
 
   const queryValidation = OffsetPaginationParamsCodec.decode(rawParams);

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,7 @@
         "@amplitude/analytics-browser": "^2.5.2",
         "@amplitude/analytics-node": "^1.3.5",
         "@auth0/nextjs-auth0": "^3.5.0",
-        "@dust-tt/sparkle": "^0.2.242",
+        "@dust-tt/sparkle": "^0.2.244",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -10737,9 +10737,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.242",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.242.tgz",
-      "integrity": "sha512-5ocLOOBFUzsYkdE2DcVbhHot5G218JibHo+3U9z2MNcI4KL+A9LgLbHWdIFviakNhjhnU9thDxmg3PlqajJ00g==",
+      "version": "0.2.244",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.244.tgz",
+      "integrity": "sha512-mNGU6XWKO37LE5qbQI+XHWv7kd66YyrZDbLLS6C8xP/HWZ9socFoZ4BBLGn0gQ34nhp3Yx6dsrna269V864aBQ==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
     "@amplitude/analytics-browser": "^2.5.2",
     "@amplitude/analytics-node": "^1.3.5",
     "@auth0/nextjs-auth0": "^3.5.0",
-    "@dust-tt/sparkle": "^0.2.242",
+    "@dust-tt/sparkle": "^0.2.244",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",

--- a/front/pages/api/poke/workspaces/[wId]/vaults/[vId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/poke/workspaces/[wId]/vaults/[vId]/data_source_views/[dsvId]/content-nodes.ts
@@ -16,8 +16,6 @@ import type { SessionWithUser } from "@app/lib/iam/provider";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { apiError } from "@app/logger/withlogging";
 
-const DEFAULT_LIMIT = 500;
-
 const GetContentNodesOrChildrenRequestBody = t.type({
   internalIds: t.union([t.array(t.union([t.string, t.null])), t.undefined]),
   parentId: t.union([t.string, t.undefined]),
@@ -124,10 +122,7 @@ async function handler(
     });
   }
 
-  const paginationRes = getOffsetPaginationParams(req, {
-    defaultLimit: DEFAULT_LIMIT,
-    defaultOffset: 0,
-  });
+  const paginationRes = getOffsetPaginationParams(req);
   if (paginationRes.isErr()) {
     return apiError(req, res, {
       status_code: 400,

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/content-nodes.ts
@@ -15,8 +15,6 @@ import type { Authenticator } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { apiError } from "@app/logger/withlogging";
 
-const DEFAULT_LIMIT = 500;
-
 const GetContentNodesOrChildrenRequestBody = t.type({
   internalIds: t.union([t.array(t.union([t.string, t.null])), t.undefined]),
   parentId: t.union([t.string, t.undefined]),
@@ -99,10 +97,7 @@ async function handler(
     });
   }
 
-  const paginationRes = getOffsetPaginationParams(req, {
-    defaultLimit: DEFAULT_LIMIT,
-    defaultOffset: 0,
-  });
+  const paginationRes = getOffsetPaginationParams(req);
   if (paginationRes.isErr()) {
     return apiError(req, res, {
       status_code: 400,

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/tables/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/tables/index.ts
@@ -15,8 +15,6 @@ export type ListTablesResponseBody = {
   tables: DataSourceViewContentNode[];
 };
 
-const DEFAULT_LIMIT = 100;
-
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<ListTablesResponseBody>>,
@@ -51,10 +49,7 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const paginationRes = getOffsetPaginationParams(req, {
-        defaultLimit: DEFAULT_LIMIT,
-        defaultOffset: 0,
-      });
+      const paginationRes = getOffsetPaginationParams(req);
       if (paginationRes.isErr()) {
         return apiError(req, res, {
           status_code: 400,

--- a/front/pages/poke/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.tsx
+++ b/front/pages/poke/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.tsx
@@ -1,5 +1,4 @@
-import type { WorkspaceType } from "@dust-tt/types";
-import type { DataSourceViewType } from "@dust-tt/types";
+import type { DataSourceViewType, WorkspaceType } from "@dust-tt/types";
 import { defaultSelectionConfiguration } from "@dust-tt/types";
 import type { InferGetServerSidePropsType } from "next";
 import type { ReactElement } from "react";
@@ -9,7 +8,7 @@ import { ViewDataSourceViewTable } from "@app/components/poke/data_source_views/
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import PokeLayout from "@app/pages/poke/PokeLayout";
-import { usePokeDataSourceViewContentNodesWithInfiniteScroll } from "@app/poke/swr/data_source_views";
+import { usePokeDataSourceViewContentNodes } from "@app/poke/swr/data_source_views";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
   dataSourceView: DataSourceViewType;
@@ -54,9 +53,7 @@ export default function DataSourceViewPage({
           readonly
           selectionConfiguration={defaultSelectionConfiguration(dataSourceView)}
           setSelectionConfigurations={() => {}}
-          useDataSourceViewContentNodes={
-            usePokeDataSourceViewContentNodesWithInfiniteScroll
-          }
+          useContentNodes={usePokeDataSourceViewContentNodes}
           viewType="documents"
         />
       </div>


### PR DESCRIPTION
## Description

- Disable server-side pagination on managed datasource
- Remove default value for pagination on content-nodes
- Remove infinite scroll in trees as it's only for managed datasources
- Fixed pagination glitches when running client side
- Use client side pagination when using filter 

## Risk



## Deploy Plan

front