### PR TITLE
Fix intercom permission tree

### DIFF
--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -22,6 +22,7 @@ import {
 } from "@connectors/connectors/intercom/lib/help_center_permissions";
 import { getIntercomAccessToken } from "@connectors/connectors/intercom/lib/intercom_access_token";
 import { fetchIntercomWorkspace } from "@connectors/connectors/intercom/lib/intercom_api";
+import { retrieveSelectedNodes } from "@connectors/connectors/intercom/lib/permissions";
 import {
   getHelpCenterArticleIdFromInternalId,
   getHelpCenterArticleInternalId,
@@ -32,7 +33,7 @@ import {
   getTeamIdFromInternalId,
   getTeamInternalId,
   getTeamsInternalId,
-  isInternalIdForAllConversations,
+  isInternalIdForAllTeams,
 } from "@connectors/connectors/intercom/lib/utils";
 import {
   launchIntercomSyncWorkflow,
@@ -329,6 +330,14 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
       return new Err(new Error("Connector not found"));
     }
 
+    if (filterPermission === "read" && parentInternalId === null) {
+      // We want all selected nodes despite the hierarchy
+      const selectedNodes = await retrieveSelectedNodes({
+        connectorId: this.connectorId,
+      });
+      return new Ok(selectedNodes);
+    }
+
     try {
       const helpCenterNodes = await retrieveIntercomHelpCentersPermissions({
         connectorId: this.connectorId,
@@ -400,7 +409,7 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
           this.connectorId,
           id
         );
-        const isAllConversations = isInternalIdForAllConversations(
+        const isAllConversations = isInternalIdForAllTeams(
           this.connectorId,
           id
         );
@@ -560,7 +569,7 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
       }
       if (
         !isAllConversations &&
-        isInternalIdForAllConversations(this.connectorId, internalId)
+        isInternalIdForAllTeams(this.connectorId, internalId)
       ) {
         isAllConversations = true;
       }

--- a/connectors/src/connectors/intercom/lib/conversation_permissions.ts
+++ b/connectors/src/connectors/intercom/lib/conversation_permissions.ts
@@ -11,8 +11,8 @@ import {
   fetchIntercomTeams,
 } from "@connectors/connectors/intercom/lib/intercom_api";
 import {
-  getAllConversationsInternalId,
   getTeamInternalId,
+  getTeamsInternalId,
 } from "@connectors/connectors/intercom/lib/utils";
 import {
   IntercomTeam,
@@ -112,7 +112,7 @@ export async function retrieveIntercomConversationsPermissions({
 
   const isReadPermissionsOnly = filterPermission === "read";
   const isRootLevel = !parentInternalId;
-  const allConvosInternalId = getAllConversationsInternalId(connectorId);
+  const allTeamsInternalId = getTeamsInternalId(connectorId);
   const nodes: ContentNode[] = [];
 
   const teamsWithReadPermission = await IntercomTeam.findAll({
@@ -135,7 +135,7 @@ export async function retrieveIntercomConversationsPermissions({
     if (isRootLevel && isAllConversationsSynced) {
       nodes.push({
         provider: "intercom",
-        internalId: allConvosInternalId,
+        internalId: allTeamsInternalId,
         parentInternalId: null,
         type: "channel",
         title: `All closed conversations from the past ${conversationsSlidingWindow} days`,
@@ -149,7 +149,7 @@ export async function retrieveIntercomConversationsPermissions({
     } else if (isRootLevel && hasTeamsWithReadPermission) {
       nodes.push({
         provider: "intercom",
-        internalId: allConvosInternalId,
+        internalId: allTeamsInternalId,
         parentInternalId: null,
         type: "channel",
         title: `Closed conversations from the past ${conversationsSlidingWindow} days for the selected Teams`,
@@ -162,12 +162,12 @@ export async function retrieveIntercomConversationsPermissions({
       });
     }
 
-    if (parentInternalId === allConvosInternalId) {
+    if (parentInternalId === allTeamsInternalId) {
       teamsWithReadPermission.forEach((team) => {
         nodes.push({
           provider: connector.type,
           internalId: getTeamInternalId(connectorId, team.teamId),
-          parentInternalId: allConvosInternalId,
+          parentInternalId: allTeamsInternalId,
           type: "folder",
           title: team.name,
           sourceUrl: null,
@@ -184,7 +184,7 @@ export async function retrieveIntercomConversationsPermissions({
     if (isRootLevel) {
       nodes.push({
         provider: "intercom",
-        internalId: allConvosInternalId,
+        internalId: allTeamsInternalId,
         parentInternalId: null,
         type: "channel",
         title: "Conversations",
@@ -196,7 +196,7 @@ export async function retrieveIntercomConversationsPermissions({
         lastUpdatedAt: null,
       });
     }
-    if (parentInternalId === allConvosInternalId) {
+    if (parentInternalId === allTeamsInternalId) {
       teams.forEach((team) => {
         const isTeamInDb = teamsWithReadPermission.some((teamFromDb) => {
           return teamFromDb.teamId === team.id;
@@ -204,7 +204,7 @@ export async function retrieveIntercomConversationsPermissions({
         nodes.push({
           provider: connector.type,
           internalId: getTeamInternalId(connectorId, team.id),
-          parentInternalId: allConvosInternalId,
+          parentInternalId: allTeamsInternalId,
           type: "folder",
           title: team.name,
           sourceUrl: null,

--- a/connectors/src/connectors/intercom/lib/permissions.ts
+++ b/connectors/src/connectors/intercom/lib/permissions.ts
@@ -1,0 +1,117 @@
+import type { ContentNode, ModelId } from "@dust-tt/types";
+
+import {
+  getHelpCenterCollectionInternalId,
+  getHelpCenterInternalId,
+  getTeamInternalId,
+  getTeamsInternalId,
+} from "@connectors/connectors/intercom/lib/utils";
+import {
+  IntercomCollection,
+  IntercomTeam,
+  IntercomWorkspace,
+} from "@connectors/lib/models/intercom";
+import logger from "@connectors/logger/logger";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+
+/**
+ * Retrieve all selected nodes by the admin when setting permissions.
+ * For intercom, the admin can set:
+ * - the top collections (= collections without parentId)
+ * - all teams (conversations are stored in Teams)
+ * - a specific team
+ */
+export async function retrieveSelectedNodes({
+  connectorId,
+}: {
+  connectorId: ModelId;
+}): Promise<ContentNode[]> {
+  const connector = await ConnectorResource.fetchById(connectorId);
+  if (!connector) {
+    logger.error({ connectorId }, "[Intercom] Connector not found.");
+    throw new Error("Connector not found");
+  }
+
+  const collections = await IntercomCollection.findAll({
+    where: {
+      connectorId: connectorId,
+      permission: "read",
+    },
+  });
+  const collectionsNodes: ContentNode[] = [];
+
+  collections.map((collection) => {
+    if (collection.parentId) {
+      // We display only level 1 collections cause selection is limited to level 1 on permission modal.
+      return;
+    }
+    const expandable = collections.some(
+      (c) => c.parentId === collection.collectionId
+    );
+
+    collectionsNodes.push({
+      provider: connector.type,
+      internalId: getHelpCenterCollectionInternalId(
+        connectorId,
+        collection.collectionId
+      ),
+      parentInternalId: getHelpCenterInternalId(
+        connectorId,
+        collection.helpCenterId
+      ),
+      type: "folder",
+      title: collection.name,
+      sourceUrl: collection.url,
+      expandable,
+      permission: collection.permission,
+      dustDocumentId: null,
+      lastUpdatedAt: collection.updatedAt.getTime() || null,
+    });
+  });
+
+  const teamsNodes: ContentNode[] = [];
+
+  const intercomWorkspace = await IntercomWorkspace.findOne({
+    where: { connectorId },
+  });
+  if (
+    intercomWorkspace?.syncAllConversations === "activated" ||
+    intercomWorkspace?.syncAllConversations === "scheduled_activate"
+  ) {
+    teamsNodes.push({
+      provider: connector.type,
+      internalId: getTeamsInternalId(connectorId),
+      parentInternalId: null,
+      type: "channel",
+      title: "Conversations",
+      sourceUrl: null,
+      expandable: false,
+      permission: "read",
+      dustDocumentId: null,
+      lastUpdatedAt: null,
+    });
+  }
+
+  const teams = await IntercomTeam.findAll({
+    where: {
+      connectorId: connectorId,
+      permission: "read",
+    },
+  });
+  teams.forEach((team) => {
+    teamsNodes.push({
+      provider: connector.type,
+      internalId: getTeamInternalId(connectorId, team.teamId),
+      parentInternalId: getTeamsInternalId(connectorId),
+      type: "folder",
+      title: team.name,
+      sourceUrl: null,
+      expandable: false,
+      permission: team.permission,
+      dustDocumentId: null,
+      lastUpdatedAt: team.updatedAt.getTime() || null,
+    });
+  });
+
+  return [...collectionsNodes, ...teamsNodes];
+}

--- a/connectors/src/connectors/intercom/lib/utils.ts
+++ b/connectors/src/connectors/intercom/lib/utils.ts
@@ -42,10 +42,6 @@ export function getConversationInternalId(
   return `intercom-conversation-${connectorId}-${conversationId}`;
 }
 
-export function getAllConversationsInternalId(connectorId: ModelId): string {
-  return `intercom-conversations-all-${connectorId}`;
-}
-
 /**
  * From internalId to id
  */
@@ -70,11 +66,11 @@ export function getHelpCenterArticleIdFromInternalId(
 ): string | null {
   return _getIdFromInternal(internalId, `intercom-article-${connectorId}-`);
 }
-export function isInternalIdForAllConversations(
+export function isInternalIdForAllTeams(
   connectorId: ModelId,
   internalId: string
 ): boolean {
-  return internalId === `intercom-conversations-all-${connectorId}`;
+  return internalId === `intercom-teams-${connectorId}`;
 }
 export function getTeamIdFromInternalId(
   connectorId: ModelId,


### PR DESCRIPTION
## Description

Fixes intercom permission tree. 
When retrievePermission is sent will permission=read & parentId= null, we expect to retrieve all the nodes that were selected by the admin. 

On Intercom the admin can select top level collection, all Conversations (= all Teams), or a specific Team.
We introduce a new retrieveSelectedNodes function that retrieves all these nodes. 

It also fixes an issue where we were using 2 different internal ids for the parent convos. 
We're now using `getTeamsInternalId` which is the one expected (the one sent to core documents). 

## Risk

Break intercom but it was already broken.
Can be rolled back.

## Deploy Plan

Deploy connectors. 
No resync is necessary. 
