### PR TITLE
Connector: models to store Remote DB nodes

### DIFF
--- a/connectors/migrations/db/migration_17.sql
+++ b/connectors/migrations/db/migration_17.sql
@@ -1,0 +1,35 @@
+CREATE TABLE IF NOT EXISTS "remote_databases" (
+    "id"  SERIAL,
+    "internalId" VARCHAR(255) NOT NULL,
+    "name" VARCHAR(255) NOT NULL,
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "connectorId" INTEGER NOT NULL REFERENCES "connectors" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, 
+    PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX "remote_databases_connector_id_internal_id" ON "remote_databases" ("connectorId", "internalId");
+
+CREATE TABLE IF NOT EXISTS "remote_schemas" (
+    "id"  SERIAL,
+    "internalId" VARCHAR(255) NOT NULL,
+    "name" VARCHAR(255) NOT NULL,
+    "database_name" VARCHAR(255) NOT NULL,
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "connectorId" INTEGER NOT NULL REFERENCES "connectors" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX "remote_schemas_connector_id_internal_id" ON "remote_schemas" ("connectorId", "internalId");
+
+CREATE TABLE IF NOT EXISTS "remote_tables" (
+    "id"  SERIAL,
+    "internalId" VARCHAR(255) NOT NULL,
+    "name" VARCHAR(255) NOT NULL,
+    "database_name" VARCHAR(255) NOT NULL,
+    "schema_name" VARCHAR(255) NOT NULL,
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "connectorId" INTEGER NOT NULL REFERENCES "connectors" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX "remote_tables_connector_id_internal_id" ON "remote_tables" ("connectorId", "internalId");

--- a/connectors/src/admin/db.ts
+++ b/connectors/src/admin/db.ts
@@ -43,6 +43,11 @@ import {
   NotionPage,
 } from "@connectors/lib/models/notion";
 import {
+  RemoteDatabaseModel,
+  RemoteSchemaModel,
+  RemoteTableModel,
+} from "@connectors/lib/models/remote_databases";
+import {
   SlackBotWhitelistModel,
   SlackChannel,
   SlackChatBotMessage,
@@ -105,6 +110,9 @@ async function main(): Promise<void> {
   await WebCrawlerPage.sync({ alter: true });
   await WebCrawlerConfigurationHeader.sync({ alter: true });
   await SnowflakeConfigurationModel.sync({ alter: true });
+  await RemoteDatabaseModel.sync({ alter: true });
+  await RemoteSchemaModel.sync({ alter: true });
+  await RemoteTableModel.sync({ alter: true });
 
   // enable the `unaccent` extension
   await sequelizeConnection.query("CREATE EXTENSION IF NOT EXISTS unaccent;");

--- a/connectors/src/lib/models/remote_databases.ts
+++ b/connectors/src/lib/models/remote_databases.ts
@@ -1,0 +1,180 @@
+import type {
+  CreationOptional,
+  ForeignKey,
+  InferAttributes,
+  InferCreationAttributes,
+} from "sequelize";
+import { DataTypes, Model } from "sequelize";
+
+import { sequelizeConnection } from "@connectors/resources/storage";
+import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
+
+export class RemoteDatabaseModel extends Model<
+  InferAttributes<RemoteDatabaseModel>,
+  InferCreationAttributes<RemoteDatabaseModel>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare internalId: string;
+  declare name: string;
+
+  declare connectorId: ForeignKey<ConnectorModel["id"]>;
+}
+RemoteDatabaseModel.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    internalId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+  },
+  {
+    sequelize: sequelizeConnection,
+    modelName: "remote_databases",
+    indexes: [{ fields: ["connectorId", "internalId"], unique: true }],
+  }
+);
+ConnectorModel.hasMany(RemoteDatabaseModel, {
+  foreignKey: { allowNull: false },
+  onDelete: "RESTRICT",
+});
+RemoteDatabaseModel.belongsTo(ConnectorModel);
+
+export class RemoteSchemaModel extends Model<
+  InferAttributes<RemoteSchemaModel>,
+  InferCreationAttributes<RemoteSchemaModel>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare internalId: string;
+  declare name: string;
+
+  declare databaseName: string;
+
+  declare connectorId: ForeignKey<ConnectorModel["id"]>;
+}
+RemoteSchemaModel.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    internalId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    databaseName: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+  },
+  {
+    sequelize: sequelizeConnection,
+    modelName: "remote_schemas",
+    indexes: [{ fields: ["connectorId", "internalId"], unique: true }],
+  }
+);
+ConnectorModel.hasMany(RemoteSchemaModel, {
+  foreignKey: { allowNull: false },
+  onDelete: "RESTRICT",
+});
+RemoteSchemaModel.belongsTo(ConnectorModel);
+
+export class RemoteTableModel extends Model<
+  InferAttributes<RemoteTableModel>,
+  InferCreationAttributes<RemoteTableModel>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare internalId: string;
+  declare name: string;
+
+  declare schemaName: string;
+  declare databaseName: string;
+
+  declare connectorId: ForeignKey<ConnectorModel["id"]>;
+}
+RemoteTableModel.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    internalId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    schemaName: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    databaseName: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+  },
+  {
+    sequelize: sequelizeConnection,
+    modelName: "remote_tables",
+    indexes: [{ fields: ["connectorId", "internalId"], unique: true }],
+  }
+);
+ConnectorModel.hasMany(RemoteTableModel, {
+  foreignKey: { allowNull: false },
+  onDelete: "RESTRICT",
+});
+RemoteTableModel.belongsTo(ConnectorModel);

--- a/connectors/src/resources/connector/snowflake.ts
+++ b/connectors/src/resources/connector/snowflake.ts
@@ -1,6 +1,11 @@
 import type { ModelId } from "@dust-tt/types";
 import type { Transaction } from "sequelize";
 
+import {
+  RemoteDatabaseModel,
+  RemoteSchemaModel,
+  RemoteTableModel,
+} from "@connectors/lib/models/remote_databases";
 import { SnowflakeConfigurationModel } from "@connectors/lib/models/snowflake";
 import type {
   ConnectorProviderConfigurationType,
@@ -35,6 +40,24 @@ export class SnowflakeConnectorStrategy
   ): Promise<void> {
     await Promise.all([
       SnowflakeConfigurationModel.destroy({
+        where: {
+          connectorId: connector.id,
+        },
+        transaction,
+      }),
+      RemoteTableModel.destroy({
+        where: {
+          connectorId: connector.id,
+        },
+        transaction,
+      }),
+      RemoteSchemaModel.destroy({
+        where: {
+          connectorId: connector.id,
+        },
+        transaction,
+      }),
+      RemoteDatabaseModel.destroy({
         where: {
           connectorId: connector.id,
         },


### PR DESCRIPTION
## Description

This PR: 
- Adds the models to store the nodes for remote db. 
- Adds the migration file. 
- Delete properly those entries when we delete the connector. 

## Risk

Not used yet. 

## Deploy Plan

Merge. 
Run migration 17 on connectors. 
Deploy connectors
