### PR TITLE
[front] fix: allow link action

### DIFF
--- a/front/components/vaults/ContentActions.tsx
+++ b/front/components/vaults/ContentActions.tsx
@@ -175,10 +175,7 @@ export const getMenuItems = (
 
   // View in source:
   // We have a source for all types of docs excepts folder docs unless manually set by the user.
-  if (
-    canReadInVault &&
-    (!isFolder(dataSourceView.dataSource) || contentNode.sourceUrl)
-  ) {
+  if (!isFolder(dataSourceView.dataSource) || contentNode.sourceUrl) {
     actions.push(makeViewSourceUrlContentAction(contentNode, dataSourceView));
   }
 


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/1370
## Description

We don't need to be able to read the vault to have a link to the original source - permissions on the provider and in the vault are unrelated. The provider will handle its own permission checks.
<img width="1409" alt="Screenshot 2024-09-27 at 09 39 32" src="https://github.com/user-attachments/assets/0e212836-49b2-4f10-a089-a2cb452dedb8">

## Risk

none

## Deploy Plan

deploy front