### PR TITLE
Extension: Manage refresh token

### DIFF
--- a/front/extension/app/background.ts
+++ b/front/extension/app/background.ts
@@ -10,6 +10,8 @@ import {
 } from "./src/lib/auth";
 import { generatePKCE } from "./src/lib/utils";
 
+const log = console.error;
+
 /**
  * Listener to open/close the side panel when the user clicks on the extension icon.
  */
@@ -34,12 +36,21 @@ chrome.runtime.onMessage.addListener(
         void authenticate(sendResponse);
         return true; // Keep the message channel open for async response.
 
+      case "REFRESH_TOKEN":
+        if (!message.refreshToken) {
+          log("No refresh token provided on REFRESH_TOKEN message.");
+          sendResponse({ success: false });
+          return true;
+        }
+        void refreshToken(message.refreshToken, sendResponse);
+        return true;
+
       case "LOGOUT":
         logout(sendResponse);
         return true; // Keep the message channel open.
 
       default:
-        console.error(`Unknown message type: ${message.type}.`);
+        log(`Unknown message type: ${message.type}.`);
     }
   }
 );
@@ -71,12 +82,12 @@ const authenticate = async (
     { url: authUrl, interactive: true },
     async (redirectUrl) => {
       if (chrome.runtime.lastError) {
-        console.error(`Auth error: ${chrome.runtime.lastError.message}`);
+        log(`launchWebAuthFlow error: ${chrome.runtime.lastError.message}`);
         sendResponse({ success: false });
         return;
       }
       if (!redirectUrl || redirectUrl.includes("error")) {
-        console.error(`Auth error in redirect URL: ${redirectUrl}`);
+        log(`launchWebAuthFlow error in redirect URL: ${redirectUrl}`);
         sendResponse({ success: false });
         return;
       }
@@ -93,11 +104,50 @@ const authenticate = async (
         );
         sendResponse(data);
       } else {
-        console.error(`No authorization code in redirect URL: ${redirectUrl}`);
+        log(`launchWebAuthFlow missing code in redirect URL: ${redirectUrl}`);
         sendResponse({ success: false });
       }
     }
   );
