### PR TITLE
Zendesk Connection Oauth UI behind FF

### DIFF
--- a/connectors/src/api/configuration.ts
+++ b/connectors/src/api/configuration.ts
@@ -68,6 +68,7 @@ const _patchConnectorConfiguration = async (
     case "intercom":
     case "microsoft":
     case "snowflake":
+    case "zendesk":
     case "slack": {
       throw new Error(
         `Connector type ${connector.type} does not support configuration patching`

--- a/connectors/src/api/create_connector.ts
+++ b/connectors/src/api/create_connector.ts
@@ -127,6 +127,7 @@ const _createConnectorAPIHandler = async (
       case "google_drive":
       case "intercom":
       case "snowflake":
+      case "zendesk":
       case "microsoft": {
         connectorRes = await createConnector({
           connectorProvider: req.params.connector_provider,

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -56,6 +56,8 @@ export function getConnectorManager({
       return new WebcrawlerConnectorManager(connectorId);
     case "snowflake":
       return new SnowflakeConnectorManager(connectorId);
+    case "zendesk":
+      throw new Error("Zendesk connector not implemented yet");
     default:
       assertNever(connectorProvider);
   }
@@ -108,6 +110,8 @@ export function createConnector({
       return WebcrawlerConnectorManager.create(params);
     case "snowflake":
       return SnowflakeConnectorManager.create(params);
+    case "zendesk":
+      throw new Error("Zendesk connector not implemented yet");
     default:
       assertNever(connectorProvider);
   }

--- a/connectors/src/lib/models/zendesk.ts
+++ b/connectors/src/lib/models/zendesk.ts
@@ -1,0 +1,57 @@
+import type {
+  CreationOptional,
+  ForeignKey,
+  InferAttributes,
+  InferCreationAttributes,
+} from "sequelize";
+import { DataTypes, Model } from "sequelize";
+
+import { sequelizeConnection } from "@connectors/resources/storage";
+import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
+
+export class ZendeskConfigurationModel extends Model<
+  InferAttributes<ZendeskConfigurationModel>,
+  InferCreationAttributes<ZendeskConfigurationModel>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare conversationsSlidingWindow: number;
+
+  declare connectorId: ForeignKey<ConnectorModel["id"]>;
+}
+ZendeskConfigurationModel.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    conversationsSlidingWindow: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 90,
+    },
+  },
+  {
+    sequelize: sequelizeConnection,
+    modelName: "zendesk_configurations",
+    indexes: [{ fields: ["connectorId"], unique: true }],
+  }
+);
+ConnectorModel.hasMany(ZendeskConfigurationModel, {
+  foreignKey: { allowNull: false },
+  onDelete: "RESTRICT",
+});
+ZendeskConfigurationModel.belongsTo(ConnectorModel);

--- a/connectors/src/resources/connector/strategy.ts
+++ b/connectors/src/resources/connector/strategy.ts
@@ -16,6 +16,7 @@ import type { NotionConnectorState } from "@connectors/lib/models/notion";
 import type { SlackConfigurationModel } from "@connectors/lib/models/slack";
 import type { SnowflakeConfigurationModel } from "@connectors/lib/models/snowflake";
 import type { WebCrawlerConfigurationModel } from "@connectors/lib/models/webcrawler";
+import type { ZendeskConfigurationModel } from "@connectors/lib/models/zendesk";
 import { ConfluenceConnectorStrategy } from "@connectors/resources/connector/confluence";
 import { GithubConnectorStrategy } from "@connectors/resources/connector/github";
 import { GoogleDriveConnectorStrategy } from "@connectors/resources/connector/google_drive";
@@ -44,6 +45,7 @@ export interface ConnectorProviderModelM {
   slack: SlackConfigurationModel;
   webcrawler: WebCrawlerConfigurationModel;
   snowflake: SnowflakeConfigurationModel;
+  zendesk: ZendeskConfigurationModel;
 }
 
 export type ConnectorProviderModelMapping = {
@@ -77,6 +79,7 @@ export interface ConnectorProviderConfigurationTypeM {
   snowflake: null;
   slack: SlackConfigurationType;
   webcrawler: WebCrawlerConfigurationType;
+  zendesk: null;
 }
 
 export type ConnectorProviderConfigurationTypeMapping = {
@@ -134,6 +137,9 @@ export function getConnectorProviderStrategy(
 
     case "snowflake":
       return new SnowflakeConnectorStrategy();
+
+    case "zendesk":
+      throw new Error(`Not implemented yet.`);
 
     default:
       assertNever(type);

--- a/connectors/src/start_worker.ts
+++ b/connectors/src/start_worker.ts
@@ -34,6 +34,9 @@ const workerFunctions: Record<WorkerType, () => Promise<void>> = {
   slack: runSlackWorker,
   webcrawler: runWebCrawlerWorker,
   snowflake: runSnowflakeWorker,
+  zendesk: async () => {
+    logger.info("Zendesk worker not implemented yet.");
+  },
 };
 
 const ALL_WORKERS = Object.keys(workerFunctions) as WorkerType[];

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -75,6 +75,7 @@ const CONNECTOR_TYPE_TO_PERMISSIONS: Record<
   },
   notion: undefined,
   github: undefined,
+  zendesk: undefined,
   intercom: {
     selected: "read",
     unselected: "none",

--- a/front/components/assistant_builder/shared.ts
+++ b/front/components/assistant_builder/shared.ts
@@ -42,6 +42,7 @@ const CONNECTOR_PROVIDER_TO_RESOURCE_NAME: Record<
   intercom: { singular: "element", plural: "elements" },
   webcrawler: { singular: "page", plural: "pages" },
   snowflake: { singular: "table", plural: "tables" },
+  zendesk: { singular: "element", plural: "elements" },
 };
 
 export const getConnectorProviderResourceName = (
@@ -314,6 +315,7 @@ export function getTableIdForContentNode(
     case "intercom":
     case "slack":
     case "github":
+    case "zendesk":
     case "webcrawler":
       throw new Error(
         `Provider ${dataSource.connectorProvider} is not supported`

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -132,6 +132,9 @@ const config = {
   getOAuthMicrosoftClientId: (): string => {
     return EnvironmentConfig.getEnvVariable("OAUTH_MICROSOFT_CLIENT_ID");
   },
+  getOAuthZendeskClientId: (): string => {
+    return EnvironmentConfig.getEnvVariable("OAUTH_ZENDESK_CLIENT_ID");
+  },
   // Text extraction.
   getTextExtractionUrl: (): string => {
     return EnvironmentConfig.getEnvVariable("TEXT_EXTRACTION_URL");

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -33,6 +33,7 @@ export function getContentNodeInternalIdFromTableId(
     case "confluence":
     case "github":
     case "slack":
+    case "zendesk":
     case "webcrawler":
       throw new Error(
         `Provider ${dataSource.connectorProvider} is not supported`

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -244,6 +244,25 @@ const PROVIDER_STRATEGIES: Record<
       return getStringFromQuery(query, "state");
     },
   },
+  zendesk: {
+    setupUri: (connection) => {
+      const scopes = ["tickets:read", "hc:read"];
+      return (
+        `https://d3v-dust.zendesk.com/oauth/authorizations/new?` +
+        `client_id=${config.getOAuthZendeskClientId()}` +
+        `&scope=${encodeURIComponent(scopes.join(" "))}` +
+        `&response_type=code` +
+        `&state=${connection.connection_id}` +
+        `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("zendesk"))}`
+      );
+    },
+    codeFromQuery: (query) => {
+      return getStringFromQuery(query, "code");
+    },
+    connectionIdFromQuery: (query) => {
+      return getStringFromQuery(query, "state");
+    },
+  },
 };
 
 export async function createConnectionAndGetSetupUrl(

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -241,7 +241,6 @@ export const isConnectorProviderAllowedForPlan = (
       // TODO(SNOWFLAKE): Add a isSnowflakeAllowed column to the plan model.
       return true;
     case "zendesk":
-      // TODO(ZENDESK): Add a isZendeskAllowed column to the plan model.
       return true;
     default:
       assertNever(provider);

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -184,6 +184,21 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     selectLabel: "Select tables",
     rollingOutFlag: "snowflake_connector_feature",
   },
+  zendesk: {
+    name: "Zendesk",
+    connectorProvider: "zendesk",
+    status: "rolling_out",
+    hide: false,
+    description:
+      "Authorize access to Zendesk for indexing tickets from your support center and articles from your help center.",
+    limitations:
+      "Dust will index the content accessible to the authorized account only. Attachments are not indexed.",
+    guideLink: "https://docs.dust.tt/docs/zendesk",
+    logoComponent: SnowflakeLogo,
+    isNested: true,
+    isSearchEnabled: false,
+    rollingOutFlag: "zendesk_connector_feature",
+  },
 };
 
 export function getConnectorProviderLogoWithFallback(
@@ -224,6 +239,9 @@ export const isConnectorProviderAllowedForPlan = (
     case "snowflake":
       // TODO(SNOWFLAKE): Add a isSnowflakeAllowed column to the plan model.
       return true;
+    case "zendesk":
+      // TODO(ZENDESK): Add a isZendeskAllowed column to the plan model.
+      return true;
     default:
       assertNever(provider);
   }
@@ -240,6 +258,7 @@ export const isConnectorProviderAssistantDefaultSelected = (
     case "google_drive":
     case "intercom":
     case "microsoft":
+    case "zendesk":
     case "snowflake":
       return true;
     case "webcrawler":
@@ -260,6 +279,7 @@ export const isConnectionIdRequiredForProvider = (
     case "google_drive":
     case "intercom":
     case "microsoft":
+    case "zendesk":
     case "snowflake":
       return true;
     case "webcrawler":

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -9,6 +9,7 @@ import {
   NotionLogo,
   SlackLogo,
   SnowflakeLogo,
+  ZendeskLogo,
 } from "@dust-tt/sparkle";
 import type {
   ConnectorProvider,
@@ -194,7 +195,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     limitations:
       "Dust will index the content accessible to the authorized account only. Attachments are not indexed.",
     guideLink: "https://docs.dust.tt/docs/zendesk",
-    logoComponent: SnowflakeLogo,
+    logoComponent: ZendeskLogo,
     isNested: true,
     isSearchEnabled: false,
     rollingOutFlag: "zendesk_connector_feature",

--- a/front/lib/data_sources.ts
+++ b/front/lib/data_sources.ts
@@ -30,6 +30,7 @@ export function getDisplayNameForDataSource(ds: DataSourceType) {
       case "intercom":
       case "microsoft":
       case "notion":
+      case "zendesk":
       case "snowflake":
         return CONNECTOR_CONFIGURATIONS[ds.connectorProvider].name;
       case "webcrawler":

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/configuration.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/configuration.ts
@@ -89,6 +89,7 @@ async function handler(
     case "notion":
     case "microsoft":
     case "slack":
+    case "zendesk":
     case "snowflake":
       if (!auth.isAdmin()) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -124,6 +124,7 @@ async function handler(
         case "notion":
         case "microsoft":
         case "snowflake":
+        case "zendesk":
         case "slack": {
           if (!auth.isAdmin()) {
             return apiError(req, res, {

--- a/types/src/front/data_source.ts
+++ b/types/src/front/data_source.ts
@@ -12,6 +12,7 @@ export const CONNECTOR_PROVIDERS = [
   "microsoft",
   "webcrawler",
   "snowflake",
+  "zendesk",
 ] as const;
 
 export const MANAGED_DS_DELETABLE: ConnectorProvider[] = [
@@ -29,6 +30,7 @@ export const CONNECTOR_TYPE_TO_NAME: Record<ConnectorProvider, string> = {
   microsoft: "Microsoft",
   webcrawler: "Website",
   snowflake: "Snowflake",
+  zendesk: "Zendesk",
 };
 
 export const CONNECTOR_TYPE_TO_MISMATCH_ERROR: Record<
@@ -49,6 +51,8 @@ export const CONNECTOR_TYPE_TO_MISMATCH_ERROR: Record<
   webcrawler: "You cannot change the URL. Please add a new Public URL instead.",
   snowflake:
     "You cannot change the Snowflake account. Please add a new Snowflake connection instead.",
+  zendesk:
+    "You cannot select another Zendesk Workspace.\nPlease contact us at support@dust.tt if you initially selected a wrong Workspace.",
 };
 
 export type ConnectorProvider = (typeof CONNECTOR_PROVIDERS)[number];

--- a/types/src/oauth/lib.ts
+++ b/types/src/oauth/lib.ts
@@ -17,6 +17,7 @@ export const OAUTH_PROVIDERS = [
   "slack",
   "gong",
   "microsoft",
+  "zendesk",
 ] as const;
 
 export type OAuthProvider = (typeof OAUTH_PROVIDERS)[number];

--- a/types/src/shared/feature_flags.ts
+++ b/types/src/shared/feature_flags.ts
@@ -8,6 +8,7 @@ export const WHITELISTABLE_FEATURES = [
   "openai_o1_feature",
   "openai_o1_mini_feature",
   "snowflake_connector_feature",
+  "zendesk_connector_feature",
 ] as const;
 export type WhitelistableFeature = (typeof WHITELISTABLE_FEATURES)[number];
 export function isWhitelistableFeature(


### PR DESCRIPTION
## Description

This PR drafts a simple version of the Zendesk connector oauth. The actual connector will likely start as a labs alpha feature (will need to show in the UI). This allows getting started on the Zendesk oauth flow and showing it to the users as we did with microsoft - we'll keep a list of users asking for Zendesk beta testing. 

- This PR handles the UI 
- This PR handles the oAuth flow (dependent on https://github.com/dust-tt/dust/pull/7971)
- oAuth flow is gated behind FF - preview for the rest


https://github.com/user-attachments/assets/f458f8d1-fd6b-4053-bdea-8933ce64d772



## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
needs to be merged first : https://github.com/dust-tt/dust/pull/7971 