### PR TITLE
[Connectors] ExternalOAuthTokenErr pause() connector instead of stop()

### DIFF
--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -142,7 +142,7 @@ export class ActivityInboundLogInterceptor
           });
 
           if (connectorManager) {
-            await connectorManager.stop();
+            await connectorManager.pause();
           } else {
             this.logger.error(
               {


### PR DESCRIPTION
Description
---
Stop has a weird semantic, sometimes doesn't do anything, e.g. slack, see [thread](https://dust4ai.slack.com/archives/C05F84CFP0E/p1727964800280029)

Pause actually stops the workflows in all cases, and prevents production checks from triggering.

Risk
---
na

Deploy
---
connectors
