### PR TITLE
[front] - fix: change icon button variant from ghost to outline

### DIFF
--- a/front/components/assistant_builder/actions/ProcessAction.tsx
+++ b/front/components/assistant_builder/actions/ProcessAction.tsx
@@ -235,7 +235,7 @@ function PropertiesFields({
                   <IconButton
                     icon={XMarkIcon}
                     tooltip="Remove Property"
-                    variant="ghost"
+                    variant="outline"
                     onClick={async () => {
                       handleRemoveProperty(index);
                     }}


### PR DESCRIPTION
## Description

This PR aims fixing the variant property of IconButton to change its appearance from 'ghost' to 'outline' for the Remove Property action.

**References:**
- [Slack thread](https://dust4ai.slack.com/archives/C07KY510DH7/p1730130161344859)

## Risk

None

## Deploy Plan

