### PR TITLE
janitorial: more dataSource.name clean-up

### DIFF
--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -31,7 +31,7 @@ import { useSWRConfig } from "swr";
 import { RequestDataSourceModal } from "@app/components/data_source/RequestDataSourceModal";
 import { setupConnection } from "@app/components/vaults/AddConnectionMenu";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
-import { getDataSourceName } from "@app/lib/data_sources";
+import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import { useConnectorPermissions } from "@app/lib/swr/connectors";
 import { useUser } from "@app/lib/swr/user";
 import { useSystemVault, useVaultDataSourceViews } from "@app/lib/swr/vaults";
@@ -671,7 +671,7 @@ export function ConnectorPermissionsModal({
       {onManageButtonClick && (
         <Button
           size="sm"
-          label={`Manage ${getDataSourceName(dataSource)}`}
+          label={`Manage ${getDisplayNameForDataSource(dataSource)}`}
           icon={CloudArrowLeftRightIcon}
           variant="primary"
           disabled={readOnly || !isAdmin}
@@ -682,7 +682,7 @@ export function ConnectorPermissionsModal({
         />
       )}
       <Modal
-        title={`Manage ${getDataSourceName(dataSource)} connection`}
+        title={`Manage ${getDisplayNameForDataSource(dataSource)} connection`}
         isOpen={modalToShow === "selection"}
         onClose={() => closeModal(false)}
         onSave={save}

--- a/front/components/data_source/DataSourcePicker.tsx
+++ b/front/components/data_source/DataSourcePicker.tsx
@@ -49,11 +49,13 @@ export default function DataSourcePicker({
   const [filteredDataSourceViews, setFilteredDataSourceViews] =
     useState(vaultDataSourceViews);
 
-  // Look for the selected data source view in the list - data_source_id can contain either dsv sId or dataSource name, try to find a match
+  // Look for the selected data source view in the list - data_source_id can is dsv sId or
+  // dataSource name, try to find a match
   const selectedDataSourceView = hasDataSourceView
     ? vaultDataSourceViews.find(
         (dsv) =>
           dsv.sId === currentDataSources[0].data_source_id ||
+          // Legacy behavior
           dsv.dataSource.name === currentDataSources[0].data_source_id
       )
     : undefined;

--- a/front/components/data_source/DeleteStaticDataSourceDialog.tsx
+++ b/front/components/data_source/DeleteStaticDataSourceDialog.tsx
@@ -2,13 +2,13 @@ import { Dialog } from "@dust-tt/sparkle";
 import type { DataSourceType, LightWorkspaceType } from "@dust-tt/types";
 import { useMemo, useState } from "react";
 
-import { getDataSourceName, isManaged } from "@app/lib/data_sources";
+import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import { useDataSourceUsage } from "@app/lib/swr/data_sources";
 
 interface DeleteStaticDataSourceDialogProps {
   owner: LightWorkspaceType;
   dataSource: DataSourceType;
-  handleDelete: () => void;
+  handleDelete: () => Promise<void>;
   isOpen: boolean;
   onClose: () => void;
 }
@@ -32,9 +32,7 @@ export function DeleteStaticDataSourceDialog({
     setIsLoading(false);
     onClose();
   };
-  const name = !isManaged(dataSource)
-    ? dataSource.name
-    : getDataSourceName(dataSource);
+  const name = getDisplayNameForDataSource(dataSource);
 
   const message = useMemo(() => {
     if (isUsageLoading) {

--- a/front/components/data_source/RequestDataSourceModal.tsx
+++ b/front/components/data_source/RequestDataSourceModal.tsx
@@ -11,7 +11,7 @@ import { useContext, useEffect, useState } from "react";
 
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
-import { getDataSourceName, isManaged } from "@app/lib/data_sources";
+import { getDisplayNameForDataSource, isManaged } from "@app/lib/data_sources";
 import { sendRequestDataSourceEmail } from "@app/lib/email";
 import logger from "@app/logger/logger";
 
@@ -81,7 +81,7 @@ export function RequestDataSourceModal({
                     {selectedDataSource && isManaged(selectedDataSource) ? (
                       <Button
                         variant="tertiary"
-                        label={getDataSourceName(selectedDataSource)}
+                        label={getDisplayNameForDataSource(selectedDataSource)}
                         icon={getConnectorProviderLogoWithFallback(
                           selectedDataSource.connectorProvider
                         )}
@@ -101,7 +101,7 @@ export function RequestDataSourceModal({
                         dataSource.connectorProvider && (
                           <DropdownMenu.Item
                             key={dataSource.sId}
-                            label={getDataSourceName(dataSource)}
+                            label={getDisplayNameForDataSource(dataSource)}
                             onClick={() => setSelectedDataSource(dataSource)}
                             icon={getConnectorProviderLogoWithFallback(
                               dataSource.connectorProvider
@@ -120,8 +120,8 @@ export function RequestDataSourceModal({
               <p className="s-mb-2 s-text-sm s-text-element-700">
                 {_.capitalize(selectedDataSource.editedByUser?.fullName ?? "")}{" "}
                 is the administrator for the{" "}
-                {getDataSourceName(selectedDataSource)} connection within Dust.
-                Send an email to{" "}
+                {getDisplayNameForDataSource(selectedDataSource)} connection
+                within Dust. Send an email to{" "}
                 {_.capitalize(selectedDataSource.editedByUser?.fullName ?? "")},
                 explaining your request.
               </p>

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -449,7 +449,7 @@ export function DataSourceViewSelector({
   );
 
   return (
-    <div id={`dataSourceViewsSelector-${dataSourceView.dataSource.name}`}>
+    <div id={`dataSourceViewsSelector-${dataSourceView.dataSource.sId}`}>
       <Tree.Item
         key={dataSourceView.dataSource.id}
         label={getDisplayNameForDataSource(dataSourceView.dataSource)}

--- a/front/components/poke/data_source_views/table.tsx
+++ b/front/components/poke/data_source_views/table.tsx
@@ -3,7 +3,7 @@ import type { DataSourceViewType, LightWorkspaceType } from "@dust-tt/types";
 import { makeColumnsForDataSourceViews } from "@app/components/poke/data_source_views/columns";
 import { PokeDataTableConditionalFetch } from "@app/components/poke/PokeConditionalDataTables";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
-import { getDataSourceName } from "@app/lib/data_sources";
+import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import { usePokeDataSourceViews } from "@app/poke/swr/data_source_views";
 
 interface DataSourceViewsDataTableProps {
@@ -18,7 +18,7 @@ function prepareDataSourceViewsForDisplay(
     return {
       ...dsv,
       dataSourceLink: `/poke/${owner.sId}/data_sources/${dsv.dataSource.sId}`,
-      dataSourceName: getDataSourceName(dsv.dataSource),
+      dataSourceName: getDisplayNameForDataSource(dsv.dataSource),
       dataSourceViewLink: `/poke/${owner.sId}/vaults/${dsv.vaultId}/data_source_views/${dsv.sId}`,
       editedAt: dsv.editedByUser?.editedAt ?? undefined,
       editedBy: dsv.editedByUser?.fullName ?? undefined,

--- a/front/components/tables/TablePicker.tsx
+++ b/front/components/tables/TablePicker.tsx
@@ -37,10 +37,12 @@ export default function TablePicker({
     workspaceId: owner.sId,
   });
 
-  // Look for the selected data source view in the list - data_source_id can contain either dsv sId or dataSource name, try to find a match
+  // Look for the selected data source view in the list - data_source_id can contain either dsv sId
+  // or dataSource name, try to find a match
   const selectedDataSourceView = vaultDataSourceViews.find(
     (dsv) =>
       dsv.sId === dataSource.data_source_id ||
+      // Legacy behavior
       dsv.dataSource.name === dataSource.data_source_id
   );
 

--- a/front/components/vaults/AddToVaultDialog.tsx
+++ b/front/components/vaults/AddToVaultDialog.tsx
@@ -67,7 +67,7 @@ export const AddToVaultDialog = ({
     );
 
     const body = {
-      name: dataSource.name,
+      dataSourceId: dataSource.sId,
       parentsIn:
         existingViewForVault && existingViewForVault.parentsIn
           ? [...existingViewForVault.parentsIn, contentNode.internalId]

--- a/front/components/vaults/ContentActions.tsx
+++ b/front/components/vaults/ContentActions.tsx
@@ -23,7 +23,7 @@ import { MultipleDocumentsUpload } from "@app/components/data_source/MultipleDoc
 import DataSourceViewDocumentModal from "@app/components/DataSourceViewDocumentModal";
 import { AddToVaultDialog } from "@app/components/vaults/AddToVaultDialog";
 import {
-  getDataSourceName,
+  getDisplayNameForDataSource,
   isFolder,
   isManaged,
   isWebsite,
@@ -243,7 +243,7 @@ const makeViewSourceUrlContentAction = (
   const label =
     isFolder(dataSource) || isWebsite(dataSource)
       ? "View associated URL"
-      : `View in ${capitalize(getDataSourceName(dataSource))}`;
+      : `View in ${capitalize(getDisplayNameForDataSource(dataSource))}`;
 
   return {
     label,

--- a/front/components/vaults/EditVaultManagedDatasourcesViews.tsx
+++ b/front/components/vaults/EditVaultManagedDatasourcesViews.tsx
@@ -65,12 +65,12 @@ export function EditVaultManagedDataSourcesViews({
   const updateVaultDataSourceViews = async (
     selectionConfigurations: DataSourceViewSelectionConfigurations
   ) => {
-    // Check if a data source view in the vault is no longer in the selection configurations by comparing the data source.
-    // If so, delete it.
+    // Check if a data source view in the vault is no longer in the selection configurations by
+    // comparing the data source.  If so, delete it.
     const deletedViews = vaultDataSourceViews.filter(
       (dsv) =>
         !Object.values(selectionConfigurations).find(
-          (sc) => sc.dataSourceView.dataSource.name === dsv.dataSource.name
+          (sc) => sc.dataSourceView.dataSource.sId === dsv.dataSource.sId
         )
     );
 

--- a/front/components/vaults/VaultWebsiteModal.tsx
+++ b/front/components/vaults/VaultWebsiteModal.tsx
@@ -356,7 +356,6 @@ export default function VaultWebsiteModal({
         description: err.error.message,
       });
     }
-    return true;
   };
 
   return (

--- a/front/lib/data_sources.ts
+++ b/front/lib/data_sources.ts
@@ -108,13 +108,5 @@ export function canBeExpanded(
 }
 
 export function getDataSourceNameFromView(dsv: DataSourceViewType): string {
-  return getDataSourceName(dsv.dataSource);
-}
-
-export function getDataSourceName(ds: DataSourceType): string {
-  if (isManaged(ds)) {
-    return CONNECTOR_CONFIGURATIONS[ds.connectorProvider].name;
-  }
-
-  return ds.name;
+  return getDisplayNameForDataSource(dsv.dataSource);
 }

--- a/front/lib/documents_post_process_hooks/hooks/document_tracker/consts.ts
+++ b/front/lib/documents_post_process_hooks/hooks/document_tracker/consts.ts
@@ -4,4 +4,6 @@ export const TRACKABLE_CONNECTOR_TYPES: ConnectorProvider[] = [
   "google_drive",
   "github",
   "notion",
+  "slack",
+  "microsoft",
 ];

--- a/front/lib/documents_post_process_hooks/hooks/document_tracker/lib.ts
+++ b/front/lib/documents_post_process_hooks/hooks/document_tracker/lib.ts
@@ -36,6 +36,8 @@ export async function getTrackableDataSources(owner: WorkspaceType): Promise<
 
   return trackableDataSources.map((ds) => ({
     workspace_id: prodAPI.workspaceId(),
-    data_source_id: ds.name,
+    // TODO(GROUPS_INFRA): this should pull the data source views from the global vaults (we need an
+    // API for that).
+    data_source_id: ds.sId,
   }));
 }

--- a/front/lib/swr/vaults.ts
+++ b/front/lib/swr/vaults.ts
@@ -8,7 +8,7 @@ import { useContext, useMemo } from "react";
 import type { Fetcher } from "swr";
 
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
-import { getDataSourceName } from "@app/lib/data_sources";
+import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import {
   fetcher,
   getErrorFromResponse,
@@ -355,7 +355,7 @@ export function useDeleteFolderOrWebsite({
       sendNotification({
         type: "success",
         title: `Successfully deleted ${category}`,
-        description: `${getDataSourceName(dataSourceView.dataSource)} was successfully deleted.`,
+        description: `${getDisplayNameForDataSource(dataSourceView.dataSource)} was successfully deleted.`,
       });
     } else {
       const errorData = await getErrorFromResponse(res);

--- a/front/migrations/20240830_check_no_undeleted_documents.ts
+++ b/front/migrations/20240830_check_no_undeleted_documents.ts
@@ -12,6 +12,7 @@ type DataSource = {
   id: number;
   connectorId: string;
   dustAPIProjectId: number;
+  dustAPIDataSourceId: string;
   name: string;
 };
 
@@ -28,7 +29,7 @@ async function checkCoreDeleted(
     {
       replacements: {
         dustAPIProjectId: dataSource.dustAPIProjectId,
-        dataSourceId: dataSource.name,
+        dataSourceId: dataSource.dustAPIDataSourceId,
       },
       type: QueryTypes.SELECT,
     }
@@ -75,7 +76,7 @@ async function checkGoogleDriveDeleted(logger: Logger) {
   const frontReplica = getFrontReplicaDbConnection();
 
   const gDriveDataSources: DataSource[] = await frontReplica.query(
-    `SELECT id, "connectorId", "dustAPIProjectId", "name" FROM data_sources WHERE "connectorProvider" = 'google_drive'`,
+    `SELECT id, "connectorId", "dustAPIProjectId", "dustAPIDataSourceId", "name" FROM data_sources WHERE "connectorProvider" = 'google_drive'`,
     { type: QueryTypes.SELECT }
   );
 
@@ -108,9 +109,10 @@ async function checkNotionDeleted(logger: Logger) {
     id: number;
     connectorId: string;
     dustAPIProjectId: number;
+    dustAPIDataSourceId: string;
     name: string;
   }[] = await frontReplica.query(
-    `SELECT id, "connectorId", "dustAPIProjectId", "name" FROM data_sources WHERE "connectorProvider" = 'notion'`,
+    `SELECT id, "connectorId", "dustAPIProjectId", "dustAPIDataSourceId", "name" FROM data_sources WHERE "connectorProvider" = 'notion'`,
     { type: QueryTypes.SELECT }
   );
 

--- a/front/migrations/20240916_backfill_ds_in_agent_table_query_configurations.ts
+++ b/front/migrations/20240916_backfill_ds_in_agent_table_query_configurations.ts
@@ -39,8 +39,7 @@ async function backfillDataSourceIdInAgentTableQueryConfigurationForWorkspace(
   const agentTablesQueryConfigurationsCount: GroupedCountResultItem[] =
     await AgentTablesQueryConfigurationTable.count({
       where: {
-        // /!\ `dataSourceId` is the data source's name, not the id.
-        dataSourceId: dataSources.map((ds) => ds.name),
+        dataSourceId: dataSources.map((ds) => ds.sId),
         // @ts-expect-error `dataSourceIdNew` has been removed.
         dataSourceIdNew: {
           [Op.is]: null,
@@ -75,7 +74,7 @@ async function backfillDataSourceIdInAgentTableQueryConfigurationForWorkspace(
       {
         where: {
           // /!\ `dataSourceId` is the data source's name, not the id.
-          dataSourceId: ds.name,
+          dataSourceId: ds.sId,
           dataSourceIdNew: {
             [Op.is]: null,
           },


### PR DESCRIPTION
## Description

- DRY `getDataSourceName` on `getDisplayNameForDataSource`
- Fix document_tracker (was still using data source name)
- Minor clean-ups

## Risk

None

## Deploy Plan

- deploy `front`