### PR TITLE
fix: redirect to documents tab after multi-upload

### DIFF
--- a/front/components/data_source/MultipleDocumentsUpload.tsx
+++ b/front/components/data_source/MultipleDocumentsUpload.tsx
@@ -32,13 +32,13 @@ export const MultipleDocumentsUpload = ({
 }: MultipleDocumentsUploadProps) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [isLimitPopupOpen, setIsLimitPopupOpen] = useState(false);
+  const [clicked, setClicked] = useState(false);
   useEffect(() => {
-    if (isOpen) {
+    if (isOpen && !clicked) {
       fileInputRef.current?.click();
-      // Reset state immediately after opening the dialog, we don't need to keep it set
-      onClose(false);
+      setClicked(true);
     }
-  }, [isOpen, onClose]);
+  }, [isOpen, onClose, clicked]);
 
   const [isBulkFilesUploading, setIsBulkFilesUploading] = useState<null | {
     total: number;

--- a/front/components/spaces/ContentActions.tsx
+++ b/front/components/spaces/ContentActions.tsx
@@ -99,10 +99,13 @@ export const ContentActions = React.forwardRef<
     }, [currentAction, setCurrentDocumentId]);
 
     const onClose = (save: boolean) => {
-      // Keep current to have it during closing animation
+      const action = currentAction.action;
+
+      // Clear the action
       setCurrentAction({ contentNode: currentAction.contentNode });
+
       if (save) {
-        onSave(currentAction.action);
+        onSave(action);
       }
     };
 

--- a/front/components/spaces/FoldersHeaderMenu.tsx
+++ b/front/components/spaces/FoldersHeaderMenu.tsx
@@ -129,7 +129,7 @@ const AddDataDropDownButton = ({
           onClick={() => {
             contentActionsRef.current?.callAction("MultipleDocumentsUpload");
           }}
-          label="Upload multiple files"
+          label="Upload multiple documents"
         />
       </DropdownMenu.Items>
     </DropdownMenu>


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/tasks/issues/1530

It looks like multi-uploading doesn't work when you are on the tables view because you aren't automatically redirected to the document page.

That was due to a logic bug in the component

## Risk

N/A

## Deploy Plan

Deploy front