### PR TITLE
core: Migration to remove all legacy GCS versions

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -35,6 +35,10 @@ path = "bin/oauth.rs"
 name = "oauth_generate_key"
 path = "bin/oauth_generate_key.rs"
 
+[[bin]]
+name = "backfill_stored_documents"
+path = "bin/migrations/20241024_clean_legacy_gcs.rs"
+
 [[test]]
 name = "oauth_connections_test"
 path = "src/oauth/tests/functional_connections.rs"

--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1904,6 +1904,59 @@ async fn data_sources_documents_delete(
     }
 }
 
+/// Scrub document deleted versions
+
+async fn data_sources_documents_scrub_deleted_versions(
+    Path((project_id, data_source_id, document_id)): Path<(i64, String, String)>,
+    State(state): State<Arc<APIState>>,
+) -> (StatusCode, Json<APIResponse>) {
+    let project = project::Project::new_from_id(project_id);
+    match state
+        .store
+        .load_data_source(&project, &data_source_id)
+        .await
+    {
+        Err(e) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "internal_server_error",
+            "Failed to retrieve data source",
+            Some(e),
+        ),
+        Ok(ds) => match ds {
+            None => error_response(
+                StatusCode::NOT_FOUND,
+                "data_source_not_found",
+                &format!("No data source found for id `{}`", data_source_id),
+                None,
+            ),
+            Some(ds) => match ds
+                .scrub_document_deleted_versions(state.store.clone(), &document_id)
+                .await
+            {
+                Err(e) => error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "internal_server_error",
+                    "Failed to scrub document deleted versions",
+                    Some(e),
+                ),
+                Ok(_) => (
+                    StatusCode::OK,
+                    Json(APIResponse {
+                        error: None,
+                        response: Some(json!({
+                            "data_source": {
+                                "created": ds.created(),
+                                "data_source_id": ds.data_source_id(),
+                                "config": ds.config(),
+                            },
+                        })),
+                    }),
+                ),
+            },
+        },
+    }
+}
+
 /// Delete a data source.
 
 async fn data_sources_delete(
@@ -2983,6 +3036,10 @@ fn main() {
         .route(
             "/projects/:project_id/data_sources/:data_source_id/documents/:document_id",
             delete(data_sources_documents_delete),
+        )
+        .route(
+            "/projects/:project_id/data_sources/:data_source_id/documents/:document_id/scrub_deleted_versions",
+            post(data_sources_documents_scrub_deleted_versions),
         )
         .route(
             "/projects/:project_id/data_sources/:data_source_id",

--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1939,16 +1939,12 @@ async fn data_sources_documents_scrub_deleted_versions(
                     "Failed to scrub document deleted versions",
                     Some(e),
                 ),
-                Ok(_) => (
+                Ok(versions) => (
                     StatusCode::OK,
                     Json(APIResponse {
                         error: None,
                         response: Some(json!({
-                            "data_source": {
-                                "created": ds.created(),
-                                "data_source_id": ds.data_source_id(),
-                                "config": ds.config(),
-                            },
+                            "versions": versions,
                         })),
                     }),
                 ),

--- a/core/bin/migrations/20241024_clean_legacy_gcs.rs
+++ b/core/bin/migrations/20241024_clean_legacy_gcs.rs
@@ -1,0 +1,183 @@
+use anyhow::{anyhow, Context, Result};
+use dust::{
+    data_sources::{
+        data_source::{make_document_id_hash, DataSource},
+        file_storage_document::FileStorageDocument,
+    },
+    stores::{postgres, store},
+};
+use tokio_postgres::Row;
+
+use bb8::Pool;
+use bb8_postgres::PostgresConnectionManager;
+use futures::{StreamExt, TryStreamExt};
+use tokio_postgres::NoTls;
+use tokio_stream::{self as stream};
+
+async fn fetch_data_sources_batch(
+    pool: &Pool<PostgresConnectionManager<NoTls>>,
+    last_id: u64,
+    limit: usize,
+) -> Result<Vec<Row>, anyhow::Error> {
+    let c = pool.get().await?;
+
+    c.query(
+        "SELECT id, internal_id FROM data_sources WHERE id > $1 ORDER BY id ASC LIMIT $2",
+        &[&(last_id as i64), &(limit as i64)],
+    )
+    .await
+    .context("Query execution failed")
+}
+
+async fn clean_stored_versions_for_document_id(
+    pool: &Pool<PostgresConnectionManager<NoTls>>,
+    data_source: &DataSource,
+    data_source_id: i64,
+    document_id: &str,
+) -> Result<()> {
+    let c = pool.get().await?;
+
+    let document_versions = c.query("SELECT hash, created, status FROM data_sources_documents WHERE data_source = $1 AND document_id = $2", &[&data_source_id, &document_id]).await?;
+    let document_id_hash = make_document_id_hash(document_id);
+
+    println!(
+        "Found {:} document versions for document {:} to clean-up.",
+        document_versions.len(),
+        document_id_hash
+    );
+
+    FileStorageDocument::delete_if_exists(&FileStorageDocument::get_legacy_document_id_path(
+        &data_source,
+        &document_id_hash,
+    ))
+    .await?;
+
+    let tasks = document_versions.into_iter().map(|d| {
+        let data_source = data_source.clone();
+        let document_id_hash = document_id_hash.to_string();
+
+        async move {
+            let document_hash: String = d.get(0);
+            FileStorageDocument::delete_if_exists(&FileStorageDocument::get_legacy_content_path(
+                &data_source,
+                &document_id_hash,
+                document_hash.as_str(),
+            ))
+            .await?;
+            Ok::<(), anyhow::Error>(())
+        }
+    });
+
+    let mut stream = stream::iter(tasks).buffer_unordered(16); // Run up to 16 in parallel.
+
+    while let Some(result) = stream.next().await {
+        result?; // Check for errors.
+    }
+
+    Ok(())
+}
+
+async fn clean_all_documents_for_data_source_id(
+    store: Box<dyn store::Store + Sync + Send>,
+    pool: &Pool<PostgresConnectionManager<NoTls>>,
+    data_source_internal_id: &str,
+    data_source_id: i64,
+) -> Result<()> {
+    println!("ds: {:?}", data_source_internal_id);
+
+    let data_source = match store
+        .load_data_source_by_internal_id(&data_source_internal_id)
+        .await?
+    {
+        Some(ds) => ds,
+        None => Err(anyhow!("Data source not found"))?,
+    };
+
+    let c = store.raw_pool().get().await?;
+
+    let document_ids = c
+        .query(
+            "SELECT DISTINCT document_id from data_sources_documents WHERE data_source = $1",
+            &[&data_source_id],
+        )
+        .await?;
+
+    println!("Found {:} document ids to update.", document_ids.len());
+
+    stream::iter(document_ids.into_iter().map(|row| {
+        let data_source = data_source.clone();
+
+        async move {
+            let document_id: String = row.get(0);
+
+            clean_stored_versions_for_document_id(&pool, &data_source, data_source_id, &document_id)
+                .await
+        }
+    }))
+    .buffer_unordered(16)
+    .try_collect::<Vec<_>>()
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    let store: Box<dyn store::Store + Sync + Send> = match std::env::var("CORE_DATABASE_URI") {
+        Ok(db_uri) => {
+            let store = postgres::PostgresStore::new(&db_uri).await?;
+            store.init().await?;
+            Box::new(store)
+        }
+        Err(_) => Err(anyhow!("CORE_DATABASE_URI is required (postgres)"))?,
+    };
+
+    let pool = store.raw_pool();
+
+    let limit: usize = 50;
+    let mut last_data_source_id = 0;
+
+    loop {
+        let rows = fetch_data_sources_batch(pool, last_data_source_id, limit).await?;
+
+        stream::iter(rows.iter().map(|row| {
+            let store = store.clone();
+
+            async move {
+                let data_source_id: i64 = row.get(0);
+                let data_source_internal_id: String = row.get(1);
+
+                clean_all_documents_for_data_source_id(
+                    store,
+                    pool,
+                    &data_source_internal_id,
+                    data_source_id,
+                )
+                .await
+            }
+        }))
+        .buffer_unordered(16)
+        .try_collect::<Vec<_>>()
+        .await?;
+
+        if rows.len() < limit {
+            println!("Updated all data_sources");
+            break;
+        }
+
+        last_data_source_id = match rows.last() {
+            Some(r) => {
+                let id: i64 = r.get(0);
+                println!("LAST_DATA_SOURCE_ID_UDPATE: {}", id);
+
+                id as u64
+            }
+            None => {
+                println!("Updated all data_sources");
+                break;
+            }
+        };
+    }
+
+    Ok(())
+}

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -1743,7 +1743,7 @@ impl DataSource {
         &self,
         store: Box<dyn Store + Sync + Send>,
         document_id: &str,
-    ) -> Result<()> {
+    ) -> Result<Vec<DocumentVersion>> {
         let store = store.clone();
 
         let (versions, _) = store
@@ -1762,8 +1762,7 @@ impl DataSource {
             .filter(|v| v.status == DocumentStatus::Deleted)
             .collect::<Vec<_>>();
 
-        println!("Document versions for scrubbing {:?}", versions);
-
+        let mut scrubbed_hashes: Vec<DocumentVersion> = vec![];
         for v in versions {
             let document_id_hash = make_document_id_hash(document_id);
 
@@ -1791,9 +1790,11 @@ impl DataSource {
                 version_hash = v.hash,
                 "Scrubbed deleted document version"
             );
+
+            scrubbed_hashes.push(v);
         }
 
-        Ok(())
+        Ok(scrubbed_hashes)
     }
 
     pub async fn delete(

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -23,6 +23,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::fmt;
+use std::str::FromStr;
 use tokio_stream::{self as stream};
 use tracing::{error, info};
 use uuid::Uuid;
@@ -206,10 +207,31 @@ pub fn make_document_id_hash(document_id: &str) -> String {
     format!("{}", hasher.finalize().to_hex())
 }
 
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DocumentStatus {
+    Latest,
+    Superseded,
+    Deleted,
+}
+
+impl FromStr for DocumentStatus {
+    type Err = utils::ParseError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "latest" => Ok(DocumentStatus::Latest),
+            "superseded" => Ok(DocumentStatus::Superseded),
+            "deleted" => Ok(DocumentStatus::Deleted),
+            _ => Err(utils::ParseError::with_message("Unknown DocumentStatus"))?,
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Clone)]
 pub struct DocumentVersion {
     pub created: u64,
     pub hash: String,
+    pub status: DocumentStatus,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
@@ -1713,6 +1735,63 @@ impl DataSource {
         qdrant_client
             .delete_points(embedder_config, &self.internal_id, filter)
             .await?;
+
+        Ok(())
+    }
+
+    pub async fn scrub_document_deleted_versions(
+        &self,
+        store: Box<dyn Store + Sync + Send>,
+        document_id: &str,
+    ) -> Result<()> {
+        let store = store.clone();
+
+        let (versions, _) = store
+            .list_data_source_document_versions(
+                &self.project,
+                &self.data_source_id,
+                document_id,
+                None,
+                &None,
+                &None,
+            )
+            .await?;
+
+        let versions = versions
+            .into_iter()
+            .filter(|v| v.status == DocumentStatus::Deleted)
+            .collect::<Vec<_>>();
+
+        println!("Document versions for scrubbing {:?}", versions);
+
+        for v in versions {
+            let document_id_hash = make_document_id_hash(document_id);
+
+            FileStorageDocument::scrub_document_version_from_file_storage(
+                &self,
+                document_id,
+                &document_id_hash,
+                &v,
+            )
+            .await?;
+
+            store
+                .scrub_data_source_document_version(
+                    &self.project,
+                    &self.data_source_id,
+                    document_id,
+                    &v,
+                )
+                .await?;
+
+            info!(
+                data_source_internal_id = self.internal_id,
+                document_id = document_id,
+                version_created = v.created,
+                version_hash = v.hash,
+                "Scrubbed deleted document version"
+            );
+        }
 
         Ok(())
     }

--- a/core/src/data_sources/file_storage_document.rs
+++ b/core/src/data_sources/file_storage_document.rs
@@ -22,6 +22,59 @@ impl FileStorageDocument {
         }
     }
 
+    pub fn get_legacy_content_path(
+        data_source: &DataSource,
+        document_id_hash: &str,
+        document_hash: &str,
+    ) -> String {
+        let legacy_bucket_path = format!(
+            "{}/{}/{}",
+            data_source.project().project_id(),
+            data_source.internal_id(),
+            document_id_hash
+        );
+
+        format!("{}/{}/content.txt", legacy_bucket_path, document_hash)
+    }
+
+    pub fn get_legacy_document_id_path(data_source: &DataSource, document_id_hash: &str) -> String {
+        let legacy_bucket_path = format!(
+            "{}/{}/{}",
+            data_source.project().project_id(),
+            data_source.internal_id(),
+            document_id_hash
+        );
+
+        format!("{}/document_id.txt", legacy_bucket_path)
+    }
+
+    pub async fn path_exists(path: &str) -> Result<bool> {
+        let bucket = FileStorageDocument::get_bucket().await?;
+
+        match Object::read(&bucket, path).await {
+            Ok(_) => Ok(true),
+            Err(_err) => Ok(false),
+        }
+    }
+
+    pub async fn delete_if_exists(path: &str) -> Result<bool> {
+        let bucket = FileStorageDocument::get_bucket().await?;
+
+        match Object::delete(&bucket, &path).await {
+            Ok(_) => {
+                println!("Deleted {}", path);
+                Ok(true)
+            }
+            Err(e) => match e {
+                cloud_storage::Error::Google(GoogleErrorResponse {
+                    error: ErrorList { code: 404, .. },
+                    ..
+                }) => Ok(false),
+                e => Err(e)?,
+            },
+        }
+    }
+
     pub async fn get_stored_document(
         data_source: &DataSource,
         document_created: u64,

--- a/core/src/data_sources/file_storage_document.rs
+++ b/core/src/data_sources/file_storage_document.rs
@@ -1,11 +1,11 @@
 use anyhow::{anyhow, Result};
-use cloud_storage::Object;
+use cloud_storage::{ErrorList, GoogleErrorResponse, Object};
 use serde::{Deserialize, Serialize};
 use tracing::info;
 
 use crate::utils;
 
-use super::data_source::{DataSource, Document, Section};
+use super::data_source::{DataSource, Document, DocumentVersion, Section};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct FileStorageDocument {
@@ -61,6 +61,53 @@ impl FileStorageDocument {
         format!("{}/{}/{}.json", ds_bucket_path, document_id_hash, filename)
     }
 
+    pub async fn scrub_document_version_from_file_storage(
+        data_source: &DataSource,
+        document_id: &str,
+        document_id_hash: &str,
+        version: &DocumentVersion,
+    ) -> Result<()> {
+        let bucket = FileStorageDocument::get_bucket().await?;
+
+        let data_source_internal_id = data_source.internal_id();
+        let document_hash = &version.hash;
+        let created = version.created;
+
+        let document_file_path = FileStorageDocument::get_document_file_path(
+            data_source,
+            created,
+            document_id_hash,
+            document_hash,
+        );
+
+        let now = utils::now();
+        match Object::delete(&bucket, &document_file_path).await {
+            Ok(_) => (),
+            Err(e) => {
+                match e {
+                    cloud_storage::Error::Google(GoogleErrorResponse {
+                        error: ErrorList { code: 404, .. },
+                        ..
+                    }) => {
+                        // Silently ignore 404 errors which means the object does not exist
+                        // anymore.
+                    }
+                    e => Err(e)?,
+                }
+            }
+        };
+
+        info!(
+            data_source_internal_id = data_source_internal_id,
+            document_id = document_id,
+            duration = utils::now() - now,
+            blob_url = format!("gs://{}/{}", bucket, document_file_path),
+            "Scrubbed document blob"
+        );
+
+        Ok(())
+    }
+
     pub async fn save_document_in_file_storage(
         data_source: &DataSource,
         document: &Document,
@@ -71,7 +118,6 @@ impl FileStorageDocument {
         let bucket = FileStorageDocument::get_bucket().await?;
 
         let data_source_internal_id = data_source.internal_id();
-
         let document_hash = &document.hash;
         let document_id = &document.document_id;
 
@@ -101,7 +147,6 @@ impl FileStorageDocument {
             data_source_internal_id = data_source_internal_id,
             document_id = document_id,
             duration = utils::now() - now,
-            // New.
             blob_url = format!("gs://{}/{}", bucket, document_file_path),
             "Created document blob"
         );

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -12,6 +12,7 @@ use std::str::FromStr;
 use tokio_postgres::types::ToSql;
 use tokio_postgres::{NoTls, Transaction};
 
+use crate::data_sources::data_source::DocumentStatus;
 use crate::{
     blocks::block::BlockType,
     cached_request::CachedRequest,
@@ -1507,13 +1508,13 @@ impl Store for PostgresStore {
                 }
             }
 
-            // get the latest version's created timestamp
+            // Get the latest version's created timestamp (accepting deleted versions).
             None => {
                 let stmt = c
                     .prepare(
                         "SELECT created FROM data_sources_documents \
                            WHERE data_source = $1 AND document_id = $2 \
-                           AND status = 'latest' LIMIT 1",
+                           ORDER BY created DESC LIMIT 1",
                     )
                     .await?;
                 let r = c.query(&stmt, &[&data_source_row_id, &document_id]).await?;
@@ -1542,7 +1543,7 @@ impl Store for PostgresStore {
         params.extend(filter_params);
 
         let sql = format!(
-            "SELECT hash, created FROM data_sources_documents \
+            "SELECT hash, created, status FROM data_sources_documents \
                WHERE {} ORDER BY created DESC",
             where_clauses.join(" AND ")
         );
@@ -1571,9 +1572,13 @@ impl Store for PostgresStore {
         for row in rows {
             let hash: String = row.get(0);
             let created: i64 = row.get(1);
+            let status_str: String = row.get(2);
+            let status = DocumentStatus::from_str(&status_str)?;
+
             versions.push(DocumentVersion {
                 hash,
                 created: created as u64,
+                status,
             });
         }
 
@@ -1923,6 +1928,49 @@ impl Store for PostgresStore {
             )
             .await?;
         let _ = c.query(&stmt, &[&data_source_row_id, &document_id]).await?;
+
+        Ok(())
+    }
+
+    async fn scrub_data_source_document_version(
+        &self,
+        project: &Project,
+        data_source_id: &str,
+        document_id: &str,
+        version: &DocumentVersion,
+    ) -> Result<()> {
+        let project_id = project.project_id();
+        let data_source_id = data_source_id.to_string();
+        let document_id = document_id.to_string();
+        let created = version.created as i64;
+        let hash = version.hash.clone();
+
+        let pool = self.pool.clone();
+        let c = pool.get().await?;
+
+        let r = c
+            .query(
+                "SELECT id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
+                &[&project_id, &data_source_id],
+            )
+            .await?;
+
+        let data_source_row_id: i64 = match r.len() {
+            0 => Err(anyhow!("Unknown DataSource: {}", data_source_id))?,
+            1 => r[0].get(0),
+            _ => unreachable!(),
+        };
+
+        let stmt = c
+            .prepare(
+                "DELETE FROM data_sources_documents \
+                   WHERE data_source = $1 AND document_id = $2 \
+                   AND created = $3 AND hash = $4 AND status='deleted'",
+            )
+            .await?;
+        let _ = c
+            .query(&stmt, &[&data_source_row_id, &document_id, &created, &hash])
+            .await?;
 
         Ok(())
     }

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -132,6 +132,10 @@ impl PostgresStore {
 
 #[async_trait]
 impl Store for PostgresStore {
+    fn raw_pool(&self) -> &Pool<PostgresConnectionManager<NoTls>> {
+        return &self.pool;
+    }
+
     async fn create_project(&self) -> Result<Project> {
         let pool = self.pool.clone();
         let c = pool.get().await?;

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -1502,7 +1502,7 @@ impl Store for PostgresStore {
                     .query(&stmt, &[&data_source_row_id, &document_id, &latest_hash])
                     .await?;
                 match r.len() {
-                    0 => Err(anyhow!("Unknown Document: {}", document_id))?,
+                    0 => Err(anyhow!("Unknown document hash"))?,
                     1 => r[0].get(0),
                     _ => unreachable!(),
                 }
@@ -1519,7 +1519,9 @@ impl Store for PostgresStore {
                     .await?;
                 let r = c.query(&stmt, &[&data_source_row_id, &document_id]).await?;
                 match r.len() {
-                    0 => Err(anyhow!("Unknown Document: {}", document_id))?,
+                    // If no hash was specified and there are no versions, just return an empty
+                    // array.
+                    0 => return Ok((vec![], 0)),
                     1 => r[0].get(0),
                     _ => unreachable!(),
                 }

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -1,6 +1,9 @@
 use anyhow::Result;
 use async_trait::async_trait;
+use bb8::Pool;
+use bb8_postgres::PostgresConnectionManager;
 use std::collections::HashMap;
+use tokio_postgres::NoTls;
 
 use crate::{
     blocks::block::BlockType,
@@ -21,6 +24,7 @@ use crate::{
 
 #[async_trait]
 pub trait Store {
+    fn raw_pool(&self) -> &Pool<PostgresConnectionManager<NoTls>>;
     // Projects
     async fn create_project(&self) -> Result<Project>;
     async fn delete_project(&self, project: &Project) -> Result<()>;

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -175,6 +175,13 @@ pub trait Store {
         data_source_id: &str,
         document_id: &str,
     ) -> Result<()>;
+    async fn scrub_data_source_document_version(
+        &self,
+        project: &Project,
+        data_source_id: &str,
+        document_id: &str,
+        version: &DocumentVersion,
+    ) -> Result<()>;
     async fn delete_data_source(&self, project: &Project, data_source_id: &str) -> Result<u64>;
     // Databases
     async fn upsert_database(

--- a/front/lib/production_checks/checks/scrub_deleted_core_document_versions.ts
+++ b/front/lib/production_checks/checks/scrub_deleted_core_document_versions.ts
@@ -1,19 +1,12 @@
-import type { Bucket, File } from "@google-cloud/storage";
-import { Storage } from "@google-cloud/storage";
-import { createHash } from "blake3";
+import { CoreAPI } from "@dust-tt/types";
 import type { LoggerOptions } from "pino";
 import type pino from "pino";
 
+import config from "@app/lib/api/config";
 import type { CheckFunction } from "@app/lib/production_checks/types";
-import {
-  getCorePrimaryDbConnection,
-  getCoreReplicaDbConnection,
-} from "@app/lib/production_checks/utils";
-import { withRetries } from "@app/lib/utils/retries";
-import logger from "@app/logger/logger";
+import { getCoreReplicaDbConnection } from "@app/lib/production_checks/utils";
 
-const { CORE_DATABASE_URI, SERVICE_ACCOUNT, DUST_DATA_SOURCES_BUCKET } =
-  process.env;
+const { CORE_DATABASE_URI } = process.env;
 
 export const scrubDeletedCoreDocumentVersionsCheck: CheckFunction = async (
   checkName,
@@ -25,13 +18,8 @@ export const scrubDeletedCoreDocumentVersionsCheck: CheckFunction = async (
   if (!CORE_DATABASE_URI) {
     throw new Error("Env var CORE_DATABASE_URI is not defined");
   }
-  if (!SERVICE_ACCOUNT) {
-    throw new Error("Env var SERVICE_ACCOUNT is not defined");
-  }
 
   const coreReplica = getCoreReplicaDbConnection();
-
-  const storage = new Storage({ keyFilename: SERVICE_ACCOUNT });
 
   let lastSeenId = 0;
   let totalDeletedCount = 0;
@@ -39,16 +27,20 @@ export const scrubDeletedCoreDocumentVersionsCheck: CheckFunction = async (
   do {
     // paginate by id
     const deletedDocumentsData = await coreReplica.query(
-      `SELECT * FROM data_sources_documents WHERE status = 'deleted' AND id > ${lastSeenId} ORDER BY id LIMIT 1000`
+      `SELECT dsd.id, dsd.created, dsd.document_id, dsd.hash, ds.data_source_id, ds.project
+        FROM data_sources_documents dsd
+        JOIN data_sources ds ON ds.id = dsd.data_source
+        WHERE dsd.status = 'deleted' AND dsd.id > 0
+        ORDER BY dsd.id LIMIT 1000`
     );
 
     const deletedDocuments = deletedDocumentsData[0] as {
       id: number;
+      project: number;
       created: number;
-      data_source: number;
+      data_source_id: string;
       document_id: string;
       hash: string;
-      timestamp: number;
     }[];
 
     logger.info(
@@ -63,7 +55,6 @@ export const scrubDeletedCoreDocumentVersionsCheck: CheckFunction = async (
       chunks.push(deletedDocuments.slice(i, i + 32));
     }
 
-    const seen: Set<string> = new Set();
     let deletedCount = 0;
 
     for (let i = 0; i < chunks.length; i++) {
@@ -74,13 +65,9 @@ export const scrubDeletedCoreDocumentVersionsCheck: CheckFunction = async (
           return (async () => {
             const done = await scrubDocument({
               logger,
-              seen,
-              storage,
-              data_source: d.data_source,
-              document_id: d.document_id,
-              created: d.created,
-              hash: d.hash,
-              id: d.id,
+              project: d.project,
+              dataSourceId: d.data_source_id,
+              documentId: d.document_id,
             });
             if (done) {
               deletedCount++;
@@ -108,192 +95,37 @@ export const scrubDeletedCoreDocumentVersionsCheck: CheckFunction = async (
   });
 };
 
-async function getFiles({ bucket, path }: { bucket: Bucket; path: string }) {
-  return bucket.getFiles({ prefix: path });
-}
-
-async function deleteFile({ file }: { file: File }) {
-  if (!(await file.exists())) {
-    logger.error(
-      { name: file.name, bucket: file.bucket.name, panic: true },
-      "Delete: File does not exist. Can be ignored if single file, otherwise investigate"
-    );
-  } else {
-    return file.delete();
-  }
-}
-
-async function deleteFilesFromFolder(
-  logger: pino.Logger<LoggerOptions>,
-  bucket: Bucket,
-  seen: Set<string>,
-  path: string,
-  filename?: string
-) {
-  const [files] = await withRetries(getFiles)({ bucket, path });
-
-  const deletePromises = files
-    .filter(
-      (f) =>
-        !seen.has(f.name) && (!filename || f.name === `${path}/${filename}`)
-    )
-    .map((f) => {
-      seen.add(f.name);
-      logger.info(
-        {
-          path: f.name,
-          filesCount: files.length,
-        },
-        "Scrubbing"
-      );
-
-      return withRetries(deleteFile)({ file: f });
-    });
-
-  if (filename) {
-    // Remove document_id.txt if all other files are deleted
-    const documentIdFile = files.find(
-      (f) => f.name === `${path}/document_id.txt`
-    );
-
-    if (
-      documentIdFile &&
-      files
-        .filter((f) => f !== documentIdFile)
-        .map((file) => file.name)
-        .every((f) => seen.has(f))
-    ) {
-      deletePromises.push(withRetries(deleteFile)({ file: documentIdFile }));
-    }
-  }
-
-  await Promise.all(deletePromises);
-}
-
 async function scrubDocument({
   logger,
-  storage,
-  seen,
-  data_source,
-  document_id,
-  created,
-  hash,
-  id,
+  project,
+  dataSourceId,
+  documentId,
 }: {
   logger: pino.Logger<LoggerOptions>;
-  storage: Storage;
-  seen: Set<string>;
-  data_source: number;
-  document_id: string;
-  created: number;
-  hash: string;
-  id: number;
+  project: number;
+  dataSourceId: string;
+  documentId: string;
 }) {
-  if (!DUST_DATA_SOURCES_BUCKET) {
-    throw new Error("Env var DUST_DATA_SOURCES_BUCKET is not defined");
-  }
-  const corePrimary = getCorePrimaryDbConnection();
+  const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 
-  // Process same version of same document only once.
-  const uid = `${data_source}-${document_id}-${hash}`;
-  if (seen.has(uid)) {
-    return false;
-  }
-
-  const moreRecentSameHash = await corePrimary.query(
-    `SELECT id FROM data_sources_documents WHERE data_source = :data_source AND document_id = :document_id AND hash = :hash AND status != 'deleted' AND created >= :created LIMIT 1`,
-    {
-      replacements: {
-        data_source: data_source,
-        document_id: document_id,
-        hash: hash,
-        created: created,
-      },
-    }
-  );
-
-  if (moreRecentSameHash[0].length > 0) {
-    // delete the row
-    await corePrimary.query(
-      `DELETE FROM data_sources_documents WHERE id = :id`,
-      {
-        replacements: {
-          id: id,
-        },
-      }
-    );
-
-    // Skipping as there is a more recent version with the same hash
-    return false;
-  }
-
-  const dataSourceData = await corePrimary.query(
-    `SELECT * FROM data_sources WHERE id = :data_source`,
-    {
-      replacements: {
-        data_source: data_source,
-      },
-    }
-  );
-
-  if (dataSourceData[0].length === 0) {
-    throw new Error(`Could not find data source ${data_source}`);
-  }
-
-  const dataSource = dataSourceData[0][0] as {
-    id: number;
-    project: number;
-    internal_id: string;
-  };
-
-  const hasher = createHash();
-  hasher.update(Buffer.from(document_id));
-  const documentIdHash = hasher.digest("hex");
-
-  // Legacy logic.
-  const legacyPath = `${dataSource.project}/${dataSource.internal_id}/${documentIdHash}/${hash}`;
-
-  // New logic.
-  const path = `${dataSource.project}/${dataSource.internal_id}/${documentIdHash}`;
-  const filename = `${created}_${hash}.json`;
-
-  const bucket = storage.bucket(DUST_DATA_SOURCES_BUCKET);
-
-  const localLogger = logger.child({
-    documentId: document_id,
-    documentHash: hash,
-    dataSourceProject: dataSource.project,
-    dataSourceInternalId: dataSource.internal_id,
-    dataSourceId: dataSource.id,
+  const sRes = await coreAPI.scrubDataSourceDocumentDeletedVersions({
+    projectId: `${project}`,
+    dataSourceId,
+    documentId,
   });
-  // Always delete legacy files first!
-  await deleteFilesFromFolder(localLogger, bucket, seen, legacyPath);
 
-  await deleteFilesFromFolder(localLogger, bucket, seen, path, filename);
-
-  await corePrimary.query(
-    `DELETE FROM data_sources_documents WHERE data_source = :data_source AND document_id = :document_id AND hash = :hash AND status = 'deleted'`,
-    {
-      replacements: {
-        data_source: data_source,
-        document_id: document_id,
-        hash: hash,
-      },
-    }
-  );
+  if (sRes.isErr()) {
+    throw new Error(`Failed to scrub versions: ${sRes.error}`);
+  }
 
   logger.info(
     {
-      documentId: document_id,
-      documentHash: hash,
-      dataSourceProject: dataSource.project,
-      dataSourceInternalId: dataSource.internal_id,
-      dataSourceId: dataSource.id,
+      documentId,
+      dataSourceProject: project,
+      dataSourceId: dataSourceId,
     },
     "Scrubbed deleted versions"
   );
-
-  seen.add(uid);
 
   return true;
 }

--- a/front/lib/production_checks/checks/scrub_deleted_core_document_versions.ts
+++ b/front/lib/production_checks/checks/scrub_deleted_core_document_versions.ts
@@ -30,7 +30,7 @@ export const scrubDeletedCoreDocumentVersionsCheck: CheckFunction = async (
       `SELECT dsd.id, dsd.created, dsd.document_id, dsd.hash, ds.data_source_id, ds.project
         FROM data_sources_documents dsd
         JOIN data_sources ds ON ds.id = dsd.data_source
-        WHERE dsd.status = 'deleted' AND dsd.id > 0
+        WHERE dsd.status = 'deleted' AND dsd.id > ${lastSeenId}
         ORDER BY dsd.id LIMIT 1000`
     );
 

--- a/types/src/core/data_source.ts
+++ b/types/src/core/data_source.ts
@@ -71,3 +71,11 @@ export type CoreAPILightDocument = {
   token_count: number;
   created: number;
 };
+
+export type CoreAPIDocumentVersionStatus = "latest" | "superseded" | "deleted";
+
+export type CoreAPIDocumentVersion = {
+  hash: string;
+  created: number;
+  status: CoreAPIDocumentVersionStatus;
+};

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -5,6 +5,7 @@ import {
   CoreAPIDataSourceConfig,
   CoreAPIDataSourceDocumentSection,
   CoreAPIDocument,
+  CoreAPIDocumentVersion,
   CoreAPILightDocument,
   EmbedderType,
 } from "../../core/data_source";
@@ -784,7 +785,7 @@ export class CoreAPI {
     latest_hash?: string | null;
   }): Promise<
     CoreAPIResponse<{
-      versions: { hash: string; created: number }[];
+      versions: CoreAPIDocumentVersion[];
       offset: number;
       limit: number;
       total: number;
@@ -962,6 +963,33 @@ export class CoreAPI {
       )}/documents/${encodeURIComponent(documentId)}`,
       {
         method: "DELETE",
+      }
+    );
+
+    return this._resultFromResponse(response);
+  }
+
+  async scrubDataSourceDocumentDeletedVersions({
+    projectId,
+    dataSourceId,
+    documentId,
+  }: {
+    projectId: string;
+    dataSourceId: string;
+    documentId: string;
+  }): Promise<
+    CoreAPIResponse<{
+      versions: CoreAPIDocumentVersion[];
+    }>
+  > {
+    const response = await this._fetchWithError(
+      `${this._url}/projects/${encodeURIComponent(
+        projectId
+      )}/data_sources/${encodeURIComponent(
+        dataSourceId
+      )}/documents/${encodeURIComponent(documentId)}/scrub_deleted_versions`,
+      {
+        method: "POST",
       }
     );
 


### PR DESCRIPTION
## Description

We had kept the legacy GCS version as part of moving to a JSON format. It is now time to delete them all so that we stop handling them when scrubbing data source documents.

## Risk

Low paths are pretty explicit.

## Deploy Plan

- deploy `prodbox`
- Run from `prodbox`: `cargo run --release --bin migration_clean_legacy_gcs`