### PR TITLE
Fix & improvements to existing vaults endpoints for apps

### DIFF
--- a/front/pages/api/v1/w/[wId]/vaults/[vId]/apps/index.ts
+++ b/front/pages/api/v1/w/[wId]/vaults/[vId]/apps/index.ts
@@ -20,21 +20,12 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<GetAppsResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
-  const owner = auth.workspace();
-  if (!owner) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you're trying to access was not found",
-      },
-    });
-  }
+  const { vId } = req.query;
 
-  // Handling the case where vId is undefined to keep support
-  // for the legacy endpoint (not under vault, global vault assumed).
+  // Handling the case where vId is undefined to keep support for the legacy endpoint (not under
+  // vault, global vault assumed).
   const vault =
-    req.query.vId === undefined
+    vId === undefined
       ? await VaultResource.fetchWorkspaceGlobalVault(auth)
       : await VaultResource.fetchById(auth, req.query.vId as string);
 


### PR DESCRIPTION
## Description

- Small improvements (remove double check of owner, standardize the code a bit).
- Fixes the authenticator used to find the default vault in the run creation.

## Risk

Low (the only dangerous change is not used in prod as we use URLs with vaults for our own usage of Dust apps)

r? @fontanierh 

## Deploy Plan

- deploy `front`