### PR TITLE
Upg: stop fetching feature flags on all requests, do it on-demand

### DIFF
--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -13,6 +13,7 @@ import { isOnlyAdmin, isOnlyBuilder, isOnlyUser } from "@dust-tt/types";
 import { useMemo } from "react";
 
 import { canForceUserRole, forceUserRole } from "@app/lib/development";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
 
 export function UserMenu({
   user,
@@ -21,7 +22,9 @@ export function UserMenu({
   user: UserType;
   owner: WorkspaceType;
 }) {
-  const hasBetaAccess = owner.flags.some((flag: string) =>
+  const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
+
+  const hasBetaAccess = featureFlags.some((flag: string) =>
     flag.startsWith("labs_")
   );
   const sendNotification = useSendNotification();
@@ -69,7 +72,7 @@ export function UserMenu({
         {hasBetaAccess && (
           <>
             <DropdownMenu.SectionHeader label="Beta" />
-            {owner.flags.includes("labs_transcripts") && (
+            {featureFlags.includes("labs_transcripts") && (
               <DropdownMenu.Item
                 label="Transcripts processing"
                 link={{ href: `/w/${owner.sId}/assistant/labs/transcripts` }}

--- a/front/components/data_source/DocumentOrTableUploadOrEditModal.tsx
+++ b/front/components/data_source/DocumentOrTableUploadOrEditModal.tsx
@@ -37,6 +37,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { handleFileUploadToText } from "@app/lib/client/handle_file_upload";
 import { useDataSourceViewDocument } from "@app/lib/swr/data_source_views";
 import { useTable } from "@app/lib/swr/tables";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
 
 const MAX_NAME_CHARS = 32;
 
@@ -469,6 +470,8 @@ const TableUploadOrEditModal = ({
     tableId: initialId ?? null,
   });
 
+  const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
+
   useEffect(() => {
     if (!initialId) {
       setTableState({
@@ -702,7 +705,7 @@ const TableUploadOrEditModal = ({
                   </div>
                 )}
               </div>
-              {owner.flags.includes("use_app_for_header_detection") && (
+              {featureFlags.includes("use_app_for_header_detection") && (
                 <div>
                   <Page.SectionHeader
                     title="Enable header detection"

--- a/front/components/poke/features/table.tsx
+++ b/front/components/poke/features/table.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/router";
 
 import { makeColumnsForFeatureFlags } from "@app/components/poke/features/columns";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
 
 interface FeatureFlagsDataTableProps {
   owner: WorkspaceType;
@@ -11,11 +12,11 @@ interface FeatureFlagsDataTableProps {
 }
 
 function prepareFeatureFlagsForDisplay(
-  owner: WorkspaceType,
+  workspaceFlags: WhitelistableFeature[],
   whitelistableFeatures: WhitelistableFeature[]
 ) {
   return whitelistableFeatures.map((ff) => {
-    const isEnabledForWorkspace = owner.flags.some((f) => f === ff);
+    const isEnabledForWorkspace = workspaceFlags.some((f) => f === ff);
 
     return {
       name: ff,
@@ -29,6 +30,7 @@ export function FeatureFlagsDataTable({
   whitelistableFeatures,
 }: FeatureFlagsDataTableProps) {
   const router = useRouter();
+  const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
   const sendNotification = useSendNotification();
 
   return (
@@ -40,7 +42,10 @@ export function FeatureFlagsDataTable({
           router.reload,
           sendNotification
         )}
-        data={prepareFeatureFlagsForDisplay(owner, whitelistableFeatures)}
+        data={prepareFeatureFlagsForDisplay(
+          featureFlags,
+          whitelistableFeatures
+        )}
       />
     </div>
   );

--- a/front/components/vaults/AddConnectionMenu.tsx
+++ b/front/components/vaults/AddConnectionMenu.tsx
@@ -29,6 +29,7 @@ import {
   isConnectorProviderAllowedForPlan,
 } from "@app/lib/connector_providers";
 import { useSystemVault } from "@app/lib/swr/vaults";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { PostDataSourceRequestBody } from "@app/pages/api/w/[wId]/vaults/[vId]/data_sources";
 
 export type DataSourceIntegration = {
@@ -97,6 +98,7 @@ export const AddConnectionMenu = ({
   });
 
   const router = useRouter();
+  const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
 
   const availableIntegrations = integrations.filter(
     (i) =>
@@ -228,7 +230,7 @@ export const AddConnectionMenu = ({
       configuration.status === "built" ||
       (configuration.status === "rolling_out" &&
         !!configuration.rollingOutFlag &&
-        owner.flags.includes(configuration.rollingOutFlag));
+        featureFlags.includes(configuration.rollingOutFlag));
     const isProviderAllowed = isConnectorProviderAllowedForPlan(
       plan,
       configuration.connectorProvider

--- a/front/components/workspace/connection.tsx
+++ b/front/components/workspace/connection.tsx
@@ -26,7 +26,10 @@ import { useRouter } from "next/router";
 import { useCallback, useState } from "react";
 
 import { isUpgraded } from "@app/lib/plans/plan_codes";
-import { useWorkspaceEnterpriseConnection } from "@app/lib/swr/workspaces";
+import {
+  useFeatureFlags,
+  useWorkspaceEnterpriseConnection,
+} from "@app/lib/swr/workspaces";
 import type { PostCreateEnterpriseConnectionRequestBodySchemaType } from "@app/pages/api/w/[wId]/enterprise-connection";
 
 interface EnterpriseConnectionDetailsProps {
@@ -64,13 +67,14 @@ export function EnterpriseConnectionDetails({
   ] = useState(false);
 
   const router = useRouter();
+  const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
 
   const { enterpriseConnection, mutateEnterpriseConnection } =
     useWorkspaceEnterpriseConnection({
       workspaceId: owner.sId,
     });
 
-  if (!owner.flags.includes("okta_enterprise_connection")) {
+  if (!featureFlags.includes("okta_enterprise_connection")) {
     return <></>;
   }
 

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -40,6 +40,7 @@ import {
   DEFAULT_WEBSEARCH_ACTION_NAME,
 } from "@app/lib/api/assistant/actions/names";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import {
   AgentUserRelation,
   GlobalAgentSettings,
@@ -1291,12 +1292,14 @@ export async function getGlobalAgents(
       (sId) => !RETIRED_GLOABL_AGENTS_SID.includes(sId)
     );
 
-  if (!owner.flags.includes("openai_o1_feature")) {
+  const flags = await getFeatureFlags(owner.id);
+
+  if (!flags.includes("openai_o1_feature")) {
     agentsIdsToFetch = agentsIdsToFetch.filter(
       (sId) => sId !== GLOBAL_AGENTS_SID.O1
     );
   }
-  if (!owner.flags.includes("openai_o1_mini_feature")) {
+  if (!flags.includes("openai_o1_mini_feature")) {
     agentsIdsToFetch = agentsIdsToFetch.filter(
       (sId) => sId !== GLOBAL_AGENTS_SID.O1_MINI
     );

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -27,6 +27,7 @@ import { sendGithubDeletionEmail } from "@app/lib/api/email";
 import { rowsFromCsv, upsertTableFromCsv } from "@app/lib/api/tables";
 import { getMembers } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { generateLegacyModelSId } from "@app/lib/resources/string_ids";
@@ -405,9 +406,11 @@ export async function upsertTable({
     tableParents.push(nonNullTableId);
   }
 
-  const useAppForHeaderDetectionFlag = auth
-    .getNonNullableWorkspace()
-    .flags.includes("use_app_for_header_detection");
+  const flags = await getFeatureFlags(auth.getNonNullableWorkspace().id);
+
+  const useAppForHeaderDetectionFlag = flags.includes(
+    "use_app_for_header_detection"
+  );
 
   const useApp = !!useAppForHeaderDetection && useAppForHeaderDetectionFlag;
 

--- a/front/lib/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
+++ b/front/lib/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
@@ -4,6 +4,7 @@ import { Op } from "sequelize";
 import showdown from "showdown";
 
 import config from "@app/lib/api/config";
+import { getFeatureFlags } from "@app/lib/auth";
 import type {
   DocumentsPostProcessHookFilterParams,
   DocumentsPostProcessHookOnUpsertParams,
@@ -49,7 +50,10 @@ export async function shouldDocumentTrackerSuggestChangesRun(
 ): Promise<boolean> {
   const auth = params.auth;
   const owner = auth.getNonNullableWorkspace();
-  if (!owner.flags.includes("document_tracker")) {
+
+  const flags = await getFeatureFlags(owner.id);
+
+  if (!flags.includes("document_tracker")) {
     return false;
   }
 

--- a/front/lib/documents_post_process_hooks/hooks/document_tracker/update_tracked_documents/lib.ts
+++ b/front/lib/documents_post_process_hooks/hooks/document_tracker/update_tracked_documents/lib.ts
@@ -1,5 +1,6 @@
 import type { ConnectorProvider } from "@dust-tt/types";
 
+import { getFeatureFlags } from "@app/lib/auth";
 import { updateTrackedDocuments } from "@app/lib/document_tracker";
 import type {
   DocumentsPostProcessHookFilterParams,
@@ -34,7 +35,9 @@ export async function shouldDocumentTrackerUpdateTrackedDocumentsRun(
     documentId,
   });
 
-  if (!owner.flags.includes("document_tracker")) {
+  const flags = await getFeatureFlags(owner.id);
+
+  if (!flags.includes("document_tracker")) {
     return false;
   }
 

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -3,6 +3,7 @@ import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { GetWorkspaceFeatureFlagsResponseType } from "@app/pages/api/w/[wId]/feature-flags";
 import type { GetSubscriptionsResponseBody } from "@app/pages/api/w/[wId]/subscriptions";
 import type { GetWorkspaceAnalyticsResponse } from "@app/pages/api/w/[wId]/workspace-analytics";
 
@@ -109,5 +110,30 @@ export function useWorkspaceActiveSubscription({
     activeSubscription,
     isActiveSubscriptionLoading: !error && !data,
     isActiveSubscriptionError: error,
+  };
+}
+
+export function useFeatureFlags({
+  workspaceId,
+  disabled,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
+  const featureFlagsFetcher: Fetcher<GetWorkspaceFeatureFlagsResponseType> =
+    fetcher;
+
+  const { data, error } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/feature-flags`,
+    featureFlagsFetcher,
+    {
+      disabled,
+    }
+  );
+
+  return {
+    featureFlags: data ? data.feature_flags : [],
+    isFeatureFlagsLoading: !error && !data,
+    isFeatureFlagsError: error,
   };
 }

--- a/front/pages/api/v1/w/[wId]/usage.ts
+++ b/front/pages/api/v1/w/[wId]/usage.ts
@@ -5,6 +5,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { unsafeGetUsageData } from "@app/lib/workspace_usage";
 import { apiError } from "@app/logger/withlogging";
 
@@ -34,7 +35,8 @@ async function handler(
   auth: Authenticator
 ): Promise<void> {
   const owner = auth.getNonNullableWorkspace();
-  if (!owner.flags.includes("usage_data_api")) {
+  const flags = await getFeatureFlags(owner.id);
+  if (!flags.includes("usage_data_api")) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {

--- a/front/pages/api/v1/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/v1/w/[wId]/workspace-usage.ts
@@ -8,6 +8,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import {
   getAssistantsUsageData,
   getBuildersUsageData,
@@ -123,7 +124,8 @@ async function handler(
   auth: Authenticator
 ): Promise<void> {
   const owner = auth.getNonNullableWorkspace();
-  if (!owner.flags.includes("usage_data_api")) {
+  const flags = await getFeatureFlags(owner.id);
+  if (!flags.includes("usage_data_api")) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/tables/csv.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/tables/csv.ts
@@ -7,6 +7,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { rowsFromCsv, upsertTableFromCsv } from "@app/lib/api/tables";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { generateLegacyModelSId } from "@app/lib/resources/string_ids";
 import { enqueueUpsertTable } from "@app/lib/upsert_queue";
@@ -148,9 +149,11 @@ export async function handleDataSourceTableCSVUpsert({
     tableParents.push(tableId);
   }
 
+  const flags = await getFeatureFlags(owner.id);
+
   const useAppForHeaderDetection =
     !!bodyValidation.right.useAppForHeaderDetection &&
-    owner.flags.includes("use_app_for_header_detection");
+    flags.includes("use_app_for_header_detection");
 
   if (async) {
     // Ensure the CSV is valid before enqueuing the upsert.

--- a/front/pages/api/w/[wId]/feature-flags.ts
+++ b/front/pages/api/w/[wId]/feature-flags.ts
@@ -4,35 +4,23 @@ import type {
 } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
-export type WorkspaceFeatureFlagsResponseBody = {
+export type GetWorkspaceFeatureFlagsResponseType = {
   feature_flags: WhitelistableFeature[];
 };
 
-/**
- * @ignoreswagger
- * System API key only endpoint. Undocumented.
- */
-
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<WorkspaceFeatureFlagsResponseBody>>,
+  res: NextApiResponse<
+    WithAPIErrorResponse<GetWorkspaceFeatureFlagsResponseType>
+  >,
   auth: Authenticator
 ): Promise<void> {
   const owner = auth.getNonNullableWorkspace();
-  if (!auth.isSystemKey()) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace was not found.",
-      },
-    });
-  }
 
   switch (req.method) {
     case "GET":
@@ -50,4 +38,4 @@ async function handler(
   }
 }
 
-export default withPublicAPIAuthentication(handler);
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
@@ -6,6 +6,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
 import { apiError } from "@app/logger/withlogging";
 import {
@@ -35,8 +36,9 @@ async function handler(
 ): Promise<void> {
   const user = auth.getNonNullableUser();
   const owner = auth.getNonNullableWorkspace();
+  const flags = await getFeatureFlags(owner.id);
 
-  if (!owner.flags.includes("labs_transcripts")) {
+  if (!flags.includes("labs_transcripts")) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {

--- a/front/pages/api/w/[wId]/labs/transcripts/default.ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/default.ts
@@ -5,6 +5,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { GetLabsTranscriptsConfigurationResponseBody } from "@app/pages/api/w/[wId]/labs/transcripts";
@@ -24,8 +25,9 @@ async function handler(
   auth: Authenticator
 ): Promise<void> {
   const owner = auth.getNonNullableWorkspace();
+  const flags = await getFeatureFlags(owner.id);
 
-  if (!owner.flags.includes("labs_transcripts")) {
+  if (!flags.includes("labs_transcripts")) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {

--- a/front/pages/api/w/[wId]/labs/transcripts/index.ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/index.ts
@@ -6,6 +6,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
 import { apiError } from "@app/logger/withlogging";
 
@@ -32,8 +33,9 @@ async function handler(
 ): Promise<void> {
   const user = auth.getNonNullableUser();
   const owner = auth.getNonNullableWorkspace();
+  const flags = await getFeatureFlags(owner.id);
 
-  if (!owner.flags.includes("labs_transcripts")) {
+  if (!flags.includes("labs_transcripts")) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {

--- a/types/src/front/user.ts
+++ b/types/src/front/user.ts
@@ -4,7 +4,6 @@ import {
   EmbeddingProviderIdType,
   ModelProviderIdType,
 } from "../front/lib/assistant";
-import { WhitelistableFeature } from "../shared/feature_flags";
 import { ModelId } from "../shared/model_id";
 import { assertNever } from "../shared/utils/assert_never";
 
@@ -44,7 +43,6 @@ export type LightWorkspaceType = {
 };
 
 export type WorkspaceType = LightWorkspaceType & {
-  flags: WhitelistableFeature[];
   ssoEnforced?: boolean;
 };
 


### PR DESCRIPTION
## Description

Querying the feature flag is the sixth query that cost us the most CPU according to [GCP insight](https://console.cloud.google.com/sql/instances/dust-api-db/insights;database=dust-front;duration=P1D;sort_by=CPU/executed?project=or1g1n-186209).

It's very fast but done 9 millions times / day.

This refactor the code to fetch the feature flags only when needed.

If it's efficient, we should then look into the other query done 9 millions times (active subscription + plan), and then the other ones done 5-3 millions times (such as fetching the groups, the memberships etc..).

## Risk

I tested locally. Worst case, the feature behind feature flags are disabled.

## Deploy Plan

Deploy `front`