### PR TITLE
[connectors] - fix(slack): auto join

### DIFF
--- a/connectors/src/connectors/slack/auto_read_channel.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.ts
@@ -123,13 +123,13 @@ export async function autoReadChannel(
     const joinSlackRes = await fetch(
       `${DUST_FRONT_API}/api/v1/w/${connector.workspaceId}/vaults/${dataSourceView.vaultId}/data_source_views/${dataSourceView.id}`,
       {
-        method: "POST",
+        method: "PATCH",
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${connector.workspaceAPIKey}`,
         },
         body: JSON.stringify({
-          parentsIn: [createdChannel.slackChannelId],
+          parentsToAdd: [createdChannel.slackChannelId],
         }),
       }
     );

--- a/connectors/src/connectors/slack/auto_read_channel.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.ts
@@ -86,7 +86,8 @@ export async function autoReadChannel(
 
     const baseSearchUrl = `${DUST_FRONT_API}/api/v1/w/${connector.workspaceId}/data_source_views/search`;
     const searchUrl =
-      baseSearchUrl + `?kind=custom&dataSourceId=${connector.dataSourceId}`;
+      baseSearchUrl +
+      `?kind=custom&vaultKind=global&dataSourceId=${connector.dataSourceId}`;
     const searchRes = await fetch(searchUrl, {
       method: "GET",
       headers: {

--- a/connectors/src/connectors/slack/auto_read_channel.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.ts
@@ -106,11 +106,11 @@ export async function autoReadChannel(
       return new Err(new Error("Failed to join Slack channel in Dust."));
     }
 
-    const dataSourceViews = (
+    const [dataSourceView] = (
       (await searchRes.json()) as SearchDataSourceViewsResponse
     ).data_source_views;
 
-    if (dataSourceViews.length === 0 || !dataSourceViews[0]) {
+    if (!dataSourceView) {
       logger.error({
         connectorId,
         channelId: slackChannelId,
@@ -121,7 +121,7 @@ export async function autoReadChannel(
       );
     }
     const joinSlackRes = await fetch(
-      `${DUST_FRONT_API}/api/v1/w/${connector.workspaceId}/data_source_views/${dataSourceViews[0].id}`,
+      `${DUST_FRONT_API}/api/v1/w/${connector.workspaceId}/vaults/${dataSourceView.vaultId}/data_source_views/${dataSourceView.id}`,
       {
         method: "POST",
         headers: {

--- a/connectors/src/connectors/slack/auto_read_channel.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.ts
@@ -1,4 +1,4 @@
-import type { Result } from "@dust-tt/types";
+import type { DataSourceViewType, Result } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 
 import { joinChannel } from "@connectors/connectors/slack/lib/channels";
@@ -9,6 +9,15 @@ import {
 } from "@connectors/lib/models/slack";
 import type { Logger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
+
+const { DUST_FRONT_API } = process.env;
+if (!DUST_FRONT_API) {
+  throw new Error("FRONT_API not set");
+}
+
+type SearchDataSourceViewsResponse = {
+  data_source_views: DataSourceViewType[];
+};
 
 export function isChannelNameWhitelisted(
   remoteChannelName: string,
@@ -68,12 +77,64 @@ export async function autoReadChannel(
     if (joinChannelRes.isErr()) {
       return joinChannelRes;
     }
-    await SlackChannel.create({
+    const createdChannel = await SlackChannel.create({
       connectorId,
       slackChannelId,
       slackChannelName: remoteChannelName,
       permission: "read_write",
     });
+
+    const baseSearchUrl = `${DUST_FRONT_API}/api/v1/w/${connector.workspaceId}/data_source_views/search`;
+    const searchUrl =
+      baseSearchUrl + `?kind=custom&dataSourceId=${connector.dataSourceId}`;
+    const searchRes = await fetch(searchUrl, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${connector.workspaceAPIKey}`,
+      },
+    });
+
+    if (!searchRes.ok) {
+      logger.error({
+        connectorId,
+        channelId: slackChannelId,
+        error: await searchRes.text(),
+      });
+      return new Err(new Error("Failed to join Slack channel in Dust."));
+    }
+
+    const dataSourceViews = (
+      (await searchRes.json()) as SearchDataSourceViewsResponse
+    ).data_source_views;
+
+    if (dataSourceViews.length === 0 || !dataSourceViews[0]) {
+      return new Err(
+        new Error("There was an issue retrieving dataSourceViews")
+      );
+    }
+    const joinSlackRes = await fetch(
+      `${DUST_FRONT_API}/api/v1/w/${connector.workspaceId}/data_source_views/${dataSourceViews[0].id}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${connector.workspaceAPIKey}`,
+        },
+        body: JSON.stringify({
+          parentsIn: [createdChannel.slackChannelId],
+        }),
+      }
+    );
+
+    if (!joinSlackRes.ok) {
+      logger.error({
+        connectorId,
+        channelId: slackChannelId,
+        error: await searchRes.text(),
+      });
+      return new Err(new Error("Failed to join Slack channel in Dust."));
+    }
   }
   return new Ok(undefined);
 }

