### PR TITLE
[Slack Whitelisting] Fix indexing condition

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -216,10 +216,12 @@ export async function syncChannel(
   for (const message of messages.messages) {
     if (
       !message.user &&
-      message.bot_profile?.name &&
-      !(await slackConfiguration.isBotWhitelistedToIndexMessages(
-        message.bot_profile.name
-      ))
+      !(
+        message.bot_profile?.name &&
+        (await slackConfiguration.isBotWhitelistedToIndexMessages(
+          message.bot_profile.name
+        ))
+      )
     ) {
       // We do not support messages not posted by users for now, unless it's a whitelisted bot
       continue;
@@ -445,10 +447,12 @@ export async function syncNonThreaded(
       }
       if (
         !message.user &&
-        message.bot_profile?.name &&
-        !(await slackConfiguration.isBotWhitelistedToIndexMessages(
-          message.bot_profile.name
-        ))
+        !(
+          message.bot_profile?.name &&
+          (await slackConfiguration.isBotWhitelistedToIndexMessages(
+            message.bot_profile.name
+          ))
+        )
       ) {
         // We do not support messages not posted by users for now, unless it's a whitelisted bot
         continue;


### PR DESCRIPTION
Description
---
An assumption from #7692 that when the message comes from a "bot" then `bot_profile` is always set might have changed the indexation logic outside the scope of whitelisting.

This can be a cause for the rate limit issues that appeared after #7692 discussed [here](https://dust4ai.slack.com/archives/C05F84CFP0E/p1727370227511109)

This PR ensures indexing of bots is exactly what it was before, save for presence in whitelist, by fixing the condition

Risks
---
na

Deploy
---
connectors
