### PR TITLE
fix(snowflake connector): allow SELECT grant on snowflake views

### DIFF
--- a/connectors/src/connectors/snowflake/lib/snowflake_api.ts
+++ b/connectors/src/connectors/snowflake/lib/snowflake_api.ts
@@ -261,7 +261,7 @@ export const isConnectionReadonly = async ({
   for (const g of [...currentGrantsRes.value, ...futureGrantsRes.value]) {
     const grantOn = "granted_on" in g ? g.granted_on : g.grant_on;
 
-    if (grantOn === "TABLE") {
+    if (["TABLE", "VIEW"].includes(grantOn)) {
       // We only allow SELECT grants on tables.
       if (g.privilege !== "SELECT") {
         return new Err(


### PR DESCRIPTION
## Description

No reason to not allow roles that have SELECT grants on views.
We might also need to support querying views : TBD

## Risk

N/A

## Deploy Plan

Deploy connectors