+};
+
+/**
+ * Refresh the access token using the refresh token.
+ */
+const refreshToken = async (
+  refreshToken: string,
+  sendResponse: (auth: Auth0AuthorizeResponse | AuthBackgroundResponse) => void
+) => {
+  try {
+    const tokenUrl = `https://${AUTH0_CLIENT_DOMAIN}/oauth/token`;
+    const response = await fetch(tokenUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        client_id: AUTH0_CLIENT_ID,
+        refresh_token: refreshToken,
+      }),
+    });
+
+    if (!response.ok) {
+      const data = await response.json();
+      throw new Error(
+        `Token refresh failed: ${data.error} - ${data.error_description}`
+      );
+    }
+
+    const data = await response.json();
+    sendResponse({
+      idToken: data.id_token,
+      accessToken: data.access_token,
+      refreshToken: data.refresh_token || refreshToken,
+      expiresIn: data.expires_in,
+    });
+  } catch (error) {
+    log("Token refresh failed: unknown error", error);
+    sendResponse({ success: false });
+  }
 };
 
 /**
@@ -132,14 +182,12 @@ const exchangeCodeForTokens = async (
     return {
       idToken: data.id_token,
       accessToken: data.access_token,
+      refreshToken: data.refresh_token,
       expiresIn: data.expires_in,
     };
   } catch (error) {
-    const message =
-      error instanceof Error
-        ? error.message
-        : "Token exchange error: unknown error occurred.";
-    console.error(`Token exchange error: ${message}`, error);
+    const message = error instanceof Error ? error.message : "Unknown error.";
+    log(`Token exchange failed: ${message}`, error);
     return { success: false };
   }
 };
@@ -155,7 +203,7 @@ const logout = (sendResponse: (response: AuthBackgroundResponse) => void) => {
     { url: logoutUrl, interactive: true },
     () => {
       if (chrome.runtime.lastError) {
-        console.error("Logout error:", chrome.runtime.lastError.message);
+        log("Logout failed:", chrome.runtime.lastError.message);
         sendResponse({ success: false });
       } else {
         sendResponse({ success: true });

--- a/front/extension/app/background.ts
+++ b/front/extension/app/background.ts
@@ -49,6 +49,9 @@ chrome.runtime.onMessage.addListener(
         logout(sendResponse);
         return true; // Keep the message channel open.
 
+      case "SIGN_CONNECT":
+        return true;
+
       default:
         log(`Unknown message type: ${message.type}.`);
     }

--- a/front/extension/app/main.tsx
+++ b/front/extension/app/main.tsx
@@ -8,14 +8,18 @@ import "@app/styles/components.css";
 import ReactDOM from "react-dom/client";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 
+import { AuthProvider } from "./src/context/AuthProvider";
 import { routes } from "./src/routes";
 
 const router = createBrowserRouter(routes);
 
 const App = () => {
-  return <RouterProvider router={router} />;
+  return (
+    <AuthProvider>
+      <RouterProvider router={router} />
+    </AuthProvider>
+  );
 };
-
 const rootElement = document.getElementById("root");
 if (rootElement) {
   const root = ReactDOM.createRoot(rootElement);

--- a/front/extension/app/src/context/AuthProvider.tsx
+++ b/front/extension/app/src/context/AuthProvider.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from "react";
+import React, { createContext, useContext } from "react";
+
+import { useAuthHook } from "../hooks/useAuth";
+
+type AuthContextType = {
+  token: string | null;
+  isLoading: boolean;
+  isAuthenticated: boolean;
+  handleLogin: () => void;
+  handleLogout: () => void;
+};
+
+const AuthContext = createContext<AuthContextType | null>(null);
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const { token, isLoading, isAuthenticated, handleLogin, handleLogout } =
+    useAuthHook();
+
+  return (
+    <AuthContext.Provider
+      value={{ token, isLoading, isAuthenticated, handleLogin, handleLogout }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+  return context;
+};

--- a/front/extension/app/src/context/ProtectedRoute.tsx
+++ b/front/extension/app/src/context/ProtectedRoute.tsx
@@ -1,0 +1,53 @@
+import {
+  Button,
+  ExternalLinkIcon,
+  LogoHorizontalColorLogo,
+  LogoutIcon,
+  Spinner,
+} from "@dust-tt/sparkle";
+import type { ReactNode } from "react";
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { useAuth } from "./AuthProvider";
+
+export const ProtectedRoute = ({ children }: { children: ReactNode }) => {
+  const { isLoading, isAuthenticated, handleLogout } = useAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated) {
+      navigate("/login");
+    }
+  }, [isLoading, isAuthenticated, navigate]);
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col p-4 gap-2 h-screen">
+        <div className="flex justify-center items-center w-full h-full">
+          <Spinner />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col p-4 gap-2 h-screen">
+      <div className="flex justify-between items-start">
+        <div className="flex items-center gap-2 pb-10">
+          <LogoHorizontalColorLogo className="h-4 w-16" />
+          <a href="https://dust.tt" target="_blank">
+            <ExternalLinkIcon color="#64748B" />
+          </a>
+        </div>
+        <Button
+          icon={LogoutIcon}
+          variant="tertiary"
+          label="Sign out"
+          onClick={handleLogout}
+        />
+      </div>
+      <>{children}</>
+    </div>
+  );
+};

--- a/front/extension/app/src/hooks/useAuth.ts
+++ b/front/extension/app/src/hooks/useAuth.ts
@@ -12,7 +12,7 @@ import {
 
 const log = console.error;
 
-export const useAuth = () => {
+export const useAuthHook = () => {
   const [tokens, setTokens] = useState<StoredTokens | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
@@ -20,7 +20,7 @@ export const useAuth = () => {
 
   // User is authenticated if we have a valid access token.
   const isTokenValid = useCallback(() => {
-    return tokens?.accessToken && tokens.expiresAt > Date.now();
+    return !!(tokens?.accessToken && tokens.expiresAt > Date.now());
   }, [tokens]);
   const isAuthenticated = useMemo(() => isTokenValid(), [isTokenValid]);
 

--- a/front/extension/app/src/hooks/useAuth.ts
+++ b/front/extension/app/src/hooks/useAuth.ts
@@ -1,65 +1,131 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { sendAuthMessage, sentLogoutMessage } from "../lib/auth";
+import type { StoredTokens } from "../lib/auth";
 import {
-  clearAccessToken,
-  getAccessToken,
-  saveAccessToken,
-} from "../lib/utils";
+  clearStoredTokens,
+  getStoredTokens,
+  saveTokens,
+  sendAuthMessage,
+  sendRefreshTokenMessage,
+  sentLogoutMessage,
+} from "../lib/auth";
+
+const log = console.error;
 
 export const useAuth = () => {
-  const [token, setToken] = useState<string | null>(null);
+  const [tokens, setTokens] = useState<StoredTokens | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
+  const refreshTimerRef = useRef<NodeJS.Timeout | null>(null);
+
+  // User is authenticated if we have a valid access token.
+  const isTokenValid = useCallback(() => {
+    return tokens?.accessToken && tokens.expiresAt > Date.now();
+  }, [tokens]);
+  const isAuthenticated = useMemo(() => isTokenValid(), [isTokenValid]);
+
+  // Schedule a token refresh before the current token expires.
+  const scheduleTokenRefresh = useCallback((expiresAt: number) => {
+    if (refreshTimerRef.current) {
+      clearTimeout(refreshTimerRef.current);
+    }
+    const refreshTime = Math.max(expiresAt - Date.now() - 60000, 0);
+    refreshTimerRef.current = setTimeout(handleRefreshToken, refreshTime);
+  }, []);
+
+  // Send a refresh token message to the background script to get a new access token.
+  const handleRefreshToken = useCallback(async () => {
+    if (!tokens?.refreshToken) {
+      return;
+    }
+    try {
+      const response = await sendRefreshTokenMessage(tokens.refreshToken);
+      if (!response) {
+        log("Refresh token: empty response from background.");
+      }
+      const savedTokens = await saveTokens(response);
+      setTokens(savedTokens);
+      scheduleTokenRefresh(savedTokens.expiresAt);
+    } catch (error) {
+      log("Refresh token: unknown error.", error);
+      await handleLogout();
+    }
+  }, [tokens, scheduleTokenRefresh]);
+
+  // On mount, check if we have stored tokens and if they are still valid.
   useEffect(() => {
-    const fetchToken = async () => {
+    const fetchTokens = async () => {
       try {
-        const storedToken = await getAccessToken();
-        if (storedToken && typeof storedToken === "string") {
-          setToken(storedToken);
+        const storedTokens = await getStoredTokens();
+        if (!storedTokens) {
+          setIsLoading(false);
+          return;
+        }
+        setTokens(storedTokens);
+        if (storedTokens.expiresAt > Date.now()) {
+          scheduleTokenRefresh(storedTokens.expiresAt);
+        } else {
+          await handleRefreshToken();
         }
       } catch (error) {
-        console.error("Error retrieving token:", error);
+        log("Unknown error retrieving tokens.", error);
       } finally {
         setIsLoading(false);
       }
     };
-    void fetchToken();
-  }, []);
+    void fetchTokens();
 
+    return () => {
+      if (refreshTimerRef.current) {
+        clearTimeout(refreshTimerRef.current);
+      }
+    };
+  }, [handleRefreshToken, scheduleTokenRefresh]);
+
+  // Send an auth message to the background script to start the authentication flow.
   const handleLogin = useCallback(async () => {
     setIsLoading(true);
     try {
       const response = await sendAuthMessage();
-      if (response?.accessToken) {
-        await saveAccessToken(response.accessToken);
-        setToken(response.accessToken);
-      } else {
-        console.error("Authentication failed.");
+      if (!response.accessToken) {
+        log("Login failed: No access token received.");
+        return;
       }
+      const savedTokens = await saveTokens(response);
+      setTokens(savedTokens);
+      scheduleTokenRefresh(savedTokens.expiresAt);
     } catch (error) {
-      console.error("Error sending auth message:", error);
+      log("Login failed: Unknown error.", error);
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [scheduleTokenRefresh]);
 
+  // Send a logout message to the background script to clear the stored tokens.
   const handleLogout = useCallback(async () => {
     setIsLoading(true);
     try {
       const response = await sentLogoutMessage();
-      if (response?.success) {
-        await clearAccessToken();
-        setToken(null);
-      } else {
-        console.error("Logout failed.");
+      if (!response || !response.success === true) {
+        log("Logout failed: No success response received.");
+      }
+      await clearStoredTokens();
+      setTokens(null);
+      if (refreshTimerRef.current) {
+        clearTimeout(refreshTimerRef.current);
       }
     } catch (error) {
-      console.error("Error sending logout message:", error);
+      log("Logout failed: Unknown error.", error);
     } finally {
       setIsLoading(false);
     }
   }, []);
 
-  return { token, isLoading, handleLogin, handleLogout };
+  return {
+    token: tokens?.accessToken ?? null,
+    isLoading,
+    isAuthenticated,
+    handleLogin,
+    handleLogout,
+  };
 };

--- a/front/extension/app/src/lib/auth.ts
+++ b/front/extension/app/src/lib/auth.ts
@@ -5,9 +5,16 @@ export const AUTH0_AUDIENCE = `https://${AUTH0_CLIENT_DOMAIN}/api/v2/`;
 export const AUTH0_PROFILE_ROUTE = `https://${AUTH0_CLIENT_DOMAIN}/userinfo`;
 
 export type Auth0AuthorizeResponse = {
-  idToken: string | null;
-  accessToken: string | null;
-  expiresIn: string | null;
+  accessToken: string;
+  idToken: string;
+  refreshToken: string;
+  expiresIn: number;
+};
+
+export type StoredTokens = {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
 };
 
 export type AuthBackgroundResponse = {
@@ -15,13 +22,14 @@ export type AuthBackgroundResponse = {
 };
 
 export type AuthBackroundMessage = {
-  type: "AUTHENTICATE" | "LOGOUT";
+  type: "AUTHENTICATE" | "REFRESH_TOKEN" | "LOGOUT";
+  refreshToken?: string;
 };
 
 /**
- * Sends an authentication request to the background script.
- * Wrapped to ensure the service worker is ready to receive messages.
+ * Messages to the background script to authenticate, refresh tokens, and logout.
  */
