### PR TITLE
enh: split LocalTable out of Table

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -37,7 +37,7 @@ use dust::{
         qdrant::QdrantClients,
     },
     databases::{
-        database::{QueryDatabaseError, Row, Table},
+        database::{LocalTable, QueryDatabaseError, Row, Table},
         transient_database::execute_query_on_transient_database,
     },
     databases_store::store::{self as databases_store, DatabasesStore},
@@ -2290,35 +2290,47 @@ async fn tables_rows_upsert(
                 None,
             )
         }
-        Ok(Some(table)) => match table
-            .upsert_rows(
-                state.store.clone(),
-                state.databases_store.clone(),
-                &payload.rows,
-                match payload.truncate {
-                    Some(v) => v,
-                    None => false,
-                },
-            )
-            .await
-        {
+        Ok(Some(mut table)) => match LocalTable::from_table(&mut table) {
             Err(e) => {
                 return error_response(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "internal_server_error",
-                    "Failed to upsert rows",
+                    StatusCode::BAD_REQUEST,
+                    "invalid_table",
+                    "Table is not local",
                     Some(e),
                 )
             }
-            Ok(_) => (
-                StatusCode::OK,
-                Json(APIResponse {
-                    error: None,
-                    response: Some(json!({
-                        "success": true,
-                    })),
-                }),
-            ),
+            Ok(table) => {
+                match table
+                    .upsert_rows(
+                        state.store.clone(),
+                        state.databases_store.clone(),
+                        &payload.rows,
+                        match payload.truncate {
+                            Some(v) => v,
+                            None => false,
+                        },
+                    )
+                    .await
+                {
+                    Err(e) => {
+                        return error_response(
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "internal_server_error",
+                            "Failed to upsert rows",
+                            Some(e),
+                        )
+                    }
+                    Ok(_) => (
+                        StatusCode::OK,
+                        Json(APIResponse {
+                            error: None,
+                            response: Some(json!({
+                                "success": true,
+                            })),
+                        }),
+                    ),
+                }
+            }
         },
     }
 }
@@ -2368,31 +2380,49 @@ async fn tables_rows_retrieve(
                     None,
                 )
             }
-            Some(table) => match table
-                .retrieve_row(state.databases_store.clone(), &row_id)
-                .await
-            {
-                Err(e) => error_response(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "internal_server_error",
-                    "Failed to load row",
-                    Some(e),
-                ),
-                Ok(None) => error_response(
-                    StatusCode::NOT_FOUND,
-                    "table_row_not_found",
-                    &format!("No table row found for id `{}`", row_id),
-                    None,
-                ),
-                Ok(Some(row)) => (
-                    StatusCode::OK,
-                    Json(APIResponse {
-                        error: None,
-                        response: Some(json!({
-                            "row": row,
-                        })),
-                    }),
-                ),
+            Some(mut table) => match LocalTable::from_table(&mut table) {
+                Err(e) => {
+                    return error_response(
+                        StatusCode::BAD_REQUEST,
+                        "invalid_table",
+                        "Table is not local",
+                        Some(e),
+                    )
+                }
+                Ok(table) => {
+                    match table
+                        .retrieve_row(state.databases_store.clone(), &row_id)
+                        .await
+                    {
+                        Err(e) => {
+                            return error_response(
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                "internal_server_error",
+                                "Failed to load row",
+                                Some(e),
+                            )
+                        }
+                        Ok(None) => {
+                            return error_response(
+                                StatusCode::NOT_FOUND,
+                                "table_row_not_found",
+                                &format!("No table row found for id `{}`", row_id),
+                                None,
+                            )
+                        }
+                        Ok(Some(row)) => {
+                            return (
+                                StatusCode::OK,
+                                Json(APIResponse {
+                                    error: None,
+                                    response: Some(json!({
+                                        "row": row,
+                                    })),
+                                }),
+                            )
+                        }
+                    }
+                }
             },
         },
     }
@@ -2429,25 +2459,39 @@ async fn tables_rows_delete(
                 }),
             )
         }
