### PR TITLE
[front fix: Reload dataSource view detail after modification

### DIFF
--- a/front/components/vaults/EditVaultStaticDatasourcesViews.tsx
+++ b/front/components/vaults/EditVaultStaticDatasourcesViews.tsx
@@ -6,13 +6,11 @@ import type {
   VaultType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { isWebCrawlerConfiguration } from "@dust-tt/types";
 import { useRouter } from "next/router";
-import React, { useCallback, useState } from "react";
+import { useCallback, useState } from "react";
 
 import VaultFolderModal from "@app/components/vaults/VaultFolderModal";
 import VaultWebsiteModal from "@app/components/vaults/VaultWebsiteModal";
-import { useDataSourceViewConnectorConfiguration } from "@app/lib/swr/data_source_views";
 
 interface EditVaultStaticDatasourcesViewsProps {
   owner: WorkspaceType;
@@ -42,12 +40,6 @@ export function EditVaultStaticDatasourcesViews({
   const router = useRouter();
   const [showDatasourceLimitPopup, setShowDatasourceLimitPopup] =
     useState(false);
-
-  const { configuration, mutateConfiguration } =
-    useDataSourceViewConnectorConfiguration({
-      dataSourceView: category === "website" ? dataSourceView : null,
-      owner,
-    });
 
   const planDataSourcesLimit = plan.limits.dataSources.count;
 
@@ -84,7 +76,7 @@ export function EditVaultStaticDatasourcesViews({
           owner={owner}
           vault={vault}
           dataSources={dataSources}
-          folder={dataSourceView?.dataSource ?? null}
+          dataSourceViewId={dataSourceView ? dataSourceView.sId : null}
         />
       ) : category === "website" ? (
         <VaultWebsiteModal
@@ -94,12 +86,6 @@ export function EditVaultStaticDatasourcesViews({
           vault={vault}
           dataSources={dataSources}
           dataSourceView={dataSourceView}
-          webCrawlerConfiguration={
-            configuration && isWebCrawlerConfiguration(configuration)
-              ? configuration
-              : null
-          }
-          mutateConfiguration={mutateConfiguration}
         />
       ) : null}
       {canWriteInVault ? (

--- a/front/components/vaults/FoldersHeaderMenu.tsx
+++ b/front/components/vaults/FoldersHeaderMenu.tsx
@@ -8,7 +8,11 @@ import {
   TableIcon,
   Tooltip,
 } from "@dust-tt/sparkle";
-import type { DataSourceType, VaultType, WorkspaceType } from "@dust-tt/types";
+import type {
+  DataSourceViewType,
+  VaultType,
+  WorkspaceType,
+} from "@dust-tt/types";
 import type { RefObject } from "react";
 import { useState } from "react";
 
@@ -20,7 +24,7 @@ type FoldersHeaderMenuProps = {
   owner: WorkspaceType;
   vault: VaultType;
   canWriteInVault: boolean;
-  folder: DataSourceType;
+  folder: DataSourceViewType;
   contentActionsRef: RefObject<ContentActionsRef>;
 };
 
@@ -133,7 +137,7 @@ const AddDataDropDownButton = ({
 type EditFolderButtonProps = {
   owner: WorkspaceType;
   vault: VaultType;
-  folder: DataSourceType;
+  folder: DataSourceViewType;
   canWriteInVault: boolean;
 };
 
@@ -157,7 +161,7 @@ const EditFolderButton = ({
         owner={owner}
         vault={vault}
         dataSources={dataSources}
-        folder={folder}
+        dataSourceViewId={folder.sId}
       />
       <Button
         size="sm"

--- a/front/components/vaults/VaultDataSourceViewContentList.tsx
+++ b/front/components/vaults/VaultDataSourceViewContentList.tsx
@@ -404,7 +404,7 @@ export const VaultDataSourceViewContentList = ({
               owner={owner}
               vault={vault}
               canWriteInVault={canWriteInVault}
-              folder={dataSourceView.dataSource}
+              folder={dataSourceView}
               contentActionsRef={contentActionsRef}
             />
           </>

--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -366,7 +366,7 @@ export const VaultResourcesList = ({
 
   const onDeleteFolderOrWebsite = async () => {
     if (selectedDataSourceView?.dataSource) {
-      const res = await doDelete(selectedDataSourceView.dataSource);
+      const res = await doDelete(selectedDataSourceView);
       if (res) {
         await router.push(
           `/w/${owner.sId}/vaults/${vault.sId}/categories/${selectedDataSourceView.category}`

--- a/front/components/vaults/WebsitesHeaderMenu.tsx
+++ b/front/components/vaults/WebsitesHeaderMenu.tsx
@@ -2,14 +2,11 @@ import { Button, Cog6ToothIcon } from "@dust-tt/sparkle";
 import type {
   DataSourceViewType,
   VaultType,
-  WebCrawlerConfigurationType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { isWebCrawlerConfiguration } from "@dust-tt/types";
 import { useState } from "react";
 
 import VaultWebsiteModal from "@app/components/vaults/VaultWebsiteModal";
-import { useDataSourceViewConnectorConfiguration } from "@app/lib/swr/data_source_views";
 import { useDataSources } from "@app/lib/swr/data_sources";
 
 type WebsitesHeaderMenuProps = {
@@ -28,16 +25,6 @@ export const WebsitesHeaderMenu = ({
   const [showEditWebsiteModal, setShowEditWebsiteModal] = useState(false);
 
   const { dataSources } = useDataSources(owner);
-  const { configuration, mutateConfiguration } =
-    useDataSourceViewConnectorConfiguration({
-      dataSourceView,
-      owner,
-    });
-
-  let webCrawlerConfiguration: WebCrawlerConfigurationType | null = null;
-  if (isWebCrawlerConfiguration(configuration)) {
-    webCrawlerConfiguration = configuration;
-  }
 
   return (
     <>
@@ -50,8 +37,6 @@ export const WebsitesHeaderMenu = ({
         vault={vault}
         dataSources={dataSources}
         dataSourceView={dataSourceView}
-        webCrawlerConfiguration={webCrawlerConfiguration}
-        mutateConfiguration={mutateConfiguration}
       />
       <Button
         size="sm"


### PR DESCRIPTION
fixes: https://github.com/dust-tt/dust/issues/7633

## Description

- Use a view id as prop in VaultFolderModal and load the folder view through swr. 
- invalidate query after update
- cleanup modal reset
- Simplify VaultWebsiteModal to have teh same behaviour - move hooks calls inside the modal where it's used.

## Risk

-

## Deploy Plan

deploy front