### PR TITLE
[front] - fix(assistant-builder): fix padding

### DIFF
--- a/front/components/assistant_builder/vaults/VaultSelector.tsx
+++ b/front/components/assistant_builder/vaults/VaultSelector.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Dialog, Icon, Page } from "@dust-tt/sparkle";
+import { Checkbox, Dialog, Icon, Separator } from "@dust-tt/sparkle";
 import type { VaultType } from "@dust-tt/types";
 import React, { useState } from "react";
 
@@ -46,16 +46,16 @@ export function VaultSelector({
   // elements in between labels. We are aiming to refactor RadioButton
   return (
     <>
-      {sortedVaults.map((vault) => {
+      {sortedVaults.map((vault, index) => {
         const isDisabled =
           allowedVaults && !allowedVaults.some((v) => v.sId === vault.sId);
         const isChecked = selectedVault === vault.sId;
 
         return (
           <div key={vault.sId}>
-            <Page.Separator />
+            {index > 0 && <Separator />}
             <div
-              className="flex items-center gap-2"
+              className="flex items-center py-2"
               onClick={() => {
                 if (isDisabled) {
                   setAlertIsDialogOpen(true);
@@ -100,7 +100,7 @@ export function VaultSelector({
           </div>
         );
       })}
-      <Page.Separator />
+      <Separator />
       <Dialog
         alertDialog={true}
         isOpen={isAlertDialogOpen}

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,7 @@
         "@amplitude/analytics-browser": "^2.5.2",
         "@amplitude/analytics-node": "^1.3.5",
         "@auth0/nextjs-auth0": "^3.5.0",
-        "@dust-tt/sparkle": "^0.2.262",
+        "@dust-tt/sparkle": "^0.2.263",
         "@dust-tt/types": "file:../types",
         "@headlessui/react": "^1.7.7",
         "@heroicons/react": "^2.0.11",
@@ -10984,9 +10984,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.262",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.262.tgz",
-      "integrity": "sha512-Na+kDbJe0jZMTd5AVxnF9bL7dQbP1r0OYYKgtKxPBP962q3qsmuUi0Rv3kv648GAYcLMAecwufr0O9qagvmMEg==",
+      "version": "0.2.263",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.263.tgz",
+      "integrity": "sha512-6iSA9IQGFVOqd5FuY3ohIUm3hGxMy9fcfF1n+h75TRfT1K0Yov1y4/MlFF0wict6srEzIKa7WTJ149wcdMXp3A==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
     "@amplitude/analytics-browser": "^2.5.2",
     "@amplitude/analytics-node": "^1.3.5",
     "@auth0/nextjs-auth0": "^3.5.0",
-    "@dust-tt/sparkle": "^0.2.262",
+    "@dust-tt/sparkle": "^0.2.263",
     "@dust-tt/types": "file:../types",
     "@headlessui/react": "^1.7.7",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description

This PR aims at fixing the padding in the assistant vault selector.

Before:
<img width="813" alt="Screenshot 2024-10-10 at 10 32 42" src="https://github.com/user-attachments/assets/2d071e89-ed0d-4fe0-a949-dba69deac138">

Now:
<img width="821" alt="Screenshot 2024-10-10 at 10 32 19" src="https://github.com/user-attachments/assets/b902a1b0-6870-42e2-85c6-b7f68061643e">

## Risk

None

## Deploy Plan

Deploy `front`