### PR TITLE
feat: save tables query output as file attachment

### DIFF
--- a/core/src/databases/remote_databases/snowflake.rs
+++ b/core/src/databases/remote_databases/snowflake.rs
@@ -44,8 +44,7 @@ struct SnowflakeQueryPlanEntry {
     operation: Option<String>,
 }
 
-// TODO(SNOWFLAKE) actual limit TBD
-pub const MAX_QUERY_RESULT_SIZE_BYTES: usize = 128 * 1024 * 1024; // 128MB
+pub const MAX_QUERY_RESULT_SIZE_BYTES: usize = 8 * 1024 * 1024; // 8MB
 
 // TODO(SNOWFLAKE) make sure we're not missing any
 pub const FORBIDDEN_OPERATIONS: [&str; 3] = ["UPDATE", "DELETE", "INSERT"];

--- a/front/components/actions/tables_query/TablesQueryActionDetails.tsx
+++ b/front/components/actions/tables_query/TablesQueryActionDetails.tsx
@@ -5,7 +5,7 @@ import {
   InformationCircleIcon,
   TableIcon,
 } from "@dust-tt/sparkle";
-import type { TablesQueryActionType, WorkspaceType } from "@dust-tt/types";
+import type { LightWorkspaceType, TablesQueryActionType } from "@dust-tt/types";
 import { getTablesQueryResultsFileTitle } from "@dust-tt/types";
 import { useCallback, useContext } from "react";
 
