### PR TITLE
Soft delete AppResource

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -62,7 +62,7 @@ import {
   WorkspaceHasDomain,
 } from "@app/lib/models/workspace";
 import {
-  App,
+  AppModel,
   Clone,
   Dataset,
   Provider,
@@ -104,7 +104,7 @@ async function main() {
   await GroupMembershipModel.sync({ alter: true });
 
   await VaultModel.sync({ alter: true });
-  await App.sync({ alter: true });
+  await AppModel.sync({ alter: true });
   await Dataset.sync({ alter: true });
   await Provider.sync({ alter: true });
   await Clone.sync({ alter: true });

--- a/front/components/vaults/VaultCreateAppModal.tsx
+++ b/front/components/vaults/VaultCreateAppModal.tsx
@@ -73,7 +73,6 @@ export const VaultCreateAppModal = ({
         body: JSON.stringify({
           name: name.slice(0, MODELS_STRING_MAX_LENGTH),
           description: description.slice(0, MODELS_STRING_MAX_LENGTH),
-          visibility: "private",
         }),
       });
       if (res.ok) {

--- a/front/lib/resources/app_resource.ts
+++ b/front/lib/resources/app_resource.ts
@@ -1,5 +1,5 @@
 import type { AppType, Result } from "@dust-tt/types";
-import { Err, Ok } from "@dust-tt/types";
+import { Ok } from "@dust-tt/types";
 import assert from "assert";
 import type { Attributes, CreationAttributes, ModelStatic } from "sequelize";
 import { Op } from "sequelize";

--- a/front/lib/resources/app_resource.ts
+++ b/front/lib/resources/app_resource.ts
@@ -1,4 +1,4 @@
-import type { AppType, AppVisibility, Result } from "@dust-tt/types";
+import type { AppType, Result } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 import assert from "assert";
 import type { Attributes, CreationAttributes, ModelStatic } from "sequelize";
@@ -9,7 +9,7 @@ import { DatasetResource } from "@app/lib/resources/dataset_resource";
 import { ResourceWithVault } from "@app/lib/resources/resource_with_vault";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
-import { App, Clone } from "@app/lib/resources/storage/models/apps";
+import { AppModel, Clone } from "@app/lib/resources/storage/models/apps";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { VaultResource } from "@app/lib/resources/vault_resource";
@@ -17,36 +17,37 @@ import type { VaultResource } from "@app/lib/resources/vault_resource";
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unsafe-declaration-merging
-export interface AppResource extends ReadonlyAttributesType<App> {}
+export interface AppResource extends ReadonlyAttributesType<AppModel> {}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export class AppResource extends ResourceWithVault<App> {
-  static model: ModelStatic<App> = App;
+export class AppResource extends ResourceWithVault<AppModel> {
+  static model: ModelStatic<AppModel> = AppModel;
 
   constructor(
-    model: ModelStatic<App>,
-    blob: Attributes<App>,
+    model: ModelStatic<AppModel>,
+    blob: Attributes<AppModel>,
     vault: VaultResource
   ) {
-    super(App, blob, vault);
+    super(AppModel, blob, vault);
   }
 
   static async makeNew(
-    blob: Omit<CreationAttributes<App>, "vaultId">,
+    blob: Omit<CreationAttributes<AppModel>, "vaultId">,
     vault: VaultResource
   ) {
-    const app = await App.create({
+    const app = await AppModel.create({
       ...blob,
       vaultId: vault.id,
+      visibility: "private",
     });
 
-    return new this(App, app.get(), vault);
+    return new this(AppModel, app.get(), vault);
   }
 
   // Fetching.
 
   private static async baseFetch(
     auth: Authenticator,
-    options?: ResourceFindOptions<App>
+    options?: ResourceFindOptions<AppModel>
   ) {
     const apps = await this.baseFetchWithAuthorization(auth, {
       ...options,
@@ -56,8 +57,6 @@ export class AppResource extends ResourceWithVault<App> {
     return apps.filter((app) => auth.isAdmin() || app.canRead(auth));
   }
 
-  // `fetchByIds` filters out deleted apps. The accessibility of an app is enforced by its
-  // associated vault enforced in `baseFetch`.
   static async fetchByIds(
     auth: Authenticator,
     ids: string[]
@@ -65,7 +64,6 @@ export class AppResource extends ResourceWithVault<App> {
     return this.baseFetch(auth, {
       where: {
         sId: ids,
-        visibility: { [Op.ne]: "deleted" },
       },
     });
   }
@@ -79,13 +77,10 @@ export class AppResource extends ResourceWithVault<App> {
     return app ?? null;
   }
 
-  // `listByWorkspace` filters out deleted apps. The accessibility of an app is enforced by its
-  // associated vault enforced in `baseFetch`.
   static async listByWorkspace(auth: Authenticator) {
     return this.baseFetch(auth, {
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
-        visibility: { [Op.ne]: "deleted" },
       },
     });
   }
@@ -94,7 +89,6 @@ export class AppResource extends ResourceWithVault<App> {
     return this.baseFetch(auth, {
       where: {
         vaultId: vault.id,
-        visibility: { [Op.ne]: "deleted" },
       },
     });
   }
@@ -126,25 +120,15 @@ export class AppResource extends ResourceWithVault<App> {
     {
       name,
       description,
-      visibility,
     }: {
       name: string;
       description: string | null;
-      visibility: AppVisibility;
     }
   ) {
     assert(this.canWrite(auth), "Unauthorized write attempt");
     await this.update({
       name,
       description,
-      visibility,
-    });
-  }
-
-  async markAsDeleted(auth: Authenticator) {
-    assert(this.canWrite(auth), "Unauthorized write attempt");
-    await this.update({
-      visibility: "deleted",
     });
   }
 
@@ -168,7 +152,7 @@ export class AppResource extends ResourceWithVault<App> {
         throw res.error;
       }
 
-      return App.destroy({
+      return AppModel.destroy({
         where: {
           workspaceId: auth.getNonNullableWorkspace().id,
           id: this.id,
@@ -183,24 +167,18 @@ export class AppResource extends ResourceWithVault<App> {
     return new Ok(deletedCount);
   }
 
-  // TODO(2024-09-27 flav): Implement soft delete of apps.
-  protected softDelete(): Promise<Result<number, Error>> {
-    throw new Error("Method not implemented.");
-  }
+  protected async softDelete(
+    auth: Authenticator
+  ): Promise<Result<number, Error>> {
+    const deletedCount = await AppModel.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        id: this.id,
+      },
+      hardDelete: false,
+    });
 
-  // TODO(2024-09-27 flav): Implement soft delete of apps.
-  async delete(
-    auth: Authenticator,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    { hardDelete }: { hardDelete: true }
-  ): Promise<Result<undefined, Error>> {
-    try {
-      await this.hardDelete(auth);
-
-      return new Ok(undefined);
-    } catch (err) {
-      return new Err(err as Error);
-    }
+    return new Ok(deletedCount);
   }
 
   // Serialization.
@@ -211,7 +189,6 @@ export class AppResource extends ResourceWithVault<App> {
       sId: this.sId,
       name: this.name,
       description: this.description,
-      visibility: this.visibility,
       savedSpecification: this.savedSpecification,
       savedConfig: this.savedConfig,
       savedRun: this.savedRun,

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -17,7 +17,7 @@ import { Op } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
-import { App } from "@app/lib/resources/storage/models/apps";
+import { AppModel } from "@app/lib/resources/storage/models/apps";
 import {
   RunModel,
   RunUsageModel,
@@ -25,7 +25,7 @@ import {
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { getRunExecutionsDeletionCutoffDate } from "@app/temporal/hard_delete/utils";
 
-type RunResourceWithApp = RunResource & { app: App };
+type RunResourceWithApp = RunResource & { app: AppModel };
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface RunResource extends ReadonlyAttributesType<RunModel> {}
@@ -50,7 +50,7 @@ export class RunResource extends BaseResource<RunModel> {
     const include = includeApp
       ? [
           {
-            model: App,
+            model: AppModel,
             as: "app",
             required: true,
           },

--- a/front/lib/resources/storage/models/apps.ts
+++ b/front/lib/resources/storage/models/apps.ts
@@ -13,7 +13,8 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { VaultModel } from "@app/lib/resources/storage/models/vaults";
 import { SoftDeletableModel } from "@app/lib/resources/storage/wrappers";
 
-export class App extends SoftDeletableModel<App> {
+// TODO(2024-10-04 flav) Remove visibility from here.
+export class AppModel extends SoftDeletableModel<AppModel> {
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
@@ -33,7 +34,7 @@ export class App extends SoftDeletableModel<App> {
   declare vault: NonAttribute<VaultModel>;
   declare workspace: NonAttribute<Workspace>;
 }
-App.init(
+AppModel.init(
   {
     id: {
       type: DataTypes.INTEGER,
@@ -93,17 +94,17 @@ App.init(
   }
 );
 
-Workspace.hasMany(App, {
+Workspace.hasMany(AppModel, {
   foreignKey: { allowNull: false },
   onDelete: "CASCADE",
 });
-App.belongsTo(Workspace);
+AppModel.belongsTo(Workspace);
 
-VaultModel.hasMany(App, {
+VaultModel.hasMany(AppModel, {
   foreignKey: { allowNull: false },
   onDelete: "RESTRICT",
 });
-App.belongsTo(VaultModel);
+AppModel.belongsTo(VaultModel);
 
 export class Provider extends Model<
   InferAttributes<Provider>,
@@ -168,7 +169,7 @@ export class Dataset extends Model<
   declare schema: DatasetSchema | null;
 
   declare workspaceId: ForeignKey<Workspace["id"]>;
-  declare appId: ForeignKey<App["id"]>;
+  declare appId: ForeignKey<AppModel["id"]>;
 }
 Dataset.init(
   {
@@ -206,11 +207,11 @@ Dataset.init(
   }
 );
 
-App.hasMany(Dataset, {
+AppModel.hasMany(Dataset, {
   foreignKey: { allowNull: false },
   onDelete: "CASCADE",
 });
-Dataset.belongsTo(App);
+Dataset.belongsTo(AppModel);
 
 Workspace.hasMany(Dataset, {
   foreignKey: { allowNull: false },
@@ -225,8 +226,8 @@ export class Clone extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare fromId: ForeignKey<App["id"]>;
-  declare toId: ForeignKey<App["id"]>;
+  declare fromId: ForeignKey<AppModel["id"]>;
+  declare toId: ForeignKey<AppModel["id"]>;
 }
 Clone.init(
   {
@@ -267,11 +268,11 @@ Clone.init(
     sequelize: frontSequelize,
   }
 );
-Clone.belongsTo(App, {
+Clone.belongsTo(AppModel, {
   foreignKey: { name: "fromId", allowNull: false },
   onDelete: "CASCADE",
 });
-Clone.belongsTo(App, {
+Clone.belongsTo(AppModel, {
   foreignKey: { name: "toId", allowNull: false },
   onDelete: "CASCADE",
 });

--- a/front/lib/resources/storage/models/runs.ts
+++ b/front/lib/resources/storage/models/runs.ts
@@ -9,7 +9,7 @@ import { DataTypes, Model } from "sequelize";
 
 import { Workspace } from "@app/lib/models/workspace";
 import { frontSequelize } from "@app/lib/resources/storage";
-import { App } from "@app/lib/resources/storage/models/apps";
+import { AppModel } from "@app/lib/resources/storage/models/apps";
 
 export class RunModel extends Model<
   InferAttributes<RunModel>,
@@ -22,10 +22,10 @@ export class RunModel extends Model<
   declare dustRunId: string;
   declare runType: string;
 
-  declare appId: ForeignKey<App["id"]>;
+  declare appId: ForeignKey<AppModel["id"]>;
   declare workspaceId: ForeignKey<Workspace["id"]>;
 
-  declare app: NonAttribute<App>;
+  declare app: NonAttribute<AppModel>;
 }
 
 RunModel.init(
@@ -64,11 +64,11 @@ RunModel.init(
     ],
   }
 );
-App.hasMany(RunModel, {
+AppModel.hasMany(RunModel, {
   foreignKey: { allowNull: false },
   onDelete: "CASCADE",
 });
-RunModel.belongsTo(App, {
+RunModel.belongsTo(AppModel, {
   as: "app",
   foreignKey: { name: "appId", allowNull: false },
 });

--- a/front/migrations/20230413_objects_workspaces.ts
+++ b/front/migrations/20230413_objects_workspaces.ts
@@ -2,13 +2,17 @@
 
 import { personalWorkspace } from "@app/lib/auth";
 import { User } from "@app/lib/models/user";
-import { App, Dataset, Provider } from "@app/lib/resources/storage/models/apps";
+import {
+  AppModel,
+  Dataset,
+  Provider,
+} from "@app/lib/resources/storage/models/apps";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { KeyModel } from "@app/lib/resources/storage/models/keys";
 import { RunModel } from "@app/lib/resources/storage/models/runs";
 
 async function addWorkspaceToObject(
-  object: App | Dataset | Provider | KeyModel | DataSourceModel | RunModel
+  object: AppModel | Dataset | Provider | KeyModel | DataSourceModel | RunModel
 ) {
   if (object.workspaceId) {
     // @ts-expect-error old migration code kept for reference
@@ -43,7 +47,7 @@ async function addWorkspaceToObject(
 
 async function updateObjects(
   objects:
-    | App[]
+    | AppModel[]
     | Dataset[]
     | Provider[]
     | KeyModel[]
@@ -67,7 +71,7 @@ async function updateObjects(
 }
 
 async function updateApps() {
-  const apps = await App.findAll();
+  const apps = await AppModel.findAll();
   await updateObjects(apps);
 }
 

--- a/front/migrations/20230413_runs.ts
+++ b/front/migrations/20230413_runs.ts
@@ -1,6 +1,6 @@
 import { Sequelize } from "sequelize";
 
-import { App } from "@app/lib/resources/storage/models/apps";
+import { AppModel } from "@app/lib/resources/storage/models/apps";
 import { RunModel } from "@app/lib/resources/storage/models/runs";
 
 const { CORE_DATABASE_URI } = process.env;
@@ -42,14 +42,14 @@ async function main() {
   );
 
   console.log("Retrieving apps to backfill");
-  const appsToBackfill = await App.findAll({
+  const appsToBackfill = await AppModel.findAll({
     where: {
       dustAPIProjectId: projectIdsToBackfill,
     },
   });
 
   console.log("Generating appByProjectId");
-  const appByProjectId = {} as { [key: number]: App };
+  const appByProjectId = {} as { [key: number]: AppModel };
   appsToBackfill.forEach((a) => {
     appByProjectId[(a as any).dustAPIProjectId] = a as any;
   });

--- a/front/migrations/20240906_backfill_apps_vault_ids.ts
+++ b/front/migrations/20240906_backfill_apps_vault_ids.ts
@@ -2,12 +2,12 @@ import assert from "assert";
 
 import { Authenticator } from "@app/lib/auth";
 import { Workspace } from "@app/lib/models/workspace";
-import { App } from "@app/lib/resources/storage/models/apps";
+import { AppModel } from "@app/lib/resources/storage/models/apps";
 import { VaultResource } from "@app/lib/resources/vault_resource";
 import { makeScript } from "@app/scripts/helpers";
 
 makeScript({}, async ({ execute }, logger) => {
-  const apps = await App.findAll();
+  const apps = await AppModel.findAll();
 
   for (const app of apps) {
     const workspace = await Workspace.findOne({

--- a/front/migrations/20240906_registry_apps_to_public_vault.ts
+++ b/front/migrations/20240906_registry_apps_to_public_vault.ts
@@ -3,7 +3,7 @@ import {
   DustProdActionRegistry,
   PRODUCTION_DUST_APPS_WORKSPACE_ID,
 } from "@app/lib/registry";
-import { App } from "@app/lib/resources/storage/models/apps";
+import { AppModel } from "@app/lib/resources/storage/models/apps";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import { makeScript } from "@app/scripts/helpers";
 
@@ -35,7 +35,7 @@ makeScript({}, async ({ execute }, logger) => {
         `(sId=${dustAppsWorkspace.sId}) with vaultId ${vaultId}`
     );
     if (execute) {
-      await App.update(
+      await AppModel.update(
         {
           vaultId,
         },

--- a/front/migrations/20240912_backfill_agent_group_ids_dust_apps.ts
+++ b/front/migrations/20240912_backfill_agent_group_ids_dust_apps.ts
@@ -3,14 +3,14 @@ import { Op } from "sequelize";
 
 import { AgentDustAppRunConfiguration } from "@app/lib/models/assistant/actions/dust_app_run";
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
-import { App } from "@app/lib/resources/storage/models/apps";
+import { AppModel } from "@app/lib/resources/storage/models/apps";
 import { GroupVaultModel } from "@app/lib/resources/storage/models/group_vaults";
 import { VaultModel } from "@app/lib/resources/storage/models/vaults";
 import { makeScript } from "@app/scripts/helpers";
 
 makeScript({}, async ({ execute }, logger) => {
   const allDustAppRunConfigs = await AgentDustAppRunConfiguration.findAll();
-  const allDustAppModels = await App.findAll({
+  const allDustAppModels = await AppModel.findAll({
     where: {
       sId: allDustAppRunConfigs.map((config) => config.appId),
     },

--- a/front/migrations/db/migration_98.sql
+++ b/front/migrations/db/migration_98.sql
@@ -1,0 +1,7 @@
+-- Migration created on Sep 26, 2024
+UPDATE apps
+SET
+  "deletedAt" = NOW ()
+WHERE
+  "visibility" = 'deleted'
+  AND "deletedAt" IS NULL;

--- a/front/pages/api/v1/w/[wId]/apps/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/index.ts
@@ -42,9 +42,6 @@ import handler from "@app/pages/api/v1/w/[wId]/vaults/[vId]/apps";
  *                       description:
  *                         type: string
  *                         description: Description of the app
- *                       visibility:
- *                         type: string
- *                         description: Visibility setting of the app
  *                       savedSpecification:
  *                         type: string
  *                         description: Saved specification of the app

--- a/front/pages/api/w/[wId]/vaults/[vId]/apps/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/apps/[aId]/index.ts
@@ -1,5 +1,8 @@
 import type { AppType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -9,6 +12,11 @@ import { apiError } from "@app/logger/withlogging";
 export type GetOrPostAppResponseBody = {
   app: AppType;
 };
+
+const PatchAppBodySchema = t.type({
+  name: t.string,
+  description: t.string,
+});
 
 async function handler(
   req: NextApiRequest,
@@ -43,6 +51,7 @@ async function handler(
         app: app.toJSON(),
       });
       break;
+
     case "POST":
       if (!app.canWrite(auth)) {
         return apiError(req, res, {
@@ -55,28 +64,24 @@ async function handler(
         });
       }
 
-      if (
-        !req.body ||
-        !(typeof req.body.name == "string") ||
-        !(typeof req.body.description == "string") ||
-        !["private", "deleted"].includes(req.body.visibility)
-      ) {
+      const bodyValidation = PatchAppBodySchema.decode(req.body);
+      if (isLeft(bodyValidation)) {
+        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message:
-              "The request body is invalid, expects { name: string, description: string, visibility }.",
+            message: `The request body is invalid: ${pathError}`,
           },
         });
       }
 
-      const description = req.body.description ? req.body.description : null;
+      const { name, description } = bodyValidation.right;
 
       await app.updateSettings(auth, {
-        name: req.body.name,
+        name,
         description,
-        visibility: req.body.visibility,
       });
 
       return res.status(200).json({
@@ -95,7 +100,7 @@ async function handler(
         });
       }
 
-      await app.markAsDeleted(auth);
+      await app.delete(auth, { hardDelete: false });
 
       res.status(204).end();
       return;

--- a/front/pages/api/w/[wId]/vaults/[vId]/apps/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/apps/[aId]/index.ts
@@ -1,8 +1,8 @@
 import type { AppType, WithAPIErrorResponse } from "@dust-tt/types";
-import type { NextApiRequest, NextApiResponse } from "next";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/vaults/[vId]/apps/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/apps/index.ts
@@ -68,15 +68,14 @@ async function handler(
       if (
         !req.body ||
         !(typeof req.body.name == "string") ||
-        !(typeof req.body.description == "string") ||
-        !["private"].includes(req.body.visibility)
+        !(typeof req.body.description == "string")
       ) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
             message:
-              "The request body is invalid, expects { name: string, description: string, visibility }.",
+              "The request body is invalid, expects { name: string, description: string }.",
           },
         });
       }
@@ -101,7 +100,6 @@ async function handler(
           sId: generateLegacyModelSId(),
           name: req.body.name,
           description,
-          visibility: req.body.visibility,
           dustAPIProjectId: p.value.project.project_id.toString(),
           workspaceId: owner.id,
         },

--- a/front/pages/api/w/[wId]/vaults/[vId]/apps/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/apps/index.ts
@@ -102,6 +102,7 @@ async function handler(
           description,
           dustAPIProjectId: p.value.project.project_id.toString(),
           workspaceId: owner.id,
+          visibility: "private",
         },
         vault
       );

--- a/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/settings.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/settings.tsx
@@ -133,7 +133,6 @@ export default function SettingsView({
         body: JSON.stringify({
           name: appName.slice(0, MODELS_STRING_MAX_LENGTH),
           description: appDescription.slice(0, MODELS_STRING_MAX_LENGTH),
-          visibility: "private",
         }),
       }
     );

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -251,10 +251,6 @@
                             "type": "string",
                             "description": "Description of the app"
                           },
-                          "visibility": {
-                            "type": "string",
-                            "description": "Visibility setting of the app"
-                          },
                           "savedSpecification": {
                             "type": "string",
                             "description": "Saved specification of the app"

--- a/types/src/front/app.ts
+++ b/types/src/front/app.ts
@@ -13,7 +13,6 @@ export type AppType = {
   sId: string;
   name: string;
   description: string | null;
-  visibility: AppVisibility;
   savedSpecification: string | null;
   savedConfig: string | null;
   savedRun: string | null;

--- a/types/src/front/groups.ts
+++ b/types/src/front/groups.ts
@@ -28,7 +28,7 @@ export function isGlobalGroupKind(value: GroupKind): boolean {
 
 export function prettifyGroupName(group: GroupType) {
   if (group.kind === "global") {
-    return "Company Data"
+    return "Company Data";
   }
   return group.name.replace("Group for vault ", "");
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR depends on https://github.com/dust-tt/dust/pull/7688.

This update fully uses the newly introduced soft deletion concept for `AppResource`. Previously, apps had a soft deletion feature implemented via a `visibility` field. This pull request revisits this logic to adopt the new soft deletion mechanism. The migration included in this PR sets the "deleteAt" timestamp to `NOW()` for all apps marked as "deleted" in the visibility field. 

The visibility field has been removed from the API body since it's no longer used after transitioning to vault endpoints. We can likely remove this field from the database once this PR is live, as it is currently unused (verified in our production database). Additionally, the name App has been changed to AppModel to adhere to naming conventions.

This PR does not affect the existing process and is a NO-OP regarding the current deletion flow.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Safe to rollback.

## Deploy Plan

- [x] Apply SQL migration
- [x] Deploy
- [ ] Apply SQL migration again (in case some apps were deleted during the deploy)
