### PR TITLE
Fix Gong logic when transcript is not supposed to be processed

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -187,6 +187,7 @@
       }
     },
     "../sdks/js": {
+      "name": "@dust-tt/client",
       "version": "1.0",
       "dependencies": {
         "@dust-tt/types": "file:../../types",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -187,7 +187,6 @@
       }
     },
     "../sdks/js": {
-      "name": "@dust-tt/client",
       "version": "1.0",
       "dependencies": {
         "@dust-tt/types": "file:../../types",

--- a/front/temporal/labs/activities.ts
+++ b/front/temporal/labs/activities.ts
@@ -228,6 +228,15 @@ export async function processTranscriptActivity(
     throw error;
   }
 
+  // Short transcripts are not useful to process.
+  if (transcriptContent.length < 100) {
+    localLogger.info(
+      { contentLength: transcriptContent.length },
+      "[processTranscriptActivity] Transcript content too short or empty. Skipping."
+    );
+    return;
+  }
+
   const owner = auth.workspace();
 
   if (!owner) {

--- a/front/temporal/labs/activities.ts
+++ b/front/temporal/labs/activities.ts
@@ -183,6 +183,7 @@ export async function processTranscriptActivity(
 
   let transcriptTitle = "";
   let transcriptContent = "";
+  let doNotProcess = false;
 
   switch (transcriptsConfiguration.provider) {
     case "google_drive":
@@ -203,8 +204,12 @@ export async function processTranscriptActivity(
         fileId,
         localLogger
       );
-      transcriptTitle = gongResult?.transcriptTitle || "";
-      transcriptContent = gongResult?.transcriptContent || "";
+      if (!gongResult) {
+        doNotProcess = true;
+        break;
+      }
+      transcriptTitle = gongResult.transcriptTitle || "";
+      transcriptContent = gongResult.transcriptContent || "";
       break;
 
     default:
@@ -215,8 +220,16 @@ export async function processTranscriptActivity(
     await transcriptsConfiguration.recordHistory({
       configurationId: transcriptsConfiguration.id,
       fileId,
-      fileName: transcriptTitle,
+      fileName: doNotProcess ? "Not processed" : transcriptTitle,
     });
+
+    if (doNotProcess) {
+      localLogger.info(
+        {},
+        "[processTranscriptActivity] Transcript not to be processed. Stopping."
+      );
+      return;
+    }
   } catch (error) {
     if (error instanceof UniqueConstraintError) {
       localLogger.info(
@@ -226,15 +239,6 @@ export async function processTranscriptActivity(
       return; // Already processed.
     }
     throw error;
-  }
-
-  // Short transcripts are not useful to process.
-  if (transcriptContent.length < 100) {
-    localLogger.info(
-      { contentLength: transcriptContent.length },
-      "[processTranscriptActivity] Transcript content too short or empty. Skipping."
-    );
-    return;
   }
 
   const owner = auth.workspace();


### PR DESCRIPTION
## Description

In Gong, as we monitor all transcripts coming through, we need to make sure we only go for processing for legit transcripts. 

So if retrieveGongTranscriptContent() returns null (can come from a few reasons, one of them being that current user has not participated in the call), we should simply not try to process the transcript. 



## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
