### PR TITLE
[Assistant views] Remove 'assistant-search' & '{conversationId}' views

### DIFF
--- a/front/components/assistant/conversation/AgentSuggestion.tsx
+++ b/front/components/assistant/conversation/AgentSuggestion.tsx
@@ -26,7 +26,7 @@ export function AgentSuggestion({
 }: AgentSuggestionProps) {
   const { agentConfigurations } = useAgentConfigurations({
     workspaceId: owner.sId,
-    agentsGetView: { conversationId: conversationId },
+    agentsGetView: "list",
     includes: ["authors", "usage"],
   });
   const sendNotification = useContext(SendNotificationsContext);

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -79,7 +79,7 @@ export function AssistantInputBar({
   const { agentConfigurations: baseAgentConfigurations } =
     useAgentConfigurations({
       workspaceId: owner.sId,
-      agentsGetView: "assistants-search",
+      agentsGetView: "list",
     });
 
   // Files upload.

--- a/front/components/assistant/conversation/input_bar/editor/useAssistantSuggestions.ts
+++ b/front/components/assistant/conversation/input_bar/editor/useAssistantSuggestions.ts
@@ -26,7 +26,7 @@ const useAssistantSuggestions = (
 ) => {
   const { agentConfigurations } = useAgentConfigurations({
     workspaceId: owner.sId,
-    agentsGetView: "assistants-search",
+    agentsGetView: "list",
   });
 
   // `useMemo` will ensure that suggestions is only recalculated

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -94,10 +94,6 @@ export function useAgentConfigurations({
     const params = new URLSearchParams();
     if (typeof agentsGetView === "string") {
       params.append("view", agentsGetView);
-    } else {
-      if (agentsGetView && "conversationId" in agentsGetView) {
-        params.append("conversationId", agentsGetView.conversationId);
-      }
     }
     if (includes.includes("usage")) {
       params.append("withUsage", "true");
@@ -151,7 +147,7 @@ export function useProgressiveAgentConfigurations({
     isAgentConfigurationsLoading: isInitialAgentConfigurationsLoading,
   } = useAgentConfigurations({
     workspaceId,
-    agentsGetView: "assistants-search",
+    agentsGetView: "list",
     limit: 24,
     includes: ["usage"],
     disabled,
@@ -164,7 +160,7 @@ export function useProgressiveAgentConfigurations({
     mutateRegardlessOfQueryParams,
   } = useAgentConfigurations({
     workspaceId,
-    agentsGetView: "assistants-search",
+    agentsGetView: "list",
     includes: ["authors", "usage"],
   });
 

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
@@ -56,7 +56,7 @@ async function handler(
     case "GET": {
       const agentConfigurations = await getAgentConfigurations({
         auth,
-        agentsGetView: auth.user() ? "assistants-search" : "all",
+        agentsGetView: auth.user() ? "list" : "all",
         variant: "light",
       });
       return res.status(200).json({

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -80,11 +80,7 @@ async function handler(
 
       const { view, conversationId, limit, withUsage, withAuthors, sort } =
         queryValidation.right;
-      const viewParam = view
-        ? view
-        : conversationId
-          ? { conversationId }
-          : "all";
+      const viewParam = view ? view : "all";
       if (viewParam === "admin_internal" && !auth.isDustSuperUser()) {
         return apiError(req, res, {
           status_code: 404,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -78,7 +78,7 @@ async function handler(
         });
       }
 
-      const { view, conversationId, limit, withUsage, withAuthors, sort } =
+      const { view, limit, withUsage, withAuthors, sort } =
         queryValidation.right;
       const viewParam = view ? view : "all";
       if (viewParam === "admin_internal" && !auth.isDustSuperUser()) {

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -100,7 +100,7 @@ export default function WorkspaceAssistants({
   const { agentConfigurations: searchableAgentConfigurations } =
     useAgentConfigurations({
       workspaceId: owner.sId,
-      agentsGetView: assistantSearch ? "assistants-search" : null,
+      agentsGetView: assistantSearch ? "list" : null,
     });
 
   const filteredAgents = (

--- a/types/src/front/api_handlers/internal/agent_configuration.ts
+++ b/types/src/front/api_handlers/internal/agent_configuration.ts
@@ -21,7 +21,6 @@ export const GetAgentConfigurationsQuerySchema = t.type({
     t.literal("global"),
     t.literal("admin_internal"),
     t.literal("all"),
-    t.literal("assistants-search"),
     t.undefined,
   ]),
   conversationId: t.union([t.string, t.undefined]),

--- a/types/src/front/api_handlers/internal/agent_configuration.ts
+++ b/types/src/front/api_handlers/internal/agent_configuration.ts
@@ -23,7 +23,6 @@ export const GetAgentConfigurationsQuerySchema = t.type({
     t.literal("all"),
     t.undefined,
   ]),
-  conversationId: t.union([t.string, t.undefined]),
   withUsage: t.union([t.literal("true"), t.literal("false"), t.undefined]),
   withAuthors: t.union([t.literal("true"), t.literal("false"), t.undefined]),
   limit: t.union([LimitCodec, t.undefined]),

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -97,13 +97,8 @@ export type AgentConfigurationScope =
  * 'views':
  * - 'list': Retrieves all active agents accessible to the user
  * - {agentIds: string}: Retrieves specific agents by their sIds.
- * - {conversationId: string}: like 'list', plus the agents mentioned in the
- *   conversation with the provided id. This can be useful to share
- *   conversations with personal agents
  * - 'all': All non-private agents (so combines workspace, published and global
  *   agents); used e.g. for non-user calls such as API
- * - 'assistants-search': retrieves all global agents including inactive ones,
- *   all workspace, all published and the user's private agents.
  * - 'workspace': Retrieves all agents exclusively with a 'workspace' scope.
  * - 'published': Retrieves all agents exclusively with a 'published' scope.
  * - 'global': Retrieves all agents exclusively with a 'global' scope.
@@ -115,9 +110,7 @@ export type AgentConfigurationScope =
 export type AgentsGetViewType =
   | { agentIds: string[]; allVersions?: boolean }
   | "list"
-  | { conversationId: string }
   | "all"
-  | "assistants-search"
   | "workspace"
   | "published"
   | "global"

--- a/types/src/shared/cache.ts
+++ b/types/src/shared/cache.ts
@@ -7,13 +7,19 @@ import { redisClient } from "../shared/redis_client";
 
 // if caching big objects, there is a possible race condition (mulitple calls to
 // caching), therefore, we use a lock
-export function cacheWithRedis<T extends (...args: any[]) => Promise<any>>(
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export function cacheWithRedis<
+  T extends (...args: any[]) => Promise<Awaited<ReturnType<T>>>
+>(
   fn: T,
   resolver: (...args: Parameters<T>) => string,
   ttlMs: number,
   redisUri?: string,
   lockCaching?: boolean
-): (...args: Parameters<T>) => Promise<Awaited<ReturnType<T>>> {
+): (
+  ...args: Parameters<T>
+) => Promise<Awaited<ReturnType<T>>> | Promise<ReturnType<T>> {
   if (ttlMs > 60 * 60 * 24 * 1000) {
     throw new Error("ttlMs should be less than 24 hours");
   }
@@ -70,6 +76,7 @@ export function cacheWithRedis<T extends (...args: any[]) => Promise<any>>(
     }
   };
 }
+/* eslint-enable @typescript-eslint/no-explicit-any */
 
 const locks: Record<string, (() => void)[]> = {};
 


### PR DESCRIPTION
Description
---
- Removes 'assistant-search' view, which was actually exactly the same as "list". The comment indicating inactive global agents were returned was erroneous

- Removes '{conversationId}' view, since:
  - it was actually only used in AssistantSuggestion, not anywhere else;
  - the view didn't actually work, it was ~equivalent to list;
  - the use case it was supposed to enable, viewing a shared conversation with somebody else's personal assistant, is already somewhat working: user can view conversation but not mention assistant or see its details which is kind of fine.

We could aim in a follow-up PR to reinstate the conversation view cleanly; that would require more work and is IMO low value and not a priority.

Risks
---
Low, since it's just a view change. Tested locally

Regarding the conversationId removal specifically:
- handled all explicit calls with `conversationId`
- looked for agentsGetView with potential implicit `agentsGetView: { conversationId }`: there are
  - the internal api `asisstant/agent_configurations`, which is only called via swr's `useAgentConfigurations`
	 => checked it does not use conversationId (since it also takes agentsGetView as param)
  - the v1 api DustApi.getAgentsConfiguration call => here also, conversationId not used


Deploy
---
front
