### PR TITLE
[front] - fix: streamline error handling in dsv parent nodes migration

### DIFF
--- a/front/migrations/20240927_backfill_dsv_parent_nodes.ts
+++ b/front/migrations/20240927_backfill_dsv_parent_nodes.ts
@@ -10,6 +10,7 @@ import { makeScript } from "@app/scripts/helpers";
 
 makeScript({}, async ({ execute }, logger) => {
   let revertScript = "";
+  let revertScriptFailingConnectors = "";
 
   const dataSourceViews = await DataSourceViewModel.findAll({
     where: {
@@ -82,7 +83,11 @@ makeScript({}, async ({ execute }, logger) => {
     }
 
     const revertQuery = `UPDATE data_source_views SET "parentsIn"=${JSON.stringify(dataSourceView.parentsIn)} WHERE id=${dataSourceView.id};`;
-    revertScript += revertQuery + "\n";
+    if (rootNodeIds.length > 0) {
+      revertScript += revertQuery + "\n";
+    } else {
+      revertScriptFailingConnectors += revertQuery + "\n";
+    }
 
     if (execute) {
       await dataSourceView.update({
@@ -100,5 +105,9 @@ makeScript({}, async ({ execute }, logger) => {
   fs.writeFileSync(
     "revert_20240927_backfill_dsv_parent_nodes.sql",
     revertScript
+  );
+  fs.writeFileSync(
+    "revert_20240927_backfill_dsv_parent_nodes_failed_connectors.sql",
+    revertScriptFailingConnectors
   );
 });


### PR DESCRIPTION
## Description

This PR aims at updating the `front/migrations/20240927_backfill_dsv_parent_nodes.ts` script to handle errors and set `parentsId` to `null` for connectors for which we are not able to retrieve content nodes.

## Risk

Quite important

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
