### PR TITLE
[front] - chore: hide conversation message labels

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -328,6 +328,8 @@ export function AgentMessage({
           <Button
             key="copy-msg-button"
             tooltip="Copy to clipboard"
+            variant="outline"
+            size="xs"
             onClick={() => {
               void navigator.clipboard.writeText(
                 cleanUpCitations(agentMessageToRender.content || "")
@@ -338,6 +340,8 @@ export function AgentMessage({
           <Button
             key="retry-msg-button"
             tooltip="Retry"
+            variant="outline"
+            size="xs"
             onClick={() => {
               void retryHandler(agentMessageToRender);
             }}

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -325,23 +325,25 @@ export function AgentMessage({
     message.status === "failed"
       ? []
       : [
-          {
-            label: "Copy to clipboard",
-            icon: ClipboardIcon,
-            onClick: () => {
+          <Button
+            key="copy-msg-button"
+            tooltip="Copy to clipboard"
+            onClick={() => {
               void navigator.clipboard.writeText(
                 cleanUpCitations(agentMessageToRender.content || "")
               );
-            },
-          },
-          {
-            label: "Retry",
-            icon: ArrowPathIcon,
-            onClick: () => {
+            }}
+            icon={ClipboardIcon}
+          />,
+          <Button
+            key="retry-msg-button"
+            tooltip="Retry"
+            onClick={() => {
               void retryHandler(agentMessageToRender);
-            },
-            disabled: isRetryHandlerProcessing || shouldStream,
-          },
+            }}
+            icon={ArrowPathIcon}
+            disabled={isRetryHandlerProcessing || shouldStream}
+          />,
         ];
 
   // References logic.

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.280",
+        "@dust-tt/sparkle": "^0.2.281",
         "@dust-tt/types": "file:../types",
         "@headlessui/react": "^1.7.7",
         "@heroicons/react": "^2.0.11",
@@ -11504,9 +11504,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.280",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.280.tgz",
-      "integrity": "sha512-eWBwMBHsWj/W4J23+vMdoygQfsm5v+lxVtDJPOOuUW48JKP8gg8GTkXsZiVQ5j9ZAQp0C1ng8r0G8C0sOKjHlA==",
+      "version": "0.2.281",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.281.tgz",
+      "integrity": "sha512-Hs85n/GVix/SIhxkTM+8iY6DzGVHogQnyKypIqyb6y7yWiAQUjbYhxbxJTbZo46PMd3pGLFU615WLxxX2skRUw==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.280",
+    "@dust-tt/sparkle": "^0.2.281",
     "@dust-tt/types": "file:../types",
     "@headlessui/react": "^1.7.7",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description

This PR aims at hiding the label of the conversation messages actions.

From:
<img width="252" alt="Screenshot 2024-10-28 at 13 44 39" src="https://github.com/user-attachments/assets/1c225e08-75a4-4cfe-9044-3f65e1258842">

To:
![Screenshot 2024-10-28 at 13 44 55](https://github.com/user-attachments/assets/b27a0cdd-bce1-4ea0-b855-5a00db21e592)

**References:**
- https://github.com/dust-tt/dust/pull/8273

## Risk

Low

## Deploy Plan

- Publish https://github.com/dust-tt/dust/pull/8273
- Update sparkle version
- Deploy front
