### PR TITLE
[sparkle] Add rule to exclude import from tw-base

### DIFF
--- a/sparkle/.eslintrc.js
+++ b/sparkle/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
     "plugin:@typescript-eslint/recommended",
     "plugin:storybook/recommended",
   ],
-  plugins: ["simple-import-sort"],
+  plugins: ["import", "simple-import-sort"],
   ignorePatterns: [
     "rollup.config.js",
     "eslint.js",
@@ -18,6 +18,7 @@ module.exports = {
     "svgr-*-template.js",
   ],
   rules: {
+    "import/no-cycle": "error",
     curly: ["error", "all"],
     "@typescript-eslint/no-floating-promises": "error",
     "simple-import-sort/imports": [
@@ -44,11 +45,17 @@ module.exports = {
     ],
     "simple-import-sort/exports": "error",
     "@typescript-eslint/return-await": ["error", "in-try-catch"],
+    "no-restricted-imports": ["error", {
+      "patterns": ["*/index_with_tw_base"]
+    }]
   },
   overrides: [
     {
-      files: ["*.jsx", "*.js", "*.ts", "*.tsx", "**/*.jsx"],
-    },
+      files: ["*.stories.tsx"],
+      rules: {
+        "no-restricted-imports": ["off"]
+      }
+    }
   ],
   env: {
     browser: true,

--- a/sparkle/src/components/NewDropdown.tsx
+++ b/sparkle/src/components/NewDropdown.tsx
@@ -1,12 +1,8 @@
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import * as React from "react";
 
-import {
-  CheckIcon,
-  ChevronRightIcon,
-  CircleIcon,
-  Icon,
-} from "@sparkle/index_with_tw_base";
+import { Icon } from "@sparkle/components";
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "@sparkle/icons";
 import { cn } from "@sparkle/lib/utils";
 
 export const menuStyleClasses = {

--- a/sparkle/tsconfig.json
+++ b/sparkle/tsconfig.json
@@ -25,5 +25,5 @@
     "declarationMap": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["node_modules", "dist", "src/index_with_tw_base"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sparkle/tsconfig.json
+++ b/sparkle/tsconfig.json
@@ -25,5 +25,5 @@
     "declarationMap": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/index_with_tw_base"]
 }


### PR DESCRIPTION
## Description

This should prevent any import from index_with_tw_base , which will break the entire styling.
Also added a rule to prevent cycles.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
