### PR TITLE
clean-up AgentTableQueryConfigurationTable

### DIFF
--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -81,7 +81,6 @@ export async function getDataSourceViewsUsageByCategory({
       return {};
     default:
       assertNever(category);
-      break;
   }
 
   const res = (await Promise.all([

--- a/front/lib/api/assistant/configuration/process.ts
+++ b/front/lib/api/assistant/configuration/process.ts
@@ -12,7 +12,6 @@ import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/
 import { AgentProcessConfiguration } from "@app/lib/models/assistant/actions/process";
 import { Workspace } from "@app/lib/models/workspace";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
-import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 
 export async function fetchAgentProcessActionConfigurations({
@@ -45,26 +44,12 @@ export async function fetchAgentProcessActionConfigurations({
       },
       include: [
         {
-          model: DataSourceModel,
-          as: "dataSource",
-          include: [
-            {
-              model: Workspace,
-              as: "workspace",
-            },
-          ],
-        },
-        {
           model: DataSourceViewModel,
           as: "dataSourceView",
           include: [
             {
               model: Workspace,
               as: "workspace",
-            },
-            {
-              model: DataSourceModel,
-              as: "dataSourceForView",
             },
           ],
         },

--- a/front/lib/api/assistant/configuration/retrieval.ts
+++ b/front/lib/api/assistant/configuration/retrieval.ts
@@ -12,7 +12,6 @@ import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/
 import { AgentRetrievalConfiguration } from "@app/lib/models/assistant/actions/retrieval";
 import { Workspace } from "@app/lib/models/workspace";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
-import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 
 export async function fetchAgentRetrievalActionConfigurations({
@@ -45,26 +44,12 @@ export async function fetchAgentRetrievalActionConfigurations({
       },
       include: [
         {
-          model: DataSourceModel,
-          as: "dataSource",
-          include: [
-            {
-              model: Workspace,
-              as: "workspace",
-            },
-          ],
-        },
-        {
           model: DataSourceViewModel,
           as: "dataSourceView",
           include: [
             {
               model: Workspace,
               as: "workspace",
-            },
-            {
-              model: DataSourceModel,
-              as: "dataSourceForView",
             },
           ],
         },

--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -91,8 +91,6 @@ export class AgentTablesQueryConfigurationTable extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare dataSourceWorkspaceId: string;
-
   declare tableId: string;
 
   declare dataSourceId: ForeignKey<DataSourceModel["id"]> | null;
@@ -121,11 +119,6 @@ AgentTablesQueryConfigurationTable.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
-    },
-
-    dataSourceWorkspaceId: {
-      type: DataTypes.STRING,
-      allowNull: false,
     },
     tableId: {
       type: DataTypes.STRING(512),

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -327,7 +327,6 @@ export class DataSourceResource extends ResourceWithVault<DataSourceModel> {
     });
   }
 
-  // TODO(20240801 flav): Refactor this to make auth required on all fetchers.
   static async fetchByModelIdWithAuth(auth: Authenticator, id: ModelId) {
     const [dataSource] = await this.baseFetchWithAuthorization(auth, {
       where: { id },
@@ -347,12 +346,11 @@ export class DataSourceResource extends ResourceWithVault<DataSourceModel> {
       transaction,
     });
 
-    // TODO(DATASOURCE_SID): state storing the datasource name.
     await AgentTablesQueryConfigurationTable.destroy({
       where: {
-        dataSourceWorkspaceId: auth.getNonNullableWorkspace().sId,
         dataSourceId: this.id,
       },
+      transaction,
     });
 
     // We directly delete the DataSourceViewResource.model here to avoid a circular dependency.

--- a/front/migrations/20240902_backfill_views_in_agent_table_query_configurations.ts
+++ b/front/migrations/20240902_backfill_views_in_agent_table_query_configurations.ts
@@ -40,8 +40,7 @@ async function backfillViewsInAgentTableQueryConfigurationForWorkspace(
     await AgentTablesQueryConfigurationTable.count({
       // @ts-expect-error `dataSourceViewId` is not nullable.
       where: {
-        // /!\ `dataSourceId` is the data source's name, not the id.
-        dataSourceId: dataSources.map((ds) => ds.name),
+        dataSourceId: dataSources.map((ds) => ds.id),
         dataSourceViewId: {
           [Op.is]: null,
         },
@@ -69,7 +68,6 @@ async function backfillViewsInAgentTableQueryConfigurationForWorkspace(
       { dataSourceViewId: dataSourceView.id },
       {
         where: {
-          // /!\ `dataSourceId` is the data source's name, not the id.
           dataSourceId: ds.id,
         },
       }

--- a/front/migrations/20240902_backfill_views_in_agent_table_query_configurations.ts
+++ b/front/migrations/20240902_backfill_views_in_agent_table_query_configurations.ts
@@ -70,7 +70,7 @@ async function backfillViewsInAgentTableQueryConfigurationForWorkspace(
       {
         where: {
           // /!\ `dataSourceId` is the data source's name, not the id.
-          dataSourceId: ds.name,
+          dataSourceId: ds.id,
         },
       }
     );

--- a/front/migrations/db/migration_88.sql
+++ b/front/migrations/db/migration_88.sql
@@ -1,0 +1,2 @@
+-- Migration created on Sep 24, 2024
+ALTER TABLE "public"."agent_tables_query_configuration_tables" DROP COLUMN "dataSourceWorkspaceId";


### PR DESCRIPTION
## Description

Remove `dataSourceWorkspaceId` from `AgentTablesQueryConfigurationTable`

Standardize `AgentTablesQueryConfigurationTable` and `AgentDataSourceConfiguration` around the following:
- store dataSourceViewId foreign key
- store `dataSourceId` (not per se required but convenient to have (some usage queries currently rely on it))

In particular cleans up a bit the query to retrieve these configurations which were pulling much more than needed.

r? @flvndvd since you wrote these queries ^

## Risk

Low (if deploy procedure is properly followed)

## Deploy Plan

- Make `dataSourceWorkspaceId` non required in production
```
ALTER TABLE "agent_tables_query_configuration_tables" ALTER COLUMN "dataSourceWorkspaceId" DROP NOT NULL;
```
- deploy `front`
- run migration