### PR TITLE
[front] fix : Fix vault deletion

### DIFF
--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -18,6 +18,7 @@ import {
   Ok,
   sectionFullText,
 } from "@dust-tt/types";
+import type { Transaction } from "sequelize";
 
 import { default as apiConfig, default as config } from "@app/lib/api/config";
 import { sendGithubDeletionEmail } from "@app/lib/api/email";
@@ -58,7 +59,8 @@ export async function getDataSources(
 
 export async function deleteDataSource(
   auth: Authenticator,
-  dataSource: DataSourceResource
+  dataSource: DataSourceResource,
+  transaction?: Transaction
 ): Promise<
   Result<DataSourceType, { code: "unauthorized_deletion"; message: string }>
 > {
@@ -120,7 +122,7 @@ export async function deleteDataSource(
     }
   }
 
-  await dataSource.delete(auth);
+  await dataSource.delete(auth, transaction);
 
   await launchScrubDataSourceWorkflow({
     wId: owner.sId,

--- a/front/lib/api/vaults.ts
+++ b/front/lib/api/vaults.ts
@@ -1,6 +1,7 @@
 import type { DataSourceWithAgentsUsageType } from "@dust-tt/types";
 import { uniq } from "lodash";
 
+import { deleteDataSource } from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -57,7 +58,7 @@ export const deleteVault = async (
     }
 
     for (const ds of dataSources) {
-      const res = await ds.delete(auth, t);
+      const res = await deleteDataSource(auth, ds, t);
       if (res.isErr()) {
         throw res.error;
       }

--- a/front/lib/api/vaults.ts
+++ b/front/lib/api/vaults.ts
@@ -2,6 +2,7 @@ import type { DataSourceWithAgentsUsageType } from "@dust-tt/types";
 import { uniq } from "lodash";
 
 import type { Authenticator } from "@app/lib/auth";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import type { VaultResource } from "@app/lib/resources/vault_resource";
@@ -28,10 +29,21 @@ export const deleteVault = async (
       usages.push(usage.value);
     }
   }
+
+  const dataSources = await DataSourceResource.listByVault(auth, vault);
+  for (const ds of dataSources) {
+    const usage = await ds.getUsagesByAgents(auth);
+    if (usage.isErr()) {
+      throw usage.error;
+    } else if (usage.value.count > 0) {
+      usages.push(usage.value);
+    }
+  }
+
   if (usages.length > 0) {
     const agentNames = uniq(usages.map((u) => u.agentNames).flat());
     throw new Error(
-      `Cannot delete vault with data source views in use by assistant(s): ${agentNames.join(", ")}.`
+      `Cannot delete vault with data source in use by assistant(s): ${agentNames.join(", ")}.`
     );
   }
 
@@ -39,6 +51,13 @@ export const deleteVault = async (
     // delete all data source views
     for (const view of dataSourceViews) {
       const res = await view.delete(auth, t);
+      if (res.isErr()) {
+        throw res.error;
+      }
+    }
+
+    for (const ds of dataSources) {
+      const res = await ds.delete(auth, t);
       if (res.isErr()) {
         throw res.error;
       }


### PR DESCRIPTION
fixes: [#1381](https://github.com/dust-tt/tasks/issues/1381)

## Description

Delete data-sources in vault by calling deleteDataSource. If using a connected datasource ( webfolder ), correctly remove the connector. Scrub all content that has been upserted in core

## Risk

If an error happens during deletion, we can get into some inconsistent state for webfolders - connectors removed but data-sources still there. 

## Deploy Plan

deploy front
