### PR TITLE
Don't send transcript error email if transcript too short

### DIFF
--- a/front/temporal/labs/activities.ts
+++ b/front/temporal/labs/activities.ts
@@ -234,25 +234,6 @@ export async function processTranscriptActivity(
       { contentLength: transcriptContent.length },
       "[processTranscriptActivity] Transcript content too short or empty. Skipping."
     );
-
-    await sendEmailWithTemplate({
-      to: user.email,
-      from: {
-        name: "Dust team",
-        email: "team@dust.help",
-      },
-      subject: "[DUST] - Unable to Generate Your Meeting Transcript Summary",
-      body: `
-        <p>We encountered an issue while trying to generate a summary for your recent Google Meet session. Unfortunately, the transcript provided by Google was either too short or empty, which prevented us from creating a meaningful summary.</p>
-        <p>What you can do:</p>
-        <ul>
-        <li>Check your Google Meet settings to ensure transcription is properly enabled;</li>
-        <li>If this issue persists, you may want to contact Google Meet support for assistance with their transcription service.</li>
-        </ul>
-        <p>We apologize for any inconvenience this may have caused. If you have any questions or need further assistance, please don't hesitate to reach out to our support team at <a href="mailto:support@dust.tt">support@dust.tt</a>.</p>
-        <p>Thank you for your understanding,</p>`,
-    });
-
     return;
   }
 
@@ -346,6 +327,7 @@ export async function processTranscriptActivity(
       },
       "[processTranscriptActivity] Unreachable: Error getting conversation after creation."
     );
+
     return;
   }
 


### PR DESCRIPTION
## Description

Watershed had a question about the error email having bad wording (mentioning Google) 
This email was only sent when not enough characters were in the transcript. It's quite useless to even send it, just feels like an error when it shouldn't. Removing.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
