### PR TITLE
Fix retrieveContentNodeParents Snowflake & Intercom

### DIFF
--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -694,6 +694,10 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
     return new Ok(nodes);
   }
 
+  /**
+   * Retrieves the parent IDs of a content node in hierarchical order.
+   * The first ID is the internal ID of the content node itself.
+   */
   async retrieveContentNodeParents({
     internalId,
   }: {
@@ -706,14 +710,14 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
       internalId
     );
     if (helpCenterId) {
-      return new Ok([]);
+      return new Ok([internalId]);
     }
     const teamId = getTeamIdFromInternalId(this.connectorId, internalId);
     if (teamId) {
-      return new Ok([getTeamsInternalId(this.connectorId)]);
+      return new Ok([internalId, getTeamsInternalId(this.connectorId)]);
     }
 
-    const parents: string[] = [];
+    const parents: string[] = [internalId];
     let collection = null;
 
     const collectionId = getHelpCenterCollectionIdFromInternalId(

--- a/connectors/src/connectors/snowflake/lib/permissions.ts
+++ b/connectors/src/connectors/snowflake/lib/permissions.ts
@@ -366,7 +366,8 @@ export const saveNodesFromPermissions = async ({
 };
 
 /**
- * Gets the list of parent internalIds for a given content node.
+ * Retrieves the parent IDs of a content node in hierarchical order.
+ * The first ID is the internal ID of the content node itself.
  * Quite straightforward for Snowflake as we can extract the parent IDs from the internalId.
  */
 export const getContentNodeParents = ({
@@ -378,13 +379,13 @@ export const getContentNodeParents = ({
   const internalType = getContentNodeTypeFromInternalId(internalId);
 
   if (internalType === "database") {
-    return new Ok([]);
+    return new Ok([internalId]);
   }
   if (internalType === "schema") {
-    return new Ok([`${database}`]);
+    return new Ok([internalId, `${database}`]);
   }
   if (internalType === "table") {
-    return new Ok([`${database}.${schema}`, `${database}`]);
+    return new Ok([internalId, `${database}.${schema}`, `${database}`]);
   }
   return new Err(
     new Error(


### PR DESCRIPTION
## Description

Fix `retrieveContentNodeParents` for Snowflake & Intercom. 
It is supposed to retrieve the current node first then its parents. It was not retrieving the current node. 
https://github.com/dust-tt/dust/blob/main/connectors/src/connectors/interface.ts#L58-L62

## Risk

Can be rolled back. 

## Deploy Plan

Deploy connectors. 
