### PR TITLE
Fix index table query after removal of dataSourceWorkspaceId

### DIFF
--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -131,7 +131,12 @@ AgentTablesQueryConfigurationTable.init(
       {
         unique: true,
         fields: ["dataSourceViewId", "tableId", "tablesQueryConfigurationId"],
-        name: "agent_tables_query_configuration_table_unique",
+        name: "agent_tables_query_configuration_table_unique_dsv",
+      },
+      {
+        unique: true,
+        fields: ["dataSourceId", "tableId", "tablesQueryConfigurationId"],
+        name: "agent_tables_query_configuration_table_unique_ds",
       },
     ],
     sequelize: frontSequelize,

--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -130,7 +130,7 @@ AgentTablesQueryConfigurationTable.init(
     indexes: [
       {
         unique: true,
-        fields: ["dataSourceId", "tableId", "tablesQueryConfigurationId"],
+        fields: ["dataSourceViewId", "tableId", "tablesQueryConfigurationId"],
         name: "agent_tables_query_configuration_table_unique",
       },
     ],

--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -130,12 +130,7 @@ AgentTablesQueryConfigurationTable.init(
     indexes: [
       {
         unique: true,
-        fields: [
-          "dataSourceWorkspaceId",
-          "dataSourceId",
-          "tableId",
-          "tablesQueryConfigurationId",
-        ],
+        fields: ["dataSourceId", "tableId", "tablesQueryConfigurationId"],
         name: "agent_tables_query_configuration_table_unique",
       },
     ],

--- a/front/migrations/db/migration_89.sql
+++ b/front/migrations/db/migration_89.sql
@@ -1,3 +1,4 @@
 -- Migration created on Sep 24, 2024
 DROP INDEX IF EXISTS "agent_tables_query_configuration_table_unique";
-CREATE UNIQUE INDEX "agent_tables_query_configuration_table_unique" ON "agent_tables_query_configuration_tables" ("dataSourceViewId", "tableId", "tablesQueryConfigurationId");
+CREATE UNIQUE INDEX "agent_tables_query_configuration_table_unique_dsv" ON "agent_tables_query_configuration_tables" ("dataSourceViewId", "tableId", "tablesQueryConfigurationId");
+CREATE UNIQUE INDEX "agent_tables_query_configuration_table_unique_ds" ON "agent_tables_query_configuration_tables" ("dataSourceId", "tableId", "tablesQueryConfigurationId");

--- a/front/migrations/db/migration_89.sql
+++ b/front/migrations/db/migration_89.sql
@@ -1,0 +1,3 @@
+-- Migration created on Sep 24, 2024
+DROP INDEX IF EXISTS "agent_tables_query_configuration_table_unique";
+CREATE UNIQUE INDEX "agent_tables_query_configuration_table_unique" ON "agent_tables_query_configuration_tables" ("dataSourceId", "tableId", "tablesQueryConfigurationId");

--- a/front/migrations/db/migration_89.sql
+++ b/front/migrations/db/migration_89.sql
@@ -1,3 +1,3 @@
 -- Migration created on Sep 24, 2024
 DROP INDEX IF EXISTS "agent_tables_query_configuration_table_unique";
-CREATE UNIQUE INDEX "agent_tables_query_configuration_table_unique" ON "agent_tables_query_configuration_tables" ("dataSourceId", "tableId", "tablesQueryConfigurationId");
+CREATE UNIQUE INDEX "agent_tables_query_configuration_table_unique" ON "agent_tables_query_configuration_tables" ("dataSourceViewId", "tableId", "tablesQueryConfigurationId");


### PR DESCRIPTION
## Description

`dataSourceWorkspaceId` column that was removed is still used from an index: https://github.com/dust-tt/dust/pull/7647/files

## Risk

/

## Deploy Plan

Run migration 89
Deploy front. 
