### PR TITLE
enh: show Snowflake connector create invalid req error to user

### DIFF
--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -353,14 +353,27 @@ async function handler(
             "Failed to delete the data source"
           );
         }
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: "Failed to create the connector.",
-            connectors_error: connectorsRes.error,
-          },
-        });
+        switch (connectorsRes.error.type) {
+          case "authorization_error":
+          case "invalid_request_error":
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: "Failed to create the connector.",
+                connectors_error: connectorsRes.error,
+              },
+            });
+          default:
+            return apiError(req, res, {
+              status_code: 500,
+              api_error: {
+                type: "internal_server_error",
+                message: "Failed to create the connector.",
+                connectors_error: connectorsRes.error,
+              },
+            });
+        }
       }
       const email = auth.user()?.email;
       if (email && !isDisposableEmailDomain(email)) {

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/index.ts
@@ -435,14 +435,28 @@ const handleDataSourceWithProvider = async ({
         "Failed to delete the data source"
       );
     }
-    return apiError(req, res, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: "Failed to create the connector.",
-        connectors_error: connectorsRes.error,
-      },
-    });
+
+    switch (connectorsRes.error.type) {
+      case "authorization_error":
+      case "invalid_request_error":
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Failed to create the connector.",
+            connectors_error: connectorsRes.error,
+          },
+        });
+      default:
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to create the connector.",
+            connectors_error: connectorsRes.error,
+          },
+        });
+    }
   }
 
   await dataSource.setConnectorId(connectorsRes.value.id);


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/1419

When creating the Snowflake connector fails with `invalid_request_error`, the Snowflake-provided error message must be displayed to the admin for them to understand what went wrong / what needs to be fixed.

## Risk

N/A

## Deploy Plan

Deploy front