### PR TITLE
[Confluence] Fix: slow retrieval of content nodes

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -23,6 +23,7 @@
         "@types/minimist": "^1.2.2",
         "@types/remove-markdown": "^0.3.4",
         "@types/uuid": "^9.0.2",
+        "async-mutex": "^0.5.0",
         "axios": "^1.5.1",
         "blake3": "^2.1.7",
         "body-parser": "^1.20.2",
@@ -5566,6 +5567,14 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/async-retry": {
       "version": "1.3.3",

--- a/connectors/package.json
+++ b/connectors/package.json
@@ -29,6 +29,7 @@
     "@types/minimist": "^1.2.2",
     "@types/remove-markdown": "^0.3.4",
     "@types/uuid": "^9.0.2",
+    "async-mutex": "^0.5.0",
     "axios": "^1.5.1",
     "blake3": "^2.1.7",
     "body-parser": "^1.20.2",

--- a/connectors/src/lib/api/content_nodes.ts
+++ b/connectors/src/lib/api/content_nodes.ts
@@ -4,6 +4,7 @@ import type {
   Result,
 } from "@dust-tt/types";
 import { Ok } from "@dust-tt/types";
+import { hash as blake3 } from "blake3";
 import { zip } from "fp-ts/lib/Array";
 
 import { getConnectorManager } from "@connectors/connectors";
@@ -27,9 +28,15 @@ export async function getParentIdsForContentNodes(
     connectorId: connector.id,
   });
 
+  const memoizationKey = `content-node-parents-${connector.id}-${blake3(internalIds.join("-"), { length: 256 }).toString()}`;
+
   const parentsResults = await concurrentExecutor(
     internalIds,
-    (internalId) => connectorManager.retrieveContentNodeParents({ internalId }),
+    (internalId) =>
+      connectorManager.retrieveContentNodeParents({
+        internalId,
+        memoizationKey,
+      }),
     { concurrency: 30 }
   );
 


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/1410

For confluence, the expensive `getSpaceHierarchy` is recomputed at every call to retrieveContentNodeParent; if there are more than a few dozens of children (e.g. doctolib), the slowness pops monitors (network timeouts) and shows failures to retrieve to the users.

This PR fixes by caching `getSpaceHierarchy` across concurrent accesses

Passing a memoization key in any case is also a good thing for connectors who support it.

Risks
---
Breaking confluence tree view. Tested locally, works well

Deploy
---
connectors
