### PR TITLE
Use canRead in registry lookup

### DIFF
--- a/core/src/blocks/data_source.rs
+++ b/core/src/blocks/data_source.rs
@@ -86,7 +86,6 @@ impl DataSource {
                 &workspace_id,
                 &data_source_or_data_source_view_id,
                 env,
-                "data_source",
             )
             .await?;
 

--- a/core/src/blocks/database_schema.rs
+++ b/core/src/blocks/database_schema.rs
@@ -135,12 +135,7 @@ pub async fn load_tables_from_identifiers(
     // Get a vec of the corresponding project ids for each (workspace_id, data_source_id) pair.
     let project_ids_view_filters = try_join_all(data_source_identifiers.iter().map(
         |(workspace_id, data_source_or_view_id)| {
-            get_data_source_project_and_view_filter(
-                workspace_id,
-                data_source_or_view_id,
-                env,
-                "database_schema",
-            )
+            get_data_source_project_and_view_filter(workspace_id, data_source_or_view_id, env)
         },
     ))
     .await?;

--- a/core/src/blocks/helpers.rs
+++ b/core/src/blocks/helpers.rs
@@ -20,7 +20,6 @@ pub async fn get_data_source_project_and_view_filter(
     workspace_id: &String,
     data_source_id: &String,
     env: &Env,
-    origin: &str,
 ) -> Result<(Project, Option<SearchFilter>, String)> {
     let dust_workspace_id = match env.credentials.get("DUST_WORKSPACE_ID") {
         None => Err(anyhow!(
@@ -63,7 +62,6 @@ pub async fn get_data_source_project_and_view_filter(
         )
         .header("X-Dust-Workspace-Id", dust_workspace_id)
         .header("X-Dust-Group-Ids", dust_group_ids)
-        .header("X-Dust-Origin", origin)
         .send()
         .await?;
 

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -66,6 +66,9 @@ const config = {
   getDustDevelopmentWorkspaceId: (): string => {
     return EnvironmentConfig.getEnvVariable("DUST_DEVELOPMENT_WORKSPACE_ID");
   },
+  getDustRegistrySecret: (): string => {
+    return EnvironmentConfig.getEnvVariable("DUST_REGISTRY_SECRET");
+  },
   getCoreAPIConfig: (): { url: string; apiKey: string | null } => {
     return {
       url: EnvironmentConfig.getEnvVariable("CORE_API"),

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -405,7 +405,12 @@ export class Authenticator {
     };
   }
 
-  // /!\ Should only be used in the context of the registry lookup.
+  // /!\ This method is intended exclusively for use within the registry lookup context.
+  // It securely authenticates access by verifying a provided secret against the
+  // configured registry secret. If the secret is valid, it retrieves the specified
+  // workspace and its associated group resources using a system API key.
+  // Modifications to this method should be handled with caution, as it involves
+  // sensitive operations related to secret validation and workspace access.
   static async fromRegistrySecret({
     groupIds,
     secret,

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -145,6 +145,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     if (!key.isSystem) {
       throw new Error("Only system keys are supported.");
     }
+
     const groups = await this.model.findAll({
       where: {
         workspaceId: key.workspaceId,

--- a/front/lib/resources/resource_with_vault.ts
+++ b/front/lib/resources/resource_with_vault.ts
@@ -132,6 +132,10 @@ export abstract class ResourceWithVault<
     return this.vault.canWrite(auth);
   }
 
+  // This method determines if the authenticated user can fetch data,
+  // based on workspace ownership or public vault access. Changes to
+  // this logic can impact data security, so they must be reviewed
+  // and tested carefully to prevent unauthorized access.
   private canFetch(auth: Authenticator) {
     return (
       this.workspaceId === auth.getNonNullableWorkspace().id ||

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -323,6 +323,9 @@ export class VaultResource extends BaseResource<VaultModel> {
     }
   }
 
+  // Ensure thorough testing when modifying this method, as it is crucial for
+  // the integrity of the permissions system. It acts as the gatekeeper,
+  // determining who has the right to read resources from a vault.
   canRead(auth: Authenticator) {
     const isPrivateVaultsEnabled = auth
       .getNonNullableWorkspace()


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR is a follow-up to https://github.com/dust-tt/dust/pull/7641. It refactors the registry lookup by using the existing `canRead` method from the resources associated with a vault. This change will simplify the code and establish a single, definitive source for enforcing read permissions on content from a data source/data source view.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
There is some security risks as this endpoint is the one that enforces read permissions on data source and data source view. Safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
