### PR TITLE
[Slack connector] Fix not-in-channel issue: handle in `syncThread`

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -645,8 +645,17 @@ export async function syncThread(
     const slackError = e as CodedError;
     if (slackError.code === ErrorCode.PlatformError) {
       const platformError = slackError as WebAPIPlatformError;
+
       if (platformError.data.error === "thread_not_found") {
         // If the thread is not found we just return and don't upsert anything.
+        return;
+      }
+
+      if (
+        platformError.code === "slack_webapi_platform_error" &&
+        platformError.data?.error === "not_in_channel"
+      ) {
+        // If the bot is no longer in the channel, we don't upsert anything.
         return;
       }
     }


### PR DESCRIPTION
Description
---
See monitor [thread](https://dust4ai.slack.com/archives/C05F84CFP0E/p1727370227511109)

We handle `not_in_channel` for `syncNonThreaded` but up to now we didn't do it for `syncThread`, leading to monitoring errors

This PR addresses that

Risks
---
na

Deploy
---
connectors
