### PR TITLE
Fix: handle better the paused / running status of connectors

### DIFF
--- a/connectors/src/api/update_connector.ts
+++ b/connectors/src/api/update_connector.ts
@@ -79,7 +79,7 @@ const _postConnectorUpdateAPIHandler = async (
     }
   }
 
-  await connector.update({ errorType: null });
+  await connector.update({ errorType: null, pausedAt: null });
 
   return res.status(200).json({
     connectorId: updateRes.value,

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -1,4 +1,4 @@
-import { Modal } from "@dust-tt/sparkle";
+import { Chip, Modal } from "@dust-tt/sparkle";
 import type {
   ConnectorType,
   CoreAPIDataSource,
@@ -23,15 +23,22 @@ export function ViewDataSourceTable({
   coreDataSource,
   dataSource,
   temporalWorkspace,
+  temporalRunningWorkflows,
 }: {
   connector: ConnectorType | null;
   coreDataSource: CoreAPIDataSource;
   dataSource: DataSourceType;
   temporalWorkspace: string;
+  temporalRunningWorkflows: {
+    workflowId: string;
+    runId: string;
+    status: string;
+  }[];
 }) {
   const [showRawObjectsModal, setShowRawObjectsModal] = useState(false);
 
   const isPaused = connector && !!connector.pausedAt;
+  const isRunning = temporalRunningWorkflows.length > 0;
 
   return (
     <>
@@ -56,6 +63,12 @@ export function ViewDataSourceTable({
                 🤓 Show raw objects
               </PokeButton>
             </div>
+            {isPaused && isRunning && (
+              <Chip color="warning" size="sm" className="my-4">
+                Connector is marked as paused but has temporal workflows
+                running. Potential resolution: unpause the connector.
+              </Chip>
+            )}
             <PokeTable>
               <PokeTableBody>
                 <PokeTableRow>
@@ -105,8 +118,8 @@ export function ViewDataSourceTable({
                 {connector && (
                   <>
                     <PokeTableRow>
-                      <PokeTableCell>Is Running?</PokeTableCell>
-                      <PokeTableCell>{isPaused ? "❌" : "✅"}</PokeTableCell>
+                      <PokeTableCell>Is Running? </PokeTableCell>
+                      <PokeTableCell>{isRunning ? "✅" : "❌"}</PokeTableCell>
                     </PokeTableRow>
                     <PokeTableRow>
                       <PokeTableCell>Paused at</PokeTableCell>

--- a/front/lib/production_checks/checks/check_extraneous_workflows_for_paused_connectors.ts
+++ b/front/lib/production_checks/checks/check_extraneous_workflows_for_paused_connectors.ts
@@ -1,0 +1,86 @@
+import type { ConnectorProvider } from "@dust-tt/types";
+import type { Client } from "@temporalio/client";
+import { QueryTypes } from "sequelize";
+
+import type { CheckFunction } from "@app/lib/production_checks/types";
+import { getConnectorsPrimaryDbConnection } from "@app/lib/production_checks/utils";
+import { getTemporalConnectorsNamespaceConnection } from "@app/lib/temporal";
+
+interface ConnectorBlob {
+  id: number;
+  dataSourceId: string;
+  workspaceId: string;
+  provider: ConnectorProvider;
+  pausedAt: Date | null;
+}
+
+const connectorsDb = getConnectorsPrimaryDbConnection();
+
+async function listPausedConnectors() {
+  const connectors: ConnectorBlob[] = await connectorsDb.query(
+    `SELECT id, "dataSourceId", "workspaceId", "pausedAt", "provider" FROM connectors WHERE pausedAt IS NULL`,
+    {
+      type: QueryTypes.SELECT,
+    }
+  );
+
+  return connectors;
+}
+
+async function areTemporalWorkflowsRunning(
+  client: Client,
+  connector: ConnectorBlob
+) {
+  try {
+    const workflowInfos = client.workflow.list({
+      query: `ExecutionStatus = 'Running' AND connectorId = ${connector.id}`,
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for await (const _ of workflowInfos) {
+      // workflowInfos is an async iterable, so we need to consume it to actually get the results
+      return true;
+    }
+    return false;
+  } catch (err) {
+    return true;
+  }
+}
+
+export const checkExtraneousWorkflows: CheckFunction = async (
+  _checkName,
+  logger,
+  reportSuccess,
+  reportFailure,
+  heartbeat
+) => {
+  const connectors = await listPausedConnectors();
+
+  logger.info(`Found ${connectors.length} paused connectors.`);
+
+  const client = await getTemporalConnectorsNamespaceConnection();
+
+  const hasExtraneousWorklows: any[] = [];
+  for (const connector of connectors) {
+    heartbeat();
+
+    const isActive = await areTemporalWorkflowsRunning(client, connector);
+    if (isActive) {
+      hasExtraneousWorklows.push({
+        connectorId: connector.id,
+        workspaceId: connector.workspaceId,
+        dataSourceId: connector.dataSourceId,
+        provider: connector.provider,
+      });
+    }
+  }
+
+  if (hasExtraneousWorklows.length > 0) {
+    reportFailure(
+      { hasExtraneousWorklows },
+      `Extraneous temporal workflows (connector is paused but workflows are running). Potential resolution: unpause the connector.`
+    );
+  } else {
+    reportSuccess({});
+  }
+};

--- a/front/temporal/production_checks/activities.ts
+++ b/front/temporal/production_checks/activities.ts
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from "uuid";
 import { checkActiveWorkflows } from "@app/lib/production_checks/checks/check_active_workflows_for_connectors";
 import { checkConnectorsLastSyncSuccess } from "@app/lib/production_checks/checks/check_connectors_last_sync_success";
 import { checkDataSourcesConsistency } from "@app/lib/production_checks/checks/check_data_sources_consistency";
+import { checkExtraneousWorkflows } from "@app/lib/production_checks/checks/check_extraneous_workflows_for_paused_connectors";
 import { checkNotionActiveWorkflows } from "@app/lib/production_checks/checks/check_notion_active_workflows";
 import { managedDataSourceGCGdriveCheck } from "@app/lib/production_checks/checks/managed_data_source_gdrive_gc";
 import { scrubDeletedCoreDocumentVersionsCheck } from "@app/lib/production_checks/checks/scrub_deleted_core_document_versions";
@@ -29,6 +30,11 @@ export const REGISTERED_CHECKS: Check[] = [
   {
     name: "check_active_workflows_for_connector",
     check: checkActiveWorkflows,
+    everyHour: 1,
+  },
+  {
+    name: "check_extraneous_workflows_for_paused_connectors",
+    check: checkExtraneousWorkflows,
     everyHour: 1,
   },
   {


### PR DESCRIPTION
## Description

Clean up a bit around pausedAt.

- Clear `pausedAt` when the user update the connection of a connector.
- Add production check for extraneous running workflows.
- Update poke so the running status of a connector reflect the temporal truth and no longer the pausedAt value.
- Add a warning if the connector is marked as paused and yet has running workflow(s).

notes: 
- this is until we decide to do something about the pause concept
- i'm wondering if we shouldn't also clear the pausedAt when the permissions are updated. Right now, if I'm not mistaken, at least in gdrive, we are launchnig the workflow regardless of the pausedAt value.

## Risk

None (there are a few extraneous workflows already, I tested my code in prod)

## Deploy Plan

Deploy `connectors`