### PR TITLE
Add "Add data button" on all view pages

### DIFF
--- a/front/components/data_source/RequestDataSourceModal.tsx
+++ b/front/components/data_source/RequestDataSourceModal.tsx
@@ -116,8 +116,8 @@ export function RequestDataSourceModal({
           </div>
 
           {selectedDataSource && (
-            <div>
-              <p className="s-mb-2 s-text-sm s-text-element-700">
+            <div className="flex flex-col gap-2">
+              <p className="mb-2 text-sm text-element-700">
                 {_.capitalize(selectedDataSource.editedByUser?.fullName ?? "")}{" "}
                 is the administrator for the{" "}
                 {getDisplayNameForDataSource(selectedDataSource)} connection
@@ -131,52 +131,54 @@ export function RequestDataSourceModal({
                 onChange={(e) => setMessage(e.target.value)}
                 className="s-mb-2"
               />
-              <Button
-                label="Send"
-                variant="primary"
-                size="sm"
-                onClick={async () => {
-                  const userToId = selectedDataSource?.editedByUser?.userId;
-                  if (!userToId || !selectedDataSource) {
-                    sendNotification({
-                      type: "error",
-                      title: "Error sending email",
-                      description:
-                        "An unexpected error occurred while sending email.",
-                    });
-                  } else {
-                    try {
-                      await sendRequestDataSourceEmail({
-                        userTo: userToId,
-                        emailMessage: message,
-                        dataSourceName: selectedDataSource.name,
-                        owner,
-                      });
-                      sendNotification({
-                        type: "success",
-                        title: "Email sent!",
-                        description: `Your request was sent to ${selectedDataSource?.editedByUser?.fullName}.`,
-                      });
-                    } catch (e) {
+              <div>
+                <Button
+                  label="Send"
+                  variant="primary"
+                  size="sm"
+                  onClick={async () => {
+                    const userToId = selectedDataSource?.editedByUser?.userId;
+                    if (!userToId || !selectedDataSource) {
                       sendNotification({
                         type: "error",
                         title: "Error sending email",
                         description:
-                          "An unexpected error occurred while sending the request.",
+                          "An unexpected error occurred while sending email.",
                       });
-                      logger.error(
-                        {
-                          userToId,
+                    } else {
+                      try {
+                        await sendRequestDataSourceEmail({
+                          userTo: userToId,
+                          emailMessage: message,
                           dataSourceName: selectedDataSource.name,
-                          error: e,
-                        },
-                        "Error sending email"
-                      );
+                          owner,
+                        });
+                        sendNotification({
+                          type: "success",
+                          title: "Email sent!",
+                          description: `Your request was sent to ${selectedDataSource?.editedByUser?.fullName}.`,
+                        });
+                      } catch (e) {
+                        sendNotification({
+                          type: "error",
+                          title: "Error sending email",
+                          description:
+                            "An unexpected error occurred while sending the request.",
+                        });
+                        logger.error(
+                          {
+                            userToId,
+                            dataSourceName: selectedDataSource.name,
+                            error: e,
+                          },
+                          "Error sending email"
+                        );
+                      }
+                      onClose();
                     }
-                    onClose();
-                  }
-                }}
-              />
+                  }}
+                />
+              </div>
             </div>
           )}
         </div>

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -220,6 +220,7 @@ export function DataSourceViewsSelector({
                   setSelectionConfigurations={setSelectionConfigurations}
                   viewType={viewType}
                   isRootSelectable={isRootSelectable}
+                  defaultCollapsed={filteredDSVs.length > 1}
                 />
               ))}
           </Tree.Item>
@@ -237,9 +238,9 @@ export function DataSourceViewsSelector({
               setSelectionConfigurations={setSelectionConfigurations}
               viewType={viewType}
               isRootSelectable={false}
+              defaultCollapsed={filteredDSVs.length > 1}
             />
           ))}
-
         {folders.length > 0 && (
           <Tree.Item
             key="folders"
@@ -258,11 +259,11 @@ export function DataSourceViewsSelector({
                 setSelectionConfigurations={setSelectionConfigurations}
                 viewType={viewType}
                 isRootSelectable={isRootSelectable}
+                defaultCollapsed={filteredDSVs.length > 1}
               />
             ))}
           </Tree.Item>
         )}
-
         {websites.length > 0 && (
           <Tree.Item
             key="websites"
@@ -281,6 +282,7 @@ export function DataSourceViewsSelector({
                 setSelectionConfigurations={setSelectionConfigurations}
                 viewType={viewType}
                 isRootSelectable={isRootSelectable}
+                defaultCollapsed={filteredDSVs.length > 1}
               />
             ))}
           </Tree.Item>
@@ -300,6 +302,7 @@ interface DataSourceViewSelectorProps {
   useContentNodes?: typeof useDataSourceViewContentNodes;
   viewType: ContentNodesViewType;
   isRootSelectable: boolean;
+  defaultCollapsed?: boolean;
 }
 
 export function DataSourceViewSelector({
@@ -310,6 +313,7 @@ export function DataSourceViewSelector({
   useContentNodes = useDataSourceViewContentNodes,
   viewType,
   isRootSelectable,
+  defaultCollapsed = true,
 }: DataSourceViewSelectorProps) {
   const dataSourceView = selectionConfiguration.dataSourceView;
 
@@ -454,6 +458,7 @@ export function DataSourceViewSelector({
         key={dataSourceView.dataSource.id}
         label={getDisplayNameForDataSource(dataSourceView.dataSource)}
         visual={LogoComponent}
+        defaultCollapsed={defaultCollapsed}
         type={
           canBeExpanded(viewType, dataSourceView.dataSource) ? "node" : "leaf"
         }

--- a/front/components/vaults/EditVaultManagedDatasourcesViews.tsx
+++ b/front/components/vaults/EditVaultManagedDatasourcesViews.tsx
@@ -1,7 +1,8 @@
-import { Button, Dialog, PlusIcon, Spinner } from "@dust-tt/sparkle";
+import { Button, Dialog, PlusIcon } from "@dust-tt/sparkle";
 import type {
   APIError,
   DataSourceViewSelectionConfigurations,
+  DataSourceViewType,
   VaultType,
   WorkspaceType,
 } from "@dust-tt/types";
@@ -23,6 +24,7 @@ interface EditVaultManagedDataSourcesViewsProps {
   owner: WorkspaceType;
   systemVault: VaultType;
   vault: VaultType;
+  dataSourceView?: DataSourceViewType;
 }
 
 export function EditVaultManagedDataSourcesViews({
@@ -30,6 +32,7 @@ export function EditVaultManagedDataSourcesViews({
   owner,
   systemVault,
   vault,
+  dataSourceView,
 }: EditVaultManagedDataSourcesViewsProps) {
   const sendNotification = React.useContext(SendNotificationsContext);
 
@@ -59,15 +62,26 @@ export function EditVaultManagedDataSourcesViews({
     disabled: !isAdmin,
   });
   const filteredSystemVaultDataSourceViews = useMemo(
-    () => systemVaultDataSourceViews.filter((dsv) => isManaged(dsv.dataSource)),
-    [systemVaultDataSourceViews]
+    () =>
+      systemVaultDataSourceViews.filter(
+        (dsv) =>
+          isManaged(dsv.dataSource) &&
+          (!dataSourceView ||
+            dsv.dataSource.sId === dataSourceView.dataSource.sId)
+      ),
+    [systemVaultDataSourceViews, dataSourceView]
   );
+
+  const filteredDataSourceViews = vaultDataSourceViews.filter(
+    (dsv) => !dataSourceView || dsv.sId === dataSourceView.sId
+  );
+
   const updateVaultDataSourceViews = async (
     selectionConfigurations: DataSourceViewSelectionConfigurations
   ) => {
     // Check if a data source view in the vault is no longer in the selection configurations by
     // comparing the data source.  If so, delete it.
-    const deletedViews = vaultDataSourceViews.filter(
+    const deletedViews = filteredDataSourceViews.filter(
       (dsv) =>
         !Object.values(selectionConfigurations).find(
           (sc) => sc.dataSourceView.dataSource.sId === dsv.dataSource.sId
@@ -104,7 +118,7 @@ export function EditVaultManagedDataSourcesViews({
             dataSourceView: { dataSource: sDs },
           } = selectionConfiguration;
 
-          const existingViewForDs = vaultDataSourceViews.find(
+          const existingViewForDs = filteredDataSourceViews.find(
             (d) => d.dataSource.sId === sDs.sId
           );
 
@@ -185,11 +199,7 @@ export function EditVaultManagedDataSourcesViews({
   };
 
   if (isSystemVaultDataSourceViewsLoading || isVaultDataSourceViewsLoading) {
-    return (
-      <div className="mt-8 flex justify-center">
-        <Spinner size="lg" />
-      </div>
-    );
+    return false;
   }
   return isAdmin ? (
     <>
@@ -204,7 +214,7 @@ export function EditVaultManagedDataSourcesViews({
         onSave={async (selectionConfigurations) => {
           await updateVaultDataSourceViews(selectionConfigurations);
         }}
-        initialSelectedDataSources={vaultDataSourceViews}
+        initialSelectedDataSources={filteredDataSourceViews}
       />
       <Dialog
         isOpen={showNoConnectionDialog}
@@ -221,7 +231,7 @@ export function EditVaultManagedDataSourcesViews({
         <p>You have no connection set up.</p>
       </Dialog>
       <Button
-        label="Add data from connections"
+        label="Link data from connections"
         variant="primary"
         icon={PlusIcon}
         size="sm"
@@ -236,7 +246,7 @@ export function EditVaultManagedDataSourcesViews({
     </>
   ) : (
     <RequestDataSourceModal
-      dataSources={vaultDataSourceViews.map((view) => view.dataSource)}
+      dataSources={filteredDataSourceViews.map((view) => view.dataSource)}
       owner={owner}
     />
   );

--- a/front/components/vaults/EditVaultManagedDatasourcesViews.tsx
+++ b/front/components/vaults/EditVaultManagedDatasourcesViews.tsx
@@ -231,7 +231,7 @@ export function EditVaultManagedDataSourcesViews({
         <p>You have no connection set up.</p>
       </Dialog>
       <Button
-        label="Link data from connections"
+        label="Add data from connections"
         variant="primary"
         icon={PlusIcon}
         size="sm"

--- a/front/components/vaults/VaultDataSourceViewContentList.tsx
+++ b/front/components/vaults/VaultDataSourceViewContentList.tsx
@@ -38,6 +38,7 @@ import {
   ContentActions,
   getMenuItems,
 } from "@app/components/vaults/ContentActions";
+import { EditVaultManagedDataSourcesViews } from "@app/components/vaults/EditVaultManagedDatasourcesViews";
 import { FoldersHeaderMenu } from "@app/components/vaults/FoldersHeaderMenu";
 import { WebsitesHeaderMenu } from "@app/components/vaults/WebsitesHeaderMenu";
 import { getVisualForContentNode } from "@app/lib/content_nodes";
@@ -46,7 +47,7 @@ import {
   useDataSourceViewContentNodes,
   useDataSourceViews,
 } from "@app/lib/swr/data_source_views";
-import { useSystemVault, useVaults } from "@app/lib/swr/vaults";
+import { useVaults } from "@app/lib/swr/vaults";
 import { classNames, formatTimestampToFriendlyDate } from "@app/lib/utils";
 
 type RowData = DataSourceViewContentNode & {
@@ -64,6 +65,7 @@ type VaultDataSourceViewContentListProps = {
   owner: WorkspaceType;
   parentId?: string;
   isAdmin: boolean;
+  systemVault: VaultType;
   connector: ConnectorType | null;
 };
 
@@ -169,6 +171,7 @@ export const VaultDataSourceViewContentList = ({
   onSelect,
   parentId,
   isAdmin,
+  systemVault,
   connector,
 }: VaultDataSourceViewContentListProps) => {
   const [dataSourceSearch, setDataSourceSearch] = useState<string>("");
@@ -192,11 +195,6 @@ export const VaultDataSourceViewContentList = ({
   const { dataSourceViews } = useDataSourceViews(owner, {
     disabled: !showVaultUsage,
   });
-  const { systemVault } = useSystemVault({
-    workspaceId: owner.sId,
-    disabled: !isAdmin,
-  });
-
   const handleViewTypeChange = useCallback(
     (newViewType?: ContentNodesViewType) => {
       if (newViewType !== viewType) {
@@ -417,6 +415,17 @@ export const VaultDataSourceViewContentList = ({
             dataSourceView={dataSourceView}
           />
         )}
+        {isManaged(dataSourceView.dataSource) &&
+          vault.kind !== "system" &&
+          !isEmpty && (
+            <EditVaultManagedDataSourcesViews
+              owner={owner}
+              vault={vault}
+              systemVault={systemVault}
+              isAdmin={isAdmin}
+              dataSourceView={dataSourceView}
+            />
+          )}
         {isManaged(dataSourceView.dataSource) &&
           connector &&
           !parentId &&

--- a/front/components/vaults/VaultLayout.tsx
+++ b/front/components/vaults/VaultLayout.tsx
@@ -54,7 +54,7 @@ export function VaultLayout({
 
   const { vaults } = useVaultsAsAdmin({
     workspaceId: owner.sId,
-    disabled: plan.limits.vaults.maxVaults === 0,
+    disabled: plan.limits.vaults.maxVaults === 0 || !isAdmin,
   });
 
   const isPrivateVaultsEnabled = owner.flags.includes(

--- a/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
+++ b/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
@@ -137,7 +137,7 @@ export default function VaultManagedDataSourcesViewsModal({
       }}
       hasChanged={hasChanged}
       variant="side-md"
-      title={`Link connected data to vault "${vault.name}"`}
+      title={`Add connected data to vault "${vault.name}"`}
     >
       <div className="w-full pt-12">
         <div className="overflow-x-auto">

--- a/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
+++ b/front/components/vaults/VaultManagedDatasourcesViewsModal.tsx
@@ -137,7 +137,7 @@ export default function VaultManagedDataSourcesViewsModal({
       }}
       hasChanged={hasChanged}
       variant="side-md"
-      title={`Add connected data to vault "${vault.name}"`}
+      title={`Link connected data to vault "${vault.name}"`}
     >
       <div className="w-full pt-12">
         <div className="overflow-x-auto">

--- a/front/lib/swr/vaults.ts
+++ b/front/lib/swr/vaults.ts
@@ -95,7 +95,7 @@ export function useVaultInfo({
   return {
     vaultInfo: data ? data.vault : null,
     mutateVaultInfo: mutate,
-    isVaultInfoLoading: !error && !data,
+    isVaultInfoLoading: !error && !data && !disabled,
     isVaultInfoError: error,
   };
 }
@@ -208,7 +208,7 @@ export function useVaultDataSourceViewsWithDetails({
     vaultDataSourceViews,
     mutate,
     mutateRegardlessOfQueryParams,
-    isVaultDataSourceViewsLoading: !error && !data,
+    isVaultDataSourceViewsLoading: !error && !data && !disabled,
     isVaultDataSourceViewsError: error,
   };
 }

--- a/front/pages/w/[wId]/vaults/[vaultId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
@@ -4,6 +4,7 @@ import type {
   DataSourceType,
   DataSourceViewCategory,
   DataSourceViewType,
+  VaultType,
 } from "@dust-tt/types";
 import { ConnectorsAPI } from "@dust-tt/types";
 import type { InferGetServerSidePropsType } from "next";
@@ -16,6 +17,7 @@ import { VaultLayout } from "@app/components/vaults/VaultLayout";
 import config from "@app/lib/api/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { VaultResource } from "@app/lib/resources/vault_resource";
 import logger from "@app/logger/logger";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<
@@ -26,6 +28,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     canWriteInVault: boolean;
     canReadInVault: boolean;
     parentId?: string;
+    systemVault: VaultType;
     connector: ConnectorType | null;
   }
 >(async (context, auth) => {
@@ -71,6 +74,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     };
   }
 
+  const systemVault = await VaultResource.fetchWorkspaceSystemVault(auth);
   const vault = dataSourceView.vault;
   const canWriteInVault = vault.canWrite(auth);
   const canReadInVault = vault.canRead(auth);
@@ -103,6 +107,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
       plan,
       subscription,
       vault: vault.toJSON(),
+      systemVault: systemVault.toJSON(),
       connector,
     },
   };
@@ -118,6 +123,7 @@ export default function Vault({
   parentId,
   plan,
   isAdmin,
+  systemVault,
   connector,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
@@ -137,6 +143,7 @@ export default function Vault({
           );
         }}
         isAdmin={isAdmin}
+        systemVault={systemVault}
         connector={connector}
       />
     </Page.Vertical>


### PR DESCRIPTION
fixes: [#7924](https://github.com/dust-tt/dust/issues/7924)

## Description

- Add button to add data to a data source view at every level of the datasource view. 
- Renamed to "Link data"
- Expand the selection tree if there's only one possible ds
- Display "data request" on the correct ds
- Layout issues in request data modal (added gap)

<img width="984" alt="Screenshot 2024-10-07 at 16 06 17" src="https://github.com/user-attachments/assets/37a729a1-68b1-4268-9f17-f53e42af7458">
<img width="993" alt="Screenshot 2024-10-07 at 16 06 24" src="https://github.com/user-attachments/assets/87277b65-9ec3-4e84-a357-4fd0de9d48fe">
<img width="845" alt="Screenshot 2024-10-07 at 16 06 33" src="https://github.com/user-attachments/assets/5dbe2825-0987-4c43-a377-55c94e5c798d">
<img width="983" alt="Screenshot 2024-10-07 at 16 06 45" src="https://github.com/user-attachments/assets/9dcf9195-f222-438b-ada7-423008110157">
<img width="979" alt="Screenshot 2024-10-07 at 16 06 51" src="https://github.com/user-attachments/assets/e175117f-3110-4864-a96a-d7133dd01c4f">


## Risk



## Deploy Plan

deploy front
