### PR TITLE
enh(tables query): allow fetching 2048 rows on transient db

### DIFF
--- a/core/src/sqlite_workers/sqlite_database.rs
+++ b/core/src/sqlite_workers/sqlite_database.rs
@@ -46,7 +46,7 @@ impl From<anyhow::Error> for SqliteDatabaseError {
     }
 }
 
-const MAX_ROWS: usize = 128;
+const MAX_ROWS: usize = 2048;
 
 impl SqliteDatabase {
     pub fn new() -> Self {

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -158,7 +158,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "b4f205e453",
       appHash:
-        "d2bfd8d38ad3fa5f71fb7c95cdd9eed158ae3b25f737cb27b8fa3e2d344388ce",
+        "59b0d9aa49ed9232f88f3ac1cd260ae25e0cd68e0622058c87cd4a42edce18da",
       appVaultId: PRODUCTION_DUST_APPS_VAULT_ID,
     },
     config: {


### PR DESCRIPTION
## Description

allow fetching 2048 (instead of 128) rows on transient DB.

This is OK as we now have files for output

## Risk

Potentially more load on sqlite workers

## Deploy Plan

Core + front