### PR TITLE
Fix: edit vault modal state loss, developer secret modal

### DIFF
--- a/front/components/app/ManageAppSecretsButtonModal.tsx
+++ b/front/components/app/ManageAppSecretsButtonModal.tsx
@@ -109,7 +109,7 @@ export function DustAppSecrets({ owner }: { owner: WorkspaceType }) {
           onChange={(e) =>
             setNewDustAppSecret({
               ...newDustAppSecret,
-              name: cleanSecretName(e.target.name),
+              name: cleanSecretName(e.target.value),
             })
           }
         />


### PR DESCRIPTION
## Description

- Fix vault edit modal (open -> cancel -> open would lose the state)
- Fix dev secret modal (could not enter name).

## Risk

none

## Deploy Plan

deploy `front`