### PR TITLE
[Vaults UI] Add groupIds to conversation

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -866,7 +866,7 @@ export async function* postUserMessage(
       }[];
 
       await updateConversationGroups({
-        mentionedAgents: agentMessages.map((a) => a.configuration),
+        mentionedAgents: nonNullResults.map(({ m }) => m.configuration),
         conversation,
         t,
       });
@@ -1356,7 +1356,7 @@ export async function* editUserMessage(
       // updateConversationGroups is purely additive, this will not remove any
       // group from the conversation (see function description)
       await updateConversationGroups({
-        mentionedAgents: agentMessages.map((a) => a.configuration),
+        mentionedAgents: nonNullResults.map(({ m }) => m.configuration),
         conversation,
         t,
       });

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -102,6 +102,7 @@ export async function createConversation(
     workspaceId: owner.id,
     title: title,
     visibility: visibility,
+    groupIds: [],
   });
 
   return {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1922,14 +1922,12 @@ async function updateConversationGroups({
   conversation: ConversationType;
   t: Transaction;
 }): Promise<void> {
-  const newGroupIds = new Set(
-    mentionedAgents.flatMap((agent) => agent.groupIds)
-  );
+  const newGroupIds = mentionedAgents.flatMap((agent) => agent.groupIds);
 
   const currentGroupIds = new Set(conversation.groupIds);
 
   // no need to update if  newGroupIds is a subset of currentGroupIds
-  if (!newGroupIds.isSubsetOf(currentGroupIds)) {
+  if (!newGroupIds.every((g) => currentGroupIds.has(g))) {
     const groupIds = Array.from(newGroupIds).map((g) => {
       const id = getResourceIdFromSId(g);
       if (id === null) {

--- a/front/lib/api/assistant/participants.ts
+++ b/front/lib/api/assistant/participants.ts
@@ -69,7 +69,6 @@ export async function fetchConversationParticipants(
     where: {
       conversationId: conversation.id,
     },
-    order: [["rank", "ASC"]],
     include: [
       {
         model: UserMessage,

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -32,6 +32,8 @@ export class Conversation extends Model<
   declare title: string | null;
   declare visibility: CreationOptional<ConversationVisibility>;
 
+  declare groupIds: number[];
+
   declare workspaceId: ForeignKey<Workspace["id"]>;
 }
 
@@ -64,6 +66,11 @@ Conversation.init(
       type: DataTypes.STRING,
       allowNull: false,
       defaultValue: "unlisted",
+    },
+    groupIds: {
+      type: DataTypes.ARRAY(DataTypes.INTEGER),
+      allowNull: false,
+      defaultValue: [],
     },
   },
   {

--- a/front/migrations/20240927_backfill_conversations_groupIds.ts
+++ b/front/migrations/20240927_backfill_conversations_groupIds.ts
@@ -4,16 +4,16 @@ import { Sequelize } from "sequelize";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import { Authenticator } from "@app/lib/auth";
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
-import { Workspace } from "@app/lib/models/workspace";
-import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
-import type { Logger } from "@app/logger/logger";
-import { getDataSourceViewIdsFromActions } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
-import { makeScript } from "@app/scripts/helpers";
 import {
   AgentMessage,
   Conversation,
   Message,
 } from "@app/lib/models/assistant/conversation";
+import { Workspace } from "@app/lib/models/workspace";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import type { Logger } from "@app/logger/logger";
+import { getDataSourceViewIdsFromActions } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
+import { makeScript } from "@app/scripts/helpers";
 
 makeScript({}, async ({ execute }, logger) => {
   // All workspaces that have at least one agent

--- a/front/migrations/20240927_backfill_conversations_groupIds.ts
+++ b/front/migrations/20240927_backfill_conversations_groupIds.ts
@@ -1,7 +1,6 @@
 import _ from "lodash";
 import { Sequelize } from "sequelize";
 
-import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import { Authenticator } from "@app/lib/auth";
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import {
@@ -10,9 +9,7 @@ import {
   Message,
 } from "@app/lib/models/assistant/conversation";
 import { Workspace } from "@app/lib/models/workspace";
-import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import type { Logger } from "@app/logger/logger";
-import { getDataSourceViewIdsFromActions } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 import { makeScript } from "@app/scripts/helpers";
 
 makeScript({}, async ({ execute }, logger) => {

--- a/front/migrations/20240927_backfill_conversations_groupIds.ts
+++ b/front/migrations/20240927_backfill_conversations_groupIds.ts
@@ -85,6 +85,9 @@ async function updateConversation(
   execute: boolean,
   logger: Logger
 ) {
+  // we get all messages without checking rank, because we only use them to get
+  // the agentConfigurationIds. At the time of writing (pre-vaults release), we
+  // don't need to consider message version at all for the backfill.
   const messages = await Message.findAll({
     where: {
       conversationId: conversation.id,

--- a/front/migrations/20240927_backfill_conversations_groupIds.ts
+++ b/front/migrations/20240927_backfill_conversations_groupIds.ts
@@ -1,0 +1,142 @@
+import _ from "lodash";
+import { Sequelize } from "sequelize";
+
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
+import { Authenticator } from "@app/lib/auth";
+import { AgentConfiguration } from "@app/lib/models/assistant/agent";
+import { Workspace } from "@app/lib/models/workspace";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import type { Logger } from "@app/logger/logger";
+import { getDataSourceViewIdsFromActions } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
+import { makeScript } from "@app/scripts/helpers";
+import {
+  AgentMessage,
+  Conversation,
+  Message,
+} from "@app/lib/models/assistant/conversation";
+
+makeScript({}, async ({ execute }, logger) => {
+  // All workspaces that have at least one agent
+  const workspaceIds = await getDistinctWorkspaceIds();
+
+  const workspaceChunks = _.chunk(workspaceIds, 8);
+
+  for (const workspaceChunk of workspaceChunks) {
+    await Promise.all(
+      workspaceChunk.map((id) =>
+        updateConversationsForWorkspace(id, execute, logger)
+      )
+    );
+  }
+});
+
+async function getDistinctWorkspaceIds(): Promise<number[]> {
+  const workspaceIds = await AgentConfiguration.findAll({
+    attributes: [
+      [Sequelize.fn("DISTINCT", Sequelize.col("workspaceId")), "workspaceId"],
+    ],
+    raw: true,
+  });
+
+  return workspaceIds.map((entry) => entry.workspaceId);
+}
+
+async function updateConversationsForWorkspace(
+  workspaceId: number,
+  execute: boolean,
+  logger: Logger
+) {
+  const conversations = await Conversation.findAll({
+    attributes: ["sId", "groupIds"],
+    where: { workspaceId },
+  });
+
+  logger.info(
+    { workspaceId, count: conversations.length },
+    "Updating convos for workspace"
+  );
+
+  const conversationChunks = _.chunk(conversations, 16);
+
+  // get workspace sid
+  const workspace = await Workspace.findByPk(workspaceId);
+
+  if (!workspace) {
+    logger.error(
+      {
+        workspaceId,
+      },
+      "Unexpected: Workspace not found"
+    );
+    return;
+  }
+
+  for (const conversationChunk of conversationChunks) {
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    await Promise.all(
+      conversationChunk.map((conversation) =>
+        updateConversation(auth, conversation, execute, logger)
+      )
+    );
+  }
+}
+
+async function updateConversation(
+  auth: Authenticator,
+  conversation: Conversation,
+  execute: boolean,
+  logger: Logger
+) {
+  const messages = await Message.findAll({
+    where: {
+      conversationId: conversation.id,
+    },
+    include: [
+      {
+        model: AgentMessage,
+        as: "agentMessage",
+        required: true,
+        attributes: ["agentConfigurationId"],
+      },
+    ],
+  });
+
+  const agentConfigurationIds = _.uniq(
+    messages.map((m) => {
+      if (!m.agentMessage) {
+        throw new Error("Unexpected: Message without agentMessage");
+      }
+      return m.agentMessage.agentConfigurationId;
+    })
+  );
+
+  const groupIds = _.uniq(
+    (
+      await AgentConfiguration.findAll({
+        where: { sId: agentConfigurationIds },
+      })
+    )
+      .map((agent) => agent.groupIds)
+      .flat()
+  );
+
+  if (execute) {
+    await conversation.update({ groupIds });
+    logger.info(
+      {
+        conversationId: conversation.sId,
+        execute,
+      },
+      "Updated agent"
+    );
+  } else {
+    logger.info(
+      {
+        conversationId: conversation.sId,
+        execute,
+      },
+      "Would have updated agent"
+    );
+  }
+}

--- a/front/migrations/20240927_backfill_conversations_groupIds.ts
+++ b/front/migrations/20240927_backfill_conversations_groupIds.ts
@@ -44,7 +44,7 @@ async function updateConversationsForWorkspace(
   logger: Logger
 ) {
   const conversations = await Conversation.findAll({
-    attributes: ["sId", "groupIds"],
+    attributes: ["id", "sId", "groupIds"],
     where: { workspaceId },
   });
 
@@ -128,7 +128,7 @@ async function updateConversation(
         conversationId: conversation.sId,
         execute,
       },
-      "Updated agent"
+      "Updated convo"
     );
   } else {
     logger.info(
@@ -136,7 +136,7 @@ async function updateConversation(
         conversationId: conversation.sId,
         execute,
       },
-      "Would have updated agent"
+      "Would have updated convo"
     );
   }
 }

--- a/front/migrations/db/migration_96.sql
+++ b/front/migrations/db/migration_96.sql
@@ -1,0 +1,2 @@
+-- Migration created on Oct 02, 2024
+ALTER TABLE "public"."conversations" ADD COLUMN "groupIds" INTEGER[] NOT NULL DEFAULT ARRAY[]::INTEGER[];

--- a/types/src/front/assistant/conversation.ts
+++ b/types/src/front/assistant/conversation.ts
@@ -161,16 +161,22 @@ export type ConversationVisibility =
   | "test";
 
 /**
+ * A lighter version of Conversation without the content (for menu display).
+ */
+export type ConversationWithoutContentType = {
+  id: ModelId;
+  created: number;
+  owner: WorkspaceType;
+  sId: string;
+  title: string | null;
+  visibility: ConversationVisibility;
+};
+
+/**
  * content [][] structure is intended to allow retries (of agent messages) or edits (of user
  * messages).
  */
-export type ConversationType = {
-  id: ModelId;
-  created: number;
-  sId: string;
-  owner: WorkspaceType;
-  title: string | null;
-  visibility: ConversationVisibility;
+export type ConversationType = ConversationWithoutContentType & {
   content: (UserMessageType[] | AgentMessageType[] | ContentFragmentType[])[];
 };
 
@@ -183,18 +189,6 @@ export type AgentParticipant = {
   configurationId: string;
   name: string;
   pictureUrl: string | null;
-};
-
-/**
- * A lighter version of Conversation without the content (for menu display).
- */
-export type ConversationWithoutContentType = {
-  created: number;
-  id: ModelId;
-  owner: WorkspaceType;
-  sId: string;
-  title: string | null;
-  visibility: ConversationVisibility;
 };
 
 export type ParticipantActionType = "posted" | "reacted" | "subscribed";

--- a/types/src/front/assistant/conversation.ts
+++ b/types/src/front/assistant/conversation.ts
@@ -170,6 +170,7 @@ export type ConversationWithoutContentType = {
   sId: string;
   title: string | null;
   visibility: ConversationVisibility;
+  groupIds: string[];
 };
 
 /**


### PR DESCRIPTION
## Description
Preliminary to PR #7631 and to fix issue #6903, following the decision to denormalize groups on conversations

This PR creates a `groupIds` field on conversations based on the ACL of messages it contains. The field will be populated / updated:
- at postUserMessage;
- at editUserMessage;
- at retryAgentMessage;

### Cases with special attention

**at editUserMessage--if a mention is removed** and for when  we implement the ability to delete an agent message from a conversation

Currently, it does not delete former agent messages if mention is changed so the convo should not loosen its permission.

In the future, there's a question of updating convo permission if a message is deleted. But we'd have to be careful in depending on how we implement it, e.g. if we still keep the agent messages versions when deleted just as we keep the various messages versions, then the best would be to  keep a "purely additive" stance and *not* remove permission restriction

The purely additive model seems cleaner, yielding simpler code,  and user downside very limited (only case is: now that the message is deleted user should be able to access the convo but can't, seems very edge-casey and easily overcomable)

This is why no step is taken in this PR towards permission loosening on message deletion.

**when agent groupIds change**

We do not update conversations' groupIds at those points, see [thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1727423063794339). Mainly because the update will happen naturally next time the agent is pinged, and older conversation messages are legitimate to keep the former permissioning for a while.

**when a vault's groups change**
The denormalization also raises the question of vaults whose groups would change since theoretically, vaults <-> groups is a many-to-many relationship. Updating a vault's groups should trigger an update of all agentmessages.

In practice though, it is currently a one-to-one relationship and there is no code location in which the relationship can mutate after creation. This case is therefore *not* adressed.

## Risk
Field is not used yet, so risk is limited.
Tests: 
- check conversations are properly backfilled
- check posting a message with a restricted agent fills convo groupid properly
- check retrying a message with a newly restricted agent does the same

## Deploy Plan
- run migration
- deploy front
- run backfill

