### PR TITLE
Extension Env var

### DIFF
--- a/extension/.gitignore
+++ b/extension/.gitignore
@@ -1,5 +1,8 @@
 .DS_Store
 .idea/
 
+.env.development
+.env.production
+
 node_modules/
 build/*

--- a/extension/config/env.ts
+++ b/extension/config/env.ts
@@ -2,11 +2,4 @@ export type Environment = "production" | "development";
 export const ENV_DEV: Environment = "development";
 export const ENV_PROD: Environment = "production";
 
-export const isDevEnv = () => process.env.NODE_ENV === ENV_DEV;
-export const isProdEnv = () => process.env.NODE_ENV === ENV_PROD;
-
-const isValidEnv = (env?: string): env is Environment =>
-  env === ENV_DEV || env === ENV_PROD;
-
-export const getEnv = (): Environment =>
-  isValidEnv(process.env.NODE_ENV) ? process.env.NODE_ENV : ENV_DEV;
+export const isDevEnv = (env: string) => env === ENV_DEV;

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -27,6 +27,7 @@
         "autoprefixer": "^10.4.20",
         "copy-webpack-plugin": "^12.0.2",
         "css-loader": "^7.1.2",
+        "dotenv-webpack": "^8.1.0",
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-import": "^2.31.0",
@@ -3297,6 +3298,39 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/dotenv-defaults": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-2.0.2.tgz",
+      "integrity": "sha512-iOIzovWfsUHU91L5i8bJce3NYK5JXeAwH50Jh6+ARUdLiiGlYWfGw6UkzsYqaXZH/hjE/eCd/PlfM/qqyK0AMg==",
+      "dev": true,
+      "dependencies": {
+        "dotenv": "^8.2.0"
+      }
+    },
+    "node_modules/dotenv-webpack": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-8.1.0.tgz",
+      "integrity": "sha512-owK1JcsPkIobeqjVrk6h7jPED/W6ZpdFsMPR+5ursB7/SdgDyO+VzAU+szK8C8u3qUhtENyYnj8eyXMR5kkGag==",
+      "dev": true,
+      "dependencies": {
+        "dotenv-defaults": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "webpack": "^4 || ^5"
       }
     },
     "node_modules/duplexer": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -4,9 +4,9 @@
   "description": "Dust Chrome Extension",
   "scripts": {
     "clean": "rm -rf build/*",
-    "dev": "NODE_ENV=development npm run clean && tsx run/watch.ts --mode=development",
-    "analyze": "NODE_ENV=production tsx run/build.ts --analyze",
-    "build": "NODE_ENV=production tsx run/build.ts",
+    "dev": "npm run clean && tsx run/watch.ts --mode=development",
+    "analyze": "tsx run/build.ts --analyze",
+    "build": "tsx run/build.ts",
     "lint": "eslint app"
   },
   "author": "@dust-tt",
@@ -27,6 +27,7 @@
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-react": "^7.37.1",
     "eslint-plugin-simple-import-sort": "^12.1.1",
+    "dotenv-webpack": "^8.1.0",
     "postcss": "^8.4.47",
     "postcss-loader": "^8.1.1",
     "prettier": "^3.3.3",

--- a/extension/run/build.ts
+++ b/extension/run/build.ts
@@ -3,6 +3,7 @@ import { getConfig } from "../config/webpack";
 
 async function main() {
   const config = await getConfig({
+    env: "production",
     shouldBuild: process.argv.includes("--analyze") ? "analyze" : "prod",
   });
   const compiler = webpack(config);

--- a/extension/run/watch.ts
+++ b/extension/run/watch.ts
@@ -1,10 +1,8 @@
 import webpack from "webpack";
-import { getEnv } from "../config/env";
 import { getConfig } from "../config/webpack";
 
 async function main() {
-  const environment = getEnv();
-  const config = await getConfig({ shouldBuild: "none" });
+  const config = await getConfig({ env: "development", shouldBuild: "none" });
   const compiler = webpack(config);
   compiler.watch({ ignored: /node_modules/ }, async (err, res) => {
     if (err) {
@@ -13,9 +11,7 @@ async function main() {
     if (res?.hasErrors) {
       console.error(res.compilation.errors);
     }
-    console.log(
-      `[Dust Extension][${environment}] Webpack successfully compiled.`
-    );
+    console.log(`[Dust Extension][development] Webpack successfully compiled.`);
   });
 }
 


### PR DESCRIPTION
## Description

- Install `dotenv-webpack` (wraps dotenv and Webpack.DefinePlugin. As such, it does a text replace in the resulting bundle for any instances of process.env.)
- Simplify and fix our env setting -> with watch with development, otherwise we're prod. 

This means I'll be able to save the config for Auth0 (clientid and domain) on .env.development and .env.production. 
They will be exposed since all code will be client side but this allows us to not put them on the codebase. 

WDYT?

## Risk

/

## Deploy Plan

Add this to the extension install doc (that does not exist yet 😅 )
Nothing. 