### PR TITLE
enh: return appropriate status code from create connectors

### DIFF
--- a/connectors/src/api/create_connector.ts
+++ b/connectors/src/api/create_connector.ts
@@ -16,6 +16,7 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
 
 import { createConnector } from "@connectors/connectors";
+import type { ConnectorManagerError } from "@connectors/connectors/interface";
 import { errorFromAny } from "@connectors/lib/error";
 import logger from "@connectors/logger/logger";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
@@ -59,7 +60,7 @@ const _createConnectorAPIHandler = async (
       configuration,
     } = bodyValidation.right;
 
-    let connectorRes: Result<string, Error> | null = null;
+    let connectorRes: Result<string, ConnectorManagerError> | null = null;
 
     switch (req.params.connector_provider) {
       case "webcrawler": {
@@ -148,14 +149,27 @@ const _createConnectorAPIHandler = async (
     if (connectorRes.isErr()) {
       // Error result means this is an "expected" error, so not
       // an internal server error.
-      // We return a 400 status code for expected errors.
-      return apiError(req, res, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: connectorRes.error.message,
-        },
-      });
+      // We return a 4xx status code for expected errors.
+      switch (connectorRes.error.code) {
+        case "INVALID_CONFIGURATION":
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: connectorRes.error.message,
+            },
+          });
+        case "PERMISSION_REVOKED":
+          return apiError(req, res, {
+            status_code: 403,
+            api_error: {
+              type: "authorization_error",
+              message: connectorRes.error.message,
+            },
+          });
+        default:
+          assertNever(connectorRes.error.code);
+      }
     }
 
     const connector = await ConnectorResource.fetchById(connectorRes.value);

