### PR TITLE
[front] - chore(dsv): disable dsv root node check

### DIFF
--- a/front/components/DataSourceViewResourceSelectorTree.tsx
+++ b/front/components/DataSourceViewResourceSelectorTree.tsx
@@ -58,9 +58,7 @@ export default function DataSourceViewResourceSelectorTree({
         readonly={readonly}
         selectedResourceIds={selectedResourceIds}
         selectedParents={selectedParents}
-        onSelectChange={(resource, parents, selected) => {
-          onSelectChange(resource, parents, selected);
-        }}
+        onSelectChange={onSelectChange}
         useContentNodes={useContentNodes}
         viewType={viewType}
       />
@@ -73,6 +71,7 @@ type DataSourceResourceSelectorChildrenProps =
     parentId?: string;
     parents: string[];
     selectedParents: string[];
+    parentIsSelected?: boolean;
   };
 
 function DataSourceViewResourceSelectorChildren({

--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -1,4 +1,4 @@
-import { Button, ListCheckIcon, Modal } from "@dust-tt/sparkle";
+import { Modal } from "@dust-tt/sparkle";
 import type {
   ContentNodesViewType,
   DataSourceViewSelectionConfigurations,
@@ -82,40 +82,19 @@ export default function AssistantBuilderDataSourceModal({
       className="flex flex-col overflow-hidden"
     >
       <div
-        className="flex shrink flex-col overflow-hidden px-2" // Otherwise, padding do not match figma and we can't alter Page's padding
+        id="dataSourceViewsSelector"
+        className="overflow-y-auto scrollbar-hide"
       >
-        <div className="flex w-full justify-end py-4">
-          <Button
-            variant="tertiary"
-            label="Select all visible"
-            icon={ListCheckIcon}
-            onClick={() => {
-              document
-                .querySelectorAll<HTMLInputElement>(
-                  '#dataSourceViewsSelector div.is-collapsed label > input[type="checkbox"]:first-child'
-                )
-                .forEach((el) => {
-                  if (!el.checked) {
-                    el.click();
-                  }
-                });
-            }}
-          />
-        </div>
-        <div
-          id="dataSourceViewsSelector"
-          className="overflow-y-auto scrollbar-hide"
-        >
-          <DataSourceViewsSelector
-            useCase="assistantBuilder"
-            dataSourceViews={supportedDataSourceViewsForViewType}
-            allowedVaults={allowedVaults}
-            owner={owner}
-            selectionConfigurations={selectionConfigurations}
-            setSelectionConfigurations={setSelectionConfigurationsCallback}
-            viewType={viewType}
-          />
-        </div>
+        <DataSourceViewsSelector
+          useCase="assistantBuilder"
+          dataSourceViews={supportedDataSourceViewsForViewType}
+          allowedVaults={allowedVaults}
+          owner={owner}
+          selectionConfigurations={selectionConfigurations}
+          setSelectionConfigurations={setSelectionConfigurationsCallback}
+          viewType={viewType}
+          isRootSelectable={true}
+        />
       </div>
     </Modal>
   );

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -1,7 +1,9 @@
 import {
+  Button,
   CloudArrowLeftRightIcon,
   FolderIcon,
   GlobeAltIcon,
+  ListCheckIcon,
   Spinner,
   Tree,
 } from "@dust-tt/sparkle";
@@ -16,7 +18,8 @@ import type {
 } from "@dust-tt/types";
 import { defaultSelectionConfiguration } from "@dust-tt/types";
 import _ from "lodash";
-import type { Dispatch, SetStateAction } from "react";
+import type { Dispatch, SetStateAction} from "react";
+import { useState } from "react";
 import { useCallback, useMemo } from "react";
 
 import { VaultSelector } from "@app/components/assistant_builder/vaults/VaultSelector";
@@ -38,8 +41,6 @@ import {
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import { useVaults } from "@app/lib/swr/vaults";
 
-const MIN_TOTAL_DATA_SOURCES_TO_GROUP = 12;
-const MIN_DATA_SOURCES_PER_KIND_TO_GROUP = 3;
 const ONLY_ONE_VAULT_PER_SELECTION = true;
 
 interface DataSourceViewsSelectorProps {
@@ -52,6 +53,7 @@ interface DataSourceViewsSelectorProps {
     SetStateAction<DataSourceViewSelectionConfigurations>
   >;
   viewType: ContentNodesViewType;
+  isRootSelectable: boolean;
 }
 
 export function DataSourceViewsSelector({
@@ -62,6 +64,7 @@ export function DataSourceViewsSelector({
   selectionConfigurations,
   setSelectionConfigurations,
   viewType,
+  isRootSelectable,
 }: DataSourceViewsSelectorProps) {
   const { vaults, isVaultsLoading } = useVaults({ workspaceId: owner.sId });
 
@@ -102,24 +105,9 @@ export function DataSourceViewsSelector({
           !excludesConnectorIDs.includes(dsv.dataSource.connectorId)))
   );
 
-  // Apply grouping if there are many data sources, and there are enough of each kind
-  // So we don't show a long list of data sources to the user
-  const applyGrouping = filteredDSVs.length >= MIN_TOTAL_DATA_SOURCES_TO_GROUP;
-
-  const groupManaged =
-    applyGrouping &&
-    filteredDSVs.filter((dsv) => isManaged(dsv.dataSource)).length >=
-      MIN_DATA_SOURCES_PER_KIND_TO_GROUP;
-
-  const groupFolders =
-    applyGrouping &&
-    filteredDSVs.filter((dsv) => isFolder(dsv.dataSource)).length >=
-      MIN_DATA_SOURCES_PER_KIND_TO_GROUP;
-
-  const groupWebsites =
-    applyGrouping &&
-    filteredDSVs.filter((dsv) => isWebsite(dsv.dataSource)).length >=
-      MIN_DATA_SOURCES_PER_KIND_TO_GROUP;
+  const managedDsv = filteredDSVs.filter((dsv) => isManaged(dsv.dataSource));
+  const folders = filteredDSVs.filter((dsv) => isFolder(dsv.dataSource));
+  const websites = filteredDSVs.filter((dsv) => isWebsite(dsv.dataSource));
 
   const orderDatasourceViews = useMemo(
     () => orderDatasourceViewByImportance(filteredDSVs),
@@ -165,6 +153,7 @@ export function DataSourceViewsSelector({
               selectionConfigurations={selectionConfigurations}
               setSelectionConfigurations={setSelectionConfigurations}
               viewType={viewType}
+              isRootSelectable={isRootSelectable}
             />
           );
         }}
@@ -173,7 +162,7 @@ export function DataSourceViewsSelector({
   } else {
     return (
       <Tree isLoading={false}>
-        {groupManaged && (
+        {managedDsv.length > 0 && useCase === "assistantBuilder" && (
           <Tree.Item
             key="connected"
             label="Connected Data"
@@ -192,19 +181,14 @@ export function DataSourceViewsSelector({
                   }
                   setSelectionConfigurations={setSelectionConfigurations}
                   viewType={viewType}
+                  isRootSelectable={isRootSelectable}
                 />
               ))}
           </Tree.Item>
         )}
-
-        {orderDatasourceViews
-          .filter(
-            (dsv) =>
-              (!groupFolders && isFolder(dsv.dataSource)) ||
-              (!groupWebsites && isWebsite(dsv.dataSource)) ||
-              (!groupManaged && isManaged(dsv.dataSource))
-          )
-          .map((dataSourceView) => (
+        {managedDsv.length > 0 &&
+          useCase === "vaultDatasourceManagement" &&
+          managedDsv.map((dataSourceView) => (
             <DataSourceViewSelector
               key={dataSourceView.sId}
               owner={owner}
@@ -214,54 +198,53 @@ export function DataSourceViewsSelector({
               }
               setSelectionConfigurations={setSelectionConfigurations}
               viewType={viewType}
+              isRootSelectable={false}
             />
           ))}
 
-        {groupFolders && (
+        {folders.length > 0 && (
           <Tree.Item
             key="folders"
             label="Folders"
             visual={FolderIcon}
             type="node"
           >
-            {dataSourceViews
-              .filter((dsv) => isFolder(dsv.dataSource))
-              .map((dataSourceView) => (
-                <DataSourceViewSelector
-                  key={dataSourceView.sId}
-                  owner={owner}
-                  selectionConfiguration={
-                    selectionConfigurations[dataSourceView.sId] ??
-                    defaultSelectionConfiguration(dataSourceView)
-                  }
-                  setSelectionConfigurations={setSelectionConfigurations}
-                  viewType={viewType}
-                />
-              ))}
+            {folders.map((dataSourceView) => (
+              <DataSourceViewSelector
+                key={dataSourceView.sId}
+                owner={owner}
+                selectionConfiguration={
+                  selectionConfigurations[dataSourceView.sId] ??
+                  defaultSelectionConfiguration(dataSourceView)
+                }
+                setSelectionConfigurations={setSelectionConfigurations}
+                viewType={viewType}
+                isRootSelectable={isRootSelectable}
+              />
+            ))}
           </Tree.Item>
         )}
 
-        {groupWebsites && (
+        {websites.length > 0 && (
           <Tree.Item
             key="websites"
             label="Websites"
             visual={GlobeAltIcon}
             type="node"
           >
-            {dataSourceViews
-              .filter((dsv) => isWebsite(dsv.dataSource))
-              .map((dataSourceView) => (
-                <DataSourceViewSelector
-                  key={dataSourceView.sId}
-                  owner={owner}
-                  selectionConfiguration={
-                    selectionConfigurations[dataSourceView.sId] ??
-                    defaultSelectionConfiguration(dataSourceView)
-                  }
-                  setSelectionConfigurations={setSelectionConfigurations}
-                  viewType={viewType}
-                />
-              ))}
+            {websites.map((dataSourceView) => (
+              <DataSourceViewSelector
+                key={dataSourceView.sId}
+                owner={owner}
+                selectionConfiguration={
+                  selectionConfigurations[dataSourceView.sId] ??
+                  defaultSelectionConfiguration(dataSourceView)
+                }
+                setSelectionConfigurations={setSelectionConfigurations}
+                viewType={viewType}
+                isRootSelectable={isRootSelectable}
+              />
+            ))}
           </Tree.Item>
         )}
       </Tree>
@@ -278,6 +261,7 @@ interface DataSourceViewSelectorProps {
   >;
   useContentNodes?: typeof useDataSourceViewContentNodes;
   viewType: ContentNodesViewType;
+  isRootSelectable: boolean;
 }
 
 export function DataSourceViewSelector({
@@ -287,7 +271,15 @@ export function DataSourceViewSelector({
   setSelectionConfigurations,
   useContentNodes = useDataSourceViewContentNodes,
   viewType,
+  isRootSelectable,
 }: DataSourceViewSelectorProps) {
+  const [isSelectedAll, setIsSelectedAll] = useState(
+    selectionConfiguration.selectedResources.length > 0
+  );
+  const { parentsById, setParentsById } = useParentResourcesById({
+    selectedResources: selectionConfiguration.selectedResources,
+  });
+
   const dataSourceView = selectionConfiguration.dataSourceView;
   const config = dataSourceView.dataSource.connectorProvider
     ? CONNECTOR_CONFIGURATIONS[dataSourceView.dataSource.connectorProvider]
@@ -301,21 +293,9 @@ export function DataSourceViewSelector({
     (r) => r.internalId
   );
 
-  const { parentsById, setParentsById } = useParentResourcesById({
-    selectedResources: selectionConfiguration.selectedResources,
-  });
-
   const selectedParents = [
     ...new Set(Object.values(parentsById).flatMap((c) => [...c])),
   ];
-
-  const isPartiallyChecked = internalIds.length > 0;
-
-  const checkedStatus = selectionConfiguration.isSelectAll
-    ? "checked"
-    : isPartiallyChecked
-      ? "partial"
-      : "unchecked";
 
   // When users have multiple vaults, they can opt to select only one vault per tool.
   // This is enforced in the UI via a radio button, ensuring single selection at a time.
@@ -336,42 +316,6 @@ export function DataSourceViewSelector({
       );
     },
     [dataSourceView]
-  );
-
-  const onToggleSelectAll = useCallback(
-    (checked: boolean) => {
-      // Setting parentsById
-      setParentsById({});
-
-      // Setting selectedResources
-      setSelectionConfigurations(
-        (prevState: DataSourceViewSelectionConfigurations) => {
-          if (!checked) {
-            // Nothing is selected at all, remove from the list
-            return _.omit(prevState, dataSourceView.sId);
-          }
-
-          const config =
-            prevState[dataSourceView.sId] ??
-            defaultSelectionConfiguration(dataSourceView);
-
-          config.isSelectAll = checked;
-          config.selectedResources = [];
-
-          // Return a new object to trigger a re-render
-          return keepOnlyOneVaultIfApplicable({
-            ...prevState,
-            [dataSourceView.sId]: config,
-          });
-        }
-      );
-    },
-    [
-      dataSourceView,
-      keepOnlyOneVaultIfApplicable,
-      setParentsById,
-      setSelectionConfigurations,
-    ]
   );
 
   const onSelectChange = useCallback(
@@ -428,40 +372,91 @@ export function DataSourceViewSelector({
     ]
   );
 
+  const handleSelectAll = () => {
+    document
+      .querySelectorAll<HTMLInputElement>(
+        `#dataSourceViewsSelector-${dataSourceView.dataSource.name} input[type="checkbox"]:first-child`
+      )
+      .forEach((el) => {
+        if (el.checked === isSelectedAll) {
+          el.click();
+        }
+      });
+    setIsSelectedAll(!isSelectedAll);
+  };
+
+  const isPartiallyChecked = internalIds.length > 0;
+
+  const checkedStatus = selectionConfiguration.isSelectAll
+    ? "checked"
+    : isPartiallyChecked
+      ? "partial"
+      : "unchecked";
+
   const isTableView = viewType === "tables";
 
   // Show the checkbox by default. Hide it only for tables where no child items are partially checked.
   const hideCheckbox = readonly || (isTableView && !isPartiallyChecked);
 
   return (
-    <Tree.Item
-      key={dataSourceView.dataSource.id}
-      label={getDisplayNameForDataSource(dataSourceView.dataSource)}
-      visual={LogoComponent}
-      type={
-        canBeExpanded(viewType, dataSourceView.dataSource) ? "node" : "leaf"
-      }
-      checkbox={
-        hideCheckbox
-          ? undefined
-          : {
-              checked: checkedStatus,
-              onChange: onToggleSelectAll,
-            }
-      }
-    >
-      <DataSourceViewResourceSelectorTree
-        dataSourceView={dataSourceView}
-        onSelectChange={onSelectChange}
-        owner={owner}
-        parentIsSelected={selectionConfiguration.isSelectAll}
-        readonly={readonly}
-        selectedParents={selectedParents}
-        selectedResourceIds={internalIds}
-        showExpand={config?.isNested ?? true}
-        useContentNodes={useContentNodes}
-        viewType={viewType}
-      />
-    </Tree.Item>
+    <div id={`dataSourceViewsSelector-${dataSourceView.dataSource.name}`}>
+      <Tree.Item
+        key={dataSourceView.dataSource.id}
+        label={getDisplayNameForDataSource(dataSourceView.dataSource)}
+        visual={LogoComponent}
+        type={
+          canBeExpanded(viewType, dataSourceView.dataSource) ? "node" : "leaf"
+        }
+        checkbox={
+          hideCheckbox || !isRootSelectable
+            ? undefined
+            : {
+                checked: checkedStatus,
+                onChange: () => {
+                  setSelectionConfigurations((prevState) => {
+                    const prevSelectionConfiguration =
+                      prevState[dataSourceView.sId] ??
+                      defaultSelectionConfiguration(dataSourceView);
+                    const udpatedConfig = {
+                      ...prevSelectionConfiguration,
+                      selectedResources: [],
+                      isSelectAll: checkedStatus !== "checked",
+                    };
+
+                    return {
+                      ...prevState,
+                      [dataSourceView.sId]: udpatedConfig,
+                    };
+                  });
+                },
+              }
+        }
+        actions={
+          isManaged(dataSourceView.dataSource) && (
+            <Button
+              variant="tertiary"
+              size="xs"
+              className="mr-4 h-5 text-xs"
+              label={isSelectedAll ? "Unselect All" : "Select All"}
+              icon={ListCheckIcon}
+              onClick={handleSelectAll}
+            />
+          )
+        }
+      >
+        <DataSourceViewResourceSelectorTree
+          dataSourceView={dataSourceView}
+          onSelectChange={onSelectChange}
+          owner={owner}
+          parentIsSelected={selectionConfiguration.isSelectAll}
+          readonly={readonly}
+          selectedParents={selectedParents}
+          selectedResourceIds={internalIds}
+          showExpand={config?.isNested ?? true}
+          useContentNodes={useContentNodes}
+          viewType={viewType}
+        />
+      </Tree.Item>
+    </div>
   );
 }

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -432,7 +432,7 @@ export function DataSourceViewSelector({
               }
         }
         actions={
-          isManaged(dataSourceView.dataSource) && (
+          !isRootSelectable && (
             <Button
               variant="tertiary"
               size="xs"

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -18,7 +18,7 @@ import type {
 } from "@dust-tt/types";
 import { defaultSelectionConfiguration } from "@dust-tt/types";
 import _ from "lodash";
-import type { Dispatch, SetStateAction} from "react";
+import type { Dispatch, SetStateAction } from "react";
 import { useState } from "react";
 import { useCallback, useMemo } from "react";
 

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -94,8 +94,12 @@ export function DataSourceViewsSelector({
       }
     }
   }
+  const orderDatasourceViews = useMemo(
+    () => orderDatasourceViewByImportance(dataSourceViews),
+    [dataSourceViews]
+  );
 
-  const filteredDSVs = dataSourceViews.filter(
+  const filteredDSVs = orderDatasourceViews.filter(
     (dsv) =>
       !dsv.dataSource.connectorId ||
       (dsv.dataSource.connectorId &&
@@ -108,11 +112,6 @@ export function DataSourceViewsSelector({
   const managedDsv = filteredDSVs.filter((dsv) => isManaged(dsv.dataSource));
   const folders = filteredDSVs.filter((dsv) => isFolder(dsv.dataSource));
   const websites = filteredDSVs.filter((dsv) => isWebsite(dsv.dataSource));
-
-  const orderDatasourceViews = useMemo(
-    () => orderDatasourceViewByImportance(filteredDSVs),
-    [filteredDSVs]
-  );
 
   const defaultVault = useMemo(() => {
     const firstKey = Object.keys(selectionConfigurations)[0] ?? null;

--- a/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
+++ b/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
@@ -113,6 +113,7 @@ export default function VaultManagedDataSourcesViewsModal({
             selectionConfigurations={selectionConfigurations}
             setSelectionConfigurations={setSelectionConfigurationsCallback}
             viewType="documents"
+            isRootSelectable={true}
           />
         </div>
       </div>

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -128,7 +128,6 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
         auth,
         dataSource.vault,
         dataSource,
-        "default",
         transaction
       );
     });

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -123,7 +123,7 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
         vault,
         transaction
       );
-      return this.createViewInVaultFromDataSourceIncludingAllDocuments(
+      return this.createDefaultViewInVaultFromDataSourceIncludingAllDocuments(
         auth,
         dataSource.vault,
         dataSource,
@@ -152,7 +152,7 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
   }
 
   // This view has access to all documents, which is represented by null.
-  private static async createViewInVaultFromDataSourceIncludingAllDocuments(
+  private static async createDefaultViewInVaultFromDataSourceIncludingAllDocuments(
     auth: Authenticator,
     vault: VaultResource,
     dataSource: DataSourceResource,

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -138,7 +138,7 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
     auth: Authenticator,
     vault: VaultResource,
     dataSource: DataSourceResource,
-    parentsIn: string[] | null
+    parentsIn: string[]
   ) {
     return this.makeNew(
       auth,
@@ -154,11 +154,10 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
   }
 
   // This view has access to all documents, which is represented by null.
-  static async createViewInVaultFromDataSourceIncludingAllDocuments(
+  private static async createViewInVaultFromDataSourceIncludingAllDocuments(
     auth: Authenticator,
     vault: VaultResource,
     dataSource: DataSourceResource,
-    kind: DataSourceViewKind = "default",
     transaction?: Transaction
   ) {
     return this.makeNew(
@@ -167,7 +166,7 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
         dataSourceId: dataSource.id,
         parentsIn: null,
         workspaceId: vault.workspaceId,
-        kind,
+        kind: "default",
       },
       vault,
       dataSource,

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -3,7 +3,6 @@
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 import type {
   DataSourceViewCategory,
-  DataSourceViewKind,
   DataSourceViewType,
   ModelId,
   PokeDataSourceViewType,

--- a/front/migrations/20240730_backfill_data_source_views.ts
+++ b/front/migrations/20240730_backfill_data_source_views.ts
@@ -45,10 +45,11 @@ async function backfillDataSourceViewsForWorkspace(
     }
 
     // Create a view for this data source in the global vault.
-    await DataSourceViewResource.createViewInVaultFromDataSourceIncludingAllDocuments(
+    await DataSourceViewResource.createViewInVaultFromDataSource(
       auth,
       globalVault,
-      dataSource
+      dataSource,
+      []
     );
 
     updated++;

--- a/front/migrations/20240820_backfill_data_source_views.ts
+++ b/front/migrations/20240820_backfill_data_source_views.ts
@@ -38,10 +38,11 @@ async function backfillDefaultViewForDataSource(
   }
 
   // Create a default view for this data source in the vault.
-  await DataSourceViewResource.createViewInVaultFromDataSourceIncludingAllDocuments(
+  await DataSourceViewResource.createViewInVaultFromDataSource(
     auth,
     vault,
-    dataSource
+    dataSource,
+    []
   );
 
   logger.info(`View created for data source ${dataSource.id}.`);

--- a/front/migrations/20240821_backfill_all_data_source_views.ts
+++ b/front/migrations/20240821_backfill_all_data_source_views.ts
@@ -34,10 +34,11 @@ async function backfillDefaultViewForDataSource(
   }
 
   // Create a default view for this data source in the vault.
-  await DataSourceViewResource.createViewInVaultFromDataSourceIncludingAllDocuments(
+  await DataSourceViewResource.createViewInVaultFromDataSource(
     auth,
     vault,
-    dataSource
+    dataSource,
+    []
   );
 
   logger.info(`View created for data source ${dataSource.id}.`);

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -323,11 +323,11 @@ async function handler(
       if (dataSource.vault.isSystem()) {
         const globalVault = await VaultResource.fetchWorkspaceGlobalVault(auth);
 
-        await DataSourceViewResource.createViewInVaultFromDataSourceIncludingAllDocuments(
+        await DataSourceViewResource.createViewInVaultFromDataSource(
           auth,
           globalVault,
           dataSource,
-          "custom"
+          []
         );
       }
 

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/index.ts
@@ -401,11 +401,11 @@ const handleDataSourceWithProvider = async ({
   // If the data source resides in the system vault, we also create a custom view in the global vault until vault are released.
   if (dataSource.vault.isSystem()) {
     const globalVault = await VaultResource.fetchWorkspaceGlobalVault(auth);
-    await DataSourceViewResource.createViewInVaultFromDataSourceIncludingAllDocuments(
+    await DataSourceViewResource.createViewInVaultFromDataSource(
       auth,
       globalVault,
       dataSource,
-      "custom"
+      []
     );
   }
 

--- a/front/pages/poke/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.tsx
+++ b/front/pages/poke/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.tsx
@@ -55,6 +55,7 @@ export default function DataSourceViewPage({
           setSelectionConfigurations={() => {}}
           useContentNodes={usePokeDataSourceViewContentNodes}
           viewType="documents"
+          isRootSelectable={true}
         />
       </div>
     </div>

--- a/types/src/front/api_handlers/public/vaults.ts
+++ b/types/src/front/api_handlers/public/vaults.ts
@@ -4,18 +4,18 @@ import { ContentNodeType } from "../../lib/connectors_api";
 
 export const ContentSchema = t.type({
   dataSourceId: t.string,
-  parentsIn: t.union([t.array(t.string), t.null]),
+  parentsIn: t.array(t.string),
 });
 
 export const PostDataSourceViewSchema = t.type({
   dataSourceId: t.string,
-  parentsIn: t.union([t.array(t.string), t.null]),
+  parentsIn: t.array(t.string),
 });
 
 export type PostDataSourceViewType = t.TypeOf<typeof PostDataSourceViewSchema>;
 
 export const PatchDataSourceViewSchema = t.type({
-  parentsIn: t.union([t.array(t.string), t.null]),
+  parentsIn: t.array(t.string),
 });
 
 export type PatchDataSourceViewType = t.TypeOf<


### PR DESCRIPTION
## Description

This PR refactors the `DataSourceViewSelector` component to improve the user experience when selecting data sources. 

The main changes include:
- Removing the checkbox from the root node of the `DataSourceViewSelector` tree when updating connections, while keeping it in the assistant builder.
- Introducing a "Select All" button as an action for the root node, replacing the previous checkbox functionality for managed data sources.
- Streamlining the `DataSourceViewResource` creation method to improve consistency and reduce code duplication.
- Updating the `VaultManagedDataSourcesViewsModal` component to use the new isRootSelectable prop.
- We now only allow `parents_in` to be a `string[]` in Post/PatchDataSourceViewSchema. Previously setting it to `null` would be default automatically process all newly added data files.

## Risk

Quite high blast radius

## Deploy Plan

- Run migration https://github.com/dust-tt/dust/pull/7808 on our workspace
- Deploy to `front-edge`
- Run migration https://github.com/dust-tt/dust/pull/7808 on all workspaces
- Deploy `front`