### PR TITLE
[connectors] fix(slack): Add fallback text

### DIFF
--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -263,6 +263,7 @@ export async function streamConversationToSlack(
           await slackClient.chat.postEphemeral({
             channel: slackChannelId,
             user: slackUserId,
+            text: "You can use another assistant by using the dropdown in slack.",
             blocks: makeAssistantSelectionBlock(
               agentConfigurations,
               JSON.stringify({


### PR DESCRIPTION
## Description

This is to avoid the warning, as fallback text used in notifcation are recommended 

## Risk

none

## Deploy Plan

deploy connectors
