### PR TITLE
Upg: use proxy for core snowflake

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -3828,9 +3828,8 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "snowflake-connector-rs"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc20ac34805fb7acfa7420dc6891ff43f1e64f09f7f1216b8a2011afc49080db"
+version = "0.6.2"
+source = "git+https://github.com/dust-tt/snowflake-connector-rs?rev=5a16356#5a16356d78bf242b93cdb9a009b80c1725a71c6b"
 dependencies = [
  "base64 0.21.7",
  "chrono",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -93,5 +93,5 @@ sqids = "0.4.1"
 ring = "0.17.8"
 jsonwebtoken = "9.3.0"
 rslock = { version = "0.4.0", default-features = false, features = ["tokio-comp"] }
-snowflake-connector-rs = "0.6.1"
+snowflake-connector-rs = { git = "https://github.com/dust-tt/snowflake-connector-rs", rev = "5a16356" }
 axum-test = "16.0.0"

--- a/core/src/databases/remote_databases/snowflake.rs
+++ b/core/src/databases/remote_databases/snowflake.rs
@@ -136,16 +136,18 @@ impl SnowflakeRemoteDatabase {
             },
         )?;
 
-        if env::var("PROXY_HOST").is_ok()
-            && env::var("PROXY_PORT").is_ok()
-            && env::var("PROXY_USER_NAME").is_ok()
-            && env::var("PROXY_USER_PASSWORD").is_ok()
-        {
+        if let (Ok(proxy_host), Ok(proxy_port), Ok(proxy_user_name), Ok(proxy_user_password)) = (
+            env::var("PROXY_HOST"),
+            env::var("PROXY_PORT"),
+            env::var("PROXY_USER_NAME"),
+            env::var("PROXY_USER_PASSWORD"),
+        ) {
+            let proxy_port = proxy_port.parse::<u16>()?;
             client = client.with_proxy(
-                env::var("PROXY_HOST").as_ref().unwrap(),
-                env::var("PROXY_PORT").as_ref().unwrap().parse::<u16>()?,
-                env::var("PROXY_USER_NAME").as_ref().unwrap(),
-                env::var("PROXY_USER_PASSWORD").as_ref().unwrap(),
+                &proxy_host,
+                proxy_port,
+                &proxy_user_name,
+                &proxy_user_password,
             )?;
         }
 


### PR DESCRIPTION
## Description

Update snowflake to use our fork that add proxy and set proxy.

## Risk

Tested locally, env vars are normally already on core pods.

## Deploy Plan

Deploy `core`