### PR TITLE
add esbuild/linux-x64

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -12722,6 +12722,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
+      "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "dev": true,


### PR DESCRIPTION
## Description

Add esbuild/linux-x64 to package-lock.json. Should be stable through npm install even on Mac

## Risk

N/A

## Deploy Plan

N/A