### PR TITLE
front: redirect when getting a 401 from SWR

### DIFF
--- a/front/components/app/RootLayout.tsx
+++ b/front/components/app/RootLayout.tsx
@@ -1,8 +1,11 @@
 import { UserProvider } from "@auth0/nextjs-auth0/client";
 import { SparkleContext } from "@dust-tt/sparkle";
 import { Notification } from "@dust-tt/sparkle";
+import { isAPIErrorResponse } from "@dust-tt/types";
 import Link from "next/link";
+import { useRouter } from "next/router";
 import type { MouseEvent } from "react";
+import { SWRConfig } from "swr";
 import type { UrlObject } from "url";
 
 import { ConfirmPopupArea } from "@app/components/Confirm";
@@ -61,15 +64,31 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const router = useRouter();
+
   return (
     <SparkleContext.Provider value={{ components: { link: NextLinkWrapper } }}>
-      <UserProvider>
-        <SidebarProvider>
-          <ConfirmPopupArea>
-            <Notification.Area>{children}</Notification.Area>
-          </ConfirmPopupArea>
-        </SidebarProvider>
-      </UserProvider>
+      <SWRConfig
+        value={{
+          onError: async (error) => {
+            if (
+              isAPIErrorResponse(error) &&
+              error.error.type === "not_authenticated"
+            ) {
+              // Redirect to login page.
+              await router.push("/api/auth/login");
+            }
+          },
+        }}
+      >
+        <UserProvider>
+          <SidebarProvider>
+            <ConfirmPopupArea>
+              <Notification.Area>{children}</Notification.Area>
+            </ConfirmPopupArea>
+          </SidebarProvider>
+        </UserProvider>
+      </SWRConfig>
     </SparkleContext.Provider>
   );
 }

--- a/front/lib/swr/swr.ts
+++ b/front/lib/swr/swr.ts
@@ -122,6 +122,17 @@ const resHandler = async (res: Response) => {
       res.headers,
       errorText
     );
+    if (res.status === 401) {
+      try {
+        const body = JSON.parse(errorText);
+        if (body.error.type === "not_authenticated") {
+          // We are de-authenticated let's redirect to the home page.
+          window.location.href = "/";
+        }
+      } catch (e) {
+        // Do nothing.
+      }
+    }
     throw new Error(errorText);
   }
   return res.json();


### PR DESCRIPTION
## Description

If we get a 401 and it matches our error code, we redirect back to the landing.

Goal is to get rid of these gazilion 401 on our API. The app does get a bit crazy on conversations and participants when you open a conversation in one window and signout from another.

I tested returning a redirect in the route but SWR does not honour it.

## Risk

Low

## Deploy Plan

- deploy `front`