+
 export const sendAuthMessage = (): Promise<Auth0AuthorizeResponse> => {
   return new Promise((resolve, reject) => {
     const message: AuthBackroundMessage = { type: "AUTHENTICATE" };
@@ -59,9 +67,29 @@ export const sendAuthMessage = (): Promise<Auth0AuthorizeResponse> => {
   });
 };
 
-/**
- * Sends a logout request to the background script.
- */
+export const sendRefreshTokenMessage = (
+  refreshToken: string
+): Promise<Auth0AuthorizeResponse> => {
+  return new Promise((resolve, reject) => {
+    const message: AuthBackroundMessage = {
+      type: "REFRESH_TOKEN",
+      refreshToken,
+    };
+    chrome.runtime.sendMessage(
+      message,
+      (response: Auth0AuthorizeResponse | undefined) => {
+        if (chrome.runtime.lastError) {
+          return reject(chrome.runtime.lastError);
+        }
+        if (!response) {
+          return reject(new Error("No response received."));
+        }
+        return resolve(response);
+      }
+    );
+  });
+};
+
 export const sentLogoutMessage = (): Promise<AuthBackgroundResponse> => {
   return new Promise((resolve, reject) => {
     const message: AuthBackroundMessage = { type: "LOGOUT" };
@@ -75,6 +103,53 @@ export const sentLogoutMessage = (): Promise<AuthBackgroundResponse> => {
           return reject(new Error("No response received."));
         }
         return resolve(response);
+      }
+    );
+  });
+};
+
+/**
+ * Utils to manage tokens.
+ * We store the access token, refresh token, and expiration time in Chrome storage.
+ */
+
+export const saveTokens = async (
+  rawTokens: Auth0AuthorizeResponse
+): Promise<StoredTokens> => {
+  const tokens: StoredTokens = {
+    accessToken: rawTokens.accessToken,
+    refreshToken: rawTokens.refreshToken,
+    expiresAt: Date.now() + rawTokens.expiresIn * 1000,
+  };
+  await chrome.storage.local.set(tokens);
+  return tokens;
+};
+
+export const getStoredTokens = async (): Promise<StoredTokens | null> => {
+  const result = await chrome.storage.local.get([
+    "accessToken",
+    "refreshToken",
+    "expiresAt",
+  ]);
+  if (result.accessToken && result.refreshToken && result.expiresAt) {
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresAt: result.expiresAt,
+    };
+  }
+  return null;
+};
+
+export const clearStoredTokens = async (): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    chrome.storage.local.remove(
+      ["accessToken", "refreshToken", "expiresAt"],
+      () => {
+        if (chrome.runtime.lastError) {
+          return reject(chrome.runtime.lastError);
+        }
+        return resolve();
       }
     );
   });

