### PR TITLE
Reduce the number of simulatenous garbage collect activities in notion workflow

### DIFF
--- a/connectors/src/connectors/notion/temporal/workflows.ts
+++ b/connectors/src/connectors/notion/temporal/workflows.ts
@@ -57,7 +57,7 @@ const MAX_PAGE_IDS_PER_CHILD_WORKFLOW = 100;
 
 const MAX_PENDING_UPSERT_ACTIVITIES = 5;
 
-const MAX_PENDING_GARBAGE_COLLECTION_ACTIVITIES = 3;
+const MAX_PENDING_GARBAGE_COLLECTION_ACTIVITIES = 1;
 
 // If set to true, the workflow will process all discovered resources until empty.
 const PROCESS_ALL_DISCOVERED_RESOURCES = false;


### PR DESCRIPTION
## Description

With our largest customers, we are hitting the rate limit (seems to be 2700/15 minutes) pretty often.

## Risk

None

## Deploy Plan

Deploy `connectors`