### PR TITLE
[sparkle] - chore: ensure buttons have an accessible `aria-label`

### DIFF
--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -129,6 +129,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       isSelect = false,
       isPulsing = false,
       size,
+      "aria-label": ariaLabel,
       ...props
     },
     ref
@@ -163,6 +164,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         variant={variant}
         disabled={isLoading || props.disabled}
         className={isPulsing ? "s-animate-pulse" : ""}
+        aria-label={ariaLabel || tooltip || label}
         style={
           {
             "--pulse-color": "#93C5FD",


### PR DESCRIPTION
## Description

This PR makes sure `Button` have an accessible `aria-label`

**References:**
- [Slack thread](https://dust4ai.slack.com/archives/C07HPD3QMDM/p1729876615099929)

## Risk

N/A

## Deploy Plan

N/A