### PR TITLE
[front] Skip tables with more than 500 cols

### DIFF
--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -26,6 +26,8 @@ import logger from "@app/logger/logger";
 
 import type { DataSourceResource } from "../resources/data_source_resource";
 
+const MAX_TABLE_COLUMNS = 500;
+
 type CsvParsingError = {
   type:
     | "invalid_delimiter"
@@ -519,6 +521,10 @@ async function detectHeaders(
     }
 
     const record = anyRecord as string[];
+
+    if (record.length > MAX_TABLE_COLUMNS) {
+      return new Err({ type: "invalid_header", message: "Too many columns" });
+    }
 
     if (!useAppForHeaderDetection) {
       return staticHeaderDetection(record);

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -26,7 +26,7 @@ import logger from "@app/logger/logger";
 
 import type { DataSourceResource } from "../resources/data_source_resource";
 
-const MAX_TABLE_COLUMNS = 500;
+const MAX_TABLE_COLUMNS = 512;
 
 type CsvParsingError = {
   type:


### PR DESCRIPTION
## Description

This will return a 400 when trying to enqueue a table with more than 500 columns. The error is already catched in microsoft and gdrive, and table is skipped in that case.

## Risk

none

## Deploy Plan

deploy front
