### PR TITLE
Flav/fix edited at migration

### DIFF
--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -116,7 +116,10 @@ export class DataSourceResource extends ResourceWithVault<DataSourceModel> {
 
   static async makeNew(
     auth: Authenticator,
-    blob: Omit<CreationAttributes<DataSourceModel>, "editedAt" | "vaultId">,
+    blob: Omit<
+      CreationAttributes<DataSourceModel>,
+      "editedAt" | "editedByUserId" | "vaultId"
+    >,
     vault: VaultResource
   ) {
     const dataSource = await DataSourceModel.create({

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -80,7 +80,10 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
 
   private static async makeNew(
     auth: Authenticator,
-    blob: Omit<CreationAttributes<DataSourceViewModel>, "vaultId">,
+    blob: Omit<
+      CreationAttributes<DataSourceViewModel>,
+      "editedAt" | "editedByUserId" | "vaultId"
+    >,
     vault: VaultResource,
     dataSource: DataSourceResource
   ) {

--- a/front/lib/resources/storage/models/data_source_view.ts
+++ b/front/lib/resources/storage/models/data_source_view.ts
@@ -24,7 +24,7 @@ export class DataSourceViewModel extends Model<
 
   // Corresponds to the ID of the last user to configure the connection.
   declare editedByUserId: ForeignKey<User["id"]>;
-  declare editedAt: CreationOptional<Date>;
+  declare editedAt: Date;
 
   declare kind: DataSourceViewKind;
   declare parentsIn: string[] | null;
@@ -52,9 +52,7 @@ DataSourceViewModel.init(
     },
     editedAt: {
       type: DataTypes.DATE,
-      // TODO(2024-08-28 (thomas) Set `allowNull` to `false` once backfilled.
-      allowNull: true,
-      defaultValue: DataTypes.NOW,
+      allowNull: false,
     },
     kind: {
       type: DataTypes.STRING,
@@ -105,6 +103,5 @@ DataSourceViewModel.belongsTo(DataSourceModel, {
 
 DataSourceViewModel.belongsTo(User, {
   as: "editedByUser",
-  // TODO(2024-08-28 (thomas) Set `allowNull` to `false` once backfilled.
-  foreignKey: { name: "editedByUserId", allowNull: true },
+  foreignKey: { name: "editedByUserId", allowNull: false },
 });

--- a/front/migrations/db/migration_85.sql
+++ b/front/migrations/db/migration_85.sql
@@ -10,6 +10,10 @@ BEGIN
     END IF;
 
 -- Migration created on Sep 23, 2024
+UPDATE data_sources
+SET "editedAt" = "updatedAt"
+WHERE "editedAt" IS NULL;
+
 ALTER TABLE "data_sources"
 ALTER COLUMN "editedAt"
 SET

--- a/front/migrations/db/migration_86.sql
+++ b/front/migrations/db/migration_86.sql
@@ -1,29 +1,22 @@
 -- -- This migration is dependant on a backfill script
--- -- The backfill script is: 20240912_backfill_editedbyuser_id
+-- -- The backfill script is: <insert_script>
 -- -- run psql with --set=backfilled=1 argument if you have rune the script.
 
 CREATE OR REPLACE FUNCTION perform_migration(backfilled boolean DEFAULT false)
 RETURNS VARCHAR AS $$
 BEGIN
     IF NOT backfilled THEN
-        RAISE NOTICE 'The backfill script: 20240912_backfill_editedbyuser_id is required before applying this migation. If you already did it, run psql with --set=backfilled=1 argument.';
+        RAISE NOTICE 'The backfill script: <insert_script> is required before applying this migation. If you already did it, run psql with --set=backfilled=1 argument.';
     END IF;
 
 -- Migration created on Sep 23, 2024
-UPDATE "data_sources"
+UPDATE "data_source_views"
 SET "editedAt" = "updatedAt"
 WHERE "editedAt" IS NULL;
 
-ALTER TABLE "data_sources"
-ALTER COLUMN "editedAt"
-SET
-  NOT NULL;
-
-ALTER TABLE "data_sources"
-ALTER COLUMN "editedAt"
-DROP DEFAULT;
-
-ALTER TABLE "data_sources"
+ALTER TABLE "data_source_views" ALTER COLUMN "editedAt" SET NOT NULL;
+ALTER TABLE "data_source_views" ALTER COLUMN "editedAt" DROP DEFAULT;
+ALTER TABLE "data_source_views"
 ALTER COLUMN "editedByUserId"
 SET
   NOT NULL;
@@ -36,7 +29,7 @@ $$ LANGUAGE plpgsql;
    SELECT perform_migration(:'backfilled'::boolean);
 \else
     \echo '!! Migration was NOT applied !!'
-    \echo 'The backfill script: 20240912_backfill_editedbyuser_id is required before applying this migation. If you already did it, run psql with --set=backfilled=1 argument.'
+    \echo 'The backfill script: <insert_script> is required before applying this migation. If you already did it, run psql with --set=backfilled=1 argument.'
 \endif
 
 DROP FUNCTION perform_migration(boolean);

--- a/front/migrations/db/migration_86.sql
+++ b/front/migrations/db/migration_86.sql
@@ -17,6 +17,7 @@ WHERE "editedAt" IS NULL;
 UPDATE "data_source_views"
 SET
     "editedByUserId" = "data_sources"."editedByUserId"
+    "editedAt" = "data_sources"."editedAt"
 FROM "data_sources"
 WHERE
     "data_sources"."id" = "data_source_views"."dataSourceId"

--- a/front/migrations/db/migration_86.sql
+++ b/front/migrations/db/migration_86.sql
@@ -14,6 +14,14 @@ UPDATE "data_source_views"
 SET "editedAt" = "updatedAt"
 WHERE "editedAt" IS NULL;
 
+UPDATE "data_source_views"
+SET
+    "editedByUserId" = "data_sources"."editedByUserId"
+FROM "data_sources"
+WHERE
+    "data_sources"."id" = "data_source_views"."dataSourceId"
+    AND "data_source_views"."editedByUserId" IS NULL;
+
 ALTER TABLE "data_source_views" ALTER COLUMN "editedAt" SET NOT NULL;
 ALTER TABLE "data_source_views" ALTER COLUMN "editedAt" DROP DEFAULT;
 ALTER TABLE "data_source_views"

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -204,7 +204,6 @@ async function handler(
           dustAPIDataSourceId: dustDataSource.value.data_source.data_source_id,
           workspaceId: owner.id,
           assistantDefaultSelected: req.body.assistantDefaultSelected,
-          editedByUserId: user.id,
         },
         vault
       );

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -303,7 +303,6 @@ async function handler(
           description: dataSourceDescription,
           dustAPIProjectId: dustProject.value.project.project_id.toString(),
           dustAPIDataSourceId: dustDataSource.value.data_source.data_source_id,
-          editedByUserId: user.id,
           name: dataSourceName,
           workspaceId: owner.id,
         },

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/index.ts
@@ -2,7 +2,6 @@ import type {
   DataSourceType,
   DataSourceViewType,
   PlanType,
-  UserType,
   WithAPIErrorResponse,
   WorkspaceType,
 } from "@dust-tt/types";
@@ -87,7 +86,6 @@ async function handler(
 ): Promise<void> {
   const owner = auth.getNonNullableWorkspace();
   const plan = auth.getNonNullablePlan();
-  const user = auth.getNonNullableUser();
 
   if (typeof req.query.vId !== "string") {
     return apiError(req, res, {
@@ -165,7 +163,6 @@ async function handler(
         >;
         await handleDataSourceWithProvider({
           auth,
-          user,
           plan,
           owner,
           vault,
@@ -179,7 +176,6 @@ async function handler(
         >;
         await handleDataSourceWithoutProvider({
           auth,
-          user,
           plan,
           owner,
           vault,
@@ -207,7 +203,6 @@ async function handler(
  */
 const handleDataSourceWithProvider = async ({
   auth,
-  user,
   plan,
   owner,
   vault,
@@ -216,7 +211,6 @@ const handleDataSourceWithProvider = async ({
   res,
 }: {
   auth: Authenticator;
-  user: UserType;
   plan: PlanType;
   owner: WorkspaceType;
   vault: VaultResource;
@@ -392,7 +386,6 @@ const handleDataSourceWithProvider = async ({
       description: dataSourceDescription,
       dustAPIProjectId: dustProject.value.project.project_id.toString(),
       dustAPIDataSourceId: dustDataSource.value.data_source.data_source_id,
-      editedByUserId: user.id,
       name: dataSourceName,
       workspaceId: owner.id,
     },
@@ -475,7 +468,7 @@ const handleDataSourceWithProvider = async ({
     // Asynchronous tracking & operations without awaiting, handled safely
     void ServerSideTracking.trackDataSourceCreated({
       dataSource: dataSource.toJSON(),
-      user,
+      user: auth.getNonNullableUser(),
       workspace: owner,
     });
 
@@ -509,7 +502,6 @@ const handleDataSourceWithProvider = async ({
  */
 const handleDataSourceWithoutProvider = async ({
   auth,
-  user,
   plan,
   owner,
   vault,
@@ -518,7 +510,6 @@ const handleDataSourceWithoutProvider = async ({
   res,
 }: {
   auth: Authenticator;
-  user: UserType;
   plan: PlanType;
   owner: WorkspaceType;
   vault: VaultResource;
@@ -618,7 +609,6 @@ const handleDataSourceWithoutProvider = async ({
       dustAPIDataSourceId: dustDataSource.value.data_source.data_source_id,
       workspaceId: owner.id,
       assistantDefaultSelected: false,
-      editedByUserId: user.id,
     },
     vault
   );
@@ -638,7 +628,7 @@ const handleDataSourceWithoutProvider = async ({
   try {
     // Asynchronous tracking without awaiting, handled safely
     void ServerSideTracking.trackDataSourceCreated({
-      user,
+      user: auth.getNonNullableUser(),
       workspace: owner,
       dataSource: dataSource.toJSON(),
     });


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Same logic as https://github.com/dust-tt/dust/pull/7602.

This PR changes the `editedAt` and `editedByUserId` fields to be non-nullable on `data_source_views` table. It bundles the migration to backfill the fields before setting them to non-nullable.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [x] Backfill editedBy.
- [x] Run SQL migration
- [ ] Deploy front.
