### PR TITLE
[front] - fix: `Tree` action button variant

### DIFF
--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -227,7 +227,7 @@ function ContentNodeTreeChildren({
                     n.sourceUrl ? "" : "pointer-events-none opacity-0"
                   )}
                   disabled={!n.sourceUrl}
-                  variant="ghost"
+                  variant="outline"
                 />
                 {onDocumentViewClick && (
                   <IconButton

--- a/front/components/assistant/details/AssistantActionsSection.tsx
+++ b/front/components/assistant/details/AssistantActionsSection.tsx
@@ -385,7 +385,7 @@ function DataSourceViewSelectedNodes({
                   node.dustDocumentId ? "" : "pointer-events-none opacity-0"
                 )}
                 disabled={!node.dustDocumentId}
-                variant="ghost"
+                variant="outline"
               />
             </div>
           }

--- a/front/components/assistant_builder/DataSourceSelectionSection.tsx
+++ b/front/components/assistant_builder/DataSourceSelectionSection.tsx
@@ -142,7 +142,7 @@ export default function DataSourceSelectionSection({
                                   : "pointer-events-none opacity-0"
                               )}
                               disabled={!node.sourceUrl}
-                              variant="ghost"
+                              variant="outline"
                             />
                             <IconButton
                               size="xs"

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.277",
+        "@dust-tt/sparkle": "^0.2.278",
         "@dust-tt/types": "file:../types",
         "@headlessui/react": "^1.7.7",
         "@heroicons/react": "^2.0.11",
@@ -11504,9 +11504,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.277",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.277.tgz",
-      "integrity": "sha512-Vx9SbIH1N4fl1/WttZz4xE9kXGU5KT1AopnDbrrp/C56MPuSqs0d1OQpC0prywwNh3BiOmrC2oAHvg7xFf+dzg==",
+      "version": "0.2.278",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.278.tgz",
+      "integrity": "sha512-4ciWBZm8A2xx7v0f1/JS3oHZAGO6NWcu+4qYYd6/miIEudGIQzHT2/B+0psM3SXvyngcNCZLr4E/AcC9xsTMXg==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.277",
+    "@dust-tt/sparkle": "^0.2.278",
     "@dust-tt/types": "file:../types",
     "@headlessui/react": "^1.7.7",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description

This PR aims at changing the variant of the action `IconButton` used in `Tree`. It also bumps the sparkle version to include [those changes](https://github.com/dust-tt/dust/pull/8233/files).

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
