### PR TITLE
Migration fix column name remote tables

### DIFF
--- a/connectors/migrations/db/migration_19.sql
+++ b/connectors/migrations/db/migration_19.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "remote_schemas" RENAME COLUMN "database_name" TO "databaseName";
+ALTER TABLE "remote_tables" RENAME COLUMN "database_name" TO "databaseName";
+ALTER TABLE "remote_tables" RENAME COLUMN "schema_name" TO "schemaName";


### PR DESCRIPTION
## Description

I messed up the name of the columns in camel case. 

## Risk

/

## Deploy Plan

Launch migration. 