### PR TITLE
chore: migrate qdrant client to use new API

### DIFF
--- a/core/bin/qdrant/migrate_embedder.rs
+++ b/core/bin/qdrant/migrate_embedder.rs
@@ -443,7 +443,7 @@ async fn migrate_shadow_embedder(
                 qdrant::PointStruct::new(
                     r.id.unwrap(),
                     r.vectors.unwrap(),
-                    Payload::new_from_hashmap(r.payload),
+                    Payload::from(r.payload),
                 )
             })
             .collect::<Vec<_>>();
@@ -512,7 +512,7 @@ async fn migrate_shadow_embedder(
                 .iter()
                 .map(|ci| match embeddings.get(&ci.hash) {
                     Some(v) => {
-                        let payload = Payload::new_from_hashmap(ci.payload.clone());
+                        let payload = Payload::from(ci.payload.clone());
 
                         let ps = qdrant::PointStruct::new(
                             ci.hash.to_string(),


### PR DESCRIPTION
## Description

We have deprecation warnings when building `core` since we updated `qdrant_client` from 1.9.x to 1.10+.

Main changes:
- `QdrantClient` -> `Qdrant`
- `QdrantClientConfig` -> `QdrantConfig`
- client methods now use a "builder" pattern, instead of positional args + `...Default()`
- They removed all the `xxx_blocking` methods, and there is now a `.wait()` method to replace them. By default, qdrant is eventually consistent but with `wait` you can wait for changes to be actually propagated (but AFAICT we never use that)
- `Payload::new_from_hashmap` is deprecated and replaced with `::from`

## Risk

Somewhat risky as it touches qdrant client

## Deploy Plan

deploy core