### PR TITLE
[connectors] Handle bad credentials as transient errors

### DIFF
--- a/connectors/src/connectors/github/lib/errors.ts
+++ b/connectors/src/connectors/github/lib/errors.ts
@@ -15,3 +15,11 @@ export function isGithubRequestRedirectCountExceededError(
     error.message.includes("redirect count exceeded")
   );
 }
+
+export function isBadCredentials(error: unknown): error is RequestError {
+  return (
+    error instanceof RequestError &&
+    error.status === 401 &&
+    error.message.includes("Bad credentials")
+  );
+}

--- a/connectors/src/connectors/github/lib/github_api.ts
+++ b/connectors/src/connectors/github/lib/github_api.ts
@@ -14,6 +14,7 @@ import { pipeline } from "stream/promises";
 import { extract } from "tar";
 
 import {
+  isBadCredentials,
   isGithubRequestErrorNotFound,
   isGithubRequestRedirectCountExceededError,
 } from "@connectors/connectors/github/lib/errors";
@@ -202,9 +203,9 @@ export async function getIssue(
   issueNumber: number,
   loggerArgs: Record<string, string | number>
 ): Promise<GithubIssue | null> {
-  const octokit = await getOctokit(connectionId);
-
   try {
+    const octokit = await getOctokit(connectionId);
+
     const issue = (
       await octokit.rest.issues.get({
         owner: login,
@@ -234,7 +235,8 @@ export async function getIssue(
     // by safely ignoring the issue and logging the error.
     if (
       isGithubRequestRedirectCountExceededError(err) ||
-      isGithubRequestErrorNotFound(err)
+      isGithubRequestErrorNotFound(err) ||
+      isBadCredentials(err)
     ) {
       logger.info({ ...loggerArgs, err: err.message }, "Failed to get issue.");
 


### PR DESCRIPTION
## Description

"Bad credentials" is sent here when a token needs refresh. Just skipping issue for this activity run, will be retried on next run.

## Risk

miss another error (but it still logged)

## Deploy Plan

deploy `connectors`
