### PR TITLE
[Agent Configurations] Allow fetching multiple agent configurations by sIds

### DIFF
--- a/front/lib/api/assistant/participants.ts
+++ b/front/lib/api/assistant/participants.ts
@@ -10,7 +10,10 @@ import type {
 import { Err, formatUserFullName, Ok } from "@dust-tt/types";
 import { Op } from "sequelize";
 
-import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
+import {
+  getAgentConfiguration,
+  getAgentConfigurations,
+} from "@app/lib/api/assistant/configuration";
 import type { Authenticator } from "@app/lib/auth";
 import {
   AgentMessage,
@@ -44,14 +47,11 @@ async function fetchAllAgentsById(
   auth: Authenticator,
   agentConfigurationIds: string[]
 ): Promise<AgentParticipantType[]> {
-  // TODO(2024-3-25 flav) Support fetching many agents by id.
-  const agents = (
-    await Promise.all(
-      agentConfigurationIds.map((agentConfigId) => {
-        return getAgentConfiguration(auth, agentConfigId);
-      })
-    )
-  ).filter((a) => a !== null) as LightAgentConfigurationType[];
+  const agents = await getAgentConfigurations({
+    auth,
+    agentsGetView: { agentIds: agentConfigurationIds },
+    variant: "light",
+  });
 
   return agents.map((a) => ({
     configurationId: a.sId,

--- a/front/lib/api/assistant/participants.ts
+++ b/front/lib/api/assistant/participants.ts
@@ -2,7 +2,6 @@ import type {
   AgentParticipantType,
   ConversationParticipantsType,
   ConversationWithoutContentType,
-  LightAgentConfigurationType,
   ModelId,
   Result,
   UserParticipantType,
@@ -10,10 +9,7 @@ import type {
 import { Err, formatUserFullName, Ok } from "@dust-tt/types";
 import { Op } from "sequelize";
 
-import {
-  getAgentConfiguration,
-  getAgentConfigurations,
-} from "@app/lib/api/assistant/configuration";
+import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import type { Authenticator } from "@app/lib/auth";
 import {
   AgentMessage,

--- a/front/pages/poke/[wId]/assistants/[aId]/index.tsx
+++ b/front/pages/poke/[wId]/assistants/[aId]/index.tsx
@@ -20,7 +20,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
 
   const agentConfigurations = await getAgentConfigurations({
     auth,
-    agentsGetView: { agentId: aId, allVersions: true },
+    agentsGetView: { agentIds: [aId], allVersions: true },
     variant: "full",
   });
 

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -104,7 +104,7 @@ export type AgentUserListStatus = "in-list" | "not-in-list";
  *   private agents, agents from the workspace and global scope, plus any
  *   published agents they've added to their list (refer to
  *   AgentUserRelationTable).
- * - {agentId: string}: Retrieves a single agent by its ID.
+ * - {agentIds: string}: Retrieves specific agents by their sIds.
  * - {conversationId: string}: all agent from the user's list view, plus the
  *   agents mentioned in the conversation with the provided Id.
  * - 'all': Combines workspace and published agents, excluding private agents.
@@ -120,7 +120,7 @@ export type AgentUserListStatus = "in-list" | "not-in-list";
  *   authorization.
  */
 export type AgentsGetViewType =
-  | { agentId: string; allVersions?: boolean }
+  | { agentIds: string[]; allVersions?: boolean }
   | "list"
   | { conversationId: string }
   | "all"


### PR DESCRIPTION
Description
---
We previously could only get a single agent this way.

Fixes a remaining todo, useful for upcoming work on conversation restrictions.

In addition, turns a get agent from full to light which should reduce load.

Risk
---
Somewhat high, it's a critical part of the code. But the change is straightforward.

Tested locally

Deploy
---
front
