### PR TITLE
[connectors] Move assistant selection into  ephemeral message

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -540,17 +540,12 @@ async function answerMessage(
     .sort((a, b) => a.name.localeCompare(b.name));
 
   const mainMessage = await slackClient.chat.postMessage({
-    ...makeMessageUpdateBlocksAndText(
-      null,
-      connector.workspaceId,
-      slackUserInfo,
-      {
-        assistantName: mention.assistantName,
-        agentConfigurations: mostPopularAgentConfigurations,
-        isComplete: false,
-        isThinking: true,
-      }
-    ),
+    ...makeMessageUpdateBlocksAndText(null, connector.workspaceId, {
+      assistantName: mention.assistantName,
+      agentConfigurations: mostPopularAgentConfigurations,
+      isComplete: false,
+      isThinking: true,
+    }),
     channel: slackChannel,
     thread_ts: slackMessageTs,
     metadata: {
@@ -648,8 +643,10 @@ async function answerMessage(
       slackClient,
       slackMessageTs,
       slackUserInfo,
+      slackUserId,
     },
     userMessage,
+    slackChatBotMessage,
     agentConfigurations: mostPopularAgentConfigurations,
   });
 

--- a/connectors/src/connectors/slack/chat/blocks.ts
+++ b/connectors/src/connectors/slack/chat/blocks.ts
@@ -1,10 +1,10 @@
 import type { LightAgentConfigurationType } from "@dust-tt/types";
 import { truncate } from "@dust-tt/types";
+import type { ChatPostMessageResponse } from "@slack/web-api";
 
 import { STATIC_AGENT_CONFIG } from "@connectors/api/webhooks/webhook_slack_interaction";
 import type { SlackMessageFootnotes } from "@connectors/connectors/slack/chat/citations";
 import { makeDustAppUrl } from "@connectors/connectors/slack/chat/utils";
-import type { SlackUserInfo } from "@connectors/connectors/slack/lib/slack_client";
 
 /*
  * This length threshold is set to prevent the "msg_too_long" error
@@ -78,14 +78,12 @@ function makeContextSectionBlocks(
   return resultBlocks;
 }
 
-function makeAssistantSelectionBlock(
+function makeThinkingBlock(
   assistantName: string,
-  agentConfigurations: LightAgentConfigurationType[],
-  slackUserInfo: SlackUserInfo,
   isThinking: boolean,
   thinkingText: string
 ) {
-  return assistantName && !slackUserInfo.is_bot
+  return assistantName
     ? [
         {
           type: "section",
@@ -95,30 +93,41 @@ function makeAssistantSelectionBlock(
               ? `@${assistantName}: _${thinkingText}_`
               : `@${assistantName}`,
           },
-          accessory:
-            agentConfigurations && agentConfigurations.length > 0
-              ? {
-                  type: "static_select",
-                  placeholder: {
-                    type: "plain_text",
-                    text: "Switch to another assistant",
-                    emoji: true,
-                  },
-                  options: agentConfigurations.map((ac) => {
-                    return {
-                      text: {
-                        type: "plain_text",
-                        text: ac.name,
-                      },
-                      value: ac.sId,
-                    };
-                  }),
-                  action_id: STATIC_AGENT_CONFIG,
-                }
-              : undefined,
         },
       ]
     : [];
+}
+
+export function makeAssistantSelectionBlock(
+  agentConfigurations: LightAgentConfigurationType[],
+  id: string
+) {
+  return [
+    {
+      type: "actions",
+      block_id: id,
+      elements: [
+        {
+          type: "static_select",
+          placeholder: {
+            type: "plain_text",
+            text: "Ask another assistant",
+            emoji: true,
+          },
+          options: agentConfigurations.map((ac) => {
+            return {
+              text: {
+                type: "plain_text",
+                text: ac.name,
+              },
+              value: ac.sId,
+            };
+          }),
+          action_id: STATIC_AGENT_CONFIG,
+        },
+      ],
+    },
+  ];
 }
 
 export type SlackMessageUpdate = {
@@ -153,7 +162,6 @@ export function makeFooterBlock(
 export function makeMessageUpdateBlocksAndText(
   conversationUrl: string | null,
   workspaceId: string,
-  slackUserInfo: SlackUserInfo,
   messageUpdate: SlackMessageUpdate
 ) {
   const {
@@ -161,7 +169,6 @@ export function makeMessageUpdateBlocksAndText(
     isThinking,
     thinkingAction,
     assistantName,
-    agentConfigurations,
     text,
     footnotes,
   } = messageUpdate;
@@ -172,10 +179,8 @@ export function makeMessageUpdateBlocksAndText(
 
   return {
     blocks: [
-      ...makeAssistantSelectionBlock(
+      ...makeThinkingBlock(
         assistantName,
-        agentConfigurations,
-        slackUserInfo,
         isThinking ?? false,
         thinkingTextWithAction
       ),

--- a/connectors/src/connectors/slack/chat/blocks.ts
+++ b/connectors/src/connectors/slack/chat/blocks.ts
@@ -1,6 +1,5 @@
 import type { LightAgentConfigurationType } from "@dust-tt/types";
 import { truncate } from "@dust-tt/types";
-import type { ChatPostMessageResponse } from "@slack/web-api";
 
 import { STATIC_AGENT_CONFIG } from "@connectors/api/webhooks/webhook_slack_interaction";
 import type { SlackMessageFootnotes } from "@connectors/connectors/slack/chat/citations";

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -13,12 +13,14 @@ import slackifyMarkdown from "slackify-markdown";
 
 import type { SlackMessageUpdate } from "@connectors/connectors/slack/chat/blocks";
 import {
+  makeAssistantSelectionBlock,
   makeMessageUpdateBlocksAndText,
   MAX_SLACK_MESSAGE_LENGTH,
 } from "@connectors/connectors/slack/chat/blocks";
 import { annotateCitations } from "@connectors/connectors/slack/chat/citations";
 import { makeConversationUrl } from "@connectors/connectors/slack/chat/utils";
 import type { SlackUserInfo } from "@connectors/connectors/slack/lib/slack_client";
+import type { SlackChatBotMessage } from "@connectors/lib/models/slack";
 import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 
@@ -32,8 +34,10 @@ interface StreamConversationToSlackParams {
     slackClient: WebClient;
     slackMessageTs: string;
     slackUserInfo: SlackUserInfo;
+    slackUserId: string | null;
   };
   userMessage: UserMessageType;
+  slackChatBotMessage: SlackChatBotMessage;
   agentConfigurations: LightAgentConfigurationType[];
 }
 
@@ -50,10 +54,17 @@ export async function streamConversationToSlack(
     mainMessage,
     slack,
     userMessage,
+    slackChatBotMessage,
     agentConfigurations,
   }: StreamConversationToSlackParams
 ): Promise<Result<undefined, Error>> {
-  const { slackChannelId, slackClient, slackMessageTs, slackUserInfo } = slack;
+  const {
+    slackChannelId,
+    slackClient,
+    slackMessageTs,
+    slackUserInfo,
+    slackUserId,
+  } = slack;
 
   let lastSentDate = new Date();
   let backoffTime = initialBackoffTime;
@@ -81,7 +92,6 @@ export async function streamConversationToSlack(
       ...makeMessageUpdateBlocksAndText(
         conversationUrl,
         connector.workspaceId,
-        slackUserInfo,
         messageUpdate
       ),
       channel: slackChannelId,
@@ -245,6 +255,27 @@ export async function streamConversationToSlack(
           },
           { adhereToRateLimit: false }
         );
+        if (
+          slackUserId &&
+          !slackUserInfo.is_bot &&
+          agentConfigurations.length > 0
+        ) {
+          await slackClient.chat.postEphemeral({
+            channel: slackChannelId,
+            text: "hello",
+            user: slackUserId,
+            blocks: makeAssistantSelectionBlock(
+              agentConfigurations,
+              JSON.stringify({
+                slackChatBotMessage: slackChatBotMessage.id,
+                slackThreadTs: mainMessage.message?.thread_ts,
+                messageTs: mainMessage.message?.ts,
+                botId: mainMessage.message?.bot_id,
+              })
+            ),
+            thread_ts: slackMessageTs,
+          });
+        }
 
         return new Ok(undefined);
       }

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -262,7 +262,6 @@ export async function streamConversationToSlack(
         ) {
           await slackClient.chat.postEphemeral({
             channel: slackChannelId,
-            text: "hello",
             user: slackUserId,
             blocks: makeAssistantSelectionBlock(
               agentConfigurations,


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/1500 

## Description

Move assistant selection into  ephemeral message.
The tricky part is about sending the bot message metadata to the interaction webhook (which was previously directly passed, as the action was on it, and now it is on a different message) - only the value and the blockId of the block can be passed to the webhook.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy connectors
