### PR TITLE
Store transcripts in spaces - UI

### DIFF
--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -272,7 +272,7 @@ export function DataSourceViewsSelector({
             ))}
           </Tree.Item>
         )}
-        {websites.length > 0 && (
+        {websites.length > 0 && useCase !== "transcriptsProcessing" && (
           <Tree.Item
             key="websites"
             label="Websites"

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -87,7 +87,10 @@ const getNodesFromConfig = (
 
 interface DataSourceViewsSelectorProps {
   owner: LightWorkspaceType;
-  useCase: "spaceDatasourceManagement" | "assistantBuilder";
+  useCase:
+    | "spaceDatasourceManagement"
+    | "assistantBuilder"
+    | "transcriptsProcessing";
   dataSourceViews: DataSourceViewType[];
   allowedSpaces?: SpaceType[];
   selectionConfigurations: DataSourceViewSelectionConfigurations;
@@ -96,7 +99,6 @@ interface DataSourceViewsSelectorProps {
   >;
   viewType: ContentNodesViewType;
   isRootSelectable: boolean;
-  hideLeafNodes?: boolean;
 }
 
 export function DataSourceViewsSelector({
@@ -108,7 +110,6 @@ export function DataSourceViewsSelector({
   setSelectionConfigurations,
   viewType,
   isRootSelectable,
-  hideLeafNodes,
 }: DataSourceViewsSelectorProps) {
   const { spaces, isSpacesLoading } = useSpaces({ workspaceId: owner.sId });
 
@@ -196,7 +197,6 @@ export function DataSourceViewsSelector({
               setSelectionConfigurations={setSelectionConfigurations}
               viewType={viewType}
               isRootSelectable={isRootSelectable}
-              hideLeafNodes={hideLeafNodes}
             />
           );
         }}
@@ -226,7 +226,7 @@ export function DataSourceViewsSelector({
                   viewType={viewType}
                   isRootSelectable={isRootSelectable}
                   defaultCollapsed={filteredDSVs.length > 1}
-                  hideLeafNodes={hideLeafNodes}
+                  useCase={useCase}
                 />
               ))}
           </Tree.Item>
@@ -245,7 +245,7 @@ export function DataSourceViewsSelector({
               viewType={viewType}
               isRootSelectable={false}
               defaultCollapsed={filteredDSVs.length > 1}
-              hideLeafNodes={hideLeafNodes}
+              useCase={useCase}
             />
           ))}
         {folders.length > 0 && (
@@ -267,7 +267,7 @@ export function DataSourceViewsSelector({
                 viewType={viewType}
                 isRootSelectable={isRootSelectable}
                 defaultCollapsed={filteredDSVs.length > 1}
-                hideLeafNodes={hideLeafNodes}
+                useCase={useCase}
               />
             ))}
           </Tree.Item>
@@ -291,7 +291,7 @@ export function DataSourceViewsSelector({
                 viewType={viewType}
                 isRootSelectable={isRootSelectable}
                 defaultCollapsed={filteredDSVs.length > 1}
-                hideLeafNodes={hideLeafNodes}
+                useCase={useCase}
               />
             ))}
           </Tree.Item>
@@ -312,7 +312,7 @@ interface DataSourceViewSelectorProps {
   viewType: ContentNodesViewType;
   isRootSelectable: boolean;
   defaultCollapsed?: boolean;
-  hideLeafNodes?: boolean;
+  useCase?: DataSourceViewsSelectorProps["useCase"];
 }
 
 export function DataSourceViewSelector({
@@ -324,7 +324,7 @@ export function DataSourceViewSelector({
   viewType,
   isRootSelectable,
   defaultCollapsed = true,
-  hideLeafNodes = false,
+  useCase,
 }: DataSourceViewSelectorProps) {
   const dataSourceView = selectionConfiguration.dataSourceView;
 
@@ -493,7 +493,7 @@ export function DataSourceViewSelector({
           )
         }
       >
-        {!hideLeafNodes && (
+        {useCase !== "transcriptsProcessing" && (
           <ContentNodeTree
             selectedNodes={selectedNodes}
             setSelectedNodes={readonly ? undefined : setSelectedNodes}

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -96,6 +96,7 @@ interface DataSourceViewsSelectorProps {
   >;
   viewType: ContentNodesViewType;
   isRootSelectable: boolean;
+  hideLeafNodes?: boolean;
 }
 
 export function DataSourceViewsSelector({
@@ -107,6 +108,7 @@ export function DataSourceViewsSelector({
   setSelectionConfigurations,
   viewType,
   isRootSelectable,
+  hideLeafNodes,
 }: DataSourceViewsSelectorProps) {
   const { spaces, isSpacesLoading } = useSpaces({ workspaceId: owner.sId });
 
@@ -194,6 +196,7 @@ export function DataSourceViewsSelector({
               setSelectionConfigurations={setSelectionConfigurations}
               viewType={viewType}
               isRootSelectable={isRootSelectable}
+              hideLeafNodes={hideLeafNodes}
             />
           );
         }}
@@ -223,6 +226,7 @@ export function DataSourceViewsSelector({
                   viewType={viewType}
                   isRootSelectable={isRootSelectable}
                   defaultCollapsed={filteredDSVs.length > 1}
+                  hideLeafNodes={hideLeafNodes}
                 />
               ))}
           </Tree.Item>
@@ -241,6 +245,7 @@ export function DataSourceViewsSelector({
               viewType={viewType}
               isRootSelectable={false}
               defaultCollapsed={filteredDSVs.length > 1}
+              hideLeafNodes={hideLeafNodes}
             />
           ))}
         {folders.length > 0 && (
@@ -262,6 +267,7 @@ export function DataSourceViewsSelector({
                 viewType={viewType}
                 isRootSelectable={isRootSelectable}
                 defaultCollapsed={filteredDSVs.length > 1}
+                hideLeafNodes={hideLeafNodes}
               />
             ))}
           </Tree.Item>
@@ -285,6 +291,7 @@ export function DataSourceViewsSelector({
                 viewType={viewType}
                 isRootSelectable={isRootSelectable}
                 defaultCollapsed={filteredDSVs.length > 1}
+                hideLeafNodes={hideLeafNodes}
               />
             ))}
           </Tree.Item>
@@ -305,6 +312,7 @@ interface DataSourceViewSelectorProps {
   viewType: ContentNodesViewType;
   isRootSelectable: boolean;
   defaultCollapsed?: boolean;
+  hideLeafNodes?: boolean;
 }
 
 export function DataSourceViewSelector({
@@ -316,6 +324,7 @@ export function DataSourceViewSelector({
   viewType,
   isRootSelectable,
   defaultCollapsed = true,
+  hideLeafNodes = false,
 }: DataSourceViewSelectorProps) {
   const dataSourceView = selectionConfiguration.dataSourceView;
 
@@ -484,19 +493,21 @@ export function DataSourceViewSelector({
           )
         }
       >
-        <ContentNodeTree
-          selectedNodes={selectedNodes}
-          setSelectedNodes={readonly ? undefined : setSelectedNodes}
-          parentIsSelected={selectionConfiguration.isSelectAll}
-          useResourcesHook={useResourcesHook}
-          emptyComponent={
-            viewType === "tables" ? (
-              <Tree.Empty label="No tables" />
-            ) : (
-              <Tree.Empty label="No documents" />
-            )
-          }
-        />
+        {!hideLeafNodes && (
+          <ContentNodeTree
+            selectedNodes={selectedNodes}
+            setSelectedNodes={readonly ? undefined : setSelectedNodes}
+            parentIsSelected={selectionConfiguration.isSelectAll}
+            useResourcesHook={useResourcesHook}
+            emptyComponent={
+              viewType === "tables" ? (
+                <Tree.Empty label="No tables" />
+              ) : (
+                <Tree.Empty label="No documents" />
+              )
+            }
+          />
+        )}
       </Tree.Item>
     </div>
   );

--- a/front/components/spaces/SpaceFolderModal.tsx
+++ b/front/components/spaces/SpaceFolderModal.tsx
@@ -165,7 +165,7 @@ export default function SpaceFolderModal({
                 <p className="mt-1 flex items-center gap-1 text-sm text-gray-500">
                   <ExclamationCircleStrokeIcon />{" "}
                   {!dataSourceView
-                    ? "Folder name must be unique and not use spaces."
+                    ? "Folder name must be unique."
                     : "Folder name cannot be changed."}
                 </p>
               </div>

--- a/front/lib/resources/labs_transcripts_resource.ts
+++ b/front/lib/resources/labs_transcripts_resource.ts
@@ -132,8 +132,12 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
   }
 
   async setDataSourceId(auth: Authenticator, dataSourceId: string | null) {
-    if (!dataSourceId) {
+    if (dataSourceId === undefined) {
       return;
+    }
+
+    if (dataSourceId === null) {
+      return this.update({ dataSourceId: null });
     }
 
     const dataSource = await DataSourceResource.fetchById(auth, dataSourceId);

--- a/front/lib/resources/labs_transcripts_resource.ts
+++ b/front/lib/resources/labs_transcripts_resource.ts
@@ -10,7 +10,7 @@ import type { CreationAttributes } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
-import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { LabsTranscriptsConfigurationModel } from "@app/lib/resources/storage/models/labs_transcripts";
 import { LabsTranscriptsHistoryModel } from "@app/lib/resources/storage/models/labs_transcripts";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
@@ -143,16 +143,16 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
       return this.update({ dataSourceViewId: null });
     }
 
-    const dataSource = await DataSourceResource.fetchById(
+    const dataSourceView = await DataSourceViewResource.fetchById(
       auth,
       dataSourceViewId
     );
 
-    if (!dataSource || this.dataSourceViewId === dataSource.id) {
+    if (!dataSourceView || this.dataSourceViewId === dataSourceView.id) {
       return;
     }
 
-    return this.update({ dataSourceViewId: dataSource.id });
+    return this.update({ dataSourceViewId: dataSourceView.id });
   }
 
   async delete(

--- a/front/lib/resources/labs_transcripts_resource.ts
+++ b/front/lib/resources/labs_transcripts_resource.ts
@@ -131,22 +131,28 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
     return this.update({ isActive });
   }
 
-  async setDataSourceId(auth: Authenticator, dataSourceId: string | null) {
-    if (dataSourceId === undefined) {
+  async setDataSourceViewId(
+    auth: Authenticator,
+    dataSourceViewId: string | null
+  ) {
+    if (dataSourceViewId === undefined) {
       return;
     }
 
-    if (dataSourceId === null) {
-      return this.update({ dataSourceId: null });
+    if (dataSourceViewId === null) {
+      return this.update({ dataSourceViewId: null });
     }
 
-    const dataSource = await DataSourceResource.fetchById(auth, dataSourceId);
+    const dataSource = await DataSourceResource.fetchById(
+      auth,
+      dataSourceViewId
+    );
 
-    if (!dataSource || this.dataSourceId === dataSource.id) {
+    if (!dataSource || this.dataSourceViewId === dataSource.id) {
       return;
     }
 
-    return this.update({ dataSourceId: dataSource.id });
+    return this.update({ dataSourceViewId: dataSource.id });
   }
 
   async delete(

--- a/front/lib/resources/storage/models/labs_transcripts.ts
+++ b/front/lib/resources/storage/models/labs_transcripts.ts
@@ -12,7 +12,7 @@ import type { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { User } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
 import { frontSequelize } from "@app/lib/resources/storage";
-import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
+import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 
 export class LabsTranscriptsConfigurationModel extends Model<
   InferAttributes<LabsTranscriptsConfigurationModel>,
@@ -29,7 +29,7 @@ export class LabsTranscriptsConfigurationModel extends Model<
 
   declare userId: ForeignKey<User["id"]>;
   declare workspaceId: ForeignKey<Workspace["id"]>;
-  declare dataSourceId: ForeignKey<DataSourceModel["id"]> | null;
+  declare dataSourceViewId: ForeignKey<DataSourceViewModel["id"]> | null;
 }
 
 LabsTranscriptsConfigurationModel.init(
@@ -92,12 +92,12 @@ LabsTranscriptsConfigurationModel.belongsTo(Workspace, {
   foreignKey: { name: "workspaceId", allowNull: false },
 });
 
-DataSourceModel.hasMany(LabsTranscriptsConfigurationModel, {
-  foreignKey: { name: "dataSourceId", allowNull: true },
+DataSourceViewModel.hasMany(LabsTranscriptsConfigurationModel, {
+  foreignKey: { name: "dataSourceViewId", allowNull: true },
 });
-LabsTranscriptsConfigurationModel.belongsTo(DataSourceModel, {
-  as: "dataSource",
-  foreignKey: { name: "dataSourceId", allowNull: true },
+LabsTranscriptsConfigurationModel.belongsTo(DataSourceViewModel, {
+  as: "dataSourceView",
+  foreignKey: { name: "dataSourceViewId", allowNull: true },
 });
 
 export class LabsTranscriptsHistoryModel extends Model<

--- a/front/migrations/db/migration_108.sql
+++ b/front/migrations/db/migration_108.sql
@@ -1,0 +1,3 @@
+-- Migration created on Oct 25, 2024
+ALTER TABLE "public"."labs_transcripts_configurations" ADD COLUMN "dataSourceViewId" INTEGER REFERENCES "data_source_views" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "public"."labs_transcripts_configurations" DROP COLUMN "dataSourceId";

--- a/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
@@ -21,7 +21,7 @@ export type GetLabsTranscriptsConfigurationResponseBody = {
 export const PatchLabsTranscriptsConfigurationBodySchema = t.partial({
   agentConfigurationId: t.string,
   isActive: t.boolean,
-  dataSourceId: t.union([t.string, t.null]),
+  dataSourceViewId: t.union([t.string, t.null]),
 });
 export type PatchTranscriptsConfiguration = t.TypeOf<
   typeof PatchLabsTranscriptsConfigurationBodySchema
@@ -104,7 +104,7 @@ async function handler(
       const {
         agentConfigurationId: patchAgentId,
         isActive,
-        dataSourceId,
+        dataSourceViewId,
       } = patchBodyValidation.right;
 
       if (patchAgentId) {
@@ -123,9 +123,12 @@ async function handler(
         }
       }
 
-      if (dataSourceId !== undefined) {
-        console.log("Setting data source id", dataSourceId);
-        await transcriptsConfiguration.setDataSourceId(auth, dataSourceId);
+      if (dataSourceViewId !== undefined) {
+        console.log("Setting data source id", dataSourceViewId);
+        await transcriptsConfiguration.setDataSourceViewId(
+          auth,
+          dataSourceViewId
+        );
       }
 
       return res.status(200).json({ configuration: transcriptsConfiguration });

--- a/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
@@ -124,7 +124,6 @@ async function handler(
       }
 
       if (dataSourceViewId !== undefined) {
-        console.log("Setting data source id", dataSourceViewId);
         await transcriptsConfiguration.setDataSourceViewId(
           auth,
           dataSourceViewId

--- a/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
@@ -124,6 +124,7 @@ async function handler(
       }
 
       if (dataSourceId !== undefined) {
+        console.log("Setting data source id", dataSourceId);
         await transcriptsConfiguration.setDataSourceId(auth, dataSourceId);
       }
 

--- a/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
+++ b/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
@@ -633,48 +633,6 @@ export default function LabsTranscriptsIndex({
           (transcriptsConfigurationState.isGDriveConnected ||
             transcriptsConfigurationState.isGongConnected) && (
             <>
-              <Page.Layout direction="vertical">
-                <Page.SectionHeader title="Pick an assistant" />
-                <Page.Layout direction="vertical">
-                  <Page.P>
-                    Pick the assistant that will process the transcripts
-                    received from{" "}
-                    {transcriptsConfigurationState.provider
-                      .charAt(0)
-                      .toUpperCase() +
-                      transcriptsConfigurationState.provider.slice(1)}
-                    .
-                  </Page.P>
-                  <Page.Layout direction="horizontal">
-                    <AssistantPicker
-                      owner={owner}
-                      size="sm"
-                      onItemClick={(assistant) =>
-                        handleSelectAssistant(
-                          transcriptsConfiguration.id,
-                          assistant
-                        )
-                      }
-                      assistants={agents}
-                      showFooterButtons={false}
-                    />
-                    {transcriptsConfigurationState.assistantSelected && (
-                      <div className="mt-2">
-                        <Page.P>
-                          <strong>
-                            @
-                            {
-                              transcriptsConfigurationState.assistantSelected
-                                .name
-                            }
-                          </strong>
-                        </Page.P>
-                      </div>
-                    )}
-                  </Page.Layout>
-                </Page.Layout>
-              </Page.Layout>
-
               {featureFlags.includes("labs_transcripts_datasource") && (
                 <Page.Layout direction="vertical">
                   <Page.SectionHeader

--- a/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
+++ b/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
@@ -677,7 +677,10 @@ export default function LabsTranscriptsIndex({
 
               {featureFlags.includes("labs_transcripts_datasource") && (
                 <Page.Layout direction="vertical">
-                  <Page.SectionHeader title="Store transcripts" />
+                  <Page.SectionHeader
+                    title="Store transcripts"
+                    description="After each transcribed meeting, store the full transcript in a Dust folder for later use."
+                  />
                   <Page.Layout direction="horizontal" gap="xl">
                     <SliderToggle
                       selected={storeInFolder}
@@ -686,9 +689,7 @@ export default function LabsTranscriptsIndex({
                         !transcriptsConfigurationState.assistantSelected
                       }
                     />
-                    <Page.P>
-                      Store transcripts in a Folder for later use.
-                    </Page.P>
+                    <Page.P>Enable transcripts storage</Page.P>
                   </Page.Layout>
                   <Page.Layout direction="horizontal">
                     <div className="w-full">
@@ -716,7 +717,52 @@ export default function LabsTranscriptsIndex({
               )}
 
               <Page.Layout direction="vertical">
-                <Page.SectionHeader title="Process transcripts automatically" />
+                <Page.SectionHeader
+                  title="Process transcripts automatically"
+                  description="After each transcribed meeting, Dust will run the assistant you selected and send you the result by email."
+                />
+                <Page.Layout direction="vertical">
+                  <Page.Layout direction="vertical">
+                    <Page.Layout direction="horizontal">
+                      <AssistantPicker
+                        owner={owner}
+                        size="sm"
+                        onItemClick={(assistant) =>
+                          handleSelectAssistant(
+                            transcriptsConfiguration.id,
+                            assistant
+                          )
+                        }
+                        assistants={agents}
+                        showFooterButtons={false}
+                      />
+                      {transcriptsConfigurationState.assistantSelected && (
+                        <div className="mt-2">
+                          <Page.P>
+                            <strong>
+                              @
+                              {
+                                transcriptsConfigurationState.assistantSelected
+                                  .name
+                              }
+                            </strong>
+                          </Page.P>
+                        </div>
+                      )}
+                      <div className="mt-2">
+                        <Page.P>
+                          The assistant that will process the transcripts
+                          received from{" "}
+                          {transcriptsConfigurationState.provider
+                            .charAt(0)
+                            .toUpperCase() +
+                            transcriptsConfigurationState.provider.slice(1)}
+                          .
+                        </Page.P>
+                      </div>
+                    </Page.Layout>
+                  </Page.Layout>
+                </Page.Layout>
                 <Page.Layout direction="horizontal" gap="xl">
                   <SliderToggle
                     selected={transcriptsConfigurationState.isActive}
@@ -728,10 +774,7 @@ export default function LabsTranscriptsIndex({
                     }
                     disabled={!transcriptsConfigurationState.assistantSelected}
                   />
-                  <Page.P>
-                    After each transcribed meeting, Dust will run the assistant
-                    you selected and send you the result by email.
-                  </Page.P>
+                  <Page.P>Enable transcripts email processing</Page.P>
                 </Page.Layout>
               </Page.Layout>
             </>

--- a/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
+++ b/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
@@ -42,7 +42,7 @@ const defaultTranscriptConfigurationState = {
   isGongConnected: false,
   assistantSelected: null,
   isActive: false,
-  dataSource: null,
+  dataSourceView: null,
 };
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
@@ -145,14 +145,14 @@ export default function LabsTranscriptsIndex({
       isGongConnected: boolean;
       assistantSelected: LightAgentConfigurationType | null;
       isActive: boolean;
-      dataSource: DataSourceViewType | null;
+      dataSourceView: DataSourceViewType | null;
     }>(defaultTranscriptConfigurationState);
 
   useEffect(() => {
     if (transcriptsConfiguration) {
-      if (transcriptsConfiguration?.dataSourceId) {
+      if (transcriptsConfiguration.dataSourceViewId) {
         const dataSourceView = dataSourcesViews.find(
-          (ds) => ds.id === transcriptsConfiguration.dataSourceId
+          (ds) => ds.id === transcriptsConfiguration.dataSourceViewId
         );
         if (dataSourceView) {
           setSelectionConfigurations({
@@ -164,7 +164,7 @@ export default function LabsTranscriptsIndex({
           });
         }
       }
-      setStoreInFolder(!!transcriptsConfiguration.dataSourceId);
+      setStoreInFolder(!!transcriptsConfiguration.dataSourceViewId);
       setTranscriptsConfigurationState((prev) => {
         return {
           ...prev,
@@ -177,9 +177,9 @@ export default function LabsTranscriptsIndex({
               (a) => a.sId === transcriptsConfiguration.agentConfigurationId
             ) || null,
           isActive: transcriptsConfiguration.isActive || false,
-          dataSource:
+          dataSourceView:
             dataSourcesViews.find(
-              (ds) => ds.id === transcriptsConfiguration.dataSourceId
+              (ds) => ds.id === transcriptsConfiguration.dataSourceViewId
             ) || null,
         };
       });
@@ -297,21 +297,21 @@ export default function LabsTranscriptsIndex({
 
   const handleSetDataSource = async (
     transcriptConfigurationId: number,
-    dataSource: DataSourceViewType | null
+    dataSourceView: DataSourceViewType | null
   ) => {
     setTranscriptsConfigurationState((prev) => {
       return {
         ...prev,
-        dataSource,
+        dataSourceView,
       };
     });
 
     let successMessage = "The transcripts will not be stored.";
 
-    if (dataSource) {
+    if (dataSourceView) {
       successMessage =
         "The transcripts will be stored in the folder " +
-        dataSource.dataSource.name;
+        dataSourceView.dataSource.name;
     } else {
       successMessage = "The transcripts will not be stored.";
     }
@@ -319,7 +319,7 @@ export default function LabsTranscriptsIndex({
     await makePatchRequest(
       transcriptConfigurationId,
       {
-        dataSourceId: dataSource ? dataSource.dataSource.sId : null,
+        dataSourceViewId: dataSourceView ? dataSourceView.dataSource.sId : null,
       },
       successMessage
     );

--- a/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
+++ b/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
@@ -319,7 +319,7 @@ export default function LabsTranscriptsIndex({
     await makePatchRequest(
       transcriptConfigurationId,
       {
-        dataSourceViewId: dataSourceView ? dataSourceView.dataSource.sId : null,
+        dataSourceViewId: dataSourceView ? dataSourceView.sId : null,
       },
       successMessage
     );

--- a/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
+++ b/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
@@ -20,6 +20,7 @@ import type {
 } from "@dust-tt/types";
 import { setupOAuthConnection } from "@dust-tt/types";
 import type { InferGetServerSidePropsType } from "next";
+import type { Dispatch, SetStateAction } from "react";
 import { useEffect, useState } from "react";
 
 import { AssistantPicker } from "@app/components/assistant/AssistantPicker";
@@ -30,7 +31,6 @@ import { getFeatureFlags } from "@app/lib/auth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import type { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import { useLabsTranscriptsConfiguration } from "@app/lib/swr/labs";
 import { useSpaces } from "@app/lib/swr/spaces";
@@ -98,12 +98,33 @@ export default function LabsTranscriptsIndex({
   const { vaults, isVaultsLoading } = useSpaces({
     workspaceId: owner.sId,
   });
-
   const { agentConfigurations } = useAgentConfigurations({
     workspaceId: owner.sId,
     agentsGetView: "list",
     sort: "priority",
   });
+
+  const handleSetSelectionConfigurations: Dispatch<
+    SetStateAction<DataSourceViewSelectionConfigurations>
+  > = (newValue) => {
+    const newSelectionConfigurations =
+      typeof newValue === "function"
+        ? newValue(selectionConfigurations)
+        : newValue;
+
+    const keys = Object.keys(newSelectionConfigurations);
+
+    if (keys.length > 0) {
+      const lastKey = keys[keys.length - 1];
+      const finalConfigurations: DataSourceViewSelectionConfigurations = {
+        [lastKey]: newSelectionConfigurations[lastKey],
+      };
+
+      setSelectionConfigurations(finalConfigurations);
+    } else {
+      setSelectionConfigurations({});
+    }
+  };
 
   const {
     transcriptsConfiguration,
@@ -645,7 +666,7 @@ export default function LabsTranscriptsIndex({
                               owner={owner}
                               selectionConfigurations={selectionConfigurations}
                               setSelectionConfigurations={
-                                setSelectionConfigurations
+                                handleSetSelectionConfigurations
                               }
                               viewType={"documents"}
                               isRootSelectable={true}

--- a/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
+++ b/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
@@ -1,7 +1,6 @@
 import {
   BookOpenIcon,
   Button,
-  Checkbox,
   CloudArrowLeftRightIcon,
   Dialog,
   Page,
@@ -497,7 +496,7 @@ export default function LabsTranscriptsIndex({
           description="Receive meeting minutes summarized by email automatically."
         />
         <Page.Layout direction="vertical">
-          <Page.SectionHeader title="1. Connect your transcripts provider" />
+          <Page.SectionHeader title="Connect your transcripts provider" />
           {!transcriptsConfiguration && (
             <Page.Layout direction="horizontal" gap="xl">
               <div
@@ -610,11 +609,16 @@ export default function LabsTranscriptsIndex({
             transcriptsConfigurationState.isGongConnected) && (
             <>
               <Page.Layout direction="vertical">
-                <Page.SectionHeader title="2. Choose an assistant" />
+                <Page.SectionHeader title="Pick an assistant" />
                 <Page.Layout direction="vertical">
                   <Page.P>
-                    Choose the assistant that will process the transcripts the
-                    way you want.
+                    Pick the assistant that will process the transcripts
+                    received from{" "}
+                    {transcriptsConfigurationState.provider
+                      .charAt(0)
+                      .toUpperCase() +
+                      transcriptsConfigurationState.provider.slice(1)}
+                    .
                   </Page.P>
                   <Page.Layout direction="horizontal">
                     <AssistantPicker
@@ -630,12 +634,17 @@ export default function LabsTranscriptsIndex({
                       showFooterButtons={false}
                     />
                     {transcriptsConfigurationState.assistantSelected && (
-                      <Page.P>
-                        <strong>
-                          @
-                          {transcriptsConfigurationState.assistantSelected.name}
-                        </strong>
-                      </Page.P>
+                      <div className="mt-2">
+                        <Page.P>
+                          <strong>
+                            @
+                            {
+                              transcriptsConfigurationState.assistantSelected
+                                .name
+                            }
+                          </strong>
+                        </Page.P>
+                      </div>
                     )}
                   </Page.Layout>
                 </Page.Layout>
@@ -643,15 +652,19 @@ export default function LabsTranscriptsIndex({
 
               {featureFlags.includes("labs_transcripts_datasource") && (
                 <Page.Layout direction="vertical">
-                  <Page.SectionHeader title="3. Store transcripts in Folder" />
+                  <Page.SectionHeader title="Store transcripts" />
                   <Page.Layout direction="horizontal" gap="xl">
+                    <SliderToggle
+                      selected={storeInFolder}
+                      onClick={() => setStoreInFolder(!storeInFolder)}
+                      disabled={
+                        !transcriptsConfigurationState.assistantSelected
+                      }
+                    />
                     <Page.P>
-                      Store transcripts in a Folder to use them with Dust
-                      assistants.
+                      Store transcripts in a Folder to use them as sources of
+                      your assistants.
                     </Page.P>
-                    <div onClick={() => setStoreInFolder(!storeInFolder)}>
-                      <Checkbox checked={storeInFolder} />
-                    </div>
                   </Page.Layout>
                   <Page.Layout direction="horizontal">
                     <div className="w-full">
@@ -679,7 +692,7 @@ export default function LabsTranscriptsIndex({
               )}
 
               <Page.Layout direction="vertical">
-                <Page.SectionHeader title="3. Enable transcripts processing" />
+                <Page.SectionHeader title="Process transcripts automatically" />
                 <Page.Layout direction="horizontal" gap="xl">
                   <SliderToggle
                     selected={transcriptsConfigurationState.isActive}
@@ -692,11 +705,8 @@ export default function LabsTranscriptsIndex({
                     disabled={!transcriptsConfigurationState.assistantSelected}
                   />
                   <Page.P>
-                    When enabled, each new meeting transcript in 'My Drive' will
-                    be processed.
-                    <br />
-                    Summaries can take up to 30 minutes to be sent after
-                    meetings end.
+                    After each transcribed meeting, Dust will run the assistant
+                    you selected and send you the result by email.
                   </Page.P>
                 </Page.Layout>
               </Page.Layout>

--- a/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
+++ b/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
@@ -55,16 +55,9 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   const subscription = auth.subscription();
   const user = auth.user();
 
-  const globalVault = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
-  const globalDataSourceViews = await DataSourceViewResource.listBySpace(
-    auth,
-    globalVault
-  );
-
-  const dataSourcesViews = globalDataSourceViews
-    .map((dsv) => dsv.toJSON())
-    .filter((dsv) => !dsv.dataSource.connectorId)
-    .sort((a, b) => a.dataSource.name.localeCompare(b.dataSource.name));
+  const dataSourcesViews = (
+    await DataSourceViewResource.listByWorkspace(auth)
+  ).map((dsv) => dsv.toJSON());
 
   if (!owner || !subscription || !user) {
     return {
@@ -632,35 +625,34 @@ export default function LabsTranscriptsIndex({
                   <Page.SectionHeader title="3. Store transcripts in Folder" />
                   <Page.Layout direction="horizontal" gap="xl">
                     <Page.P>
-                      Store transcripts in a Folder to keep using them in your
-                      assistants?
-                      <br />
-                      <small>
-                        Warning: this can make your transcripts public within
-                        your workspace.
-                      </small>
+                      Store transcripts in a Folder to use them with Dust
+                      assistants.
                     </Page.P>
                     <div onClick={() => setStoreInFolder(!storeInFolder)}>
                       <Checkbox checked={storeInFolder} />
                     </div>
                   </Page.Layout>
                   <Page.Layout direction="horizontal">
-                    {!isVaultsLoading &&
-                      storeInFolder &&
-                      selectionConfigurations && (
-                        <DataSourceViewsSelector
-                          useCase="transcriptsProcessing"
-                          dataSourceViews={dataSourcesViews}
-                          allowedVaults={vaults}
-                          owner={owner}
-                          selectionConfigurations={selectionConfigurations}
-                          setSelectionConfigurations={
-                            setSelectionConfigurations
-                          }
-                          viewType={"documents"}
-                          isRootSelectable={true}
-                        />
-                      )}
+                    <div className="w-full">
+                      <div className="overflow-x-auto">
+                        {!isVaultsLoading &&
+                          storeInFolder &&
+                          selectionConfigurations && (
+                            <DataSourceViewsSelector
+                              useCase="transcriptsProcessing"
+                              dataSourceViews={dataSourcesViews}
+                              allowedVaults={vaults}
+                              owner={owner}
+                              selectionConfigurations={selectionConfigurations}
+                              setSelectionConfigurations={
+                                setSelectionConfigurations
+                              }
+                              viewType={"documents"}
+                              isRootSelectable={true}
+                            />
+                          )}
+                      </div>
+                    </div>
                   </Page.Layout>
                 </Page.Layout>
               )}


### PR DESCRIPTION
## Description

This PR enables the UI for storing transcripts in a Folder inside a Space. 
Since Spaces became available, it now makes sense to be able to store my meeting transcripts in a secure space if I want to. 

- We store the datasourceViewId 
- Separate toggles between 'storing transcripts' and 'processing transcripts' : I can want to have one, the other or both
- This is provider agnostic. This will enable us to add more providers to the 'meeting transcripts connector' like mojo, etc. 
- This does not import the history of calls
- When active, it only imports the meetings of the user that activated the feature.

This PR also edits the DatasourceViewSelector to pass the useCase all the way down, as in this selector I only want to be able to select **one** folder (the destination)
We're also only showing folders and not any other datasource types.

https://github.com/user-attachments/assets/8ecaf27c-8f33-4534-be19-b6e8c667b22a



## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Run migration 108