### PR TITLE
[front] - chore(vault): select vault in API key

### DIFF
--- a/front/lib/resources/key_resource.ts
+++ b/front/lib/resources/key_resource.ts
@@ -176,6 +176,7 @@ export class KeyResource extends BaseResource<KeyModel> {
       name: this.name,
       secret,
       status: this.status,
+      groupId: this.groupId,
     };
   }
 

--- a/front/pages/w/[wId]/developers/api-keys.tsx
+++ b/front/pages/w/[wId]/developers/api-keys.tsx
@@ -65,10 +65,9 @@ export function APIKeys({
   groups: GroupType[];
 }) {
   const { mutate } = useSWRConfig();
-  const nonGlobalGroups = groups.filter((g) => g.kind != "global");
   const [newApiKeyName, setNewApiKeyName] = useState("");
   const [newApiKeyGroup, setNewApiKeyGroup] = useState<GroupType>(
-    nonGlobalGroups[0]
+    groups[0]
   );
   const [isNewApiKeyPromptOpen, setIsNewApiKeyPromptOpen] = useState(false);
   const [isNewApiKeyCreatedOpen, setIsNewApiKeyCreatedOpen] = useState(false);
@@ -184,7 +183,7 @@ export function APIKeys({
               label={prettifyGroupName(newApiKeyGroup)}
             />
             <DropdownMenu.Items width={220}>
-              {nonGlobalGroups.map((group: GroupType) => (
+              {groups.map((group: GroupType) => (
                 <DropdownMenu.Item
                   key={group.id}
                   label={prettifyGroupName(group)}

--- a/front/pages/w/[wId]/developers/api-keys.tsx
+++ b/front/pages/w/[wId]/developers/api-keys.tsx
@@ -2,7 +2,8 @@ import {
   BookOpenIcon,
   Button,
   ClipboardIcon,
-  Dialog, DropdownMenu,
+  Dialog,
+  DropdownMenu,
   IconButton,
   Input,
   Modal,
@@ -10,8 +11,15 @@ import {
   PlusIcon,
   ShapesIcon,
 } from "@dust-tt/sparkle";
-import type { GroupType, KeyType, SubscriptionType,UserType, WorkspaceType } from "@dust-tt/types";
-import { prettifyGroupName } from "@dust-tt/types"
+import type {
+  GroupType,
+  KeyType,
+  ModelId,
+  SubscriptionType,
+  UserType,
+  WorkspaceType,
+} from "@dust-tt/types";
+import { prettifyGroupName } from "@dust-tt/types";
 import type { InferGetServerSidePropsType } from "next";
 import React from "react";
 import { useState } from "react";
@@ -57,13 +65,24 @@ export function APIKeys({
   groups: GroupType[];
 }) {
   const { mutate } = useSWRConfig();
-  const nonGlobalGroups = groups.filter((g) => g.kind != "global")
+  const nonGlobalGroups = groups.filter((g) => g.kind != "global");
   const [newApiKeyName, setNewApiKeyName] = useState("");
-  const [newApiKeyGroup, setNewApiKeyGroup] = useState<GroupType>(nonGlobalGroups[0]);
+  const [newApiKeyGroup, setNewApiKeyGroup] = useState<GroupType>(
+    nonGlobalGroups[0]
+  );
   const [isNewApiKeyPromptOpen, setIsNewApiKeyPromptOpen] = useState(false);
   const [isNewApiKeyCreatedOpen, setIsNewApiKeyCreatedOpen] = useState(false);
 
   const { keys } = useKeys(owner);
+
+  const groupsById = groups.reduce(
+    (acc, group) => {
+      acc[group.id] = group;
+      return acc;
+    },
+    {} as Record<ModelId, GroupType>
+  );
+
   const { submit: handleGenerate, isSubmitting: isGenerating } =
     useSubmitFunction(
       async ({ name, group }: { name: string; group?: GroupType }) => {
@@ -158,7 +177,10 @@ export function APIKeys({
             Assign permissions to group:{" "}
           </span>
           <DropdownMenu>
-            <DropdownMenu.Button type="select" label={prettifyGroupName(newApiKeyGroup)} />
+            <DropdownMenu.Button
+              type="select"
+              label={prettifyGroupName(newApiKeyGroup)}
+            />
             <DropdownMenu.Items width={220}>
               {nonGlobalGroups.map((group: GroupType) => (
                 <DropdownMenu.Item
@@ -217,7 +239,18 @@ export function APIKeys({
                               "font-mono truncate text-sm text-slate-700"
                             )}
                           >
+                            Name:{" "}
                             <strong>{key.name ? key.name : "Unnamed"}</strong>
+                          </p>
+                          <p
+                            className={classNames(
+                              "font-mono truncate text-sm text-slate-700"
+                            )}
+                          >
+                            Scoped to vault:{" "}
+                            <strong>
+                              {prettifyGroupName(groupsById[key.groupId])}
+                            </strong>
                           </p>
                           <pre className="text-sm">{key.secret}</pre>
                           <p className="front-normal text-xs text-element-700">

--- a/front/pages/w/[wId]/developers/api-keys.tsx
+++ b/front/pages/w/[wId]/developers/api-keys.tsx
@@ -75,12 +75,12 @@ export function APIKeys({
   const { keys } = useKeys(owner);
 
   const groupsById = useMemo(() => {
-    return groups.reduce(
+    return groups.reduce<Record<ModelId, GroupType>>(
       (acc, group) => {
         acc[group.id] = group;
         return acc;
       },
-      {} as Record<ModelId, GroupType>
+      {}
     );
   }, [groups]);
 

--- a/front/pages/w/[wId]/developers/api-keys.tsx
+++ b/front/pages/w/[wId]/developers/api-keys.tsx
@@ -174,7 +174,7 @@ export function APIKeys({
         />
         <div className="align-center flex flex-row items-center gap-2 p-2">
           <span className="mr-1 flex flex-initial text-sm font-medium leading-8 text-gray-700">
-            Assign permissions to group:{" "}
+            Assign permissions to vault:{" "}
           </span>
           <DropdownMenu>
             <DropdownMenu.Button

--- a/front/pages/w/[wId]/developers/api-keys.tsx
+++ b/front/pages/w/[wId]/developers/api-keys.tsx
@@ -2,7 +2,7 @@ import {
   BookOpenIcon,
   Button,
   ClipboardIcon,
-  Dialog,
+  Dialog, DropdownMenu,
   IconButton,
   Input,
   Modal,
@@ -10,9 +10,8 @@ import {
   PlusIcon,
   ShapesIcon,
 } from "@dust-tt/sparkle";
-import type { GroupType, UserType, WorkspaceType } from "@dust-tt/types";
-import type { SubscriptionType } from "@dust-tt/types";
-import type { KeyType } from "@dust-tt/types";
+import type { GroupType, KeyType, SubscriptionType,UserType, WorkspaceType } from "@dust-tt/types";
+import { prettifyGroupName } from "@dust-tt/types"
 import type { InferGetServerSidePropsType } from "next";
 import React from "react";
 import { useState } from "react";
@@ -58,9 +57,9 @@ export function APIKeys({
   groups: GroupType[];
 }) {
   const { mutate } = useSWRConfig();
-  const globalGroup = groups.find((group) => group.kind === "global");
+  const nonGlobalGroups = groups.filter((g) => g.kind != "global")
   const [newApiKeyName, setNewApiKeyName] = useState("");
-  const [newApiKeyGroup] = useState(globalGroup);
+  const [newApiKeyGroup, setNewApiKeyGroup] = useState<GroupType>(nonGlobalGroups[0]);
   const [isNewApiKeyPromptOpen, setIsNewApiKeyPromptOpen] = useState(false);
   const [isNewApiKeyCreatedOpen, setIsNewApiKeyCreatedOpen] = useState(false);
 
@@ -154,26 +153,23 @@ export function APIKeys({
           value={newApiKeyName}
           onChange={(e) => setNewApiKeyName(e)}
         />
-        {/* TODO(20240731 thomas) Enable group selection }
-        {/* <div className="align-center flex flex-row items-center gap-2 p-2">
+        <div className="align-center flex flex-row items-center gap-2 p-2">
           <span className="mr-1 flex flex-initial text-sm font-medium leading-8 text-gray-700">
-            Assign group permissions:{" "}
+            Assign permissions to group:{" "}
           </span>
           <DropdownMenu>
-            <DropdownMenu.Button type="select" label={newApiKeyGroup?.name} />
+            <DropdownMenu.Button type="select" label={prettifyGroupName(newApiKeyGroup)} />
             <DropdownMenu.Items width={220}>
-              {groups.map((group: GroupType) => (
-                <>
-                  <DropdownMenu.Item
-                    key={group.id}
-                    label={group.name}
-                    onClick={() => setNewApiKeyGroup(group)}
-                  />
-                </>
+              {nonGlobalGroups.map((group: GroupType) => (
+                <DropdownMenu.Item
+                  key={group.id}
+                  label={prettifyGroupName(group)}
+                  onClick={() => setNewApiKeyGroup(group)}
+                />
               ))}
             </DropdownMenu.Items>
           </DropdownMenu>
-        </div> */}
+        </div>
       </Dialog>
       <Page.Horizontal align="stretch">
         <div className="w-full" />

--- a/front/pages/w/[wId]/developers/api-keys.tsx
+++ b/front/pages/w/[wId]/developers/api-keys.tsx
@@ -21,7 +21,7 @@ import type {
 } from "@dust-tt/types";
 import { prettifyGroupName } from "@dust-tt/types";
 import type { InferGetServerSidePropsType } from "next";
-import React from "react";
+import React, { useMemo } from "react";
 import { useState } from "react";
 import { useSWRConfig } from "swr";
 
@@ -75,13 +75,15 @@ export function APIKeys({
 
   const { keys } = useKeys(owner);
 
-  const groupsById = groups.reduce(
-    (acc, group) => {
-      acc[group.id] = group;
-      return acc;
-    },
-    {} as Record<ModelId, GroupType>
-  );
+  const groupsById = useMemo(() => {
+    return groups.reduce(
+      (acc, group) => {
+        acc[group.id] = group;
+        return acc;
+      },
+      {} as Record<ModelId, GroupType>
+    );
+  }, [groups]);
 
   const { submit: handleGenerate, isSubmitting: isGenerating } =
     useSubmitFunction(

--- a/front/pages/w/[wId]/developers/api-keys.tsx
+++ b/front/pages/w/[wId]/developers/api-keys.tsx
@@ -66,22 +66,17 @@ export function APIKeys({
 }) {
   const { mutate } = useSWRConfig();
   const [newApiKeyName, setNewApiKeyName] = useState("");
-  const [newApiKeyGroup, setNewApiKeyGroup] = useState<GroupType>(
-    groups[0]
-  );
+  const [newApiKeyGroup, setNewApiKeyGroup] = useState<GroupType>(groups[0]);
   const [isNewApiKeyPromptOpen, setIsNewApiKeyPromptOpen] = useState(false);
   const [isNewApiKeyCreatedOpen, setIsNewApiKeyCreatedOpen] = useState(false);
 
   const { keys } = useKeys(owner);
 
   const groupsById = useMemo(() => {
-    return groups.reduce<Record<ModelId, GroupType>>(
-      (acc, group) => {
-        acc[group.id] = group;
-        return acc;
-      },
-      {}
-    );
+    return groups.reduce<Record<ModelId, GroupType>>((acc, group) => {
+      acc[group.id] = group;
+      return acc;
+    }, {});
   }, [groups]);
 
   const { submit: handleGenerate, isSubmitting: isGenerating } =

--- a/front/pages/w/[wId]/developers/api-keys.tsx
+++ b/front/pages/w/[wId]/developers/api-keys.tsx
@@ -244,16 +244,18 @@ export function APIKeys({
                             Name:{" "}
                             <strong>{key.name ? key.name : "Unnamed"}</strong>
                           </p>
-                          <p
-                            className={classNames(
-                              "font-mono truncate text-sm text-slate-700"
-                            )}
-                          >
-                            Scoped to vault:{" "}
-                            <strong>
-                              {prettifyGroupName(groupsById[key.groupId])}
-                            </strong>
-                          </p>
+                          {key.groupId && (
+                            <p
+                              className={classNames(
+                                "font-mono truncate text-sm text-slate-700"
+                              )}
+                            >
+                              Scoped to vault:{" "}
+                              <strong>
+                                {prettifyGroupName(groupsById[key.groupId])}
+                              </strong>
+                            </p>
+                          )}
                           <pre className="text-sm">{key.secret}</pre>
                           <p className="front-normal text-xs text-element-700">
                             Created {key.creator ? `by ${key.creator} ` : ""}

--- a/types/src/front/groups.ts
+++ b/types/src/front/groups.ts
@@ -27,6 +27,9 @@ export function isGlobalGroupKind(value: GroupKind): boolean {
 }
 
 export function prettifyGroupName(group: GroupType) {
+  if (group.kind === "global") {
+    return "Company Data"
+  }
   return group.name.replace("Group for vault ", "");
 }
 

--- a/types/src/front/groups.ts
+++ b/types/src/front/groups.ts
@@ -27,7 +27,7 @@ export function isGlobalGroupKind(value: GroupKind): boolean {
 }
 
 export function prettifyGroupName(group: GroupType) {
-  return group.name.replace("Group for vault ", "")
+  return group.name.replace("Group for vault ", "");
 }
 
 export type GroupType = {

--- a/types/src/front/groups.ts
+++ b/types/src/front/groups.ts
@@ -26,6 +26,10 @@ export function isGlobalGroupKind(value: GroupKind): boolean {
   return value === "global";
 }
 
+export function prettifyGroupName(group: GroupType) {
+  return group.name.replace("Group for vault ", "")
+}
+
 export type GroupType = {
   id: ModelId;
   name: string;

--- a/types/src/front/key.ts
+++ b/types/src/front/key.ts
@@ -8,4 +8,5 @@ export type KeyType = {
   secret: string;
   status: string;
   name: string | null;
+  groupId?: ModelId;
 };


### PR DESCRIPTION
## Description

This PR aims at adding a `DropdownMenu` to select the vault to scope an API key to.

<img width="1101" alt="Screenshot 2024-10-03 at 14 58 35" src="https://github.com/user-attachments/assets/f701e432-14b4-45d2-b5cb-44670592caec">
<img width="1096" alt="Screenshot 2024-10-03 at 14 59 16" src="https://github.com/user-attachments/assets/75c396c6-29dc-4c3d-995c-fba7395227e2">



**References:**
 - https://github.com/dust-tt/dust/issues/7862

## Risk

Low

## Deploy Plan

Deploy `front`