### PR TITLE
core: async + optimized TableSchema::from_rows

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -2302,7 +2302,7 @@ async fn tables_rows_upsert(
                     .upsert_rows(
                         state.store.clone(),
                         state.databases_store.clone(),
-                        &payload.rows,
+                        payload.rows,
                         match payload.truncate {
                             Some(v) => v,
                             None => false,

--- a/core/src/databases/table_schema.rs
+++ b/core/src/databases/table_schema.rs
@@ -158,6 +158,8 @@ impl TableSchema {
     }
 
     pub fn from_rows<T: HasValue>(rows: &Vec<T>) -> Result<Self> {
+        // We store the ordering and the column in an hashmap to avoid a quadratic complexity in
+        // column count.
         let mut schema_order: Vec<String> = Vec::new();
         let mut schema_map: HashMap<String, TableSchemaColumn> = HashMap::new();
 
@@ -232,6 +234,8 @@ impl TableSchema {
             }
         }
 
+        // The unwrap below is guaranteed to work as we insert in both schema_map and schema_order
+        // at the same time.
         let schema = schema_order
             .iter()
             .map(|k| schema_map.get(k).unwrap().clone())

--- a/core/src/databases/table_schema.rs
+++ b/core/src/databases/table_schema.rs
@@ -4,7 +4,10 @@ use itertools::Itertools;
 use rusqlite::{types::ToSqlOutput, ToSql};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use crate::databases::{database::HasValue, table::Row};
 
@@ -148,8 +151,14 @@ impl TableSchema {
         }
     }
 
+    pub async fn from_rows_async<T: HasValue + Send + Sync + 'static>(
+        rows: Arc<Vec<T>>,
+    ) -> Result<TableSchema> {
+        tokio::task::spawn_blocking(move || TableSchema::from_rows(&rows)).await?
+    }
+
     pub fn from_rows<T: HasValue>(rows: &Vec<T>) -> Result<Self> {
-        let mut schema: Vec<TableSchemaColumn> = vec![];
+        let mut schema: HashMap<String, TableSchemaColumn> = HashMap::new();
 
         for (row_index, row) in rows.iter().enumerate() {
             let object = match row.value().as_object() {
@@ -191,34 +200,37 @@ impl TableSchema {
                     Value::Null => unreachable!(),
                 };
 
-                if let Some(column) = schema.iter_mut().find(|c| &c.name == k) {
-                    if column.value_type != value_type {
-                        use TableSchemaFieldType::*;
-                        match (&column.value_type, &value_type) {
-                            // Ints and Floats can be merged into Floats.
-                            (Int, Float) | (Float, Int) => {
-                                column.value_type = Float;
-                            }
-                            // Otherwise we default to Text.
-                            _ => {
-                                column.value_type = Text;
+                match schema.get_mut(k) {
+                    Some(column) => {
+                        if column.value_type != value_type {
+                            use TableSchemaFieldType::*;
+                            match (&column.value_type, &value_type) {
+                                // Ints and Floats can be merged into Floats.
+                                (Int, Float) | (Float, Int) => {
+                                    column.value_type = Float;
+                                }
+                                // Otherwise we default to Text.
+                                _ => {
+                                    column.value_type = Text;
+                                }
                             }
                         }
+                        Self::accumulate_value(column, v);
                     }
-                    Self::accumulate_value(column, v);
-                } else {
-                    let mut column = TableSchemaColumn {
-                        name: k.clone(),
-                        value_type,
-                        possible_values: Some(vec![]),
-                    };
-                    Self::accumulate_value(&mut column, v);
-                    schema.push(column);
+                    None => {
+                        let mut column = TableSchemaColumn {
+                            name: k.clone(),
+                            value_type,
+                            possible_values: Some(vec![]),
+                        };
+                        Self::accumulate_value(&mut column, v);
+                        schema.insert(k.clone(), column);
+                    }
                 }
             }
         }
 
-        Ok(Self(schema))
+        Ok(Self(schema.into_values().collect()))
     }
 
     pub fn get_create_table_sql_string(&self, table_name: &str) -> String {

--- a/core/src/providers/tiktoken/tiktoken.rs
+++ b/core/src/providers/tiktoken/tiktoken.rs
@@ -186,10 +186,11 @@ pub async fn encode_async(bpe: Arc<RwLock<CoreBPE>>, text: &str) -> Result<Vec<u
     Ok(r)
 }
 
-// We use the Rayon thread pool to parallelize the tokenization of multiple texts (which is a CPU bound task)
-// Rayon is a better fit than Tokio spawn_blocking because it is optimized for CPU-bound tasks (Tokio's blocking pool has a large number
-// of threads, making it less efficient for CPU-bound tasks).
-// We still need to use spawn_blocking at the top level to avoid blocking the Tokio event loop.
+// We use the Rayon thread pool to parallelize the tokenization of multiple texts (which is a CPU
+// bound task) Rayon is a better fit than Tokio spawn_blocking because it is optimized for
+// CPU-bound tasks (Tokio's blocking pool has a large number of threads, making it less efficient
+// for CPU-bound tasks). We still need to use spawn_blocking at the top level to avoid blocking
+// the Tokio event loop.
 pub async fn batch_tokenize_async(
     bpe: Arc<RwLock<CoreBPE>>,
     texts: Vec<String>,

--- a/core/src/sqlite_workers/client.rs
+++ b/core/src/sqlite_workers/client.rs
@@ -52,7 +52,7 @@ impl From<serde_json::Error> for SqliteWorkerError {
 impl SqliteWorker {
     pub fn new(url: String, last_heartbeat: u64) -> Self {
         Self {
-            last_heartbeat: last_heartbeat,
+            last_heartbeat,
             url,
         }
     }

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -26,7 +26,7 @@ import logger from "@app/logger/logger";
 
 import type { DataSourceResource } from "../resources/data_source_resource";
 
-const MAX_TABLE_COLUMNS = 52000;
+const MAX_TABLE_COLUMNS = 512;
 
 type CsvParsingError = {
   type:

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -26,7 +26,7 @@ import logger from "@app/logger/logger";
 
 import type { DataSourceResource } from "../resources/data_source_resource";
 
-const MAX_TABLE_COLUMNS = 512;
+const MAX_TABLE_COLUMNS = 52000;
 
 type CsvParsingError = {
   type:


### PR DESCRIPTION
## Description

- Move all loops in upsert_rows to a blocking_spawn
- Optimize TableSchema::from_rows from LC^2 complexity to LC

To achieve that we move rows into the main api handler function and then wrap it in an Arc<> for safe cross-thread read-only operations.

We also do that when querying a table and creating the table schema. We unwrap the Arc at the end (which can't fail as we won't have more than 1 weak reference at this time)

## Risk

Tested locally

## Deploy Plan

- deploy `core`