### PR TITLE
Move upsert table to its own worker

### DIFF
--- a/.github/workflows/deploy-front.yml
+++ b/.github/workflows/deploy-front.yml
@@ -50,6 +50,7 @@ jobs:
           chmod +x ./k8s/deploy-image.sh
           ./k8s/deploy-image.sh gcr.io/$GCLOUD_PROJECT_ID/front-image:${{ steps.short_sha.outputs.short_sha }} front-deployment
           ./k8s/deploy-image.sh gcr.io/$GCLOUD_PROJECT_ID/front-image:${{ steps.short_sha.outputs.short_sha }} front-worker-deployment
+          ./k8s/deploy-image.sh gcr.io/$GCLOUD_PROJECT_ID/front-image:${{ steps.short_sha.outputs.short_sha }} upsert-table-worker-deployment
 
       - name: Wait for rollout to complete
         run: |
@@ -57,3 +58,5 @@ jobs:
           kubectl rollout status deployment/front-deployment --timeout=10m
           echo "Waiting for rollout to complete (worker)"
           kubectl rollout status deployment/front-worker-deployment --timeout=10m
+          echo "Waiting for rollout to complete (upsert table worker)"
+          kubectl rollout status deployment/upsert-table-worker-deployment --timeout=10m

--- a/front/lib/upsert_queue.ts
+++ b/front/lib/upsert_queue.ts
@@ -20,10 +20,8 @@ import { getDocumentsPostUpsertHooksToRun } from "@app/lib/documents_post_proces
 import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/withlogging";
 import { launchRunPostUpsertHooksWorkflow } from "@app/temporal/documents_post_process_hooks/client";
-import {
-  launchUpsertDocumentWorkflow,
-  launchUpsertTableWorkflow,
-} from "@app/temporal/upsert_queue/client";
+import { launchUpsertDocumentWorkflow } from "@app/temporal/upsert_queue/client";
+import { launchUpsertTableWorkflow } from "@app/temporal/upsert_tables/client";
 
 import type { DataSourceResource } from "./resources/data_source_resource";
 

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -122,7 +122,8 @@
         "tailwindcss": "^3.2.4",
         "tailwindcss-animate": "^1.0.7",
         "three": "^0.163.0",