--- a/front/extension/app/src/lib/auth.ts
+++ b/front/extension/app/src/lib/auth.ts
@@ -22,7 +22,7 @@ export type AuthBackgroundResponse = {
 };
 
 export type AuthBackroundMessage = {
-  type: "AUTHENTICATE" | "REFRESH_TOKEN" | "LOGOUT";
+  type: "AUTHENTICATE" | "REFRESH_TOKEN" | "LOGOUT" | "SIGN_CONNECT";
   refreshToken?: string;
 };
 

--- a/front/extension/app/src/lib/utils.ts
+++ b/front/extension/app/src/lib/utils.ts
@@ -22,51 +22,11 @@ const generateCodeChallenge = async (codeVerifier: string): Promise<string> => {
   return base64URLEncode(digest);
 };
 
-export async function generatePKCE(): Promise<{
+export const generatePKCE = async (): Promise<{
   codeVerifier: string;
   codeChallenge: string;
-}> {
+}> => {
   const codeVerifier = generateCodeVerifier();
   const codeChallenge = await generateCodeChallenge(codeVerifier);
   return { codeVerifier, codeChallenge };
-}
-
-/**
- * Utils to manage access token in local storage.
- */
-
-export const saveAccessToken = async (accessToken: string): Promise<void> => {
-  return new Promise((resolve, reject) => {
-    chrome.storage.local.set({ accessToken }, () => {
-      if (chrome.runtime.lastError) {
-        reject(chrome.runtime.lastError);
-      } else {
-        resolve();
-      }
-    });
-  });
-};
-
-export const getAccessToken = async (): Promise<string | undefined> => {
-  return new Promise((resolve, reject) => {
-    chrome.storage.local.get(["accessToken"], (result) => {
-      if (chrome.runtime.lastError) {
-        reject(chrome.runtime.lastError);
-      } else {
-        resolve(result.accessToken);
-      }
-    });
-  });
-};
-
-export const clearAccessToken = async (): Promise<void> => {
-  return new Promise((resolve, reject) => {
-    chrome.storage.local.remove("accessToken", () => {
-      if (chrome.runtime.lastError) {
-        reject(chrome.runtime.lastError);
-      } else {
-        resolve();
-      }
-    });
-  });
 };

--- a/front/extension/app/src/pages/LoginPage.tsx
+++ b/front/extension/app/src/pages/LoginPage.tsx
@@ -1,0 +1,29 @@
+import { Button, LoginIcon } from "@dust-tt/sparkle";
+import { useAuth } from "@extension/context/AuthProvider";
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+
+export const LoginPage = () => {
+  const navigate = useNavigate();
+  const { handleLogin, isAuthenticated, isLoading } = useAuth();
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      navigate("/");
+    }
+  }, [isAuthenticated, navigate]);
+
+  return (
+    <div className="flex flex-col p-4 gap-2 h-screen">
+      <div className="flex justify-center items-center w-full h-full">
+        <Button
+          icon={LoginIcon}
+          variant="primary"
+          label="Sign in"
+          onClick={handleLogin}
+          disabled={isLoading}
+        />
+      </div>
+    </div>
+  );
+};

