### PR TITLE
Display workspace ID in API keys

### DIFF
--- a/front/pages/w/[wId]/developers/api-keys.tsx
+++ b/front/pages/w/[wId]/developers/api-keys.tsx
@@ -49,7 +49,7 @@ export default function APIKeysPage({
         <Page.Header
           title="API Keys"
           icon={ShapesIcon}
-          description="Manage your API Keys. API Keys allows you to securely connect to Dust from other applications and work with your data."
+          description="API Keys allow you to securely connect to Dust from other applications and work with your data programmatically."
         />
         <Page.Vertical align="stretch" gap="md">
           <APIKeys owner={owner} groups={groups} />

--- a/front/pages/w/[wId]/vaults/[vaultId]/apps/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/apps/index.tsx
@@ -2,11 +2,14 @@ import {
   BookOpenIcon,
   BracesIcon,
   Button,
+  ClipboardIcon,
   CommandLineIcon,
   Dialog,
   ExternalLinkIcon,
+  IconButton,
   Input,
   LockIcon,
+  Modal,
   Page,
   PlusIcon,
   ShapesIcon,
@@ -276,6 +279,7 @@ export function APIKeys({
   const [newApiKeyName, setNewApiKeyName] = useState("");
   const [newApiKeyGroup] = useState(globalGroup);
   const [isNewApiKeyPromptOpen, setIsNewApiKeyPromptOpen] = useState(false);
+  const [isNewApiKeyCreatedOpen, setIsNewApiKeyCreatedOpen] = useState(false);
 
   const { keys } = useKeys(owner);
   const { submit: handleGenerate, isSubmitting: isGenerating } =
@@ -291,6 +295,7 @@ export function APIKeys({
         await mutate(`/api/w/${owner.sId}/keys`);
         setIsNewApiKeyPromptOpen(false);
         setNewApiKeyName("");
+        setIsNewApiKeyCreatedOpen(true);
       }
     );
 
@@ -309,6 +314,49 @@ export function APIKeys({
 
   return (
     <>
+      <Modal
+        isOpen={isNewApiKeyCreatedOpen}
+        title={"API Key Created"}
+        onClose={function (): void {
+          setIsNewApiKeyCreatedOpen(false);
+        }}
+        hasChanged={false}
+      >
+        <div className="mt-4">
+          <p className="text-sm text-gray-700">
+            Your API key will remain visible for 10 minutes only. <br />
+            You can use it to authenticate with the Dust API. <br />
+          </p>
+          <br />
+          <div className="mt-4">
+            <Page.H variant="h5">Workspace ID</Page.H>
+            <Page.Horizontal align="stretch">
+              <pre>{owner.sId}</pre>
+              <IconButton
+                tooltip="Copy to clipboard"
+                icon={ClipboardIcon}
+                onClick={() => {
+                  void navigator.clipboard.writeText(owner.sId);
+                }}
+              />
+            </Page.Horizontal>
+          </div>
+          <div className="mt-4">
+            <Page.H variant="h5">API Key</Page.H>
+            <Page.Horizontal align="stretch">
+              <pre>{keys[0]?.secret}</pre>
+              <IconButton
+                tooltip="Copy to clipboard"
+                icon={ClipboardIcon}
+                onClick={() => {
+                  void navigator.clipboard.writeText(keys[0]?.secret);
+                }}
+              />
+            </Page.Horizontal>
+          </div>
+        </div>
+      </Modal>
+
       <Dialog
         isOpen={isNewApiKeyPromptOpen}
         title="New API Key"
@@ -345,15 +393,7 @@ export function APIKeys({
         </div> */}
       </Dialog>
       <Page.Horizontal align="stretch">
-        <div className="w-full">
-          <div className="inline-flex items-center rounded-lg bg-gray-100 p-3 shadow-sm">
-            <span className="mr-2">Your workspace ID:</span>
-            <code className="font-mono rounded bg-white px-2 py-1 text-sm">
-              {owner.sId}
-            </code>
-          </div>
-        </div>
-
+        <div className="w-full" />
         <Button
           label="Read the API reference"
           size="sm"

--- a/front/pages/w/[wId]/vaults/[vaultId]/apps/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/apps/index.tsx
@@ -317,7 +317,7 @@ export function APIKeys({
       <Modal
         isOpen={isNewApiKeyCreatedOpen}
         title={"API Key Created"}
-        onClose={function (): void {
+        onClose={() => {
           setIsNewApiKeyCreatedOpen(false);
         }}
         hasChanged={false}

--- a/front/pages/w/[wId]/vaults/[vaultId]/apps/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/apps/index.tsx
@@ -1,4 +1,5 @@
 import {
+  BookOpenIcon,
   BracesIcon,
   Button,
   CommandLineIcon,
@@ -343,19 +344,32 @@ export function APIKeys({
           </DropdownMenu>
         </div> */}
       </Dialog>
-      <Page.SectionHeader
-        title="API Keys"
-        description="Keys used to communicate between your servers and Dust. Do not share them with anyone. Do not use them in client-side or browser code."
-        action={{
-          label: "Create API Key",
-          variant: "primary",
-          onClick: async () => {
-            setIsNewApiKeyPromptOpen(true);
-          },
-          icon: PlusIcon,
-          disabled: isGenerating || isRevoking,
-        }}
-      />
+      <Page.Horizontal align="stretch">
+        <div className="w-full">
+          <div className="inline-flex items-center rounded-lg bg-gray-100 p-3 shadow-sm">
+            <span className="mr-2">Your workspace ID:</span>
+            <code className="font-mono rounded bg-white px-2 py-1 text-sm">
+              {owner.sId}
+            </code>
+          </div>
+        </div>
+
+        <Button
+          label="Read the API reference"
+          size="sm"
+          variant="secondary"
+          icon={BookOpenIcon}
+          onClick={() => {
+            window.open("https://docs.dust.tt/reference", "_blank");
+          }}
+        />
+        <Button
+          label="Create API Key"
+          icon={PlusIcon}
+          disabled={isGenerating || isRevoking}
+          onClick={() => setIsNewApiKeyPromptOpen(true)}
+        />
+      </Page.Horizontal>
       <div className="space-y-4 divide-y divide-gray-200">
         <ul role="list" className="pt-4">
           {keys


### PR DESCRIPTION
## Description

- People constantly ask us where to find their workspace ID and we always answer "after the w in your URL". This is just bad UX
- Let's make the workspace ID available neatly :) 

<img width="1017" alt="Screenshot 2024-09-24 at 16 31 10" src="https://github.com/user-attachments/assets/f9dfd74e-b7b1-430b-958d-8af48176e5ec">


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
