### PR TITLE
Fix vault administration

### DIFF
--- a/front/components/vaults/CreateOrEditVaultModal.tsx
+++ b/front/components/vaults/CreateOrEditVaultModal.tsx
@@ -311,7 +311,7 @@ export function CreateOrEditVaultModal({
               </div>
             )}
           </div>
-          {vault && vault.kind === "regular" && (
+          {isAdmin && vault && vault.kind === "regular" && (
             <>
               <Page.Separator />
               <ConfirmDeleteVaultDialog

--- a/front/components/vaults/VaultCategoriesList.tsx
+++ b/front/components/vaults/VaultCategoriesList.tsx
@@ -39,13 +39,6 @@ type RowData = {
 
 type Info = CellContext<RowData, unknown>;
 
-type VaultCategoriesListProps = {
-  owner: WorkspaceType;
-  vault: VaultType;
-  onSelect: (category: string) => void;
-  onButtonClick?: () => void;
-};
-
 export const CATEGORY_DETAILS: {
   [key: string]: {
     label: string;
@@ -106,11 +99,20 @@ const getTableColumns = () => {
   ];
 };
 
+type VaultCategoriesListProps = {
+  isAdmin: boolean;
+  onButtonClick?: () => void;
+  onSelect: (category: string) => void;
+  owner: WorkspaceType;
+  vault: VaultType;
+};
+
 export const VaultCategoriesList = ({
+  isAdmin,
+  onButtonClick,
+  onSelect,
   owner,
   vault,
-  onSelect,
-  onButtonClick,
 }: VaultCategoriesListProps) => {
   const [dataSourceSearch, setDataSourceSearch] = useState<string>("");
 
@@ -170,7 +172,7 @@ export const VaultCategoriesList = ({
                 setDataSourceSearch(s);
               }}
             />
-            {onButtonClick && vault.kind === "regular" && (
+            {isAdmin && onButtonClick && vault.kind === "regular" && (
               <Button
                 label="Settings and Members"
                 icon={Cog6ToothIcon}
@@ -222,7 +224,7 @@ export const VaultCategoriesList = ({
           columns={getTableColumns()}
           className="pb-4"
           filter={dataSourceSearch}
-          filterColumn={"name"}
+          filterColumn="name"
           columnsBreakpoints={{
             usage: "md",
           }}

--- a/front/pages/api/w/[wId]/vaults/[vId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/index.ts
@@ -122,19 +122,18 @@ async function handler(
     }
 
     case "PATCH": {
-      if (!auth.isAdmin() || !auth.isBuilder()) {
+      if (!auth.isAdmin()) {
         // Only admins, or builders who have access to the vault, can patch
         return apiError(req, res, {
           status_code: 403,
           api_error: {
             type: "workspace_auth_error",
-            message:
-              "Only users that are `admins` or `builder` can administrate vaults.",
+            message: "Only admins can administrate vaults.",
           },
         });
       }
-      const bodyValidation = PatchVaultRequestBodySchema.decode(req.body);
 
+      const bodyValidation = PatchVaultRequestBodySchema.decode(req.body);
       if (isLeft(bodyValidation)) {
         const pathError = reporter.formatValidationErrors(bodyValidation.left);
 
@@ -203,7 +202,7 @@ async function handler(
 
     case "DELETE": {
       if (!auth.isAdmin()) {
-        // Only admins, who have access to the vault, can delete
+        // Only admins, who have access to the vault, can delete.
         return apiError(req, res, {
           status_code: 403,
           api_error: {

--- a/front/pages/api/w/[wId]/vaults/index.ts
+++ b/front/pages/api/w/[wId]/vaults/index.ts
@@ -74,6 +74,7 @@ async function handler(
       return res.status(200).json({
         vaults: vaults.map((vault) => vault.toJSON()),
       });
+
     case "POST":
       if (!auth.isAdmin() || !auth.isBuilder()) {
         return apiError(req, res, {
@@ -167,6 +168,7 @@ async function handler(
       }
 
       return res.status(201).json({ vault: vault.toJSON() });
+
     default:
       return apiError(req, res, {
         status_code: 405,

--- a/front/pages/w/[wId]/vaults/[vaultId]/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/index.tsx
@@ -14,7 +14,7 @@ import { useVaultInfo } from "@app/lib/swr/vaults";
 import { getVaultIcon, getVaultName } from "@app/lib/vaults";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<
-  VaultLayoutProps & { userId?: string }
+  VaultLayoutProps & { userId: string }
 >(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
   const subscription = auth.subscription();
@@ -54,16 +54,16 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
       plan,
       subscription,
       vault: vault.toJSON(),
-      userId: auth.user()?.sId,
+      userId: auth.getNonNullableUser().sId,
     },
   };
 });
 
 export default function Vault({
-  owner,
-  vault,
-  userId,
   isAdmin,
+  owner,
+  userId,
+  vault,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const { vaultInfo } = useVaultInfo({
     workspaceId: owner.sId,
@@ -99,6 +99,7 @@ export default function Vault({
           );
         }}
         onButtonClick={() => setShowVaultEditionModal(true)}
+        isAdmin={isAdmin}
       />
       <CreateOrEditVaultModal
         owner={owner}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR refactors the vault administration UI. As of today, everyone could see the "Settings and members" button, except that only admins can administrate and delete vaults. Here, we ensure that only admins can see this button. 

**Admins:**
<img width="1004" alt="image" src="https://github.com/user-attachments/assets/fd2f8076-f9cb-4eb0-ad8e-81f18266fc79">

**Builders & Users:**
<img width="945" alt="image" src="https://github.com/user-attachments/assets/3fcd5f72-21e0-42b3-b521-66d8c35f3ac3">


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
