### PR TITLE
[front/pages/w] - fix: reverse year iteration in workspace admin

### DIFF
--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -181,7 +181,7 @@ export default function WorkspaceAdmin({
       const currentYear = new Date().getFullYear();
       const currentMonth = new Date().getMonth();
 
-      for (let year = startDateYear; year <= currentYear; year++) {
+      for (let year = currentYear; year >= startDateYear; year--) {
         const startMonth = year === startDateYear ? startDateMonth : 0;
         const endMonth = year === currentYear ? currentMonth : 11;
         for (let month = endMonth; month >= startMonth; month--) {

--- a/front/poke/swr/plugins.ts
+++ b/front/poke/swr/plugins.ts
@@ -1,5 +1,4 @@
 import type {
-  LightWorkspaceType,
   PluginWorkspaceResource,
   Result,
 } from "@dust-tt/types";

--- a/front/poke/swr/plugins.ts
+++ b/front/poke/swr/plugins.ts
@@ -1,7 +1,4 @@
-import type {
-  PluginWorkspaceResource,
-  Result,
-} from "@dust-tt/types";
+import type { PluginWorkspaceResource, Result } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 import { useMemo } from "react";
 import type { Fetcher } from "swr";


### PR DESCRIPTION
## Description

This PR aims at fixing the order in which we display the activity report options to have the most recent one first. It used to start with the oldest year first.

Previously:
<img width="467" alt="Screenshot 2024-10-11 at 09 42 55" src="https://github.com/user-attachments/assets/6a963a7b-3715-4ba1-96ac-247734f45021">


Now:
<img width="470" alt="Screenshot 2024-10-11 at 09 42 40" src="https://github.com/user-attachments/assets/d7d1d856-8694-476b-a605-fa22fe19129b">


## Risk

None

## Deploy Plan

Deploy `front`