### PR TITLE
Fix Snowflake: when getting all selected node filter tables selected

### DIFF
--- a/connectors/src/connectors/snowflake/lib/permissions.ts
+++ b/connectors/src/connectors/snowflake/lib/permissions.ts
@@ -137,7 +137,9 @@ export const fetchReadNodes = async ({
     await Promise.all([
       RemoteDatabaseModel.findAll({ where: { connectorId } }),
       RemoteSchemaModel.findAll({ where: { connectorId } }),
-      RemoteTableModel.findAll({ where: { connectorId } }),
+      RemoteTableModel.findAll({
+        where: { connectorId, permission: "selected" },
+      }),
     ]);
 
   return new Ok([


### PR DESCRIPTION
## Description

When we fetch all the nodes selected explicitely as read, we need to filter tables as permission: "selected".

For Snowflake all tables are created so we can keep them synced with Core. 
We make the difference between those explicitely selected using permission = selected / inherited

## Risk

/ 

## Deploy Plan

Deploy connector. 