### PR TITLE
Add a way to find assistant ID

### DIFF
--- a/front/components/assistant/AssistantDetailsDropdownMenu.tsx
+++ b/front/components/assistant/AssistantDetailsDropdownMenu.tsx
@@ -153,15 +153,25 @@ export function AssistantDetailsDropdownMenu({
                   close();
                 }}
               />
-              {showAssistantDetails && (
+              {showAssistantDetails ? (
                 <DropdownMenu.Item
-                  label={`More about @${agentConfiguration.name}`}
+                  label={`More info`}
                   onClick={(e) => {
                     e.stopPropagation();
                     close();
                     showAssistantDetails();
                   }}
                   icon={EyeIcon}
+                />
+              ) : (
+                <DropdownMenu.Item
+                  label={`Copy assistant ID`}
+                  onClick={async (e) => {
+                    e.stopPropagation();
+                    await navigator.clipboard.writeText(agentConfiguration.sId);
+                    close();
+                  }}
+                  icon={ClipboardIcon}
                 />
               )}
               {!isGlobalAgent && (


### PR DESCRIPTION
## Description

- Users currently don't have anything else than a hacky way to find their assistants IDs.
- With API usage growth and apps like Zendesk or Raycast, users need a way to find their assistant's ids. Adding in in the 'More info' panel and will add that to the documentation .

<img width="451" alt="Screenshot 2024-10-01 at 15 57 43" src="https://github.com/user-attachments/assets/4bbdf614-a154-4cf3-8a3a-533fe742c92a">

- Also removing the 'More about {assistantName}' which always ends up truncating the name because our popovers are too small :')

<img width="251" alt="Screenshot 2024-10-01 at 15 57 28" src="https://github.com/user-attachments/assets/d9a03275-4b2f-4b26-a090-2ed93e0b7471">

becomes

<img width="571" alt="Screenshot 2024-10-01 at 16 13 59" src="https://github.com/user-attachments/assets/9c558d5f-fd3d-4060-9474-ec359c17d6d3">



## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
