### PR TITLE
Support public data sources in registry lookup.

### DIFF
--- a/front/lib/resources/retrieval_document_resource.ts
+++ b/front/lib/resources/retrieval_document_resource.ts
@@ -172,6 +172,15 @@ export class RetrievalDocumentResource extends BaseResource<RetrievalDocument> {
       return null;
     }
 
+    // Prevents users from accessing the document contents of a public data source
+    // that is not associated with their current workspace.
+    const isExternalPublicDataSource =
+      this.dataSourceView.vault.isPublic() &&
+      this.dataSourceView.workspaceId !== auth.getNonNullableWorkspace().id;
+    if (isExternalPublicDataSource) {
+      return null;
+    }
+
     const dsv = this.dataSourceView.toJSON();
 
     return `${config.getClientFacingUrl()}/w/${

--- a/front/pages/api/registry/[type]/lookup.ts
+++ b/front/pages/api/registry/[type]/lookup.ts
@@ -93,20 +93,14 @@ async function handler(
             });
           };
 
-          const {
-            data_source_id: dataSourceOrDataSourceViewId,
-            workspace_id: workspaceId,
-          } = req.query;
-          if (
-            typeof workspaceId !== "string" ||
-            typeof dataSourceOrDataSourceViewId !== "string"
-          ) {
+          const { data_source_id: dataSourceOrDataSourceViewId } = req.query;
+          if (typeof dataSourceOrDataSourceViewId !== "string") {
             return notFoundError();
           }
 
           const owner = await Workspace.findOne({
             where: {
-              sId: workspaceId,
+              sId: dustWorkspaceId,
             },
           });
           if (!owner) {
@@ -116,7 +110,7 @@ async function handler(
           const auth = await Authenticator.fromRegistrySecret({
             groupIds: dustGroupIds,
             secret,
-            workspaceId,
+            workspaceId: dustWorkspaceId,
           });
 
           if (

--- a/front/pages/api/registry/[type]/lookup.ts
+++ b/front/pages/api/registry/[type]/lookup.ts
@@ -9,7 +9,6 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";
 import { isManaged } from "@app/lib/data_sources";
-import { Workspace } from "@app/lib/models/workspace";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { VaultResource } from "@app/lib/resources/vault_resource";

--- a/front/pages/api/registry/[type]/lookup.ts
+++ b/front/pages/api/registry/[type]/lookup.ts
@@ -62,6 +62,7 @@ async function handler(
     return;
   }
 
+  // Extract and validate headers necessary for user permission checks.
   const userWorkspaceId = req.headers["x-dust-workspace-id"];
   const rawDustGroupIds = req.headers["x-dust-group-ids"];
   if (


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR removes the restriction on querying data sources, which was previously limited to those within the workspace. This logic is now managed by the `canRead` logic introduced in https://github.com/dust-tt/dust/pull/7653.

Currently, the registry lookup accepts two workspace IDs:
- The `X-Dust-Workspace-Id` header, which represents the user's workspace.
- The `workspace_id` query parameter, which indicates the workspace ID for the current data source or data source views.

Since the permission system in vaults now manages the logic, we **MUST ALWAYS** use the user's workspace ID.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
⚠️ Important security risks! 

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
