### PR TITLE
Update unrestricted vault ACLs

### DIFF
--- a/front/pages/w/[wId]/vaults/[vaultId]/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/index.tsx
@@ -84,7 +84,7 @@ export default function Vault({
         <div>
           <Chip
             color="pink"
-            label="You are not a member of this vault."
+            label="You are not a member of this space."
             size="sm"
             icon={InformationCircleIcon}
           />


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The recent introduction of unrestricted spaces leverages the global group created at workspace creation time, resulting in vaults having two groups: global and regular. While our infrastructure mainly supports multiple groups, there's a discrepancy in how we handle group permissions:
- Conversation and assistant group_ids use a logical AND between groups.
- ACL checks in `canXX` methods use a logical OR between groups.

This inconsistency limits our flexibility. In the future, we should consider restructuring how we store and process group IDs to allow for OR logic between groups within the same vault on `conversations` and `agent_configurations`.

For now, this PR modifies the `acl()` method to return only one group for unrestricted spaces, addressing the immediate concern. Although it might seem logical to remove the regular group for unrestricted spaces entirely, but our codebase has deep assumptions about its presence. So I'd encourage us to maintain this structure.

We're fixing a small problem for now, but we know we'll need to do more later.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Tested locally. Safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
There are no assistant that are using data from unrestricted vaults, except on our workspace.
