### PR TITLE
[front] - refacto(DocumentOrTableUploadOrEditModal): enhancements & fixes

### DIFF
--- a/front/components/data_source/DocumentOrTableUploadOrEditModal.tsx
+++ b/front/components/data_source/DocumentOrTableUploadOrEditModal.tsx
@@ -443,7 +443,8 @@ interface Table {
   file: File | null;
 }
 
-interface TableUploadOrEditModalProps extends DocumentOrTableUploadOrEditModalProps {
+interface TableUploadOrEditModalProps
+  extends DocumentOrTableUploadOrEditModalProps {
   table: CoreAPITable | null;
   isTableError: boolean;
   isTableLoading: boolean;

--- a/front/components/data_source/DocumentOrTableUploadOrEditModal.tsx
+++ b/front/components/data_source/DocumentOrTableUploadOrEditModal.tsx
@@ -58,6 +58,11 @@ interface TableOrDocument {
   sourceUrl: string;
 }
 
+interface EditionStatus {
+  name: boolean;
+  content: boolean;
+}
+
 const supportedTableFormats = [".csv", ".tsv"].join(", ");
 
 const supportedDocumentFormats = [".txt", ".pdf", ".md", ".csv"].join(", ");
@@ -96,6 +101,10 @@ export function DocumentOrTableUploadOrEditModal({
     text: "",
     tags: [],
     sourceUrl: "",
+  });
+  const [editionStatus, setEditionStatus] = useState<EditionStatus>({
+    name: false,
+    content: false,
   });
 
   const [uploading, setUploading] = useState(false);
@@ -379,15 +388,19 @@ export function DocumentOrTableUploadOrEditModal({
                   maxLength={MAX_NAME_CHARS}
                   disabled={!!initialId}
                   value={tableOrDoc.name}
-                  onChange={(value) =>
-                    setTableOrDoc((prev) => ({ ...prev, name: value }))
-                  }
+                  onChange={(value) => {
+                    setEditionStatus((prev) => ({ ...prev, name: true }));
+                    setTableOrDoc((prev) => ({ ...prev, name: value }));
+                  }}
                   error={
                     isTable &&
                     !tableOrDoc.name &&
+                    editionStatus.name &&
                     !isSlugified(tableOrDoc.name)
                       ? `Invalid name: Must be alphanumeric, max ${MAX_NAME_CHARS} characters and no space.`
-                      : !isTable && !tableOrDoc.name ? "You need to provide a name." : null
+                      : !isTable && editionStatus.name && !tableOrDoc.name
+                        ? "You need to provide a name."
+                        : null
                   }
                   showErrorLabel={true}
                 />
@@ -403,13 +416,17 @@ export function DocumentOrTableUploadOrEditModal({
                     placeholder="This table contains..."
                     value={tableOrDoc.description}
                     onChange={(value) => {
+                      setEditionStatus((prev) => ({
+                        ...prev,
+                        content: true,
+                      }));
                       setTableOrDoc((prev) => ({
                         ...prev,
                         description: value,
                       }));
                     }}
                     error={
-                      !tableOrDoc.description
+                      !tableOrDoc.description && editionStatus.content
                         ? "You need to provide a description to your CSV file."
                         : null
                     }
@@ -494,12 +511,12 @@ export function DocumentOrTableUploadOrEditModal({
                       "focus:border-action-300 focus:ring-action-300"
                     )}
                     value={tableOrDoc.text}
-                    onChange={(e) =>
+                    onChange={(e) => {
                       setTableOrDoc((prev) => ({
                         ...prev,
                         text: e.target.value,
-                      }))
-                    }
+                      }));
+                    }}
                   />
                 )}
               </div>

--- a/front/components/data_source/DocumentOrTableUploadOrEditModal.tsx
+++ b/front/components/data_source/DocumentOrTableUploadOrEditModal.tsx
@@ -16,56 +16,22 @@ import type {
   ContentNodesViewType,
   CoreAPIDocument,
   CoreAPILightDocument,
+  CoreAPITable,
   DataSourceViewType,
   LightContentNode,
   LightWorkspaceType,
   PlanType,
 } from "@dust-tt/types";
-import {
-  BIG_FILE_SIZE,
-  Err,
-  isSlugified,
-  MAX_FILE_LENGTH,
-  MAX_FILE_SIZES,
-  parseAndStringifyCsv,
-} from "@dust-tt/types";
+import { parseAndStringifyCsv } from "@dust-tt/types";
+import { Err } from "@dust-tt/types";
+import { BIG_FILE_SIZE, isSlugified, MAX_FILE_SIZES } from "@dust-tt/types";
 import React, { useContext, useEffect, useRef, useState } from "react";
 
-import { DocumentLimitPopup } from "@app/components/data_source/DocumentLimitPopup";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { handleFileUploadToText } from "@app/lib/client/handle_file_upload";
 import { useDataSourceViewDocument } from "@app/lib/swr/data_source_views";
 import { useTable } from "@app/lib/swr/tables";
 import { classNames } from "@app/lib/utils";
-
-interface DocumentOrTableUploadOrEditModalProps {
-  contentNode?: LightContentNode;
-  dataSourceView: DataSourceViewType;
-  isOpen: boolean;
-  onClose: (save: boolean) => void;
-  owner: LightWorkspaceType;
-  plan: PlanType;
-  totalNodesCount: number;
-  viewType: ContentNodesViewType;
-}
-
-interface TableOrDocument {
-  name: string;
-  description: string;
-  file: File | null;
-  text: string;
-  tags: string[];
-  sourceUrl: string;
-}
-
-interface EditionStatus {
-  name: boolean;
-  content: boolean;
-}
-
-const supportedTableFormats = [".csv", ".tsv"].join(", ");
-
-const supportedDocumentFormats = [".txt", ".pdf", ".md", ".csv"].join(", ");
 
 const MAX_NAME_CHARS = 32;
 
@@ -81,93 +47,111 @@ function isCoreAPIDocumentType(
   );
 }
 
