### PR TITLE
Provider list: display models available in the builder

### DIFF
--- a/front/components/workspace/ProviderManagementModal.tsx
+++ b/front/components/workspace/ProviderManagementModal.tsx
@@ -8,11 +8,14 @@ import {
 } from "@dust-tt/sparkle";
 import type { ModelProviderIdType, WorkspaceType } from "@dust-tt/types";
 import { EMBEDDING_PROVIDER_IDS } from "@dust-tt/types";
-import { MODEL_PROVIDER_IDS, SUPPORTED_MODEL_CONFIGS } from "@dust-tt/types";
+import { MODEL_PROVIDER_IDS } from "@dust-tt/types";
 import { isEqual } from "lodash";
 import { useCallback, useContext, useMemo, useState } from "react";
 
-import { MODEL_PROVIDER_LOGOS } from "@app/components/providers/types";
+import {
+  MODEL_PROVIDER_LOGOS,
+  USED_MODEL_CONFIGS,
+} from "@app/components/providers/types";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 
 interface ProviderManagementModalProps {
@@ -31,7 +34,7 @@ const prettyfiedProviderNames: { [key in ModelProviderIdType]: string } = {
 };
 
 const modelProviders: Record<ModelProviderIdType, string[]> =
-  SUPPORTED_MODEL_CONFIGS.reduce(
+  USED_MODEL_CONFIGS.reduce(
     (acc, model) => {
       if (!model.isLegacy) {
         acc[model.providerId] = acc[model.providerId] || [];


### PR DESCRIPTION
## Description

Fixes https://dust4ai.slack.com/archives/C050A0S2Z7F/p1729494135279079

This PR makes a small change on the modal in workspace admin page to allow admins to manage providers. We just load `USED_MODEL_CONFIGS` over `SUPPORTED_MODEL_CONFIGS` to display the models that are actually available on the builder. 

<img width="571" alt="Screenshot 2024-10-21 at 10 50 45" src="https://github.com/user-attachments/assets/53708738-5b90-4934-bf79-16d5948a7942">


## Risk

This can still be too permissive since it does not make any check on feature flags or anything like that, but better than what we have before and I think good enough considering where this wording is and what's its purpose. 

## Deploy Plan

Deploy front. 
