### PR TITLE
[sparkle] - enh: `TextArea`

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.251",
+  "version": "0.2.252",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.251",
+      "version": "0.2.252",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.251",
+  "version": "0.2.252",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/TextArea.tsx
+++ b/sparkle/src/components/TextArea.tsx
@@ -1,51 +1,46 @@
-import React, { useRef } from "react";
+import React from "react";
 
 import { classNames } from "@sparkle/lib/utils";
 
-type TextAreaProps = {
-  placeholder: string;
-  value: string | null;
-  onChange: (value: string) => void;
+export interface TextAreaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
   error?: string | null;
   showErrorLabel?: boolean;
-  className?: string;
   minRows?: number;
-};
-
-export function TextArea({
-  placeholder,
-  value,
-  onChange,
-  error,
-  showErrorLabel = false,
-  className,
-  minRows = 10
-}: TextAreaProps) {
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-
-  return (
-    <div className="s-flex s-flex-col s-gap-1 s-p-px">
-      <textarea
-        rows={minRows}
-        ref={textareaRef}
-        className={classNames(
-          "overflow-y-auto s-block s-w-full s-min-w-0 s-rounded-xl s-text-sm s-placeholder-element-700 s-transition-all s-duration-200 s-scrollbar-hide",
-          !error
-            ? "s-border-structure-100 focus:s-border-action-300 focus:s-ring-action-300"
-            : "s-border-red-500 focus:s-border-red-500 focus:s-ring-red-500",
-          "s-border-structure-200 s-bg-structure-50",
-          "s-resize-y",
-          className ?? ""
-        )}
-        placeholder={placeholder}
-        value={value ?? ""}
-        onChange={(e) => {
-          onChange(e.target.value);
-        }}
-      />
-      {error && showErrorLabel && (
-        <div className="s-ml-2 s-text-sm s-text-warning-500">{error}</div>
-      )}
-    </div>
-  );
+  className?: string;
 }
+
+export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
+  (
+    {
+      error,
+      showErrorLabel = false,
+      className,
+      minRows = 10,
+      ...props
+    }: TextAreaProps,
+    ref
+  ) => {
+    return (
+      <div className="s-flex s-flex-col s-gap-1 s-p-px">
+        <textarea
+          rows={minRows}
+          ref={ref}
+          className={classNames(
+            "overflow-y-auto s-block s-w-full s-min-w-0 s-rounded-xl s-text-sm s-placeholder-element-700 s-transition-all s-duration-200 s-scrollbar-hide",
+            !error
+              ? "s-border-structure-100 focus:s-border-action-300 focus:s-ring-action-300"
+              : "s-border-red-500 focus:s-border-red-500 focus:s-ring-red-500",
+            "s-border-structure-200 s-bg-structure-50",
+            "s-resize-y",
+            className ?? ""
+          )}
+          {...props}
+        />
+        {error && showErrorLabel && (
+          <div className="s-ml-2 s-text-sm s-text-warning-500">{error}</div>
+        )}
+      </div>
+    );
+  }
+);

--- a/sparkle/src/stories/TextArea.stories.tsx
+++ b/sparkle/src/stories/TextArea.stories.tsx
@@ -22,26 +22,27 @@ export const TextAreaExample = () => {
       <div className="s-grid s-grid-cols-3 s-gap-4">
         <TextArea
           placeholder="placeholder"
-          value={textValues[0]}
-          onChange={(v) =>
-            setTextValues([v, textValues[1], textValues[2], textValues[3]])
-          }
+          onChange={(e) => {
+            console.log(e.target.value)
+            setTextValues([e.target.value, textValues[1], textValues[2], textValues[3]])
+          }}
           minRows={2}
+          defaultValue={textValues[0]}
         />
         <TextArea
           placeholder="placeholder"
-          value={textValues[1]}
+          defaultValue={textValues[1]}
           error={"errored because blah"}
-          onChange={(v) =>
-            setTextValues([textValues[0], v, textValues[2], textValues[3]])
+          onChange={(e) =>
+            setTextValues([textValues[0], e.target.value, textValues[2], textValues[3]])
           }
           showErrorLabel
         />
         <TextArea
           placeholder="placeholder"
-          value={textValues[2]}
-          onChange={(v) =>
-            setTextValues([textValues[0], textValues[1], v, textValues[3]])
+          defaultValue={textValues[2]}
+          onChange={(e) =>
+            setTextValues([textValues[0], textValues[1], e.target.value, textValues[3]])
           }
           error={"errored because blah"}
         />


### PR DESCRIPTION
## Description

This PR aims at enhancing the `TextArea` component of `sparkle`.

These changes are part of the efforts to get rid of the `Poke*` components we have in `front`. Also, this PR aligns with the efforts introduced by https://github.com/dust-tt/dust/pull/7475 to have our design system to be heavily based on [shacdn](https://ui.shadcn.com/docs/components/textarea).

**References:**
- https://github.com/dust-tt/dust/issues/7747

## Risk

Breaking changes on `TextArea` components used by front

## Deploy Plan

- Deploy `sparkle`
- Create a new PR to update front components and get rid of `PokeTextarea`
