### PR TITLE
Remove first batch of TODO(DATASOURCE_SID)

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -275,12 +275,7 @@ const dataSource = async (command: string, args: parseArgs.ParsedArgs) => {
 
       const auth = await Authenticator.internalAdminForWorkspace(args.wId);
 
-      const dataSource = await DataSourceResource.fetchByNameOrId(
-        auth,
-        args.dsId,
-        // TODO(DATASOURCE_SID): Clean-up
-        { origin: "cli_delete" }
-      );
+      const dataSource = await DataSourceResource.fetchById(auth, args.dsId);
       if (!dataSource) {
         throw new Error(
           `DataSource not found: wId='${args.wId}' dsId='${args.dsId}'`
@@ -391,14 +386,7 @@ const dataSource = async (command: string, args: parseArgs.ParsedArgs) => {
 
       const auth = await Authenticator.internalAdminForWorkspace(args.wId);
 
-      const dataSource = await DataSourceResource.fetchByNameOrId(
-        auth,
-        args.dsId,
-        {
-          // TODO(DATASOURCE_SID): Clean-up
-          origin: "cli_delete_document",
-        }
-      );
+      const dataSource = await DataSourceResource.fetchById(auth, args.dsId);
       if (!dataSource) {
         throw new Error(
           `DataSource not found: wId='${args.wId}' dsId='${args.dsId}'`

--- a/front/lib/documents_post_process_hooks/hooks/data_source_helpers.ts
+++ b/front/lib/documents_post_process_hooks/hooks/data_source_helpers.ts
@@ -114,12 +114,8 @@ export async function getDatasource(
   if (!workspace) {
     throw new Error(`Could not find workspace ${owner.sId}`);
   }
-  const dataSource = await DataSourceResource.fetchByNameOrId(
-    auth,
-    dataSourceId,
-    // TOOD(DATASOURCE_SID): clean-up
-    { origin: "post_upsert_hook_helper" }
-  );
+
+  const dataSource = await DataSourceResource.fetchById(auth, dataSourceId);
   if (!dataSource) {
     throw new Error(
       `Could not find data source with name ${dataSourceId} and workspace ${owner.sId}`

--- a/front/lib/resources/labs_transcripts_resource.ts
+++ b/front/lib/resources/labs_transcripts_resource.ts
@@ -136,12 +136,7 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
       return;
     }
 
-    const dataSource = await DataSourceResource.fetchByNameOrId(
-      auth,
-      dataSourceId,
-      // TODO(DATASOURCE_SID): clean-up
-      { origin: "labs_transcripts_resource" }
-    );
+    const dataSource = await DataSourceResource.fetchById(auth, dataSourceId);
 
     if (!dataSource || this.dataSourceId === dataSource.id) {
       return;

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/config.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/config.ts
@@ -45,12 +45,7 @@ async function handler(
     });
   }
 
-  const dataSource = await DataSourceResource.fetchByNameOrId(
-    auth,
-    dsId,
-    // TODO(DATASOURCE_SID): Clean-up
-    { origin: "poke_data_sources_config" }
-  );
+  const dataSource = await DataSourceResource.fetchById(auth, dsId);
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/documents/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/documents/index.ts
@@ -45,12 +45,7 @@ async function handler(
     });
   }
 
-  const dataSource = await DataSourceResource.fetchByNameOrId(
-    auth,
-    dsId,
-    // TODO(DATASOURCE_SID): Clean-up
-    { origin: "poke_data_sources_documents" }
-  );
+  const dataSource = await DataSourceResource.fetchById(auth, dsId);
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/index.ts
@@ -44,12 +44,7 @@ async function handler(
     });
   }
 
-  const dataSource = await DataSourceResource.fetchByNameOrId(
-    auth,
-    dsId,
-    // TODO(DATASOURCE_SID): Clean-up
-    { origin: "poke_data_sources" }
-  );
+  const dataSource = await DataSourceResource.fetchById(auth, dsId);
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/managed/permissions.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/managed/permissions.ts
@@ -41,12 +41,7 @@ async function handler(
     });
   }
 
-  const dataSource = await DataSourceResource.fetchByNameOrId(
-    auth,
-    dsId,
-    // TODO(DATASOURCE_SID): Clean-up
-    { origin: "poke_data_sources_permissions" }
-  );
+  const dataSource = await DataSourceResource.fetchById(auth, dsId);
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/search.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/search.ts
@@ -39,12 +39,7 @@ async function handler(
     });
   }
 
