### PR TITLE
[sparkle] - enh: introduce `LinkWrapper`

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.282",
+  "version": "0.2.283",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.282",
+      "version": "0.2.283",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.282",
+  "version": "0.2.283",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/LinkWrapper.tsx
+++ b/sparkle/src/components/LinkWrapper.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+
+import { SparkleContext } from "@sparkle/context";
+
+export interface LinkWrapperProps {
+  href?: string;
+  target?: string;
+  rel?: string;
+  replace?: boolean;
+  shallow?: boolean;
+  className?: string;
+  children: React.ReactNode;
+}
+
+export function LinkWrapper({
+  href,
+  target,
+  rel,
+  replace,
+  shallow,
+  className,
+  children,
+}: LinkWrapperProps) {
+  const { components } = React.useContext(SparkleContext);
+
+  if (href) {
+    return (
+      <components.link
+        href={href}
+        target={target}
+        rel={rel}
+        replace={replace}
+        shallow={shallow}
+        className={className}
+      >
+        {children}
+      </components.link>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -1,7 +1,12 @@
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
-import { Button, Icon } from "@sparkle/components/";
+import {
+  Button,
+  Icon,
+  LinkWrapper,
+  LinkWrapperProps,
+} from "@sparkle/components/";
 import { MoreIcon } from "@sparkle/icons";
 import { cn } from "@sparkle/lib/utils";
 
@@ -43,62 +48,94 @@ const NavigationList = React.forwardRef<
 ));
 NavigationList.displayName = "NavigationList";
 
-interface NavigationListItemProps extends React.HTMLAttributes<HTMLDivElement> {
+interface NavigationListItemProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    Omit<LinkWrapperProps, "children" | "className"> {
   selected?: boolean;
   label?: string;
   icon?: React.ComponentType;
+  showMoreIcon?: boolean;
 }
 
 const NavigationListItem = React.forwardRef<
   HTMLDivElement,
   NavigationListItemProps
->(({ className, selected, label, icon, ...props }, ref) => {
-  const [isHovered, setIsHovered] = React.useState(false);
-  const [isPressed, setIsPressed] = React.useState(false);
+>(
+  (
+    {
+      className,
+      selected,
+      label,
+      icon,
+      href,
+      target,
+      rel,
+      replace,
+      shallow,
+      ...props
+    },
+    ref
+  ) => {
+    const [isHovered, setIsHovered] = React.useState(false);
+    const [isPressed, setIsPressed] = React.useState(false);
 
-  const handleMouseDown = (event: React.MouseEvent) => {
-    if (!(event.target as HTMLElement).closest(".new-button-class")) {
-      setIsPressed(true);
-    }
-  };
+    const handleMouseDown = (event: React.MouseEvent) => {
+      if (!(event.target as HTMLElement).closest(".new-button-class")) {
+        setIsPressed(true);
+      }
+    };
 
-  return (
-    <div className={className} ref={ref} {...props}>
-      <div
-        className={listStyles({
-          layout: "item",
-          state: selected ? "selected" : isPressed ? "active" : "unselected",
-        })}
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => {
-          setIsHovered(false);
-          setIsPressed(false);
-        }}
-        onMouseDown={handleMouseDown}
-        onMouseUp={() => setIsPressed(false)}
-      >
-        {icon && <Icon visual={icon} size="sm" />}
-        {label && (
-          <span className="s-grow s-overflow-hidden s-text-ellipsis s-whitespace-nowrap">
-            {label}
-          </span>
-        )}
-        {isHovered && (
-          <div className="-s-mr-2 s-flex s-h-4 s-items-center">
-            <Button
-              variant="ghost"
-              icon={MoreIcon}
-              size="xs"
-              onClick={(e) => e.stopPropagation()}
-              onMouseDown={(e) => e.stopPropagation()}
-              onMouseUp={(e) => e.stopPropagation()}
-            />
-          </div>
-        )}
+    const content = (
+      <div className={className} ref={ref} {...props}>
+        <div
+          className={listStyles({
+            layout: "item",
+            state: selected ? "selected" : isPressed ? "active" : "unselected",
+          })}
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => {
+            setIsHovered(false);
+            setIsPressed(false);
+          }}
+          onMouseDown={handleMouseDown}
+          onMouseUp={() => setIsPressed(false)}
+        >
+          {icon && <Icon visual={icon} size="sm" />}
+          {label && (
+            <span className="s-grow s-overflow-hidden s-text-ellipsis s-whitespace-nowrap">
+              {label}
+            </span>
+          )}
+          {isHovered && (
+            <div className="-s-mr-2 s-flex s-h-4 s-items-center">
+              <Button
+                variant="ghost"
+                icon={MoreIcon}
+                size="xs"
+                onClick={(e) => e.stopPropagation()}
+                onMouseDown={(e) => e.stopPropagation()}
+                onMouseUp={(e) => e.stopPropagation()}
+              />
+            </div>
+          )}
+        </div>
       </div>
-    </div>
-  );
-});
+    );
+
+    return (
+      <LinkWrapper
+        href={href}
+        target={target}
+        rel={rel}
+        replace={replace}
+        shallow={shallow}
+        className={className}
+      >
+        {content}
+      </LinkWrapper>
+    );
+  }
+);
 NavigationListItem.displayName = "NavigationListItem";
 
 const variantStyles = cva("", {

--- a/sparkle/src/components/NewDropdown.tsx
+++ b/sparkle/src/components/NewDropdown.tsx
@@ -2,7 +2,7 @@ import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import { cva } from "class-variance-authority";
 import * as React from "react";
 
-import { Icon } from "@sparkle/components";
+import { Icon, LinkWrapper, LinkWrapperProps } from "@sparkle/components";
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "@sparkle/icons";
 import { cn } from "@sparkle/lib/utils";
 
@@ -170,38 +170,70 @@ const NewDropdownMenuContent = React.forwardRef<
 ));
 NewDropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
 
