### PR TITLE
Update API routes for remote_db id and secret id

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1968,6 +1968,8 @@ struct DatabasesTablesUpsertPayload {
     timestamp: Option<u64>,
     tags: Vec<String>,
     parents: Vec<String>,
+    remote_database_table_id: Option<String>,
+    remote_database_secret_id: Option<String>,
 }
 
 async fn tables_upsert(
@@ -1991,6 +1993,8 @@ async fn tables_upsert(
             },
             &payload.tags,
             &payload.parents,
+            payload.remote_database_table_id,
+            payload.remote_database_secret_id,
         )
         .await
     {

--- a/core/src/databases/database.rs
+++ b/core/src/databases/database.rs
@@ -151,6 +151,9 @@ pub struct Table {
 
     schema: Option<TableSchema>,
     schema_stale_at: Option<u64>,
+
+    remote_database_table_id: Option<String>,
+    remote_database_secret_id: Option<String>,
 }
 
 pub fn get_table_unique_id(project: &Project, data_source_id: &str, table_id: &str) -> String {
@@ -170,6 +173,8 @@ impl Table {
         parents: Vec<String>,
         schema: &Option<TableSchema>,
         schema_stale_at: Option<u64>,
+        remote_database_table_id: Option<String>,
+        remote_database_secret_id: Option<String>,
     ) -> Self {
         Table {
             project: project.clone(),
@@ -183,6 +188,8 @@ impl Table {
             parents,
             schema: schema.clone(),
             schema_stale_at,
+            remote_database_table_id,
+            remote_database_secret_id,
         }
     }
 
@@ -212,6 +219,12 @@ impl Table {
     }
     pub fn unique_id(&self) -> String {
         get_table_unique_id(&self.project, &self.data_source_id, &self.table_id)
+    }
+    pub fn remote_database_table_id(&self) -> Option<&str> {
+        self.remote_database_table_id.as_deref()
+    }
+    pub fn remote_database_secret_id(&self) -> Option<&str> {
+        self.remote_database_secret_id.as_deref()
     }
 
     pub fn render_dbml(&self, name: Option<&str>) -> String {
@@ -567,6 +580,8 @@ mod tests {
             vec![],
             vec![],
             &Some(schema),
+            None,
+            None,
             None,
         );
 

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -199,6 +199,8 @@ pub trait Store {
         timestamp: u64,
         tags: &Vec<String>,
         parents: &Vec<String>,
+        remote_database_table_id: Option<String>,
+        remote_database_secret_id: Option<String>,
     ) -> Result<Table>;
     async fn update_table_schema(
         &self,

--- a/front/pages/api/v1/w/[wId]/data_sources/[dsId]/tables/[tId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[dsId]/tables/[tId]/index.ts
@@ -1,4 +1,4 @@
-import type { CoreAPITableSchema, WithAPIErrorResponse } from "@dust-tt/types";
+import type { CoreAPITablePublic, WithAPIErrorResponse } from "@dust-tt/types";
 import { assertNever, CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -11,15 +11,7 @@ import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 
 export type GetTableResponseBody = {
-  table: {
-    name: string;
-    table_id: string;
-    description: string;
-    schema: CoreAPITableSchema | null;
-    timestamp: number;
-    tags: string[];
-    parents: string[];
-  };
+  table: CoreAPITablePublic;
 };
 
 /**

--- a/front/pages/api/v1/w/[wId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[dsId]/tables/index.ts
@@ -104,6 +104,25 @@ type UpsertTableResponseBody = {
  *               description:
  *                 type: string
  *                 description: Description of the table
+ *               timestamp:
+ *                 type: number
+ *                 description: Timestamp of the table
+ *               tags:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *                 description: Tags associated with the table
+ *               parents:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *                 description: Parent tables of this table
+ *               remote_database_table_id:
+ *                 type: string
+ *                 description: ID of the remote database table (optional)
+ *               remote_database_secret_id:
+ *                 type: string
+ *                 description: ID of the remote database secret (optional)
  *     responses:
  *       200:
  *         description: The table

--- a/front/pages/api/v1/w/[wId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[dsId]/tables/index.ts
@@ -1,4 +1,4 @@
-import type { CoreAPITableSchema, WithAPIErrorResponse } from "@dust-tt/types";
+import type { CoreAPITablePublic, WithAPIErrorResponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -14,30 +14,26 @@ import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 
 export type ListTablesResponseBody = {
-  tables: {
-    name: string;
-    table_id: string;
-    description: string;
-    schema: CoreAPITableSchema | null;
-  }[];
+  tables: CoreAPITablePublic[];
 };
 
-const UpsertDatabaseTableRequestBodySchema = t.type({
-  table_id: t.union([t.string, t.undefined]),
-  name: t.string,
-  description: t.string,
-  timestamp: t.union([t.number, t.undefined, t.null]),
-  tags: t.union([t.array(t.string), t.undefined, t.null]),
-  parents: t.union([t.array(t.string), t.undefined, t.null]),
-});
+const UpsertDatabaseTableRequestBodySchema = t.intersection([
+  t.type({
+    table_id: t.union([t.string, t.undefined]),
+    name: t.string,
+    description: t.string,
+    timestamp: t.union([t.number, t.undefined, t.null]),
+    tags: t.union([t.array(t.string), t.undefined, t.null]),
+    parents: t.union([t.array(t.string), t.undefined, t.null]),
+  }),
+  t.partial({
+    remote_database_table_id: t.union([t.string, t.null]),
+    remote_database_secret_id: t.union([t.string, t.null]),
+  }),
+]);
 
 type UpsertTableResponseBody = {
-  table: {
-    name: string;
-    table_id: string;
-    description: string;
-    schema: CoreAPITableSchema | null;
-  };
+  table: CoreAPITablePublic;
 };
 
 /**
@@ -194,6 +190,9 @@ async function handler(
             table_id: table.table_id,
             description: table.description,
             schema: table.schema,
+            timestamp: table.timestamp,
+            tags: table.tags,
+            parents: table.parents,
           };
         }),
       });
@@ -219,6 +218,8 @@ async function handler(
         timestamp,
         tags,
         parents,
+        remote_database_table_id: remoteDatabaseTableId,
+        remote_database_secret_id: remoteDatabaseSecretId,
       } = bodyValidation.right;
 
       const tableId = maybeTableId || generateLegacyModelSId();
@@ -267,6 +268,8 @@ async function handler(
         timestamp: timestamp ?? null,
         tags: tags || [],
         parents: parents || [],
+        remoteDatabaseTableId: remoteDatabaseTableId ?? null,
+        remoteDatabaseSecretId: remoteDatabaseSecretId ?? null,
       });
 
       if (upsertRes.isErr()) {
@@ -300,6 +303,9 @@ async function handler(
           table_id: table.table_id,
           description: table.description,
           schema: table.schema,
+          timestamp: table.timestamp,
+          tags: table.tags,
+          parents: table.parents,
         },
       });
 

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -1923,6 +1923,32 @@
                   "description": {
                     "type": "string",
                     "description": "Description of the table"
+                  },
+                  "timestamp": {
+                    "type": "number",
+                    "description": "Timestamp of the table"
+                  },
+                  "tags": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Tags associated with the table"
+                  },
+                  "parents": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Parent tables of this table"
+                  },
+                  "remote_database_table_id": {
+                    "type": "string",
+                    "description": "ID of the remote database table (optional)"
+                  },
+                  "remote_database_secret_id": {
+                    "type": "string",
+                    "description": "ID of the remote database secret (optional)"
                   }
                 }
               }

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -116,16 +116,21 @@ export type CoreAPITableSchema = {
   possible_values: string[] | null;
 }[];
 
-export type CoreAPITable = {
-  created: number;
+export type CoreAPITablePublic = {
   table_id: string;
-  data_source_id: string;
   name: string;
   description: string;
   schema: CoreAPITableSchema | null;
   timestamp: number;
   tags: string[];
   parents: string[];
+};
+
+export type CoreAPITable = CoreAPITablePublic & {
+  created: number;
+  data_source_id: string;
+  remote_database_table_id: string | null;
+  remote_database_secret_id: string | null;
 };
 
 export type CoreAPIRowValue =
@@ -1048,6 +1053,8 @@ export class CoreAPI {
     timestamp,
     tags,
     parents,
+    remoteDatabaseTableId,
+    remoteDatabaseSecretId,
   }: {
     projectId: string;
     dataSourceId: string;
@@ -1057,6 +1064,8 @@ export class CoreAPI {
     timestamp: number | null;
     tags: string[];
     parents: string[];
+    remoteDatabaseTableId?: string | null;
+    remoteDatabaseSecretId?: string | null;
   }): Promise<CoreAPIResponse<{ table: CoreAPITable }>> {
     const response = await this._fetchWithError(
       `${this._url}/projects/${encodeURIComponent(

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -1083,6 +1083,8 @@ export class CoreAPI {
           timestamp,
           tags,
           parents,
+          remote_database_table_id: remoteDatabaseTableId ?? null,
+          remote_database_secret_id: remoteDatabaseSecretId ?? null,
         }),
       }
     );


### PR DESCRIPTION
## Description

Update Core and Front tables routes to take into account `remote_database_table_id` and `remote_database_secret_id`.


Changes in the public API: 
Post of a table takes optional params `remote_database_table_id` and `remote_database_secret_id`.
Somehow this is not taken by swagger. 

We were returning different types on the routes to list the tables or get a table. I'm now returning the same type for both, stored in `CoreAPITablePublic` for more consistency. This means the 3 fields `timestamp`, `tags` & `parents` are now retrieved on the list route. 


## Risk

Break those routes. 
Locally tested: upload a table, query it from an assistant, delete it. 

## Deploy Plan

Deploy Core. 
Deploy front. 
Deploy Docs.
