### PR TITLE
More dataSource.sId

### DIFF
--- a/front/components/data_source/RequestDataSourceModal.tsx
+++ b/front/components/data_source/RequestDataSourceModal.tsx
@@ -100,7 +100,7 @@ export function RequestDataSourceModal({
                       (dataSource) =>
                         dataSource.connectorProvider && (
                           <DropdownMenu.Item
-                            key={dataSource.name}
+                            key={dataSource.sId}
                             label={getDataSourceName(dataSource)}
                             onClick={() => setSelectedDataSource(dataSource)}
                             icon={getConnectorProviderLogoWithFallback(

--- a/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
+++ b/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
@@ -62,14 +62,13 @@ export default function VaultManagedDataSourcesViewsModal({
           const isSelectAll = config.dataSourceView.parentsIn === null;
           const selectedResources = isSelectAll ? [] : config.nodes;
 
-          // We are selecting from the system data source views to create / edit a vault data source view.
-          // The initialSelectedDataSources represents the current selection.
-          // Here, we must remap to the system view that corresponds to the non system vault data source view.
+          // We are selecting from the system data source views to create / edit a vault data source
+          // view. The initialSelectedDataSources represents the current selection. Here, we must
+          // remap to the system view that corresponds to the non system vault data source view.
           const systemDataSourceView =
             systemVaultDataSourceViews.find(
               (dsv) =>
-                // TODO(DATASOURCE_SID): move to sId
-                dsv.dataSource.name === config.dataSourceView.dataSource.name
+                dsv.dataSource.sId === config.dataSourceView.dataSource.sId
             ) ?? config.dataSourceView; // Fallback to make sure we are never undefined
 
           acc[systemDataSourceView.sId] = {

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -772,7 +772,7 @@ function _getManagedDataSourceAgent(
         relativeTimeFrame: "auto",
         topK: "auto",
         dataSources: filteredDataSourceViews.map((dsView) => ({
-          dataSourceId: dsView.dataSource.name,
+          dataSourceId: dsView.dataSource.sId,
           dataSourceViewId: dsView.sId,
           workspaceId: preFetchedDataSources.workspaceId,
           filter: { tags: null, parents: null },
@@ -1014,7 +1014,7 @@ function _getDustGlobalAgent(
       relativeTimeFrame: "auto",
       topK: "auto",
       dataSources: dataSourceViews.map((dsView) => ({
-        dataSourceId: dsView.dataSource.name,
+        dataSourceId: dsView.dataSource.sId,
         dataSourceViewId: dsView.sId,
         workspaceId: preFetchedDataSources.workspaceId,
         filter: { parents: null },
@@ -1036,7 +1036,7 @@ function _getDustGlobalAgent(
         sId:
           GLOBAL_AGENTS_SID.DUST +
           "-datasource-action-" +
-          dsView.dataSource.name,
+          dsView.dataSource.sId,
         type: "retrieval_configuration",
         query: "auto",
         relativeTimeFrame: "auto",

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -137,6 +137,7 @@ async function handler(
       const embedderConfig = EMBEDDING_CONFIGS[dataSourceEmbedder];
       const dustDataSource = await coreAPI.createDataSource({
         projectId: dustProject.value.project.project_id.toString(),
+        // TODO(DATASOURCE_SID): Start creating Core API with sId
         dataSourceId: req.body.name as string,
         config: {
           qdrant_config: {

--- a/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
+++ b/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
@@ -265,7 +265,7 @@ export default function LabsTranscriptsIndex({
     await makePatchRequest(
       transcriptConfigurationId,
       {
-        dataSourceId: dataSource ? dataSource.dataSource.name : null,
+        dataSourceId: dataSource ? dataSource.dataSource.sId : null,
       },
       successMessage
     );


### PR DESCRIPTION
## Description

- Fix transcripts patching whose associated route expected a sId not a name
- Use sId in global_agent:dust (tested locally)

## Risk

Low

## Deploy Plan

- deploy `front`