### PR TITLE
Snowflake: Flow creation ds and connector

### DIFF
--- a/connectors/src/connectors/snowflake/index.ts
+++ b/connectors/src/connectors/snowflake/index.ts
@@ -38,7 +38,7 @@ export class SnowflakeConnectorManager extends BaseConnectorManager<null> {
     if (credentialsRes.isErr()) {
       return new Err(Error("Failed to retrieve credentials"));
     }
-    const credentials = credentialsRes.value.credentials;
+    const credentials = credentialsRes.value.credential.content;
 
     // Then we test the connection is successful.
     const connection = await testConnection({ credentials });

--- a/front/components/vaults/AddConnectionMenu.tsx
+++ b/front/components/vaults/AddConnectionMenu.tsx
@@ -12,6 +12,7 @@ import type {
   LightWorkspaceType,
   PlanType,
   Result,
+  VaultType,
   WorkspaceType,
 } from "@dust-tt/types";
 import { Err, isOAuthProvider, Ok, setupOAuthConnection } from "@dust-tt/types";
@@ -107,7 +108,46 @@ export const AddConnectionMenu = ({
     workspaceId: owner.sId,
   });
 
-  const handleEnableManagedDataSource = async (
+  if (!systemVault) {
+    return null;
+  }
+
+  const postDataSource = async ({
+    owner,
+    systemVault,
+    provider,
+    connectionId,
+    suffix,
+  }: {
+    owner: WorkspaceType;
+    systemVault: VaultType;
+    provider: ConnectorProvider;
+    connectionId: string;
+    suffix: string | null;
+  }): Promise<Response> => {
+    const test = await fetch(
+      suffix
+        ? `/api/w/${
+            owner.sId
+          }/vaults/${systemVault.sId}/data_sources?suffix=${encodeURIComponent(suffix)}`
+        : `/api/w/${owner.sId}/vaults/${systemVault.sId}/data_sources`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          provider,
+          connectionId,
+          name: undefined,
+          configuration: null,
+        } satisfies PostDataSourceRequestBody),
+      }
+    );
+    return test;
+  };
+
+  const handleOauthProviderManagedDataSource = async (
     provider: ConnectorProvider,
     suffix: string | null
   ) => {
@@ -126,25 +166,13 @@ export const AddConnectionMenu = ({
       }));
       setIsProviderLoading(provider, true);
 