-  const dataSource = await DataSourceResource.fetchByNameOrId(
-    auth,
-    dsId,
-    // TODO(DATASOURCE_SID): Clean-up
-    { origin: "poke_data_sources_search" }
-  );
+  const dataSource = await DataSourceResource.fetchById(auth, dsId);
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/configuration.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/configuration.ts
@@ -46,12 +46,7 @@ async function handler(
       },
     });
   }
-  const dataSource = await DataSourceResource.fetchByNameOrId(
-    auth,
-    dsId,
-    // TODO(DATASOURCE_SID): Clean-up
-    { origin: "data_source_configuration" }
-  );
+  const dataSource = await DataSourceResource.fetchById(auth, dsId);
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/connector.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/connector.ts
@@ -28,12 +28,8 @@ async function handler(
       },
     });
   }
-  const dataSource = await DataSourceResource.fetchByNameOrId(
-    auth,
-    dsId,
-    // TODO(DATASOURCE_SID): Clean-up
-    { origin: "data_source_configuration" }
-  );
+
+  const dataSource = await DataSourceResource.fetchById(auth, dsId);
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -48,12 +48,7 @@ async function handler(
     });
   }
 
-  const dataSource = await DataSourceResource.fetchByNameOrId(
-    auth,
-    dsId,
-    // TODO(DATASOURCE_SID): Clean-up
-    { origin: "data_source_get_document_by_id" }
-  );
+  const dataSource = await DataSourceResource.fetchById(auth, dsId);
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/documents/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/documents/index.ts
@@ -30,12 +30,7 @@ async function handler(
     });
   }
 
-  const dataSource = await DataSourceResource.fetchByNameOrId(
-    auth,
-    dsId,
-    // TODO(DATASOURCE_SID): Clean-up
-    { origin: "data_source_get_documents" }
-  );
+  const dataSource = await DataSourceResource.fetchById(auth, dsId);
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 400,

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/index.ts
@@ -32,12 +32,7 @@ async function handler(
     });
   }
 
-  const dataSource = await DataSourceResource.fetchByNameOrId(
-    auth,
-    dsId,
-    // TODO(DATASOURCE_SID): Clean-up and rename parameter as [dsId]
-    { origin: "data_source_get_or_post" }
-  );
+  const dataSource = await DataSourceResource.fetchById(auth, dsId);
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]/index.ts
@@ -38,12 +38,7 @@ async function handler(
     });
   }
 
-  const dataSource = await DataSourceResource.fetchByNameOrId(
-    auth,
-    dsId,
-    // TODO(DATASOURCE_SID): Clean-up
-    { origin: "data_source_managed_config" }
-  );
+  const dataSource = await DataSourceResource.fetchById(auth, dsId);
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions/index.ts
@@ -71,12 +71,7 @@ async function handler(
     });
   }
 
-  const dataSource = await DataSourceResource.fetchByNameOrId(
-    auth,
-    dsId,
-    // TODO(DATASOURCE_SID): Clean-up
-    { origin: "data_source_managed_permissions" }
-  );
+  const dataSource = await DataSourceResource.fetchById(auth, dsId);
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/slack/channels_linked_with_agent.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/slack/channels_linked_with_agent.ts
@@ -46,12 +46,7 @@ async function handler(
     });
   }
 
-  const dataSource = await DataSourceResource.fetchByNameOrId(
-    auth,
-    dsId,
-    // TODO(DATASOURCE_SID): Clean-up
-    { origin: "data_source_managed_slack" }
-  );
+  const dataSource = await DataSourceResource.fetchById(auth, dsId);
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/update.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/update.ts
@@ -53,13 +53,8 @@ async function handler(
     });
   }
 
-  // fetchByName enforces through auth the authorization (workspace here mainly).
-  const dataSource = await DataSourceResource.fetchByNameOrId(
-    auth,
-    dsId,
-    // TOOD(DATASOURCE_SID): Clean-up and rename param as [dsId]
-    { origin: "data_source_managed_update" }
-  );
+  // fetchById enforces through auth the authorization (workspace here mainly).
+  const dataSource = await DataSourceResource.fetchById(auth, dsId);
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/search.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/search.ts
@@ -62,12 +62,7 @@ async function handler(
     });
   }
 
