### PR TITLE
API v1: agent confiugrations `agentsGetView` to `list`

### DIFF
--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
@@ -56,7 +56,7 @@ async function handler(
     case "GET": {
       const agentConfigurations = await getAgentConfigurations({
         auth,
-        agentsGetView: "all",
+        agentsGetView: "list",
         variant: "light",
       });
       return res.status(200).json({


### PR DESCRIPTION
## Description

Move `agentsGetView` to `list` instead of `all` which has no effect if no user is tied to the Authenticator. If a user is tied to the Authenticator (for now system key + user header), then it will return its personal assistants on top of the workspace ones.

r? @fontanierh as initial author

## Risk

Low

## Deploy Plan

- deploy `front`