### PR TITLE
core: Migration to remove all legacy GCS versions

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -36,7 +36,7 @@ name = "oauth_generate_key"
 path = "bin/oauth_generate_key.rs"
 
 [[bin]]
-name = "backfill_stored_documents"
+name = "migration_clean_legacy_gcs"
 path = "bin/migrations/20241024_clean_legacy_gcs.rs"
 
 [[test]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -35,6 +35,10 @@ path = "bin/oauth.rs"
 name = "oauth_generate_key"
 path = "bin/oauth_generate_key.rs"
 
+[[bin]]
+name = "backfill_stored_documents"
+path = "bin/migrations/20241024_clean_legacy_gcs.rs"
+
 [[test]]
 name = "oauth_connections_test"
 path = "src/oauth/tests/functional_connections.rs"

--- a/core/bin/migrations/20241024_clean_legacy_gcs.rs
+++ b/core/bin/migrations/20241024_clean_legacy_gcs.rs
@@ -142,7 +142,7 @@ async fn clean_stored_versions_for_data_source(
                     Ok::<(), anyhow::Error>(())
                 }),
         )
-        .buffer_unordered(24)
+        .buffer_unordered(32)
         .try_collect::<Vec<_>>()
         .await?;
 
@@ -210,7 +210,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let pool = store.raw_pool();
 
-    let limit: usize = 256;
+    let limit: usize = 16000;
     let mut last_data_source_id = 0;
     let mut iteration = 0;
 
@@ -232,7 +232,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 .await
             }
         }))
-        .buffer_unordered(12)
+        .buffer_unordered(16)
         .try_collect::<Vec<_>>()
         .await?;
 

--- a/core/bin/migrations/20241024_clean_legacy_gcs.rs
+++ b/core/bin/migrations/20241024_clean_legacy_gcs.rs
@@ -61,7 +61,7 @@ async fn clean_stored_versions_for_data_source(
 
     let pool = store.raw_pool();
 
-    let limit: usize = 64;
+    let limit: usize = 1024;
     let mut last_data_source_document_id = 0;
     let mut iteration = 0;
     let mut document_id_hashs = HashSet::new();
@@ -109,7 +109,7 @@ async fn clean_stored_versions_for_data_source(
                     Ok::<(), anyhow::Error>(())
                 }),
         )
-        .buffer_unordered(16)
+        .buffer_unordered(32)
         .try_collect::<Vec<_>>()
         .await?;
 
@@ -177,7 +177,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let pool = store.raw_pool();
 
-    let limit: usize = 64;
+    let limit: usize = 256;
     let mut last_data_source_id = 0;
     let mut iteration = 0;
 

