### PR TITLE
[connectors] - fix(slack): auto-join channel creation

### DIFF
--- a/connectors/src/connectors/slack/auto_read_channel.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.ts
@@ -75,12 +75,24 @@ export async function autoReadChannel(
     if (joinChannelRes.isErr()) {
       return joinChannelRes;
     }
-    const createdChannel = await SlackChannel.create({
-      connectorId,
-      slackChannelId,
-      slackChannelName: remoteChannelName,
-      permission: "read_write",
+    const channel = await SlackChannel.findOne({
+      where: {
+        slackChannelId,
+        connectorId,
+      },
     });
+    if (!channel) {
+      await SlackChannel.create({
+        connectorId,
+        slackChannelId,
+        slackChannelName: remoteChannelName,
+        permission: "read_write",
+      });
+    } else {
+      await channel.update({
+        permission: "read_write",
+      });
+    }
 
     const dustAPI = new DustAPI(
       apiConfig.getDustAPIConfig(),

--- a/connectors/src/connectors/slack/auto_read_channel.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.ts
@@ -75,14 +75,15 @@ export async function autoReadChannel(
     if (joinChannelRes.isErr()) {
       return joinChannelRes;
     }
-    const channel = await SlackChannel.findOne({
+    let channel: SlackChannel | null = null;
+    channel = await SlackChannel.findOne({
       where: {
         slackChannelId,
         connectorId,
       },
     });
     if (!channel) {
-      await SlackChannel.create({
+      channel = await SlackChannel.create({
         connectorId,
         slackChannelId,
         slackChannelName: remoteChannelName,
@@ -138,7 +139,7 @@ export async function autoReadChannel(
     }
 
     const patchData = {
-      parentsToAdd: [createdChannel.slackChannelId],
+      parentsToAdd: [channel.slackChannelId],
       parentsToRemove: undefined,
     };
     const joinSlackRes = await dustAPI.patchDataSourceViews(


### PR DESCRIPTION
## Description

This PR updates the Slack channel creation logic in the auto-read channel functionality. It now checks for the existence of a channel before creation to avoid duplicates. If a channel already exists, it updates its permission to "read_write" instead of creating a new one.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