-        "uuid": "^9.0.0"
+        "uuid": "^9.0.0",
+        "yargs": "^17.7.2"
       },
       "devDependencies": {
         "@google-cloud/storage": "^7.11.2",
@@ -35441,7 +35442,8 @@
     },
     "node_modules/yargs": {
       "version": "17.7.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -134,7 +134,8 @@
     "tailwindcss": "^3.2.4",
     "tailwindcss-animate": "^1.0.7",
     "three": "^0.163.0",
-    "uuid": "^9.0.0"
+    "uuid": "^9.0.0",
+    "yargs": "^17.7.2"
   },
   "devDependencies": {
     "@google-cloud/storage": "^7.11.2",

--- a/front/start_worker.ts
+++ b/front/start_worker.ts
@@ -1,4 +1,6 @@
 import { setupGlobalErrorHandler } from "@dust-tt/types";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
 
 import logger from "@app/logger/logger";
 import { runPokeWorker } from "@app/poke/temporal/worker";
@@ -13,37 +15,54 @@ import { runUpdateWorkspaceUsageWorker } from "@app/temporal/usage_queue/worker"
 
 setupGlobalErrorHandler(logger);
 
-runPostUpsertHooksWorker().catch((err) =>
-  logger.error({ error: err }, "Error running post upsert hooks worker.")
-);
-runPokeWorker().catch((err) =>
-  logger.error({ error: err }, "Error running poke worker.")
-);
+type WorkerName =
+  | "hard_delete"
+  | "labs"
+  | "mentions_count"
+  | "poke"
+  | "post_upsert_hooks"
+  | "production_checks"
+  | "scrub_workspace_queue"
+  | "update_workspace_usage"
+  | "upsert_queue"
+  | "upsert_table_queue";
 
-runProductionChecksWorker().catch((err) =>
-  logger.error({ error: err }, "Error running production checks worker.")
-);
+const workerFunctions: Record<WorkerName, () => Promise<void>> = {
+  hard_delete: runHardDeleteWorker,
+  labs: runLabsWorker,
+  mentions_count: runMentionsCountWorker,
+  poke: runPokeWorker,
+  post_upsert_hooks: runPostUpsertHooksWorker,
+  production_checks: runProductionChecksWorker,
+  scrub_workspace_queue: runScrubWorkspaceQueueWorker,
+  update_workspace_usage: runUpdateWorkspaceUsageWorker,
+  upsert_queue: runUpsertQueueWorker,
+  upsert_table_queue: runUpsertQueueWorker,
+};
+const ALL_WORKERS = Object.keys(workerFunctions);
 
-runUpsertQueueWorker().catch((err) =>
-  logger.error({ error: err }, "Error running upsert queue worker.")
-);
+async function runWorkers(workers: WorkerName[]) {
+  for (const worker of workers) {
+    workerFunctions[worker]().catch((err) =>
+      logger.error({ error: err }, `Error running ${worker} worker.`)
+    );
+  }
+}
 
-runUpdateWorkspaceUsageWorker().catch((err) =>
-  logger.error({ error: err }, "Error running usage queue worker.")
-);
-
-runScrubWorkspaceQueueWorker().catch((err) =>
-  logger.error({ error: err }, "Error running scrub workspace queue worker.")
-);
-
-runLabsWorker().catch((err) =>
-  logger.error({ error: err }, "Error running labs worker.")
-);
-
-runHardDeleteWorker().catch((err) =>
-  logger.error({ error: err }, "Error running hard delete worker.")
-);
-
-runMentionsCountWorker().catch((err) =>
-  logger.error({ error: err }, "Error running mentions count worker.")
-);
+yargs(hideBin(process.argv))
+  .option("workers", {
+    alias: "w",
+    type: "array",
+    choices: ALL_WORKERS,
+    default: ALL_WORKERS,
+    demandOption: true,
+    description: "Choose one or multiple workers to run.",
+  })
+  .help()
+  .alias("help", "h")
+  .parseAsync()
+  .then(async (args) => runWorkers(args.workers as WorkerName[]))
+  .catch((err) => {
+    logger.error({ error: err }, "Error running workers");
+    process.exit(1);
+  });

--- a/front/temporal/config.ts
+++ b/front/temporal/config.ts
@@ -1,0 +1,12 @@
+import { EnvironmentConfig } from "@dust-tt/types";
+
+const config = {
+  getUpsertQueueBucket: (): string => {
+    return EnvironmentConfig.getEnvVariable("DUST_UPSERT_QUEUE_BUCKET");
+  },
+  getServiceAccount: (): string => {
+    return EnvironmentConfig.getEnvVariable("SERVICE_ACCOUNT");
+  },
+};
+
+export default config;

--- a/front/temporal/upsert_queue/activities.ts
+++ b/front/temporal/upsert_queue/activities.ts
@@ -154,6 +154,7 @@ export async function upsertDocumentActivity(
   });
 }
 
