### PR TITLE
feat: ensure snowflake connection is read only

### DIFF
--- a/connectors/src/connectors/snowflake/lib/content_nodes.ts
+++ b/connectors/src/connectors/snowflake/lib/content_nodes.ts
@@ -1,19 +1,11 @@
 import type { ConnectorPermission, ContentNode } from "@dust-tt/types";
 
 /**
- * Some databases and schemas are not useful to show in the content tree.
- * We exclude them here.
- */
-export const EXCLUDE_DATABASES = ["SNOWFLAKE"];
-export const EXCLUDE_SCHEMAS = ["INFORMATION_SCHEMA"];
-
-/**
  * 3 types of nodes in a remote database content tree:
  * - database: internalId = "database_name"
  * - schema: internalId = "database_name.schema_name"
  * - table: internalId = "database_name.schema_name.table_name"
  */
-
 export type REMOTE_DB_CONTENT_NODE_TYPES = "database" | "schema" | "table";
 
 export const getContentNodeTypeFromInternalId = (

--- a/connectors/src/connectors/snowflake/lib/permissions.ts
+++ b/connectors/src/connectors/snowflake/lib/permissions.ts
@@ -4,11 +4,9 @@ import type {
   Result,
   SnowflakeCredentials,
 } from "@dust-tt/types";
-import { Err, Ok } from "@dust-tt/types";
+import { Err, EXCLUDE_DATABASES, EXCLUDE_SCHEMAS, Ok } from "@dust-tt/types";
 
 import {
-  EXCLUDE_DATABASES,
-  EXCLUDE_SCHEMAS,
   getContentNodeFromInternalId,
   getContentNodeTypeFromInternalId,
 } from "@connectors/connectors/snowflake/lib/content_nodes";

--- a/connectors/src/connectors/snowflake/lib/snowflake_api.ts
+++ b/connectors/src/connectors/snowflake/lib/snowflake_api.ts
@@ -281,7 +281,17 @@ async function _connectToSnowflake(
   try {
     const connection = await new Promise<Connection>((resolve, reject) => {
       snowflake
-        .createConnection(credentials)
+        .createConnection({
+          ...credentials,
+
+          // Use proxy if defined to have all requests coming from the same IP.
+          proxyHost: process.env.PROXY_HOST,
+          proxyPort: process.env.PROXY_PORT
+            ? parseInt(process.env.PROXY_PORT)
+            : undefined,
+          proxyUser: process.env.PROXY_USER_NAME,
+          proxyPassword: process.env.PROXY_USER_PASSWORD,
+        })
         .connect((err: SnowflakeError | undefined, conn: Connection) => {
           if (err) {
             reject(err);

--- a/connectors/src/connectors/snowflake/lib/snowflake_api.ts
+++ b/connectors/src/connectors/snowflake/lib/snowflake_api.ts
@@ -81,6 +81,10 @@ export const testConnection = async ({
 export async function connectToSnowflake(
   credentials: SnowflakeCredentials
 ): Promise<Result<Connection, Error>> {
+  snowflake.configure({
+    // @ts-expect-error OFF is not in the types but it's a valid value.
+    logLevel: "OFF",
+  });
   try {
     const connection = await new Promise<Connection>((resolve, reject) => {
       snowflake
@@ -266,11 +270,6 @@ async function _fetchRows<T>({
   codec: t.Type<T>;
   connection?: Connection;
 }): Promise<Result<Array<T>, Error>> {
-  snowflake.configure({
-    // @ts-expect-error OFF is not in the types but it's a valid value.
-    logLevel: "OFF",
-  });
-
   const connRes = await (() =>
     connection ? new Ok(connection) : connectToSnowflake(credentials))();
   if (connRes.isErr()) {

--- a/connectors/src/connectors/snowflake/lib/snowflake_api.ts
+++ b/connectors/src/connectors/snowflake/lib/snowflake_api.ts
@@ -1,12 +1,40 @@
 import type { Result } from "@dust-tt/types";
 import type { SnowflakeCredentials } from "@dust-tt/types";
-import { Err, Ok } from "@dust-tt/types";
+import { Err, EXCLUDE_DATABASES, EXCLUDE_SCHEMAS, Ok } from "@dust-tt/types";
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
 import type { Connection, RowStatement, SnowflakeError } from "snowflake-sdk";
 import snowflake from "snowflake-sdk";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type SnowflakeRow = Record<string, any>;
 export type SnowflakeRows = Array<SnowflakeRow>;
+
+const snowflakeDatabaseCodec = t.type({
+  name: t.string,
+});
+type SnowflakeDatabase = t.TypeOf<typeof snowflakeDatabaseCodec>;
+
+const snowflakeSchemaCodec = t.type({
+  name: t.string,
+  database_name: t.string,
+});
+type SnowflakeSchema = t.TypeOf<typeof snowflakeSchemaCodec>;
+
+const snowflakeTableCodec = t.type({
+  name: t.string,
+  database_name: t.string,
+  schema_name: t.string,
+});
+type SnowflakeTable = t.TypeOf<typeof snowflakeTableCodec>;
+
+const snowflakeGrantCodec = t.type({
+  privilege: t.string,
+  grant_on: t.string,
+  name: t.string,
+});
+type SnowflakeGrant = t.TypeOf<typeof snowflakeGrantCodec>;
 
 /**
  * Test the connection to Snowflake with the provided credentials.
@@ -17,32 +45,66 @@ export const testConnection = async ({
 }: {
   credentials: SnowflakeCredentials;
 }): Promise<Result<string, Error>> => {
-  const connection = snowflake.createConnection({
-    ...credentials,
-
-    // Use proxy if defined to have all requests coming from the same IP.
-    proxyHost: process.env.PROXY_HOST,
-    proxyPort: process.env.PROXY_PORT
-      ? parseInt(process.env.PROXY_PORT)
-      : undefined,
-    proxyUser: process.env.PROXY_USER_NAME,
-    proxyPassword: process.env.PROXY_USER_PASSWORD,
-  });
-
-  try {
-    const conn = await _connectToSnowflake(connection);
-    // TODO(SNOWFLAKE): Improve checks: we want to make sure we have read and read-only access.
-    const rows = await _executeQuery(conn, "SHOW TABLES");
-
-    if (!rows || rows.length === 0) {
-      throw new Error("No tables found or no access to any tables");
-    }
-
-    await _closeConnection(conn);
-    return new Ok("Connection successful");
-  } catch (error) {
-    return new Err(error instanceof Error ? error : new Error(String(error)));
+  // Connect to snowflake, fetch tables and grants, and close the connection.
+  const connectionRes = await _connectToSnowflake(credentials);
+  if (connectionRes.isErr()) {
+    return connectionRes;
   }
+  const connection = connectionRes.value;
+  const tablesRes = await fetchTables({ credentials, connection });
+  const grantsRes = await fetchGrants({ credentials, connection });
+  const closeConnectionRes = await _closeConnection(connection);
+  if (closeConnectionRes.isErr()) {
+    return closeConnectionRes;
+  }
+
+  if (tablesRes.isErr()) {
+    return tablesRes;
+  }
+  const tables = tablesRes.value.filter(
+    (t) =>
+      !EXCLUDE_DATABASES.includes(t.database_name) &&
+      !EXCLUDE_SCHEMAS.includes(t.schema_name)
+  );
+  if (tables.length === 0) {
+    return new Err(new Error("No tables found or no access to any table."));
+  }
+
+  if (grantsRes.isErr()) {
+    return grantsRes;
+  }
+  const grants = grantsRes.value;
+  // We go ove each grant to greenlight them.
+  for (const g of grants) {
+    if (g.grant_on === "TABLE") {
+      // We only allow SELECT grants on tables.
+      if (g.privilege !== "SELECT") {
+        return new Err(
+          new Error(
+            `Non-select grant found on ${g.grant_on} "${g.name}": privilege=${g.privilege} (connection must be read-only).`
+          )
+        );
+      }
+    } else if (["SCHEMA", "DATABASE", "WAREHOUSE"].includes(g.grant_on)) {
+      // We only allow USAGE grants on schemas / databases / warehouses.
+      if (g.privilege !== "USAGE") {
+        return new Err(
+          new Error(
+            `Non-usage grant found on ${g.grant_on} "${g.name}": privilege=${g.privilege} (connection must be read-only).`
+          )
+        );
+      }
+    } else {
+      // We don't allow any other grants.
+      return new Err(
+        new Error(
+          `Unsupported grant found on ${g.grant_on} "${g.name}": privilege=${g.privilege} (connection must be read-only).`
+        )
+      );
+    }
+  }
+
+  return new Ok("Connection successful");
 };
 
 /**
@@ -50,11 +112,18 @@ export const testConnection = async ({
  */
 export const fetchDatabases = async ({
   credentials,
+  connection,
 }: {
   credentials: SnowflakeCredentials;
-}): Promise<Result<SnowflakeRows, Error>> => {
+  connection?: Connection;
+}): Promise<Result<Array<SnowflakeDatabase>, Error>> => {
   const query = "SHOW DATABASES";
-  return _fetchRows({ credentials, query });
+  return _fetchRows<SnowflakeDatabase>({
+    credentials,
+    query,
+    codec: snowflakeDatabaseCodec,
+    connection,
+  });
 };
 
 /**
@@ -63,14 +132,21 @@ export const fetchDatabases = async ({
 export const fetchSchemas = async ({
   credentials,
   fromDatabase,
+  connection,
 }: {
   credentials: SnowflakeCredentials;
   fromDatabase?: string;
-}): Promise<Result<SnowflakeRows, Error>> => {
+  connection?: Connection;
+}): Promise<Result<Array<SnowflakeSchema>, Error>> => {
   const query = fromDatabase
     ? `SHOW SCHEMAS IN DATABASE ${fromDatabase}`
     : "SHOW SCHEMAS";
-  return _fetchRows({ credentials, query });
+  return _fetchRows<SnowflakeSchema>({
+    credentials,
+    query,
+    codec: snowflakeSchemaCodec,
+    connection,
+  });
 };
 
 /**
@@ -79,112 +155,199 @@ export const fetchSchemas = async ({
 export const fetchTables = async ({
   credentials,
   fromSchema,
+  connection,
 }: {
   credentials: SnowflakeCredentials;
   fromSchema?: string;
-}): Promise<Result<SnowflakeRows, Error>> => {
+  connection?: Connection;
+}): Promise<Result<Array<SnowflakeTable>, Error>> => {
   const query = fromSchema
     ? `SHOW TABLES IN SCHEMA ${fromSchema}`
     : "SHOW TABLES";
 
-  return _fetchRows({ credentials, query });
+  return _fetchRows<SnowflakeTable>({
+    credentials,
+    query,
+    codec: snowflakeTableCodec,
+    connection,
+  });
+};
+
+/**
+ * Fetch the grants available for the Snowflake role.
+ */
+export const fetchGrants = async ({
+  credentials,
+  connection,
+}: {
+  credentials: SnowflakeCredentials;
+  connection?: Connection;
+}): Promise<Result<Array<SnowflakeGrant>, Error>> => {
+  const currentGrantsRes = await _fetchRows<SnowflakeGrant>({
+    credentials,
+    query: `SHOW GRANTS TO ROLE ${credentials.role}`,
+    codec: snowflakeGrantCodec,
+    connection,
+  });
+  if (currentGrantsRes.isErr()) {
+    return currentGrantsRes;
+  }
+
+  const futureGrantsRes = await _fetchRows<SnowflakeGrant>({
+    credentials,
+    query: `SHOW FUTURE GRANTS TO ROLE ${credentials.role}`,
+    codec: snowflakeGrantCodec,
+  });
+  if (futureGrantsRes.isErr()) {
+    return futureGrantsRes;
+  }
+
+  const allGrantsRows = [...currentGrantsRes.value, ...futureGrantsRes.value];
+
+  const parsedRows: Array<SnowflakeGrant> = [];
+  for (const row of allGrantsRows) {
+    const decoded = snowflakeGrantCodec.decode(row);
+    if (isLeft(decoded)) {
+      const pathError = reporter.formatValidationErrors(decoded.left);
+      return new Err(new Error(`Could not parse row: ${pathError}`));
+    }
+
+    parsedRows.push(decoded.right);
+  }
+
+  return new Ok(parsedRows);
 };
 
 // UTILS
 
-async function _fetchRows({
+async function _fetchRows<T>({
   credentials,
   query,
+  codec,
+  connection,
 }: {
   credentials: SnowflakeCredentials;
   query: string;
-}): Promise<Result<SnowflakeRows, Error>> {
+  codec: t.Type<T>;
+  connection?: Connection;
+}): Promise<Result<Array<T>, Error>> {
   snowflake.configure({
     // @ts-expect-error OFF is not in the types but it's a valid value.
     logLevel: "OFF",
   });
 
-  const connection = snowflake.createConnection({
-    ...credentials,
+  const connRes = await (() =>
+    connection ? new Ok(connection) : _connectToSnowflake(credentials))();
+  if (connRes.isErr()) {
+    return connRes;
+  }
+  const conn = connRes.value;
 
-    // Use proxy if defined to have all requests coming from the same IP.
-    proxyHost: process.env.PROXY_HOST,
-    proxyPort: process.env.PROXY_PORT
-      ? parseInt(process.env.PROXY_PORT)
-      : undefined,
-    proxyUser: process.env.PROXY_USER_NAME,
-    proxyPassword: process.env.PROXY_USER_PASSWORD,
-  });
+  const rowsRes = await _executeQuery(conn, query);
+  if (rowsRes.isErr()) {
+    return rowsRes;
+  }
+  const rows = rowsRes.value;
 
-  try {
-    const conn = await _connectToSnowflake(connection);
-    const rows = await _executeQuery(conn, query);
+  // We close the connection if we created it.
+  if (!connection) {
     await _closeConnection(conn);
+  }
 
-    if (!rows) {
-      throw new Error("No tables found or no access to any table.");
+  if (!rows) {
+    return new Err(new Error("No tables found or no access to any table."));
+  }
+
+  const parsedRows: Array<T> = [];
+  for (const row of rows) {
+    const decoded = codec.decode(row);
+    if (isLeft(decoded)) {
+      const pathError = reporter.formatValidationErrors(decoded.left);
+      return new Err(new Error(`Could not parse row: ${pathError}`));
     }
 
-    return new Ok(rows);
+    parsedRows.push(decoded.right);
+  }
+
+  return new Ok(parsedRows);
+}
+
+/**
+ * Util: Connect to Snowflake.
+ */
+async function _connectToSnowflake(
+  credentials: SnowflakeCredentials
+): Promise<Result<Connection, Error>> {
+  try {
+    const connection = await new Promise<Connection>((resolve, reject) => {
+      snowflake
+        .createConnection(credentials)
+        .connect((err: SnowflakeError | undefined, conn: Connection) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(conn);
+          }
+        });
+    });
+
+    return new Ok(connection);
   } catch (error) {
     return new Err(error instanceof Error ? error : new Error(String(error)));
   }
 }
 
 /**
- * Util: Connect to Snowflake.
+ * Util: Close the Snowflake connection.
  */
-function _connectToSnowflake(
-  connection: snowflake.Connection
-): Promise<Connection> {
-  return new Promise((resolve, reject) => {
-    connection.connect((err: SnowflakeError | undefined, conn: Connection) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(conn);
-      }
+async function _closeConnection(
+  conn: Connection
+): Promise<Result<void, Error>> {
+  try {
+    await new Promise<void>((resolve, reject) => {
+      conn.destroy((err: SnowflakeError | undefined) => {
+        if (err) {
+          console.error("Error closing connection:", err);
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
     });
-  });
+    return new Ok(undefined);
+  } catch (error) {
+    return new Err(error instanceof Error ? error : new Error(String(error)));
+  }
 }
 
 /**
  * Util: Execute a query on the Snowflake connection.
  */
-function _executeQuery(
+async function _executeQuery(
   conn: Connection,
   sqlText: string
-): Promise<SnowflakeRows | undefined> {
-  return new Promise((resolve, reject) => {
-    conn.execute({
-      sqlText,
-      complete: (
-        err: SnowflakeError | undefined,
-        stmt: RowStatement,
-        rows: SnowflakeRows | undefined
-      ) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(rows);
-        }
-      },
-    });
-  });
-}
-
-/**
- * Util: Close the Snowflake connection.
- */
-function _closeConnection(conn: Connection): Promise<void> {
-  return new Promise((resolve, reject) => {
-    conn.destroy((err: SnowflakeError | undefined) => {
-      if (err) {
-        console.error("Error closing connection:", err);
-        reject(err);
-      } else {
-        resolve();
+): Promise<Result<SnowflakeRows | undefined, Error>> {
+  try {
+    const r = await new Promise<SnowflakeRows | undefined>(
+      (resolve, reject) => {
+        conn.execute({
+          sqlText,
+          complete: (
+            err: SnowflakeError | undefined,
+            stmt: RowStatement,
+            rows: SnowflakeRows | undefined
+          ) => {
+            if (err) {
+              reject(err);
+            } else {
+              resolve(rows);
+            }
+          },
+        });
       }
-    });
-  });
+    );
+    return new Ok(r);
+  } catch (error) {
+    return new Err(error instanceof Error ? error : new Error(String(error)));
+  }
 }

--- a/connectors/src/lib/models/remote_databases.ts
+++ b/connectors/src/lib/models/remote_databases.ts
@@ -126,7 +126,7 @@ export class RemoteTableModel extends Model<
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
-  declare lastUpsertedAt: CreationOptional<Date>;
+  declare lastUpsertedAt: CreationOptional<Date> | null;
 
   declare internalId: string;
   declare name: string;

--- a/types/src/connectors/snowflake.ts
+++ b/types/src/connectors/snowflake.ts
@@ -1,0 +1,6 @@
+/**
+ * Some databases and schemas are not useful to show in the content tree.
+ * We exclude them here.
+ */
+export const EXCLUDE_DATABASES = ["SNOWFLAKE", "SNOWFLAKE_SAMPLE_DATA"];
+export const EXCLUDE_SCHEMAS = ["INFORMATION_SCHEMA"];

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -18,6 +18,7 @@ const CONNECTORS_ERROR_TYPES = [
   "oauth_token_revoked",
   "third_party_internal_error",
   "webcrawling_error",
+  "remote_database_connection_not_readonly",
 ] as const;
 
 export type ConnectorErrorType = (typeof CONNECTORS_ERROR_TYPES)[number];

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -11,6 +11,7 @@ export * from "./connectors/intercom";
 export * from "./connectors/microsoft";
 export * from "./connectors/notion";
 export * from "./connectors/slack";
+export * from "./connectors/snowflake";
 export * from "./connectors/webcrawler";
 export * from "./core/data_source";
 export * from "./front/acl";


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/tasks/issues/1403

On creating the Snowflake connector, we want to ensure the provided `role` only has the necessary grants to query tables -- nothing else:
- we allow `SELECT` grants on tables and future tables
- we allow `USAGE` grants on DBs, Schemas and Warehouses
- we disallow any other type of grants

Also moved the `EXCLUDE_DATABASES` and `EXCLUDE_SCHEMAS` to types as we need those from `connectors`. Added "SNOWFLAKE_SAMPLE_DATA" as an excluded DB (not useful, I think every / a lot of snowflake DB have it)

I refactored a bit snowflake api: 
- utils now return `Result`s (avoid wrapping whole public methods in try/catch). Will also help to have typed errors in the next PR (needed to display clear error messages for the admin)
- added types and schema decoding to the public methods

## Risk

N/A

## Deploy Plan

Deploy `front` and `connectors`