### PR TITLE
feat(snowflake): enforce tables are compatible w/ each other (core)

### DIFF
--- a/core/src/blocks/database.rs
+++ b/core/src/blocks/database.rs
@@ -10,7 +10,9 @@ use crate::{
         database_schema::load_tables_from_identifiers,
     },
     databases::{
-        error::QueryDatabaseError, transient_database::execute_query_on_transient_database,
+        error::QueryDatabaseError,
+        table::{get_table_type_for_tables, TableType},
+        transient_database::execute_query_on_transient_database,
     },
     Rule,
 };
@@ -107,7 +109,20 @@ impl Block for Database {
         let query = replace_variables_in_string(&self.query, "query", env)?;
         let tables = load_tables_from_identifiers(&table_identifiers, env).await?;
 
-        match execute_query_on_transient_database(&tables, env.store.clone(), &query).await {
+        let result = match get_table_type_for_tables(tables.iter().collect::<Vec<_>>())? {
+            TableType::Local => {
+                execute_query_on_transient_database(&tables, env.store.clone(), &query).await
+            }
+            TableType::Remote(_remote_db_secret_id) => Err(QueryDatabaseError::GenericError(
+                // TODO(SNOWFLAKE) - Implement remote tables support.
+                // - fetch secret from oauth
+                // - create RemoteDatabase of correct type based on provider
+                // - execute query
+                anyhow!("Remote tables support is not yet implemented."),
+            )),
+        };
+
+        match result {
             Ok((results, schema)) => Ok(BlockResult {
                 value: json!({
                     "results": results,


### PR DESCRIPTION
## Description

Adds a check to enforce `Table` instances are compatible with each other before querying or getting schema for a DB in `core`

## Risk

N/A

## Deploy Plan

N/A