### PR TITLE
Increase token margin in render conversation for model

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -232,7 +232,7 @@ export async function renderConversationForModelMultiActions({
 
   // We initialize `tokensUsed` to the prompt tokens + a bit of buffer for message rendering
   // approximations, 64 tokens seems small enough and ample enough.
-  const tokensMargin = 64;
+  const tokensMargin = 1024;
   let tokensUsed = promptCount + tokensMargin;
 
   // Go backward and accumulate as much as we can within allowedTokenCount.


### PR DESCRIPTION
## Description

Increase our token margin on renderConversationForModels to avoid Maximum content length exceeded errors on models. 

## Risk

/ 
## Deploy Plan

Deploy front. 
