### PR TITLE
[Slack] Whitelist to allow indexing a bot's messages

### DIFF
--- a/connectors/migrations/db/migration_16.sql
+++ b/connectors/migrations/db/migration_16.sql
@@ -1,0 +1,3 @@
+-- Migration created on Sep 25, 2024
+ALTER TABLE "public"."slack_bot_whitelist" ADD COLUMN "whitelistType" VARCHAR(255) NOT NULL DEFAULT 'summon_agent';
+[22:29:37.338] INFO (1009038): Done;

--- a/connectors/migrations/db/migration_16.sql
+++ b/connectors/migrations/db/migration_16.sql
@@ -1,3 +1,2 @@
 -- Migration created on Sep 25, 2024
 ALTER TABLE "public"."slack_bot_whitelist" ADD COLUMN "whitelistType" VARCHAR(255) NOT NULL DEFAULT 'summon_agent';
-[22:29:37.338] INFO (1009038): Done;

--- a/connectors/src/connectors/slack/lib/workspace_limits.ts
+++ b/connectors/src/connectors/slack/lib/workspace_limits.ts
@@ -216,7 +216,7 @@ export async function isBotAllowed(
   const slackConfig = await SlackConfigurationResource.fetchByConnectorId(
     connector.id
   );
-  const whitelist = await slackConfig?.isBotWhitelisted(realName);
+  const whitelist = await slackConfig?.isBotWhitelistedToSummon(realName);
 
   if (!whitelist) {
     logger.info(

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -39,6 +39,7 @@ import {
 } from "@connectors/lib/sync_status";
 import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
+import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
 import { getWeekEnd, getWeekStart } from "../lib/utils";
@@ -171,6 +172,16 @@ export async function syncChannel(
     slackChannelName: remoteChannel.name,
     connectorId: connectorId,
   });
+
+  const slackConfiguration =
+    await SlackConfigurationResource.fetchByConnectorId(connectorId);
+
+  if (!slackConfiguration) {
+    throw new Error(
+      `Could not find slack configuration for connector ${connectorId}`
+    );
+  }
+
   if (!["read", "read_write"].includes(channel.permission)) {
     logger.info(
       {
@@ -203,8 +214,14 @@ export async function syncChannel(
   // first).
   let allSkip = true;
   for (const message of messages.messages) {
-    if (!message.user) {
-      // We do not support messages not posted by users for now
+    if (
+      !message.user &&
+      message.bot_profile?.name &&
+      !(await slackConfiguration.isBotWhitelistedToIndexMessages(
+        message.bot_profile.name
+      ))
+    ) {
+      // We do not support messages not posted by users for now, unless it's a whitelisted bot
       continue;
     }
     let skip = false;
@@ -370,6 +387,14 @@ export async function syncNonThreaded(
     throw new Error(`Connector ${connectorId} not found`);
   }
 
+  const slackConfiguration =
+    await SlackConfigurationResource.fetchByConnectorId(connectorId);
+  if (!slackConfiguration) {
+    throw new Error(
+      `Could not find slack configuration for connector ${connector}`
+    );
+  }
+
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
   const client = await getSlackClient(connectorId);
   const nextCursor: string | undefined = undefined;
@@ -418,7 +443,14 @@ export async function syncNonThreaded(
       if (message.ts) {
         latestTsSec = parseInt(message.ts);
       }
-      if (!message.user) {
+      if (
+        !message.user &&
+        message.bot_profile?.name &&
+        !(await slackConfiguration.isBotWhitelistedToIndexMessages(
+          message.bot_profile.name
+        ))
+      ) {
+        // We do not support messages not posted by users for now, unless it's a whitelisted bot
         continue;
       }
       if (!message.thread_ts && message.ts) {

--- a/connectors/src/lib/models/slack.ts
+++ b/connectors/src/lib/models/slack.ts
@@ -311,6 +311,7 @@ export class SlackBotWhitelistModel extends Model<
   declare updatedAt: CreationOptional<Date>;
   declare botName: string;
   declare groupIds: string[];
+  declare whitelistType: "summon_agent" | "index_messages";
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
   declare slackConfigurationId: ForeignKey<SlackConfigurationModel["id"]>;
 }
@@ -335,6 +336,11 @@ SlackBotWhitelistModel.init(
     botName: {
       type: DataTypes.STRING,
       allowNull: false,
+    },
+    whitelistType: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: "summon_agent",
     },
     groupIds: {
       type: DataTypes.ARRAY(DataTypes.STRING),

--- a/connectors/src/lib/models/slack.ts
+++ b/connectors/src/lib/models/slack.ts
@@ -1,4 +1,7 @@
-import type { ConnectorPermission } from "@dust-tt/types";
+import type {
+  ConnectorPermission,
+  SlackbotWhitelistType,
+} from "@dust-tt/types";
 import type {
   CreationOptional,
   ForeignKey,
@@ -311,7 +314,7 @@ export class SlackBotWhitelistModel extends Model<
   declare updatedAt: CreationOptional<Date>;
   declare botName: string;
   declare groupIds: string[];
-  declare whitelistType: "summon_agent" | "index_messages";
+  declare whitelistType: SlackbotWhitelistType;
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
   declare slackConfigurationId: ForeignKey<SlackConfigurationModel["id"]>;
 }

--- a/connectors/src/resources/slack_configuration_resource.ts
+++ b/connectors/src/resources/slack_configuration_resource.ts
@@ -1,4 +1,9 @@
-import type { ModelId, Result, SlackConfigurationType } from "@dust-tt/types";
+import type {
+  ModelId,
+  Result,
+  SlackbotWhitelistType,
+  SlackConfigurationType,
+} from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 import type { Attributes, ModelStatic, Transaction } from "sequelize";
 
@@ -106,24 +111,39 @@ export class SlackConfigurationResource extends BaseResource<SlackConfigurationM
     return new this(this.model, blob.get());
   }
 
-  async isBotWhitelisted(botName: string | string[]): Promise<boolean> {
+  async isBotWhitelistedToSummon(botName: string | string[]): Promise<boolean> {
     return !!(await SlackBotWhitelistModel.findOne({
       where: {
         connectorId: this.connectorId,
         botName: botName,
+        whitelistType: "summon_agent",
+      },
+    }));
+  }
+
+  async isBotWhitelistedToIndexMessages(
+    botName: string | string[]
+  ): Promise<boolean> {
+    return !!(await SlackBotWhitelistModel.findOne({
+      where: {
+        connectorId: this.connectorId,
+        botName: botName,
+        whitelistType: "index_messages",
       },
     }));
   }
 
   async whitelistBot(
     botName: string,
-    groupIds: string[]
+    groupIds: string[],
+    whitelistType: SlackbotWhitelistType
   ): Promise<Result<undefined, Error>> {
     await SlackBotWhitelistModel.create({
       connectorId: this.connectorId,
       slackConfigurationId: this.id,
       botName,
       groupIds,
+      whitelistType,
     });
 
     return new Ok(undefined);

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -14,6 +14,7 @@ import type {
   GroupType,
   NotionCheckUrlResponseType,
   NotionFindUrlResponseType,
+  SlackbotWhitelistType,
 } from "@dust-tt/types";
 import type { WorkspaceType } from "@dust-tt/types";
 import type { ConnectorType } from "@dust-tt/types";
@@ -575,11 +576,17 @@ async function handleCheckOrFindNotionUrl(
   return res.json();
 }
 
-async function handleWhitelistBot(
-  botName: string,
-  wId: string,
-  groupId: string
-): Promise<void> {
+async function handleWhitelistBot({
+  botName,
+  wId,
+  groupId,
+  whitelistType,
+}: {
+  botName: string;
+  wId: string;
+  groupId: string;
+  whitelistType: SlackbotWhitelistType;
+}): Promise<void> {
   const res = await fetch(`/api/poke/admin`, {
     method: "POST",
     headers: {
@@ -592,6 +599,7 @@ async function handleWhitelistBot(
         botName,
         wId,
         groupId,
+        whitelistType,
       },
     }),
   });
@@ -880,7 +888,12 @@ function SlackWhitelistBot({
               alert("Please select a group");
               return;
             }
-            await handleWhitelistBot(botName, owner.sId, selectedGroup);
+            await handleWhitelistBot({
+              botName,
+              wId: owner.sId,
+              groupId: selectedGroup,
+              whitelistType: "summon_agent",
+            });
             setBotName("");
           }}
         />

--- a/types/src/connectors/slack.ts
+++ b/types/src/connectors/slack.ts
@@ -11,3 +11,11 @@ export const SlackConfigurationTypeSchema = t.type({
 });
 
 export type SlackConfiguration = t.TypeOf<typeof SlackConfigurationTypeSchema>;
+
+export type SlackbotWhitelistType = "summon_agent" | "index_messages";
+
+export function isSlackbotWhitelistType(
+  value: unknown
+): value is SlackbotWhitelistType {
+  return value === "summon_agent" || value === "index_messages";
+}


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/1248

Whitelisting bot for indexing reuses the whitelist table for summoning dust with a newly introduced `whitelistType` field

For now, since demand is very low and we should monitor, whitelisting is via papertrailing the psql command on `prodbox`:
```
INSERT INTO slack_bot_whitelist ("createdAt", "updatedAt", "botName", "connectorId", "whitelistType") VALUES (NOW(), NOW(), 'BOTNAME', 1, 'index_messages');
```
If needed, a further PR will add the capability to cli/poke

Risks
---
Refactoring affects slackbot's whitelist for summoning dust, so we should be careful about that. Blast radius otherwise limited

## Deploy Plan
- run migration
- deploy connectors
- deploy front
