### PR TITLE
[sparkle] - fix: missing `ButtonEmoji` key

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.283",
+  "version": "0.2.284",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.283",
+      "version": "0.2.284",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.283",
+  "version": "0.2.284",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/ConversationMessageActions.tsx
+++ b/sparkle/src/components/ConversationMessageActions.tsx
@@ -22,6 +22,7 @@ export function ConversationMessageActions({
   if (messageEmoji) {
     buttons.push(
       <ConversationMessageEmojiSelector
+        key="emoji-selector"
         reactions={messageEmoji.reactions}
         onSubmitEmoji={messageEmoji.onSubmitEmoji}
         isSubmittingEmoji={messageEmoji.isSubmittingEmoji}
@@ -71,7 +72,7 @@ function ConversationMessageEmojiSelector({
         emojiData={emojiData}
         isSubmittingEmoji={isSubmittingEmoji}
       />
-      {slicedReactions.map((reaction) => {
+      {slicedReactions.map((reaction, index) => {
         const hasReacted = reaction.hasReacted;
         const emoji = emojiData?.emojis[reaction.emoji];
         const nativeEmoji = emoji?.skins[0].native;
@@ -80,7 +81,7 @@ function ConversationMessageEmojiSelector({
         }
         return (
           <ButtonEmoji
-            key={reaction.emoji}
+            key={`${reaction.emoji}-${index}`}
             variant={hasReacted ? "selected" : "unselected"}
             emoji={nativeEmoji}
             count={reaction.count.toString()}


### PR DESCRIPTION
## Description

This PR aims at passing a key to the `ButtonEmoji` component being used in `ConversationMessageActions`. This used to cause the following error:
```
Warning: Each child in a list should have a unique "key" prop.
```

## Risk

Low

## Deploy Plan

Publish `sparkle`