### PR TITLE
[Core] Remove index on deleted status

### DIFF
--- a/core/src/stores/migrations/20241002_2_ds_docs_delete_deleted_index.sql
+++ b/core/src/stores/migrations/20241002_2_ds_docs_delete_deleted_index.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_status_deleted;

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -477,7 +477,7 @@ pub const POSTGRES_TABLES: [&'static str; 14] = [
     );",
 ];
 
-pub const SQL_INDEXES: [&'static str; 27] = [
+pub const SQL_INDEXES: [&'static str; 26] = [
     "CREATE INDEX IF NOT EXISTS
        idx_specifications_project_created ON specifications (project, created);",
     "CREATE INDEX IF NOT EXISTS
@@ -536,8 +536,6 @@ pub const SQL_INDEXES: [&'static str; 27] = [
        idx_tables_parents_array ON tables USING GIN (parents);",
     "CREATE UNIQUE INDEX IF NOT EXISTS
         idx_sqlite_workers_url ON sqlite_workers (url);",
-    "CREATE INDEX IF NOT EXISTS
-        idx_status_deleted ON data_sources_documents (id) WHERE status = 'deleted';",
 ];
 
 pub const SQL_FUNCTIONS: [&'static str; 2] = [


### PR DESCRIPTION
Description
---
Index was introduced by #7496 and is not needed anymore, see this [thread](https://dust4ai.slack.com/archives/C05B529FHV1/p1727850921128689)

Risk
---
na, the query for prod checks is done on the secondary anyways

Deploy
---
1. run index deletion on prodbox (done)
2. deploy core
