### PR TITLE
fix(poke): use correct endpoint to retrieve features

### DIFF
--- a/front/components/poke/features/table.tsx
+++ b/front/components/poke/features/table.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/router";
 
 import { makeColumnsForFeatureFlags } from "@app/components/poke/features/columns";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
+import { usePokeFeatureFlags } from "@app/lib/swr/poke";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 
 interface FeatureFlagsDataTableProps {
@@ -30,7 +31,7 @@ export function FeatureFlagsDataTable({
   whitelistableFeatures,
 }: FeatureFlagsDataTableProps) {
   const router = useRouter();
-  const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
+  const { featureFlags } = usePokeFeatureFlags({ workspaceId: owner.sId });
   const sendNotification = useSendNotification();
 
   return (

--- a/front/lib/swr/poke.ts
+++ b/front/lib/swr/poke.ts
@@ -9,6 +9,7 @@ import type { Fetcher } from "swr";
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetPokePlansResponseBody } from "@app/pages/api/poke/plans";
 import type { GetPokeWorkspacesResponseBody } from "@app/pages/api/poke/workspaces";
+import type { GetPokeFeaturesResponseBody } from "@app/pages/api/poke/workspaces/[wId]/features";
 import type { GetDataSourcePermissionsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions";
 
 export function usePokeConnectorPermissions({
@@ -94,5 +95,20 @@ export function usePokePlans() {
     plans: useMemo(() => (data ? data.plans : []), [data]),
     isPlansLoading: !error && !data,
     isPlansError: error,
+  };
+}
+
+export function usePokeFeatureFlags({ workspaceId }: { workspaceId: string }) {
+  const featureFlagsFetcher: Fetcher<GetPokeFeaturesResponseBody> = fetcher;
+
+  const { data, error } = useSWRWithDefaults(
+    `/api/poke/workspaces/${workspaceId}/features`,
+    featureFlagsFetcher
+  );
+
+  return {
+    featureFlags: useMemo(() => (data ? data.features : []), [data]),
+    isFeatureFlagsLoading: !error && !data,
+    isFeatureFlagsError: error,
   };
 }


### PR DESCRIPTION
## Description
fixes https://github.com/dust-tt/tasks/issues/1562
https://github.com/dust-tt/dust/pull/8260 broke feature flags fetching on poke (can't use the regular API endpoint to fetch feature flags as a super user)

## Risk

N/A

## Deploy Plan

Deploy front