### PR TITLE
Add: in assistant builder, only allow to pick one remote database provider or N non-remote database providers

### DIFF
--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -107,6 +107,7 @@ export default function AssistantBuilderDataSourceModal({
           className="overflow-y-auto scrollbar-hide"
         >
           <DataSourceViewsSelector
+            useCase="assistantBuilder"
             dataSourceViews={supportedDataSourceViewsForViewType}
             allowedVaults={allowedVaults}
             owner={owner}

--- a/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
+++ b/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
@@ -107,6 +107,7 @@ export default function VaultManagedDataSourcesViewsModal({
       <div className="w-full pt-12">
         <div className="overflow-x-auto">
           <DataSourceViewsSelector
+            useCase="vaultDatasourceManagement"
             dataSourceViews={systemVaultDataSourceViews}
             owner={owner}
             selectionConfigurations={selectionConfigurations}

--- a/front/lib/data_sources.ts
+++ b/front/lib/data_sources.ts
@@ -71,6 +71,7 @@ const STRUCTURED_DATA_SOURCES: ConnectorProvider[] = [
   "google_drive",
   "notion",
   "microsoft",
+  "snowflake",
 ];
 
 export function supportsStructuredData(ds: DataSource): boolean {

--- a/front/lib/data_sources.ts
+++ b/front/lib/data_sources.ts
@@ -61,6 +61,12 @@ export function isManaged(ds: DataSource): ds is DataSource & WithConnector {
   return ds.connectorProvider !== null && !isWebsite(ds);
 }
 
+export function isRemoteDatabase(
+  ds: DataSource
+): ds is DataSource & WithConnector & { connectorProvider: "snowflake" } {
+  return ds.connectorProvider === "snowflake";
+}
+
 const STRUCTURED_DATA_SOURCES: ConnectorProvider[] = [
   "google_drive",
   "notion",


### PR DESCRIPTION
## Description

Update data source selector in the case of AssistantBuilder to only allow selection from ONE remote database or N non-remote database.

## Risk

Break assistant builder selection.

## Deploy Plan

Deploy `front`