### PR TITLE
[Mobile] Hide help button on conversation

### DIFF
--- a/front/components/assistant/conversation/ConversationLayout.tsx
+++ b/front/components/assistant/conversation/ConversationLayout.tsx
@@ -111,6 +111,7 @@ export default function ConversationLayout({
           subscription={subscription}
           owner={owner}
           isWideMode
+          hideHelpOnMobile
           pageTitle={
             conversation?.title
               ? `Dust - ${conversation?.title}`

--- a/front/components/sparkle/AppLayout.tsx
+++ b/front/components/sparkle/AppLayout.tsx
@@ -40,6 +40,7 @@ export default function AppLayout({
   navChildren,
   titleChildren,
   children,
+  hideHelpOnMobile,
 }: {
   owner: WorkspaceType;
   subscription: SubscriptionType;
@@ -50,6 +51,7 @@ export default function AppLayout({
   navChildren?: React.ReactNode;
   titleChildren?: React.ReactNode;
   children: React.ReactNode;
+  hideHelpOnMobile?: boolean;
 }) {
   const [loaded, setLoaded] = useState(false);
   const router = useRouter();
@@ -164,10 +166,17 @@ export default function AppLayout({
           </main>
         </div>
       </div>
-      {user.user && (
+      {user.user && !hideHelpOnMobile && (
         <GenerationContextProvider>
           <HelpAndQuickGuideWrapper owner={owner} user={user.user} />
         </GenerationContextProvider>
+      )}
+      {user.user && hideHelpOnMobile && (
+        <div className="hidden sm:block">
+          <GenerationContextProvider>
+            <HelpAndQuickGuideWrapper owner={owner} user={user.user} />
+          </GenerationContextProvider>
+        </div>
       )}
       <>
         <Script


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/1486

Fixes a currently broken help button on conversations on mobile by hiding it. Related thread:
https://dust4ai.slack.com/archives/C050SM8NSPK/p1728810636220099

cc @gabhubert

Risks
---
na

Deploy
---
front
