### PR TITLE
[connectors] Implement cleanup for Zendesk brands and categories

### DIFF
--- a/connectors/src/connectors/zendesk/lib/brand_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/brand_permissions.ts
@@ -96,6 +96,6 @@ export async function revokeSyncZendeskBrand({
     return null;
   }
 
-  await brand.revokePermissions();
+  await brand.revokeAllPermissions();
   return brand;
 }

--- a/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
@@ -105,7 +105,9 @@ export async function revokeSyncZendeskHelpCenter({
     return null;
   }
 
+  // updating the field helpCenterPermission to "none" for the brand
   await brand.revokeHelpCenterPermissions();
+  // revoking the permissions for all the children categories and articles
   await ZendeskCategoryResource.revokePermissionsForBrand({
     connectorId,
     brandId,

--- a/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
@@ -7,6 +7,7 @@ import {
 } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import logger from "@connectors/logger/logger";
 import {
+  ZendeskArticleResource,
   ZendeskBrandResource,
   ZendeskCategoryResource,
 } from "@connectors/resources/zendesk_resources";
@@ -105,6 +106,14 @@ export async function revokeSyncZendeskHelpCenter({
   }
 
   await brand.revokeHelpCenterPermissions();
+  await ZendeskCategoryResource.revokePermissionsForBrand({
+    connectorId,
+    brandId,
+  });
+  await ZendeskArticleResource.revokePermissionsForBrand({
+    connectorId,
+    brandId,
+  });
   return brand;
 }
 

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -113,7 +113,7 @@ export async function retrieveChildrenNodes({
   if (!parentInternalId) {
     if (isReadPermissionsOnly) {
       const brandsInDatabase =
-        await ZendeskBrandResource.fetchBrandsWithHelpCenter({ connectorId });
+        await ZendeskBrandResource.fetchAllWithHelpCenter({ connectorId });
       nodes = brandsInDatabase.map((brand) =>
         brand.toContentNode({ connectorId })
       );

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -1,9 +1,4 @@
-import type {
-  ConnectorPermission,
-  ContentNode,
-  ContentNodesViewType,
-  ModelId,
-} from "@dust-tt/types";
+import type { ConnectorPermission, ContentNode, ContentNodesViewType, ModelId } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
 
 import {
@@ -14,15 +9,14 @@ import {
   getTicketsInternalId,
 } from "@connectors/connectors/zendesk/lib/id_conversions";
 import { getZendeskAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
-import {
-  changeZendeskClientSubdomain,
-  createZendeskClient,
-} from "@connectors/connectors/zendesk/lib/zendesk_api";
+import { changeZendeskClientSubdomain, createZendeskClient } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import {
+  ZendeskArticleResource,
   ZendeskBrandResource,
   ZendeskCategoryResource,
+  ZendeskTicketResource,
 } from "@connectors/resources/zendesk_resources";
 
 /**
@@ -186,10 +180,11 @@ export async function retrieveChildrenNodes({
       // If the parent is a brand's tickets, we retrieve the list of tickets for the brand.
       case "tickets": {
         if (isReadPermissionsOnly) {
-          const ticketsInDb = await ZendeskBrandResource.fetchReadOnlyTickets({
-            connectorId,
-            brandId: objectId,
-          });
+          const ticketsInDb =
+            await ZendeskTicketResource.fetchByBrandIdReadOnly({
+              connectorId,
+              brandId: objectId,
+            });
           nodes = ticketsInDb.map((ticket) =>
             ticket.toContentNode({ connectorId })
           );
@@ -199,7 +194,7 @@ export async function retrieveChildrenNodes({
       // If the parent is a brand's help center, we retrieve the list of Categories for this brand.
       case "help-center": {
         const categoriesInDatabase =
-          await ZendeskBrandResource.fetchReadOnlyCategories({
+          await ZendeskCategoryResource.fetchByBrandIdReadOnly({
             connectorId,
             brandId: objectId,
           });
@@ -239,7 +234,7 @@ export async function retrieveChildrenNodes({
       case "category": {
         if (isReadPermissionsOnly) {
           const articlesInDb =
-            await ZendeskCategoryResource.fetchReadOnlyArticles({
+            await ZendeskArticleResource.fetchByCategoryIdReadOnly({
               connectorId,
               categoryId: objectId,
             });

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -1,4 +1,9 @@
-import type { ConnectorPermission, ContentNode, ContentNodesViewType, ModelId } from "@dust-tt/types";
+import type {
+  ConnectorPermission,
+  ContentNode,
+  ContentNodesViewType,
+  ModelId,
+} from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
 
 import {
@@ -9,7 +14,10 @@ import {
   getTicketsInternalId,
 } from "@connectors/connectors/zendesk/lib/id_conversions";
 import { getZendeskAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
-import { changeZendeskClientSubdomain, createZendeskClient } from "@connectors/connectors/zendesk/lib/zendesk_api";
+import {
+  changeZendeskClientSubdomain,
+  createZendeskClient,
+} from "@connectors/connectors/zendesk/lib/zendesk_api";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import {

--- a/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
@@ -84,7 +84,9 @@ export async function revokeSyncZendeskTickets({
     return null;
   }
 
+  // updating the field ticketsPermission to "none" for the brand
   await brand.revokeTicketsPermissions();
+  // revoking the permissions for all the children tickets
   await ZendeskTicketResource.revokePermissionsForBrand({
     connectorId,
     brandId,

--- a/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
@@ -3,7 +3,10 @@ import type { ModelId } from "@dust-tt/types";
 import { getZendeskAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
 import { createZendeskClient } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import logger from "@connectors/logger/logger";
-import { ZendeskBrandResource } from "@connectors/resources/zendesk_resources";
+import {
+  ZendeskBrandResource,
+  ZendeskTicketResource,
+} from "@connectors/resources/zendesk_resources";
 
 export async function allowSyncZendeskTickets({
   subdomain,
@@ -82,5 +85,9 @@ export async function revokeSyncZendeskTickets({
   }
 
   await brand.revokeTicketsPermissions();
+  await ZendeskTicketResource.revokePermissionsForBrand({
+    connectorId,
+    brandId,
+  });
   return brand;
 }

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -13,11 +13,12 @@ import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_c
 import { deleteFromDataSource } from "@connectors/lib/data_sources";
 import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
-import type { ZendeskTicketResource } from "@connectors/resources/zendesk_resources";
 import {
+  ZendeskArticleResource,
   ZendeskBrandResource,
   ZendeskCategoryResource,
   ZendeskConfigurationResource,
+  ZendeskTicketResource,
 } from "@connectors/resources/zendesk_resources";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
@@ -126,7 +127,7 @@ export async function syncZendeskBrandActivity({
   }
 
   const categoriesWithReadPermissions =
-    await ZendeskBrandResource.fetchReadOnlyCategories({
+    await ZendeskCategoryResource.fetchByBrandIdReadOnly({
       connectorId,
       brandId,
     });
@@ -323,11 +324,11 @@ async function deleteBrandWithChildren({
   brandInDb: ZendeskBrandResource;
   dataSourceConfig: DataSourceConfig;
 }) {
-  const categories = await ZendeskBrandResource.fetchAllCategories({
+  const categories = await ZendeskCategoryResource.fetchByBrandId({
     connectorId: brandInDb.connectorId,
     brandId: brandInDb.brandId,
   });
-  const tickets = await ZendeskBrandResource.fetchAllTickets({
+  const tickets = await ZendeskTicketResource.fetchByBrandId({
     connectorId: brandInDb.connectorId,
     brandId: brandInDb.brandId,
   });
@@ -352,7 +353,7 @@ async function deleteCategoryWithChildren({
   categoryInDb: ZendeskCategoryResource;
   dataSourceConfig: DataSourceConfig;
 }) {
-  const articles = await ZendeskCategoryResource.fetchAllArticles({
+  const articles = await ZendeskArticleResource.fetchByCategoryId({
     connectorId: categoryInDb.connectorId,
     categoryId: categoryInDb.brandId,
   });

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -261,15 +261,7 @@ export async function syncZendeskCategoryActivity({
 
   // if all rights were revoked, we delete the category data.
   if (categoryInDb.permission === "none") {
-    await deleteUpsertedArticlesInCategory({
-      connectorId,
-      categoryId,
-      dataSourceConfig,
-    });
-    await ZendeskArticleResource.deleteByCategoryId({
-      connectorId,
-      categoryId,
-    });
+    await deleteCategoryChildren({ connectorId, dataSourceConfig, categoryId });
     await categoryInDb.delete();
     return false;
   }
@@ -284,15 +276,7 @@ export async function syncZendeskCategoryActivity({
   const { result: fetchedCategory } =
     await zendeskApiClient.helpcenter.categories.show(categoryId);
   if (!fetchedCategory) {
-    await deleteUpsertedArticlesInCategory({
-      connectorId,
-      categoryId,
-      dataSourceConfig,
-    });
-    await ZendeskArticleResource.deleteByCategoryId({
-      connectorId,
-      categoryId,
-    });
+    await deleteCategoryChildren({ connectorId, categoryId, dataSourceConfig });
     await categoryInDb.delete();
     return false;
   }
@@ -361,6 +345,29 @@ async function deleteBrandChildren({
   await ZendeskCategoryResource.deleteByBrandId({ connectorId, brandId });
   /// deleting the tickets stored in the db
   await ZendeskTicketResource.deleteByBrandId({ connectorId, brandId });
+}
+
+/**
+ * Deletes all the data stored in the db and in the data source relative to a category (articles).
+ */
+async function deleteCategoryChildren({
+  connectorId,
+  categoryId,
+  dataSourceConfig,
+}: {
+  connectorId: number;
+  categoryId: number;
+  dataSourceConfig: DataSourceConfig;
+}) {
+  await deleteUpsertedArticlesInCategory({
+    connectorId,
+    categoryId,
+    dataSourceConfig,
+  });
+  await ZendeskArticleResource.deleteByCategoryId({
+    connectorId,
+    categoryId,
+  });
 }
 
 /**

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -1,25 +1,18 @@
 import type { ModelId } from "@dust-tt/types";
 
-import {
-  getArticleInternalId,
-  getTicketInternalId,
-} from "@connectors/connectors/zendesk/lib/id_conversions";
 import { getZendeskAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
 import {
   changeZendeskClientSubdomain,
   createZendeskClient,
 } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
-import { deleteFromDataSource } from "@connectors/lib/data_sources";
 import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
-import type { ZendeskTicketResource } from "@connectors/resources/zendesk_resources";
 import {
   ZendeskBrandResource,
   ZendeskCategoryResource,
   ZendeskConfigurationResource,
 } from "@connectors/resources/zendesk_resources";
-import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
 async function _getZendeskConnectorOrRaise(connectorId: ModelId) {
   const connector = await ConnectorResource.fetchById(connectorId);
@@ -121,7 +114,7 @@ export async function syncZendeskBrandActivity({
     result: { brand: fetchedBrand },
   } = await zendeskApiClient.brand.show(brandId);
   if (!fetchedBrand) {
-    await deleteBrandWithChildren({ brandInDb, dataSourceConfig });
+    await brandInDb.deleteWithChildren({ dataSourceConfig });
     return { helpCenterAllowed: false, ticketsAllowed: false };
   }
 
@@ -135,7 +128,7 @@ export async function syncZendeskBrandActivity({
   if (noMoreAllowedCategories) {
     // if the tickets and all children categories are not allowed anymore, we delete the brand data
     if (brandInDb.ticketsPermission !== "read") {
-      await deleteBrandWithChildren({ brandInDb, dataSourceConfig });
+      await brandInDb.deleteWithChildren({ dataSourceConfig });
       return { helpCenterAllowed: false, ticketsAllowed: false };
     }
     await brandInDb.update({ helpCenterPermission: "none" });
@@ -259,7 +252,7 @@ export async function syncZendeskCategoryActivity({
 
   // if all rights were revoked, we delete the category data.
   if (categoryInDb.permission === "none") {
-    await deleteCategoryWithChildren({ categoryInDb, dataSourceConfig });
+    await categoryInDb.deleteWithChildren({ dataSourceConfig });
     return false;
   }
 
@@ -273,7 +266,7 @@ export async function syncZendeskCategoryActivity({
   const { result: fetchedCategory } =
     await zendeskApiClient.helpcenter.categories.show(categoryId);
   if (!fetchedCategory) {
-    await deleteCategoryWithChildren({ categoryInDb, dataSourceConfig });
+    await categoryInDb.deleteWithChildren({ dataSourceConfig });
     return false;
   }
 
@@ -311,80 +304,4 @@ export async function syncZendeskTicketsActivity({}: {
   afterCursor: string | null;
 }): Promise<{ hasMore: boolean; afterCursor: string }> {
   return { hasMore: false, afterCursor: "" };
-}
-
-/**
- * Deletes all the data stored in the db and in the data source relative to a brand (category, articles and tickets).
- */
-async function deleteBrandWithChildren({
-  brandInDb,
-  dataSourceConfig,
-}: {
-  brandInDb: ZendeskBrandResource;
-  dataSourceConfig: DataSourceConfig;
-}) {
-  const categories = await ZendeskBrandResource.fetchAllCategories({
-    connectorId: brandInDb.connectorId,
-    brandId: brandInDb.brandId,
-  });
-  const tickets = await ZendeskBrandResource.fetchAllTickets({
-    connectorId: brandInDb.connectorId,
-    brandId: brandInDb.brandId,
-  });
-  await Promise.all([
-    ...categories.map((categoryInDb) =>
-      deleteCategoryWithChildren({ categoryInDb, dataSourceConfig })
-    ),
-    ...tickets.map((ticketInDb) =>
-      deleteTicket({ ticketInDb, dataSourceConfig })
-    ),
-  ]);
-  await brandInDb.delete();
-}
-
-/**
- * Deletes all the data relative to a category stored in the db and in the data source (category and articles).
- */
-async function deleteCategoryWithChildren({
-  categoryInDb,
-  dataSourceConfig,
-}: {
-  categoryInDb: ZendeskCategoryResource;
-  dataSourceConfig: DataSourceConfig;
-}) {
-  const articles = await ZendeskCategoryResource.fetchAllArticles({
-    connectorId: categoryInDb.connectorId,
-    categoryId: categoryInDb.brandId,
-  });
-  await Promise.all(
-    articles.map((article) =>
-      Promise.all([
-        deleteFromDataSource(
-          dataSourceConfig,
-          getArticleInternalId(article.connectorId, article.articleId)
-        ),
-        article.delete(),
-      ])
-    )
-  );
-  await categoryInDb.delete();
-}
-
-/**
- * Deletes the data relative to a ticket stored in the db and the data source.
- */
-async function deleteTicket({
-  ticketInDb,
-  dataSourceConfig,
-}: {
-  ticketInDb: ZendeskTicketResource;
-  dataSourceConfig: DataSourceConfig;
-}) {
-  await Promise.all([
-    deleteFromDataSource(
-      dataSourceConfig,
-      getTicketInternalId(ticketInDb.connectorId, ticketInDb.ticketId)
-    ),
-    ticketInDb.delete(),
-  ]);
 }

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -1,18 +1,25 @@
 import type { ModelId } from "@dust-tt/types";
 
+import {
+  getArticleInternalId,
+  getTicketInternalId,
+} from "@connectors/connectors/zendesk/lib/id_conversions";
 import { getZendeskAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
 import {
   changeZendeskClientSubdomain,
   createZendeskClient,
 } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { deleteFromDataSource } from "@connectors/lib/data_sources";
 import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
+import type { ZendeskTicketResource } from "@connectors/resources/zendesk_resources";
 import {
   ZendeskBrandResource,
   ZendeskCategoryResource,
   ZendeskConfigurationResource,
 } from "@connectors/resources/zendesk_resources";
+import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
 async function _getZendeskConnectorOrRaise(connectorId: ModelId) {
   const connector = await ConnectorResource.fetchById(connectorId);
@@ -82,12 +89,6 @@ export async function syncZendeskBrandActivity({
 }): Promise<{ helpCenterAllowed: boolean; ticketsAllowed: boolean }> {
   const connector = await _getZendeskConnectorOrRaise(connectorId);
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
-  const loggerArgs = {
-    workspaceId: dataSourceConfig.workspaceId,
-    connectorId,
-    provider: "zendesk",
-    dataSourceId: dataSourceConfig.dataSourceId,
-  };
   const configuration = await _getZendeskConfigurationOrRaise(connectorId);
 
   const brandInDb = await ZendeskBrandResource.fetchByBrandId({
@@ -105,7 +106,7 @@ export async function syncZendeskBrandActivity({
     brandInDb.helpCenterPermission === "none" &&
     brandInDb.ticketsPermission === "none"
   ) {
-    await brandInDb.remove({ dataSourceConfig, loggerArgs });
+    await brandInDb.delete();
     return { helpCenterAllowed: false, ticketsAllowed: false };
   }
 
@@ -120,7 +121,7 @@ export async function syncZendeskBrandActivity({
     result: { brand: fetchedBrand },
   } = await zendeskApiClient.brand.show(brandId);
   if (!fetchedBrand) {
-    await brandInDb.remove({ dataSourceConfig, loggerArgs });
+    await deleteBrandWithChildren({ brandInDb, dataSourceConfig });
     return { helpCenterAllowed: false, ticketsAllowed: false };
   }
 
@@ -134,7 +135,7 @@ export async function syncZendeskBrandActivity({
   if (noMoreAllowedCategories) {
     // if the tickets and all children categories are not allowed anymore, we delete the brand data
     if (brandInDb.ticketsPermission !== "read") {
-      await brandInDb.remove({ dataSourceConfig, loggerArgs });
+      await deleteBrandWithChildren({ brandInDb, dataSourceConfig });
       return { helpCenterAllowed: false, ticketsAllowed: false };
     }
     await brandInDb.update({ helpCenterPermission: "none" });
@@ -245,12 +246,6 @@ export async function syncZendeskCategoryActivity({
 }): Promise<boolean> {
   const connector = await _getZendeskConnectorOrRaise(connectorId);
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
-  const loggerArgs = {
-    workspaceId: dataSourceConfig.workspaceId,
-    connectorId,
-    provider: "zendesk",
-    dataSourceId: dataSourceConfig.dataSourceId,
-  };
   const configuration = await _getZendeskConfigurationOrRaise(connectorId);
   const categoryInDb = await ZendeskCategoryResource.fetchByCategoryId({
     connectorId,
@@ -264,7 +259,7 @@ export async function syncZendeskCategoryActivity({
 
   // if all rights were revoked, we delete the category data.
   if (categoryInDb.permission === "none") {
-    await categoryInDb.remove({ dataSourceConfig, loggerArgs });
+    await deleteCategoryWithChildren({ categoryInDb, dataSourceConfig });
     return false;
   }
 
@@ -278,7 +273,7 @@ export async function syncZendeskCategoryActivity({
   const { result: fetchedCategory } =
     await zendeskApiClient.helpcenter.categories.show(categoryId);
   if (!fetchedCategory) {
-    await categoryInDb.remove({ dataSourceConfig, loggerArgs });
+    await deleteCategoryWithChildren({ categoryInDb, dataSourceConfig });
     return false;
   }
 
@@ -316,4 +311,80 @@ export async function syncZendeskTicketsActivity({}: {
   afterCursor: string | null;
 }): Promise<{ hasMore: boolean; afterCursor: string }> {
   return { hasMore: false, afterCursor: "" };
+}
+
+/**
+ * Deletes all the data stored in the db and in the data source relative to a brand (category, articles and tickets).
+ */
+async function deleteBrandWithChildren({
+  brandInDb,
+  dataSourceConfig,
+}: {
+  brandInDb: ZendeskBrandResource;
+  dataSourceConfig: DataSourceConfig;
+}) {
+  const categories = await ZendeskBrandResource.fetchAllCategories({
+    connectorId: brandInDb.connectorId,
+    brandId: brandInDb.brandId,
+  });
+  const tickets = await ZendeskBrandResource.fetchAllTickets({
+    connectorId: brandInDb.connectorId,
+    brandId: brandInDb.brandId,
+  });
+  await Promise.all([
+    ...categories.map((categoryInDb) =>
+      deleteCategoryWithChildren({ categoryInDb, dataSourceConfig })
+    ),
+    ...tickets.map((ticketInDb) =>
+      deleteTicket({ ticketInDb, dataSourceConfig })
+    ),
+  ]);
+  await brandInDb.delete();
+}
+
+/**
+ * Deletes all the data relative to a category stored in the db and in the data source (category and articles).
+ */
+async function deleteCategoryWithChildren({
+  categoryInDb,
+  dataSourceConfig,
+}: {
+  categoryInDb: ZendeskCategoryResource;
+  dataSourceConfig: DataSourceConfig;
+}) {
+  const articles = await ZendeskCategoryResource.fetchAllArticles({
+    connectorId: categoryInDb.connectorId,
+    categoryId: categoryInDb.brandId,
+  });
+  await Promise.all(
+    articles.map((article) =>
+      Promise.all([
+        deleteFromDataSource(
+          dataSourceConfig,
+          getArticleInternalId(article.connectorId, article.articleId)
+        ),
+        article.delete(),
+      ])
+    )
+  );
+  await categoryInDb.delete();
+}
+
+/**
+ * Deletes the data relative to a ticket stored in the db and the data source.
+ */
+async function deleteTicket({
+  ticketInDb,
+  dataSourceConfig,
+}: {
+  ticketInDb: ZendeskTicketResource;
+  dataSourceConfig: DataSourceConfig;
+}) {
+  await Promise.all([
+    deleteFromDataSource(
+      dataSourceConfig,
+      getTicketInternalId(ticketInDb.connectorId, ticketInDb.ticketId)
+    ),
+    ticketInDb.delete(),
+  ]);
 }

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -527,6 +527,16 @@ export class ZendeskTicketResource extends BaseResource<ZendeskTicket> {
     );
   }
 
+  static async deleteByBrandId({
+    connectorId,
+    brandId,
+  }: {
+    connectorId: number;
+    brandId: number;
+  }): Promise<void> {
+    await ZendeskTicket.destroy({ where: { connectorId, brandId } });
+  }
+
   static async revokePermissionsForBrand({
     connectorId,
     brandId,
@@ -642,6 +652,16 @@ export class ZendeskArticleResource extends BaseResource<ZendeskArticle> {
     return articles.map(
       (article) => new ZendeskArticleResource(ZendeskArticle, article)
     );
+  }
+
+  static async deleteByCategoryId({
+    connectorId,
+    categoryId,
+  }: {
+    connectorId: number;
+    categoryId: number;
+  }) {
+    await ZendeskArticle.destroy({ where: { connectorId, categoryId } });
   }
 
   static async revokePermissionsForBrand({

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -674,6 +674,16 @@ export class ZendeskArticleResource extends BaseResource<ZendeskArticle> {
     await ZendeskArticle.destroy({ where: { connectorId, categoryId } });
   }
 
+  static async deleteByBrandId({
+    connectorId,
+    brandId,
+  }: {
+    connectorId: number;
+    brandId: number;
+  }) {
+    await ZendeskArticle.destroy({ where: { connectorId, brandId } });
+  }
+
   static async revokePermissionsForBrand({
     connectorId,
     brandId,

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -664,6 +664,21 @@ export class ZendeskArticleResource extends BaseResource<ZendeskArticle> {
     );
   }
 
+  static async fetchByBrandId({
+    connectorId,
+    brandId,
+  }: {
+    connectorId: number;
+    brandId: number;
+  }): Promise<ZendeskArticleResource[]> {
+    const articles = await ZendeskArticle.findAll({
+      where: { connectorId, brandId },
+    });
+    return articles.map(
+      (article) => new ZendeskArticleResource(ZendeskArticle, article)
+    );
+  }
+
   static async deleteByCategoryId({
     connectorId,
     categoryId,

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -390,6 +390,16 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
     return categories.map((category) => new this(this.model, category.get()));
   }
 
+  static async deleteByBrandId({
+    connectorId,
+    brandId,
+  }: {
+    connectorId: number;
+    brandId: number;
+  }): Promise<void> {
+    await ZendeskCategory.destroy({ where: { connectorId, brandId } });
+  }
+
   static async revokePermissionsForBrand({
     connectorId,
     brandId,

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -25,7 +25,6 @@ import {
 } from "@connectors/lib/models/zendesk";
 import { BaseResource } from "@connectors/resources/base_resource";
 import type { ReadonlyAttributesType } from "@connectors/resources/storage/types";
-import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -104,17 +103,6 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
       transaction,
     });
     return new Ok(undefined);
-  }
-
-  /**
-   * Deletes the brand and all associated data (tickets, categories, articles).
-   */
-  // eslint-disable-next-line no-empty-pattern
-  async remove({}: {
-    dataSourceConfig: DataSourceConfig;
-    loggerArgs: Record<string, string | number>;
-  }) {
-    // TODO: implement removal for the children first.
   }
 
   toJSON(): Record<string, unknown> {
@@ -235,6 +223,21 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
     );
   }
 
+  static async fetchAllTickets({
+    connectorId,
+    brandId,
+  }: {
+    connectorId: number;
+    brandId: number;
+  }): Promise<ZendeskTicketResource[]> {
+    const tickets = await ZendeskTicket.findAll({
+      where: { connectorId, brandId },
+    });
+    return tickets.map(
+      (ticket) => new ZendeskTicketResource(ZendeskTicket, ticket)
+    );
+  }
+
   static async fetchReadOnlyCategories({
     connectorId,
     brandId,
@@ -244,6 +247,22 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
   }): Promise<ZendeskCategoryResource[]> {
     const categories = await ZendeskCategory.findAll({
       where: { connectorId, brandId, permission: "read" },
+    });
+    return categories.map(
+      (category) =>
+        category && new ZendeskCategoryResource(ZendeskCategory, category)
+    );
+  }
+
+  static async fetchAllCategories({
+    connectorId,
+    brandId,
+  }: {
+    connectorId: number;
+    brandId: number;
+  }): Promise<ZendeskCategoryResource[]> {
+    const categories = await ZendeskCategory.findAll({
+      where: { connectorId, brandId },
     });
     return categories.map(
       (category) =>
@@ -366,17 +385,6 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
     return new Ok(undefined);
   }
 
-  /**
-   * Deletes the category and all associated data (articles).
-   */
-  // eslint-disable-next-line no-empty-pattern
-  async remove({}: {
-    dataSourceConfig: DataSourceConfig;
-    loggerArgs: Record<string, string | number>;
-  }) {
-    // TODO: implement removal for the children first.
-  }
-
   toJSON(): Record<string, unknown> {
     return {
       id: this.id,
@@ -441,6 +449,21 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
   }): Promise<ZendeskArticleResource[]> {
     const articles = await ZendeskArticle.findAll({
       where: { connectorId, categoryId, permission: "read" },
+    });
+    return articles.map(
+      (article) => new ZendeskArticleResource(ZendeskArticle, article)
+    );
+  }
+
+  static async fetchAllArticles({
+    connectorId,
+    categoryId,
+  }: {
+    connectorId: number;
+    categoryId: number;
+  }): Promise<ZendeskArticleResource[]> {
+    const articles = await ZendeskArticle.findAll({
+      where: { connectorId, categoryId },
     });
     return articles.map(
       (article) => new ZendeskArticleResource(ZendeskArticle, article)

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -99,9 +99,7 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
    */
   async delete(transaction?: Transaction): Promise<Result<undefined, Error>> {
     await this.model.destroy({
-      where: {
-        connectorId: this.connectorId,
-      },
+      where: { connectorId: this.connectorId, brandId: this.brandId },
       transaction,
     });
     return new Ok(undefined);
@@ -412,9 +410,7 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
 
   async delete(transaction?: Transaction): Promise<Result<undefined, Error>> {
     await this.model.destroy({
-      where: {
-        connectorId: this.connectorId,
-      },
+      where: { connectorId: this.connectorId, categoryId: this.categoryId },
       transaction,
     });
     return new Ok(undefined);
@@ -575,9 +571,7 @@ export class ZendeskTicketResource extends BaseResource<ZendeskTicket> {
 
   async delete(transaction?: Transaction): Promise<Result<undefined, Error>> {
     await this.model.destroy({
-      where: {
-        connectorId: this.connectorId,
-      },
+      where: { connectorId: this.connectorId, ticketId: this.ticketId },
       transaction,
     });
     return new Ok(undefined);
@@ -650,9 +644,7 @@ export class ZendeskArticleResource extends BaseResource<ZendeskArticle> {
 
   async delete(transaction?: Transaction): Promise<Result<undefined, Error>> {
     await this.model.destroy({
-      where: {
-        connectorId: this.connectorId,
-      },
+      where: { connectorId: this.connectorId, articleId: this.articleId },
       transaction,
     });
     return new Ok(undefined);

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -192,7 +192,7 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
     return brands.map((brand) => new this(this.model, brand.get()));
   }
 
-  static async fetchBrandsWithHelpCenter({
+  static async fetchAllWithHelpCenter({
     connectorId,
   }: {
     connectorId: number;

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -16,6 +16,7 @@ import {
   getTicketInternalId,
   getTicketsInternalId,
 } from "@connectors/connectors/zendesk/lib/id_conversions";
+import { deleteFromDataSource } from "@connectors/lib/data_sources";
 import {
   ZendeskArticle,
   ZendeskBrand,
@@ -25,6 +26,7 @@ import {
 } from "@connectors/lib/models/zendesk";
 import { BaseResource } from "@connectors/resources/base_resource";
 import type { ReadonlyAttributesType } from "@connectors/resources/storage/types";
+import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -103,6 +105,39 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
       transaction,
     });
     return new Ok(undefined);
+  }
+
+  /**
+   * Deletes all the data stored in the db and in the data source relative to a brand (category, articles and tickets).
+   */
+  async deleteWithChildren({
+    dataSourceConfig,
+  }: {
+    dataSourceConfig: DataSourceConfig;
+  }) {
+    const categories = await ZendeskBrandResource.fetchAllCategories({
+      connectorId: this.connectorId,
+      brandId: this.brandId,
+    });
+    const tickets = await ZendeskBrandResource.fetchAllTickets({
+      connectorId: this.connectorId,
+      brandId: this.brandId,
+    });
+    await Promise.all([
+      ...categories.map((category) =>
+        category.deleteWithChildren({ dataSourceConfig })
+      ),
+      ...tickets.map((ticket) =>
+        Promise.all([
+          deleteFromDataSource(
+            dataSourceConfig,
+            getTicketInternalId(ticket.connectorId, ticket.ticketId)
+          ),
+          ticket.delete(),
+        ])
+      ),
+    ]);
+    await this.delete();
   }
 
   toJSON(): Record<string, unknown> {
@@ -383,6 +418,32 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
       transaction,
     });
     return new Ok(undefined);
+  }
+
+  /**
+   * Deletes all the data relative to a category stored in the db and in the data source (category and articles).
+   */
+  async deleteWithChildren({
+    dataSourceConfig,
+  }: {
+    dataSourceConfig: DataSourceConfig;
+  }) {
+    const articles = await ZendeskCategoryResource.fetchAllArticles({
+      connectorId: this.connectorId,
+      categoryId: this.brandId,
+    });
+    await Promise.all(
+      articles.map((article) =>
+        Promise.all([
+          deleteFromDataSource(
+            dataSourceConfig,
+            getArticleInternalId(article.connectorId, article.articleId)
+          ),
+          article.delete(),
+        ])
+      )
+    );
+    await this.delete();
   }
 
   toJSON(): Record<string, unknown> {


### PR DESCRIPTION
## Description

- Implement brand and category cleanup (from upserted documents + postgres db).
- Close [#1549](https://github.com/dust-tt/tasks/issues/1549)

For context, in Zendesk the data available is structured in Brands, which each have a Help Center and Tickets, the Help Center being a collection of Categories that each contain Sections and Articles (we do not allow selecting sections, only categories).

## Risk

## Deploy Plan

- Deploy connectors