### PR TITLE
Add missing webcrawler pages index

### DIFF
--- a/connectors/migrations/db/migration_24.sql
+++ b/connectors/migrations/db/migration_24.sql
@@ -1,2 +1,4 @@
 -- Migration created on Oct 11, 2024
 CREATE UNIQUE INDEX "webcrawler_pages_connector_id_document_id" ON "webcrawler_pages" ("connectorId", "documentId");
+
+CREATE UNIQUE INDEX "webcrawler_folders_connector_id_internal_id" ON "webcrawler_folders" ("connectorId", "internalId");

--- a/connectors/migrations/db/migration_24.sql
+++ b/connectors/migrations/db/migration_24.sql
@@ -1,0 +1,2 @@
+-- Migration created on Oct 11, 2024
+CREATE UNIQUE INDEX "webcrawler_pages_connector_id_document_id" ON "webcrawler_pages" ("connectorId", "documentId");

--- a/connectors/migrations/db/migration_24.sql
+++ b/connectors/migrations/db/migration_24.sql
@@ -1,4 +1,4 @@
 -- Migration created on Oct 11, 2024
-CREATE UNIQUE INDEX "webcrawler_pages_connector_id_document_id" ON "webcrawler_pages" ("connectorId", "documentId");
+CREATE UNIQUE INDEX CONCURRENTLY "webcrawler_pages_connector_id_document_id" ON "webcrawler_pages" ("connectorId", "documentId");
 
-CREATE UNIQUE INDEX "webcrawler_folders_connector_id_internal_id" ON "webcrawler_folders" ("connectorId", "internalId");
+CREATE UNIQUE INDEX CONCURRENTLY "webcrawler_folders_connector_id_internal_id" ON "webcrawler_folders" ("connectorId", "internalId");

--- a/connectors/src/lib/models/webcrawler.ts
+++ b/connectors/src/lib/models/webcrawler.ts
@@ -194,6 +194,10 @@ WebCrawlerFolder.init(
         unique: true,
         fields: ["url", "connectorId", "webcrawlerConfigurationId"],
       },
+      {
+        unique: true,
+        fields: ["connectorId", "internalId"],
+      },
     ],
     modelName: "webcrawler_folders",
   }

--- a/connectors/src/lib/models/webcrawler.ts
+++ b/connectors/src/lib/models/webcrawler.ts
@@ -270,6 +270,10 @@ WebCrawlerPage.init(
         unique: true,
         fields: ["url", "connectorId", "webcrawlerConfigurationId"],
       },
+      {
+        unique: true,
+        fields: ["connectorId", "documentId"],
+      },
     ],
     modelName: "webcrawler_pages",
   }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We've had recurrent monitors for high CPU on our DB. The main load comes from the connectors database that lacks an index on the webcrawler pages ([explain](https://console.cloud.google.com/sql/instances/dust-api-db/insights;database=dust-connectors;duration=PT1H;trace=f7aee6f573e9f8bf494097e946bc71a6;span=d06aa476109db2a1;query_hash=16200446853746427218;sort_by=TOTAL_EXEC_TIME/executed?project=or1g1n-186209&pli=1)).

While we are at it, I'm also adding a missing index on `webcrawler_folders`.

Index can be unique 👇 yields no records.
```
SELECT "connectorId", "documentId", COUNT(*) AS c FROM webcrawler_pages GROUP BY 1, 2 HAVING COUNT(*) > 1
```

Query is run to retrieve the content nodes of a website:
https://github.com/dust-tt/dust/blob/16e0bc08a3eb3d16daa30aa723fd94bd144f901d/connectors/src/connectors/webcrawler/index.ts#L259-L264

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] Apply migration