### PR TITLE
[front] - chore(migrations): backfill parent node ids

### DIFF
--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -3,7 +3,6 @@
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 import type {
   DataSourceViewCategory,
-  DataSourceViewKind,
   DataSourceViewType,
   ModelId,
   PokeDataSourceViewType,
@@ -128,7 +127,6 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
         auth,
         dataSource.vault,
         dataSource,
-        "default",
         transaction
       );
     });
@@ -138,7 +136,7 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
     auth: Authenticator,
     vault: VaultResource,
     dataSource: DataSourceResource,
-    parentsIn: string[] | null
+    parentsIn: string[]
   ) {
     return this.makeNew(
       auth,
@@ -154,11 +152,10 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
   }
 
   // This view has access to all documents, which is represented by null.
-  static async createViewInVaultFromDataSourceIncludingAllDocuments(
+  private static async createViewInVaultFromDataSourceIncludingAllDocuments(
     auth: Authenticator,
     vault: VaultResource,
     dataSource: DataSourceResource,
-    kind: DataSourceViewKind = "default",
     transaction?: Transaction
   ) {
     return this.makeNew(
@@ -167,7 +164,7 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
         dataSourceId: dataSource.id,
         parentsIn: null,
         workspaceId: vault.workspaceId,
-        kind,
+        kind: "default",
       },
       vault,
       dataSource,

--- a/front/migrations/20240730_backfill_data_source_views.ts
+++ b/front/migrations/20240730_backfill_data_source_views.ts
@@ -45,10 +45,11 @@ async function backfillDataSourceViewsForWorkspace(
     }
 
     // Create a view for this data source in the global vault.
-    await DataSourceViewResource.createViewInVaultFromDataSourceIncludingAllDocuments(
+    await DataSourceViewResource.createViewInVaultFromDataSource(
       auth,
       globalVault,
-      dataSource
+      dataSource,
+      []
     );
 
     updated++;

--- a/front/migrations/20240820_backfill_data_source_views.ts
+++ b/front/migrations/20240820_backfill_data_source_views.ts
@@ -38,10 +38,11 @@ async function backfillDefaultViewForDataSource(
   }
 
   // Create a default view for this data source in the vault.
-  await DataSourceViewResource.createViewInVaultFromDataSourceIncludingAllDocuments(
+  await DataSourceViewResource.createViewInVaultFromDataSource(
     auth,
     vault,
-    dataSource
+    dataSource,
+    []
   );
 
   logger.info(`View created for data source ${dataSource.id}.`);

--- a/front/migrations/20240821_backfill_all_data_source_views.ts
+++ b/front/migrations/20240821_backfill_all_data_source_views.ts
@@ -34,10 +34,11 @@ async function backfillDefaultViewForDataSource(
   }
 
   // Create a default view for this data source in the vault.
-  await DataSourceViewResource.createViewInVaultFromDataSourceIncludingAllDocuments(
+  await DataSourceViewResource.createViewInVaultFromDataSource(
     auth,
     vault,
-    dataSource
+    dataSource,
+    []
   );
 
   logger.info(`View created for data source ${dataSource.id}.`);

--- a/front/migrations/20240927_backfill_dsv_parent_nodes.ts
+++ b/front/migrations/20240927_backfill_dsv_parent_nodes.ts
@@ -7,8 +7,8 @@ import { Workspace } from "@app/lib/models/workspace";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
-import { makeScript } from "@app/scripts/helpers";
 import { VaultModel } from "@app/lib/resources/storage/models/vaults";
+import { makeScript } from "@app/scripts/helpers";
 
 makeScript({}, async ({ execute }, logger) => {
   // fetch all data source views with parentsIn set to null
@@ -32,10 +32,10 @@ makeScript({}, async ({ execute }, logger) => {
         as: "VaultModel",
         where: {
           kind: {
-            [Op.not]: "system"
-          }
-        }
-      }
+            [Op.not]: "system",
+          },
+        },
+      },
     ],
   });
 
@@ -79,7 +79,9 @@ makeScript({}, async ({ execute }, logger) => {
     );
 
     if (contentNodesDocumentsRes.isErr() || contentNodesTablesRes.isErr()) {
-      throw new Error(`Error fetching content nodes for data source view ${dataSourceView.id}`);
+      throw new Error(
+        `Error fetching content nodes for data source view ${dataSourceView.id}`
+      );
     }
 
     const rootNodesDocuments = contentNodesDocumentsRes.value.nodes.filter(

--- a/front/migrations/20240927_backfill_dsv_parent_nodes.ts
+++ b/front/migrations/20240927_backfill_dsv_parent_nodes.ts
@@ -1,42 +1,18 @@
 import * as _ from "lodash";
-import { Op } from "sequelize";
 
 import { getContentNodesForDataSourceView } from "@app/lib/api/data_source_view";
 import { Authenticator } from "@app/lib/auth";
 import { Workspace } from "@app/lib/models/workspace";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
-import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
-import { VaultModel } from "@app/lib/resources/storage/models/vaults";
 import { makeScript } from "@app/scripts/helpers";
 
 makeScript({}, async ({ execute }, logger) => {
-  // fetch all data source views with parentsIn set to null
   const dataSourceViews = await DataSourceViewModel.findAll({
     where: {
       parentsIn: null,
+      kind: "custom",
     },
-    include: [
-      {
-        model: DataSourceModel,
-        as: "dataSourceForView",
-        where: {
-          connectorProvider: {
-            // skipping websites and folders
-            [Op.and]: [{ [Op.not]: "webcrawler" }, { [Op.not]: null }],
-          },
-        },
-      },
-      {
-        model: VaultModel,
-        as: "VaultModel",
-        where: {
-          kind: {
-            [Op.not]: "system",
-          },
-        },
-      },
-    ],
   });
 
   logger.info(`Found ${dataSourceViews.length} data source views to process`);

--- a/front/migrations/20240927_backfill_dsv_parent_nodes.ts
+++ b/front/migrations/20240927_backfill_dsv_parent_nodes.ts
@@ -8,6 +8,7 @@ import { DataSourceViewResource } from "@app/lib/resources/data_source_view_reso
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 import { makeScript } from "@app/scripts/helpers";
+import { VaultModel } from "@app/lib/resources/storage/models/vaults";
 
 makeScript({}, async ({ execute }, logger) => {
   // fetch all data source views with parentsIn set to null
@@ -26,6 +27,15 @@ makeScript({}, async ({ execute }, logger) => {
           },
         },
       },
+      {
+        model: VaultModel,
+        as: "VaultModel",
+        where: {
+          kind: {
+            [Op.not]: "system"
+          }
+        }
+      }
     ],
   });
 
@@ -69,21 +79,18 @@ makeScript({}, async ({ execute }, logger) => {
     );
 
     if (contentNodesDocumentsRes.isErr() || contentNodesTablesRes.isErr()) {
-      logger.error(
-        `Error fetching content nodes for data source view ${dataSourceView.id}`
-      );
-      continue;
+      throw new Error(`Error fetching content nodes for data source view ${dataSourceView.id}`);
     }
 
     const rootNodesDocuments = contentNodesDocumentsRes.value.nodes.filter(
       (node) => node.parentInternalId === null
     );
-    const rooNodesTables = contentNodesTablesRes.value.nodes.filter(
+    const rootNodesTables = contentNodesTablesRes.value.nodes.filter(
       (node) => node.parentInternalId === null
     );
 
     const rootNodes = _.uniqBy(
-      [...rootNodesDocuments, ...rooNodesTables],
+      [...rootNodesDocuments, ...rootNodesTables],
       "internalId"
     );
 

--- a/front/migrations/20240927_backfill_dsv_parent_nodes.ts
+++ b/front/migrations/20240927_backfill_dsv_parent_nodes.ts
@@ -1,0 +1,81 @@
+import { getContentNodesForDataSourceView } from "@app/lib/api/data_source_view";
+import { Authenticator } from "@app/lib/auth";
+import { Workspace } from "@app/lib/models/workspace";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
+import { makeScript } from "@app/scripts/helpers";
+
+makeScript({}, async ({ execute }, logger) => {
+  // fetch all data source views with parentsIn set to null
+  const dataSourceViews = await DataSourceViewModel.findAll({
+    where: {
+      parentsIn: null,
+    },
+  });
+
+  logger.info(`Found ${dataSourceViews.length} data source views to process`);
+
+  for (const dataSourceView of dataSourceViews) {
+    const workspace = await Workspace.findOne({
+      where: { id: dataSourceView.workspaceId },
+    });
+
+    if (!workspace) {
+      logger.warn(`Couldn't find workspace ${dataSourceView.workspaceId}`);
+      continue;
+    }
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const dsvSId = DataSourceViewResource.modelIdToSId({
+      id: dataSourceView.id,
+      workspaceId: workspace.id,
+    });
+    const dataSourceViewResource = await DataSourceViewResource.fetchById(
+      auth,
+      dsvSId
+    );
+
+    if (!dataSourceViewResource) {
+      logger.warn(`DataSourceView not found for id ${dataSourceView.id}`);
+      continue;
+    }
+
+    const contentNodesRes = await getContentNodesForDataSourceView(
+      dataSourceViewResource,
+      {
+        viewType: "documents",
+      }
+    );
+
+    if (contentNodesRes.isErr()) {
+      logger.error(
+        `Error fetching content nodes for data source view ${dataSourceView.id}: ${contentNodesRes.error.message}`
+      );
+      continue;
+    }
+
+    const rootNodes = contentNodesRes.value.nodes.filter(
+      (node) => node.parentInternalId === null
+    );
+
+    if (rootNodes.length > 0) {
+      const rootNodeIds = rootNodes.map((node) => node.internalId);
+
+      if (execute) {
+        await dataSourceView.update({
+          parentsIn: rootNodeIds,
+        });
+        logger.info(
+          `Updated data source view ${dataSourceView.id} with ${rootNodeIds.length} root nodes`
+        );
+      } else {
+        logger.info(
+          `Would update data source view ${dataSourceView.id} with ${rootNodeIds.length} root nodes`
+        );
+      }
+    } else {
+      logger.info(
+        `No root nodes found for data source view ${dataSourceView.id}`
+      );
+    }
+  }
+});

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -322,12 +322,12 @@ async function handler(
 
       if (dataSource.vault.isSystem()) {
         const globalVault = await VaultResource.fetchWorkspaceGlobalVault(auth);
-
-        await DataSourceViewResource.createViewInVaultFromDataSourceIncludingAllDocuments(
+        // TODO
+        await DataSourceViewResource.createViewInVaultFromDataSource(
           auth,
           globalVault,
           dataSource,
-          "custom"
+          []
         );
       }
 

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -322,7 +322,7 @@ async function handler(
 
       if (dataSource.vault.isSystem()) {
         const globalVault = await VaultResource.fetchWorkspaceGlobalVault(auth);
-        // TODO
+
         await DataSourceViewResource.createViewInVaultFromDataSource(
           auth,
           globalVault,

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/index.ts
@@ -206,7 +206,7 @@ async function handler(
           auth,
           vault,
           dataSource,
-          parentsIn
+          isManaged(dataSource) && !parentsIn ? [] : parentsIn
         );
       return res.status(201).json({
         dataSourceView: dataSourceView.toJSON(),

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/index.ts
@@ -206,7 +206,7 @@ async function handler(
           auth,
           vault,
           dataSource,
-          isManaged(dataSource) && !parentsIn ? [] : parentsIn
+          parentsIn
         );
       return res.status(201).json({
         dataSourceView: dataSourceView.toJSON(),

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/index.ts
@@ -397,12 +397,11 @@ const handleDataSourceWithProvider = async ({
   // If the data source resides in the system vault, we also create a custom view in the global vault until vault are released.
   if (dataSource.vault.isSystem()) {
     const globalVault = await VaultResource.fetchWorkspaceGlobalVault(auth);
-
-    await DataSourceViewResource.createViewInVaultFromDataSourceIncludingAllDocuments(
+    await DataSourceViewResource.createViewInVaultFromDataSource(
       auth,
       globalVault,
       dataSource,
-      "custom"
+      []
     );
   }
 

--- a/types/src/front/api_handlers/public/vaults.ts
+++ b/types/src/front/api_handlers/public/vaults.ts
@@ -4,18 +4,18 @@ import { ContentNodeType } from "../../lib/connectors_api";
 
 export const ContentSchema = t.type({
   dataSourceId: t.string,
-  parentsIn: t.union([t.array(t.string), t.null]),
+  parentsIn:t.array(t.string),
 });
 
 export const PostDataSourceViewSchema = t.type({
   dataSourceId: t.string,
-  parentsIn: t.union([t.array(t.string), t.null]),
+  parentsIn: t.array(t.string),
 });
 
 export type PostDataSourceViewType = t.TypeOf<typeof PostDataSourceViewSchema>;
 
 export const PatchDataSourceViewSchema = t.type({
-  parentsIn: t.union([t.array(t.string), t.null]),
+  parentsIn: t.array(t.string),
 });
 
 export type PatchDataSourceViewType = t.TypeOf<


### PR DESCRIPTION
## Description

This PR aims at providing a script to backfill `DataSourceView` parent nodes with actual nodes and not root-level nodes.
This is part of the efforts to prevent users from selecting the whole connection.

The main changes include:
 - Add a migration script to populate parent node IDs for data source views where this field is null

**References:**
- https://github.com/dust-tt/tasks/issues/1390
 
## Risk

Quite high blast radius

## Deploy Plan

- Apply migration 
- Deploy UI changes https://github.com/dust-tt/dust/pull/7689
