### PR TITLE
feat(remote databases): execute_query for snowflake

### DIFF
--- a/core/src/blocks/database.rs
+++ b/core/src/blocks/database.rs
@@ -1,15 +1,19 @@
-use crate::blocks::block::{parse_pair, Block, BlockResult, BlockType, Env};
-use crate::databases::database::{query_database, QueryDatabaseError};
-use crate::Rule;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-
 use pest::iterators::Pair;
 use serde_json::{json, Value};
 use tokio::sync::mpsc::UnboundedSender;
 
-use super::block::replace_variables_in_string;
-use super::database_schema::load_tables_from_identifiers;
+use crate::{
+    blocks::{
+        block::{parse_pair, replace_variables_in_string, Block, BlockResult, BlockType, Env},
+        database_schema::load_tables_from_identifiers,
+    },
+    databases::{
+        database::QueryDatabaseError, transient_database::execute_query_on_transient_database,
+    },
+    Rule,
+};
 
 #[derive(Clone)]
 pub struct Database {
@@ -103,7 +107,7 @@ impl Block for Database {
         let query = replace_variables_in_string(&self.query, "query", env)?;
         let tables = load_tables_from_identifiers(&table_identifiers, env).await?;
 
-        match query_database(&tables, env.store.clone(), &query).await {
+        match execute_query_on_transient_database(&tables, env.store.clone(), &query).await {
             Ok((results, schema)) => Ok(BlockResult {
                 value: json!({
                     "results": results,

--- a/core/src/blocks/database_schema.rs
+++ b/core/src/blocks/database_schema.rs
@@ -1,7 +1,3 @@
-use super::helpers::get_data_source_project_and_view_filter;
-use crate::blocks::block::{Block, BlockResult, BlockType, Env};
-use crate::databases::database::{get_unique_table_names_for_database, Table};
-use crate::Rule;
 use anyhow::{anyhow, Ok, Result};
 use async_trait::async_trait;
 use futures::future::try_join_all;
@@ -9,6 +5,18 @@ use itertools::Itertools;
 use pest::iterators::Pair;
 use serde_json::{json, Value};
 use tokio::sync::mpsc::UnboundedSender;
+
+use crate::{
+    blocks::{
+        block::{Block, BlockResult, BlockType, Env},
+        helpers::get_data_source_project_and_view_filter,
+    },
+    databases::{
+        database::Table, transient_database::get_unique_table_names_for_transient_database,
+    },
+    Rule,
+};
+
 #[derive(Clone)]
 pub struct DatabaseSchema {}
 
@@ -74,7 +82,7 @@ impl Block for DatabaseSchema {
         let mut tables = load_tables_from_identifiers(&table_identifiers, env).await?;
 
         // Compute the unique table names for each table.
-        let unique_table_names = get_unique_table_names_for_database(&tables);
+        let unique_table_names = get_unique_table_names_for_transient_database(&tables);
 
         // Load the schema for each table.
         // If the schema cache is stale, this will update it in place.

--- a/core/src/databases/remote_databases/remote_database.rs
+++ b/core/src/databases/remote_databases/remote_database.rs
@@ -1,8 +1,16 @@
 use anyhow::Result;
-
 use async_trait::async_trait;
+
+use crate::databases::{
+    database::{QueryDatabaseError, QueryResult},
+    table_schema::TableSchema,
+};
 
 #[async_trait]
 pub trait RemoteDatabase {
     async fn get_tables_used_by_query(&self, query: &str) -> Result<Vec<String>>;
+    async fn execute_query(
+        &self,
+        query: &str,
+    ) -> Result<(Vec<QueryResult>, TableSchema), QueryDatabaseError>;
 }

--- a/core/src/databases/remote_databases/snowflake.rs
+++ b/core/src/databases/remote_databases/snowflake.rs
@@ -119,6 +119,7 @@ impl RemoteDatabase for SnowflakeRemoteDatabase {
             .map(|row| row.try_into())
             .collect::<Result<Vec<QueryResult>>>()?;
 
+        // TODO(@fontanierh): decide if we want to infer query result schema for remote DBs.
         let schema = TableSchema::empty();
 
         Ok((rows, schema))

--- a/core/src/databases/remote_databases/snowflake.rs
+++ b/core/src/databases/remote_databases/snowflake.rs
@@ -1,9 +1,15 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use serde::Deserialize;
-use snowflake_connector_rs::{SnowflakeAuthMethod, SnowflakeClient, SnowflakeClientConfig};
+use snowflake_connector_rs::{
+    SnowflakeAuthMethod, SnowflakeClient, SnowflakeClientConfig, SnowflakeDecode, SnowflakeRow,
+};
 
-use crate::databases::remote_databases::remote_database::RemoteDatabase;
+use crate::databases::{
+    database::{QueryDatabaseError, QueryResult},
+    remote_databases::remote_database::RemoteDatabase,
+    table_schema::TableSchema,
+};
 
 pub struct SnowflakeRemoteDatabase {
     client: SnowflakeClient,
@@ -39,13 +45,51 @@ impl SnowflakeRemoteDatabase {
     }
 }
 
+impl TryFrom<SnowflakeRow> for QueryResult {
+    type Error = anyhow::Error;
+
+    fn try_from(row: SnowflakeRow) -> Result<Self> {
+        fn decode_column<T: SnowflakeDecode>(row: &SnowflakeRow, name: &str) -> Result<T> {
+            match row.get::<T>(name) {
+                Ok(value) => Ok(value),
+                Err(_) => Err(anyhow!("Error decoding column")),
+            }
+        }
+
+        let mut map = serde_json::Map::new();
+        for col in row.column_types() {
+            let name = col.name();
+            let snowflake_type = col.column_type().snowflake_type().to_ascii_uppercase();
+            let value = match snowflake_type.as_str() {
+                "NUMBER" | "INT" | "INTEGER" | "BIGINT" | "SMALLINT" | "TINYINT" | "BYTEINT" => {
+                    serde_json::Value::Number(decode_column::<i64>(&row, name)?.into())
+                }
+                "STRING" | "TEXT" | "VARCHAR" | "CHAR" => {
+                    serde_json::Value::String(decode_column::<String>(&row, name)?.into())
+                }
+                "BOOLEAN" => serde_json::Value::Bool(decode_column::<bool>(&row, name)?.into()),
+                "TIMESTAMP" => {
+                    serde_json::Value::String(decode_column::<String>(&row, name)?.into())
+                }
+                // default to string
+                _ => serde_json::Value::String(decode_column::<String>(&row, name)?.into()),
+            };
+            map.insert(name.to_string(), value);
+        }
+
+        Ok(QueryResult {
+            value: serde_json::Value::Object(map),
+        })
+    }
+}
+
 #[async_trait]
 impl RemoteDatabase for SnowflakeRemoteDatabase {
     async fn get_tables_used_by_query(&self, query: &str) -> Result<Vec<String>> {
         let session = self.client.create_session().await?;
 
         let explain_query = format!("EXPLAIN {}", query);
-        let explain_rows = session
+        let used_tables = session
             .query(explain_query.clone())
             .await?
             .iter()
@@ -55,6 +99,28 @@ impl RemoteDatabase for SnowflakeRemoteDatabase {
             })
             .collect();
 
-        Ok(explain_rows)
+        Ok(used_tables)
+    }
+
+    async fn execute_query(
+        &self,
+        query: &str,
+    ) -> Result<(Vec<QueryResult>, TableSchema), QueryDatabaseError> {
+        let session = self.client.create_session().await.map_err(|e| {
+            QueryDatabaseError::ExecutionError(anyhow!("Error creating session: {}", e).to_string())
+        })?;
+
+        let snowflake_rows = session.query(query).await.map_err(|e| {
+            QueryDatabaseError::ExecutionError(anyhow!("Error executing query: {}", e).to_string())
+        })?;
+
+        let rows = snowflake_rows
+            .into_iter()
+            .map(|row| row.try_into())
+            .collect::<Result<Vec<QueryResult>>>()?;
+
+        let schema = TableSchema::empty();
+
+        Ok((rows, schema))
     }
 }

--- a/core/src/databases/transient_database.rs
+++ b/core/src/databases/transient_database.rs
@@ -1,0 +1,132 @@
+use std::collections::HashMap;
+
+use anyhow::{anyhow, Result};
+use itertools::Itertools;
+use serde::Serialize;
+use tracing::info;
+
+use crate::{
+    databases::{
+        database::{QueryDatabaseError, QueryResult, Table},
+        table_schema::TableSchema,
+    },
+    sqlite_workers::client::{SqliteWorker, SqliteWorkerError, HEARTBEAT_INTERVAL_MS},
+    stores::store::Store,
+    utils,
+};
+
+impl From<SqliteWorkerError> for QueryDatabaseError {
+    fn from(e: SqliteWorkerError) -> Self {
+        match &e {
+            SqliteWorkerError::TooManyResultRows => QueryDatabaseError::TooManyResultRows,
+            SqliteWorkerError::QueryExecutionError(msg) => {
+                QueryDatabaseError::ExecutionError(msg.clone())
+            }
+            _ => QueryDatabaseError::GenericError(e.into()),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct TransientDatabase {
+    created: u64,
+    table_ids_hash: String,
+    sqlite_worker: Option<SqliteWorker>,
+}
+
+impl TransientDatabase {
+    pub fn new(created: u64, table_ids_hash: &str, sqlite_worker: &Option<SqliteWorker>) -> Self {
+        TransientDatabase {
+            created,
+            table_ids_hash: table_ids_hash.to_string(),
+            sqlite_worker: sqlite_worker.clone(),
+        }
+    }
+
+    pub async fn invalidate(&self, store: Box<dyn Store + Sync + Send>) -> Result<()> {
+        if let Some(worker) = self.sqlite_worker() {
+            worker.invalidate_database(self.unique_id()).await?;
+        } else {
+            // If the worker is not alive, we delete the database row in case the worker becomes alive again.
+            store.delete_database(self.unique_id()).await?;
+        }
+
+        Ok(())
+    }
+
+    pub fn sqlite_worker(&self) -> &Option<SqliteWorker> {
+        &self.sqlite_worker
+    }
+
+    pub fn unique_id(&self) -> &str {
+        &self.table_ids_hash
+    }
+}
+
+pub async fn execute_query_on_transient_database(
+    tables: &Vec<Table>,
+    store: Box<dyn Store + Sync + Send>,
+    query: &str,
+) -> Result<(Vec<QueryResult>, TableSchema), QueryDatabaseError> {
+    let table_ids_hash = tables.iter().map(|t| t.unique_id()).sorted().join("/");
+
+    let database = store
+        .upsert_database(&table_ids_hash, HEARTBEAT_INTERVAL_MS)
+        .await?;
+
+    let time_query_start = utils::now();
+
+    let result_rows = match database.sqlite_worker() {
+        Some(sqlite_worker) => {
+            let result_rows = sqlite_worker
+                .execute_query(&table_ids_hash, tables, query)
+                .await?;
+            result_rows
+        }
+        None => Err(anyhow!(
+            "No live SQLite worker found for database {}",
+            database.unique_id()
+        ))?,
+    };
+
+    info!(
+        duration = utils::now() - time_query_start,
+        "DSSTRUCTSTAT Finished executing user query on worker"
+    );
+
+    let infer_result_schema_start = utils::now();
+    let table_schema = TableSchema::from_rows(&result_rows)?;
+
+    info!(
+        duration = utils::now() - infer_result_schema_start,
+        "DSSTRUCTSTAT Finished inferring schema"
+    );
+    info!(
+        duration = utils::now() - time_query_start,
+        "DSSTRUCTSTAT Finished query database"
+    );
+
+    Ok((result_rows, table_schema))
+}
+
+pub fn get_unique_table_names_for_transient_database(tables: &[Table]) -> HashMap<String, String> {
+    let mut name_count: HashMap<&str, usize> = HashMap::new();
+
+    tables
+        .iter()
+        .sorted_by_key(|table| table.unique_id())
+        .map(|table| {
+            let base_name = table.name();
+            let count = name_count.entry(base_name).or_insert(0);
+            *count += 1;
+
+            (
+                table.unique_id(),
+                match *count {
+                    1 => base_name.to_string(),
+                    _ => format!("{}_{}", base_name, *count - 1),
+                },
+            )
+        })
+        .collect()
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod databases {
         pub mod remote_database;
         pub mod snowflake;
     }
+    pub mod transient_database;
 }
 pub mod project;
 pub mod run;

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -1,20 +1,25 @@
-use crate::blocks::block::BlockType;
-use crate::cached_request::CachedRequest;
-use crate::data_sources::data_source::{DataSource, DataSourceConfig, Document, DocumentVersion};
-use crate::databases::database::{Database, Table};
-use crate::databases::table_schema::TableSchema;
-use crate::dataset::Dataset;
-use crate::http::request::{HttpRequest, HttpResponse};
-use crate::project::Project;
-use crate::providers::embedder::{EmbedderRequest, EmbedderVector};
-use crate::providers::llm::{LLMChatGeneration, LLMChatRequest, LLMGeneration, LLMRequest};
-use crate::run::{Run, RunStatus, RunType};
-use crate::search_filter::SearchFilter;
-use crate::sqlite_workers::client::SqliteWorker;
-
 use anyhow::Result;
 use async_trait::async_trait;
 use std::collections::HashMap;
+
+use crate::{
+    blocks::block::BlockType,
+    cached_request::CachedRequest,
+    data_sources::data_source::{DataSource, DataSourceConfig, Document, DocumentVersion},
+    databases::{
+        database::Table, table_schema::TableSchema, transient_database::TransientDatabase,
+    },
+    dataset::Dataset,
+    http::request::{HttpRequest, HttpResponse},
+    project::Project,
+    providers::{
+        embedder::{EmbedderRequest, EmbedderVector},
+        llm::{LLMChatGeneration, LLMChatRequest, LLMGeneration, LLMRequest},
+    },
+    run::{Run, RunStatus, RunType},
+    search_filter::SearchFilter,
+    sqlite_workers::client::SqliteWorker,
+};
 
 #[async_trait]
 pub trait Store {
@@ -174,19 +179,23 @@ pub trait Store {
     ) -> Result<()>;
     async fn delete_data_source(&self, project: &Project, data_source_id: &str) -> Result<()>;
     // Databases
-    async fn upsert_database(&self, table_ids_hash: &str, worker_ttl: u64) -> Result<Database>;
+    async fn upsert_database(
+        &self,
+        table_ids_hash: &str,
+        worker_ttl: u64,
+    ) -> Result<TransientDatabase>;
     async fn load_database(
         &self,
         table_ids_hash: &str,
         worker_ttl: u64,
-    ) -> Result<Option<Database>>;
+    ) -> Result<Option<TransientDatabase>>;
     async fn find_databases_using_table(
         &self,
         project: &Project,
         data_source_id: &str,
         table_id: &str,
         worker_ttl: u64,
-    ) -> Result<Vec<Database>>;
+    ) -> Result<Vec<TransientDatabase>>;
     async fn delete_database(&self, table_ids_hash: &str) -> Result<()>;
     // Tables
     async fn upsert_table(


### PR DESCRIPTION
## Description

https://github.com/dust-tt/dust/issues/7450

### first commit

Add `execute_query` on the `RemoteDatabase` trait + implement for Snowflake. This means parsing a query output into a vec of `QueryResult` (wrapper around serde value).

### second commit

Start splitting the "transient databases" code out of `database.rs` (which will ultimately serve as a unified interface for both remote DBs and transient DBs.
For now, code external to the `databases` module still interface directly with transient DBs, and the `impl` for the `Table` struct is still primarly focused on transient DBs (but will not refactor everything at once to avoid making the PR too messy).


## Risk

Moves around some tables query code used in prod.

## Deploy Plan

N/A