### PR TITLE
[sparkle] - feat: add `tailwindcss-animate` plugin

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.255",
+  "version": "0.2.256",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.255",
+      "version": "0.2.256",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
@@ -68,6 +68,7 @@
         "sass-loader": "^13.3.2",
         "storybook": "^7.4.6",
         "tailwindcss": "^3.2.4",
+        "tailwindcss-animate": "^1.0.7",
         "tsc-alias": "^1.8.10",
         "typescript": "^5.4.5",
         "typescript-transform-paths": "^3.4.7",
@@ -27408,6 +27409,15 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tailwindcss-animate": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
+      "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
+      "dev": true,
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders"
       }
     },
     "node_modules/tapable": {

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.255",
+  "version": "0.2.256",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",
@@ -66,6 +66,7 @@
     "tailwindcss": "^3.2.4",
     "tsc-alias": "^1.8.10",
     "typescript": "^5.4.5",
+    "tailwindcss-animate": "^1.0.7",
     "typescript-transform-paths": "^3.4.7",
     "uuid": "^9.0.1"
   },

--- a/sparkle/tailwind.config.js
+++ b/sparkle/tailwind.config.js
@@ -231,7 +231,11 @@ module.exports = {
       backgroundColor: ["dark"],
     },
   },
-  plugins: [require("@tailwindcss/forms"), require("tailwind-scrollbar-hide")],
+  plugins: [
+    require("@tailwindcss/forms"),
+    require("tailwind-scrollbar-hide"),
+    require("tailwindcss-animate"),
+  ],
   prefix: "s-",
   content: ["./src/**/*.{html,js,ts,jsx,tsx}"],
   safelist: [


### PR DESCRIPTION
## Description

This PR aims at adding the `tailwindcss-animate` plugin to `sparkle`. Currently we do not see animations on `Tooltip` open/close

## Risk


## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
