### PR TITLE
[front] Shift production checks at different time

### DIFF
--- a/front/temporal/production_checks/client.ts
+++ b/front/temporal/production_checks/client.ts
@@ -27,7 +27,7 @@ export async function launchProductionChecksWorkflow(): Promise<
       args: [],
       taskQueue: QUEUE_NAME,
       workflowId: workflowId,
-      cronSchedule: "30 * * * *", // every hour, on the hour
+      cronSchedule: "20 * * * *", // every hour, on 20 minutes past the hour
     });
     logger.info(
       {

--- a/front/temporal/production_checks/client.ts
+++ b/front/temporal/production_checks/client.ts
@@ -27,7 +27,7 @@ export async function launchProductionChecksWorkflow(): Promise<
       args: [],
       taskQueue: QUEUE_NAME,
       workflowId: workflowId,
-      cronSchedule: "0 * * * *", // every hour, on the hour
+      cronSchedule: "30 * * * *", // every hour, on the hour
     });
     logger.info(
       {


### PR DESCRIPTION
## Description

Move time to start production check, in case there's a conflict with other jobs
context : https://dust4ai.slack.com/archives/C05F84CFP0E/p1729091340664469

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

front
