### PR TITLE
Use dataSource.sId in Vaults/DataSourceView POST/PATCH routes

### DIFF
--- a/front/components/vaults/EditVaultManagedDatasourcesViews.tsx
+++ b/front/components/vaults/EditVaultManagedDatasourcesViews.tsx
@@ -101,11 +101,11 @@ export function EditVaultManagedDataSourcesViews({
           } = selectionConfiguration;
 
           const existingViewForDs = vaultDataSourceViews.find(
-            (d) => d.dataSource.name === sDs.name
+            (d) => d.dataSource.sId === sDs.sId
           );
 
           const body = {
-            name: sDs.name,
+            dataSourceId: sDs.sId,
             parentsIn: selectionConfiguration.isSelectAll
               ? null
               : selectionConfiguration.selectedResources.map(
@@ -121,7 +121,8 @@ export function EditVaultManagedDataSourcesViews({
                 selectionConfiguration.selectedResources.length === 0
               ) {
                 throw new Error(
-                  "We should never have a view with no data in the selection, it should have been removed. Action: check the DataSourceViewSelector component."
+                  "We should never have a view with no data in the selection, " +
+                    "it should have been removed. Action: check the DataSourceViewSelector component."
                 );
               } else {
                 res = await fetch(

--- a/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
+++ b/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
@@ -102,7 +102,7 @@ export default function VaultManagedDataSourcesViewsModal({
       }}
       hasChanged={hasChanged}
       variant="side-md"
-      title={`Add connected datasources to vault "${vault.name}"`}
+      title={`Add connected data to vault "${vault.name}"`}
     >
       <div className="w-full pt-12">
         <div className="overflow-x-auto">

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -34,8 +34,6 @@ import { DataSourceViewModel } from "./storage/models/data_source_view";
 
 export type FetchDataSourceOrigin =
   | "document_tracker"
-  | "vault_patch_content"
-  | "data_source_view_create"
   | "registry_lookup"
   | "v1_data_sources_search"
   | "v1_data_sources_documents"

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/index.ts
@@ -174,19 +174,16 @@ async function handler(
         });
       }
 
-      const { name, parentsIn } = bodyValidation.right;
+      const { dataSourceId, parentsIn } = bodyValidation.right;
 
       // Create a new view
-      const dataSource = await DataSourceResource.fetchByNameOrId(auth, name, {
-        // TODO(DATASOURCE_SID): Clean-up
-        origin: "data_source_view_create",
-      });
+      const dataSource = await DataSourceResource.fetchById(auth, dataSourceId);
       if (!dataSource) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid data source: ${name}`,
+            message: `Invalid data source: ${dataSourceId}`,
           },
         });
       }
@@ -200,7 +197,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `View already exists for data source: ${name}`,
+            message: `View already exists for data source: ${dataSourceId}`,
           },
         });
       }

--- a/front/pages/api/w/[wId]/vaults/[vId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/index.ts
@@ -155,27 +155,25 @@ async function handler(
           vault
         );
 
-        const viewByDataSourceName = currentViews.reduce(
+        const viewByDataSourceId = currentViews.reduce(
           (acc, view) => {
-            acc[view.dataSource.name] = view;
+            acc[view.dataSource.sId] = view;
             return acc;
           },
           {} as { [key: string]: DataSourceViewResource }
         );
 
         for (const dataSourceConfig of content) {
-          const view = viewByDataSourceName[dataSourceConfig.dataSource];
+          const view = viewByDataSourceId[dataSourceConfig.dataSourceId];
           if (view) {
             // Update existing view
             await view.updateParents(dataSourceConfig.parentsIn);
             await view.setEditedBy(auth);
           } else {
             // Create a new view
-            const dataSource = await DataSourceResource.fetchByNameOrId(
+            const dataSource = await DataSourceResource.fetchById(
               auth,
-              dataSourceConfig.dataSource,
-              // TODO(DATASOURCE_SID): Clean-up
-              { origin: "vault_patch_content" }
+              dataSourceConfig.dataSourceId
             );
             if (dataSource) {
               await DataSourceViewResource.createViewInVaultFromDataSource(
@@ -188,9 +186,9 @@ async function handler(
           }
         }
 
-        for (const dataSourceName of Object.keys(viewByDataSourceName)) {
-          if (!content.map((c) => c.dataSource).includes(dataSourceName)) {
-            const view = viewByDataSourceName[dataSourceName];
+        for (const dataSourceId of Object.keys(viewByDataSourceId)) {
+          if (!content.map((c) => c.dataSourceId).includes(dataSourceId)) {
+            const view = viewByDataSourceId[dataSourceId];
             await view.delete(auth);
           }
         }

--- a/types/src/front/api_handlers/public/vaults.ts
+++ b/types/src/front/api_handlers/public/vaults.ts
@@ -3,9 +3,6 @@ import * as t from "io-ts";
 import { ContentNodeType } from "../../lib/connectors_api";
 
 export const ContentSchema = t.type({
-  // TODO(DATASOURCE_SID): remove `dataSource`
-  dataSource: t.string,
-  // server done
   dataSourceId: t.string,
   parentsIn: t.union([t.array(t.string), t.null]),
 });

--- a/types/src/front/api_handlers/public/vaults.ts
+++ b/types/src/front/api_handlers/public/vaults.ts
@@ -3,14 +3,15 @@ import * as t from "io-ts";
 import { ContentNodeType } from "../../lib/connectors_api";
 
 export const ContentSchema = t.type({
-  // TODO(DATASOURCE_SID): rename to `dataSourceId`
+  // TODO(DATASOURCE_SID): remove `dataSource`
   dataSource: t.string,
+  // server done
+  dataSourceId: t.string,
   parentsIn: t.union([t.array(t.string), t.null]),
 });
 
 export const PostDataSourceViewSchema = t.type({
-  // TODO(DATASOURCE_SID): rename to `dataSourceId`
-  name: t.string,
+  dataSourceId: t.string,
   parentsIn: t.union([t.array(t.string), t.null]),
 });
 


### PR DESCRIPTION
## Description

- Rely on dataSource.sId instead of dataSource.name in vaults code

## Risk

Low. not released.

## Deploy Plan

- deploy `front`