### PR TITLE
Add Zendesk as Oauth Provider

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -108,6 +108,7 @@ pub mod oauth {
         pub mod notion;
         pub mod slack;
         pub mod utils;
+        pub mod zendesk;
     }
 
     pub mod tests {

--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -5,7 +5,8 @@ use crate::oauth::{
         gong::GongConnectionProvider, google_drive::GoogleDriveConnectionProvider,
         intercom::IntercomConnectionProvider, microsoft::MicrosoftConnectionProvider,
         mock::MockConnectionProvider, notion::NotionConnectionProvider,
-        slack::SlackConnectionProvider, utils::ProviderHttpRequestError, zendesk::ZendeskConnectionProvider
+        slack::SlackConnectionProvider, utils::ProviderHttpRequestError,
+        zendesk::ZendeskConnectionProvider,
     },
     store::OAuthStore,
 };

--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -5,7 +5,7 @@ use crate::oauth::{
         gong::GongConnectionProvider, google_drive::GoogleDriveConnectionProvider,
         intercom::IntercomConnectionProvider, microsoft::MicrosoftConnectionProvider,
         mock::MockConnectionProvider, notion::NotionConnectionProvider,
-        slack::SlackConnectionProvider, utils::ProviderHttpRequestError,
+        slack::SlackConnectionProvider, utils::ProviderHttpRequestError, zendesk::ZendeskConnectionProvider
     },
     store::OAuthStore,
 };
@@ -89,6 +89,7 @@ pub enum ConnectionProvider {
     Notion,
     Slack,
     Mock,
+    Zendesk,
 }
 
 impl fmt::Display for ConnectionProvider {
@@ -176,6 +177,7 @@ pub fn provider(t: ConnectionProvider) -> Box<dyn Provider + Sync + Send> {
         ConnectionProvider::Notion => Box::new(NotionConnectionProvider::new()),
         ConnectionProvider::Slack => Box::new(SlackConnectionProvider::new()),
         ConnectionProvider::Mock => Box::new(MockConnectionProvider::new()),
+        ConnectionProvider::Zendesk => Box::new(ZendeskConnectionProvider::new()),
     }
 }
 

--- a/core/src/oauth/providers/zendesk.rs
+++ b/core/src/oauth/providers/zendesk.rs
@@ -1,0 +1,90 @@
+use crate::oauth::{
+    connection::{
+        Connection, ConnectionProvider, FinalizeResult, Provider, ProviderError, RefreshResult,
+    },
+    providers::utils::execute_request,
+};
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use lazy_static::lazy_static;
+use serde_json::json;
+use std::env;
+
+lazy_static! {
+    static ref OAUTH_ZENDESK_CLIENT_ID: String = env::var("OAUTH_ZENDESK_CLIENT_ID").unwrap();
+    static ref OAUTH_ZENDESK_CLIENT_SECRET: String =
+        env::var("OAUTH_ZENDESK_CLIENT_SECRET").unwrap();
+}
+
+pub struct ZendeskConnectionProvider {}
+
+impl ZendeskConnectionProvider {
+    pub fn new() -> Self {
+        ZendeskConnectionProvider {}
+    }
+}
+
+#[async_trait]
+impl Provider for ZendeskConnectionProvider {
+    fn id(&self) -> ConnectionProvider {
+        ConnectionProvider::Zendesk
+    }
+
+    async fn finalize(
+        &self,
+        _connection: &Connection,
+        code: &str,
+        redirect_uri: &str,
+    ) -> Result<FinalizeResult, ProviderError> {
+        let body = json!({
+            "grant_type": "authorization_code",
+            "code": code,
+            "client_id": *OAUTH_ZENDESK_CLIENT_ID,
+            "client_secret": *OAUTH_ZENDESK_CLIENT_SECRET,
+            "redirect_uri": redirect_uri,
+            "scope": "read"
+        });
+
+        let req = reqwest::Client::new()
+            .post("https://d3v-dust.zendesk.com/oauth/tokens")
+            .header("Content-Type", "application/json")
+            .json(&body);
+
+        let raw_json = execute_request(ConnectionProvider::Zendesk, req)
+            .await
+            .map_err(|e| self.handle_provider_request_error(e))?;
+
+        let access_token = match raw_json["access_token"].as_str() {
+            Some(token) => token,
+            None => Err(anyhow!("Missing `access_token` in response from Zendesk"))?,
+        };
+
+        // The flow doesn't use refresh tokens. The access token doesn't expire.
+        Ok(FinalizeResult {
+            redirect_uri: redirect_uri.to_string(),
+            code: code.to_string(),
+            access_token: access_token.to_string(),
+            access_token_expiry: None,
+            refresh_token: None,
+            raw_json,
+        })
+    }
+
+    async fn refresh(&self, _connection: &Connection) -> Result<RefreshResult, ProviderError> {
+        Err(ProviderError::ActionNotSupportedError(
+            "Zendesk access tokens do not expire".to_string(),
+        ))?
+    }
+
+    fn scrubbed_raw_json(&self, raw_json: &serde_json::Value) -> Result<serde_json::Value> {
+        let raw_json = match raw_json.clone() {
+            serde_json::Value::Object(mut map) => {
+                map.remove("access_token");
+                serde_json::Value::Object(map)
+            }
+            _ => Err(anyhow!("Invalid raw_json, not an object"))?,
+        };
+
+        Ok(raw_json)
+    }
+}

--- a/core/src/oauth/providers/zendesk.rs
+++ b/core/src/oauth/providers/zendesk.rs
@@ -42,7 +42,7 @@ impl Provider for ZendeskConnectionProvider {
             "client_id": *OAUTH_ZENDESK_CLIENT_ID,
             "client_secret": *OAUTH_ZENDESK_CLIENT_SECRET,
             "redirect_uri": redirect_uri,
-            "scope": "read"
+            "scope": "tickets:read hc:read"
         });
 
         let req = reqwest::Client::new()


### PR DESCRIPTION
## Description

This PR adds zendesk as an oAuth provider 
Documentation available here: https://support.zendesk.com/hc/en-us/articles/4408845965210-Using-OAuth-authentication-with-your-application
The tricky part compared to current implementation is that there's no refresh token involved.

Tested E2E, error unrelated to oauth

https://github.com/user-attachments/assets/fc953319-300c-4780-9c51-fba99541c549




## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Need to add 2 secrets : OAUTH_ZENDESK_CLIENT_ID and OAUTH_ZENDESK_CLIENT_SECRET
Already added.