@@ -98,7 +98,7 @@ function QueryTablesResults({
   owner,
 }: {
   action: TablesQueryActionType;
-  owner: WorkspaceType;
+  owner: LightWorkspaceType;
 }) {
   const sendNotification = useContext(SendNotificationsContext);
   const { output } = action;
@@ -108,7 +108,7 @@ function QueryTablesResults({
     if (action.resultsFileId) {
       try {
         const downloadUrl = `/api/w/${owner.sId}/files/${action.resultsFileId}?action=download`;
-        // Open the download URL in a new tab/window. Otherwise we get a CORS error due to the reirection
+        // Open the download URL in a new tab/window. Otherwise we get a CORS error due to the redirection
         // to cloud storage.
         window.open(downloadUrl, "_blank");
       } catch (error) {
@@ -143,7 +143,7 @@ function QueryTablesResults({
   return (
     <div>
       <span className="text-sm font-bold text-slate-900">Results</span>
-      <div onClick={() => handleDownload()} className="py-2">
+      <div onClick={handleDownload} className="py-2">
         <Citation size="xs" title={title} />
       </div>
 

--- a/front/components/actions/tables_query/TablesQueryActionDetails.tsx
+++ b/front/components/actions/tables_query/TablesQueryActionDetails.tsx
@@ -5,8 +5,8 @@ import {
   InformationCircleIcon,
   TableIcon,
 } from "@dust-tt/sparkle";
-import type { TablesQueryActionType } from "@dust-tt/types";
-import { stringify } from "csv-stringify";
+import type { TablesQueryActionType, WorkspaceType } from "@dust-tt/types";
+import { getTablesQueryResultsFileTitle } from "@dust-tt/types";
 import { useCallback, useContext } from "react";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
@@ -21,6 +21,7 @@ import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 export function TablesQueryActionDetails({
   action,
   defaultOpen,
+  owner,
 }: ActionDetailsComponentBaseProps<TablesQueryActionType>) {
   return (
     <ActionDetailsWrapper
@@ -31,7 +32,7 @@ export function TablesQueryActionDetails({
       <div className="flex flex-col gap-1 gap-4 pl-6 pt-4">
         <QueryThinking action={action} />
         <TablesQuery action={action} />
-        <QueryTablesResults action={action} />
+        <QueryTablesResults action={action} owner={owner} />
       </div>
     </ActionDetailsWrapper>
   );
@@ -92,78 +93,72 @@ function QueryThinking({ action }: { action: TablesQueryActionType }) {
   );
 }
 
-type TablesQueryActionWithResultsType = TablesQueryActionType & {
-  output: {
-    query_title?: string;
-    results: unknown[];
-  };
-};
-
-function hasQueryResults(
-  action: TablesQueryActionType
-): action is TablesQueryActionWithResultsType {
-  const { output } = action;
-
-  return (
-    output !== null &&
-    typeof output === "object" &&
-    "results" in output &&
-    Array.isArray(output.results)
-  );
-}
-
-function QueryTablesResults({ action }: { action: TablesQueryActionType }) {
+function QueryTablesResults({
+  action,
+  owner,
+}: {
+  action: TablesQueryActionType;
+  owner: WorkspaceType;
+}) {
   const sendNotification = useContext(SendNotificationsContext);
+  const { output } = action;
+  const title = getTablesQueryResultsFileTitle({ output });
 
-  const handleDownload = useCallback(
-    (title: string) => {
-      if (!hasQueryResults(action)) {
-        return null;
+  const handleDownload = useCallback(() => {
+    if (action.resultsFileId) {
+      try {
+        const downloadUrl = `/api/w/${owner.sId}/files/${action.resultsFileId}?action=download`;
+        // Open the download URL in a new tab/window. Otherwise we get a CORS error due to the reirection
+        // to cloud storage.
+        window.open(downloadUrl, "_blank");
+      } catch (error) {
+        console.error("Download failed:", error);
+        sendNotification({
+          title: "Download Failed",
+          type: "error",
+          description: "An error occurred while opening the download link.",
+        });
       }
-      if (
-        !action.output ||
-        !action.output.results ||
-        action.output.results.length === 0
-      ) {
-        return;
-      }
-
-      stringify(action.output.results, { header: true }, (err, csvOutput) => {
-        if (err) {
-          sendNotification({
-            title: "Error Downloading CSV",
-            type: "error",
-            description: `An error occurred while downloading the CSV: ${err}`,
-          });
-          return;
-        }
-
-        const blob = new Blob([csvOutput], { type: "text/csv" });
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement("a");
-        a.href = url;
-        a.download = `${title}.csv`;
-        a.click();
+    } else {
+      sendNotification({
+        title: "No Results Available",
+        type: "error",
+        description: "There are no results available to download.",
       });
-    },
-    [action, sendNotification]
-  );
+    }
+  }, [action.resultsFileId, sendNotification, owner.sId]);
 
-  if (!hasQueryResults(action)) {
+  if (!action.resultsFileId!) {
+    if (typeof output?.error === "string") {
+      return (
+        <div>
+          <span className="pb-2 text-sm font-bold text-slate-900">Error</span>
+          <div className="text-sm">{output.error}</div>
+        </div>
+      );
+    }
     return null;
   }
-  const { output } = action;
-  const title = output?.query_title ?? "query_results";
 
   return (
     <div>
-      <Collapsible defaultOpen={true}>
+      <span className="text-sm font-bold text-slate-900">Results</span>
+      <div onClick={() => handleDownload()} className="py-2">
+        <Citation size="xs" title={title} />
+      </div>
+
+      <Collapsible defaultOpen={false}>
         <Collapsible.Button>
-          <span className="text-sm font-bold text-slate-900">Results</span>
+          <span className="text-sm font-bold text-slate-600">Preview</span>
         </Collapsible.Button>
         <Collapsible.Panel>
-          <div onClick={() => handleDownload(title)}>
-            <Citation size="xs" title={title} />
+          <div className="py-2">
+            <CodeBlock
+              className="language-csv max-h-60 overflow-y-auto"
+              wrapLongLines={true}
+            >
+              {action.resultsFileSnippet}
+            </CodeBlock>
           </div>
         </Collapsible.Panel>
       </Collapsible>

--- a/front/components/actions/types.ts
+++ b/front/components/actions/types.ts
@@ -1,4 +1,4 @@
-import type { AgentActionType } from "@dust-tt/types";
+import type { AgentActionType, WorkspaceType } from "@dust-tt/types";
 import { ACTION_RUNNING_LABELS } from "@dust-tt/types";
 
 import { BrowseActionDetails } from "@app/components/actions/browse/BrowseActionDetails";
@@ -12,6 +12,7 @@ export interface ActionDetailsComponentBaseProps<
   T extends AgentActionType = AgentActionType,
 > {
   action: T;
+  owner: WorkspaceType;
   defaultOpen: boolean;
 }
 

--- a/front/components/actions/types.ts
+++ b/front/components/actions/types.ts
@@ -1,4 +1,4 @@
-import type { AgentActionType, WorkspaceType } from "@dust-tt/types";
+import type { AgentActionType, LightWorkspaceType } from "@dust-tt/types";
 import { ACTION_RUNNING_LABELS } from "@dust-tt/types";
 
 import { BrowseActionDetails } from "@app/components/actions/browse/BrowseActionDetails";
@@ -12,7 +12,7 @@ export interface ActionDetailsComponentBaseProps<
   T extends AgentActionType = AgentActionType,
 > {
   action: T;
-  owner: WorkspaceType;
+  owner: LightWorkspaceType;
   defaultOpen: boolean;
 }
 

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -506,7 +506,11 @@ export function AgentMessage({
 
     return (
       <div className="flex flex-col gap-y-4">
-        <AgentMessageActions agentMessage={agentMessage} size={size} />
+        <AgentMessageActions
+          agentMessage={agentMessage}
+          size={size}
+          owner={owner}
+        />
 
         {agentMessage.chainOfThought?.length ? (
           <ContentMessage

--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -2,7 +2,7 @@ import { Button, Chip, EyeIcon, Spinner } from "@dust-tt/sparkle";
 import type {
   AgentActionType,
   AgentMessageType,
-  WorkspaceType,
+  LightWorkspaceType,
 } from "@dust-tt/types";
 import { useEffect, useMemo, useState } from "react";
 
@@ -14,7 +14,7 @@ import { classNames } from "@app/lib/utils";
 interface AgentMessageActionsProps {
   agentMessage: AgentMessageType;
   size?: MessageSizeType;
-  owner: WorkspaceType;
+  owner: LightWorkspaceType;
 }
 
 export function AgentMessageActions({

--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -1,5 +1,9 @@
 import { Button, Chip, EyeIcon, Spinner } from "@dust-tt/sparkle";
-import type { AgentActionType, AgentMessageType } from "@dust-tt/types";
+import type {
+  AgentActionType,
+  AgentMessageType,
+  WorkspaceType,
+} from "@dust-tt/types";
 import { useEffect, useMemo, useState } from "react";
 
 import { getActionSpecification } from "@app/components/actions/types";
@@ -10,10 +14,12 @@ import { classNames } from "@app/lib/utils";
 interface AgentMessageActionsProps {
   agentMessage: AgentMessageType;
   size?: MessageSizeType;
+  owner: WorkspaceType;
 }
 
 export function AgentMessageActions({
   agentMessage,
+  owner,
   size = "normal",
 }: AgentMessageActionsProps) {
   const [chipLabel, setChipLabel] = useState<string | undefined>("Thinking");
@@ -48,6 +54,7 @@ export function AgentMessageActions({
         isOpened={isActionDrawerOpened}
         onClose={() => setIsActionDrawerOpened(false)}
         isStreaming={isThinkingOrActing || agentMessage.actions.length === 0}
+        owner={owner}
       />
       <ActionDetails
         hasActions={agentMessage.actions.length !== 0}

--- a/front/components/assistant/conversation/actions/AgentMessageActionsDrawer.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActionsDrawer.tsx
@@ -1,5 +1,5 @@
 import { Modal, Page, Spinner } from "@dust-tt/sparkle";
-import type { AgentActionType } from "@dust-tt/types";
+import type { AgentActionType, WorkspaceType } from "@dust-tt/types";
 
 import { getActionSpecification } from "@app/components/actions/types";
 
@@ -8,6 +8,7 @@ interface AgentMessageActionsDrawerProps {
   isOpened: boolean;
   isStreaming: boolean;
   onClose: () => void;
+  owner: WorkspaceType;
 }
 
 export function AgentMessageActionsDrawer({
@@ -15,6 +16,7 @@ export function AgentMessageActionsDrawer({
   isOpened,
   isStreaming,
   onClose,
+  owner,
 }: AgentMessageActionsDrawerProps) {
   const groupedActionsByStep = actions.reduce(
     (acc, current) => {
@@ -61,6 +63,7 @@ export function AgentMessageActionsDrawer({
                         <ActionDetailsComponent
                           action={action}
                           defaultOpen={idx === 0 && step === "1"}
+                          owner={owner}
                         />
                       </div>
                     );

--- a/front/components/assistant/conversation/actions/AgentMessageActionsDrawer.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActionsDrawer.tsx
@@ -1,5 +1,5 @@
 import { Modal, Page, Spinner } from "@dust-tt/sparkle";
-import type { AgentActionType, WorkspaceType } from "@dust-tt/types";
+import type { AgentActionType, LightWorkspaceType } from "@dust-tt/types";
 
 import { getActionSpecification } from "@app/components/actions/types";
 
@@ -8,7 +8,7 @@ interface AgentMessageActionsDrawerProps {
   isOpened: boolean;
   isStreaming: boolean;
   onClose: () => void;
-  owner: WorkspaceType;
+  owner: LightWorkspaceType;
 }
 
 export function AgentMessageActionsDrawer({

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -12,17 +12,25 @@ import type {
   TablesQueryOutputEvent,
   TablesQueryStartedEvent,
 } from "@dust-tt/types";
-import { BaseAction, Ok } from "@dust-tt/types";
+import {
+  BaseAction,
+  getTablesQueryResultsFileAttachment,
+  getTablesQueryResultsFileTitle,
+  Ok,
+} from "@dust-tt/types";
+import { stringify } from "csv-stringify";
 
 import { runActionStreamed } from "@app/lib/actions/server";
 import { DEFAULT_TABLES_QUERY_ACTION_NAME } from "@app/lib/api/assistant/actions/names";
 import type { BaseActionRunParams } from "@app/lib/api/assistant/actions/types";
 import { BaseActionConfigurationServerRunner } from "@app/lib/api/assistant/actions/types";
 import { renderConversationForModelMultiActions } from "@app/lib/api/assistant/generation";
+import { internalCreateToolOutputCsvFile } from "@app/lib/api/files/tool_output";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentTablesQueryAction } from "@app/lib/models/assistant/actions/tables_query";
 import { cloneBaseConfig, DustProdActionRegistry } from "@app/lib/registry";
+import { FileResource } from "@app/lib/resources/file_resource";
 import { sanitizeJSONOutput } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 
@@ -30,11 +38,17 @@ import logger from "@app/logger/logger";
 const TABLES_QUERY_MIN_TOKEN = 28_000;
 const RENDERED_CONVERSATION_MIN_TOKEN = 4_000;
 
+// Max number of lines from the CSV ouptut file that will be saved in the DB
+// and inlined in the rendered conversation.
+const MAX_SNIPPET_LINES_QUERY_RESULT_FILE = 128;
+
 interface TablesQueryActionBlob {
   id: ModelId; // AgentTablesQueryAction.
   agentMessageId: ModelId;
   params: DustAppParameters;
   output: Record<string, string | number | boolean> | null;
+  resultsFileId: string | null;
+  resultsFileSnippet: string | null;
   functionCallId: string | null;
   functionCallName: string | null;
   step: number;
@@ -44,6 +58,8 @@ export class TablesQueryAction extends BaseAction {
   readonly agentMessageId: ModelId;
   readonly params: DustAppParameters;
   readonly output: Record<string, string | number | boolean> | null;
+  readonly resultsFileId: string | null;
+  readonly resultsFileSnippet: string | null;
   readonly functionCallId: string | null;
   readonly functionCallName: string | null;
   readonly step: number;
@@ -58,6 +74,8 @@ export class TablesQueryAction extends BaseAction {
     this.functionCallId = blob.functionCallId;
     this.functionCallName = blob.functionCallName;
     this.step = blob.step;
+    this.resultsFileId = blob.resultsFileId;
+    this.resultsFileSnippet = blob.resultsFileSnippet;
   }
 
   renderForFunctionCall(): FunctionCallType {
@@ -69,19 +87,91 @@ export class TablesQueryAction extends BaseAction {
   }
 
   renderForMultiActionsModel(): FunctionMessageTypeModel {
-    let content = "";
-    content += `OUTPUT:\n`;
-
-    if (this.output === null) {
-      content += "(query failed)\n";
-    } else {
-      content += `${JSON.stringify(this.output, null, 2)}\n`;
-    }
-
-    return {
+    const partialOutput: Omit<FunctionMessageTypeModel, "content"> = {
       role: "function" as const,
       name: this.functionCallName ?? DEFAULT_TABLES_QUERY_ACTION_NAME,
       function_call_id: this.functionCallId ?? `call_${this.id.toString()}`,
+    };
+
+    // Unexpected error case -- we don't have any action output.
+    if (!this.output) {
+      return {
+        ...partialOutput,
+        content: "(query failed)",
+      };
+    }
+
+    let content = "";
+
+    // Add reasoning if it exists (should always exist).
+    if (typeof this.output.thinking === "string") {
+      content += `Reasoning:\n${this.output.thinking}\n\n`;
+    }
+
+    const query =
+      typeof this.output.query === "string" ? this.output.query : null;
+
+    if (!query) {
+      // Model didn't generate a query, so we don't have any results.
+      content += "No query was executed.\n";
+      return {
+        ...partialOutput,
+        content,
+      };
+    }
+
+    content += `Query:\n${this.output.query}\n\n`;
+
+    const error =
+      typeof this.output.error === "string" ? this.output.error : null;
+
+    if (error) {
+      // Generated query failed to execute.
+      content += `Error:\n${this.output.error}\n\n`;
+      return {
+        ...partialOutput,
+        content,
+      };
+    }
+
+    const hasResultsFile = this.resultsFileId && this.resultsFileSnippet;
+
+    if (!hasResultsFile && !this.output.results) {
+      // We don't have any results -- this is unexpected, we should always
+      // have either an eror or some results (either a file or a `results` prop).
+      content += "No results were returned.\n";
+      return {
+        ...partialOutput,
+        content,
+      };
+    }
+
+    if (hasResultsFile) {
+      const attachment = getTablesQueryResultsFileAttachment({
+        resultsFileId: this.resultsFileId,
+        resultsFileSnippet: this.resultsFileSnippet,
+        output: this.output,
+        includeSnippet: true,
+      });
+      if (!attachment) {
+        throw new Error(
+          "Unexpected: No file attachment for tables query with results file."
+        );
+      }
+      // New path -- we have a results file.
+      // We render it as an attachment.
+      return {
+        ...partialOutput,
+        content: attachment,
+      };
+    }
+
+    // Legacy path -- we don't have a results file.
+    // We render the raw results object inline.
+    content += `OUTPUT:\n${JSON.stringify(this.output, null, 2)}`;
+
+    return {
+      ...partialOutput,
       content,
     };
   }
@@ -91,13 +181,17 @@ export class TablesQueryAction extends BaseAction {
 // used outside of api/assistant. We allow a ModelId interface here because we don't have `sId` on
 // actions (the `sId` is on the `Message` object linked to the `UserMessage` parent of this action).
 export async function tableQueryTypesFromAgentMessageIds(
+  auth: Authenticator,
   agentMessageIds: ModelId[]
 ): Promise<TablesQueryActionType[]> {
+  const owner = auth.getNonNullableWorkspace();
+
   const actions = await AgentTablesQueryAction.findAll({
     where: {
       agentMessageId: agentMessageIds,
     },
   });
+
   return actions.map((action) => {
     return new TablesQueryAction({
       id: action.id,
@@ -107,6 +201,13 @@ export async function tableQueryTypesFromAgentMessageIds(
       functionCallName: action.functionCallName,
       agentMessageId: action.agentMessageId,
       step: action.step,
+      resultsFileId: action.resultsFileId
+        ? FileResource.modelIdToSId({
+            id: action.resultsFileId,
+            workspaceId: owner.id,
+          })
+        : null,
+      resultsFileSnippet: action.resultsFileSnippet,
     });
   });
 }
@@ -206,6 +307,8 @@ export class TablesQueryConfigurationServerRunner extends BaseActionConfiguratio
         functionCallName: action.functionCallName,
         agentMessageId: action.agentMessageId,
         step: action.step,
+        resultsFileId: null,
+        resultsFileSnippet: null,
       }),
     };
 
@@ -404,6 +507,8 @@ export class TablesQueryConfigurationServerRunner extends BaseActionConfiguratio
                 functionCallName: action.functionCallName,
                 agentMessageId: agentMessage.id,
                 step: action.step,
+                resultsFileId: null,
+                resultsFileSnippet: null,
               }),
             };
           }
@@ -415,10 +520,44 @@ export class TablesQueryConfigurationServerRunner extends BaseActionConfiguratio
       }
     }
 
-    const sanitizedOutput = sanitizeJSONOutput(output);
+    const sanitizedOutput = sanitizeJSONOutput(output) as Record<
+      string,
+      unknown
+    >;
+
+    const updateParams: {
+      resultsFileId: number | null;
+      resultsFileSnippet: string | null;
+      output: Record<string, unknown> | null;
+    } = {
+      resultsFileId: null,
+      resultsFileSnippet: null,
+      output: null,
+    };
+
+    if (
+      "results" in sanitizedOutput &&
+      Array.isArray(sanitizedOutput.results)
+    ) {
+      const results = sanitizedOutput.results;
+      const queryTitle = getTablesQueryResultsFileTitle({
+        output: sanitizedOutput,
+      });
+
+      const { file, snippet } = await getTablesQueryOutputCsvFileAndSnippet({
+        auth,
+        title: queryTitle,
+        results,
+      });
+
+      delete sanitizedOutput.results;
+      updateParams.resultsFileId = file.id;
+      updateParams.resultsFileSnippet = snippet;
+    }
 
     // Updating action
     await action.update({
+      ...updateParams,
       output: sanitizedOutput,
       runId: await dustRunId,
     });
@@ -436,8 +575,64 @@ export class TablesQueryConfigurationServerRunner extends BaseActionConfiguratio
         functionCallName: action.functionCallName,
         agentMessageId: action.agentMessageId,
         step: action.step,
+        resultsFileId: updateParams.resultsFileId
+          ? FileResource.modelIdToSId({
+              id: updateParams.resultsFileId,
+              workspaceId: owner.id,
+            })
+          : null,
+        resultsFileSnippet: updateParams.resultsFileSnippet,
       }),
     };
     return;
   }
+}
+
+async function getTablesQueryOutputCsvFileAndSnippet({
+  auth,
+  title,
+  results,
+}: {
+  auth: Authenticator;
+  title: string;
+  results: Array<Record<string, string | number | boolean>>;
+}): Promise<{
+  file: FileResource;
+  snippet: string;
+}> {
+  const toCsv = (
+    records: Array<Record<string, string | number | boolean>>
+  ): Promise<string> => {
+    return new Promise((resolve, reject) => {
+      stringify(records, { header: true }, (err, data) => {
+        if (err) {
+          reject(err);
+        }
+        resolve(data);
+      });
+    });
+  };
+
+  const csvOutput = await toCsv(results);
+
+  const file = await internalCreateToolOutputCsvFile({
+    auth,
+    title,
+    content: csvOutput,
+    contentType: "text/csv",
+  });
+
+  let snippetOuptut = `TOTAL_LINES: ${results.length}\n`;
+  if (results.length > MAX_SNIPPET_LINES_QUERY_RESULT_FILE) {
+    snippetOuptut += `Showing the first ${MAX_SNIPPET_LINES_QUERY_RESULT_FILE} lines of the results.\n\n`;
+    snippetOuptut += await toCsv(
+      results.slice(0, MAX_SNIPPET_LINES_QUERY_RESULT_FILE)
+    );
+    snippetOuptut += `\n... (${results.length - MAX_SNIPPET_LINES_QUERY_RESULT_FILE} lines omitted)\n`;
+  } else {
+    snippetOuptut += await toCsv(results);
+    snippetOuptut += `\n(end of file)\n`;
+  }
+
+  return { file, snippet: snippetOuptut };
 }

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -544,11 +544,13 @@ export class TablesQueryConfigurationServerRunner extends BaseActionConfiguratio
         output: sanitizedOutput,
       });
 
-      const { file, snippet } = await getTablesQueryOutputCsvFileAndSnippet({
+      const { file, snippet } = await getTablesQueryOutputCsvFileAndSnippet(
         auth,
-        title: queryTitle,
-        results,
-      });
+        {
+          title: queryTitle,
+          results,
+        }
+      );
 
       delete sanitizedOutput.results;
       updateParams.resultsFileId = file.id;
@@ -588,15 +590,16 @@ export class TablesQueryConfigurationServerRunner extends BaseActionConfiguratio
   }
 }
 
-async function getTablesQueryOutputCsvFileAndSnippet({
-  auth,
-  title,
-  results,
-}: {
-  auth: Authenticator;
-  title: string;
-  results: Array<Record<string, string | number | boolean>>;
-}): Promise<{
+async function getTablesQueryOutputCsvFileAndSnippet(
+  auth: Authenticator,
+  {
+    title,
+    results,
+  }: {
+    title: string;
+    results: Array<Record<string, string | number | boolean>>;
+  }
+): Promise<{
   file: FileResource;
   snippet: string;
 }> {
@@ -615,8 +618,7 @@ async function getTablesQueryOutputCsvFileAndSnippet({
 
   const csvOutput = await toCsv(results);
 
-  const file = await internalCreateToolOutputCsvFile({
-    auth,
+  const file = await internalCreateToolOutputCsvFile(auth, {
     title,
     content: csvOutput,
     contentType: "text/csv",

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -145,7 +145,7 @@ async function batchRenderAgentMessages(
     (async () =>
       retrievalActionTypesFromAgentMessageIds(auth, agentMessageIds))(),
     (async () => dustAppRunTypesFromAgentMessageIds(agentMessageIds))(),
-    (async () => tableQueryTypesFromAgentMessageIds(agentMessageIds))(),
+    (async () => tableQueryTypesFromAgentMessageIds(auth, agentMessageIds))(),
     (async () => processActionTypesFromAgentMessageIds(agentMessageIds))(),
     (async () => websearchActionTypesFromAgentMessageIds(agentMessageIds))(),
     (async () => browseActionTypesFromAgentMessageIds(agentMessageIds))(),

--- a/front/lib/api/assistant/visualization.ts
+++ b/front/lib/api/assistant/visualization.ts
@@ -1,5 +1,11 @@
 import type { ContentFragmentType, ConversationType } from "@dust-tt/types";
-import { isContentFragmentType, removeNulls } from "@dust-tt/types";
+import {
+  getTablesQueryResultsFileAttachment,
+  isAgentMessageType,
+  isContentFragmentType,
+  isTablesQueryActionType,
+  removeNulls,
+} from "@dust-tt/types";
 import _ from "lodash";
 import * as readline from "readline"; // Add this line
 import type { Readable } from "stream";
@@ -76,14 +82,36 @@ export async function getVisualizationPrompt({
 
   let prompt = visualizationSystemPrompt.trim() + "\n\n";
 
-  if (contentFragmentMessages.length > 0) {
+  const fileAttachments: string[] = [];
+  for (const m of conversation.content.flat(1)) {
+    if (isContentFragmentType(m)) {
+      if (!m.fileId || !contentFragmentFileBySid[m.fileId]) {
+        continue;
+      }
+      fileAttachments.push(
+        `<file id="${m.fileId}" name="${m.title}" type="${m.contentType}" />`
+      );
+    } else if (isAgentMessageType(m)) {
+      for (const a of m.actions) {
+        if (isTablesQueryActionType(a)) {
+          const attachment = getTablesQueryResultsFileAttachment({
+            resultsFileId: a.resultsFileId,
+            resultsFileSnippet: a.resultsFileSnippet,
+            output: a.output,
+            includeSnippet: false,
+          });
+          if (attachment) {
+            fileAttachments.push(attachment);
+          }
+        }
+      }
+    }
+  }
+
+  if (fileAttachments.length > 0) {
     prompt +=
       "Files accessible to the :::visualization directive environment:\n";
-    prompt += contentFragmentMessages
-      .map((m) => {
-        return `<file id="${m.fileId}" name="${m.title}" type="${m.contentType}">\n${contentFragmentTextByMessageId[m.sId]?.join("\n")}(truncated...)</file>`;
-      })
-      .join("\n");
+    prompt += fileAttachments.join("\n");
   } else {
     prompt +=
       "No files are currently accessible to the :::visualization directive environment in this conversation.";
@@ -116,12 +144,13 @@ Guidelines using the :::visualization tag:
   - Tailwind's arbitrary values like \`h-[600px]\` must never be used, as they are not available in the visualization environment. No tailwind class that include a square bracket should ever be used in the visualization code, as they will cause the visualization to fail for the user.
   - When arbitrary / specific values are required, regular CSS (using the \`style\` prop) can be used as a fallback.
   - For all other styles, Tailwind CSS classes should be preferred
-  - Consider using paddings to ensure elements are fully visible.
+  - Always use padding around plots to ensure elements are fully visible and labels/legends do not overlap with the plot or with each other.
   - Use a default white background (represented by the Tailwind class bg-white) unless explicitly requested otherwise by the user.
   - If you need to generate a legend for a chart, ensure it uses relative positioning or follows the natural flow of the layout, avoiding \`position: absolute\`, to maintain responsiveness and adaptability.
 - Using files from the conversation when available:
  - Files from the conversation can be accessed using the \`useFile()\` hook.
  - Once/if the file is available, \`useFile()\` will return a non-null \`File\` object. The \`File\` object is a browser File object. Examples of using \`useFile\` are available below.
+ - Always use \`papaparse\` to parse CSV files.
 - Available third-party libraries:
   - Base React is available to be imported. In order to use hooks, they have to be imported at the top of the script, e.g. \`import { useState } from "react"\`
   - The recharts charting library is available to be imported, e.g. \`import { LineChart, XAxis, ... } from "recharts"\` & \`<LineChart ...><XAxis dataKey="name"> ...\`.

--- a/front/lib/api/files/preprocessing.ts
+++ b/front/lib/api/files/preprocessing.ts
@@ -329,57 +329,57 @@ const processingPerContentType: PreprocessingPerContentType = {
   "application/msword": {
     conversation: extractTextFromFile,
     avatar: notSupportedError,
-    toolOutput: notSupportedError,
+    tool_output: notSupportedError,
   },
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document": {
     conversation: extractTextFromFile,
     avatar: notSupportedError,
-    toolOutput: notSupportedError,
+    tool_output: notSupportedError,
   },
   "application/pdf": {
     conversation: extractTextFromFile,
     avatar: notSupportedError,
-    toolOutput: notSupportedError,
+    tool_output: notSupportedError,
   },
   "image/jpeg": {
     conversation: resizeAndUploadToFileStorage,
     avatar: uploadToPublicBucket,
-    toolOutput: notSupportedError,
+    tool_output: notSupportedError,
   },
   "image/png": {
     conversation: resizeAndUploadToFileStorage,
     avatar: uploadToPublicBucket,
-    toolOutput: notSupportedError,
+    tool_output: notSupportedError,
   },
   "text/comma-separated-values": {
     conversation: storeRawText,
     avatar: notSupportedError,
-    toolOutput: notSupportedError,
+    tool_output: notSupportedError,
   },
   "text/csv": {
     conversation: extractContentAndSchemaFromCSV,
     avatar: notSupportedError,
-    toolOutput: notSupportedError,
+    tool_output: notSupportedError,
   },
   "text/markdown": {
     conversation: storeRawText,
     avatar: notSupportedError,
-    toolOutput: notSupportedError,
+    tool_output: notSupportedError,
   },
   "text/plain": {
     conversation: storeRawText,
     avatar: notSupportedError,
-    toolOutput: notSupportedError,
+    tool_output: notSupportedError,
   },
   "text/tab-separated-values": {
     conversation: storeRawText,
     avatar: notSupportedError,
-    toolOutput: notSupportedError,
+    tool_output: notSupportedError,
   },
   "text/tsv": {
     conversation: storeRawText,
     avatar: notSupportedError,
-    toolOutput: notSupportedError,
+    tool_output: notSupportedError,
   },
 };
 

--- a/front/lib/api/files/preprocessing.ts
+++ b/front/lib/api/files/preprocessing.ts
@@ -329,46 +329,57 @@ const processingPerContentType: PreprocessingPerContentType = {
   "application/msword": {
     conversation: extractTextFromFile,
     avatar: notSupportedError,
+    toolOutput: notSupportedError,
   },
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document": {
     conversation: extractTextFromFile,
     avatar: notSupportedError,
+    toolOutput: notSupportedError,
   },
   "application/pdf": {
     conversation: extractTextFromFile,
     avatar: notSupportedError,
+    toolOutput: notSupportedError,
   },
   "image/jpeg": {
     conversation: resizeAndUploadToFileStorage,
     avatar: uploadToPublicBucket,
+    toolOutput: notSupportedError,
   },
   "image/png": {
     conversation: resizeAndUploadToFileStorage,
     avatar: uploadToPublicBucket,
+    toolOutput: notSupportedError,
   },
   "text/comma-separated-values": {
     conversation: storeRawText,
     avatar: notSupportedError,
+    toolOutput: notSupportedError,
   },
   "text/csv": {
     conversation: extractContentAndSchemaFromCSV,
     avatar: notSupportedError,
+    toolOutput: notSupportedError,
   },
   "text/markdown": {
     conversation: storeRawText,
     avatar: notSupportedError,
+    toolOutput: notSupportedError,
   },
   "text/plain": {
     conversation: storeRawText,
     avatar: notSupportedError,
+    toolOutput: notSupportedError,
   },
   "text/tab-separated-values": {
     conversation: storeRawText,
     avatar: notSupportedError,
+    toolOutput: notSupportedError,
   },
   "text/tsv": {
     conversation: storeRawText,
     avatar: notSupportedError,
+    toolOutput: notSupportedError,
   },
 };
 

--- a/front/lib/api/files/tool_output.ts
+++ b/front/lib/api/files/tool_output.ts
@@ -3,17 +3,18 @@ import { pipeline } from "stream/promises";
 
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
-export async function internalCreateToolOutputCsvFile({
-  auth,
-  title,
-  content,
-  contentType,
-}: {
-  auth: Authenticator;
-  title: string;
-  content: string;
-  contentType: "text/csv";
-}): Promise<FileResource> {
+export async function internalCreateToolOutputCsvFile(
+  auth: Authenticator,
+  {
+    title,
+    content,
+    contentType,
+  }: {
+    title: string;
+    content: string;
+    contentType: "text/csv";
+  }
+): Promise<FileResource> {
   const workspace = auth.getNonNullableWorkspace();
   const user = auth.getNonNullableUser();
 
@@ -23,7 +24,7 @@ export async function internalCreateToolOutputCsvFile({
     contentType,
     fileName: title,
     fileSize: Buffer.byteLength(content),
-    useCase: "toolOutput",
+    useCase: "tool_output",
   });
 
   // Write both the "original" and "processed" versions simultaneously

--- a/front/lib/api/files/tool_output.ts
+++ b/front/lib/api/files/tool_output.ts
@@ -1,0 +1,51 @@
+import { Readable } from "stream";
+import { pipeline } from "stream/promises";
+
+import type { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
+export async function internalCreateToolOutputCsvFile({
+  auth,
+  title,
+  content,
+  contentType,
+}: {
+  auth: Authenticator;
+  title: string;
+  content: string;
+  contentType: "text/csv";
+}): Promise<FileResource> {
+  const workspace = auth.getNonNullableWorkspace();
+  const user = auth.getNonNullableUser();
+
+  const fileResource = await FileResource.makeNew({
+    workspaceId: workspace.id,
+    userId: user.id,
+    contentType,
+    fileName: title,
+    fileSize: Buffer.byteLength(content),
+    useCase: "toolOutput",
+  });
+
+  // Write both the "original" and "processed" versions simultaneously
+
+  await Promise.all([
+    pipeline(
+      Readable.from(content),
+      fileResource.getWriteStream({
+        auth,
+        version: "original",
+      })
+    ),
+    pipeline(
+      Readable.from(content),
+      fileResource.getWriteStream({
+        auth,
+        version: "processed",
+      })
+    ),
+  ]);
+
+  await fileResource.markAsReady();
+
+  return fileResource;
+}

--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -270,7 +270,9 @@ AgentMessage.hasMany(AgentTablesQueryAction, {
 
 FileModel.hasMany(AgentTablesQueryAction, {
   foreignKey: { name: "resultsFileId", allowNull: true },
+  onDelete: "SET NULL",
 });
 AgentTablesQueryAction.belongsTo(FileModel, {
   foreignKey: { name: "resultsFileId", allowNull: true },
+  onDelete: "SET NULL",
 });

--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -12,6 +12,7 @@ import { AgentMessage } from "@app/lib/models/assistant/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
+import { FileModel } from "@app/lib/resources/storage/models/files";
 
 export class AgentTablesQueryConfiguration extends Model<
   InferAttributes<AgentTablesQueryConfiguration>,
@@ -180,12 +181,15 @@ export class AgentTablesQueryAction extends Model<
 
   declare params: unknown | null;
   declare output: unknown | null;
+  declare resultsFileSnippet: string | null;
+
   declare functionCallId: string | null;
   declare functionCallName: string | null;
 
   declare agentMessageId: ForeignKey<AgentMessage["id"]>;
 
   declare step: number;
+  declare resultsFileId: ForeignKey<FileModel["id"]> | null;
 }
 
 AgentTablesQueryAction.init(
@@ -223,6 +227,10 @@ AgentTablesQueryAction.init(
       type: DataTypes.JSONB,
       allowNull: true,
     },
+    resultsFileSnippet: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
     functionCallId: {
       type: DataTypes.STRING,
       allowNull: true,
@@ -244,6 +252,10 @@ AgentTablesQueryAction.init(
         fields: ["agentMessageId"],
         concurrently: true,
       },
+      {
+        fields: ["resultsFileId"],
+        concurrently: true,
+      },
     ],
   }
 );
@@ -254,4 +266,11 @@ AgentTablesQueryAction.belongsTo(AgentMessage, {
 
 AgentMessage.hasMany(AgentTablesQueryAction, {
   foreignKey: { name: "agentMessageId", allowNull: false },
+});
+
+FileModel.hasMany(AgentTablesQueryAction, {
+  foreignKey: { name: "resultsFileId", allowNull: true },
+});
+AgentTablesQueryAction.belongsTo(FileModel, {
+  foreignKey: { name: "resultsFileId", allowNull: true },
 });

--- a/front/migrations/db/migration_101.sql
+++ b/front/migrations/db/migration_101.sql
@@ -1,9 +1,9 @@
 -- Migration created on Oct 07, 2024
 CREATE UNIQUE INDEX "data_source_view_workspace_data_source_vault_deleted_at_unique" ON "data_source_views" (
-  "workspaceId",
-  "dataSourceId",
-  "vaultId",
-  "deletedAt"
+    "workspaceId",
+    "dataSourceId",
+    "vaultId",
+    "deletedAt"
 );
 
 -- Delete the previous truncated index.

--- a/front/migrations/db/migration_102.sql
+++ b/front/migrations/db/migration_102.sql
@@ -1,0 +1,13 @@
+ALTER TABLE
+    "agent_tables_query_actions"
+ADD
+    COLUMN "resultsFileId" INTEGER,
+ADD
+    COLUMN "resultsFileSnippet" TEXT;
+
+ALTER TABLE
+    "agent_tables_query_actions"
+ADD
+    FOREIGN KEY ("resultsFileId") REFERENCES "files" ("id") ON DELETE
+SET
+    NULL ON UPDATE CASCADE;

--- a/types/src/front/assistant/actions/tables_query.ts
+++ b/types/src/front/assistant/actions/tables_query.ts
@@ -21,9 +21,49 @@ export interface TablesQueryActionType extends BaseAction {
   id: ModelId;
   params: DustAppParameters;
   output: Record<string, string | number | boolean> | null;
+  resultsFileId: string | null;
+  resultsFileSnippet: string | null;
   functionCallId: string | null;
   functionCallName: string | null;
   agentMessageId: ModelId;
   step: number;
   type: "tables_query_action";
+}
+
+export function getTablesQueryResultsFileTitle({
+  output,
+}: {
+  output: Record<string, unknown> | null;
+}): string {
+  return typeof output?.query_title === "string"
+    ? output.query_title
+    : "query_results";
+}
+
+export function getTablesQueryResultsFileAttachment({
+  resultsFileId,
+  resultsFileSnippet,
+  output,
+  includeSnippet = true,
+}: {
+  resultsFileId: string | null;
+  resultsFileSnippet: string | null;
+  output: Record<string, unknown> | null;
+  includeSnippet: boolean;
+}): string | null {
+  if (!resultsFileId || !resultsFileSnippet) {
+    return null;
+  }
+
+  const attachment =
+    `<file ` +
+    `id="${resultsFileId}" type="text/csv" title=${getTablesQueryResultsFileTitle(
+      { output }
+    )}`;
+
+  if (!includeSnippet) {
+    return `${attachment} />`;
+  }
+
+  return `${attachment}>\n${resultsFileSnippet}\n</file>`;
 }

--- a/types/src/front/files.ts
+++ b/types/src/front/files.ts
@@ -136,7 +136,7 @@ export function isSupportedImageContentType(
 
 export type FileStatus = "created" | "failed" | "ready";
 
-export type FileUseCase = "conversation" | "avatar";
+export type FileUseCase = "conversation" | "avatar" | "toolOutput";
 
 export interface FileType {
   contentType: SupportedFileContentType;

--- a/types/src/front/files.ts
+++ b/types/src/front/files.ts
@@ -136,7 +136,7 @@ export function isSupportedImageContentType(
 
 export type FileStatus = "created" | "failed" | "ready";
 
-export type FileUseCase = "conversation" | "avatar" | "toolOutput";
+export type FileUseCase = "conversation" | "avatar" | "tool_output";
 
 export interface FileType {
   contentType: SupportedFileContentType;


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/tasks/issues/1435

Tables query outputs are currently rendered as raw text in the function result to the model.
Because of this:
- we need to severely reduce the amount of lines a tables query can return to not overflow the context window
- the model has to repeat the whole data inside of the visualization code to create a viz on the data

This PR changes this by creating a File containing the whole result (in CSV) and rendering the output as a "file attachment" to the model. The file attachment contains up to 128 lines from the CSV inlined in the function result (128 was our existing limit).
Because it is a file, the model is able to download the whole content from the visualization code without having to repeat the data, which is much faster and also prevents hitting the maximum token generation limit for any non-trivial result.

This is done "ad-hoc" using primitives that already exist (file API), and support has only been added for tables query.
The long term solution will ideally also support custom dust app run actions, ideally without requiring saving the whole results in core's database and without requiring front to download the entire results. This likely means that we'll have to move the file API to `core` (but that's controversial).

## Risk

- Risks of affecting current tables query
- a (only one line) code path is kept to maintain support with the legacy way of storing query results. This will likely get deleted in the future, but keeping it for the transition period to ensure the best experience possilble
- While we enforce a 8MB limit on query results (for remote DBs only), this is still a big increase from our legacy 128 rows limit. Some browsers may struggle to render a viz that uses an 8mb file, and there may be some increased load if a lot of users start to routinely produce 8MB TQ outputs
- There's a migration in this PR

## Deploy Plan

- run sql migration (add columns on tables query actions)
- deploy front & core