### PR TITLE
[front] show unsupported directives

### DIFF
--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -33,6 +33,8 @@ import type { GetContentToDownloadFunction } from "@app/components/misc/ContentB
 import { ContentBlockWrapper } from "@app/components/misc/ContentBlockWrapper";
 import { classNames } from "@app/lib/utils";
 
+const supportedDirectives = ["mention", "cite", "visualization"];
+
 const SyntaxHighlighter = dynamic(
   () => import("react-syntax-highlighter").then((mod) => mod.Light),
   { ssr: false }
@@ -102,6 +104,20 @@ function visualizationDirective() {
         data.hProperties = {
           position: node.position,
         };
+      }
+    });
+  };
+}
+
+function showUnsupportedDirective() {
+  return (tree: any) => {
+    visit(tree, ["textDirective"], (node) => {
+      if (node.type === "textDirective") {
+        if (!supportedDirectives.includes(node.name)) {
+          // it's not a valid directive, so we'll leave it as plain text
+          node.type = "text";
+          node.value = `:${node.name}${node.children ? node.children.map((c) => c.value).join("") : ""}`;
+        }
       }
     });
   };
@@ -317,6 +333,7 @@ export function RenderMessageMarkdown({
       citeDirective(),
       remarkGfm,
       [remarkMath, { singleDollarTextMath: false }],
+      showUnsupportedDirective,
     ],
     []
   );

--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -116,7 +116,7 @@ function showUnsupportedDirective() {
         if (!supportedDirectives.includes(node.name)) {
           // it's not a valid directive, so we'll leave it as plain text
           node.type = "text";
-          node.value = `:${node.name}${node.children ? node.children.map((c) => c.value).join("") : ""}`;
+          node.value = `:${node.name}${node.children ? node.children.map((c: any) => c.value).join("") : ""}`;
         }
       }
     });


### PR DESCRIPTION
fixes: [#1497](https://github.com/dust-tt/tasks/issues/1497)
## Description

Show text that are not a directive 

## Risk

Make some directive unexpectedly appear in message rendering

## Deploy Plan

deploy front
