### PR TITLE
[front] - fix(poke): workspace deletion workflow

### DIFF
--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -670,13 +670,17 @@ export class GroupResource extends BaseResource<GroupModel> {
     });
     await GroupMembershipModel.destroy({
       where: {
-        workspaceId: workspace.id,
+        groupId: {
+          [Op.in]: groupIds,
+        },
       },
       transaction,
     });
     await this.model.destroy({
       where: {
-        workspaceId: workspace.id,
+        id: {
+          [Op.in]: groupIds,
+        },
       },
       transaction,
     });

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -656,15 +656,15 @@ export class GroupResource extends BaseResource<GroupModel> {
       attributes: ["id"],
       where: { workspaceId: workspace.id },
       transaction,
-    })
+    });
 
     const groupIds = groups.map((group) => group.id);
 
     await GroupVaultModel.destroy({
       where: {
         groupId: {
-          [Op.in]: groupIds
-        }
+          [Op.in]: groupIds,
+        },
       },
       transaction,
     });

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -652,6 +652,22 @@ export class GroupResource extends BaseResource<GroupModel> {
     workspace: LightWorkspaceType,
     transaction?: Transaction
   ) {
+    const groups = await this.model.findAll({
+      attributes: ["id"],
+      where: { workspaceId: workspace.id },
+      transaction,
+    })
+
+    const groupIds = groups.map((group) => group.id);
+
+    await GroupVaultModel.destroy({
+      where: {
+        groupId: {
+          [Op.in]: groupIds
+        }
+      },
+      transaction,
+    });
     await GroupMembershipModel.destroy({
       where: {
         workspaceId: workspace.id,

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -280,7 +280,9 @@ export class VaultResource extends BaseResource<VaultModel> {
 
     await this.model.destroy({
       where: {
-        workspaceId: owner.id,
+        id: {
+          [Op.in]: vaultIds,
+        },
       },
       transaction,
     });

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -260,12 +260,26 @@ export class VaultResource extends BaseResource<VaultModel> {
     transaction?: Transaction
   ) {
     const owner = auth.getNonNullableWorkspace();
+
+    const vaults = await this.model.findAll({
+      attributes: ["id"],
+      where: { workspaceId: owner.id },
+      transaction,
+    })
+
+    const vaultIds = vaults.map(
+      (vault) => vault.id,
+    )
+
     await GroupVaultModel.destroy({
       where: {
-        vaultId: owner.id,
+        vaultId: {
+          [Op.in]: vaultIds
+        }
       },
       transaction,
     });
+
     await this.model.destroy({
       where: {
         workspaceId: owner.id,

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -260,6 +260,12 @@ export class VaultResource extends BaseResource<VaultModel> {
     transaction?: Transaction
   ) {
     const owner = auth.getNonNullableWorkspace();
+    await GroupVaultModel.destroy({
+      where: {
+        vaultId: owner.id,
+      },
+      transaction,
+    });
     await this.model.destroy({
       where: {
         workspaceId: owner.id,

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -265,17 +265,15 @@ export class VaultResource extends BaseResource<VaultModel> {
       attributes: ["id"],
       where: { workspaceId: owner.id },
       transaction,
-    })
+    });
 
-    const vaultIds = vaults.map(
-      (vault) => vault.id,
-    )
+    const vaultIds = vaults.map((vault) => vault.id);
 
     await GroupVaultModel.destroy({
       where: {
         vaultId: {
-          [Op.in]: vaultIds
-        }
+          [Op.in]: vaultIds,
+        },
       },
       transaction,
     });

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -537,8 +537,8 @@ export async function deleteWorkspaceActivity({
     });
     await FileResource.deleteAllForWorkspace(workspace, t);
     await DataSourceViewResource.deleteAllForWorkspace(auth, t);
-    await GroupResource.deleteAllForWorkspace(workspace, t);
     await VaultResource.deleteAllForWorkspace(auth, t);
+    await GroupResource.deleteAllForWorkspace(workspace, t);
     logger.info(`[Workspace delete] Deleting Worskpace ${workspace.sId}`);
     await Workspace.destroy({
       where: {

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -537,8 +537,8 @@ export async function deleteWorkspaceActivity({
     });
     await FileResource.deleteAllForWorkspace(workspace, t);
     await DataSourceViewResource.deleteAllForWorkspace(auth, t);
-    await VaultResource.deleteAllForWorkspace(auth, t);
     await GroupResource.deleteAllForWorkspace(workspace, t);
+    await VaultResource.deleteAllForWorkspace(auth, t);
     logger.info(`[Workspace delete] Deleting Worskpace ${workspace.sId}`);
     await Workspace.destroy({
       where: {


### PR DESCRIPTION
## Description

This PR aims at fixing the `deleteWorkspaceWorkflow` workflow. We are hitting the following error:
```
update or delete on table \"vaults\" violates foreign key constraint \"group_vaults_vaultId_fkey\" on table \"group_vaults\"
```
which I guess occurs because we aim to delete the vault resources and not the associated group_vaults.

The main changes include:
-  Moved VaultResource delete call to ensure group resources are removed first

**References:**
- https://github.com/dust-tt/tasks/issues/1397

## Risk

Low as it mainly swaps two deletion calls 

## Deploy Plan

Deploy `front`