### PR TITLE
[Vaults] Restrict access to conversations and messages

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -456,11 +456,12 @@ const conversation = async (command: string, args: parseArgs.ParsedArgs) => {
       const verbose = args.verbose === "true";
 
       const auth = await Authenticator.internalAdminForWorkspace(args.wId);
-      const conversation = await getConversation(auth, args.cId as string);
+      const conversationRes = await getConversation(auth, args.cId as string);
 
-      if (!conversation) {
-        throw new Error(`Conversation not found: cId='${args.cId}'`);
+      if (conversationRes.isErr()) {
+        throw new Error(conversationRes.error.message);
       }
+      const conversation = conversationRes.value;
 
       const MIN_GENERATION_TOKENS = 2048;
       const allowedTokenCount = model.contextSize - MIN_GENERATION_TOKENS;

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -83,7 +83,6 @@ import { ServerSideTracking } from "@app/lib/tracking/server";
 import { isEmailValid } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import { launchUpdateUsageWorkflow } from "@app/temporal/usage_queue/client";
-import { message } from "danger";
 
 /**
  * Conversation Creation, update and deletion
@@ -363,7 +362,7 @@ export async function getConversationWithoutContent(
   auth: Authenticator,
   conversationId: string,
   includeDeleted?: boolean
-): Promise<ConversationWithoutContentType | null> {
+): Promise<Result<ConversationWithoutContentType, Error>> {
   const owner = auth.workspace();
   if (!owner) {
     throw new Error("Unexpected `auth` without `workspace`.");
@@ -378,17 +377,21 @@ export async function getConversationWithoutContent(
   });
 
   if (!conversation) {
-    return null;
+    return new Err(new ConversationNotFoundError());
   }
 
-  return {
+  if (!canAccessConversation(auth, conversation)) {
+    return new Err(new ConversationPermissionError());
+  }
+
+  return new Ok({
     id: conversation.id,
     created: conversation.createdAt.getTime(),
     sId: conversation.sId,
     owner,
     title: conversation.title,
     visibility: conversation.visibility,
-  };
+  });
 }
 
 export async function getConversationMessageType(
@@ -1954,7 +1957,7 @@ export function normalizeContentFragmentType({
 
 export async function canAccessConversation(
   auth: Authenticator,
-  conversation: ConversationWithoutContentType | ConversationType
+  conversation: ConversationWithoutContentType | ConversationType | Conversation
 ): Promise<boolean> {
   if ("content" in conversation) {
     // If the conversation has its content already loaded, we can check without an additional query

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -32,6 +32,7 @@ import type {
 } from "@dust-tt/types";
 import {
   assertNever,
+  ConversationPermissionError,
   getSmallWhitelistedModel,
   isProviderWhitelisted,
   md5,
@@ -154,13 +155,17 @@ export async function updateConversation(
     visibility: visibility,
   });
 
-  const c = await getConversation(auth, conversationId);
+  const cRes = await getConversation(auth, conversationId);
 
-  if (!c) {
+  if (cRes.isErr()) {
+    throw cRes.error;
+  }
+
+  if (!cRes.value) {
     throw new Error(`Conversation ${conversationId} not found`);
   }
 
-  return c;
+  return cRes.value;
 }
 
 /**
@@ -271,7 +276,7 @@ export async function getConversation(
   auth: Authenticator,
   conversationId: string,
   includeDeleted?: boolean
-): Promise<ConversationType | null> {
+): Promise<Result<ConversationType | null, ConversationPermissionError>> {
   const owner = auth.workspace();
   if (!owner) {
     throw new Error("Unexpected `auth` without `workspace`.");
@@ -286,7 +291,7 @@ export async function getConversation(
   });
 
   if (!conversation) {
-    return null;
+    return new Ok(null);
   }
 
   const messages = await Message.findAll({
@@ -326,7 +331,13 @@ export async function getConversation(
     ],
   });
 
-  const render = await batchRenderMessages(auth, conversation.sId, messages);
+  const renderRes = await batchRenderMessages(auth, conversation.sId, messages);
+
+  if (renderRes.isErr()) {
+    return new Err(renderRes.error);
+  }
+
+  const render = renderRes.value;
 
   // We need to escape the type system here to create content. We pre-create an array that will hold
   // the versions of each User/Assistant/ContentFragment message. The lenght of that array is by definition the
@@ -341,7 +352,7 @@ export async function getConversation(
     content[rank] = [...content[rank], m];
   }
 
-  return {
+  return new Ok({
     id: conversation.id,
     created: conversation.createdAt.getTime(),
     sId: conversation.sId,
@@ -349,7 +360,7 @@ export async function getConversation(
     title: conversation.title,
     visibility: conversation.visibility,
     content,
-  };
+  });
 }
 
 export async function getConversationWithoutContent(

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -701,19 +701,15 @@ export async function* postUserMessage(
   }
 
   const results = await Promise.all([
-    await Promise.all(
+    Promise.all(
       mentions.filter(isAgentMention).map((mention) => {
         return getLightAgentConfiguration(auth, mention.configurationId);
       })
     ),
-    await createOrUpdateParticipation(),
+    createOrUpdateParticipation(),
   ]);
 
-  // casting non-null is ok here because we check right below that there's no
-  // nulls and err if there is
-  const agentConfigurations = results[0] as LightAgentConfigurationType[];
-
-  if (agentConfigurations.some((a) => a === null)) {
+  if (results[0].some((a) => a === null)) {
     yield {
       type: "user_message_error",
       created: Date.now(),
@@ -724,6 +720,10 @@ export async function* postUserMessage(
     };
     return;
   }
+
+  // casting non-null is ok here because we check right above that there's no
+  // nulls and err if there is
+  const agentConfigurations = results[0] as LightAgentConfigurationType[];
 
   for (const agentConfig of agentConfigurations) {
     if (!isProviderWhitelisted(owner, agentConfig.model.providerId)) {
@@ -1178,11 +1178,7 @@ export async function* editUserMessage(
     await createOrUpdateParticipation(),
   ]);
 
-  // casting non-null is ok here because we check right below that there's no
-  // nulls and err if there is
-  const agentConfigurations = results[0] as LightAgentConfigurationType[];
-
-  if (agentConfigurations.some((a) => a === null)) {
+  if (results[0].some((a) => a === null)) {
     yield {
       type: "user_message_error",
       created: Date.now(),
@@ -1193,6 +1189,10 @@ export async function* editUserMessage(
     };
     return;
   }
+
+  // casting non-null is ok here because we check right above that there's no
+  // nulls and err if there is
+  const agentConfigurations = results[0] as LightAgentConfigurationType[];
 
   for (const agentConfig of agentConfigurations) {
     if (!isProviderWhitelisted(owner, agentConfig.model.providerId)) {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1521,7 +1521,17 @@ export async function* retryAgentMessage(
   class AgentMessageError extends Error {}
 
   if (!canReadMessage(auth, message)) {
-    throw new AgentMessageError("Agent cannot be used by this user");
+    yield {
+      type: "agent_error",
+      created: Date.now(),
+      configurationId: message.configuration.sId,
+      messageId: message.sId,
+      error: {
+        code: "message_access_denied",
+        message: "The message to retry is not accessible.",
+      },
+    };
+    return;
   }
 
   let agentMessageResult: {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -149,6 +149,10 @@ export async function updateConversation(
     throw new Error(`Conversation ${conversationId} not found`);
   }
 
+  if (!(await canAccessConversation(auth, conversation))) {
+    throw new Error("Conversation access denied");
+  }
+
   await conversation.update({
     title: title,
     visibility: visibility,
@@ -192,6 +196,10 @@ export async function deleteConversation(
 
   if (!conversation) {
     throw new Error(`Conversation ${conversationId} not found`);
+  }
+
+  if (!(await canAccessConversation(auth, conversation))) {
+    throw new Error("Conversation access denied");
   }
 
   if (destroy) {
@@ -380,7 +388,7 @@ export async function getConversationWithoutContent(
     return new Err(new ConversationNotFoundError());
   }
 
-  if (!canAccessConversation(auth, conversation)) {
+  if (!(await canAccessConversation(auth, conversation))) {
     return new Err(new ConversationPermissionError());
   }
 

--- a/front/lib/api/assistant/conversation/helper.ts
+++ b/front/lib/api/assistant/conversation/helper.ts
@@ -1,0 +1,41 @@
+import {
+  ConversationNotFoundError,
+  ConversationPermissionError,
+} from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { apiError } from "@app/logger/withlogging";
+
+export function apiErrorForConversation(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  error: Error
+) {
+  if (error instanceof ConversationPermissionError) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "conversation_access_denied",
+        message: "Access to the conversation is denied.",
+      },
+    });
+  }
+
+  if (error instanceof ConversationNotFoundError) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "conversation_not_found",
+        message: "Conversation not found.",
+      },
+    });
+  }
+
+  return apiError(req, res, {
+    status_code: 500,
+    api_error: {
+      type: "internal_server_error",
+      message: "An internal server error occurred.",
+    },
+  });
+}

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -1,16 +1,14 @@
-import {
-  AgentActionType,
-  ConversationPermissionError,
-  MessageWithRankType,
-  ModelId,
-  Result,
-} from "@dust-tt/types";
 import type {
+  AgentActionType,
   AgentMessageType,
   ContentFragmentType,
   LightAgentConfigurationType,
+  MessageWithRankType,
+  ModelId,
+  Result,
   UserMessageType,
 } from "@dust-tt/types";
+import { ConversationPermissionError } from "@dust-tt/types";
 import { Err, isAgentMessageType, Ok, removeNulls } from "@dust-tt/types";
 import type { WhereOptions } from "sequelize";
 import { Op, Sequelize } from "sequelize";

--- a/front/lib/api/assistant/participants.ts
+++ b/front/lib/api/assistant/participants.ts
@@ -6,7 +6,12 @@ import type {
   Result,
   UserParticipantType,
 } from "@dust-tt/types";
-import { Err, formatUserFullName, Ok } from "@dust-tt/types";
+import {
+  ConversationPermissionError,
+  Err,
+  formatUserFullName,
+  Ok,
+} from "@dust-tt/types";
 import { Op } from "sequelize";
 
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
@@ -108,6 +113,12 @@ export async function fetchConversationParticipants(
     fetchAllUsersById([...userIds]),
     fetchAllAgentsById(auth, [...agentConfigurationIds]),
   ]);
+
+  // if less agents than agentConfigurationIds, it means some agents are forbidden
+  // to the user
+  if (agents.length < agentConfigurationIds.size) {
+    return new Err(new ConversationPermissionError());
+  }
 
   return new Ok({
     agents,

--- a/front/lib/api/assistant/participants.ts
+++ b/front/lib/api/assistant/participants.ts
@@ -16,8 +16,7 @@ import { Op } from "sequelize";
 
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import type { Authenticator } from "@app/lib/auth";
-import type {
-  Conversation} from "@app/lib/models/assistant/conversation";
+import type { Conversation } from "@app/lib/models/assistant/conversation";
 import {
   AgentMessage,
   Message,

--- a/front/lib/api/assistant/participants.ts
+++ b/front/lib/api/assistant/participants.ts
@@ -16,6 +16,8 @@ import { Op } from "sequelize";
 
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import type { Authenticator } from "@app/lib/auth";
+import type {
+  Conversation} from "@app/lib/models/assistant/conversation";
 import {
   AgentMessage,
   Message,
@@ -63,7 +65,7 @@ async function fetchAllAgentsById(
 
 export async function fetchConversationParticipants(
   auth: Authenticator,
-  conversation: ConversationWithoutContentType
+  conversation: ConversationWithoutContentType | Conversation
 ): Promise<Result<ConversationParticipantsType, Error>> {
   const owner = auth.workspace();
   if (!owner) {

--- a/front/lib/api/assistant/participants.ts
+++ b/front/lib/api/assistant/participants.ts
@@ -75,7 +75,7 @@ export async function fetchConversationParticipants(
     where: {
       conversationId: conversation.id,
     },
-    order: [["rank", "ASC"]],
+    attributes: [],
     include: [
       {
         model: UserMessage,

--- a/front/lib/api/assistant/reaction.ts
+++ b/front/lib/api/assistant/reaction.ts
@@ -5,12 +5,8 @@ import type {
   MessageReactionType,
   Result,
 } from "@dust-tt/types";
-import type {UserType} from "@dust-tt/types";
-import {
-  ConversationPermissionError,
-  Err,
-  Ok
-} from "@dust-tt/types";
+import type { UserType } from "@dust-tt/types";
+import { ConversationPermissionError, Err, Ok } from "@dust-tt/types";
 
 import { canAccessConversation } from "@app/lib/api/assistant/conversation";
 import type { Authenticator } from "@app/lib/auth";
@@ -31,7 +27,7 @@ export async function getMessageReactions(
     throw new Error("Unexpected `auth` without `workspace`.");
   }
 
-  if (!canAccessConversation(auth, conversation)) {
+  if (!(await canAccessConversation(auth, conversation))) {
     return new Err(new ConversationPermissionError());
   }
 

--- a/front/lib/api/assistant/reaction.ts
+++ b/front/lib/api/assistant/reaction.ts
@@ -1,9 +1,3 @@
-import {
-  ConversationPermissionError,
-  Err,
-  Ok,
-  type UserType,
-} from "@dust-tt/types";
 import type {
   ConversationMessageReactions,
   ConversationType,
@@ -11,13 +5,19 @@ import type {
   MessageReactionType,
   Result,
 } from "@dust-tt/types";
+import type {UserType} from "@dust-tt/types";
+import {
+  ConversationPermissionError,
+  Err,
+  Ok
+} from "@dust-tt/types";
 
+import { canAccessConversation } from "@app/lib/api/assistant/conversation";
 import type { Authenticator } from "@app/lib/auth";
 import {
   Message,
   MessageReaction,
 } from "@app/lib/models/assistant/conversation";
-import { canAccessConversation } from "@app/lib/api/assistant/conversation";
 
 /**
  * We retrieve the reactions for a whole conversation, not just a single message.

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/index.ts
@@ -2,6 +2,7 @@ import type { ConversationType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
@@ -43,17 +44,13 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const conversation = await getConversation(auth, cId, true);
+      const conversationRes = await getConversation(auth, cId, true);
 
-      if (!conversation) {
-        return apiError(req, res, {
-          status_code: 404,
-          api_error: {
-            type: "conversation_not_found",
-            message: "Could not find the conversation.",
-          },
-        });
+      if (conversationRes.isErr()) {
+        return apiErrorForConversation(req, res, conversationRes.error);
       }
+
+      const conversation = conversationRes.value;
 
       return res.status(200).json({ conversation });
 

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -10,6 +10,7 @@ import {
   normalizeContentFragmentType,
   postNewContentFragment,
 } from "@app/lib/api/assistant/conversation";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
@@ -82,16 +83,13 @@ async function handler(
     });
   }
 
-  const conversation = await getConversation(auth, cId);
-  if (!conversation) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "conversation_not_found",
-        message: "Conversation not found.",
-      },
-    });
+  const conversationRes = await getConversation(auth, cId);
+
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
   }
+
+  const conversation = conversationRes.value;
 
   switch (req.method) {
     case "POST":

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -5,6 +5,7 @@ import type {
   WithAPIErrorResponse,
 } from "@dust-tt/types";
 import {
+  ConversationNotFoundError,
   isEmptyString,
   PublicPostConversationsRequestBodySchema,
 } from "@dust-tt/types";
@@ -18,6 +19,7 @@ import {
   normalizeContentFragmentType,
   postNewContentFragment,
 } from "@app/lib/api/assistant/conversation";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { postUserMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
 import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -184,12 +186,24 @@ async function handler(
         }
 
         newContentFragment = cfRes.value;
-        const updatedConversation = await getConversation(
+        const updatedConversationRes = await getConversation(
           auth,
           conversation.sId
         );
-        if (updatedConversation) {
-          conversation = updatedConversation;
+
+        if (updatedConversationRes.isErr()) {
+          // Preserving former code in which if the conversation was not found here, we do not error
+          if (
+            !(updatedConversationRes.error instanceof ConversationNotFoundError)
+          ) {
+            return apiErrorForConversation(
+              req,
+              res,
+              updatedConversationRes.error
+            );
+          }
+        } else {
+          conversation = updatedConversationRes.value;
         }
       }
 
@@ -229,13 +243,12 @@ async function handler(
         // created as well, so pulling the conversation again will allow to have an up to date view
         // of the conversation with agent messages included so that the user of the API can start
         // streaming events from these agent messages directly.
-        const updated = await getConversation(auth, conversation.sId);
+        const updatedRes = await getConversation(auth, conversation.sId);
 
-        if (!updated) {
-          throw `Conversation unexpectedly not found after creation: ${conversation.sId}`;
+        if (updatedRes.isErr()) {
+          return apiErrorForConversation(req, res, updatedRes.error);
         }
-
-        conversation = updated;
+        conversation = updatedRes.value;
       }
 
       res.status(200).json({

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
@@ -5,6 +5,7 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { cancelMessageGenerationEvent } from "@app/lib/api/assistant/pubsub";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -33,19 +34,13 @@ async function handler(
     });
   }
   const conversationId = req.query.cId;
-  const conversation = await getConversationWithoutContent(
+  const conversationRes = await getConversationWithoutContent(
     auth,
     conversationId
   );
 
-  if (!conversation) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "conversation_not_found",
-        message: "The conversation you're trying to access was not found.",
-      },
-    });
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
   }
 
   switch (req.method) {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/content_fragment/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/content_fragment/index.ts
@@ -9,6 +9,7 @@ import {
   getConversation,
   postNewContentFragment,
 } from "@app/lib/api/assistant/conversation";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
@@ -37,16 +38,13 @@ async function handler(
   }
 
   const conversationId = req.query.cId;
-  const conversation = await getConversation(auth, conversationId);
-  if (!conversation) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "conversation_not_found",
-        message: "Conversation not found.",
-      },
-    });
+  const conversationRes = await getConversation(auth, conversationId);
+
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
   }
+
+  const conversation = conversationRes.value;
 
   switch (req.method) {
     case "POST":

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -2,6 +2,7 @@ import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { getConversationEvents } from "@app/lib/api/assistant/pubsub";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -22,20 +23,16 @@ async function handler(
     });
   }
   const conversationId = req.query.cId;
-  const conversation = await getConversationWithoutContent(
+  const conversationRes = await getConversationWithoutContent(
     auth,
     conversationId
   );
 
-  if (!conversation) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "conversation_not_found",
-        message: "The conversation you're trying to access was not found.",
-      },
-    });
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
   }
+
+  const conversation = conversationRes.value;
 
   const lastEventId = req.query.lastEventId || null;
   if (lastEventId && typeof lastEventId !== "string") {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -12,6 +12,7 @@ import {
   getConversationWithoutContent,
   updateConversation,
 } from "@app/lib/api/assistant/conversation";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
@@ -47,16 +48,16 @@ async function handler(
     });
   }
 
-  const conversation = await getConversationWithoutContent(auth, req.query.cId);
-  if (!conversation) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "conversation_not_found",
-        message: "The conversation you're trying to access was not found.",
-      },
-    });
+  const conversationRes = await getConversationWithoutContent(
+    auth,
+    req.query.cId
+  );
+
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
   }
+
+  const conversation = conversationRes.value;
 
   switch (req.method) {
     case "GET":

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/raw_content_fragment/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/raw_content_fragment/index.ts
@@ -4,6 +4,7 @@ import { IncomingForm } from "formidable";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
@@ -41,16 +42,13 @@ async function handler(
   }
 
   const conversationId = req.query.cId;
-  const conversation = await getConversation(auth, conversationId);
-  if (!conversation) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "conversation_not_found",
-        message: "Conversation not found.",
-      },
-    });
+  const conversationRes = await getConversation(auth, conversationId);
+
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
   }
+
+  const conversation = conversationRes.value;
 
   if (!(typeof req.query.mId === "string")) {
     return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
@@ -5,6 +5,7 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import {
   createMessageReaction,
   deleteMessageReaction,
@@ -39,19 +40,16 @@ async function handler(
   }
 
   const conversationId = req.query.cId;
-  const conversation = await getConversationWithoutContent(
+  const conversationRes = await getConversationWithoutContent(
     auth,
     conversationId
   );
-  if (!conversation) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "conversation_not_found",
-        message: "Conversation not found.",
-      },
-    });
+
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
   }
+
+  const conversation = conversationRes.value;
 
   if (!(typeof req.query.mId === "string")) {
     return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
@@ -6,6 +6,7 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { retryAgentMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -34,16 +35,13 @@ async function handler(
   }
 
   const conversationId = req.query.cId;
-  const conversation = await getConversation(auth, conversationId);
-  if (!conversation) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "conversation_not_found",
-        message: "Conversation not found.",
-      },
-    });
+  const conversationRes = await getConversation(auth, conversationId);
+
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
   }
+
+  const conversation = conversationRes.value;
 
   if (!(typeof req.query.mId === "string")) {
     return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -67,13 +67,7 @@ async function handler(
       );
 
       if (messagesRes.isErr()) {
-        return apiError(req, res, {
-          status_code: 404,
-          api_error: {
-            type: "conversation_not_found",
-            message: "Conversation not found",
-          },
-        });
+        return apiErrorForConversation(req, res, messagesRes.error);
       }
 
       res.status(200).json(messagesRes.value);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -5,6 +5,7 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import type { FetchConversationMessagesResponse } from "@app/lib/api/assistant/messages";
 import { fetchConversationMessages } from "@app/lib/api/assistant/messages";
 import { postUserMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
@@ -97,16 +98,13 @@ async function handler(
 
       const { content, context, mentions } = bodyValidation.right;
 
-      const conversation = await getConversation(auth, conversationId);
-      if (!conversation) {
-        return apiError(req, res, {
-          status_code: 404,
-          api_error: {
-            type: "conversation_not_found",
-            message: "Conversation not found.",
-          },
-        });
+      const conversationRes = await getConversation(auth, conversationId);
+
+      if (conversationRes.isErr()) {
+        return apiErrorForConversation(req, res, conversationRes.error);
       }
+
+      const conversation = conversationRes.value;
 
       /* postUserMessageWithPubSub returns swiftly since it only waits for the
         initial message creation event (or error) */

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/reactions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/reactions.ts
@@ -44,7 +44,19 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const reactions = await getMessageReactions(auth, conversation);
+      const reactionsRes = await getMessageReactions(auth, conversation);
+
+      if (reactionsRes.isErr()) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "conversation_access_denied",
+            message: "You do not have permission to access this conversation.",
+          },
+        });
+      }
+
+      const reactions = reactionsRes.value;
 
       res.status(200).json({ reactions });
       return;

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/reactions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/reactions.ts
@@ -5,6 +5,7 @@ import type {
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { getMessageReactions } from "@app/lib/api/assistant/reaction";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -28,19 +29,16 @@ async function handler(
   }
 
   const conversationId = req.query.cId;
-  const conversation = await getConversationWithoutContent(
+  const conversationRes = await getConversationWithoutContent(
     auth,
     conversationId
   );
-  if (!conversation) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "conversation_not_found",
-        message: "Conversation not found.",
-      },
-    });
+
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
   }
