### PR TITLE
[connectors] Fixed expandable flag in notion nodes

### DIFF
--- a/connectors/src/connectors/notion/lib/parents.ts
+++ b/connectors/src/connectors/notion/lib/parents.ts
@@ -10,7 +10,7 @@ import {
 } from "@connectors/connectors/notion/lib/connectors_db_helpers";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { updateDocumentParentsField } from "@connectors/lib/data_sources";
-import type { NotionDatabase, NotionPage } from "@connectors/lib/models/notion";
+import { NotionDatabase, NotionPage } from "@connectors/lib/models/notion";
 import { heartbeat } from "@connectors/lib/temporal";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -239,3 +239,22 @@ function notionPageOrDbId(pageOrDb: NotionPage | NotionDatabase): string {
     (pageOrDb as NotionDatabase).notionDatabaseId
   );
 }
+
+export const hasChildren = async (page: NotionPage, connectorId: number) => {
+  const [childPage, childDB] = await Promise.all([
+    NotionPage.findOne({
+      where: {
+        connectorId,
+        parentId: page.notionPageId,
+      },
+    }),
+    NotionDatabase.findOne({
+      where: {
+        connectorId,
+        parentId: page.notionPageId,
+      },
+    }),
+  ]);
+
+  return childPage || childDB ? true : false;
+};


### PR DESCRIPTION
## Description

Fixed the expandable flag on content nodes when using "retrieveBatchContentNodes". It's used for example in assistant details to fetch the root selected nodes for an assistant, which can't be expanded :
 
Before:
![Screenshot 2024-09-30 at 09 27 50](https://github.com/user-attachments/assets/679fc111-840c-4a56-8bc5-777f0849a93a)

After:
![Screenshot 2024-09-30 at 09 27 23](https://github.com/user-attachments/assets/65601496-0007-4412-b77e-b8626e5ebf5f)

## Risk

none

## Deploy Plan

deploy `connectors`