### PR TITLE
[Slack connector] Fix excessive rate limiting due to start-to-close

### DIFF
--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -15,8 +15,6 @@ import { newWebhookSignal, syncChannelSignal } from "./signals";
 
 const {
   getChannel,
-  syncThread,
-  syncNonThreaded,
   syncChannel,
   fetchUsers,
   saveSuccessSyncActivity,
@@ -27,6 +25,10 @@ const {
   deleteChannelsFromConnectorDb,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minutes",
+});
+
+const { syncThread, syncNonThreaded } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "30 minutes",
 });
 
 /**


### PR DESCRIPTION
Description
---
Following issue reported in this [thread](), rate limiting debounce may be pre-empted by start-to-close failure, in which case we would excessively retry slack api and never go through

This attempts to fix the issue by increasing activity start-to-close timeout for sync activities, which btw seems fair.

Risk
---
na

Deploy
---
connectors
