### PR TITLE
Add: create/get credentials in oauth service

### DIFF
--- a/core/bin/oauth.rs
+++ b/core/bin/oauth.rs
@@ -221,28 +221,19 @@ async fn credentials_create(
             "Failed to create credential",
             Some(e),
         ),
-        Ok(c) => match c.unseal_encrypted_content() {
-            Err(e) => error_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "internal_server_error",
-                "Failed to unseal encrypted content",
-                Some(e),
-            ),
-            Ok(content) => (
-                StatusCode::OK,
-                Json(APIResponse {
-                    error: None,
-                    response: Some(json!({
-                        "credential": {
-                            "credential_id": c.credential_id(),
-                            "created": c.created(),
-                            "provider": c.provider(),
-                            "content": content,
-                        },
-                    })),
-                }),
-            ),
-        },
+        Ok(c) => (
+            StatusCode::OK,
+            Json(APIResponse {
+                error: None,
+                response: Some(json!({
+                    "credential": {
+                        "credential_id": c.credential_id(),
+                        "created": c.created(),
+                        "provider": c.provider(),
+                    },
+                })),
+            }),
+        ),
     }
 }
 

--- a/core/bin/oauth.rs
+++ b/core/bin/oauth.rs
@@ -207,20 +207,14 @@ async fn connections_access_token(
 #[derive(Deserialize)]
 struct CredentialPayload {
     provider: CredentialProvider,
-    raw_json: String,
+    credentials: serde_json::Map<String, serde_json::Value>,
 }
 
 async fn oauth_service_create_credential(
     State(state): State<Arc<OAuthState>>,
     Json(payload): Json<CredentialPayload>,
 ) -> (StatusCode, Json<APIResponse>) {
-    match Credential::create(
-        state.store.clone(),
-        payload.provider,
-        serde_json::Value::String(payload.raw_json),
-    )
-    .await
-    {
+    match Credential::create(state.store.clone(), payload.provider, payload.credentials).await {
         Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
             "internal_server_error",
@@ -236,7 +230,7 @@ async fn oauth_service_create_credential(
                         "credential_id": c.credential_id(),
                         "created": c.created(),
                         "provider": c.provider(),
-                        "raw_json": c.raw_json(),
+                        "credentials": c.credentials(),
                     },
                 })),
             }),
