### PR TITLE
Align transactional and contact emails

### DIFF
--- a/front/components/home/menu/config.ts
+++ b/front/components/home/menu/config.ts
@@ -41,7 +41,7 @@ const AboutMenuConfig: MenuConfig = {
     },
     {
       title: "Contact",
-      href: "mailto:team@dust.tt",
+      href: "mailto:support@dust.tt",
       isExternal: true,
     },
     {

--- a/front/components/workspace/connection.tsx
+++ b/front/components/workspace/connection.tsx
@@ -177,11 +177,11 @@ export function EnterpriseConnectionDetails({
         <Popup
           show={showNoVerifiedDomainPopup}
           chipLabel="Domain Verification Required"
-          description="Single Sign-On (SSO) is not available because your domain isn't verified yet. Contact us at team@dust.tt for assistance."
+          description="Single Sign-On (SSO) is not available because your domain isn't verified yet. Contact us at support@dust.tt for assistance."
           buttonLabel="Get Help"
           buttonClick={() => {
             window.location.href =
-              "mailto:team@dust.tt?subject=Help with Domain Verification for SSO";
+              "mailto:support@dust.tt?subject=Help with Domain Verification for SSO";
           }}
           className="absolute bottom-8 right-8"
           onClose={() => setShowNoVerifiedDomainPopup(false)}

--- a/front/lib/api/email.ts
+++ b/front/lib/api/email.ts
@@ -25,7 +25,7 @@ export async function sendGithubDeletionEmail(email: string): Promise<void> {
     to: email,
     from: {
       name: "Dust team",
-      email: "team@dust.tt",
+      email: "support@dust.help",
     },
     subject: "[Dust] Github connection deleted - important information",
     body: `<p>Your Dust connection to Github was deleted, along with all the related data on Dust servers.</p>
@@ -52,7 +52,7 @@ export async function sendCancelSubscriptionEmail(
     to: email,
     from: {
       name: "Dust team",
-      email: "team@dust.tt",
+      email: "support@dust.help",
     },
     subject: `[Dust] Subscription canceled - important information`,
     body: `
@@ -76,7 +76,7 @@ export async function sendReactivateSubscriptionEmail(
     to: email,
     from: {
       name: "Dust team",
-      email: "team@dust.tt",
+      email: "support@dust.help",
     },
     subject: `[Dust] Your subscription has been reactivated`,
     body: `<p>You have requested to reactivate your subscription.</p>
@@ -94,7 +94,7 @@ export async function sendAdminSubscriptionPaymentFailedEmail(
     to: email,
     from: {
       name: "Dust team",
-      email: "team@dust.tt",
+      email: "support@dust.help",
     },
     subject: `[Dust] Your payment has failed`,
     body: `
@@ -121,7 +121,7 @@ export async function sendAdminDataDeletionEmail({
     to: email,
     from: {
       name: "Dust team",
-      email: "team@dust.tt",
+      email: "support@dust.help",
     },
     subject: `${
       isLast ? "Last Reminder: " : ""

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -172,7 +172,7 @@ export async function sendWorkspaceInvitationEmail(
     to: invitation.inviteEmail,
     from: {
       name: "Dust team",
-      email: "team@dust.tt",
+      email: "support@dust.help",
     },
     templateId: config.getInvitationEmailTemplate(),
     dynamic_template_data: {

--- a/front/lib/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
+++ b/front/lib/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
@@ -450,7 +450,7 @@ async function sendSuggestionEmail({
 
   const msg = {
     to: recipientEmail,
-    from: "team@dust.tt",
+    from: "support@dust.tt",
     subject: `DUST: Document update suggestion for ${matchedDocumentName}`,
     html:
       "Hello!<br>" +

--- a/front/pages/api/w/[wId]/data_sources/request_access.ts
+++ b/front/pages/api/w/[wId]/data_sources/request_access.ts
@@ -92,7 +92,7 @@ async function handler(
 
   const result = await sendEmailWithTemplate({
     to: userReceipent.email,
-    from: { name: "Dust team", email: "team@dust.tt" },
+    from: { name: "Dust team", email: "support@dust.help" },
     subject: `[Dust] Request Data source from ${emailRequester}`,
     body,
   });

--- a/front/temporal/labs/activities.ts
+++ b/front/temporal/labs/activities.ts
@@ -393,7 +393,7 @@ export async function processTranscriptActivity(
     to: user.email,
     from: {
       name: "Dust team",
-      email: "team@dust.help",
+      email: "support@dust.help",
     },
     subject: `[DUST] Meeting summary - ${transcriptTitle}`,
     body: `${htmlAnswer}<div style="text-align: center; margin-top: 20px;">


### PR DESCRIPTION
All transactional emails sent by support@dust.help 
All inbound contact emails changed to support@dust.tt

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Make sure support@dust.help forwards to support@dust.tt