### PR TITLE
feat: limit snowflake query result size

### DIFF
--- a/core/src/databases/database.rs
+++ b/core/src/databases/database.rs
@@ -35,6 +35,8 @@ pub enum QueryDatabaseError {
     GenericError(#[from] anyhow::Error),
     #[error("Too many result rows")]
     TooManyResultRows,
+    #[error("Result is too large: {0}")]
+    ResultTooLarge(String),
     #[error("Query execution error: {0}")]
     ExecutionError(String),
 }


### PR DESCRIPTION
## Description

Fetch snowflake query result chunk-by-chunk and ensure the total result size is less than 128MB.
We don't trust assistant-generated queries and don't want to crash `core` with gigantic queries.

## Risk

N/A

## Deploy Plan

N/A