### PR TITLE
Fix mentions matching on paste

### DIFF
--- a/front/components/assistant/conversation/input_bar/editor/MentionWithPaste.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/MentionWithPaste.tsx
@@ -20,7 +20,7 @@ export const MentionWithPaste = Mention.extend({
                 // Note: matching the @ that are found either at the start of a line or after a whitespace character.
                 // and that also are followed by a newline, a whitespace character or the end of the string.
                 new RegExp(
-                  "(^@|\\s@)" + escapeRegExp(suggestion.label) + "(\\n|\\s|$)",
+                  "(^@|\\s@)" + escapeRegExp(suggestion.label) + "(\\s|$)",
                   "g"
                 )
               ),

--- a/front/components/assistant/conversation/input_bar/editor/MentionWithPaste.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/MentionWithPaste.tsx
@@ -18,7 +18,11 @@ export const MentionWithPaste = Mention.extend({
             return [
               ...text.matchAll(
                 // Note: matching the @ that are found either at the start of a line or after a whitespace character.
-                new RegExp("(^@|\\s@)" + escapeRegExp(suggestion.label), "g")
+                // and that also are followed by a newline, a whitespace character or the end of the string.
+                new RegExp(
+                  "(^@|\\s@)" + escapeRegExp(suggestion.label) + "(\\n|\\s|$)",
+                  "g"
+                )
               ),
             ].map((match) => {
               return {


### PR DESCRIPTION
## Description

- In the chat, update the way mentions are matched to prevent @engineering from mentioning @eng.

## Risk

## Deploy Plan

- Deploy front.