### PR TITLE
Ext: End of login flow: call /me, save user & pick workspace

### DIFF
--- a/front/extension/app/background.ts
+++ b/front/extension/app/background.ts
@@ -1,13 +1,13 @@
-import type {
-  Auth0AuthorizeResponse,
-  AuthBackgroundResponse,
-  AuthBackroundMessage,
-} from "./src/lib/auth";
 import {
   AUTH0_AUDIENCE,
   AUTH0_CLIENT_DOMAIN,
   AUTH0_CLIENT_ID,
-} from "./src/lib/auth";
+} from "./src/lib/config";
+import type {
+  Auth0AuthorizeResponse,
+  AuthBackgroundResponse,
+  AuthBackroundMessage,
+} from "./src/lib/messages";
 import { generatePKCE } from "./src/lib/utils";
 
 const log = console.error;

--- a/front/extension/app/src/context/AuthProvider.tsx
+++ b/front/extension/app/src/context/AuthProvider.tsx
@@ -1,3 +1,4 @@
+import type { StoredUser } from "@app/extension/app/src/lib/storage";
 import type { ReactNode } from "react";
 import React, { createContext, useContext } from "react";
 
@@ -5,21 +6,41 @@ import { useAuthHook } from "../hooks/useAuth";
 
 type AuthContextType = {
   token: string | null;
-  isLoading: boolean;
   isAuthenticated: boolean;
+  user: StoredUser | null;
+  isUserSetup: boolean;
+  isLoading: boolean;
   handleLogin: () => void;
   handleLogout: () => void;
+  handleSelectWorkspace: (workspaceId: string) => void;
 };
 
 const AuthContext = createContext<AuthContextType | null>(null);
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
-  const { token, isLoading, isAuthenticated, handleLogin, handleLogout } =
-    useAuthHook();
+  const {
+    token,
+    isAuthenticated,
+    user,
+    isUserSetup,
+    isLoading,
+    handleLogin,
+    handleLogout,
+    handleSelectWorkspace,
+  } = useAuthHook();
 
   return (
     <AuthContext.Provider
-      value={{ token, isLoading, isAuthenticated, handleLogin, handleLogout }}
+      value={{
+        token,
+        isAuthenticated,
+        user,
+        isUserSetup,
+        isLoading,
+        handleLogin,
+        handleLogout,
+        handleSelectWorkspace,
+      }}
     >
       {children}
     </AuthContext.Provider>

--- a/front/extension/app/src/context/ProtectedRoute.tsx
+++ b/front/extension/app/src/context/ProtectedRoute.tsx
@@ -12,14 +12,15 @@ import { useNavigate } from "react-router-dom";
 import { useAuth } from "./AuthProvider";
 
 export const ProtectedRoute = ({ children }: { children: ReactNode }) => {
-  const { isLoading, isAuthenticated, handleLogout } = useAuth();
+  const { isLoading, isAuthenticated, isUserSetup, handleLogout } = useAuth();
+
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (!isLoading && !isAuthenticated) {
+    if (!isAuthenticated || !isUserSetup) {
       navigate("/login");
     }
-  }, [isLoading, isAuthenticated, navigate]);
+  }, [navigate, isLoading, isAuthenticated, isUserSetup]);
 
   if (isLoading) {
     return (

--- a/front/extension/app/src/hooks/useAuth.ts
+++ b/front/extension/app/src/hooks/useAuth.ts
@@ -14,11 +14,7 @@ export const useAuthHook = () => {
   );
 
   const [user, setUser] = useState<StoredUser | null>(null);
-  const isUserSetup = useMemo(
-    () => !!(user && user.userId && user.selectedWorkspace),
-    [user]
-  );
-
+  const isUserSetup = !!(user && user.userId && user.selectedWorkspace);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const refreshTimerRef = useRef<NodeJS.Timeout | null>(null);
 

--- a/front/extension/app/src/hooks/useAuth.ts
+++ b/front/extension/app/src/hooks/useAuth.ts
@@ -1,72 +1,52 @@
+import { login, logout, refreshToken } from "@app/extension/app/src/lib/auth";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import type { StoredTokens } from "../lib/auth";
-import {
-  clearStoredTokens,
-  getStoredTokens,
-  saveTokens,
-  sendAuthMessage,
-  sendRefreshTokenMessage,
-  sentLogoutMessage,
-} from "../lib/auth";
+import type { StoredTokens, StoredUser } from "../lib/storage";
+import { getStoredTokens, saveSelectedWorkspace } from "../lib/storage";
 
 const log = console.error;
 
 export const useAuthHook = () => {
   const [tokens, setTokens] = useState<StoredTokens | null>(null);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-  const refreshTimerRef = useRef<NodeJS.Timeout | null>(null);
-
   const isAuthenticated = useMemo(
     () => !!(tokens?.accessToken && tokens.expiresAt > Date.now()),
     [tokens]
   );
 
-  // Logout sends a message to the background script to call the auth0 logout endpoint.
-  // It also clears the stored tokens in the extension.
+  const [user, setUser] = useState<StoredUser | null>(null);
+  const isUserSetup = useMemo(
+    () => !!(user && user.userId && user.selectedWorkspace),
+    [user]
+  );
+
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const refreshTimerRef = useRef<NodeJS.Timeout | null>(null);
+
   const handleLogout = useCallback(async () => {
     setIsLoading(true);
-    try {
-      const response = await sentLogoutMessage();
-      if (!response?.success) {
-        log("Logout failed: No success response received.");
-        return;
-      }
-      await clearStoredTokens();
-      setTokens(null);
-      if (refreshTimerRef.current) {
-        clearTimeout(refreshTimerRef.current);
-      }
-    } catch (error) {
-      log("Logout failed: Unknown error.", error);
-    } finally {
+    const success = await logout();
+    if (!success) {
+      // TODO(EXT): User facing error message if logout failed.
       setIsLoading(false);
-    }
-  }, []);
-
-  // Refresh token sends a message to the background script to call the auth0 refresh token endpoint.
-  // It updates the stored tokens with the new access token.
-  // If the refresh token is invalid, it will call handleLogout.
-  const handleRefreshToken = useCallback(async () => {
-    if (!tokens?.refreshToken) {
       return;
     }
-    try {
-      const response = await sendRefreshTokenMessage(tokens.refreshToken);
-      if (!response?.accessToken) {
-        log("Refresh token: No access token received.");
-        await handleLogout();
-        return;
-      }
-      const savedTokens = await saveTokens(response);
-      setTokens(savedTokens);
-    } catch (error) {
-      log("Refresh token: unknown error.", error);
-      await handleLogout();
+    setTokens(null);
+    if (refreshTimerRef.current) {
+      clearTimeout(refreshTimerRef.current);
     }
-  }, [tokens, handleLogout]);
+    setIsLoading(false);
+  }, []);
 
-  // Schedule token refresh sets a timeout to call handleRefreshToken before the token expires.
+  const handleRefreshToken = useCallback(async () => {
+    const savedTokens = await refreshToken();
+    if (!savedTokens) {
+      log("Refresh token: No access token received.");
+      await handleLogout();
+      return;
+    }
+    setTokens(savedTokens);
+  }, [handleLogout]);
+
   const scheduleTokenRefresh = useCallback(
     (expiresAt: number) => {
       if (refreshTimerRef.current) {
@@ -78,27 +58,23 @@ export const useAuthHook = () => {
     [handleRefreshToken]
   );
 
-  // Initialize auth checks if there are stored tokens and if they are still valid.
-  // It is called on component mount.
   useEffect(() => {
-    const initializeAuth = async () => {
-      try {
-        const storedTokens = await getStoredTokens();
-        if (storedTokens) {
-          setTokens(storedTokens);
-          if (storedTokens.expiresAt > Date.now()) {
-            scheduleTokenRefresh(storedTokens.expiresAt);
-          } else {
-            await handleRefreshToken();
-          }
-        }
-      } catch (error) {
-        log("Unknown error retrieving tokens.", error);
-      } finally {
+    void (async () => {
+      setIsLoading(true);
+      const storedTokens = await getStoredTokens();
+      if (!storedTokens) {
+        // TODO(EXT): User facing error message if no tokens found.
         setIsLoading(false);
+        return;
       }
-    };
-    void initializeAuth();
+      setTokens(storedTokens);
+      if (storedTokens.expiresAt > Date.now()) {
+        scheduleTokenRefresh(storedTokens.expiresAt);
+      } else {
+        await handleRefreshToken();
+      }
+      setIsLoading(false);
+    })();
 
     return () => {
       if (refreshTimerRef.current) {
@@ -107,31 +83,34 @@ export const useAuthHook = () => {
     };
   }, [handleRefreshToken, scheduleTokenRefresh]);
 
-  // Login sends a message to the background script to call the auth0 login endpoint.
-  // It saves the tokens in the extension and schedules a token refresh.
   const handleLogin = useCallback(async () => {
     setIsLoading(true);
-    try {
-      const response = await sendAuthMessage();
-      if (response.accessToken) {
-        const savedTokens = await saveTokens(response);
-        setTokens(savedTokens);
-        scheduleTokenRefresh(savedTokens.expiresAt);
-      } else {
-        log("Login failed: No access token received.");
-      }
-    } catch (error) {
-      log("Login failed: Unknown error.", error);
-    } finally {
+
+    const response = await login();
+    if (!response) {
+      // TODO(EXT): User facing error message if login failed.
       setIsLoading(false);
+      return;
     }
+    setTokens(response.tokens);
+    scheduleTokenRefresh(response.tokens.expiresAt);
+    setUser(response.user);
+    setIsLoading(false);
   }, [scheduleTokenRefresh]);
+
+  const handleSelectWorkspace = async (workspaceId: string) => {
+    const updatedUser = await saveSelectedWorkspace(workspaceId);
+    setUser(updatedUser);
+  };
 
   return {
     token: tokens?.accessToken ?? null,
-    isLoading,
     isAuthenticated,
+    user,
+    isUserSetup,
+    isLoading,
     handleLogin,
     handleLogout,
+    handleSelectWorkspace,
   };
 };

--- a/front/extension/app/src/lib/auth.ts
+++ b/front/extension/app/src/lib/auth.ts
@@ -1,156 +1,92 @@
-// Auth0 config.
-export const AUTH0_CLIENT_DOMAIN = process.env.AUTH0_CLIENT_DOMAIN ?? "";
-export const AUTH0_CLIENT_ID = process.env.AUTH0_CLIENT_ID ?? "";
-export const AUTH0_AUDIENCE = `https://${AUTH0_CLIENT_DOMAIN}/api/v2/`;
-export const AUTH0_PROFILE_ROUTE = `https://${AUTH0_CLIENT_DOMAIN}/userinfo`;
+import {
+  sendAuthMessage,
+  sendRefreshTokenMessage,
+  sentLogoutMessage,
+} from "@app/extension/app/src/lib/messages";
+import type {
+  StoredTokens,
+  StoredUser,
+} from "@app/extension/app/src/lib/storage";
+import {
+  clearStoredData,
+  getStoredTokens,
+  saveTokens,
+  saveUser,
+} from "@app/extension/app/src/lib/storage";
+import type { UserTypeWithWorkspaces } from "@dust-tt/types";
 
-export type Auth0AuthorizeResponse = {
-  accessToken: string;
-  idToken: string;
-  refreshToken: string;
-  expiresIn: number;
-};
+const log = console.error;
 
-export type StoredTokens = {
-  accessToken: string;
-  refreshToken: string;
-  expiresAt: number;
-};
-
-export type AuthBackgroundResponse = {
-  success: boolean;
-};
-
-export type AuthBackroundMessage = {
-  type: "AUTHENTICATE" | "REFRESH_TOKEN" | "LOGOUT" | "SIGN_CONNECT";
-  refreshToken?: string;
-};
-
-/**
- * Messages to the background script to authenticate, refresh tokens, and logout.
- */
-
-export const sendAuthMessage = (): Promise<Auth0AuthorizeResponse> => {
-  return new Promise((resolve, reject) => {
-    const message: AuthBackroundMessage = { type: "AUTHENTICATE" };
-    chrome.runtime.sendMessage(
-      message,
-      (response: Auth0AuthorizeResponse | undefined) => {
-        const error = chrome.runtime.lastError;
-        if (error) {
-          if (error.message?.includes("Could not establish connection")) {
-            // Attempt to wake up the service worker
-            chrome.runtime.getBackgroundPage(() => {
-              chrome.runtime.sendMessage(
-                message,
-                (response: Auth0AuthorizeResponse | undefined) => {
-                  if (chrome.runtime.lastError) {
-                    return reject(chrome.runtime.lastError);
-                  }
-                  if (!response) {
-                    return reject(new Error("No response received."));
-                  }
-                  return resolve(response);
-                }
-              );
-            });
-          } else {
-            reject(new Error(error.message || "An unknown error occurred."));
-          }
-        }
-        if (!response) {
-          return reject(new Error("No response received."));
-        }
-        return resolve(response);
-      }
-    );
-  });
-};
-
-export const sendRefreshTokenMessage = (
-  refreshToken: string
-): Promise<Auth0AuthorizeResponse> => {
-  return new Promise((resolve, reject) => {
-    const message: AuthBackroundMessage = {
-      type: "REFRESH_TOKEN",
-      refreshToken,
-    };
-    chrome.runtime.sendMessage(
-      message,
-      (response: Auth0AuthorizeResponse | undefined) => {
-        if (chrome.runtime.lastError) {
-          return reject(chrome.runtime.lastError);
-        }
-        if (!response) {
-          return reject(new Error("No response received."));
-        }
-        return resolve(response);
-      }
-    );
-  });
-};
-
-export const sentLogoutMessage = (): Promise<AuthBackgroundResponse> => {
-  return new Promise((resolve, reject) => {
-    const message: AuthBackroundMessage = { type: "LOGOUT" };
-    chrome.runtime.sendMessage(
-      message,
-      (response: AuthBackgroundResponse | undefined) => {
-        if (chrome.runtime.lastError) {
-          return reject(chrome.runtime.lastError);
-        }
-        if (!response) {
-          return reject(new Error("No response received."));
-        }
-        return resolve(response);
-      }
-    );
-  });
-};
-
-/**
- * Utils to manage tokens.
- * We store the access token, refresh token, and expiration time in Chrome storage.
- */
-
-export const saveTokens = async (
-  rawTokens: Auth0AuthorizeResponse
-): Promise<StoredTokens> => {
-  const tokens: StoredTokens = {
-    accessToken: rawTokens.accessToken,
-    refreshToken: rawTokens.refreshToken,
-    expiresAt: Date.now() + rawTokens.expiresIn * 1000,
-  };
-  await chrome.storage.local.set(tokens);
-  return tokens;
-};
-
-export const getStoredTokens = async (): Promise<StoredTokens | null> => {
-  const result = await chrome.storage.local.get([
-    "accessToken",
-    "refreshToken",
-    "expiresAt",
-  ]);
-  if (result.accessToken && result.refreshToken && result.expiresAt) {
-    return {
-      accessToken: result.accessToken,
-      refreshToken: result.refreshToken,
-      expiresAt: result.expiresAt,
-    };
+// Login sends a message to the background script to call the auth0 login endpoint.
+// It saves the tokens in the extension and schedules a token refresh.
+// Then it calls the /me route to get the user info.
+export const login = async (): Promise<
+  { tokens: StoredTokens; user: StoredUser } | undefined
+> => {
+  try {
+    const response = await sendAuthMessage();
+    if (!response.accessToken) {
+      throw new Error("No access token received.");
+    }
+    const tokens = await saveTokens(response);
+    const me = await fetchMe(tokens.accessToken);
+    if (!me) {
+      throw new Error("Login failed: No user profile received.");
+    }
+    const user = await saveUser(me);
+    return { tokens, user };
+  } catch (error) {
+    log("Login failed:", error);
   }
-  return null;
 };
 
-export const clearStoredTokens = async (): Promise<void> => {
-  return new Promise((resolve, reject) => {
-    chrome.storage.local.remove(
-      ["accessToken", "refreshToken", "expiresAt"],
-      () => {
-        if (chrome.runtime.lastError) {
-          return reject(chrome.runtime.lastError);
-        }
-        return resolve();
-      }
-    );
+// Logout sends a message to the background script to call the auth0 logout endpoint.
+// It also clears the stored tokens in the extension.
+export const logout = async (): Promise<boolean> => {
+  try {
+    const response = await sentLogoutMessage();
+    if (!response?.success) {
+      throw new Error("No success response received.");
+    }
+    return true;
+  } catch (error) {
+    log("Logout failed: Unknown error.", error);
+    return false;
+  } finally {
+    await clearStoredData();
+  }
+};
+
+// Refresh token sends a message to the background script to call the auth0 refresh token endpoint.
+// It updates the stored tokens with the new access token.
+// If the refresh token is invalid, it will call handleLogout.
+export const refreshToken = async (): Promise<StoredTokens | undefined> => {
+  try {
+    const tokens = await getStoredTokens();
+    if (!tokens) {
+      throw new Error("No tokens found.");
+    }
+    const response = await sendRefreshTokenMessage(tokens.refreshToken);
+    if (!response?.accessToken) {
+      throw new Error("No access token received.");
+    }
+    return await saveTokens(response);
+  } catch (error) {
+    log("Refresh token: unknown error.", error);
+    await logout();
+  }
+};
+
+// Fetch me sends a request to the /me route to get the user info.
+const fetchMe = async (token: string): Promise<UserTypeWithWorkspaces> => {
+  const response = await fetch(`${process.env.API_URL_OVERRIDE}/me`, {
+    headers: { Authorization: `Bearer ${token}` },
   });
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch /me: ${response.status} ${response.statusText}`
+    );
+  }
+  const me = await response.json();
+  return me.user;
 };

--- a/front/extension/app/src/lib/config.ts
+++ b/front/extension/app/src/lib/config.ts
@@ -1,0 +1,5 @@
+// Auth0 config.
+export const AUTH0_CLIENT_DOMAIN = process.env.AUTH0_CLIENT_DOMAIN ?? "";
+export const AUTH0_CLIENT_ID = process.env.AUTH0_CLIENT_ID ?? "";
+export const AUTH0_AUDIENCE = `https://${AUTH0_CLIENT_DOMAIN}/api/v2/`;
+export const AUTH0_PROFILE_ROUTE = `https://${AUTH0_CLIENT_DOMAIN}/userinfo`;

--- a/front/extension/app/src/lib/messages.ts
+++ b/front/extension/app/src/lib/messages.ts
@@ -1,0 +1,106 @@
+import { saveTokens } from "@app/extension/app/src/lib/storage";
+
+export type Auth0AuthorizeResponse = {
+  accessToken: string;
+  idToken: string;
+  refreshToken: string;
+  expiresIn: number;
+};
+export type AuthBackgroundResponse = {
+  success: boolean;
+};
+
+export type AuthBackroundMessage = {
+  type: "AUTHENTICATE" | "REFRESH_TOKEN" | "LOGOUT" | "SIGN_CONNECT";
+  refreshToken?: string;
+};
+
+/**
+ * Messages to the background script to authenticate, refresh tokens, and logout.
+ */
+
+export const sendAuthMessage = (): Promise<Auth0AuthorizeResponse> => {
+  return new Promise((resolve, reject) => {
+    const message: AuthBackroundMessage = { type: "AUTHENTICATE" };
+    chrome.runtime.sendMessage(
+      message,
+      (response: Auth0AuthorizeResponse | undefined) => {
+        const error = chrome.runtime.lastError;
+        if (error) {
+          if (error.message?.includes("Could not establish connection")) {
+            // Attempt to wake up the service worker
+            chrome.runtime.getBackgroundPage(() => {
+              chrome.runtime.sendMessage(
+                message,
+                (response: Auth0AuthorizeResponse | undefined) => {
+                  if (chrome.runtime.lastError) {
+                    return reject(chrome.runtime.lastError);
+                  }
+                  if (!response) {
+                    return reject(new Error("No response received."));
+                  }
+                  return resolve(response);
+                }
+              );
+            });
+          } else {
+            reject(new Error(error.message || "An unknown error occurred."));
+          }
+        }
+        if (!response) {
+          return reject(new Error("No response received."));
+        }
+        return resolve(response);
+      }
+    );
+  });
+};
+
+export const sendRefreshTokenMessage = (
+  refreshToken: string
+): Promise<Auth0AuthorizeResponse> => {
+  return new Promise((resolve, reject) => {
+    const message: AuthBackroundMessage = {
+      type: "REFRESH_TOKEN",
+      refreshToken,
+    };
+    chrome.runtime.sendMessage(
+      message,
+      (response: Auth0AuthorizeResponse | undefined) => {
+        if (chrome.runtime.lastError) {
+          return reject(chrome.runtime.lastError);
+        }
+        if (!response) {
+          return reject(new Error("No response received."));
+        }
+        if (
+          !response.accessToken ||
+          !response.refreshToken ||
+          !response.expiresIn
+        ) {
+          return reject(new Error("Invalid response received."));
+        }
+        void saveTokens(response);
+        return resolve(response);
+      }
+    );
+  });
+};
+
+export const sentLogoutMessage = (): Promise<AuthBackgroundResponse> => {
+  return new Promise((resolve, reject) => {
+    const message: AuthBackroundMessage = { type: "LOGOUT" };
+    chrome.runtime.sendMessage(
+      message,
+      (response: AuthBackgroundResponse | undefined) => {
+        if (chrome.runtime.lastError) {
+          return reject(chrome.runtime.lastError);
+        }
+        if (!response) {
+          return reject(new Error("No response received."));
+        }
+        return resolve(response);
+      }
+    );
+  });
+};

--- a/front/extension/app/src/lib/storage.ts
+++ b/front/extension/app/src/lib/storage.ts
@@ -1,0 +1,105 @@
+import type { Auth0AuthorizeResponse } from "@app/extension/app/src/lib/messages";
+import type {
+  LightWorkspaceType,
+  UserTypeWithWorkspaces,
+} from "@dust-tt/types";
+
+export type StoredTokens = {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+};
+
+export type StoredUser = {
+  userId: string;
+  firstName: string;
+  selectedWorkspace: string | null;
+  workspaces: LightWorkspaceType[];
+};
+
+/**
+ * Tokens.
+ * We store the access token, refresh token, and expiration time in Chrome storage.
+ */
+
+export const saveTokens = async (
+  rawTokens: Auth0AuthorizeResponse
+): Promise<StoredTokens> => {
+  const tokens: StoredTokens = {
+    accessToken: rawTokens.accessToken,
+    refreshToken: rawTokens.refreshToken,
+    expiresAt: Date.now() + rawTokens.expiresIn * 1000,
+  };
+  await chrome.storage.local.set(tokens);
+  return tokens;
+};
+
+export const getStoredTokens = async (): Promise<StoredTokens | null> => {
+  const result = await chrome.storage.local.get([
+    "accessToken",
+    "refreshToken",
+    "expiresAt",
+  ]);
+  if (result.accessToken && result.refreshToken && result.expiresAt) {
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresAt: result.expiresAt,
+    };
+  }
+  return null;
+};
+
+/**
+ * User.
+ * We store the basic user information with list of workspaces and currently selected workspace in Chrome storage.
+ */
+
+export const saveUser = async (
+  user: UserTypeWithWorkspaces
+): Promise<StoredUser> => {
+  const storedUser: StoredUser = {
+    userId: user.sId,
+    firstName: user.firstName,
+    selectedWorkspace:
+      user.workspaces.length === 1 ? user.workspaces[0].sId : null,
+    workspaces: user.workspaces,
+  };
+  await chrome.storage.local.set({ user: storedUser });
+  return storedUser;
+};
+
+export const saveSelectedWorkspace = async (
+  workspaceId: string
+): Promise<StoredUser> => {
+  const storedUser = await getStoredUser();
+  if (!storedUser) {
+    throw new Error("No user found.");
+  }
+  storedUser.selectedWorkspace = workspaceId;
+  await chrome.storage.local.set({ user: storedUser });
+  return storedUser;
+};
+
+export const getStoredUser = async (): Promise<StoredUser | null> => {
+  const result = await chrome.storage.local.get(["user"]);
+  return result.user ?? null;
+};
+
+/**
+ * Clear all stored data.
+ */
+
+export const clearStoredData = async (): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    chrome.storage.local.remove(
+      ["accessToken", "refreshToken", "expiresAt", "user"],
+      () => {
+        if (chrome.runtime.lastError) {
+          return reject(chrome.runtime.lastError);
+        }
+        return resolve();
+      }
+    );
+  });
+};

--- a/front/extension/app/src/pages/LoginPage.tsx
+++ b/front/extension/app/src/pages/LoginPage.tsx
@@ -1,28 +1,53 @@
-import { Button, LoginIcon } from "@dust-tt/sparkle";
+import { Button, DropdownMenu, LoginIcon } from "@dust-tt/sparkle";
 import { useAuth } from "@extension/context/AuthProvider";
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
 export const LoginPage = () => {
   const navigate = useNavigate();
-  const { handleLogin, isAuthenticated, isLoading } = useAuth();
+  const {
+    user,
+    isAuthenticated,
+    isUserSetup,
+    handleLogin,
+    handleSelectWorkspace,
+    isLoading,
+  } = useAuth();
 
   useEffect(() => {
-    if (isAuthenticated) {
+    if (isAuthenticated && isUserSetup) {
       navigate("/");
     }
-  }, [isAuthenticated, navigate]);
+  }, [navigate, user, isAuthenticated, isUserSetup]);
 
   return (
     <div className="flex h-screen flex-col gap-2 p-4">
       <div className="flex h-full w-full items-center justify-center">
-        <Button
-          icon={LoginIcon}
-          variant="primary"
-          label="Sign in"
-          onClick={handleLogin}
-          disabled={isLoading}
-        />
+        {!isAuthenticated && (
+          <Button
+            icon={LoginIcon}
+            variant="primary"
+            label="Sign in"
+            onClick={handleLogin}
+            disabled={isLoading}
+          />
+        )}
+        {isAuthenticated && !isUserSetup && user?.workspaces.length && (
+          <DropdownMenu className="flex">
+            <DropdownMenu.Button label="Select workspace" />
+            <DropdownMenu.Items>
+              {user.workspaces.map((w) => {
+                return (
+                  <DropdownMenu.Item
+                    key={w.sId}
+                    onClick={() => handleSelectWorkspace(w.sId)}
+                    label={w.name}
+                  />
+                );
+              })}
+            </DropdownMenu.Items>
+          </DropdownMenu>
+        )}
       </div>
     </div>
   );

--- a/front/extension/app/src/pages/MainPage.tsx
+++ b/front/extension/app/src/pages/MainPage.tsx
@@ -3,21 +3,33 @@ import { FixedAssistantInputBar } from "@app/components/assistant/conversation/i
 import { useAuth } from "@app/extension/app/src/context/AuthProvider";
 import { Page } from "@dust-tt/sparkle";
 import type { WorkspaceType } from "@dust-tt/types";
+import { useNavigate } from "react-router-dom";
 
 export const MainPage = () => {
-  const { token } = useAuth();
-  if (!token) {
-    return <div>Not logged in!!!</div>;
+  const navigate = useNavigate();
+  const { isAuthenticated, user } = useAuth();
+  if (!isAuthenticated || !user) {
+    navigate("/login");
+    return;
+  }
+
+  const workspace = user.workspaces.find(
+    (w) => w.sId === user.selectedWorkspace
+  );
+
+  if (!workspace) {
+    navigate("/login");
+    return;
   }
 
   const owner: WorkspaceType = {
-    id: 1,
-    sId: "7ea8c3d99c",
-    name: "test",
-    role: "user",
-    segmentation: null,
-    whiteListedProviders: null,
-    defaultEmbeddingProvider: null,
+    id: workspace.id,
+    sId: workspace.sId,
+    name: workspace.name,
+    role: workspace.role,
+    segmentation: workspace.segmentation,
+    whiteListedProviders: workspace.whiteListedProviders,
+    defaultEmbeddingProvider: workspace.defaultEmbeddingProvider,
     flags: [],
   };
 


### PR DESCRIPTION
## Description

Updates the Login components so it calls /me to identify the user and her workspace before redirecting to the main page. If she has multiple workspaces we display a workspace picker. 

I'm sorry for the diff I also moved some things for clarity without changing the logic: 
- Move some config var to a file `config.ts`.
- Move the function to send a message to the background script to `messages.ts`.
- Move the function to save / get data from chrome storage api in `storage.ts`.
- Update `useAuth` hook to call /me and save the user and workspace. 

## Risk

Not very risky since only impacts the extension. 

## Deploy Plan

This needs to be deployed first: https://github.com/dust-tt/dust/pull/8085 to front. 
Then no specific deploy for this one. 
