### PR TITLE
[front] - fix(vault): show empty content message in empty managed connection

### DIFF
--- a/front/components/vaults/VaultDataSourceViewContentList.tsx
+++ b/front/components/vaults/VaultDataSourceViewContentList.tsx
@@ -373,7 +373,7 @@ export const VaultDataSourceViewContentList = ({
             />
           </>
         )}
-        {isEmpty && !emptyContent}
+        {isEmpty && emptyContent}
         {isFolder(dataSourceView.dataSource) && (
           <>
             {((viewType === "tables" && hasDocuments) ||


### PR DESCRIPTION
## Description

This PR correctly displays the empty content in the vault data source view when the list is empty. It basically resolves a logical condition error that prevented the empty message from showing

**References:**
- https://github.com/dust-tt/tasks/issues/1367

## Risk

None

## Deploy Plan

Deploy `front`