### PR TITLE
[front] Split query to fetch agent_configurations

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -323,7 +323,7 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
         where: {
           ...baseWhereConditions,
           authorId: user.id,
-          scope: { [Op.notIn]: ["workspace", "published"] },
+          scope: "private",
         },
       });
 

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -307,17 +307,27 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
     case "list":
       const user = auth.user();
 
-      return AgentConfiguration.findAll({
+      const sharedAssistants = await AgentConfiguration.findAll({
         ...baseAgentsSequelizeQuery,
         where: {
           ...baseWhereConditions,
-          [Op.or]: [
-            { scope: { [Op.in]: ["workspace", "published"] } },
-            { authorId: user?.id },
-          ],
+          scope: { [Op.in]: ["workspace", "published"] },
+        },
+      });
+      if (!user) {
+        return sharedAssistants;
+      }
+
+      const userAssistants = await AgentConfiguration.findAll({
+        ...baseAgentsSequelizeQuery,
+        where: {
+          ...baseWhereConditions,
+          authorId: user.id,
+          scope: { [Op.notIn]: ["workspace", "published"] },
         },
       });
 
+      return [...sharedAssistants, ...userAssistants];
     default:
       if (typeof agentsGetView === "object" && "agentIds" in agentsGetView) {
         return AgentConfiguration.findAll({


### PR DESCRIPTION
## Description

followup https://github.com/dust-tt/dust/pull/8050

Retrieving all assistants is very slow because of a complex query plan, due to an "or" in the query. Splitting in 2 queries which only have an index scan may be more efficient (especially in terms of memory)

Current query :
```
EXPLAIN SELECT * FROM "agent_configurations" AS "agent_configuration"
WHERE
  ("agent_configuration"."scope" in ('workspace', 'published')
    OR "agent_configuration"."authorId" = 6334)
  AND "agent_configuration"."workspaceId" = 4525
  AND "agent_configuration"."status" = 'active'

QUERY PLAN
Bitmap Heap Scan on agent_configurations agent_configuration (cost=22.22..322.72 rows=77 width=802)
Recheck Cond: ((("workspaceId" = 4525) AND ((scope)::text = ANY ('{workspace,published}'::text[])) AND ((status)::text = 'active'::text)) OR (("workspaceId" = 4525) AND ("authorId" = 6334) AND ((status)::text = 'active'::text)))
-> BitmapOr (cost=22.22..22.22 rows=77 width=0)
-> Bitmap Index Scan on partial_agent_config_active (cost=0.00..9.33 rows=77 width=0)
Index Cond: (("workspaceId" = 4525) AND ((scope)::text = ANY ('{workspace,published}'::text[])))
-> Bitmap Index Scan on partial_agent_config_active (cost=0.00..12.86 rows=1 width=0)
Index Cond: (("workspaceId" = 4525) AND ("authorId" = 6334))
```  
Replacing with :
```
EXPLAIN SELECT * FROM "agent_configurations" AS "agent_configuration"
WHERE
  "agent_configuration"."scope" = 'private'
  AND "agent_configuration"."authorId" = 6334
  AND "agent_configuration"."workspaceId" = 4525
  AND "agent_configuration"."status" = 'active'
  
QUERY PLAN
Index Scan using partial_agent_config_active on agent_configurations agent_configuration (cost=0.29..8.31 rows=1 width=799)
Index Cond: (("workspaceId" = 4525) AND ((scope)::text = 'private'::text) AND ("authorId" = 6334))
```
And : 
```
EXPLAIN SELECT * FROM "agent_configurations" AS "agent_configuration"
WHERE
  "agent_configuration"."scope" in ('workspace', 'published')
  AND "agent_configuration"."workspaceId" = 4525
  AND "agent_configuration"."status" = 'active'

QUERY PLAN
Index Scan using partial_agent_config_active on agent_configurations agent_configuration (cost=0.29..317.96 rows=79 width=799)
Index Cond: (("workspaceId" = 4525) AND ((scope)::text = ANY ('{workspace,published}'::text[])))
```

Total planning and execution time is smaller, but more importantly we only do index scans.

## Risk

List of assistants different (order ? )

## Deploy Plan

deploy front
