### PR TITLE
[viz] Get rid of scrollbars

### DIFF
--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -197,7 +197,7 @@ export function VisualizationActionIframe({
                     height: !isErrored ? `${contentHeight}px` : "100%",
                     minHeight: !isErrored ? "96" : undefined,
                   }}
-                  className={classNames("w-full")}
+                  className={classNames("w-full max-h-[600px]")}
                 >
                   <iframe
                     ref={vizIframeRef}

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -197,7 +197,7 @@ export function VisualizationActionIframe({
                     height: !isErrored ? `${contentHeight}px` : "100%",
                     minHeight: !isErrored ? "96" : undefined,
                   }}
-                  className={classNames("w-full max-h-[600px]")}
+                  className={classNames("max-h-[600px] w-full")}
                 >
                   <iframe
                     ref={vizIframeRef}

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -197,7 +197,7 @@ export function VisualizationActionIframe({
                     height: !isErrored ? `${contentHeight}px` : "100%",
                     minHeight: !isErrored ? "96" : undefined,
                   }}
-                  className={classNames("max-h-[60vh] w-full")}
+                  className={classNames("w-full")}
                 >
                   <iframe
                     ref={vizIframeRef}

--- a/front/lib/api/assistant/visualization.ts
+++ b/front/lib/api/assistant/visualization.ts
@@ -108,7 +108,6 @@ Guidelines using the :::visualization tag:
 - Props:
   - The generated component should not have any required props / parameters
 - Responsiveness:
-  - The content should be responsive and should not have fixed widths or heights
   - The component should be able to adapt to different screen sizes
   - The content should never overflow the viewport and should never have horizontal or vertical scrollbars
 - Styling:

--- a/front/lib/api/assistant/visualization.ts
+++ b/front/lib/api/assistant/visualization.ts
@@ -109,7 +109,7 @@ Guidelines using the :::visualization tag:
   - The generated component should not have any required props / parameters
 - Responsiveness:
   - The content should be responsive
-  - The content should have a total height between 200 and 600
+  - The outermost container should have a fixed height between 200 and 600 pixels
   - The component should be able to adapt to different screen sizes
   - The content should never overflow the viewport and should never have horizontal or vertical scrollbars
 - Styling:

--- a/front/lib/api/assistant/visualization.ts
+++ b/front/lib/api/assistant/visualization.ts
@@ -108,6 +108,8 @@ Guidelines using the :::visualization tag:
 - Props:
   - The generated component should not have any required props / parameters
 - Responsiveness:
+  - The content should be responsive
+  - The content should have a total height between 200 and 600
   - The component should be able to adapt to different screen sizes
   - The content should never overflow the viewport and should never have horizontal or vertical scrollbars
 - Styling:


### PR DESCRIPTION
## Description

- Prevent scrollbars from appearing when running a viz.
- Proposal: the chart generated controls its own width and height, and the outer iframe resizes itself to match.

## Risk

## Deploy Plan

- Deploy front.