### PR TITLE
Fix guide link in connection permission modal

### DIFF
--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -265,16 +265,19 @@ function DataSourceEditionModal({
                 Assistants using them.
               </div>
 
-              <div className="pl-4 text-sm text-amber-800">
-                Read our{" "}
-                <a
-                  href="https://docs.dust.tt/docs/google-drive-connection"
-                  className="text-blue-600"
-                >
-                  Playbook
-                </a>
-                .
-              </div>
+              {connectorConfiguration.guideLink && (
+                <div className="pl-4 text-sm text-amber-800">
+                  Read our{" "}
+                  <a
+                    href={connectorConfiguration.guideLink}
+                    className="text-blue-600"
+                    target="_blank"
+                  >
+                    Playbook
+                  </a>
+                  .
+                </div>
+              )}
             </div>
           )}
         </div>
@@ -319,16 +322,19 @@ function DataSourceEditionModal({
                 them.
               </div>
 
-              <div className="pl-4 text-sm text-amber-800">
-                Read our{" "}
-                <a
-                  href="https://docs.dust.tt/docs/google-drive-connection"
-                  className="text-blue-600"
-                >
-                  Playbook
-                </a>
-                .
-              </div>
+              {connectorConfiguration.guideLink && (
+                <div className="pl-4 text-sm text-amber-800">
+                  Read our{" "}
+                  <a
+                    href={connectorConfiguration.guideLink}
+                    className="text-blue-600"
+                    target="_blank"
+                  >
+                    Playbook
+                  </a>
+                  .
+                </div>
+              )}
             </div>
             <div className="flex items-center justify-center">
               <Button


### PR DESCRIPTION
## Description

The guide link was broken on the connection permission modal.
It was opening the link not in another tab (making us leave Dust) & it was opening google drive for all connections. 

<kbd>
<img width="448" alt="Screenshot 2024-09-30 at 18 26 23" src="https://github.com/user-attachments/assets/2de8f076-0e92-460c-bffc-c839540aabc0">
</kbd>

## Risk

/ 

## Deploy Plan

Deploy front. 