### PR TITLE
[front] - fix(transcripts): unicity constraint

### DIFF
--- a/front/lib/resources/storage/models/labs_transcripts.ts
+++ b/front/lib/resources/storage/models/labs_transcripts.ts
@@ -169,3 +169,7 @@ LabsTranscriptsConfigurationModel.hasMany(LabsTranscriptsHistoryModel, {
   as: "configuration",
   foreignKey: { name: "configurationId", allowNull: false },
 });
+LabsTranscriptsHistoryModel.belongsTo(LabsTranscriptsHistoryModel, {
+  as: "configuration",
+  foreignKey: { name: "userId", allowNull: false },
+});

--- a/front/lib/resources/storage/models/labs_transcripts.ts
+++ b/front/lib/resources/storage/models/labs_transcripts.ts
@@ -166,6 +166,6 @@ LabsTranscriptsHistoryModel.belongsTo(LabsTranscriptsConfigurationModel, {
   foreignKey: { name: "configurationId", allowNull: false },
 });
 LabsTranscriptsConfigurationModel.hasMany(LabsTranscriptsHistoryModel, {
-  as: "history",
+  as: "configuration",
   foreignKey: { name: "configurationId", allowNull: false },
 });

--- a/front/lib/resources/storage/models/labs_transcripts.ts
+++ b/front/lib/resources/storage/models/labs_transcripts.ts
@@ -114,7 +114,7 @@ export class LabsTranscriptsHistoryModel extends Model<
   declare conversationId: string | null;
 
   declare configurationId: ForeignKey<LabsTranscriptsConfigurationModel["id"]>;
-  declare userId: ForeignKey<LabsTranscriptsConfigurationModel["userId"]>;
+
   declare configuration: NonAttribute<LabsTranscriptsConfigurationModel>;
 }
 
@@ -153,9 +153,9 @@ LabsTranscriptsHistoryModel.init(
     sequelize: frontSequelize,
     indexes: [
       {
-        fields: ["fileId", "userId"],
+        fields: ["fileId", "configurationId"],
         unique: true,
-        name: "labs_transcripts_history_file_user_idx",
+        name: "labs_transcripts_histories_file_configuration_id",
       },
     ],
   }
@@ -166,10 +166,6 @@ LabsTranscriptsHistoryModel.belongsTo(LabsTranscriptsConfigurationModel, {
   foreignKey: { name: "configurationId", allowNull: false },
 });
 LabsTranscriptsConfigurationModel.hasMany(LabsTranscriptsHistoryModel, {
-  as: "configuration",
+  as: "history",
   foreignKey: { name: "configurationId", allowNull: false },
-});
-LabsTranscriptsHistoryModel.hasOne(LabsTranscriptsConfigurationModel, {
-  as: "configuration",
-  foreignKey: { name: "userId", allowNull: false },
 });

--- a/front/lib/resources/storage/models/labs_transcripts.ts
+++ b/front/lib/resources/storage/models/labs_transcripts.ts
@@ -169,7 +169,7 @@ LabsTranscriptsConfigurationModel.hasMany(LabsTranscriptsHistoryModel, {
   as: "configuration",
   foreignKey: { name: "configurationId", allowNull: false },
 });
