### PR TITLE
[front] - fix: disable tooltip for `ActionEditor` dropdown button

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -852,6 +852,7 @@ function ActionEditor({
                     icon={MoreIcon}
                     size="sm"
                     variant="tertiary"
+                    disabledTooltip={true}
                   />
                 </DropdownMenu.Button>
                 <DropdownMenu.Items width={320} overflow="visible">


### PR DESCRIPTION
## Description

This PR aims at adding a property to disable the tooltip display on the ActionEditor dropdown button to improve the user interface.

**References:**
- https://github.com/dust-tt/tasks/issues/1373

## Risk

None

## Deploy Plan

Deploy `front`