### PR TITLE
Extension: Improve protected route pass props to child component

### DIFF
--- a/front/extension/app/src/components/auth/AuthProvider.tsx
+++ b/front/extension/app/src/components/auth/AuthProvider.tsx
@@ -1,5 +1,6 @@
 import { useAuthHook } from "@app/extension/app/src/components/auth/useAuth";
 import type { StoredUser } from "@app/extension/app/src/lib/storage";
+import type { LightWorkspaceType } from "@dust-tt/types";
 import type { ReactNode } from "react";
 import React, { createContext, useContext } from "react";
 
@@ -7,6 +8,7 @@ type AuthContextType = {
   token: string | null;
   isAuthenticated: boolean;
   user: StoredUser | null;
+  workspace: LightWorkspaceType | undefined;
   isUserSetup: boolean;
   isLoading: boolean;
   handleLogin: () => void;
@@ -21,6 +23,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     token,
     isAuthenticated,
     user,
+    workspace,
     isUserSetup,
     isLoading,
     handleLogin,
@@ -34,6 +37,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         token,
         isAuthenticated,
         user,
+        workspace,
         isUserSetup,
         isLoading,
         handleLogin,

--- a/front/extension/app/src/components/auth/ProtectedRoute.tsx
+++ b/front/extension/app/src/components/auth/ProtectedRoute.tsx
@@ -1,4 +1,5 @@
 import { useAuth } from "@app/extension/app/src/components/auth/AuthProvider";
+import type { StoredUser } from "@app/extension/app/src/lib/storage";
 import {
   Button,
   ExternalLinkIcon,
@@ -6,22 +7,40 @@ import {
   LogoutIcon,
   Spinner,
 } from "@dust-tt/sparkle";
+import type { LightWorkspaceType } from "@dust-tt/types";
 import type { ReactNode } from "react";
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
-export const ProtectedRoute = ({ children }: { children: ReactNode }) => {
-  const { isLoading, isAuthenticated, isUserSetup, handleLogout } = useAuth();
+type ProtectedRouteProps = {
+  children: ReactNode | ((props: ProtectedRouteChildrenProps) => ReactNode);
+};
+
+export type ProtectedRouteChildrenProps = {
+  user: StoredUser;
+  workspace: LightWorkspaceType;
+};
+
+export const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
+  const {
+    isLoading,
+    isAuthenticated,
+    isUserSetup,
+    user,
+    workspace,
+    handleLogout,
+  } = useAuth();
 
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (!isAuthenticated || !isUserSetup) {
+    if (!isAuthenticated || !isUserSetup || !user || !workspace) {
       navigate("/login");
+      return;
     }
-  }, [navigate, isLoading, isAuthenticated, isUserSetup]);
+  }, [navigate, isLoading, isAuthenticated, isUserSetup, user, workspace]);
 
