### PR TITLE
Add: missing indexes on agent_data_source_configurations

### DIFF
--- a/front/lib/models/assistant/actions/data_sources.ts
+++ b/front/lib/models/assistant/actions/data_sources.ts
@@ -74,6 +74,15 @@ AgentDataSourceConfiguration.init(
       {
         fields: ["retrievalConfigurationId"],
       },
+      {
+        fields: ["processConfigurationId"],
+      },
+      {
+        fields: ["dataSourceId"],
+      },
+      {
+        fields: ["dataSourceViewId"],
+      },
     ],
     sequelize: frontSequelize,
     hooks: {

--- a/front/migrations/db/migration_90.sql
+++ b/front/migrations/db/migration_90.sql
@@ -1,0 +1,4 @@
+-- Migration created on Sep 25, 2024
+CREATE INDEX CONCURRENTLY "agent_data_source_configurations_data_source_id" ON "agent_data_source_configurations" ("dataSourceId");
+CREATE INDEX CONCURRENTLY "agent_data_source_configurations_data_source_view_id" ON "agent_data_source_configurations" ("dataSourceViewId");
+CREATE INDEX CONCURRENTLY "agent_data_source_configurations_process_configuration_id" ON "agent_data_source_configurations" ("processConfigurationId");


### PR DESCRIPTION
## Description

**Indexes on dataSourceId & dataSouceViewId**
We noticed that theses indexes were missing and are probably useful.

**Index on processConfigurationId**
For consistency with `retrievalConfigurationId`.

## Risk

None

## Deploy Plan

Already applied in prod manually.