### PR TITLE
[connectors] Fixed github parents ordering

### DIFF
--- a/connectors/src/connectors/github/lib/hierarchy.ts
+++ b/connectors/src/connectors/github/lib/hierarchy.ts
@@ -42,9 +42,9 @@ async function getGithubCodeDirectoryParentIds(
       directory.parentInternalId,
       repoId
     );
-    return [...parents, directory.parentInternalId];
+    return [directory.parentInternalId, ...parents];
   } else if (directory.parentInternalId === `github-code-${repoId}`) {
-    return [`${repoId}`, `github-code-${repoId}`];
+    return [`github-code-${repoId}`, `${repoId}`];
   }
   return [];
 }
@@ -72,7 +72,7 @@ async function getGithubCodeFileParentIds(
       file.parentInternalId,
       repoId
     );
-    return [...parents, file.parentInternalId];
+    return [file.parentInternalId, ...parents];
   } else if (file.parentInternalId === `github-code-${repoId}`) {
     return [`${repoId}`, `github-code-${repoId}`];
   }


### PR DESCRIPTION
fixes: https://github.com/dust-tt/dust/issues/7529

## Description

github parent returned in reversed order, breaking breadcrumb

## Risk

this was not used for upserts (parents are in vaid order in that case), no issue here

## Deploy Plan

deploy `connectors`
