### PR TITLE
Add logging to identify key used on v1 API

### DIFF
--- a/front/components/ViewFolderAPIModal.tsx
+++ b/front/components/ViewFolderAPIModal.tsx
@@ -38,7 +38,7 @@ export function ViewFolderAPIModal({
       "source_url": "https://acme.com"
     }'`;
       case "search":
-        return `curl "${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}/api/v1/w/${owner.sId}/vaults/${vault.sId}/data_sources/${dataSource.sId}/search?search=foo+bar&top_k=16&full_text=false" \\
+        return `curl "${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}/api/v1/w/${owner.sId}/vaults/${vault.sId}/data_sources/${dataSource.sId}/search?query=foo+bar&top_k=16&full_text=false" \\
     -H "Authorization: Bearer YOUR_API_KEY"`;
       default:
         assertNever(type);

--- a/front/lib/api/wrappers.ts
+++ b/front/lib/api/wrappers.ts
@@ -6,6 +6,7 @@ import { Authenticator, getAPIKey } from "@app/lib/auth";
 import { getSession } from "@app/lib/auth";
 import { getGroupIdsFromHeaders } from "@app/lib/http_api/group_header";
 import type { SessionWithUser } from "@app/lib/iam/provider";
+import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
 /**
@@ -229,6 +230,17 @@ export function withPublicAPIAuthentication<T, U extends boolean>(
             }
           )) ?? workspaceAuth;
       }
+
+      const apiKey = keyAuth.key();
+
+      logger.info(
+        {
+          method: req.method,
+          url: req.url,
+          key: apiKey ? { id: apiKey.id, name: apiKey.name } : null,
+        },
+        "withPublicAPIAuthentication request"
+      );
 
       return handler(
         req,

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -752,6 +752,10 @@ export class Authenticator {
   canWrite(acls: ACLType[]): boolean {
     return this.hasPermission(acls, "write");
   }
+
+  key(): KeyAuthType | null {
+    return this._key ?? null;
+  }
 }
 
 /**


### PR DESCRIPTION
## Description

Adds a log before the handler in `withPublicAPIAuthentication` wrapper to identify the API key used to handle a request. This is asked by one of our users tracking where the API calls are coming from.

We explicitely log id and name vs the whole keyType to prevent leaking keys in case one day the actual key make it to the type.

Also fixes the folders API modals search GET parameter

## Risk

N/A

## Deploy Plan

- deploy `front`