### PR TITLE
Fix: conversations grouping label

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -142,7 +142,7 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
       } else if (createdDate.isSameOrAfter(lastMonth)) {
         groups["Last Month"].push(conversation);
       } else if (createdDate.isSameOrAfter(lastYear)) {
-        groups["Last Year"].push(conversation);
+        groups["Last 12 Months"].push(conversation);
       } else {
         groups["Older"].push(conversation);
       }


### PR DESCRIPTION
## Description

Misleading label for convos > 1 month but <= 12 moths. (eng runner card)

## Risk

None

## Deploy Plan

Deploy `front`