### PR TITLE
fix: handle null user in internalCreateToolOutputCsvFile

### DIFF
--- a/front/lib/api/files/tool_output.ts
+++ b/front/lib/api/files/tool_output.ts
@@ -3,6 +3,7 @@ import { pipeline } from "stream/promises";
 
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
+
 export async function internalCreateToolOutputCsvFile(
   auth: Authenticator,
   {
@@ -16,11 +17,11 @@ export async function internalCreateToolOutputCsvFile(
   }
 ): Promise<FileResource> {
   const workspace = auth.getNonNullableWorkspace();
-  const user = auth.getNonNullableUser();
+  const user = auth.user();
 
   const fileResource = await FileResource.makeNew({
     workspaceId: workspace.id,
-    userId: user.id,
+    userId: user?.id ?? null,
     contentType,
     fileName: title,
     fileSize: Buffer.byteLength(content),


### PR DESCRIPTION
## Description

When calling the assistant from the public API, the `user`  may be null. In such cases, we're crashing when attempting to create the file. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
