### PR TITLE
[connectors] fix: breadcrumb for webcrawler

### DIFF
--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -16,6 +16,7 @@ import {
 } from "@dust-tt/types";
 
 import {
+  getDisplayNameForFolder,
   getDisplayNameForPage,
   normalizeFolderUrl,
   stableIdForUrl,
@@ -199,11 +200,7 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
                   ressourceType: "folder",
                 })
               : null,
-            title:
-              new URL(folder.url).pathname
-                .split("/")
-                .filter((x) => x)
-                .pop() || folder.url,
+            title: getDisplayNameForFolder(folder),
             sourceUrl: null,
             expandable: true,
             permission: "read",
@@ -257,7 +254,7 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
       WebCrawlerFolder.findAll({
         where: {
           connectorId: this.connectorId,
-          url: internalIds,
+          internalId,
         },
       }),
       WebCrawlerPage.findAll({
@@ -273,7 +270,7 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
         provider: "webcrawler",
         internalId: folder.internalId,
         parentInternalId: folder.parentUrl,
-        title: folder.url,
+        title: getDisplayNameForFolder(folder),
         sourceUrl: folder.url,
         expandable: true,
         permission: "read",
@@ -332,7 +329,7 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
 
     // If the Page or Folder has no parentUrl, we return an empty array
     if (!parentUrl) {
-      return new Ok([]);
+      return new Ok(parents);
     }
 
     // Otherwise we loop on the parentUrl to retrieve all the parents

--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -254,7 +254,7 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
       WebCrawlerFolder.findAll({
         where: {
           connectorId: this.connectorId,
-          internalId,
+          internalId: internalIds,
         },
       }),
       WebCrawlerPage.findAll({

--- a/connectors/src/connectors/webcrawler/lib/utils.ts
+++ b/connectors/src/connectors/webcrawler/lib/utils.ts
@@ -2,7 +2,10 @@ import type { ContentNodeType } from "@dust-tt/types";
 import { hash as blake3 } from "blake3";
 import dns from "dns";
 
-import type { WebCrawlerPage } from "@connectors/lib/models/webcrawler";
+import type {
+  WebCrawlerFolder,
+  WebCrawlerPage,
+} from "@connectors/lib/models/webcrawler";
 
 // Generate a stable id for a given url and ressource type
 // That way we don't have to send URL as documentId to the front API.
@@ -103,6 +106,15 @@ export function getDisplayNameForPage(page: WebCrawlerPage): string {
   }
 
   return result;
+}
+
+export function getDisplayNameForFolder(folder: WebCrawlerFolder): string {
+  return (
+    new URL(folder.url).pathname
+      .split("/")
+      .filter((x) => x)
+      .pop() || folder.url
+  );
 }
 
 export async function getIpAddressForUrl(url: string) {


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/1353

## Description

Fix webcrawler connector to return correct values . Replaced sql query to fetch based on id instead of url.

## Risk

Call on content_node with url will break, but i was not able to find any usage .. ?

## Deploy Plan

deploy connectors