### PR TITLE
[front] Handle select all in datasource views / assistant  tree

### DIFF
--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -349,13 +349,13 @@ export function DataSourceViewSelector({
     viewType,
   });
 
-  const isSomethingSelected =
+  const hasActiveSelection =
     selectionConfiguration.selectedResources.length > 0 ||
     selectionConfiguration.isSelectAll;
 
   const handleSelectAll = () => {
     setSelectionConfigurations((prevState) => {
-      if (isSomethingSelected) {
+      if (hasActiveSelection) {
         // remove the whole dataSourceView from the list
         return _.omit(prevState, dataSourceView.sId);
       } else {
@@ -458,7 +458,7 @@ export function DataSourceViewSelector({
           canBeExpanded(viewType, dataSourceView.dataSource) ? "node" : "leaf"
         }
         checkbox={
-          hideCheckbox || (!isRootSelectable && !isSomethingSelected)
+          hideCheckbox || (!isRootSelectable && !hasActiveSelection)
             ? undefined
             : {
                 checked: checkedStatus,
@@ -473,7 +473,7 @@ export function DataSourceViewSelector({
               size="xs"
               disabled={rootNodes.length === 0}
               className="mr-4 h-5 text-xs"
-              label={isSomethingSelected ? "Unselect All" : "Select All"}
+              label={hasActiveSelection ? "Unselect All" : "Select All"}
               icon={ListCheckIcon}
               onClick={handleSelectAll}
             />

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -18,7 +18,7 @@ import type {
 import { defaultSelectionConfiguration } from "@dust-tt/types";
 import _ from "lodash";
 import type { Dispatch, SetStateAction } from "react";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 
 import { VaultSelector } from "@app/components/assistant_builder/vaults/VaultSelector";
 import type {
@@ -311,10 +311,6 @@ export function DataSourceViewSelector({
   viewType,
   isRootSelectable,
 }: DataSourceViewSelectorProps) {
-  const [isSelectedAll, setIsSelectedAll] = useState(
-    selectionConfiguration.selectedResources.length > 0
-  );
-
   const dataSourceView = selectionConfiguration.dataSourceView;
 
   const LogoComponent = getConnectorProviderLogoWithFallback(
@@ -347,17 +343,45 @@ export function DataSourceViewSelector({
     [dataSourceView]
   );
 
+  const { nodes: rootNodes, isNodesLoading } = useContentNodes({
+    owner,
+    dataSourceView,
+    viewType,
+  });
+
+  const isSomethingSelected =
+    selectionConfiguration.selectedResources.length > 0 ||
+    selectionConfiguration.isSelectAll;
+
   const handleSelectAll = () => {
-    document
-      .querySelectorAll<HTMLInputElement>(
-        `#dataSourceViewsSelector-${dataSourceView.dataSource.name} .tree-depth-0 input[type="checkbox"]:first-child`
-      )
-      .forEach((el) => {
-        if (el.checked === isSelectedAll) {
-          el.click();
-        }
-      });
-    setIsSelectedAll(!isSelectedAll);
+    setSelectionConfigurations((prevState) => {
+      if (isSomethingSelected) {
+        // remove the whole dataSourceView from the list
+        return _.omit(prevState, dataSourceView.sId);
+      } else {
+        const { sId } = dataSourceView;
+        const defaultConfig = defaultSelectionConfiguration(dataSourceView);
+        const prevConfig = prevState[sId] || defaultConfig;
+
+        const updatedConfig = isRootSelectable
+          ? {
+              ...prevConfig,
+              selectedResources: [],
+              isSelectAll: true,
+            }
+          : {
+              ...prevConfig,
+              selectedResources: rootNodes,
+              isSelectAll: false,
+            };
+
+        // Return a new object to trigger a re-render
+        return keepOnlyOneVaultIfApplicable({
+          ...prevState,
+          [dataSourceView.sId]: updatedConfig,
+        });
+      }
+    });
   };
 
   const isPartiallyChecked = internalIds.length > 0;
@@ -434,37 +458,12 @@ export function DataSourceViewSelector({
           canBeExpanded(viewType, dataSourceView.dataSource) ? "node" : "leaf"
         }
         checkbox={
-          hideCheckbox || !isRootSelectable
+          hideCheckbox
             ? undefined
             : {
                 checked: checkedStatus,
-                onChange: () => {
-                  setSelectionConfigurations((prevState) => {
-                    const { sId } = dataSourceView;
-                    const defaultConfig =
-                      defaultSelectionConfiguration(dataSourceView);
-                    const prevConfig = prevState[sId] || defaultConfig;
-
-                    const updatedConfig = {
-                      ...prevConfig,
-                      selectedResources: [],
-                      isSelectAll: checkedStatus === "unchecked",
-                    };
-
-                    // If nothing is selected and selectAll is false, remove the entry from the state.
-                    if (
-                      !updatedConfig.selectedResources.length &&
-                      !updatedConfig.isSelectAll
-                    ) {
-                      return _.omit(prevState, sId);
-                    }
-
-                    return {
-                      ...prevState,
-                      [sId]: updatedConfig,
-                    };
-                  });
-                },
+                disabled: !isRootSelectable && rootNodes.length === 0,
+                onChange: handleSelectAll,
               }
         }
         actions={
@@ -472,8 +471,9 @@ export function DataSourceViewSelector({
             <Button
               variant="tertiary"
               size="xs"
+              disabled={isNodesLoading}
               className="mr-4 h-5 text-xs"
-              label={isSelectedAll ? "Unselect All" : "Select All"}
+              label={isSomethingSelected ? "Unselect All" : "Select All"}
               icon={ListCheckIcon}
               onClick={handleSelectAll}
             />

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -343,7 +343,7 @@ export function DataSourceViewSelector({
     [dataSourceView]
   );
 
-  const { nodes: rootNodes, isNodesLoading } = useContentNodes({
+  const { nodes: rootNodes } = useContentNodes({
     owner,
     dataSourceView,
     viewType,
@@ -458,11 +458,11 @@ export function DataSourceViewSelector({
           canBeExpanded(viewType, dataSourceView.dataSource) ? "node" : "leaf"
         }
         checkbox={
-          hideCheckbox
+          hideCheckbox || (!isRootSelectable && !isSomethingSelected)
             ? undefined
             : {
                 checked: checkedStatus,
-                disabled: !isRootSelectable && rootNodes.length === 0,
+                disabled: !isRootSelectable,
                 onChange: handleSelectAll,
               }
         }
@@ -471,7 +471,7 @@ export function DataSourceViewSelector({
             <Button
               variant="tertiary"
               size="xs"
-              disabled={isNodesLoading}
+              disabled={rootNodes.length === 0}
               className="mr-4 h-5 text-xs"
               label={isSomethingSelected ? "Unselect All" : "Select All"}
               icon={ListCheckIcon}

--- a/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
+++ b/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
@@ -119,13 +119,6 @@ export default function VaultManagedDataSourcesViewsModal({
     }
   }, [initialConfigurations, vaultDataSourceViews]);
 
-  useEffect(() => {
-    console.log("vaultDataSourceViews", vaultDataSourceViews);
-  }, [vaultDataSourceViews]);
-  useEffect(() => {
-    console.log("initialConfigurations", initialConfigurations);
-  }, [initialConfigurations]);
-
   const setSelectionConfigurationsCallback = useCallback(
     (func: SetStateAction<DataSourceViewSelectionConfigurations>) => {
       setHasChanged(true);

--- a/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
+++ b/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
@@ -23,6 +23,24 @@ interface VaultManagedDataSourcesViewsModalProps {
   vault: VaultType;
 }
 
+// We need to stabilize the initial state of the selection configurations,
+// to avoid resetting state when swr revalidates initialSelectedDataSources
+function useStabilizedValue<T>(
+  initialValue: T,
+  isOpen: boolean,
+  defaultValue: T
+): T {
+  const [value, setValue] = useState<T | undefined>();
+  useEffect(() => {
+    if (isOpen && !value) {
+      setValue(initialValue);
+    } else if (!isOpen) {
+      setValue(undefined);
+    }
+  }, [isOpen, initialValue, value]);
+  return value ?? defaultValue;
+}
+
 export default function VaultManagedDataSourcesViewsModal({
   initialSelectedDataSources,
   isOpen,
@@ -32,12 +50,18 @@ export default function VaultManagedDataSourcesViewsModal({
   systemVaultDataSourceViews,
   vault,
 }: VaultManagedDataSourcesViewsModalProps) {
+  const defaultSelectedDataSources = useStabilizedValue(
+    initialSelectedDataSources,
+    isOpen,
+    []
+  );
+
   const [systemDataSourceViews, vaultDataSourceViews] = useMemo(() => {
     const [systemDataSourceViews, vaultDataSourceViews]: Record<
       string,
       DataSourceViewType
     >[] = [{}, {}];
-    initialSelectedDataSources.forEach((dsv) => {
+    defaultSelectedDataSources.forEach((dsv) => {
       systemDataSourceViews[dsv.dataSource.sId] =
         systemVaultDataSourceViews.find(
           (sdsv) => sdsv.dataSource.sId === dsv.dataSource.sId
@@ -45,17 +69,17 @@ export default function VaultManagedDataSourcesViewsModal({
       vaultDataSourceViews[dsv.dataSource.sId] = dsv;
     });
     return [systemDataSourceViews, vaultDataSourceViews];
-  }, [initialSelectedDataSources, systemVaultDataSourceViews]);
+  }, [defaultSelectedDataSources, systemVaultDataSourceViews]);
 
   const dataSourceViewsAndInternalIds = useMemo(
     () =>
-      initialSelectedDataSources.map((dsv) => ({
+      defaultSelectedDataSources.map((dsv) => ({
         // We are selecting from the system dataSourceView and fetching the nodes from there,
         // so we need to find the corresponding one in the systemVaultDataSourceViews
         dataSourceView: systemDataSourceViews[dsv.dataSource.sId],
         internalIds: dsv.parentsIn ?? [],
       })),
-    [initialSelectedDataSources, systemDataSourceViews]
+    [defaultSelectedDataSources, systemDataSourceViews]
   );
 
   const initialConfigurations = useMultipleDataSourceViewsContentNodes({
@@ -94,6 +118,13 @@ export default function VaultManagedDataSourcesViewsModal({
       setSelectionConfigurations(converted);
     }
   }, [initialConfigurations, vaultDataSourceViews]);
+
+  useEffect(() => {
+    console.log("vaultDataSourceViews", vaultDataSourceViews);
+  }, [vaultDataSourceViews]);
+  useEffect(() => {
+    console.log("initialConfigurations", initialConfigurations);
+  }, [initialConfigurations]);
 
   const setSelectionConfigurationsCallback = useCallback(
     (func: SetStateAction<DataSourceViewSelectionConfigurations>) => {


### PR DESCRIPTION
fixes: https://github.com/dust-tt/dust/issues/7834

## Description

Map select all and checkbox on the same function - if isRootSelectable, enable "selectAll", otherwise select all root items.
Button shows "select all" if nothing is selected, and "unselect all" if anytning is selected.

## Risk

none

## Deploy Plan

deploy front