### PR TITLE
Improve setPermissions on Intercom

### DIFF
--- a/connectors/src/connectors/intercom/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/intercom/lib/help_center_permissions.ts
@@ -231,31 +231,13 @@ export async function allowSyncCollection({
     throw new Error(" Collection not found.");
   }
 
-  // We create the Help Center if it doesn't exist and fetch the children collections
-  const [, childrenCollections] = await Promise.all([
-    allowSyncHelpCenter({
-      connectorId,
-      connectionId,
-      helpCenterId: collection.helpCenterId,
-      region,
-    }),
-    fetchIntercomCollections({
-      accessToken,
-      helpCenterId: collection.helpCenterId,
-      parentId: collection.collectionId,
-    }),
-  ]);
-
-  const collectionPermissionPromises = childrenCollections.map((c) =>
-    allowSyncCollection({
-      connectorId,
-      connectionId,
-      collectionId: c.id,
-      helpCenterId,
-      region,
-    })
-  );
-  await Promise.all(collectionPermissionPromises);
+  // Create the help center if it doesn't exist.
+  await allowSyncHelpCenter({
+    connectorId,
+    connectionId,
+    helpCenterId: collection.helpCenterId,
+    region,
+  });
 
   return collection;
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes https://github.com/dust-tt/tasks/issues/1484.

Today, when an admin adds collection from their help center in Notion, in the API call, we attempt to browse all the children, which on some workspaces can be pretty long. This performance issue leads to a timeout, and admins can't add their help desk.

This PR removes the discovery part as it being already handled by the workflow started once the permissions have been updated. It's done here:

https://github.com/dust-tt/dust/blob/666fdb5c54c3b883e1c53f199d395e3e28898c1b/connectors/src/connectors/intercom/temporal/sync_help_center.ts#L140

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Tested locally.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
