### PR TITLE
Handle Notion orphaned nodes retrieve content nodes

### DIFF
--- a/connectors/src/connectors/notion/lib/parents.ts
+++ b/connectors/src/connectors/notion/lib/parents.ts
@@ -53,6 +53,9 @@ async function _getParents(
     //    (see https://dust4ai.slack.com/archives/C050SM8NSPK/p1693241129921369)
     case null:
     case "unknown":
+      // If parentType is unknown, consider it as the parent page id.
+      return [...parents, "unknown"];
+
     case "block":
     case "workspace":
       // workspace -> root level pages, with no parents other than themselves

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -71,7 +71,7 @@ interface GetContentNodesForDataSourceViewResult {
   total: number;
 }
 
-export async function getContentNodesForManagedDataSourceView(
+async function getContentNodesForManagedDataSourceView(
   dataSourceView: DataSourceViewResource | DataSourceViewType,
   { internalIds, parentId, viewType }: GetContentNodesForDataSourceViewParams
 ): Promise<Result<GetContentNodesForDataSourceViewResult, Error>> {
@@ -140,7 +140,7 @@ export async function getContentNodesForManagedDataSourceView(
 
 // Static data sources are data sources that are not managed by a connector.
 // They are flat and do not have a hierarchy.
-export async function getContentNodesForStaticDataSourceView(
+async function getContentNodesForStaticDataSourceView(
   dataSourceView: DataSourceViewResource,
   { internalIds, pagination, viewType }: GetContentNodesForDataSourceViewParams
 ): Promise<


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See context [here](https://dust4ai.slack.com/archives/C07L7A5K2NM/p1727887722384709).

We currently can't retrieve content nodes for Orphaned resources in Notion, the connector API does return them but they are filtered out in the `filterAndCropContentNodesByView` because `unknown` is not included in the parents.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
