### PR TITLE
Fix flow when reopening the sidepanel

### DIFF
--- a/front/extension/app/src/context/AuthProvider.tsx
+++ b/front/extension/app/src/context/AuthProvider.tsx
@@ -1,8 +1,7 @@
+import { useAuthHook } from "@app/extension/app/src/hooks/useAuth";
 import type { StoredUser } from "@app/extension/app/src/lib/storage";
 import type { ReactNode } from "react";
 import React, { createContext, useContext } from "react";
-
-import { useAuthHook } from "../hooks/useAuth";
 
 type AuthContextType = {
   token: string | null;

--- a/front/extension/app/src/lib/storage.ts
+++ b/front/extension/app/src/lib/storage.ts
@@ -40,7 +40,7 @@ export const getStoredTokens = async (): Promise<StoredTokens | null> => {
     "refreshToken",
     "expiresAt",
   ]);
-  if (result.accessToken && result.refreshToken && result.expiresAt) {
+  if (result.accessToken && result.expiresAt) {
     return {
       accessToken: result.accessToken,
       refreshToken: result.refreshToken,

--- a/front/extension/app/src/pages/MainPage.tsx
+++ b/front/extension/app/src/pages/MainPage.tsx
@@ -1,13 +1,24 @@
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { FixedAssistantInputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
 import { useAuth } from "@app/extension/app/src/context/AuthProvider";
-import { Page } from "@dust-tt/sparkle";
+import { Page, Spinner } from "@dust-tt/sparkle";
 import type { WorkspaceType } from "@dust-tt/types";
 import { useNavigate } from "react-router-dom";
 
 export const MainPage = () => {
   const navigate = useNavigate();
-  const { isAuthenticated, user } = useAuth();
+  const { isLoading, isAuthenticated, user } = useAuth();
+
+  if (isLoading) {
+    return (
+      <div className="h-full w-full">
+        <div className="flex h-full w-full items-center justify-center">
+          <Spinner />
+        </div>
+      </div>
+    );
+  }
+
   if (!isAuthenticated || !user) {
     navigate("/login");
     return;


### PR DESCRIPTION
## Description

When we were closing and reopening the panel we would necessarily go back to the login button. 

- Display a loader on the login page when we're loading. 
- When we mount the app, check if we already have tokens and a user, if yes, do not show again the login button. 
- Fixes some relative imports. 

## Risk

Not used in prod, only changes are in the extension code. 

## Deploy Plan

Nothing. 
