### PR TITLE
Upg: heartbeat during github repo tarball extraction. Filter early

### DIFF
--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -946,11 +946,18 @@ export async function githubCodeSyncActivity({
   );
 
   Context.current().heartbeat();
+  let nbEntries = 0;
   const repoRes = await processRepository({
     connectionId: connector.connectionId,
     repoLogin,
     repoName,
     repoId,
+    onEntry: () => {
+      if (nbEntries % 100 === 0) {
+        Context.current().heartbeat();
+      }
+      ++nbEntries;
+    },
     logger: logger,
   });
   Context.current().heartbeat();


### PR DESCRIPTION
## Description

We have a workflow stuck because github repo tarball extraction takes too long than the heartbeat timeout.
This PR should fix it by heartbeating every 100 items during extraction and extraction time should be shorter because filtering is done earlier.

## Risk

None

## Deploy Plan

Deploy `connectors`