### PR TITLE
[front] Use main db for production checks

### DIFF
--- a/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
+++ b/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
@@ -12,7 +12,7 @@ import type { Client, WorkflowHandle } from "@temporalio/client";
 import { QueryTypes } from "sequelize";
 
 import type { CheckFunction } from "@app/lib/production_checks/types";
-import { getConnectorReplicaDbConnection } from "@app/lib/production_checks/utils";
+import { getConnectorsPrimaryDbConnection } from "@app/lib/production_checks/utils";
 import { getTemporalConnectorsNamespaceConnection } from "@app/lib/temporal";
 
 interface ConnectorBlob {
@@ -26,7 +26,7 @@ interface ProviderCheck {
   makeIdsFn: (connector: ConnectorBlob) => string[];
 }
 
-const connectorsReplica = getConnectorReplicaDbConnection();
+const connectorsDb = getConnectorsPrimaryDbConnection();
 
 const providersToCheck: Partial<Record<ConnectorProvider, ProviderCheck>> = {
   confluence: {
@@ -53,7 +53,7 @@ const providersToCheck: Partial<Record<ConnectorProvider, ProviderCheck>> = {
 };
 
 async function listAllConnectorsForProvider(provider: ConnectorProvider) {
-  const connectors: ConnectorBlob[] = await connectorsReplica.query(
+  const connectors: ConnectorBlob[] = await connectorsDb.query(
     `SELECT id, "dataSourceId", "workspaceId", "pausedAt" FROM connectors WHERE "type" = :provider and  "errorType" IS NULL`,
     {
       type: QueryTypes.SELECT,

--- a/front/lib/production_checks/checks/check_connectors_last_sync_success.ts
+++ b/front/lib/production_checks/checks/check_connectors_last_sync_success.ts
@@ -3,7 +3,7 @@ import { isWebhookBasedProvider } from "@dust-tt/types";
 import { QueryTypes } from "sequelize";
 
 import type { CheckFunction } from "@app/lib/production_checks/types";
-import { getConnectorReplicaDbConnection } from "@app/lib/production_checks/utils";
+import { getConnectorsPrimaryDbConnection } from "@app/lib/production_checks/utils";
 
 interface ConnectorBlob {
   id: number;
@@ -16,10 +16,10 @@ interface ConnectorBlob {
   lastSyncStartTime: Date | null;
 }
 
-const connectorsReplica = getConnectorReplicaDbConnection();
+const connectorsDb = getConnectorsPrimaryDbConnection();
 
 async function listAllConnectors() {
-  const connectors: ConnectorBlob[] = await connectorsReplica.query(
+  const connectors: ConnectorBlob[] = await connectorsDb.query(
     `SELECT id, "dataSourceId", "workspaceId", "pausedAt", "lastSyncSuccessfulTime", "lastSyncStartTime", "createdAt", "type" FROM connectors WHERE "errorType" IS NULL AND "pausedAt" IS NULL AND "type" <> 'webcrawler'`,
     {
       type: QueryTypes.SELECT,

--- a/front/lib/production_checks/checks/check_notion_active_workflows.ts
+++ b/front/lib/production_checks/checks/check_notion_active_workflows.ts
@@ -3,7 +3,7 @@ import type { Client } from "@temporalio/client";
 import { QueryTypes } from "sequelize";
 
 import type { CheckFunction } from "@app/lib/production_checks/types";
-import { getConnectorReplicaDbConnection } from "@app/lib/production_checks/utils";
+import { getConnectorsPrimaryDbConnection } from "@app/lib/production_checks/utils";
 import { getTemporalConnectorsNamespaceConnection } from "@app/lib/temporal";
 import { withRetries } from "@app/lib/utils/retries";
 
@@ -15,9 +15,9 @@ interface NotionConnector {
 }
 
 async function listAllNotionConnectors() {
-  const connectorsReplica = getConnectorReplicaDbConnection();
+  const connectorsDb = getConnectorsPrimaryDbConnection();
 
-  const notionConnectors: NotionConnector[] = await connectorsReplica.query(
+  const notionConnectors: NotionConnector[] = await connectorsDb.query(
     `SELECT id, "dataSourceId", "workspaceId", "pausedAt" FROM connectors WHERE "type" = 'notion' and  "errorType" IS NULL`,
     {
       type: QueryTypes.SELECT,

--- a/front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts
+++ b/front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts
@@ -3,7 +3,7 @@ import { QueryTypes } from "sequelize";
 import { getCoreDocuments } from "@app/lib/production_checks/managed_ds";
 import type { CheckFunction } from "@app/lib/production_checks/types";
 import {
-  getConnectorReplicaDbConnection,
+  getConnectorsReplicaDbConnection,
   getFrontReplicaDbConnection,
 } from "@app/lib/production_checks/utils";
 
@@ -14,7 +14,7 @@ export const managedDataSourceGCGdriveCheck: CheckFunction = async (
   reportFailure,
   heartbeat
 ) => {
-  const connectorsReplica = getConnectorReplicaDbConnection();
+  const connectorsReplica = getConnectorsReplicaDbConnection();
   const frontReplica = getFrontReplicaDbConnection();
   const GdriveDataSources: { id: number; connectorId: string }[] =
     await frontReplica.query(

--- a/front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts
+++ b/front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts
@@ -3,8 +3,8 @@ import { QueryTypes } from "sequelize";
 import { getCoreDocuments } from "@app/lib/production_checks/managed_ds";
 import type { CheckFunction } from "@app/lib/production_checks/types";
 import {
-  getConnectorsPrimaryDbConnection,
-  getFrontPrimaryDbConnection,
+  getConnectorsReplicaDbConnection,
+  getFrontReplicaDbConnection,
 } from "@app/lib/production_checks/utils";
 
 export const managedDataSourceGCGdriveCheck: CheckFunction = async (
@@ -14,10 +14,10 @@ export const managedDataSourceGCGdriveCheck: CheckFunction = async (
   reportFailure,
   heartbeat
 ) => {
-  const connectorsDb = getConnectorsPrimaryDbConnection();
-  const frontDb = getFrontPrimaryDbConnection();
+  const connectorsReplica = getConnectorsReplicaDbConnection();
+  const frontReplica = getFrontReplicaDbConnection();
   const GdriveDataSources: { id: number; connectorId: string }[] =
-    await frontDb.query(
+    await frontReplica.query(
       `SELECT id, "connectorId" FROM data_sources WHERE "connectorProvider" = 'google_drive'`,
       { type: QueryTypes.SELECT }
     );
@@ -27,7 +27,7 @@ export const managedDataSourceGCGdriveCheck: CheckFunction = async (
 
     // Retrieve all documents from the connector (first)
     const connectorDocuments: { id: number; coreDocumentId: string }[] =
-      await connectorsDb.query(
+      await connectorsReplica.query(
         'SELECT id, "dustFileId" as "coreDocumentId" FROM google_drive_files WHERE "connectorId" = :connectorId',
         {
           replacements: {

--- a/front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts
+++ b/front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts
@@ -3,8 +3,8 @@ import { QueryTypes } from "sequelize";
 import { getCoreDocuments } from "@app/lib/production_checks/managed_ds";
 import type { CheckFunction } from "@app/lib/production_checks/types";
 import {
-  getConnectorsReplicaDbConnection,
-  getFrontReplicaDbConnection,
+  getConnectorsPrimaryDbConnection,
+  getFrontPrimaryDbConnection,
 } from "@app/lib/production_checks/utils";
 
 export const managedDataSourceGCGdriveCheck: CheckFunction = async (
@@ -14,10 +14,10 @@ export const managedDataSourceGCGdriveCheck: CheckFunction = async (
   reportFailure,
   heartbeat
 ) => {
-  const connectorsReplica = getConnectorsReplicaDbConnection();
-  const frontReplica = getFrontReplicaDbConnection();
+  const connectorsDb = getConnectorsPrimaryDbConnection();
+  const frontDb = getFrontPrimaryDbConnection();
   const GdriveDataSources: { id: number; connectorId: string }[] =
-    await frontReplica.query(
+    await frontDb.query(
       `SELECT id, "connectorId" FROM data_sources WHERE "connectorProvider" = 'google_drive'`,
       { type: QueryTypes.SELECT }
     );
@@ -27,7 +27,7 @@ export const managedDataSourceGCGdriveCheck: CheckFunction = async (
 
     // Retrieve all documents from the connector (first)
     const connectorDocuments: { id: number; coreDocumentId: string }[] =
-      await connectorsReplica.query(
+      await connectorsDb.query(
         'SELECT id, "dustFileId" as "coreDocumentId" FROM google_drive_files WHERE "connectorId" = :connectorId',
         {
           replacements: {

--- a/front/lib/production_checks/config.ts
+++ b/front/lib/production_checks/config.ts
@@ -1,15 +1,18 @@
 import { EnvironmentConfig } from "@dust-tt/types";
 
 const config = {
+  getConnectorsDatabasePrimaryUri: (): string => {
+    return EnvironmentConfig.getEnvVariable("CONNECTORS_DATABASE_URI");
+  },
   getConnectorsDatabaseReadReplicaUri: (): string => {
     return EnvironmentConfig.getEnvVariable(
       "CONNECTORS_DATABASE_READ_REPLICA_URI"
     );
   },
-  getPrimaryCoreDatabaseUri: (): string => {
+  getCoreDatabasePrimaryUri: (): string => {
     return EnvironmentConfig.getEnvVariable("CORE_DATABASE_URI");
   },
-  getReadReplicaCoreDatabaseUri: (): string => {
+  getCoreDatabaseReadReplicaUri: (): string => {
     return EnvironmentConfig.getEnvVariable("CORE_DATABASE_READ_REPLICA_URI");
   },
   getFrontDatabaseReadReplicaUri: (): string => {

--- a/front/lib/production_checks/config.ts
+++ b/front/lib/production_checks/config.ts
@@ -15,6 +15,9 @@ const config = {
   getCoreDatabaseReadReplicaUri: (): string => {
     return EnvironmentConfig.getEnvVariable("CORE_DATABASE_READ_REPLICA_URI");
   },
+  getFrontDatabasePrimaryUri: (): string => {
+    return EnvironmentConfig.getEnvVariable("FRONT_DATABASE_URI");
+  },
   getFrontDatabaseReadReplicaUri: (): string => {
     return EnvironmentConfig.getEnvVariable("FRONT_DATABASE_READ_REPLICA_URI");
   },

--- a/front/lib/production_checks/utils.ts
+++ b/front/lib/production_checks/utils.ts
@@ -3,14 +3,15 @@ import { Sequelize } from "sequelize";
 import config from "@app/lib/production_checks/config";
 
 // Variables to hold the singleton instances.
-let connectorReplicaDbInstance: Sequelize | null = null;
+let connectorsReplicaDbInstance: Sequelize | null = null;
+let connectorsPrimaryDbInstance: Sequelize | null = null;
 let coreReplicaDbInstance: Sequelize | null = null;
 let frontReplicaDbInstance: Sequelize | null = null;
 let corePrimaryDbInstance: Sequelize | null = null;
 
-export function getConnectorReplicaDbConnection() {
-  if (!connectorReplicaDbInstance) {
-    connectorReplicaDbInstance = new Sequelize(
+export function getConnectorsReplicaDbConnection() {
+  if (!connectorsReplicaDbInstance) {
+    connectorsReplicaDbInstance = new Sequelize(
       config.getConnectorsDatabaseReadReplicaUri() as string,
       {
         logging: false,
@@ -18,13 +19,13 @@ export function getConnectorReplicaDbConnection() {
     );
   }
 
-  return connectorReplicaDbInstance;
+  return connectorsReplicaDbInstance;
 }
 
 export function getCoreReplicaDbConnection() {
   if (!coreReplicaDbInstance) {
     coreReplicaDbInstance = new Sequelize(
-      config.getReadReplicaCoreDatabaseUri() as string,
+      config.getCoreDatabaseReadReplicaUri() as string,
       {
         logging: false,
       }
@@ -47,10 +48,23 @@ export function getFrontReplicaDbConnection() {
   return frontReplicaDbInstance;
 }
 
+export function getConnectorsPrimaryDbConnection() {
+  if (!connectorsPrimaryDbInstance) {
+    connectorsPrimaryDbInstance = new Sequelize(
+      config.getConnectorsDatabasePrimaryUri() as string,
+      {
+        logging: false,
+      }
+    );
+  }
+
+  return connectorsPrimaryDbInstance;
+}
+
 export function getCorePrimaryDbConnection() {
   if (!corePrimaryDbInstance) {
     corePrimaryDbInstance = new Sequelize(
-      config.getPrimaryCoreDatabaseUri() as string,
+      config.getCoreDatabasePrimaryUri() as string,
       {
         logging: false,
       }

--- a/front/lib/production_checks/utils.ts
+++ b/front/lib/production_checks/utils.ts
@@ -6,8 +6,9 @@ import config from "@app/lib/production_checks/config";
 let connectorsReplicaDbInstance: Sequelize | null = null;
 let connectorsPrimaryDbInstance: Sequelize | null = null;
 let coreReplicaDbInstance: Sequelize | null = null;
-let frontReplicaDbInstance: Sequelize | null = null;
 let corePrimaryDbInstance: Sequelize | null = null;
+let frontReplicaDbInstance: Sequelize | null = null;
+let frontPrimaryDbInstance: Sequelize | null = null;
 
 export function getConnectorsReplicaDbConnection() {
   if (!connectorsReplicaDbInstance) {
@@ -72,4 +73,17 @@ export function getCorePrimaryDbConnection() {
   }
 
   return corePrimaryDbInstance;
+}
+
+export function getFrontPrimaryDbConnection() {
+  if (!frontPrimaryDbInstance) {
+    frontPrimaryDbInstance = new Sequelize(
+      config.getFrontDatabasePrimaryUri() as string,
+      {
+        logging: false,
+      }
+    );
+  }
+
+  return frontPrimaryDbInstance;
 }

--- a/front/migrations/20240227_cleanup_dangling_webcrawler_connectors.ts
+++ b/front/migrations/20240227_cleanup_dangling_webcrawler_connectors.ts
@@ -2,13 +2,13 @@ import { ConnectorsAPI } from "@dust-tt/types";
 import { QueryTypes } from "sequelize";
 
 import config from "@app/lib/api/config";
-import { getConnectorReplicaDbConnection } from "@app/lib/production_checks/utils";
+import { getConnectorsReplicaDbConnection } from "@app/lib/production_checks/utils";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import logger from "@app/logger/logger";
 
 async function main() {
   const { LIVE } = process.env;
-  const connectorsReplica = getConnectorReplicaDbConnection();
+  const connectorsReplica = getConnectorsReplicaDbConnection();
   const connectors: { id: number }[] = await connectorsReplica.query(
     "SELECT id FROM connectors WHERE type = 'webcrawler' ORDER BY id ASC",
     {

--- a/front/migrations/20240830_check_no_undeleted_documents.ts
+++ b/front/migrations/20240830_check_no_undeleted_documents.ts
@@ -1,7 +1,7 @@
 import { QueryTypes } from "sequelize";
 
 import {
-  getConnectorReplicaDbConnection,
+  getConnectorsReplicaDbConnection,
   getCoreReplicaDbConnection,
 } from "@app/lib/production_checks/utils";
 import { getFrontReplicaDbConnection } from "@app/lib/resources/storage";
@@ -72,7 +72,7 @@ async function checkCoreDeleted(
 }
 
 async function checkGoogleDriveDeleted(logger: Logger) {
-  const connectorsReplica = getConnectorReplicaDbConnection();
+  const connectorsReplica = getConnectorsReplicaDbConnection();
   const frontReplica = getFrontReplicaDbConnection();
 
   const gDriveDataSources: DataSource[] = await frontReplica.query(
@@ -102,7 +102,7 @@ async function checkGoogleDriveDeleted(logger: Logger) {
 }
 
 async function checkNotionDeleted(logger: Logger) {
-  const connectorsReplica = getConnectorReplicaDbConnection();
+  const connectorsReplica = getConnectorsReplicaDbConnection();
   const frontReplica = getFrontReplicaDbConnection();
 
   const notionDataSources: {

--- a/front/temporal/hard_delete/activities.ts
+++ b/front/temporal/hard_delete/activities.ts
@@ -15,7 +15,7 @@ import {
 const BATCH_SIZE = 100;
 
 export async function purgeExpiredRunExecutionsActivity() {
-  const primaryCoreDatabaseUri = config.getPrimaryCoreDatabaseUri();
+  const primaryCoreDatabaseUri = config.getCoreDatabasePrimaryUri();
   const coreSequelize = new Sequelize(primaryCoreDatabaseUri, {
     logging: false,
   });


### PR DESCRIPTION
## Description

As we've got too many sync conflict errors when running production check, trying to run them on main db instance.

## Risk

Add load on main db (queries are very light, but still)

## Deploy Plan

add secret for CONNECTORS_DATABASE_URI on front
deploy front