+
+  const conversation = conversationRes.value;
 
   switch (req.method) {
     case "GET":

--- a/types/src/front/assistant/conversation.ts
+++ b/types/src/front/assistant/conversation.ts
@@ -219,3 +219,9 @@ export interface ConversationParticipantsType {
   agents: AgentParticipant[];
   users: UserParticipant[];
 }
+
+export class ConversationPermissionError extends Error {
+  constructor() {
+    super("Cannot access conversation: Some agents are forbidden to the user.");
+  }
+}

--- a/types/src/front/assistant/conversation.ts
+++ b/types/src/front/assistant/conversation.ts
@@ -225,3 +225,9 @@ export class ConversationPermissionError extends Error {
     super("Cannot access conversation: Some agents are forbidden to the user.");
   }
 }
+
+export class ConversationNotFoundError extends Error {
+  constructor() {
+    super("Cannot access conversation: Conversation not found.");
+  }
+}


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/dust/issues/6903

Left a few comments on the PR for reviewers to check.

Now that agents have ACLs, conversations and messages should be restricted to users that have access to the related assistants.

Restriction is implemented on conversations by: 
- checking if any of its agent messages shouldn't be accessed by the user. ACLs are naturally present on agent messages via their attached agent configuration's groupIds.
- in cases where we don't have access to all the messages of a conversation, checking conversation access via a new function `canAccessConversation`,  relying on conversation participants---that will now return an error if one of the agents or more is not accessible to the user;

Summary: 
- checked all references to AgentMessage and Message models (details below) and acted where needed
- changed getConversation to a Result with ConversationPermissionError / ConversationNotFoundError
  - wrapped conversation api errors in a dedicated function, drying quite a bit
- did the same with getConversationWithoutContent, further drying
- double-check: all endpoints, and references to Conversation


## Risk
### Latency
Some calls become more heavy due to the addition of a `canAccessConversation` call relying on `fetchConversationParticipants` and as such making 2 additional database queries. The calls are indexed and query results are ~small volume, but still worth monitoring. This is the cost of checking per-conversation in addition to per-messages.

### Testing
Test scenarios:
- with allowed agents, all below should work
  - UX 
	- start a convo :heavy_check_mark: 
	- read a convo :heavy_check_mark: 
	- post a message to a convo :heavy_check_mark: 
	- destroy a convo :heavy_check_mark: 
  - API v1
	- start a convo, 
	- read a convo, 
	- post a message to a convo, 
	- destroy a convo
- with unallowed agents, all below should fail
  - start a convo (only API v1)
  - read a convo (both UX and v1) :heavy_check_mark: 
  - post a message to a convo (only v1) 
  - destroy a convo (only v1)

## Deploy Plan
test on front-edge
front

