### PR TITLE
fix: disable connectors snowflake client logging

### DIFF
--- a/connectors/src/connectors/snowflake/lib/snowflake_api.ts
+++ b/connectors/src/connectors/snowflake/lib/snowflake_api.ts
@@ -89,6 +89,11 @@ async function _fetchRows({
   credentials: SnowflakeCredentials;
   query: string;
 }): Promise<Result<SnowflakeRows, Error>> {
+  snowflake.configure({
+    // @ts-expect-error OFF is not in the types but it's a valid value.
+    logLevel: "OFF",
+  });
+
   const connection = snowflake.createConnection(credentials);
 
   try {


### PR DESCRIPTION
## Description

The library logs a lot, and we don't need those logs. And it logs into a file.

## Risk

N/A

## Deploy Plan

deploy connectors