### PR TITLE
Side tree item empty

### DIFF
--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -518,15 +518,13 @@ const SpaceDataSourceViewItem = ({
               node={node}
             />
           ))}
-          {notExpandableNodes.length > 0 && expandableNodes.length > 0 && (
+          {notExpandableNodes.length > 0 && (
             <Tree.Empty
-              label={`and ${notExpandableNodes.length} ${notExpandableNodesLabel}`}
-              onItemClick={() => router.push(dataSourceViewPath)}
-            />
-          )}
-          {notExpandableNodes.length > 0 && !expandableNodes.length && (
-            <Tree.Empty
-              label={`${notExpandableNodes.length} ${notExpandableNodesLabel}`}
+              label={
+                expandableNodes.length
+                  ? `and ${notExpandableNodes.length} ${notExpandableNodesLabel}`
+                  : `${notExpandableNodes.length} ${notExpandableNodesLabel}`
+              }
               onItemClick={() => router.push(dataSourceViewPath)}
             />
           )}

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -490,9 +490,10 @@ const SpaceDataSourceViewItem = ({
     : basePath;
 
   const isEmpty = isExpanded && !isNodesLoading && nodes.length === 0;
-  const folders = nodes.filter((node) => node.expandable);
-  const notFolders = nodes.filter((node) => !node.expandable);
-  const itemsLabel = notFolders.length === 1 ? "item" : "items";
+  const expandableNodes = nodes.filter((node) => node.expandable);
+  const notExpandableNodes = nodes.filter((node) => !node.expandable);
+  const notExpandableNodesLabel =
+    notExpandableNodes.length === 1 ? "item" : "items";
 
   return (
     <Tree.Item
@@ -508,7 +509,7 @@ const SpaceDataSourceViewItem = ({
     >
       {isExpanded && (
         <Tree isLoading={isNodesLoading}>
-          {folders.map((node) => (
+          {expandableNodes.map((node) => (
             <SpaceDataSourceViewItem
               item={item}
               key={node.internalId}
@@ -517,9 +518,16 @@ const SpaceDataSourceViewItem = ({
               node={node}
             />
           ))}
-          {notFolders.length > 0 && (
+          {notExpandableNodes.length > 0 && expandableNodes.length > 0 && (
             <Tree.Empty
-              label={`+ ${notFolders.length} ${folders.length > 0 ? "other " : ""} ${itemsLabel}`}
+              label={`and ${notExpandableNodes.length} ${notExpandableNodesLabel}`}
+              onItemClick={() => router.push(dataSourceViewPath)}
+            />
+          )}
+          {notExpandableNodes.length > 0 && !expandableNodes.length && (
+            <Tree.Empty
+              label={`${notExpandableNodes.length} ${notExpandableNodesLabel}`}
+              onItemClick={() => router.push(dataSourceViewPath)}
             />
           )}
         </Tree>

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.279",
+        "@dust-tt/sparkle": "^0.2.280",
         "@dust-tt/types": "file:../types",
         "@headlessui/react": "^1.7.7",
         "@heroicons/react": "^2.0.11",
@@ -11504,9 +11504,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.279",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.279.tgz",
-      "integrity": "sha512-0JP1kmLP67b2ALMMqHAhbYM2D5Zp47kVOVuGfgBSXk32isXsP/+V/t2E/SUcTWi9T+pCpvH5ESt6HJ2gChdRAA==",
+      "version": "0.2.280",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.280.tgz",
+      "integrity": "sha512-eWBwMBHsWj/W4J23+vMdoygQfsm5v+lxVtDJPOOuUW48JKP8gg8GTkXsZiVQ5j9ZAQp0C1ng8r0G8C0sOKjHlA==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.279",
+    "@dust-tt/sparkle": "^0.2.280",
     "@dust-tt/types": "file:../types",
     "@headlessui/react": "^1.7.7",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/1534

Request from @Duncid : 
- `+ X items` -> `and X items`
- When there are no SubNodes in the Node, display `X items`
- Make it clickable > Open the Node page (Exactly like clicking on the parent Node)


Deployed to front-edge.

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
