### PR TITLE
feat: implement get_tables_schema for snowflake

### DIFF
--- a/core/src/databases/remote_databases/remote_database.rs
+++ b/core/src/databases/remote_databases/remote_database.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use async_trait::async_trait;
+use std::collections::HashMap;
 
 use crate::databases::{
     database::{QueryDatabaseError, QueryResult},
@@ -13,4 +14,8 @@ pub trait RemoteDatabase {
         &self,
         query: &str,
     ) -> Result<(Vec<QueryResult>, TableSchema), QueryDatabaseError>;
+    async fn get_tables_schema(
+        &self,
+        opaque_ids: Vec<String>,
+    ) -> Result<HashMap<String, TableSchema>>;
 }

--- a/core/src/databases/table_schema.rs
+++ b/core/src/databases/table_schema.rs
@@ -94,6 +94,10 @@ impl TableSchemaColumn {
 pub struct TableSchema(Vec<TableSchemaColumn>);
 
 impl TableSchema {
+    pub fn from_columns(columns: Vec<TableSchemaColumn>) -> Self {
+        Self(columns)
+    }
+
     pub fn empty() -> Self {
         Self(vec![])
     }


### PR DESCRIPTION
## Description

- add `async fn get_tables_schema(&self, opaque_ids: Vec<String>) -> Result<HashMap<String, TableSchema>>` to the `RemoteDatabase` trait
- add implementation for `snowflake`

## Risk

N/A

## Deploy Plan

N/A