### PR TITLE
[front] - fix: restrict system vault access exclusively to admins

### DIFF
--- a/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/index.tsx
@@ -28,6 +28,7 @@ import config from "@app/lib/api/config";
 import { extractConfig } from "@app/lib/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { AppResource } from "@app/lib/resources/app_resource";
+import { VaultResource } from "@app/lib/resources/vault_resource";
 import {
   addBlock,
   deleteBlock,
@@ -48,7 +49,12 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   const owner = auth.workspace();
   const subscription = auth.subscription();
 
-  if (!owner || !subscription) {
+  const vault = await VaultResource.fetchById(
+    auth,
+    context.query.vaultId as string
+  );
+
+  if (!owner || !subscription || !vault || !vault.canList(auth)) {
     return {
       notFound: true,
     };

--- a/front/pages/w/[wId]/vaults/[vaultId]/apps/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/apps/index.tsx
@@ -45,6 +45,7 @@ import {
   serviceProviders,
 } from "@app/lib/providers";
 import { AppResource } from "@app/lib/resources/app_resource";
+import { VaultResource } from "@app/lib/resources/vault_resource";
 import { useDustAppSecrets, useKeys, useProviders } from "@app/lib/swr/apps";
 import { classNames, timeAgoFrom } from "@app/lib/utils";
 
@@ -59,7 +60,12 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   const groups = auth.groups();
   const subscription = auth.subscription();
 
-  if (!owner || !subscription || !auth.isBuilder()) {
+  const vault = await VaultResource.fetchById(
+    auth,
+    context.query.vaultId as string
+  );
+
+  if (!owner || !subscription || !vault || !vault.canList(auth)) {
     return {
       notFound: true,
     };

--- a/front/pages/w/[wId]/vaults/[vaultId]/categories/[category]/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/categories/[category]/index.tsx
@@ -42,6 +42,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
   const owner = auth.getNonNullableWorkspace();
   const subscription = auth.subscription();
   const plan = auth.getNonNullablePlan();
+  const isAdmin = auth.isAdmin();
 
   if (!subscription) {
     return {
@@ -54,12 +55,12 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     auth,
     context.query.vaultId as string
   );
-  if (!vault || !systemVault) {
+  if (!vault || !systemVault || (vault.isSystem() && !isAdmin)) {
     return {
       notFound: true,
     };
   }
-  const isAdmin = auth.isAdmin();
+
   const isBuilder = auth.isBuilder();
   const canWriteInVault = vault.canWrite(auth);
 

--- a/front/pages/w/[wId]/vaults/[vaultId]/categories/[category]/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/categories/[category]/index.tsx
@@ -55,7 +55,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     auth,
     context.query.vaultId as string
   );
-  if (!vault || !systemVault || (vault.canRead(auth))) {
+  if (!vault || !systemVault || (!vault.canRead(auth))) {
     return {
       notFound: true,
     };

--- a/front/pages/w/[wId]/vaults/[vaultId]/categories/[category]/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/categories/[category]/index.tsx
@@ -55,7 +55,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     auth,
     context.query.vaultId as string
   );
-  if (!vault || !systemVault || (vault.isSystem() && !isAdmin)) {
+  if (!vault || !systemVault || (vault.canRead(auth))) {
     return {
       notFound: true,
     };

--- a/front/pages/w/[wId]/vaults/[vaultId]/categories/[category]/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/categories/[category]/index.tsx
@@ -55,7 +55,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     auth,
     context.query.vaultId as string
   );
-  if (!vault || !systemVault || !vault.canRead(auth)) {
+  if (!vault || !systemVault || !vault.canList(auth)) {
     return {
       notFound: true,
     };

--- a/front/pages/w/[wId]/vaults/[vaultId]/categories/[category]/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/categories/[category]/index.tsx
@@ -55,7 +55,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     auth,
     context.query.vaultId as string
   );
-  if (!vault || !systemVault || (!vault.canRead(auth))) {
+  if (!vault || !systemVault || !vault.canRead(auth)) {
     return {
       notFound: true,
     };

--- a/front/pages/w/[wId]/vaults/[vaultId]/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/index.tsx
@@ -30,7 +30,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     auth,
     context.query.vaultId as string
   );
-  if (!vault || (!isAdmin && vault.isSystem())) {
+  if (!vault || (vault.canRead(auth))) {
     return {
       notFound: true,
     };

--- a/front/pages/w/[wId]/vaults/[vaultId]/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/index.tsx
@@ -30,7 +30,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     auth,
     context.query.vaultId as string
   );
-  if (!vault || !vault.canRead(auth)) {
+  if (!vault || !vault.canList(auth)) {
     return {
       notFound: true,
     };

--- a/front/pages/w/[wId]/vaults/[vaultId]/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/index.tsx
@@ -30,7 +30,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     auth,
     context.query.vaultId as string
   );
-  if (!vault || (vault.canRead(auth))) {
+  if (!vault || (!vault.canRead(auth))) {
     return {
       notFound: true,
     };

--- a/front/pages/w/[wId]/vaults/[vaultId]/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/index.tsx
@@ -30,7 +30,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     auth,
     context.query.vaultId as string
   );
-  if (!vault || (!vault.canRead(auth))) {
+  if (!vault || !vault.canRead(auth)) {
     return {
       notFound: true,
     };

--- a/front/pages/w/[wId]/vaults/[vaultId]/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/index.tsx
@@ -18,6 +18,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
 >(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
   const subscription = auth.subscription();
+  const isAdmin = auth.isAdmin();
 
   if (!subscription) {
     return {
@@ -29,11 +30,12 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     auth,
     context.query.vaultId as string
   );
-  if (!vault) {
+  if (!vault || (!isAdmin && vault.isSystem())) {
     return {
       notFound: true,
     };
   }
+
   // No root page for System vaults since it contains only managed data sources.
   if (vault.isSystem()) {
     return {
@@ -43,8 +45,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
       },
     };
   }
-
-  const isAdmin = auth.isAdmin();
 
   return {
     props: {


### PR DESCRIPTION
## Description

This PR aims at restricting system vault views to admins only.

**References:**
- https://github.com/dust-tt/tasks/issues/1351

## Risk

Low

## Deploy Plan

Deploy `front`
