### PR TITLE
Vaults to spaces - move permissions to ACLs

### DIFF
--- a/front/admin/init_dust_apps.ts
+++ b/front/admin/init_dust_apps.ts
@@ -43,7 +43,7 @@ async function main() {
 
   await VaultResource.makeNew(
     { id: 93077, name: "Public Dust Apps", kind: "public", workspaceId: w.id },
-    group
+    [group]
   );
 
   await internalSubscribeWorkspaceToFreePlan({

--- a/front/components/vaults/CreateOrEditVaultModal.tsx
+++ b/front/components/vaults/CreateOrEditVaultModal.tsx
@@ -73,19 +73,13 @@ export function CreateOrEditVaultModal({
     vault?.name ?? null
   );
   const [selectedMembers, setSelectedMembers] = useState<string[]>([]);
-  const [searchTerm, setSearchTerm] = useState<string>("");
   const [isSaving, setIsSaving] = useState(false);
-  const [pagination, setPagination] = React.useState<PaginationState>({
-    pageIndex: 0,
-    pageSize: 25,
-  });
   const [showDeleteConfirmDialog, setShowDeleteConfirmDialog] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [isRestricted, setIsRestricted] = useState(
     vault?.isRestricted ?? false
   );
 
-  const sendNotifications = useContext(SendNotificationsContext);
   const doCreate = useCreateVault({ owner });
   const doUpdate = useUpdateVault({ owner });
   const doDelete = useDeleteVault({ owner });
@@ -96,19 +90,217 @@ export function CreateOrEditVaultModal({
     workspaceId: owner.sId,
     vaultId: vault?.sId ?? null,
   });
-  const vaultMembers = vaultInfo?.members ?? null;
 
   useEffect(() => {
-    if (vaultMembers) {
-      if (selectedMembers.length === 0) {
+    if (isOpen) {
+      const vaultMembers = vaultInfo?.members ?? null;
+
+      if (vaultMembers && vaultInfo?.isRestricted) {
         setSelectedMembers(vaultMembers.map((vm) => vm.sId));
       }
 
-      if (!vaultName) {
-        setVaultName(vault?.name ?? null);
+      setVaultName(vaultInfo?.name ?? null);
+
+      setIsRestricted(vaultInfo?.isRestricted ?? false);
+    }
+  }, [isOpen, vaultInfo]);
+
+  const handleClose = useCallback(() => {
+    // Call the original onClose function.
+    onClose();
+
+    setTimeout(() => {
+      // Reset state.
+      setVaultName("");
+      setIsRestricted(false);
+      setSelectedMembers([]);
+      setShowDeleteConfirmDialog(false);
+      setIsDeleting(false);
+      setIsSaving(false);
+    }, 500);
+  }, [onClose, vaultInfo]);
+
+  const onSave = useCallback(async () => {
+    setIsSaving(true);
+
+    if (selectedMembers.length > 0 && vault) {
+      if (isRestricted) {
+        await doUpdate(vault, {
+          isRestricted: true,
+          memberIds: selectedMembers,
+          name: vaultName,
+        });
+      } else {
+        await doUpdate(vault, {
+          isRestricted: false,
+          memberIds: null,
+          name: vaultName,
+        });
+      }
+
+      // FIXME: we should update the page vault's name as well.
+      await mutateVaultInfo();
+    } else if (!vault) {
+      let createdVault;
+
+      if (isRestricted) {
+        createdVault = await doCreate({
+          name: vaultName,
+          isRestricted: true,
+          memberIds: selectedMembers, // must be a string[] when isRestricted is true
+        });
+      } else {
+        createdVault = await doCreate({
+          name: vaultName,
+          isRestricted: false,
+          memberIds: null, // must be null when isRestricted is false
+        });
+      }
+
+      setIsSaving(false);
+      if (createdVault && onCreated) {
+        onCreated(createdVault);
       }
     }
-  }, [vault?.name, vaultMembers, selectedMembers, vaultName, isSaving]);
+
+    handleClose();
+  }, [
+    doCreate,
+    doUpdate,
+    handleClose,
+    isRestricted,
+    mutateVaultInfo,
+    onCreated,
+    selectedMembers,
+    vault,
+    vaultName,
+  ]);
+
+  const onDelete = useCallback(async () => {
+    if (!vault) {
+      setShowDeleteConfirmDialog(false);
+      return;
+    }
+
+    setIsDeleting(true);
+
+    const res = await doDelete(vault);
+    setIsDeleting(false);
+    setShowDeleteConfirmDialog(false);
+
+    if (res) {
+      handleClose();
+      await router.push(`/w/${owner.sId}/vaults`);
+    }
+  }, [doDelete, handleClose, owner.sId, router, vault]);
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      title={vault ? `Edit ${vault.name}` : "Create a Vault"}
+      saveLabel={vault ? "Save" : "Create"}
+      variant="side-md"
+      hasChanged={
+        !!vaultName &&
+        (!isRestricted || (isRestricted && selectedMembers.length > 0))
+      }
+      isSaving={isSaving}
+      className="flex overflow-visible" // overflow-visible is needed to avoid clipping the delete button
+      onSave={onSave}
+    >
+      <Page.Vertical gap="md" sizing="grow">
+        <div className="flex w-full flex-col gap-y-4 overflow-y-hidden">
+          <div className="mb-4 flex w-full flex-col gap-y-2 pt-2">
+            <Page.SectionHeader title="Name" />
+            <Input
+              placeholder="Vault's name"
+              value={vaultName}
+              name="vaultName"
+              onChange={(e) => setVaultName(e.target.value)}
+            />
+            {!vault && (
+              <div className="flex gap-1 text-xs text-element-700">
+                <Icon visual={InformationCircleIcon} size="xs" />
+                <span>Vault name must be unique</span>
+              </div>
+            )}
+          </div>
+          <div className="flex w-full grow flex-col gap-y-2 overflow-y-hidden border-t pt-2">
+            <div className="flex w-full items-center justify-between">
+              <Page.SectionHeader title="Restricted Access" />
+              <SliderToggle
+                selected={isRestricted}
+                onClick={() => setIsRestricted(!isRestricted)}
+              />
+            </div>
+            <div className="text-sm font-normal text-element-700">
+              {isRestricted ? (
+                <p>Restricted access is active.</p>
+              ) : (
+                <p>
+                  Restricted access is disabled. The space is accessible to
+                  everyone in the workspace.
+                </p>
+              )}
+            </div>
+            <MembersSearchAndList
+              isAdmin={isAdmin}
+              isRestricted={isRestricted}
+              onMembersUpdated={setSelectedMembers}
+              owner={owner}
+              selectedMembers={selectedMembers}
+            />
+          </div>
+          {isAdmin && vault && vault.kind === "regular" && (
+            <>
+              <Page.Separator />
+              <ConfirmDeleteVaultDialog
+                vault={vault}
+                handleDelete={onDelete}
+                isOpen={showDeleteConfirmDialog}
+                isDeleting={isDeleting}
+                onClose={() => setShowDeleteConfirmDialog(false)}
+              />
+              <div className="flex w-full justify-end">
+                <Button
+                  size="sm"
+                  label="Delete Vault"
+                  variant="primaryWarning"
+                  className="mr-2"
+                  onClick={() => setShowDeleteConfirmDialog(true)}
+                />
+              </div>
+            </>
+          )}
+        </div>
+      </Page.Vertical>
+    </Modal>
+  );
+}
+
+interface MembersSearchAndListProps {
+  isAdmin: boolean;
+  isRestricted: boolean;
+  onMembersUpdated: (members: string[]) => void;
+  owner: LightWorkspaceType;
+  selectedMembers: string[];
+}
+
+function MembersSearchAndList({
+  isAdmin,
+  isRestricted,
+  onMembersUpdated,
+  owner,
+  selectedMembers,
+}: MembersSearchAndListProps) {
+  const [searchTerm, setSearchTerm] = useState<string>("");
+  const [pagination, setPagination] = React.useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 25,
+  });
+
+  const sendNotifications = useContext(SendNotificationsContext);
 
   const { members, totalMembersCount, isLoading } = useSearchMembers({
     workspaceId: owner.sId,
@@ -117,24 +309,6 @@ export function CreateOrEditVaultModal({
     pageSize: pagination.pageSize,
     disabled: !isAdmin,
   });
-
-  const handleClose = useCallback(() => {
-    // Call the original onClose function.
-    onClose();
-
-    // Sleep for a bit to avoid flickering when closing the modal.
-    setTimeout(() => {
-      // Reset state.
-      setVaultName(null);
-      setIsRestricted(false);
-      setSelectedMembers([]);
-      setSearchTerm("");
-      setPagination({ pageIndex: 0, pageSize: 25 });
-      setShowDeleteConfirmDialog(false);
-      setIsDeleting(false);
-      setIsSaving(false);
-    }, 500);
-  }, [onClose]);
 
   const getTableColumns = useCallback(() => {
     const manageMembers = (userId: string, addOrRemove: "add" | "remove") => {
@@ -147,9 +321,9 @@ export function CreateOrEditVaultModal({
           });
           return;
         }
-        setSelectedMembers(selectedMembers.filter((m) => m !== userId));
+        onMembersUpdated(selectedMembers.filter((m) => m !== userId));
       } else {
-        setSelectedMembers([...selectedMembers, userId]);
+        onMembersUpdated([...selectedMembers, userId]);
       }
     };
     return [
@@ -219,190 +393,44 @@ export function CreateOrEditVaultModal({
         },
       },
     ];
-  }, [selectedMembers, sendNotifications]);
+  }, [onMembersUpdated, selectedMembers, sendNotifications]);
 
   const rows = useMemo(() => getTableRows(members), [members]);
 
   const columns = useMemo(() => getTableColumns(), [getTableColumns]);
 
