### PR TITLE
Actually do not put remote_database ids on api docs because can't be …

### DIFF
--- a/front/pages/api/v1/w/[wId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[dsId]/tables/index.ts
@@ -117,12 +117,6 @@ type UpsertTableResponseBody = {
  *                 items:
  *                   type: string
  *                 description: Parent tables of this table
- *               remote_database_table_id:
- *                 type: string
- *                 description: ID of the remote database table (optional)
- *               remote_database_secret_id:
- *                 type: string
- *                 description: ID of the remote database secret (optional)
  *     responses:
  *       200:
  *         description: The table

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -1941,14 +1941,6 @@
                       "type": "string"
                     },
                     "description": "Parent tables of this table"
-                  },
-                  "remote_database_table_id": {
-                    "type": "string",
-                    "description": "ID of the remote database table (optional)"
-                  },
-                  "remote_database_secret_id": {
-                    "type": "string",
-                    "description": "ID of the remote database secret (optional)"
                   }
                 }
               }


### PR DESCRIPTION
…used by users directly

## Description

Actually we don't want to put those ids in the doc, since even on public API those fields will be accepted only if used with a system key. 

## Risk

/

## Deploy Plan

Deploy docs
