### PR TITLE
Redirect to conversation page when conversation is posted

### DIFF
--- a/front/extension/app/src/components/assistants/AssistantPicker.tsx
+++ b/front/extension/app/src/components/assistants/AssistantPicker.tsx
@@ -11,7 +11,7 @@ import {
 } from "@dust-tt/sparkle";
 import type {
   LightAgentConfigurationType,
-  WorkspaceType,
+  LightWorkspaceType,
 } from "@dust-tt/types";
 import { useEffect, useState } from "react";
 
@@ -21,7 +21,7 @@ export function AssistantPicker({
   pickerButton,
   size = "md",
 }: {
-  owner: WorkspaceType;
+  owner: LightWorkspaceType;
   assistants: LightAgentConfigurationType[];
   onItemClick: (assistant: LightAgentConfigurationType) => void;
   pickerButton?: React.ReactNode;

--- a/front/extension/app/src/components/conversation/ConversationContainer.tsx
+++ b/front/extension/app/src/components/conversation/ConversationContainer.tsx
@@ -1,3 +1,4 @@
+import { ConversationViewer } from "@app/extension/app/src/components/conversation/ConversationViewer";
 import { ReachedLimitPopup } from "@app/extension/app/src/components/conversation/ReachedLimitPopup";
 import { AssistantInputBar } from "@app/extension/app/src/components/input_bar/InputBar";
 import { InputBarContext } from "@app/extension/app/src/components/input_bar/InputBarContext";
@@ -6,18 +7,20 @@ import {
   postConversation,
   postMessage,
 } from "@app/extension/app/src/lib/conversation";
-import type { MentionType, WorkspaceType } from "@dust-tt/types";
+import type { LightWorkspaceType, MentionType } from "@dust-tt/types";
 import { useCallback, useContext, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 interface ConversationContainerProps {
   conversationId: string | null;
-  owner: WorkspaceType;
+  owner: LightWorkspaceType;
 }
 
 export function ConversationContainer({
   conversationId,
   owner,
 }: ConversationContainerProps) {
+  const navigate = useNavigate();
   const [activeConversationId, setActiveConversationId] =
     useState(conversationId);
   const [planLimitReached, setPlanLimitReached] = useState(false);
@@ -33,6 +36,14 @@ export function ConversationContainer({
       setTimeout(() => setAnimate(false), 500);
     }
   });
+
+  useEffect(() => {
+    if (activeConversationId) {
+      navigate(`/conversations/${activeConversationId}`, {
+        replace: true,
+      });
+    }
+  }, [activeConversationId, navigate]);
 
   const handlePostMessage = async (input: string, mentions: MentionType[]) => {
     if (!activeConversationId) {
@@ -82,8 +93,6 @@ export function ConversationContainer({
           }
         } else {
           setActiveConversationId(conversationRes.value.sId);
-          // Probably here we want to navigate to /conversations/id
-          // navigate(`/conversations/${conversationRes.value.sId}`);
         }
       },
       [owner, sendNotification, setActiveConversationId]
@@ -92,7 +101,12 @@ export function ConversationContainer({
 
   return (
     <>
-      {activeConversationId && <p>Congrats you just posted a conversation</p>}
+      {activeConversationId && (
+        <ConversationViewer
+          conversationId={activeConversationId}
+          owner={owner}
+        />
+      )}
       <AssistantInputBar
         owner={owner}
         onSubmit={

--- a/front/extension/app/src/components/conversation/ConversationViewer.tsx
+++ b/front/extension/app/src/components/conversation/ConversationViewer.tsx
@@ -1,0 +1,14 @@
+import type { LightWorkspaceType } from "@dust-tt/types";
+
+interface ConversationViewerProps {
+  conversationId: string;
+  owner: LightWorkspaceType;
+}
+
+export function ConversationViewer({
+  conversationId,
+  owner,
+}: ConversationViewerProps) {
+  console.log(conversationId, owner);
+  return <div>Viewing conversation {conversationId}</div>;
+}

--- a/front/extension/app/src/components/input_bar/InputBar.tsx
+++ b/front/extension/app/src/components/input_bar/InputBar.tsx
@@ -3,11 +3,12 @@ import type { InputBarContainerProps } from "@app/extension/app/src/components/i
 import { InputBarContainer } from "@app/extension/app/src/components/input_bar/InputBarContainer";
 import { InputBarContext } from "@app/extension/app/src/components/input_bar/InputBarContext";
 import { classNames } from "@app/extension/app/src/lib/utils";
-import type { AgentMention, MentionType } from "@dust-tt/types";
 import type {
-  LightAgentConfigurationType,
-  WorkspaceType,
+  AgentMention,
+  LightWorkspaceType,
+  MentionType,
 } from "@dust-tt/types";
+import type { LightAgentConfigurationType } from "@dust-tt/types";
 import { compareAgentsForSort } from "@dust-tt/types";
 import { useContext, useEffect, useMemo, useRef, useState } from "react";
 
@@ -45,7 +46,7 @@ export function AssistantInputBar({
   isFloating = true,
   isFloatingWithoutMargin = false,
 }: {
-  owner: WorkspaceType;
+  owner: LightWorkspaceType;
   onSubmit: (input: string, mentions: MentionType[]) => void;
   stickyMentions?: AgentMention[];
   additionalAgentConfiguration?: LightAgentConfigurationType;

--- a/front/extension/app/src/components/input_bar/InputBarContainer.tsx
+++ b/front/extension/app/src/components/input_bar/InputBarContainer.tsx
@@ -9,7 +9,7 @@ import { ArrowUpIcon, Button } from "@dust-tt/sparkle";
 import type {
   AgentMention,
   LightAgentConfigurationType,
-  WorkspaceType,
+  LightWorkspaceType,
 } from "@dust-tt/types";
 import { EditorContent } from "@tiptap/react";
 import React, { useContext, useEffect } from "react";
@@ -18,7 +18,7 @@ export interface InputBarContainerProps {
   allAssistants: LightAgentConfigurationType[];
   agentConfigurations: LightAgentConfigurationType[];
   onEnterKeyDown: CustomEditorProps["onEnterKeyDown"];
-  owner: WorkspaceType;
+  owner: LightWorkspaceType;
   selectedAssistant: AgentMention | null;
   stickyMentions?: AgentMention[];
   disableAutoFocus: boolean;

--- a/front/extension/app/src/components/input_bar/editor/usePublicAssistantSuggestions.ts
+++ b/front/extension/app/src/components/input_bar/editor/usePublicAssistantSuggestions.ts
@@ -1,7 +1,7 @@
 import { usePublicAgentConfigurations } from "@app/extension/app/src/components/assistants/usePublicAgentConfigurations";
 import type {
   LightAgentConfigurationType,
-  WorkspaceType,
+  LightWorkspaceType,
 } from "@dust-tt/types";
 import { compareAgentsForSort } from "@dust-tt/types";
 import { useMemo } from "react";
@@ -21,7 +21,7 @@ function makeEditorSuggestions(
 
 export const usePublicAssistantSuggestions = (
   inListAgentConfigurations: LightAgentConfigurationType[],
-  owner: WorkspaceType
+  owner: LightWorkspaceType
 ) => {
   const { agentConfigurations } = usePublicAgentConfigurations({
     workspaceId: owner.sId,

--- a/front/extension/app/src/lib/conversation.ts
+++ b/front/extension/app/src/lib/conversation.ts
@@ -5,12 +5,12 @@ import {
 import type {
   ConversationType,
   ConversationVisibility,
+  LightWorkspaceType,
   MentionType,
   PublicPostConversationsRequestBody,
   Result,
   SubmitMessageError,
   UserMessageWithRankType,
-  WorkspaceType,
 } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 
@@ -20,7 +20,7 @@ export async function postConversation({
   visibility = "unlisted",
   title,
 }: {
-  owner: WorkspaceType;
+  owner: LightWorkspaceType;
   messageData: {
     input: string;
     mentions: MentionType[];
@@ -96,7 +96,7 @@ export async function postMessage({
   conversationId,
   messageData,
 }: {
-  owner: WorkspaceType;
+  owner: LightWorkspaceType;
   conversationId: string;
   messageData: {
     input: string;

--- a/front/extension/app/src/pages/ConversationPage.tsx
+++ b/front/extension/app/src/pages/ConversationPage.tsx
@@ -1,16 +1,51 @@
-import { BarHeader, ChevronLeftIcon } from "@dust-tt/sparkle";
-import { Link } from "react-router-dom";
+import { useAuth } from "@app/extension/app/src/components/auth/AuthProvider";
+import { ConversationContainer } from "@app/extension/app/src/components/conversation/ConversationContainer";
+import { Page, Spinner } from "@dust-tt/sparkle";
+import { useNavigate, useParams } from "react-router-dom";
 
 export const ConversationPage = () => {
+  const navigate = useNavigate();
+  const { isLoading, isAuthenticated, user } = useAuth();
+  const { conversationId } = useParams();
+
+  console.log(conversationId);
+
+  if (isLoading) {
+    return (
+      <div className="h-full w-full">
+        <div className="flex h-full w-full items-center justify-center">
+          <Spinner />
+        </div>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated || !user) {
+    navigate("/login");
+    return;
+  }
+
+  const workspace = user.workspaces.find(
+    (w) => w.sId === user.selectedWorkspace
+  );
+
+  if (!workspace) {
+    navigate("/login");
+    return;
+  }
+
+  if (!conversationId) {
+    navigate("/");
+    return;
+  }
+
   return (
-    <BarHeader
-      title="Conversations"
-      leftActions={
-        <Link to="/main.html">
-          <ChevronLeftIcon />
-          You're in the conversation page!
-        </Link>
-      }
-    />
+    <div className="h-full w-full">
+      <Page.SectionHeader title="Conversation" />
+      <ConversationContainer
+        owner={workspace}
+        conversationId={conversationId}
+      />
+    </div>
   );
 };

--- a/front/extension/app/src/pages/ConversationPage.tsx
+++ b/front/extension/app/src/pages/ConversationPage.tsx
@@ -1,7 +1,7 @@
 import { useAuth } from "@app/extension/app/src/components/auth/AuthProvider";
 import { ConversationContainer } from "@app/extension/app/src/components/conversation/ConversationContainer";
-import { Page, Spinner } from "@dust-tt/sparkle";
-import { useNavigate, useParams } from "react-router-dom";
+import { BarHeader, ChevronLeftIcon, Page, Spinner } from "@dust-tt/sparkle";
+import { Link, useNavigate, useParams } from "react-router-dom";
 
 export const ConversationPage = () => {
   const navigate = useNavigate();
@@ -40,12 +40,22 @@ export const ConversationPage = () => {
   }
 
   return (
-    <div className="h-full w-full">
-      <Page.SectionHeader title="Conversation" />
-      <ConversationContainer
-        owner={workspace}
-        conversationId={conversationId}
+    <>
+      <BarHeader
+        title="Back"
+        leftActions={
+          <Link to="/">
+            <ChevronLeftIcon />
+          </Link>
+        }
       />
-    </div>
+      <div className="h-full w-full pt-4">
+        <Page.SectionHeader title="Conversation" />
+        <ConversationContainer
+          owner={workspace}
+          conversationId={conversationId}
+        />
+      </div>
+    </>
   );
 };

--- a/front/extension/app/src/pages/MainPage.tsx
+++ b/front/extension/app/src/pages/MainPage.tsx
@@ -1,7 +1,6 @@
 import { useAuth } from "@app/extension/app/src/components/auth/AuthProvider";
 import { ConversationContainer } from "@app/extension/app/src/components/conversation/ConversationContainer";
 import { Page, Spinner } from "@dust-tt/sparkle";
-import type { WorkspaceType } from "@dust-tt/types";
 import { useNavigate } from "react-router-dom";
 
 export const MainPage = () => {
@@ -32,21 +31,10 @@ export const MainPage = () => {
     return;
   }
 
-  const owner: WorkspaceType = {
-    id: workspace.id,
-    sId: workspace.sId,
-    name: workspace.name,
-    role: workspace.role,
-    segmentation: workspace.segmentation,
-    whiteListedProviders: workspace.whiteListedProviders,
-    defaultEmbeddingProvider: workspace.defaultEmbeddingProvider,
-    flags: [],
-  };
-
   return (
     <div className="h-full w-full">
       <Page.SectionHeader title="Conversation" />
-      <ConversationContainer owner={owner} conversationId={null} />
+      <ConversationContainer owner={workspace} conversationId={null} />
     </div>
   );
 };

--- a/front/extension/app/src/pages/MainPage.tsx
+++ b/front/extension/app/src/pages/MainPage.tsx
@@ -32,7 +32,7 @@ export const MainPage = () => {
   }
 
   return (
-    <div className="h-full w-full">
+    <div className="h-full w-full pt-4">
       <Page.SectionHeader title="Conversation" />
       <ConversationContainer owner={workspace} conversationId={null} />
     </div>

--- a/front/extension/app/src/pages/routes.tsx
+++ b/front/extension/app/src/pages/routes.tsx
@@ -17,7 +17,7 @@ export const routes = [
     ),
   },
   {
-    path: "/conversations/*",
+    path: "/conversations/:conversationId",
     element: (
       <ProtectedRoute>
         <ConversationPage />


### PR DESCRIPTION
## Description

- Use LightWorkspaceType everywhere. 
- Once we posted the convo, redirect to the convo page. 
- Convo page renders the convo container with a new (empty) ConversationViewer that we now need to fill. 

## Risk

Code extension only. 

## Deploy Plan

/
