### PR TITLE
fix(doc tracker revival): use vaults

### DIFF
--- a/front/lib/documents_post_process_hooks/hooks/document_tracker/lib.ts
+++ b/front/lib/documents_post_process_hooks/hooks/document_tracker/lib.ts
@@ -1,43 +1,21 @@
-import { DustAPI } from "@dust-tt/client";
-import type { WorkspaceType } from "@dust-tt/types";
-
-import config from "@app/lib/api/config";
-import { prodAPICredentialsForOwner } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { TRACKABLE_CONNECTOR_TYPES } from "@app/lib/documents_post_process_hooks/hooks/document_tracker/consts";
-import logger from "@app/logger/logger";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { VaultResource } from "@app/lib/resources/vault_resource";
 
-export async function getTrackableDataSources(owner: WorkspaceType): Promise<
-  {
-    workspace_id: string;
-    data_source_id: string;
-  }[]
-> {
-  const prodCredentials = await prodAPICredentialsForOwner(owner);
-
-  const prodAPI = new DustAPI(
-    config.getDustAPIConfig(),
-    prodCredentials,
-    logger
-  );
-
-  // Fetch data sources
-  const dsRes = await prodAPI.getDataSources(prodAPI.workspaceId());
-  if (dsRes.isErr()) {
-    throw dsRes.error;
-  }
-  const dataSources = dsRes.value;
+export async function getTrackableDataSourceViews(
+  auth: Authenticator
+): Promise<DataSourceViewResource[]> {
+  const globalVault = await VaultResource.fetchWorkspaceGlobalVault(auth);
+  // TODO(DOC_TRACKER):
+  const views = await DataSourceViewResource.listByVault(auth, globalVault);
 
   // Filter data sources to only include trackable ones
-  const trackableDataSources = dataSources.filter(
-    (ds) =>
-      ds.connectorProvider &&
-      TRACKABLE_CONNECTOR_TYPES.includes(ds.connectorProvider)
+  const trackableViews = views.filter(
+    (view) =>
+      view.dataSource.connectorProvider &&
+      TRACKABLE_CONNECTOR_TYPES.includes(view.dataSource.connectorProvider)
   );
 
-  return trackableDataSources.map((ds) => ({
-    workspace_id: prodAPI.workspaceId(),
-    // TODO(GROUPS_INFRA): this should pull the data source views from the global vaults (we need an
-    // API for that).
-    data_source_id: ds.sId,
-  }));
+  return trackableViews;
 }


### PR DESCRIPTION
## Description

Doc tracker retrieval was relying on the prod API. This setup was not working as expected since the introduction of vaults (fetching from global vault although we need system vault) -> we could switch to a data source view API, but it wouldn't make much sense either as the second step of the pipeline manipulates resources directly.

this PR updates the logic to fetch resources directly, using vaults and data source views.

## Risk

N/A

## Deploy Plan

N/A