### PR TITLE
Allow fetching public data sources and data source views.

### DIFF
--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -272,6 +272,7 @@ export class DataSourceResource extends ResourceWithVault<DataSourceModel> {
       where: {
         name: {
           [Op.in]: names,
+          workspaceId: auth.getNonNullableWorkspace().id,
         },
       },
     });

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -272,6 +272,7 @@ export class DataSourceResource extends ResourceWithVault<DataSourceModel> {
       where: {
         name: {
           [Op.in]: names,
+          // /!\ Names being generic, we need to filter by workspace.
           workspaceId: auth.getNonNullableWorkspace().id,
         },
       },
@@ -298,20 +299,6 @@ export class DataSourceResource extends ResourceWithVault<DataSourceModel> {
   ): Promise<DataSourceResource[]> {
     return this.baseFetch(auth, options, {
       where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
-      },
-    });
-  }
-
-  static async listByWorkspaceIdAndNames(
-    auth: Authenticator,
-    names: string[]
-  ): Promise<DataSourceResource[]> {
-    return this.baseFetch(auth, undefined, {
-      where: {
-        name: {
-          [Op.in]: names,
-        },
         workspaceId: auth.getNonNullableWorkspace().id,
       },
     });

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -204,12 +204,15 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
   ) {
     const dataSourceViews = await this.baseFetch(
       auth,
-      fetchDataSourceViewOptions
+      fetchDataSourceViewOptions,
+      {
+        where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+      }
     );
 
-    return dataSourceViews.filter(
-      (dsv) => auth.isAdmin() || auth.hasPermission([dsv.vault.acl()], "read")
-    );
+    return dataSourceViews.filter((dsv) => dsv.canList(auth));
   }
 
   static async listByVault(

--- a/front/lib/resources/resource_with_vault.ts
+++ b/front/lib/resources/resource_with_vault.ts
@@ -31,7 +31,7 @@ interface ModelWithVault extends ResourceWithId {
 export abstract class ResourceWithVault<
   M extends Model & ModelWithVault,
 > extends BaseResource<M> {
-  readonly workspaceId: number;
+  readonly workspaceId: ModelWithVault["workspaceId"];
 
   protected constructor(
     model: ModelStatic<M>,

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -349,21 +349,28 @@ export class VaultResource extends BaseResource<VaultModel> {
       .getNonNullableWorkspace()
       .flags.includes("private_data_vaults_feature");
 
-    if (this.isRegular() && !isPrivateVaultsEnabled) {
-      return false;
-    }
+    const isWorkspaceAdmin =
+      auth.isAdmin() && auth.getNonNullableWorkspace().id === this.workspaceId;
 
-    // Admins can list all vaults.
-    if (auth.isAdmin()) {
-      return true;
-    }
+    switch (this.kind) {
+      case "global":
+        return auth.canRead([this.acl()]);
 
-    // Public vaults can be listed by anyone.
-    if (this.isPublic()) {
-      return true;
-    }
+      // Public vaults can be listed by anyone.
+      case "public":
+        return true;
 
-    return auth.canRead([this.acl()]);
+      case "regular":
+        return isPrivateVaultsEnabled
+          ? isWorkspaceAdmin || auth.canRead([this.acl()])
+          : false;
+
+      case "system":
+        return isWorkspaceAdmin;
+
+      default:
+        assertNever(this.kind);
+    }
   }
 
   isGlobal() {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
With the introduction of the public vault concept, we aim to use public data sources. However, in practice, this isn't currently possible because all SQL queries are restricted to the current workspace, preventing access to public data sources from other workspaces.

This PR removes the SQL clause that limits queries by workspace ID in all cases of fetching by ID. Instead, it introduces a `canFetch` method to ensure that either the vault is public or the user is a member of the workspace.

I took the opportunity to refactor the `canList` method to make it more robust.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Worst case it breaks the listing of data sources, data source views and apps. Safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
