### PR TITLE
Account for missing response on Webcrawler

### DIFF
--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -355,6 +355,7 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
           "webcrawler failedRequestHandler"
         );
         if (
+          !context.response ||
           context.response.statusCode === 403 ||
           context.response.statusCode === 429
         ) {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR addresses an issue with a broken monitor on Webcrawler. In https://github.com/dust-tt/dust/pull/7985, we assumed that a response would always be present (the Cheerio types are always set to `any`, which isn't very helpful). We've observed errors in production when a web page times out, resulting in no available response.

Logs are [here](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAZKGzQdGfBOSxAAAAAAAAAAYAAAAAEFaS0d6UTNGQUFDaWhjV1A3SlF1bHdBUgAAACQAAAAAMDE5Mjg2ZWYtODkzYy00OGU3LWEzNzctNDViNDJkZmRjNjRk&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1728837556000&to_ts=1728838456000&live=false).

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
