### PR TITLE
Ext: Auth login flow with Auth0

### DIFF
--- a/extension/app/background.ts
+++ b/extension/app/background.ts
@@ -53,11 +53,12 @@ const authenticate = async (
     return;
   }
 
+  // First we call /authorize endpoint to get the authorization code (PKCE flow).
   const redirectUrl = chrome.identity.getRedirectURL();
   const { codeVerifier, codeChallenge } = await generatePKCE();
   const options = {
     client_id: AUTH0_CLIENT_ID,
-    response_type: "code", // Use code response type for PKCE.
+    response_type: "code",
     scope: "openid profile email offline_access",
     redirect_uri: redirectUrl,
     audience: AUTH0_AUDIENCE,
@@ -87,6 +88,7 @@ const authenticate = async (
       const authorizationCode = queryParams.get("code");
 
       if (authorizationCode) {
+        // Once we have the code we call /token endpoint to exchange it for tokens.
         const data = await exchangeCodeForTokens(
           authorizationCode,
           codeVerifier
@@ -140,7 +142,9 @@ const exchangeCodeForTokens = async (
     };
   } catch (error) {
     const message =
-      error instanceof Error ? error.message : "An unknown error occurred.";
+      error instanceof Error
+        ? error.message
+        : "Token exchange error: unknown error occurred.";
     console.error(`Token exchange error: ${message}`);
     return { success: false };
   }

--- a/extension/app/background.ts
+++ b/extension/app/background.ts
@@ -29,11 +29,11 @@ chrome.runtime.onMessage.addListener(
   ) => {
     switch (message.type) {
       case "AUTHENTICATE":
-        authenticate(sendResponse);
+        void authenticate(sendResponse);
         return true; // Keep the message channel open for async response.
 
       case "LOGOUT":
-        logout(sendResponse);
+        void logout(sendResponse);
         return true; // Keep the message channel open.
 
       default:

--- a/extension/app/background.ts
+++ b/extension/app/background.ts
@@ -1,3 +1,114 @@
+import { randomString } from "./src/lib/utils";
+import {
+  AUTH0_AUDIENCE,
+  AUTH0_CLIENT_DOMAIN,
+  AUTH0_CLIENT_ID,
+  AuthBackroundMessage,
+  Auth0AuthorizeResponse,
+  AuthBackgroundResponse,
+} from "./src/lib/auth";
+
+/**
+ * Listener to open/close the side panel when the user clicks on the extension icon.
+ */
 chrome.runtime.onInstalled.addListener(() => {
   void chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
 });
+
+/**
+ * Listener for messages sent from the react app to the background script.
+ * For now we use messages to authenticate the user.
+ */
+chrome.runtime.onMessage.addListener(
+  (
+    message: AuthBackroundMessage,
+    sender,
+    sendResponse: (
+      response: Auth0AuthorizeResponse | AuthBackgroundResponse
+    ) => void
+  ) => {
+    switch (message.type) {
+      case "AUTHENTICATE":
+        authenticate(sendResponse);
+        return true; // Keep the message channel open for async response.
+
+      case "LOGOUT":
+        logout(sendResponse);
+        return true; // Keep the message channel open.
+
+      default:
+        console.error(`Unknown message type: ${message.type}.`);
+    }
+  }
+);
+
+/**
+ * Authenticate the user using Auth0.
+ */
+const authenticate = async (
+  sendResponse: (auth: Auth0AuthorizeResponse | AuthBackgroundResponse) => void
+) => {
+  if (!AUTH0_CLIENT_ID || !AUTH0_CLIENT_DOMAIN) {
+    console.error("Auth0 client ID or domain is missing.");
+    return;
+  }
+
+  const redirectUrl = chrome.identity.getRedirectURL();
+  const options = {
+    client_id: AUTH0_CLIENT_ID,
+    response_type: "id_token token code",
+    scope: "offline_access openid profile email",
+    redirect_uri: redirectUrl,
+    nonce: randomString(16),
+    audience: AUTH0_AUDIENCE,
+  };
+
+  const queryString = new URLSearchParams(options).toString();
+  const authUrl = `https://${AUTH0_CLIENT_DOMAIN}/authorize?${queryString}`;
+
+  chrome.identity.launchWebAuthFlow(
+    { url: authUrl, interactive: true },
+    (redirectUrl) => {
+      if (chrome.runtime.lastError) {
+        console.error(`Auth error: ${chrome.runtime.lastError.message}`);
+        sendResponse({ success: false });
+        return;
+      }
+      if (!redirectUrl || redirectUrl.includes("error")) {
+        console.error(`Auth error in redirect URL: ${redirectUrl}`);
+        sendResponse({ success: false });
+        return;
+      }
+
+      const url = new URL(redirectUrl);
+      const hashParams = new URLSearchParams(url.hash.substring(1));
+
+      sendResponse({
+        idToken: hashParams.get("id_token"),
+        accessToken: hashParams.get("access_token"),
+        code: hashParams.get("code"),
+        expiresIn: hashParams.get("expires_in"),
+      });
+    }
+  );
+};
+
+/**
+ * Logout the user from Auth0.
+ */
+const logout = (sendResponse: (response: AuthBackgroundResponse) => void) => {
+  const redirectUri = chrome.identity.getRedirectURL();
+  const logoutUrl = `https://${AUTH0_CLIENT_DOMAIN}/v2/logout?client_id=${AUTH0_CLIENT_ID}&returnTo=${encodeURIComponent(redirectUri)}`;
+
+  chrome.identity.launchWebAuthFlow(
+    { url: logoutUrl, interactive: true },
+    () => {
+      if (chrome.runtime.lastError) {
+        console.error("Logout error:", chrome.runtime.lastError.message);
+        sendResponse({ success: false });
+      } else {
+        sendResponse({ success: true });
+      }
+    }
+  );
+};

--- a/extension/app/background.ts
+++ b/extension/app/background.ts
@@ -1,12 +1,14 @@
-import { generatePKCE, randomString } from "./src/lib/utils";
+import type {
+  Auth0AuthorizeResponse,
+  AuthBackgroundResponse,
+  AuthBackroundMessage,
+} from "./src/lib/auth";
 import {
   AUTH0_AUDIENCE,
   AUTH0_CLIENT_DOMAIN,
   AUTH0_CLIENT_ID,
-  AuthBackroundMessage,
-  Auth0AuthorizeResponse,
-  AuthBackgroundResponse,
 } from "./src/lib/auth";
+import { generatePKCE } from "./src/lib/utils";
 
 /**
  * Listener to open/close the side panel when the user clicks on the extension icon.

--- a/extension/app/background.ts
+++ b/extension/app/background.ts
@@ -127,8 +127,6 @@ const exchangeCodeForTokens = async (
 
     if (!response.ok) {
       const data = await response.json();
-      console.log({ data });
-
       throw new Error(
         `Token exchange failed: ${data.error} - ${data.error_description}`
       );

--- a/extension/app/background.ts
+++ b/extension/app/background.ts
@@ -35,7 +35,7 @@ chrome.runtime.onMessage.addListener(
         return true; // Keep the message channel open for async response.
 
       case "LOGOUT":
-        void logout(sendResponse);
+        logout(sendResponse);
         return true; // Keep the message channel open.
 
       default:
@@ -50,11 +50,6 @@ chrome.runtime.onMessage.addListener(
 const authenticate = async (
   sendResponse: (auth: Auth0AuthorizeResponse | AuthBackgroundResponse) => void
 ) => {
-  if (!AUTH0_CLIENT_ID || !AUTH0_CLIENT_DOMAIN) {
-    console.error("Auth0 client ID or domain is missing.");
-    return;
-  }
-
   // First we call /authorize endpoint to get the authorization code (PKCE flow).
   const redirectUrl = chrome.identity.getRedirectURL();
   const { codeVerifier, codeChallenge } = await generatePKCE();
@@ -112,10 +107,6 @@ const exchangeCodeForTokens = async (
   codeVerifier: string
 ): Promise<Auth0AuthorizeResponse | AuthBackgroundResponse> => {
   try {
-    if (!AUTH0_CLIENT_ID || !AUTH0_CLIENT_DOMAIN) {
-      throw new Error("Auth0 client ID or domain is missing.");
-    }
-
     const tokenUrl = `https://${AUTH0_CLIENT_DOMAIN}/oauth/token`;
     const response = await fetch(tokenUrl, {
       method: "POST",
@@ -147,7 +138,7 @@ const exchangeCodeForTokens = async (
       error instanceof Error
         ? error.message
         : "Token exchange error: unknown error occurred.";
-    console.error(`Token exchange error: ${message}`);
+    console.error(`Token exchange error: ${message}`, error);
     return { success: false };
   }
 };

--- a/extension/app/background.ts
+++ b/extension/app/background.ts
@@ -56,7 +56,8 @@ const authenticate = async (
   const options = {
     client_id: AUTH0_CLIENT_ID,
     response_type: "code",
-    scope: "openid profile email offline_access",
+    // "offline_access" to receive refresh tokens to maintain user sessions without re-prompting for authentication.
+    scope: "openid offline_access",
     redirect_uri: redirectUrl,
     audience: AUTH0_AUDIENCE,
     code_challenge_method: "S256",

--- a/extension/app/src/hooks/useAuth.ts
+++ b/extension/app/src/hooks/useAuth.ts
@@ -1,0 +1,65 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { sendAuthMessage, sentLogoutMessage } from "../lib/auth";
+import {
+  clearAccessToken,
+  getAccessToken,
+  saveAccessToken,
+} from "../lib/utils";
+
+export const useAuth = () => {
+  const [token, setToken] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    const fetchToken = async () => {
+      try {
+        const storedToken = await getAccessToken();
+        if (storedToken && typeof storedToken === "string") {
+          setToken(storedToken);
+        }
+      } catch (error) {
+        console.error("Error retrieving token:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    void fetchToken();
+  }, []);
+
+  const handleLogin = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const response = await sendAuthMessage();
+      if (response?.accessToken) {
+        await saveAccessToken(response.accessToken);
+        setToken(response.accessToken);
+      } else {
+        console.error("Authentication failed.");
+      }
+    } catch (error) {
+      console.error("Error sending auth message:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const handleLogout = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const response = await sentLogoutMessage();
+      if (response?.success) {
+        await clearAccessToken();
+        setToken(null);
+      } else {
+        console.error("Logout failed.");
+      }
+    } catch (error) {
+      console.error("Error sending logout message:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  return { token, isLoading, handleLogin, handleLogout };
+};

--- a/extension/app/src/lib/auth.ts
+++ b/extension/app/src/lib/auth.ts
@@ -7,7 +7,6 @@ export const AUTH0_PROFILE_ROUTE = `https://${AUTH0_CLIENT_DOMAIN}/userinfo`;
 export type Auth0AuthorizeResponse = {
   idToken: string | null;
   accessToken: string | null;
-  code: string | null;
   expiresIn: string | null;
 };
 
@@ -41,18 +40,20 @@ export const sendAuthMessage = (): Promise<Auth0AuthorizeResponse> => {
                     return reject(chrome.runtime.lastError);
                   }
                   if (!response) {
-                    return reject(new Error("No response received"));
+                    return reject(new Error("No response received."));
                   }
                   return resolve(response);
                 }
               );
             });
           } else {
-            reject(new Error(error.message || "An unknown error occurred"));
+            reject(new Error(error.message || "An unknown error occurred."));
           }
-        } else {
-          resolve(response as Auth0AuthorizeResponse);
         }
+        if (!response) {
+          return reject(new Error("No response received."));
+        }
+        return resolve(response);
       }
     );
   });

--- a/extension/app/src/lib/auth.ts
+++ b/extension/app/src/lib/auth.ts
@@ -58,3 +58,21 @@ export const sendAuthMessage = (): Promise<Auth0AuthorizeResponse> => {
     );
   });
 };
+
+export const sentLogoutMessage = (): Promise<AuthBackgroundResponse> => {
+  return new Promise((resolve, reject) => {
+    const message: AuthBackroundMessage = { type: "LOGOUT" };
+    chrome.runtime.sendMessage(
+      message,
+      (response: AuthBackgroundResponse | undefined) => {
+        if (chrome.runtime.lastError) {
+          return reject(chrome.runtime.lastError);
+        }
+        if (!response) {
+          return reject(new Error("No response received."));
+        }
+        return resolve(response);
+      }
+    );
+  });
+};

--- a/extension/app/src/lib/auth.ts
+++ b/extension/app/src/lib/auth.ts
@@ -1,6 +1,6 @@
 // Auth0 config.
-export const AUTH0_CLIENT_DOMAIN = process.env.AUTH0_CLIENT_DOMAIN;
-export const AUTH0_CLIENT_ID = process.env.AUTH0_CLIENT_ID;
+export const AUTH0_CLIENT_DOMAIN = process.env.AUTH0_CLIENT_DOMAIN ?? "";
+export const AUTH0_CLIENT_ID = process.env.AUTH0_CLIENT_ID ?? "";
 export const AUTH0_AUDIENCE = `https://${AUTH0_CLIENT_DOMAIN}/api/v2/`;
 export const AUTH0_PROFILE_ROUTE = `https://${AUTH0_CLIENT_DOMAIN}/userinfo`;
 
@@ -59,6 +59,9 @@ export const sendAuthMessage = (): Promise<Auth0AuthorizeResponse> => {
   });
 };
 
+/**
+ * Sends a logout request to the background script.
+ */
 export const sentLogoutMessage = (): Promise<AuthBackgroundResponse> => {
   return new Promise((resolve, reject) => {
     const message: AuthBackroundMessage = { type: "LOGOUT" };

--- a/extension/app/src/lib/auth.ts
+++ b/extension/app/src/lib/auth.ts
@@ -38,10 +38,12 @@ export const sendAuthMessage = (): Promise<Auth0AuthorizeResponse> => {
                 message,
                 (response: Auth0AuthorizeResponse | undefined) => {
                   if (chrome.runtime.lastError) {
-                    reject(chrome.runtime.lastError);
-                  } else {
-                    resolve(response as Auth0AuthorizeResponse);
+                    return reject(chrome.runtime.lastError);
                   }
+                  if (!response) {
+                    return reject(new Error("No response received"));
+                  }
+                  return resolve(response);
                 }
               );
             });

--- a/extension/app/src/lib/auth.ts
+++ b/extension/app/src/lib/auth.ts
@@ -1,0 +1,57 @@
+// Auth0 config.
+export const AUTH0_CLIENT_DOMAIN = process.env.AUTH0_CLIENT_DOMAIN;
+export const AUTH0_CLIENT_ID = process.env.AUTH0_CLIENT_ID;
+export const AUTH0_AUDIENCE = `https://${AUTH0_CLIENT_DOMAIN}/api/v2/`;
+export const AUTH0_PROFILE_ROUTE = `https://${AUTH0_CLIENT_DOMAIN}/userinfo`;
+
+export type Auth0AuthorizeResponse = {
+  idToken: string | null;
+  accessToken: string | null;
+  code: string | null;
+  expiresIn: string | null;
+};
+
+export type AuthBackgroundResponse = {
+  success: boolean;
+};
+
+export type AuthBackroundMessage = {
+  type: "AUTHENTICATE" | "LOGOUT";
+};
+
+/**
+ * Sends an authentication request to the background script.
+ * Wrapped to ensure the service worker is ready to receive messages.
+ */
+export const sendAuthMessage = (): Promise<Auth0AuthorizeResponse> => {
+  return new Promise((resolve, reject) => {
+    const message: AuthBackroundMessage = { type: "AUTHENTICATE" };
+    chrome.runtime.sendMessage(
+      message,
+      (response: Auth0AuthorizeResponse | undefined) => {
+        const error = chrome.runtime.lastError;
+        if (error) {
+          if (error.message?.includes("Could not establish connection")) {
+            // Attempt to wake up the service worker
+            chrome.runtime.getBackgroundPage(() => {
+              chrome.runtime.sendMessage(
+                message,
+                (response: Auth0AuthorizeResponse | undefined) => {
+                  if (chrome.runtime.lastError) {
+                    reject(chrome.runtime.lastError);
+                  } else {
+                    resolve(response as Auth0AuthorizeResponse);
+                  }
+                }
+              );
+            });
+          } else {
+            reject(new Error(error.message || "An unknown error occurred"));
+          }
+        } else {
+          resolve(response as Auth0AuthorizeResponse);
+        }
+      }
+    );
+  });
+};

--- a/extension/app/src/lib/utils.ts
+++ b/extension/app/src/lib/utils.ts
@@ -1,6 +1,6 @@
 export const randomString = (length: number): string => {
   const charset =
-    "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz+/";
+    "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-._~";
   let result = "";
   const bytes = new Uint8Array(length);
 
@@ -11,4 +11,16 @@ export const randomString = (length: number): string => {
   }
 
   return result;
+};
+
+export const generatePKCE = async () => {
+  const codeVerifier = randomString(128);
+  const encoder = new TextEncoder();
+  const data = encoder.encode(codeVerifier);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  const base64Digest = btoa(String.fromCharCode(...new Uint8Array(digest)))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+  return { codeVerifier, codeChallenge: base64Digest };
 };

--- a/extension/app/src/lib/utils.ts
+++ b/extension/app/src/lib/utils.ts
@@ -48,3 +48,15 @@ export const getAccessToken = () => {
     });
   });
 };
+
+export const clearAccessToken = () => {
+  return new Promise((resolve, reject) => {
+    chrome.storage.local.remove("accessToken", () => {
+      if (chrome.runtime.lastError) {
+        reject(chrome.runtime.lastError);
+      } else {
+        resolve(true);
+      }
+    });
+  });
+};

--- a/extension/app/src/lib/utils.ts
+++ b/extension/app/src/lib/utils.ts
@@ -1,0 +1,14 @@
+export const randomString = (length: number): string => {
+  const charset =
+    "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz+/";
+  let result = "";
+  const bytes = new Uint8Array(length);
+
+  crypto.getRandomValues(bytes);
+
+  for (let i = 0; i < length; i++) {
+    result += charset[bytes[i] % charset.length];
+  }
+
+  return result;
+};

--- a/extension/app/src/lib/utils.ts
+++ b/extension/app/src/lib/utils.ts
@@ -24,3 +24,27 @@ export const generatePKCE = async () => {
     .replace(/=+$/, "");
   return { codeVerifier, codeChallenge: base64Digest };
 };
+
+export const saveAccessToken = (accessToken: string) => {
+  return new Promise((resolve, reject) => {
+    chrome.storage.local.set({ accessToken }, () => {
+      if (chrome.runtime.lastError) {
+        reject(chrome.runtime.lastError);
+      } else {
+        resolve(true);
+      }
+    });
+  });
+};
+
+export const getAccessToken = () => {
+  return new Promise((resolve, reject) => {
+    chrome.storage.local.get(["accessToken"], (result) => {
+      if (chrome.runtime.lastError) {
+        reject(chrome.runtime.lastError);
+      } else {
+        resolve(result.accessToken);
+      }
+    });
+  });
+};

--- a/extension/app/src/pages/MainPage.tsx
+++ b/extension/app/src/pages/MainPage.tsx
@@ -9,7 +9,7 @@ import {
   TextArea,
 } from "@dust-tt/sparkle";
 import { useCallback, useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+
 import { sendAuthMessage, sentLogoutMessage } from "../lib/auth";
 import {
   clearAccessToken,
@@ -34,8 +34,7 @@ export const MainPage = () => {
         setIsLoading(false);
       }
     };
-
-    fetchToken();
+    void fetchToken();
   }, []);
 
   const handleLogin = useCallback(async () => {

--- a/extension/app/src/pages/MainPage.tsx
+++ b/extension/app/src/pages/MainPage.tsx
@@ -8,68 +8,11 @@ import {
   Spinner,
   TextArea,
 } from "@dust-tt/sparkle";
-import { useCallback, useEffect, useState } from "react";
 
-import { sendAuthMessage, sentLogoutMessage } from "../lib/auth";
-import {
-  clearAccessToken,
-  getAccessToken,
-  saveAccessToken,
-} from "../lib/utils";
+import { useAuth } from "../hooks/useAuth";
 
 export const MainPage = () => {
-  const [token, setToken] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-
-  useEffect(() => {
-    const fetchToken = async () => {
-      try {
-        const storedToken = await getAccessToken();
-        if (storedToken && typeof storedToken === "string") {
-          setToken(storedToken);
-        }
-      } catch (error) {
-        console.error("Error retrieving token:", error);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-    void fetchToken();
-  }, []);
-
-  const handleLogin = useCallback(async () => {
-    setIsLoading(true);
-    try {
-      const response = await sendAuthMessage();
-      if (response?.accessToken) {
-        await saveAccessToken(response.accessToken);
-        setToken(response.accessToken);
-      } else {
-        console.error("Authentication failed.");
-      }
-    } catch (error) {
-      console.error("Error sending auth message:", error);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [sendAuthMessage, setIsLoading, setToken]);
-
-  const handleLogout = useCallback(async () => {
-    setIsLoading(true);
-    try {
-      const response = await sentLogoutMessage();
-      if (response?.success) {
-        await clearAccessToken();
-        setToken(null);
-      } else {
-        console.error("Logout failed.");
-      }
-    } catch (error) {
-      console.error("Error sending logout message:", error);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [setToken]);
+  const { token, isLoading, handleLogin, handleLogout } = useAuth();
 
   return (
     <div className="flex flex-col p-4 gap-2 h-screen">

--- a/extension/app/src/pages/MainPage.tsx
+++ b/extension/app/src/pages/MainPage.tsx
@@ -8,7 +8,7 @@ import {
   Spinner,
   TextArea,
 } from "@dust-tt/sparkle";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { sendAuthMessage } from "../lib/auth";
 
@@ -24,27 +24,25 @@ export const MainPage = () => {
     setIsLoading(false);
   }, []);
 
-  const handleLogin = () => {
+  const handleLogin = useCallback(async () => {
     setIsLoading(true);
-    sendAuthMessage()
-      .then((response) => {
-        console.log(response);
-        if (response?.accessToken) {
-          localStorage.setItem("authToken", response.accessToken);
-          setToken(response.accessToken);
-        } else {
-          console.error("Authentication failed.");
-        }
-        localStorage.setItem("full", JSON.stringify(response));
-        setIsLoading(false);
-      })
-      .catch((error) => {
-        console.error("Error sending message:", error);
-        setIsLoading(false);
-      });
-  };
+    try {
+      const response = await sendAuthMessage();
+      if (response?.accessToken) {
+        localStorage.setItem("authToken", response.accessToken);
+        setToken(response.accessToken);
+      } else {
+        console.error("Authentication failed.");
+      }
+      localStorage.setItem("full", JSON.stringify(response));
+    } catch (error) {
+      console.error("Error sending message:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [sendAuthMessage, setIsLoading, setToken]);
 
-  const handleLogout = () => {
+  const handleLogout = useCallback(() => {
     chrome.runtime.sendMessage({ type: "LOGOUT" }, (response) => {
       if (response?.success) {
         localStorage.removeItem("authToken");
@@ -53,7 +51,7 @@ export const MainPage = () => {
         console.error("Logout failed.");
       }
     });
-  };
+  }, [setToken]);
 
   return (
     <div className="flex flex-col p-4 gap-2 h-screen">

--- a/extension/app/src/pages/MainPage.tsx
+++ b/extension/app/src/pages/MainPage.tsx
@@ -1,40 +1,110 @@
 import {
   Button,
   ExternalLinkIcon,
+  LoginIcon,
   LogoHorizontalColorLogo,
-  MarkPenIcon,
+  LogoutIcon,
   Page,
-  TranslateIcon,
+  Spinner,
+  TextArea,
 } from "@dust-tt/sparkle";
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { sendAuthMessage } from "../lib/auth";
 
 export const MainPage = () => {
-  return (
-    <div className="flex flex-col p-4 gap-2">
-      <div className="flex gap-2 align-center">
-        <LogoHorizontalColorLogo className="h-4 w-16" />
-        <a href="https://dust.tt" target="_blank">
-          <ExternalLinkIcon color="#64748B" />
-        </a>
-      </div>
-      <div className="flex flex-grow gap-2 p-1">
-        <Button
-          className="flex-grow"
-          icon={MarkPenIcon}
-          variant="secondary"
-          label="Summarize"
-        ></Button>
-        <Button
-          className="flex-grow"
-          icon={TranslateIcon}
-          variant="secondary"
-          label="Translate"
-        ></Button>
-      </div>
-      <Page.SectionHeader title="Conversation" />
-      <Link to="/conversation">Conversations</Link>
+  const [token, setToken] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
 
-      <Page.SectionHeader title="Favorites" />
+  useEffect(() => {
+    const storedToken = localStorage.getItem("authToken");
+    if (storedToken) {
+      setToken(storedToken);
+    }
+    setIsLoading(false);
+  }, []);
+
+  const handleLogin = () => {
+    setIsLoading(true);
+    sendAuthMessage()
+      .then((response) => {
+        console.log(response);
+        if (response?.accessToken) {
+          localStorage.setItem("authToken", response.accessToken);
+          setToken(response.accessToken);
+        } else {
+          console.error("Authentication failed.");
+        }
+        localStorage.setItem("full", JSON.stringify(response));
+        setIsLoading(false);
+      })
+      .catch((error) => {
+        console.error("Error sending message:", error);
+        setIsLoading(false);
+      });
+  };
+
+  const handleLogout = () => {
+    chrome.runtime.sendMessage({ type: "LOGOUT" }, (response) => {
+      if (response?.success) {
+        localStorage.removeItem("authToken");
+        setToken(null);
+      } else {
+        console.error("Logout failed.");
+      }
+    });
+  };
+
+  return (
+    <div className="flex flex-col p-4 gap-2 h-screen">
+      <div className="flex justify-between items-start">
+        <div className="flex items-center gap-2 pb-10">
+          <LogoHorizontalColorLogo className="h-4 w-16" />
+          <a href="https://dust.tt" target="_blank">
+            <ExternalLinkIcon color="#64748B" />
+          </a>
+        </div>
+
+        {token && (
+          <Button
+            icon={LogoutIcon}
+            variant="tertiary"
+            label="Sign out"
+            onClick={handleLogout}
+          />
+        )}
+      </div>
+
+      {isLoading && (
+        <div className="flex justify-center items-center w-full h-full">
+          <Spinner />
+        </div>
+      )}
+
+      {!isLoading && !token && (
+        <div className="flex justify-center items-center w-full h-full">
+          <Button
+            icon={LoginIcon}
+            variant="primary"
+            label="Sign in"
+            onClick={handleLogin}
+          />
+        </div>
+      )}
+
+      {token && (
+        <div className="w-full h-full">
+          <Page.SectionHeader title="Conversation" />
+          {/* <Link to="/conversation">Conversations</Link> */}
+          <TextArea />
+          <Button
+            variant="primary"
+            label="Send"
+            className="mt-4"
+            onClick={() => alert("Sorry, not implemented yet!")}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -15,5 +15,5 @@
   "side_panel": {
     "default_path": "main.html"
   },
-  "permissions": ["sidePanel", "cookies", "identity"]
+  "permissions": ["sidePanel", "identity", "storage"]
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -15,7 +15,5 @@
   "side_panel": {
     "default_path": "main.html"
   },
-  "permissions": [
-    "sidePanel"
-  ]
+  "permissions": ["sidePanel", "cookies", "identity"]
 }


### PR DESCRIPTION
## Description

This handles the auth flow from the extension. 
We're using a dedicated Auth0 app to login from the extension. 

We're saving `AUTH0_CLIENT_DOMAIN` & `AUTH0_CLIENT_ID` on a `.env.development` and `.env.production` files that are gitignored. They will still be on the bundle but not super sensitive informations. 

I'll write a runbook to share the links to the Auth0 app with domain and id so that everyone can set up their extension locally. 

We're using the messaging system to discuss between the React app and the background script. 

Demo of the flow: https://dust4ai.slack.com/archives/C07Q9HE2YUC/p1728552189905559

Some things might change of course since this is currently plugged to nothing; 
I'm going to now focus on using the token to login to the public API and will adjust this code if needed. 
Submitting already to validate the global logic. 

## Risk

/ 

## Deploy Plan

Nothing. 