### PR TITLE
Fix: change status code for error when failing to upload datasource due to limits

### DIFF
--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -91,6 +91,10 @@ async function _upsertToDatasource({
         span?.setTag(key, loggerArgs[key]);
       });
 
+      const endpoint =
+        `${DUST_FRONT_API}/api/v1/w/${dataSourceConfig.workspaceId}` +
+        `/data_sources/${dataSourceConfig.dataSourceId}/documents/${documentId}`;
+
       const localLogger = logger.child({
         ...loggerArgs,
         documentId,
@@ -98,6 +102,7 @@ async function _upsertToDatasource({
         documentLength: sectionFullText(documentContent).length,
         workspaceId: dataSourceConfig.workspaceId,
         dataSourceId: dataSourceConfig.dataSourceId,
+        endpoint,
         parents,
       });
       const statsDTags = [
@@ -114,9 +119,6 @@ async function _upsertToDatasource({
 
       const now = new Date();
 
-      const endpoint =
-        `${DUST_FRONT_API}/api/v1/w/${dataSourceConfig.workspaceId}` +
-        `/data_sources/${dataSourceConfig.dataSourceId}/documents/${documentId}`;
       const dustRequestPayload: PostDataSourceDocumentRequestBody = {
         text: null,
         section: documentContent,

--- a/front/pages/api/v1/w/[wId]/vaults/[vId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/vaults/[vId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -455,7 +455,7 @@ async function handler(
           documents.value.total >= plan.limits.dataSources.documents.count
         ) {
           return apiError(req, res, {
-            status_code: 401,
+            status_code: 403,
             api_error: {
               type: "data_source_quota_error",
               message:
@@ -472,7 +472,7 @@ async function handler(
         fullText.length > 1024 * 1024 * plan.limits.dataSources.documents.sizeMb
       ) {
         return apiError(req, res, {
-          status_code: 401,
+          status_code: 403,
           api_error: {
             type: "data_source_quota_error",
             message:


### PR DESCRIPTION
## Description

Return a more appropriate status code & add the front url (to easily see the original error).

## Risk

None

## Deploy Plan

Deploy front & connector.