### PR TITLE
[connectors] Improve logging data

### DIFF
--- a/connectors/src/logger/logger.ts
+++ b/connectors/src/logger/logger.ts
@@ -1,5 +1,10 @@
+import { Context } from "@temporalio/activity";
 import type { LoggerOptions } from "pino";
 import pino from "pino";
+
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import type { ConnectorResource } from "@connectors/resources/connector_resource";
+import type { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 
 const NODE_ENV = process.env.NODE_ENV;
 const LOG_LEVEL = process.env.LOG_LEVEL || "info";
@@ -47,3 +52,32 @@ const logger = pino(pinoOptions);
 
 export default logger;
 export type { Logger } from "pino";
+
+export const getActivityLogger = (
+  connector: ConnectorResource | ConnectorModel,
+  loggerArgs?: Record<string, string | number | null>
+) => {
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+  const effectiveArgs: Record<string, string | number | null> = {
+    workspaceId: dataSourceConfig.workspaceId,
+    connectorId: connector.id,
+    provider: connector.type,
+    dataSourceId: dataSourceConfig.dataSourceId,
+    ...loggerArgs,
+  };
+
+  try {
+    const ctx = Context.current();
+    Object.assign(effectiveArgs, {
+      activityName: ctx.info.activityType,
+      workflowName: ctx.info.workflowType,
+      workflowId: ctx.info.workflowExecution.workflowId,
+      workflowRunId: ctx.info.workflowExecution.runId,
+      activityId: ctx.info.activityId,
+    });
+  } catch (e) {
+    // Cannot read context, ignore
+  }
+
+  return logger.child(effectiveArgs);
+};


### PR DESCRIPTION
## Description

This is improving the data logged in connectors - logging in an activity now contains a common set of data about the connector and the workflow and activity, returned by `getActivityLogger`, allowing to follow more easily ni datadog what is done in an activity.

The idea is to use a properly preconfigured child logger instead of passing loggerArgs, and not use the main logger anywhere in activity, always use the one from the caller. This avoid using improper logger and make the code much concise.

I kept the activities/workflows api as-is to avoid issues with temporal.

Ideally we should do this for all connectors. Starting with github for today .

## Risk

Lose some data in the logs

## Deploy Plan

deploy connectors