@@ -264,7 +258,7 @@ async fn oauth_service_retrieve_credential(
                         "credential_id": c.credential_id(),
                         "created": c.created(),
                         "provider": c.provider(),
-                        "raw_json": c.raw_json(),
+                        "credentials": c.credentials(),
                     },
                 })),
             }),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -89,6 +89,8 @@ pub mod consts;
 
 pub mod oauth {
     pub mod connection;
+    pub mod credential;
+    pub mod encryption;
     pub mod store;
     pub mod providers {
         pub mod confluence;

--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -1,4 +1,5 @@
 use crate::oauth::{
+    encryption::{seal_str, unseal_str},
     providers::{
         confluence::ConfluenceConnectionProvider, github::GithubConnectionProvider,
         gong::GongConnectionProvider, google_drive::GoogleDriveConnectionProvider,
@@ -12,12 +13,7 @@ use crate::utils;
 use crate::utils::ParseError;
 use anyhow::Result;
 use async_trait::async_trait;
-use base64::{engine::general_purpose, Engine as _};
 use lazy_static::lazy_static;
-use ring::{
-    aead,
-    rand::{self, SecureRandom},
-};
 use rslock::LockManager;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
@@ -37,12 +33,6 @@ pub static ACCESS_TOKEN_REFRESH_BUFFER_MILLIS: u64 = 10 * 60 * 1000;
 
 lazy_static! {
     static ref REDIS_URI: String = env::var("REDIS_URI").unwrap();
-    static ref ENCRYPTION_KEY: aead::LessSafeKey = {
-        let encoded_key = env::var("OAUTH_ENCRYPTION_KEY").unwrap();
-        let key_bytes = general_purpose::STANDARD.decode(&encoded_key).unwrap();
-        let unbound_key = aead::UnboundKey::new(&aead::CHACHA20_POLY1305, &key_bytes).unwrap();
-        aead::LessSafeKey::new(unbound_key)
-    };
 }
 
 // API Error types.
@@ -392,7 +382,7 @@ impl Connection {
 
     pub fn unseal_authorization_code(&self) -> Result<Option<String>> {
         match &self.encrypted_authorization_code {
-            Some(t) => Ok(Some(Connection::unseal_str(t)?)),
+            Some(t) => Ok(Some(unseal_str(t)?)),
             None => Ok(None),
         }
     }
@@ -407,7 +397,7 @@ impl Connection {
 
     pub fn unseal_access_token(&self) -> Result<Option<String>> {
         match &self.encrypted_access_token {
-            Some(t) => Ok(Some(Connection::unseal_str(t)?)),
+            Some(t) => Ok(Some(unseal_str(t)?)),
             None => Ok(None),
         }
     }
@@ -418,7 +408,7 @@ impl Connection {
 
     pub fn unseal_refresh_token(&self) -> Result<Option<String>> {
         match &self.encrypted_refresh_token {
-            Some(t) => Ok(Some(Connection::unseal_str(t)?)),
+            Some(t) => Ok(Some(unseal_str(t)?)),
             None => Ok(None),
         }
     }
@@ -429,49 +419,9 @@ impl Connection {
 
     pub fn unseal_raw_json(&self) -> Result<Option<serde_json::Value>> {
         match &self.encrypted_raw_json {
-            Some(t) => Ok(Some(serde_json::from_str(&Connection::unseal_str(t)?)?)),
+            Some(t) => Ok(Some(serde_json::from_str(&unseal_str(t)?)?)),
             None => Ok(None),
         }
-    }
-
-    fn seal_str(s: &str) -> Result<Vec<u8>> {
-        let key = &ENCRYPTION_KEY;
-        let rng = rand::SystemRandom::new();
-
-        let mut nonce_bytes = [0u8; aead::NONCE_LEN];
-        rng.fill(&mut nonce_bytes)
-            .map_err(|_| anyhow::anyhow!("Nonce generation failed"))?;
-        let nonce = aead::Nonce::assume_unique_for_key(nonce_bytes);
-
-        let mut combined = nonce.as_ref().to_vec();
-
-        let mut in_out = s.as_bytes().to_vec();
-        let tag = key
-            .seal_in_place_separate_tag(nonce, aead::Aad::empty(), &mut in_out)
-            .map_err(|_| anyhow::anyhow!("Encryption failed"))?;
-
-        combined.append(&mut in_out);
-        combined.extend_from_slice(tag.as_ref());
-
-        Ok(combined)
-    }
-
-    fn unseal_str(encrypted_data: &[u8]) -> Result<String> {
-        let key = &ENCRYPTION_KEY;
-
-        let nonce_bytes = &encrypted_data[0..aead::NONCE_LEN];
-        let ciphertext_and_tag = &encrypted_data[aead::NONCE_LEN..];
-
-        let nonce = aead::Nonce::try_assume_unique_for_key(nonce_bytes)
-            .map_err(|_| anyhow::anyhow!("Invalid nonce"))?;
-        let mut in_out = ciphertext_and_tag.to_vec();
-
-        key.open_in_place(nonce, aead::Aad::empty(), &mut in_out)
-            .map_err(|_| anyhow::anyhow!("Decryption failed"))?;
-
-        Ok(String::from_utf8(
-            in_out[0..(in_out.len() - aead::CHACHA20_POLY1305.tag_len())].to_vec(),
-        )?)
     }
 
     async fn reload(&mut self, store: Box<dyn OAuthStore + Sync + Send>) -> Result<()> {
@@ -504,16 +454,14 @@ impl Connection {
         if let Some(creds) = migrated_credentials {
             c.redirect_uri = Some(creds.redirect_uri);
             c.access_token_expiry = creds.access_token_expiry;
-            c.encrypted_access_token = Some(Connection::seal_str(&creds.access_token)?);
-            c.encrypted_raw_json = Some(Connection::seal_str(&serde_json::to_string(
-                &creds.raw_json,
-            )?)?);
+            c.encrypted_access_token = Some(seal_str(&creds.access_token)?);
+            c.encrypted_raw_json = Some(seal_str(&serde_json::to_string(&creds.raw_json)?)?);
 
             if let Some(code) = creds.authorization_code {
-                c.encrypted_authorization_code = Some(Connection::seal_str(&code)?);
+                c.encrypted_authorization_code = Some(seal_str(&code)?);
             }
             if let Some(token) = creds.refresh_token {
-                c.encrypted_refresh_token = Some(Connection::seal_str(&token)?);
+                c.encrypted_refresh_token = Some(seal_str(&token)?);
             }
 
             store.update_connection_secrets(&c).await?;
@@ -586,16 +534,14 @@ impl Connection {
         store.update_connection_status(self).await?;
 
         self.redirect_uri = Some(finalize.redirect_uri);
-        self.encrypted_authorization_code = Some(Connection::seal_str(&finalize.code)?);
+        self.encrypted_authorization_code = Some(seal_str(&finalize.code)?);
         self.access_token_expiry = finalize.access_token_expiry;
-        self.encrypted_access_token = Some(Connection::seal_str(&finalize.access_token)?);
+        self.encrypted_access_token = Some(seal_str(&finalize.access_token)?);
         self.encrypted_refresh_token = match &finalize.refresh_token {
-            Some(t) => Some(Connection::seal_str(t)?),
+            Some(t) => Some(seal_str(t)?),
             None => None,
         };
-        self.encrypted_raw_json = Some(Connection::seal_str(&serde_json::to_string(
-            &finalize.raw_json,
-        )?)?);
+        self.encrypted_raw_json = Some(seal_str(&serde_json::to_string(&finalize.raw_json)?)?);
         store.update_connection_secrets(self).await?;
 
         info!(
@@ -673,7 +619,7 @@ impl Connection {
 
     fn valid_access_token(&self) -> Result<Option<String>, ConnectionError> {
         let access_token = match &self.encrypted_access_token {
-            Some(t) => Connection::unseal_str(t).map_err(|e| {
+            Some(t) => unseal_str(t).map_err(|e| {
                 error!(error = ?e, "Failed to unseal access_token");
                 ConnectionError {
                     code: ConnectionErrorCode::InternalError,
@@ -729,14 +675,12 @@ impl Connection {
         let refresh = provider(self.provider).refresh(self).await?;
 
         self.access_token_expiry = refresh.access_token_expiry;
-        self.encrypted_access_token = Some(Connection::seal_str(&refresh.access_token)?);
+        self.encrypted_access_token = Some(seal_str(&refresh.access_token)?);
         self.encrypted_refresh_token = match &refresh.refresh_token {
-            Some(t) => Some(Connection::seal_str(t)?),
+            Some(t) => Some(seal_str(t)?),
             None => None,
         };
-        self.encrypted_raw_json = Some(Connection::seal_str(&serde_json::to_string(
-            &refresh.raw_json,
-        )?)?);
+        self.encrypted_raw_json = Some(seal_str(&serde_json::to_string(&refresh.raw_json)?)?);
         store.update_connection_secrets(self).await?;
 
         info!(

--- a/core/src/oauth/credential.rs
+++ b/core/src/oauth/credential.rs
@@ -38,7 +38,7 @@ pub struct Credential {
     credential_id: String,
     created: u64,
     provider: CredentialProvider,
-    raw_json: serde_json::Value,
+    credentials: serde_json::Map<String, serde_json::Value>,
 }
 
 impl Credential {
@@ -46,13 +46,13 @@ impl Credential {
         credential_id: String,
         created: u64,
         provider: CredentialProvider,
-        raw_json: serde_json::Value,
+        credentials: serde_json::Map<String, serde_json::Value>,
     ) -> Self {
         Self {
             credential_id,
             created,
             provider,
-            raw_json,
+            credentials,
         }
     }
 
@@ -88,9 +88,9 @@ impl Credential {
     pub async fn create(
         store: Box<dyn OAuthStore + Sync + Send>,
         provider: CredentialProvider,
-        raw_json: serde_json::Value,
+        credentials: serde_json::Map<String, serde_json::Value>,
     ) -> Result<Self> {
-        let c = store.create_credential(provider, raw_json).await?;
+        let c = store.create_credential(provider, credentials).await?;
 
         Ok(c)
     }
@@ -107,7 +107,7 @@ impl Credential {
         self.provider
     }
 
-    pub fn raw_json(&self) -> &serde_json::Value {
-        &self.raw_json
+    pub fn credentials(&self) -> &serde_json::Map<String, serde_json::Value> {
+        &self.credentials
     }
 }

--- a/core/src/oauth/credential.rs
+++ b/core/src/oauth/credential.rs
@@ -94,7 +94,9 @@ impl Credential {
     ) -> Result<Self> {
         // Check format of content based on provider
         let keys_to_check = match provider {
-            CredentialProvider::Snowflake => vec!["warehouse", "user", "password", "role"],
+            CredentialProvider::Snowflake => {
+                vec!["account", "warehouse", "user", "password", "role"]
+            }
         };
 
         for key in keys_to_check {

--- a/core/src/oauth/credential.rs
+++ b/core/src/oauth/credential.rs
@@ -1,0 +1,113 @@
+use core::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+use crate::oauth::store::OAuthStore;
+use crate::utils::{self, ParseError};
+use anyhow::Result;
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CredentialProvider {
+    Snowflake,
+}
+
+impl fmt::Display for CredentialProvider {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            serde_json::to_string(&self).unwrap().trim_matches('"')
+        )
+    }
+}
+
+impl FromStr for CredentialProvider {
+    type Err = ParseError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match serde_json::from_str(&format!("\"{}\"", s)) {
+            Ok(v) => Ok(v),
+            Err(_) => Err(ParseError::new()),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct Credential {
+    credential_id: String,
+    created: u64,
+    provider: CredentialProvider,
+    raw_json: serde_json::Value,
+}
+
+impl Credential {
+    pub fn new(
+        credential_id: String,
+        created: u64,
+        provider: CredentialProvider,
+        raw_json: serde_json::Value,
+    ) -> Self {
+        Self {
+            credential_id,
+            created,
+            provider,
+            raw_json,
+        }
+    }
+
+    pub fn credential_id_from_row_id_and_secret(row_id: i64, secret: &str) -> Result<String> {
+        Ok(format!(
+            "{}-{}",
+            utils::make_id("cred", row_id as u64)?,
+            secret
+        ))
+    }
+
+    pub fn row_id_and_secret_from_credential_id(credential_id: &str) -> Result<(i64, String)> {
+        let parts = credential_id.split('-').collect::<Vec<&str>>();
+        if parts.len() != 2 {
+            return Err(anyhow::anyhow!(
+                "Invalid credential_id format: {}",
+                credential_id
+            ));
+        }
+        let (prefix, row_id) = utils::parse_id(parts[0])?;
+        let secret = parts[1].to_string();
+
+        if prefix != "cred" {
+            return Err(anyhow::anyhow!(
+                "Invalid credential_id prefix: {}",
+                credential_id
+            ));
+        }
+
+        Ok((row_id as i64, secret))
+    }
+
+    pub async fn create(
+        store: Box<dyn OAuthStore + Sync + Send>,
+        provider: CredentialProvider,
+        raw_json: serde_json::Value,
+    ) -> Result<Self> {
+        let c = store.create_credential(provider, raw_json).await?;
+
+        Ok(c)
+    }
+
+    pub fn credential_id(&self) -> &str {
+        &self.credential_id
+    }
+
+    pub fn created(&self) -> u64 {
+        self.created
+    }
+
+    pub fn provider(&self) -> CredentialProvider {
+        self.provider
+    }
+
+    pub fn raw_json(&self) -> &serde_json::Value {
+        &self.raw_json
+    }
+}

--- a/core/src/oauth/encryption.rs
+++ b/core/src/oauth/encryption.rs
@@ -1,0 +1,58 @@
+use anyhow::Result;
+use base64::{engine::general_purpose, Engine as _};
+use ring::{
+    aead,
+    rand::{self, SecureRandom},
+};
+use std::env;
+
+use lazy_static::lazy_static;
+
+lazy_static! {
+    static ref ENCRYPTION_KEY: aead::LessSafeKey = {
+        let encoded_key = env::var("OAUTH_ENCRYPTION_KEY").unwrap();
+        let key_bytes = general_purpose::STANDARD.decode(&encoded_key).unwrap();
+        let unbound_key = aead::UnboundKey::new(&aead::CHACHA20_POLY1305, &key_bytes).unwrap();
+        aead::LessSafeKey::new(unbound_key)
+    };
+}
+
+pub fn seal_str(s: &str) -> Result<Vec<u8>> {
+    let key = &ENCRYPTION_KEY;
+    let rng = rand::SystemRandom::new();
+
+    let mut nonce_bytes = [0u8; aead::NONCE_LEN];
+    rng.fill(&mut nonce_bytes)
+        .map_err(|_| anyhow::anyhow!("Nonce generation failed"))?;
+    let nonce = aead::Nonce::assume_unique_for_key(nonce_bytes);
+
+    let mut combined = nonce.as_ref().to_vec();
+
+    let mut in_out = s.as_bytes().to_vec();
+    let tag = key
+        .seal_in_place_separate_tag(nonce, aead::Aad::empty(), &mut in_out)
+        .map_err(|_| anyhow::anyhow!("Encryption failed"))?;
+
+    combined.append(&mut in_out);
+    combined.extend_from_slice(tag.as_ref());
+
+    Ok(combined)
+}
+
+pub fn unseal_str(encrypted_data: &[u8]) -> Result<String> {
+    let key = &ENCRYPTION_KEY;
+
+    let nonce_bytes = &encrypted_data[0..aead::NONCE_LEN];
+    let ciphertext_and_tag = &encrypted_data[aead::NONCE_LEN..];
+
+    let nonce = aead::Nonce::try_assume_unique_for_key(nonce_bytes)
+        .map_err(|_| anyhow::anyhow!("Invalid nonce"))?;
+    let mut in_out = ciphertext_and_tag.to_vec();
+
+    key.open_in_place(nonce, aead::Aad::empty(), &mut in_out)
+        .map_err(|_| anyhow::anyhow!("Decryption failed"))?;
+
+    Ok(String::from_utf8(
+        in_out[0..(in_out.len() - aead::CHACHA20_POLY1305.tag_len())].to_vec(),
+    )?)
+}


### PR DESCRIPTION
## Description

Add the ability to create and retrieve some credentials from the oauth service.
I moved the seal / unseal methods to a encryption module in order to encrypt the credentials at rest.

## Risk

My first ever rust code.
(tested locally with curl)

## Deploy Plan

Deploy `oauth`