### PR TITLE
Upg: add workspace and connector search in poke

### DIFF
--- a/front/lib/poke/search.ts
+++ b/front/lib/poke/search.ts
@@ -1,9 +1,14 @@
+import type { ConnectorType } from "@dust-tt/types";
+import { ConnectorsAPI } from "@dust-tt/types";
 import type { PokeItemBase } from "@dust-tt/types/dist/front/lib/poke";
 
+import config from "@app/lib/api/config";
+import { getWorkspaceInfos } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { getResourceNameAndIdFromSId } from "@app/lib/resources/string_ids";
+import logger from "@app/logger/logger";
 
 // TODO: Implement search on workspaces.
 export async function searchPokeResources(
@@ -13,6 +18,34 @@ export async function searchPokeResources(
   const resourceInfo = getResourceNameAndIdFromSId(searchTerm);
   if (resourceInfo) {
     return searchPokeResourcesBySId(auth, resourceInfo);
+  } else {
+    // Fallback to handle resources without the cool sId format.
+    const workspaceInfos = await getWorkspaceInfos(searchTerm);
+    if (workspaceInfos) {
+      return [
+        {
+          id: workspaceInfos.id,
+          name: `Workspace (${workspaceInfos.name})`,
+          link: `${config.getClientFacingUrl()}/poke/${workspaceInfos.sId}`,
+        },
+      ];
+    }
+    const connectorsAPI = new ConnectorsAPI(
+      config.getConnectorsAPIConfig(),
+      logger
+    );
+    const cRes = await connectorsAPI.getConnector(searchTerm);
+    if (cRes.isOk()) {
+      const connector: ConnectorType = cRes.value;
+
+      return [
+        {
+          id: parseInt(connector.id),
+          name: `Connector`,
+          link: `${config.getClientFacingUrl()}/poke/${connector.workspaceId}/data_sources/${connector.dataSourceId}`,
+        },
+      ];
+    }
   }
 
   return [];


### PR DESCRIPTION
## Description

Add poke quick search for workspace (sid) and connector (id), which are very common needs.
(note: if it was me I would remove the toPokeJSON())

## Risk

None

## Deploy Plan

Deploy `front`