--- a/core/bin/migrations/20241024_clean_legacy_gcs.rs
+++ b/core/bin/migrations/20241024_clean_legacy_gcs.rs
@@ -114,7 +114,7 @@ async fn clean_all_documents_for_data_source_id(
 
     println!(
         "Processing: data_source={} document_count={:}",
-        data_source_internal_id
+        data_source_internal_id,
         document_ids.len(),
     );
 

--- a/core/bin/migrations/20241024_clean_legacy_gcs.rs
+++ b/core/bin/migrations/20241024_clean_legacy_gcs.rs
@@ -113,9 +113,9 @@ async fn clean_all_documents_for_data_source_id(
         .await?;
 
     println!(
-        "Processing: document_count={:} data_source={}",
-        document_ids.len(),
+        "Processing: data_source={} document_count={:}",
         data_source_internal_id
+        document_ids.len(),
     );
 
     stream::iter(document_ids.into_iter().map(|row| {

--- a/core/bin/migrations/20241024_clean_legacy_gcs.rs
+++ b/core/bin/migrations/20241024_clean_legacy_gcs.rs
@@ -1,0 +1,183 @@
+use anyhow::{anyhow, Context, Result};
+use dust::{
+    data_sources::{
+        data_source::{make_document_id_hash, DataSource},
+        file_storage_document::FileStorageDocument,
+    },
+    stores::{postgres, store},
+};
+use tokio_postgres::Row;
+
+use bb8::Pool;
+use bb8_postgres::PostgresConnectionManager;
+use futures::{StreamExt, TryStreamExt};
+use tokio_postgres::NoTls;
+use tokio_stream::{self as stream};
+
+async fn fetch_data_sources_batch(
+    pool: &Pool<PostgresConnectionManager<NoTls>>,
+    last_id: u64,
+    limit: usize,
+) -> Result<Vec<Row>, anyhow::Error> {
+    let c = pool.get().await?;
+
+    c.query(
+        "SELECT id, internal_id FROM data_sources WHERE id > $1 ORDER BY id ASC LIMIT $2",
+        &[&(last_id as i64), &(limit as i64)],
+    )
+    .await
+    .context("Query execution failed")
+}
+
+async fn clean_stored_versions_for_document_id(
+    pool: &Pool<PostgresConnectionManager<NoTls>>,
+    data_source: &DataSource,
+    data_source_id: i64,
+    document_id: &str,
+) -> Result<()> {
+    let c = pool.get().await?;
+
+    let document_versions = c.query("SELECT hash, created, status FROM data_sources_documents WHERE data_source = $1 AND document_id = $2", &[&data_source_id, &document_id]).await?;
+    let document_id_hash = make_document_id_hash(document_id);
+
+    println!(
+        "Found {:} document versions for document {:} to clean-up.",
+        document_versions.len(),
+        document_id_hash
+    );
+
+    FileStorageDocument::delete_if_exists(&FileStorageDocument::get_legacy_document_id_path(
+        &data_source,
+        &document_id_hash,
+    ))
+    .await?;
+
+    let tasks = document_versions.into_iter().map(|d| {
+        let data_source = data_source.clone();
+        let document_id_hash = document_id_hash.to_string();
+
+        async move {
+            let document_hash: String = d.get(0);
+            FileStorageDocument::delete_if_exists(&FileStorageDocument::get_legacy_content_path(
+                &data_source,
+                &document_id_hash,
+                document_hash.as_str(),
+            ))
+            .await?;
+            Ok::<(), anyhow::Error>(())
+        }
+    });
+
+    let mut stream = stream::iter(tasks).buffer_unordered(16); // Run up to 16 in parallel.
+
+    while let Some(result) = stream.next().await {
+        result?; // Check for errors.
+    }
+
+    Ok(())
+}
+
+async fn clean_all_documents_for_data_source_id(
+    store: Box<dyn store::Store + Sync + Send>,
+    pool: &Pool<PostgresConnectionManager<NoTls>>,
+    data_source_internal_id: &str,
+    data_source_id: i64,
+) -> Result<()> {
+    println!("ds: {:?}", data_source_internal_id);
+
+    let data_source = match store
+        .load_data_source_by_internal_id(&data_source_internal_id)
+        .await?
+    {
+        Some(ds) => ds,
+        None => Err(anyhow!("Data source not found"))?,
+    };
+
+    let c = store.raw_pool().get().await?;
+
+    let document_ids = c
+        .query(
+            "SELECT DISTINCT document_id from data_sources_documents WHERE data_source = $1",
+            &[&data_source_id],
+        )
+        .await?;
+
+    println!("Found {:} document ids to update.", document_ids.len());
+
+    stream::iter(document_ids.into_iter().map(|row| {
+        let data_source = data_source.clone();
+
+        async move {
+            let document_id: String = row.get(0);
+
+            clean_stored_versions_for_document_id(&pool, &data_source, data_source_id, &document_id)
+                .await
+        }
+    }))
+    .buffer_unordered(16)
+    .try_collect::<Vec<_>>()
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    let store: Box<dyn store::Store + Sync + Send> = match std::env::var("CORE_DATABASE_URI") {
+        Ok(db_uri) => {
+            let store = postgres::PostgresStore::new(&db_uri).await?;
+            store.init().await?;
+            Box::new(store)
+        }
+        Err(_) => Err(anyhow!("CORE_DATABASE_URI is required (postgres)"))?,
+    };
+
+    let pool = store.raw_pool();
+
+    let limit: usize = 50;
+    let mut last_data_source_id = 0;
+
+    loop {
+        let rows = fetch_data_sources_batch(pool, last_data_source_id, limit).await?;
+
+        stream::iter(rows.iter().map(|row| {
+            let store = store.clone();
+
+            async move {
+                let data_source_id: i64 = row.get(0);
+                let data_source_internal_id: String = row.get(1);
+
+                clean_all_documents_for_data_source_id(
+                    store,
+                    pool,
+                    &data_source_internal_id,
+                    data_source_id,
+                )
+                .await
+            }
+        }))
+        .buffer_unordered(16)
+        .try_collect::<Vec<_>>()
+        .await?;
+
+        if rows.len() < limit {
+            println!("Updated all data_sources");
+            break;
+        }
+
+        last_data_source_id = match rows.last() {
+            Some(r) => {
+                let id: i64 = r.get(0);
+                println!("LAST_DATA_SOURCE_ID_UDPATE: {}", id);
+
+                id as u64
+            }
+            None => {
+                println!("Updated all data_sources");
+                break;
+            }
+        };
+    }
+
+    Ok(())
+}

--- a/core/bin/migrations/20241024_clean_legacy_gcs.rs
+++ b/core/bin/migrations/20241024_clean_legacy_gcs.rs
@@ -109,7 +109,7 @@ async fn clean_stored_versions_for_data_source(
                     Ok::<(), anyhow::Error>(())
                 }),
         )
-        .buffer_unordered(32)
+        .buffer_unordered(24)
         .try_collect::<Vec<_>>()
         .await?;
 
@@ -199,7 +199,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 .await
             }
         }))
