### PR TITLE
[Confluence] Remove mutex lib, use cacheWithRedis with lock

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -24,7 +24,6 @@
         "@types/minimist": "^1.2.2",
         "@types/remove-markdown": "^0.3.4",
         "@types/uuid": "^9.0.2",
-        "async-mutex": "^0.5.0",
         "axios": "^1.5.1",
         "blake3": "^2.1.7",
         "body-parser": "^1.20.2",
@@ -5593,14 +5592,6 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
-    },
-    "node_modules/async-mutex": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
-      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/async-retry": {
       "version": "1.3.3",

--- a/connectors/package.json
+++ b/connectors/package.json
@@ -30,7 +30,6 @@
     "@types/minimist": "^1.2.2",
     "@types/remove-markdown": "^0.3.4",
     "@types/uuid": "^9.0.2",
-    "async-mutex": "^0.5.0",
     "axios": "^1.5.1",
     "blake3": "^2.1.7",
     "body-parser": "^1.20.2",

--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -5,8 +5,7 @@ import type {
   ContentNodesViewType,
   Result,
 } from "@dust-tt/types";
-import { Err, Ok } from "@dust-tt/types";
-import { Mutex } from "async-mutex";
+import { cacheWithRedis, Err, Ok } from "@dust-tt/types";
 
 import {
   getConfluenceAccessToken,
@@ -469,30 +468,6 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
     return new Ok(contentNodes);
   }
 
-  private _cachedHierarchyMutex = new Mutex();
-  private _cachedHierarchy: Map<string, Map<string, string | null>> = new Map();
-
-  private async getCachedHierarchy(
-    memoizationKey: string,
-    spaceId: string
-  ): Promise<Map<string, string | null>> {
-    return this._cachedHierarchyMutex.runExclusive(async () => {
-      if (!this._cachedHierarchy.has(memoizationKey)) {
-        this._cachedHierarchy.set(
-          memoizationKey,
-          await getSpaceHierarchy(this.connectorId, spaceId)
-        );
-      }
-
-      // pleasing typescript
-      const cachedHierarchy = this._cachedHierarchy.get(memoizationKey);
-      if (!cachedHierarchy) {
-        throw new Error("Unreachable: Cached hierarchy is not set.");
-      }
-      return cachedHierarchy;
-    });
-  }
-
   async retrieveContentNodeParents({
     internalId,
     memoizationKey,
@@ -529,7 +504,11 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
       // if a memoization key is provided, use it to cache the hierarchy which
       // is expensive to compute
       const cachedHierarchy = memoizationKey
-        ? await this.getCachedHierarchy(memoizationKey, currentPage.spaceId)
+        ? await cacheWithRedis(
+            getSpaceHierarchy,
+            () => memoizationKey,
+            60 * 60 * 1000
+          )(this.connectorId, currentPage.spaceId)
         : undefined;
 
       const parentIds = await getConfluencePageParentIds(

--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -507,7 +507,9 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
         ? await cacheWithRedis(
             getSpaceHierarchy,
             () => memoizationKey,
-            60 * 60 * 1000
+            60 * 60 * 1000,
+            undefined,
+            true
           )(this.connectorId, currentPage.spaceId)
         : undefined;
 

--- a/types/src/shared/cache.ts
+++ b/types/src/shared/cache.ts
@@ -70,6 +70,8 @@ async function lock(key: string) {
     if (locks[key]) {
       locks[key].push(resolve);
     } else {
+      // use array to allow multiple locks
+      // array set to empty indicates first lock
       locks[key] = [];
       resolve();
     }


### PR DESCRIPTION
Description
---
After IRL discussion & ensuing thinking:
- remove the `async-mutex` lib (using a mutex library is bad form in general)
- use cacheWithRedis for the confluence case (see details in PR #7906 for the need for this caching)
- adds a custom lock to cacheWithRedis.

For cacheWithRedis, a lock is legitimate (and needed to address the initial issue of #7906), but in order to limit the scope of locking and avoid spreading its use in our codebase, we use a simple self-made inline implementation rather than a lib.

Locking operation is quite fast, it shouldn't impact run (but waiting for the lock could and will).

Implementing the lock could have the added benefit of fixing former unnoticed issues of caching not being used efficiently.

Risks
---
Blast radius: all cacheWithRedis calls => careful. See deploy plan

Deploy plan
---
- local tests on a few cachewithredis calls
- deploy connectors
- deploy front
- monitor deployment
- warn eng runner