-  const onSave = useCallback(async () => {
-    setIsSaving(true);
-
-    if (selectedMembers.length > 0 && vault) {
-      if (isRestricted) {
-        await doUpdate(vault, {
-          isRestricted: true,
-          memberIds: selectedMembers,
-          name: vaultName,
-        });
-      } else {
-        await doUpdate(vault, {
-          isRestricted: false,
-          memberIds: null,
-          name: vaultName,
-        });
-      }
-
-      // FIXME: we should update the page vault's name as well.
-      await mutateVaultInfo();
-    } else if (!vault) {
-      let createdVault;
-
-      if (isRestricted) {
-        createdVault = await doCreate({
-          name: vaultName,
-          isRestricted: true,
-          memberIds: selectedMembers, // must be a string[] when isRestricted is true
-        });
-      } else {
-        createdVault = await doCreate({
-          name: vaultName,
-          isRestricted: false,
-          memberIds: null, // must be null when isRestricted is false
-        });
-      }
-
-      setIsSaving(false);
-      if (createdVault && onCreated) {
-        onCreated(createdVault);
-      }
-    }
-    handleClose();
-  }, [
-    doCreate,
-    doUpdate,
-    handleClose,
-    isRestricted,
-    mutateVaultInfo,
-    onCreated,
-    selectedMembers,
-    vault,
-    vaultName,
-  ]);
-
-  const onDelete = useCallback(async () => {
-    if (!vault) {
-      setShowDeleteConfirmDialog(false);
-      return;
-    }
-
-    setIsDeleting(true);
-
-    const res = await doDelete(vault);
-    setIsDeleting(false);
-    setShowDeleteConfirmDialog(false);
-
-    if (res) {
-      handleClose();
-      await router.push(`/w/${owner.sId}/vaults`);
-    }
-  }, [doDelete, handleClose, owner.sId, router, vault]);
+  if (!isRestricted) {
+    return null;
+  }
 
   return (
-    <Modal
-      isOpen={isOpen}
-      onClose={handleClose}
-      title={vault ? `Edit ${vault.name}` : "Create a Vault"}
-      saveLabel={vault ? "Save" : "Create"}
-      variant="side-md"
-      hasChanged={
-        !!vaultName &&
-        (!isRestricted || (isRestricted && selectedMembers.length > 0))
-      }
-      isSaving={isSaving}
-      className="flex overflow-visible" // overflow-visible is needed to avoid clipping the delete button
-      onSave={onSave}
-    >
-      <Page.Vertical gap="md" sizing="grow">
-        <div className="flex w-full flex-col gap-y-4 overflow-y-hidden">
-          <div className="mb-4 flex w-full flex-col gap-y-2 pt-2">
-            <Page.SectionHeader title="Name" />
-            <Input
-              placeholder="Vault's name"
-              value={vaultName}
-              name="vaultName"
-              onChange={(e) => setVaultName(e.target.value)}
-            />
-            {!vault && (
-              <div className="flex gap-1 text-xs text-element-700">
-                <Icon visual={InformationCircleIcon} size="xs" />
-                <span>Vault name must be unique</span>
-              </div>
-            )}
-          </div>
-          {/* TODO: Extract to a dedicated component */}
-          <div className="flex w-full grow flex-col gap-y-2 overflow-y-hidden border-t pt-2">
-            <div className="flex w-full items-center justify-between">
-              <Page.SectionHeader title="Restricted Access" />
-              <SliderToggle
-                selected={isRestricted}
-                onClick={() => setIsRestricted(!isRestricted)}
-              />
-            </div>
-            <div className="text-sm font-normal text-element-700">
-              {isRestricted ? (
-                <p>Restricted access is active.</p>
-              ) : (
-                <p>
-                  Restricted access is disabled. The space is accessible to
-                  everyone in the workspace.
-                </p>
-              )}
-            </div>
-            {isRestricted && (
-              <>
-                <div className="flex w-full">
-                  <Searchbar
-                    name="search"
-                    placeholder="Search members (email)"
-                    value={searchTerm}
-                    onChange={setSearchTerm}
-                  />
-                </div>
-                {isLoading ? (
-                  <div className="mt-8 flex justify-center">
-                    <Spinner size="lg" variant="color" />
-                  </div>
-                ) : (
-                  <div className="flex grow flex-col overflow-y-auto scrollbar-hide">
-                    <DataTable
-                      data={rows}
-                      columns={columns}
-                      pagination={pagination}
-                      setPagination={setPagination}
-                      totalRowCount={totalMembersCount}
-                      columnsBreakpoints={{
-                        email: "md",
-                      }}
-                    />
-                  </div>
-                )}
-              </>
-            )}
-          </div>
-          {isAdmin && vault && vault.kind === "regular" && (
-            <>
-              <Page.Separator />
-              <ConfirmDeleteVaultDialog
-                vault={vault}
-                handleDelete={onDelete}
-                isOpen={showDeleteConfirmDialog}
-                isDeleting={isDeleting}
-                onClose={() => setShowDeleteConfirmDialog(false)}
-              />
-              <div className="flex w-full justify-end">
-                <Button
-                  size="sm"
-                  label="Delete Vault"
-                  variant="primaryWarning"
-                  className="mr-2"
-                  onClick={() => setShowDeleteConfirmDialog(true)}
-                />
-              </div>
-            </>
-          )}
+    <>
+      <div className="flex w-full">
+        <Searchbar
+          name="search"
+          placeholder="Search members (email)"
+          value={searchTerm}
+          onChange={setSearchTerm}
+        />
+      </div>
+      {isLoading ? (
+        <div className="mt-8 flex justify-center">
+          <Spinner size="lg" variant="color" />
         </div>
-      </Page.Vertical>
-    </Modal>
+      ) : (
+        <div className="flex grow flex-col overflow-y-auto scrollbar-hide">
+          <DataTable
+            data={rows}
+            columns={columns}
+            pagination={pagination}
+            setPagination={setPagination}
+            totalRowCount={totalMembersCount}
+            columnsBreakpoints={{
+              email: "md",
+            }}
+          />
+        </div>
+      )}
+    </>
   );
 }

