### PR TITLE
 enh: cleanup tables query events

### DIFF
--- a/front/components/actions/tables_query/TablesQueryActionDetails.tsx
+++ b/front/components/actions/tables_query/TablesQueryActionDetails.tsx
@@ -31,16 +31,7 @@ export function TablesQueryActionDetails({
       <div className="flex flex-col gap-1 gap-4 pl-6 pt-4">
         <QueryThinking action={action} />
         <TablesQuery action={action} />
-        <div>
-          <Collapsible defaultOpen={defaultOpen}>
-            <Collapsible.Button>
-              <span className="text-sm font-bold text-slate-900">Results</span>
-            </Collapsible.Button>
-            <Collapsible.Panel>
-              <QueryTablesResults action={action} />
-            </Collapsible.Panel>
-          </Collapsible>
-        </div>
+        <QueryTablesResults action={action} />
       </div>
     </ActionDetailsWrapper>
   );
@@ -49,9 +40,8 @@ export function TablesQueryActionDetails({
 function TablesQuery({ action }: { action: TablesQueryActionType }) {
   const { output } = action;
   const query = typeof output?.query === "string" ? output.query : null;
-  const noQuery = output?.no_query === true;
 
-  if (noQuery || !query) {
+  if (!query) {
     return null;
   }
 
@@ -166,8 +156,17 @@ function QueryTablesResults({ action }: { action: TablesQueryActionType }) {
   const title = output?.query_title ?? "query_results";
 
   return (
-    <div onClick={() => handleDownload(title)}>
-      <Citation size="xs" title={title} />
+    <div>
+      <Collapsible defaultOpen={true}>
+        <Collapsible.Button>
+          <span className="text-sm font-bold text-slate-900">Results</span>
+        </Collapsible.Button>
+        <Collapsible.Panel>
+          <div onClick={() => handleDownload(title)}>
+            <Citation size="xs" title={title} />
+          </div>
+        </Collapsible.Panel>
+      </Collapsible>
     </div>
   );
 }

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -176,7 +176,8 @@ export function AgentMessage({
       case "retrieval_params":
       case "dust_app_run_params":
       case "dust_app_run_block":
-      case "tables_query_params":
+      case "tables_query_started":
+      case "tables_query_model_output":
       case "tables_query_output":
       case "process_params":
       case "websearch_params":

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -948,8 +948,8 @@ async function* runAction(
 
     for await (const event of eventStream) {
       switch (event.type) {
-        case "tables_query_params":
-        case "tables_query_output":
+        case "tables_query_started":
+        case "tables_query_model_output":
           yield event;
           break;
         case "tables_query_error":
@@ -964,7 +964,7 @@ async function* runAction(
             },
           };
           return;
-        case "tables_query_success":
+        case "tables_query_output":
           yield {
             type: "agent_action_success",
             created: event.created,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1790,8 +1790,9 @@ async function* streamRunAgentEvents(
       case "retrieval_params":
       case "dust_app_run_params":
       case "dust_app_run_block":
-      case "tables_query_params":
+      case "tables_query_started":
       case "tables_query_output":
+      case "tables_query_model_output":
       case "process_params":
       case "websearch_params":
       case "browse_params":

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -184,7 +184,8 @@ async function handleUserMessageEvents(
             case "retrieval_params":
             case "dust_app_run_params":
             case "dust_app_run_block":
-            case "tables_query_params":
+            case "tables_query_started":
+            case "tables_query_model_output":
             case "tables_query_output":
             case "process_params":
             case "websearch_params":
@@ -336,7 +337,8 @@ export async function retryAgentMessageWithPubSub(
               case "retrieval_params":
               case "dust_app_run_params":
               case "dust_app_run_block":
-              case "tables_query_params":
+              case "tables_query_started":
+              case "tables_query_model_output":
               case "tables_query_output":
               case "process_params":
               case "websearch_params":

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -158,7 +158,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "b4f205e453",
       appHash:
-        "b667240e7f68b583bd5a216de5d009760051f257b0306c06b5c0d93b6cb9a7ea",
+        "5f78a3f5328f8d6fd714035250c880927e665cb7adb0d717ee255fcc850a03e4",
       appVaultId: PRODUCTION_DUST_APPS_VAULT_ID,
     },
     config: {

--- a/types/src/front/lib/api/assistant/actions/tables_query.ts
+++ b/types/src/front/lib/api/assistant/actions/tables_query.ts
@@ -6,24 +6,21 @@ export type TablesQueryErrorEvent = {
   configurationId: string;
   messageId: string;
   error: {
-    code:
-      | "tables_query_error"
-      | "tables_query_parameters_generation_error"
-      | "too_many_result_rows";
+    code: "tables_query_error" | "too_many_result_rows";
     message: string;
   };
 };
 
-export type TablesQuerySuccessEvent = {
-  type: "tables_query_success";
+export type TablesQueryStartedEvent = {
+  type: "tables_query_started";
   created: number;
   configurationId: string;
   messageId: string;
   action: TablesQueryActionType;
 };
 
-export type TablesQueryParamsEvent = {
-  type: "tables_query_params";
+export type TablesQueryModelOutputEvent = {
+  type: "tables_query_model_output";
   created: number;
   configurationId: string;
   messageId: string;

--- a/types/src/front/lib/api/assistant/agent.ts
+++ b/types/src/front/lib/api/assistant/agent.ts
@@ -12,8 +12,9 @@ import {
 } from "../../../../front/lib/api/assistant/actions/dust_app_run";
 import { RetrievalParamsEvent } from "../../../../front/lib/api/assistant/actions/retrieval";
 import {
+  TablesQueryModelOutputEvent,
   TablesQueryOutputEvent,
-  TablesQueryParamsEvent,
+  TablesQueryStartedEvent,
 } from "../../../../front/lib/api/assistant/actions/tables_query";
 import {
   AgentActionConfigurationType,
@@ -61,7 +62,8 @@ export type AgentActionSpecificEvent =
   | RetrievalParamsEvent
   | DustAppRunParamsEvent
   | DustAppRunBlockEvent
-  | TablesQueryParamsEvent
+  | TablesQueryStartedEvent
+  | TablesQueryModelOutputEvent
   | TablesQueryOutputEvent
   | ProcessParamsEvent
   | WebsearchParamsEvent


### PR DESCRIPTION
## Description

- `TablesQueryParamsEvent` is a leftover from a time we were generating a question from `generateInputs` for the tables query dust app. 
We no longer do this, instead we pass a rendered conversation to the app. 
So there's no "tables query params". 
However, this event is being used to let the frontend know the assistant is running a Tables Query, which is useful to display "querying tables" on the UI before the query is complete. I renamed the event into `TablesQueryStartedEvent`.

- `TablesQueryOutput` : this was really a misnomer as it is used as soon as the SQL query is done generating but before the actual output is ready (i.e the actual DB query). Renamed it into `TablesQueryModelOutput`, and it now also sets `thinking`, so we display that part as soon as its ready

-  `TablesQuerySuccess` also is a misnomer. We still emit if the model generated a sql query that failed to execute successfully (in which case we show the error to the model to give it a chance to fix).  Renamed this into `TablesQueryOutput`

## Risk

N/A

## Deploy Plan

deploy `front`