-        Ok(Some(table)) => match table
-            .delete_row(state.databases_store.clone(), &row_id)
-            .await
-        {
-            Err(e) => error_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "internal_server_error",
-                "Failed to delete row",
-                Some(e),
-            ),
-            Ok(_) => (
-                StatusCode::OK,
-                Json(APIResponse {
-                    error: None,
-                    response: Some(json!({
-                        "success": true,
-                    })),
-                }),
-            ),
+        Ok(Some(mut table)) => match LocalTable::from_table(&mut table) {
+            Err(e) => {
+                return error_response(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_table",
+                    "Table is not local",
+                    Some(e),
+                )
+            }
+            Ok(table) => {
+                match table
+                    .delete_row(state.databases_store.clone(), &row_id)
+                    .await
+                {
+                    Err(e) => {
+                        return error_response(
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "internal_server_error",
+                            "Failed to delete row",
+                            Some(e),
+                        )
+                    }
+                    Ok(_) => (
+                        StatusCode::OK,
+                        Json(APIResponse {
+                            error: None,
+                            response: Some(json!({
+                                "success": true,
+                            })),
+                        }),
+                    ),
+                }
+            }
         },
     }
 }
@@ -2504,31 +2548,39 @@ async fn tables_rows_list(
                     None,
                 )
             }
-            Some(table) => match table
-                .list_rows(
-                    state.databases_store.clone(),
-                    Some((query.limit, query.offset)),
-                )
-                .await
-            {
+            Some(mut table) => match LocalTable::from_table(&mut table) {
                 Err(e) => error_response(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "internal_server_error",
-                    "Failed to list rows",
+                    StatusCode::BAD_REQUEST,
+                    "invalid_table",
+                    "Table is not local",
                     Some(e),
                 ),
-                Ok((rows, total)) => (
-                    StatusCode::OK,
-                    Json(APIResponse {
-                        error: None,
-                        response: Some(json!({
-                            "offset": query.offset,
-                            "limit": query.limit,
-                            "total": total,
-                            "rows": rows,
-                        })),
-                    }),
-                ),
+                Ok(table) => match table
+                    .list_rows(
+                        state.databases_store.clone(),
+                        Some((query.limit, query.offset)),
+                    )
+                    .await
+                {
+                    Err(e) => error_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "internal_server_error",
+                        "Failed to list rows",
+                        Some(e),
+                    ),
+                    Ok((rows, total)) => (
+                        StatusCode::OK,
+                        Json(APIResponse {
+                            error: None,
+                            response: Some(json!({
+                                "offset": query.offset,
+                                "limit": query.limit,
+                                "total": total,
+                                "rows": rows,
+                            })),
+                        }),
+                    ),
+                },
             },
         },
     }

--- a/core/src/databases/remote_databases/snowflake.rs
+++ b/core/src/databases/remote_databases/snowflake.rs
@@ -54,7 +54,7 @@ impl TryFrom<SnowflakeSchemaColumn> for TableSchemaColumn {
         Ok(TableSchemaColumn {
             name: col.name,
             value_type: col_type,
-            // TODO(@fontanierh): decide if we want possible values for remote DBs.
+            // TODO(SNOWFLAKE): decide if we want possible values for remote DBs.
             // We could potentially look at rows count and decide based on that.
             // Or have a cache specifically for this.
             possible_values: None,
@@ -222,7 +222,7 @@ impl RemoteDatabase for SnowflakeRemoteDatabase {
             }?;
         }
 
-        // TODO(@fontanierh): decide if we want to infer query result schema for remote DBs.
+        // TODO(SNOWFLAKE): decide if we want to infer query result schema for remote DBs.
         let schema = TableSchema::empty();
 
         Ok((all_rows, schema))

--- a/core/src/databases/table_schema.rs
+++ b/core/src/databases/table_schema.rs
@@ -375,6 +375,18 @@ impl TableSchema {
         Ok(TableSchema(merged_schema))
     }
 
+    pub fn render_dbml(&self, name: &str, description: &str) -> String {
+        return format!(
+            "Table {} {{\n{}\n\n  Note: '{}'\n}}",
+            name,
+            self.columns()
+                .iter()
+                .map(|c| format!("  {}", c.render_dbml()))
+                .join("\n"),
+            description
+        );
+    }
+
     fn try_parse_date_object(maybe_date_obj: &serde_json::Map<String, Value>) -> Option<String> {
         match (maybe_date_obj.get("type"), maybe_date_obj.get("epoch")) {
             (Some(Value::String(date_type)), Some(Value::Number(epoch))) => {


### PR DESCRIPTION
## Description

- create a new `LocalTable` struct that contains all the methods from `Table` that are very specific to local sqlite tables
- the new struct has a check to ensure the associated table is local
- move usage from `Table` to `LocalTable` for local-specific features (or features not yet implemented for remote tables)

Next step, I'll add `RemoteTable` + add support for database schema through it.

## Risk

N/A

## Deploy Plan

N/A