+type NewDropdownMenuItemProps = MutuallyExclusiveProps<
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean;
+    variant?: ItemVariantType;
+  } & Omit<LinkWrapperProps, "children" | "className">,
+  LabelAndIconProps & { description?: string }
+>;
+
 const NewDropdownMenuItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Item>,
-  MutuallyExclusiveProps<
-    React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
-      inset?: boolean;
-      variant?: ItemVariantType;
-    },
-    LabelAndIconProps & { description?: string }
-  >
+  NewDropdownMenuItemProps
 >(
   (
-    { children, variant, description, className, inset, icon, label, ...props },
+    {
+      children,
+      variant,
+      description,
+      className,
+      inset,
+      icon,
+      label,
+      href,
+      target,
+      rel,
+      asChild,
+      replace,
+      shallow,
+      ...props
+    },
     ref
-  ) => (
-    <DropdownMenuPrimitive.Item
-      ref={ref}
-      className={cn(
-        menuStyleClasses.item({ variant }),
-        inset ? menuStyleClasses.inset : "",
-        className
-      )}
-      {...props}
-    >
-      <ItemWithLabelIconAndDescription
-        label={label}
-        icon={icon}
-        description={description}
+  ) => {
+    const content = (
+      <DropdownMenuPrimitive.Item
+        ref={ref}
+        className={cn(
+          menuStyleClasses.item({ variant }),
+          inset ? menuStyleClasses.inset : "",
+          className
+        )}
+        {...props}
+        asChild={!!href && asChild}
       >
-        {children}
-      </ItemWithLabelIconAndDescription>
-    </DropdownMenuPrimitive.Item>
-  )
+        <ItemWithLabelIconAndDescription
+          label={label}
+          icon={icon}
+          description={description}
+        >
+          {children}
+        </ItemWithLabelIconAndDescription>
+      </DropdownMenuPrimitive.Item>
+    );
+
+    return (
+      <LinkWrapper
+        href={href}
+        target={target}
+        rel={rel}
+        replace={replace}
+        shallow={shallow}
+      >
+        {content}
+      </LinkWrapper>
+    );
+  }
 );
 NewDropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
 

--- a/sparkle/src/components/NewDropdown.tsx
+++ b/sparkle/src/components/NewDropdown.tsx
@@ -210,7 +210,7 @@ const NewDropdownMenuItem = React.forwardRef<
           className
         )}
         {...props}
