### PR TITLE
Sparkle: Empty item tree is clickable

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.279",
+  "version": "0.2.280",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.279",
+      "version": "0.2.280",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.279",
+  "version": "0.2.280",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Tree.tsx
+++ b/sparkle/src/components/Tree.tsx
@@ -157,7 +157,7 @@ Tree.Item = function ({
           type,
           className
         )}
-        onClick={onItemClick ? onItemClick : undefined}
+        onClick={onItemClick}
       >
         {type === "node" && (
           <IconButton
@@ -212,7 +212,7 @@ Tree.Empty = function ({ label, onItemClick }: TreeEmptyProps) {
         "s-font-regular s-py-1.5 s-pl-6 s-text-sm s-text-muted-foreground",
         onItemClick ? "s-cursor-pointer" : ""
       )}
-      onClick={onItemClick ? onItemClick : undefined}
+      onClick={onItemClick}
     >
       {label}
     </div>

--- a/sparkle/src/components/Tree.tsx
+++ b/sparkle/src/components/Tree.tsx
@@ -202,11 +202,18 @@ Tree.Item = function ({
 
 interface TreeEmptyProps {
   label: string;
+  onItemClick?: () => void;
 }
 
-Tree.Empty = function ({ label }: TreeEmptyProps) {
+Tree.Empty = function ({ label, onItemClick }: TreeEmptyProps) {
   return (
-    <div className="s-font-regular s-py-1.5 s-pl-6 s-text-sm s-text-muted-foreground">
+    <div
+      className={cn(
+        "s-font-regular s-py-1.5 s-pl-6 s-text-sm s-text-muted-foreground",
+        onItemClick ? "s-cursor-pointer" : ""
+      )}
+      onClick={onItemClick ? onItemClick : undefined}
+    >
       {label}
     </div>
   );

--- a/sparkle/src/stories/Tree.stories.tsx
+++ b/sparkle/src/stories/Tree.stories.tsx
@@ -381,6 +381,14 @@ export const TreeExample = () => {
                       <Tree.Empty label="No documents" />
                     </Tree>
                   </Tree.Item>
+                  <Tree.Item label="Item 2" collapsed={false}>
+                    <Tree>
+                      <Tree.Empty
+                        label="Empty tree can be clickable"
+                        onItemClick={() => alert("Soupinou")}
+                      />
+                    </Tree>
+                  </Tree.Item>
                 </Tree>
               </Tree.Item>
               <Tree.Item


### PR DESCRIPTION
## Description

Make empty item tree clickable (optional of course). 
Required for https://github.com/dust-tt/tasks/issues/1534

## Risk

/

## Deploy Plan

Publish Sparkle. 
