### PR TITLE
fix: don't slugify __dust_id header name

### DIFF
--- a/types/src/shared/utils/structured_data.ts
+++ b/types/src/shared/utils/structured_data.ts
@@ -12,7 +12,9 @@ export function getSanitizedHeaders(
 ): Result<string[], Error> {
   try {
     const value = rawHeaders.reduce<string[]>((acc, curr) => {
-      const slugifiedName = slugify(curr);
+      // Special case for __dust_id, which is a reserved header name that we use
+      // to assign unique row_id to make incremental row updates possible.
+      const slugifiedName = curr === "__dust_id" ? curr : slugify(curr);
 
       if (!acc.includes(slugifiedName) || !slugifiedName.length) {
         acc.push(slugifiedName);


### PR DESCRIPTION
## Description

we use `__dust_id` as a reserved header name to assign a `row_id` for incremental updates. Slugifying this string causes the header to be changed to `_dust_id` which breaks this mechanic

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
