### PR TITLE
[k8s] - chore: add dynamic client-facing URL to Docker builds

### DIFF
--- a/.github/workflows/deploy-alerting-temporal.yml
+++ b/.github/workflows/deploy-alerting-temporal.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build.sh --image-name=alerting-temporal --dockerfile-path=./Dockerfile --working-dir=./alerting/temporal/
+          ./k8s/cloud-build.sh --image-name=alerting-temporal --dockerfile-path=./Dockerfile --working-dir=./alerting/temporal/ --dust-client-facing-url=https://dust.tt
 
       - name: Deploy the image on Kubernetes
         run: |

--- a/.github/workflows/deploy-and-test-front-qa.yml
+++ b/.github/workflows/deploy-and-test-front-qa.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build.sh --image-name=$IMAGE_NAME --dockerfile-path=./front/Dockerfile --working-dir=./
+          ./k8s/cloud-build.sh --image-name=$IMAGE_NAME --dockerfile-path=./front/Dockerfile --working-dir=./ --dust-client-facing-url=https://front-qa.dust.tt
 
       - name: Deploy the image on Kubernetes
         run: |

--- a/.github/workflows/deploy-connectors.yml
+++ b/.github/workflows/deploy-connectors.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build.sh --image-name=connectors --dockerfile-path=./connectors/Dockerfile --working-dir=./
+          ./k8s/cloud-build.sh --image-name=connectors --dockerfile-path=./connectors/Dockerfile --working-dir=./ --dust-client-facing-url=https://dust.tt
 
       - name: Deploy the image on Kubernetes
         run: |

--- a/.github/workflows/deploy-core.yml
+++ b/.github/workflows/deploy-core.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build.sh --image-name=core --dockerfile-path=./Dockerfile --working-dir=./core/
+          ./k8s/cloud-build.sh --image-name=core --dockerfile-path=./Dockerfile --working-dir=./core/ --dust-client-facing-url=https://dust.tt
 
       - name: Deploy the image on Kubernetes
         run: |

--- a/.github/workflows/deploy-front-edge.yml
+++ b/.github/workflows/deploy-front-edge.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build.sh --image-name=$IMAGE_NAME --dockerfile-path=./front/Dockerfile --working-dir=./
+          ./k8s/cloud-build.sh --image-name=$IMAGE_NAME --dockerfile-path=./front/Dockerfile --working-dir=./ --dust-client-facing-url=https://front-edge.dust.tt
 
       - name: Deploy the image on Kubernetes
         run: |

--- a/.github/workflows/deploy-front.yml
+++ b/.github/workflows/deploy-front.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build.sh --image-name=front --dockerfile-path=./front/Dockerfile --working-dir=./
+          ./k8s/cloud-build.sh --image-name=front --dockerfile-path=./front/Dockerfile --working-dir=./ --dust-client-facing-url=https://dust.tt
 
       - name: Deploy the image on Kubernetes
         run: |

--- a/.github/workflows/deploy-oauth.yml
+++ b/.github/workflows/deploy-oauth.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build.sh --image-name=oauth --dockerfile-path=./oauth.Dockerfile --working-dir=./core/
+          ./k8s/cloud-build.sh --image-name=oauth --dockerfile-path=./oauth.Dockerfile --working-dir=./core/ --dust-client-facing-url=https://dust.tt
 
       - name: Deploy the image on Kubernetes
         run: |

--- a/.github/workflows/deploy-prodbox.yml
+++ b/.github/workflows/deploy-prodbox.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build.sh --image-name=prodbox --dockerfile-path=./prodbox.Dockerfile --working-dir=./ --gcloud-ignore-file=.gcloudignore-prodbox
+          ./k8s/cloud-build.sh --image-name=prodbox --dockerfile-path=./prodbox.Dockerfile --working-dir=./ --gcloud-ignore-file=.gcloudignore-prodbox --dust-client-facing-url=https://dust.tt
 
       - name: Deploy the image on Kubernetes
         run: |

--- a/.github/workflows/deploy-viz.yml
+++ b/.github/workflows/deploy-viz.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build.sh --image-name=viz --dockerfile-path=./viz/Dockerfile --working-dir=./
+          ./k8s/cloud-build.sh --image-name=viz --dockerfile-path=./viz/Dockerfile --working-dir=./ --dust-client-facing-url=https://dust.tt
 
       - name: Deploy the image on Kubernetes
         run: |

--- a/k8s/cloud-build.sh
+++ b/k8s/cloud-build.sh
@@ -9,6 +9,7 @@ WORKING_DIR=""
 GCLOUD_IGNORE_FILE=""
 IMAGE_NAME=""
 DOCKERFILE_PATH=""
+DUST_CLIENT_FACING_URL=""
 
 # parse command-line arguments
 while [[ $# -gt 0 ]]; do
@@ -27,6 +28,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --dockerfile-path=*)
       DOCKERFILE_PATH="${1#*=}"
+      shift
+      ;;
+    --dust-client-facing-url=*)
+      DUST_CLIENT_FACING_URL="${1#*=}"
       shift
       ;;
     *)
@@ -54,6 +59,9 @@ echo "current working directory is $(pwd)"
 
 # prepare substitutions
 SUBSTITUTIONS="SHORT_SHA=$(git rev-parse --short HEAD),_IMAGE_NAME=$IMAGE_NAME,_DOCKERFILE_PATH=$DOCKERFILE_PATH"
+if [ -n "$DUST_CLIENT_FACING_URL" ]; then
+    SUBSTITUTIONS="$SUBSTITUTIONS,_DUST_CLIENT_FACING_URL=$DUST_CLIENT_FACING_URL"
+fi
 
 # start the build and get its id
 echo "starting build..."

--- a/k8s/cloudbuild.yaml
+++ b/k8s/cloudbuild.yaml
@@ -18,7 +18,7 @@ steps:
       - --build-arg
       - NEXT_PUBLIC_GA_TRACKING_ID=G-K9HQ2LE04G
       - --build-arg
-      - NEXT_PUBLIC_DUST_CLIENT_FACING_URL=https://dust.tt
+      - NEXT_PUBLIC_DUST_CLIENT_FACING_URL=${_DUST_CLIENT_FACING_URL}
       - .
     secretEnv:
       - "DEPOT_TOKEN"


### PR DESCRIPTION
## Description

This PR aims at dynamically passing the env var `NEXT_PUBLIC_DUST_CLIENT_FACING_URL` at build time.

 - Provide `dust-client-facing-url` as a build argument across various GitHub Actions for Docker image builds
 - Enable dynamic setting of the client-facing URL environment variable during cloud builds for Docker images
 - Update cloudbuild.yaml to accept the `_DUST_CLIENT_FACING_URL` substitution and set the `NEXT_PUBLIC_DUST_CLIENT_FACING_URL` build argument accordingly

## Risk

Breaking deployments

## Deploy Plan


