### PR TITLE
[connectors] Allow to retrieve orphaned pages node

### DIFF
--- a/connectors/src/connectors/notion/lib/parents.ts
+++ b/connectors/src/connectors/notion/lib/parents.ts
@@ -278,3 +278,22 @@ export const hasChildren = async (pages: NotionPage[], connectorId: number) => {
 
   return { ...hasChildrenPage, ...hasChildrenDb };
 };
+
+export const getOrphanedCount = async (connectorId: number) => {
+  const [orphanedPagesCount, orphanedDbsCount] = await Promise.all([
+    NotionPage.count({
+      where: {
+        connectorId: connectorId,
+        parentId: "unknown",
+      },
+    }),
+    NotionDatabase.count({
+      where: {
+        connectorId: connectorId,
+        parentId: "unknown",
+      },
+    }),
+  ]);
+
+  return orphanedDbsCount + orphanedPagesCount;
+};


### PR DESCRIPTION
## Description

The node with id="unknown" (Orphaned resources) should be returned by retrieveBatchContentNodes when asked.  Otherwise this node cannot be selected in the datasource views tree.


## Risk


none

## Deploy Plan

deploy connectors
