### PR TITLE
[Core] Fix secrets replacement in URL

### DIFF
--- a/core/src/blocks/block.rs
+++ b/core/src/blocks/block.rs
@@ -230,40 +230,6 @@ pub fn find_secrets(text: &str) -> Vec<String> {
         })
         .collect::<Vec<_>>()
 }
-pub fn replace_secrets_in_string(text: &str, field: &str, env: &Env) -> Result<String> {
-    let secrets_found = find_secrets(text);
-
-    // Run Tera templating engine one_off on the result (before replacing variables but after
-    // looking for them).
-    let context = Context::from_value(json!(env.state))?;
-
-    let mut result = match Tera::one_off(text, &context, false) {
-        Ok(r) => r,
-        Err(e) => {
-            let err_msg = e
-                .source()
-                .unwrap()
-                .to_string()
-                .replace("__tera_one_off", field);
-
-            Err(anyhow!("Templating error: {}", err_msg))?
-        }
-    };
-
-    secrets_found
-        .iter()
-        .map(|key| {
-            if let Some(secret) = env.secrets.secrets.get(key) {
-                result = result.replace(&format!("${{secrets.{}}}", key), secret);
-                Ok(())
-            } else {
-                Err(anyhow!("`secrets.{}` is not a string", key))
-            }
-        })
-        .collect::<Result<Vec<_>>>()?;
-
-    Ok(result)
-}
 
 pub fn find_variables(text: &str) -> Vec<(String, String)> {
     lazy_static! {

--- a/core/src/blocks/curl.rs
+++ b/core/src/blocks/curl.rs
@@ -1,6 +1,5 @@
 use crate::blocks::block::{
-    parse_pair, replace_secrets_in_string, replace_variables_in_string, Block, BlockResult,
-    BlockType, Env,
+    parse_pair, replace_variables_in_string, Block, BlockResult, BlockType, Env,
 };
 use crate::deno::js_executor::JSExecutor;
 use crate::http::request::HttpRequest;
@@ -125,15 +124,19 @@ impl Block for Curl {
             .await
             .map_err(|e| anyhow!("Error in `headers_code`: {}", e))?;
 
-        let e = env.clone_with_unredacted_secrets();
+        let mut e = env.clone_with_unredacted_secrets();
         let body_code = self.body_code.clone();
         let (body_value, body_logs): (Value, Vec<Value>) = JSExecutor::client()?
             .exec(&body_code, "_fun", &e, std::time::Duration::from_secs(10))
             .await
             .map_err(|e| anyhow!("Error in `body_code`: {}", e))?;
 
-        let mut url = replace_variables_in_string(&self.url, "url", env)?;
-        url = replace_secrets_in_string(&url, "url", env)?;
+        // adding secrets so they can be used in URL replacement
+        let secrets_value = serde_json::to_value(&e.secrets.secrets)
+            .map_err(|e| anyhow!("Failed to convert secrets to JSON: {}", e))?;
+        e.state.insert(String::from("secrets"), secrets_value);
+
+        let url = replace_variables_in_string(&self.url, "url", &e)?;
 
         if url.contains("https://dust.tt") || url.contains("https://www.dust.tt") {
             Err(anyhow!(

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -1187,10 +1187,9 @@ impl DataSource {
                             Ok::<Option<Document>, anyhow::Error>(Some(d))
                         }
                         None => {
-                            // document not found should never happen
-                            // if it unexpectedly does, we skip it via returning None
-                            // to let the search move forward
-                            // but we raise a panic log
+                            // document not found should never happen if it unexpectedly does,
+                            // we skip it via returning None to let the search move forward but we
+                            // raise a panic log
                             error!(
                                 data_source_id = %data_source_id,
                                 document_id = %document_id,


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/1438

In curl block, there were successive calls to `replace_variables` and `replace_secrets` for URL that both ran tera variable replacement, making it fail.

Furthermore, secrets were not included in the env so could not have been replaced.

Another option would have been to go with only string replacement (not tera) for secrets but tera seemed the standard way to go, + it removed the most code
![image](https://github.com/user-attachments/assets/f3af9c14-4767-4868-af0a-5956ecedccfe)
![image](https://github.com/user-attachments/assets/2a36c23e-01d5-4fdb-b3fc-3f29c1e120b1)


Risks
---
Blast radius limited to secrets replacement in url. Tested locally.

Deploy
---
core
