### PR TITLE
Fix: visual glitch in assistant builder when filtering datasources

### DIFF
--- a/connectors/src/connectors/snowflake/index.ts
+++ b/connectors/src/connectors/snowflake/index.ts
@@ -132,7 +132,18 @@ export class SnowflakeConnectorManager extends BaseConnectorManager<null> {
 
     const dataSourceConfig = dataSourceConfigFromConnector(connector);
     try {
-      await launchSnowflakeSyncWorkflow(connector.id);
+      const launchRes = await launchSnowflakeSyncWorkflow(connector.id);
+      if (launchRes.isErr()) {
+        logger.error(
+          {
+            workspaceId: dataSourceConfig.workspaceId,
+            dataSourceId: dataSourceConfig.dataSourceId,
+            error: launchRes.error,
+          },
+          "Error launching snowflake sync workflow."
+        );
+        return launchRes;
+      }
     } catch (e) {
       logger.error(
         {

--- a/connectors/src/connectors/snowflake/index.ts
+++ b/connectors/src/connectors/snowflake/index.ts
@@ -26,6 +26,7 @@ import {
   launchSnowflakeSyncWorkflow,
   stopSnowflakeSyncWorkflow,
 } from "@connectors/connectors/snowflake/temporal/client";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { SnowflakeConfigurationModel } from "@connectors/lib/models/snowflake";
 import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -117,7 +118,33 @@ export class SnowflakeConnectorManager extends BaseConnectorManager<null> {
   }
 
   async resume(): Promise<Result<undefined, Error>> {
-    throw new Error("Method resume not implemented.");
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+
+    if (!connector) {
+      logger.error(
+        {
+          connectorId: this.connectorId,
+        },
+        "Snowflake connector not found."
+      );
+      return new Err(new Error("Connector not found"));
+    }
+
+    const dataSourceConfig = dataSourceConfigFromConnector(connector);
+    try {
+      await launchSnowflakeSyncWorkflow(connector.id);
+    } catch (e) {
+      logger.error(
+        {
+          workspaceId: dataSourceConfig.workspaceId,
+          dataSourceId: dataSourceConfig.dataSourceId,
+          error: e,
+        },
+        "Error launching snowflake sync workflow."
+      );
+    }
+
+    return new Ok(undefined);
   }
 
   async sync({

--- a/connectors/src/lib/cli.ts
+++ b/connectors/src/lib/cli.ts
@@ -253,6 +253,7 @@ export const batch = async ({
         "intercom",
         "confluence",
         "github",
+        "snowflake",
       ];
       if (!PROVIDERS_ALLOWING_RESTART.includes(args.provider)) {
         throw new Error(

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -68,8 +68,8 @@ export function DataSourceViewsSelector({
 }: DataSourceViewsSelectorProps) {
   const { vaults, isVaultsLoading } = useVaults({ workspaceId: owner.sId });
 
-  const includesConnectorIDs: string[] = [];
-  const excludesConnectorIDs: string[] = [];
+  const includesConnectorIDs: (string | null)[] = [];
+  const excludesConnectorIDs: (string | null)[] = [];
 
   // If view type is tables
   // You can either select tables from the same remote database (as the query will be executed live on the database)
@@ -101,12 +101,10 @@ export function DataSourceViewsSelector({
 
   const filteredDSVs = orderDatasourceViews.filter(
     (dsv) =>
-      !dsv.dataSource.connectorId ||
-      (dsv.dataSource.connectorId &&
-        (!includesConnectorIDs.length ||
-          includesConnectorIDs.includes(dsv.dataSource.connectorId)) &&
-        (!excludesConnectorIDs.length ||
-          !excludesConnectorIDs.includes(dsv.dataSource.connectorId)))
+      (!includesConnectorIDs.length ||
+        includesConnectorIDs.includes(dsv.dataSource.connectorId)) &&
+      (!excludesConnectorIDs.length ||
+        !excludesConnectorIDs.includes(dsv.dataSource.connectorId))
   );
 
   const managedDsv = filteredDSVs.filter((dsv) => isManaged(dsv.dataSource));


### PR DESCRIPTION
## Description

Instead of filtering first then grouping the sources, I filter AFTER grouping so the tree doesn't change visually.
(also, added support for stop and therefor restart-all as I had some issues with the connectors worker)

## Risk

None

## Deploy Plan

Deploy `front`