### PR TITLE
[sparkle] - enh(input): add forwardeRef and maxLength

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.248",
+  "version": "0.2.249",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.248",
+      "version": "0.2.249",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.248",
+  "version": "0.2.249",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Input.tsx
+++ b/sparkle/src/components/Input.tsx
@@ -1,6 +1,11 @@
-import React from "react";
+import React, { forwardRef } from "react";
 
 import { classNames } from "@sparkle/lib/utils";
+
+const sizeInputClasses = {
+  sm: "s-text-base s-rounded-md s-py-1.5 s-pl-4 s-pr-8",
+  md: "s-text-lg s-rounded-lg s-py-2 s-pl-4 s-pr-10",
+};
 
 type InputProps = {
   placeholder: string;
@@ -14,71 +19,75 @@ type InputProps = {
   disabled?: boolean;
   className?: string;
   label?: string;
+  maxLength?: number;
 };
 
-const sizeInputClasses = {
-  sm: "s-text-base s-rounded-md s-py-1.5 s-pl-4 s-pr-8",
-  md: "s-text-lg s-rounded-lg s-py-2 s-pl-4 s-pr-10",
-};
-
-export function Input({
-  placeholder,
-  value,
-  size = "sm",
-  onChange,
-  error,
-  showErrorLabel = false,
-  name,
-  isPassword = false,
-  disabled = false,
-  className = "",
-  label,
-}: InputProps) {
-  return (
-    <div className="s-flex s-flex-col s-gap-1 s-p-px">
-      {label && (
-        <label
-          htmlFor={name}
-          className="s-pb-1 s-text-sm s-font-medium s-text-element-700 dark:s-text-element-700-dark"
-        >
-          {label}
-        </label>
-      )}
-      <input
-        type={isPassword ? "password" : "text"}
-        name={name}
-        id={name}
-        className={classNames(
-          "s-w-full s-border-0 s-outline-none s-ring-1 focus:s-outline-none focus:s-ring-2",
-          "s-bg-structure-50 s-placeholder-element-700",
-          "dark:s-bg-structure-50-dark dark:s-placeholder-element-700-dark",
-          sizeInputClasses[size],
-          "s-transition-all s-duration-300 s-ease-out",
-          className ?? "",
-          !error
-            ? classNames(
-                "s-ring-structure-200 focus:s-ring-action-300",
-                "dark:s-ring-structure-300-dark dark:focus:s-ring-action-300-dark"
-              )
-            : classNames(
-                "s-ring-warning-200 focus:s-ring-warning-300",
-                "dark:s-ring-warning-200-dark dark:focus:s-ring-warning-300-dark"
-              ),
-          disabled
-            ? "s-text-element-500 hover:s-cursor-not-allowed"
-            : "s-text-element-900 dark:s-text-element-800-dark"
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  (
+    {
+      placeholder,
+      value,
+      size = "sm",
+      onChange,
+      error,
+      showErrorLabel = false,
+      name,
+      isPassword = false,
+      disabled = false,
+      className = "",
+      label,
+      maxLength,
+    },
+    ref
+  ) => {
+    return (
+      <div className="s-flex s-flex-col s-gap-1 s-p-px">
+        {label && (
+          <label
+            htmlFor={name}
+            className="s-pb-1 s-text-sm s-font-medium s-text-element-700 dark:s-text-element-700-dark"
+          >
+            {label}
+          </label>
         )}
-        placeholder={placeholder}
-        value={value ?? ""}
-        onChange={(e) => {
-          onChange?.(e.target.value);
-        }}
-        data-1p-ignore={!isPassword}
-        disabled={disabled}
-      />
-      <div className="s-ml-2 s-text-sm s-text-warning-500">
-        {showErrorLabel && error ? error : null}
+        <input
+          ref={ref}
+          type={isPassword ? "password" : "text"}
+          name={name}
+          id={name}
+          maxLength={maxLength}
+          className={classNames(
+            "s-w-full s-border-0 s-outline-none s-ring-1 focus:s-outline-none focus:s-ring-2",
+            "s-bg-structure-50 s-placeholder-element-700",
+            "dark:s-bg-structure-50-dark dark:s-placeholder-element-700-dark",
+            sizeInputClasses[size],
+            "s-transition-all s-duration-300 s-ease-out",
+            className ?? "",
+            !error
+              ? classNames(
+                  "s-ring-structure-200 focus:s-ring-action-300",
+                  "dark:s-ring-structure-300-dark dark:focus:s-ring-action-300-dark"
+                )
+              : classNames(
+                  "s-ring-warning-200 focus:s-ring-warning-300",
+                  "dark:s-ring-warning-200-dark dark:focus:s-ring-warning-300-dark"
+                ),
+            disabled
+              ? "s-text-element-500 hover:s-cursor-not-allowed"
+              : "s-text-element-900 dark:s-text-element-800-dark"
+          )}
+          placeholder={placeholder}
+          value={value ?? ""}
+          onChange={(e) => {
+            onChange?.(e.target.value);
+          }}
+          data-1p-ignore={!isPassword}
+          disabled={disabled}
+        />
+        <div className="s-ml-2 s-text-sm s-text-warning-500">
+          {showErrorLabel && error ? error : null}
+        </div>
       </div>
-    </div>
-  );
-}
+    );
+  }
+);

--- a/sparkle/src/components/Input.tsx
+++ b/sparkle/src/components/Input.tsx
@@ -91,3 +91,5 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     );
   }
 );
+
+Input.displayName = "Input"

--- a/sparkle/src/components/Searchbar.tsx
+++ b/sparkle/src/components/Searchbar.tsx
@@ -17,18 +17,19 @@ const iconClasses = {
   md: "s-pr-4",
 };
 
+type SearchbarProps = {
+  placeholder: string;
+  value: string | null;
+  onChange?: (value: string) => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  name: string;
+  size?: "xs" | "sm" | "md";
+  disabled?: boolean;
+  className?: string;
+}
+
 export const Searchbar = forwardRef<
-  HTMLInputElement,
-  {
-    placeholder: string;
-    value: string | null;
-    onChange?: (value: string) => void;
-    onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
-    name: string;
-    size?: "xs" | "sm" | "md";
-    disabled?: boolean;
-    className?: string;
-  }
+  HTMLInputElement, SearchbarProps
 >(
   (
     {


### PR DESCRIPTION
## Description

This PR aims at enhancing the `sparkle` `Input` component by passing it an optional `maxLength` props (e.g. useful when we want to limit a folder's name)

## Risk

Low

## Deploy Plan

Publish `sparkle`