### PR TITLE
[connectors] Add sync activities for Zendesk Categories and Brands

### DIFF
--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -18,6 +18,7 @@ export async function changeZendeskClientSubdomain({
   client: Client;
   brandId: number;
 }) {
+  // TODO: in some cases the brand in db is available and can be used to retrieve the subdomain
   const {
     result: { brand },
   } = await client.brand.show(brandId);

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -18,7 +18,7 @@ export async function changeZendeskClientSubdomain({
   client: Client;
   brandId: number;
 }) {
-  // TODO: in some cases the brand in db is available and can be used to retrieve the subdomain
+  // TODO(2024-10-29 aubin): in some cases the brand in db is available and can be used to retrieve the subdomain
   const {
     result: { brand },
   } = await client.brand.show(brandId);

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -366,6 +366,17 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
     return new Ok(undefined);
   }
 
+  /**
+   * Deletes the category and all associated data (articles).
+   */
+  // eslint-disable-next-line no-empty-pattern
+  async remove({}: {
+    dataSourceConfig: DataSourceConfig;
+    loggerArgs: Record<string, string | number>;
+  }) {
+    // TODO: implement removal for the children first.
+  }
+
   toJSON(): Record<string, unknown> {
     return {
       id: this.id,

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -25,6 +25,7 @@ import {
 } from "@connectors/lib/models/zendesk";
 import { BaseResource } from "@connectors/resources/base_resource";
 import type { ReadonlyAttributesType } from "@connectors/resources/storage/types";
+import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -92,6 +93,9 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
     return;
   }
 
+  /**
+   * Deletes the brand data, keeping all children data (tickets, categories, articles).
+   */
   async delete(transaction?: Transaction): Promise<Result<undefined, Error>> {
     await this.model.destroy({
       where: {
@@ -100,6 +104,17 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
       transaction,
     });
     return new Ok(undefined);
+  }
+
+  /**
+   * Deletes the brand and all associated data (tickets, categories, articles).
+   */
+  // eslint-disable-next-line no-empty-pattern
+  async remove({}: {
+    dataSourceConfig: DataSourceConfig;
+    loggerArgs: Record<string, string | number>;
+  }) {
+    // TODO: implement removal for the children first.
   }
 
   toJSON(): Record<string, unknown> {


### PR DESCRIPTION
## Description

- Add a sync activities for Brands and Categories, which are the ones that do not have to upsert anything and only interact with the db.
- For context, in Zendesk the data available is structured in Brands, which each have a Help Center and Tickets, the Help Center being a collection of Categories that each contain Sections and Articles (we do not allow selecting sections, only categories).

## Risk

## Deploy Plan

- Deploy connectors.