### PR TITLE
[connectors] Skip assistant selector when calling from a slack bot

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -539,12 +539,17 @@ async function answerMessage(
     .sort((a, b) => a.name.localeCompare(b.name));
 
   const mainMessage = await slackClient.chat.postMessage({
-    ...makeMessageUpdateBlocksAndText(null, connector.workspaceId, {
-      assistantName: mention.assistantName,
-      agentConfigurations: mostPopularAgentConfigurations,
-      isComplete: false,
-      isThinking: true,
-    }),
+    ...makeMessageUpdateBlocksAndText(
+      null,
+      connector.workspaceId,
+      slackUserInfo,
+      {
+        assistantName: mention.assistantName,
+        agentConfigurations: mostPopularAgentConfigurations,
+        isComplete: false,
+        isThinking: true,
+      }
+    ),
     channel: slackChannel,
     thread_ts: slackMessageTs,
     metadata: {
@@ -637,7 +642,12 @@ async function answerMessage(
     connector,
     conversation,
     mainMessage,
-    slack: { slackChannelId: slackChannel, slackClient, slackMessageTs },
+    slack: {
+      slackChannelId: slackChannel,
+      slackClient,
+      slackMessageTs,
+      slackUserInfo,
+    },
     userMessage,
     agentConfigurations: mostPopularAgentConfigurations,
   });

--- a/connectors/src/connectors/slack/chat/blocks.ts
+++ b/connectors/src/connectors/slack/chat/blocks.ts
@@ -4,6 +4,7 @@ import { truncate } from "@dust-tt/types";
 import { STATIC_AGENT_CONFIG } from "@connectors/api/webhooks/webhook_slack_interaction";
 import type { SlackMessageFootnotes } from "@connectors/connectors/slack/chat/citations";
 import { makeDustAppUrl } from "@connectors/connectors/slack/chat/utils";
+import type { SlackUserInfo } from "@connectors/connectors/slack/lib/slack_client";
 
 /*
  * This length threshold is set to prevent the "msg_too_long" error
@@ -80,10 +81,11 @@ function makeContextSectionBlocks(
 function makeAssistantSelectionBlock(
   assistantName: string,
   agentConfigurations: LightAgentConfigurationType[],
+  slackUserInfo: SlackUserInfo,
   isThinking: boolean,
   thinkingText: string
 ) {
-  return assistantName
+  return assistantName && !slackUserInfo.is_bot
     ? [
         {
           type: "section",
@@ -151,6 +153,7 @@ export function makeFooterBlock(
 export function makeMessageUpdateBlocksAndText(
   conversationUrl: string | null,
   workspaceId: string,
+  slackUserInfo: SlackUserInfo,
   messageUpdate: SlackMessageUpdate
 ) {
   const {
@@ -172,6 +175,7 @@ export function makeMessageUpdateBlocksAndText(
       ...makeAssistantSelectionBlock(
         assistantName,
         agentConfigurations,
+        slackUserInfo,
         isThinking ?? false,
         thinkingTextWithAction
       ),

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -18,6 +18,7 @@ import {
 } from "@connectors/connectors/slack/chat/blocks";
 import { annotateCitations } from "@connectors/connectors/slack/chat/citations";
 import { makeConversationUrl } from "@connectors/connectors/slack/chat/utils";
+import type { SlackUserInfo } from "@connectors/connectors/slack/lib/slack_client";
 import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 
@@ -30,6 +31,7 @@ interface StreamConversationToSlackParams {
     slackChannelId: string;
     slackClient: WebClient;
     slackMessageTs: string;
+    slackUserInfo: SlackUserInfo;
   };
   userMessage: UserMessageType;
   agentConfigurations: LightAgentConfigurationType[];
@@ -51,7 +53,7 @@ export async function streamConversationToSlack(
     agentConfigurations,
   }: StreamConversationToSlackParams
 ): Promise<Result<undefined, Error>> {
-  const { slackChannelId, slackClient, slackMessageTs } = slack;
+  const { slackChannelId, slackClient, slackMessageTs, slackUserInfo } = slack;
 
   let lastSentDate = new Date();
   let backoffTime = initialBackoffTime;
@@ -79,6 +81,7 @@ export async function streamConversationToSlack(
       ...makeMessageUpdateBlocksAndText(
         conversationUrl,
         connector.workspaceId,
+        slackUserInfo,
         messageUpdate
       ),
       channel: slackChannelId,


### PR DESCRIPTION
## Description

Use slackUserInfo to determine if assisrtant selector shjould be displayed or not.

## Risk


## Deploy Plan

deploy connectors
