### PR TITLE
v1: assistants-search view when user is set in agent configurations list

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -592,7 +592,10 @@ export async function getAgentConfigurations<V extends "light" | "full">({
   }
 
   if (agentsGetView === "list" && !user) {
-    throw new Error("List view is specific to a user.");
+    throw new Error("`list` view is specific to a user.");
+  }
+  if (agentsGetView === "assistants-search" && !user) {
+    throw new Error("`assistant-search` view is specific to a user.");
   }
 
   const applySortAndLimit = makeApplySortAndLimit(sort, limit);

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -591,11 +591,13 @@ export async function getAgentConfigurations<V extends "light" | "full">({
     throw new Error("Archived view is for dust superusers only.");
   }
 
-  if (agentsGetView === "list" && !user) {
-    throw new Error("`list` view is specific to a user.");
-  }
-  if (agentsGetView === "assistants-search" && !user) {
-    throw new Error("`assistant-search` view is specific to a user.");
+  if (
+    (agentsGetView === "list" || agentsGetView === "assistants-search") &&
+    !user
+  ) {
+    throw new Error(
+      "`list` or `assistants-search` view is specific to a user."
+    );
   }
 
   const applySortAndLimit = makeApplySortAndLimit(sort, limit);

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
@@ -56,7 +56,7 @@ async function handler(
     case "GET": {
       const agentConfigurations = await getAgentConfigurations({
         auth,
-        agentsGetView: "all",
+        agentsGetView: auth.user() ? "assistants-search" : "all",
         variant: "light",
       });
       return res.status(200).json({


### PR DESCRIPTION
## Description

Fix of https://github.com/dust-tt/dust/pull/7912 which caused an incident with our slack workflow (system api key without user override). Use `assistants-search` when a user is set (which will give us all agents + agents owned by the user. Otherwise use the existing code-path relying on `all`.

Also add a check for presence of user for `assistant-search` out of consistency with `list` (otherwise would error at a lower level when querying the models)

Also `assistants-search` seems to be preferable to `list` when `user` is set as there is no `in-list` filtering, but happy to reconsider this?

## Risk

Low (tested locally that the flow used by the slack bot is preserved)

## Deploy Plan

- deploy `front`