### PR TITLE
[front] - chore(api): join slack endpoint

### DIFF
--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -11,7 +11,9 @@ import assert from "assert";
 import config from "@app/lib/api/config";
 import { getContentNodeInternalIdFromTableId } from "@app/lib/api/content_nodes";
 import type { OffsetPaginationParams } from "@app/lib/api/pagination";
-import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import type { Authenticator } from "@app/lib/auth";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import type { VaultResource } from "@app/lib/resources/vault_resource";
 import logger from "@app/logger/logger";
 
 export function filterAndCropContentNodesByView(
@@ -272,4 +274,23 @@ export async function getContentNodesForDataSourceView(
     nodes: contentNodesInView,
     total: contentNodesResult.total,
   });
+}
+
+export async function getDataSourceViewFromVaultAndDataSourceId(
+  auth: Authenticator,
+  vault: VaultResource,
+  dataSourceId: string
+) {
+  const vaultDataSourceViews = await DataSourceViewResource.listByVault(
+    auth,
+    vault
+  );
+
+  const dataSourceView = vaultDataSourceViews.filter(
+    (dsv) => dsv.dataSource.sId === dataSourceId
+  );
+  if (dataSourceView.length > 1) {
+    return new Err("Error retrieving data source view");
+  }
+  return new Ok(dataSourceView.length == 1 ? dataSourceView[0] : null);
 }

--- a/front/lib/api/vaults.ts
+++ b/front/lib/api/vaults.ts
@@ -6,7 +6,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
-import type { VaultResource } from "@app/lib/resources/vault_resource";
+import { VaultResource } from "@app/lib/resources/vault_resource";
 
 export const deleteVault = async (
   auth: Authenticator,
@@ -83,3 +83,9 @@ export const deleteVault = async (
     }
   });
 };
+
+export async function getGlobalVault(
+  auth: Authenticator
+): Promise<VaultResource> {
+  return VaultResource.fetchWorkspaceGlobalVault(auth);
+}

--- a/front/pages/api/v1/w/[wId]/data_sources/[dsId]/join-slack.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[dsId]/join-slack.ts
@@ -1,0 +1,165 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getDataSourceViewFromVaultAndDataSourceId } from "@app/lib/api/data_source_view";
+import { getGlobalVault } from "@app/lib/api/vaults";
+import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+
+/**
+ * @swagger
+ * /api/v1/w/{wId}/data_sources/{dsId}/join-slack:
+ *   post:
+ *     summary: Join a Slack channel to a data source
+ *     description: Add a new Slack channel to the list of channels associated with a data source.
+ *     tags:
+ *       - Data Sources
+ *     security:
+ *       - BearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: Unique string identifier for the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: dsId
+ *         required: true
+ *         description: Unique string identifier for the data source
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - newChannelId
+ *             properties:
+ *               newChannelId:
+ *                 type: string
+ *                 description: The ID of the new Slack channel to add
+ *     responses:
+ *       200:
+ *         description: Successfully added the new channel
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *                 dataSourceView:
+ *                   $ref: '#/components/schemas/DataSourceView'
+ *       400:
+ *         description: Bad request (invalid input)
+ *       401:
+ *         description: Unauthorized
+ *       404:
+ *         description: Workspace or data source not found
+ *       405:
+ *         description: Method not allowed
+ *       500:
+ *         description: Internal server error
+ */
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  auth: Authenticator
+) {
+  const { dsId } = req.query;
+
+  if (!dsId || typeof dsId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing or invalid newChannelId in request body.",
+      },
+    });
+  }
+
+  const { newChannelId } = req.body;
+
+  if (req.method !== "POST") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "Only POST requests are allowed for this endpoint.",
+      },
+    });
+  }
+
+  if (!newChannelId || typeof newChannelId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing or invalid newChannelId in request body.",
+      },
+    });
+  }
+
+  try {
+    const globalVault = await getGlobalVault(auth);
+    if (!globalVault) {
+      return apiError(req, res, {
+        status_code: 404,
+        api_error: {
+          type: "vault_not_found",
+          message: "Global vault not found for the workspace.",
+        },
+      });
+    }
+
+    const dataSourceViewRes = await getDataSourceViewFromVaultAndDataSourceId(
+      auth,
+      globalVault,
+      dsId
+    );
+    if (dataSourceViewRes.isErr()) {
+      return apiError(req, res, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "An error occurred while retrieving the dataSourceView.",
+        },
+      });
+    }
+    const dataSourceView = dataSourceViewRes.value;
+
+    if (!dataSourceView) {
+      // slack wasn't added to the global vault so no need to add the channel
+    } else {
+      if (dataSourceView.dataSource.connectorProvider !== "slack"){
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Invalid data source connector provider.",
+          },
+        });
+      }
+      await dataSourceView.updateParents([
+        ...new Set([...(dataSourceView.parentsIn ?? []), newChannelId]),
+      ]);
+    }
+
+    res.status(200).json({ success: true, dataSourceView });
+  } catch (error) {
+    console.error("Error in slack-join endpoint:", error);
+    return apiError(req, res, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: "An error occurred while processing the request.",
+      },
+    });
+  }
+}
+
+export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/data_sources/[dsId]/join-slack.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[dsId]/join-slack.ts
@@ -135,7 +135,7 @@ async function handler(
     if (!dataSourceView) {
       // slack wasn't added to the global vault so no need to add the channel
     } else {
-      if (dataSourceView.dataSource.connectorProvider !== "slack"){
+      if (dataSourceView.dataSource.connectorProvider !== "slack") {
         return apiError(req, res, {
           status_code: 500,
           api_error: {


### PR DESCRIPTION
## Description

This is a temporary solution but with the release of vault slack channels that are automatically joined are not added to the global data source view. This is a regression as it requires human intervention and hence looses its "automatic" aspect.

To overcome this we add a new public endpoint `/api/v1/w/{wId}/data_sources/{dsId}/join-slack` which will add a given slack channel name to the global vault's data source view.

## Risk

Limited

## Deploy Plan

- Deploy `front`
- Deploy `connectors`
