### PR TITLE
Fix Poke search to retrieve free no plans workspaces

### DIFF
--- a/front/components/poke/plugins/PluginList.tsx
+++ b/front/components/poke/plugins/PluginList.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from "@dust-tt/sparkle";
 import type { PluginWorkspaceResource } from "@dust-tt/types";
 import React, { useState } from "react";
 
@@ -19,14 +20,14 @@ interface PluginCardProps {
 function PluginCard({ onClick, plugin }: PluginCardProps) {
   return (
     <PokeCard
-      className="flex w-44 cursor-pointer hover:bg-gray-100"
+      className="flex h-20 w-44 cursor-pointer hover:bg-gray-100"
       onClick={onClick}
     >
-      <PokeCardHeader className="space-y-1.5 p-2">
+      <PokeCardHeader className="flex space-y-1.5 overflow-hidden p-2 text-left">
         <PokeCardTitle className="text-sm font-medium">
           {plugin.name}
         </PokeCardTitle>
-        <PokeCardDescription className="text-xs">
+        <PokeCardDescription className="overflow-hidden truncate whitespace-normal text-xs">
           {plugin.description}
         </PokeCardDescription>
       </PokeCardHeader>
@@ -63,10 +64,16 @@ export function PluginList({
       </div>
       <div className="flex w-full flex-row items-start gap-3 p-4">
         {plugins.map((plugin) => (
-          <PluginCard
+          <Tooltip
             key={plugin.id}
-            plugin={plugin}
-            onClick={() => handlePluginSelect(plugin)}
+            trigger={
+              <PluginCard
+                key={plugin.id}
+                plugin={plugin}
+                onClick={() => handlePluginSelect(plugin)}
+              />
+            }
+            label={plugin.description}
           />
         ))}
       </div>

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -289,7 +289,8 @@ async function handler(
               {
                 plan: activeSubscription
                   ? activeSubscription.plan
-                  : FREE_NO_PLAN_DATA,
+                  : // If there is no active subscription, we use the free plan data.
+                    FREE_NO_PLAN_DATA,
                 activeSubscription: activeSubscription,
               }
             );

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -14,6 +14,7 @@ import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { Plan, Subscription } from "@app/lib/models/plan";
 import { Workspace, WorkspaceHasDomain } from "@app/lib/models/workspace";
+import { FREE_NO_PLAN_DATA } from "@app/lib/plans/free_plans";
 import {
   FREE_TEST_PLAN_CODE,
   isEntreprisePlan,
@@ -246,7 +247,7 @@ async function handler(
             model: Subscription,
             as: "subscriptions",
             where: { status: "active" },
-            required: true,
+            required: false,
             include: [
               {
                 model: Plan,
@@ -255,15 +256,22 @@ async function handler(
             ],
           },
         ],
-        order: order,
+        order,
       });
 
-      // if limit is above originalLimit, sort manually and then splice
+      // If limit is above originalLimit, sort manually and then splice.
       if (limit > originalLimit) {
-        // Order by plan, entreprise first, then pro, then free and old free using isEntreprisePlan, isProPlan and isFreePlan, isOldFreePlan methods
+        // Order by plan, entreprise first, then pro, then free and old free using isEntreprisePlan,
+        // isProPlan and isFreePlan, isOldFreePlan methods.
         workspaces.sort((a, b) => {
-          const planAPriority = getPlanPriority(a.subscriptions[0].plan.code);
-          const planBPriority = getPlanPriority(b.subscriptions[0].plan.code);
+          // Note: TypeScript may incorrectly assume that `subscriptions` is always defined.
+          // Using optional chaining and default values to handle potential undefined cases.
+          const planAPriority = getPlanPriority(
+            a.subscriptions?.[0]?.plan?.code || ""
+          );
+          const planBPriority = getPlanPriority(
+            b.subscriptions?.[0]?.plan?.code || ""
+          );
 
           return planAPriority - planBPriority;
         });
@@ -274,10 +282,15 @@ async function handler(
       return res.status(200).json({
         workspaces: await Promise.all(
           workspaces.map(async (ws): Promise<PokeWorkspaceType> => {
+            // Note: TypeScript may incorrectly assume that `subscriptions` is always defined.
+            const [activeSubscription] = ws.subscriptions;
+
             const subscription: SubscriptionType = renderSubscriptionFromModels(
               {
-                plan: ws.subscriptions[0].plan,
-                activeSubscription: ws.subscriptions[0],
+                plan: activeSubscription
+                  ? activeSubscription.plan
+                  : FREE_NO_PLAN_DATA,
+                activeSubscription: activeSubscription,
               }
             );
 

--- a/types/src/shared/feature_flags.ts
+++ b/types/src/shared/feature_flags.ts
@@ -4,7 +4,6 @@ export const WHITELISTABLE_FEATURES = [
   "labs_transcripts",
   "labs_transcripts_datasource",
   "document_tracker",
-  "data_vaults_feature",
   "private_data_vaults_feature",
   "use_app_for_header_detection",
   "openai_o1_feature",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR resolves https://github.com/dust-tt/tasks/issues/1469.

The current search implementation only returns workspaces with an active subscriptions, it prevents retrieving free no plan workspaces.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
