### PR TITLE
[front] - fix: handle content node fetch errors gracefully in migration

### DIFF
--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -318,41 +318,57 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
     }[] = [];
 
     try {
-      const [remoteChannels, localChannels] = await Promise.all([
-        getChannels(c.id, false),
-        SlackChannel.findAll({
+      if (filterPermission === "read") {
+        const localChannels = await SlackChannel.findAll({
           where: {
             connectorId: this.connectorId,
+            permission: permissionToFilter,
           },
-        }),
-      ]);
+        })
+        slackChannels.push(...localChannels.map(
+          (channel) => ({
+            slackChannelId: channel.slackChannelId,
+            slackChannelName: channel.slackChannelName,
+            permission: channel.permission
+          })
+        ))
+      } else {
+        const [remoteChannels, localChannels] = await Promise.all([
+          getChannels(c.id, false),
+          SlackChannel.findAll({
+            where: {
+              connectorId: this.connectorId,
+            },
+          }),
+        ]);
 
-      const localChannelsById = localChannels.reduce(
-        (acc, ch) => {
-          acc[ch.slackChannelId] = ch;
-          return acc;
-        },
-        {} as Record<string, SlackChannel>
-      );
+        const localChannelsById = localChannels.reduce(
+          (acc, ch) => {
+            acc[ch.slackChannelId] = ch;
+            return acc;
+          },
+          {} as Record<string, SlackChannel>
+        );
 
-      for (const remoteChannel of remoteChannels) {
-        if (!remoteChannel.id || !remoteChannel.name) {
-          continue;
-        }
+        for (const remoteChannel of remoteChannels) {
+          if (!remoteChannel.id || !remoteChannel.name) {
+            continue;
+          }
 
-        const permissions =
-          localChannelsById[remoteChannel.id]?.permission ||
-          (remoteChannel.is_member ? "write" : "none");
+          const permissions =
+            localChannelsById[remoteChannel.id]?.permission ||
+            (remoteChannel.is_member ? "write" : "none");
 
-        if (
-          permissionToFilter.length === 0 ||
-          permissionToFilter.includes(permissions)
-        ) {
-          slackChannels.push({
-            slackChannelId: remoteChannel.id,
-            slackChannelName: remoteChannel.name,
-            permission: permissions,
-          });
+          if (
+            permissionToFilter.length === 0 ||
+            permissionToFilter.includes(permissions)
+          ) {
+            slackChannels.push({
+              slackChannelId: remoteChannel.id,
+              slackChannelName: remoteChannel.name,
+              permission: permissions,
+            });
+          }
         }
       }
 

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -324,14 +324,14 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
             connectorId: this.connectorId,
             permission: permissionToFilter,
           },
-        })
-        slackChannels.push(...localChannels.map(
-          (channel) => ({
+        });
+        slackChannels.push(
+          ...localChannels.map((channel) => ({
             slackChannelId: channel.slackChannelId,
             slackChannelName: channel.slackChannelName,
-            permission: channel.permission
-          })
-        ))
+            permission: channel.permission,
+          }))
+        );
       } else {
         const [remoteChannels, localChannels] = await Promise.all([
           getChannels(c.id, false),

--- a/front/migrations/20240927_backfill_dsv_parent_nodes.ts
+++ b/front/migrations/20240927_backfill_dsv_parent_nodes.ts
@@ -58,9 +58,10 @@ makeScript({}, async ({ execute }, logger) => {
     );
 
     if (contentNodesDocumentsRes.isErr() || contentNodesTablesRes.isErr()) {
-      throw new Error(
+      logger.error(
         `Error fetching content nodes for data source view ${dataSourceView.id}`
       );
+      continue;
     }
 
     const rootNodesDocuments = contentNodesDocumentsRes.value.nodes.filter(

--- a/front/migrations/20240927_backfill_dsv_parent_nodes.ts
+++ b/front/migrations/20240927_backfill_dsv_parent_nodes.ts
@@ -58,10 +58,9 @@ makeScript({}, async ({ execute }, logger) => {
     );
 
     if (contentNodesDocumentsRes.isErr() || contentNodesTablesRes.isErr()) {
-      logger.error(
+      throw new Error(
         `Error fetching content nodes for data source view ${dataSourceView.id}`
       );
-      continue;
     }
 
     const rootNodesDocuments = contentNodesDocumentsRes.value.nodes.filter(


### PR DESCRIPTION
## Description

This PR aims at fixing `front/migrations/20240927_backfill_dsv_parent_nodes.ts` to not throw on content nodes retrieval error. Changes include:
 - Errors during content node fetch for a data source view now log an error instead of throwing and allow the migration to continue with the next item

## Risk

Low

## Deploy Plan

- Deploy `connectors`
- Apply migration