-        .buffer_unordered(16)
+        .buffer_unordered(12)
         .try_collect::<Vec<_>>()
         .await?;
 

--- a/core/bin/migrations/20241024_clean_legacy_gcs.rs
+++ b/core/bin/migrations/20241024_clean_legacy_gcs.rs
@@ -40,11 +40,11 @@ async fn clean_stored_versions_for_document_id(
     let document_versions = c.query("SELECT hash, created, status FROM data_sources_documents WHERE data_source = $1 AND document_id = $2", &[&data_source_id, &document_id]).await?;
     let document_id_hash = make_document_id_hash(document_id);
 
-    println!(
-        "Found {:} document versions for document {:} to clean-up.",
-        document_versions.len(),
-        document_id_hash
-    );
+    // println!(
+    //     "Found {:} document versions for document {:} to clean-up.",
+    //     document_versions.len(),
+    //     document_id_hash
+    // );
 
     FileStorageDocument::delete_if_exists(&FileStorageDocument::get_legacy_document_id_path(
         &data_source,
@@ -64,10 +64,10 @@ async fn clean_stored_versions_for_document_id(
             // IF we are after this date we just skip version deletion as no legacy version was
             // created after this date. https://github.com/dust-tt/dust/pull/6405
             if version_created > 1721952000000 {
-                println!(
-                    "Skipping version {:} for document {:}.",
-                    version_hash, document_id_hash
-                );
+                // println!(
+                //     "Skipping version {:} for document {:}.",
+                //     version_hash, document_id_hash
+                // );
                 return Ok::<(), anyhow::Error>(());
             }
             FileStorageDocument::delete_if_exists(&FileStorageDocument::get_legacy_content_path(
@@ -95,8 +95,6 @@ async fn clean_all_documents_for_data_source_id(
     data_source_internal_id: &str,
     data_source_id: i64,
 ) -> Result<()> {
-    println!("ds: {:?}", data_source_internal_id);
-
     let data_source = match store
         .load_data_source_by_internal_id(&data_source_internal_id)
         .await?
@@ -114,7 +112,11 @@ async fn clean_all_documents_for_data_source_id(
         )
         .await?;
 
-    println!("Found {:} document ids to clean-up.", document_ids.len());
+    println!(
+        "Processing: document_count={:} data_source={}",
+        document_ids.len(),
+        data_source_internal_id
+    );
 
     stream::iter(document_ids.into_iter().map(|row| {
         let data_source = data_source.clone();
@@ -173,19 +175,19 @@ async fn main() -> Result<(), anyhow::Error> {
         .await?;
 
         if rows.len() < limit {
-            println!("Updated all data_sources");
+            println!("Done");
             break;
         }
 
         last_data_source_id = match rows.last() {
             Some(r) => {
                 let id: i64 = r.get(0);
-                println!("LAST_DATA_SOURCE_ID_UDPATE: {}", id);
+                println!("Loop: last_data_source_id={}", id);
 
                 id as u64
             }
             None => {
-                println!("Updated all data_sources");
+                println!("Done");
                 break;
             }
         };

--- a/core/bin/migrations/20241024_clean_legacy_gcs.rs
+++ b/core/bin/migrations/20241024_clean_legacy_gcs.rs
@@ -57,18 +57,30 @@ async fn clean_stored_versions_for_document_id(
         let document_id_hash = document_id_hash.to_string();
 
         async move {
-            let document_hash: String = d.get(0);
+            let version_hash: String = d.get(0);
+            let version_created: i64 = d.get(1);
+
+            // 2024-07-26:00:00.000Z
+            // IF we are after this date we just skip version deletion as no legacy version was
+            // created after this date. https://github.com/dust-tt/dust/pull/6405
+            if version_created > 1721952000000 {
+                println!(
+                    "Skipping version {:} for document {:}.",
+                    version_hash, document_id_hash
+                );
+                return Ok::<(), anyhow::Error>(());
+            }
             FileStorageDocument::delete_if_exists(&FileStorageDocument::get_legacy_content_path(
                 &data_source,
                 &document_id_hash,
-                document_hash.as_str(),
+                version_hash.as_str(),
             ))
             .await?;
             Ok::<(), anyhow::Error>(())
         }
     });
 
-    let mut stream = stream::iter(tasks).buffer_unordered(16); // Run up to 16 in parallel.
+    let mut stream = stream::iter(tasks).buffer_unordered(16);
 
     while let Some(result) = stream.next().await {
         result?; // Check for errors.
@@ -102,7 +114,7 @@ async fn clean_all_documents_for_data_source_id(
         )
         .await?;
 
-    println!("Found {:} document ids to update.", document_ids.len());
+    println!("Found {:} document ids to clean-up.", document_ids.len());
 
     stream::iter(document_ids.into_iter().map(|row| {
         let data_source = data_source.clone();
@@ -114,7 +126,7 @@ async fn clean_all_documents_for_data_source_id(
                 .await
         }
     }))
-    .buffer_unordered(16)
+    .buffer_unordered(32)
     .try_collect::<Vec<_>>()
     .await?;
 

--- a/core/src/data_sources/file_storage_document.rs
+++ b/core/src/data_sources/file_storage_document.rs
@@ -62,7 +62,7 @@ impl FileStorageDocument {
 
         match Object::delete(&bucket, &path).await {
             Ok(_) => {
-                println!("Deleted: path={}", path);
+                // println!("Deleted: path={}", path);
                 Ok(true)
             }
             Err(e) => match e {

--- a/core/src/data_sources/file_storage_document.rs
+++ b/core/src/data_sources/file_storage_document.rs
@@ -22,6 +22,59 @@ impl FileStorageDocument {
         }
     }
 
+    pub fn get_legacy_content_path(
+        data_source: &DataSource,
+        document_id_hash: &str,
+        document_hash: &str,
+    ) -> String {
+        let legacy_bucket_path = format!(
+            "{}/{}/{}",
+            data_source.project().project_id(),
+            data_source.internal_id(),
+            document_id_hash
+        );
+
+        format!("{}/{}/content.txt", legacy_bucket_path, document_hash)
+    }
+
+    pub fn get_legacy_document_id_path(data_source: &DataSource, document_id_hash: &str) -> String {
+        let legacy_bucket_path = format!(
+            "{}/{}/{}",
+            data_source.project().project_id(),
+            data_source.internal_id(),
+            document_id_hash
+        );
+
+        format!("{}/document_id.txt", legacy_bucket_path)
+    }
+
+    pub async fn path_exists(path: &str) -> Result<bool> {
+        let bucket = FileStorageDocument::get_bucket().await?;
+
+        match Object::read(&bucket, path).await {
+            Ok(_) => Ok(true),
+            Err(_err) => Ok(false),
+        }
+    }
+
+    pub async fn delete_if_exists(path: &str) -> Result<bool> {
+        let bucket = FileStorageDocument::get_bucket().await?;
+
+        match Object::delete(&bucket, &path).await {
+            Ok(_) => {
+                println!("Deleted {}", path);
+                Ok(true)
+            }
+            Err(e) => match e {
+                cloud_storage::Error::Google(GoogleErrorResponse {
+                    error: ErrorList { code: 404, .. },
+                    ..
+                }) => Ok(false),
+                e => Err(e)?,
+            },
+        }
+    }
+
     pub async fn get_stored_document(
         data_source: &DataSource,
         document_created: u64,

--- a/core/src/data_sources/file_storage_document.rs
+++ b/core/src/data_sources/file_storage_document.rs
@@ -62,7 +62,7 @@ impl FileStorageDocument {
 
         match Object::delete(&bucket, &path).await {
             Ok(_) => {
-                println!("Deleted {}", path);
+                println!("Deleted: path={}", path);
                 Ok(true)
             }
             Err(e) => match e {

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -132,6 +132,10 @@ impl PostgresStore {
 
 #[async_trait]
 impl Store for PostgresStore {
+    fn raw_pool(&self) -> &Pool<PostgresConnectionManager<NoTls>> {
+        return &self.pool;
+    }
+
     async fn create_project(&self) -> Result<Project> {
         let pool = self.pool.clone();
         let c = pool.get().await?;

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -1,6 +1,9 @@
 use anyhow::Result;
 use async_trait::async_trait;
+use bb8::Pool;
+use bb8_postgres::PostgresConnectionManager;
 use std::collections::HashMap;
+use tokio_postgres::NoTls;
 
 use crate::{
     blocks::block::BlockType,
@@ -21,6 +24,7 @@ use crate::{
 
 #[async_trait]
 pub trait Store {
+    fn raw_pool(&self) -> &Pool<PostgresConnectionManager<NoTls>>;
     // Projects
     async fn create_project(&self) -> Result<Project>;
     async fn delete_project(&self, project: &Project) -> Result<()>;


### PR DESCRIPTION
## Description

We had kept the legacy GCS version as part of moving to a JSON format. It is now time to delete them all so that we stop handling them when scrubbing data source documents.

## Risk

Low paths are pretty explicit.

## Deploy Plan

- deploy `prodbox`
- Run from `prodbox`: `cargo run --release --bin migration_clean_legacy_gcs`