-        asChild={!!href && asChild}
+        asChild={!!href || asChild}
       >
         <ItemWithLabelIconAndDescription
           label={label}

--- a/sparkle/src/components/Tabs.tsx
+++ b/sparkle/src/components/Tabs.tsx
@@ -27,49 +27,54 @@ const TabsTrigger = React.forwardRef<
     label?: string;
     icon?: React.ComponentType;
     isLoading?: boolean;
+  } & Omit<LinkWrapperProps, "children" | "className">
+>(
+  (
+    { className, label, icon, href, target, rel, replace, shallow, ...props },
+    ref
+  ) => {
+    const content = (
+      <TabsPrimitive.Trigger
+        ref={ref}
+        className={cn(
+          "s-border-0 s-border-b-2 s-border-primary-800/0 s-pb-1 disabled:s-pointer-events-none data-[state=active]:s-border-primary-800",
+          className
+        )}
+        {...props}
+        asChild={!!href}
+      >
+        <Button variant="ghost" size="sm" label={label} icon={icon} />
+      </TabsPrimitive.Trigger>
+    );
+
+    return (
+      <LinkWrapper
+        href={href}
+        target={target}
+        rel={rel}
+        replace={replace}
+        shallow={shallow}
+        className={className}
+      >
+        {content}
+      </LinkWrapper>
+    );
   }
->(({ className, label, icon, ...props }, ref) => (
-  <TabsPrimitive.Trigger
-    ref={ref}
-    className={cn(
-      "s-border-0 s-border-b-2 s-border-primary-800/0 s-pb-1 disabled:s-pointer-events-none data-[state=active]:s-border-primary-800",
-      className
-    )}
-    {...props}
-  >
-    <Button variant="ghost" size="sm" label={label} icon={icon} />
-  </TabsPrimitive.Trigger>
-));
-TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+);
 
 const TabsContent = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content> &
-    Omit<LinkWrapperProps, "children" | "className">
->(({ className, href, target, rel, replace, shallow, ...props }, ref) => {
-  const content = (
-    <TabsPrimitive.Content
-      ref={ref}
-      className={cn(
-        "s-contents s-ring-offset-background focus-visible:s-outline-none focus-visible:s-ring-2 focus-visible:s-ring-ring focus-visible:s-ring-offset-2",
-        className
-      )}
-      {...props}
-    />
-  );
-
-  return (
-    <LinkWrapper
-      href={href}
-      target={target}
-      rel={rel}
-      replace={replace}
-      shallow={shallow}
-      className={className}
-    >
-      {content}
-    </LinkWrapper>
-  );
-});
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "s-contents s-ring-offset-background focus-visible:s-outline-none focus-visible:s-ring-2 focus-visible:s-ring-ring focus-visible:s-ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
 
 export { Tabs, TabsContent, TabsList, TabsTrigger };

--- a/sparkle/src/components/Tabs.tsx
+++ b/sparkle/src/components/Tabs.tsx
@@ -1,7 +1,7 @@
 import * as TabsPrimitive from "@radix-ui/react-tabs";
 import * as React from "react";
 
-import { Button } from "@sparkle/components";
+import { Button, LinkWrapper, LinkWrapperProps } from "@sparkle/components";
 import { cn } from "@sparkle/lib/utils";
 
 const Tabs = TabsPrimitive.Root;
@@ -44,17 +44,32 @@ TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
 
 const TabsContent = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.Content
-    ref={ref}
-    className={cn(
-      "focus-visible:s-ring-ring s-contents s-ring-offset-background focus-visible:s-outline-none focus-visible:s-ring-2 focus-visible:s-ring-offset-2",
-      className
-    )}
-    {...props}
-  />
-));
-TabsContent.displayName = TabsPrimitive.Content.displayName;
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content> &
+    Omit<LinkWrapperProps, "children" | "className">
+>(({ className, href, target, rel, replace, shallow, ...props }, ref) => {
+  const content = (
+    <TabsPrimitive.Content
+      ref={ref}
+      className={cn(
+        "s-contents s-ring-offset-background focus-visible:s-outline-none focus-visible:s-ring-2 focus-visible:s-ring-ring focus-visible:s-ring-offset-2",
+        className
+      )}
+      {...props}
+    />
+  );
+
+  return (
+    <LinkWrapper
+      href={href}
+      target={target}
+      rel={rel}
+      replace={replace}
+      shallow={shallow}
+      className={className}
+    >
+      {content}
+    </LinkWrapper>
+  );
+});
 
 export { Tabs, TabsContent, TabsList, TabsTrigger };

