### PR TITLE
[front] - fix(apps): adjust tabs visibility on role 

### DIFF
--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -17,7 +17,7 @@ import {
 import { GlobeAltIcon } from "@dust-tt/sparkle";
 import type { AppType } from "@dust-tt/types";
 import type { WorkspaceType } from "@dust-tt/types";
-import { isAdmin, isBuilder, isUser } from "@dust-tt/types";
+import { isAdmin, isBuilder } from "@dust-tt/types";
 import { UsersIcon } from "@heroicons/react/20/solid";
 
 /**
@@ -396,7 +396,7 @@ export const subNavigationApp = ({
     },
   ];
 
-  if (isUser(owner)) {
+  if (isAdmin(owner) || isBuilder(owner)) {
     nav = nav.concat([
       {
         id: "runs",

--- a/front/poke/swr/data_source_views.ts
+++ b/front/poke/swr/data_source_views.ts
@@ -3,6 +3,7 @@ import type {
   DataSourceViewType,
   LightWorkspaceType,
 } from "@dust-tt/types";
+import type { PaginationState } from "@tanstack/react-table";
 import { useMemo } from "react";
 import type { Fetcher, KeyedMutator } from "swr";
 
@@ -16,7 +17,6 @@ import {
 import type { PokeListDataSourceViews } from "@app/pages/api/poke/workspaces/[wId]/data_source_views";
 import type { PokeGetDataSourceViewContentNodes } from "@app/pages/api/poke/workspaces/[wId]/vaults/[vId]/data_source_views/[dsvId]/content-nodes";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
-import { PaginationState } from "@tanstack/react-table";
 
 export function usePokeDataSourceViews({
   disabled,


### PR DESCRIPTION
## Description

This PR aims at hiding the "logs" and "settings" tabs of Dust Apps for "users".

**References:**
- https://github.com/dust-tt/dust/issues/7530

## Risk

Low

## Deploy Plan

Deploy `front`