### PR TITLE
Snowflake creation flow: step 1 basic form + post credentials to oauth

### DIFF
--- a/front/components/data_source/CreateConnectionSnowflakeModal.tsx
+++ b/front/components/data_source/CreateConnectionSnowflakeModal.tsx
@@ -1,0 +1,194 @@
+import {
+  BookOpenIcon,
+  Button,
+  CloudArrowLeftRightIcon,
+  Input,
+  Modal,
+  Page,
+} from "@dust-tt/sparkle";
+import type { SnowflakeCredentials, WorkspaceType } from "@dust-tt/types";
+import { useState } from "react";
+
+import type { ConnectorProviderConfiguration } from "@app/lib/connector_providers";
+
+type CreateConnectionSnowflakeModalProps = {
+  owner: WorkspaceType;
+  connectorProviderConfiguration: ConnectorProviderConfiguration;
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+export function CreateConnectionSnowflakeModal({
+  owner,
+  connectorProviderConfiguration,
+  isOpen,
+  onClose,
+}: CreateConnectionSnowflakeModalProps) {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [credentials, setCredentials] = useState<SnowflakeCredentials>({
+    username: "",
+    password: "",
+    account: "",
+    role: "",
+    warehouse: "",
+  });
+
+  if (connectorProviderConfiguration.connectorProvider !== "snowflake") {
+    // Should never happen.
+    return null;
+  }
+
+  const areCredentialsValid = () => {
+    return Object.values(credentials).every((value) => value.length > 0);
+  };
+
+  const createSnowflakeConnection = async () => {
+    setIsLoading(false);
+
+    // First we post the credentials to OAuth service.
+    const res = await fetch(`/api/w/${owner.sId}/credentials`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        provider: "snowflake",
+        credentials,
+      }),
+    });
+
+    if (!res.ok) {
+      setError("Failed to create connection: cannot verify those credentials.");
+      return;
+    }
+
+    // Then we can try to create the connector.
+    // TODO(SNOWFLAKE): Create the connector.
+    const data = await res.json();
+    console.log({ data });
+    alert("Credential posted. Todo - create connector.");
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      title="Connection Setup"
+      onClose={onClose}
+      hasChanged={false}
+      variant="side-sm"
+    >
+      <Page variant="modal">
+        <div className="w-full">
+          <Page.Vertical sizing="grow">
+            <Page.Header
+              title={`Connecting ${connectorProviderConfiguration.name}`}
+              icon={connectorProviderConfiguration.logoComponent}
+            />
+            <a
+              href={connectorProviderConfiguration.guideLink ?? ""}
+              target="_blank"
+            >
+              <Button
+                label="Read our guide"
+                size="xs"
+                variant="secondary"
+                icon={BookOpenIcon}
+              />
+            </a>
+            {connectorProviderConfiguration.limitations && (
+              <div className="flex flex-col gap-y-2">
+                <div className="grow text-sm font-medium text-element-800">
+                  Limitations
+                </div>
+                <div className="text-sm font-normal text-element-700">
+                  {connectorProviderConfiguration.limitations}
+                </div>
+              </div>
+            )}
+
+            <Page.SectionHeader title="Snowflake Credentials" />
+
+            {error && (
+              <div className="w-full rounded-md bg-red-100 p-4 text-red-800">
+                {error}
+              </div>
+            )}
+
+            <div className="w-full space-y-4">
+              <Input
+                label="Snowflake Account identifier"
+                name="username"
+                value={credentials.account}
+                placeholder="au12345.us-east-1"
+                onChange={(value) => {
+                  setCredentials({ ...credentials, account: value });
+                  setError(null);
+                }}
+              />
+              <Input
+                label="Role"
+                name="username"
+                value={credentials.role}
+                placeholder="dev_role"
+                onChange={(value) => {
+                  setCredentials({ ...credentials, role: value });
+                  setError(null);
+                }}
+              />
+              <Input
+                label="Warehouse"
+                name="warehouse"
+                value={credentials.warehouse}
+                placeholder="dev_warehouse"
+                onChange={(value) => {
+                  setCredentials({ ...credentials, warehouse: value });
+                  setError(null);
+                }}
+              />
+              <Input
+                label="Username"
+                name="username"
+                value={credentials.username}
+                placeholder="dev_user"
+                onChange={(value) => {
+                  setCredentials({ ...credentials, username: value });
+                  setError(null);
+                }}
+              />
+              <Input
+                label="Password"
+                name="password"
+                isPassword={true}
+                value={credentials.password}
+                placeholder=""
+                onChange={(value) => {
+                  setCredentials({ ...credentials, password: value });
+                  setError(null);
+                }}
+              />
+            </div>
+
+            <div className="flex justify-center pt-2">
+              <Button.List isWrapping={true}>
+                <Button
+                  variant="primary"
+                  size="md"
+                  icon={CloudArrowLeftRightIcon}
+                  onClick={async () => {
+                    setIsLoading(true);
+                    await createSnowflakeConnection();
+                  }}
+                  disabled={isLoading || !areCredentialsValid()}
+                  label={
+                    isLoading ? "Connecting..." : "Connect and select tables"
+                  }
+                />
+              </Button.List>
+            </div>
+          </Page.Vertical>
+        </div>
+      </Page>
+    </Modal>
+  );
+}

