### PR TITLE
enh: rework getLargeWhitelistedModel

### DIFF
--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -63,11 +63,11 @@ export function getSmallWhitelistedModel(
 export function getLargeWhitelistedModel(
   owner: WorkspaceType
 ): ModelConfigurationType | null {
-  if (isProviderWhitelisted(owner, "openai")) {
-    return GPT_4_TURBO_MODEL_CONFIG;
-  }
   if (isProviderWhitelisted(owner, "anthropic")) {
-    return CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG;
+    return CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG;
+  }
+  if (isProviderWhitelisted(owner, "openai")) {
+    return GPT_4O_MODEL_CONFIG;
   }
   if (isProviderWhitelisted(owner, "google_ai_studio")) {
     return GEMINI_PRO_DEFAULT_MODEL_CONFIG;


### PR DESCRIPTION
## Description

- Current default is Turbo -> probably not what we want
- The first fallback was Claude Opus which is definitely not right
- We've been doing Sonnet by default in builder & `@Dust`

So this proposal switches the default model to Sonnet, and the first fallback is GPT4o (fully removing Turbo).

## Risk

The following are defaulting to Turbo and will now default to Sonnet:
- `helper`
- document tracker
- instructions suggestions 
- extract data generate schema

This could potentially affect those (eg "Assistant Thoughts" in helper)

## Deploy Plan

N/A