### PR TITLE
fix mistral tool sanitization

### DIFF
--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -110,7 +110,7 @@ fn sanitize_tool_call_id(id: &str) -> String {
         .collect::<String>();
 
     if s.len() > 9 {
-        s = id[0..9].to_string();
+        s = s[0..9].to_string();
     }
     if s.len() < 9 {
         s = format!("{:0>9}", s);


### PR DESCRIPTION
## Description

Fixes:  https://github.com/dust-tt/tasks/issues/1430

Fixes tool call sanitization for mistral models.

100+ agent errors over the past week:
https://app.datadoghq.eu/logs?query=%22but%20must%20be%20a-z%2C%20A-Z%2C%200-9%2C%20with%20a%20length%20of%209.%22%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1727438963830&to_ts=1728043763830&live=true

## Risk

N/A tested locally

## Deploy Plan

- deploy `core`