### PR TITLE
fix: retrieve content node with remote schema parent

### DIFF
--- a/connectors/src/connectors/snowflake/lib/permissions.ts
+++ b/connectors/src/connectors/snowflake/lib/permissions.ts
@@ -211,7 +211,7 @@ export const fetchSyncedChildren = async ({
   // Since we have all tables in the database, we can just return the tables for the schema.
   if (parentType === "schema") {
     const tables = availableTables
-      .filter((table) => table.schemaName === parentInternalId)
+      .filter((table) => table.internalId.startsWith(parentInternalId))
       .map((table) => getContentNodeFromInternalId(table.internalId, "read"));
 
     return new Ok(tables);

--- a/connectors/src/connectors/snowflake/temporal/activities.ts
+++ b/connectors/src/connectors/snowflake/temporal/activities.ts
@@ -126,6 +126,7 @@ export async function syncSnowflakeConnection(connectorId: ModelId) {
           // TODO(SNOWFLAKE): decide what to do wrt description.
           tableDescription: "",
           parents: [
+            table.internalId,
             `${table.databaseName}.${table.schemaName}`,
             table.databaseName,
           ],


### PR DESCRIPTION
## Description

- retrieving children of a remote DB schema was broken (filtering was excluding every table)
- We are not adding the table's internal ID itself to the parents in `core` 

## Risk

N/A

## Deploy Plan

will delete and re-create our snowflake connector after deploying