-LabsTranscriptsHistoryModel.belongsTo(LabsTranscriptsHistoryModel, {
+LabsTranscriptsHistoryModel.hasOne(LabsTranscriptsConfigurationModel, {
   as: "configuration",
   foreignKey: { name: "userId", allowNull: false },
 });

--- a/front/lib/resources/storage/models/labs_transcripts.ts
+++ b/front/lib/resources/storage/models/labs_transcripts.ts
@@ -114,7 +114,7 @@ export class LabsTranscriptsHistoryModel extends Model<
   declare conversationId: string | null;
 
   declare configurationId: ForeignKey<LabsTranscriptsConfigurationModel["id"]>;
-
+  declare userId: ForeignKey<LabsTranscriptsConfigurationModel["userId"]>;
   declare configuration: NonAttribute<LabsTranscriptsConfigurationModel>;
 }
 
@@ -151,7 +151,13 @@ LabsTranscriptsHistoryModel.init(
   {
     modelName: "labs_transcripts_history",
     sequelize: frontSequelize,
-    indexes: [{ fields: ["fileId"], unique: true }],
+    indexes: [
+      {
+        fields: ["fileId", "userId"],
+        unique: true,
+        name: "labs_transcripts_history_file_user_idx",
+      },
+    ],
   }
 );
 

--- a/front/migrations/db/migration_93.sql
+++ b/front/migrations/db/migration_93.sql
@@ -1,0 +1,13 @@
+-- Migration created on Sep 26, 2024
+ALTER TABLE "labs_transcripts_histories" ADD COLUMN "userId" INTEGER;
+
+UPDATE "labs_transcripts_histories"
+SET "userId" = "labs_transcripts_configurations"."userId"
+FROM "labs_transcripts_configurations"
+WHERE "labs_transcripts_histories"."configurationId" = "labs_transcripts_configurations"."id";
+
+ALTER TABLE "labs_transcripts_histories" ALTER COLUMN "userId" SET NOT NULL;
+
+DROP INDEX IF EXISTS "labs_transcripts_histories_file_user_idx";
+CREATE UNIQUE INDEX "labs_transcripts_histories_file_user_idx" ON "labs_transcripts_histories" ("fileId", "userId");
+

--- a/front/migrations/db/migration_93.sql
+++ b/front/migrations/db/migration_93.sql
@@ -1,18 +1,4 @@
 -- Migration created on Sep 26, 2024
-ALTER TABLE "labs_transcripts_histories" ADD COLUMN "userId" INTEGER;
-
-UPDATE "labs_transcripts_histories"
-SET "userId" = "labs_transcripts_configurations"."userId"
-FROM "labs_transcripts_configurations"
-WHERE "labs_transcripts_histories"."configurationId" = "labs_transcripts_configurations"."id";
-
-ALTER TABLE "labs_transcripts_histories"
-ADD CONSTRAINT "labs_transcripts_histories_userId_fkey"
-FOREIGN KEY ("userId")
-REFERENCES "users"("id");
-
 DROP INDEX IF EXISTS "labs_transcripts_histories_file_id";
-DROP INDEX IF EXISTS "labs_transcripts_histories_file_id_user_id";
-CREATE UNIQUE INDEX "labs_transcripts_histories_file_id_user_id" ON "labs_transcripts_histories" ("fileId", "userId");
-
-ALTER TABLE "labs_transcripts_histories" ALTER COLUMN "userId" SET NOT NULL;
+DROP INDEX IF EXISTS "labs_transcripts_histories_file_id_configuration_id";
+CREATE UNIQUE INDEX "labs_transcripts_histories_file_id_configuration_id" ON "labs_transcripts_histories" ("fileId", "configurationId");

--- a/front/migrations/db/migration_93.sql
+++ b/front/migrations/db/migration_93.sql
@@ -9,8 +9,10 @@ WHERE "labs_transcripts_histories"."configurationId" = "labs_transcripts_configu
 ALTER TABLE "labs_transcripts_histories"
 ADD CONSTRAINT "labs_transcripts_histories_userId_fkey"
 FOREIGN KEY ("userId")
-REFERENCES "labs_transcripts_configurations" ("userId");
+REFERENCES "users"("id");
 
 DROP INDEX IF EXISTS "labs_transcripts_histories_file_id";
 DROP INDEX IF EXISTS "labs_transcripts_histories_file_id_user_id";
 CREATE UNIQUE INDEX "labs_transcripts_histories_file_id_user_id" ON "labs_transcripts_histories" ("fileId", "userId");
+
+ALTER TABLE "labs_transcripts_histories" ALTER COLUMN "userId" SET NOT NULL;

--- a/front/migrations/db/migration_93.sql
+++ b/front/migrations/db/migration_93.sql
@@ -8,6 +8,7 @@ WHERE "labs_transcripts_histories"."configurationId" = "labs_transcripts_configu
 
 ALTER TABLE "labs_transcripts_histories" ALTER COLUMN "userId" SET NOT NULL;
 
+DROP INDEX IF EXISTS "labs_transcripts_histories_file_id";
 DROP INDEX IF EXISTS "labs_transcripts_histories_file_user_idx";
 CREATE UNIQUE INDEX "labs_transcripts_histories_file_user_idx" ON "labs_transcripts_histories" ("fileId", "userId");
 

--- a/front/migrations/db/migration_93.sql
+++ b/front/migrations/db/migration_93.sql
@@ -9,6 +9,6 @@ WHERE "labs_transcripts_histories"."configurationId" = "labs_transcripts_configu
 ALTER TABLE "labs_transcripts_histories" ALTER COLUMN "userId" SET NOT NULL;
 
 DROP INDEX IF EXISTS "labs_transcripts_histories_file_id";
-DROP INDEX IF EXISTS "labs_transcripts_histories_file_user_idx";
-CREATE UNIQUE INDEX "labs_transcripts_histories_file_user_idx" ON "labs_transcripts_histories" ("fileId", "userId");
+DROP INDEX IF EXISTS "labs_transcripts_histories_file_id_user_id";
+CREATE UNIQUE INDEX "labs_transcripts_histories_file_id_user_id" ON "labs_transcripts_histories" ("fileId", "userId");
 

--- a/front/migrations/db/migration_93.sql
+++ b/front/migrations/db/migration_93.sql
@@ -1,4 +1,4 @@
 -- Migration created on Sep 26, 2024
-DROP INDEX IF EXISTS "labs_transcripts_histories_file_id";
 DROP INDEX IF EXISTS "labs_transcripts_histories_file_id_configuration_id";
 CREATE UNIQUE INDEX "labs_transcripts_histories_file_id_configuration_id" ON "labs_transcripts_histories" ("fileId", "configurationId");
+DROP INDEX IF EXISTS "labs_transcripts_histories_file_id";

--- a/front/migrations/db/migration_93.sql
+++ b/front/migrations/db/migration_93.sql
@@ -14,4 +14,3 @@ REFERENCES "labs_transcripts_configurations" ("userId");
 DROP INDEX IF EXISTS "labs_transcripts_histories_file_id";
 DROP INDEX IF EXISTS "labs_transcripts_histories_file_id_user_id";
 CREATE UNIQUE INDEX "labs_transcripts_histories_file_id_user_id" ON "labs_transcripts_histories" ("fileId", "userId");
-

--- a/front/migrations/db/migration_93.sql
+++ b/front/migrations/db/migration_93.sql
@@ -6,7 +6,10 @@ SET "userId" = "labs_transcripts_configurations"."userId"
 FROM "labs_transcripts_configurations"
 WHERE "labs_transcripts_histories"."configurationId" = "labs_transcripts_configurations"."id";
 
-ALTER TABLE "labs_transcripts_histories" ALTER COLUMN "userId" SET NOT NULL;
+ALTER TABLE "labs_transcripts_histories"
+ADD CONSTRAINT "labs_transcripts_histories_userId_fkey"
+FOREIGN KEY ("userId")
+REFERENCES "labs_transcripts_configurations" ("userId");
 
 DROP INDEX IF EXISTS "labs_transcripts_histories_file_id";
 DROP INDEX IF EXISTS "labs_transcripts_histories_file_id_user_id";

--- a/front/temporal/labs/activities.ts
+++ b/front/temporal/labs/activities.ts
@@ -216,7 +216,6 @@ export async function processTranscriptActivity(
       configurationId: transcriptsConfiguration.id,
       fileId,
       fileName: transcriptTitle,
-      userId: user.id,
     });
   } catch (error) {
     if (error instanceof UniqueConstraintError) {
@@ -240,7 +239,6 @@ export async function processTranscriptActivity(
       fileId,
       fileName: transcriptTitle,
       conversationId: null,
-      userId: user.id,
     });
 
     await sendEmailWithTemplate({

--- a/front/temporal/labs/activities.ts
+++ b/front/temporal/labs/activities.ts
@@ -216,6 +216,7 @@ export async function processTranscriptActivity(
       configurationId: transcriptsConfiguration.id,
       fileId,
       fileName: transcriptTitle,
+      userId: user.id,
     });
   } catch (error) {
     if (error instanceof UniqueConstraintError) {
@@ -239,6 +240,7 @@ export async function processTranscriptActivity(
       fileId,
       fileName: transcriptTitle,
       conversationId: null,
+      userId: user.id,
     });
 
     await sendEmailWithTemplate({


### PR DESCRIPTION
## Description

This PR aims at changing the unicity constraint on `LabsTranscriptsHistoryModel`.

Historically Google used to send transcripts only to the meeting owner. However, they now send it to all the participants of a meeting, which can lead to two users having receiving the same file transcripts.

We now add a unicity constraint on the tuple ("fileId", "configurationId") which requires to add a new constraint on "labs_transcripts_histories".

**References:**
- [Datadog](https://app.datadoghq.eu/logs?query=%22Unhandled%20activity%20error%22%20%40error.type%3AUniqueConstraintError&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1727254107444&to_ts=1727268507444&live=true)

## Risk

Touches database --> ⚠️ 

## Deploy Plan

- Apply migration
- Deploy front
