### PR TITLE
[front/components/app/blocks] - feature: update icon and readOnly sta…

### DIFF
--- a/front/components/app/blocks/Input.tsx
+++ b/front/components/app/blocks/Input.tsx
@@ -1,4 +1,4 @@
-import { Button, Modal, PencilSquareIcon } from "@dust-tt/sparkle";
+import { Button, EyeIcon, Modal, PencilSquareIcon } from "@dust-tt/sparkle";
 import type { WorkspaceType } from "@dust-tt/types";
 import type {
   AppType,
@@ -130,7 +130,7 @@ export default function Input({
                     <Button
                       variant="secondary"
                       onClick={() => setIsDatasetModalOpen(true)}
-                      icon={PencilSquareIcon}
+                      icon={readOnly ? EyeIcon : PencilSquareIcon}
                       label={readOnly ? "View" : "Edit"}
                       size="xs"
                     />
@@ -161,7 +161,7 @@ export default function Input({
                 />
               )}
               <DatasetView
-                readOnly={false}
+                readOnly={readOnly}
                 datasets={[dataset]}
                 dataset={dataset}
                 schema={dataset.schema}


### PR DESCRIPTION
## Description

This PR aims at fixing a hardcoded `readOnly` prop that was passed to the `DatasetView`, causing a user to "fake-edit" Dust apps datasets.

 - Change the edit icon to an eye icon when the Input component is in read-only mode
 - Pass the readOnly prop correctly to the DatasetView component to reflect the state

**References:**
- https://github.com/dust-tt/tasks/issues/1374

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