-  const dataSource = await DataSourceResource.fetchByNameOrId(
-    auth,
-    dsId,
-    // TODO(DATASOURCE_SID): Clean-up
-    { origin: "data_source_search" }
-  );
+  const dataSource = await DataSourceResource.fetchById(auth, dsId);
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/tables/[tId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/tables/[tId]/index.ts
@@ -32,12 +32,7 @@ async function handler(
     });
   }
 
-  const dataSource = await DataSourceResource.fetchByNameOrId(
-    auth,
-    dsId,
-    // TODO(DATASOURCE_SID): Clean-up
-    { origin: "data_source_tables_table" }
-  );
+  const dataSource = await DataSourceResource.fetchById(auth, dsId);
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/tables/csv.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/tables/csv.ts
@@ -77,12 +77,7 @@ async function handler(
     });
   }
 
-  const dataSource = await DataSourceResource.fetchByNameOrId(
-    auth,
-    dsId,
-    // TODO(DATASOURCE_SID): Clean-up
-    { origin: "data_source_tables_csv" }
-  );
+  const dataSource = await DataSourceResource.fetchById(auth, dsId);
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/tables/index.ts
@@ -41,12 +41,7 @@ async function handler(
     });
   }
 
-  const dataSource = await DataSourceResource.fetchByNameOrId(
-    auth,
-    dsId,
-    // TODO(DATASOURCE_SID): Clean-up
-    { origin: "data_source_tables" }
-  );
+  const dataSource = await DataSourceResource.fetchById(auth, dsId);
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/usage.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/usage.ts
@@ -32,13 +32,7 @@ async function handler(
     });
   }
 
-  const dataSource = await DataSourceResource.fetchByNameOrId(
-    auth,
-    dsId,
-    // TODO(DATASOURCE_SID): Clean-up and rename parameter as [dsId]
-    { origin: "data_source_get_or_post" }
-  );
-
+  const dataSource = await DataSourceResource.fetchById(auth, dsId);
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/[dsId]/configuration.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/[dsId]/configuration.ts
@@ -34,22 +34,13 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  if (typeof req.query.vId !== "string") {
+  const { dsId, vId } = req.query;
+  if (typeof dsId !== "string" || typeof vId !== "string") {
     return apiError(req, res, {
-      status_code: 404,
+      status_code: 400,
       api_error: {
-        type: "vault_not_found",
-        message: "The vault you requested was not found.",
-      },
-    });
-  }
-
-  if (!req.query.dsId || typeof req.query.dsId !== "string") {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "data_source_not_found",
-        message: "The data source you requested was not found.",
+        type: "invalid_request_error",
+        message: "Invalid path parameters.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/[dsId]/configuration.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/[dsId]/configuration.ts
@@ -54,12 +54,7 @@ async function handler(
     });
   }
 
-  const dataSource = await DataSourceResource.fetchByNameOrId(
-    auth,
-    req.query.dsId,
-    // TODO(DATASOURCE_SID): Clean-up
-    { origin: "vault_data_source_config" }
-  );
+  const dataSource = await DataSourceResource.fetchById(auth, dsId);
   if (!dataSource || dataSource.vault.sId !== req.query.vId) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/[dsId]/documents/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/[dsId]/documents/index.ts
@@ -43,11 +43,7 @@ async function handler(
     });
   }
 
-  const dataSource = await DataSourceResource.fetchByNameOrId(auth, dsId, {
-    // TODO(DATASOURCE_SID): clean-up
-    origin: "vault_data_source_documents",
-  });
-
+  const dataSource = await DataSourceResource.fetchById(auth, dsId);
   if (
     !dataSource ||
     vId !== dataSource.vault.sId ||

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/[dsId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/[dsId]/index.ts
@@ -81,12 +81,7 @@ async function handler(
     });
   }
 
-  const dataSource = await DataSourceResource.fetchByNameOrId(
-    auth,
-    dsId,
-    // TODO(DATASOURCE_SID): Clean-up
-    { origin: "vault_patch_or_delete_data_source" }
-  );
+  const dataSource = await DataSourceResource.fetchById(auth, dsId);
   if (!dataSource) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -72,10 +72,8 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
     };
   }
 
