### PR TITLE
[connector] Turn the Zendesk continuous workflow into a Cron one

### DIFF
--- a/connectors/src/connectors/zendesk/temporal/client.ts
+++ b/connectors/src/connectors/zendesk/temporal/client.ts
@@ -85,6 +85,7 @@ export async function launchZendeskSyncWorkflow({
       signal: zendeskUpdatesSignal,
       signalArgs: [signals],
       memo: { connectorId },
+      cronSchedule: "*/5 * * * *", // Every 5 minutes.
     });
   } catch (err) {
     return new Err(err as Error);

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -1,11 +1,6 @@
 import type { ModelId } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
-import {
-  continueAsNew,
-  proxyActivities,
-  setHandler,
-  sleep,
-} from "@temporalio/workflow";
+import { proxyActivities, setHandler, sleep } from "@temporalio/workflow";
 
 import type * as activities from "@connectors/connectors/zendesk/temporal/activities";
 import { INTERVAL_BETWEEN_SYNCS_MS } from "@connectors/connectors/zendesk/temporal/config";
@@ -121,6 +116,4 @@ export async function zendeskSyncWorkflow({
   await saveZendeskConnectorSuccessSync({ connectorId });
 
   await sleep(INTERVAL_BETWEEN_SYNCS_MS);
-
-  await continueAsNew<typeof zendeskSyncWorkflow>({ connectorId });
 }


### PR DESCRIPTION
## Description

- Turn the Zendesk continuous sync workflow into a Cron workflow triggered every 5 minutes.

## Risk

## Deploy Plan

- Deploy connectors