### PR TITLE
Support downloading viz as PNG

### DIFF
--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -68,6 +68,18 @@ function useVisualizationDataHandler({
     [workspaceId]
   );
 
+  const downloadScreenshotFromBlob = useCallback(
+    (blob: Blob) => {
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `visualization-${visualization.identifier}.png`;
+      link.click();
+      URL.revokeObjectURL(url);
+    },
+    [visualization.identifier]
+  );
+
   useEffect(() => {
     const listener = async (event: MessageEvent) => {
       const { data } = event;
@@ -105,6 +117,10 @@ function useVisualizationDataHandler({
           setIsErrored(true);
           break;
 
+        case "sendScreenshotBlob":
+          downloadScreenshotFromBlob(data.params.blob);
+          break;
+
         default:
           assertNever(data);
       }
@@ -113,11 +129,12 @@ function useVisualizationDataHandler({
     window.addEventListener("message", listener);
     return () => window.removeEventListener("message", listener);
   }, [
-    visualization.identifier,
     code,
+    downloadScreenshotFromBlob,
     getFileBlob,
     setContentHeight,
     setIsErrored,
+    visualization.identifier,
     vizIframeRef,
   ]);
 }
@@ -189,7 +206,7 @@ export function VisualizationActionIframe({
                       !isErrored ? "min-h-96" : ""
                     )}
                     src={`${process.env.NEXT_PUBLIC_VIZ_URL}/content?identifier=${visualization.identifier}`}
-                    sandbox="allow-scripts"
+                    sandbox="allow-scripts allow-downloads"
                   />
                 </div>
               )}

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -206,7 +206,7 @@ export function VisualizationActionIframe({
                       !isErrored ? "min-h-96" : ""
                     )}
                     src={`${process.env.NEXT_PUBLIC_VIZ_URL}/content?identifier=${visualization.identifier}`}
-                    sandbox="allow-scripts allow-downloads"
+                    sandbox="allow-scripts"
                   />
                 </div>
               )}

--- a/types/src/front/assistant/visualization.ts
+++ b/types/src/front/assistant/visualization.ts
@@ -16,12 +16,17 @@ interface SetContentHeightParams {
   height: number;
 }
 
+interface SendScreenshotBlobParams {
+  blob: Blob;
+}
+
 // Define a mapped type to extend the base with specific parameters.
 export type VisualizationRPCRequestMap = {
   getFile: GetFileParams;
   getCodeToExecute: null;
   setContentHeight: SetContentHeightParams;
   setErrored: void;
+  sendScreenshotBlob: SendScreenshotBlobParams;
 };
 
 // Derive the command type from the keys of the request map
@@ -137,6 +142,28 @@ export function isSetErroredRequest(
   );
 }
 
