### PR TITLE
fix: timestamp must be integer when upserting doc

### DIFF
--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -354,7 +354,9 @@ export async function upsertDocument({
     tags: nonNullTags,
     parents: parents || [],
     sourceUrl,
-    timestamp: timestamp || null,
+    // TEMPORARY -- need to unstuck a specific entry
+    // TODO(FONTANIERH): remove this once the entry is unstuck
+    timestamp: timestamp ? Math.floor(timestamp) : null,
     section: generatedSection,
     credentials,
     lightDocumentOutput: light_document_output === true,

--- a/types/src/front/api_handlers/public/data_sources.ts
+++ b/types/src/front/api_handlers/public/data_sources.ts
@@ -28,7 +28,7 @@ export type FrontDataSourceDocumentSectionType = t.TypeOf<
 >;
 
 export const PostDataSourceDocumentRequestBodySchema = t.type({
-  timestamp: t.union([t.number, t.undefined, t.null]),
+  timestamp: t.union([t.Int, t.undefined, t.null]),
   tags: t.union([t.array(t.string), t.undefined, t.null]),
   parents: t.union([t.array(t.string), t.undefined, t.null]),
   source_url: t.union([t.string, t.undefined, t.null]),


### PR DESCRIPTION
## Description

`core` fails when we try to pass a float. But api v1 accepts it.
So right now we have an entry in upsert queue that is rejected by `core` (but was accepted by v1).
It's for a non-managed datasource that is using async upserts.

This PR:
- enforces integer in v1
- `Math.floor`s the timestamp before sending it to `core`

I will remove the `Math.floor` as soon as that entry is un-stuck.

## Risk

N/A

## Deploy Plan

Deploy front, wait for entry to unstuck, remove math.floor