### PR TITLE
Refactor permission trees

### DIFF
--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -12,6 +12,7 @@ import type {
   ConnectorPermission,
   ConnectorProvider,
   ConnectorType,
+  ContentNodeWithParentIds,
   DataSourceType,
   LightWorkspaceType,
   UpdateConnectorRequestBody,
@@ -24,13 +25,16 @@ import { useContext, useEffect, useState } from "react";
 import { useSWRConfig } from "swr";
 
 import { RequestDataSourceModal } from "@app/components/data_source/RequestDataSourceModal";
+import ManagedDataSourceDocumentModal from "@app/components/ManagedDataSourceDocumentModal";
 import { setupConnection } from "@app/components/vaults/AddConnectionMenu";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { getDataSourceName } from "@app/lib/data_sources";
+import { useConnectorPermissions } from "@app/lib/swr/connectors";
 import { useUser } from "@app/lib/swr/user";
 import { useWorkspaceActiveSubscription } from "@app/lib/swr/workspaces";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 
+import type { PermissionTreeNodeStatus } from "./ConnectorPermissionsTree";
 import { PermissionTree } from "./ConnectorPermissionsTree";
 import type { NotificationType } from "./sparkle/Notification";
 import { SendNotificationsContext } from "./sparkle/Notification";
@@ -43,6 +47,38 @@ const PERMISSIONS_EDITABLE_CONNECTOR_TYPES: Set<ConnectorProvider> = new Set([
   "intercom",
 ]);
 
+const CONNECTOR_TYPE_TO_PERMISSIONS: Record<
+  ConnectorProvider,
+  { selected: ConnectorPermission; unselected: ConnectorPermission } | undefined
+> = {
+  confluence: {
+    selected: "read",
+    unselected: "none",
+  },
+  slack: {
+    selected: "read_write",
+    unselected: "write",
+  },
+  google_drive: {
+    selected: "read",
+    unselected: "none",
+  },
+  microsoft: {
+    selected: "read",
+    unselected: "none",
+  },
+  notion: undefined,
+  github: undefined,
+  intercom: {
+    selected: "read",
+    unselected: "none",
+  },
+  webcrawler: undefined,
+  snowflake: {
+    selected: "read",
+    unselected: "none",
+  },
+};
 interface DataSourceManagementModalProps {
   children: React.ReactNode;
   isOpen: boolean;
@@ -345,8 +381,64 @@ export function ConnectorPermissionsModal({
 }: ConnectorPermissionsModalProps) {
   const { mutate } = useSWRConfig();
 
-  const [updatedPermissionByInternalId, setUpdatedPermissionByInternalId] =
-    useState<Record<string, ConnectorPermission>>({});
+  const [documentToDisplay, setDocumentToDisplay] = useState<string | null>(
+    null
+  );
+
+  const [treeSelectionModel, setTreeSelectionModel] = useState<
+    Record<string, PermissionTreeNodeStatus>
+  >({});
+
+  const canUpdatePermissions = PERMISSIONS_EDITABLE_CONNECTOR_TYPES.has(
+    connector.type
+  );
+  const selectedPermission: ConnectorPermission =
+    (dataSource.connectorProvider &&
+      CONNECTOR_TYPE_TO_PERMISSIONS[dataSource.connectorProvider]?.selected) ||
+    "none";
+  const unselectedPermission: ConnectorPermission =
+    (dataSource.connectorProvider &&
+      CONNECTOR_TYPE_TO_PERMISSIONS[dataSource.connectorProvider]
+        ?.unselected) ||
+    "none";
+
+  const useResourcesHook = (parentId: string | null) =>
+    useConnectorPermissions({
+      dataSource,
+      filterPermission: null,
+      owner,
+      parentId,
+      viewType: "documents",
+    });
+
+  const { resources: allSelectedResources } = useConnectorPermissions({
+    dataSource,
+    filterPermission: "read",
+    owner,
+    parentId: null,
+    viewType: "documents",
+    includeParents: true,
+    disabled: !canUpdatePermissions,
+  });
+
+  useEffect(() => {
+    if (isOpen) {
+      setTreeSelectionModel(
+        allSelectedResources.reduce(
+          (acc, r) => ({
+            ...acc,
+            [r.internalId]: {
+              isSelected: true,
+              node: r,
+              parents: r.parentInternalIds,
+            },
+          }),
+          {} as Record<string, PermissionTreeNodeStatus>
+        )
+      );
+    }
+  }, [allSelectedResources, isOpen]);
+
   const [modalToShow, setModalToShow] = useState<
     "edition" | "selection" | null
   >(null);
@@ -364,18 +456,14 @@ export function ConnectorPermissionsModal({
     setModalToShow(null);
     onClose(save);
     setTimeout(() => {
-      setUpdatedPermissionByInternalId({});
+      setTreeSelectionModel({});
     }, 300);
   }
-
-  const canUpdatePermissions = PERMISSIONS_EDITABLE_CONNECTOR_TYPES.has(
-    connector.type
-  );
 
   async function save() {
     setSaving(true);
     try {
-      if (Object.keys(updatedPermissionByInternalId).length) {
+      if (Object.keys(treeSelectionModel).length) {
         const r = await fetch(
           `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/permissions`,
           {
@@ -384,12 +472,12 @@ export function ConnectorPermissionsModal({
               "Content-Type": "application/json",
             },
             body: JSON.stringify({
-              resources: Object.keys(updatedPermissionByInternalId).map(
-                (internalId) => ({
-                  internal_id: internalId,
-                  permission: updatedPermissionByInternalId[internalId],
-                })
-              ),
+              resources: Object.keys(treeSelectionModel).map((internalId) => ({
+                internal_id: internalId,
+                permission: treeSelectionModel[internalId].isSelected
+                  ? selectedPermission
+                  : unselectedPermission,
+              })),
             }),
           }
         );
@@ -467,7 +555,7 @@ export function ConnectorPermissionsModal({
         saveLabel="Save"
         savingLabel="Saving..."
         isSaving={saving}
-        hasChanged={!!Object.keys(updatedPermissionByInternalId).length}
+        hasChanged={!!Object.keys(treeSelectionModel).length}
         className="flex"
         variant="side-md"
       >
@@ -501,25 +589,33 @@ export function ConnectorPermissionsModal({
             {CONNECTOR_CONFIGURATIONS[connector.type].selectLabel}
           </div>
 
+          <ManagedDataSourceDocumentModal
+            owner={owner}
+            dataSource={dataSource}
+            documentId={documentToDisplay}
+            isOpen={!!documentToDisplay}
+            setOpen={(open) => {
+              if (!open) {
+                setDocumentToDisplay(null);
+              }
+            }}
+          />
           <PermissionTree
+            displayDocumentSource={(documentId: string) => {
+              setDocumentToDisplay(documentId);
+            }}
             isSearchEnabled={
               CONNECTOR_CONFIGURATIONS[connector.type].isSearchEnabled
             }
             isRoundedBackground={true}
-            owner={owner}
-            dataSource={dataSource}
-            canUpdatePermissions={canUpdatePermissions}
-            onPermissionUpdate={(node, { newPermission }) => {
-              const { internalId } = node;
-
-              setUpdatedPermissionByInternalId((prev) => ({
-                ...prev,
-                [internalId]: newPermission,
-              }));
-            }}
+            useResourcesHook={useResourcesHook}
+            treeSelectionModel={
+              canUpdatePermissions ? treeSelectionModel : undefined
+            }
+            setTreeSelectionModel={
+              canUpdatePermissions ? setTreeSelectionModel : undefined
+            }
             showExpand={CONNECTOR_CONFIGURATIONS[connector.type]?.isNested}
-            // List only document-type items when displaying permissions for a data source.
-            viewType="documents"
           />
         </div>
       </Modal>

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -19,8 +19,7 @@ import type {
 } from "@dust-tt/types";
 import { assertNever, CONNECTOR_TYPE_TO_MISMATCH_ERROR } from "@dust-tt/types";
 import { InformationCircleIcon } from "@heroicons/react/20/solid";
-import * as React from "react";
-import { useContext, useEffect, useMemo, useState } from "react";
+import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { useSWRConfig } from "swr";
 
 import { RequestDataSourceModal } from "@app/components/data_source/RequestDataSourceModal";
@@ -78,6 +77,17 @@ const CONNECTOR_TYPE_TO_PERMISSIONS: Record<
     unselected: "none",
   },
 };
+
+const getUseResourceHook =
+  (owner: LightWorkspaceType, dataSource: DataSourceType) =>
+  (parentId: string | null) =>
+    useConnectorPermissions({
+      dataSource,
+      filterPermission: null,
+      owner,
+      parentId,
+      viewType: "documents",
+    });
 interface DataSourceManagementModalProps {
   children: React.ReactNode;
   isOpen: boolean;
@@ -401,14 +411,11 @@ export function ConnectorPermissionsModal({
         ?.unselected) ||
     "none";
 
-  const useResourcesHook = (parentId: string | null) =>
-    useConnectorPermissions({
-      dataSource,
-      filterPermission: null,
-      owner,
-      parentId,
-      viewType: "documents",
-    });
+  const useResourcesHook = useCallback(
+    (parentId: string | null) =>
+      getUseResourceHook(owner, dataSource)(parentId),
+    [owner, dataSource]
+  );
 
   const { resources: allSelectedResources, isResourcesLoading } =
     useConnectorPermissions({

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -34,8 +34,8 @@ import { useUser } from "@app/lib/swr/user";
 import { useWorkspaceActiveSubscription } from "@app/lib/swr/workspaces";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 
-import type { PermissionTreeNodeStatus } from "./ConnectorPermissionsTree";
-import { PermissionTree } from "./ConnectorPermissionsTree";
+import type { ContentNodeTreeNodeStatus } from "./ContentNodeTree";
+import { ContentNodeTree } from "./ContentNodeTree";
 import type { NotificationType } from "./sparkle/Notification";
 import { SendNotificationsContext } from "./sparkle/Notification";
 
@@ -386,7 +386,7 @@ export function ConnectorPermissionsModal({
   );
 
   const [treeSelectionModel, setTreeSelectionModel] = useState<
-    Record<string, PermissionTreeNodeStatus>
+    Record<string, ContentNodeTreeNodeStatus>
   >({});
 
   const canUpdatePermissions = PERMISSIONS_EDITABLE_CONNECTOR_TYPES.has(
@@ -433,7 +433,7 @@ export function ConnectorPermissionsModal({
               parents: r.parentInternalIds,
             },
           }),
-          {} as Record<string, PermissionTreeNodeStatus>
+          {} as Record<string, ContentNodeTreeNodeStatus>
         )
       );
     }
@@ -600,7 +600,7 @@ export function ConnectorPermissionsModal({
               }
             }}
           />
-          <PermissionTree
+          <ContentNodeTree
             displayDocumentSource={(documentId: string) => {
               setDocumentToDisplay(documentId);
             }}

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -411,15 +411,16 @@ export function ConnectorPermissionsModal({
       viewType: "documents",
     });
 
-  const { resources: allSelectedResources } = useConnectorPermissions({
-    dataSource,
-    filterPermission: "read",
-    owner,
-    parentId: null,
-    viewType: "documents",
-    includeParents: true,
-    disabled: !canUpdatePermissions,
-  });
+  const { resources: allSelectedResources, isResourcesLoading } =
+    useConnectorPermissions({
+      dataSource,
+      filterPermission: "read",
+      owner,
+      parentId: null,
+      viewType: "documents",
+      includeParents: true,
+      disabled: !canUpdatePermissions,
+    });
 
   useEffect(() => {
     if (isOpen) {
@@ -613,7 +614,9 @@ export function ConnectorPermissionsModal({
               canUpdatePermissions ? treeSelectionModel : undefined
             }
             setTreeSelectionModel={
-              canUpdatePermissions ? setTreeSelectionModel : undefined
+              canUpdatePermissions && !isResourcesLoading
+                ? setTreeSelectionModel
+                : undefined
             }
             showExpand={CONNECTOR_CONFIGURATIONS[connector.type]?.isNested}
           />

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -12,7 +12,6 @@ import type {
   ConnectorPermission,
   ConnectorProvider,
   ConnectorType,
-  ContentNodeWithParentIds,
   DataSourceType,
   LightWorkspaceType,
   UpdateConnectorRequestBody,

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -423,7 +423,7 @@ export function ConnectorPermissionsModal({
 
   const initialTreeSelectionModel = useMemo(
     () =>
-      allSelectedResources.reduce(
+      allSelectedResources.reduce<Record<string, ContentNodeTreeNodeStatus>>(
         (acc, r) => ({
           ...acc,
           [r.internalId]: {
@@ -432,7 +432,7 @@ export function ConnectorPermissionsModal({
             parents: r.parentInternalIds || [],
           },
         }),
-        {} as Record<string, ContentNodeTreeNodeStatus>
+        {}
       ),
     [allSelectedResources]
   );
@@ -513,7 +513,7 @@ export function ConnectorPermissionsModal({
     setSaving(false);
   }
 
-  const unchanged = useMemo(
+  const isUnchanged = useMemo(
     () =>
       Object.values(treeSelectionModel)
         .filter((item) => item.isSelected)
@@ -574,7 +574,7 @@ export function ConnectorPermissionsModal({
         saveLabel="Save"
         savingLabel="Saving..."
         isSaving={saving}
-        hasChanged={!unchanged}
+        hasChanged={!isUnchanged}
         className="flex"
         variant="side-md"
       >
@@ -620,7 +620,7 @@ export function ConnectorPermissionsModal({
             }}
           />
           <ContentNodeTree
-            displayDocumentSource={(documentId: string) => {
+            onDocumentViewClick={(documentId: string) => {
               setDocumentToDisplay(documentId);
             }}
             isSearchEnabled={

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -431,7 +431,7 @@ export function ConnectorPermissionsModal({
             [r.internalId]: {
               isSelected: true,
               node: r,
-              parents: r.parentInternalIds,
+              parents: r.parentInternalIds || [],
             },
           }),
           {} as Record<string, ContentNodeTreeNodeStatus>

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -23,7 +23,6 @@ import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { useSWRConfig } from "swr";
 
 import { RequestDataSourceModal } from "@app/components/data_source/RequestDataSourceModal";
-import ManagedDataSourceDocumentModal from "@app/components/ManagedDataSourceDocumentModal";
 import { setupConnection } from "@app/components/vaults/AddConnectionMenu";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { getDataSourceName } from "@app/lib/data_sources";
@@ -390,10 +389,6 @@ export function ConnectorPermissionsModal({
 }: ConnectorPermissionsModalProps) {
   const { mutate } = useSWRConfig();
 
-  const [documentToDisplay, setDocumentToDisplay] = useState<string | null>(
-    null
-  );
-
   const [selectedNodes, setSelectedNodes] = useState<
     Record<string, ContentNodeTreeItemStatus>
   >({});
@@ -615,21 +610,7 @@ export function ConnectorPermissionsModal({
             {CONNECTOR_CONFIGURATIONS[connector.type].selectLabel}
           </div>
 
-          <ManagedDataSourceDocumentModal
-            owner={owner}
-            dataSource={dataSource}
-            documentId={documentToDisplay}
-            isOpen={!!documentToDisplay}
-            setOpen={(open) => {
-              if (!open) {
-                setDocumentToDisplay(null);
-              }
-            }}
-          />
           <ContentNodeTree
-            onDocumentViewClick={(documentId: string) => {
-              setDocumentToDisplay(documentId);
-            }}
             isSearchEnabled={
               CONNECTOR_CONFIGURATIONS[connector.type].isSearchEnabled
             }

--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -156,15 +156,41 @@ function ContentNodeTreeChildren({
                     disabled: parentIsSelected || !setSelectedNodes,
                     checked: checkedState,
                     onChange: (checked) => {
-                      if (checkedState !== "partial" && setSelectedNodes) {
-                        setSelectedNodes((prev) => ({
-                          ...prev,
-                          [n.internalId]: {
-                            isSelected: checked,
-                            node: n,
-                            parents: checked ? breadcrumb : [],
-                          },
-                        }));
+                      if (setSelectedNodes) {
+                        if (checkedState === "partial") {
+                          // Handle clicking on partial : unselect all selected children
+                          setSelectedNodes((prev) => {
+                            return {
+                              ...Object.entries(prev).reduce((acc, [k, v]) => {
+                                const shouldUnselect = v.parents.includes(
+                                  n.internalId
+                                );
+                                return {
+                                  ...acc,
+                                  [k]: {
+                                    ...v,
+                                    parents: shouldUnselect ? [] : v.parents,
+                                    isSelected: v.isSelected && !shouldUnselect,
+                                  },
+                                };
+                              }, {}),
+                              [n.internalId]: {
+                                isSelected: true,
+                                node: n,
+                                parents: breadcrumb,
+                              },
+                            };
+                          });
+                        } else {
+                          setSelectedNodes((prev) => ({
+                            ...prev,
+                            [n.internalId]: {
+                              isSelected: checked,
+                              node: n,
+                              parents: checked ? breadcrumb : [],
+                            },
+                          }));
+                        }
                       }
                     },
                   }

--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -27,6 +27,10 @@ export type ContentNodeTreeNodeStatus = {
   parents: string[];
 };
 
+type TreeSelectionModelUpdater = (
+  prev: Record<string, ContentNodeTreeNodeStatus>
+) => Record<string, ContentNodeTreeNodeStatus>;
+
 type ContextType = {
   // Custom function to determine if a node is checked.
   // This is used to override the default behavior of checking if a node has read or read_write permissions.
@@ -34,9 +38,7 @@ type ContextType = {
   showExpand?: boolean;
   useResourcesHook: UseResourcesHook;
   treeSelectionModel?: Record<string, ContentNodeTreeNodeStatus>;
-  setTreeSelectionModel?: React.Dispatch<
-    React.SetStateAction<Record<string, ContentNodeTreeNodeStatus>>
-  >;
+  setTreeSelectionModel?: (updater: TreeSelectionModelUpdater) => void;
 };
 
 const ContentNodeTreeContext = React.createContext<ContextType | undefined>(
@@ -292,9 +294,7 @@ interface ContentNodeTreeProps {
   showExpand?: boolean;
   useResourcesHook: UseResourcesHook;
   treeSelectionModel?: Record<string, ContentNodeTreeNodeStatus>;
-  setTreeSelectionModel?: React.Dispatch<
-    React.SetStateAction<Record<string, ContentNodeTreeNodeStatus>>
-  >;
+  setTreeSelectionModel?: (updater: TreeSelectionModelUpdater) => void;
 }
 
 export function ContentNodeTree({

--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -33,10 +33,10 @@ type TreeSelectionModelUpdater = (
 
 type ContextType = {
   onDocumentViewClick?: (documentId: string) => void;
-  showExpand?: boolean;
-  useResourcesHook: UseResourcesHook;
   selectedNodes?: Record<string, ContentNodeTreeItemStatus>;
   setSelectedNodes?: (updater: TreeSelectionModelUpdater) => void;
+  showExpand?: boolean;
+  useResourcesHook: UseResourcesHook;
 };
 
 const ContentNodeTreeContext = React.createContext<ContextType | undefined>(
@@ -71,16 +71,16 @@ interface ContentNodeTreeChildrenProps {
   isRoundedBackground?: boolean;
   isSearchEnabled?: boolean;
   parentId: string | null;
+  parentIds: string[];
   parentIsSelected?: boolean;
-  breadcrumb: string[];
 }
 
 function ContentNodeTreeChildren({
-  isSearchEnabled,
   isRoundedBackground,
-  parentIsSelected,
-  breadcrumb,
+  isSearchEnabled,
   parentId,
+  parentIds,
+  parentIsSelected,
 }: ContentNodeTreeChildrenProps) {
   const { onDocumentViewClick, selectedNodes, setSelectedNodes } =
     useContentNodeTreeContext();
@@ -177,7 +177,7 @@ function ContentNodeTreeChildren({
                               [n.internalId]: {
                                 isSelected: true,
                                 node: n,
-                                parents: breadcrumb,
+                                parents: parentIds,
                               },
                             };
                           });
@@ -187,7 +187,7 @@ function ContentNodeTreeChildren({
                             [n.internalId]: {
                               isSelected: checked,
                               node: n,
-                              parents: checked ? breadcrumb : [],
+                              parents: checked ? parentIds : [],
                             },
                           }));
                         }
@@ -245,8 +245,8 @@ function ContentNodeTreeChildren({
             renderTreeItems={() => (
               <ContentNodeTreeChildren
                 parentId={n.internalId}
+                parentIds={[n.internalId, ...parentIds]}
                 parentIsSelected={getCheckedState(n) === "checked"}
-                breadcrumb={[n.internalId, ...breadcrumb]}
               />
             )}
           />
@@ -262,23 +262,23 @@ function ContentNodeTreeChildren({
           <div className="flex w-full flex-row items-center">
             <div className="flex-grow p-1">
               <Searchbar
+                name="search"
                 placeholder="Search..."
                 value={search}
                 onChange={(v) => {
                   setSearch(v);
                   setSelectAllClicked(false);
                 }}
-                name="search"
               />
             </div>
 
             <div className="p-1">
               <Button
-                variant="tertiary"
-                size="sm"
-                label={selectAllClicked ? "Unselect All" : "Select All"}
-                icon={ListCheckIcon}
                 disabled={search.trim().length === 0}
+                icon={ListCheckIcon}
+                label={selectAllClicked ? "Unselect All" : "Select All"}
+                size="sm"
+                variant="tertiary"
                 onClick={() => {
                   const isSelected = !selectAllClicked;
                   setSelectAllClicked(isSelected);
@@ -288,7 +288,7 @@ function ContentNodeTreeChildren({
                       newState[n.internalId] = {
                         isSelected,
                         node: n,
-                        parents: isSelected ? breadcrumb : [],
+                        parents: isSelected ? parentIds : [],
                       };
                     });
                     return newState;
@@ -311,41 +311,41 @@ function ContentNodeTreeChildren({
 }
 
 interface ContentNodeTreeProps {
-  isSearchEnabled?: boolean;
-  isRoundedBackground?: boolean;
-  onDocumentViewClick?: (documentId: string) => void;
   customIsNodeChecked?: (node: BaseContentNode) => boolean;
-  showExpand?: boolean;
-  useResourcesHook: UseResourcesHook;
+  isRoundedBackground?: boolean;
+  isSearchEnabled?: boolean;
+  onDocumentViewClick?: (documentId: string) => void;
   selectedNodes?: Record<string, ContentNodeTreeItemStatus>;
   setSelectedNodes?: (updater: TreeSelectionModelUpdater) => void;
+  showExpand?: boolean;
+  useResourcesHook: UseResourcesHook;
 }
 
 export function ContentNodeTree({
-  isSearchEnabled,
   isRoundedBackground,
-  useResourcesHook,
+  isSearchEnabled,
   onDocumentViewClick,
   selectedNodes,
   setSelectedNodes,
   showExpand,
+  useResourcesHook,
 }: ContentNodeTreeProps) {
   return (
     <ContentNodeTreeContextProvider
       value={{
-        showExpand,
-        useResourcesHook,
+        onDocumentViewClick,
         selectedNodes,
         setSelectedNodes,
-        onDocumentViewClick,
+        showExpand,
+        useResourcesHook,
       }}
     >
       <ContentNodeTreeChildren
-        isSearchEnabled={isSearchEnabled}
         isRoundedBackground={isRoundedBackground}
+        isSearchEnabled={isSearchEnabled}
         parentId={null}
+        parentIds={[]}
         parentIsSelected={false}
-        breadcrumb={[]}
       />
     </ContentNodeTreeContextProvider>
   );

--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -21,22 +21,22 @@ export type UseResourcesHook = (parentId: string | null) => {
   isResourcesError: boolean;
 };
 
-export type ContentNodeTreeNodeStatus = {
+export type ContentNodeTreeItemStatus = {
   isSelected: boolean;
   node: BaseContentNode;
   parents: string[];
 };
 
 type TreeSelectionModelUpdater = (
-  prev: Record<string, ContentNodeTreeNodeStatus>
-) => Record<string, ContentNodeTreeNodeStatus>;
+  prev: Record<string, ContentNodeTreeItemStatus>
+) => Record<string, ContentNodeTreeItemStatus>;
 
 type ContextType = {
   onDocumentViewClick?: (documentId: string) => void;
   showExpand?: boolean;
   useResourcesHook: UseResourcesHook;
-  treeSelectionModel?: Record<string, ContentNodeTreeNodeStatus>;
-  setTreeSelectionModel?: (updater: TreeSelectionModelUpdater) => void;
+  selectedNodes?: Record<string, ContentNodeTreeItemStatus>;
+  setSelectedNodes?: (updater: TreeSelectionModelUpdater) => void;
 };
 
 const ContentNodeTreeContext = React.createContext<ContextType | undefined>(
@@ -82,7 +82,7 @@ function ContentNodeTreeChildren({
   breadcrumb,
   parentId,
 }: ContentNodeTreeChildrenProps) {
-  const { onDocumentViewClick, treeSelectionModel, setTreeSelectionModel } =
+  const { onDocumentViewClick, selectedNodes, setSelectedNodes } =
     useContentNodeTreeContext();
 
   const [search, setSearch] = useState("");
@@ -102,7 +102,7 @@ function ContentNodeTreeChildren({
 
   const getCheckedState = useCallback(
     (node: BaseContentNode) => {
-      if (!treeSelectionModel) {
+      if (!selectedNodes) {
         return "unchecked";
       }
 
@@ -112,12 +112,12 @@ function ContentNodeTreeChildren({
       }
 
       // Check if there is a local state for this node.
-      const localState = treeSelectionModel[node.internalId];
+      const localState = selectedNodes[node.internalId];
       if (localState?.isSelected) {
         return "checked";
       }
 
-      const internalPartiallySelectedId = Object.values(treeSelectionModel)
+      const internalPartiallySelectedId = Object.values(selectedNodes)
         .map((status) => status.parents)
         .flat();
       if (internalPartiallySelectedId.includes(node.internalId)) {
@@ -127,7 +127,7 @@ function ContentNodeTreeChildren({
       // Return false if no custom function is provided.
       return "unchecked";
     },
-    [parentIsSelected, treeSelectionModel]
+    [parentIsSelected, selectedNodes]
   );
 
   if (isResourcesError) {
@@ -151,13 +151,13 @@ function ContentNodeTreeChildren({
             visual={getVisualForContentNode(n)}
             className="whitespace-nowrap"
             checkbox={
-              n.preventSelection !== true && treeSelectionModel
+              n.preventSelection !== true && selectedNodes
                 ? {
-                    disabled: parentIsSelected || !setTreeSelectionModel,
+                    disabled: parentIsSelected || !setSelectedNodes,
                     checked: checkedState,
                     onChange: (checked) => {
-                      if (checkedState !== "partial" && setTreeSelectionModel) {
-                        setTreeSelectionModel((prev) => ({
+                      if (checkedState !== "partial" && setSelectedNodes) {
+                        setSelectedNodes((prev) => ({
                           ...prev,
                           [n.internalId]: {
                             isSelected: checked,
@@ -231,7 +231,7 @@ function ContentNodeTreeChildren({
 
   return (
     <>
-      {isSearchEnabled && setTreeSelectionModel && (
+      {isSearchEnabled && setSelectedNodes && (
         <>
           <div className="flex w-full flex-row items-center">
             <div className="flex-grow p-1">
@@ -256,7 +256,7 @@ function ContentNodeTreeChildren({
                 onClick={() => {
                   const isSelected = !selectAllClicked;
                   setSelectAllClicked(isSelected);
-                  setTreeSelectionModel((prev) => {
+                  setSelectedNodes((prev) => {
                     const newState = { ...prev };
                     filteredNodes.forEach((n) => {
                       newState[n.internalId] = {
@@ -291,8 +291,8 @@ interface ContentNodeTreeProps {
   customIsNodeChecked?: (node: BaseContentNode) => boolean;
   showExpand?: boolean;
   useResourcesHook: UseResourcesHook;
-  treeSelectionModel?: Record<string, ContentNodeTreeNodeStatus>;
-  setTreeSelectionModel?: (updater: TreeSelectionModelUpdater) => void;
+  selectedNodes?: Record<string, ContentNodeTreeItemStatus>;
+  setSelectedNodes?: (updater: TreeSelectionModelUpdater) => void;
 }
 
 export function ContentNodeTree({
@@ -300,8 +300,8 @@ export function ContentNodeTree({
   isRoundedBackground,
   useResourcesHook,
   onDocumentViewClick,
-  treeSelectionModel,
-  setTreeSelectionModel,
+  selectedNodes,
+  setSelectedNodes,
   showExpand,
 }: ContentNodeTreeProps) {
   return (
@@ -309,8 +309,8 @@ export function ContentNodeTree({
       value={{
         showExpand,
         useResourcesHook,
-        treeSelectionModel,
-        setTreeSelectionModel,
+        selectedNodes,
+        setSelectedNodes,
         onDocumentViewClick,
       }}
     >

--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -305,24 +305,22 @@ export function ContentNodeTree({
   showExpand,
 }: ContentNodeTreeProps) {
   return (
-    <>
-      <ContentNodeTreeContextProvider
-        value={{
-          showExpand,
-          useResourcesHook,
-          treeSelectionModel,
-          setTreeSelectionModel,
-          onDocumentViewClick,
-        }}
-      >
-        <ContentNodeTreeChildren
-          isSearchEnabled={isSearchEnabled}
-          isRoundedBackground={isRoundedBackground}
-          parentId={null}
-          parentIsSelected={false}
-          breadcrumb={[]}
-        />
-      </ContentNodeTreeContextProvider>
-    </>
+    <ContentNodeTreeContextProvider
+      value={{
+        showExpand,
+        useResourcesHook,
+        treeSelectionModel,
+        setTreeSelectionModel,
+        onDocumentViewClick,
+      }}
+    >
+      <ContentNodeTreeChildren
+        isSearchEnabled={isSearchEnabled}
+        isRoundedBackground={isRoundedBackground}
+        parentId={null}
+        parentIsSelected={false}
+        breadcrumb={[]}
+      />
+    </ContentNodeTreeContextProvider>
   );
 }

--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -32,9 +32,7 @@ type TreeSelectionModelUpdater = (
 ) => Record<string, ContentNodeTreeNodeStatus>;
 
 type ContextType = {
-  // Custom function to determine if a node is checked.
-  // This is used to override the default behavior of checking if a node has read or read_write permissions.
-  displayDocumentSource?: (documentId: string) => void;
+  onDocumentViewClick?: (documentId: string) => void;
   showExpand?: boolean;
   useResourcesHook: UseResourcesHook;
   treeSelectionModel?: Record<string, ContentNodeTreeNodeStatus>;
@@ -84,7 +82,7 @@ function ContentNodeTreeChildren({
   breadcrumb,
   parentId,
 }: ContentNodeTreeChildrenProps) {
-  const { displayDocumentSource, treeSelectionModel, setTreeSelectionModel } =
+  const { onDocumentViewClick, treeSelectionModel, setTreeSelectionModel } =
     useContentNodeTreeContext();
 
   const [search, setSearch] = useState("");
@@ -200,13 +198,13 @@ function ContentNodeTreeChildren({
                   disabled={!n.sourceUrl}
                   variant="tertiary"
                 />
-                {displayDocumentSource && (
+                {onDocumentViewClick && (
                   <IconButton
                     size="xs"
                     icon={BracesIcon}
                     onClick={() => {
                       if (n.dustDocumentId) {
-                        displayDocumentSource(n.dustDocumentId);
+                        onDocumentViewClick(n.dustDocumentId);
                       }
                     }}
                     className={classNames(
@@ -289,7 +287,7 @@ function ContentNodeTreeChildren({
 interface ContentNodeTreeProps {
   isSearchEnabled?: boolean;
   isRoundedBackground?: boolean;
-  displayDocumentSource?: (documentId: string) => void;
+  onDocumentViewClick?: (documentId: string) => void;
   customIsNodeChecked?: (node: BaseContentNode) => boolean;
   showExpand?: boolean;
   useResourcesHook: UseResourcesHook;
@@ -301,7 +299,7 @@ export function ContentNodeTree({
   isSearchEnabled,
   isRoundedBackground,
   useResourcesHook,
-  displayDocumentSource,
+  onDocumentViewClick,
   treeSelectionModel,
   setTreeSelectionModel,
   showExpand,
@@ -314,7 +312,7 @@ export function ContentNodeTree({
           useResourcesHook,
           treeSelectionModel,
           setTreeSelectionModel,
-          displayDocumentSource,
+          onDocumentViewClick,
         }}
       >
         <ContentNodeTreeChildren

--- a/front/components/DataSourceViewPermissionTree.tsx
+++ b/front/components/DataSourceViewPermissionTree.tsx
@@ -1,0 +1,64 @@
+import type {
+  ConnectorPermission,
+  ContentNodesViewType,
+  DataSourceViewType,
+  LightWorkspaceType,
+} from "@dust-tt/types";
+
+import type { ContentNodeTreeNodeStatus } from "@app/components/ContentNodeTree";
+import { ContentNodeTree } from "@app/components/ContentNodeTree";
+import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
+
+interface DataSourceViewPermissionTreeProps {
+  dataSourceView: DataSourceViewType;
+  displayDocumentSource: (documentId: string) => void;
+  isSearchEnabled?: boolean;
+  isRoundedBackground?: boolean;
+  owner: LightWorkspaceType;
+  parentId?: string | null;
+  permissionFilter?: ConnectorPermission;
+  showExpand?: boolean;
+  viewType: ContentNodesViewType;
+  treeSelectionModel?: Record<string, ContentNodeTreeNodeStatus>;
+  setTreeSelectionModel?: React.Dispatch<
+    React.SetStateAction<Record<string, ContentNodeTreeNodeStatus>>
+  >;
+}
+
+export function DataSourceViewPermissionTree({
+  dataSourceView,
+  isSearchEnabled,
+  isRoundedBackground,
+  owner,
+  displayDocumentSource,
+  showExpand,
+  viewType,
+  treeSelectionModel,
+  setTreeSelectionModel,
+}: DataSourceViewPermissionTreeProps) {
+  const useResourcesHook = (parentId: string | null) => {
+    const res = useDataSourceViewContentNodes({
+      dataSourceView: dataSourceView,
+      owner,
+      parentId: parentId ?? undefined,
+      viewType,
+    });
+    return {
+      resources: res.nodes,
+      isResourcesLoading: res.isNodesLoading,
+      isResourcesError: res.isNodesError,
+    };
+  };
+
+  return (
+    <ContentNodeTree
+      isSearchEnabled={isSearchEnabled}
+      isRoundedBackground={isRoundedBackground}
+      displayDocumentSource={displayDocumentSource}
+      showExpand={showExpand}
+      useResourcesHook={useResourcesHook}
+      treeSelectionModel={treeSelectionModel}
+      setTreeSelectionModel={setTreeSelectionModel}
+    />
+  );
+}

--- a/front/components/DataSourceViewPermissionTree.tsx
+++ b/front/components/DataSourceViewPermissionTree.tsx
@@ -4,10 +4,31 @@ import type {
   DataSourceViewType,
   LightWorkspaceType,
 } from "@dust-tt/types";
+import { useCallback } from "react";
 
 import type { ContentNodeTreeItemStatus } from "@app/components/ContentNodeTree";
 import { ContentNodeTree } from "@app/components/ContentNodeTree";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
+
+const getUseResourceHook =
+  (
+    owner: LightWorkspaceType,
+    dataSourceView: DataSourceViewType,
+    viewType: ContentNodesViewType
+  ) =>
+  (parentId: string | null) => {
+    const res = useDataSourceViewContentNodes({
+      dataSourceView: dataSourceView,
+      owner,
+      parentId: parentId ?? undefined,
+      viewType,
+    });
+    return {
+      resources: res.nodes,
+      isResourcesLoading: res.isNodesLoading,
+      isResourcesError: res.isNodesError,
+    };
+  };
 
 interface DataSourceViewPermissionTreeProps {
   dataSourceView: DataSourceViewType;
@@ -38,19 +59,11 @@ export function DataSourceViewPermissionTree({
   selectedNodes,
   setSelectedNodes,
 }: DataSourceViewPermissionTreeProps) {
-  const useResourcesHook = (parentId: string | null) => {
-    const res = useDataSourceViewContentNodes({
-      dataSourceView: dataSourceView,
-      owner,
-      parentId: parentId ?? undefined,
-      viewType,
-    });
-    return {
-      resources: res.nodes,
-      isResourcesLoading: res.isNodesLoading,
-      isResourcesError: res.isNodesError,
-    };
-  };
+  const useResourcesHook = useCallback(
+    (parentId: string | null) =>
+      getUseResourceHook(owner, dataSourceView, viewType)(parentId),
+    [owner, dataSourceView, viewType]
+  );
 
   return (
     <ContentNodeTree

--- a/front/components/DataSourceViewPermissionTree.tsx
+++ b/front/components/DataSourceViewPermissionTree.tsx
@@ -5,7 +5,7 @@ import type {
   LightWorkspaceType,
 } from "@dust-tt/types";
 
-import type { ContentNodeTreeNodeStatus } from "@app/components/ContentNodeTree";
+import type { ContentNodeTreeItemStatus } from "@app/components/ContentNodeTree";
 import { ContentNodeTree } from "@app/components/ContentNodeTree";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 
@@ -19,11 +19,11 @@ interface DataSourceViewPermissionTreeProps {
   permissionFilter?: ConnectorPermission;
   showExpand?: boolean;
   viewType: ContentNodesViewType;
-  treeSelectionModel?: Record<string, ContentNodeTreeNodeStatus>;
-  setTreeSelectionModel?: (
+  selectedNodes?: Record<string, ContentNodeTreeItemStatus>;
+  setSelectedNodes?: (
     updater: (
-      prev: Record<string, ContentNodeTreeNodeStatus>
-    ) => Record<string, ContentNodeTreeNodeStatus>
+      prev: Record<string, ContentNodeTreeItemStatus>
+    ) => Record<string, ContentNodeTreeItemStatus>
   ) => void;
 }
 
@@ -35,8 +35,8 @@ export function DataSourceViewPermissionTree({
   onDocumentViewClick,
   showExpand,
   viewType,
-  treeSelectionModel,
-  setTreeSelectionModel,
+  selectedNodes,
+  setSelectedNodes,
 }: DataSourceViewPermissionTreeProps) {
   const useResourcesHook = (parentId: string | null) => {
     const res = useDataSourceViewContentNodes({
@@ -59,8 +59,8 @@ export function DataSourceViewPermissionTree({
       onDocumentViewClick={onDocumentViewClick}
       showExpand={showExpand}
       useResourcesHook={useResourcesHook}
-      treeSelectionModel={treeSelectionModel}
-      setTreeSelectionModel={setTreeSelectionModel}
+      selectedNodes={selectedNodes}
+      setSelectedNodes={setSelectedNodes}
     />
   );
 }

--- a/front/components/DataSourceViewPermissionTree.tsx
+++ b/front/components/DataSourceViewPermissionTree.tsx
@@ -20,9 +20,11 @@ interface DataSourceViewPermissionTreeProps {
   showExpand?: boolean;
   viewType: ContentNodesViewType;
   treeSelectionModel?: Record<string, ContentNodeTreeNodeStatus>;
-  setTreeSelectionModel?: React.Dispatch<
-    React.SetStateAction<Record<string, ContentNodeTreeNodeStatus>>
-  >;
+  setTreeSelectionModel?: (
+    updater: (
+      prev: Record<string, ContentNodeTreeNodeStatus>
+    ) => Record<string, ContentNodeTreeNodeStatus>
+  ) => void;
 }
 
 export function DataSourceViewPermissionTree({

--- a/front/components/DataSourceViewPermissionTree.tsx
+++ b/front/components/DataSourceViewPermissionTree.tsx
@@ -11,7 +11,7 @@ import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 
 interface DataSourceViewPermissionTreeProps {
   dataSourceView: DataSourceViewType;
-  displayDocumentSource: (documentId: string) => void;
+  onDocumentViewClick: (documentId: string) => void;
   isSearchEnabled?: boolean;
   isRoundedBackground?: boolean;
   owner: LightWorkspaceType;
@@ -32,7 +32,7 @@ export function DataSourceViewPermissionTree({
   isSearchEnabled,
   isRoundedBackground,
   owner,
-  displayDocumentSource,
+  onDocumentViewClick,
   showExpand,
   viewType,
   treeSelectionModel,
@@ -56,7 +56,7 @@ export function DataSourceViewPermissionTree({
     <ContentNodeTree
       isSearchEnabled={isSearchEnabled}
       isRoundedBackground={isRoundedBackground}
-      displayDocumentSource={displayDocumentSource}
+      onDocumentViewClick={onDocumentViewClick}
       showExpand={showExpand}
       useResourcesHook={useResourcesHook}
       treeSelectionModel={treeSelectionModel}

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -40,7 +40,7 @@ import AssistantListActions from "@app/components/assistant/AssistantListActions
 import { ReadOnlyTextArea } from "@app/components/assistant/ReadOnlyTextArea";
 import { assistantUsageMessage } from "@app/components/assistant/Usage";
 import { SharingDropdown } from "@app/components/assistant_builder/Sharing";
-import { DataSourceViewPermissionTreeChildren } from "@app/components/ConnectorPermissionsTree";
+import { DataSourceViewPermissionTree } from "@app/components/ConnectorPermissionsTree";
 import DataSourceViewDocumentModal from "@app/components/DataSourceViewDocumentModal";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { GLOBAL_AGENTS_SID } from "@app/lib/assistant";
@@ -436,16 +436,13 @@ function DataSourceViewsSection({
               className="whitespace-nowrap"
             >
               {dataSourceView && isAllSelected && (
-                <DataSourceViewPermissionTreeChildren
+                <DataSourceViewPermissionTree
                   owner={owner}
                   dataSourceView={dataSourceView}
-                  parentId={null}
-                  canUpdatePermissions={false}
                   displayDocumentSource={(documentId: string) => {
                     setDataSourceViewToDisplay(dataSourceView);
                     setDocumentToDisplay(documentId);
                   }}
-                  isSearchEnabled={false}
                   viewType={viewType}
                 />
               )}
@@ -532,16 +529,14 @@ function DataSourceViewSelectedNodes({
             </div>
           }
         >
-          <DataSourceViewPermissionTreeChildren
+          <DataSourceViewPermissionTree
             owner={owner}
             dataSourceView={dataSourceView}
             parentId={node.internalId}
-            canUpdatePermissions={true}
             displayDocumentSource={(documentId: string) => {
               setDataSourceViewToDisplay(dataSourceView);
               setDocumentToDisplay(documentId);
             }}
-            isSearchEnabled={false}
             viewType="documents"
           />
         </Tree.Item>

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -439,7 +439,7 @@ function DataSourceViewsSection({
                 <DataSourceViewPermissionTree
                   owner={owner}
                   dataSourceView={dataSourceView}
-                  displayDocumentSource={(documentId: string) => {
+                  onDocumentViewClick={(documentId: string) => {
                     setDataSourceViewToDisplay(dataSourceView);
                     setDocumentToDisplay(documentId);
                   }}
@@ -533,7 +533,7 @@ function DataSourceViewSelectedNodes({
             owner={owner}
             dataSourceView={dataSourceView}
             parentId={node.internalId}
-            displayDocumentSource={(documentId: string) => {
+            onDocumentViewClick={(documentId: string) => {
               setDataSourceViewToDisplay(dataSourceView);
               setDocumentToDisplay(documentId);
             }}

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -40,8 +40,8 @@ import AssistantListActions from "@app/components/assistant/AssistantListActions
 import { ReadOnlyTextArea } from "@app/components/assistant/ReadOnlyTextArea";
 import { assistantUsageMessage } from "@app/components/assistant/Usage";
 import { SharingDropdown } from "@app/components/assistant_builder/Sharing";
-import { DataSourceViewPermissionTree } from "@app/components/ConnectorPermissionsTree";
 import DataSourceViewDocumentModal from "@app/components/DataSourceViewDocumentModal";
+import { DataSourceViewPermissionTree } from "@app/components/DataSourceViewPermissionTree";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { GLOBAL_AGENTS_SID } from "@app/lib/assistant";
 import { updateAgentScope } from "@app/lib/client/dust_api";

--- a/front/components/assistant_builder/DataSourceSelectionSection.tsx
+++ b/front/components/assistant_builder/DataSourceSelectionSection.tsx
@@ -15,7 +15,7 @@ import type {
 import { useContext, useState } from "react";
 
 import { AssistantBuilderContext } from "@app/components/assistant_builder/AssistantBuilderContext";
-import { DataSourceViewPermissionTreeChildren } from "@app/components/ConnectorPermissionsTree";
+import { DataSourceViewPermissionTree } from "@app/components/ConnectorPermissionsTree";
 import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
 import ManagedDataSourceDocumentModal from "@app/components/ManagedDataSourceDocumentModal";
 import { orderDatasourceViewSelectionConfigurationByImportance } from "@app/lib/assistant";
@@ -113,16 +113,14 @@ export default function DataSourceSelectionSection({
                   className="whitespace-nowrap"
                 >
                   {dsConfig.isSelectAll && (
-                    <DataSourceViewPermissionTreeChildren
+                    <DataSourceViewPermissionTree
                       owner={owner}
                       dataSourceView={dsConfig.dataSourceView}
                       parentId={null}
-                      canUpdatePermissions={true}
                       displayDocumentSource={(documentId: string) => {
                         setDataSourceViewToDisplay(dsConfig.dataSourceView);
                         setDocumentToDisplay(documentId);
                       }}
-                      isSearchEnabled={false}
                       viewType={viewType}
                     />
                   )}
@@ -174,16 +172,14 @@ export default function DataSourceSelectionSection({
                           </div>
                         }
                       >
-                        <DataSourceViewPermissionTreeChildren
+                        <DataSourceViewPermissionTree
                           owner={owner}
                           dataSourceView={dsConfig.dataSourceView}
                           parentId={node.internalId}
-                          canUpdatePermissions={true}
                           displayDocumentSource={(documentId: string) => {
                             setDataSourceViewToDisplay(dsConfig.dataSourceView);
                             setDocumentToDisplay(documentId);
                           }}
-                          isSearchEnabled={false}
                           viewType={viewType}
                         />
                       </Tree.Item>

--- a/front/components/assistant_builder/DataSourceSelectionSection.tsx
+++ b/front/components/assistant_builder/DataSourceSelectionSection.tsx
@@ -15,7 +15,7 @@ import type {
 import { useContext, useState } from "react";
 
 import { AssistantBuilderContext } from "@app/components/assistant_builder/AssistantBuilderContext";
-import { DataSourceViewPermissionTree } from "@app/components/ConnectorPermissionsTree";
+import { DataSourceViewPermissionTree } from "@app/components/DataSourceViewPermissionTree";
 import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
 import ManagedDataSourceDocumentModal from "@app/components/ManagedDataSourceDocumentModal";
 import { orderDatasourceViewSelectionConfigurationByImportance } from "@app/lib/assistant";

--- a/front/components/assistant_builder/DataSourceSelectionSection.tsx
+++ b/front/components/assistant_builder/DataSourceSelectionSection.tsx
@@ -117,7 +117,7 @@ export default function DataSourceSelectionSection({
                       owner={owner}
                       dataSourceView={dsConfig.dataSourceView}
                       parentId={null}
-                      displayDocumentSource={(documentId: string) => {
+                      onDocumentViewClick={(documentId: string) => {
                         setDataSourceViewToDisplay(dsConfig.dataSourceView);
                         setDocumentToDisplay(documentId);
                       }}
@@ -176,7 +176,7 @@ export default function DataSourceSelectionSection({
                           owner={owner}
                           dataSourceView={dsConfig.dataSourceView}
                           parentId={node.internalId}
-                          displayDocumentSource={(documentId: string) => {
+                          onDocumentViewClick={(documentId: string) => {
                             setDataSourceViewToDisplay(dsConfig.dataSourceView);
                             setDocumentToDisplay(documentId);
                           }}

--- a/front/components/assistant_builder/SlackIntegration.tsx
+++ b/front/components/assistant_builder/SlackIntegration.tsx
@@ -7,7 +7,7 @@ import type {
 import { useCallback, useEffect, useState } from "react";
 import React from "react";
 
-import type { ContentNodeTreeNodeStatus } from "@app/components/ContentNodeTree";
+import type { ContentNodeTreeItemStatus } from "@app/components/ContentNodeTree";
 import { ContentNodeTree } from "@app/components/ContentNodeTree";
 import { useConnectorPermissions } from "@app/lib/swr/connectors";
 
@@ -61,7 +61,7 @@ export function SlackIntegration({
     });
 
   const { resources } = useResourcesHook(null);
-  const treeSelectionModel = resources.reduce(
+  const selectedNodes = resources.reduce(
     (acc, c) =>
       customIsNodeChecked(c)
         ? {
@@ -73,15 +73,15 @@ export function SlackIntegration({
             },
           }
         : acc,
-    {} as Record<string, ContentNodeTreeNodeStatus>
+    {} as Record<string, ContentNodeTreeItemStatus>
   );
 
   return (
     <ContentNodeTree
       // not limited to those synced with Dust.
-      treeSelectionModel={treeSelectionModel}
-      setTreeSelectionModel={(updater) => {
-        const newModel = updater(treeSelectionModel);
+      selectedNodes={selectedNodes}
+      setSelectedNodes={(updater) => {
+        const newModel = updater(selectedNodes);
 
         setNewSelection((prevSelection) => {
           const newSelection = [...prevSelection];

--- a/front/components/assistant_builder/SlackIntegration.tsx
+++ b/front/components/assistant_builder/SlackIntegration.tsx
@@ -108,15 +108,8 @@ export function SlackIntegration({
     <ContentNodeTree
       // not limited to those synced with Dust.
       treeSelectionModel={treeSelectionModel}
-      setTreeSelectionModel={(
-        updater:
-          | ((
-              prev: Record<string, ContentNodeTreeNodeStatus>
-            ) => Record<string, ContentNodeTreeNodeStatus>)
-          | Record<string, ContentNodeTreeNodeStatus>
-      ) => {
-        const newModel =
-          typeof updater === "function" ? updater(treeSelectionModel) : updater;
+      setTreeSelectionModel={(updater) => {
+        const newModel = updater(treeSelectionModel);
 
         setNewSelection((prevSelection) => {
           const newSelection = [...prevSelection];

--- a/front/components/assistant_builder/SlackIntegration.tsx
+++ b/front/components/assistant_builder/SlackIntegration.tsx
@@ -8,8 +8,8 @@ import type {
 import { useCallback, useEffect, useState } from "react";
 import React from "react";
 
-import type { PermissionTreeNodeStatus } from "@app/components/ConnectorPermissionsTree";
-import { PermissionTree } from "@app/components/ConnectorPermissionsTree";
+import type { ContentNodeTreeNodeStatus } from "@app/components/ContentNodeTree";
+import { ContentNodeTree } from "@app/components/ContentNodeTree";
 import { useConnectorPermissions } from "@app/lib/swr/connectors";
 
 export type SlackChannel = { slackChannelId: string; slackChannelName: string };
@@ -101,19 +101,19 @@ export function SlackIntegration({
             },
           }
         : acc,
-    {} as Record<string, PermissionTreeNodeStatus>
+    {} as Record<string, ContentNodeTreeNodeStatus>
   );
 
   return (
-    <PermissionTree
+    <ContentNodeTree
       // not limited to those synced with Dust.
       treeSelectionModel={treeSelectionModel}
       setTreeSelectionModel={(
         updater:
           | ((
-              prev: Record<string, PermissionTreeNodeStatus>
-            ) => Record<string, PermissionTreeNodeStatus>)
-          | Record<string, PermissionTreeNodeStatus>
+              prev: Record<string, ContentNodeTreeNodeStatus>
+            ) => Record<string, ContentNodeTreeNodeStatus>)
+          | Record<string, ContentNodeTreeNodeStatus>
       ) => {
         const newModel =
           typeof updater === "function" ? updater(treeSelectionModel) : updater;

--- a/front/components/assistant_builder/SlackIntegration.tsx
+++ b/front/components/assistant_builder/SlackIntegration.tsx
@@ -1,7 +1,6 @@
 import { ContentMessage, Modal, Page, SlackLogo } from "@dust-tt/sparkle";
 import type {
   BaseContentNode,
-  ConnectorPermission,
   DataSourceViewType,
   WorkspaceType,
 } from "@dust-tt/types";
@@ -42,33 +41,6 @@ export function SlackIntegration({
       );
     },
     [newSelection]
-  );
-
-  const handlePermissionUpdate = useCallback(
-    (
-      node: BaseContentNode,
-      { newPermission }: { newPermission: ConnectorPermission }
-    ) => {
-      const { internalId, title } = node;
-
-      setNewSelection((prevSelection) => {
-        const channel = { slackChannelId: internalId, slackChannelName: title };
-        const index = prevSelection.findIndex(
-          (c) => c.slackChannelId === internalId
-        );
-
-        if (newPermission === "read_write" && index === -1) {
-          return [...prevSelection, channel];
-        }
-
-        if (newPermission !== "read_write" && index !== -1) {
-          return prevSelection.filter((_, i) => i !== index);
-        }
-
-        return prevSelection;
-      });
-    },
-    [setNewSelection]
   );
 
   // Notify parent component when newSelection changes.

--- a/front/components/assistant_builder/SlackIntegration.tsx
+++ b/front/components/assistant_builder/SlackIntegration.tsx
@@ -13,6 +13,18 @@ import { useConnectorPermissions } from "@app/lib/swr/connectors";
 
 export type SlackChannel = { slackChannelId: string; slackChannelName: string };
 
+// The "write" permission filter is applied to retrieve all available channels on Slack,
+const getUseResourceHook =
+  (owner: WorkspaceType, slackDataSourceView: DataSourceViewType) =>
+  (parentId: string | null) =>
+    useConnectorPermissions({
+      dataSource: slackDataSourceView.dataSource,
+      filterPermission: "write",
+      owner,
+      parentId,
+      viewType: "documents",
+    });
+
 interface SlacIntegrationProps {
   existingSelection: SlackChannel[];
   onSelectionChange: (channels: SlackChannel[]) => void;
@@ -50,15 +62,11 @@ export function SlackIntegration({
     }
   }, [newSelection, onSelectionChange]);
 
-  // The "write" permission filter is applied to retrieve all available channels on Slack,
-  const useResourcesHook = (parentId: string | null) =>
-    useConnectorPermissions({
-      dataSource: slackDataSourceView.dataSource,
-      filterPermission: "write",
-      owner,
-      parentId,
-      viewType: "documents",
-    });
+  const useResourcesHook = useCallback(
+    (parentId: string | null) =>
+      getUseResourceHook(owner, slackDataSourceView)(parentId),
+    [owner, slackDataSourceView]
+  );
 
   const { resources } = useResourcesHook(null);
   const selectedNodes = resources.reduce(

--- a/front/components/poke/PokeConnectorPermissionsTree.tsx
+++ b/front/components/poke/PokeConnectorPermissionsTree.tsx
@@ -4,38 +4,37 @@ import type {
   WorkspaceType,
 } from "@dust-tt/types";
 
-import { DataSourcePermissionTreeChildren } from "@app/components/ConnectorPermissionsTree";
+import { PermissionTree } from "@app/components/ConnectorPermissionsTree";
 import { usePokeConnectorPermissions } from "@app/lib/swr/poke";
 
 export function PokePermissionTree({
   owner,
   dataSource,
   permissionFilter,
-  canUpdatePermissions,
   showExpand,
   displayDocumentSource,
 }: {
   owner: WorkspaceType;
   dataSource: DataSourceType;
   permissionFilter?: ConnectorPermission;
-  canUpdatePermissions?: boolean;
   showExpand?: boolean;
   displayDocumentSource: (documentId: string) => void;
 }) {
+  const useResourcesHook = (parentId: string | null) =>
+    usePokeConnectorPermissions({
+      dataSource,
+      filterPermission: permissionFilter ?? null,
+      owner,
+      parentId,
+    });
+
   return (
     <div className="overflow-x-auto">
-      <DataSourcePermissionTreeChildren
-        owner={owner}
-        dataSource={dataSource}
-        parentId={null}
-        permissionFilter={permissionFilter}
-        canUpdatePermissions={canUpdatePermissions}
+      <PermissionTree
         showExpand={showExpand}
-        parentIsSelected={false}
         displayDocumentSource={displayDocumentSource}
-        useConnectorPermissionsHook={usePokeConnectorPermissions}
+        useResourcesHook={useResourcesHook}
         isSearchEnabled={false}
-        viewType="documents"
       />
     </div>
   );

--- a/front/components/poke/PokeConnectorPermissionsTree.tsx
+++ b/front/components/poke/PokeConnectorPermissionsTree.tsx
@@ -12,13 +12,13 @@ export function PokePermissionTree({
   dataSource,
   permissionFilter,
   showExpand,
-  displayDocumentSource,
+  onDocumentViewClick,
 }: {
   owner: WorkspaceType;
   dataSource: DataSourceType;
   permissionFilter?: ConnectorPermission;
   showExpand?: boolean;
-  displayDocumentSource: (documentId: string) => void;
+  onDocumentViewClick: (documentId: string) => void;
 }) {
   const useResourcesHook = (parentId: string | null) =>
     usePokeConnectorPermissions({
@@ -32,7 +32,7 @@ export function PokePermissionTree({
     <div className="overflow-x-auto">
       <ContentNodeTree
         showExpand={showExpand}
-        displayDocumentSource={displayDocumentSource}
+        onDocumentViewClick={onDocumentViewClick}
         useResourcesHook={useResourcesHook}
         isSearchEnabled={false}
       />

--- a/front/components/poke/PokeConnectorPermissionsTree.tsx
+++ b/front/components/poke/PokeConnectorPermissionsTree.tsx
@@ -3,9 +3,32 @@ import type {
   DataSourceType,
   WorkspaceType,
 } from "@dust-tt/types";
+import { useCallback } from "react";
 
 import { ContentNodeTree } from "@app/components/ContentNodeTree";
 import { usePokeConnectorPermissions } from "@app/lib/swr/poke";
+
+const getUseResourceHook =
+  (
+    owner: WorkspaceType,
+    dataSource: DataSourceType,
+    permissionFilter?: ConnectorPermission
+  ) =>
+  (parentId: string | null) =>
+    usePokeConnectorPermissions({
+      dataSource,
+      filterPermission: permissionFilter ?? null,
+      owner,
+      parentId,
+    });
+
+type PokePermissionTreeProps = {
+  owner: WorkspaceType;
+  dataSource: DataSourceType;
+  permissionFilter?: ConnectorPermission;
+  showExpand?: boolean;
+  onDocumentViewClick: (documentId: string) => void;
+};
 
 export function PokePermissionTree({
   owner,
@@ -13,20 +36,12 @@ export function PokePermissionTree({
   permissionFilter,
   showExpand,
   onDocumentViewClick,
-}: {
-  owner: WorkspaceType;
-  dataSource: DataSourceType;
-  permissionFilter?: ConnectorPermission;
-  showExpand?: boolean;
-  onDocumentViewClick: (documentId: string) => void;
-}) {
-  const useResourcesHook = (parentId: string | null) =>
-    usePokeConnectorPermissions({
-      dataSource,
-      filterPermission: permissionFilter ?? null,
-      owner,
-      parentId,
-    });
+}: PokePermissionTreeProps) {
+  const useResourcesHook = useCallback(
+    (parentId: string | null) =>
+      getUseResourceHook(owner, dataSource, permissionFilter)(parentId),
+    [owner, dataSource, permissionFilter]
+  );
 
   return (
     <div className="overflow-x-auto">

--- a/front/components/poke/PokeConnectorPermissionsTree.tsx
+++ b/front/components/poke/PokeConnectorPermissionsTree.tsx
@@ -4,7 +4,7 @@ import type {
   WorkspaceType,
 } from "@dust-tt/types";
 
-import { PermissionTree } from "@app/components/ConnectorPermissionsTree";
+import { ContentNodeTree } from "@app/components/ContentNodeTree";
 import { usePokeConnectorPermissions } from "@app/lib/swr/poke";
 
 export function PokePermissionTree({
@@ -30,7 +30,7 @@ export function PokePermissionTree({
 
   return (
     <div className="overflow-x-auto">
-      <PermissionTree
+      <ContentNodeTree
         showExpand={showExpand}
         displayDocumentSource={displayDocumentSource}
         useResourcesHook={useResourcesHook}

--- a/front/lib/swr/connectors.ts
+++ b/front/lib/swr/connectors.ts
@@ -17,12 +17,13 @@ import type { GetConnectorResponseBody } from "@app/pages/api/w/[wId]/data_sourc
 import type { GetOrPostManagedDataSourceConfigResponseBody } from "@app/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]";
 import type { GetDataSourcePermissionsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions";
 
-export function useConnectorPermissions({
+export function useConnectorPermissions<IncludeParents extends boolean>({
   owner,
   dataSource,
   parentId,
   filterPermission,
   disabled,
+  includeParents,
   viewType,
 }: {
   owner: LightWorkspaceType;
@@ -30,6 +31,7 @@ export function useConnectorPermissions({
   parentId: string | null;
   filterPermission: ConnectorPermission | null;
   disabled?: boolean;
+  includeParents?: IncludeParents;
   viewType?: ContentNodesViewType;
 }) {
   const permissionsFetcher: Fetcher<GetDataSourcePermissionsResponseBody> =
@@ -41,6 +43,9 @@ export function useConnectorPermissions({
   }
   if (filterPermission) {
     url += `&filterPermission=${filterPermission}`;
+  }
+  if (includeParents) {
+    url += "&includeParents=true";
   }
 
   const { data, error } = useSWRWithDefaults(url, permissionsFetcher, {

--- a/front/lib/swr/connectors.ts
+++ b/front/lib/swr/connectors.ts
@@ -17,7 +17,7 @@ import type { GetConnectorResponseBody } from "@app/pages/api/w/[wId]/data_sourc
 import type { GetOrPostManagedDataSourceConfigResponseBody } from "@app/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]";
 import type { GetDataSourcePermissionsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions";
 
-interface UseConnectorPermissionsReturnBase<IncludeParents extends boolean> {
+interface UseConnectorPermissionsReturn<IncludeParents extends boolean> {
   resources: GetDataSourcePermissionsResponseBody<IncludeParents>["resources"];
   isResourcesLoading: boolean;
   isResourcesError: any;
@@ -39,7 +39,7 @@ export function useConnectorPermissions<IncludeParents extends boolean>({
   disabled?: boolean;
   includeParents?: IncludeParents;
   viewType?: ContentNodesViewType;
-}): UseConnectorPermissionsReturnBase<IncludeParents> {
+}): UseConnectorPermissionsReturn<IncludeParents> {
   const permissionsFetcher: Fetcher<
     GetDataSourcePermissionsResponseBody<IncludeParents>
   > = fetcher;

--- a/front/lib/swr/connectors.ts
+++ b/front/lib/swr/connectors.ts
@@ -1,8 +1,6 @@
 import type {
   ConnectorPermission,
-  ContentNode,
   ContentNodesViewType,
-  ContentNodeWithParentIds,
   DataSourceType,
   LightWorkspaceType,
 } from "@dust-tt/types";

--- a/front/lib/swr/connectors.ts
+++ b/front/lib/swr/connectors.ts
@@ -1,6 +1,8 @@
 import type {
   ConnectorPermission,
+  ContentNode,
   ContentNodesViewType,
+  ContentNodeWithParentIds,
   DataSourceType,
   LightWorkspaceType,
 } from "@dust-tt/types";
@@ -16,6 +18,21 @@ import {
 import type { GetConnectorResponseBody } from "@app/pages/api/w/[wId]/data_sources/[dsId]/connector";
 import type { GetOrPostManagedDataSourceConfigResponseBody } from "@app/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]";
 import type { GetDataSourcePermissionsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions";
+
+type UseConnectorPermissionsReturn<IncludeParents extends boolean = false> = {
+  isResourcesLoading: boolean;
+  isResourcesError: boolean;
+} & IncludeParents extends true
+  ? {
+      resources: ContentNodeWithParentIds[];
+      isResourcesLoading: boolean;
+      isResourcesError: boolean;
+    }
+  : {
+      resources: ContentNode[];
+      isResourcesLoading: boolean;
+      isResourcesError: boolean;
+    };
 
 export function useConnectorPermissions<IncludeParents extends boolean>({
   owner,
@@ -33,9 +50,10 @@ export function useConnectorPermissions<IncludeParents extends boolean>({
   disabled?: boolean;
   includeParents?: IncludeParents;
   viewType?: ContentNodesViewType;
-}) {
-  const permissionsFetcher: Fetcher<GetDataSourcePermissionsResponseBody> =
-    fetcher;
+}): UseConnectorPermissionsReturn<IncludeParents> {
+  const permissionsFetcher: Fetcher<
+    GetDataSourcePermissionsResponseBody<IncludeParents>
+  > = fetcher;
 
   let url = `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/permissions?viewType=${viewType}`;
   if (parentId) {

--- a/front/lib/swr/connectors.ts
+++ b/front/lib/swr/connectors.ts
@@ -19,20 +19,11 @@ import type { GetConnectorResponseBody } from "@app/pages/api/w/[wId]/data_sourc
 import type { GetOrPostManagedDataSourceConfigResponseBody } from "@app/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]";
 import type { GetDataSourcePermissionsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions";
 
-type UseConnectorPermissionsReturn<IncludeParents extends boolean = false> = {
+interface UseConnectorPermissionsReturnBase<IncludeParents extends boolean> {
+  resources: GetDataSourcePermissionsResponseBody<IncludeParents>["resources"];
   isResourcesLoading: boolean;
-  isResourcesError: boolean;
-} & IncludeParents extends true
-  ? {
-      resources: ContentNodeWithParentIds[];
-      isResourcesLoading: boolean;
-      isResourcesError: boolean;
-    }
-  : {
-      resources: ContentNode[];
-      isResourcesLoading: boolean;
-      isResourcesError: boolean;
-    };
+  isResourcesError: any;
+}
 
 export function useConnectorPermissions<IncludeParents extends boolean>({
   owner,
@@ -50,7 +41,7 @@ export function useConnectorPermissions<IncludeParents extends boolean>({
   disabled?: boolean;
   includeParents?: IncludeParents;
   viewType?: ContentNodesViewType;
-}): UseConnectorPermissionsReturn<IncludeParents> {
+}): UseConnectorPermissionsReturnBase<IncludeParents> {
   const permissionsFetcher: Fetcher<
     GetDataSourcePermissionsResponseBody<IncludeParents>
   > = fetcher;

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions/index.ts
@@ -204,6 +204,8 @@ export async function getManagedDataSourcePermissionsHandler(
     }
   }
 
+  const includeParents = req.query.includeParents === "true";
+
   switch (filterPermission) {
     case "read":
       // We let users get the read  permissions of a connector
@@ -265,6 +267,7 @@ export async function getManagedDataSourcePermissionsHandler(
     parentId,
     filterPermission,
     viewType,
+    includeParents,
   });
   if (permissionsRes.isErr()) {
     return apiError(req, res, {

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions/index.ts
@@ -1,6 +1,7 @@
 import type {
   ConnectorPermission,
   ContentNode,
+  ContentNodeWithParentIds,
   DataSourceType,
   WithAPIErrorResponse,
 } from "@dust-tt/types";
@@ -31,9 +32,15 @@ const SetConnectorPermissionsRequestBodySchema = t.type({
   ),
 });
 
-export type GetDataSourcePermissionsResponseBody = {
-  resources: ContentNode[];
-};
+export type GetDataSourcePermissionsResponseBody<
+  IncludeParents extends boolean = false,
+> = IncludeParents extends true
+  ? {
+      resources: ContentNodeWithParentIds[];
+    }
+  : {
+      resources: ContentNode[];
+    };
 
 export type SetDataSourcePermissionsResponseBody = {
   success: true;

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -532,7 +532,7 @@ const DataSourcePage = ({
               <PokePermissionTree
                 owner={owner}
                 dataSource={dataSource}
-                displayDocumentSource={onDisplayDocumentSource}
+                onDocumentViewClick={onDisplayDocumentSource}
                 permissionFilter="read"
               />
             )}


### PR DESCRIPTION
fixes: [#1358](https://github.com/dust-tt/tasks/issues/1358)

## Description

This refactor the PermissionTree in a more reusable and configurable way. 
Main changes are : 
- Handling of selection is now fully controlled, when passing a treeSelectionModel / setTreeSelectionModel object. No more internal states duplicating external state
- One single ContentNodeTree which takes a simple hook as parameter, used to fetch the nodes under a specific parent. Same tree can be used for datasources, views, or anything that list content nodes
- All logic regarding permissions is moved outside
- Handle the partial checkbox selection when a subnode is selected, and the disabled checkboxes under a selected parent


## Risk

Can break trees in different places, need to be tested on frontedge first. Usages are : 
- Connection management , readonly (notion, ..) and not readonly (google, slack,..)
- Assistant details view
- Slack integration (channels selection)
- Poke data source view

## Deploy Plan

deploy front
