### PR TITLE
[Favorites] Invert fill/stroke icon for add/remove

### DIFF
--- a/front/components/assistant/AssistantDetailsButtonBar.tsx
+++ b/front/components/assistant/AssistantDetailsButtonBar.tsx
@@ -133,15 +133,29 @@ export function AssistantDetailsButtonBar({
 
   return (
     <div className="flex flex-row items-center gap-2 px-1.5">
-      <Button
-        icon={agentConfiguration.userFavorite ? StarIcon : StarStrokeIcon}
-        label={`${agentConfiguration.userFavorite ? "Remove from" : "Add to"} favorites`}
-        labelVisible={false}
-        size="sm"
-        variant="tertiary"
-        hasMagnifying={false}
-        onClick={() => updateUserFavorite(!agentConfiguration.userFavorite)}
-      />
+      <div className="group">
+        <Button
+          icon={agentConfiguration.userFavorite ? StarIcon : StarStrokeIcon}
+          label={`${agentConfiguration.userFavorite ? "Remove from" : "Add to"} favorites`}
+          labelVisible={false}
+          size="sm"
+          className="group-hover:hidden"
+          variant="tertiary"
+          hasMagnifying={false}
+          onClick={() => updateUserFavorite(!agentConfiguration.userFavorite)}
+        />
+
+        <Button
+          icon={agentConfiguration.userFavorite ? StarStrokeIcon : StarIcon}
+          label={`${agentConfiguration.userFavorite ? "Remove from" : "Add to"} favorites`}
+          labelVisible={false}
+          size="sm"
+          className="hidden group-hover:block"
+          variant="tertiary"
+          hasMagnifying={false}
+          onClick={() => updateUserFavorite(!agentConfiguration.userFavorite)}
+        />
+      </div>
 
       <Separator orientation="vertical" className="h-6" />
 

--- a/front/components/assistant/AssistantDropdownMenu.tsx
+++ b/front/components/assistant/AssistantDropdownMenu.tsx
@@ -149,6 +149,21 @@ export function AssistantDropdownMenu({
                   icon={ClipboardIcon}
                 />
               )}
+              {showAddRemoveToFavorite && (
+                <>
+                  <DropdownMenu.Item
+                    label={
+                      isFavorite ? "Remove from favorites" : "Add to favorites"
+                    }
+                    disabled={isUpdatingFavorites}
+                    onClick={() => {
+                      void updateFavorite(isFavorite ? false : true);
+                    }}
+                    icon={isFavorite ? StarIcon : StarStrokeIcon}
+                  />
+                </>
+              )}
+
               {!isGlobalAgent && (
                 <>
                   <DropdownMenu.SectionHeader label="Edition" />
@@ -194,21 +209,6 @@ export function AssistantDropdownMenu({
                       }}
                     />
                   )}
-                </>
-              )}
-              {showAddRemoveToFavorite && (
-                <>
-                  <DropdownMenu.SectionHeader label="MY ASSISTANTS" />
-                  <DropdownMenu.Item
-                    label={
-                      isFavorite ? "Remove from favorites" : "Add to favorites"
-                    }
-                    disabled={isUpdatingFavorites}
-                    onClick={() => {
-                      void updateFavorite(isFavorite ? false : true);
-                    }}
-                    icon={isFavorite ? StarStrokeIcon : StarIcon}
-                  />
                 </>
               )}
             </DropdownMenu.Items>


### PR DESCRIPTION
Description
---
As per title; related [thread](https://dust4ai.slack.com/archives/C05BUSJQP5W/p1729155315538599)
![image](https://github.com/user-attachments/assets/c0f7f657-4af8-46d4-81c0-838c5a9acd8f)

Also removes a header for favorites that uselessly increases dropdown length and sometimes makes a scrollbar appear

Risks
---
na

Deploy
---
front