--- a/front/extension/app/src/pages/MainPage.tsx
+++ b/front/extension/app/src/pages/MainPage.tsx
@@ -15,7 +15,7 @@ import { useAuth } from "@extension/hooks/useAuth";
 import { WorkspaceType } from "@dust-tt/types";
 
 export const MainPage = () => {
-  const { token, isLoading, handleLogin, handleLogout } = useAuth();
+  const { isLoading, isAuthenticated, handleLogin, handleLogout } = useAuth();
 
   const owner: WorkspaceType = {
     id: 1,
@@ -38,7 +38,7 @@ export const MainPage = () => {
           </a>
         </div>
 
-        {token && (
+        {isAuthenticated && (
           <Button
             icon={LogoutIcon}
             variant="tertiary"
@@ -54,7 +54,7 @@ export const MainPage = () => {
         </div>
       )}
 
-      {!isLoading && !token && (
+      {!isLoading && !isAuthenticated && (
         <div className="flex justify-center items-center w-full h-full">
           <Button
             icon={LoginIcon}
@@ -65,7 +65,7 @@ export const MainPage = () => {
         </div>
       )}
 
-      {token && (
+      {isAuthenticated && (
         <div className="w-full h-full">
           <Page.SectionHeader title="Conversation" />
           <GenerationContextProvider>

--- a/front/extension/app/src/pages/MainPage.tsx
+++ b/front/extension/app/src/pages/MainPage.tsx
@@ -1,22 +1,9 @@
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { FixedAssistantInputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
-import {
-  Button,
-  ExternalLinkIcon,
-  LoginIcon,
-  LogoHorizontalColorLogo,
-  LogoutIcon,
-  Page,
-  Spinner,
-  TextArea,
-} from "@dust-tt/sparkle";
-
-import { useAuth } from "@extension/hooks/useAuth";
-import { WorkspaceType } from "@dust-tt/types";
+import { Page } from "@dust-tt/sparkle";
+import type { WorkspaceType } from "@dust-tt/types";
 
 export const MainPage = () => {
-  const { isLoading, isAuthenticated, handleLogin, handleLogout } = useAuth();
-
   const owner: WorkspaceType = {
     id: 1,
     sId: "IQw2NP0Anb",
@@ -29,64 +16,17 @@ export const MainPage = () => {
   };
 
   return (
-    <div className="flex flex-col p-4 gap-2 h-screen">
-      <div className="flex justify-between items-start">
-        <div className="flex items-center gap-2 pb-10">
-          <LogoHorizontalColorLogo className="h-4 w-16" />
-          <a href="https://dust.tt" target="_blank">
-            <ExternalLinkIcon color="#64748B" />
-          </a>
-        </div>
-
-        {isAuthenticated && (
-          <Button
-            icon={LogoutIcon}
-            variant="tertiary"
-            label="Sign out"
-            onClick={handleLogout}
-          />
-        )}
-      </div>
-
-      {isLoading && (
-        <div className="flex justify-center items-center w-full h-full">
-          <Spinner />
-        </div>
-      )}
-
-      {!isLoading && !isAuthenticated && (
-        <div className="flex justify-center items-center w-full h-full">
-          <Button
-            icon={LoginIcon}
-            variant="primary"
-            label="Sign in"
-            onClick={handleLogin}
-          />
-        </div>
-      )}
-
-      {isAuthenticated && (
-        <div className="w-full h-full">
-          <Page.SectionHeader title="Conversation" />
-          <GenerationContextProvider>
-            <FixedAssistantInputBar
-              owner={owner}
-              onSubmit={() => {}}
-              stickyMentions={[]}
-              actions={["attachment", "assistants-list"]}
-              conversationId={null}
-            />
-          </GenerationContextProvider>
-          {/* <Link to="/conversation">Conversations</Link> */}
-          <TextArea />
-          <Button
-            variant="primary"
-            label="Send"
-            className="mt-4"
-            onClick={() => alert("Sorry, not implemented yet!")}
-          />
-        </div>
-      )}
+    <div className="w-full h-full">
+      <Page.SectionHeader title="Conversation" />
+      <GenerationContextProvider>
+        <FixedAssistantInputBar
+          owner={owner}
+          onSubmit={() => {}}
+          stickyMentions={[]}
+          actions={["attachment", "assistants-list"]}
+          conversationId={null}
+        />
+      </GenerationContextProvider>
     </div>
   );
 };

--- a/front/extension/app/src/routes.tsx
+++ b/front/extension/app/src/routes.tsx
@@ -1,13 +1,27 @@
+import { ProtectedRoute } from "@extension/context/ProtectedRoute";
 import { ConversationPage } from "@extension/pages/ConversationPage";
+import { LoginPage } from "@extension/pages/LoginPage";
 import { MainPage } from "@extension/pages/MainPage";
 
 export const routes = [
   {
+    path: "/login",
+    element: <LoginPage />,
+  },
+  {
     path: "*",
-    element: <MainPage />,
+    element: (
+      <ProtectedRoute>
+        <MainPage />,
+      </ProtectedRoute>
+    ),
   },
   {
     path: "/conversation",
-    element: <ConversationPage />,
+    element: (
+      <ProtectedRoute>
+        <ConversationPage />
+      </ProtectedRoute>
+    ),
   },
 ];


### PR DESCRIPTION
## Description

On the initial PR with the Auth flow we were "only" fetching a token from Auth0, not checking if it was still valid or not. 
On this PR we're properly handling the flow with a refresh token. 

- Updates background script to add a new message type we support: `REFRESH_TOKEN`. When we receive this message we will call `/oauth/token` from Auth0 to get a new token. 
- Updates the `useAuth` hook to check if our token is still valid, and schedule a token refresh if needed. 
- Stores "accessToken" + "refreshToken" + "expiresAt" (instead of just accessToken) on Chrome storage.
- Improve a bit the logs -> I initially wanted to create a log class to log in a channel but when we log an error we get the stack trace from the line that launch the console.log so better keeping them as is. 

We will probably need to wrap api call in something that fetches silently a token if not valid anymore but since we don't have API calls yet I did not implement it there. Will do when we need it (likely my next PR 😄 )

On commit 2 I'm introducing an AuthProvider and ProtectedComponent to be cleaner, review per commit advised!

## Risk

None.

## Deploy Plan

Nothing. 
