### PR TITLE
API Documentation modals

### DIFF
--- a/front/components/ViewFolderAPIModal.tsx
+++ b/front/components/ViewFolderAPIModal.tsx
@@ -1,16 +1,7 @@
 import "@uiw/react-textarea-code-editor/dist.css";
 
-import {
-  Button,
-  ClipboardIcon,
-  CubeIcon,
-  Modal,
-  Page,
-  Tooltip,
-} from "@dust-tt/sparkle";
-import type { AppType, SpecificationType } from "@dust-tt/types";
-import type { RunConfig, RunType } from "@dust-tt/types";
-import type { WorkspaceType } from "@dust-tt/types";
+import { Button, ClipboardIcon, Modal, Page } from "@dust-tt/sparkle";
+import type { DataSourceType, VaultType, WorkspaceType } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
 import dynamic from "next/dynamic";
 import Link from "next/link";
@@ -21,67 +12,57 @@ const CodeEditor = dynamic(
   { ssr: false }
 );
 
-const cleanUpConfig = (config: RunConfig) => {
-  if (!config) {
-    return "{}";
-  }
-  const c = {} as { [key: string]: any };
-  for (const key in config.blocks) {
-    if (config.blocks[key].type !== "input") {
-      c[key] = config.blocks[key];
-      delete c[key].type;
-    }
-  }
-  return JSON.stringify(c);
-};
-
-const DEFAULT_INPUTS = [{ hello: "world" }];
-
-interface ViewAppAPIModalProps {
+interface ViewFolderAPIModalProps {
   owner: WorkspaceType;
-  app: AppType;
-  run: RunType;
-  inputs?: unknown[];
+  vault: VaultType;
+  dataSource: DataSourceType;
   isOpen: boolean;
   onClose: () => void;
 }
 
-export function ViewAppAPIModal({
+export function ViewFolderAPIModal({
   owner,
-  app,
-  run,
-  inputs = DEFAULT_INPUTS,
+  vault,
+  dataSource,
   isOpen,
   onClose,
-}: ViewAppAPIModalProps) {
-  const cURLRequest = (type: "run") => {
+}: ViewFolderAPIModalProps) {
+  const cURLRequest = (type: "upsert" | "search") => {
     switch (type) {
-      case "run":
-        return `curl ${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}/api/v1/w/${owner.sId}/vaults/${app.vault.sId}/apps/${app.sId}/runs \\
+      case "upsert":
+        return `curl "${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}/api/v1/w/${owner.sId}/data_sources/${dataSource.sId}/documents/YOUR_DOCUMENT_ID" \\
     -H "Authorization: Bearer YOUR_API_KEY" \\
     -H "Content-Type: application/json" \\
     -d '{
-      "specification_hash": "${run?.app_hash}",
-      "config": ${cleanUpConfig(run?.config)},
-      "blocking": true,
-      "inputs": ${JSON.stringify(inputs)}
+      "text": "Lorem ipsum dolor sit amet...",
+      "source_url": "https://acme.com"
     }'`;
+      case "search":
+        return `curl "${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}/api/v1/w/${owner.sId}/data_sources/${dataSource.sId}/search?search=foo+bar&top_k=16" \\
+    -H "Authorization: Bearer YOUR_API_KEY"`;
       default:
         assertNever(type);
     }
   };
 
-  const [copyRunButtonText, setCopyRunButtonText] = useState("Copy");
+  const [copySearchButtonText, setCopySearchButtonText] = useState("Copy");
+  const [copyUpsertButtonText, setCopyUpsertButtonText] = useState("Copy");
 
   // Copy the cURL request to the clipboard
-  const handleCopyClick = async (type: "run") => {
+  const handleCopyClick = async (type: "upsert" | "search") => {
     await navigator.clipboard.writeText(cURLRequest(type));
 
     switch (type) {
-      case "run":
-        setCopyRunButtonText("Copied!");
+      case "upsert":
+        setCopyUpsertButtonText("Copied!");
         setTimeout(() => {
-          setCopyRunButtonText("Copy");
+          setCopyUpsertButtonText("Copy");
+        }, 1500);
+        break;
+      case "search":
+        setCopySearchButtonText("Copied!");
+        setTimeout(() => {
+          setCopySearchButtonText("Copy");
         }, 1500);
         break;
       default:
@@ -95,7 +76,7 @@ export function ViewAppAPIModal({
       onClose={onClose}
       hasChanged={false}
       variant="side-sm"
-      title={"Apps API"}
+      title={"Data source API"}
     >
       <Page variant="modal">
         <div className="w-full">
@@ -103,25 +84,26 @@ export function ViewAppAPIModal({
             <Page.P>
               <ul className="text-gray-500">
                 <li>
-                  vaultId: <span className="font-bold">{app.vault.sId}</span>{" "}
+                  vaultId: <span className="font-bold">{vault.sId}</span>{" "}
                 </li>
                 <li>
-                  appId: <span className="font-bold">{app.sId}</span>
+                  dataSourceId:{" "}
+                  <span className="font-bold">{dataSource.sId}</span>
                 </li>
               </ul>
             </Page.P>
 
             <Page.Separator />
 
-            <Page.SectionHeader title="Run an app" />
+            <Page.SectionHeader title="Upsert a document" />
             <Page.P>
-              Use the following cURL command to run the app{" "}
-              <span className="italic">{app.name}</span>:
+              Use the following cURL command to upsert a document to folder{" "}
+              <span className="italic">{dataSource.name}</span>:
             </Page.P>
             <CodeEditor
               data-color-mode="light"
               readOnly={true}
-              value={`$ ${cURLRequest("run")}`}
+              value={`$ ${cURLRequest("upsert")}`}
               language="shell"
               padding={15}
               className="font-mono mt-5 rounded-md bg-gray-700 px-4 py-4 text-[13px] text-white"
@@ -140,12 +122,47 @@ export function ViewAppAPIModal({
               <div className="flex">
                 <Button
                   variant="secondary"
-                  onClick={() => handleCopyClick("run")}
-                  label={copyRunButtonText}
+                  onClick={() => handleCopyClick("upsert")}
+                  label={copyUpsertButtonText}
                   icon={ClipboardIcon}
                 />
               </div>
             </div>
+            <Page.Separator />
+
+            <Page.SectionHeader title="Search" />
+            <Page.P>
+              Use the following cURL command to search in folder{" "}
+              <span className="italic">{dataSource.name}</span>:
+            </Page.P>
+            <CodeEditor
+              data-color-mode="light"
+              readOnly={true}
+              value={`$ ${cURLRequest("search")}`}
+              language="shell"
+              padding={15}
+              className="font-mono mt-5 rounded-md bg-gray-700 px-4 py-4 text-[13px] text-white"
+              style={{
+                fontSize: 13,
+                fontFamily:
+                  "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",
+                backgroundColor: "rgb(241 245 249)",
+                width: "100%",
+                marginTop: "0rem",
+              }}
+            />
+            <div className="flex w-full flex-row items-end">
+              <div className="flex-grow"></div>
+              <div className="flex">
+                <Button
+                  variant="secondary"
+                  onClick={() => handleCopyClick("search")}
+                  label={copySearchButtonText}
+                  icon={ClipboardIcon}
+                />
+              </div>
+            </div>
+
             <Page.Separator />
 
             <Page.SectionHeader title="API Keys" />
@@ -176,7 +193,7 @@ export function ViewAppAPIModal({
               to the{" "}
               <Link
                 href={
-                  "https://docs.dust.tt/reference/post_api-v1-w-wid-apps-aid-runs"
+                  "https://docs.dust.tt/reference/get_api-v1-w-wid-data-sources-dsid-documents-documentid"
                 }
                 className="py-1 font-bold text-action-600"
               >
@@ -187,49 +204,5 @@ export function ViewAppAPIModal({
         </div>
       </Page>
     </Modal>
-  );
-}
-
-export default function Deploy({
-  owner,
-  app,
-  run,
-  disabled,
-}: {
-  owner: WorkspaceType;
-  app: AppType;
-  spec: SpecificationType;
-  run: RunType;
-  disabled: boolean;
-}) {
-  const [showViewAppAPIModal, setShowViewAppAPIModal] = useState(false);
-
-  return (
-    <div>
-      <ViewAppAPIModal
-        owner={owner}
-        app={app}
-        run={run}
-        isOpen={showViewAppAPIModal}
-        onClose={() => setShowViewAppAPIModal(false)}
-      />
-      <Tooltip
-        label={
-          disabled
-            ? "You need to run this app at least once successfully to view the endpoint"
-            : "View how to run this app programmatically"
-        }
-      >
-        <Button
-          label="View API endpoint"
-          variant="primary"
-          onClick={() => {
-            setShowViewAppAPIModal(true);
-          }}
-          disabled={disabled}
-          icon={CubeIcon}
-        />
-      </Tooltip>
-    </div>
   );
 }

--- a/front/components/ViewFolderAPIModal.tsx
+++ b/front/components/ViewFolderAPIModal.tsx
@@ -95,7 +95,7 @@ export function ViewFolderAPIModal({
 
             <Page.Separator />
 
-            <Page.SectionHeader title="Upsert a document" />
+            <Page.SectionHeader title="Upsert document" />
             <Page.P>
               Use the following cURL command to upsert a document to folder{" "}
               <span className="italic">{dataSource.name}</span>:

--- a/front/components/app/CopyRun.tsx
+++ b/front/components/app/CopyRun.tsx
@@ -4,8 +4,7 @@ import { Button, CubeIcon, Tooltip } from "@dust-tt/sparkle";
 import type { WorkspaceType } from "@dust-tt/types";
 import type { AppType, SpecificationType } from "@dust-tt/types";
 import type { RunType } from "@dust-tt/types";
-import { Dialog, Transition } from "@headlessui/react";
-import { Fragment, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 
 import {
   ViewAppAPIModal,

--- a/front/components/app/CopyRun.tsx
+++ b/front/components/app/CopyRun.tsx
@@ -7,7 +7,9 @@ import type { RunType } from "@dust-tt/types";
 import { Dialog, Transition } from "@headlessui/react";
 import { Fragment, useMemo, useState } from "react";
 
-import { DisplayCurlRequest } from "@app/components/app/Deploy";
+import {
+  ViewAppAPIModal,
+} from "@app/components/app/Deploy";
 import { useRunBlock } from "@app/lib/swr/apps";
 
 interface CopyRunProps {
@@ -25,9 +27,9 @@ export default function CopyRun({
   run,
   spec,
 }: CopyRunProps) {
-  const [open, setOpen] = useState(false);
-
   const [firstBlock] = spec;
+
+  const [showViewAppAPIModal, setShowViewAppAPIModal] = useState(false);
 
   const { run: runDetails } = useRunBlock(
     owner,
@@ -52,77 +54,25 @@ export default function CopyRun({
 
   return (
     <div>
+      <ViewAppAPIModal
+        owner={owner}
+        app={app}
+        run={run}
+        isOpen={showViewAppAPIModal}
+        onClose={() => setShowViewAppAPIModal(false)}
+        inputs={inputs}
+      />
       <Tooltip label="Copy run specifications.">
         <Button
-          label="Copy run"
+          label="API"
           variant="primary"
           onClick={() => {
-            setOpen(!open);
+            setShowViewAppAPIModal(true);
           }}
           disabled={disabled}
           icon={CubeIcon}
         />
       </Tooltip>
-
-      <Transition.Root show={open} as={Fragment}>
-        <Dialog
-          as="div"
-          className="relative z-30"
-          onClose={() => setOpen(false)}
-        >
-          <Transition.Child
-            as={Fragment}
-            enter="ease-out duration-300"
-            enterFrom="opacity-0"
-            enterTo="opacity-100"
-            leave="ease-in duration-200"
-            leaveFrom="opacity-100"
-            leaveTo="opacity-0"
-          >
-            <div className="fixed inset-0 bg-gray-800 bg-opacity-75 transition-opacity" />
-          </Transition.Child>
-
-          <div className="fixed inset-0 z-10 overflow-y-auto">
-            <div className="flex min-h-full items-end items-center justify-center p-4">
-              <Transition.Child
-                as={Fragment}
-                enter="ease-out duration-300"
-                leave="ease-in duration-200"
-                leaveTo="opacity-0"
-              >
-                <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-4xl sm:p-6 lg:max-w-4xl">
-                  <div data-color-mode="light">
-                    <div className="mt-3">
-                      <Dialog.Title
-                        as="h3"
-                        className="text-lg font-medium leading-6 text-gray-900"
-                      >
-                        Run as API Endpoint
-                      </Dialog.Title>
-                      <DisplayCurlRequest
-                        app={app}
-                        inputs={inputs}
-                        owner={owner}
-                        run={run}
-                      />
-                    </div>
-                  </div>
-                  <div className="mt-5 flex flex-row items-center space-x-2 sm:mt-6">
-                    <div className="flex-1"></div>
-                    <div className="flex flex-initial">
-                      <Button
-                        variant="secondary"
-                        onClick={() => setOpen(false)}
-                        label="Close"
-                      />
-                    </div>
-                  </div>
-                </Dialog.Panel>
-              </Transition.Child>
-            </div>
-          </div>
-        </Dialog>
-      </Transition.Root>
     </div>
   );
 }

--- a/front/components/app/CopyRun.tsx
+++ b/front/components/app/CopyRun.tsx
@@ -6,9 +6,7 @@ import type { AppType, SpecificationType } from "@dust-tt/types";
 import type { RunType } from "@dust-tt/types";
 import { useMemo, useState } from "react";
 
-import {
-  ViewAppAPIModal,
-} from "@app/components/app/Deploy";
+import { ViewAppAPIModal } from "@app/components/app/Deploy";
 import { useRunBlock } from "@app/lib/swr/apps";
 
 interface CopyRunProps {

--- a/front/components/app/Deploy.tsx
+++ b/front/components/app/Deploy.tsx
@@ -113,7 +113,7 @@ export function ViewAppAPIModal({
 
             <Page.Separator />
 
-            <Page.SectionHeader title="Run an app" />
+            <Page.SectionHeader title="Run app" />
             <Page.P>
               Use the following cURL command to run the app{" "}
               <span className="italic">{app.name}</span>:
@@ -146,6 +146,7 @@ export function ViewAppAPIModal({
                 />
               </div>
             </div>
+
             <Page.Separator />
 
             <Page.SectionHeader title="API Keys" />
@@ -221,7 +222,7 @@ export default function Deploy({
         }
       >
         <Button
-          label="View API endpoint"
+          label="API"
           variant="primary"
           onClick={() => {
             setShowViewAppAPIModal(true);

--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -325,7 +325,7 @@ export const VaultResourcesList = ({
           });
           if (isFolder) {
             moreMenuItems.push({
-              label: "View API",
+              label: "API",
               icon: CubeIcon,
               onClick: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
                 e.stopPropagation();

--- a/front/components/vaults/VaultResourcesList.tsx
+++ b/front/components/vaults/VaultResourcesList.tsx
@@ -3,6 +3,7 @@ import {
   Chip,
   CloudArrowLeftRightIcon,
   Cog6ToothIcon,
+  CubeIcon,
   DataTable,
   FolderIcon,
   PencilSquareIcon,
@@ -52,6 +53,8 @@ import {
   useVaultDataSourceViewsWithDetails,
 } from "@app/lib/swr/vaults";
 import { classNames } from "@app/lib/utils";
+
+import { ViewFolderAPIModal } from "../ViewFolderAPIModal";
 
 const REDIRECT_TO_EDIT_PERMISSIONS = [
   "confluence",
@@ -265,6 +268,7 @@ export const VaultResourcesList = ({
   const [showDeleteConfirmDialog, setShowDeleteConfirmDialog] = useState(false);
   const [showFolderOrWebsiteModal, setShowFolderOrWebsiteModal] =
     useState(false);
+  const [showViewFolderAPIModal, setShowViewFolderAPIModal] = useState(false);
   const [isNewConnectorLoading, setIsNewConnectorLoading] = useState(false);
   const [sorting, setSorting] = React.useState<SortingState>([
     { id: "name", desc: false },
@@ -277,6 +281,7 @@ export const VaultResourcesList = ({
   const isSystemVault = systemVault.sId === vault.sId;
   const isManagedCategory = category === "managed";
   const isWebsite = category === "website";
+  const isFolder = category === "folder";
   const isWebsiteOrFolder = isWebsiteOrFolderCategory(category);
 
   const [isLoadingByProvider, setIsLoadingByProvider] = useState<
@@ -318,6 +323,17 @@ export const VaultResourcesList = ({
               setShowFolderOrWebsiteModal(true);
             },
           });
+          if (isFolder) {
+            moreMenuItems.push({
+              label: "View API",
+              icon: CubeIcon,
+              onClick: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+                e.stopPropagation();
+                setSelectedDataSourceView(dataSourceView);
+                setShowViewFolderAPIModal(true);
+              },
+            });
+          }
           moreMenuItems.push({
             label: "Delete",
             icon: TrashIcon,
@@ -353,6 +369,7 @@ export const VaultResourcesList = ({
       owner,
       vaultDataSourceViews,
       isAdmin,
+      isFolder,
       isWebsiteOrFolder,
       canWriteInVault,
     ]
@@ -457,6 +474,15 @@ export const VaultResourcesList = ({
             vault={vault}
             systemVault={systemVault}
             isAdmin={isAdmin}
+          />
+        )}
+        {isFolder && selectedDataSourceView && (
+          <ViewFolderAPIModal
+            isOpen={showViewFolderAPIModal}
+            owner={owner}
+            vault={vault}
+            dataSource={selectedDataSourceView?.dataSource}
+            onClose={() => setShowViewFolderAPIModal(false)}
           />
         )}
         {isWebsiteOrFolder && (


### PR DESCRIPTION
## Description

Introduce a Data source API modal on folders to get curl command and retrieve vault and data source Ids.
Align the Dust Apps "View API Endpoint" experience

Stop showing API keys as this is an admin concern. Instead invite admins to manage keys or invite other users to ping an admin.

Blocked on follow-up PR to move data sources endpoint below vaults in v1 (with backward compat).

![Screenshot from 2024-09-30 11-17-13](https://github.com/user-attachments/assets/ca6e472a-4421-46ab-8caf-01c7206d8c8e)
![Screenshot from 2024-09-30 11-17-20](https://github.com/user-attachments/assets/eab44df3-58eb-4b61-998f-f69a810bbb23)
![Screenshot from 2024-09-30 11-16-55](https://github.com/user-attachments/assets/f313afe1-6cb3-4fa7-8075-3b67bb682e63)


## Risk

Low

## Deploy Plan

- deploy `front`