### PR TITLE
[front] - fix: conversation checkboxes visibility

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -298,6 +298,7 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
                                 isMultiSelect
                                   ? () => (
                                       <Checkbox
+                                        className="bg-white"
                                         checked={selectedConversations.includes(
                                           c
                                         )}


### PR DESCRIPTION
## Description

This PR aims at making sure the conversation checkboxes are visible.

Before:
![Screenshot 2024-10-22 at 10 26 21](https://github.com/user-attachments/assets/18e0a46d-0ecd-4f6e-a3e1-c4c1db2b3110)

After:
![Screenshot 2024-10-22 at 10 26 10](https://github.com/user-attachments/assets/609a25ca-af32-4b9a-b0f3-13cceadc079d)


## Risk

None

## Deploy Plan

Deploy `front`
