### PR TITLE
Open the Zendesk connection in preview status

### DIFF
--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -189,7 +189,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
   zendesk: {
     name: "Zendesk",
     connectorProvider: "zendesk",
-    status: "rolling_out",
+    status: "preview",
     hide: false,
     description:
       "Authorize access to Zendesk for indexing tickets from your support center and articles from your help center.",


### PR DESCRIPTION
## Description

- Set the status of the Zendesk connection in `preview` instead of `rolling_out`.
The goal is to potentially gather some user feedback.

## Risk

## Deploy Plan

- Deploy front