### PR TITLE
[CacheWithRedis] Fix double unlock

### DIFF
--- a/types/src/shared/cache.ts
+++ b/types/src/shared/cache.ts
@@ -47,7 +47,6 @@ export function cacheWithRedis<T extends (...args: any[]) => Promise<any>>(
         await lock(key);
         cacheVal = await redisCli.get(key);
         if (cacheVal) {
-          unlock(key);
           return JSON.parse(cacheVal) as Awaited<ReturnType<T>>;
         }
       }


### PR DESCRIPTION
Description
---
Fixes an issue from #8077 related in this [thread](https://dust4ai.slack.com/archives/C05F84CFP0E/p1729249237889019)

In some cases, lock was released twice (one in the finally, one outside it)

Risks
---
na

Deploy
---
connectors
