### PR TITLE
[front] - chore(migrations): root node filtering in dsv

### DIFF
--- a/front/migrations/20240927_backfill_dsv_parent_nodes.ts
+++ b/front/migrations/20240927_backfill_dsv_parent_nodes.ts
@@ -62,12 +62,8 @@ makeScript({}, async ({ execute }, logger) => {
       );
 
       if (contentNodesDocumentsRes.isOk() && contentNodesTablesRes.isOk()) {
-        const rootNodesDocuments = contentNodesDocumentsRes.value.nodes.filter(
-          (node) => node.parentInternalId === null
-        );
-        const rootNodesTables = contentNodesTablesRes.value.nodes.filter(
-          (node) => node.parentInternalId === null
-        );
+        const rootNodesDocuments = contentNodesDocumentsRes.value.nodes
+        const rootNodesTables = contentNodesTablesRes.value.nodes
 
         const rootNodes = _.uniqBy(
           [...rootNodesDocuments, ...rootNodesTables],

--- a/front/migrations/20240927_backfill_dsv_parent_nodes.ts
+++ b/front/migrations/20240927_backfill_dsv_parent_nodes.ts
@@ -62,8 +62,8 @@ makeScript({}, async ({ execute }, logger) => {
       );
 
       if (contentNodesDocumentsRes.isOk() && contentNodesTablesRes.isOk()) {
-        const rootNodesDocuments = contentNodesDocumentsRes.value.nodes
-        const rootNodesTables = contentNodesTablesRes.value.nodes
+        const rootNodesDocuments = contentNodesDocumentsRes.value.nodes;
+        const rootNodesTables = contentNodesTablesRes.value.nodes;
 
         const rootNodes = _.uniqBy(
           [...rootNodesDocuments, ...rootNodesTables],


### PR DESCRIPTION
## Description

This PR aims at fixing the `DataSourceView` migration to remove unnecessary filtering and take all nodes returned by `getContentNodesForDataSourceView`.

**References:**
 - [Slack message](https://dust4ai.slack.com/archives/C05DS517CUR/p1727799945328259?thread_ts=1727784937.337019&cid=C05DS517CUR)
 
## Risk

Quite high blast radius when running this migration

## Deploy Plan

- Run on our workspace
- Run on all workspace
