### PR TITLE
[front] - enh(builder): vault selection

### DIFF
--- a/front/components/assistant_builder/vaults/VaultSelector.tsx
+++ b/front/components/assistant_builder/vaults/VaultSelector.tsx
@@ -35,6 +35,9 @@ export function VaultSelector({
     return renderChildren(allowedVaults ? allowedVaults[0] : undefined);
   }
 
+  // TODO: we are using Checkboxes here as our RadioButton isn't flexible
+  // enough to allow a onClick callback on a disabled item and to render
+  // elements in between labels. We are aiming to refactor RadioButton
   return (
     <>
       {vaults.map((vault) => {
@@ -52,6 +55,7 @@ export function VaultSelector({
                 }
               }}
             >
+
               <Checkbox
                 variant="checkable"
                 checked={isChecked ? "checked" : "unchecked"}

--- a/front/components/assistant_builder/vaults/VaultSelector.tsx
+++ b/front/components/assistant_builder/vaults/VaultSelector.tsx
@@ -1,5 +1,5 @@
 import { Checkbox, Dialog, Icon, Page, Spinner } from "@dust-tt/sparkle";
-import type { VaultType } from "@dust-tt/types";
+import type { LightWorkspaceType, VaultType } from "@dust-tt/types";
 import React, { useState } from "react";
 
 import { useVaults } from "@app/lib/swr/vaults";
@@ -7,7 +7,7 @@ import { classNames } from "@app/lib/utils";
 import { getVaultIcon, getVaultName } from "@app/lib/vaults";
 
 interface VaultSelectorProps {
-  owner: { sId: string };
+  owner: LightWorkspaceType;
   allowedVaults?: VaultType[];
   defaultVault: string;
   renderChildren: (vault?: VaultType) => React.ReactNode;
@@ -36,7 +36,7 @@ export function VaultSelector({
   }
 
   return (
-    <div>
+    <>
       {vaults.map((vault) => {
         const isDisabled = !allowedVaults?.some((v) => v.sId === vault.sId);
         const isChecked = selectedVault === vault.sId;
@@ -100,6 +100,6 @@ export function VaultSelector({
         An assistant can access one source of data only. The other tools are
         using a different source.
       </Dialog>
-    </div>
+    </>
   );
 }

--- a/front/components/assistant_builder/vaults/VaultSelector.tsx
+++ b/front/components/assistant_builder/vaults/VaultSelector.tsx
@@ -1,18 +1,17 @@
-import { Chip, Icon, Page, RadioButton, Spinner } from "@dust-tt/sparkle";
-import type { LightWorkspaceType, VaultType } from "@dust-tt/types";
-import { useState } from "react";
+import { Checkbox, Dialog, Icon, Page, Spinner } from "@dust-tt/sparkle";
+import type { VaultType } from "@dust-tt/types";
+import React, { useState } from "react";
 
 import { useVaults } from "@app/lib/swr/vaults";
 import { classNames } from "@app/lib/utils";
 import { getVaultIcon, getVaultName } from "@app/lib/vaults";
 
 interface VaultSelectorProps {
-  owner: LightWorkspaceType;
+  owner: { sId: string };
   allowedVaults?: VaultType[];
   defaultVault: string;
   renderChildren: (vault?: VaultType) => React.ReactNode;
 }
-
 export function VaultSelector({
   owner,
   allowedVaults,
@@ -22,8 +21,8 @@ export function VaultSelector({
   const { vaults, isVaultsError, isVaultsLoading } = useVaults({
     workspaceId: owner.sId,
   });
-
   const [selectedVault, setSelectedVault] = useState<string>(defaultVault);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   if (isVaultsLoading || isVaultsError) {
     return <Spinner />;
@@ -32,60 +31,75 @@ export function VaultSelector({
   const shouldRenderDirectly = !allowedVaults || vaults.length === 1;
   const selectedVaultObj = vaults.find((v) => v.sId === selectedVault);
 
+  if (shouldRenderDirectly) {
+    return renderChildren(allowedVaults ? allowedVaults[0] : undefined);
+  }
+
   return (
     <div>
-      {shouldRenderDirectly
-        ? renderChildren(allowedVaults ? allowedVaults[0] : undefined)
-        : vaults.map((vault) => {
-            const isDisabled = !allowedVaults?.some((v) => v.sId === vault.sId);
+      {vaults.map((vault) => {
+        const isDisabled = !allowedVaults?.some((v) => v.sId === vault.sId);
+        const isChecked = selectedVault === vault.sId;
 
-            return (
-              <div key={vault.sId}>
-                <Page.Separator />
-                <RadioButton
-                  name={`Vault ${vault.name}`}
-                  choices={[
-                    {
-                      label: (
-                        <>
-                          <Icon
-                            visual={getVaultIcon(vault)}
-                            size="md"
-                            className="ml-3 mr-2 inline-block flex-shrink-0 align-middle text-brand"
-                          />
-                          <span
-                            className={classNames(
-                              "text-element-900",
-                              "align-middle",
-                              !isDisabled ? "font-bold" : "italic"
-                            )}
-                          >
-                            {getVaultName(vault)}
-                            {isDisabled && (
-                              <Chip
-                                size="xs"
-                                className="ml-2"
-                                label="Disabled: only one vault allowed per assistant"
-                                color="warning"
-                              />
-                            )}
-                          </span>
-                        </>
-                      ),
-                      value: vault.sId,
-                      disabled: isDisabled,
-                    },
-                  ]}
-                  value={selectedVault}
-                  onChange={() => setSelectedVault(vault.sId)}
+        return (
+          <div key={vault.sId}>
+            <Page.Separator />
+            <div
+              className="s-flex s-items-center s-gap-2"
+              onClick={() => {
+                if (isDisabled) {
+                  setIsDialogOpen(true);
+                }
+              }}
+            >
+              <Checkbox
+                variant="checkable"
+                checked={isChecked ? "checked" : "unchecked"}
+                onChange={() => {
+                  if (!isDisabled) {
+                    setSelectedVault(isChecked ? "" : vault.sId);
+                  }
+                }}
+                disabled={isDisabled}
+              />
+              <div className="s-flex s-items-center s-gap-2">
+                <Icon
+                  visual={getVaultIcon(vault)}
+                  size="md"
+                  className={classNames(
+                    "ml-3 mr-2 inline-block flex-shrink-0 align-middle",
+                    isDisabled ? "text-element-700" : "text-brand"
+                  )}
                 />
-                {selectedVault === vault.sId && (
-                  <div className="m-2">{renderChildren(selectedVaultObj)}</div>
-                )}
+                <span
+                  className={classNames(
+                    "font-bold",
+                    "align-middle",
+                    isDisabled ? "text-element-700" : "text-element-900"
+                  )}
+                >
+                  {getVaultName(vault)}
+                </span>
               </div>
-            );
-          })}
+            </div>
+            {isChecked && (
+              <div className="ml-8 mt-2">
+                {renderChildren(selectedVaultObj)}
+              </div>
+            )}
+          </div>
+        );
+      })}
       <Page.Separator />
+      <Dialog
+        alertDialog={true}
+        isOpen={isDialogOpen}
+        onValidate={() => setIsDialogOpen(false)}
+        title="Changing source selection"
+      >
+        An assistant can access one source of data only. The other tools are
+        using a different source.
+      </Dialog>
     </div>
   );
 }

--- a/front/components/assistant_builder/vaults/VaultSelector.tsx
+++ b/front/components/assistant_builder/vaults/VaultSelector.tsx
@@ -55,7 +55,6 @@ export function VaultSelector({
                 }
               }}
             >
-
               <Checkbox
                 variant="checkable"
                 checked={isChecked ? "checked" : "unchecked"}

--- a/front/components/assistant_builder/vaults/VaultSelector.tsx
+++ b/front/components/assistant_builder/vaults/VaultSelector.tsx
@@ -22,7 +22,7 @@ export function VaultSelector({
     workspaceId: owner.sId,
   });
   const [selectedVault, setSelectedVault] = useState<string>(defaultVault);
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [isAlertDialogOpen, setAlertIsDialogOpen] = useState(false);
 
   if (isVaultsLoading || isVaultsError) {
     return <Spinner />;
@@ -45,10 +45,10 @@ export function VaultSelector({
           <div key={vault.sId}>
             <Page.Separator />
             <div
-              className="s-flex s-items-center s-gap-2"
+              className="flex items-center gap-2"
               onClick={() => {
                 if (isDisabled) {
-                  setIsDialogOpen(true);
+                  setAlertIsDialogOpen(true);
                 }
               }}
             >
@@ -62,7 +62,7 @@ export function VaultSelector({
                 }}
                 disabled={isDisabled}
               />
-              <div className="s-flex s-items-center s-gap-2">
+              <div className="flex items-center gap-2">
                 <Icon
                   visual={getVaultIcon(vault)}
                   size="md"
@@ -93,8 +93,8 @@ export function VaultSelector({
       <Page.Separator />
       <Dialog
         alertDialog={true}
-        isOpen={isDialogOpen}
-        onValidate={() => setIsDialogOpen(false)}
+        isOpen={isAlertDialogOpen}
+        onValidate={() => setAlertIsDialogOpen(false)}
         title="Changing source selection"
       >
         An assistant can access one source of data only. The other tools are

--- a/front/components/data_source/DeleteStaticDataSourceDialog.tsx
+++ b/front/components/data_source/DeleteStaticDataSourceDialog.tsx
@@ -59,7 +59,6 @@ export function DeleteStaticDataSourceDialog({
       title={`Removing ${name}`}
       onValidate={onDelete}
       isSaving={isLoading || isUsageLoading}
-      onCancel={onClose}
       validateVariant="primaryWarning"
     >
       <div>

--- a/front/components/data_source/DeleteStaticDataSourceDialog.tsx
+++ b/front/components/data_source/DeleteStaticDataSourceDialog.tsx
@@ -59,6 +59,7 @@ export function DeleteStaticDataSourceDialog({
       title={`Removing ${name}`}
       onValidate={onDelete}
       isSaving={isLoading || isUsageLoading}
+      onCancel={onClose}
       validateVariant="primaryWarning"
     >
       <div>

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,7 @@
         "@amplitude/analytics-browser": "^2.5.2",
         "@amplitude/analytics-node": "^1.3.5",
         "@auth0/nextjs-auth0": "^3.5.0",
-        "@dust-tt/sparkle": "^0.2.247",
+        "@dust-tt/sparkle": "^0.2.248",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -10737,9 +10737,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.247",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.247.tgz",
-      "integrity": "sha512-V1Jl5ELomYjV4KyU5sCZjjOD5B9F7Qd3jmzRkGhjx/CyL4j1knkML84DFKizTNNSd4dwCccthQizbRfhjZf13g==",
+      "version": "0.2.248",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.248.tgz",
+      "integrity": "sha512-B4z/yd99QYFvn1wow4SxG8mf3VJAfqxN3gBlrVNZ2CvJUI8rZ16RFi2eefvl4dGGMpYfR6YTFAaa05DIAJ70xw==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,7 @@
         "@amplitude/analytics-browser": "^2.5.2",
         "@amplitude/analytics-node": "^1.3.5",
         "@auth0/nextjs-auth0": "^3.5.0",
-        "@dust-tt/sparkle": "^0.2.246",
+        "@dust-tt/sparkle": "^0.2.247",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -10737,9 +10737,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.246",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.246.tgz",
-      "integrity": "sha512-RwSg18MCY0BYSpu86k5IfGX7n3oTaAlc8pyR//Yp1r+/8/ueh7my2w1wWsn/LcFd0QKzv/DNLWykus2pGJyh0A==",
+      "version": "0.2.247",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.247.tgz",
+      "integrity": "sha512-V1Jl5ELomYjV4KyU5sCZjjOD5B9F7Qd3jmzRkGhjx/CyL4j1knkML84DFKizTNNSd4dwCccthQizbRfhjZf13g==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
     "@amplitude/analytics-browser": "^2.5.2",
     "@amplitude/analytics-node": "^1.3.5",
     "@auth0/nextjs-auth0": "^3.5.0",
-    "@dust-tt/sparkle": "^0.2.246",
+    "@dust-tt/sparkle": "^0.2.247",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
     "@amplitude/analytics-browser": "^2.5.2",
     "@amplitude/analytics-node": "^1.3.5",
     "@auth0/nextjs-auth0": "^3.5.0",
-    "@dust-tt/sparkle": "^0.2.247",
+    "@dust-tt/sparkle": "^0.2.248",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",


### PR DESCRIPTION
## Description

This PR refactors the `VaultSelector` component to improve its functionality and user experience within the assistant builder. 

The main changes include:
- Updating the `VaultSelector` to use checkboxes instead of radio buttons, allowing for multiple vault selections.
- Implementing a dialog to inform users when changing source selection is not possible due to existing tool configurations.
- Enhancing the visual presentation of vault options, including better handling of disabled states.

**References:**
- https://github.com/dust-tt/tasks/issues/1361

## Risk

Low

## Deploy Plan

Deploy `front`