### PR TITLE
Improve vaults data source views update

### DIFF
--- a/front/components/vaults/EditVaultManagedDatasourcesViews.tsx
+++ b/front/components/vaults/EditVaultManagedDatasourcesViews.tsx
@@ -1,4 +1,4 @@
-import { Button, Dialog, PlusIcon } from "@dust-tt/sparkle";
+import { Button, ContentMessage, Dialog, PlusIcon } from "@dust-tt/sparkle";
 import type {
   APIError,
   DataSourceViewSelectionConfigurations,
@@ -102,28 +102,30 @@ export function EditVaultManagedDataSourcesViews({
         validateLabel: "Delete anyway",
         cancelLabel: "Cancel",
         validateVariant: "primaryWarning",
+        alertDialog: true,
         children: (
-          <div className="space-y-4">
+          <div className="space-y-4 text-slate-900">
             <p>The following data sources are currently in use:</p>
 
             {deletedViewsWithUsage.map((view) => (
-              <p key={view.sId} className="font-medium text-gray-700">
-                {getDisplayNameForDataSource(view.dataSource)}™
-                <span className="text-gray-500">
+              <p key={view.sId} className="font-medium">
+                {getDisplayNameForDataSource(view.dataSource)}{" "}
+                <span className="italic text-slate-500">
                   (used by {view.usage.count} assistant
                   {view.usage.count > 1 ? "s" : ""})
                 </span>
               </p>
             ))}
 
-            <div>
-              <p>Are you sure you want to remove them?</p>
-              <p className="mt-2 text-amber-600">
-                Warning: Deleting these data sources will affect the assistants
-                using them. These assistants will no longer have access to this
-                data and may not work as expected.
+            <ContentMessage size="md" variant="warning" title="Warning">
+              <p>
+                Deleting these data sources will affect the assistants using
+                them. These assistants will no longer have access to this data
+                and may not work as expected.
               </p>
-            </div>
+            </ContentMessage>
+
+            <p>Are you sure you want to remove them?</p>
           </div>
         ),
       });

--- a/front/hooks/useAwaitableDialog.tsx
+++ b/front/hooks/useAwaitableDialog.tsx
@@ -1,0 +1,55 @@
+import { Dialog } from "@dust-tt/sparkle";
+import type { ComponentProps } from "react";
+import { useState } from "react";
+
+type ShowDialogProps = Omit<
+  ComponentProps<typeof Dialog>,
+  "isOpen" | "onCancel" | "onValidate"
+>;
+interface DialogState {
+  isOpen: boolean;
+  props: ShowDialogProps | null;
+  resolve?: (value: boolean) => void;
+}
+
+export function useAwaitableDialog() {
+  const [dialogState, setDialogState] = useState<DialogState>({
+    isOpen: false,
+    props: null,
+  });
+
+  const showDialog = (props: ShowDialogProps): Promise<boolean> => {
+    return new Promise((resolve) => {
+      setDialogState({
+        isOpen: true,
+        props,
+        resolve,
+      });
+    });
+  };
+
+  const handleConfirm = () => {
+    dialogState.resolve?.(true);
+    setDialogState({ isOpen: false, props: null });
+  };
+
+  const handleCancel = () => {
+    dialogState.resolve?.(false);
+    setDialogState({ isOpen: false, props: null });
+  };
+
+  const DialogRenderer = () =>
+    dialogState.props ? (
+      <Dialog
+        {...dialogState.props}
+        isOpen={dialogState.isOpen}
+        onCancel={handleCancel}
+        onValidate={handleConfirm}
+      />
+    ) : null;
+
+  return {
+    AwaitableDialog: DialogRenderer,
+    showDialog,
+  };
+}

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.ts
@@ -126,17 +126,20 @@ async function handler(
         });
       }
 
-      const usageRes = await dataSourceView.getUsagesByAgents(auth);
-      if (usageRes.isErr() || usageRes.value.count > 0) {
-        return apiError(req, res, {
-          status_code: 401,
-          api_error: {
-            type: "data_source_error",
-            message: usageRes.isOk()
-              ? `The data source view is in use by ${usageRes.value.agentNames.join(", ")} and cannot be deleted.`
-              : "The data source view is in use and cannot be deleted.",
-          },
-        });
+      const force = req.query.force === "true";
+      if (!force) {
+        const usageRes = await dataSourceView.getUsagesByAgents(auth);
+        if (usageRes.isErr() || usageRes.value.count > 0) {
+          return apiError(req, res, {
+            status_code: 401,
+            api_error: {
+              type: "data_source_error",
+              message: usageRes.isOk()
+                ? `The data source view is in use by ${usageRes.value.agentNames.join(", ")} and cannot be deleted.`
+                : "The data source view is in use and cannot be deleted.",
+            },
+          });
+        }
       }
 
       // Directly, hard delete the data source view.


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes https://github.com/dust-tt/dust/issues/8163.

In the current implementation, we prevent removing a data source view from a vault, if it's being used by an assistant. This was relevant in most scenarios except the one where it's being used by a private assistant on which the admin can't do anything.

This PR:
- Introduces a generic hook to have an `AwaitableDialog` to interrupt a flow and resume based on the user's input
- Refactor the vaults data source views update to let the user force delete those views.

Next: I'll implement the same behavior when deleting a vault.

![ForceDeleteDataSourceViews](https://github.com/user-attachments/assets/124d86f6-290b-401e-8068-a2ae3e58b684)

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