--- a/front/components/vaults/CreateOrEditVaultModal.tsx
+++ b/front/components/vaults/CreateOrEditVaultModal.tsx
@@ -118,7 +118,7 @@ export function CreateOrEditVaultModal({
       setIsDeleting(false);
       setIsSaving(false);
     }, 500);
-  }, [onClose, vaultInfo]);
+  }, [onClose]);
 
   const onSave = useCallback(async () => {
     setIsSaving(true);

--- a/front/lib/api/vaults.ts
+++ b/front/lib/api/vaults.ts
@@ -5,15 +5,15 @@ import { uniq } from "lodash";
 
 import { hardDeleteApp } from "@app/lib/api/apps";
 import type { Authenticator } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { UserResource } from "@app/lib/resources/user_resource";
 import type { VaultResource } from "@app/lib/resources/vault_resource";
 import { launchScrubVaultWorkflow } from "@app/poke/temporal/client";
-import { UserResource } from "@app/lib/resources/user_resource";
-import { DustError } from "@app/lib/error";
 
 export async function softDeleteVaultAndLaunchScrubWorkflow(
   auth: Authenticator,
@@ -159,7 +159,7 @@ export async function updateVaultPermissions(
     memberIds,
   }: { isRestricted: boolean; memberIds: string[] | null }
 ): Promise<Result<undefined, DustError | Error>> {
-  if (vault.canAdministrate(auth)) {
+  if (!vault.canAdministrate(auth)) {
     return new Err(
       new DustError("unauthorized", "Cannot update permissions for vault.")
     );

--- a/front/lib/api/vaults.ts
+++ b/front/lib/api/vaults.ts
@@ -12,6 +12,8 @@ import { KeyResource } from "@app/lib/resources/key_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import type { VaultResource } from "@app/lib/resources/vault_resource";
 import { launchScrubVaultWorkflow } from "@app/poke/temporal/client";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { DustError } from "@app/lib/error";
 
 export async function softDeleteVaultAndLaunchScrubWorkflow(
   auth: Authenticator,
@@ -147,4 +149,63 @@ export async function hardDeleteVault(
   });
 
   return new Ok(undefined);
+}
+
+export async function updateVaultPermissions(
+  auth: Authenticator,
+  vault: VaultResource,
+  {
+    isRestricted,
+    memberIds,
+  }: { isRestricted: boolean; memberIds: string[] | null }
+): Promise<Result<undefined, DustError | Error>> {
+  if (vault.canAdministrate(auth)) {
+    return new Err(
+      new DustError("unauthorized", "Cannot update permissions for vault.")
+    );
+  }
+
+  const regularGroups = vault.groups.filter(
+    (group) => group.kind === "regular"
+  );
+  // Assert that there is exactly one regular group associated with the vault.
+  assert(
+    regularGroups.length === 1,
+    `Expected exactly one regular group for the vault, but found ${regularGroups.length}.`
+  );
+  const [defaultVaultGroup] = regularGroups;
+
+  const wasRestricted = vault.groups.every((g) => !g.isGlobal());
+
+  if (isRestricted) {
+    // If the vault should be restricted and was not restricted before, remove the global group.
+    if (!wasRestricted) {
+      const updateRes = await vault.updatePermissions(auth, true);
+      if (updateRes.isErr()) {
+        return updateRes;
+      }
+    }
+
+    if (memberIds) {
+      const users = await UserResource.fetchByIds(memberIds);
+
+      return defaultVaultGroup.setMembers(
+        auth,
+        users.map((u) => u.toJSON())
+      );
+    }
+
+    return new Ok(undefined);
+  } else {
+    // If the vault should not be restricted and was restricted before, add the global group.
+    if (wasRestricted) {
+      const updateRes = await vault.updatePermissions(auth, false);
+      if (updateRes.isErr()) {
+        return updateRes;
+      }
+    }
+
+    // Remove all members.
+    return defaultVaultGroup.setMembers(auth, []);
+  }
 }

--- a/front/lib/resources/resource_with_vault.ts
+++ b/front/lib/resources/resource_with_vault.ts
@@ -153,8 +153,8 @@ export abstract class ResourceWithVault<
 
   // Permissions.
 
-  acl() {
-    return this.vault.acl();
+  acl(auth: Authenticator) {
+    return this.vault.acl(auth);
   }
 
   canList(auth: Authenticator) {

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -328,8 +328,12 @@ export class VaultResource extends BaseResource<VaultModel> {
 
   /**
    * Determines the permissions a group has for resources within a vault.
-   * This function may be moved to a group_vaults join table in the future
+   * This function may be moved to the group_vaults join table in the future
    * to define more granular permissions per group within each vault.
+   *
+   * Ensure thorough testing when modifying this method, as it is crucial for
+   * the integrity of the permissions system. It acts as the gatekeeper,
+   * determining who has the right to read resources from a vault.
    */
   private getGroupPermissionsForVault(
     auth: Authenticator,
@@ -366,11 +370,9 @@ export class VaultResource extends BaseResource<VaultModel> {
   canWrite(auth: Authenticator) {
     switch (this.kind) {
       case "global":
+      case "public":
       case "regular":
       case "system":
-        return auth.canWrite([this.acl(auth)]);
-
-      case "public":
         return auth.canWrite([this.acl(auth)]);
 
       default:

--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -347,6 +347,12 @@ export class VaultResource extends BaseResource<VaultModel> {
         return auth.isBuilder() && auth.canWrite([this.acl()]);
 
       case "regular":
+        // TODO(SPACE_INFRA): Represent this in ACL.
+        // In the meantime, if the vault has a global group, only builders can write.
+        if (this.groups.some((group) => group.isGlobal())) {
+          return auth.isBuilder() && auth.canWrite([this.acl()]);
+        }
+
         return auth.canWrite([this.acl()]);
 
       case "public":

--- a/front/lib/swr/vaults.ts
+++ b/front/lib/swr/vaults.ts
@@ -452,9 +452,7 @@ export function useUpdateVault({ owner }: { owner: LightWorkspaceType }) {
 
   const doUpdate = async (
     vault: VaultType,
-    params:
-      | DoCreateOrUpdateAllowedParams
-      | { name: string | null; memberIds: string[]; isRestricted: true }
+    params: DoCreateOrUpdateAllowedParams
   ) => {
     const { name: newName, memberIds, isRestricted } = params;
 

--- a/front/lib/swr/vaults.ts
+++ b/front/lib/swr/vaults.ts
@@ -371,19 +371,31 @@ export function useDeleteFolderOrWebsite({
   return doDelete;
 }
 
+type DoCreateOrUpdateAllowedParams =
+  | { name: string | null; memberIds: null; isRestricted: false }
+  | { name: string | null; memberIds: string[]; isRestricted: true };
+
 export function useCreateVault({ owner }: { owner: LightWorkspaceType }) {
   const sendNotification = useContext(SendNotificationsContext);
   const { mutate: mutateVaults } = useVaults({
     workspaceId: owner.sId,
-    disabled: true, // Needed just to mutate
+    disabled: true, // Needed just to mutate.
   });
   const { mutate: mutateVaultsAsAdmin } = useVaultsAsAdmin({
     workspaceId: owner.sId,
-    disabled: true, // Needed just to mutate
+    disabled: true, // Needed just to mutate.
   });
 
-  const doCreate = async (name: string | null, memberIds: string[] | null) => {
-    if (!name || !memberIds || memberIds?.length < 1) {
+  const doCreate = async ({
+    name,
+    memberIds,
+    isRestricted,
+  }: DoCreateOrUpdateAllowedParams) => {
+    if (!name) {
+      return null;
+    }
+
+    if (isRestricted && (!memberIds || memberIds?.length < 1)) {
       return null;
     }
 
@@ -396,6 +408,7 @@ export function useCreateVault({ owner }: { owner: LightWorkspaceType }) {
       body: JSON.stringify({
         name,
         memberIds,
+        isRestricted,
       }),
     });
 
@@ -439,12 +452,11 @@ export function useUpdateVault({ owner }: { owner: LightWorkspaceType }) {
 
   const doUpdate = async (
     vault: VaultType,
-    memberIds: string[] | null,
-    newName: string | null
+    params:
+      | DoCreateOrUpdateAllowedParams
+      | { name: string | null; memberIds: string[]; isRestricted: true }
   ) => {
-    if (!vault) {
-      return null;
-    }
+    const { name: newName, memberIds, isRestricted } = params;
 
     const updatePromises: Promise<Response>[] = [];
 
@@ -459,26 +471,26 @@ export function useUpdateVault({ owner }: { owner: LightWorkspaceType }) {
           },
           body: JSON.stringify({
             name: newName,
+            isRestricted,
           }),
         })
       );
     }
 
     // Prepare vault members update request if provided.
-    if (memberIds && memberIds.length > 0) {
-      const vaultMembersUrl = `/api/w/${owner.sId}/vaults/${vault.sId}/members`;
-      updatePromises.push(
-        fetch(vaultMembersUrl, {
-          method: "PATCH",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            memberIds,
-          }),
-        })
-      );
-    }
+    const vaultMembersUrl = `/api/w/${owner.sId}/vaults/${vault.sId}/members`;
+    updatePromises.push(
+      fetch(vaultMembersUrl, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          memberIds,
+          isRestricted,
+        }),
+      })
+    );
 
     if (updatePromises.length === 0) {
       return null;

--- a/front/migrations/20240906_2_backfill_agents_groupIds.ts
+++ b/front/migrations/20240906_2_backfill_agents_groupIds.ts
@@ -100,7 +100,7 @@ async function updateAgent(
   const groupIds = (
     await DataSourceViewResource.fetchByIds(auth, dataSourceViewIds)
   )
-    .map((view) => view.acl().aclEntries.map((entry) => entry.groupId))
+    .map((view) => view.acl(auth).aclEntries.map((entry) => entry.groupId))
     .flat();
 
   if (execute) {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -497,10 +497,10 @@ async function getAgentConfigurationGroupIdsFromActions(
   return uniq(
     [
       ...dsViews.map((view) =>
-        view.acl().aclEntries.map((entry) => entry.groupId)
+        view.acl(auth).aclEntries.map((entry) => entry.groupId)
       ),
       ...dustApps.map((app) =>
-        app.acl().aclEntries.map((entry) => entry.groupId)
+        app.acl(auth).aclEntries.map((entry) => entry.groupId)
       ),
     ].flat()
   );

--- a/front/pages/api/w/[wId]/vaults/[vId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/index.ts
@@ -20,6 +20,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
 import { VaultResource } from "@app/lib/resources/vault_resource";
 import { apiError } from "@app/logger/withlogging";
 
@@ -123,7 +124,7 @@ async function handler(
 
     case "PATCH": {
       if (!auth.isAdmin()) {
-        // Only admins, or builders who have access to the vault, can patch
+        // Only admins can update.
         return apiError(req, res, {
           status_code: 403,
           api_error: {
@@ -154,13 +155,12 @@ async function handler(
           vault
         );
 
-        const viewByDataSourceId = currentViews.reduce(
-          (acc, view) => {
-            acc[view.dataSource.sId] = view;
-            return acc;
-          },
-          {} as { [key: string]: DataSourceViewResource }
-        );
+        const viewByDataSourceId = currentViews.reduce<
+          Record<string, DataSourceViewResource>
+        >((acc, view) => {
+          acc[view.dataSource.sId] = view;
+          return acc;
+        }, {});
 
         for (const dataSourceConfig of content) {
           const view = viewByDataSourceId[dataSourceConfig.dataSourceId];
@@ -194,6 +194,7 @@ async function handler(
           }
         }
       }
+
       if (name) {
         await vault.updateName(auth, name);
       }

--- a/front/pages/api/w/[wId]/vaults/[vId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/index.ts
@@ -20,7 +20,6 @@ import type { Authenticator } from "@app/lib/auth";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
-import { GroupResource } from "@app/lib/resources/group_resource";
 import { VaultResource } from "@app/lib/resources/vault_resource";
 import { apiError } from "@app/logger/withlogging";
 

--- a/front/pages/api/w/[wId]/vaults/[vId]/members.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/members.ts
@@ -1,16 +1,15 @@
 import type { VaultType, WithAPIErrorResponse } from "@dust-tt/types";
 import { PatchVaultMembersRequestBodySchema } from "@dust-tt/types";
-import assert from "assert";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { updateVaultPermissions } from "@app/lib/api/vaults";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
 import { VaultResource } from "@app/lib/resources/vault_resource";
 import { apiError } from "@app/logger/withlogging";
-import { updateVaultPermissions } from "@app/lib/api/vaults";
-import { DustError } from "@app/lib/error";
 
 export interface PatchVaultMembersResponseBody {
   vault: VaultType;

--- a/types/src/front/api_handlers/public/groups.ts
+++ b/types/src/front/api_handlers/public/groups.ts
@@ -1,9 +1,0 @@
-import * as t from "io-ts";
-
-export const PatchGroupRequestBodySchema = t.type({
-  memberIds: t.union([t.array(t.string), t.undefined]),
-});
-
-export type PatchGroupRequestBodyType = t.TypeOf<
-  typeof PatchGroupRequestBodySchema
->;

--- a/types/src/front/api_handlers/public/vaults.ts
+++ b/types/src/front/api_handlers/public/vaults.ts
@@ -32,10 +32,22 @@ export type PatchDataSourceViewType = t.TypeOf<
   typeof PatchDataSourceViewSchema
 >;
 
-export const PostVaultRequestBodySchema = t.type({
-  name: t.string,
-  memberIds: t.union([t.array(t.string), t.undefined]),
+const PostRestrictedVault = t.type({
+  memberIds: t.array(t.string),
+  isRestricted: t.literal(true),
 });
+
+const PostUnrestrictedVault = t.type({
+  memberIds: t.null,
+  isRestricted: t.literal(false),
+});
+
+export const PostVaultRequestBodySchema = t.intersection([
+  t.type({
+    name: t.string,
+  }),
+  t.union([PostRestrictedVault, PostUnrestrictedVault]),
+]);
 
 export type PostVaultRequestBodyType = t.TypeOf<
   typeof PostVaultRequestBodySchema
@@ -43,13 +55,17 @@ export type PostVaultRequestBodyType = t.TypeOf<
 
 export const PatchVaultRequestBodySchema = t.type({
   name: t.union([t.string, t.undefined]),
-  memberIds: t.union([t.array(t.string), t.undefined]),
   content: t.union([t.array(ContentSchema), t.undefined]),
 });
 
 export type PatchVaultRequestBodyType = t.TypeOf<
   typeof PatchVaultRequestBodySchema
 >;
+
+export const PatchVaultMembersRequestBodySchema = t.union([
+  PostRestrictedVault,
+  PostUnrestrictedVault,
+]);
 
 export type LightContentNode = {
   dustDocumentId: string | null;

--- a/types/src/front/vault.ts
+++ b/types/src/front/vault.ts
@@ -6,4 +6,5 @@ export type VaultType = {
   sId: string;
   kind: VaultKind;
   groupIds: string[];
+  isRestricted: boolean;
 };

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -19,7 +19,6 @@ export * from "./front/api_handlers/internal/agent_configuration";
 export * from "./front/api_handlers/internal/assistant";
 export * from "./front/api_handlers/public/assistant";
 export * from "./front/api_handlers/public/data_sources";
-export * from "./front/api_handlers/public/groups";
 export * from "./front/api_handlers/public/vaults";
 export * from "./front/app";
 export * from "./front/assistant/actions/browse";


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
As we move from vaults to spaces, we want to leverage multiple groups associated with one vault. The current implementation applies permissions checks directly on the vault, ignoring group-specific nuances. This PR shifts the logic to ACLs, tailoring permissions to user roles as our primary source of truth for now (see more details [here](https://github.com/dust-tt/dust/pull/8091)).

Main changes:
- simplified `canWrite` and `canRead` methods, now consistently using `auth.canRead` and `auth.canWrite`
- centralized vault read and write logic for each group kind in one place
- improved flexibility for future granular permission adjustments.

The logic is implemented in `VaultResource` rather than `GroupResource` for two main reasons:
- it keeps permission logic close to vault functionality
- it allows for future granular permission (that customers already start asking around about) (e.g., non-admin/builder users that can add members to a vault, ...)

This approach sets the foundation for more sophisticated permission models, such as storing specific permissions in the `group_vault` join table, enabling fine-grained access control per group within each vault/space.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Pretty risky, as permissions are the gatekeeper to our data. I tested all three roles, run queries on private API using all three roles. Safe to rollback. 

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
