### PR TITLE
[front] - enh(DataSourceViewSelector): disable root node check

### DIFF
--- a/front/components/DataSourceViewResourceSelectorTree.tsx
+++ b/front/components/DataSourceViewResourceSelectorTree.tsx
@@ -58,9 +58,7 @@ export default function DataSourceViewResourceSelectorTree({
         readonly={readonly}
         selectedResourceIds={selectedResourceIds}
         selectedParents={selectedParents}
-        onSelectChange={(resource, parents, selected) => {
-          onSelectChange(resource, parents, selected);
-        }}
+        onSelectChange={onSelectChange}
         useContentNodes={useContentNodes}
         viewType={viewType}
       />
@@ -73,6 +71,7 @@ type DataSourceResourceSelectorChildrenProps =
     parentId?: string;
     parents: string[];
     selectedParents: string[];
+    parentIsSelected?: boolean;
   };
 
 function DataSourceViewResourceSelectorChildren({

--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -82,7 +82,8 @@ export default function AssistantBuilderDataSourceModal({
       className="flex flex-col overflow-hidden"
     >
       <div
-        className="flex shrink flex-col overflow-hidden px-2" // Otherwise, padding do not match figma and we can't alter Page's padding
+        id="dataSourceViewsSelector"
+        className="overflow-y-auto scrollbar-hide"
       >
         <div className="flex w-full justify-end py-4">
           <Button
@@ -114,7 +115,7 @@ export default function AssistantBuilderDataSourceModal({
             selectionConfigurations={selectionConfigurations}
             setSelectionConfigurations={setSelectionConfigurationsCallback}
             viewType={viewType}
-            showSelectAll={false}
+            isRootSelectable={true}
           />
         </div>
       </div>

--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -114,7 +114,7 @@ export default function AssistantBuilderDataSourceModal({
             selectionConfigurations={selectionConfigurations}
             setSelectionConfigurations={setSelectionConfigurationsCallback}
             viewType={viewType}
-            displayMode="assistant_builder"
+            showSelectAll={false}
           />
         </div>
       </div>

--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -114,6 +114,7 @@ export default function AssistantBuilderDataSourceModal({
             selectionConfigurations={selectionConfigurations}
             setSelectionConfigurations={setSelectionConfigurationsCallback}
             viewType={viewType}
+            displayMode="assistant_builder"
           />
         </div>
       </div>

--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -1,4 +1,4 @@
-import { Button, ListCheckIcon, Modal } from "@dust-tt/sparkle";
+import { Modal } from "@dust-tt/sparkle";
 import type {
   ContentNodesViewType,
   DataSourceViewSelectionConfigurations,
@@ -85,24 +85,6 @@ export default function AssistantBuilderDataSourceModal({
         id="dataSourceViewsSelector"
         className="overflow-y-auto scrollbar-hide"
       >
-        <div className="flex w-full justify-end py-4">
-          <Button
-            variant="tertiary"
-            label="Select all visible"
-            icon={ListCheckIcon}
-            onClick={() => {
-              document
-                .querySelectorAll<HTMLInputElement>(
-                  '#dataSourceViewsSelector div.is-collapsed label > input[type="checkbox"]:first-child'
-                )
-                .forEach((el) => {
-                  if (!el.checked) {
-                    el.click();
-                  }
-                });
-            }}
-          />
-        </div>
         <div
           id="dataSourceViewsSelector"
           className="overflow-y-auto scrollbar-hide"

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -52,7 +52,7 @@ interface DataSourceViewsSelectorProps {
     SetStateAction<DataSourceViewSelectionConfigurations>
   >;
   viewType: ContentNodesViewType;
-  showSelectAll: boolean;
+  isRootSelectable: boolean;
 }
 
 export function DataSourceViewsSelector({
@@ -63,7 +63,7 @@ export function DataSourceViewsSelector({
   selectionConfigurations,
   setSelectionConfigurations,
   viewType,
-  showSelectAll,
+  isRootSelectable,
 }: DataSourceViewsSelectorProps) {
   const { vaults, isVaultsLoading } = useVaults({ workspaceId: owner.sId });
 
@@ -156,7 +156,7 @@ export function DataSourceViewsSelector({
               selectionConfigurations={selectionConfigurations}
               setSelectionConfigurations={setSelectionConfigurations}
               viewType={viewType}
-              showSelectAll={showSelectAll}
+              isRootSelectable={isRootSelectable}
             />
           );
         }}
@@ -182,7 +182,7 @@ export function DataSourceViewsSelector({
                 }
                 setSelectionConfigurations={setSelectionConfigurations}
                 viewType={viewType}
-                showSelectAll={showSelectAll}
+                isRootSelectable={isRootSelectable}
               />
             ))}
           </Tree.Item>
@@ -205,7 +205,7 @@ export function DataSourceViewsSelector({
                 }
                 setSelectionConfigurations={setSelectionConfigurations}
                 viewType={viewType}
-                showSelectAll={showSelectAll}
+                isRootSelectable={isRootSelectable}
               />
             ))}
           </Tree.Item>
@@ -228,7 +228,7 @@ export function DataSourceViewsSelector({
                 }
                 setSelectionConfigurations={setSelectionConfigurations}
                 viewType={viewType}
-                showSelectAll={showSelectAll}
+                isRootSelectable={isRootSelectable}
               />
             ))}
           </Tree.Item>
@@ -247,7 +247,7 @@ interface DataSourceViewSelectorProps {
   >;
   useContentNodes?: typeof useDataSourceViewContentNodes;
   viewType: ContentNodesViewType;
-  showSelectAll: boolean;
+  isRootSelectable: boolean;
 }
 
 export function DataSourceViewSelector({
@@ -257,9 +257,11 @@ export function DataSourceViewSelector({
   setSelectionConfigurations,
   useContentNodes = useDataSourceViewContentNodes,
   viewType,
-  showSelectAll,
+  isRootSelectable,
 }: DataSourceViewSelectorProps) {
-  const [isSelectedAll, setIsSelectedAll] = useState(false);
+  const [isSelectedAll, setIsSelectedAll] = useState(
+    selectionConfiguration.selectedResources.length > 0
+  );
   const { parentsById, setParentsById } = useParentResourcesById({
     selectedResources: selectionConfiguration.selectedResources,
   });
@@ -367,7 +369,7 @@ export function DataSourceViewSelector({
   const handleSelectAll = () => {
     document
       .querySelectorAll<HTMLInputElement>(
-        `#dataSourceViewsSelector-${dataSourceView.dataSource.name} label > input[type="checkbox"]:first-child`
+        `#dataSourceViewsSelector-${dataSourceView.dataSource.name} input[type="checkbox"]:first-child`
       )
       .forEach((el) => {
         if (el.checked === isSelectedAll) {
@@ -387,17 +389,18 @@ export function DataSourceViewSelector({
           canBeExpanded(viewType, dataSourceView.dataSource) ? "node" : "leaf"
         }
         checkbox={
-          !showSelectAll
+          !isRootSelectable
             ? {
                 checked: checkedStatus,
                 onChange: () => {
-                  selectionConfiguration.isSelectAll = checkedStatus === "checked";
+                  selectionConfiguration.isSelectAll =
+                    checkedStatus === "checked";
                 },
               }
             : undefined
         }
         actions={
-          showSelectAll && (
+          isManaged(dataSourceView.dataSource) && (
             <Button
               variant="tertiary"
               size="xs"

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -18,7 +18,7 @@ import type {
 } from "@dust-tt/types";
 import { defaultSelectionConfiguration } from "@dust-tt/types";
 import _ from "lodash";
-import type { Dispatch, SetStateAction} from "react";
+import type { Dispatch, SetStateAction } from "react";
 import { useState } from "react";
 import { useCallback, useMemo } from "react";
 

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -393,9 +393,23 @@ export function DataSourceViewSelector({
             ? {
                 checked: checkedStatus,
                 onChange: () => {
-                  selectionConfiguration.isSelectAll =
-                    checkedStatus === "checked";
+                  setSelectionConfigurations((prevState) => {
+                    const prevSelectionConfiguration =
+                      prevState[dataSourceView.sId] ??
+                      defaultSelectionConfiguration(dataSourceView);
+                    const udpatedConfig = {
+                      ...prevSelectionConfiguration,
+                      selectedResources: [],
+                      isSelectAll: checkedStatus !== "checked",
+                    };
+
+                    return {
+                      ...prevState,
+                      [dataSourceView.sId]: udpatedConfig,
+                    };
+                  });
                 },
+
               }
             : undefined
         }

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -309,14 +309,6 @@ export function DataSourceViewSelector({
     ...new Set(Object.values(parentsById).flatMap((c) => [...c])),
   ];
 
-  const isPartiallyChecked = internalIds.length > 0;
-
-  const checkedStatus = selectionConfiguration.isSelectAll
-    ? "checked"
-    : isPartiallyChecked
-      ? "partial"
-      : "unchecked";
-
   // When users have multiple vaults, they can opt to select only one vault per tool.
   // This is enforced in the UI via a radio button, ensuring single selection at a time.
   // However, selecting a new item in a different vault doesn't automatically clear previous selections.
@@ -336,42 +328,6 @@ export function DataSourceViewSelector({
       );
     },
     [dataSourceView]
-  );
-
-  const onToggleSelectAll = useCallback(
-    (checked: boolean) => {
-      // Setting parentsById
-      setParentsById({});
-
-      // Setting selectedResources
-      setSelectionConfigurations(
-        (prevState: DataSourceViewSelectionConfigurations) => {
-          if (!checked) {
-            // Nothing is selected at all, remove from the list
-            return _.omit(prevState, dataSourceView.sId);
-          }
-
-          const config =
-            prevState[dataSourceView.sId] ??
-            defaultSelectionConfiguration(dataSourceView);
-
-          config.isSelectAll = checked;
-          config.selectedResources = [];
-
-          // Return a new object to trigger a re-render
-          return keepOnlyOneVaultIfApplicable({
-            ...prevState,
-            [dataSourceView.sId]: config,
-          });
-        }
-      );
-    },
-    [
-      dataSourceView,
-      keepOnlyOneVaultIfApplicable,
-      setParentsById,
-      setSelectionConfigurations,
-    ]
   );
 
   const onSelectChange = useCallback(
@@ -428,11 +384,6 @@ export function DataSourceViewSelector({
     ]
   );
 
-  const isTableView = viewType === "tables";
-
-  // Show the checkbox by default. Hide it only for tables where no child items are partially checked.
-  const hideCheckbox = readonly || (isTableView && !isPartiallyChecked);
-
   return (
     <Tree.Item
       key={dataSourceView.dataSource.id}
@@ -440,14 +391,6 @@ export function DataSourceViewSelector({
       visual={LogoComponent}
       type={
         canBeExpanded(viewType, dataSourceView.dataSource) ? "node" : "leaf"
-      }
-      checkbox={
-        hideCheckbox
-          ? undefined
-          : {
-              checked: checkedStatus,
-              onChange: onToggleSelectAll,
-            }
       }
     >
       <DataSourceViewResourceSelectorTree

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -390,7 +390,9 @@ export function DataSourceViewSelector({
           !showSelectAll
             ? {
                 checked: checkedStatus,
-                onChange: handleSelectAll,
+                onChange: () => {
+                  selectionConfiguration.isSelectAll = checkedStatus === "checked";
+                },
               }
             : undefined
         }

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -1,8 +1,10 @@
 import {
+  Button,
   CloudArrowLeftRightIcon,
   FolderIcon,
   GlobeAltIcon,
   Spinner,
+  ListCheckIcon,
   Tree,
 } from "@dust-tt/sparkle";
 import type {
@@ -384,6 +386,41 @@ export function DataSourceViewSelector({
     ]
   );
 
+  const onToggleSelectAll = useCallback(
+    (checked: boolean) => {
+      // Setting parentsById
+      setParentsById({});
+
+      // Setting selectedResources
+      setSelectionConfigurations(
+        (prevState: DataSourceViewSelectionConfigurations) => {
+          if (!checked) {
+            // Nothing is selected at all, remove from the list
+            return _.omit(prevState, dataSourceView.sId);
+          }
+          const config =
+            prevState[dataSourceView.sId] ??
+            defaultSelectionConfiguration(dataSourceView);
+
+          config.isSelectAll = checked;
+          config.selectedResources = [];
+
+          // Return a new object to trigger a re-render
+          return keepOnlyOneVaultIfApplicable({
+            ...prevState,
+            [dataSourceView.sId]: config,
+          });
+        }
+      );
+    },
+    [
+      dataSourceView,
+      keepOnlyOneVaultIfApplicable,
+      setParentsById,
+      setSelectionConfigurations,
+    ]
+  );
+
   return (
     <Tree.Item
       key={dataSourceView.dataSource.id}
@@ -391,6 +428,20 @@ export function DataSourceViewSelector({
       visual={LogoComponent}
       type={
         canBeExpanded(viewType, dataSourceView.dataSource) ? "node" : "leaf"
+      }
+      actions={
+        <Button
+          variant="tertiary"
+          size="xs"
+          className="mr-4"
+          label={
+            selectionConfiguration.isSelectAll ? "Unselect All" : "Select All"
+          }
+          icon={ListCheckIcon}
+          onClick={() => {
+            onToggleSelectAll(!selectionConfiguration.isSelectAll);
+          }}
+        />
       }
     >
       <DataSourceViewResourceSelectorTree

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -413,6 +413,19 @@ export function DataSourceViewSelector({
       ? "partial"
       : "unchecked";
 
+  const handleSelectAll = () => {
+    document
+      .querySelectorAll<HTMLInputElement>(
+        `#dataSourceViewsSelector-${dataSourceView.dataSource.name} label > input[type="checkbox"]:first-child`
+      )
+      .forEach((el) => {
+        if (el.checked === isSelectedAll) {
+          el.click();
+        }
+      });
+    setIsSelectedAll(!isSelectedAll);
+  };
+
   return (
     <div id={`dataSourceViewsSelector-${dataSourceView.dataSource.name}`}>
       {displayMode === "assistant_builder" ? (
@@ -469,37 +482,23 @@ export function DataSourceViewSelector({
               className="mr-4"
               label={isSelectedAll ? "Unselect All" : "Select All"}
               icon={ListCheckIcon}
-              onClick={() => {
-                document
-                  .querySelectorAll<HTMLInputElement>(
-                    `#dataSourceViewsSelector-${dataSourceView.dataSource.name} label > input[type="checkbox"]:first-child`
-                  )
-                  .forEach((el) => {
-                    if (el.checked && !isSelectedAll) {
-                      return;
-                    } else {
-                      el.click();
-                    }
-                  });
-                setIsSelectedAll(!isSelectedAll);
-              }}
+              onClick={handleSelectAll}
             />
           }
-        >
-          <DataSourceViewResourceSelectorTree
-            dataSourceView={dataSourceView}
-            onSelectChange={onSelectChange}
-            owner={owner}
-            parentIsSelected={false}
-            readonly={readonly}
-            selectedParents={selectedParents}
-            selectedResourceIds={internalIds}
-            showExpand={config?.isNested ?? true}
-            useContentNodes={useContentNodes}
-            viewType={viewType}
-          />
-        </Tree.Item>
+        />
       )}
+      <DataSourceViewResourceSelectorTree
+        dataSourceView={dataSourceView}
+        onSelectChange={onSelectChange}
+        owner={owner}
+        parentIsSelected={selectionConfiguration.isSelectAll}
+        readonly={readonly}
+        selectedParents={selectedParents}
+        selectedResourceIds={internalIds}
+        showExpand={config?.isNested ?? true}
+        useContentNodes={useContentNodes}
+        viewType={viewType}
+      />
     </div>
   );
 }

--- a/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
+++ b/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
@@ -113,7 +113,7 @@ export default function VaultManagedDataSourcesViewsModal({
             selectionConfigurations={selectionConfigurations}
             setSelectionConfigurations={setSelectionConfigurationsCallback}
             viewType="documents"
-            showSelectAll={true}
+            isRootSelectable={true}
           />
         </div>
       </div>

--- a/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
+++ b/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
@@ -113,6 +113,7 @@ export default function VaultManagedDataSourcesViewsModal({
             selectionConfigurations={selectionConfigurations}
             setSelectionConfigurations={setSelectionConfigurationsCallback}
             viewType="documents"
+            displayMode="managed_datasource"
           />
         </div>
       </div>

--- a/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
+++ b/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
@@ -113,7 +113,7 @@ export default function VaultManagedDataSourcesViewsModal({
             selectionConfigurations={selectionConfigurations}
             setSelectionConfigurations={setSelectionConfigurationsCallback}
             viewType="documents"
-            displayMode="managed_datasource"
+            showSelectAll={true}
           />
         </div>
       </div>

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -216,6 +216,14 @@ export function orderDatasourceByImportance<Type extends ComparableByProvider>(
   return dataSources.sort(compareByImportance);
 }
 
+export function orderDatasourceViewByImportance<
+  Type extends { dataSource: ComparableByProvider },
+>(dataSourceViews: Type[]) {
+  return dataSourceViews.sort((a, b) => {
+    return compareByImportance(a.dataSource, b.dataSource);
+  });
+}
+
 export function orderDatasourceViewSelectionConfigurationByImportance<
   Type extends { dataSourceView: { dataSource: ComparableByProvider } },
 >(dataSourceViews: Type[]) {

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -216,14 +216,6 @@ export function orderDatasourceByImportance<Type extends ComparableByProvider>(
   return dataSources.sort(compareByImportance);
 }
 
-export function orderDatasourceViewByImportance<
-  Type extends { dataSource: ComparableByProvider },
->(dataSourceViews: Type[]) {
-  return dataSourceViews.sort((a, b) => {
-    return compareByImportance(a.dataSource, b.dataSource);
-  });
-}
-
 export function orderDatasourceViewSelectionConfigurationByImportance<
   Type extends { dataSourceView: { dataSource: ComparableByProvider } },
 >(dataSourceViews: Type[]) {

--- a/front/pages/poke/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.tsx
+++ b/front/pages/poke/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.tsx
@@ -55,6 +55,7 @@ export default function DataSourceViewPage({
           setSelectionConfigurations={() => {}}
           useContentNodes={usePokeDataSourceViewContentNodes}
           viewType="documents"
+          displayMode="managed_datasource"
         />
       </div>
     </div>

--- a/front/pages/poke/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.tsx
+++ b/front/pages/poke/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.tsx
@@ -55,7 +55,7 @@ export default function DataSourceViewPage({
           setSelectionConfigurations={() => {}}
           useContentNodes={usePokeDataSourceViewContentNodes}
           viewType="documents"
-          displayMode="managed_datasource"
+          showSelectAll={true}
         />
       </div>
     </div>

--- a/front/pages/poke/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.tsx
+++ b/front/pages/poke/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.tsx
@@ -55,7 +55,7 @@ export default function DataSourceViewPage({
           setSelectionConfigurations={() => {}}
           useContentNodes={usePokeDataSourceViewContentNodes}
           viewType="documents"
-          showSelectAll={true}
+          isRootSelectable={true}
         />
       </div>
     </div>


### PR DESCRIPTION
## Description

This PR refactors the `DataSourceViewSelector` component to improve the user experience when selecting data sources. 

The main changes include:
- Removing the checkbox from the root node of the `DataSourceViewSelector` tree when updating the connection (while keeping it in the assistant builder).
- Introducing a "Select All" button as an action for the root node, replacing the previous checkbox functionality.

<img width="797" alt="Screenshot 2024-09-25 at 17 29 17" src="https://github.com/user-attachments/assets/0e4d5402-f212-4c2d-a4c1-1b7679e8fcee">


**References:**
- https://github.com/dust-tt/tasks/issues/1390

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- Apply migration from https://github.com/dust-tt/dust/pull/7716 first
- Deploy `front`

Note: there will be a short time span during which people will be able to unselect/select root nodes while the backend won't accept it
