### PR TITLE
feat: add support for remote tables in DatabaseSchema block

### DIFF
--- a/core/src/databases/remote_databases/get_remote_database.rs
+++ b/core/src/databases/remote_databases/get_remote_database.rs
@@ -1,0 +1,21 @@
+use anyhow::Result;
+
+use crate::{
+    databases::remote_databases::remote_database::RemoteDatabase,
+    oauth::{client::OauthClient, credential::CredentialProvider},
+};
+
+use super::snowflake::SnowflakeRemoteDatabase;
+
+pub async fn get_remote_database(
+    credential_id: &str,
+) -> Result<Box<dyn RemoteDatabase + Sync + Send>> {
+    let (provider, content) = OauthClient::get_credential(credential_id).await?;
+
+    match provider {
+        CredentialProvider::Snowflake => {
+            let db = SnowflakeRemoteDatabase::new(content)?;
+            Ok(Box::new(db) as Box<dyn RemoteDatabase + Sync + Send>)
+        }
+    }
+}

--- a/core/src/databases/remote_databases/remote_database.rs
+++ b/core/src/databases/remote_databases/remote_database.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use async_trait::async_trait;
-use std::collections::HashMap;
 
 use crate::{
     databases::{
@@ -23,10 +22,7 @@ pub trait RemoteDatabase {
         tables: &Vec<Table>,
         query: &str,
     ) -> Result<(Vec<QueryResult>, TableSchema), QueryDatabaseError>;
-    async fn get_tables_schema(
-        &self,
-        opaque_ids: Vec<String>,
-    ) -> Result<HashMap<String, TableSchema>>;
+    async fn get_tables_schema(&self, opaque_ids: &Vec<&str>) -> Result<Vec<TableSchema>>;
 }
 
 pub async fn get_remote_database(

--- a/core/src/databases/remote_databases/snowflake.rs
+++ b/core/src/databases/remote_databases/snowflake.rs
@@ -253,10 +253,7 @@ impl RemoteDatabase for SnowflakeRemoteDatabase {
 
         // Ensure that query only uses tables that are allowed.
         let used_tables = self._get_tables_used_by_query(&session, query).await?;
-        let allowed_tables: HashSet<&str> = tables
-            .iter()
-            .filter_map(|table| table.remote_database_table_id())
-            .collect();
+        let allowed_tables: HashSet<&str> = tables.iter().map(|table| table.name()).collect();
 
         if used_tables
             .iter()
@@ -271,10 +268,7 @@ impl RemoteDatabase for SnowflakeRemoteDatabase {
     }
 
     // TODO(SNOWFLAKE): TBD caching
-    async fn get_tables_schema(
-        &self,
-        opaque_ids: Vec<String>,
-    ) -> Result<std::collections::HashMap<String, TableSchema>> {
+    async fn get_tables_schema(&self, opaque_ids: &Vec<&str>) -> Result<Vec<TableSchema>> {
         // Construct a "DESCRIBE TABLE" query for each opaque table ID.
         let queries: Vec<String> = opaque_ids
             .iter()
@@ -316,7 +310,7 @@ impl RemoteDatabase for SnowflakeRemoteDatabase {
                         )
                     })?;
 
-                Ok((opaque_id, TableSchema::from_columns(columns)))
+                Ok(TableSchema::from_columns(columns))
             })
             .collect()
     }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -22,6 +22,7 @@ pub mod databases {
     pub mod table;
     pub mod table_schema;
     pub mod remote_databases {
+        pub mod get_remote_database;
         pub mod remote_database;
         pub mod snowflake;
     }


### PR DESCRIPTION
## Description

Adds support for remote tables to the `DatabaseSchema` dust app block. 
Introduces the `get_tables_schema` the handles the complexity of picking local/remote implementation (or erroring) and converting output into the same format (which for now is the same we have been using for tables query, i.e DBML). TBC if we keep this format (maybe we get rid of the `TableSchema` in the output entirely, maybe we pick something closer to SQL -- although DBML has worked well).

## Risk

N/A

## Deploy Plan

N/A