### PR TITLE
Disable check on teams, since we don't grant permission anymore

### DIFF
--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -68,7 +68,6 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
     try {
       // Sanity checks - check connectivity and permissions. User should be able to access the sites and teams list.
       await getSites(client);
-      await getTeams(client);
     } catch (err) {
       logger.error(
         {


### PR DESCRIPTION
## Description

Getting an error on /me/joinedTeams when trying to create a ms connection :

https://app.datadoghq.eu/logs?query=status:error%20service:connectors%20%22Ensure%20user%20has%20a%20valid%20Office365%20license%20assigned%20to%20them%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host,service&fromUser=true&graphType=flamegraph&messageDisplay=inline&sort=time&storage=hot&stream_sort=desc&viz=stream&from_ts=1729515374539&to_ts=1729601774539&live=true

We don't request for teams permissions, so it makes sense this request fails. Removing the request (only here for checking connection) as we don't use teams at ll for now.

## Risk

none

## Deploy Plan

deploy connectors