### PR TITLE
Remove comment for RetrievalDocument (verify backfill)

### DIFF
--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -270,7 +270,7 @@ export class RetrievalDocument extends Model<
   declare tags: string[];
   declare score: number | null;
 
-  // TODO(VAULTS_INFRA) Make not nullable once backfilled.
+  // This is nullable as it has to be set null when data sources are deleted.
   declare dataSourceViewId: ForeignKey<DataSourceViewModel["id"]> | null;
   declare retrievalActionId: ForeignKey<AgentRetrievalAction["id"]>;
 
@@ -343,7 +343,6 @@ RetrievalDocument.belongsTo(AgentRetrievalAction, {
   foreignKey: { name: "retrievalActionId", allowNull: false },
 });
 
-// TODO(VAULTS_INFRA) Set to not null once backfilled.
 DataSourceViewModel.hasMany(RetrievalDocument, {
   foreignKey: { allowNull: true },
   onDelete: "SET NULL",


### PR DESCRIPTION
## Description

Checked that this collection has been backfilled and clarified comment
```
dust-front=> SELECT COUNT(*) FROM retrieval_documents WHERE "dataSourceViewId" IS NOT NULL;
  count   
----------
 10398194
(1 row)

dust-front=> SELECT COUNT(*) FROM retrieval_documents WHERE "dataSourceViewId" IS NULL;
 count  
--------
 404082
(1 row)
```

The migration is here: https://github.com/dust-tt/dust/blob/main/front/migrations/20240911_backfill_views_in_retrieval_documents.ts

## Risk

N/A

## Deploy Plan

N/A