### PR TITLE
[front] - fix: change button style in ConversationTitle

### DIFF
--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -166,7 +166,7 @@ export function ConversationTitle({
                 setIsEditingTitle(true);
               }}
               size="sm"
-              variant="ghost"
+              variant="outline"
             />
           )}
         </div>


### PR DESCRIPTION
## Description

This PR aims at fixing the variant of the conversation title edition button to "outline" for better visibility

## Risk

None

## Deploy Plan