### PR TITLE
Fix mentions matching on paste 

### DIFF
--- a/front/components/assistant/conversation/input_bar/editor/MentionWithPaste.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/MentionWithPaste.tsx
@@ -20,14 +20,14 @@ export const MentionWithPaste = Mention.extend({
                 // Note: matching the @ that are found either at the start of a line or after a whitespace character.
                 // and that also are followed by a newline, a whitespace character or the end of the string.
                 new RegExp(
-                  "(^@|\\s@)" + escapeRegExp(suggestion.label) + "(\\s|$)",
+                  `((^@|\\s@)${escapeRegExp(suggestion.label)})(\\s|$)`,
                   "g"
                 )
               ),
             ].map((match) => {
               return {
                 index: match.index,
-                text: match[0],
+                text: match[1],
                 replaceWith: suggestion.label,
                 data: { id: suggestion.id, label: suggestion.label },
               };


### PR DESCRIPTION
## Description

- In the chat, prevent spaces that come after a mention from being removed.

Note: this is an edge case I missed in https://github.com/dust-tt/dust/pull/7989

## Risk

## Deploy Plan

- Deploy front.