-  if (isLoading) {
+  if (isLoading || !isAuthenticated || !isUserSetup || !user || !workspace) {
     return (
       <div className="flex h-screen flex-col gap-2 p-4">
         <div className="flex h-full w-full items-center justify-center">
@@ -48,7 +67,11 @@ export const ProtectedRoute = ({ children }: { children: ReactNode }) => {
           size="sm"
         />
       </div>
-      <>{children}</>
+      <>
+        {typeof children === "function"
+          ? children({ user, workspace })
+          : children}
+      </>
     </div>
   );
 };

--- a/front/extension/app/src/components/auth/useAuth.ts
+++ b/front/extension/app/src/components/auth/useAuth.ts
@@ -117,6 +117,7 @@ export const useAuthHook = () => {
     token: tokens?.accessToken ?? null,
     isAuthenticated,
     user,
+    workspace: user?.workspaces.find((w) => w.sId === user.selectedWorkspace),
     isUserSetup,
     isLoading,
     handleLogin,

--- a/front/extension/app/src/lib/storage.ts
+++ b/front/extension/app/src/lib/storage.ts
@@ -14,6 +14,7 @@ export type StoredUser = {
   userId: string;
   email: string;
   username: string;
+  firstName: string;
   fullName: string;
   selectedWorkspace: string | null;
   workspaces: LightWorkspaceType[];
@@ -69,6 +70,7 @@ export const saveUser = async (
     userId: user.sId,
     email: user.email,
     username: user.username,
+    firstName: user.firstName,
     fullName: user.fullName,
     selectedWorkspace:
       user.workspaces.length === 1 ? user.workspaces[0].sId : null,

--- a/front/extension/app/src/pages/ConversationPage.tsx
+++ b/front/extension/app/src/pages/ConversationPage.tsx
@@ -1,38 +1,13 @@
-import { useAuth } from "@app/extension/app/src/components/auth/AuthProvider";
+import type { ProtectedRouteChildrenProps } from "@app/extension/app/src/components/auth/ProtectedRoute";
 import { ConversationContainer } from "@app/extension/app/src/components/conversation/ConversationContainer";
-import { BarHeader, ChevronLeftIcon, Page, Spinner } from "@dust-tt/sparkle";
+import { BarHeader, ChevronLeftIcon, Page } from "@dust-tt/sparkle";
 import { Link, useNavigate, useParams } from "react-router-dom";
 
-export const ConversationPage = () => {
+export const ConversationPage = ({
+  workspace,
+}: ProtectedRouteChildrenProps) => {
   const navigate = useNavigate();
-  const { isLoading, isAuthenticated, user } = useAuth();
   const { conversationId } = useParams();
-
-  console.log(conversationId);
-
-  if (isLoading) {
-    return (
-      <div className="h-full w-full">
-        <div className="flex h-full w-full items-center justify-center">
-          <Spinner />
-        </div>
-      </div>
-    );
-  }
-
-  if (!isAuthenticated || !user) {
-    navigate("/login");
-    return;
-  }
-
-  const workspace = user.workspaces.find(
-    (w) => w.sId === user.selectedWorkspace
-  );
-
-  if (!workspace) {
-    navigate("/login");
-    return;
-  }
 
   if (!conversationId) {
     navigate("/");

--- a/front/extension/app/src/pages/ConversationsPage.tsx
+++ b/front/extension/app/src/pages/ConversationsPage.tsx
@@ -1,34 +1,11 @@
-import { useAuth } from "@app/extension/app/src/components/auth/AuthProvider";
-import { BarHeader, ChevronLeftIcon, Page, Spinner } from "@dust-tt/sparkle";
-import { Link, useNavigate } from "react-router-dom";
+import type { ProtectedRouteChildrenProps } from "@app/extension/app/src/components/auth/ProtectedRoute";
+import { BarHeader, ChevronLeftIcon, Page } from "@dust-tt/sparkle";
+import { Link } from "react-router-dom";
 
-export const ConversationsPage = () => {
-  const navigate = useNavigate();
-  const { isLoading, isAuthenticated, user } = useAuth();
-
-  if (isLoading) {
-    return (
-      <div className="h-full w-full">
-        <div className="flex h-full w-full items-center justify-center">
-          <Spinner />
-        </div>
-      </div>
-    );
-  }
-
-  if (!isAuthenticated || !user) {
-    navigate("/login");
-    return;
-  }
-
-  const workspace = user.workspaces.find(
-    (w) => w.sId === user.selectedWorkspace
-  );
-
-  if (!workspace) {
-    navigate("/login");
-    return;
-  }
+export const ConversationsPage = ({
+  workspace,
+}: ProtectedRouteChildrenProps) => {
+  console.log(workspace);
 
   return (
     <>

--- a/front/extension/app/src/pages/MainPage.tsx
+++ b/front/extension/app/src/pages/MainPage.tsx
@@ -1,40 +1,15 @@
-import { useAuth } from "@app/extension/app/src/components/auth/AuthProvider";
+import type { ProtectedRouteChildrenProps } from "@app/extension/app/src/components/auth/ProtectedRoute";
 import { ConversationContainer } from "@app/extension/app/src/components/conversation/ConversationContainer";
-import { Button, HistoryIcon, Page, Spinner } from "@dust-tt/sparkle";
+import { Button, HistoryIcon, Page } from "@dust-tt/sparkle";
 import { useNavigate } from "react-router-dom";
 
-export const MainPage = () => {
+export const MainPage = ({ user, workspace }: ProtectedRouteChildrenProps) => {
   const navigate = useNavigate();
-  const { isLoading, isAuthenticated, user } = useAuth();
-
-  if (isLoading) {
-    return (
-      <div className="h-full w-full">
-        <div className="flex h-full w-full items-center justify-center">
-          <Spinner />
-        </div>
-      </div>
-    );
-  }
-
-  if (!isAuthenticated || !user) {
-    navigate("/login");
-    return;
-  }
-
-  const workspace = user.workspaces.find(
-    (w) => w.sId === user.selectedWorkspace
-  );
-
-  if (!workspace) {
-    navigate("/login");
-    return;
-  }
 
   return (
     <div className="h-full w-full pt-4">
       <div className="flex items-center justify-between pb-2">
-        <Page.SectionHeader title="Conversation" />
+        <Page.SectionHeader title={`Hi ${user.firstName},`} />
         <Button
           icon={HistoryIcon}
           variant="outline"

--- a/front/extension/app/src/pages/routes.tsx
+++ b/front/extension/app/src/pages/routes.tsx
@@ -13,7 +13,9 @@ export const routes = [
     path: "*",
     element: (
       <ProtectedRoute>
-        <MainPage />,
+        {({ user, workspace }) => (
+          <MainPage user={user} workspace={workspace} />
+        )}
       </ProtectedRoute>
     ),
   },
@@ -21,7 +23,9 @@ export const routes = [
     path: "/conversations/:conversationId",
     element: (
       <ProtectedRoute>
-        <ConversationPage />
+        {({ user, workspace }) => (
+          <ConversationPage user={user} workspace={workspace} />
+        )}
       </ProtectedRoute>
     ),
   },
@@ -29,7 +33,9 @@ export const routes = [
     path: "/conversations",
     element: (
       <ProtectedRoute>
-        <ConversationsPage />
+        {({ user, workspace }) => (
+          <ConversationsPage user={user} workspace={workspace} />
+        )}
       </ProtectedRoute>
     ),
   },


### PR DESCRIPTION
## Description

Update `ProtectedRoute` to directly pass the user & workspace to the children component to avoid some un-necessary computation on each protected page. 

I also added the firstName on the user we store to display "Hello Daph". 

## Risk

Only code on the extension. 

## Deploy Plan

No plan. 