--- a/connectors/src/api/create_connector.ts
+++ b/connectors/src/api/create_connector.ts
@@ -188,7 +188,11 @@ const _createConnectorAPIHandler = async (
   } catch (e) {
     logger.error(errorFromAny(e), "Error in createConnectorAPIHandler");
     let errorMessage = `An unexpected error occured while creating the ${req.params.connector_provider} connector`;
-    const maybeInnerErrorMessage = (e as Error).message;
+    const maybeInnerErrorMessage = (
+      e as {
+        message?: string;
+      }
+    ).message;
     if (maybeInnerErrorMessage) {
       errorMessage += `: ${maybeInnerErrorMessage}`;
     } else {

--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -34,6 +34,7 @@ import {
   launchConfluenceSyncWorkflow,
   stopConfluenceSyncWorkflow,
 } from "@connectors/connectors/confluence/temporal/client";
+import type { ConnectorManagerError } from "@connectors/connectors/interface";
 import { BaseConnectorManager } from "@connectors/connectors/interface";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import {
@@ -56,7 +57,7 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
   }: {
     dataSourceConfig: DataSourceConfig;
     connectionId: string;
-  }): Promise<Result<string, Error>> {
+  }): Promise<Result<string, ConnectorManagerError>> {
     const confluenceAccessTokenRes =
       await getConfluenceAccessToken(connectionId);
     if (confluenceAccessTokenRes.isErr()) {

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -11,6 +11,7 @@ import {
 import { getGithubCodeOrDirectoryParentIds } from "@connectors/connectors/github/lib/hierarchy";
 import { matchGithubInternalIdType } from "@connectors/connectors/github/lib/utils";
 import { launchGithubFullSyncWorkflow } from "@connectors/connectors/github/temporal/client";
+import type { ConnectorManagerError } from "@connectors/connectors/interface";
 import { BaseConnectorManager } from "@connectors/connectors/interface";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import {
@@ -35,7 +36,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
   }: {
     dataSourceConfig: DataSourceConfig;
     connectionId: string;
-  }): Promise<Result<string, Error>> {
+  }): Promise<Result<string, ConnectorManagerError>> {
     const installationId = await installationIdFromConnectionId(connectionId);
     if (!installationId) {
       throw new Error("Github: received connectionId is invalid");

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -38,37 +38,31 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
   }): Promise<Result<string, Error>> {
     const installationId = await installationIdFromConnectionId(connectionId);
     if (!installationId) {
-      return new Err(new Error("Github: received connectionId is invalid"));
+      throw new Error("Github: received connectionId is invalid");
     }
 
-    try {
-      const githubConfigurationBlob = {
-        webhooksEnabledAt: new Date(),
-        codeSyncEnabled: false,
-        installationId,
-      };
+    const githubConfigurationBlob = {
+      webhooksEnabledAt: new Date(),
+      codeSyncEnabled: false,
+      installationId,
+    };
 
-      const connector = await ConnectorResource.makeNew(
-        "github",
-        {
-          connectionId,
-          workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
-          workspaceId: dataSourceConfig.workspaceId,
-          dataSourceId: dataSourceConfig.dataSourceId,
-        },
-        githubConfigurationBlob
-      );
+    const connector = await ConnectorResource.makeNew(
+      "github",
+      {
+        connectionId,
+        workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
+        workspaceId: dataSourceConfig.workspaceId,
+        dataSourceId: dataSourceConfig.dataSourceId,
+      },
+      githubConfigurationBlob
+    );
 
-      await launchGithubFullSyncWorkflow({
-        connectorId: connector.id,
-        syncCodeOnly: false,
-      });
-      return new Ok(connector.id.toString());
-    } catch (err) {
-      logger.error({ error: err }, "Error creating github connector");
-
-      return new Err(err as Error);
-    }
+    await launchGithubFullSyncWorkflow({
+      connectorId: connector.id,
+      syncCodeOnly: false,
+    });
+    return new Ok(connector.id.toString());
   }
 
   async update({

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -39,6 +39,7 @@ import {
   getAuthObject,
   getDriveClient,
 } from "@connectors/connectors/google_drive/temporal/utils";
+import type { ConnectorManagerError } from "@connectors/connectors/interface";
 import { BaseConnectorManager } from "@connectors/connectors/interface";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { GoogleDriveSheet } from "@connectors/lib/models/google_drive";
@@ -68,7 +69,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
   }: {
     dataSourceConfig: DataSourceConfig;
     connectionId: string;
-  }): Promise<Result<string, Error>> {
+  }): Promise<Result<string, ConnectorManagerError>> {
     const driveClient = await getDriveClient(connectionId);
 
     // Sanity checks to confirm we have sufficient permissions.

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -69,49 +69,39 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
     dataSourceConfig: DataSourceConfig;
     connectionId: string;
   }): Promise<Result<string, Error>> {
-    try {
-      const driveClient = await getDriveClient(connectionId);
+    const driveClient = await getDriveClient(connectionId);
 
-      // Sanity checks to confirm we have sufficient permissions.
-      const [sanityCheckAbout, sanityCheckFilesGet, sanityCheckFilesList] =
-        await Promise.all([
-          driveClient.about.get({ fields: "*" }),
-          driveClient.files.get({ fileId: "root" }),
-          driveClient.drives.list({
-            pageSize: 10,
-            fields: "nextPageToken, drives(id, name)",
-          }),
-        ]);
+    // Sanity checks to confirm we have sufficient permissions.
+    const [sanityCheckAbout, sanityCheckFilesGet, sanityCheckFilesList] =
+      await Promise.all([
+        driveClient.about.get({ fields: "*" }),
+        driveClient.files.get({ fileId: "root" }),
+        driveClient.drives.list({
+          pageSize: 10,
+          fields: "nextPageToken, drives(id, name)",
+        }),
+      ]);
 
-      if (sanityCheckAbout.status !== 200) {
-        throw new Error(
-          `Could not get google drive info. Error message: ${
-            sanityCheckAbout.statusText || "unknown"
-          }`
-        );
-      }
-      if (sanityCheckFilesGet.status !== 200) {
-        throw new Error(
-          `Could not call google drive files get. Error message: ${
-            sanityCheckFilesGet.statusText || "unknown"
-          }`
-        );
-      }
-      if (sanityCheckFilesList.status !== 200) {
-        throw new Error(
-          `Could not call google drive files list. Error message: ${
-            sanityCheckFilesList.statusText || "unknown"
-          }`
-        );
-      }
-    } catch (err) {
-      logger.error(
-        {
-          err,
-        },
-        "Error creating Google Drive connector"
+    if (sanityCheckAbout.status !== 200) {
+      throw new Error(
+        `Could not get google drive info. Error message: ${
+          sanityCheckAbout.statusText || "unknown"
+        }`
       );
-      return new Err(new Error("Error creating Google Drive connector"));
+    }
+    if (sanityCheckFilesGet.status !== 200) {
+      throw new Error(
+        `Could not call google drive files get. Error message: ${
+          sanityCheckFilesGet.statusText || "unknown"
+        }`
+      );
+    }
+    if (sanityCheckFilesList.status !== 200) {
+      throw new Error(
+        `Could not call google drive files list. Error message: ${
+          sanityCheckFilesList.statusText || "unknown"
+        }`
+      );
     }
 
     const googleDriveConfigurationBlob = {
@@ -137,7 +127,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
     // We nonetheless launch the incremental sync.
     const res = await launchGoogleDriveIncrementalSyncWorkflow(connector.id);
     if (res.isErr()) {
-      return res;
+      throw res.error;
     }
 
     return new Ok(connector.id.toString());

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -11,6 +11,7 @@ import { ConfluenceConnectorManager } from "@connectors/connectors/confluence";
 import { GithubConnectorManager } from "@connectors/connectors/github";
 import { GoogleDriveConnectorManager } from "@connectors/connectors/google_drive";
 import { IntercomConnectorManager } from "@connectors/connectors/intercom";
+import type { ConnectorManagerError } from "@connectors/connectors/interface";
 import { MicrosoftConnectorManager } from "@connectors/connectors/microsoft";
 import { NotionConnectorManager } from "@connectors/connectors/notion";
 import { SlackConnectorManager } from "@connectors/connectors/slack";
@@ -87,7 +88,7 @@ export function createConnector({
         connectionId: string;
         configuration: SlackConfiguration;
       };
-    }): Promise<Result<string, Error>> {
+    }): Promise<Result<string, ConnectorManagerError>> {
   switch (connectorProvider) {
     case "confluence":
       return ConfluenceConnectorManager.create(params);

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -64,63 +64,52 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
 
     let connector = null;
 
-    try {
-      const intercomWorkspace = await fetchIntercomWorkspace({
-        accessToken: intercomAccessToken,
-      });
-      if (!intercomWorkspace) {
-        return new Err(
-          new Error(
-            "Error retrieving intercom workspace, cannot create Connector."
-          )
-        );
-      }
-
-      const intercomConfigurationBlob = {
-        intercomWorkspaceId: intercomWorkspace.id,
-        name: intercomWorkspace.name,
-        conversationsSlidingWindow: 90,
-        region: intercomWorkspace.region,
-        syncAllConversations: "disabled" as const,
-        shouldSyncNotes: true,
-      };
-
-      connector = await ConnectorResource.makeNew(
-        "intercom",
-        {
-          connectionId,
-          workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
-          workspaceId: dataSourceConfig.workspaceId,
-          dataSourceId: dataSourceConfig.dataSourceId,
-        },
-        intercomConfigurationBlob
+    const intercomWorkspace = await fetchIntercomWorkspace({
+      accessToken: intercomAccessToken,
+    });
+    if (!intercomWorkspace) {
+      throw new Error(
+        "Error retrieving intercom workspace, cannot create Connector."
       );
-
-      const workflowStarted = await launchIntercomSyncWorkflow({
-        connectorId: connector.id,
-      });
-      if (workflowStarted.isErr()) {
-        await connector.delete();
-        logger.error(
-          {
-            workspaceId: dataSourceConfig.workspaceId,
-            error: workflowStarted.error,
-          },
-          "[Intercom] Error creating connector Could not launch sync workflow."
-        );
-        return new Err(workflowStarted.error);
-      }
-      return new Ok(connector.id.toString());
-    } catch (e) {
-      logger.error(
-        { workspaceId: dataSourceConfig.workspaceId, error: e },
-        "[Intercom] Unknown Error creating connector."
-      );
-      if (connector) {
-        await connector.delete();
-      }
-      return new Err(e as Error);
     }
+
+    const intercomConfigurationBlob = {
+      intercomWorkspaceId: intercomWorkspace.id,
+      name: intercomWorkspace.name,
+      conversationsSlidingWindow: 90,
+      region: intercomWorkspace.region,
+      syncAllConversations: "disabled" as const,
+      shouldSyncNotes: true,
+    };
+
+    connector = await ConnectorResource.makeNew(
+      "intercom",
+      {
+        connectionId,
+        workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
+        workspaceId: dataSourceConfig.workspaceId,
+        dataSourceId: dataSourceConfig.dataSourceId,
+      },
+      intercomConfigurationBlob
+    );
+
+    const workflowStarted = await launchIntercomSyncWorkflow({
+      connectorId: connector.id,
+    });
+
+    if (workflowStarted.isErr()) {
+      await connector.delete();
+      logger.error(
+        {
+          workspaceId: dataSourceConfig.workspaceId,
+          error: workflowStarted.error,
+        },
+        "[Intercom] Error creating connector Could not launch sync workflow."
+      );
+      throw workflowStarted.error;
+    }
+
+    return new Ok(connector.id.toString());
   }
 
   async update({

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -39,6 +39,7 @@ import {
   launchIntercomSyncWorkflow,
   stopIntercomSyncWorkflow,
 } from "@connectors/connectors/intercom/temporal/client";
+import type { ConnectorManagerError } from "@connectors/connectors/interface";
 import { BaseConnectorManager } from "@connectors/connectors/interface";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import {
@@ -59,7 +60,7 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
   }: {
     dataSourceConfig: DataSourceConfig;
     connectionId: string;
-  }): Promise<Result<string, Error>> {
+  }): Promise<Result<string, ConnectorManagerError>> {
     const intercomAccessToken = await getIntercomAccessToken(connectionId);
 
     let connector = null;

--- a/connectors/src/connectors/interface.ts
+++ b/connectors/src/connectors/interface.ts
@@ -10,6 +10,18 @@ import type { ConnectorConfiguration } from "@dust-tt/types";
 
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
+type ConnectorManagerErrorCode = "INVALID_CONFIGURATION" | "PERMISSION_REVOKED";
+
+export class ConnectorManagerError extends Error {
+  code: ConnectorManagerErrorCode;
+
+  constructor(code: ConnectorManagerErrorCode, message: string) {
+    super(message);
+    this.name = "ConnectorManagerError";
+    this.code = code;
+  }
+}
+
 export abstract class BaseConnectorManager<T extends ConnectorConfiguration> {
   readonly connectorId: ModelId;
 
@@ -22,7 +34,7 @@ export abstract class BaseConnectorManager<T extends ConnectorConfiguration> {
     dataSourceConfig: DataSourceConfig;
     connectionId: string;
     configuration: ConnectorConfiguration;
-  }): Promise<Result<string, Error>> {
+  }): Promise<Result<string, ConnectorManagerError>> {
     throw new Error("Method not implemented.");
   }
 

--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -75,7 +75,7 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
         },
         "Error creating Microsoft connector"
       );
-      return new Err(new Error("Error creating Microsoft connector"));
+      throw new Error("Error creating Microsoft connector");
     }
 
     const microsoftConfigurationBlob = {
@@ -99,7 +99,7 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
 
     const res = await launchMicrosoftIncrementalSyncWorkflow(connector.id);
     if (res.isErr()) {
-      return res;
+      throw res.error;
     }
 
     return new Ok(connector.id.toString());

--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -8,6 +8,7 @@ import type {
 import { assertNever, Err, Ok } from "@dust-tt/types";
 import { Client } from "@microsoft/microsoft-graph-client";
 
+import type { ConnectorManagerError } from "@connectors/connectors/interface";
 import { BaseConnectorManager } from "@connectors/connectors/interface";
 import {
   getChannelAsContentNode,
@@ -61,7 +62,7 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
   }: {
     dataSourceConfig: DataSourceConfig;
     connectionId: string;
-  }): Promise<Result<string, Error>> {
+  }): Promise<Result<string, ConnectorManagerError>> {
     const client = await getClient(connectionId);
 
     try {

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -28,6 +28,7 @@ import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
+import type { ConnectorManagerError } from "../interface";
 import { BaseConnectorManager } from "../interface";
 import { getOrphanedCount, getParents, hasChildren } from "./lib/parents";
 
@@ -56,7 +57,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
   }: {
     dataSourceConfig: DataSourceConfig;
     connectionId: string;
-  }): Promise<Result<string, Error>> {
+  }): Promise<Result<string, ConnectorManagerError>> {
     const tokRes = await getOAuthConnectionAccessToken({
       config: apiConfig.getOAuthAPIConfig(),
       logger,

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -46,21 +46,17 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
 
     const teamInfo = await client.team.info();
     if (teamInfo.ok !== true) {
-      return new Err(
-        new Error(
-          `Could not get slack team info. Error message: ${
-            teamInfo.error || "unknown"
-          }`
-        )
+      throw new Error(
+        `Could not get slack team info. Error message: ${
+          teamInfo.error || "unknown"
+        }`
       );
     }
     if (!teamInfo.team?.id) {
-      return new Err(
-        new Error(
-          `Could not get slack team id. Error message: ${
-            teamInfo.error || "unknown"
-          }`
-        )
+      throw new Error(
+        `Could not get slack team id. Error message: ${
+          teamInfo.error || "unknown"
+        }`
       );
     }
     const connector = await ConnectorResource.makeNew(

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -11,6 +11,7 @@ import { Err, Ok } from "@dust-tt/types";
 import { WebClient } from "@slack/web-api";
 import PQueue from "p-queue";
 
+import type { ConnectorManagerError } from "@connectors/connectors/interface";
 import { BaseConnectorManager } from "@connectors/connectors/interface";
 import { getChannels } from "@connectors/connectors/slack//temporal/activities";
 import { getBotEnabled } from "@connectors/connectors/slack/bot";
@@ -39,7 +40,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
     dataSourceConfig: DataSourceConfig;
     connectionId: string;
     configuration: SlackConfigurationType;
-  }): Promise<Result<string, Error>> {
+  }): Promise<Result<string, ConnectorManagerError>> {
     const slackAccessToken = await getSlackAccessToken(connectionId);
 
     const client = new WebClient(slackAccessToken);

--- a/connectors/src/connectors/snowflake/index.ts
+++ b/connectors/src/connectors/snowflake/index.ts
@@ -7,6 +7,7 @@ import type {
 } from "@dust-tt/types";
 import { assertNever, Err, Ok } from "@dust-tt/types";
 
+import { ConnectorManagerError } from "@connectors/connectors/interface";
 import { BaseConnectorManager } from "@connectors/connectors/interface";
 import {
   fetchAvailableChildrenInSnowflake,
@@ -43,7 +44,7 @@ export class SnowflakeConnectorManager extends BaseConnectorManager<null> {
   }: {
     dataSourceConfig: DataSourceConfig;
     connectionId: string;
-  }): Promise<Result<string, Error>> {
+  }): Promise<Result<string, ConnectorManagerError>> {
     const credentialsRes = await getCredentials({
       credentialsId: connectionId,
       logger,
@@ -60,7 +61,12 @@ export class SnowflakeConnectorManager extends BaseConnectorManager<null> {
         case "INVALID_CREDENTIALS":
         case "NOT_READONLY":
         case "NO_TABLES":
-          return connectionRes;
+          return new Err(
+            new ConnectorManagerError(
+              "INVALID_CONFIGURATION",
+              connectionRes.error.message
+            )
+          );
         case "UNKNOWN":
           throw connectionRes.error;
         default:

--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -50,12 +50,10 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
     }
     const depth = configuration.depth;
     if (!isDepthOption(depth)) {
-      return new Err(new Error("Invalid depth option"));
+      throw new Error("Invalid depth option");
     }
     if (configuration.maxPageToCrawl > WEBCRAWLER_MAX_PAGES) {
-      return new Err(
-        new Error(`Maximum value for Max Page is ${WEBCRAWLER_MAX_PAGES}`)
-      );
+      throw new Error(`Maximum value for Max Page is ${WEBCRAWLER_MAX_PAGES}`);
     }
     const url = configuration.url.trim();
     const webCrawlerConfigurationBlob = {
@@ -81,7 +79,7 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
 
     const workflowRes = await launchCrawlWebsiteWorkflow(connector.id);
     if (workflowRes.isErr()) {
-      return workflowRes;
+      throw workflowRes.error;
     }
     logger.info(
       { connectorId: connector.id },

--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -30,6 +30,7 @@ import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { WebCrawlerConfigurationResource } from "@connectors/resources/webcrawler_resource";
 import type { DataSourceConfig } from "@connectors/types/data_source_config.js";
 
+import type { ConnectorManagerError } from "../interface";
 import { BaseConnectorManager } from "../interface";
 import {
   launchCrawlWebsiteWorkflow,
@@ -44,7 +45,7 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
     dataSourceConfig: DataSourceConfig;
     connectionId: string;
     configuration: WebCrawlerConfigurationType;
-  }): Promise<Result<string, Error>> {
+  }): Promise<Result<string, ConnectorManagerError>> {
     if (!configuration) {
       throw new Error("Configuration is required");
     }


### PR DESCRIPTION
## Description

We ned to distinguish "bad request" from "internal error" when creating a connector from front: Snowflake create connector relies on user-provided details which may be wrong.

Errors in connector creation that should result in "internal server error" (i.e all but some for snowflake) should use `throw` (which we should always use for unhandled / unrecoverable errors that end up with 500).
Only results that should end in 400 should use an error `Result`.

Next step is handling this properly on `front` so we can display the right error message to admins when failing to connect snowflake.

## Risk

Critical connectors path is touched

## Deploy Plan

deploy connectors