### PR TITLE
[front] - chore(navigation): use new `NavigationList`

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -357,7 +357,7 @@ const RenderConversations = ({
           <Checkbox
             className="bg-white"
             checked={selectedConversations.includes(conversation)}
-            onChange={() => toggleConversationSelection(conversation)}
+            onCheckedChange={() => toggleConversationSelection(conversation)}
           />
           <span className="ml-2 text-sm text-muted-foreground">
             {conversationLabel}

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -7,6 +7,9 @@ import {
   Label,
   ListCheckIcon,
   MoreIcon,
+  NavigationList,
+  NavigationListItem,
+  NavigationListLabel,
   NewDropdownMenu,
   NewDropdownMenuContent,
   NewDropdownMenuItem,
@@ -308,25 +311,37 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
                 return (
                   conversations.length > 0 && (
                     <React.Fragment key={dateLabel}>
-                      <Label className="py-1 text-xs font-medium text-element-800">
-                        {dateLabel.toUpperCase()}
-                      </Label>
-                      <Item.List>
+                      <NavigationListLabel
+                        label={dateLabel.toUpperCase()}
+                        className="py-1 pl-1 text-xs font-medium text-element-800"
+                      />
+                      <NavigationList>
                         {conversations.map((c: ConversationType) => (
-                          <RenderConversation
+                          <NavigationListItem
                             key={c.sId}
-                            conversation={c}
-                            isMultiSelect={isMultiSelect}
-                            selectedConversations={selectedConversations}
-                            toggleConversationSelection={
-                              toggleConversationSelection
+                            selected={router.query.cId === c.sId}
+                            label={
+                              c.title ||
+                              (moment(c.created).isSame(moment(), "day")
+                                ? "New Conversation"
+                                : `Conversation from ${new Date(c.created).toLocaleDateString()}`)
                             }
-                            setSidebarOpen={setSidebarOpen}
-                            router={router}
-                            owner={owner}
+                            onClick={() => {
+                              if (isMultiSelect) {
+                                toggleConversationSelection(c);
+                              } else {
+                                setSidebarOpen(false);
+                              }
+                            }}
+                            href={
+                              isMultiSelect
+                                ? undefined
+                                : `/w/${owner.sId}/assistant/${c.sId}`
+                            }
+                            className="px-2"
                           />
                         ))}
-                      </Item.List>
+                      </NavigationList>
                     </React.Fragment>
                   )
                 );

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -3,7 +3,6 @@ import {
   ChatBubbleBottomCenterPlusIcon,
   Checkbox,
   Dialog,
-  Item,
   Label,
   ListCheckIcon,
   MoreIcon,
@@ -313,7 +312,6 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
                   isMultiSelect={isMultiSelect}
                   selectedConversations={selectedConversations}
                   toggleConversationSelection={toggleConversationSelection}
-                  setSidebarOpen={setSidebarOpen}
                   router={router}
                   owner={owner}
                 />
@@ -331,7 +329,6 @@ const RenderConversations = ({
   isMultiSelect,
   selectedConversations,
   toggleConversationSelection,
-  setSidebarOpen,
   router,
   owner,
 }: {
@@ -340,61 +337,54 @@ const RenderConversations = ({
   isMultiSelect: boolean;
   selectedConversations: ConversationType[];
   toggleConversationSelection: (c: ConversationType) => void;
-  setSidebarOpen: (open: boolean) => void;
   router: NextRouter;
   owner: WorkspaceType;
 }) => {
-  const renderConversationItem = (conversation: ConversationType) => {
-    const conversationLabel =
-      conversation.title ||
-      (moment(conversation.created).isSame(moment(), "day")
-        ? "New Conversation"
-        : `Conversation from ${new Date(conversation.created).toLocaleDateString()}`);
+  const conversationLabel = (conversation: ConversationType) =>
+    conversation.title ||
+    (moment(conversation.created).isSame(moment(), "day")
+      ? "New Conversation"
+      : `Conversation from ${new Date(conversation.created).toLocaleDateString()}`);
 
-    if (isMultiSelect) {
-      return (
-        <div className="flex items-center px-2 py-2" key={conversation.sId}>
-          <Checkbox
-            className="bg-white"
-            checked={selectedConversations.includes(conversation)}
-            onCheckedChange={() => toggleConversationSelection(conversation)}
-          />
-          <span className="ml-2 text-sm text-muted-foreground">
-            {conversationLabel}
-          </span>
-        </div>
-      );
-    }
-
-    return (
-      <NavigationListItem
-        key={conversation.sId}
-        selected={router.query.cId === conversation.sId}
-        label={conversationLabel}
-        onClick={() => setSidebarOpen(false)}
-        href={`/w/${owner.sId}/assistant/${conversation.sId}`}
-        className="px-2"
-      />
-    );
-  };
-
+  if (!conversations.length) {
+    return null;
+  }
   return (
-    conversations.length > 0 && (
-      <>
-        <NavigationListLabel
-          label={dateLabel.toUpperCase()}
-          className="py-1 text-xs font-medium text-element-800"
-        />
-        {isMultiSelect ? (
-          <div className="flex flex-col">
-            {conversations.map(renderConversationItem)}
-          </div>
-        ) : (
-          <NavigationList>
-            {conversations.map(renderConversationItem)}
-          </NavigationList>
-        )}
-      </>
-    )
+    <>
+      <NavigationListLabel
+        label={dateLabel.toUpperCase()}
+        className="py-1 text-xs font-medium text-element-800"
+      />
+      {isMultiSelect ? (
+        <div className="flex flex-col">
+          {conversations.map((conversation) => (
+            <div className="flex items-center px-2 py-2" key={conversation.sId}>
+              <Checkbox
+                className="bg-white"
+                checked={selectedConversations.includes(conversation)}
+                onCheckedChange={() =>
+                  toggleConversationSelection(conversation)
+                }
+              />
+              <span className="ml-2 text-sm text-muted-foreground">
+                {conversationLabel(conversation)}
+              </span>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <NavigationList>
+          {conversations.map((conversation) => (
+            <NavigationListItem
+              key={conversation.sId}
+              selected={router.query.cId === conversation.sId}
+              label={conversationLabel(conversation)}
+              href={`/w/${owner.sId}/assistant/${conversation.sId}`}
+              className="px-2"
+            />
+          ))}
+        </NavigationList>
+      )}
+    </>
   );
 };

--- a/front/components/assistant_builder/actions/ProcessAction.tsx
+++ b/front/components/assistant_builder/actions/ProcessAction.tsx
@@ -206,7 +206,7 @@ function PropertiesFields({
 
                 <div className="col-span-2">
                   <DropdownMenu>
-                    <DropdownMenu.Button tooltipPosition="top">
+                    <DropdownMenu.Button>
                       <Button
                         isSelect
                         label={prop["type"]}
@@ -563,7 +563,7 @@ export function ActionProcess({
           }}
         />
         <DropdownMenu>
-          <DropdownMenu.Button tooltipPosition="top">
+          <DropdownMenu.Button>
             <Button
               isSelect
               label={

--- a/front/components/assistant_builder/actions/RetrievalAction.tsx
+++ b/front/components/assistant_builder/actions/RetrievalAction.tsx
@@ -187,7 +187,7 @@ export function ActionRetrievalExhaustive({
           }}
         />
         <DropdownMenu>
-          <DropdownMenu.Button tooltipPosition="top">
+          <DropdownMenu.Button>
             <Button
               isSelect
               label={

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -1,7 +1,9 @@
 import {
   CollapseButton,
-  Item,
   Logo,
+  NavigationList,
+  NavigationListItem,
+  NavigationListLabel,
   Tabs,
   TabsList,
   TabsTrigger,
@@ -141,29 +143,27 @@ export const NavigationSidebar = React.forwardRef<
         )}
         {subNavigation && (
           <div className="pt-3">
-            {subNavigation.map((nav) => {
-              return (
-                <div key={nav.id} className="grow py-1 pl-4 pr-3">
-                  <Item.List>
-                    {nav.label && (
-                      <Item.SectionHeader
-                        label={nav.label}
-                        variant={nav.variant}
-                        className="!pt-4"
-                      />
-                    )}
-                    {nav.menus.map((menu) => {
-                      return (
+            {subNavigation && (
+              <div className="pt-3">
+                {subNavigation.map((nav) => (
+                  <div key={nav.id} className="grow py-1 pl-4 pr-3">
+                    <NavigationList>
+                      {nav.label && (
+                        <NavigationListLabel
+                          label={nav.label}
+                          variant={nav.variant}
+                          className="!pt-4"
+                        />
+                      )}
+                      {nav.menus.map((menu) => (
                         <React.Fragment key={menu.id}>
-                          <Item.Navigation
+                          <NavigationListItem
                             selected={menu.current}
                             label={menu.label}
                             icon={menu.icon}
-                            link={
-                              menu.href
-                                ? { href: menu.href, target: menu.target }
-                                : undefined
-                            }
+                            href={menu.href}
+                            target={menu.target}
+                            showMoreIcon={false}
                           />
                           {menu.subMenuLabel && (
                             <div className="grow pb-3 pl-14 pr-4 pt-2 text-sm uppercase text-slate-400">
@@ -172,34 +172,26 @@ export const NavigationSidebar = React.forwardRef<
                           )}
                           {menu.subMenu && (
                             <div className="mb-2 flex flex-col">
-                              {menu.subMenu.map((nav) => {
-                                return (
-                                  <div key={nav.id} className="flex grow">
-                                    <Item.Entry
-                                      selected={nav.current}
-                                      label={nav.label}
-                                      icon={nav.icon}
-                                      className="TEST grow pl-14 pr-4"
-                                      link={
-                                        nav.href
-                                          ? {
-                                              href: nav.href,
-                                            }
-                                          : undefined
-                                      }
-                                    />
-                                  </div>
-                                );
-                              })}
+                              {menu.subMenu.map((nav) => (
+                                <NavigationListItem
+                                  showMoreIcon={false}
+                                  key={nav.id}
+                                  selected={nav.current}
+                                  label={nav.label}
+                                  icon={nav.icon}
+                                  className="grow pl-14 pr-4"
+                                  href={nav.href ? nav.href : undefined}
+                                />
+                              ))}
                             </div>
                           )}
                         </React.Fragment>
-                      );
-                    })}
-                  </Item.List>
-                </div>
-              );
-            })}
+                      ))}
+                    </NavigationList>
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -163,7 +163,6 @@ export const NavigationSidebar = React.forwardRef<
                             icon={menu.icon}
                             href={menu.href}
                             target={menu.target}
-                            showMoreIcon={false}
                           />
                           {menu.subMenuLabel && (
                             <div className="grow pb-3 pl-14 pr-4 pt-2 text-sm uppercase text-slate-400">
@@ -174,7 +173,6 @@ export const NavigationSidebar = React.forwardRef<
                             <div className="mb-2 flex flex-col">
                               {menu.subMenu.map((nav) => (
                                 <NavigationListItem
-                                  showMoreIcon={false}
                                   key={nav.id}
                                   selected={nav.current}
                                   label={nav.label}

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.284",
+        "@dust-tt/sparkle": "^0.2.286",
         "@dust-tt/types": "file:../types",
         "@headlessui/react": "^1.7.7",
         "@heroicons/react": "^2.0.11",
@@ -11504,9 +11504,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.284",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.284.tgz",
-      "integrity": "sha512-JHwInsVURpIFlQY8tPHHCgEB8crjT99wP3BMQjZ0jY6oqdBktHEljGLA3cJFg+p5NHkLf+cihU98+X8J3a3Z9g==",
+      "version": "0.2.286",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.286.tgz",
+      "integrity": "sha512-kBRTgavOHwF9zrO/nMZLnjTjDu7ePuxxb1R00c5DzK5lR68wT/lqgE9LL8F45S6g03RiUthwl1XfaFIhnN1AWg==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.284",
+    "@dust-tt/sparkle": "^0.2.286",
     "@dust-tt/types": "file:../types",
     "@headlessui/react": "^1.7.7",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description

This PR aims at using the new `NavigationList` from sparkle in the navigation side bar.

![Screenshot 2024-10-30 at 10 56 26](https://github.com/user-attachments/assets/58625e8a-d0f8-4727-83c8-0a8db81869e6)

![Screenshot 2024-10-30 at 10 57 10](https://github.com/user-attachments/assets/71e991cb-a989-43ab-ab74-eeed75cfa01a)


## Risk

Low

## Deploy Plan

Deploy front