### PR TITLE
Delete group_vaults when deleting a vault

### DIFF
--- a/front/lib/resources/vault_resource.ts
+++ b/front/lib/resources/vault_resource.ts
@@ -272,6 +272,13 @@ export class VaultResource extends BaseResource<VaultModel> {
   ): Promise<Result<undefined, Error>> {
     const { hardDelete, transaction } = options;
 
+    await GroupVaultModel.destroy({
+      where: {
+        vaultId: this.id,
+      },
+      transaction,
+    });
+
     await VaultModel.destroy({
       where: {
         id: this.id,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
When we introduced opened spaces we started to rely on the global group. The deletion of open spaces is currently broken as we don't delete the associated `group_vaults` row that links the vault to the global group. This PR fixes it. Workflows should pick up the new code on deploy fixing the ongoing [error](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E14%20%40dd.service%3Afront-worker&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAZK0JvhTPCIWpgAAAAAAAAAYAAAAAEFaSzBKd0hIQUFEOWE2enk5RzB4TXdDTwAAACQAAAAAMDE5MmI0NTAtMTQ1OS00YmVkLWEzMWEtNWU2YjI1ZGQ0MDQ5&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1729598408000&to_ts=1729599308000&live=false). 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
