### PR TITLE
Fix Authenticator for internalAdminForWorkspace

### DIFF
--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -175,7 +175,7 @@ export class GroupResource extends BaseResource<GroupModel> {
 
   static async internalFetchWorkspaceGlobalGroup(
     workspaceId: ModelId
-  ): Promise<GroupResource> {
+  ): Promise<GroupResource | null> {
     const group = await this.model.findOne({
       where: {
         workspaceId,
@@ -184,7 +184,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     });
 
     if (!group) {
-      throw new Error("Global group not found.");
+      return null;
     }
 
     return new this(GroupModel, group.get());

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -9,7 +9,6 @@ import config from "@app/lib/api/config";
 import { hardDeleteDataSource } from "@app/lib/api/data_sources";
 import { hardDeleteVault } from "@app/lib/api/vaults";
 import { areAllSubscriptionsCanceled } from "@app/lib/api/workspace";
-import { getWorkspaceInfos } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
 import { AgentBrowseAction } from "@app/lib/models/assistant/actions/browse";
 import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
@@ -585,11 +584,8 @@ export async function deleteWorkspaceActivity({
 }: {
   workspaceId: string;
 }) {
-  // TODO(2024-10-08 flav) Fix auth issue when global group has already been deleted.
-  // We can't use Authenticator as all groups have already been deleted.
-  // In the interim use `getWorkspaceInfos` to get the workspace.
-  const workspace = await getWorkspaceInfos(workspaceId);
-  assert(workspace, "Workspace not found.");
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+  const workspace = auth.getNonNullableWorkspace();
 
   await frontSequelize.transaction(async (t) => {
     await Subscription.destroy({


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR revert the temporary hack introduced in: https://github.com/dust-tt/dust/pull/7954.
See [DD](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E14%20%40dd.service%3Afront-worker%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAZJxjjwj5HUv9AAAAAAAAAAYAAAAAEFaSnhqazN0QUFEQkdyWHhERmF5M1FBQgAAACQAAAAAMDE5MjcxOTQtNTZhZS00YTJmLWI4MzQtNDI5MjdkMTYxODhl&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1728481148000&to_ts=1728482048000&live=false) logs.

Asserting that the global group exist in this internal function is causing some issues, as if the global vault is not the last one to be deleted, then we can't deleted anymore.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
