### PR TITLE
Add Snowflake connector in Preview mode and skeletton

### DIFF
--- a/connectors/migrations/db/migration_15.sql
+++ b/connectors/migrations/db/migration_15.sql
@@ -1,9 +1,8 @@
--- Migration created on Sep 24, 2024
+-- Migration created on Sep 25, 2024
 CREATE TABLE IF NOT EXISTS "snowflake_configurations" (
     "id"  SERIAL,
     "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
     "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
-    "connectorId" INTEGER REFERENCES "connectors" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
-    PRIMARY KEY ("id")
-);
+    "connectorId" INTEGER NOT NULL REFERENCES "connectors" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+PRIMARY KEY ("id"));
 CREATE UNIQUE INDEX "snowflake_configurations_connector_id" ON "snowflake_configurations" ("connectorId");

--- a/connectors/migrations/db/migration_15.sql
+++ b/connectors/migrations/db/migration_15.sql
@@ -1,0 +1,9 @@
+-- Migration created on Sep 24, 2024
+CREATE TABLE IF NOT EXISTS "snowflake_configurations" (
+    "id"  SERIAL,
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "connectorId" INTEGER REFERENCES "connectors" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX "snowflake_configurations_connector_id" ON "snowflake_configurations" ("connectorId");

--- a/connectors/src/admin/db.ts
+++ b/connectors/src/admin/db.ts
@@ -49,6 +49,7 @@ import {
   SlackConfigurationModel,
   SlackMessages,
 } from "@connectors/lib/models/slack";
+import { SnowflakeConfigurationModel } from "@connectors/lib/models/snowflake";
 import {
   WebCrawlerConfigurationHeader,
   WebCrawlerConfigurationModel,
@@ -103,6 +104,7 @@ async function main(): Promise<void> {
   await WebCrawlerFolder.sync({ alter: true });
   await WebCrawlerPage.sync({ alter: true });
   await WebCrawlerConfigurationHeader.sync({ alter: true });
+  await SnowflakeConfigurationModel.sync({ alter: true });
 
   // enable the `unaccent` extension
   await sequelizeConnection.query("CREATE EXTENSION IF NOT EXISTS unaccent;");

--- a/connectors/src/api/configuration.ts
+++ b/connectors/src/api/configuration.ts
@@ -67,6 +67,7 @@ const _patchConnectorConfiguration = async (
     case "google_drive":
     case "intercom":
     case "microsoft":
+    case "snowflake":
     case "slack": {
       throw new Error(
         `Connector type ${connector.type} does not support configuration patching`

--- a/connectors/src/api/create_connector.ts
+++ b/connectors/src/api/create_connector.ts
@@ -124,6 +124,7 @@ const _createConnectorAPIHandler = async (
       case "confluence":
       case "google_drive":
       case "intercom":
+      case "snowflake":
       case "microsoft": {
         connectorRes = await createConnector({
           connectorProvider: req.params.connector_provider,

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -14,6 +14,7 @@ import { IntercomConnectorManager } from "@connectors/connectors/intercom";
 import { MicrosoftConnectorManager } from "@connectors/connectors/microsoft";
 import { NotionConnectorManager } from "@connectors/connectors/notion";
 import { SlackConnectorManager } from "@connectors/connectors/slack";
+import { SnowflakeConnectorManager } from "@connectors/connectors/snowflake";
 import { WebcrawlerConnectorManager } from "@connectors/connectors/webcrawler";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
@@ -25,7 +26,8 @@ type ConnectorManager =
   | SlackConnectorManager
   | IntercomConnectorManager
   | GithubConnectorManager
-  | GoogleDriveConnectorManager;
+  | GoogleDriveConnectorManager
+  | SnowflakeConnectorManager;
 
 export function getConnectorManager({
   connectorProvider,
@@ -51,6 +53,8 @@ export function getConnectorManager({
       return new SlackConnectorManager(connectorId);
     case "webcrawler":
       return new WebcrawlerConnectorManager(connectorId);
+    case "snowflake":
+      return new SnowflakeConnectorManager(connectorId);
     default:
       assertNever(connectorProvider);
   }
@@ -101,6 +105,8 @@ export function createConnector({
       return SlackConnectorManager.create(params);
     case "webcrawler":
       return WebcrawlerConnectorManager.create(params);
+    case "snowflake":
+      return SnowflakeConnectorManager.create(params);
     default:
       assertNever(connectorProvider);
   }

--- a/connectors/src/connectors/snowflake/index.ts
+++ b/connectors/src/connectors/snowflake/index.ts
@@ -1,0 +1,126 @@
+import type {
+  ConnectorPermission,
+  ConnectorsAPIError,
+  ContentNode,
+  ContentNodesViewType,
+  Result,
+} from "@dust-tt/types";
+
+import { BaseConnectorManager } from "@connectors/connectors/interface";
+import mainLogger from "@connectors/logger/logger";
+import type { DataSourceConfig } from "@connectors/types/data_source_config";
+
+const logger = mainLogger.child({
+  connector: "snowflake",
+});
+
+export class SnowflakeConnectorManager extends BaseConnectorManager<null> {
+  static async create({
+    dataSourceConfig,
+    connectionId,
+  }: {
+    dataSourceConfig: DataSourceConfig;
+    connectionId: string;
+  }): Promise<Result<string, Error>> {
+    logger.info({ dataSourceConfig, connectionId }, "To be implemented");
+    throw new Error("Method not implemented.");
+  }
+
+  async update({
+    connectionId,
+  }: {
+    connectionId?: string | null;
+  }): Promise<Result<string, ConnectorsAPIError>> {
+    logger.info({ connectionId }, "To be implemented");
+    throw new Error("Method not implemented.");
+  }
+
+  async clean(): Promise<Result<undefined, Error>> {
+    throw new Error("Method not implemented.");
+  }
+
+  async stop(): Promise<Result<undefined, Error>> {
+    throw new Error("Method not implemented.");
+  }
+
+  async resume(): Promise<Result<undefined, Error>> {
+    throw new Error("Method not implemented.");
+  }
+
+  async sync({
+    fromTs,
+  }: {
+    fromTs: number | null;
+  }): Promise<Result<string, Error>> {
+    logger.info({ fromTs }, "To be implemented");
+    throw new Error("Method not implemented.");
+  }
+
+  async retrievePermissions({
+    parentInternalId,
+    filterPermission,
+  }: {
+    parentInternalId: string | null;
+    filterPermission: ConnectorPermission | null;
+  }): Promise<Result<ContentNode[], Error>> {
+    logger.info({ parentInternalId, filterPermission }, "To be implemented");
+    throw new Error("Method not implemented.");
+  }
+
+  async setPermissions({
+    permissions,
+  }: {
+    permissions: Record<string, ConnectorPermission>;
+  }): Promise<Result<void, Error>> {
+    logger.info({ permissions }, "To be implemented");
+    throw new Error("Method not implemented.");
+  }
+
+  async retrieveBatchContentNodes({
+    internalIds,
+  }: {
+    internalIds: string[];
+    viewType: ContentNodesViewType;
+  }): Promise<Result<ContentNode[], Error>> {
+    logger.info({ internalIds }, "To be implemented");
+    throw new Error("Method not implemented.");
+  }
+
+  /**
+   * Retrieves the parent IDs of a content node in hierarchical order.
+   * The first ID is the internal ID of the content node itself.
+   */
+  async retrieveContentNodeParents({
+    internalId,
+  }: {
+    internalId: string;
+    memoizationKey?: string;
+  }): Promise<Result<string[], Error>> {
+    logger.info({ internalId }, "To be implemented");
+    throw new Error("Method not implemented.");
+  }
+
+  async pause(): Promise<Result<undefined, Error>> {
+    throw new Error("Method not implemented.");
+  }
+
+  async unpause(): Promise<Result<undefined, Error>> {
+    throw new Error("Method not implemented.");
+  }
+
+  async setConfigurationKey(): Promise<Result<void, Error>> {
+    throw new Error("Method not implemented.");
+  }
+
+  async getConfigurationKey(): Promise<Result<string | null, Error>> {
+    throw new Error("Method not implemented.");
+  }
+
+  async garbageCollect(): Promise<Result<string, Error>> {
+    throw new Error("Method not implemented.");
+  }
+
+  async configure(): Promise<Result<void, Error>> {
+    throw new Error("Method not implemented.");
+  }
+}

--- a/connectors/src/lib/models/snowflake.ts
+++ b/connectors/src/lib/models/snowflake.ts
@@ -45,4 +45,8 @@ SnowflakeConfigurationModel.init(
     indexes: [{ fields: ["connectorId"], unique: true }],
   }
 );
-ConnectorModel.hasOne(SnowflakeConfigurationModel);
+ConnectorModel.hasMany(SnowflakeConfigurationModel, {
+  foreignKey: { allowNull: false },
+  onDelete: "RESTRICT",
+});
+SnowflakeConfigurationModel.belongsTo(ConnectorModel);

--- a/connectors/src/lib/models/snowflake.ts
+++ b/connectors/src/lib/models/snowflake.ts
@@ -1,0 +1,48 @@
+import type {
+  CreationOptional,
+  ForeignKey,
+  InferAttributes,
+  InferCreationAttributes,
+} from "sequelize";
+import { DataTypes, Model } from "sequelize";
+
+import { sequelizeConnection } from "@connectors/resources/storage";
+import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
+
+export class SnowflakeConfigurationModel extends Model<
+  InferAttributes<SnowflakeConfigurationModel>,
+  InferCreationAttributes<SnowflakeConfigurationModel>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  // TODO(SNOWFLAKE): Add the fields for the Snowflake configuration.
+
+  declare connectorId: ForeignKey<ConnectorModel["id"]>;
+}
+SnowflakeConfigurationModel.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+  },
+  {
+    sequelize: sequelizeConnection,
+    modelName: "snowflake_configurations",
+    indexes: [{ fields: ["connectorId"], unique: true }],
+  }
+);
+ConnectorModel.hasOne(SnowflakeConfigurationModel);

--- a/connectors/src/resources/connector/snowflake.ts
+++ b/connectors/src/resources/connector/snowflake.ts
@@ -1,0 +1,55 @@
+import type { ModelId } from "@dust-tt/types";
+import type { Transaction } from "sequelize";
+
+import { SnowflakeConfigurationModel } from "@connectors/lib/models/snowflake";
+import type {
+  ConnectorProviderConfigurationType,
+  ConnectorProviderModelResourceMapping,
+  ConnectorProviderStrategy,
+  WithCreationAttributes,
+} from "@connectors/resources/connector/strategy";
+import type { ConnectorResource } from "@connectors/resources/connector_resource";
+
+export class SnowflakeConnectorStrategy
+  implements ConnectorProviderStrategy<"snowflake">
+{
+  async makeNew(
+    connectorId: ModelId,
+    blob: WithCreationAttributes<SnowflakeConfigurationModel>,
+    transaction: Transaction
+  ): Promise<ConnectorProviderModelResourceMapping["snowflake"] | null> {
+    await SnowflakeConfigurationModel.create(
+      {
+        ...blob,
+        connectorId,
+      },
+      { transaction }
+    );
+
+    return null;
+  }
+
+  async delete(
+    connector: ConnectorResource,
+    transaction: Transaction
+  ): Promise<void> {
+    await Promise.all([
+      SnowflakeConfigurationModel.destroy({
+        where: {
+          connectorId: connector.id,
+        },
+        transaction,
+      }),
+    ]);
+  }
+
+  async fetchConfigurationsbyConnectorIds(): Promise<
+    Record<ModelId, ConnectorProviderModelResourceMapping["snowflake"]>
+  > {
+    return {};
+  }
+
+  configurationJSON(): ConnectorProviderConfigurationType {
+    return null;
+  }
+}

--- a/connectors/src/resources/connector/strategy.ts
+++ b/connectors/src/resources/connector/strategy.ts
@@ -14,6 +14,7 @@ import type { IntercomWorkspace } from "@connectors/lib/models/intercom";
 import type { MicrosoftConfigurationModel } from "@connectors/lib/models/microsoft";
 import type { NotionConnectorState } from "@connectors/lib/models/notion";
 import type { SlackConfigurationModel } from "@connectors/lib/models/slack";
+import type { SnowflakeConfigurationModel } from "@connectors/lib/models/snowflake";
 import type { WebCrawlerConfigurationModel } from "@connectors/lib/models/webcrawler";
 import { ConfluenceConnectorStrategy } from "@connectors/resources/connector/confluence";
 import { GithubConnectorStrategy } from "@connectors/resources/connector/github";
@@ -22,6 +23,7 @@ import { IntercomConnectorStrategy } from "@connectors/resources/connector/inter
 import { MicrosoftConnectorStrategy } from "@connectors/resources/connector/microsoft";
 import { NotionConnectorStrategy } from "@connectors/resources/connector/notion";
 import { SlackConnectorStrategy } from "@connectors/resources/connector/slack";
+import { SnowflakeConnectorStrategy } from "@connectors/resources/connector/snowflake";
 import { WebCrawlerStrategy } from "@connectors/resources/connector/webcrawler";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 
@@ -41,6 +43,7 @@ export interface ConnectorProviderModelM {
   notion: NotionConnectorState;
   slack: SlackConfigurationModel;
   webcrawler: WebCrawlerConfigurationModel;
+  snowflake: SnowflakeConfigurationModel;
 }
 
 export type ConnectorProviderModelMapping = {
@@ -71,6 +74,7 @@ export interface ConnectorProviderConfigurationTypeM {
   intercom: null;
   microsoft: null;
   notion: null;
+  snowflake: null;
   slack: SlackConfigurationType;
   webcrawler: WebCrawlerConfigurationType;
 }
@@ -127,6 +131,9 @@ export function getConnectorProviderStrategy(
 
     case "webcrawler":
       return new WebCrawlerStrategy();
+
+    case "snowflake":
+      return new SnowflakeConnectorStrategy();
 
     default:
       assertNever(type);

--- a/connectors/src/start_worker.ts
+++ b/connectors/src/start_worker.ts
@@ -33,6 +33,9 @@ const workerFunctions: Record<
   notion_garbage_collector: runNotionGarbageCollectWorker,
   slack: runSlackWorker,
   webcrawler: runWebCrawlerWorker,
+  snowflake: async () => {
+    // TODO(SNOWFLAKE): Implement worker.
+  },
 };
 
 const ALL_WORKERS = Object.keys(workerFunctions) as ConnectorProvider[];

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -142,6 +142,7 @@ export function showAddDataModal(
     case "webcrawler":
     case "slack":
     case "intercom":
+    case "snowflake":
       return true;
     case "notion":
     case "github":

--- a/front/components/ConnectorPermissionsTree.tsx
+++ b/front/components/ConnectorPermissionsTree.tsx
@@ -52,6 +52,10 @@ const CONNECTOR_TYPE_TO_PERMISSIONS: Record<
     unselected: "none",
   },
   webcrawler: undefined,
+  snowflake: {
+    selected: "read",
+    unselected: "none",
+  },
 };
 
 type onPermissionUpdateType = (

--- a/front/components/assistant_builder/shared.ts
+++ b/front/components/assistant_builder/shared.ts
@@ -40,6 +40,7 @@ const CONNECTOR_PROVIDER_TO_RESOURCE_NAME: Record<
   github: { singular: "repository", plural: "repositories" },
   intercom: { singular: "element", plural: "elements" },
   webcrawler: { singular: "page", plural: "pages" },
+  snowflake: { singular: "table", plural: "tables" },
 };
 
 export const getConnectorProviderResourceName = (

--- a/front/components/vaults/AddConnectionMenu.tsx
+++ b/front/components/vaults/AddConnectionMenu.tsx
@@ -14,13 +14,7 @@ import type {
   Result,
   WorkspaceType,
 } from "@dust-tt/types";
-import {
-  Err,
-  isConnectorProviderAllowed,
-  isOAuthProvider,
-  Ok,
-  setupOAuthConnection,
-} from "@dust-tt/types";
+import { Err, isOAuthProvider, Ok, setupOAuthConnection } from "@dust-tt/types";
 import { useRouter } from "next/router";
 import { useContext, useState } from "react";
 
@@ -183,9 +177,9 @@ export const AddConnectionMenu = ({
       (configuration.status === "rolling_out" &&
         !!configuration.rollingOutFlag &&
         owner.flags.includes(configuration.rollingOutFlag));
-    const isProviderAllowed = isConnectorProviderAllowed(
-      configuration.connectorProvider,
-      plan.limits.connections
+    const isProviderAllowed = isConnectorProviderAllowedForPlan(
+      plan,
+      configuration.connectorProvider
     );
 
     const existingDataSource = existingDataSources.find(

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -8,6 +8,7 @@ import {
   MicrosoftLogo,
   NotionLogo,
   SlackLogo,
+  SnowflakeLogo,
 } from "@dust-tt/sparkle";
 import type {
   ConnectorProvider,
@@ -169,6 +170,19 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     isNested: true,
     isSearchEnabled: false,
   },
+  snowflake: {
+    name: "Snowflake",
+    connectorProvider: "snowflake",
+    status: "rolling_out",
+    hide: true,
+    description: "Query a Snowflake database.",
+    limitations: null,
+    logoComponent: SnowflakeLogo,
+    isNested: true,
+    isSearchEnabled: false,
+    guideLink: "https://docs.dust.tt/", // TODO(SNOWFLAKE): Add a doc for snowflake and point.
+    rollingOutFlag: "snowflake_connector_feature",
+  },
 };
 
 export function getConnectorProviderLogoWithFallback(
@@ -206,6 +220,9 @@ export const isConnectorProviderAllowedForPlan = (
       return true;
     case "webcrawler":
       return plan.limits.connections.isWebCrawlerAllowed;
+    case "snowflake":
+      // TODO(SNOWFLAKE): Add a isSnowflakeAllowed column to the plan model.
+      return true;
     default:
       assertNever(provider);
   }
@@ -222,6 +239,7 @@ export const isConnectorProviderAssistantDefaultSelected = (
     case "google_drive":
     case "intercom":
     case "microsoft":
+    case "snowflake":
       return true;
     case "webcrawler":
       return false;
@@ -241,6 +259,7 @@ export const isConnectionIdRequiredForProvider = (
     case "google_drive":
     case "intercom":
     case "microsoft":
+    case "snowflake":
       return true;
     case "webcrawler":
       return false;

--- a/front/lib/data_sources.ts
+++ b/front/lib/data_sources.ts
@@ -30,6 +30,7 @@ export function getDisplayNameForDataSource(ds: DataSourceType) {
       case "intercom":
       case "microsoft":
       case "notion":
+      case "snowflake":
         return CONNECTOR_CONFIGURATIONS[ds.connectorProvider].name;
       case "webcrawler":
         return ds.name;

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,7 @@
         "@amplitude/analytics-browser": "^2.5.2",
         "@amplitude/analytics-node": "^1.3.5",
         "@auth0/nextjs-auth0": "^3.5.0",
-        "@dust-tt/sparkle": "^0.2.248",
+        "@dust-tt/sparkle": "^0.2.251",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -10737,9 +10737,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.248",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.248.tgz",
-      "integrity": "sha512-B4z/yd99QYFvn1wow4SxG8mf3VJAfqxN3gBlrVNZ2CvJUI8rZ16RFi2eefvl4dGGMpYfR6YTFAaa05DIAJ70xw==",
+      "version": "0.2.251",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.251.tgz",
+      "integrity": "sha512-nIkCrGSvu/bUEb9G+FTUgbJxl2Srx+Q2RtdhdscDroobpDFS0gB3FH0PQqvx/tfWA7XAoo0IZlXls3dm2QhJ8w==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
     "@amplitude/analytics-browser": "^2.5.2",
     "@amplitude/analytics-node": "^1.3.5",
     "@auth0/nextjs-auth0": "^3.5.0",
-    "@dust-tt/sparkle": "^0.2.248",
+    "@dust-tt/sparkle": "^0.2.251",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/configuration.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/configuration.ts
@@ -94,6 +94,7 @@ async function handler(
     case "notion":
     case "microsoft":
     case "slack":
+    case "snowflake":
       if (!auth.isAdmin()) {
         return apiError(req, res, {
           status_code: 403,

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -123,6 +123,7 @@ async function handler(
         case "intercom":
         case "notion":
         case "microsoft":
+        case "snowflake":
         case "slack": {
           if (!auth.isAdmin()) {
             return apiError(req, res, {

--- a/front/pages/w/[wId]/builder/data-sources/[dsId]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[dsId]/index.tsx
@@ -981,6 +981,12 @@ function getRenderingConfigForConnectorProvider(
         displayWebcrawlerSettingsButton: true,
         guideLink: CONNECTOR_CONFIGURATIONS[connectorProvider].guideLink,
       };
+    case "snowflake":
+      return {
+        ...commonConfig,
+        displayEditionModal: true,
+        guideLink: CONNECTOR_CONFIGURATIONS[connectorProvider].guideLink,
+      };
     default:
       assertNever(connectorProvider);
   }
@@ -1143,6 +1149,7 @@ function ManagedDataSourceView({
                 case "notion":
                 case "intercom":
                 case "microsoft":
+                case "snowflake":
                   return `Manage Dust connection to ${CONNECTOR_CONFIGURATIONS[connectorProvider].name}`;
                 case "webcrawler":
                   return `Manage Website`;
@@ -1216,6 +1223,7 @@ function ManagedDataSourceView({
                     case "notion":
                     case "intercom":
                     case "microsoft":
+                    case "snowflake":
                       return (
                         <>
                           Selected resources will be accessible to all members

--- a/types/src/front/data_source.ts
+++ b/types/src/front/data_source.ts
@@ -1,7 +1,6 @@
 import { ModelId } from "../shared/model_id";
 import { Err, Ok, Result } from "../shared/result";
 import { ConnectorType } from "./lib/connectors_api";
-import { ManageDataSourcesLimitsType } from "./plan";
 
 export const CONNECTOR_PROVIDERS = [
   "confluence",
@@ -12,6 +11,7 @@ export const CONNECTOR_PROVIDERS = [
   "slack",
   "microsoft",
   "webcrawler",
+  "snowflake",
 ] as const;
 
 export const CONNECTOR_TYPE_TO_NAME: Record<ConnectorProvider, string> = {
@@ -23,6 +23,7 @@ export const CONNECTOR_TYPE_TO_NAME: Record<ConnectorProvider, string> = {
   slack: "Slack",
   microsoft: "Microsoft",
   webcrawler: "Website",
+  snowflake: "Snowflake",
 };
 
 export const CONNECTOR_TYPE_TO_MISMATCH_ERROR: Record<
@@ -41,6 +42,8 @@ export const CONNECTOR_TYPE_TO_MISMATCH_ERROR: Record<
     "You cannot select another Intercom Workspace.\nPlease contact us at support@dust.tt if you initially selected a wrong Workspace.",
   microsoft: `Microsoft / mismatch error.`,
   webcrawler: "You cannot change the URL. Please add a new Public URL instead.",
+  snowflake:
+    "You cannot change the Snowflake account. Please add a new Snowflake connection instead.",
 };
 
 export type ConnectorProvider = (typeof CONNECTOR_PROVIDERS)[number];
@@ -120,38 +123,4 @@ export function isDataSourceNameValid(name: string): Result<void, string> {
   }
 
   return new Ok(undefined);
-}
-
-export function isConnectorProviderAllowed(
-  provider: ConnectorProvider,
-  limits: ManageDataSourcesLimitsType
-): boolean {
-  switch (provider) {
-    case "confluence": {
-      return limits.isConfluenceAllowed;
-    }
-    case "slack": {
-      return limits.isSlackAllowed;
-    }
-    case "notion": {
-      return limits.isNotionAllowed;
-    }
-    case "github": {
-      return limits.isGithubAllowed;
-    }
-    case "google_drive": {
-      return limits.isGoogleDriveAllowed;
-    }
-    case "intercom": {
-      return limits.isIntercomAllowed;
-    }
-    case "microsoft": {
-      return true;
-    }
-    case "webcrawler": {
-      return false;
-    }
-    default:
-      throw new Error(`Unknown connector provider ${provider}`);
-  }
 }

--- a/types/src/shared/feature_flags.ts
+++ b/types/src/shared/feature_flags.ts
@@ -8,6 +8,7 @@ export const WHITELISTABLE_FEATURES = [
   "private_data_vaults_feature",
   "openai_o1_feature",
   "openai_o1_mini_feature",
+  "snowflake_connector_feature",
 ] as const;
 export type WhitelistableFeature = (typeof WHITELISTABLE_FEATURES)[number];
 export function isWhitelistableFeature(


### PR DESCRIPTION
## Description

This PRs adds the skeleton of the Snowflake connector & displays it as preview mode on the UI. 
It introduces a feature flag to prepare its rollout. 

Goal is to ship the skeleton as small as possible so  we can // work (and PR review is easy)
- The skeleton of the connector was added, methods are not yet implemented. 
- Regarding models, the strict minimum is in this PR (a model for the connector configuration).
- The worker boilerplate was not added yet. 


### Changes on the UI

<kbd>
<img width="347" alt="Screenshot 2024-09-24 at 21 01 59" src="https://github.com/user-attachments/assets/4d792a58-8dda-452c-884e-a2ae943c795f">
</kbd>

If a user clicks on this, it will display a modal saying to contact us to get more info about this connector. 


## Risk

Unused connector at the moment so not very risky. 
If needed both front and connector could be rolled back

## Deploy Plan

- Merge. 
- Run migration 15 on connectors. 
- Deploy connectors. 
- Deploy front. 