### PR TITLE
[sparkle] Add css in side effects

### DIFF
--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -22,7 +22,7 @@
   ],
   "sideEffects": [
     "src/index_with_tw_base.ts",
-    "dist/sparkle.css"
+    "*.css"
   ],
   "devDependencies": {
     "@babel/core": "^7.22.9",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -21,7 +21,8 @@
     "src/"
   ],
   "sideEffects": [
-    "src/index_with_tw_base.ts"
+    "src/index_with_tw_base.ts",
+    "dist/sparkle.css"
   ],
   "devDependencies": {
     "@babel/core": "^7.22.9",


### PR DESCRIPTION
## Description

Avoid tree shaking on css files when importing them. Otherwise, webpack removes it when optimizing, as no module is imported.

## Risk


## Deploy Plan

publish sparkle