### PR TITLE
Render title tags as title of documents in content nodes views

### DIFF
--- a/front/components/vaults/VaultDataSourceViewContentList.tsx
+++ b/front/components/vaults/VaultDataSourceViewContentList.tsx
@@ -229,6 +229,8 @@ export const VaultDataSourceViewContentList = ({
     viewType: isValidContentNodesViewType(viewType) ? viewType : "documents",
   });
 
+  console.log(nodes);
+
   const { hasContent: hasDocuments, isNodesValidating: isDocumentsValidating } =
     useStaticDataSourceViewHasContent({
       owner,

--- a/front/components/vaults/VaultDataSourceViewContentList.tsx
+++ b/front/components/vaults/VaultDataSourceViewContentList.tsx
@@ -229,8 +229,6 @@ export const VaultDataSourceViewContentList = ({
     viewType: isValidContentNodesViewType(viewType) ? viewType : "documents",
   });
 
-  console.log(nodes);
-
   const { hasContent: hasDocuments, isNodesValidating: isDocumentsValidating } =
     useStaticDataSourceViewHasContent({
       owner,

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -174,19 +174,28 @@ async function getContentNodesForStaticDataSourceView(
     }
 
     const documentsAsContentNodes: DataSourceViewContentNode[] =
-      documentsRes.value.documents.map((doc) => ({
-        dustDocumentId: doc.document_id,
-        expandable: false,
-        internalId: doc.document_id,
-        lastUpdatedAt: doc.timestamp,
-        parentInternalId: null,
-        parentInternalIds: [],
-        permission: "read",
-        preventSelection: false,
-        sourceUrl: doc.source_url ?? null,
-        title: doc.document_id,
-        type: "file",
-      }));
+      documentsRes.value.documents.map((doc) => {
+        let title = doc.document_id;
+        for (const t of doc.tags) {
+          if (t.startsWith("title:")) {
+            title = t.slice(6);
+            break;
+          }
+        }
+        return {
+          dustDocumentId: doc.document_id,
+          expandable: false,
+          internalId: doc.document_id,
+          lastUpdatedAt: doc.timestamp,
+          parentInternalId: null,
+          parentInternalIds: [],
+          permission: "read",
+          preventSelection: false,
+          sourceUrl: doc.source_url ?? null,
+          title,
+          type: "file",
+        };
+      });
 
     return new Ok({
       nodes: documentsAsContentNodes,


### PR DESCRIPTION
## Description

Fix https://github.com/dust-tt/tasks/issues/1529

Use the tag `title:....` as title of a document when available in content-nodes endpoints for folders.

## Risk

Low. Tested in dev.

## Deploy Plan

- deploy `front`