### PR TITLE
front: Fix cloning workspace assistant as user

### DIFF
--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -89,6 +89,10 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
         notFound: true,
       };
     }
+    // We reset the scope according to the current flow. This ensures that cloning a workspace
+    // assistant with flow `personal_assistants` will initialize the assistant as private.
+    configuration.scope =
+      flow === "personal_assistants" ? "private" : "workspace";
   } else if (templateId) {
     const agentConfigRes = await generateMockAgentConfigurationFromTemplate(
       templateId,


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/dust/issues/8023

If a `user` would duplicate a workspace assistant it would trigger the assistant builder with scope workspace preventing the user from changing the scope or saving the assistant. Instead initialize the duplicate as a private assistant.

## Risk

Low. Tested in dev.

## Deploy Plan

- deploy `front`