### PR TITLE
[front] - fix: remove redundant outline class from button

### DIFF
--- a/front/components/spaces/SpaceWebsiteModal.tsx
+++ b/front/components/spaces/SpaceWebsiteModal.tsx
@@ -689,7 +689,6 @@ const AdvancedSettingsModal = ({
           <div className="flex">
             <Button
               variant="outline"
-              className="outline"
               label="Add Header"
               onClick={() => {
                 onSave([...headers, { key: "", value: "" }]);


### PR DESCRIPTION
## Description

This PR aims at fixing the website's advanced settings modal.

Old:
<img width="360" alt="Screenshot 2024-10-28 at 15 38 13" src="https://github.com/user-attachments/assets/37518d5f-7084-45dd-8f05-ae6286a31302">

New:
<img width="360" alt="Screenshot 2024-10-28 at 15 37 49" src="https://github.com/user-attachments/assets/0f9dd7bb-ce5c-4ef3-8a6e-9a95460a2ca3">

**References:**
- https://github.com/dust-tt/tasks/issues/1532#issuecomment-2441652953

## Risk

None

## Deploy Plan

Deploy front