-  const dataSource = await DataSourceResource.fetchByNameOrId(auth, dsId, {
+  const dataSource = await DataSourceResource.fetchById(auth, dsId, {
     includeEditedBy: true,
-    // TODO(DATASOURCE_SID): Clean-up
-    origin: "poke_data_sources_page",
   });
   if (!dataSource) {
     return {

--- a/front/pages/poke/[wId]/data_sources/[dsId]/search.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/search.tsx
@@ -25,10 +25,8 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
     };
   }
 
-  const dataSource = await DataSourceResource.fetchByNameOrId(auth, dsId, {
+  const dataSource = await DataSourceResource.fetchById(auth, dsId, {
     includeEditedBy: true,
-    // TODO(DATASOURCE_SID): Clean-up
-    origin: "poke_data_sources_page_search",
   });
   if (!dataSource) {
     return {

--- a/front/pages/poke/[wId]/data_sources/[dsId]/view.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/view.tsx
@@ -20,10 +20,8 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
     };
   }
 
-  const dataSource = await DataSourceResource.fetchByNameOrId(auth, dsId, {
+  const dataSource = await DataSourceResource.fetchById(auth, dsId, {
     includeEditedBy: true,
-    // TODO(DATASOURCE_SID): Clean-up
-    origin: "poke_data_sources_page_view",
   });
   if (!dataSource) {
     return {

--- a/front/temporal/documents_post_process_hooks/activities.ts
+++ b/front/temporal/documents_post_process_hooks/activities.ts
@@ -135,16 +135,12 @@ async function getDataSourceDocument({
   }
 
   const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
-  const dataSource = await DataSourceResource.fetchByNameOrId(
-    auth,
-    dataSourceId,
-    // TODO(DATASOURCE_SID): clean-up
-    { origin: "post_upsert_hook_activities" }
-  );
 
+  const dataSource = await DataSourceResource.fetchById(auth, dataSourceId);
   if (!dataSource) {
     return new Err(new Error(`Could not find data source ${dataSourceId}`));
   }
+
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
   const docText = await coreAPI.getDataSourceDocument({
     projectId: dataSource.dustAPIProjectId,

--- a/front/temporal/upsert_queue/activities.ts
+++ b/front/temporal/upsert_queue/activities.ts
@@ -57,11 +57,9 @@ export async function upsertDocumentActivity(
     upsertQueueItem.workspaceId
   );
 
-  const dataSource = await DataSourceResource.fetchByNameOrId(
+  const dataSource = await DataSourceResource.fetchById(
     auth,
-    upsertQueueItem.dataSourceId,
-    // TODO(DATASOURCE_SID): Clean-up
-    { origin: "upsert_queue_activities" }
+    upsertQueueItem.dataSourceId
   );
   if (!dataSource) {
     // If the data source was not found, we simply give up and remove the item from the queue as it
@@ -205,11 +203,9 @@ export async function upsertTableActivity(
     return;
   }
 
-  const dataSource = await DataSourceResource.fetchByNameOrId(
+  const dataSource = await DataSourceResource.fetchById(
     auth,
-    upsertQueueItem.dataSourceId,
-    // TODO(DATASOURCE_SID): Clean-up
-    { origin: "upsert_queue_activities" }
+    upsertQueueItem.dataSourceId
   );
   if (!dataSource) {
     // If the data source was not found, we simply give up and remove the item from the queue as it


### PR DESCRIPTION
## Description

All these queries are using `sId`s as per:
https://app.datadoghq.eu/logs?query=%22fetchByNameOrId%22%20%40type%3Aname%20&agg_m=count&agg_m_source=base&agg_q=%40origin%2C%40success&agg_q_source=base%2Cbase&agg_t=count&analyticsOptions=%5B%22bars%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&cols=host%2Cservice%2C%40origin%2C%40success&fromUser=true&messageDisplay=inline&refresh_mode=sliding&sort_m=%2C&sort_m_source=%2C&sort_t=%2C&storage=hot&stream_sort=time%2Cdesc&top_n=10%2C10&top_o=top%2Ctop&viz=toplist&x_missing=true%2Ctrue&from_ts=1725445881711&to_ts=1725532281711&live=true

So we move to `fetchById` directly instead of `fetchByIdOrName` and remove the associated TODOs

Design doc: https://www.notion.so/dust-tt/Engineering-e0f834b5be5a43569baaf76e9c41adf2?p=55a4dee1fb6f40309674ec262ddf964d&pm=s

## Risk

Low. Tested in dev thoroughly

## Deploy Plan

- deploy `front`