### PR TITLE
Remote tables: add flags to specify permission

### DIFF
--- a/connectors/migrations/db/migration_18.sql
+++ b/connectors/migrations/db/migration_18.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "public"."remote_tables" ADD COLUMN "permission" VARCHAR(255) NOT NULL;
+ALTER TABLE "public"."remote_tables" ADD COLUMN "lastUpsertedAt" TIMESTAMP WITH TIME ZONE;
+

--- a/connectors/src/lib/models/remote_databases.ts
+++ b/connectors/src/lib/models/remote_databases.ts
@@ -9,6 +9,8 @@ import { DataTypes, Model } from "sequelize";
 import { sequelizeConnection } from "@connectors/resources/storage";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 
+type RemoteTablePermission = "selected" | "inherited"; // todo Daph move in next PR
+
 export class RemoteDatabaseModel extends Model<
   InferAttributes<RemoteDatabaseModel>,
   InferCreationAttributes<RemoteDatabaseModel>
@@ -124,12 +126,14 @@ export class RemoteTableModel extends Model<
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
+  declare lastUpsertedAt: CreationOptional<Date>;
 
   declare internalId: string;
   declare name: string;
 
   declare schemaName: string;
   declare databaseName: string;
+  declare permission: RemoteTablePermission;
 
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
 }
@@ -156,6 +160,10 @@ RemoteTableModel.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
+    permission: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -165,6 +173,10 @@ RemoteTableModel.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
+    },
+    lastUpsertedAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
     },
   },
   {


### PR DESCRIPTION
## Description

Adds some flags on remote_tables. 
We will need to sync them all on connectors even if not selected by the admin directly. Why? Because we need to know what we upserted or not to Core (to be able to delete tables if not found anymore during a sync). 

## Risk

Unused yet. 
No entry on prod db so not risky to add a non nullable column. 

## Deploy Plan

Merge. 
Run migration 18 on connector db. 
Deploy connectors. 
