### PR TITLE
Rerevert: [Agent Configurations] Allow fetching multiple agent configurations by sIds

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -227,7 +227,7 @@ async function fetchGlobalAgentConfigurationForView(
 
 // Workspace agent configurations.
 
-async function fetchAgentConfigurationsForView(
+async function fetchWorkspaceAgentConfigurationsWithoutActions(
   auth: Authenticator,
   {
     agentPrefix,
@@ -331,7 +331,7 @@ async function fetchAgentConfigurationsForView(
           where: {
             workspaceId: owner.id,
             ...(agentPrefix ? { name: { [Op.iLike]: `${agentPrefix}%` } } : {}),
-            sId: agentsGetView.agentIds.filter(isGlobalAgentId),
+            sId: agentsGetView.agentIds.filter((id) => !isGlobalAgentId(id)),
           },
           order: [["version", "DESC"]],
           ...(agentsGetView.allVersions ? {} : { limit: 1 }),
@@ -399,13 +399,14 @@ async function fetchWorkspaceAgentConfigurationsForView(
 ) {
   const user = auth.user();
 
-  const agentConfigurations = await fetchAgentConfigurationsForView(auth, {
-    agentPrefix,
-    agentsGetView,
-    limit,
-    owner,
-    sort,
-  });
+  const agentConfigurations =
+    await fetchWorkspaceAgentConfigurationsWithoutActions(auth, {
+      agentPrefix,
+      agentsGetView,
+      limit,
+      owner,
+      sort,
+    });
 
   const configurationIds = agentConfigurations.map((a) => a.id);
   const configurationSIds = agentConfigurations.map((a) => a.sId);

--- a/front/lib/api/assistant/participants.ts
+++ b/front/lib/api/assistant/participants.ts
@@ -2,7 +2,6 @@ import type {
   AgentParticipantType,
   ConversationParticipantsType,
   ConversationWithoutContentType,
-  LightAgentConfigurationType,
   ModelId,
   Result,
   UserParticipantType,
@@ -10,7 +9,7 @@ import type {
 import { Err, formatUserFullName, Ok } from "@dust-tt/types";
 import { Op } from "sequelize";
 
-import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
+import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import type { Authenticator } from "@app/lib/auth";
 import {
   AgentMessage,
@@ -44,14 +43,11 @@ async function fetchAllAgentsById(
   auth: Authenticator,
   agentConfigurationIds: string[]
 ): Promise<AgentParticipantType[]> {
-  // TODO(2024-3-25 flav) Support fetching many agents by id.
-  const agents = (
-    await Promise.all(
-      agentConfigurationIds.map((agentConfigId) => {
-        return getAgentConfiguration(auth, agentConfigId);
-      })
-    )
-  ).filter((a) => a !== null) as LightAgentConfigurationType[];
+  const agents = await getAgentConfigurations({
+    auth,
+    agentsGetView: { agentIds: agentConfigurationIds },
+    variant: "light",
+  });
 
   return agents.map((a) => ({
     configurationId: a.sId,

--- a/front/pages/poke/[wId]/assistants/[aId]/index.tsx
+++ b/front/pages/poke/[wId]/assistants/[aId]/index.tsx
@@ -20,7 +20,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
 
   const agentConfigurations = await getAgentConfigurations({
     auth,
-    agentsGetView: { agentId: aId, allVersions: true },
+    agentsGetView: { agentIds: [aId], allVersions: true },
     variant: "full",
   });
 

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -104,7 +104,7 @@ export type AgentUserListStatus = "in-list" | "not-in-list";
  *   private agents, agents from the workspace and global scope, plus any
  *   published agents they've added to their list (refer to
  *   AgentUserRelationTable).
- * - {agentId: string}: Retrieves a single agent by its ID.
+ * - {agentIds: string}: Retrieves specific agents by their sIds.
  * - {conversationId: string}: all agent from the user's list view, plus the
  *   agents mentioned in the conversation with the provided Id.
  * - 'all': Combines workspace and published agents, excluding private agents.
@@ -120,7 +120,7 @@ export type AgentUserListStatus = "in-list" | "not-in-list";
  *   authorization.
  */
 export type AgentsGetViewType =
-  | { agentId: string; allVersions?: boolean }
+  | { agentIds: string[]; allVersions?: boolean }
   | "list"
   | { conversationId: string }
   | "all"


### PR DESCRIPTION
Description
---
Fixes  the [issue](https://dust4ai.slack.com/archives/C05B529FHV1/p1726844729804709) of #7570 
 (thus Reverts dust-tt/dust#7576 )

Added the missing `!`

Risk
---
na... but still, will pay attention

Deploy
---
front