### PR TITLE
Stop relying on name as core.data_source_id

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1136,7 +1136,6 @@ async fn runs_retrieve_status(
 
 #[derive(serde::Deserialize)]
 struct DataSourcesRegisterPayload {
-    data_source_id: String,
     config: data_source::DataSourceConfig,
     #[allow(dead_code)]
     credentials: run::Credentials,
@@ -1148,7 +1147,7 @@ async fn data_sources_register(
     Json(payload): Json<DataSourcesRegisterPayload>,
 ) -> (StatusCode, Json<APIResponse>) {
     let project = project::Project::new_from_id(project_id);
-    let ds = data_source::DataSource::new(&project, &payload.data_source_id, &payload.config);
+    let ds = data_source::DataSource::new(&project, &payload.config);
     match state.store.register_data_source(&project, &ds).await {
         Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -1164,7 +1163,6 @@ async fn data_sources_register(
                     "data_source": {
                         "created": ds.created(),
                         "data_source_id": ds.data_source_id(),
-                        "data_source_internal_id": ds.internal_id(),
                         "config": ds.config(),
                     },
                 })),

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -309,11 +309,11 @@ fn target_document_tokens_offsets(
 }
 
 impl DataSource {
-    pub fn new(project: &Project, data_source_id: &str, config: &DataSourceConfig) -> Self {
+    pub fn new(project: &Project, config: &DataSourceConfig) -> Self {
         DataSource {
             project: project.clone(),
             created: utils::now(),
-            data_source_id: data_source_id.to_string(),
+            data_source_id: utils::new_id(),
             internal_id: utils::new_id(),
             config: config.clone(),
         }
@@ -941,7 +941,6 @@ impl DataSource {
                 payload.insert("timestamp", document.timestamp as i64);
                 payload.insert("chunk_offset", c.offset as i64);
                 payload.insert("chunk_hash", c.hash.clone());
-                payload.insert("data_source_id", self.data_source_id.clone());
                 payload.insert("data_source_internal_id", self.internal_id.clone());
                 payload.insert("document_id", document.document_id.clone());
                 payload.insert("document_id_hash", document_id_hash);

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -36,7 +36,6 @@ import logger from "@app/logger/logger";
 import { DataSourceViewModel } from "./storage/models/data_source_view";
 
 export type FetchDataSourceOrigin =
-  | "document_tracker"
   | "registry_lookup"
   | "v1_data_sources_search"
   | "v1_data_sources_documents"
@@ -246,6 +245,20 @@ export class DataSourceResource extends ResourceWithVault<DataSourceModel> {
     }
   }
 
+  static async fetchByDustAPIDataSourceId(
+    auth: Authenticator,
+    dustAPIDataSourceId: string,
+    options?: FetchDataSourceOptions
+  ): Promise<DataSourceResource | null> {
+    const [dataSource] = await this.fetchByDustAPIDataSourceIds(
+      auth,
+      [dustAPIDataSourceId],
+      options
+    );
+
+    return dataSource ?? null;
+  }
+
   // TODO(DATASOURCE_SID): remove
   static async fetchByNames(
     auth: Authenticator,
@@ -287,6 +300,18 @@ export class DataSourceResource extends ResourceWithVault<DataSourceModel> {
       removeNulls(ids.map(getResourceIdFromSId)),
       options
     );
+  }
+
+  static async fetchByDustAPIDataSourceIds(
+    auth: Authenticator,
+    dustAPIDataSourceIds: string[],
+    options?: FetchDataSourceOptions
+  ) {
+    return this.baseFetch(auth, options, {
+      where: {
+        dustAPIDataSourceId: dustAPIDataSourceIds,
+      },
+    });
   }
 
   static async listByWorkspace(

--- a/front/lib/resources/resource_with_vault.ts
+++ b/front/lib/resources/resource_with_vault.ts
@@ -132,10 +132,9 @@ export abstract class ResourceWithVault<
     return this.vault.canWrite(auth);
   }
 
-  // This method determines if the authenticated user can fetch data,
-  // based on workspace ownership or public vault access. Changes to
-  // this logic can impact data security, so they must be reviewed
-  // and tested carefully to prevent unauthorized access.
+  // This method determines if the authenticated user can fetch data, based on workspace ownership
+  // or public vault access. Changes to this logic can impact data security, so they must be
+  // reviewed and tested carefully to prevent unauthorized access.
   private canFetch(auth: Authenticator) {
     return (
       // Superusers can fetch any resource.

--- a/front/lib/resources/storage/models/data_source.ts
+++ b/front/lib/resources/storage/models/data_source.ts
@@ -95,6 +95,7 @@ DataSourceModel.init(
       { fields: ["workspaceId", "name"], unique: true },
       { fields: ["workspaceId", "connectorProvider"] },
       { fields: ["workspaceId", "vaultId"] },
+      { fields: ["dustAPIProjectId"] },
     ],
   }
 );

--- a/front/migrations/20230522_slack_doc_rename_incident.ts
+++ b/front/migrations/20230522_slack_doc_rename_incident.ts
@@ -56,7 +56,6 @@ async function main() {
 
         const dustDataSource = await coreAPI.createDataSource({
           projectId: dustProject.value.project.project_id.toString(),
-          dataSourceId: dataSourceName,
           config: {
             embedder_config: {
               embedder: {

--- a/front/migrations/20230803_wipe_gdrive_connectors.ts
+++ b/front/migrations/20230803_wipe_gdrive_connectors.ts
@@ -44,7 +44,6 @@ async function main() {
     console.log(`creating data source ${d.name} in core`);
     await coreAPI.createDataSource({
       projectId: d.dustAPIProjectId,
-      dataSourceId: d.name,
       config: {
         embedder_config: {
           embedder: {

--- a/front/migrations/db/migration_92.sql
+++ b/front/migrations/db/migration_92.sql
@@ -1,0 +1,2 @@
+-- Migration created on Sep 26, 2024
+CREATE INDEX "data_sources_dust_api_project_id" ON "data_sources" ("dustAPIProjectId");

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -137,8 +137,6 @@ async function handler(
       const embedderConfig = EMBEDDING_CONFIGS[dataSourceEmbedder];
       const dustDataSource = await coreAPI.createDataSource({
         projectId: dustProject.value.project.project_id.toString(),
-        // TODO(DATASOURCE_SID): Start creating Core API with sId
-        dataSourceId: req.body.name as string,
         config: {
           qdrant_config: {
             cluster: DEFAULT_QDRANT_CLUSTER,

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -266,7 +266,6 @@ async function handler(
 
       const dustDataSource = await coreAPI.createDataSource({
         projectId: dustProject.value.project.project_id.toString(),
-        dataSourceId: dataSourceName,
         config: {
           embedder_config: {
             embedder: {

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/index.ts
@@ -348,7 +348,6 @@ const handleDataSourceWithProvider = async ({
 
   const dustDataSource = await coreAPI.createDataSource({
     projectId: dustProject.value.project.project_id.toString(),
-    dataSourceId: dataSourceName,
     config: {
       embedder_config: {
         embedder: {
@@ -565,7 +564,6 @@ const handleDataSourceWithoutProvider = async ({
 
   const dustDataSource = await coreAPI.createDataSource({
     projectId: dustProject.value.project.project_id.toString(),
-    dataSourceId: name,
     config: {
       qdrant_config: {
         cluster: DEFAULT_QDRANT_CLUSTER,

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -573,12 +573,10 @@ export class CoreAPI {
 
   async createDataSource({
     projectId,
-    dataSourceId,
     config,
     credentials,
   }: {
     projectId: string;
-    dataSourceId: string;
     config: CoreAPIDataSourceConfig;
     credentials: CredentialsType;
   }): Promise<CoreAPIResponse<{ data_source: CoreAPIDataSource }>> {
@@ -590,7 +588,6 @@ export class CoreAPI {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          data_source_id: dataSourceId,
           config: config,
           credentials: credentials,
         }),


### PR DESCRIPTION
## Description

- `core` generates a unique ID for `data_source_id` instead of receiving it from `front`
- `front` stop sending name (store the received Id in dustAPIDataSourceId)
- improve handling of core retrieved data_source_id in document tracker

Migration to move all core data_source_id to generated IDs will be tackled in a follow-up PR. Everything works properly for now since core data_source_id is stored in dustAPIDataSourceId on front side.

Tests:
- [x] create a data source with core deployed but not front
- [x] create a folder
- [x] create a connection
- [x] check upsertion works
- [x] check retrieval works on both new and old data sources

r? @Fraggle cc @flvndvd 

Follow-up work: migration to move all core.data_source_id to a generated Id and update dustAPIDataSourceId

## Risk

Low once properly tested

## Deploy Plan

- deploy `core` (first)
- deploy `front`
- run migration