### PR TITLE
Finalize AgentDataSourceConfigurations

### DIFF
--- a/front/lib/models/assistant/actions/data_sources.ts
+++ b/front/lib/models/assistant/actions/data_sources.ts
@@ -28,7 +28,7 @@ export class AgentDataSourceConfiguration extends Model<
   declare parentsNotIn: string[] | null;
 
   declare dataSourceId: ForeignKey<DataSource["id"]>;
-  declare dataSourceViewId: ForeignKey<DataSourceViewModel["id"]> | null;
+  declare dataSourceViewId: ForeignKey<DataSourceViewModel["id"]>;
 
   // AgentDataSourceConfiguration can be used by both the retrieval and the process actions'
   // configurations.
@@ -124,8 +124,7 @@ DataSourceViewModel.hasMany(AgentDataSourceConfiguration, {
   foreignKey: { allowNull: true },
   onDelete: "RESTRICT",
 });
-// TODO(GROUPS_INFRA): This should be a required relationship.
 AgentDataSourceConfiguration.belongsTo(DataSourceViewModel, {
   as: "dataSourceView",
-  foreignKey: { allowNull: true },
+  foreignKey: { allowNull: false },
 });

--- a/front/migrations/20240820_backfill_views_in_agent_data_source_configurations.ts
+++ b/front/migrations/20240820_backfill_views_in_agent_data_source_configurations.ts
@@ -1,95 +1,95 @@
-import type { LightWorkspaceType } from "@dust-tt/types";
-import assert from "assert";
-import { Op } from "sequelize";
-
-import { Authenticator } from "@app/lib/auth";
-import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
-import { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
-import { VaultResource } from "@app/lib/resources/vault_resource";
-import type { Logger } from "@app/logger/logger";
-import { makeScript, runOnAllWorkspaces } from "@app/scripts/helpers";
-
-async function backfillViewsInAgentDataSourceConfigurationForWorkspace(
-  workspace: LightWorkspaceType,
-  logger: Logger,
-  execute: boolean
-) {
-  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-
-  // List workspace data sources.
-  const dataSources = await DataSourceResource.listByWorkspace(auth);
-
-  logger.info(
-    `Found ${dataSources.length} data sources for workspace(${workspace.sId}).`
-  );
-
-  const globalVault = await VaultResource.fetchWorkspaceGlobalVault(auth);
-
-  // Retrieve data source views for data sources.
-  const dataSourceViews =
-    await DataSourceViewResource.listForDataSourcesInVault(
-      auth,
-      dataSources,
-      globalVault
-    );
-
-  // Count agent data source configurations that uses those data sources and have no dataSourceViewId.
-
-  const agentDataSourceConfigurationsCount =
-    await AgentDataSourceConfiguration.count({
-      where: {
-        dataSourceId: dataSources.map((ds) => ds.id),
-        dataSourceViewId: {
-          [Op.is]: null,
-        },
-      },
-    });
-
-  logger.info(
-    `About to update ${agentDataSourceConfigurationsCount} agent data source configurations for workspace(${workspace.sId}).`
-  );
-
-  if (!execute) {
-    return;
-  }
-
-  for (const ds of dataSources) {
-    const dataSourceView = dataSourceViews.find(
-      (dsv) => dsv.dataSourceId === ds.id
-    );
-    assert(
-      dataSourceView,
-      `Data source view not found for data source ${ds.id}.`
-    );
-
-    await AgentDataSourceConfiguration.update(
-      { dataSourceViewId: dataSourceView.id },
-      {
-        where: {
-          dataSourceId: ds.id,
-        },
-      }
-    );
-
-    logger.info(
-      `Updated agent data source configuration for data source ${ds.id}.`
-    );
-  }
-
-  logger.info(
-    `Updated all agent data source configurations for workspace(${workspace.sId}).`
-  );
-}
-
-makeScript({}, async ({ execute }, logger) => {
-  return runOnAllWorkspaces(async (workspace) => {
-    await backfillViewsInAgentDataSourceConfigurationForWorkspace(
-      workspace,
-      logger,
-      execute
-    );
-
-    logger.info(`Finished backfilling views for workspace(${workspace.sId}).`);
-  });
-});
+// import type { LightWorkspaceType } from "@dust-tt/types";
+// import assert from "assert";
+// import { Op } from "sequelize";
+//
+// import { Authenticator } from "@app/lib/auth";
+// import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
+// import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+// import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+// import { VaultResource } from "@app/lib/resources/vault_resource";
+// import type { Logger } from "@app/logger/logger";
+// import { makeScript, runOnAllWorkspaces } from "@app/scripts/helpers";
+//
+// async function backfillViewsInAgentDataSourceConfigurationForWorkspace(
+//   workspace: LightWorkspaceType,
+//   logger: Logger,
+//   execute: boolean
+// ) {
+//   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+//
+//   // List workspace data sources.
+//   const dataSources = await DataSourceResource.listByWorkspace(auth);
+//
+//   logger.info(
+//     `Found ${dataSources.length} data sources for workspace(${workspace.sId}).`
+//   );
+//
+//   const globalVault = await VaultResource.fetchWorkspaceGlobalVault(auth);
+//
+//   // Retrieve data source views for data sources.
+//   const dataSourceViews =
+//     await DataSourceViewResource.listForDataSourcesInVault(
+//       auth,
+//       dataSources,
+//       globalVault
+//     );
+//
+//   // Count agent data source configurations that uses those data sources and have no dataSourceViewId.
+//
+//   const agentDataSourceConfigurationsCount =
+//     await AgentDataSourceConfiguration.count({
+//       where: {
+//         dataSourceId: dataSources.map((ds) => ds.id),
+//         dataSourceViewId: {
+//           [Op.is]: null,
+//         },
+//       },
+//     });
+//
+//   logger.info(
+//     `About to update ${agentDataSourceConfigurationsCount} agent data source configurations for workspace(${workspace.sId}).`
+//   );
+//
+//   if (!execute) {
+//     return;
+//   }
+//
+//   for (const ds of dataSources) {
+//     const dataSourceView = dataSourceViews.find(
+//       (dsv) => dsv.dataSourceId === ds.id
+//     );
+//     assert(
+//       dataSourceView,
+//       `Data source view not found for data source ${ds.id}.`
+//     );
+//
+//     await AgentDataSourceConfiguration.update(
+//       { dataSourceViewId: dataSourceView.id },
+//       {
+//         where: {
+//           dataSourceId: ds.id,
+//         },
+//       }
+//     );
+//
+//     logger.info(
+//       `Updated agent data source configuration for data source ${ds.id}.`
+//     );
+//   }
+//
+//   logger.info(
+//     `Updated all agent data source configurations for workspace(${workspace.sId}).`
+//   );
+// }
+//
+// makeScript({}, async ({ execute }, logger) => {
+//   return runOnAllWorkspaces(async (workspace) => {
+//     await backfillViewsInAgentDataSourceConfigurationForWorkspace(
+//       workspace,
+//       logger,
+//       execute
+//     );
+//
+//     logger.info(`Finished backfilling views for workspace(${workspace.sId}).`);
+//   });
+// });

--- a/front/migrations/db/migration_84.sql
+++ b/front/migrations/db/migration_84.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "agent_data_source_configurations" ALTER COLUMN "dataSourceViewId" SET NOT NULL;


### PR DESCRIPTION
## Description

Enforce not null on dataSourceViewId on AgentDataSourceConfigurations.

```
dust-front=> SELECT COUNT(*) FROM agent_data_source_configurations WHERE "dataSourceViewId" IS NULL;
 count 
-------
     0
(1 row)

dust-front=> SELECT COUNT(*) FROM agent_data_source_configurations WHERE "dataSourceViewId" IS NOT NULL;
 count  
--------
 191412
(1 row)
```

## Risk

N/A

## Deploy Plan

- deploy migration in DB
- deploy `front`