### PR TITLE
[Infra] Delete instead of soft delete for scrub ds production check

### DIFF
--- a/core/src/stores/migrations/20241002_delete_soft-deleted_rows.sql
+++ b/core/src/stores/migrations/20241002_delete_soft-deleted_rows.sql
@@ -1,0 +1,1 @@
+DELETE FROM data_sources_documents WHERE status = 'soft-hard-deleted';

--- a/front/lib/production_checks/checks/scrub_deleted_core_document_versions.ts
+++ b/front/lib/production_checks/checks/scrub_deleted_core_document_versions.ts
@@ -213,9 +213,9 @@ async function scrubDocument({
   );
 
   if (moreRecentSameHash[0].length > 0) {
-    // mark the row as 'soft-hard-deleted'
+    // delete the row
     await corePrimary.query(
-      `UPDATE data_sources_documents SET status = 'soft-hard-deleted' WHERE id = :id`,
+      `DELETE FROM data_sources_documents WHERE id = :id`,
       {
         replacements: {
           id: id,


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/1293 (all details there)

- delete rows that were formerly soft deleted
- cleans the table

Removing the many rows might help queries related to this table, relatedly to this [incident](https://dust4ai.slack.com/archives/C05B529FHV1/p1727855661886639?thread_ts=1727850921.128689&cid=C05B529FHV1)

Risk
---
We wondered if we needed to keep those rows, but have gone > 1 week without them so we should be able to remove

Deploy
---
1. front
2. run migration on core