+export function isSendScreenshotBlobRequest(
+  value: unknown
+): value is VisualizationRPCRequest & {
+  command: "sendScreenshotBlob";
+  params: SendScreenshotBlobParams;
+} {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const v = value as Partial<VisualizationRPCRequest>;
+
+  return (
+    v.command === "sendScreenshotBlob" &&
+    typeof v.identifier === "string" &&
+    typeof v.messageUniqueId === "string" &&
+    typeof v.params === "object" &&
+    v.params !== null &&
+    (v.params as SendScreenshotBlobParams).blob instanceof Blob
+  );
+}
+
 export function isVisualizationRPCRequest(
   value: unknown
 ): value is VisualizationRPCRequest {
@@ -147,6 +174,7 @@ export function isVisualizationRPCRequest(
   return (
     isGetCodeToExecuteRequest(value) ||
     isGetFileRequest(value) ||
+    isSendScreenshotBlobRequest(value) ||
     isSetContentHeightRequest(value) ||
     isSetErroredRequest(value)
   );

--- a/types/src/front/assistant/visualization.ts
+++ b/types/src/front/assistant/visualization.ts
@@ -50,8 +50,9 @@ export const validCommands: VisualizationRPCCommand[] = [
 // Command results.
 
 export interface CommandResultMap {
-  getFile: { fileBlob: Blob | null };
   getCodeToExecute: { code: string };
+  getFile: { fileBlob: Blob | null };
+  sendScreenshotBlob: { blob: Blob };
   setContentHeight: void;
   setErrored: void;
 }

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -218,7 +218,7 @@ export function VisualizationWrapper({
     if (ref.current) {
       try {
         const blob = await toBlob(ref.current, {
-          // Skip embedding fonts in the Blob since we cannot access cssRules from the iframe,
+          // Skip embedding fonts in the Blob since we cannot access cssRules from the iframe.
           skipFonts: true,
         });
         if (blob) {

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -14,6 +14,8 @@ import { importCode, Runner } from "react-runner";
 import * as rechartsAll from "recharts";
 import { useResizeDetector } from "react-resize-detector";
 import { ErrorBoundary } from "@viz/app/components/ErrorBoundary";
+import { Download } from "lucide-react";
+import { toBlob } from "html-to-image";
 
 export function useVisualizationAPI(
   sendCrossDocumentMessage: ReturnType<typeof makeSendCrossDocumentMessage>
@@ -74,7 +76,20 @@ export function useVisualizationAPI(
     [sendCrossDocumentMessage]
   );
 
-  return { fetchCode, fetchFile, error, sendHeightToParent };
+  const sendScreenshotBlob = useCallback(
+    async (blob: Blob) => {
+      await sendCrossDocumentMessage("sendScreenshotBlob", { blob });
+    },
+    [sendCrossDocumentMessage]
+  );
+
+  return {
+    error,
+    fetchCode,
+    fetchFile,
+    sendHeightToParent,
+    sendScreenshotBlob,
+  };
 }
 
 const useFile = (
@@ -145,7 +160,13 @@ export function VisualizationWrapper({
 
   const [errored, setErrored] = useState<Error | null>(null);
 
-  const { fetchCode, fetchFile, error, sendHeightToParent } = api;
+  const {
+    fetchCode,
+    fetchFile,
+    error,
+    sendHeightToParent,
+    sendScreenshotBlob,
+  } = api;
 
   useEffect(() => {
     const loadCode = async () => {
@@ -193,6 +214,22 @@ export function VisualizationWrapper({
     onResize: sendHeightToParent,
   });
 
+  const handleDownload = useCallback(async () => {
+    if (ref.current) {
+      try {
+        const blob = await toBlob(ref.current, {
+          // Skip embedding fonts in the Blob since we cannot access cssRules from the iframe,
+          skipFonts: true,
+        });
+        if (blob) {
+          await sendScreenshotBlob(blob);
+        }
+      } catch (err) {
+        console.error("Failed to convert to Blob", err);
+      }
+    }
+  }, [ref, sendScreenshotBlob]);
+
   useEffect(() => {
     if (error) {
       setErrored(error);
@@ -209,16 +246,24 @@ export function VisualizationWrapper({
   }
 
   return (
-    <div ref={ref}>
-      <Runner
-        code={runnerParams.code}
-        scope={runnerParams.scope}
-        onRendered={(error) => {
-          if (error) {
-            setErrored(error);
-          }
-        }}
-      />
+    <div className="relative group/viz">
+      <button
+        onClick={handleDownload}
+        className="absolute top-2 right-2 bg-white p-2 rounded shadow hover:bg-gray-100 transition opacity-0 group-hover/viz:opacity-100"
+      >
+        <Download size={24} />
+      </button>
+      <div ref={ref}>
+        <Runner
+          code={runnerParams.code}
+          scope={runnerParams.scope}
+          onRendered={(error) => {
+            if (error) {
+              setErrored(error);
+            }
+          }}
+        />
+      </div>
     </div>
   );
 }

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -251,7 +251,7 @@ export function VisualizationWrapper({
         onClick={handleDownload}
         className="absolute top-2 right-2 bg-white p-2 rounded shadow hover:bg-gray-100 transition opacity-0 group-hover/viz:opacity-100"
       >
-        <Download size={24} />
+        <Download size={20} />
       </button>
       <div ref={ref}>
         <Runner

--- a/viz/package-lock.json
+++ b/viz/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@dust-tt/types": "file:../types",
         "dd-trace": "^5.1.0",
+        "html-to-image": "^1.11.11",
+        "lucide-react": "^0.446.0",
         "next": "14.2.5",
         "papaparse": "^5.4.1",
         "react": "^18",
@@ -3210,6 +3212,11 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-to-image": {
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.11.tgz",
+      "integrity": "sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA=="
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -3951,6 +3958,14 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+    },
+    "node_modules/lucide-react": {
+      "version": "0.446.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.446.0.tgz",
+      "integrity": "sha512-BU7gy8MfBMqvEdDPH79VhOXSEgyG8TSPOKWaExWGCQVqnGH7wGgDngPbofu+KdtVjPQBWbEmnfMTq90CTiiDRg==",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/merge2": {
       "version": "1.4.1",

--- a/viz/package.json
+++ b/viz/package.json
@@ -11,6 +11,8 @@
   "dependencies": {
     "@dust-tt/types": "file:../types",
     "dd-trace": "^5.1.0",
+    "html-to-image": "^1.11.11",
+    "lucide-react": "^0.446.0",
     "next": "14.2.5",
     "papaparse": "^5.4.1",
     "react": "^18",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Fixes https://github.com/dust-tt/dust/issues/6822.

This PR introduces a button in the Visualization service that allows users to download the currently displayed node within the iframe. Due to the constraints of the sandboxed iframe and other limitations, the logic to convert the current node into a blob is implemented directly within the Visualization service. This approach bypasses the use of fonts from CSS, as accessing cssRules from the iframe is restricted by CORS policies. Once the blob is captured, it is sent to the main window, which manages the download process.

![DownloadViz](https://github.com/user-attachments/assets/d987b45e-fc77-4c8e-81ff-dfae8fb1dc58)

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
First deploy Front, then viz
