### PR TITLE
[Vaults] Fix: private vaults unusable: feature flags not in auth

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -339,11 +339,6 @@ export class Authenticator {
     const getSubscriptionForWorkspace = (workspace: Workspace) =>
       subscriptionForWorkspace(renderLightWorkspaceType({ workspace }));
 
-    const getFeatureFlags = async (workspace: Workspace) =>
-      (await FeatureFlag.findAll({ where: { workspaceId: workspace.id } })).map(
-        (flag) => flag.name
-      );
-
     let keyGroups: GroupResource[] = [];
     let requestedGroups: GroupResource[] = [];
     let keyFlags: WhitelistableFeature[] = [];
@@ -447,7 +442,7 @@ export class Authenticator {
     );
 
     return new Authenticator({
-      flags: [],
+      flags: await getFeatureFlags(workspace),
       groups,
       role: "builder",
       subscription: null,
@@ -902,3 +897,8 @@ export async function prodAPICredentialsForOwner(
     workspaceId: owner.sId,
   };
 }
+
+const getFeatureFlags = async (workspace: Workspace) =>
+  (await FeatureFlag.findAll({ where: { workspaceId: workspace.id } })).map(
+    (flag) => flag.name
+  );


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/1415

Issue was broader than just websites: permission checks were always false on private vaults datasources for assistant retrieval

This was due to a test on the private vault feature flag, while the auth instance used to check permissions, using fromRegistry, had no flag sets

Risk
---
na

Deploy
---
front
