### PR TITLE
[Vaults] Restrict access to conversations and messages (bis)

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -334,11 +334,12 @@ const conversation = async (command: string, args: parseArgs.ParsedArgs) => {
       const verbose = args.verbose === "true";
 
       const auth = await Authenticator.internalAdminForWorkspace(args.wId);
-      const conversation = await getConversation(auth, args.cId as string);
+      const conversationRes = await getConversation(auth, args.cId as string);
 
-      if (!conversation) {
-        throw new Error(`Conversation not found: cId='${args.cId}'`);
+      if (conversationRes.isErr()) {
+        throw new Error(conversationRes.error.message);
       }
+      const conversation = conversationRes.value;
 
       const MIN_GENERATION_TOKENS = 2048;
       const allowedTokenCount = model.contextSize - MIN_GENERATION_TOKENS;

--- a/front/components/assistant/conversation/ConversationError.tsx
+++ b/front/components/assistant/conversation/ConversationError.tsx
@@ -1,12 +1,13 @@
+import type { ConversationError, ConversationErrorType } from "@dust-tt/types";
 import { Icon, StopSignIcon } from "@dust-tt/sparkle";
 import { isAPIErrorResponse, safeParseJSON } from "@dust-tt/types";
 import type { ComponentType } from "react";
 
-interface ConversationError {
-  error: Error;
+interface ConversationErrorProps {
+  error: ConversationError;
 }
 
-export function ConversationError({ error }: ConversationError) {
+export function ConversationErrorDisplay({ error }: ConversationErrorProps) {
   const errorMessageRes = safeParseJSON(error.message);
 
   if (errorMessageRes.isErr() || !isAPIErrorResponse(errorMessageRes.value)) {

--- a/front/components/assistant/conversation/ConversationError.tsx
+++ b/front/components/assistant/conversation/ConversationError.tsx
@@ -1,5 +1,5 @@
-import type { ConversationError, ConversationErrorType } from "@dust-tt/types";
 import { Icon, StopSignIcon } from "@dust-tt/sparkle";
+import type { ConversationError } from "@dust-tt/types";
 import { isAPIErrorResponse, safeParseJSON } from "@dust-tt/types";
 import type { ComponentType } from "react";
 

--- a/front/components/assistant/conversation/ConversationError.tsx
+++ b/front/components/assistant/conversation/ConversationError.tsx
@@ -14,8 +14,8 @@ export function ConversationError({ error }: ConversationError) {
   }
 
   switch (errorMessageRes.value.error.type) {
-    case "conversation_access_denied":
-      return <ConversationAccessDenied />;
+    case "conversation_access_restricted":
+      return <ConversationAccessRestricted />;
 
     case "conversation_not_found":
       return <ConversationNotFound />;
@@ -25,7 +25,7 @@ export function ConversationError({ error }: ConversationError) {
   }
 }
 
-function ConversationAccessDenied() {
+function ConversationAccessRestricted() {
   return (
     <ErrorDisplay
       icon={StopSignIcon}

--- a/front/components/assistant/conversation/ConversationLayout.tsx
+++ b/front/components/assistant/conversation/ConversationLayout.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useEffect, useState } from "react";
 
 import RootLayout from "@app/components/app/RootLayout";
 import { AssistantDetails } from "@app/components/assistant/AssistantDetails";
-import { ConversationError } from "@app/components/assistant/conversation/ConversationError";
+import { ConversationErrorDisplay } from "@app/components/assistant/conversation/ConversationError";
 import { ConversationTitle } from "@app/components/assistant/conversation/ConversationTitle";
 import { FileDropProvider } from "@app/components/assistant/conversation/FileUploaderContext";
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
@@ -130,7 +130,7 @@ export default function ConversationLayout({
           navChildren={<AssistantSidebarMenu owner={owner} />}
         >
           {conversationError ? (
-            <ConversationError error={conversationError} />
+            <ConversationErrorDisplay error={conversationError} />
           ) : (
             <>
               <AssistantDetails

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -17,7 +17,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import React from "react";
 import { useInView } from "react-intersection-observer";
 
-import { ConversationError } from "@app/components/assistant/conversation/ConversationError";
+import { ConversationErrorDisplay } from "@app/components/assistant/conversation/ConversationError";
 import { CONVERSATION_PARENT_SCROLL_DIV_ID } from "@app/components/assistant/conversation/lib";
 import MessageGroup from "@app/components/assistant/conversation/messages/MessageGroup";
 import { useEventSource } from "@app/hooks/useEventSource";
@@ -332,7 +332,9 @@ const ConversationViewer = React.forwardRef<
       )}
       ref={ref}
     >
-      {conversationError && <ConversationError error={conversationError} />}
+      {conversationError && (
+        <ConversationErrorDisplay error={conversationError} />
+      )}
       {/* Invisible span to detect when the user has scrolled to the top of the list. */}
       {hasMore && !isMessagesLoading && !prevFirstMessageId && (
         <span ref={viewRef} className="py-4" />

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -180,8 +180,7 @@ export async function deleteConversation(
     destroy?: boolean;
   }
 ): Promise<Result<{ success: true }, ConversationError>> {
-  const owner = auth.workspace();
-  if (!owner) {
+  if (!auth.workspace()) {
     throw new Error("Unexpected `auth` without `workspace`.");
   }
 
@@ -2039,10 +2038,7 @@ export function canAccessConversation(
   auth: Authenticator,
   conversation: ConversationWithoutContentType | ConversationType | Conversation
 ): boolean {
-  const owner = auth.workspace();
-  if (!owner) {
-    throw new Error("Unexpected: owner without auth");
-  }
+  const owner = auth.getNonNullableWorkspace();
 
   const groupIds =
     conversation instanceof Conversation

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -91,6 +91,7 @@ import { ServerSideTracking } from "@app/lib/tracking/server";
 import { isEmailValid } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import { launchUpdateUsageWorkflow } from "@app/temporal/usage_queue/client";
+import { message } from "danger";
 
 /**
  * Conversation Creation, update and deletion
@@ -1703,6 +1704,10 @@ export async function postNewContentFragment(
     throw new Error("Invalid auth for conversation.");
   }
 
+  if (!(await canAccessConversation(auth, conversation))) {
+    return new Err(new ConversationPermissionError());
+  }
+
   const messageId = generateLegacyModelSId();
 
   const cfBlobRes = await getContentFragmentBlob(
@@ -2026,8 +2031,17 @@ function getConversationGroupIdsFromModel(
 
 export async function canAccessConversation(
   auth: Authenticator,
-  conversation: ConversationWithoutContentType
+  conversation: ConversationWithoutContentType | ConversationType
 ): Promise<boolean> {
+  if ("content" in conversation) {
+    // If the conversation has its content already loaded, we can check without an additional query
+    return conversation.content.every(
+      (messages) =>
+        !isAgentMessageType(messages[messages.length - 1]) ||
+        canReadMessage(auth, messages[messages.length - 1] as AgentMessageType)
+    );
+  }
+
   const res = await fetchConversationParticipants(auth, conversation);
   if (res.isErr() && res.error instanceof ConversationPermissionError) {
     return false;

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -720,22 +720,15 @@ export async function* postUserMessage(
   }
 
   const results = await Promise.all([
-    await Promise.all(
+    Promise.all(
       mentions.filter(isAgentMention).map((mention) => {
         return getLightAgentConfiguration(auth, mention.configurationId);
       })
     ),
-    await createOrUpdateParticipation({
-      user,
-      conversation,
-    }),
+    createOrUpdateParticipation(),
   ]);
 
-  // casting non-null is ok here because we check right below that there's no
-  // nulls and err if there is
-  const agentConfigurations = results[0] as LightAgentConfigurationType[];
-
-  if (agentConfigurations.some((a) => a === null)) {
+  if (results[0].some((a) => a === null)) {
     yield {
       type: "user_message_error",
       created: Date.now(),
@@ -746,6 +739,10 @@ export async function* postUserMessage(
     };
     return;
   }
+
+  // casting non-null is ok here because we check right above that there's no
+  // nulls and err if there is
+  const agentConfigurations = results[0] as LightAgentConfigurationType[];
 
   for (const agentConfig of agentConfigurations) {
     if (!isProviderWhitelisted(owner, agentConfig.model.providerId)) {
@@ -1168,11 +1165,7 @@ export async function* editUserMessage(
     await createOrUpdateParticipation(),
   ]);
 
-  // casting non-null is ok here because we check right below that there's no
-  // nulls and err if there is
-  const agentConfigurations = results[0] as LightAgentConfigurationType[];
-
-  if (agentConfigurations.some((a) => a === null)) {
+  if (results[0].some((a) => a === null)) {
     yield {
       type: "user_message_error",
       created: Date.now(),
@@ -1183,6 +1176,10 @@ export async function* editUserMessage(
     };
     return;
   }
+
+  // casting non-null is ok here because we check right above that there's no
+  // nulls and err if there is
+  const agentConfigurations = results[0] as LightAgentConfigurationType[];
 
   for (const agentConfig of agentConfigurations) {
     if (!isProviderWhitelisted(owner, agentConfig.model.providerId)) {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -159,6 +159,10 @@ export async function updateConversation(
     throw new Error(`Conversation ${conversationId} not found`);
   }
 
+  if (!(await canAccessConversation(auth, conversation))) {
+    throw new Error("Conversation access denied");
+  }
+
   await conversation.update({
     title: title,
     visibility: visibility,
@@ -202,6 +206,10 @@ export async function deleteConversation(
 
   if (!conversation) {
     throw new Error(`Conversation ${conversationId} not found`);
+  }
+
+  if (!(await canAccessConversation(auth, conversation))) {
+    throw new Error("Conversation access denied");
   }
 
   if (destroy) {
@@ -420,7 +428,7 @@ export async function getConversationWithoutContent(
     return new Err(new ConversationNotFoundError());
   }
 
-  if (!canAccessConversation(auth, conversation)) {
+  if (!(await canAccessConversation(auth, conversation))) {
     return new Err(new ConversationPermissionError());
   }
 

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -163,7 +163,7 @@ export async function updateConversation(
     visibility: visibility,
   });
 
-  return await getConversation(auth, conversationId);
+  return getConversation(auth, conversationId);
 }
 
 /**

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1517,7 +1517,17 @@ export async function* retryAgentMessage(
   class AgentMessageError extends Error {}
 
   if (!canReadMessage(auth, message)) {
-    throw new AgentMessageError("Agent cannot be used by this user");
+    yield {
+      type: "agent_error",
+      created: Date.now(),
+      configurationId: message.configuration.sId,
+      messageId: message.sId,
+      error: {
+        code: "message_access_denied",
+        message: "The message to retry is not accessible.",
+      },
+    };
+    return;
   }
 
   let agentMessageResult: {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -440,7 +440,7 @@ export async function getConversationWithoutContent(
     title: conversation.title,
     visibility: conversation.visibility,
     groupIds: getConversationGroupIdsFromModel(owner, conversation),
-  };
+  });
 }
 
 export async function getConversationMessageType(
@@ -725,7 +725,7 @@ export async function* postUserMessage(
         return getLightAgentConfiguration(auth, mention.configurationId);
       })
     ),
-    createOrUpdateParticipation(),
+    createOrUpdateParticipation({ user, conversation }),
   ]);
 
   if (results[0].some((a) => a === null)) {
@@ -1162,7 +1162,7 @@ export async function* editUserMessage(
         return getLightAgentConfiguration(auth, mention.configurationId);
       })
     ),
-    await createOrUpdateParticipation(),
+    await createOrUpdateParticipation({ user, conversation }),
   ]);
 
   if (results[0].some((a) => a === null)) {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -159,7 +159,7 @@ export async function updateConversation(
   }
 
   if (!canAccessConversation(auth, conversation)) {
-    throw new Error("Conversation access denied");
+    throw new Error("Conversation access restricted");
   }
 
   await conversation.update({
@@ -208,7 +208,7 @@ export async function deleteConversation(
   }
 
   if (!canAccessConversation(auth, conversation)) {
-    throw new Error("Conversation access denied");
+    throw new Error("Conversation access restricted");
   }
 
   if (destroy) {
@@ -428,7 +428,7 @@ export async function getConversationWithoutContent(
   }
 
   if (!canAccessConversation(auth, conversation)) {
-    return new Err(new ConversationError("conversation_access_denied"));
+    return new Err(new ConversationError("conversation_access_restricted"));
   }
 
   return new Ok({
@@ -703,7 +703,7 @@ export async function* postUserMessage(
       type: "user_message_error",
       created: Date.now(),
       error: {
-        code: "conversation_access_denied",
+        code: "conversation_access_restricted",
         message: "Conversation cannot be accessed.",
       },
     };
@@ -1111,7 +1111,7 @@ export async function* editUserMessage(
       type: "user_message_error",
       created: Date.now(),
       error: {
-        code: "conversation_access_denied",
+        code: "conversation_access_restricted",
         message: "Conversation cannot be accessed.",
       },
     };
@@ -1720,7 +1720,7 @@ export async function postNewContentFragment(
   }
 
   if (!canAccessConversation(auth, conversation)) {
-    return new Err(new ConversationError("conversation_access_denied"));
+    return new Err(new ConversationError("conversation_access_restricted"));
   }
 
   const messageId = generateLegacyModelSId();

--- a/front/lib/api/assistant/conversation/helper.ts
+++ b/front/lib/api/assistant/conversation/helper.ts
@@ -1,0 +1,41 @@
+import {
+  ConversationNotFoundError,
+  ConversationPermissionError,
+} from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { apiError } from "@app/logger/withlogging";
+
+export function apiErrorForConversation(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  error: Error
+) {
+  if (error instanceof ConversationPermissionError) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "conversation_access_denied",
+        message: "Access to the conversation is denied.",
+      },
+    });
+  }
+
+  if (error instanceof ConversationNotFoundError) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "conversation_not_found",
+        message: "Conversation not found.",
+      },
+    });
+  }
+
+  return apiError(req, res, {
+    status_code: 500,
+    api_error: {
+      type: "internal_server_error",
+      message: "An internal server error occurred.",
+    },
+  });
+}

--- a/front/lib/api/assistant/conversation/helper.ts
+++ b/front/lib/api/assistant/conversation/helper.ts
@@ -1,7 +1,4 @@
-import {
-  ConversationNotFoundError,
-  ConversationPermissionError,
-} from "@dust-tt/types";
+import { ConversationError } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { apiError } from "@app/logger/withlogging";
@@ -11,22 +8,12 @@ export function apiErrorForConversation(
   res: NextApiResponse,
   error: Error
 ) {
-  if (error instanceof ConversationPermissionError) {
+  if (error instanceof ConversationError) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {
-        type: "conversation_access_denied",
-        message: "Access to the conversation is denied.",
-      },
-    });
-  }
-
-  if (error instanceof ConversationNotFoundError) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "conversation_not_found",
-        message: "Conversation not found.",
+        type: error.type,
+        message: error.message,
       },
     });
   }

--- a/front/lib/api/assistant/conversation/helper.ts
+++ b/front/lib/api/assistant/conversation/helper.ts
@@ -1,7 +1,12 @@
-import { ConversationError } from "@dust-tt/types";
+import { ConversationError, ConversationErrorType } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { apiError } from "@app/logger/withlogging";
+
+const STATUS_FOR_ERROR_TYPE: Record<ConversationErrorType, number> = {
+  conversation_access_denied: 403,
+  conversation_not_found: 404,
+};
 
 export function apiErrorForConversation(
   req: NextApiRequest,
@@ -10,7 +15,7 @@ export function apiErrorForConversation(
 ) {
   if (error instanceof ConversationError) {
     return apiError(req, res, {
-      status_code: 403,
+      status_code: STATUS_FOR_ERROR_TYPE[error.type],
       api_error: {
         type: error.type,
         message: error.message,

--- a/front/lib/api/assistant/conversation/helper.ts
+++ b/front/lib/api/assistant/conversation/helper.ts
@@ -1,4 +1,5 @@
-import { ConversationError, ConversationErrorType } from "@dust-tt/types";
+import type { ConversationErrorType } from "@dust-tt/types";
+import { ConversationError } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { apiError } from "@app/logger/withlogging";

--- a/front/lib/api/assistant/conversation/helper.ts
+++ b/front/lib/api/assistant/conversation/helper.ts
@@ -5,7 +5,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { apiError } from "@app/logger/withlogging";
 
 const STATUS_FOR_ERROR_TYPE: Record<ConversationErrorType, number> = {
-  conversation_access_denied: 403,
+  conversation_access_restricted: 403,
   conversation_not_found: 404,
 };
 

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -424,14 +424,6 @@ export async function fetchConversationMessages(
 
   const renderedMessages = renderedMessagesRes.value;
 
-  if (
-    renderedMessages.some(
-      (m) => isAgentMessageType(m) && !canReadMessage(auth, m)
-    )
-  ) {
-    return new Err(new ConversationError("conversation_access_denied"));
-  }
-
   return new Ok({
     hasMore,
     lastValue: renderedMessages.at(0)?.rank ?? null,

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -361,15 +361,22 @@ export async function batchRenderMessages(
   auth: Authenticator,
   conversationId: string,
   messages: Message[]
-): Promise<MessageWithRankType[]> {
+): Promise<Result<MessageWithRankType[], ConversationPermissionError>> {
   const [userMessages, agentMessages, contentFragments] = await Promise.all([
     batchRenderUserMessages(messages),
     batchRenderAgentMessages(auth, messages),
     batchRenderContentFragment(auth, conversationId, messages),
   ]);
-  return [...userMessages, ...agentMessages, ...contentFragments]
-    .sort((a, b) => a.rank - b.rank || a.version - b.version)
-    .map(({ m, rank }) => ({ ...m, rank }));
+
+  if (agentMessages.some((m) => !canReadMessage(auth, m.m))) {
+    return new Err(new ConversationPermissionError());
+  }
+
+  return new Ok(
+    [...userMessages, ...agentMessages, ...contentFragments]
+      .sort((a, b) => a.rank - b.rank || a.version - b.version)
+      .map(({ m, rank }) => ({ ...m, rank }))
+  );
 }
 
 export interface FetchConversationMessagesResponse {

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -8,7 +8,7 @@ import type {
   Result,
   UserMessageType,
 } from "@dust-tt/types";
-import { ConversationPermissionError } from "@dust-tt/types";
+import { ConversationError } from "@dust-tt/types";
 import { Err, isAgentMessageType, Ok, removeNulls } from "@dust-tt/types";
 import type { WhereOptions } from "sequelize";
 import { Op, Sequelize } from "sequelize";
@@ -361,7 +361,7 @@ export async function batchRenderMessages(
   auth: Authenticator,
   conversationId: string,
   messages: Message[]
-): Promise<Result<MessageWithRankType[], ConversationPermissionError>> {
+): Promise<Result<MessageWithRankType[], ConversationError>> {
   const [userMessages, agentMessages, contentFragments] = await Promise.all([
     batchRenderUserMessages(messages),
     batchRenderAgentMessages(auth, messages),
@@ -369,7 +369,7 @@ export async function batchRenderMessages(
   ]);
 
   if (agentMessages.some((m) => !canReadMessage(auth, m.m))) {
-    return new Err(new ConversationPermissionError());
+    return new Err(new ConversationError("conversation_access_denied"));
   }
 
   return new Ok(
@@ -429,7 +429,7 @@ export async function fetchConversationMessages(
       (m) => isAgentMessageType(m) && !canReadMessage(auth, m)
     )
   ) {
-    return new Err(new ConversationPermissionError());
+    return new Err(new ConversationError("conversation_access_denied"));
   }
 
   return new Ok({

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -369,7 +369,7 @@ export async function batchRenderMessages(
   ]);
 
   if (agentMessages.some((m) => !canReadMessage(auth, m.m))) {
-    return new Err(new ConversationError("conversation_access_denied"));
+    return new Err(new ConversationError("conversation_access_restricted"));
   }
 
   return new Ok(

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -9,7 +9,7 @@ import type {
   UserMessageType,
 } from "@dust-tt/types";
 import { ConversationError } from "@dust-tt/types";
-import { Err, isAgentMessageType, Ok, removeNulls } from "@dust-tt/types";
+import { Err, Ok, removeNulls } from "@dust-tt/types";
 import type { WhereOptions } from "sequelize";
 import { Op, Sequelize } from "sequelize";
 

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -5,10 +5,10 @@ import type {
   LightAgentConfigurationType,
   MessageWithRankType,
   ModelId,
-  Result,  UserMessageType} from "@dust-tt/types";
-import {
-  ConversationPermissionError
+  Result,
+  UserMessageType,
 } from "@dust-tt/types";
+import { ConversationPermissionError } from "@dust-tt/types";
 import { Err, isAgentMessageType, Ok, removeNulls } from "@dust-tt/types";
 import type { WhereOptions } from "sequelize";
 import { Op, Sequelize } from "sequelize";

--- a/front/lib/api/assistant/participants.ts
+++ b/front/lib/api/assistant/participants.ts
@@ -16,8 +16,7 @@ import { Op } from "sequelize";
 
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import type { Authenticator } from "@app/lib/auth";
-import type {
-  Conversation} from "@app/lib/models/assistant/conversation";
+import type { Conversation } from "@app/lib/models/assistant/conversation";
 import {
   AgentMessage,
   Message,

--- a/front/lib/api/assistant/participants.ts
+++ b/front/lib/api/assistant/participants.ts
@@ -16,6 +16,8 @@ import { Op } from "sequelize";
 
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import type { Authenticator } from "@app/lib/auth";
+import type {
+  Conversation} from "@app/lib/models/assistant/conversation";
 import {
   AgentMessage,
   Message,
@@ -63,7 +65,7 @@ async function fetchAllAgentsById(
 
 export async function fetchConversationParticipants(
   auth: Authenticator,
-  conversation: ConversationWithoutContentType
+  conversation: ConversationWithoutContentType | Conversation
 ): Promise<Result<ConversationParticipantsType, Error>> {
   const owner = auth.workspace();
   if (!owner) {

--- a/front/lib/api/assistant/participants.ts
+++ b/front/lib/api/assistant/participants.ts
@@ -6,12 +6,7 @@ import type {
   Result,
   UserParticipantType,
 } from "@dust-tt/types";
-import {
-  ConversationPermissionError,
-  Err,
-  formatUserFullName,
-  Ok,
-} from "@dust-tt/types";
+import { ConversationError, Err, formatUserFullName, Ok } from "@dust-tt/types";
 import { Op } from "sequelize";
 
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
@@ -118,7 +113,7 @@ export async function fetchConversationParticipants(
   // if less agents than agentConfigurationIds, it means some agents are forbidden
   // to the user
   if (agents.length < agentConfigurationIds.size) {
-    return new Err(new ConversationPermissionError());
+    return new Err(new ConversationError("conversation_access_denied"));
   }
 
   return new Ok({

--- a/front/lib/api/assistant/participants.ts
+++ b/front/lib/api/assistant/participants.ts
@@ -6,7 +6,12 @@ import type {
   Result,
   UserParticipantType,
 } from "@dust-tt/types";
-import { Err, formatUserFullName, Ok } from "@dust-tt/types";
+import {
+  ConversationPermissionError,
+  Err,
+  formatUserFullName,
+  Ok,
+} from "@dust-tt/types";
 import { Op } from "sequelize";
 
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
@@ -107,6 +112,12 @@ export async function fetchConversationParticipants(
     fetchAllUsersById([...userIds]),
     fetchAllAgentsById(auth, [...agentConfigurationIds]),
   ]);
+
+  // if less agents than agentConfigurationIds, it means some agents are forbidden
+  // to the user
+  if (agents.length < agentConfigurationIds.size) {
+    return new Err(new ConversationPermissionError());
+  }
 
   return new Ok({
     agents,

--- a/front/lib/api/assistant/participants.ts
+++ b/front/lib/api/assistant/participants.ts
@@ -113,7 +113,7 @@ export async function fetchConversationParticipants(
   // if less agents than agentConfigurationIds, it means some agents are forbidden
   // to the user
   if (agents.length < agentConfigurationIds.size) {
-    return new Err(new ConversationError("conversation_access_denied"));
+    return new Err(new ConversationError("conversation_access_restricted"));
   }
 
   return new Ok({

--- a/front/lib/api/assistant/participants.ts
+++ b/front/lib/api/assistant/participants.ts
@@ -75,6 +75,7 @@ export async function fetchConversationParticipants(
     where: {
       conversationId: conversation.id,
     },
+    attributes: [],
     include: [
       {
         model: UserMessage,

--- a/front/lib/api/assistant/reaction.ts
+++ b/front/lib/api/assistant/reaction.ts
@@ -5,12 +5,8 @@ import type {
   MessageReactionType,
   Result,
 } from "@dust-tt/types";
-import type {UserType} from "@dust-tt/types";
-import {
-  ConversationPermissionError,
-  Err,
-  Ok
-} from "@dust-tt/types";
+import type { UserType } from "@dust-tt/types";
+import { ConversationPermissionError, Err, Ok } from "@dust-tt/types";
 
 import { canAccessConversation } from "@app/lib/api/assistant/conversation";
 import type { Authenticator } from "@app/lib/auth";
@@ -31,7 +27,7 @@ export async function getMessageReactions(
     throw new Error("Unexpected `auth` without `workspace`.");
   }
 
-  if (!canAccessConversation(auth, conversation)) {
+  if (!(await canAccessConversation(auth, conversation))) {
     return new Err(new ConversationPermissionError());
   }
 

--- a/front/lib/api/assistant/reaction.ts
+++ b/front/lib/api/assistant/reaction.ts
@@ -1,9 +1,3 @@
-import {
-  ConversationPermissionError,
-  Err,
-  Ok,
-  type UserType,
-} from "@dust-tt/types";
 import type {
   ConversationMessageReactions,
   ConversationType,
@@ -11,13 +5,19 @@ import type {
   MessageReactionType,
   Result,
 } from "@dust-tt/types";
+import type {UserType} from "@dust-tt/types";
+import {
+  ConversationPermissionError,
+  Err,
+  Ok
+} from "@dust-tt/types";
 
+import { canAccessConversation } from "@app/lib/api/assistant/conversation";
 import type { Authenticator } from "@app/lib/auth";
 import {
   Message,
   MessageReaction,
 } from "@app/lib/models/assistant/conversation";
-import { canAccessConversation } from "@app/lib/api/assistant/conversation";
 
 /**
  * We retrieve the reactions for a whole conversation, not just a single message.

--- a/front/lib/api/assistant/reaction.ts
+++ b/front/lib/api/assistant/reaction.ts
@@ -27,7 +27,7 @@ export async function getMessageReactions(
     throw new Error("Unexpected `auth` without `workspace`.");
   }
 
-  if (!(await canAccessConversation(auth, conversation))) {
+  if (!canAccessConversation(auth, conversation)) {
     return new Err(new ConversationError("conversation_access_denied"));
   }
 

--- a/front/lib/api/assistant/reaction.ts
+++ b/front/lib/api/assistant/reaction.ts
@@ -28,7 +28,7 @@ export async function getMessageReactions(
   }
 
   if (!canAccessConversation(auth, conversation)) {
-    return new Err(new ConversationError("conversation_access_denied"));
+    return new Err(new ConversationError("conversation_access_restricted"));
   }
 
   const messages = await Message.findAll({

--- a/front/lib/api/assistant/reaction.ts
+++ b/front/lib/api/assistant/reaction.ts
@@ -6,7 +6,7 @@ import type {
   Result,
 } from "@dust-tt/types";
 import type { UserType } from "@dust-tt/types";
-import { ConversationPermissionError, Err, Ok } from "@dust-tt/types";
+import { ConversationError, Err, Ok } from "@dust-tt/types";
 
 import { canAccessConversation } from "@app/lib/api/assistant/conversation";
 import type { Authenticator } from "@app/lib/auth";
@@ -21,14 +21,14 @@ import {
 export async function getMessageReactions(
   auth: Authenticator,
   conversation: ConversationType | ConversationWithoutContentType
-): Promise<Result<ConversationMessageReactions, ConversationPermissionError>> {
+): Promise<Result<ConversationMessageReactions, ConversationError>> {
   const owner = auth.workspace();
   if (!owner) {
     throw new Error("Unexpected `auth` without `workspace`.");
   }
 
   if (!(await canAccessConversation(auth, conversation))) {
-    return new Err(new ConversationPermissionError());
+    return new Err(new ConversationError("conversation_access_denied"));
   }
 
   const messages = await Message.findAll({

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -1,4 +1,5 @@
 import type {
+  ConversationError,
   ConversationMessageReactions,
   ConversationType,
   LightWorkspaceType,
@@ -25,7 +26,7 @@ export function useConversation({
 }): {
   conversation: ConversationType | null;
   isConversationLoading: boolean;
-  conversationError: Error;
+  conversationError: ConversationError;
   mutateConversation: () => void;
 } {
   const conversationFetcher: Fetcher<{ conversation: ConversationType }> =

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/index.ts
@@ -2,6 +2,7 @@ import type { ConversationType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
@@ -43,17 +44,13 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const conversation = await getConversation(auth, cId, true);
+      const conversationRes = await getConversation(auth, cId, true);
 
-      if (!conversation) {
-        return apiError(req, res, {
-          status_code: 404,
-          api_error: {
-            type: "conversation_not_found",
-            message: "Could not find the conversation.",
-          },
-        });
+      if (conversationRes.isErr()) {
+        return apiErrorForConversation(req, res, conversationRes.error);
       }
+
+      const conversation = conversationRes.value;
 
       return res.status(200).json({ conversation });
 

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -10,6 +10,7 @@ import {
   normalizeContentFragmentType,
   postNewContentFragment,
 } from "@app/lib/api/assistant/conversation";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
@@ -82,16 +83,13 @@ async function handler(
     });
   }
 
-  const conversation = await getConversation(auth, cId);
-  if (!conversation) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "conversation_not_found",
-        message: "Conversation not found.",
-      },
-    });
+  const conversationRes = await getConversation(auth, cId);
+
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
   }
+
+  const conversation = conversationRes.value;
 
   switch (req.method) {
     case "POST":

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -5,6 +5,7 @@ import type {
   WithAPIErrorResponse,
 } from "@dust-tt/types";
 import {
+  ConversationNotFoundError,
   isEmptyString,
   PublicPostConversationsRequestBodySchema,
 } from "@dust-tt/types";
@@ -18,6 +19,7 @@ import {
   normalizeContentFragmentType,
   postNewContentFragment,
 } from "@app/lib/api/assistant/conversation";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { postUserMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
 import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -184,12 +186,24 @@ async function handler(
         }
 
         newContentFragment = cfRes.value;
-        const updatedConversation = await getConversation(
+        const updatedConversationRes = await getConversation(
           auth,
           conversation.sId
         );
-        if (updatedConversation) {
-          conversation = updatedConversation;
+
+        if (updatedConversationRes.isErr()) {
+          // Preserving former code in which if the conversation was not found here, we do not error
+          if (
+            !(updatedConversationRes.error instanceof ConversationNotFoundError)
+          ) {
+            return apiErrorForConversation(
+              req,
+              res,
+              updatedConversationRes.error
+            );
+          }
+        } else {
+          conversation = updatedConversationRes.value;
         }
       }
 
@@ -229,13 +243,12 @@ async function handler(
         // created as well, so pulling the conversation again will allow to have an up to date view
         // of the conversation with agent messages included so that the user of the API can start
         // streaming events from these agent messages directly.
-        const updated = await getConversation(auth, conversation.sId);
+        const updatedRes = await getConversation(auth, conversation.sId);
 
-        if (!updated) {
-          throw `Conversation unexpectedly not found after creation: ${conversation.sId}`;
+        if (updatedRes.isErr()) {
+          return apiErrorForConversation(req, res, updatedRes.error);
         }
-
-        conversation = updated;
+        conversation = updatedRes.value;
       }
 
       res.status(200).json({

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -5,7 +5,7 @@ import type {
   WithAPIErrorResponse,
 } from "@dust-tt/types";
 import {
-  ConversationNotFoundError,
+  ConversationError,
   isEmptyString,
   PublicPostConversationsRequestBodySchema,
 } from "@dust-tt/types";
@@ -194,7 +194,10 @@ async function handler(
         if (updatedConversationRes.isErr()) {
           // Preserving former code in which if the conversation was not found here, we do not error
           if (
-            !(updatedConversationRes.error instanceof ConversationNotFoundError)
+            !(
+              updatedConversationRes.error instanceof ConversationError &&
+              updatedConversationRes.error.type === "conversation_not_found"
+            )
           ) {
             return apiErrorForConversation(
               req,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
@@ -5,6 +5,7 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { cancelMessageGenerationEvent } from "@app/lib/api/assistant/pubsub";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -33,19 +34,13 @@ async function handler(
     });
   }
   const conversationId = req.query.cId;
-  const conversation = await getConversationWithoutContent(
+  const conversationRes = await getConversationWithoutContent(
     auth,
     conversationId
   );
 
-  if (!conversation) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "conversation_not_found",
-        message: "The conversation you're trying to access was not found.",
-      },
-    });
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
   }
 
   switch (req.method) {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/content_fragment/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/content_fragment/index.ts
@@ -9,6 +9,7 @@ import {
   getConversation,
   postNewContentFragment,
 } from "@app/lib/api/assistant/conversation";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
@@ -37,16 +38,13 @@ async function handler(
   }
 
   const conversationId = req.query.cId;
-  const conversation = await getConversation(auth, conversationId);
-  if (!conversation) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "conversation_not_found",
-        message: "Conversation not found.",
-      },
-    });
+  const conversationRes = await getConversation(auth, conversationId);
+
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
   }
+
+  const conversation = conversationRes.value;
 
   switch (req.method) {
     case "POST":

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -2,6 +2,7 @@ import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { getConversationEvents } from "@app/lib/api/assistant/pubsub";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -22,20 +23,16 @@ async function handler(
     });
   }
   const conversationId = req.query.cId;
-  const conversation = await getConversationWithoutContent(
+  const conversationRes = await getConversationWithoutContent(
     auth,
     conversationId
   );
 
-  if (!conversation) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "conversation_not_found",
-        message: "The conversation you're trying to access was not found.",
-      },
-    });
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
   }
+
+  const conversation = conversationRes.value;
 
   const lastEventId = req.query.lastEventId || null;
   if (lastEventId && typeof lastEventId !== "string") {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -12,6 +12,7 @@ import {
   getConversationWithoutContent,
   updateConversation,
 } from "@app/lib/api/assistant/conversation";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
@@ -47,16 +48,16 @@ async function handler(
     });
   }
 
-  const conversation = await getConversationWithoutContent(auth, req.query.cId);
-  if (!conversation) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "conversation_not_found",
-        message: "The conversation you're trying to access was not found.",
-      },
-    });
+  const conversationRes = await getConversationWithoutContent(
+    auth,
+    req.query.cId
+  );
+
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
   }
+
+  const conversation = conversationRes.value;
 
   switch (req.method) {
     case "GET":

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -61,9 +61,6 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      // TODO(VAULTS_INFRA) Return a 401 with `conversation_access_restricted` error type
-      // when the user doesn't have access to the conversation.
-
       res.status(200).json({ conversation });
       return;
 

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -61,7 +61,7 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      // TODO(VAULTS_INFRA) Return a 401 with `conversation_access_denied` error type
+      // TODO(VAULTS_INFRA) Return a 401 with `conversation_access_restricted` error type
       // when the user doesn't have access to the conversation.
 
       res.status(200).json({ conversation });

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -78,7 +78,8 @@ async function handler(
       res.status(200).end();
       return;
     }
-    case "PATCH":
+
+    case "PATCH": {
       const bodyValidation = PatchConversationsRequestBodySchema.decode(
         req.body
       );
@@ -97,13 +98,18 @@ async function handler(
 
       const { title, visibility } = bodyValidation.right;
 
-      const c = await updateConversation(auth, conversation.sId, {
+      const result = await updateConversation(auth, conversation.sId, {
         title,
         visibility,
       });
 
-      res.status(200).json({ conversation: c });
+      if (result.isErr()) {
+        return apiErrorForConversation(req, res, result.error);
+      }
+
+      res.status(200).json({ conversation: result.value });
       return;
+    }
 
     default:
       return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -67,12 +67,17 @@ async function handler(
       res.status(200).json({ conversation });
       return;
 
-    case "DELETE":
-      await deleteConversation(auth, { conversationId: conversation.sId });
+    case "DELETE": {
+      const result = await deleteConversation(auth, {
+        conversationId: conversation.sId,
+      });
+      if (result.isErr()) {
+        return apiErrorForConversation(req, res, result.error);
+      }
 
       res.status(200).end();
       return;
-
+    }
     case "PATCH":
       const bodyValidation = PatchConversationsRequestBodySchema.decode(
         req.body

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/raw_content_fragment/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/raw_content_fragment/index.ts
@@ -4,6 +4,7 @@ import { IncomingForm } from "formidable";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
@@ -41,16 +42,13 @@ async function handler(
   }
 
   const conversationId = req.query.cId;
-  const conversation = await getConversation(auth, conversationId);
-  if (!conversation) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "conversation_not_found",
-        message: "Conversation not found.",
-      },
-    });
+  const conversationRes = await getConversation(auth, conversationId);
+
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
   }
+
+  const conversation = conversationRes.value;
 
   if (!(typeof req.query.mId === "string")) {
     return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
@@ -5,6 +5,7 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import {
   createMessageReaction,
   deleteMessageReaction,
@@ -39,19 +40,16 @@ async function handler(
   }
 
   const conversationId = req.query.cId;
-  const conversation = await getConversationWithoutContent(
+  const conversationRes = await getConversationWithoutContent(
     auth,
     conversationId
   );
-  if (!conversation) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "conversation_not_found",
-        message: "Conversation not found.",
-      },
-    });
+
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
   }
+
+  const conversation = conversationRes.value;
 
   if (!(typeof req.query.mId === "string")) {
     return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
@@ -6,6 +6,7 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { retryAgentMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -34,16 +35,13 @@ async function handler(
   }
 
   const conversationId = req.query.cId;
-  const conversation = await getConversation(auth, conversationId);
-  if (!conversation) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "conversation_not_found",
-        message: "Conversation not found.",
-      },
-    });
+  const conversationRes = await getConversation(auth, conversationId);
+
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
   }
+
+  const conversation = conversationRes.value;
 
   if (!(typeof req.query.mId === "string")) {
     return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -67,13 +67,7 @@ async function handler(
       );
 
       if (messagesRes.isErr()) {
-        return apiError(req, res, {
-          status_code: 404,
-          api_error: {
-            type: "conversation_not_found",
-            message: "Conversation not found",
-          },
-        });
+        return apiErrorForConversation(req, res, messagesRes.error);
       }
 
       res.status(200).json(messagesRes.value);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -5,6 +5,7 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import type { FetchConversationMessagesResponse } from "@app/lib/api/assistant/messages";
 import { fetchConversationMessages } from "@app/lib/api/assistant/messages";
 import { postUserMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
@@ -97,16 +98,13 @@ async function handler(
 
       const { content, context, mentions } = bodyValidation.right;
 
-      const conversation = await getConversation(auth, conversationId);
-      if (!conversation) {
-        return apiError(req, res, {
-          status_code: 404,
-          api_error: {
-            type: "conversation_not_found",
-            message: "Conversation not found.",
-          },
-        });
+      const conversationRes = await getConversation(auth, conversationId);
+
+      if (conversationRes.isErr()) {
+        return apiErrorForConversation(req, res, conversationRes.error);
       }
+
+      const conversation = conversationRes.value;
 
       /* postUserMessageWithPubSub returns swiftly since it only waits for the
         initial message creation event (or error) */

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/reactions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/reactions.ts
@@ -44,7 +44,19 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const reactions = await getMessageReactions(auth, conversation);
+      const reactionsRes = await getMessageReactions(auth, conversation);
+
+      if (reactionsRes.isErr()) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "conversation_access_denied",
+            message: "You do not have permission to access this conversation.",
+          },
+        });
+      }
+
+      const reactions = reactionsRes.value;
 
       res.status(200).json({ reactions });
       return;

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/reactions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/reactions.ts
@@ -5,6 +5,7 @@ import type {
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { getMessageReactions } from "@app/lib/api/assistant/reaction";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -28,19 +29,16 @@ async function handler(
   }
 
   const conversationId = req.query.cId;
-  const conversation = await getConversationWithoutContent(
+  const conversationRes = await getConversationWithoutContent(
     auth,
     conversationId
   );
-  if (!conversation) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "conversation_not_found",
-        message: "Conversation not found.",
-      },
-    });
+
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
   }
+
+  const conversation = conversationRes.value;
 
   switch (req.method) {
     case "GET":

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/reactions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/reactions.ts
@@ -45,13 +45,7 @@ async function handler(
       const reactionsRes = await getMessageReactions(auth, conversation);
 
       if (reactionsRes.isErr()) {
-        return apiError(req, res, {
-          status_code: 403,
-          api_error: {
-            type: "conversation_access_denied",
-            message: "You do not have permission to access this conversation.",
-          },
-        });
+        return apiErrorForConversation(req, res, reactionsRes.error);
       }
 
       const reactions = reactionsRes.value;

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -6,7 +6,7 @@ import type {
   WithAPIErrorResponse,
 } from "@dust-tt/types";
 import {
-  ConversationNotFoundError,
+  ConversationError,
   InternalPostConversationsRequestBodySchema,
 } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
@@ -119,7 +119,10 @@ async function handler(
         if (updatedConversationRes.isErr()) {
           // Preserving former code in which if the conversation was not found here, we do not error
           if (
-            !(updatedConversationRes.error instanceof ConversationNotFoundError)
+            !(
+              updatedConversationRes.error instanceof ConversationError &&
+              updatedConversationRes.error.type === "conversation_not_found"
+            )
           ) {
             return apiErrorForConversation(
               req,

--- a/front/temporal/labs/activities.ts
+++ b/front/temporal/labs/activities.ts
@@ -316,20 +316,23 @@ export async function processTranscriptActivity(
   }
 
   // Initial conversation is stale, so we need to reload it.
-  let conversation = await getConversation(auth, initialConversation.sId);
+  const conversationRes = await getConversation(auth, initialConversation.sId);
 
-  if (!conversation) {
+  if (conversationRes.isErr()) {
     localLogger.error(
       {
         agentConfigurationId,
         conversationSid: initialConversation.sId,
         panic: true,
+        error: conversationRes.error,
       },
       "[processTranscriptActivity] Unreachable: Error getting conversation after creation."
     );
 
     return;
   }
+
+  let conversation = conversationRes.value;
 
   const messageRes = await postUserMessageWithPubSub(
     auth,
@@ -354,20 +357,21 @@ export async function processTranscriptActivity(
     return;
   }
 
-  const updated = await getConversation(auth, conversation.sId);
+  const updatedRes = await getConversation(auth, conversation.sId);
 
-  if (!updated) {
+  if (updatedRes.isErr()) {
     localLogger.error(
       {
         agentConfigurationId,
         conversationSid: conversation.sId,
+        error: updatedRes.error,
       },
       "[processTranscriptActivity] Error getting conversation after creation. Stopping."
     );
     return;
   }
 
-  conversation = updated;
+  conversation = updatedRes.value;
 
   localLogger.info(
     {

--- a/types/src/front/assistant/conversation.ts
+++ b/types/src/front/assistant/conversation.ts
@@ -220,3 +220,9 @@ export class ConversationPermissionError extends Error {
     super("Cannot access conversation: Some agents are forbidden to the user.");
   }
 }
+
+export class ConversationNotFoundError extends Error {
+  constructor() {
+    super("Cannot access conversation: Conversation not found.");
+  }
+}

--- a/types/src/front/assistant/conversation.ts
+++ b/types/src/front/assistant/conversation.ts
@@ -215,14 +215,15 @@ export interface ConversationParticipantsType {
   users: UserParticipant[];
 }
 
-export class ConversationPermissionError extends Error {
-  constructor() {
-    super("Cannot access conversation: Some agents are forbidden to the user.");
-  }
-}
+export type ConversationErrorType =
+  | "conversation_not_found"
+  | "conversation_access_denied";
 
-export class ConversationNotFoundError extends Error {
-  constructor() {
-    super("Cannot access conversation: Conversation not found.");
+export class ConversationError extends Error {
+  readonly type: ConversationErrorType;
+
+  constructor(type: ConversationErrorType) {
+    super(`Cannot access conversation: ${type}`);
+    this.type = type;
   }
 }

--- a/types/src/front/assistant/conversation.ts
+++ b/types/src/front/assistant/conversation.ts
@@ -217,7 +217,7 @@ export interface ConversationParticipantsType {
 
 export type ConversationErrorType =
   | "conversation_not_found"
-  | "conversation_access_denied";
+  | "conversation_access_restricted";
 
 export class ConversationError extends Error {
   readonly type: ConversationErrorType;

--- a/types/src/front/assistant/conversation.ts
+++ b/types/src/front/assistant/conversation.ts
@@ -214,3 +214,9 @@ export interface ConversationParticipantsType {
   agents: AgentParticipant[];
   users: UserParticipant[];
 }
+
+export class ConversationPermissionError extends Error {
+  constructor() {
+    super("Cannot access conversation: Some agents are forbidden to the user.");
+  }
+}

--- a/types/src/front/lib/error.ts
+++ b/types/src/front/lib/error.ts
@@ -1,4 +1,5 @@
 import { ConnectorsAPIError } from "../../connectors/api";
+import { ConversationErrorType } from "../assistant/conversation";
 import { CoreAPIError } from "./core_api";
 
 export type InternalErrorWithStatusCode = {
@@ -94,8 +95,7 @@ export type APIErrorType =
   // Groups:
   | "group_not_found"
   // Conversations:
-  | "conversation_access_denied"
-  | "conversation_not_found"
+  | ConversationErrorType
   // Plugins:
   | "plugin_not_found"
   | "plugin_execution_failed";


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/dust/issues/6903

Rework of #7631 following decision to denormalize `groupIds` into the conversation model

Left a few comments on the PR for reviewers to check.

Now that agents have ACLs, conversations and messages should be restricted to users that have access to the related assistants.

Restriction is implemented on conversations by:
- checking conversation access via a new function `canAccessConversation`,  relying on groupIds (not async);
- additionally, when applicable, check an agent messages' ACLs (see the end of this [thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1727423063794339) for reasons for doing that).

Summary: 
- checked all references to AgentMessage and Message models (details below) and acted where needed
- changed getConversation to a Result with ConversationError
  - wrapped conversation api errors in a dedicated function, drying quite a bit
- did the same with getConversationWithoutContent, further drying
- double-check: all endpoints, and references to Conversation

![image](https://github.com/user-attachments/assets/df8bad56-8156-4956-8ed1-4c255225ed3b)

## Risk
High touch PR, all convos. Will test on front-edge in addition to locally

### Testing
Test scenarios:
- with allowed agents, all below should work
  - UX 
	- start a convo :heavy_check_mark: 
	- read a convo :heavy_check_mark: 
	- post a message to a convo :heavy_check_mark: 
	- destroy a convo :heavy_check_mark: 
  - API v1
	- start a convo, 
	- read a convo, 
	- post a message to a convo, 
	- destroy a convo
- with unallowed agents, all below should fail
  - start a convo (only API v1)
  - read a convo (both UX and v1) :heavy_check_mark: 
  - post a message to a convo (only v1) 
  - destroy a convo (only v1)

## Deploy Plan
test on front-edge
front
