### PR TITLE
[types] - chore: set keepalive to false on `/content-nodes` ConnectorsAPI

### DIFF
--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -495,6 +495,7 @@ export class ConnectorsAPI {
         connectorId
       )}/content_nodes`,
       {
+        keepalive: false,
         method: "POST",
         headers: this.getDefaultHeaders(),
         body: JSON.stringify({


### PR DESCRIPTION
## Description

This PR disables keepalive for POST requests to content nodes within the ConnectorsAPI class

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
