### PR TITLE
Revert "[Core] Remove index on deleted status (#7815)"

### DIFF
--- a/core/src/stores/migrations/20241007_ds_docs_add_deleted_index_again.sql
+++ b/core/src/stores/migrations/20241007_ds_docs_add_deleted_index_again.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_status_deleted ON data_sources_documents (id) WHERE status = 'deleted';

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -477,7 +477,7 @@ pub const POSTGRES_TABLES: [&'static str; 14] = [
     );",
 ];
 
-pub const SQL_INDEXES: [&'static str; 26] = [
+pub const SQL_INDEXES: [&'static str; 27] = [
     "CREATE INDEX IF NOT EXISTS
        idx_specifications_project_created ON specifications (project, created);",
     "CREATE INDEX IF NOT EXISTS
@@ -536,6 +536,8 @@ pub const SQL_INDEXES: [&'static str; 26] = [
        idx_tables_parents_array ON tables USING GIN (parents);",
     "CREATE UNIQUE INDEX IF NOT EXISTS
         idx_sqlite_workers_url ON sqlite_workers (url);",
+    "CREATE INDEX IF NOT EXISTS
+        idx_status_deleted ON data_sources_documents (id) WHERE status = 'deleted';",
 ];
 
 pub const SQL_FUNCTIONS: [&'static str; 2] = [


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/1442 again

See issue: removing the index put a strain on the secondary, which triggered monitors on database recovery errors every time the scrub workflow was run (every 8 hours)

This is fixed by adapting a revert of commit 294e82cb1a5eed65d7e17ca8e2ccd08978fbbbdc.

Risks
---
Risk was that the index make inserting in that table costly, but that doesn't seem to be the case, since the query we wanted to optimize by removing the index sits still:
[link](https://console.cloud.google.com/sql/instances/dust-api-db/insights;duration=PT1H;sort_by=TOTAL_EXEC_TIME/executed?project=or1g1n-186209&rapt=AEjHL4NQasz4vn3T0J-Zsp3VWj0CTH4OmyS0LsPwxqhTDxaGgQoPrfNYt6w5EiASPeX0THmwxOkg_-eeOxGdQ2LrckljoAWfFqSRGzqPwPH0YE7RWUWyJZM&inv=1&invt=AbeGkw)

(the update data source / status is still at ~25ms so removing the index actually had no effect)

Deploy
---
- run migration on prodbox
- deploy core
