### PR TITLE
[front] - fix: AssistantBrowser hidden behind input bar

### DIFF
--- a/front/components/assistant/AssistantBrowser.tsx
+++ b/front/components/assistant/AssistantBrowser.tsx
@@ -194,7 +194,9 @@ export function AssistantBrowser({
       )}
 
       {displayedTab && (
-        <div className="relative grid w-full grid-cols-1 gap-2 px-4 md:grid-cols-3">
+        // TODO(jules 2024/10/18): remove z-index when using popover instead of
+        // old DropdownMenu
+        <div className="relative z-20 grid w-full grid-cols-1 gap-2 px-4 md:grid-cols-3">
           {agentsByTab[displayedTab].map((agent) => (
             <AssistantPreview
               key={agent.sId}


### PR DESCRIPTION
## Description

This PR ensures that the AssistantBrowser's dropdown menu properly overlays other components by adjusting z-index.

Note: this is a temporary hack as this component will be refactored as soon as we implement the new sparkle `Button`.

**References:**
- https://github.com/dust-tt/tasks/issues/1509

## Risk

Low

## Deploy Plan

Deploy `front`