-const getErrorMessage = (
-  isTable: boolean,
-  tableOrDoc: TableOrDocument,
-  editionStatus: EditionStatus
-) => {
-  if (
-    isTable &&
-    !tableOrDoc.name &&
-    editionStatus.name &&
-    !isSlugified(tableOrDoc.name)
-  ) {
-    return `Invalid name: Must be alphanumeric, max ${MAX_NAME_CHARS} characters and no space.`;
-  } else if (!isTable && editionStatus.name && !tableOrDoc.name) {
-    return "You need to provide a name.";
-  }
-  return null;
-};
+interface DocumentOrTableUploadOrEditModalProps {
+  contentNode?: LightContentNode;
+  dataSourceView: DataSourceViewType;
+  isOpen: boolean;
+  onClose: (save: boolean) => void;
+  owner: LightWorkspaceType;
+  plan: PlanType;
+  totalNodesCount: number;
+  viewType: ContentNodesViewType;
+}
 
-export function DocumentOrTableUploadOrEditModal({
-  contentNode,
+export function DocumentOrTableUploadOrEditModal(
+  props: DocumentOrTableUploadOrEditModalProps
+) {
+  const isTable = props.viewType === "tables";
+  const initialId = props.contentNode?.internalId;
+
+  const { table, isTableError, isTableLoading } = useTable({
+    owner: props.owner,
+    dataSourceView: props.dataSourceView,
+    tableId: isTable ? initialId ?? null : null,
+    disabled: !isTable,
+  });
+
+  const { document, isDocumentError, isDocumentLoading } =
+    useDataSourceViewDocument({
+      owner: props.owner,
+      dataSourceView: props.dataSourceView,
+      documentId: !isTable ? initialId ?? null : null,
+      disabled: isTable,
+    });
+  return isTable ? (
+    <TableUploadOrEditModal
+      {...props}
+      table={table}
+      isTableError={isTableError}
+      isTableLoading={isTableLoading ?? false}
+      initialId={initialId}
+    />
+  ) : (
+    <DocumentUploadOrEditModal
+      {...props}
+      document={document ?? null}
+      isDocumentError={isDocumentError}
+      isDocumentLoading={isDocumentLoading}
+      initialId={initialId}
+    />
+  );
+}
+
+interface Document {
+  name: string;
+  file: File | null;
+  text: string;
+  tags: string[];
+  sourceUrl: string;
+}
+
+interface DocumentUploadOrEditModalProps
+  extends DocumentOrTableUploadOrEditModalProps {
+  document: CoreAPIDocument | null;
+  isDocumentError: boolean;
+  isDocumentLoading: boolean;
+  initialId?: string;
+}
+
+const DocumentUploadOrEditModal = ({
+  document,
+  isDocumentError,
+  isDocumentLoading,
+  initialId,
   dataSourceView,
   isOpen,
   onClose,
   owner,
   plan,
-  totalNodesCount,
-  viewType,
-}: DocumentOrTableUploadOrEditModalProps) {
+}: DocumentUploadOrEditModalProps) => {
   const sendNotification = useContext(SendNotificationsContext);
   const fileInputRef = useRef<HTMLInputElement>(null);
-
-  const [tableOrDoc, setTableOrDoc] = useState<TableOrDocument>({
+  const [documentState, setDocumentState] = useState<Document>({
     name: "",
-    description: "",
     file: null,
     text: "",
     tags: [],
     sourceUrl: "",
   });
-  const [editionStatus, setEditionStatus] = useState<EditionStatus>({
+  const [editionStatus, setEditionStatus] = useState({
     name: false,
     content: false,
   });
-
   const [uploading, setUploading] = useState(false);
-  const [isBigFile, setIsBigFile] = useState(false);
-  const [isValidDocOrTable, setIsValidDocOrTable] = useState(false);
+  const [isValidDocument, setIsValidDocument] = useState(false);
   const [developerOptionsVisible, setDeveloperOptionsVisible] = useState(false);
-
-  const isTable = viewType == "tables";
-  const initialId = contentNode?.internalId;
-
-  const { table, isTableError, isTableLoading } = useTable({
-    owner,
-    dataSourceView,
-    tableId: isTable ? initialId ?? null : null,
-  });
-
-  const { document, isDocumentError, isDocumentLoading } =
-    useDataSourceViewDocument({
-      owner,
-      dataSourceView,
-      documentId: !isTable ? initialId ?? null : null,
-    });
-
-  const resetTableOrDoc = () => {
-    setTableOrDoc({
-      name: "",
-      description: "",
-      file: null,
-      text: "",
-      tags: [],
-      sourceUrl: "",
-    });
-  };
 
   useEffect(() => {
     if (!initialId) {
-      resetTableOrDoc();
-    } else if (isTable && table) {
-      setTableOrDoc((prev) => ({
-        ...prev,
-        name: table.name,
-        description: table.description,
-      }));
-    } else if (!isTable && document && isCoreAPIDocumentType(document)) {
-      setTableOrDoc((prev) => ({
+      setDocumentState({
+        name: "",
+        file: null,
+        text: "",
+        tags: [],
+        sourceUrl: "",
+      });
+    } else if (document && isCoreAPIDocumentType(document)) {
+      setDocumentState((prev) => ({
         ...prev,
         name: initialId,
         text: document.text ?? "",
@@ -175,96 +159,15 @@ export function DocumentOrTableUploadOrEditModal({
         sourceUrl: document.source_url ?? "",
       }));
     }
-  }, [isTable, initialId, table, owner.sId, document]);
+  }, [initialId, document]);
 
   useEffect(() => {
-    const isNameValid = isTable
-      ? !!tableOrDoc.name && isSlugified(tableOrDoc.name)
-      : !!tableOrDoc.name;
-    const isContentValid = isTable
-      ? !!tableOrDoc.description
-      : !!tableOrDoc.text || !!tableOrDoc.file;
-    setIsValidDocOrTable(isNameValid && isContentValid);
-  }, [isTable, tableOrDoc]);
+    const isNameValid = !!documentState.name;
+    const isContentValid = !!documentState.text || !!documentState.file;
+    setIsValidDocument(isNameValid && isContentValid);
+  }, [documentState]);
 
-  const isLoading = isTableLoading || isDocumentLoading;
-  const isError = isDocumentError || isTableError;
-
-  if (
-    !initialId &&
-    plan.limits.dataSources.documents.count !== -1 &&
-    totalNodesCount >= plan.limits.dataSources.documents.count
-  ) {
-    return (
-      <DocumentLimitPopup
-        isOpen={isOpen}
-        plan={plan}
-        onClose={() => onClose(false)}
-        owner={owner}
-      />
-    );
-  }
-
-  const handleTableUpload = async (table: TableOrDocument) => {
-    setUploading(true);
-    try {
-      const fileContent = table.file
-        ? await handleFileUploadToText(table.file)
-        : null;
-      if (fileContent && fileContent.isErr()) {
-        return new Err(fileContent.error);
-      }
-
-      const csvContent = fileContent?.value
-        ? await parseAndStringifyCsv(fileContent.value.content)
-        : null;
-
-      if (csvContent && csvContent.length > MAX_FILE_LENGTH) {
-        throw new Error("File too large");
-      }
-
-      const base = `/api/w/${owner.sId}/vaults/${dataSourceView.vaultId}/data_sources/${dataSourceView.dataSource.sId}/tables`;
-      const endpoint = initialId ? `${base}/${initialId}` : base;
-
-      const body = JSON.stringify({
-        name: table.name,
-        description: table.description,
-        csv: csvContent,
-        tableId: initialId,
-        timestamp: null,
-        tags: [],
-        parents: [],
-        truncate: false,
-        async: false,
-      });
-
-      const res = await fetch(endpoint, {
-        method: initialId ? "PATCH" : "POST",
-        headers: { "Content-Type": "application/json" },
-        body,
-      });
-
-      if (!res.ok) {
-        throw new Error("Failed to upsert table");
-      }
-
-      sendNotification({
-        type: "success",
-        title: `Table successfully ${initialId ? "updated" : "added"}`,
-        description: `Table ${table.name} was successfully ${initialId ? "updated" : "added"}.`,
-      });
-    } catch (error) {
-      sendNotification({
-        type: "error",
-        title: "Error upserting table",
-        description: `An error occurred: ${error instanceof Error ? error.message : String(error)}.`,
-      });
-    } finally {
-      setUploading(false);
-    }
-  };
-
-  const handleDocumentUpload = async (document: TableOrDocument) => {
+  const handleDocumentUpload = async (document: Document) => {
     setUploading(true);
     try {
       const base = `/api/w/${owner.sId}/vaults/${dataSourceView.vaultId}/data_sources/${dataSourceView.dataSource.sId}/documents`;
@@ -313,14 +216,9 @@ export function DocumentOrTableUploadOrEditModal({
 
   const handleUpload = async () => {
     try {
-      if (isTable) {
-        await handleTableUpload(tableOrDoc);
-      } else {
-        await handleDocumentUpload(tableOrDoc);
-      }
+      await handleDocumentUpload(documentState);
       onClose(true);
     } catch (error) {
-      // Error notifications are already handled in the individual functions
       console.error(error);
     }
   };
@@ -343,16 +241,11 @@ export function DocumentOrTableUploadOrEditModal({
         return;
       }
 
-      if (isTable) {
-        setTableOrDoc((prev) => ({ ...prev, file: selectedFile }));
-        setIsBigFile(selectedFile.size > BIG_FILE_SIZE);
-      } else {
-        const res = await handleFileUploadToText(selectedFile);
-        if (res.isErr()) {
-          return new Err(res.error);
-        }
-        setTableOrDoc((prev) => ({ ...prev, text: res.value.content }));
+      const res = await handleFileUploadToText(selectedFile);
+      if (res.isErr()) {
+        return new Err(res.error);
       }
+      setDocumentState((prev) => ({ ...prev, text: res.value.content }));
     } catch (error) {
       sendNotification({
         type: "error",
@@ -370,110 +263,74 @@ export function DocumentOrTableUploadOrEditModal({
       onClose={() => {
         onClose(false);
       }}
-      hasChanged={!isError && !isLoading && isValidDocOrTable}
+      hasChanged={!isDocumentError && !isDocumentLoading && isValidDocument}
       variant="side-md"
-      title={`${initialId ? "Edit" : "Add"} ${isTable ? "table" : "document"}`}
+      title={`${initialId ? "Edit" : "Add"} document`}
       onSave={handleUpload}
       isSaving={uploading}
     >
-      {isLoading ? (
+      {isDocumentLoading ? (
         <div className="flex justify-center py-4">
           <Spinner variant="color" size="xs" />
         </div>
       ) : (
         <Page.Vertical align="stretch">
-          {isError ? (
+          {isDocumentError ? (
             <div className="space-y-4 p-4">Content cannot be loaded.</div>
           ) : (
             <div className="space-y-4 p-4">
               <div>
-                <Page.SectionHeader
-                  title={`${isTable ? "Table" : "Document"} name`}
-                />
+                <Page.SectionHeader title="Document name" />
                 <Input
-                  placeholder={isTable ? "table_name" : "Document title"}
+                  placeholder="Document title"
                   name="name"
                   maxLength={MAX_NAME_CHARS}
                   disabled={!!initialId}
-                  value={tableOrDoc.name}
+                  value={documentState.name}
                   onChange={(value) => {
                     setEditionStatus((prev) => ({ ...prev, name: true }));
-                    setTableOrDoc((prev) => ({ ...prev, name: value }));
+                    setDocumentState((prev) => ({ ...prev, name: value }));
                   }}
-                  error={getErrorMessage(isTable, tableOrDoc, editionStatus)}
+                  error={
+                    !documentState.name && editionStatus.name
+                      ? "You need to provide a name."
+                      : null
+                  }
                   showErrorLabel={true}
                 />
               </div>
 
-              {isTable ? (
-                <div>
-                  <Page.SectionHeader
-                    title="Description"
-                    description="Describe the content of your CSV file. It will be used by the LLM model to generate relevant queries."
-                  />
-                  <TextArea
-                    placeholder="This table contains..."
-                    value={tableOrDoc.description}
-                    onChange={(value) => {
-                      setEditionStatus((prev) => ({
-                        ...prev,
-                        content: true,
-                      }));
-                      setTableOrDoc((prev) => ({
-                        ...prev,
-                        description: value,
-                      }));
-                    }}
-                    error={
-                      !tableOrDoc.description && editionStatus.content
-                        ? "You need to provide a description to your CSV file."
-                        : null
-                    }
-                    showErrorLabel={true}
-                    minRows={10}
-                  />
-                </div>
-              ) : (
-                <div>
-                  <Page.SectionHeader
-                    title="Associated URL"
-                    description="The URL of the associated document (if any). Will be used to link users to the original document in assistants citations."
-                  />
-                  <Input
-                    placeholder="https://..."
-                    name="sourceUrl"
-                    value={tableOrDoc.sourceUrl}
-                    onChange={(value) =>
-                      setTableOrDoc((prev) => ({ ...prev, sourceUrl: value }))
-                    }
-                  />
-                </div>
-              )}
+              <div>
+                <Page.SectionHeader
+                  title="Associated URL"
+                  description="The URL of the associated document (if any). Will be used to link users to the original document in assistants citations."
+                />
+                <Input
+                  placeholder="https://..."
+                  name="sourceUrl"
+                  value={documentState.sourceUrl}
+                  onChange={(value) =>
+                    setDocumentState((prev) => ({ ...prev, sourceUrl: value }))
+                  }
+                />
+              </div>
 
               <div>
                 <Page.SectionHeader
-                  title={isTable ? "CSV File" : "Text content"}
-                  description={
-                    isTable
-                      ? "Select the CSV file for data extraction. The maximum file size allowed is 50MB."
-                      : `Copy paste content or upload a file (text or PDF). Up to ${
-                          plan.limits.dataSources.documents.sizeMb === -1
-                            ? "2"
-                            : plan.limits.dataSources.documents.sizeMb
-                        } MB of raw text.`
-                  }
+                  title="Text content"
+                  description={`Copy paste content or upload a file (text or PDF). Up to ${
+                    plan.limits.dataSources.documents.sizeMb === -1
+                      ? "2"
+                      : plan.limits.dataSources.documents.sizeMb
+                  } MB of raw text.`}
                   action={{
-                    label: (() => {
-                      if (uploading) {
-                        return "Uploading...";
-                      } else if (tableOrDoc.file) {
-                        return tableOrDoc.file.name;
-                      } else if (initialId) {
-                        return "Replace file";
-                      } else {
-                        return "Upload file";
-                      }
-                    })(),
+                    label: uploading
+                      ? "Uploading..."
+                      : documentState.file
+                        ? documentState.file.name
+                        : initialId
+                          ? "Replace file"
+                          : "Upload file",
                     variant: "primary",
                     icon: DocumentPlusIcon,
                     onClick: () => fileInputRef.current?.click(),
@@ -483,117 +340,375 @@ export function DocumentOrTableUploadOrEditModal({
                   type="file"
                   ref={fileInputRef}
                   style={{ display: "none" }}
-                  accept={
-                    isTable ? supportedTableFormats : supportedDocumentFormats
-                  }
+                  accept=".txt, .pdf, .md, .csv"
                   onChange={handleFileChange}
                 />
-                {isTable ? (
-                  isBigFile && (
-                    <div className="flex flex-col gap-y-2 pt-4">
-                      <div className="flex grow flex-row items-center gap-1 text-sm font-medium text-warning-500">
-                        <ExclamationCircleIcon />
-                        Warning: Large file (5MB+)
-                      </div>
-                      <div className="text-sm font-normal text-element-700">
-                        This file is large and may take a while to upload.
-                      </div>
-                    </div>
-                  )
-                ) : (
-                  <textarea
-                    name="text"
-                    rows={10}
-                    className={classNames(
-                      "font-mono text-normal block w-full min-w-0 flex-1 rounded-md",
-                      "border-structure-200 bg-structure-50",
-                      "focus:border-action-300 focus:ring-action-300"
-                    )}
-                    value={tableOrDoc.text}
-                    onChange={(e) => {
-                      setTableOrDoc((prev) => ({
-                        ...prev,
-                        text: e.target.value,
-                      }));
-                    }}
-                  />
-                )}
+                <textarea
+                  name="text"
+                  rows={10}
+                  className={classNames(
+                    "font-mono text-normal block w-full min-w-0 flex-1 rounded-md",
+                    "border-structure-200 bg-structure-50",
+                    "focus:border-action-300 focus:ring-action-300"
+                  )}
+                  value={documentState.text}
+                  onChange={(e) =>
+                    setDocumentState((prev) => ({
+                      ...prev,
+                      text: e.target.value,
+                    }))
+                  }
+                />
               </div>
 
-              {!isTable && (
-                <div>
-                  <Page.SectionHeader
-                    title="Developer Options"
-                    action={{
-                      label: developerOptionsVisible ? "Hide" : "Show",
-                      variant: "tertiary",
-                      icon: developerOptionsVisible ? EyeSlashIcon : EyeIcon,
-                      onClick: () =>
-                        setDeveloperOptionsVisible(!developerOptionsVisible),
-                    }}
-                  />
-                  {developerOptionsVisible && (
-                    <div className="pt-4">
-                      <Page.SectionHeader
-                        title=""
-                        description="Tags can be set to filter Data Source retrieval or provide a user-friendly title for programmatically uploaded documents (`title:User-friendly Title`)."
-                        action={{
-                          label: "Add tag",
-                          variant: "tertiary",
-                          icon: PlusIcon,
-                          onClick: () =>
-                            setTableOrDoc((prev) => ({
-                              ...prev,
-                              tags: [...prev.tags, ""],
-                            })),
-                        }}
-                      />
-                      {tableOrDoc.tags.map((tag, index) => (
-                        <div key={index} className="flex flex-grow flex-row">
-                          <div className="flex flex-1 flex-row gap-8">
-                            <div className="flex flex-1 flex-col">
-                              <Input
-                                className="w-full"
-                                placeholder="Tag"
-                                name="tag"
-                                value={tag}
-                                onChange={(value) => {
-                                  const newTags = [...tableOrDoc.tags];
-                                  newTags[index] = value;
-                                  setTableOrDoc((prev) => ({
-                                    ...prev,
-                                    tags: newTags,
-                                  }));
-                                }}
-                              />
-                            </div>
-                            <div className="flex">
-                              <Button
-                                label="Remove"
-                                icon={TrashIcon}
-                                variant="secondaryWarning"
-                                onClick={() => {
-                                  const newTags = [...tableOrDoc.tags];
-                                  newTags.splice(index, 1);
-                                  setTableOrDoc((prev) => ({
-                                    ...prev,
-                                    tags: newTags,
-                                  }));
-                                }}
-                                labelVisible={false}
-                              />
-                            </div>
+              <div>
+                <Page.SectionHeader
+                  title="Developer Options"
+                  action={{
+                    label: developerOptionsVisible ? "Hide" : "Show",
+                    variant: "tertiary",
+                    icon: developerOptionsVisible ? EyeSlashIcon : EyeIcon,
+                    onClick: () =>
+                      setDeveloperOptionsVisible(!developerOptionsVisible),
+                  }}
+                />
+                {developerOptionsVisible && (
+                  <div className="pt-4">
+                    <Page.SectionHeader
+                      title=""
+                      description="Tags can be set to filter Data Source retrieval or provide a user-friendly title for programmatically uploaded documents (`title:User-friendly Title`)."
+                      action={{
+                        label: "Add tag",
+                        variant: "tertiary",
+                        icon: PlusIcon,
+                        onClick: () =>
+                          setDocumentState((prev) => ({
+                            ...prev,
+                            tags: [...prev.tags, ""],
+                          })),
+                      }}
+                    />
+                    {documentState.tags.map((tag, index) => (
+                      <div key={index} className="flex flex-grow flex-row">
+                        <div className="flex flex-1 flex-row gap-8">
+                          <div className="flex flex-1 flex-col">
+                            <Input
+                              className="w-full"
+                              placeholder="Tag"
+                              name="tag"
+                              value={tag}
+                              onChange={(value) => {
+                                const newTags = [...documentState.tags];
+                                newTags[index] = value;
+                                setDocumentState((prev) => ({
+                                  ...prev,
+                                  tags: newTags,
+                                }));
+                              }}
+                            />
+                          </div>
+                          <div className="flex">
+                            <Button
+                              label="Remove"
+                              icon={TrashIcon}
+                              variant="secondaryWarning"
+                              onClick={() => {
+                                const newTags = [...documentState.tags];
+                                newTags.splice(index, 1);
+                                setDocumentState((prev) => ({
+                                  ...prev,
+                                  tags: newTags,
+                                }));
+                              }}
+                              labelVisible={false}
+                            />
                           </div>
                         </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
             </div>
           )}
         </Page.Vertical>
       )}
     </Modal>
   );
+};
+
+interface Table {
+  name: string;
+  description: string;
+  file: File | null;
 }
+
+interface TableUploadOrEditModalProps extends DocumentOrTableUploadOrEditModalProps {
+  table: CoreAPITable | null;
+  isTableError: boolean;
+  isTableLoading: boolean;
+  initialId?: string;
+}
+
+const TableUploadOrEditModal = ({
+  table,
+  isTableError,
+  isTableLoading,
+  initialId,
+  dataSourceView,
+  isOpen,
+  onClose,
+  owner,
+}: TableUploadOrEditModalProps) => {
+  const sendNotification = useContext(SendNotificationsContext);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [tableState, setTableState] = useState<Table>({
+    name: "",
+    description: "",
+    file: null,
+  });
+  const [editionStatus, setEditionStatus] = useState({
+    name: false,
+    description: false,
+  });
+  const [uploading, setUploading] = useState(false);
+  const [isBigFile, setIsBigFile] = useState(false);
+  const [isValidTable, setIsValidTable] = useState(false);
+
+  useEffect(() => {
+    if (!initialId) {
+      setTableState({
+        name: "",
+        description: "",
+        file: null,
+      });
+    } else if (table) {
+      setTableState((prev) => ({
+        ...prev,
+        name: table.name,
+        description: table.description,
+      }));
+    }
+  }, [initialId, table]);
+
+  useEffect(() => {
+    const isNameValid = !!tableState.name && isSlugified(tableState.name);
+    const isContentValid = !!tableState.description;
+    setIsValidTable(isNameValid && isContentValid && !!tableState.file);
+  }, [tableState]);
+
+  const handleTableUpload = async (table: Table) => {
+    setUploading(true);
+    try {
+      const fileContent = table.file
+        ? await handleFileUploadToText(table.file)
+        : null;
+      if (fileContent && fileContent.isErr()) {
+        return new Err(fileContent.error);
+      }
+
+      const csvContent = fileContent?.value
+        ? await parseAndStringifyCsv(fileContent.value.content)
+        : null;
+
+      if (csvContent && csvContent.length > BIG_FILE_SIZE) {
+        throw new Error("File too large");
+      }
+
+      const base = `/api/w/${owner.sId}/vaults/${dataSourceView.vaultId}/data_sources/${dataSourceView.dataSource.sId}/tables`;
+      const endpoint = initialId ? `${base}/${initialId}` : base;
+
+      const body = JSON.stringify({
+        name: table.name,
+        description: table.description,
+        csv: csvContent,
+        tableId: initialId,
+        timestamp: null,
+        tags: [],
+        parents: [],
+        truncate: false,
+        async: false,
+      });
+
+      const res = await fetch(endpoint, {
+        method: initialId ? "PATCH" : "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
+      });
+
+      if (!res.ok) {
+        throw new Error("Failed to upsert table");
+      }
+
+      sendNotification({
+        type: "success",
+        title: `Table successfully ${initialId ? "updated" : "added"}`,
+        description: `Table ${table.name} was successfully ${initialId ? "updated" : "added"}.`,
+      });
+    } catch (error) {
+      sendNotification({
+        type: "error",
+        title: "Error upserting table",
+        description: `An error occurred: ${error instanceof Error ? error.message : String(error)}.`,
+      });
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleUpload = async () => {
+    try {
+      await handleTableUpload(tableState);
+      onClose(true);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selectedFile = e.target.files?.[0];
+    if (!selectedFile) {
+      return;
+    }
+
+    setUploading(true);
+    try {
+      if (selectedFile.size > MAX_FILE_SIZES.plainText) {
+        sendNotification({
+          type: "error",
+          title: "File too large",
+          description: "Please upload a file smaller than 30MB.",
+        });
+        setUploading(false);
+        return;
+      }
+
+      setTableState((prev) => ({ ...prev, file: selectedFile }));
+      setIsBigFile(selectedFile.size > BIG_FILE_SIZE);
+    } catch (error) {
+      sendNotification({
+        type: "error",
+        title: "Error uploading file",
+        description: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={() => {
+        onClose(false);
+      }}
+      hasChanged={!isTableError && !isTableLoading && isValidTable}
+      variant="side-md"
+      title={`${initialId ? "Edit" : "Add"} table`}
+      onSave={handleUpload}
+      isSaving={uploading}
+    >
+      {isTableLoading ? (
+        <div className="flex justify-center py-4">
+          <Spinner variant="color" size="xs" />
+        </div>
+      ) : (
+        <Page.Vertical align="stretch">
+          {isTableError ? (
+            <div className="space-y-4 p-4">Content cannot be loaded.</div>
+          ) : (
+            <div className="space-y-4 p-4">
+              <div>
+                <Page.SectionHeader title="Table name" />
+                <Input
+                  placeholder="table_name"
+                  name="name"
+                  maxLength={MAX_NAME_CHARS}
+                  disabled={!!initialId}
+                  value={tableState.name}
+                  onChange={(value) => {
+                    setEditionStatus((prev) => ({ ...prev, name: true }));
+                    setTableState((prev) => ({ ...prev, name: value }));
+                  }}
+                  error={
+                    editionStatus.name &&
+                    (!tableState.name || !isSlugified(tableState.name))
+                      ? "Invalid name: Must be alphanumeric, max 32 characters and no space."
+                      : null
+                  }
+                  showErrorLabel={true}
+                />
+              </div>
+
+              <div>
+                <Page.SectionHeader
+                  title="Description"
+                  description="Describe the content of your CSV file. It will be used by the LLM model to generate relevant queries."
+                />
+                <TextArea
+                  placeholder="This table contains..."
+                  value={tableState.description}
+                  onChange={(value) => {
+                    setEditionStatus((prev) => ({
+                      ...prev,
+                      description: true,
+                    }));
+                    setTableState((prev) => ({
+                      ...prev,
+                      description: value,
+                    }));
+                  }}
+                  error={
+                    !tableState.description && editionStatus.description
+                      ? "You need to provide a description to your CSV file."
+                      : null
+                  }
+                  showErrorLabel={true}
+                  minRows={10}
+                />
+              </div>
+
+              <div>
+                <Page.SectionHeader
+                  title="CSV File"
+                  description="Select the CSV file for data extraction. The maximum file size allowed is 50MB."
+                  action={{
+                    label: uploading
+                      ? "Uploading..."
+                      : tableState.file
+                        ? tableState.file.name
+                        : initialId
+                          ? "Replace file"
+                          : "Upload file",
+                    variant: "primary",
+                    icon: DocumentPlusIcon,
+                    onClick: () => fileInputRef.current?.click(),
+                  }}
+                />
+                <input
+                  type="file"
+                  ref={fileInputRef}
+                  style={{ display: "none" }}
+                  accept=".csv, .tsv"
+                  onChange={handleFileChange}
+                />
+                {isBigFile && (
+                  <div className="flex flex-col gap-y-2 pt-4">
+                    <div className="flex grow flex-row items-center gap-1 text-sm font-medium text-warning-500">
+                      <ExclamationCircleIcon />
+                      Warning: Large file (5MB+)
+                    </div>
+                    <div className="text-sm font-normal text-element-700">
+                      This file is large and may take a while to upload.
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </Page.Vertical>
+      )}
+    </Modal>
+  );
+};

--- a/front/components/data_source/DocumentOrTableUploadOrEditModal.tsx
+++ b/front/components/data_source/DocumentOrTableUploadOrEditModal.tsx
@@ -81,6 +81,24 @@ function isCoreAPIDocumentType(
   );
 }
 
+const getErrorMessage = (
+  isTable: boolean,
+  tableOrDoc: TableOrDocument,
+  editionStatus: EditionStatus
+) => {
+  if (
+    isTable &&
+    !tableOrDoc.name &&
+    editionStatus.name &&
+    !isSlugified(tableOrDoc.name)
+  ) {
+    return `Invalid name: Must be alphanumeric, max ${MAX_NAME_CHARS} characters and no space.`;
+  } else if (!isTable && editionStatus.name && !tableOrDoc.name) {
+    return "You need to provide a name.";
+  }
+  return null;
+};
+
 export function DocumentOrTableUploadOrEditModal({
   contentNode,
   dataSourceView,
@@ -160,24 +178,14 @@ export function DocumentOrTableUploadOrEditModal({
   }, [isTable, initialId, table, owner.sId, document]);
 
   useEffect(() => {
-    let isNameValid: boolean;
-    let isContentValid: boolean;
-    if (isTable) {
-      isNameValid = !!tableOrDoc.name && isSlugified(tableOrDoc.name);
-      isContentValid = !!tableOrDoc.description;
-    } else {
-      isNameValid = !!tableOrDoc.name;
-      isContentValid = !!tableOrDoc.text || !!tableOrDoc.file;
-    }
+    const isNameValid = isTable
+      ? !!tableOrDoc.name && isSlugified(tableOrDoc.name)
+      : !!tableOrDoc.name;
+    const isContentValid = isTable
+      ? !!tableOrDoc.description
+      : !!tableOrDoc.text || !!tableOrDoc.file;
     setIsValidDocOrTable(isNameValid && isContentValid);
-  }, [
-    isTable,
-    isValidDocOrTable,
-    tableOrDoc.description,
-    tableOrDoc.file,
-    tableOrDoc.name,
-    tableOrDoc.text,
-  ]);
+  }, [isTable, tableOrDoc]);
 
   const isLoading = isTableLoading || isDocumentLoading;
   const isError = isDocumentError || isTableError;
@@ -392,16 +400,7 @@ export function DocumentOrTableUploadOrEditModal({
                     setEditionStatus((prev) => ({ ...prev, name: true }));
                     setTableOrDoc((prev) => ({ ...prev, name: value }));
                   }}
-                  error={
-                    isTable &&
-                    !tableOrDoc.name &&
-                    editionStatus.name &&
-                    !isSlugified(tableOrDoc.name)
-                      ? `Invalid name: Must be alphanumeric, max ${MAX_NAME_CHARS} characters and no space.`
-                      : !isTable && editionStatus.name && !tableOrDoc.name
-                        ? "You need to provide a name."
-                        : null
-                  }
+                  error={getErrorMessage(isTable, tableOrDoc, editionStatus)}
                   showErrorLabel={true}
                 />
               </div>

--- a/front/components/data_source/DocumentOrTableUploadOrEditModal.tsx
+++ b/front/components/data_source/DocumentOrTableUploadOrEditModal.tsx
@@ -30,7 +30,6 @@ import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { handleFileUploadToText } from "@app/lib/client/handle_file_upload";
 import { useDataSourceViewDocument } from "@app/lib/swr/data_source_views";
 import { useTable } from "@app/lib/swr/tables";
-import { classNames } from "@app/lib/utils";
 
 const MAX_NAME_CHARS = 32;
 
@@ -109,6 +108,7 @@ const DocumentUploadOrEditModal = ({
       owner: owner,
       dataSourceView: dataSourceView,
       documentId: initialId ?? null,
+      disabled: !initialId,
     });
 
   useEffect(() => {
@@ -313,21 +313,23 @@ const DocumentUploadOrEditModal = ({
                   accept=".txt, .pdf, .md, .csv"
                   onChange={handleFileChange}
                 />
-                <textarea
-                  name="text"
-                  rows={10}
-                  className={classNames(
-                    "font-mono text-normal block w-full min-w-0 flex-1 rounded-md",
-                    "border-structure-200 bg-structure-50",
-                    "focus:border-action-300 focus:ring-action-300"
-                  )}
+                <TextArea
+                  minRows={10}
+                  placeholder="Your document content..."
                   value={documentState.text}
-                  onChange={(e) =>
+                  onChange={(value) => {
+                    setEditionStatus((prev) => ({ ...prev, content: true }));
                     setDocumentState((prev) => ({
                       ...prev,
-                      text: e.target.value,
-                    }))
+                      text: value,
+                    }));
+                  }}
+                  error={
+                    editionStatus.content && !documentState.text
+                      ? "You need to upload a file or specify the content of the document."
+                      : null
                   }
+                  showErrorLabel={true}
                 />
               </div>
 

--- a/front/components/data_source/DocumentOrTableUploadOrEditModal.tsx
+++ b/front/components/data_source/DocumentOrTableUploadOrEditModal.tsx
@@ -16,7 +16,6 @@ import type {
   ContentNodesViewType,
   CoreAPIDocument,
   CoreAPILightDocument,
-  CoreAPITable,
   DataSourceViewType,
   LightContentNode,
   LightWorkspaceType,
@@ -56,6 +55,7 @@ interface DocumentOrTableUploadOrEditModalProps {
   plan: PlanType;
   totalNodesCount: number;
   viewType: ContentNodesViewType;
+  initialId?: string;
 }
 
 export function DocumentOrTableUploadOrEditModal(
@@ -64,36 +64,10 @@ export function DocumentOrTableUploadOrEditModal(
   const isTable = props.viewType === "tables";
   const initialId = props.contentNode?.internalId;
 
-  const { table, isTableError, isTableLoading } = useTable({
-    owner: props.owner,
-    dataSourceView: props.dataSourceView,
-    tableId: isTable ? initialId ?? null : null,
-    disabled: !isTable,
-  });
-
-  const { document, isDocumentError, isDocumentLoading } =
-    useDataSourceViewDocument({
-      owner: props.owner,
-      dataSourceView: props.dataSourceView,
-      documentId: !isTable ? initialId ?? null : null,
-      disabled: isTable,
-    });
   return isTable ? (
-    <TableUploadOrEditModal
-      {...props}
-      table={table}
-      isTableError={isTableError}
-      isTableLoading={isTableLoading ?? false}
-      initialId={initialId}
-    />
+    <TableUploadOrEditModal {...props} initialId={initialId} />
   ) : (
-    <DocumentUploadOrEditModal
-      {...props}
-      document={document ?? null}
-      isDocumentError={isDocumentError}
-      isDocumentLoading={isDocumentLoading}
-      initialId={initialId}
-    />
+    <DocumentUploadOrEditModal {...props} initialId={initialId} />
   );
 }
 
@@ -105,25 +79,14 @@ interface Document {
   sourceUrl: string;
 }
 
-interface DocumentUploadOrEditModalProps
-  extends DocumentOrTableUploadOrEditModalProps {
-  document: CoreAPIDocument | null;
-  isDocumentError: boolean;
-  isDocumentLoading: boolean;
-  initialId?: string;
-}
-
 const DocumentUploadOrEditModal = ({
-  document,
-  isDocumentError,
-  isDocumentLoading,
   initialId,
   dataSourceView,
   isOpen,
   onClose,
   owner,
   plan,
-}: DocumentUploadOrEditModalProps) => {
+}: DocumentOrTableUploadOrEditModalProps) => {
   const sendNotification = useContext(SendNotificationsContext);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [documentState, setDocumentState] = useState<Document>({
@@ -140,6 +103,13 @@ const DocumentUploadOrEditModal = ({
   const [uploading, setUploading] = useState(false);
   const [isValidDocument, setIsValidDocument] = useState(false);
   const [developerOptionsVisible, setDeveloperOptionsVisible] = useState(false);
+
+  const { document, isDocumentError, isDocumentLoading } =
+    useDataSourceViewDocument({
+      owner: owner,
+      dataSourceView: dataSourceView,
+      documentId: initialId ?? null,
+    });
 
   useEffect(() => {
     if (!initialId) {
@@ -443,24 +413,13 @@ interface Table {
   file: File | null;
 }
 
-interface TableUploadOrEditModalProps
-  extends DocumentOrTableUploadOrEditModalProps {
-  table: CoreAPITable | null;
-  isTableError: boolean;
-  isTableLoading: boolean;
-  initialId?: string;
-}
-
 const TableUploadOrEditModal = ({
-  table,
-  isTableError,
-  isTableLoading,
   initialId,
   dataSourceView,
   isOpen,
   onClose,
   owner,
-}: TableUploadOrEditModalProps) => {
+}: DocumentOrTableUploadOrEditModalProps) => {
   const sendNotification = useContext(SendNotificationsContext);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -476,6 +435,12 @@ const TableUploadOrEditModal = ({
   const [uploading, setUploading] = useState(false);
   const [isBigFile, setIsBigFile] = useState(false);
   const [isValidTable, setIsValidTable] = useState(false);
+
+  const { table, isTableError, isTableLoading } = useTable({
+    owner: owner,
+    dataSourceView: dataSourceView,
+    tableId: initialId ?? null,
+  });
 
   useEffect(() => {
     if (!initialId) {

--- a/front/components/data_source/DocumentOrTableUploadOrEditModal.tsx
+++ b/front/components/data_source/DocumentOrTableUploadOrEditModal.tsx
@@ -181,6 +181,17 @@ const DocumentUploadOrEditModal = ({
       });
     } finally {
       setUploading(false);
+      setDocumentState({
+        name: "",
+        file: null,
+        text: "",
+        tags: [],
+        sourceUrl: "",
+      });
+      setEditionStatus({
+        content: false,
+        name: false,
+      });
     }
   };
 

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -194,7 +194,7 @@ export function useDataSourceViewDocument({
 
   return {
     document: data?.document,
-    isDocumentLoading: !disabled && !error && !data,
+    isDocumentLoading: !isDisabled && !error && !data,
     isDocumentError: error,
     mutateDocument: mutate,
   };

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -174,17 +174,19 @@ export function useDataSourceViewDocument({
   dataSourceView,
   documentId,
   owner,
+  disabled,
 }: {
   dataSourceView: DataSourceViewType | null;
   documentId: string | null;
   owner: LightWorkspaceType;
+  disabled?: boolean;
 }) {
   const dataSourceViewDocumentFetcher: Fetcher<GetDataSourceViewDocumentResponseBody> =
     fetcher;
-  const disabled = !dataSourceView || !documentId;
+  const isDisabled = !dataSourceView || !documentId || disabled;
 
   const { data, error, mutate } = useSWRWithDefaults(
-    disabled
+    isDisabled
       ? null
       : `/api/w/${owner.sId}/vaults/${dataSourceView.vaultId}/data_source_views/${dataSourceView.sId}/documents/${encodeURIComponent(documentId)}`,
     dataSourceViewDocumentFetcher

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -198,7 +198,7 @@ export function useDataSourceViewDocument({
 
   return {
     document: data?.document,
-    isDocumentLoading: !error && !data,
+    isDocumentLoading: !disabled && !error && !data,
     isDocumentError: error,
     mutateDocument: mutate,
   };

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -183,18 +183,22 @@ export function useDataSourceViewDocument({
 }) {
   const dataSourceViewDocumentFetcher: Fetcher<GetDataSourceViewDocumentResponseBody> =
     fetcher;
-  const isDisabled = !dataSourceView || !documentId || disabled;
+  const url =
+    dataSourceView && documentId
+      ? `/api/w/${owner.sId}/vaults/${dataSourceView.vaultId}/data_source_views/${dataSourceView.sId}/documents/${encodeURIComponent(documentId)}`
+      : null;
 
   const { data, error, mutate } = useSWRWithDefaults(
-    isDisabled
-      ? null
-      : `/api/w/${owner.sId}/vaults/${dataSourceView.vaultId}/data_source_views/${dataSourceView.sId}/documents/${encodeURIComponent(documentId)}`,
-    dataSourceViewDocumentFetcher
+    url,
+    dataSourceViewDocumentFetcher,
+    {
+      disabled,
+    }
   );
 
   return {
     document: data?.document,
-    isDocumentLoading: !isDisabled && !error && !data,
+    isDocumentLoading: !error && !data,
     isDocumentError: error,
     mutateDocument: mutate,
   };

--- a/front/lib/swr/tables.ts
+++ b/front/lib/swr/tables.ts
@@ -8,21 +8,26 @@ export function useTable({
   owner,
   dataSourceView,
   tableId,
+  disabled,
 }: {
   owner: LightWorkspaceType;
   dataSourceView: DataSourceViewType;
   tableId: string | null;
+  disabled?: boolean;
 }) {
   const tableFetcher: Fetcher<GetTableResponseBody> = fetcher;
 
   const endpoint = `/api/w/${owner.sId}/vaults/${dataSourceView.vaultId}/data_source_views/${dataSourceView.sId}/tables/${tableId}`;
   const { data, error, mutate } = useSWRWithDefaults(
     tableId ? endpoint : null,
-    tableFetcher
+    tableFetcher,
+    {
+      disabled,
+    }
   );
   return {
     table: data ? data.table : null,
-    isTableLoading: tableId && !error && !data,
+    isTableLoading: !!tableId && !error && !data,
     isTableError: error,
     mutateTable: mutate,
   };


### PR DESCRIPTION
## Description

This PR refactors the `DocumentOrTableUploadOrEditModal` component, splitting it into separate `DocumentUploadOrEditModal` and `TableUploadOrEditModal` components. It enhances the user experience by adding input validation, improving error handling, and optimizing the loading states for both document and table uploads.

**References:**
 - https://github.com/dust-tt/dust/issues/7632

## Risk

Mainly moving stuff around but should be tested on front-edge first

## Deploy Plan

- Deploy `front-edge`
- Deploy `front`