### PR TITLE
[sparkle] - refactor: standardize Button usage in `ConversationMessageXXX` 

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.280",
+  "version": "0.2.281",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.280",
+      "version": "0.2.281",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.280",
+  "version": "0.2.281",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/ConversationMessage.tsx
+++ b/sparkle/src/components/ConversationMessage.tsx
@@ -1,5 +1,6 @@
-import React, { ComponentType, MouseEventHandler } from "react";
+import React from "react";
 
+import { Button } from "@sparkle/components";
 import {
   ConversationMessageActions,
   ConversationMessageEmojiSelectorProps,
@@ -24,12 +25,7 @@ const messageTypeClasses: Record<MessageType, string> = {
 
 type ConversationMessageProps = {
   avatarBusy?: boolean;
-  buttons?: {
-    disabled?: boolean;
-    icon: ComponentType;
-    label: string;
-    onClick: MouseEventHandler<HTMLButtonElement>;
-  }[];
+  buttons?: React.ReactElement<typeof Button>[];
   children?: React.ReactNode;
   citations?: React.ReactElement[];
   messageEmoji?: ConversationMessageEmojiSelectorProps;

--- a/sparkle/src/components/ConversationMessageActions.tsx
+++ b/sparkle/src/components/ConversationMessageActions.tsx
@@ -19,10 +19,8 @@ export function ConversationMessageActions({
   buttons = [],
   messageEmoji,
 }: ConversationMessageActionsProps) {
-  const buttonNodes = [...buttons];
-
   if (messageEmoji) {
-    buttonNodes.push(
+    buttons.push(
       <ConversationMessageEmojiSelector
         reactions={messageEmoji.reactions}
         onSubmitEmoji={messageEmoji.onSubmitEmoji}
@@ -31,11 +29,11 @@ export function ConversationMessageActions({
     );
   }
 
-  if (buttonNodes.length === 0) {
+  if (buttons.length === 0) {
     return false;
   }
 
-  return <div className="s-flex s-justify-end s-gap-2">{buttonNodes}</div>;
+  return <div className="s-flex s-justify-end s-gap-2">{buttons}</div>;
 }
 
 const MAX_MORE_REACTIONS_TO_SHOW = 9;

--- a/sparkle/src/components/ConversationMessageActions.tsx
+++ b/sparkle/src/components/ConversationMessageActions.tsx
@@ -1,5 +1,4 @@
 import React, { useRef } from "react";
-import { ComponentType, MouseEventHandler } from "react";
 
 import { Button } from "@sparkle/components/Button";
 import {
@@ -12,12 +11,7 @@ import { ReactionIcon } from "@sparkle/icons/solid";
 import { cn } from "@sparkle/lib/utils";
 
 type ConversationMessageActionsProps = {
-  buttons?: {
-    label: string;
-    icon: ComponentType;
-    onClick: MouseEventHandler<HTMLButtonElement>;
-    disabled?: boolean;
-  }[];
+  buttons?: React.ReactElement<typeof Button>[];
   messageEmoji?: ConversationMessageEmojiSelectorProps;
 };
 
@@ -25,17 +19,7 @@ export function ConversationMessageActions({
   buttons = [],
   messageEmoji,
 }: ConversationMessageActionsProps) {
-  const buttonNodes = buttons?.map((button, i) => (
-    <Button
-      key={`message-button-${i}`}
-      variant="outline"
-      size="xs"
-      label={button.label}
-      icon={button.icon}
-      onClick={button.onClick}
-      disabled={button.disabled || false}
-    />
-  ));
+  const buttonNodes = [...buttons];
 
   if (messageEmoji) {
     buttonNodes.push(

--- a/sparkle/src/stories/ConversationMessage.stories.tsx
+++ b/sparkle/src/stories/ConversationMessage.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta } from "@storybook/react";
 import React from "react";
 
 import {
+  Button,
   Citation,
   ConversationMessage,
   MagnifyingGlassIcon,
@@ -35,11 +36,11 @@ export const ConversationExample = () => {
             name="@assistant"
             pictureUrl="https://dust.tt/static/droidavatar/Droid_Pink_3.jpg"
             buttons={[
-              {
-                icon: MagnifyingGlassIcon,
-                label: "Search details",
-                onClick: () => {},
-              },
+              <Button
+                icon={MagnifyingGlassIcon}
+                label="Search details"
+                onClick={() => {}}
+              />,
             ]}
             citations={[
               <Citation
@@ -103,11 +104,11 @@ export const ConversationExample = () => {
             name="@assistant"
             pictureUrl="https://dust.tt/static/droidavatar/Droid_Pink_3.jpg"
             buttons={[
-              {
-                icon: MagnifyingGlassIcon,
-                label: "Search details",
-                onClick: () => {},
-              },
+              <Button
+                icon={MagnifyingGlassIcon}
+                label="Search details"
+                onClick={() => {}}
+              />,
             ]}
             citations={[
               <Citation


### PR DESCRIPTION
## Description

This PR aims at passing a `Button` instance direction to the `ConversationMessage` and `ConversationMessageAction` components to have more flexibility than using a pre-defined list of props.

## Risk

Low

## Deploy Plan

- Publish rc
- Do front changes
- Publish `sparkle`
- Deploy `front`