-      const res = await fetch(
-        suffix
-          ? `/api/w/${
-              owner.sId
-            }/vaults/${systemVault?.sId}/data_sources?suffix=${encodeURIComponent(suffix)}`
-          : `/api/w/${owner.sId}/vaults/${systemVault?.sId}/data_sources`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            provider,
-            connectionId: connectionIdRes.value,
-            name: undefined,
-            configuration: null,
-          } satisfies PostDataSourceRequestBody),
-        }
-      );
+      const res = await postDataSource({
+        owner,
+        systemVault,
+        provider,
+        connectionId: connectionIdRes.value,
+        suffix,
+      });
 
       if (res.ok) {
         const createdManagedDataSource: {
@@ -172,6 +200,24 @@ export const AddConnectionMenu = ({
     } finally {
       setIsProviderLoading(provider, false);
     }
+  };
+
+  const handleCredentialProviderManagedDataSource = async ({
+    connectionId,
+    provider,
+    suffix,
+  }: {
+    connectionId: string;
+    provider: ConnectorProvider;
+    suffix: string | null;
+  }) => {
+    return postDataSource({
+      owner,
+      systemVault,
+      provider,
+      connectionId,
+      suffix,
+    });
   };
 
   const handleConnectionClick = (integration: DataSourceIntegration) => {
@@ -244,6 +290,8 @@ export const AddConnectionMenu = ({
                 integration: prev.integration,
               }))
             }
+            onSubmit={handleCredentialProviderManagedDataSource}
+            onCreated={onCreated}
           />
         ) : (
           connectorProvider && (
@@ -260,7 +308,7 @@ export const AddConnectionMenu = ({
               }
               onConfirm={() => {
                 if (showConfirmConnection.integration) {
-                  void handleEnableManagedDataSource(
+                  void handleOauthProviderManagedDataSource(
                     connectorProvider,
                     integration.setupWithSuffix
                   );

--- a/front/components/vaults/AddConnectionMenu.tsx
+++ b/front/components/vaults/AddConnectionMenu.tsx
@@ -125,7 +125,7 @@ export const AddConnectionMenu = ({
     connectionId: string;
     suffix: string | null;
   }): Promise<Response> => {
-    const test = await fetch(
+    const res = await fetch(
       suffix
         ? `/api/w/${
             owner.sId
@@ -144,7 +144,7 @@ export const AddConnectionMenu = ({
         } satisfies PostDataSourceRequestBody),
       }
     );
-    return test;
+    return res;
   };
 
   const handleOauthProviderManagedDataSource = async (

--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -58,6 +58,7 @@ const REDIRECT_TO_EDIT_PERMISSIONS = [
   "microsoft",
   "slack",
   "intercom",
+  "snowflake",
 ];
 
 type RowData = {

--- a/types/src/oauth/client/credentials.ts
+++ b/types/src/oauth/client/credentials.ts
@@ -3,6 +3,7 @@ import { Result } from "../../shared/result";
 import {
   ConnectionCredentials,
   CredentialsProvider,
+  OauthAPIGetCredentialsResponse,
   OauthAPIPostCredentialsResponse,
 } from "../lib";
 import { OAuthAPI, OAuthAPIError } from "../oauth_api";
@@ -44,14 +45,7 @@ export async function getConnectionCredentials({
   config: { url: string; apiKey: string | null };
   logger: LoggerInterface;
   credentialsId: string;
-}): Promise<
-  Result<
-    {
-      credentials: ConnectionCredentials;
-    },
-    OAuthAPIError
-  >
-> {
+}): Promise<Result<OauthAPIGetCredentialsResponse, OAuthAPIError>> {
   const res = await new OAuthAPI(config, logger).getCredentials({
     credentialsId,
   });

--- a/types/src/oauth/lib.ts
+++ b/types/src/oauth/lib.ts
@@ -82,3 +82,16 @@ export type OauthAPIPostCredentialsResponse = {
     created: number;
   };
 };
+
+export type OauthAPIGetCredentialsResponse = {
+  credential: {
+    credential_id: string;
+    created: number;
+    provider: CredentialsProvider;
+    metadata: {
+      workspace_id: string;
+      user_id: string;
+    };
+    content: ConnectionCredentials;
+  };
+};

--- a/types/src/oauth/oauth_api.ts
+++ b/types/src/oauth/oauth_api.ts
@@ -1,6 +1,7 @@
 import {
   ConnectionCredentials,
   CredentialsProvider,
+  OauthAPIGetCredentialsResponse,
   OauthAPIPostCredentialsResponse,
   OAuthConnectionType,
   OAuthProvider,
@@ -173,7 +174,7 @@ export class OAuthAPI {
     credentialsId,
   }: {
     credentialsId: string;
-  }): Promise<OAuthAPIResponse<{ credentials: ConnectionCredentials }>> {
+  }): Promise<OAuthAPIResponse<OauthAPIGetCredentialsResponse>> {
     const response = await this._fetchWithError(
       `${this._url}/credentials/${credentialsId}`
     );


### PR DESCRIPTION
## Description

This PRs update the snowflake connector creation flow on front: when the user submits the form, we were already posting credentials to oAuth service. Now we're also posting the route to create a datasource that will be in charge of creating the connector. 

If the connector is unhappy we keep the snowflake form modal open and display the error. 
If the connector is happy we redirect to the permission flow (to be implemented on the next PR).

(The few changes on connector are to fix the return type of fetching credentials from oAuthService that was set wrong).

## Risk

Unused yet on prod (behind a flag). 

## Deploy Plan

Deploy connector. 
Deploy front. 