### PR TITLE
[Assistant listing] Default to alphabetical sort when no other criteria

### DIFF
--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -153,5 +153,6 @@ export function compareAgentsForSort(
     return 1;
   } // Only b is in customOrder, it comes first
 
-  return 0; // Default: keep the original order
+  // default: sort alphabetically
+  return a.name.localeCompare(b.name, "en", { sensitivity: "base" });
 }


### PR DESCRIPTION
Description
---
Assistants are often returned in a ~random order when no specific ordering is given.

This PR sorts them alphabetically in that case.

Risks
---
na

Deploy
---
front
