### PR TITLE
Fix anthropic API key error message

### DIFF
--- a/front/pages/api/w/[wId]/providers/[pId]/check.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/check.ts
@@ -114,10 +114,13 @@ async function handler(
           );
 
           if (!testGenerate.ok) {
-            const err = await testGenerate.json();
+            const errRes = await testGenerate.json();
+            const errType = errRes.error?.type ?? "unknown error";
+            const errMessage =
+              errRes.error?.message ?? "contact us at team@dust.tt";
             res
               .status(400)
-              .json({ ok: false, error: err.message || err.detail });
+              .json({ ok: false, error: `[${errType}] ${errMessage}` });
           } else {
             await testGenerate.json();
             res.status(200).json({ ok: true });


### PR DESCRIPTION
## Description

Fixes second request in https://github.com/dust-tt/tasks/issues/1551

Instead of displaying "unknown error", display the error message we get from Anthropic: 

<img width="740" alt="Screenshot 2024-10-29 at 10 55 52" src="https://github.com/user-attachments/assets/a85edeca-e1db-4848-9a3b-c2a438cdf5ec">


## Risk

/

## Deploy Plan

Deploy front. 
