### PR TITLE
clean up RetreievalDocument table

### DIFF
--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -617,8 +617,6 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
 
             return {
               blob: {
-                dataSourceWorkspaceId: details.workspaceId,
-                dataSourceId: details.dataSourceView.dataSource.sId,
                 sourceUrl: d.source_url,
                 documentId: d.document_id,
                 reference,
@@ -667,7 +665,7 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
         },
         functionCallId: action.functionCallId,
         functionCallName: action.functionCallName,
-        documents: documents.map((d) => d.toJSON()),
+        documents: documents.map((d) => d.toJSON(auth)),
         step: action.step,
       }),
     };
@@ -778,7 +776,7 @@ export async function retrievalActionTypesFromAgentMessageIds(
     }
 
     const documents: RetrievalDocumentType[] = documentRows.map((d) =>
-      d.toJSON()
+      d.toJSON(auth)
     );
 
     documents.sort((a, b) => {

--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -261,8 +261,6 @@ export class RetrievalDocument extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare dataSourceWorkspaceId: string;
-  declare dataSourceId: string;
   declare sourceUrl: string | null;
   declare documentId: string;
   declare reference: string;
@@ -294,14 +292,6 @@ RetrievalDocument.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
-    },
-    dataSourceWorkspaceId: {
-      type: DataTypes.STRING,
-      allowNull: true,
-    },
-    dataSourceId: {
-      type: DataTypes.STRING,
-      allowNull: false,
     },
     sourceUrl: {
       type: DataTypes.TEXT,

--- a/front/lib/resources/retrieval_document_resource.ts
+++ b/front/lib/resources/retrieval_document_resource.ts
@@ -163,7 +163,7 @@ export class RetrievalDocumentResource extends BaseResource<RetrievalDocument> {
   }
 
   // Helpers.
-  getSourceUrl(): string | null {
+  getSourceUrl(auth: Authenticator): string | null {
     if (this.sourceUrl) {
       return this.sourceUrl;
     }
@@ -175,18 +175,18 @@ export class RetrievalDocumentResource extends BaseResource<RetrievalDocument> {
     const dsv = this.dataSourceView.toJSON();
 
     return `${config.getClientFacingUrl()}/w/${
-      this.dataSourceWorkspaceId
+      auth.getNonNullableWorkspace().sId
     }/vaults/${dsv.vaultId}/categories/${
       dsv.category
     }/data_source_views/${dsv.sId}#?documentId=${encodeURIComponent(this.documentId)}`;
   }
 
   // Serialization.
-  toJSON(): RetrievalDocumentType {
+  toJSON(auth: Authenticator): RetrievalDocumentType {
     return {
       id: this.id,
       dataSourceView: this.dataSourceView?.toJSON() || null,
-      sourceUrl: this.getSourceUrl(),
+      sourceUrl: this.getSourceUrl(auth),
       documentId: this.documentId,
       reference: this.reference,
       timestamp: this.documentTimestamp.getTime(),

--- a/front/migrations/20240911_backfill_views_in_retrieval_documents.ts
+++ b/front/migrations/20240911_backfill_views_in_retrieval_documents.ts
@@ -1,107 +1,107 @@
-import type { LightWorkspaceType } from "@dust-tt/types";
-import { removeNulls } from "@dust-tt/types";
-import assert from "assert";
-import { pick, uniqBy } from "lodash";
-import { Op } from "sequelize";
-
-import { Authenticator } from "@app/lib/auth";
-import { RetrievalDocument } from "@app/lib/models/assistant/actions/retrieval";
-import { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
-import { VaultResource } from "@app/lib/resources/vault_resource";
-import type { Logger } from "@app/logger/logger";
-import { makeScript, runOnAllWorkspaces } from "@app/scripts/helpers";
-
-async function backfillViewsInRetrievalDocumentsForWorkspace(
-  workspace: LightWorkspaceType,
-  logger: Logger,
-  execute: boolean
-) {
-  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-
-  // List workspace data sources.
-  const dataSources = await DataSourceResource.listByWorkspace(auth);
-
-  logger.info(
-    `Found ${dataSources.length} data sources for workspace(${workspace.sId}).`
-  );
-
-  const globalVault = await VaultResource.fetchWorkspaceGlobalVault(auth);
-
-  // Retrieve data source views for data sources.
-  const dataSourceViews =
-    await DataSourceViewResource.listForDataSourcesInVault(
-      auth,
-      dataSources,
-      globalVault
-    );
-
-  const uniqueDataSources = removeNulls(
-    dataSourceViews.map((dsv) => dsv.dataSource)
-  );
-
-  // Count retrieval documents that uses those data sources and have no dataSourceViewId.
-  const retrievalDocumentsCount = await RetrievalDocument.count({
-    where: {
-      // /!\ `dataSourceId` is the data source's name, not the id.
-      dataSourceId: {
-        [Op.in]: uniqueDataSources.map((ds) => ds.name),
-      },
-      // Scope to data sources that belong to the workspace.
-      dataSourceWorkspaceId: workspace.sId,
-      dataSourceViewId: {
-        [Op.is]: null,
-      },
-    },
-  });
-
-  logger.info(
-    `About to update ${retrievalDocumentsCount} retrieval documents for workspace(${workspace.sId}).`
-  );
-
-  if (!execute) {
-    return;
-  }
-
-  for (const ds of uniqueDataSources) {
-    const dataSourceView = dataSourceViews.find(
-      (dsv) => dsv.dataSourceId === ds.id
-    );
-    assert(
-      dataSourceView,
-      `Data source view not found for data source ${ds.id}.`
-    );
-
-    await RetrievalDocument.update(
-      { dataSourceViewId: dataSourceView.id },
-      {
-        where: {
-          // /!\ `dataSourceId` is the data source's name, not the id.
-          dataSourceId: ds.name,
-          // Scope to data sources that belong to the workspace.
-          dataSourceWorkspaceId: workspace.sId,
-        },
-      }
-    );
-
-    logger.info(
-      `Updated retrieval documents for data source ${ds.id}-${ds.name}.`
-    );
-  }
-
-  logger.info(
-    `Updated all retrieval documents for workspace(${workspace.sId}).`
-  );
-}
-
-makeScript({}, async ({ execute }, logger) => {
-  return runOnAllWorkspaces(async (workspace) => {
-    await backfillViewsInRetrievalDocumentsForWorkspace(
-      workspace,
-      logger,
-      execute
-    );
-
-    logger.info(`Finished backfilling views for workspace(${workspace.sId}).`);
-  });
-});
+// import type { LightWorkspaceType } from "@dust-tt/types";
+// import { removeNulls } from "@dust-tt/types";
+// import assert from "assert";
+// import { pick, uniqBy } from "lodash";
+// import { Op } from "sequelize";
+//
+// import { Authenticator } from "@app/lib/auth";
+// import { RetrievalDocument } from "@app/lib/models/assistant/actions/retrieval";
+// import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+// import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+// import { VaultResource } from "@app/lib/resources/vault_resource";
+// import type { Logger } from "@app/logger/logger";
+// import { makeScript, runOnAllWorkspaces } from "@app/scripts/helpers";
+//
+// async function backfillViewsInRetrievalDocumentsForWorkspace(
+//   workspace: LightWorkspaceType,
+//   logger: Logger,
+//   execute: boolean
+// ) {
+//   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+//
+//   // List workspace data sources.
+//   const dataSources = await DataSourceResource.listByWorkspace(auth);
+//
+//   logger.info(
+//     `Found ${dataSources.length} data sources for workspace(${workspace.sId}).`
+//   );
+//
+//   const globalVault = await VaultResource.fetchWorkspaceGlobalVault(auth);
+//
+//   // Retrieve data source views for data sources.
+//   const dataSourceViews =
+//     await DataSourceViewResource.listForDataSourcesInVault(
+//       auth,
+//       dataSources,
+//       globalVault
+//     );
+//
+//   const uniqueDataSources = removeNulls(
+//     dataSourceViews.map((dsv) => dsv.dataSource)
+//   );
+//
+//   // Count retrieval documents that uses those data sources and have no dataSourceViewId.
+//   const retrievalDocumentsCount = await RetrievalDocument.count({
+//     where: {
+//       // /!\ `dataSourceId` is the data source's name, not the id.
+//       dataSourceId: {
+//         [Op.in]: uniqueDataSources.map((ds) => ds.name),
+//       },
+//       // Scope to data sources that belong to the workspace.
+//       dataSourceWorkspaceId: workspace.sId,
+//       dataSourceViewId: {
+//         [Op.is]: null,
+//       },
+//     },
+//   });
+//
+//   logger.info(
+//     `About to update ${retrievalDocumentsCount} retrieval documents for workspace(${workspace.sId}).`
+//   );
+//
+//   if (!execute) {
+//     return;
+//   }
+//
+//   for (const ds of uniqueDataSources) {
+//     const dataSourceView = dataSourceViews.find(
+//       (dsv) => dsv.dataSourceId === ds.id
+//     );
+//     assert(
+//       dataSourceView,
+//       `Data source view not found for data source ${ds.id}.`
+//     );
+//
+//     await RetrievalDocument.update(
+//       { dataSourceViewId: dataSourceView.id },
+//       {
+//         where: {
+//           // /!\ `dataSourceId` is the data source's name, not the id.
+//           dataSourceId: ds.name,
+//           // Scope to data sources that belong to the workspace.
+//           dataSourceWorkspaceId: workspace.sId,
+//         },
+//       }
+//     );
+//
+//     logger.info(
+//       `Updated retrieval documents for data source ${ds.id}-${ds.name}.`
+//     );
+//   }
+//
+//   logger.info(
+//     `Updated all retrieval documents for workspace(${workspace.sId}).`
+//   );
+// }
+//
+// makeScript({}, async ({ execute }, logger) => {
+//   return runOnAllWorkspaces(async (workspace) => {
+//     await backfillViewsInRetrievalDocumentsForWorkspace(
+//       workspace,
+//       logger,
+//       execute
+//     );
+//
+//     logger.info(`Finished backfilling views for workspace(${workspace.sId}).`);
+//   });
+// });

--- a/front/migrations/db/migration_87.sql
+++ b/front/migrations/db/migration_87.sql
@@ -1,0 +1,3 @@
+-- Migration created on Sep 23, 2024
+ALTER TABLE "public"."retrieval_documents" DROP COLUMN "dataSourceWorkspaceId";
+ALTER TABLE "public"."retrieval_documents" DROP COLUMN "dataSourceId";


### PR DESCRIPTION
## Description

Remove `dataSourceWorkspaceId` and `dataSourceId` from RetrievalDocument.

Checked that pre-diff created Citations are working.
Checked that new Citations work post diff.
Checked that everything worked post migration.

## Risk

Low (well tested in dev + we checked last week that everything was well backfilled)

## Deploy Plan

- deploy `front`
- run migration