### PR TITLE
[Connectors - Notion] Add continueAsNew to garbage collection

### DIFF
--- a/connectors/src/connectors/notion/temporal/workflows/index.ts
+++ b/connectors/src/connectors/notion/temporal/workflows/index.ts
@@ -188,8 +188,10 @@ export async function notionSyncWorkflow({
 // This is the garbage collector workflow that continuously runs for each notion connector.
 export async function notionGarbageCollectionWorkflow({
   connectorId,
+  cursors = [null, null],
 }: {
   connectorId: ModelId;
+  cursors?: (string | null)[];
 }) {
   const topLevelWorkflowId = workflowInfo().workflowId;
 
@@ -212,7 +214,6 @@ export async function notionGarbageCollectionWorkflow({
 
   const runTimestamp = Date.now();
 
-  let cursors: (string | null)[] = [null, null];
   let pageIndex = 0;
   const childWorkflowQueue = new PQueue({
     concurrency: MAX_CONCURRENT_CHILD_WORKFLOWS,
@@ -258,6 +259,14 @@ export async function notionGarbageCollectionWorkflow({
         forceResync: false,
       })
     );
+
+    if (pageIndex > 512) {
+      await continueAsNew<typeof notionGarbageCollectionWorkflow>({
+        connectorId,
+        cursors,
+      });
+      return;
+    }
   } while (cursors[1]);
 
   // wait for all child workflows to finish


### PR DESCRIPTION
Description
---
Fixes issue encountered [here](https://dust4ai.slack.com/archives/C05F84CFP0E/p1728324361404239)

In some cases, as can be seen on this [workflow](https://cloud.temporal.io/namespaces/dust-prod.gmnlm/workflows/workflow-notion-145-garbage-collector/1610822a-cfab-4a59-a758-f7165619fe78/history) from qonto, history size limit is reached, at activity ~5000 or so.

Fixes by continuingAsNew when there's been many activities run already as indicated by `pageIndex`. Long
workflows are a pain anyway, so continuing as new way before that, when we reach activity ~1000

Risk
---
na

Deploy
---
- connectors
- restart notion workflows