### PR TITLE
front: show dust incidents in UI

### DIFF
--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -184,18 +184,38 @@ export const NavigationSidebar = React.forwardRef<
 
 function AppStatusBanner() {
   const { appStatus } = useAppStatus();
-  const { providerStatus } = appStatus ?? {};
 
-  if (!appStatus || !providerStatus) {
+  if (!appStatus) {
     return null;
   }
 
-  return (
-    <div className="space-y-2 border-y border-pink-200 bg-pink-100 px-3 py-3 text-xs text-pink-900">
-      <div className="font-bold">{providerStatus.name}</div>
-      <div className="font-normal">{providerStatus.description}</div>
-    </div>
-  );
+  const { providersStatus, dustStatus } = appStatus;
+
+  if (dustStatus) {
+    return (
+      <div className="space-y-2 border-y border-pink-200 bg-pink-100 px-3 py-3 text-xs text-pink-900">
+        <div className="font-bold">{dustStatus.name}</div>
+        <div className="font-normal">{dustStatus.description}</div>
+        <div>
+          Check our{" "}
+          <Link href={dustStatus.link} target="_blank" className="underline">
+            status page
+          </Link>{" "}
+          for updates.
+        </div>
+      </div>
+    );
+  }
+  if (providersStatus) {
+    return (
+      <div className="space-y-2 border-y border-pink-200 bg-pink-100 px-3 py-3 text-xs text-pink-900">
+        <div className="font-bold">{providersStatus.name}</div>
+        <div className="font-normal">{providersStatus.description}</div>
+      </div>
+    );
+  }
+
+  return null;
 }
 
 function SubscriptionEndBanner({ endDate }: { endDate: number }) {

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -140,8 +140,11 @@ const config = {
     return EnvironmentConfig.getEnvVariable("TEXT_EXTRACTION_URL");
   },
   // Status page.
-  getProviderStatusPageId: (): string => {
-    return EnvironmentConfig.getEnvVariable("PROVIDER_STATUS_PAGE_ID");
+  getStatusPageProvidersPageId: (): string => {
+    return EnvironmentConfig.getEnvVariable("STATUS_PAGE_PROVIDERS_PAGE_ID");
+  },
+  getStatusPageDustPageId: (): string => {
+    return EnvironmentConfig.getEnvVariable("STATUS_PAGE_DUST_PAGE_ID");
   },
   getStatusPageApiToken: (): string => {
     return EnvironmentConfig.getEnvVariable("STATUS_PAGE_API_TOKEN");

--- a/front/lib/api/status/index.ts
+++ b/front/lib/api/status/index.ts
@@ -3,35 +3,68 @@ import { cacheWithRedis, isDevelopment } from "@dust-tt/types";
 import config from "@app/lib/api/config";
 import { getUnresolvedIncidents } from "@app/lib/api/status/status_page";
 
-async function getProviderStatus() {
+async function getProvidersStatus() {
   if (isDevelopment()) {
     return null;
   }
 
-  const providerIncidents = await getUnresolvedIncidents({
+  const providersIncidents = await getUnresolvedIncidents({
     apiToken: config.getStatusPageApiToken(),
-    pageId: config.getProviderStatusPageId(),
+    pageId: config.getStatusPageProvidersPageId(),
   });
 
-  if (providerIncidents.length === 0) {
+  if (providersIncidents.length > 0) {
+    const [incident] = providersIncidents;
+    const { name, incident_updates: incidentUpdates } = incident;
+    const [latestUpdate] = incidentUpdates;
+    return {
+      name,
+      description: latestUpdate.body,
+      link: incident.shortlink,
+    };
+  }
+
+  return null;
+}
+
+async function getDustStatus() {
+  if (isDevelopment()) {
     return null;
   }
 
-  const [incident] = providerIncidents;
-  const { name, incident_updates: incidentUpdates } = incident;
-  const [latestUpdate] = incidentUpdates;
+  const dustIncidents = await getUnresolvedIncidents({
+    apiToken: config.getStatusPageApiToken(),
+    pageId: config.getStatusPageDustPageId(),
+  });
 
-  return {
-    name,
-    description: latestUpdate.body,
-    link: incident.shortlink,
-  };
+  if (dustIncidents.length > 0) {
+    const [incident] = dustIncidents;
+    const { name, incident_updates: incidentUpdates } = incident;
+    const [latestUpdate] = incidentUpdates;
+    return {
+      name,
+      description: latestUpdate.body,
+      link: incident.shortlink,
+    };
+  }
+
+  return null;
 }
 
 export const getProviderStatusMemoized = cacheWithRedis(
-  getProviderStatus,
+  getProvidersStatus,
   () => {
     return "provider-status";
+  },
+  // Caches data for 2 minutes to limit frequent API calls.
+  // Status page rate limit is pretty aggressive.
+  2 * 60 * 1000
+);
+
+export const getDustStatusMemoized = cacheWithRedis(
+  getDustStatus,
+  () => {
+    return "dust-status";
   },
   // Caches data for 2 minutes to limit frequent API calls.
   // Status page rate limit is pretty aggressive.

--- a/front/pages/api/app-status.ts
+++ b/front/pages/api/app-status.ts
@@ -1,13 +1,21 @@
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { getProviderStatusMemoized } from "@app/lib/api/status";
+import {
+  getDustStatusMemoized,
+  getProviderStatusMemoized,
+} from "@app/lib/api/status";
 import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { getSession } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
 export interface GetAppStatusResponseBody {
-  providerStatus: {
+  dustStatus: {
+    description: string;
+    link: string;
+    name: string;
+  } | null;
+  providersStatus: {
     description: string;
     link: string;
     name: string;
@@ -34,9 +42,12 @@ async function handler(
     });
   }
 
-  const providerStatus = await getProviderStatusMemoized();
+  const [providersStatus, dustStatus] = await Promise.all([
+    getProviderStatusMemoized(),
+    getDustStatusMemoized(),
+  ]);
 
-  res.status(200).json({ providerStatus });
+  res.status(200).json({ providersStatus, dustStatus });
 }
 
 export default withSessionAuthentication(handler);


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/1507

Show in the UI when we're having an incident. This will go a long way in making our users aware of ongoing issues.

![Screenshot from 2024-10-18 16-01-12](https://github.com/user-attachments/assets/4faf9b19-fe67-4818-aef6-398fd9fdc86a)

## Risk

It does not work.

## Deploy Plan

- Secrets were updated https://dust4ai.slack.com/archives/C050SM8NSPK/p1729258285960699
- deploy `front`