--- a/front/components/data_source/CreateConnectionSnowflakeModal.tsx
+++ b/front/components/data_source/CreateConnectionSnowflakeModal.tsx
@@ -175,9 +175,9 @@ export function CreateConnectionSnowflakeModal({
                   variant="primary"
                   size="md"
                   icon={CloudArrowLeftRightIcon}
-                  onClick={async () => {
+                  onClick={() => {
                     setIsLoading(true);
-                    await createSnowflakeConnection();
+                    void createSnowflakeConnection();
                   }}
                   disabled={isLoading || !areCredentialsValid()}
                   label={

--- a/front/components/vaults/AddConnectionMenu.tsx
+++ b/front/components/vaults/AddConnectionMenu.tsx
@@ -253,9 +253,9 @@ export const AddConnectionMenu = ({
                   integration: prev.integration,
                 }))
               }
-              onConfirm={async () => {
+              onConfirm={() => {
                 if (showConfirmConnection.integration) {
-                  await handleEnableManagedDataSource(
+                  void handleEnableManagedDataSource(
                     connectorProvider,
                     integration.setupWithSuffix
                   );

--- a/front/components/vaults/AddConnectionMenu.tsx
+++ b/front/components/vaults/AddConnectionMenu.tsx
@@ -19,6 +19,7 @@ import { useRouter } from "next/router";
 import { useContext, useState } from "react";
 
 import { CreateConnectionConfirmationModal } from "@app/components/data_source/CreateConnectionConfirmationModal";
+import { CreateConnectionSnowflakeModal } from "@app/components/data_source/CreateConnectionSnowflakeModal";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import {
   CONNECTOR_CONFIGURATIONS,
@@ -208,6 +209,9 @@ export const AddConnectionMenu = ({
     }
   };
 
+  const { integration, isOpen } = showConfirmConnection || {};
+  const connectorProvider = integration?.connectorProvider;
+
   return (
     availableIntegrations.length > 0 && (
       <>
@@ -222,29 +226,43 @@ export const AddConnectionMenu = ({
           <p>Unlock this managed data source by upgrading your plan.</p>
         </Dialog>
 
-        {showConfirmConnection.integration && (
-          <CreateConnectionConfirmationModal
+        {connectorProvider === "snowflake" ? (
+          <CreateConnectionSnowflakeModal
+            owner={owner}
             connectorProviderConfiguration={
-              CONNECTOR_CONFIGURATIONS[
-                showConfirmConnection.integration.connectorProvider
-              ]
+              CONNECTOR_CONFIGURATIONS[connectorProvider]
             }
-            isOpen={showConfirmConnection.isOpen}
+            isOpen={isOpen}
             onClose={() =>
               setShowConfirmConnection((prev) => ({
                 isOpen: false,
                 integration: prev.integration,
               }))
             }
-            onConfirm={async () => {
-              if (showConfirmConnection.integration) {
-                await handleEnableManagedDataSource(
-                  showConfirmConnection.integration.connectorProvider,
-                  showConfirmConnection.integration.setupWithSuffix
-                );
-              }
-            }}
           />
+        ) : (
+          connectorProvider && (
+            <CreateConnectionConfirmationModal
+              connectorProviderConfiguration={
+                CONNECTOR_CONFIGURATIONS[connectorProvider]
+              }
+              isOpen={isOpen}
+              onClose={() =>
+                setShowConfirmConnection((prev) => ({
+                  isOpen: false,
+                  integration: prev.integration,
+                }))
+              }
+              onConfirm={async () => {
+                if (showConfirmConnection.integration) {
+                  await handleEnableManagedDataSource(
+                    connectorProvider,
+                    integration.setupWithSuffix
+                  );
+                }
+              }}
+            />
+          )
         )}
         <Dialog
           isOpen={showPreviewPopupForProvider.isOpen}

--- a/front/pages/api/w/[wId]/credentials/index.ts
+++ b/front/pages/api/w/[wId]/credentials/index.ts
@@ -1,0 +1,86 @@
+import type { WithAPIErrorResponse } from "@dust-tt/types";
+import {
+  postConnectionCredentials,
+  PostCredentialsBodySchema,
+} from "@dust-tt/types";
+import { isLeft } from "fp-ts/Either";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import apiConfig from "@app/lib/api/config";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+
+type PostCredentialsResponseBody = {
+  credentials: {
+    id: string;
+  };
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PostCredentialsResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  const user = auth.getNonNullableUser();
+  const owner = auth.getNonNullableWorkspace();
+
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message:
+          "Only the users that are `admins` for the current workspace can interact with credentials.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST":
+      const bodyValidation = PostCredentialsBodySchema.decode(req.body);
+      if (isLeft(bodyValidation)) {
+        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `The request body is invalid: ${pathError}.`,
+          },
+        });
+      }
+      const response = await postConnectionCredentials({
+        config: apiConfig.getOAuthAPIConfig(),
+        logger,
+        workspaceId: owner.sId,
+        userId: user.sId,
+        provider: bodyValidation.right.provider,
+        credentials: bodyValidation.right.credentials,
+      });
+
+      if (response.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "connector_credentials_error",
+            message: `Failed to create credentials: ${response.error.message}.`,
+          },
+        });
+      }
+
+      res.status(201).json({
+        credentials: {
+          id: response.value.credential.credential_id,
+        },
+      });
+      return;
+
+    default:
+      res.status(405).end();
+      return;
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/types/src/front/lib/error.ts
+++ b/types/src/front/lib/error.ts
@@ -45,6 +45,7 @@ export type APIErrorType =
   | "connector_update_unauthorized"
   | "connector_oauth_target_mismatch"
   | "connector_provider_not_supported"
+  | "connector_credentials_error"
   | "agent_configuration_not_found"
   | "agent_message_error"
   | "message_not_found"

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -74,6 +74,7 @@ export * from "./front/user";
 export * from "./front/vault";
 export * from "./front/workspace";
 export * from "./oauth/client/access_token";
+export * from "./oauth/client/credentials";
 export * from "./oauth/client/setup";
 export * from "./oauth/lib";
 export * from "./oauth/oauth_api";

--- a/types/src/oauth/client/credentials.ts
+++ b/types/src/oauth/client/credentials.ts
@@ -1,0 +1,37 @@
+import { LoggerInterface } from "../../shared/logger";
+import { Result } from "../../shared/result";
+import {
+  ConnectionCredentials,
+  CredentialsProvider,
+  OauthAPIPostCredentialsResponse,
+} from "../lib";
+import { OAuthAPI, OAuthAPIError } from "../oauth_api";
+
+export async function postConnectionCredentials({
+  config,
+  logger,
+  provider,
+  workspaceId,
+  userId,
+  credentials,
+}: {
+  config: { url: string; apiKey: string | null };
+  logger: LoggerInterface;
+  provider: CredentialsProvider;
+  workspaceId: string;
+  userId: string;
+  credentials: ConnectionCredentials;
+}): Promise<Result<OauthAPIPostCredentialsResponse, OAuthAPIError>> {
+  const res = await new OAuthAPI(config, logger).postCredentials({
+    provider,
+    workspaceId,
+    userId,
+    credentials,
+  });
+
+  if (res.isErr()) {
+    return res;
+  }
+
+  return res;
+}

--- a/types/src/oauth/lib.ts
+++ b/types/src/oauth/lib.ts
@@ -1,3 +1,5 @@
+import * as t from "io-ts";
+
 export const OAUTH_USE_CASES = ["connection", "labs_transcripts"] as const;
 
 export type OAuthUseCase = (typeof OAUTH_USE_CASES)[number];
@@ -42,3 +44,41 @@ export function isOAuthConnectionType(
     (connection.status === "pending" || connection.status === "finalized")
   );
 }
+
+// Credentials Providers
+
+export const CREDENTIALS_PROVIDERS = ["snowflake"] as const;
+export type CredentialsProvider = (typeof CREDENTIALS_PROVIDERS)[number];
+
+export function isCredentialProvider(obj: unknown): obj is CredentialsProvider {
+  return CREDENTIALS_PROVIDERS.includes(obj as CredentialsProvider);
+}
+
+// Credentials
+
+export const SnowflakeCredentialsSchema = t.type({
+  username: t.string,
+  password: t.string,
+  account: t.string,
+  role: t.string,
+  warehouse: t.string,
+});
+export type SnowflakeCredentials = t.TypeOf<typeof SnowflakeCredentialsSchema>;
+export type ConnectionCredentials = SnowflakeCredentials;
+
+// POST Credentials
+
+export const PostSnowflakeCredentialsBodySchema = t.type({
+  provider: t.literal("snowflake"),
+  credentials: SnowflakeCredentialsSchema,
+});
+
+export const PostCredentialsBodySchema = PostSnowflakeCredentialsBodySchema;
+
+export type OauthAPIPostCredentialsResponse = {
+  credential: {
+    credential_id: string;
+    provider: CredentialsProvider;
+    created: number;
+  };
+};

--- a/types/src/oauth/oauth_api.ts
+++ b/types/src/oauth/oauth_api.ts
@@ -1,4 +1,10 @@
-import { OAuthConnectionType, OAuthProvider } from "../oauth/lib";
+import {
+  ConnectionCredentials,
+  CredentialsProvider,
+  OauthAPIPostCredentialsResponse,
+  OAuthConnectionType,
+  OAuthProvider,
+} from "../oauth/lib";
 import { LoggerInterface } from "../shared/logger";
 import { Err, Ok, Result } from "../shared/result";
 
@@ -133,6 +139,34 @@ export class OAuthAPI {
         }),
       }
     );
+    return this._resultFromResponse(response);
+  }
+
+  async postCredentials({
+    provider,
+    userId,
+    workspaceId,
+    credentials,
+  }: {
+    provider: CredentialsProvider;
+    userId: string;
+    workspaceId: string;
+    credentials: ConnectionCredentials;
+  }): Promise<OAuthAPIResponse<OauthAPIPostCredentialsResponse>> {
+    const response = await this._fetchWithError(`${this._url}/credentials`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        provider,
+        metadata: {
+          user_id: userId,
+          workspace_id: workspaceId,
+        },
+        content: credentials,
+      }),
+    });
     return this._resultFromResponse(response);
   }
 


### PR DESCRIPTION
## Description

First PR of the Snowflake connector creation flow. In the end, the flow will be: 
1/  User fills the form with credentials. 
2/ We post credentials to OAuth service and get the cred_id.
3/ We post to create the connector with cred_id: connector is checking the connection to see if valid, if not it displays the error on the form without creating the connector. If valid we create the connector. 
4/ If connector was created, we display the permission tree to select nodes.  


On this PR I focus on 1/ and 2/ : 
- Introduce a new modal with a specific form for the setup of Snowflake. The form validation is quite basic at the moment, we only check that all fields are set. 
- Introduce a new route with associated business logic to post credentials from front (`/w/[wId]/credentials` with expected role admin). 
- Form posts the credentials and displays an alert if successful.

<kbd>
<img width="487" alt="Screenshot 2024-09-26 at 11 42 38" src="https://github.com/user-attachments/assets/39b038c6-86d8-4e7c-9951-ca5f11500320">
</kbd>


## Risk

This flow is only available if the feature flag for snowflake is available. 

## Deploy Plan

Deploy front. 
