### PR TITLE
Update table model: add new columns for remote dbs

### DIFF
--- a/core/src/stores/migrations/20240923_add_remote_db_fields.sql
+++ b/core/src/stores/migrations/20240923_add_remote_db_fields.sql
@@ -1,0 +1,4 @@
+-- pre deploy
+ALTER TABLE tables ADD COLUMN remote_database_table_id TEXT; -- nullable if not a remote table
+ALTER TABLE tables ADD COLUMN remote_database_secret_id TEXT; -- nullable if not a remote table
+

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -451,18 +451,20 @@ pub const POSTGRES_TABLES: [&'static str; 14] = [
     );",
     "-- databases tables
     CREATE TABLE IF NOT EXISTS tables (
-       id                       BIGSERIAL PRIMARY KEY,
-       created                  BIGINT NOT NULL,
-       table_id                 TEXT NOT NULL, -- unique within datasource
-       name                     TEXT NOT NULL, -- unique within datasource
-       description              TEXT NOT NULL,
-       timestamp                BIGINT NOT NULL,
-       tags_array               TEXT[] NOT NULL,
-       parents                  TEXT[] NOT NULL,
-       schema                   TEXT, -- json, kept up-to-date automatically with the last insert
-       schema_stale_at          BIGINT, -- timestamp when the schema was last invalidated
-       data_source              BIGINT NOT NULL,
-       FOREIGN KEY(data_source) REFERENCES data_sources(id)
+       id                           BIGSERIAL PRIMARY KEY,
+       created                      BIGINT NOT NULL,
+       table_id                     TEXT NOT NULL, -- unique within datasource
+       name                         TEXT NOT NULL, -- unique within datasource
+       description                  TEXT NOT NULL,
+       timestamp                    BIGINT NOT NULL,
+       tags_array                   TEXT[] NOT NULL,
+       parents                      TEXT[] NOT NULL,
+       schema                       TEXT, -- json, kept up-to-date automatically with the last insert
+       schema_stale_at              BIGINT, -- timestamp when the schema was last invalidated
+       data_source                  BIGINT NOT NULL,
+       remote_database_table_id     TEXT,
+       remote_database_secret_id    TEXT,
+       FOREIGN KEY(data_source)     REFERENCES data_sources(id)
     );",
 ];
 


### PR DESCRIPTION
## Description

Part of https://github.com/dust-tt/dust/issues/7447
Add `remote_database_table_id` and `remote_database_secret_id` columns to the `tables` table in `core`.

## Risk

New columns are not used yet. 
They are nullable so no risk of failing on creation. 

## Deploy Plan

Run `core/src/stores/migrations/20240923_add_remote_db_fields.sql` migration (manually). 
Deploy core. 
