### PR TITLE
[front] Use assistant list from cache when available

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -327,10 +327,10 @@ export default function AssistantBuilder({
         });
       } else {
         if (slackDataSource) {
-          await mutateSlackChannels();
+          void mutateSlackChannels();
         }
 
-        await mutateAgentConfigurations();
+        void mutateAgentConfigurations();
 
         // Redirect to the assistant list once saved.
         if (flow === "personal_assistants") {

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -61,6 +61,7 @@ import {
 } from "@app/components/sparkle/AppLayoutTitle";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
+import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import { ClientSideTracking } from "@app/lib/tracking/client";
 import { classNames } from "@app/lib/utils";
 
@@ -159,6 +160,13 @@ export default function AssistantBuilder({
     agentConfigurationId,
   });
   useNavigationLock(edited && !disableUnsavedChangesPrompt);
+
+  const { mutateRegardlessOfQueryParams: mutateAgentConfigurations } =
+    useAgentConfigurations({
+      workspaceId: owner.sId,
+      agentsGetView: "list", // Anything would work
+      disabled: true, // We only use the hook to mutate the cache
+    });
 
   const checkUsernameTimeout = React.useRef<NodeJS.Timeout | null>(null);
 
@@ -321,6 +329,9 @@ export default function AssistantBuilder({
         if (slackDataSource) {
           await mutateSlackChannels();
         }
+
+        await mutateAgentConfigurations();
+
         // Redirect to the assistant list once saved.
         if (flow === "personal_assistants") {
           await router.push(

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -7,7 +7,6 @@ import type {
 } from "@dust-tt/types";
 import { useCallback, useContext, useMemo } from "react";
 import type { Fetcher } from "swr";
-import { useSWRConfig } from "swr";
 
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import {
@@ -79,7 +78,6 @@ export function useAgentConfigurations({
   limit,
   sort,
   disabled,
-  revalidate,
 }: {
   workspaceId: string;
   agentsGetView: AgentsGetViewType | null;
@@ -87,7 +85,6 @@ export function useAgentConfigurations({
   limit?: number;
   sort?: "alphabetical" | "priority";
   disabled?: boolean;
-  revalidate?: boolean;
 }) {
   const agentConfigurationsFetcher: Fetcher<GetAgentConfigurationsResponseBody> =
     fetcher;
@@ -123,14 +120,11 @@ export function useAgentConfigurations({
   const queryString = getQueryString();
 
   const key = `/api/w/${workspaceId}/assistant/agent_configurations?${queryString}`;
-  const { cache } = useSWRConfig();
-  const inCache = typeof cache.get(key) !== "undefined";
 
   const { data, error, mutate, mutateRegardlessOfQueryParams } =
     useSWRWithDefaults(agentsGetView ? key : null, agentConfigurationsFetcher, {
       disabled,
-      revalidateOnMount: !inCache || revalidate,
-      revalidateOnFocus: !inCache || revalidate,
+      serveFromCache: true,
     });
 
   return {
@@ -138,7 +132,7 @@ export function useAgentConfigurations({
       () => (data ? data.agentConfigurations : []),
       [data]
     ),
-    isAgentConfigurationsLoading: !error && !data,
+    isAgentConfigurationsLoading: !disabled && !error && !data,
     isAgentConfigurationsError: error,
     mutate,
     mutateRegardlessOfQueryParams,

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -124,7 +124,8 @@ export function useAgentConfigurations({
   const { data, error, mutate, mutateRegardlessOfQueryParams } =
     useSWRWithDefaults(agentsGetView ? key : null, agentConfigurationsFetcher, {
       disabled,
-      serveFromCache: true,
+      revalidateIfStale: false,
+      keepPreviousData: true,
     });
 
   return {

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -155,7 +155,6 @@ export function useProgressiveAgentConfigurations({
     limit: 24,
     includes: ["usage"],
     disabled,
-    revalidate: false,
   });
 
   const {

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -7,7 +7,6 @@ import type {
 } from "@dust-tt/types";
 import { useCallback, useContext, useMemo } from "react";
 import type { Fetcher } from "swr";
-import { useSWRConfig } from "swr";
 
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import {
@@ -79,7 +78,6 @@ export function useAgentConfigurations({
   limit,
   sort,
   disabled,
-  loadOnceOnly,
 }: {
   workspaceId: string;
   agentsGetView: AgentsGetViewType | null;
@@ -87,7 +85,6 @@ export function useAgentConfigurations({
   limit?: number;
   sort?: "alphabetical" | "priority";
   disabled?: boolean;
-  loadOnceOnly?: boolean;
 }) {
   const agentConfigurationsFetcher: Fetcher<GetAgentConfigurationsResponseBody> =
     fetcher;
@@ -117,10 +114,6 @@ export function useAgentConfigurations({
       params.append("sort", sort);
     }
 
-    if (loadOnceOnly) {
-      params.append("no-cache-flush", "true");
-    }
-
     return params.toString();
   }
 
@@ -128,16 +121,10 @@ export function useAgentConfigurations({
 
   const key = `/api/w/${workspaceId}/assistant/agent_configurations?${queryString}`;
 
-  const { cache } = useSWRConfig();
-  const shouldNotRevalidate =
-    loadOnceOnly && cache.get(key) && cache.get(key)?.data;
-
   const { data, error, mutate, mutateRegardlessOfQueryParams } =
     useSWRWithDefaults(agentsGetView ? key : null, agentConfigurationsFetcher, {
       disabled,
       revalidateIfStale: false,
-      revalidateOnFocus: shouldNotRevalidate ? false : undefined,
-      revalidateOnMount: shouldNotRevalidate ? false : undefined,
       keepPreviousData: true,
     });
 
@@ -169,7 +156,6 @@ export function useProgressiveAgentConfigurations({
     limit: 24,
     includes: ["usage"],
     disabled,
-    loadOnceOnly: true,
   });
 
   const {

--- a/front/lib/swr/swr.ts
+++ b/front/lib/swr/swr.ts
@@ -25,17 +25,7 @@ export function useSWRWithDefaults<TKey extends Key, TData>(
 ) {
   const { mutate: globalMutate, cache } = useSWRConfig();
 
-  const inCache = key && cache.get(key.toString())?.data;
-
-  const { serveFromCache, ...mergedConfig } = {
-    ...DEFAULT_SWR_CONFIG,
-    ...config,
-  };
-
-  if (serveFromCache && inCache) {
-    mergedConfig.revalidateOnMount = false;
-    mergedConfig.revalidateOnFocus = false;
-  }
+  const mergedConfig = { ...DEFAULT_SWR_CONFIG, ...config };
 
   const disabled = !!mergedConfig.disabled;
 

--- a/front/lib/swr/swr.ts
+++ b/front/lib/swr/swr.ts
@@ -58,7 +58,11 @@ export function useSWRWithDefaults<TKey extends Key, TData>(
         // and mutate them too
         for (const k of cache.keys()) {
           const kAsUrl = tryMakeUrlWithoutParams(k as TKey);
-          if (kAsUrl === keyAsUrl && k !== key) {
+          if (
+            kAsUrl === keyAsUrl &&
+            k !== key &&
+            !k.includes("no-cache-flush=true")
+          ) {
             void globalMutate<TData>(k, undefined, options);
           }
         }

--- a/front/lib/swr/swr.ts
+++ b/front/lib/swr/swr.ts
@@ -65,11 +65,7 @@ export function useSWRWithDefaults<TKey extends Key, TData>(
         // and mutate them too
         for (const k of cache.keys()) {
           const kAsUrl = tryMakeUrlWithoutParams(k as TKey);
-          if (
-            kAsUrl === keyAsUrl &&
-            k !== key &&
-            !k.includes("no-cache-flush=true")
-          ) {
+          if (kAsUrl === keyAsUrl && k !== key) {
             void globalMutate<TData>(k, undefined, opts);
           }
         }


### PR DESCRIPTION
## Description

- This use the revalidateIfStale option to always dats from the cache and rely on the mutate calls.
- Avoid refetching  data from the preload query by adding an option to not flush in mutateKeysWithSameUrl
- Fixed swr custom mutates to allow options

## Risk

Assistant list not being refreshed automatically if a modification is done and no mutate is called.

## Deploy Plan

deploy front
