### PR TITLE
 feat(database schema block): return dialect and head

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -2634,7 +2634,7 @@ async fn databases_query_run(
                         None,
                     )
                 }
-                Some(tables) => match execute_query(&tables, &payload.query, state.store.clone())
+                Some(tables) => match execute_query(tables, &payload.query, state.store.clone())
                     .await
                 {
                     Err(QueryDatabaseError::TooManyResultRows) => error_response(

--- a/core/src/blocks/database.rs
+++ b/core/src/blocks/database.rs
@@ -105,7 +105,7 @@ impl Block for Database {
         let query = replace_variables_in_string(&self.query, "query", env)?;
         let tables = load_tables_from_identifiers(&table_identifiers, env).await?;
 
-        match execute_query(&tables, &query, env.store.clone()).await {
+        match execute_query(tables, &query, env.store.clone()).await {
             Ok((results, schema)) => Ok(BlockResult {
                 value: json!({
                     "results": results,

--- a/core/src/blocks/database_schema.rs
+++ b/core/src/blocks/database_schema.rs
@@ -81,14 +81,16 @@ impl Block for DatabaseSchema {
 
         // Compute the unique table names for each table.
 
-        let schemas =
+        let (dialect, schemas) =
             get_tables_schema(tables, env.store.clone(), env.databases_store.clone()).await?;
 
         Ok(BlockResult {
             value: serde_json::to_value(
                 schemas
                     .iter()
-                    .map(|(schema, dbml)| json!({ "table_schema": schema, "dbml": dbml }))
+                    .map(
+                        |s| json!({ "table_schema": s.schema, "dbml": s.dbml, "dialect": dialect, "head": s.head }),
+                    )
                     .collect::<Vec<_>>(),
             )?,
             meta: None,

--- a/core/src/databases/remote_databases/remote_database.rs
+++ b/core/src/databases/remote_databases/remote_database.rs
@@ -3,17 +3,18 @@ use async_trait::async_trait;
 
 use crate::{
     databases::{
-        database::{QueryDatabaseError, QueryResult},
+        database::{QueryDatabaseError, QueryResult, SqlDialect},
+        remote_databases::snowflake::SnowflakeRemoteDatabase,
         table::Table,
         table_schema::TableSchema,
     },
     oauth::{client::OauthClient, credential::CredentialProvider},
 };
 
-use super::snowflake::SnowflakeRemoteDatabase;
-
 #[async_trait]
 pub trait RemoteDatabase {
+    fn dialect(&self) -> SqlDialect;
+
     // Checks that the query only uses tables from the passed vector of tables and
     // then executes the query.
     async fn authorize_and_execute_query(

--- a/core/src/databases/remote_databases/snowflake.rs
+++ b/core/src/databases/remote_databases/snowflake.rs
@@ -10,7 +10,7 @@ use snowflake_connector_rs::{
 };
 
 use crate::databases::{
-    database::{QueryDatabaseError, QueryResult},
+    database::{QueryDatabaseError, QueryResult, SqlDialect},
     remote_databases::remote_database::RemoteDatabase,
     table::Table,
     table_schema::{TableSchema, TableSchemaColumn, TableSchemaFieldType},
@@ -239,6 +239,10 @@ impl SnowflakeRemoteDatabase {
 
 #[async_trait]
 impl RemoteDatabase for SnowflakeRemoteDatabase {
+    fn dialect(&self) -> SqlDialect {
+        SqlDialect::Snowflake
+    }
+
     async fn authorize_and_execute_query(
         &self,
         tables: &Vec<Table>,

--- a/core/src/databases/transient_database.rs
+++ b/core/src/databases/transient_database.rs
@@ -8,7 +8,7 @@ use tracing::info;
 use crate::{
     databases::{
         database::{QueryDatabaseError, QueryResult},
-        table::Table,
+        table::LocalTable,
         table_schema::TableSchema,
     },
     sqlite_workers::client::{SqliteWorker, SqliteWorkerError, HEARTBEAT_INTERVAL_MS},
@@ -65,11 +65,15 @@ impl TransientDatabase {
 }
 
 pub async fn execute_query_on_transient_database(
-    tables: &Vec<Table>,
+    tables: &Vec<LocalTable>,
     store: Box<dyn Store + Sync + Send>,
     query: &str,
 ) -> Result<(Vec<QueryResult>, TableSchema), QueryDatabaseError> {
-    let table_ids_hash = tables.iter().map(|t| t.unique_id()).sorted().join("/");
+    let table_ids_hash = tables
+        .iter()
+        .map(|lt| lt.table.unique_id())
+        .sorted()
+        .join("/");
 
     let database = store
         .upsert_database(&table_ids_hash, HEARTBEAT_INTERVAL_MS)
@@ -110,19 +114,21 @@ pub async fn execute_query_on_transient_database(
     Ok((result_rows, table_schema))
 }
 
-pub fn get_unique_table_names_for_transient_database(tables: &[Table]) -> HashMap<String, String> {
+pub fn get_transient_database_unique_table_names(
+    tables: &Vec<LocalTable>,
+) -> HashMap<String, String> {
     let mut name_count: HashMap<&str, usize> = HashMap::new();
 
     tables
         .iter()
-        .sorted_by_key(|table| table.unique_id())
-        .map(|table| {
-            let base_name = table.name();
+        .sorted_by_key(|lt| lt.table.unique_id())
+        .map(|lt| {
+            let base_name = lt.table.name();
             let count = name_count.entry(base_name).or_insert(0);
             *count += 1;
 
             (
-                table.unique_id(),
+                lt.table.unique_id(),
                 match *count {
                     1 => base_name.to_string(),
                     _ => format!("{}_{}", base_name, *count - 1),
@@ -130,4 +136,67 @@ pub fn get_unique_table_names_for_transient_database(tables: &[Table]) -> HashMa
             )
         })
         .collect()
+}
+
+pub struct TransientDatabaseTableInfo {
+    pub unique_name: String,
+    pub head: Vec<QueryResult>,
+}
+
+pub async fn get_transient_database_tables_info(
+    tables: &Vec<LocalTable>,
+    store: Box<dyn Store + Sync + Send>,
+) -> Result<Vec<TransientDatabaseTableInfo>> {
+    let table_ids_hash = tables
+        .iter()
+        .map(|lt| lt.table.unique_id())
+        .sorted()
+        .join("/");
+
+    let database = store
+        .upsert_database(&table_ids_hash, HEARTBEAT_INTERVAL_MS)
+        .await?;
+
+    let time_query_start = utils::now();
+    let mut results: Vec<TransientDatabaseTableInfo> = Vec::new();
+
+    let unique_table_names = get_transient_database_unique_table_names(tables);
+
+    for lt in tables {
+        let unique_name = unique_table_names.get(&lt.table.unique_id()).expect(
+            "Unreachable: unique_table_names should have an entry for each table in tables",
+        );
+
+        let result = match database.sqlite_worker() {
+            Some(sqlite_worker) => {
+                let result = sqlite_worker
+                    .execute_query(
+                        &table_ids_hash,
+                        tables,
+                        &format!(
+                            "SELECT * FROM \"{}\" ORDER BY RANDOM() LIMIT 16",
+                            unique_name
+                        ),
+                    )
+                    .await?;
+                result
+            }
+            None => Err(anyhow!(
+                "No live SQLite worker found for database {}",
+                database.unique_id()
+            ))?,
+        };
+
+        results.push(TransientDatabaseTableInfo {
+            unique_name: unique_name.to_string(),
+            head: result,
+        });
+    }
+
+    info!(
+        duration = utils::now() - time_query_start,
+        "DSSTRUCTSTAT Finished retrieving tables info from worker"
+    );
+
+    Ok(results)
 }

--- a/core/src/sqlite_workers/client.rs
+++ b/core/src/sqlite_workers/client.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 use urlencoding::encode;
 
 use crate::{
-    databases::{database::QueryResult, table::Table},
+    databases::{database::QueryResult, table::LocalTable},
     utils,
 };
 
@@ -71,7 +71,7 @@ impl SqliteWorker {
     pub async fn execute_query(
         &self,
         database_unique_id: &str,
-        tables: &Vec<Table>,
+        tables: &Vec<LocalTable>,
         query: &str,
     ) -> Result<Vec<QueryResult>, SqliteWorkerError> {
         let worker_url = self.url();
@@ -81,7 +81,7 @@ impl SqliteWorker {
             .post(&uri)
             .header("Content-Type", "application/json")
             .json(&json!({
-                "tables": tables,
+                "tables": tables.iter().map(|lt| &lt.table).collect::<Vec<_>>(),
                 "query": query,
             }));
 


### PR DESCRIPTION
## Description

With the addition of remote tables, the tables query dust-app will need to support multiple dialects (to correctly prompt the model). 
With this PR, the`RemoteDatabase` trait adds a `dialect` method that returns the dialect used by the remote DB. A `dialect` field has been added to the return values of the `DatabaseSchema` block.

For remote databases, we likely don't want to fetch the head of each used table (would be quite slow and token-consuming in a lot of cases). In order to avoid having 2 dust apps, a `head` optional field has been added to the return values of the `DatabaseSchema` block. This field is populated with "null" for remote DBs, and with a `Vec<QueryResult>` for local DBs (query results are the same as what we currently do in the dust app -- i.e `SELECT * FROM "${tableName}" ORDER BY RANDOM() LIMIT 16;`).

This will make the dust app much simpler, and will also likely speed up the tables query dust app as it removes a bit of overhead when gathering table heads.

## Risk

- Until I upgrade the prod tables query dust app, tables query will be a bit slower as it will be effectively fetching table heads twice
- This removes some flexibility, as the `DatabaseSchema` block will now always do a tables head for local DBs (i.e if some user use the `DatabaseSchema` block in their own dust apps, it will add latency for them). This IMHO is a fine tradeoff, and we can add a checkbox to disable this if it turns out to be necessary

## Deploy Plan

Deploy core