### PR TITLE
[Poke] Fix members table for revoked members

### DIFF
--- a/front/components/poke/members/columns.tsx
+++ b/front/components/poke/members/columns.tsx
@@ -102,6 +102,9 @@ export function makeColumnsForMembers({
       },
       cell: ({ row }) => {
         const member = row.original;
+        if (member.role === "none") {
+          return <span className="py-2 pl-3 italic">revoked</span>;
+        }
         return (
           <select
             className="rounded-lg border border-gray-300 bg-gray-50 text-sm text-gray-900"
@@ -127,7 +130,7 @@ export function makeColumnsForMembers({
       cell: ({ row }) => {
         const member = row.original;
 
-        return (
+        return member.role !== "none" ? (
           <IconButton
             icon={TrashIcon}
             size="xs"
@@ -136,7 +139,7 @@ export function makeColumnsForMembers({
               await onRevokeMember(member);
             }}
           />
-        );
+        ) : null;
       },
     },
   ];


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/1432

List of members did not take into account revoked status for dropdown & trash button
![Screenshot from 2024-10-05 12-28-48](https://github.com/user-attachments/assets/5846b429-44fb-4e15-9d8e-facb1a567c66)

Risk
---
na

Deploy
---
front
