### PR TITLE
Agent message: can't click or dropdown menu if cannot mention

### DIFF
--- a/front/components/assistant/AssistantBrowser.tsx
+++ b/front/components/assistant/AssistantBrowser.tsx
@@ -18,6 +18,7 @@ import {
 } from "@dust-tt/sparkle";
 import type {
   LightAgentConfigurationType,
+  UserType,
   WorkspaceType,
 } from "@dust-tt/types";
 import Link from "next/link";
@@ -32,6 +33,7 @@ function isValidTab(tab: string, visibleTabs: TabId[]): tab is TabId {
 
 interface AssistantListProps {
   owner: WorkspaceType;
+  user: UserType;
   isBuilder: boolean;
   agents: LightAgentConfigurationType[];
   loadingStatus: "loading" | "finished";
@@ -57,6 +59,7 @@ type TabId = (typeof ALL_AGENTS_TABS)[number]["id"];
 
 export function AssistantBrowser({
   owner,
+  user,
   isBuilder,
   agents,
   loadingStatus,
@@ -229,6 +232,7 @@ export function AssistantBrowser({
                 <AssistantDropdownMenu
                   agentConfiguration={agent}
                   owner={owner}
+                  user={user}
                   variant="button"
                   isMoreInfoVisible
                   showAddRemoveToFavorite

--- a/front/components/assistant/AssistantDropdownMenu.tsx
+++ b/front/components/assistant/AssistantDropdownMenu.tsx
@@ -18,6 +18,7 @@ import {
 } from "@dust-tt/sparkle";
 import type {
   LightAgentConfigurationType,
+  UserType,
   WorkspaceType,
 } from "@dust-tt/types";
 import { assertNever, isBuilder } from "@dust-tt/types";
@@ -32,6 +33,7 @@ import { setQueryParam } from "@app/lib/utils/router";
 interface AssistantDetailsMenuProps {
   agentConfiguration: LightAgentConfigurationType;
   owner: WorkspaceType;
+  user: UserType;
   variant?: "button" | "plain";
   canDelete?: boolean;
   isMoreInfoVisible?: boolean;
@@ -62,6 +64,11 @@ export function AssistantDropdownMenu({
     agentConfiguration.status === "archived" ||
     !user
   ) {
+    return <></>;
+  }
+
+  const isPrivate = agentConfiguration.scope === "private";
+  if (isPrivate && agentConfiguration.versionAuthorId !== user.id) {
     return <></>;
   }
 

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -25,6 +25,7 @@ import type {
   GenerationTokensEvent,
   LightAgentConfigurationType,
   RetrievalActionType,
+  UserType,
   WebsearchActionType,
   WebsearchResultType,
   WorkspaceType,
@@ -68,6 +69,7 @@ interface AgentMessageProps {
   message: AgentMessageType;
   messageEmoji?: ConversationMessageEmojiSelectorProps;
   owner: WorkspaceType;
+  user: UserType;
   size: ConversationMessageSizeType;
 }
 
@@ -84,6 +86,7 @@ export function AgentMessage({
   message,
   messageEmoji,
   owner,
+  user,
   size,
 }: AgentMessageProps) {
   const [streamedAgentMessage, setStreamedAgentMessage] =
@@ -437,6 +440,10 @@ export function AgentMessage({
     };
   }, [owner, conversationId, message.sId, agentConfiguration.sId]);
 
+  const canMention =
+    agentConfiguration.scope !== "private" ||
+    agentConfiguration.versionAuthorId === user.id;
+
   return (
     <ConversationMessage
       pictureUrl={agentConfiguration.pictureUrl}
@@ -448,12 +455,13 @@ export function AgentMessage({
         return (
           <div className="flex flex-row items-center gap-2">
             <div className="text-base font-medium">
-              {AssitantDetailViewLink(agentConfiguration)}
+              {AssitantName(agentConfiguration, canMention)}
             </div>
             {!isInModal && (
               <AssistantDropdownMenu
                 agentConfiguration={agentConfiguration}
                 owner={owner}
+                user={user}
                 showAddRemoveToFavorite
               />
             )}
@@ -585,12 +593,19 @@ export function AgentMessage({
   }
 }
 
-function AssitantDetailViewLink(assistant: LightAgentConfigurationType) {
+function AssitantName(
+  assistant: LightAgentConfigurationType,
+  canMention: boolean = true
+) {
   const router = useRouter();
   const href = {
     pathname: router.pathname,
     query: { ...router.query, assistantDetails: assistant.sId },
   };
+
+  if (!canMention) {
+    return <span>@{assistant.name}</span>;
+  }
 
   return (
     <Link

--- a/front/components/assistant/conversation/AssistantBrowserContainer.tsx
+++ b/front/components/assistant/conversation/AssistantBrowserContainer.tsx
@@ -1,6 +1,7 @@
 import { Page } from "@dust-tt/sparkle";
 import type {
   LightAgentConfigurationType,
+  UserType,
   WorkspaceType,
 } from "@dust-tt/types";
 import { useCallback } from "react";
@@ -12,6 +13,7 @@ import { classNames } from "@app/lib/utils";
 interface AssistantBrowserContainerProps {
   onAgentConfigurationClick: (agentId: string) => void;
   owner: WorkspaceType;
+  user: UserType;
   isBuilder: boolean;
   setAssistantToMention: (agent: LightAgentConfigurationType) => void;
 }
@@ -19,6 +21,7 @@ interface AssistantBrowserContainerProps {
 export function AssistantBrowserContainer({
   onAgentConfigurationClick,
   owner,
+  user,
   isBuilder,
   setAssistantToMention,
 }: AssistantBrowserContainerProps) {
@@ -69,6 +72,7 @@ export function AssistantBrowserContainer({
       </div>
       <AssistantBrowser
         owner={owner}
+        user={user}
         isBuilder={isBuilder}
         agents={agentConfigurations}
         loadingStatus={isLoading ? "loading" : "finished"}

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -318,6 +318,7 @@ export function ConversationContainer({
             assistantToMention.current = assistant;
           }}
           owner={owner}
+          user={user}
           isBuilder={isBuilder}
         />
       </Transition>

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -153,6 +153,7 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
               message={message}
               messageEmoji={messageEmoji}
               owner={owner}
+              user={user}
               size={isInModal ? "compact" : "normal"}
             />
           </div>


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/1514

On Agent message, the handle is clickable (open AssistantDetails modal) and comes with a dropdown menu. We don't want those if the user cannot mention the assistant, if it's private. 


View from the author of a private assistant: 
<kbd>
<img width="701" alt="Screenshot 2024-10-29 at 14 06 17" src="https://github.com/user-attachments/assets/75a31116-4886-4536-b317-7e811057a320">
</kbd>

View from another user who got shared a convo link in which a private assistant was mentioned: 
<kbd>
<img width="701" alt="Screenshot 2024-10-29 at 14 06 25" src="https://github.com/user-attachments/assets/a78e97e0-530e-469a-a42e-5d0d2f15b350">
<kbd>


## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
