### PR TITLE
Don't compute usage unless delete dialog is opened

### DIFF
--- a/front/components/assistant/DeleteAssistantDialog.tsx
+++ b/front/components/assistant/DeleteAssistantDialog.tsx
@@ -28,8 +28,9 @@ export function DeleteAssistantDialog({
   const doDelete = useDeleteAgentConfiguration({ owner, agentConfiguration });
 
   const agentUsage = useAgentUsage({
-    workspaceId: owner.sId,
     agentConfigurationId: agentConfiguration.sId,
+    disabled: !isOpen,
+    workspaceId: owner.sId,
   });
 
   return (

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -213,9 +213,11 @@ export function useAgentConfiguration({
 export function useAgentUsage({
   workspaceId,
   agentConfigurationId,
+  disabled,
 }: {
   workspaceId: string;
   agentConfigurationId: string | null;
+  disabled?: boolean;
 }) {
   const agentUsageFetcher: Fetcher<GetAgentUsageResponseBody> = fetcher;
   const fetchUrl = agentConfigurationId
@@ -223,7 +225,8 @@ export function useAgentUsage({
     : null;
   const { data, error, mutate } = useSWRWithDefaults(
     fetchUrl,
-    agentUsageFetcher
+    agentUsageFetcher,
+    { disabled }
   );
 
   return {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
https://github.com/dust-tt/dust/pull/7864 introduced a regression where it was fetching usage even when the dialog was not visible, this PR update the hook to only compute usage when dialog is opened.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
