### PR TITLE
[front] reduce number of unnecessary calls

### DIFF
--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -7,6 +7,7 @@ import type {
 } from "@dust-tt/types";
 import { useCallback, useContext, useMemo } from "react";
 import type { Fetcher } from "swr";
+import { useSWRConfig } from "swr";
 
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import {
@@ -78,6 +79,7 @@ export function useAgentConfigurations({
   limit,
   sort,
   disabled,
+  revalidate,
 }: {
   workspaceId: string;
   agentsGetView: AgentsGetViewType | null;
@@ -85,6 +87,7 @@ export function useAgentConfigurations({
   limit?: number;
   sort?: "alphabetical" | "priority";
   disabled?: boolean;
+  revalidate?: boolean;
 }) {
   const agentConfigurationsFetcher: Fetcher<GetAgentConfigurationsResponseBody> =
     fetcher;
@@ -118,14 +121,17 @@ export function useAgentConfigurations({
   }
 
   const queryString = getQueryString();
+
+  const key = `/api/w/${workspaceId}/assistant/agent_configurations?${queryString}`;
+  const { cache } = useSWRConfig();
+  const inCache = typeof cache.get(key) !== "undefined";
+
   const { data, error, mutate, mutateRegardlessOfQueryParams } =
-    useSWRWithDefaults(
-      agentsGetView
-        ? `/api/w/${workspaceId}/assistant/agent_configurations?${queryString}`
-        : null,
-      agentConfigurationsFetcher,
-      { disabled }
-    );
+    useSWRWithDefaults(agentsGetView ? key : null, agentConfigurationsFetcher, {
+      disabled,
+      revalidateOnMount: !inCache || revalidate,
+      revalidateOnFocus: !inCache || revalidate,
+    });
 
   return {
     agentConfigurations: useMemo(
@@ -155,6 +161,7 @@ export function useProgressiveAgentConfigurations({
     limit: 24,
     includes: ["usage"],
     disabled,
+    revalidate: false,
   });
 
   const {
@@ -166,6 +173,7 @@ export function useProgressiveAgentConfigurations({
     workspaceId,
     agentsGetView: "assistants-search",
     includes: ["authors", "usage"],
+    disabled,
   });
 
   const isLoading =


### PR DESCRIPTION
## Description

useProgressiveAgentConfiguration makes 2 (expensive) queries to get a result faster, but the first one do not need to be re-executed on every revalidation - only the real one needs to be refreshed.
Also, disabled flag was not used on one of the 2 queries.


## Risk

None

## Deploy Plan

deploy `front`