### PR TITLE
Allow deleting a Snowflake connection

### DIFF
--- a/connectors/src/connectors/snowflake/index.ts
+++ b/connectors/src/connectors/snowflake/index.ts
@@ -80,11 +80,11 @@ export class SnowflakeConnectorManager extends BaseConnectorManager<null> {
   }
 
   async clean(): Promise<Result<undefined, Error>> {
-    throw new Error("Method clean not implemented.");
+    return new Ok(undefined);
   }
 
   async stop(): Promise<Result<undefined, Error>> {
-    throw new Error("Method stop not implemented.");
+    return new Ok(undefined);
   }
 
   async resume(): Promise<Result<undefined, Error>> {

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -23,7 +23,7 @@ import {
   assertNever,
   CONNECTOR_TYPE_TO_MISMATCH_ERROR,
   isOAuthProvider,
-  MANAGED_DS_DELETABLE_AS_BUILDER,
+  MANAGED_DS_DELETABLE,
 } from "@dust-tt/types";
 import { InformationCircleIcon } from "@heroicons/react/20/solid";
 import { useCallback, useContext, useEffect, useMemo, useState } from "react";
@@ -726,7 +726,7 @@ export function ConnectorPermissionsModal({
                 }}
               />
             )}
-            {MANAGED_DS_DELETABLE_AS_BUILDER.includes(connector.type) && (
+            {MANAGED_DS_DELETABLE.includes(connector.type) && (
               <Button
                 className="ml-auto justify-self-end"
                 label="Delete connection"

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -7,8 +7,10 @@ import {
   LockIcon,
   Modal,
   Page,
+  TrashIcon,
 } from "@dust-tt/sparkle";
 import type {
+  APIError,
   ConnectorPermission,
   ConnectorProvider,
   ConnectorType,
@@ -17,7 +19,12 @@ import type {
   UpdateConnectorRequestBody,
   WorkspaceType,
 } from "@dust-tt/types";
-import { assertNever, CONNECTOR_TYPE_TO_MISMATCH_ERROR } from "@dust-tt/types";
+import {
+  assertNever,
+  CONNECTOR_TYPE_TO_MISMATCH_ERROR,
+  isOAuthProvider,
+  MANAGED_DS_DELETABLE_AS_BUILDER,
+} from "@dust-tt/types";
 import { InformationCircleIcon } from "@heroicons/react/20/solid";
 import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { useSWRConfig } from "swr";
@@ -28,6 +35,7 @@ import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { getDataSourceName } from "@app/lib/data_sources";
 import { useConnectorPermissions } from "@app/lib/swr/connectors";
 import { useUser } from "@app/lib/swr/user";
+import { useSystemVault, useVaultDataSourceViews } from "@app/lib/swr/vaults";
 import { useWorkspaceActiveSubscription } from "@app/lib/swr/workspaces";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 
@@ -367,6 +375,130 @@ function DataSourceEditionModal({
   );
 }
 
+interface DataSourceDeletionModalProps {
+  dataSource: DataSourceType;
+  isOpen: boolean;
+  onClose: () => void;
+  owner: LightWorkspaceType;
+}
+function DataSourceDeletionModal({
+  dataSource,
+  isOpen,
+  onClose,
+  owner,
+}: DataSourceDeletionModalProps) {
+  const sendNotification = useContext(SendNotificationsContext);
+  const [showConfirmDialog, setShowConfirmDialog] = useState(false);
+  const { user } = useUser();
+  const { systemVault } = useSystemVault({
+    workspaceId: owner.sId,
+  });
+  const { mutateRegardlessOfQueryParams: mutateVaultDataSourceViews } =
+    useVaultDataSourceViews({
+      workspaceId: owner.sId,
+      vaultId: systemVault?.sId ?? "",
+      disabled: true,
+    });
+  const { connectorProvider, editedByUser } = dataSource;
+
+  if (!connectorProvider || !user || !systemVault) {
+    return null;
+  }
+
+  const isDataSourceOwner = editedByUser?.userId === user.sId;
+  const connectorConfiguration = CONNECTOR_CONFIGURATIONS[connectorProvider];
+
+  const handleDelete = async () => {
+    const res = await fetch(
+      `/api/w/${owner.sId}/vaults/${systemVault.sId}/data_sources/${dataSource.sId}`,
+      {
+        method: "DELETE",
+      }
+    );
+    if (res.ok) {
+      sendNotification({
+        title: "Successfully deleted connection",
+        type: "success",
+        description: "The connection has been successfully deleted.",
+      });
+      await mutateVaultDataSourceViews();
+      onClose();
+    } else {
+      const err = (await res.json()) as { error: APIError };
+      sendNotification({
+        title: "Error deleting connection",
+        type: "error",
+        description: err.error.message,
+      });
+    }
+  };
+
+  return (
+    <DataSourceManagementModal isOpen={isOpen} onClose={onClose}>
+      <>
+        <div className="mt-4 flex flex-col">
+          <div className="flex items-center gap-2">
+            <Icon visual={connectorConfiguration.logoComponent} size="md" />
+            <Page.SectionHeader
+              title={`Deleting ${connectorConfiguration.name} connection`}
+            />
+          </div>
+          <div className="mb-4 mt-8 w-full rounded-lg bg-amber-50 p-3">
+            <div className="flex items-center gap-2 font-medium text-amber-800">
+              <Icon visual={InformationCircleIcon} />
+              Important
+            </div>
+            <div className="p-4 text-sm text-amber-900">
+              <b>Deleting</b> will break Assistants using this data.
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-col gap-2 border-t pb-4 pt-4">
+          <Page.SectionHeader title="Connection Owner" />
+          <div className="flex items-center gap-2">
+            <Avatar visual={editedByUser?.imageUrl} size="sm" />
+            <div>
+              <span className="font-bold">
+                {isDataSourceOwner ? "You" : editedByUser?.fullName}
+              </span>{" "}
+              set it up
+              {editedByUser?.editedAt
+                ? ` on ${formatTimestampToFriendlyDate(editedByUser?.editedAt)}`
+                : "."}
+            </div>
+          </div>
+        </div>
+        <div className="flex items-center justify-center">
+          <Button
+            label="Delete Connection"
+            icon={LockIcon}
+            variant="primaryWarning"
+            onClick={() => {
+              setShowConfirmDialog(true);
+            }}
+          />
+        </div>
+
+        <Dialog
+          title="Are you sure?"
+          isOpen={showConfirmDialog}
+          onCancel={() => setShowConfirmDialog(false)}
+          onValidate={() => {
+            void handleDelete();
+            setShowConfirmDialog(false);
+          }}
+          validateVariant="primaryWarning"
+          cancelLabel="Cancel"
+          validateLabel="Continue"
+        >
+          The changes you are about to make will break existing assistants using{" "}
+          {connectorConfiguration.name}. Are you sure you want to continue?
+        </Dialog>
+      </>
+    </DataSourceManagementModal>
+  );
+}
+
 interface ConnectorPermissionsModalProps {
   connector: ConnectorType;
   dataSource: DataSourceType;
@@ -447,7 +579,7 @@ export function ConnectorPermissionsModal({
   }, [initialTreeSelectionModel, isOpen]);
 
   const [modalToShow, setModalToShow] = useState<
-    "edition" | "selection" | null
+    "edition" | "selection" | "deletion" | null
   >(null);
   const { activeSubscription } = useWorkspaceActiveSubscription({
     workspaceId: owner.sId,
@@ -583,15 +715,28 @@ export function ConnectorPermissionsModal({
       >
         <div className="mx-auto mt-4 flex w-full max-w-4xl grow flex-col gap-4">
           <div className="flex">
-            <Button
-              className="ml-auto justify-self-end"
-              label="Edit permissions"
-              variant="tertiary"
-              icon={LockIcon}
-              onClick={() => {
-                setModalToShow("edition");
-              }}
-            />
+            {isOAuthProvider(connector.type) && (
+              <Button
+                className="ml-auto justify-self-end"
+                label="Edit permissions"
+                variant="tertiary"
+                icon={LockIcon}
+                onClick={() => {
+                  setModalToShow("edition");
+                }}
+              />
+            )}
+            {MANAGED_DS_DELETABLE_AS_BUILDER.includes(connector.type) && (
+              <Button
+                className="ml-auto justify-self-end"
+                label="Delete connection"
+                variant="secondaryWarning"
+                icon={TrashIcon}
+                onClick={() => {
+                  setModalToShow("deletion");
+                }}
+              />
+            )}
           </div>
           {OptionsComponent && plan && (
             <>
@@ -640,6 +785,12 @@ export function ConnectorPermissionsModal({
             sendNotification
           );
         }}
+      />
+      <DataSourceDeletionModal
+        isOpen={modalToShow === "deletion"}
+        onClose={() => closeModal(false)}
+        dataSource={dataSource}
+        owner={owner}
       />
     </>
   );

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -15,6 +15,7 @@ import {
   CoreAPI,
   dustManagedCredentials,
   Err,
+  MANAGED_DS_DELETABLE_AS_BUILDER,
   Ok,
   sectionFullText,
 } from "@dust-tt/types";
@@ -32,10 +33,6 @@ import { enqueueUpsertTable } from "@app/lib/upsert_queue";
 import { validateUrl } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import { launchScrubDataSourceWorkflow } from "@app/poke/temporal/client";
-
-export const MANAGED_DS_DELETABLE_AS_BUILDER: ConnectorProvider[] = [
-  "webcrawler",
-];
 
 export async function getDataSources(
   auth: Authenticator,

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -15,7 +15,7 @@ import {
   CoreAPI,
   dustManagedCredentials,
   Err,
-  MANAGED_DS_DELETABLE_AS_BUILDER,
+  MANAGED_DS_DELETABLE,
   Ok,
   sectionFullText,
 } from "@dust-tt/types";
@@ -74,7 +74,7 @@ export async function deleteDataSource(
 
   if (dataSource.connectorId && dataSource.connectorProvider) {
     if (
-      !MANAGED_DS_DELETABLE_AS_BUILDER.includes(dataSource.connectorProvider) &&
+      !MANAGED_DS_DELETABLE.includes(dataSource.connectorProvider) &&
       !auth.isAdmin()
     ) {
       return new Err({

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/index.ts
@@ -1,5 +1,5 @@
 import type { DataSourceType, WithAPIErrorResponse } from "@dust-tt/types";
-import { MANAGED_DS_DELETABLE_AS_BUILDER } from "@dust-tt/types";
+import { MANAGED_DS_DELETABLE } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { deleteDataSource } from "@app/lib/api/data_sources";
@@ -127,7 +127,7 @@ async function handler(
       if (
         dataSource.connectorId &&
         dataSource.connectorProvider &&
-        !MANAGED_DS_DELETABLE_AS_BUILDER.includes(dataSource.connectorProvider)
+        !MANAGED_DS_DELETABLE.includes(dataSource.connectorProvider)
       ) {
         return apiError(req, res, {
           status_code: 400,

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/index.ts
@@ -1,10 +1,8 @@
 import type { DataSourceType, WithAPIErrorResponse } from "@dust-tt/types";
+import { MANAGED_DS_DELETABLE_AS_BUILDER } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import {
-  deleteDataSource,
-  MANAGED_DS_DELETABLE_AS_BUILDER,
-} from "@app/lib/api/data_sources";
+import { deleteDataSource } from "@app/lib/api/data_sources";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/[dsId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/[dsId]/index.ts
@@ -1,13 +1,11 @@
 import type { DataSourceType, WithAPIErrorResponse } from "@dust-tt/types";
+import { MANAGED_DS_DELETABLE_AS_BUILDER } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import {
-  deleteDataSource,
-  MANAGED_DS_DELETABLE_AS_BUILDER,
-} from "@app/lib/api/data_sources";
+import { deleteDataSource } from "@app/lib/api/data_sources";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
@@ -50,16 +48,6 @@ async function handler(
       },
     });
   }
-  if (!vault.canWrite(auth)) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "data_source_auth_error",
-        message:
-          "Only the users that have `write` permission for the current vault can update a data source.",
-      },
-    });
-  }
 
   if (vault.isSystem() && !auth.isAdmin()) {
     return apiError(req, res, {
@@ -94,6 +82,17 @@ async function handler(
 
   switch (req.method) {
     case "PATCH": {
+      if (!vault.canWrite(auth)) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "data_source_auth_error",
+            message:
+              "Only the users that have `write` permission for the current vault can update a data source.",
+          },
+        });
+      }
+
       if (dataSource.connectorId) {
         // Not implemented yet, next PR will allow patching a website.
         return apiError(req, res, {
@@ -126,6 +125,23 @@ async function handler(
       });
     }
     case "DELETE": {
+      const isAuthorized =
+        vault.canWrite(auth) ||
+        (vault.isSystem() &&
+          auth.isAdmin() &&
+          dataSource.connectorProvider === "snowflake");
+
+      if (!isAuthorized) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "data_source_auth_error",
+            message:
+              "Only the users that have `write` permission for the current vault can delete a data source.",
+          },
+        });
+      }
+
       if (
         dataSource.connectorId &&
         dataSource.connectorProvider &&

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/[dsId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/[dsId]/index.ts
@@ -1,5 +1,5 @@
 import type { DataSourceType, WithAPIErrorResponse } from "@dust-tt/types";
-import { MANAGED_DS_DELETABLE_AS_BUILDER } from "@dust-tt/types";
+import { MANAGED_DS_DELETABLE } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -145,7 +145,7 @@ async function handler(
       if (
         dataSource.connectorId &&
         dataSource.connectorProvider &&
-        !MANAGED_DS_DELETABLE_AS_BUILDER.includes(dataSource.connectorProvider)
+        !MANAGED_DS_DELETABLE.includes(dataSource.connectorProvider)
       ) {
         return apiError(req, res, {
           status_code: 400,

--- a/types/src/front/data_source.ts
+++ b/types/src/front/data_source.ts
@@ -14,7 +14,7 @@ export const CONNECTOR_PROVIDERS = [
   "snowflake",
 ] as const;
 
-export const MANAGED_DS_DELETABLE_AS_BUILDER: ConnectorProvider[] = [
+export const MANAGED_DS_DELETABLE: ConnectorProvider[] = [
   "webcrawler",
   "snowflake",
 ];

--- a/types/src/front/data_source.ts
+++ b/types/src/front/data_source.ts
@@ -14,6 +14,11 @@ export const CONNECTOR_PROVIDERS = [
   "snowflake",
 ] as const;
 
+export const MANAGED_DS_DELETABLE_AS_BUILDER: ConnectorProvider[] = [
+  "webcrawler",
+  "snowflake",
+];
+
 export const CONNECTOR_TYPE_TO_NAME: Record<ConnectorProvider, string> = {
   confluence: "Confluence",
   github: "GitHub",


### PR DESCRIPTION
## Description

This PR enable deletion of a Snowflake connection. 
This means both the new deletion modal + a hack to allow DELETING a datasource that is on system vault. 

Here's the flow. It follows the same design as the Oauth update flow. 
This is the Snowflake modal. We can see the button on top right is a new Delete button. 
<kbd>
<img width="857" alt="Screenshot 2024-09-30 at 16 34 28" src="https://github.com/user-attachments/assets/25a3c733-21bc-4639-a9dd-a0d05456ee72">
</kbd>

After clicking on it, we have a confirmation modal: 
<kbd>
<img width="497" alt="Screenshot 2024-09-30 at 16 34 36" src="https://github.com/user-attachments/assets/a5ee7fff-ca2d-43cb-998b-8377f6d05bec">
</kbd>

And then a confirmation: 
<kbd>
<img width="489" alt="Screenshot 2024-09-30 at 16 35 12" src="https://github.com/user-attachments/assets/d0e561e5-0577-4323-95aa-252c1e382f8f">
</kbd>


## Risk

Can be rolled back. 

## Deploy Plan

Deploy front 
Deploy connector
(no specific order required). 
