### PR TITLE
Add log to see notion headers in case of rate limit

### DIFF
--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -393,6 +393,11 @@ export async function isAccessibleAndUnarchived(
                 waitTime = retryAfter * 1000;
                 usingHeader = true;
               }
+            } else {
+              tryLogger.warn(
+                { headers: e.headers },
+                "Retry-After header not found."
+              );
             }
           } catch (e) {
             // Ignore all errors here as the e.headers type is unknown.


### PR DESCRIPTION
## Description

Add log to see the notion headers as the Retry-After do not seem to exist.

## Risk

Nothing in particular.

## Deploy Plan

Deploy `connectors`