### PR TITLE
Fix: do not allow invalid app names

### DIFF
--- a/front/components/vaults/VaultCreateAppModal.tsx
+++ b/front/components/vaults/VaultCreateAppModal.tsx
@@ -121,7 +121,11 @@ export const VaultCreateAppModal = ({
                 name="name"
                 value={name}
                 onChange={(e) => {
-                  setName(e.target.value);
+                  setName(
+                    e.target.value
+                      .replace(/[^a-zA-Z0-9_-]/g, "")
+                      .substring(0, 64)
+                  );
                   if (errors.name) {
                     setErrors({ ...errors, name: null });
                   }
@@ -130,8 +134,8 @@ export const VaultCreateAppModal = ({
                 showErrorLabel
               />
               <p className="mt-1 flex items-center gap-1 text-sm text-gray-500">
-                <ExclamationCircleStrokeIcon /> Must be unique and not use
-                spaces or special characters.
+                <ExclamationCircleStrokeIcon /> Must be unique and only use
+                alphanumeric, - or _ characters.
               </p>
             </div>
 

--- a/front/components/vaults/VaultCreateAppModal.tsx
+++ b/front/components/vaults/VaultCreateAppModal.tsx
@@ -6,6 +6,7 @@ import {
   TextArea,
 } from "@dust-tt/sparkle";
 import type { APIError, VaultType, WorkspaceType } from "@dust-tt/types";
+import { APP_NAME_REGEXP } from "@dust-tt/types";
 import { useRouter } from "next/router";
 import { useContext, useState } from "react";
 
@@ -47,9 +48,11 @@ export const VaultCreateAppModal = ({
 
     if (!name || name.trim() === "") {
       nameError = "Name is required.";
-    } else if (!name.match(/^[a-zA-Z0-9._-]+$/)) {
+    } else if (!name.match(APP_NAME_REGEXP)) {
       nameError =
-        "Name must only contain letters, numbers, and the characters `._-`";
+        "Name must be only contain letters, numbers, and the characters `_-` and be less than 64 characters.";
+    } else if (name.length > 64) {
+      nameError = "Name must be less or equal to 64 characters.";
     } else if (apps.find((app) => app.name === name)) {
       nameError = "An App with this name already exists.";
     }
@@ -121,11 +124,7 @@ export const VaultCreateAppModal = ({
                 name="name"
                 value={name}
                 onChange={(e) => {
-                  setName(
-                    e.target.value
-                      .replace(/[^a-zA-Z0-9_-]/g, "")
-                      .substring(0, 64)
-                  );
+                  setName(e.target.value);
                   if (errors.name) {
                     setErrors({ ...errors, name: null });
                   }

--- a/front/pages/api/w/[wId]/vaults/[vId]/apps/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/apps/[aId]/index.ts
@@ -1,4 +1,5 @@
 import type { AppType, WithAPIErrorResponse } from "@dust-tt/types";
+import { APP_NAME_REGEXP } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -79,6 +80,17 @@ async function handler(
       }
 
       const { name, description } = bodyValidation.right;
+
+      if (!APP_NAME_REGEXP.test(name)) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "The app name is invalid, expects a string with a length of 1-64 characters, containing only alphanumeric characters, underscores, and dashes.",
+          },
+        });
+      }
 
       await app.updateSettings(auth, {
         name,

--- a/front/pages/api/w/[wId]/vaults/[vId]/apps/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/apps/index.ts
@@ -1,5 +1,5 @@
 import type { AppType, WithAPIErrorResponse } from "@dust-tt/types";
-import { CoreAPI } from "@dust-tt/types";
+import { APP_NAME_REGEXP, CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import config from "@app/lib/api/config";
@@ -76,6 +76,17 @@ async function handler(
             type: "invalid_request_error",
             message:
               "The request body is invalid, expects { name: string, description: string }.",
+          },
+        });
+      }
+
+      if (!APP_NAME_REGEXP.test(req.body.name)) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "The app name is invalid, expects a string with a length of 1-64 characters, containing only alphanumeric characters, underscores, and dashes.",
           },
         });
       }

--- a/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/index.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/index.tsx
@@ -1,4 +1,10 @@
-import { Button, DocumentTextIcon, PlayIcon, Tab } from "@dust-tt/sparkle";
+import {
+  BracesIcon,
+  Button,
+  DocumentTextIcon,
+  PlayIcon,
+  Tab,
+} from "@dust-tt/sparkle";
 import type {
   APIErrorResponse,
   AppType,
@@ -361,7 +367,15 @@ export default function AppView({
             ) : null}
             <div className="flex-1"></div>
             {!readOnly ? (
-              <div className="hidden flex-initial sm:block">
+              <div className="hidden flex-initial space-x-2 sm:block">
+                <Button
+                  variant="tertiary"
+                  icon={BracesIcon}
+                  label="Secrets"
+                  onClick={() => {
+                    void router.push(`/w/${owner.sId}/developers/dev-secrets`);
+                  }}
+                />
                 <Button
                   variant="tertiary"
                   icon={DocumentTextIcon}

--- a/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/settings.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/settings.tsx
@@ -205,8 +205,20 @@ export default function SettingsView({
                             : "border-gray-300 focus:border-action-500 focus:ring-action-500"
                         )}
                         value={appName}
-                        onChange={(e) => setAppName(e.target.value)}
+                        onChange={(e) =>
+                          setAppName(
+                            e.target.value
+                              .replace(/[^a-zA-Z0-9_-]/g, "")
+                              .substring(0, 64)
+                          )
+                        }
                       />
+                    </div>
+                    <div>
+                      <p className="mt-1 flex items-center gap-1 text-sm text-gray-500">
+                        Must be unique and only use alphanumeric, - or _
+                        characters.
+                      </p>
                     </div>
                   </div>
 
@@ -232,7 +244,7 @@ export default function SettingsView({
                         onChange={(e) => setAppDescription(e.target.value)}
                       />
                     </div>
-                    <p className="mt-2 text-sm text-gray-500">
+                    <p className="mt-1 flex items-center gap-1 text-sm text-gray-500">
                       This description guides assistants in understanding how to
                       use your app effectively and determines its relevance in
                       responding to user inquiries. If you don't provide a

--- a/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/settings.tsx
+++ b/front/pages/w/[wId]/vaults/[vaultId]/apps/[aId]/settings.tsx
@@ -1,8 +1,9 @@
-import { Button, Tab } from "@dust-tt/sparkle";
-import type { WorkspaceType } from "@dust-tt/types";
+import { Button, Input, Tab } from "@dust-tt/sparkle";
 import type { AppType } from "@dust-tt/types";
 import type { SubscriptionType } from "@dust-tt/types";
 import type { APIError } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
+import { APP_NAME_REGEXP } from "@dust-tt/types";
 import { ChevronRightIcon } from "@heroicons/react/24/outline";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
@@ -78,9 +79,9 @@ export default function SettingsView({
       setAppNameError("");
       return false;
       // eslint-disable-next-line no-useless-escape
-    } else if (!appName.match(/^[a-zA-Z0-9\._\-]+$/)) {
+    } else if (!appName.match(APP_NAME_REGEXP)) {
       setAppNameError(
-        "App name must only contain letters, numbers, and the characters `._-`"
+        "Name must be only contain letters, numbers, and the characters `_-` and be less than 64 characters."
       );
       return false;
     } else {
@@ -131,7 +132,7 @@ export default function SettingsView({
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          name: appName.slice(0, MODELS_STRING_MAX_LENGTH),
+          name: appName,
           description: appDescription.slice(0, MODELS_STRING_MAX_LENGTH),
         }),
       }
@@ -194,7 +195,7 @@ export default function SettingsView({
                           aria-hidden="true"
                         />
                       </span>
-                      <input
+                      <Input
                         type="text"
                         name="name"
                         id="appName"
@@ -205,13 +206,9 @@ export default function SettingsView({
                             : "border-gray-300 focus:border-action-500 focus:ring-action-500"
                         )}
                         value={appName}
-                        onChange={(e) =>
-                          setAppName(
-                            e.target.value
-                              .replace(/[^a-zA-Z0-9_-]/g, "")
-                              .substring(0, 64)
-                          )
-                        }
+                        onChange={(e) => setAppName(e.target.value)}
+                        showErrorLabel
+                        error={appNameError}
                       />
                     </div>
                     <div>

--- a/types/src/front/app.ts
+++ b/types/src/front/app.ts
@@ -1,7 +1,10 @@
 import { BlockType } from "../front/run";
 import { VaultType } from "../front/vault";
 import { ModelId } from "../shared/model_id";
+
 export type AppVisibility = "private" | "deleted";
+
+export const APP_NAME_REGEXP = /^[a-zA-Z0-9_-]{1,64}$/;
 
 export type BlockRunConfig = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Description

This PR adds validation to prevent the creation of apps with invalid names. Changes include:

- Frontend validation in `VaultCreateAppModal.tsx`
- Backend validation in API routes for app creation and updates
- Updated app name validation logic in `types/src/front/app.ts`
- UI adjustments in app settings and details pages

## Risk

Low risk. This change improves data integrity by preventing invalid app names. Existing apps are not affected.

## Deploy Plan

Standard deployment. No special steps required.