### PR TITLE
[connectors] Allow comma after bot name

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -410,8 +410,9 @@ async function answerMessage(
 
   // Extract all ~mentions and +mentions
   const mentionCandidates =
-    messageWithoutMarkdown.match(/(?<!\S)[+~]([a-zA-Z0-9_-]{1,40})(?!\S)/g) ||
-    [];
+    messageWithoutMarkdown.match(
+      /(?<!\S)[+~]([a-zA-Z0-9_-]{1,40})(?=\s|,|$)/g
+    ) || [];
 
   // First we look at mention override
   // (eg: a mention coming from the Slack assistant picker from slack).

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -411,7 +411,7 @@ async function answerMessage(
   // Extract all ~mentions and +mentions
   const mentionCandidates =
     messageWithoutMarkdown.match(
-      /(?<!\S)[+~]([a-zA-Z0-9_-]{1,40})(?=\s|,|$)/g
+      /(?<!\S)[+~]([a-zA-Z0-9_-]{1,40})(?=\s|,|\.|$)/g
     ) || [];
 
   // First we look at mention override


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/1519
## Description

Allow mention ending with comma (not allowing other chars) : `@Dust +god,hi` works , `@Dust +god+x` does not.
 
## Risk

none

## Deploy Plan

deploy connectors