### PR TITLE
fix(doc tracker): use correct ID, re-enable and use cache

### DIFF
--- a/front/lib/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
+++ b/front/lib/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
@@ -44,9 +44,6 @@ const logger = mainLogger.child({
   postProcessHook: "document_tracker_suggest_changes",
 });
 
-// Temporary
-const DISABLE_DOC_TRACKER = true;
-
 export async function shouldDocumentTrackerSuggestChangesRun(
   params: DocumentsPostProcessHookFilterParams
 ): Promise<boolean> {
@@ -151,10 +148,6 @@ export async function documentTrackerSuggestChangesOnUpsert({
   documentHash,
   documentSourceUrl,
 }: DocumentsPostProcessHookOnUpsertParams): Promise<void> {
-  if (DISABLE_DOC_TRACKER) {
-    return;
-  }
-
   const owner = auth.workspace();
   if (!owner) {
     throw new Error("Workspace not found.");
@@ -345,13 +338,13 @@ export async function documentTrackerSuggestChangesOnUpsert({
       "Match found."
     );
 
-    const trackedDocDataSource =
+    const trackedDocumentDataSource =
       await DataSourceResource.fetchByDustAPIDataSourceId(
         auth,
         trackedDocDataSourceId
       );
 
-    if (!trackedDocDataSource) {
+    if (!trackedDocumentDataSource) {
       trackedDocLocalLogger.warn(
         {
           trackedDocDataSourceId,
@@ -364,7 +357,7 @@ export async function documentTrackerSuggestChangesOnUpsert({
     // again, checking for race condition here and skipping if the
     // tracked doc is the doc that was just upserted.
     if (
-      trackedDocDataSource.id === dataSource.id &&
+      trackedDocumentDataSource.id === dataSource.id &&
       trackedDocId === documentId
     ) {
       trackedDocLocalLogger.info(
@@ -380,7 +373,7 @@ export async function documentTrackerSuggestChangesOnUpsert({
     const trackedDocuments = await TrackedDocument.findAll({
       where: {
         documentId: trackedDocId,
-        dataSourceId: trackedDocDataSourceId,
+        dataSourceId: trackedDocumentDataSource.id,
       },
     });
     if (!trackedDocuments.length) {

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -148,7 +148,7 @@ export const DustProdActionRegistry = createActionRegistry({
     config: {
       SUGGEST_CHANGES: {
         // `provider_id` and `model_id` must be set by caller.
-        use_cache: false,
+        use_cache: true,
         function_call: "suggest_changes",
       },
     },


### PR DESCRIPTION
## Description

- Was using a string ID instead of a numeric ID (database error)
- Re-enable
- Set "use_cache" on the dust app chat block to reduce cost of retries

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