+// TODO(2024-10-02 flav) Removed once all the upsert tables have been processed from this queue.
 export async function upsertTableActivity(
   upsertQueueId: string,
   enqueueTimestamp: number

--- a/front/temporal/upsert_tables/activities.ts
+++ b/front/temporal/upsert_tables/activities.ts
@@ -1,0 +1,138 @@
+import { Storage } from "@google-cloud/storage";
+import { isLeft } from "fp-ts/lib/Either";
+import * as reporter from "io-ts-reporters";
+
+import { upsertTableFromCsv } from "@app/lib/api/tables";
+import { Authenticator } from "@app/lib/auth";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import type { WorkflowError } from "@app/lib/temporal_monitoring";
+import { EnqueueUpsertTable } from "@app/lib/upsert_queue";
+import mainLogger from "@app/logger/logger";
+import { statsDClient } from "@app/logger/withlogging";
+import config from "@app/temporal/config";
+
+export async function upsertTableActivity(
+  upsertQueueId: string,
+  enqueueTimestamp: number
+) {
+  const storage = new Storage({ keyFilename: config.getServiceAccount() });
+  const bucket = storage.bucket(config.getUpsertQueueBucket());
+  const content = await bucket.file(`${upsertQueueId}.json`).download();
+
+  const upsertDocument = JSON.parse(content.toString());
+
+  const tableItemValidation = EnqueueUpsertTable.decode(upsertDocument);
+
+  if (isLeft(tableItemValidation)) {
+    const pathErrorTable = reporter.formatValidationErrors(
+      tableItemValidation.left
+    );
+    throw new Error(`Invalid upsertQueue table: ${pathErrorTable}`);
+  }
+
+  const upsertQueueItem = tableItemValidation.right;
+  const logger = mainLogger.child({
+    upsertQueueId,
+    workspaceId: upsertQueueItem.workspaceId,
+    dataSourceId: upsertQueueItem.dataSourceId,
+    tableId: upsertQueueItem.tableId,
+  });
+
+  const auth = await Authenticator.internalAdminForWorkspace(
+    upsertQueueItem.workspaceId
+  );
+
+  const owner = auth.workspace();
+  if (!owner) {
+    logger.error(
+      {
+        delaySinceEnqueueMs: Date.now() - enqueueTimestamp,
+      },
+      "[UpsertQueue] Giving up: Workspace not found"
+    );
+    return;
+  }
+
+  const dataSource = await DataSourceResource.fetchById(
+    auth,
+    upsertQueueItem.dataSourceId
+  );
+  if (!dataSource) {
+    // If the data source was not found, we simply give up and remove the item from the queue as it
+    // means that the data source was deleted.
+    logger.info(
+      {
+        delaySinceEnqueueMs: Date.now() - enqueueTimestamp,
+      },
+      "[UpsertQueue] Giving up: DataSource not found"
+    );
+    return;
+  }
+
+  const statsDTags = [
+    `data_source_name:${dataSource.name}`,
+    `workspace_id:${upsertQueueItem.workspaceId}`,
+  ];
+
+  const upsertTimestamp = Date.now();
+
+  const tableRes = await upsertTableFromCsv({
+    auth,
+    dataSource,
+    tableName: upsertQueueItem.tableName,
+    tableDescription: upsertQueueItem.tableDescription,
+    tableId: upsertQueueItem.tableId,
+    tableTimestamp: upsertQueueItem.tableTimestamp ?? null,
+    tableTags: upsertQueueItem.tableTags || [],
+    tableParents: upsertQueueItem.tableParents || [],
+    csv: upsertQueueItem.csv,
+    truncate: upsertQueueItem.truncate,
+    useAppForHeaderDetection: upsertQueueItem.useAppForHeaderDetection ?? false,
+  });
+
+  if (tableRes.isErr()) {
+    logger.error(
+      {
+        error: tableRes.error,
+        latencyMs: Date.now() - upsertTimestamp,
+        delaySinceEnqueueMs: Date.now() - enqueueTimestamp,
+        csvSize: upsertQueueItem.csv?.length || 0,
+      },
+      "[UpsertQueue] Failed table upsert"
+    );
+    statsDClient.increment("upsert_queue_table_error.count", 1, statsDTags);
+    statsDClient.distribution(
+      "upsert_queue_upsert_table_error.duration.distribution",
+      Date.now() - upsertTimestamp,
+      []
+    );
+
+    const error: WorkflowError = {
+      __is_dust_error: true,
+      message: `Upsert error: ${JSON.stringify(tableRes.error)}`,
+      type: "upsert_queue_upsert_table_error",
+    };
+
+    throw error;
+  }
+
+  logger.info(
+    {
+      latencyMs: Date.now() - upsertTimestamp,
+      delaySinceEnqueueMs: Date.now() - enqueueTimestamp,
+      csvSize: upsertQueueItem.csv?.length || 0,
+    },
+    "[UpsertQueue] Successful table upsert"
+  );
+  statsDClient.increment("upsert_queue_table_success.count", 1, statsDTags);
+  statsDClient.distribution(
+    "upsert_queue_upsert_table_success.duration.distribution",
+    Date.now() - upsertTimestamp,
+    []
+  );
+  statsDClient.distribution(
+    "upsert_queue_table.duration.distribution",
+    Date.now() - enqueueTimestamp,
+    []
+  );
+}

--- a/front/temporal/upsert_tables/client.ts
+++ b/front/temporal/upsert_tables/client.ts
@@ -5,9 +5,9 @@ import { getTemporalClient } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 
 import { QUEUE_NAME } from "./config";
-import { upsertDocumentWorkflow } from "./workflows";
+import { upsertTableWorkflow } from "./workflows";
 
-export async function launchUpsertDocumentWorkflow({
+export async function launchUpsertTableWorkflow({
   workspaceId,
   dataSourceId,
   upsertQueueId,
@@ -20,10 +20,10 @@ export async function launchUpsertDocumentWorkflow({
 }): Promise<Result<string, Error>> {
   const client = await getTemporalClient();
 
-  const workflowId = `upsert-queue-document-${workspaceId}-${dataSourceId}-${upsertQueueId}`;
+  const workflowId = `upsert-queue-table-${workspaceId}-${dataSourceId}-${upsertQueueId}`;
 
   try {
-    await client.workflow.start(upsertDocumentWorkflow, {
+    await client.workflow.start(upsertTableWorkflow, {
       args: [upsertQueueId, enqueueTimestamp],
       taskQueue: QUEUE_NAME,
       workflowId: workflowId,

--- a/front/temporal/upsert_tables/client.ts
+++ b/front/temporal/upsert_tables/client.ts
@@ -20,7 +20,7 @@ export async function launchUpsertTableWorkflow({
 }): Promise<Result<string, Error>> {
   const client = await getTemporalClient();
 
-  const workflowId = `upsert-queue-table-${workspaceId}-${dataSourceId}-${upsertQueueId}`;
+  const workflowId = `upsert-table-queue-${workspaceId}-${dataSourceId}-${upsertQueueId}`;
 
   try {
     await client.workflow.start(upsertTableWorkflow, {

--- a/front/temporal/upsert_tables/config.ts
+++ b/front/temporal/upsert_tables/config.ts
@@ -1,0 +1,2 @@
+const QUEUE_VERSION = 1;
+export const QUEUE_NAME = `upsert-table-queue-v${QUEUE_VERSION}`;

--- a/front/temporal/upsert_tables/worker.ts
+++ b/front/temporal/upsert_tables/worker.ts
@@ -1,0 +1,32 @@
+import type { Context } from "@temporalio/activity";
+import { Worker } from "@temporalio/worker";
+
+import { getTemporalWorkerConnection } from "@app/lib/temporal";
+import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import logger from "@app/logger/logger";
+import * as activities from "@app/temporal/upsert_queue/activities";
+
+import { QUEUE_NAME } from "./config";
+
+export async function runUpsertTableQueueWorker() {
+  const { connection, namespace } = await getTemporalWorkerConnection();
+  const worker = await Worker.create({
+    workflowsPath: require.resolve("./workflows"),
+    activities,
+    taskQueue: QUEUE_NAME,
+    // At the time of edit we have 1 upsert-table-worker. We target 10 overall concurrency.
+    // TODO(2024-10-02 flav) Revisit once we have better understanding of the load.
+    maxConcurrentActivityTaskExecutions: 10,
+    connection,
+    namespace,
+    interceptors: {
+      activityInbound: [
+        (ctx: Context) => {
+          return new ActivityInboundLogInterceptor(ctx, logger);
+        },
+      ],
+    },
+  });
+
+  await worker.run();
+}

--- a/front/temporal/upsert_tables/workflows.ts
+++ b/front/temporal/upsert_tables/workflows.ts
@@ -2,22 +2,10 @@ import { proxyActivities } from "@temporalio/workflow";
 
 import type * as activities from "@app/temporal/upsert_queue/activities";
 
-const { upsertDocumentActivity } = proxyActivities<typeof activities>({
-  startToCloseTimeout: "10 minutes",
-});
-
 const { upsertTableActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "20 minutes",
 });
 
-export async function upsertDocumentWorkflow(
-  upsertQueueId: string,
-  enqueueTimestamp: number
-) {
-  await upsertDocumentActivity(upsertQueueId, enqueueTimestamp);
-}
-
-// TODO(2024-10-02 flav) Removed once all the upsert tables have been processed from this queue.
 export async function upsertTableWorkflow(
   upsertQueueId: string,
   enqueueTimestamp: number

--- a/k8s/dust-kube/configmaps/front-upsert-table-worker-configmap.yaml
+++ b/k8s/dust-kube/configmaps/front-upsert-table-worker-configmap.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: upsert-table-config
+  name: front-upsert-table-config
 data:
   DD_ENV: "prod"
-  DD_SERVICE: "upsert-table-worker"
+  DD_SERVICE: "front-upsert-table-worker"
   NODE_OPTIONS: "-r dd-trace/init --max-old-space-size=4200"
   DD_LOGS_INJECTION: "true"
   DD_RUNTIME_METRICS_ENABLED: "true"

--- a/k8s/dust-kube/configmaps/upsert-table-worker-configmap.yaml
+++ b/k8s/dust-kube/configmaps/upsert-table-worker-configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: upsert-table-config
+data:
+  DD_ENV: "prod"
+  DD_SERVICE: "upsert-table-worker"
+  NODE_OPTIONS: "-r dd-trace/init --max-old-space-size=4200"
+  DD_LOGS_INJECTION: "true"
+  DD_RUNTIME_METRICS_ENABLED: "true"
+  NODE_ENV: "production"

--- a/k8s/dust-kube/deployments/front-upsert-table-worker-deployment.yaml
+++ b/k8s/dust-kube/deployments/front-upsert-table-worker-deployment.yaml
@@ -1,20 +1,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: upsert-table-worker-deployment
+  name: front-upsert-table-worker-deployment
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: upsert-table-worker
+      app: front-upsert-table-worker
   template:
     metadata:
       labels:
-        app: upsert-table-worker
-        name: upsert-table-worker-pod
+        app: front-upsert-table-worker
+        name: front-upsert-table-worker-pod
         admission.datadoghq.com/enabled: "true"
       annotations:
-        ad.datadoghq.com/web.logs: '[{"source": "upsert-table-worker","service": "upsert-table-worker","tags": ["env:prod"]}]'
+        ad.datadoghq.com/web.logs: '[{"source": "front-upsert-table-worker","service": "front-upsert-table-worker","tags": ["env:prod"]}]'
     spec:
       containers:
         - name: web

--- a/k8s/dust-kube/deployments/front-worker-deployment.yaml
+++ b/k8s/dust-kube/deployments/front-worker-deployment.yaml
@@ -23,6 +23,7 @@ spec:
           args:
             [
               "--",
+              "--workers",
               "hard_delete",
               "labs",
               "mentions_count",

--- a/k8s/dust-kube/deployments/upsert-table-worker-deployment.yaml
+++ b/k8s/dust-kube/deployments/upsert-table-worker-deployment.yaml
@@ -1,38 +1,26 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: front-worker-deployment
+  name: upsert-table-worker-deployment
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
-      app: front-worker
+      app: upsert-table-worker
   template:
     metadata:
       labels:
-        app: front-worker
-        name: front-worker-pod
+        app: upsert-table-worker
+        name: upsert-table-worker-pod
         admission.datadoghq.com/enabled: "true"
       annotations:
-        ad.datadoghq.com/web.logs: '[{"source": "front-worker","service": "front-worker","tags": ["env:prod"]}]'
+        ad.datadoghq.com/web.logs: '[{"source": "upsert-table-worker","service": "upsert-table-worker","tags": ["env:prod"]}]'
     spec:
       containers:
         - name: web
           image: gcr.io/or1g1n-186209/front-image:latest
           command: ["npm", "run", "start:worker"]
-          args:
-            [
-              "--",
-              "hard_delete",
-              "labs",
-              "mentions_count",
-              "poke",
-              "post_upsert_hooks",
-              "production_checks",
-              "scrub_workspace_queue",
-              "update_workspace_usage",
-              "upsert_queue",
-            ]
+          args: ["--", "--workers", "upsert_table_queue"]
           imagePullPolicy: Always
 
           envFrom:

--- a/k8s/dust-kube/network-policies/core-network-policy.yaml
+++ b/k8s/dust-kube/network-policies/core-network-policy.yaml
@@ -18,7 +18,7 @@ spec:
               app: front-worker
         - podSelector:
             matchLabels:
-              app: upsert-table-worker
+              app: front-upsert-table-worker
         - podSelector:
             matchLabels:
               app: front-edge

--- a/k8s/dust-kube/network-policies/core-network-policy.yaml
+++ b/k8s/dust-kube/network-policies/core-network-policy.yaml
@@ -18,6 +18,9 @@ spec:
               app: front-worker
         - podSelector:
             matchLabels:
+              app: upsert-table-worker
+        - podSelector:
+            matchLabels:
               app: front-edge
         - podSelector:
             matchLabels:


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See full context [here](https://dust4ai.slack.com/archives/C05B529FHV1/p1727850921128689).

This PR separates the upsert table logic into its own worker. We strongly suspect that this upsert table process is causing out-of-memory (OOM) issues on our core pods. Currently, the `front-workers` pods are scaled down, which limits our ability to run various types of tasks.

This PR solely focuses on moving the upsert table logic to its own pod, allowing us to scale up `front-workers` and resume task processing. The legacy workers will sill support processing upsert table activities as we are still enqueuing them at the moment in production. I've kept the relevant code for now and will remove it in a future PR once all existing events in the queue have been processed.

After this PR, all new upsert table events will be enqueued in the new queue and processed by the new deployment. In a subsequent PR, we will also separate the upsert document process into its own deployment.

I re-used the same logic as we had on connectors, by default if not worker names are provided we start all of them, otherwise we only start specified workers.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Pretty risky, worst case all front-workers tasks are failing. Safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
We need to follow a specific deployment:
- [ ] Apply infra to create the new deployment
- [ ] Deploy front (which will deploy both the enqueuing logic and the new deployment 
