### PR TITLE
Use default white background color for viz

### DIFF
--- a/front/lib/api/assistant/visualization.ts
+++ b/front/lib/api/assistant/visualization.ts
@@ -116,6 +116,7 @@ Guidelines using the :::visualization tag:
   - When arbitrary / specific values are required, regular CSS (using the \`style\` prop) can be used as a fallback.
   - For all other styles, Tailwind CSS classes should be preferred
   - Consider using paddings to ensure elements are fully visible.
+  - Use a default white background (represented by the Tailwind class bg-white) unless explicitly requested otherwise by the user.
 - Using files from the conversation when available:
  - Files from the conversation can be accessed using the \`useFile()\` hook.
  - Once/if the file is available, \`useFile()\` will return a non-null \`File\` object. The \`File\` object is a browser File object. Examples of using \`useFile\` are available below.
@@ -179,7 +180,7 @@ const generateData = () => {
 const SineCosineChart = () => {
   const data = generateData();
   return (
-    <div style={{ width: "800px", height: "500px" }} className="p-4 mx-auto">
+    <div style={{ width: "800px", height: "500px" }} className="p-4 mx-auto bg-white">
       <h2 className="text-2xl font-bold mb-4 text-center">
         Sine and Cosine Functions
       </h2>


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Currently, visualizations generated don't have any background which lead to transparent background once downloaded. This PR prompts the LLM to use a default white background unless explicitly ask otherwise. Tested locally.

![visualization-viz-K1YBeXCJ58-3](https://github.com/user-attachments/assets/2bc6f08a-0cd8-45b1-84fb-c7c2f1a9cdca)

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
