### PR TITLE
Use separate dark/light context per block

### DIFF
--- a/front/components/assistant/markdown/CodeBlockWithExtendedSupport.tsx
+++ b/front/components/assistant/markdown/CodeBlockWithExtendedSupport.tsx
@@ -3,6 +3,7 @@ import mermaid from "mermaid";
 import React, { useContext, useEffect, useRef, useState } from "react";
 
 import { CodeBlock } from "@app/components/assistant/markdown/CodeBlock";
+import { ContentBlockWrapperContext } from "@app/components/assistant/markdown/ContentBlockWrapper";
 import { MarkdownContentContext } from "@app/components/assistant/markdown/MarkdownContentContext";
 import { classNames } from "@app/lib/utils";
 
@@ -33,9 +34,9 @@ export function CodeBlockWithExtendedSupport({
 
   const [showMermaid, setShowMermaid] = useState<boolean>(false);
   const [isValidMermaid, setIsValidMermaid] = useState<boolean>(false);
-  const { isStreaming, isDarkMode, setIsDarkMode } = useContext(
-    MarkdownContentContext
-  );
+
+  const { isStreaming } = useContext(MarkdownContentContext);
+  const { isDarkMode, setIsDarkMode } = useContext(ContentBlockWrapperContext);
 
   useEffect(() => {
     if (isStreaming || !validChildrenContent || isValidMermaid || showMermaid) {

--- a/front/components/assistant/markdown/ContentBlockWrapper.tsx
+++ b/front/components/assistant/markdown/ContentBlockWrapper.tsx
@@ -4,9 +4,8 @@ import {
   ClipboardIcon,
   IconButton,
 } from "@dust-tt/sparkle";
-import { useCallback, useContext } from "react";
+import React, { useCallback, useContext } from "react";
 
-import { MarkdownContentContext } from "@app/components/assistant/markdown/MarkdownContentContext";
 import { useCopyToClipboard } from "@app/components/assistant/markdown/useCopyToClipboard";
 import { classNames } from "@app/lib/utils";
 
@@ -37,6 +36,14 @@ interface ContentBlockWrapperProps {
   getContentToDownload?: GetContentToDownloadFunction;
 }
 
+export const ContentBlockWrapperContext = React.createContext<{
+  setIsDarkMode: (v: boolean) => void;
+  isDarkMode: boolean;
+}>({
+  setIsDarkMode: () => {},
+  isDarkMode: false,
+});
+
 export function ContentBlockWrapper({
   children,
   className,
@@ -44,7 +51,7 @@ export function ContentBlockWrapper({
   getContentToDownload,
 }: ContentBlockWrapperProps) {
   const [isCopied, copyToClipboard] = useCopyToClipboard();
-  const { isDarkMode } = useContext(MarkdownContentContext);
+  const { isDarkMode } = useContext(ContentBlockWrapperContext);
   const handleCopyToClipboard = useCallback(() => {
     if (!content) {
       return;

--- a/front/components/assistant/markdown/MarkdownContentContext.tsx
+++ b/front/components/assistant/markdown/MarkdownContentContext.tsx
@@ -4,12 +4,8 @@ export const MarkdownContentContext = React.createContext<{
   content: string;
   isStreaming: boolean;
   isLastMessage: boolean;
-  setIsDarkMode: (v: boolean) => void;
-  isDarkMode: boolean;
 }>({
   content: "",
   isStreaming: false,
   isLastMessage: false,
-  setIsDarkMode: () => {},
-  isDarkMode: false,
 });


### PR DESCRIPTION
## Description

Fixes header color when using multiple blocks with ContentBlockWrapper, so that each one as its own context and mode.
Make copy icon visible in tables by using separate contexts. In case of TableBlock, use default context ( no dark mode )

## Risk

None

## Deploy Plan

deploy `front`