### PR TITLE
feat: allow `core` to fetch credentials from `oauth`

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -89,6 +89,7 @@ pub mod cached_request;
 pub mod consts;
 
 pub mod oauth {
+    pub mod client;
     pub mod connection;
     pub mod credential;
     pub mod encryption;

--- a/core/src/oauth/client.rs
+++ b/core/src/oauth/client.rs
@@ -1,0 +1,31 @@
+use anyhow::{anyhow, Result};
+use lazy_static::lazy_static;
+
+lazy_static! {
+    static ref OAUTH_API: String = std::env::var("OAUTH_API").unwrap();
+    static ref OAUTH_API_KEY: String = std::env::var("OAUTH_API_KEY").unwrap();
+}
+
+// Meant to query the `oauth`` service from `core`
+pub struct OauthClient {}
+
+impl OauthClient {
+    pub async fn get_credential(credential_id: &str) -> Result<String> {
+        let res = reqwest::Client::new()
+            .get(format!("{}/credentials/{}", *OAUTH_API, credential_id))
+            .header("Content-Type", "application/json")
+            .header("Authorization", format!("Bearer {}", *OAUTH_API_KEY))
+            .send()
+            .await?;
+
+        match res.status().as_u16() {
+            200 => {
+                let body = res.text().await?;
+                let json = serde_json::from_str::<serde_json::Value>(&body)?;
+                let content = json["content"].to_string();
+                Ok(content)
+            }
+            s => Err(anyhow!("Failed to get credential. Status: {}", s)),
+        }
+    }
+}

--- a/k8s/network-policies/oauth-network-policy.yaml
+++ b/k8s/network-policies/oauth-network-policy.yaml
@@ -31,6 +31,9 @@ spec:
         - podSelector:
             matchLabels:
               app: prodbox
+        - podSelector:
+            matchLabels:
+              app: core
       ports:
         - protocol: TCP
           port: 3006


### PR DESCRIPTION
## Description

We need `core` to be able to get a `crendential` content from `oauth`.

To achieve this:

// Done with this PR:
- whitelist `core` -> `oauth` requests in network policy 

// Already done manually:
- add an API for `core` to talk to `oauth` in `oauth` API keys file
- add an env var for the `OAUTH_API_KEY` on `core`
- add an env var for the `OAUTH_API` on `core`

also added a quick client to fetch the credential content on `oauth` from `core`

## Risk

N/A

## Deploy Plan

- apply infra
- deploy `core` and `oauth`