### PR TITLE
core: remove delete data source tx and batch documents deletion

### DIFF
--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -1765,11 +1765,12 @@ impl DataSource {
         );
 
         // Delete data source and documents (SQL).
-        store
+        let deleted_rows = store
             .delete_data_source(&self.project, &self.data_source_id)
             .await?;
 
         info!(
+            deleted_rows = deleted_rows,
             data_source_internal_id = self.internal_id(),
             "Deleted data source records"
         );

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -1927,12 +1927,12 @@ impl Store for PostgresStore {
         Ok(())
     }
 
-    async fn delete_data_source(&self, project: &Project, data_source_id: &str) -> Result<()> {
+    async fn delete_data_source(&self, project: &Project, data_source_id: &str) -> Result<u64> {
         let project_id = project.project_id();
         let data_source_id = data_source_id.to_string();
 
         let pool = self.pool.clone();
-        let mut c = pool.get().await?;
+        let c = pool.get().await?;
 
         let r = c
             .query(
@@ -1947,19 +1947,42 @@ impl Store for PostgresStore {
             _ => unreachable!(),
         };
 
-        let tx = c.transaction().await?;
+        // Data source documents can be numerous so we want to avoid any transaction that could
+        // potentially hurt the performance of the database. Also we delete documents in small
+        // batches to avoid long running operations.
+        let deletion_batch_size: u64 = 512;
+        let mut total_deleted_rows: u64 = 0;
 
-        let stmt = tx
+        let stmt = c
+            .prepare(
+                "DELETE FROM data_sources_documents WHERE id IN (
+                   SELECT id FROM data_sources_documents WHERE data_source = $1 LIMIT $2
+                 )",
+            )
+            .await?;
+
+        loop {
+            // Delete in batches
+            let deleted_rows = c
+                .execute(&stmt, &[&data_source_row_id, &(deletion_batch_size as i64)])
+                .await?;
+            total_deleted_rows += deleted_rows;
+
+            // Break if no more rows to delete
+            if deleted_rows < deletion_batch_size {
+                break;
+            }
+        }
+
+        let stmt = c
             .prepare("DELETE FROM data_sources_documents WHERE data_source = $1")
             .await?;
-        let _ = tx.query(&stmt, &[&data_source_row_id]).await?;
+        let _ = c.query(&stmt, &[&data_source_row_id]).await?;
 
-        let stmt = tx.prepare("DELETE FROM data_sources WHERE id = $1").await?;
-        let _ = tx.query(&stmt, &[&data_source_row_id]).await?;
+        let stmt = c.prepare("DELETE FROM data_sources WHERE id = $1").await?;
+        let _ = c.query(&stmt, &[&data_source_row_id]).await?;
 
-        tx.commit().await?;
-
-        Ok(())
+        Ok(total_deleted_rows)
     }
 
     async fn upsert_database(

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -1962,22 +1962,15 @@ impl Store for PostgresStore {
             .await?;
 
         loop {
-            // Delete in batches
             let deleted_rows = c
                 .execute(&stmt, &[&data_source_row_id, &(deletion_batch_size as i64)])
                 .await?;
             total_deleted_rows += deleted_rows;
 
-            // Break if no more rows to delete
             if deleted_rows < deletion_batch_size {
                 break;
             }
         }
-
-        let stmt = c
-            .prepare("DELETE FROM data_sources_documents WHERE data_source = $1")
-            .await?;
-        let _ = c.query(&stmt, &[&data_source_row_id]).await?;
 
         let stmt = c.prepare("DELETE FROM data_sources WHERE id = $1").await?;
         let _ = c.query(&stmt, &[&data_source_row_id]).await?;

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -175,7 +175,7 @@ pub trait Store {
         data_source_id: &str,
         document_id: &str,
     ) -> Result<()>;
-    async fn delete_data_source(&self, project: &Project, data_source_id: &str) -> Result<()>;
+    async fn delete_data_source(&self, project: &Project, data_source_id: &str) -> Result<u64>;
     // Databases
     async fn upsert_database(
         &self,


### PR DESCRIPTION
## Description

Full context: https://dust4ai.slack.com/archives/C05B529FHV1/p1729174672051379

We supsect a large DELETE command might have triggered an AUTOVACUUM and/or locked the DB for a long period.

Tested in dev: deletion of a data source with 5k documents.

## Risk

Missing some deletions but the data source delete is run by a workflow so if the new code fails it will fail the workflow. All queries have to succeed for the deletion to complete.

## Deploy Plan

- deploy `core`