### PR TITLE
Upg: do not fetch useless participant columns for conversations and sort client side

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -229,6 +229,7 @@ export async function getUserConversations(
   }
 
   const participations = await ConversationParticipant.findAll({
+    attributes: [],
     where: {
       userId: user.id,
       action: "posted",
@@ -240,7 +241,6 @@ export async function getUserConversations(
         required: true,
       },
     ],
-    order: [["createdAt", "DESC"]],
   });
 
   const conversations = participations.reduce<ConversationWithoutContentType[]>(

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -5,6 +5,7 @@ import type {
   ConversationType,
   LightWorkspaceType,
 } from "@dust-tt/types";
+import _ from "lodash";
 import { useCallback, useMemo } from "react";
 import type { Fetcher } from "swr";
 
@@ -58,7 +59,10 @@ export function useConversations({ workspaceId }: { workspaceId: string }) {
   );
 
   return {
-    conversations: useMemo(() => (data ? data.conversations : []), [data]),
+    conversations: useMemo(
+      () => (data ? _.sortBy(data.conversations, "createdAt").reverse() : []),
+      [data]
+    ),
     isConversationsLoading: !error && !data,
     isConversationsError: error,
     mutateConversations: mutate,


### PR DESCRIPTION
## Description

Second highest query by i/o wait.
- Remove the fetching of columns in the participant table (we don't use them).
- Remove ordering on the db (do it client side in the hook).

## Risk

Tested locally.

## Deploy Plan

Deploy `front`