### PR TITLE
Fix: hide private vaults section in sidebar if no vaults and not admin

### DIFF
--- a/front/components/vaults/VaultSideBarMenu.tsx
+++ b/front/components/vaults/VaultSideBarMenu.tsx
@@ -98,8 +98,12 @@ export default function VaultSideBarMenu({
             if (kind === "public" && !vaults.length) {
               return null;
             }
-            if (kind === "regular" && !isPrivateVaultsEnabled) {
-              return null;
+            if (kind === "regular") {
+              if (!isPrivateVaultsEnabled) {
+                return null;
+              } else if (!vaults.length && !isAdmin) {
+                return null;
+              }
             }
 
             const sectionLabel = getSectionLabel(kind);


### PR DESCRIPTION
## Description

Hide the "VAULTS" title when there are no vaults and you are not an admin.

## Risk

None

## Deploy Plan

Deploy `front`