### PR TITLE
[sparkle] - refactor: update cancellation logic in dialogs

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.247",
+  "version": "0.2.248",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.247",
+      "version": "0.2.248",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.247",
+  "version": "0.2.248",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Dialog.tsx
+++ b/sparkle/src/components/Dialog.tsx
@@ -17,16 +17,17 @@ export type BaseDialogProps = {
   title: string;
   validateLabel?: string;
   validateVariant?: "primary" | "primaryWarning";
+  cancelLabel?: string;
 };
 
 export type DialogProps = BaseDialogProps & {
   alertDialog?: false;
   onCancel: () => void;
-  cancelLabel?: string;
 }
 
 export type AlertDialogProps = BaseDialogProps & {
   alertDialog: true;
+  onCancel?: () => void;
 }
 
 export function Dialog({
@@ -91,7 +92,7 @@ export function Dialog({
                   <Button.List>
                     {!isSaving && (
                       <>
-                        {!props.alertDialog && (
+                        {props.onCancel && (
                           <Button
                             label={props.cancelLabel ?? "Cancel"}
                             variant="tertiary"


### PR DESCRIPTION
## Description

This PR fixes the `Dialog` component, to be able to pass a `onCancel` callback even to an alert dialog.

 - Allow displaying the cancel button based on the presence of an onCancel callback rather than the alertDialog boolean flag
 - Add optional cancelLabel prop to base dialog props for consistent API usage

## Risk

Low

## Deploy Plan

Deploy `sparkle`
