### PR TITLE
[front] - fix(VaultSideBarMenu): padding "Create Vault" button

### DIFF
--- a/front/components/vaults/VaultSideBarMenu.tsx
+++ b/front/components/vaults/VaultSideBarMenu.tsx
@@ -110,7 +110,7 @@ export default function VaultSideBarMenu({
 
             return (
               <Fragment key={`vault-section-${index}`}>
-                <div className="flex items-center justify-between">
+                <div className="flex items-center justify-between pr-1">
                   <Item.SectionHeader
                     label={sectionLabel}
                     variant="secondary"


### PR DESCRIPTION
## Description

This PR aims at adding a right padding on the `VaultSideBarMenu` so that the scrollbar doesn't cover the "Create Vault" button

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