--- a/connectors/src/connectors/slack/auto_read_channel.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.ts
@@ -100,6 +100,7 @@ export async function autoReadChannel(
       logger.error({
         connectorId,
         channelId: slackChannelId,
+        searchUrl,
         error: await searchRes.text(),
       });
       return new Err(new Error("Failed to join Slack channel in Dust."));
@@ -110,6 +111,11 @@ export async function autoReadChannel(
     ).data_source_views;
 
     if (dataSourceViews.length === 0 || !dataSourceViews[0]) {
+      logger.error({
+        connectorId,
+        channelId: slackChannelId,
+        error: await searchRes.text(),
+      });
       return new Err(
         new Error("There was an issue retrieving dataSourceViews")
       );

--- a/front/components/vaults/AddToVaultDialog.tsx
+++ b/front/components/vaults/AddToVaultDialog.tsx
@@ -66,14 +66,6 @@ export const AddToVaultDialog = ({
       (d) => d.vaultId === vault.sId
     );
 
-    const body = {
-      dataSourceId: dataSource.sId,
-      parentsIn:
-        existingViewForVault && existingViewForVault.parentsIn
-          ? [...existingViewForVault.parentsIn, contentNode.internalId]
-          : [contentNode.internalId],
-    };
-
     try {
       let res;
       if (existingViewForVault) {
@@ -84,7 +76,9 @@ export const AddToVaultDialog = ({
             headers: {
               "Content-Type": "application/json",
             },
-            body: JSON.stringify(body),
+            body: JSON.stringify({
+              parentsToAdd: [contentNode.internalId],
+            }),
           }
         );
       } else {
@@ -95,7 +89,10 @@ export const AddToVaultDialog = ({
             headers: {
               "Content-Type": "application/json",
             },
-            body: JSON.stringify(body),
+            body: JSON.stringify({
+              dataSourceId: dataSource.sId,
+              parentsIn: [contentNode.internalId],
+            }),
           }
         );
       }

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -3,14 +3,20 @@ import type {
   CoreAPIError,
   DataSourceViewContentNode,
   DataSourceViewType,
-  Result,
+  Result} from "@dust-tt/types";
+import {
+  PatchDataSourceViewSchema
 } from "@dust-tt/types";
 import { ConnectorsAPI, CoreAPI, Err, Ok, removeNulls } from "@dust-tt/types";
 import assert from "assert";
+import { isLeft } from "fp-ts/Either";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest } from "next";
 
 import config from "@app/lib/api/config";
 import { getContentNodeInternalIdFromTableId } from "@app/lib/api/content_nodes";
 import type { OffsetPaginationParams } from "@app/lib/api/pagination";
+import type { Authenticator } from "@app/lib/auth";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import logger from "@app/logger/logger";
 
@@ -275,4 +281,59 @@ export async function getContentNodesForDataSourceView(
     nodes: contentNodesInView,
     total: contentNodesResult.total,
   });
+}
+
+type PatchDataSourceViewResult = Result<
+  { dataSourceView: ReturnType<DataSourceViewResource["toJSON"]> },
+  { status: number; message: string }
+>;
+
+export async function handlePatchDataSourceView(
+  req: NextApiRequest,
+  auth: Authenticator,
+  dataSourceView: DataSourceViewResource
+): Promise<PatchDataSourceViewResult> {
+  if (!auth.isAdmin() && !auth.isBuilder()) {
+    return new Err({
+      status: 403,
+      message:
+        "Only users that are `admins` or `builder` can administrate vaults.",
+    });
+  }
+
+  const patchBodyValidation = PatchDataSourceViewSchema.decode(req.body);
+
+  if (isLeft(patchBodyValidation)) {
+    const pathError = reporter.formatValidationErrors(patchBodyValidation.left);
+    return new Err({
+      status: 400,
+      message: `invalid request body: ${pathError}`,
+    });
+  }
+
+  const { right: patchBody } = patchBodyValidation;
+
+  let updateResultRes;
+  if ("parentsIn" in patchBody) {
+    const { parentsIn } = patchBody;
+    updateResultRes = await dataSourceView.setParents(parentsIn);
+  } else {
+    const { parentsToAdd, parentsToRemove } = patchBody;
+    updateResultRes = await dataSourceView.updateParents(
+      parentsToAdd ?? [],
+      parentsToRemove ?? []
+    );
+  }
+
+  if (updateResultRes.isErr()) {
+    return new Err({
+      status: 500,
+      message: "The data source view cannot be updated.",
+    });
+  }
+
+  if (auth.user()) {
+    await dataSourceView.setEditedBy(auth);
+  }
+  return new Ok({ dataSourceView: dataSourceView.toJSON() });
 }

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -424,9 +424,20 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
   }
 
   async updateParents(
-    parentsIn: string[] | null
+    parentsToAdd: string[] = [],
+    parentsToRemove: string[] = []
   ): Promise<Result<undefined, Error>> {
-    await this.update({ parentsIn });
+    const currentParents = this.parentsIn || [];
+
+    // add new parents
+    const newParents = [...new Set(currentParents), ...new Set(parentsToAdd)];
+
+    // remove specified parents
+    const updatedParents = newParents.filter(
+      (parent) => !parentsToRemove.includes(parent)
+    );
+
+    await this.update({ parentsIn: updatedParents });
 
     return new Ok(undefined);
   }

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -360,7 +360,7 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
   static async search(
     auth: Authenticator,
     searchParams: {
-      [key in AllowedSearchColumns]: string | number;
+      [key in AllowedSearchColumns]: string | number | undefined;
     }
   ): Promise<DataSourceViewResource[]> {
     const owner = auth.workspace();
@@ -373,7 +373,7 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
     };
 
     for (const [key, value] of Object.entries(searchParams)) {
-      if (key !== "vaultKind") {
+      if (value && key !== "vaultKind") {
         whereClause[key] = value;
       } else {
         whereClause["$vault.kind$"] = searchParams.vaultKind;

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -39,6 +39,7 @@ import {
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { VaultResource } from "@app/lib/resources/vault_resource";
 import { getWorkspaceByModelId } from "@app/lib/workspace";
+import { VaultModel } from "@app/lib/resources/storage/models/vaults";
 
 const getDataSourceCategory = (
   dataSourceResource: DataSourceResource
@@ -370,16 +371,24 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
     };
 
     for (const [key, value] of Object.entries(searchParams)) {
-      if (value) {
+      if (value && key !== "vaultKind") {
         whereClause[key] = value;
       }
     }
+    if (searchParams.vaultKind) {
+      whereClause["$vault.kind$"] = searchParams.vaultKind;
+    }
+
     return this.baseFetch(
       auth,
       {},
       {
         where: whereClause,
         order: [["updatedAt", "DESC"]],
+        includes: [{
+          model: VaultModel,
+          as: "vault"
+        }],
       }
     );
   }

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -431,6 +431,20 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
     return new Ok(undefined);
   }
 
+  async addParents(
+    parentsIn: string[] | null
+  ): Promise<Result<undefined, Error>> {
+    const currentParents = this.parentsIn || [];
+    const updatedParents = [
+      ...new Set([...currentParents, ...(parentsIn ?? [])]),
+    ];
+    await this.update({
+      parentsIn: updatedParents.length > 0 ? updatedParents : null,
+    });
+
+    return new Ok(undefined);
+  }
+
   // Deletion.
 
   protected async softDelete(

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -30,6 +30,7 @@ import { ResourceWithVault } from "@app/lib/resources/resource_with_vault";
 import { frontSequelize } from "@app/lib/resources/storage";
 import type { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
+import { VaultModel } from "@app/lib/resources/storage/models/vaults";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import {
   getResourceIdFromSId,
@@ -39,7 +40,6 @@ import {
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { VaultResource } from "@app/lib/resources/vault_resource";
 import { getWorkspaceByModelId } from "@app/lib/workspace";
-import { VaultModel } from "@app/lib/resources/storage/models/vaults";
 
 const getDataSourceCategory = (
   dataSourceResource: DataSourceResource
@@ -385,10 +385,12 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
       {
         where: whereClause,
         order: [["updatedAt", "DESC"]],
-        includes: [{
-          model: VaultModel,
-          as: "vault"
-        }],
+        includes: [
+          {
+            model: VaultModel,
+            as: "vault",
+          },
+        ],
       }
     );
   }

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -443,6 +443,13 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
     return new Ok(undefined);
   }
 
+  async setParents(
+    parentsIn: string[] | null
+  ): Promise<Result<undefined, Error>> {
+    await this.update({ parentsIn });
+    return new Ok(undefined);
+  }
+
   // Deletion.
 
   protected async softDelete(

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -14,6 +14,7 @@ import type {
   CreationAttributes,
   ModelStatic,
   Transaction,
+  WhereOptions,
 } from "sequelize";
 import { Op } from "sequelize";
 
@@ -351,6 +352,36 @@ export class DataSourceViewResource extends ResourceWithVault<DataSourceViewMode
     );
 
     return dataSourceViews ?? null;
+  }
+
+  static async search(
+    auth: Authenticator,
+    searchParams: {
+      [key: string]: string | number | undefined;
+    }
+  ): Promise<DataSourceViewResource[]> {
+    const owner = auth.workspace();
+    if (!owner) {
+      return [];
+    }
+
+    const whereClause: WhereOptions = {
+      workspaceId: owner.id,
+    };
+
+    for (const [key, value] of Object.entries(searchParams)) {
+      if (value) {
+        whereClause[key] = value;
+      }
+    }
+    return this.baseFetch(
+      auth,
+      {},
+      {
+        where: whereClause,
+        order: [["updatedAt", "DESC"]],
+      }
+    );
   }
 
   // Updating.

--- a/front/pages/api/v1/w/[wId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_source_views/[dsvId]/index.ts
@@ -90,7 +90,7 @@ async function handler(
         api_error: {
           type: "method_not_supported_error",
           message:
-            "the method passed is not supported, GET, POST, or PATCH is expected.",
+            "the method passed is not supported, GET or PATCH is expected.",
         },
       });
   }

--- a/front/pages/api/v1/w/[wId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_source_views/[dsvId]/index.ts
@@ -68,7 +68,7 @@ async function handler(
       }
 
       const { parentsIn } = patchBodyValidation.right;
-      const updateResult = await dataSourceView.updateParents(parentsIn);
+      const updateResult = await dataSourceView.addParents(parentsIn);
 
       if (updateResult.isErr()) {
         return apiError(req, res, {

--- a/front/pages/api/v1/w/[wId]/data_source_views/search.ts
+++ b/front/pages/api/v1/w/[wId]/data_source_views/search.ts
@@ -1,0 +1,82 @@
+import type { DataSourceViewType, WithAPIErrorResponse } from "@dust-tt/types";
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { apiError } from "@app/logger/withlogging";
+
+const SearchDataSourceViewsQuerySchema = t.type({
+  dataSourceId: t.union([t.number, t.undefined]),
+  kind: t.union([t.string, t.undefined]),
+  vaultId: t.union([t.number, t.undefined]),
+});
+
+export type SearchDataSourceViewsResponseBody = {
+  data_source_views: DataSourceViewType[];
+};
+
+/**
+ * @ignoreswagger
+ * System API key only endpoint. Undocumented.
+ */
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<SearchDataSourceViewsResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  if (!auth.isSystemKey()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_view_not_found",
+        message: "The data source view was not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const queryValidation = SearchDataSourceViewsQuerySchema.decode(
+        req.query
+      );
+      if (isLeft(queryValidation)) {
+        const pathError = reporter.formatValidationErrors(queryValidation.left);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid query parameters: ${pathError}`,
+          },
+        });
+      }
+
+      const { vaultId, dataSourceId, kind } = queryValidation.right;
+
+      const data_source_views = await DataSourceViewResource.search(auth, {
+        vaultId,
+        dataSourceId,
+        kind,
+      });
+
+      res.status(200).json({
+        data_source_views: data_source_views.map((dsv) => dsv.toJSON()),
+      });
+      return;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/data_source_views/search.ts
+++ b/front/pages/api/v1/w/[wId]/data_source_views/search.ts
@@ -29,15 +29,15 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<SearchDataSourceViewsResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
-  // if (!auth.isSystemKey()) {
-  //   return apiError(req, res, {
-  //     status_code: 404,
-  //     api_error: {
-  //       type: "data_source_view_not_found",
-  //       message: "The data source view was not found.",
-  //     },
-  //   });
-  // }
+  if (!auth.isSystemKey()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_view_not_found",
+        message: "The data source view was not found.",
+      },
+    });
+  }
 
   switch (req.method) {
     case "GET":

--- a/front/pages/api/v1/w/[wId]/data_source_views/search.ts
+++ b/front/pages/api/v1/w/[wId]/data_source_views/search.ts
@@ -10,9 +10,9 @@ import { DataSourceViewResource } from "@app/lib/resources/data_source_view_reso
 import { apiError } from "@app/logger/withlogging";
 
 const SearchDataSourceViewsQuerySchema = t.type({
-  dataSourceId: t.union([t.number, t.undefined]),
+  dataSourceId: t.union([t.string, t.undefined]),
   kind: t.union([t.string, t.undefined]),
-  vaultId: t.union([t.number, t.undefined]),
+  vaultId: t.union([t.string, t.undefined]),
 });
 
 export type SearchDataSourceViewsResponseBody = {
@@ -29,15 +29,15 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<SearchDataSourceViewsResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isSystemKey()) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "data_source_view_not_found",
-        message: "The data source view was not found.",
-      },
-    });
-  }
+  // if (!auth.isSystemKey()) {
+  //   return apiError(req, res, {
+  //     status_code: 404,
+  //     api_error: {
+  //       type: "data_source_view_not_found",
+  //       message: "The data source view was not found.",
+  //     },
+  //   });
+  // }
 
   switch (req.method) {
     case "GET":

--- a/front/pages/api/v1/w/[wId]/data_source_views/search.ts
+++ b/front/pages/api/v1/w/[wId]/data_source_views/search.ts
@@ -13,6 +13,7 @@ const SearchDataSourceViewsQuerySchema = t.type({
   dataSourceId: t.union([t.string, t.undefined]),
   kind: t.union([t.string, t.undefined]),
   vaultId: t.union([t.string, t.undefined]),
+  vaultKind: t.union([t.string, t.undefined]),
 });
 
 export type SearchDataSourceViewsResponseBody = {
@@ -33,8 +34,8 @@ async function handler(
     return apiError(req, res, {
       status_code: 404,
       api_error: {
-        type: "data_source_view_not_found",
-        message: "The data source view was not found.",
+        type: "workspace_not_found",
+        message: "This endpoint is only available to system api keys.",
       },
     });
   }
@@ -55,12 +56,13 @@ async function handler(
         });
       }
 
-      const { vaultId, dataSourceId, kind } = queryValidation.right;
+      const { vaultId, dataSourceId, kind, vaultKind } = queryValidation.right;
 
       const data_source_views = await DataSourceViewResource.search(auth, {
         vaultId,
         dataSourceId,
         kind,
+        vaultKind
       });
 
       res.status(200).json({

--- a/front/pages/api/v1/w/[wId]/data_source_views/search.ts
+++ b/front/pages/api/v1/w/[wId]/data_source_views/search.ts
@@ -62,7 +62,7 @@ async function handler(
         vaultId,
         dataSourceId,
         kind,
-        vaultKind
+        vaultKind,
       });
 
       res.status(200).json({

--- a/front/pages/api/v1/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.ts
@@ -96,33 +96,6 @@ export type PatchDataSourceViewResponseBody = {
  *         description: Method not allowed
  *       '500':
  *         description: Internal server error
- *   delete:
- *     summary: Delete a data source view
- *     parameters:
- *       - name: wId
- *         in: path
- *         required: true
- *         schema:
- *           type: string
- *       - name: vId
- *         in: path
- *         required: true
- *         schema:
- *           type: string
- *       - name: dsvId
- *         in: path
- *         required: true
- *         schema:
- *           type: string
- *     responses:
- *       '400':
- *         description: Invalid request body
- *       '404':
- *         description: Data source view not found
- *       '405':
- *         description: Method not allowed
- *       '500':
- *         description: Internal server error
  */
 
 async function handler(

--- a/front/pages/api/v1/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.ts
@@ -1,4 +1,8 @@
-import type { DataSourceViewType, WithAPIErrorResponse } from "@dust-tt/types";
+import type {
+  DataSourceViewType,
+  Result,
+  WithAPIErrorResponse,
+} from "@dust-tt/types";
 import { PatchDataSourceViewSchema } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
@@ -133,13 +137,21 @@ async function handler(
         });
       }
 
-      const { parentsToAdd, parentsToRemove } = patchBodyValidation.right;
-      const updateResult = await dataSourceView.updateParents(
-        parentsToAdd ?? [],
-        parentsToRemove ?? []
-      );
+      const { right: body } = patchBodyValidation;
 
-      if (updateResult.isErr()) {
+      let updateResultRes: Result<undefined, Error>;
+      if ("parentsIn" in body) {
+        const { parentsIn } = body;
+        updateResultRes = await dataSourceView.setParents(parentsIn);
+      } else {
+        const { parentsToAdd, parentsToRemove } = body;
+        updateResultRes = await dataSourceView.updateParents(
+          parentsToAdd ?? [],
+          parentsToRemove ?? []
+        );
+      }
+
+      if (updateResultRes.isErr()) {
         return apiError(req, res, {
           status_code: 500,
           api_error: {

--- a/front/pages/api/v1/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.ts
@@ -67,8 +67,11 @@ async function handler(
         });
       }
 
-      const { parentsIn } = patchBodyValidation.right;
-      const updateResult = await dataSourceView.addParents(parentsIn);
+      const { parentsToAdd, parentsToRemove } = patchBodyValidation.right;
+      const updateResult = await dataSourceView.updateParents(
+        parentsToAdd ?? [],
+        parentsToRemove ?? []
+      );
 
       if (updateResult.isErr()) {
         return apiError(req, res, {

--- a/front/pages/api/v1/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.ts
@@ -1,11 +1,11 @@
 import type { DataSourceViewType, WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { handlePatchDataSourceView } from "@app/lib/api/data_source_view";
 import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { apiError } from "@app/logger/withlogging";
+import { handlePatchDataSourceView } from "@app/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]";
 
 export type GetOrPostDataSourceViewsResponseBody = {
   dataSourceView: DataSourceViewType;

--- a/front/pages/api/v1/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.ts
@@ -18,8 +18,111 @@ export type PatchDataSourceViewResponseBody = {
 };
 
 /**
- * @ignoreswagger
- * System API key only endpoint. Undocumented.
+ * @swagger
+ * /api/v1/w/{wId}/vaults/{vId}/data_source_views/{dsvId}:
+ *   get:
+ *     summary: Get a data source view
+ *     parameters:
+ *       - name: wId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - name: vId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - name: dsvId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       '200':
+ *         description: Successful response
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 dataSourceView:
+ *                   $ref: '#/components/schemas/DataSourceViewType'
+ *       '404':
+ *         description: Data source view not found
+ *       '405':
+ *         description: Method not allowed
+ *   patch:
+ *     summary: Update a data source view
+ *     parameters:
+ *       - name: wId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - name: vId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - name: dsvId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/PatchDataSourceViewSchema'
+ *     responses:
+ *       '200':
+ *         description: Successful response
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 dataSourceView:
+ *                   $ref: '#/components/schemas/DataSourceViewType'
+ *       '400':
+ *         description: Invalid request body
+ *       '403':
+ *         description: Unauthorized
+ *       '404':
+ *         description: Data source view not found
+ *       '405':
+ *         description: Method not allowed
+ *       '500':
+ *         description: Internal server error
+ *   delete:
+ *     summary: Delete a data source view
+ *     parameters:
+ *       - name: wId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - name: vId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - name: dsvId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       '400':
+ *         description: Invalid request body
+ *       '404':
+ *         description: Data source view not found
+ *       '405':
+ *         description: Method not allowed
+ *       '500':
+ *         description: Internal server error
  */
 
 async function handler(
@@ -31,16 +134,6 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isSystemKey()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_not_found",
-        message: "this endpoint is only available to system api keys.",
-      },
-    });
-  }
-
   const dataSourceView = await DataSourceViewResource.fetchById(
     auth,
     req.query.dsvId as string

--- a/front/pages/api/v1/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.ts
@@ -5,13 +5,10 @@ import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { apiError } from "@app/logger/withlogging";
+import type { PatchDataSourceViewResponseBody } from "@app/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]";
 import { handlePatchDataSourceView } from "@app/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]";
 
 export type GetOrPostDataSourceViewsResponseBody = {
-  dataSourceView: DataSourceViewType;
-};
-
-export type PatchDataSourceViewResponseBody = {
   dataSourceView: DataSourceViewType;
 };
 
@@ -117,17 +114,7 @@ async function handler(
       });
 
     case "PATCH":
-      const result = await handlePatchDataSourceView(req, auth, dataSourceView);
-      if (result.isErr()) {
-        return apiError(req, res, {
-          status_code: result.error.status,
-          api_error: {
-            type: "invalid_request_error",
-            message: result.error.message,
-          },
-        });
-      }
-      return res.status(200).json(result.value);
+      return handlePatchDataSourceView(req, res, auth, dataSourceView);
 
     default:
       return apiError(req, res, {

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.ts
@@ -1,7 +1,7 @@
 import type {
   DataSourceViewType,
-  WithAPIErrorResponse,
   Result,
+  WithAPIErrorResponse,
 } from "@dust-tt/types";
 import { PatchDataSourceViewSchema } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.ts
@@ -1,5 +1,4 @@
 import type { DataSourceViewType, WithAPIErrorResponse } from "@dust-tt/types";
-import { Err } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { handlePatchDataSourceView } from "@app/lib/api/data_source_view";

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.ts
@@ -69,8 +69,11 @@ async function handler(
         });
       }
 
-      const { parentsIn } = bodyValidation.right;
-      const updateResult = await dataSourceView.updateParents(parentsIn);
+      const { parentsToAdd, parentsToRemove } = bodyValidation.right;
+      const updateResult = await dataSourceView.updateParents(
+        parentsToAdd ?? [],
+        parentsToRemove ?? []
+      );
 
       if (updateResult.isErr()) {
         return apiError(req, res, {

--- a/types/src/front/api_handlers/public/vaults.ts
+++ b/types/src/front/api_handlers/public/vaults.ts
@@ -15,7 +15,8 @@ export const PostDataSourceViewSchema = t.type({
 export type PostDataSourceViewType = t.TypeOf<typeof PostDataSourceViewSchema>;
 
 export const PatchDataSourceViewSchema = t.type({
-  parentsIn: t.array(t.string),
+  parentsToAdd: t.union([t.array(t.string), t.undefined]),
+  parentsToRemove: t.union([t.array(t.string), t.undefined]),
 });
 
 export type PatchDataSourceViewType = t.TypeOf<

--- a/types/src/front/api_handlers/public/vaults.ts
+++ b/types/src/front/api_handlers/public/vaults.ts
@@ -14,10 +14,19 @@ export const PostDataSourceViewSchema = t.type({
 
 export type PostDataSourceViewType = t.TypeOf<typeof PostDataSourceViewSchema>;
 
-export const PatchDataSourceViewSchema = t.type({
+const ParentsToAddRemoveSchema = t.type({
   parentsToAdd: t.union([t.array(t.string), t.undefined]),
   parentsToRemove: t.union([t.array(t.string), t.undefined]),
 });
+
+const ParentsInSchema = t.type({
+  parentsIn: t.array(t.string),
+});
+
+export const PatchDataSourceViewSchema = t.union([
+  ParentsToAddRemoveSchema,
+  ParentsInSchema,
+]);
 
 export type PatchDataSourceViewType = t.TypeOf<
   typeof PatchDataSourceViewSchema

--- a/types/src/front/lib/dust_api.ts
+++ b/types/src/front/lib/dust_api.ts
@@ -19,7 +19,9 @@ import { WorkspaceDomain } from "../../front/workspace";
 import { WhitelistableFeature } from "../../shared/feature_flags";
 import { LoggerInterface } from "../../shared/logger";
 import { Err, Ok, Result } from "../../shared/result";
+import { PatchDataSourceViewType } from "../api_handlers/public/vaults";
 import { ContentFragmentType } from "../content_fragment";
+import { DataSourceViewType } from "../data_source_view";
 import {
   AgentActionSuccessEvent,
   AgentErrorEvent,
@@ -907,6 +909,50 @@ export class DustAPI {
     }
 
     return new Ok(r.value.feature_flags);
+  }
+
+  async searchDataSourceViews(
+    searchParams: URLSearchParams
+  ): Promise<DustAPIResponse<DataSourceViewType[]>> {
+    const endpoint = `${this.apiUrl()}/api/v1/w/${this.workspaceId()}/data_source_views/search?${searchParams.toString()}`;
+    const res = await this._fetchWithError(endpoint, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${this._credentials.apiKey}`,
+      },
+    });
+    const r: DustAPIResponse<{ data_source_views: DataSourceViewType[] }> =
+      await this._resultFromResponse(res);
+    if (r.isErr()) {
+      return r;
+    }
+
+    return new Ok(r.value.data_source_views);
+  }
+
+  async patchDataSourceViews(
+    dataSourceView: DataSourceViewType,
+    patchData: PatchDataSourceViewType
+  ) {
+    const endpoint = `${this.apiUrl()}/api/v1/w/${this.workspaceId()}/data_source_views/${
+      dataSourceView.id
+    }`;
+    const res = await this._fetchWithError(endpoint, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${this._credentials.apiKey}`,
+      },
+      body: JSON.stringify(patchData),
+    });
+    const r: DustAPIResponse<{ data_source_views: DataSourceViewType[] }> =
+      await this._resultFromResponse(res);
+    if (r.isErr()) {
+      return r;
+    }
+
+    return new Ok(undefined);
   }
 
   private async _fetchWithError(


### PR DESCRIPTION
## Description

With the release of vault slack channels that are automatically joined are not added to the global data source view. This is a regression as it requires human intervention and hence looses its "automatic" aspect.

To overcome this we add a new public endpoint `/api/v1/w/{wId}/data_source_views/search` to retrieve the custom `dataSourceView` associated to the global vault.

## Risk

Minor 

## Deploy Plan

- Deploy front
- Deploy connectors