### PR TITLE
[front] Add screen after connector creation

### DIFF
--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -492,7 +492,7 @@ export function ConnectorPermissionsModal({
           const error: { error: { message: string } } = await r.json();
           window.alert(error.error.message);
         }
-        await mutate(
+        void mutate(
           (key) =>
             typeof key === "string" &&
             key.startsWith(

--- a/front/components/assistant_builder/vaults/VaultSelector.tsx
+++ b/front/components/assistant_builder/vaults/VaultSelector.tsx
@@ -26,7 +26,7 @@ export function VaultSelector({
   const selectedVaultObj = vaults.find((v) => v.sId === selectedVault);
 
   if (shouldRenderDirectly) {
-    if (allowedVaults && !allowedVaults?.some((v) => v.sId === vaults[0].sId)) {
+    if (allowedVaults && !allowedVaults.some((v) => v.sId === vaults[0].sId)) {
       return renderChildren(undefined);
     }
     return renderChildren(vaults[0]);

--- a/front/components/assistant_builder/vaults/VaultSelector.tsx
+++ b/front/components/assistant_builder/vaults/VaultSelector.tsx
@@ -48,7 +48,7 @@ export function VaultSelector({
     <>
       {sortedVaults.map((vault) => {
         const isDisabled =
-          allowedVaults && !allowedVaults?.some((v) => v.sId === vault.sId);
+          allowedVaults && !allowedVaults.some((v) => v.sId === vault.sId);
         const isChecked = selectedVault === vault.sId;
 
         return (

--- a/front/components/assistant_builder/vaults/VaultSelector.tsx
+++ b/front/components/assistant_builder/vaults/VaultSelector.tsx
@@ -36,7 +36,7 @@ export function VaultSelector({
   const sortedVaults = groupVaults(vaults)
     .filter((i) => i.kind !== "system")
     .map((i) =>
-      [...i.vaults].sort((a, b) => {
+      i.vaults.sort((a, b) => {
         return a.name.localeCompare(b.name);
       })
     )

--- a/front/components/assistant_builder/vaults/VaultSelector.tsx
+++ b/front/components/assistant_builder/vaults/VaultSelector.tsx
@@ -1,37 +1,26 @@
-import { Checkbox, Dialog, Icon, Page, Spinner } from "@dust-tt/sparkle";
-import type { LightWorkspaceType, VaultType } from "@dust-tt/types";
+import { Checkbox, Dialog, Icon, Page } from "@dust-tt/sparkle";
+import type { VaultType } from "@dust-tt/types";
 import React, { useState } from "react";
 
-import { useVaults, useVaultsAsAdmin } from "@app/lib/swr/vaults";
 import { classNames } from "@app/lib/utils";
 import { getVaultIcon, getVaultName, groupVaults } from "@app/lib/vaults";
 
 interface VaultSelectorProps {
-  owner: LightWorkspaceType;
   allowedVaults?: VaultType[];
-  asAdmin?: boolean;
   defaultVault: string | undefined;
+  vaults: VaultType[];
   renderChildren: (vault?: VaultType) => React.ReactNode;
 }
 export function VaultSelector({
-  owner,
   allowedVaults,
-  asAdmin,
   defaultVault,
   renderChildren,
+  vaults,
 }: VaultSelectorProps) {
-  const useVaultsHook = asAdmin ? useVaultsAsAdmin : useVaults;
-  const { vaults, isVaultsError, isVaultsLoading } = useVaultsHook({
-    workspaceId: owner.sId,
-  });
   const [selectedVault, setSelectedVault] = useState<string | undefined>(
     defaultVault
   );
   const [isAlertDialogOpen, setAlertIsDialogOpen] = useState(false);
-
-  if (isVaultsLoading || isVaultsError) {
-    return <Spinner />;
-  }
 
   const shouldRenderDirectly = vaults.length === 1;
   const selectedVaultObj = vaults.find((v) => v.sId === selectedVault);

--- a/front/components/assistant_builder/vaults/VaultSelector.tsx
+++ b/front/components/assistant_builder/vaults/VaultSelector.tsx
@@ -2,46 +2,64 @@ import { Checkbox, Dialog, Icon, Page, Spinner } from "@dust-tt/sparkle";
 import type { LightWorkspaceType, VaultType } from "@dust-tt/types";
 import React, { useState } from "react";
 
-import { useVaults } from "@app/lib/swr/vaults";
+import { useVaults, useVaultsAsAdmin } from "@app/lib/swr/vaults";
 import { classNames } from "@app/lib/utils";
-import { getVaultIcon, getVaultName } from "@app/lib/vaults";
+import { getVaultIcon, getVaultName, groupVaults } from "@app/lib/vaults";
 
 interface VaultSelectorProps {
   owner: LightWorkspaceType;
   allowedVaults?: VaultType[];
-  defaultVault: string;
+  asAdmin?: boolean;
+  defaultVault: string | undefined;
   renderChildren: (vault?: VaultType) => React.ReactNode;
 }
 export function VaultSelector({
   owner,
   allowedVaults,
+  asAdmin,
   defaultVault,
   renderChildren,
 }: VaultSelectorProps) {
-  const { vaults, isVaultsError, isVaultsLoading } = useVaults({
+  const useVaultsHook = asAdmin ? useVaultsAsAdmin : useVaults;
+  const { vaults, isVaultsError, isVaultsLoading } = useVaultsHook({
     workspaceId: owner.sId,
   });
-  const [selectedVault, setSelectedVault] = useState<string>(defaultVault);
+  const [selectedVault, setSelectedVault] = useState<string | undefined>(
+    defaultVault
+  );
   const [isAlertDialogOpen, setAlertIsDialogOpen] = useState(false);
 
   if (isVaultsLoading || isVaultsError) {
     return <Spinner />;
   }
 
-  const shouldRenderDirectly = !allowedVaults || vaults.length === 1;
+  const shouldRenderDirectly = vaults.length === 1;
   const selectedVaultObj = vaults.find((v) => v.sId === selectedVault);
 
   if (shouldRenderDirectly) {
-    return renderChildren(allowedVaults ? allowedVaults[0] : undefined);
+    if (allowedVaults && !allowedVaults?.some((v) => v.sId === vaults[0].sId)) {
+      return renderChildren(undefined);
+    }
+    return renderChildren(vaults[0]);
   }
 
+  // Group by kind and sort.
+  const sortedVaults = groupVaults(vaults)
+    .filter((i) => i.kind !== "system")
+    .map((i) =>
+      [...i.vaults].sort((a, b) => {
+        return a.name.localeCompare(b.name);
+      })
+    )
+    .flat();
   // TODO: we are using Checkboxes here as our RadioButton isn't flexible
   // enough to allow a onClick callback on a disabled item and to render
   // elements in between labels. We are aiming to refactor RadioButton
   return (
     <>
-      {vaults.map((vault) => {
-        const isDisabled = !allowedVaults?.some((v) => v.sId === vault.sId);
+      {sortedVaults.map((vault) => {
+        const isDisabled =
+          allowedVaults && !allowedVaults?.some((v) => v.sId === vault.sId);
         const isChecked = selectedVault === vault.sId;
 
         return (

--- a/front/components/vaults/ConnectorCreatedModal.tsx
+++ b/front/components/vaults/ConnectorCreatedModal.tsx
@@ -20,12 +20,6 @@ export const ConnectorCreatedModal = ({
   dataSource,
   owner,
 }: DataSourceViewSelectionModalProps) => {
-  // const [showVaultCreationModal, setShowVaultCreationModal] = useState(false);
-  // const [defaultVault, setDefaultVault] = useState<VaultType | null>(null);
-  // const { vaults, isVaultsLoading } = useVaultsAsAdmin({
-  //   workspaceId: owner.sId,
-  // });
-
   return (
     <Modal
       title={`Select data sources`}
@@ -66,38 +60,8 @@ export const ConnectorCreatedModal = ({
               <em>"Vaults"</em>.
             </li>
           </ul>
-          {/* <>
-              <div className="flex w-full flex-col gap-2 border-t pb-4 pt-4">
-                <Page.SectionHeader title="Data access settings" />
-                <div className="flex items-center gap-2">
-                  By default, the access to the data is restricted. Make the
-                  data available in:
-                </div>
-                <VaultSelector
-                  key={defaultVault?.sId}
-                  vaults={vaults}
-                  defaultVault={defaultVault?.sId}
-                  renderChildren={(vault) => <div>{vault?.name}</div>}
-                />
-              </div>
-              <Button
-                className="mt-4"
-                size="xs"
-                variant="tertiary"
-                label="Create a new Vault"
-                icon={PlusIcon}
-                onClick={() => setShowVaultCreationModal(true)}
-              />
-            </> */}
         </Page.Vertical>
       </Page>
-      {/* <CreateOrEditVaultModal
-        owner={owner}
-        isOpen={showVaultCreationModal}
-        onClose={() => setShowVaultCreationModal(false)}
-        onCreated={(created) => setDefaultVault(created)}
-        isAdmin={true}
-      /> */}
     </Modal>
   );
 };

--- a/front/components/vaults/ConnectorCreatedModal.tsx
+++ b/front/components/vaults/ConnectorCreatedModal.tsx
@@ -14,7 +14,7 @@ type DataSourceViewSelectionModalProps = {
   owner: LightWorkspaceType;
 };
 
-export const DataSourceViewSelectionModal = ({
+export const ConnectorCreatedModal = ({
   isOpen,
   onClose,
   dataSource,

--- a/front/components/vaults/ConnectorCreatedModal.tsx
+++ b/front/components/vaults/ConnectorCreatedModal.tsx
@@ -22,6 +22,9 @@ export const ConnectorCreatedModal = ({
 }: DataSourceViewSelectionModalProps) => {
   // const [showVaultCreationModal, setShowVaultCreationModal] = useState(false);
   // const [defaultVault, setDefaultVault] = useState<VaultType | null>(null);
+  // const { vaults, isVaultsLoading } = useVaultsAsAdmin({
+  //   workspaceId: owner.sId,
+  // });
 
   return (
     <Modal
@@ -72,8 +75,7 @@ export const ConnectorCreatedModal = ({
                 </div>
                 <VaultSelector
                   key={defaultVault?.sId}
-                  asAdmin
-                  owner={owner}
+                  vaults={vaults}
                   defaultVault={defaultVault?.sId}
                   renderChildren={(vault) => <div>{vault?.name}</div>}
                 />

--- a/front/components/vaults/CreateOrEditVaultModal.tsx
+++ b/front/components/vaults/CreateOrEditVaultModal.tsx
@@ -46,6 +46,7 @@ interface CreateOrEditVaultModalProps {
   owner: LightWorkspaceType;
   isOpen: boolean;
   onClose: () => void;
+  onCreated?: (vault: VaultType) => void;
   isAdmin: boolean;
   vault?: VaultType;
 }
@@ -63,6 +64,7 @@ export function CreateOrEditVaultModal({
   owner,
   isOpen,
   onClose,
+  onCreated,
   isAdmin,
   vault,
 }: CreateOrEditVaultModalProps) {
@@ -216,11 +218,9 @@ export function CreateOrEditVaultModal({
       await doUpdate(vault, selectedMembers, vaultName);
     } else if (!vault) {
       const createdVault = await doCreate(vaultName, selectedMembers);
-      if (createdVault) {
-        await router.push(`/w/${owner.sId}/vaults/${createdVault.sId}`);
-      } else {
-        setIsSaving(false);
-        return;
+      setIsSaving(false);
+      if (createdVault && onCreated) {
+        onCreated(createdVault);
       }
     }
     handleClose();

--- a/front/components/vaults/CreateOrEditVaultModal.tsx
+++ b/front/components/vaults/CreateOrEditVaultModal.tsx
@@ -227,9 +227,8 @@ export function CreateOrEditVaultModal({
   }, [
     doCreate,
     doUpdate,
+    onCreated,
     handleClose,
-    owner.sId,
-    router,
     selectedMembers,
     vault,
     vaultName,

--- a/front/components/vaults/DataSourceViewSelectionModal.tsx
+++ b/front/components/vaults/DataSourceViewSelectionModal.tsx
@@ -1,0 +1,120 @@
+import { Button, Icon, Modal, Page, SparklesIcon } from "@dust-tt/sparkle";
+import type {
+  ConnectorStatusDetails,
+  DataSourceType,
+  LightWorkspaceType,
+  VaultType,
+} from "@dust-tt/types";
+import { PlusIcon } from "lucide-react";
+import { useState } from "react";
+
+import { VaultSelector } from "@app/components/assistant_builder/vaults/VaultSelector";
+import ConnectorSyncingChip from "@app/components/data_source/DataSourceSyncChip";
+import { CreateOrEditVaultModal } from "@app/components/vaults/CreateOrEditVaultModal";
+
+type DataSourceViewSelectionModalProps = {
+  dataSource: DataSourceType & ConnectorStatusDetails;
+  isOpen: boolean;
+  onClose: (shouldRefresh: boolean) => void;
+  owner: LightWorkspaceType;
+};
+
+export const DataSourceViewSelectionModal = ({
+  isOpen,
+  onClose,
+  dataSource,
+  owner,
+}: DataSourceViewSelectionModalProps) => {
+  const [showVaultCreationModal, setShowVaultCreationModal] = useState(false);
+  const [defaultVault, setDefaultVault] = useState<VaultType | null>(null);
+
+  // TODO - implement data selection when synced
+  //   const { connector: refreshedConnector } = useConnector({
+  //     workspaceId: owner.sId,
+  //     dataSource,
+  //   });
+  //   const synced = !!refreshedConnector?.firstSyncProgress;
+
+  const synced = false;
+
+  return (
+    <Modal
+      title={`Select data sources`}
+      isOpen={isOpen}
+      onClose={() => onClose(false)}
+      onSave={() => {}}
+      saveLabel="Save"
+      savingLabel="Saving..."
+      isSaving={false}
+      hasChanged={false}
+      variant="side-sm"
+    >
+      <Page variant="modal">
+        <Page.Vertical sizing="grow">
+          <div className="flex flex-col gap-2">
+            <div className="p-1 text-xl font-bold">
+              <Icon visual={SparklesIcon} className={"text-brand"} size="lg" />
+              <div>Data added.</div>
+              <div>Data Sync underway. ${synced ? "1" : "2"}</div>
+            </div>
+            {dataSource.connector && (
+              <ConnectorSyncingChip
+                initialState={dataSource.connector}
+                workspaceId={owner.sId}
+                dataSource={dataSource}
+              />
+            )}
+          </div>
+          {!synced && (
+            <ul className="list-disc pl-4 text-sm text-element-900">
+              <li className="py-1">
+                New data will appear in <em>"Connection Management"</em> as it
+                syncs.
+              </li>
+              <li>
+                Data Access is limited to{" "}
+                <strong className="font-semibold">Admins</strong> by default.
+                Share with your team through <em>"Company Data"</em> or
+                restricted
+                <em>"Vaults"</em>.
+              </li>
+            </ul>
+          )}
+          {synced && (
+            <>
+              <div className="flex w-full flex-col gap-2 border-t pb-4 pt-4">
+                <Page.SectionHeader title="Data access settings" />
+                <div className="flex items-center gap-2">
+                  By default, the access to the data is restricted. Make the
+                  data available in:
+                </div>
+                <VaultSelector
+                  key={defaultVault?.sId}
+                  asAdmin
+                  owner={owner}
+                  defaultVault={defaultVault?.sId}
+                  renderChildren={(vault) => <div>{vault?.name}</div>}
+                />
+              </div>
+              <Button
+                className="mt-4"
+                size="xs"
+                variant="tertiary"
+                label="Create a new Vault"
+                icon={PlusIcon}
+                onClick={() => setShowVaultCreationModal(true)}
+              />
+            </>
+          )}
+        </Page.Vertical>
+      </Page>
+      <CreateOrEditVaultModal
+        owner={owner}
+        isOpen={showVaultCreationModal}
+        onClose={() => setShowVaultCreationModal(false)}
+        onCreated={(created) => setDefaultVault(created)}
+        isAdmin={true}
+      />
+    </Modal>
+  );
+};

--- a/front/components/vaults/DataSourceViewSelectionModal.tsx
+++ b/front/components/vaults/DataSourceViewSelectionModal.tsx
@@ -1,16 +1,11 @@
-import { Button, Icon, Modal, Page, SparklesIcon } from "@dust-tt/sparkle";
+import { Icon, Modal, Page, SparklesIcon } from "@dust-tt/sparkle";
 import type {
   ConnectorStatusDetails,
   DataSourceType,
   LightWorkspaceType,
-  VaultType,
 } from "@dust-tt/types";
-import { PlusIcon } from "lucide-react";
-import { useState } from "react";
 
-import { VaultSelector } from "@app/components/assistant_builder/vaults/VaultSelector";
 import ConnectorSyncingChip from "@app/components/data_source/DataSourceSyncChip";
-import { CreateOrEditVaultModal } from "@app/components/vaults/CreateOrEditVaultModal";
 
 type DataSourceViewSelectionModalProps = {
   dataSource: DataSourceType & ConnectorStatusDetails;
@@ -25,17 +20,8 @@ export const DataSourceViewSelectionModal = ({
   dataSource,
   owner,
 }: DataSourceViewSelectionModalProps) => {
-  const [showVaultCreationModal, setShowVaultCreationModal] = useState(false);
-  const [defaultVault, setDefaultVault] = useState<VaultType | null>(null);
-
-  // TODO - implement data selection when synced
-  //   const { connector: refreshedConnector } = useConnector({
-  //     workspaceId: owner.sId,
-  //     dataSource,
-  //   });
-  //   const synced = !!refreshedConnector?.firstSyncProgress;
-
-  const synced = false;
+  // const [showVaultCreationModal, setShowVaultCreationModal] = useState(false);
+  // const [defaultVault, setDefaultVault] = useState<VaultType | null>(null);
 
   return (
     <Modal
@@ -55,7 +41,7 @@ export const DataSourceViewSelectionModal = ({
             <div className="p-1 text-xl font-bold">
               <Icon visual={SparklesIcon} className={"text-brand"} size="lg" />
               <div>Data added.</div>
-              <div>Data Sync underway. ${synced ? "1" : "2"}</div>
+              <div>Data Sync underway.</div>
             </div>
             {dataSource.connector && (
               <ConnectorSyncingChip
@@ -65,23 +51,19 @@ export const DataSourceViewSelectionModal = ({
               />
             )}
           </div>
-          {!synced && (
-            <ul className="list-disc pl-4 text-sm text-element-900">
-              <li className="py-1">
-                New data will appear in <em>"Connection Management"</em> as it
-                syncs.
-              </li>
-              <li>
-                Data Access is limited to{" "}
-                <strong className="font-semibold">Admins</strong> by default.
-                Share with your team through <em>"Company Data"</em> or
-                restricted
-                <em>"Vaults"</em>.
-              </li>
-            </ul>
-          )}
-          {synced && (
-            <>
+          <ul className="list-disc pl-4 text-sm text-element-900">
+            <li className="py-1">
+              New data will appear in <em>"Connection Management"</em> as it
+              syncs.
+            </li>
+            <li>
+              Data Access is limited to{" "}
+              <strong className="font-semibold">Admins</strong> by default.
+              Share with your team through <em>"Company Data"</em> or restricted{" "}
+              <em>"Vaults"</em>.
+            </li>
+          </ul>
+          {/* <>
               <div className="flex w-full flex-col gap-2 border-t pb-4 pt-4">
                 <Page.SectionHeader title="Data access settings" />
                 <div className="flex items-center gap-2">
@@ -104,17 +86,16 @@ export const DataSourceViewSelectionModal = ({
                 icon={PlusIcon}
                 onClick={() => setShowVaultCreationModal(true)}
               />
-            </>
-          )}
+            </> */}
         </Page.Vertical>
       </Page>
-      <CreateOrEditVaultModal
+      {/* <CreateOrEditVaultModal
         owner={owner}
         isOpen={showVaultCreationModal}
         onClose={() => setShowVaultCreationModal(false)}
         onCreated={(created) => setDefaultVault(created)}
         isAdmin={true}
-      />
+      /> */}
     </Modal>
   );
 };

--- a/front/components/vaults/VaultContext.tsx
+++ b/front/components/vaults/VaultContext.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+export const VaultContext = React.createContext<
+  | {
+      setShowVaultCreationModal: (show: boolean) => void;
+    }
+  | undefined
+>(undefined);
+
+export const useVaultContext = () => {
+  const context = React.useContext(VaultContext);
+  if (!context) {
+    throw new Error("useVaultContext must be used within a VaultContext");
+  }
+  return context;
+};

--- a/front/components/vaults/VaultLayout.tsx
+++ b/front/components/vaults/VaultLayout.tsx
@@ -6,6 +6,7 @@ import type {
   VaultType,
   WorkspaceType,
 } from "@dust-tt/types";
+import { useRouter } from "next/router";
 import type { ComponentType } from "react";
 import React, { useMemo, useState } from "react";
 
@@ -45,7 +46,7 @@ export function VaultLayout({
     dataSourceView,
     parentId,
   } = pageProps;
-
+  const router = useRouter();
   const isPrivateVaultsEnabled = owner.flags.includes(
     "private_data_vaults_feature"
   );
@@ -78,6 +79,9 @@ export function VaultLayout({
             owner={owner}
             isOpen={showVaultCreationModal}
             onClose={() => setShowVaultCreationModal(false)}
+            onCreated={(vault) => {
+              void router.push(`/w/${owner.sId}/vaults/${vault.sId}`);
+            }}
           />
         )}
       </AppLayout>

--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -41,7 +41,7 @@ import ConnectorSyncingChip from "@app/components/data_source/DataSourceSyncChip
 import { DeleteStaticDataSourceDialog } from "@app/components/data_source/DeleteStaticDataSourceDialog";
 import type { DataSourceIntegration } from "@app/components/vaults/AddConnectionMenu";
 import { AddConnectionMenu } from "@app/components/vaults/AddConnectionMenu";
-import { DataSourceViewSelectionModal } from "@app/components/vaults/DataSourceViewSelectionModal";
+import { ConnectorCreatedModal } from "@app/components/vaults/ConnectorCreatedModal";
 import { EditVaultManagedDataSourcesViews } from "@app/components/vaults/EditVaultManagedDatasourcesViews";
 import { EditVaultStaticDatasourcesViews } from "@app/components/vaults/EditVaultStaticDatasourcesViews";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
@@ -519,7 +519,7 @@ export const VaultResourcesList = ({
               readOnly={false}
               isAdmin={isAdmin}
             />
-            <DataSourceViewSelectionModal
+            <ConnectorCreatedModal
               owner={owner}
               dataSource={selectedDataSourceView.dataSource}
               isOpen={showSelectionModal && !showConnectorPermissionsModal}

--- a/front/components/vaults/VaultSideBarMenu.tsx
+++ b/front/components/vaults/VaultSideBarMenu.tsx
@@ -85,7 +85,9 @@ export default function VaultSideBarMenu({
   }
 
   // Group by kind and sort.
-  const sortedGroupedVaults = groupVaults(vaults);
+  const sortedGroupedVaults = groupVaults(vaults)
+    // remove the empty system menu for users & builders
+    .filter(({ vaults, kind }) => kind !== "system" || vaults.length !== 0);
 
   return (
     <div className="flex h-0 min-h-full w-full overflow-y-auto">

--- a/front/components/vaults/VaultSideBarMenu.tsx
+++ b/front/components/vaults/VaultSideBarMenu.tsx
@@ -18,7 +18,7 @@ import type {
   VaultType,
 } from "@dust-tt/types";
 import { assertNever, DATA_SOURCE_VIEW_CATEGORIES } from "@dust-tt/types";
-import { groupBy, sortBy, uniqBy } from "lodash";
+import { sortBy, uniqBy } from "lodash";
 import { useRouter } from "next/router";
 import type { ComponentType, ReactElement } from "react";
 import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
@@ -33,7 +33,7 @@ import {
   useVaults,
   useVaultsAsAdmin,
 } from "@app/lib/swr/vaults";
-import { getVaultIcon, getVaultName } from "@app/lib/vaults";
+import { getVaultIcon, getVaultName, groupVaults } from "@app/lib/vaults";
 
 interface VaultSideBarMenuProps {
   isPrivateVaultsEnabled: boolean;
@@ -41,13 +41,6 @@ interface VaultSideBarMenuProps {
   isAdmin: boolean;
   setShowVaultCreationModal: (show: boolean) => void;
 }
-
-const VAULTS_SORT_ORDER: VaultKind[] = [
-  "system",
-  "global",
-  "regular",
-  "public",
-];
 
 export default function VaultSideBarMenu({
   isPrivateVaultsEnabled,
@@ -92,12 +85,7 @@ export default function VaultSideBarMenu({
   }
 
   // Group by kind and sort.
-  const groupedVaults = groupBy(vaults, (vault) => vault.kind);
-  const sortedGroupedVaults = VAULTS_SORT_ORDER.map((kind) => ({
-    kind,
-    vaults: groupedVaults[kind] || [],
-    // remove the empty system menu for users & builders
-  })).filter(({ vaults, kind }) => !(kind === "system" && vaults.length === 0));
+  const sortedGroupedVaults = groupVaults(vaults);
 
   return (
     <div className="flex h-0 min-h-full w-full overflow-y-auto">

--- a/front/lib/vaults.ts
+++ b/front/lib/vaults.ts
@@ -1,6 +1,14 @@
 import { CompanyIcon, LockIcon, PlanetIcon } from "@dust-tt/sparkle";
-import type { VaultType, WorkspaceType } from "@dust-tt/types";
+import type { VaultKind, VaultType, WorkspaceType } from "@dust-tt/types";
+import { groupBy } from "lodash";
 import type React from "react";
+
+export const VAULTS_SORT_ORDER: VaultKind[] = [
+  "system",
+  "global",
+  "regular",
+  "public",
+];
 
 export function getVaultIcon(
   vault: VaultType
@@ -23,4 +31,14 @@ export const dustAppsListUrl = (
   vault: VaultType
 ): string => {
   return `/w/${owner.sId}/vaults/${vault.sId}/categories/apps`;
+};
+
+export const groupVaults = (vaults: VaultType[]) => {
+  // Group by kind and sort.
+  const groupedVaults = groupBy(vaults, (vault) => vault.kind);
+  return VAULTS_SORT_ORDER.map((kind) => ({
+    kind,
+    vaults: groupedVaults[kind] || [],
+    // remove the empty system menu for users & builders
+  })).filter(({ vaults, kind }) => !(kind !== "system" && vaults.length === 0));
 };

--- a/front/lib/vaults.ts
+++ b/front/lib/vaults.ts
@@ -40,5 +40,5 @@ export const groupVaults = (vaults: VaultType[]) => {
     kind,
     vaults: groupedVaults[kind] || [],
     // remove the empty system menu for users & builders
-  })).filter(({ vaults, kind }) => !(kind !== "system" && vaults.length === 0));
+  })).filter(({ vaults, kind }) => kind !== "system" || vaults.length !== 0);
 };

--- a/front/lib/vaults.ts
+++ b/front/lib/vaults.ts
@@ -39,6 +39,5 @@ export const groupVaults = (vaults: VaultType[]) => {
   return VAULTS_SORT_ORDER.map((kind) => ({
     kind,
     vaults: groupedVaults[kind] || [],
-    // remove the empty system menu for users & builders
-  })).filter(({ vaults, kind }) => kind !== "system" || vaults.length !== 0);
+  }));
 };


### PR DESCRIPTION
fixes: [#7361](https://github.com/dust-tt/dust/issues/7361)

## Description

- Add screen after connector creation. 
- improvements in VaultSelector : allow admin mode, allow unfiltered list of vaults, sort by type and name
- improvements in vault creation : allow to take callback after creation instead if redirect

<img width="457" alt="Screenshot 2024-09-27 at 16 09 58" src="https://github.com/user-attachments/assets/713bd30e-932f-4168-a18e-fcce760e0791">

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
