### PR TITLE
fix: properly truncate table when upserting CSV from UI

### DIFF
--- a/front/components/data_source/DocumentOrTableUploadOrEditModal.tsx
+++ b/front/components/data_source/DocumentOrTableUploadOrEditModal.tsx
@@ -523,7 +523,7 @@ const TableUploadOrEditModal = ({
         timestamp: null,
         tags: [],
         parents: [],
-        truncate: false,
+        truncate: true,
         async: false,
         useAppForHeaderDetection,
       });


### PR DESCRIPTION
## Description

a bug introduced in #7050 is causing CSV uploaded in the UI to not properly replace the superseded version. If the new CSV has fewer lines, then some of the old lines are kept.

## Risk

N/A

## Deploy Plan

deploy front