--- a/sparkle/src/components/Tabs.tsx
+++ b/sparkle/src/components/Tabs.tsx
@@ -40,10 +40,12 @@ const TabsTrigger = React.forwardRef<
           "s-border-0 s-border-b-2 s-border-primary-800/0 s-pb-1 disabled:s-pointer-events-none data-[state=active]:s-border-primary-800",
           className
         )}
+        asChild
         {...props}
-        asChild={!!href}
       >
-        <Button variant="ghost" size="sm" label={label} icon={icon} />
+        <div>
+          <Button variant="ghost" size="sm" label={label} icon={icon} />
+        </div>
       </TabsPrimitive.Trigger>
     );
 
@@ -69,7 +71,7 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      "s-contents s-ring-offset-background focus-visible:s-outline-none focus-visible:s-ring-2 focus-visible:s-ring-ring focus-visible:s-ring-offset-2",
+      "s-contents s-ring-offset-background focus-visible:s-outline-none focus-visible:s-ring-2 focus-visible:s-ring-offset-2",
       className
     )}
     {...props}

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -42,6 +42,8 @@ export { IconToggleButton } from "./IconToggleButton";
 export { Input } from "./Input";
 export { Item } from "./Item";
 export { Label } from "./Label";
+export type { LinkWrapperProps } from "./LinkWrapper";
+export { LinkWrapper } from "./LinkWrapper";
 export { Markdown } from "./Markdown";
 export { Modal } from "./Modal";
 export {

--- a/sparkle/src/context.tsx
+++ b/sparkle/src/context.tsx
@@ -66,7 +66,7 @@ export const noHrefLink: SparkleContextLinkType = ({
   <a
     className={className}
     aria-current={ariaCurrent}
-    arria-label={ariaLabel}
+    aria-label={ariaLabel}
     onClick={onClick}
   >
     {children}

--- a/sparkle/src/stories/NewDropdown.stories.tsx
+++ b/sparkle/src/stories/NewDropdown.stories.tsx
@@ -199,7 +199,7 @@ function ModelsDropdownDemo() {
 
   return (
     <NewDropdownMenu>
-      <NewDropdownMenuTrigger>
+      <NewDropdownMenuTrigger asChild>
         <Button label={selectedModel} variant="outline" size="sm" />
       </NewDropdownMenuTrigger>
       <NewDropdownMenuContent>
@@ -247,7 +247,7 @@ function ModelsDropdownRadioGroupDemo() {
 
   return (
     <NewDropdownMenu>
-      <NewDropdownMenuTrigger>
+      <NewDropdownMenuTrigger asChild>
         <Button label={selectedModel} variant="ghost" size="sm" />
       </NewDropdownMenuTrigger>
       <NewDropdownMenuContent>

--- a/sparkle/src/stories/Tabs.stories.tsx
+++ b/sparkle/src/stories/Tabs.stories.tsx
@@ -21,7 +21,12 @@ export function TabExample() {
   return (
     <Tabs defaultValue="account">
       <TabsList className="grid w-full grid-cols-2">
-        <TabsTrigger value="account" label="Hello" icon={CommandIcon} />
+        <TabsTrigger
+          value="account"
+          label="Hello"
+          href="hello"
+          icon={CommandIcon}
+        />
         <TabsTrigger value="password" label="World" icon={LightbulbIcon} />
         <TabsTrigger value="settings" icon={Cog6ToothIcon} />
       </TabsList>


### PR DESCRIPTION
## Description

This PR aims at introducing a `LinkWrapper` component to be used by various sparkle components. It is intended to wrap components into a `aLink` component if an "href" prop is passed.

**References:**
- https://github.com/dust-tt/dust/issues/8203

## Risk

Low

## Deploy Plan

Publish `sparkle`