### PR TITLE
[connectors] Launch workflows from ZendeskConnectorManager

### DIFF
--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -105,12 +105,11 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
   }
 
   async stop(): Promise<Result<undefined, Error>> {
-    const result = await stopZendeskSyncWorkflow(this.connectorId);
-    return result.isErr() ? result : new Ok(undefined);
+    return stopZendeskSyncWorkflow(this.connectorId);
   }
 
   async resume(): Promise<Result<undefined, Error>> {
-    const {connectorId} = this;
+    const { connectorId } = this;
     const connector = await ConnectorResource.fetchById(connectorId);
     if (!connector) {
       logger.error({ connectorId }, "[Zendesk] Connector not found.");

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -83,7 +83,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
           workspaceId: dataSourceConfig.workspaceId,
           error: workflowStartResult.error,
         },
-        "[Zendesk] Error creating connector, could not launch sync workflow."
+        "[Zendesk] Error launching the sync workflow."
       );
       throw workflowStartResult.error;
     }

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -118,7 +118,10 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
 
     const dataSourceConfig = dataSourceConfigFromConnector(connector);
     try {
-      await launchZendeskSyncWorkflow({ connector });
+      const result = await launchZendeskSyncWorkflow({ connector });
+      if (result.isErr()) {
+        return result;
+      }
     } catch (e) {
       logger.error(
         {
@@ -128,6 +131,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         },
         "[Zendesk] Error resuming the sync workflow."
       );
+      return new Err(e as Error);
     }
     return new Ok(undefined);
   }

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -336,16 +336,13 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
       toBeSignaledHelpCenterIds.size > 0 ||
       toBeSignaledCategoryIds.size > 0
     ) {
-      const sendSignalToWorkflowResult = await launchZendeskSyncWorkflow({
+      return launchZendeskSyncWorkflow({
         connector,
         brandIds: [...toBeSignaledBrandIds],
         ticketsBrandIds: [...toBeSignaledTicketsIds],
         helpCenterBrandIds: [...toBeSignaledHelpCenterIds],
         categoryIds: [...toBeSignaledCategoryIds],
       });
-      if (sendSignalToWorkflowResult.isErr()) {
-        return new Err(sendSignalToWorkflowResult.error);
-      }
     }
 
     return new Ok(undefined);
@@ -561,9 +558,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     const brandIds = await ZendeskBrandResource.fetchAllBrandIds({
       connectorId,
     });
-    const result = await launchZendeskSyncWorkflow({ connector, brandIds });
-
-    return result.isErr() ? result : new Ok(undefined);
+    return launchZendeskSyncWorkflow({ connector, brandIds });
   }
 
   async garbageCollect(): Promise<Result<string, Error>> {

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -117,21 +117,17 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     }
 
     const dataSourceConfig = dataSourceConfigFromConnector(connector);
-    try {
-      const result = await launchZendeskSyncWorkflow({ connector });
-      if (result.isErr()) {
-        return result;
-      }
-    } catch (e) {
+    const result = await launchZendeskSyncWorkflow({ connector });
+    if (result.isErr()) {
       logger.error(
         {
           workspaceId: dataSourceConfig.workspaceId,
           dataSourceId: dataSourceConfig.dataSourceId,
-          error: e,
+          error: result.error,
         },
         "[Zendesk] Error resuming the sync workflow."
       );
-      return new Err(e as Error);
+      return result;
     }
     return new Ok(undefined);
   }

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -202,9 +202,8 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     }
 
     const connectionId = connector.connectionId;
-    const zendeskConfiguration = await ZendeskConfigurationResource.fetchById(
-      this.connectorId
-    );
+    const zendeskConfiguration =
+      await ZendeskConfigurationResource.fetchByConnectorId(connectorId);
     if (!zendeskConfiguration) {
       logger.error(
         { connectorId },

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -35,8 +35,10 @@ import {
   revokeSyncZendeskTickets,
 } from "@connectors/connectors/zendesk/lib/ticket_permissions";
 import { getZendeskAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
-import { launchZendeskSyncWorkflow } from "@connectors/connectors/zendesk/temporal/client";
-import { zendeskStopSyncWorkflow } from "@connectors/connectors/zendesk/temporal/workflows";
+import {
+  launchZendeskSyncWorkflow,
+  stopZendeskSyncWorkflow,
+} from "@connectors/connectors/zendesk/temporal/client";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -103,7 +105,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
   }
 
   async stop(): Promise<Result<undefined, Error>> {
-    const result = await zendeskStopSyncWorkflow(this.connectorId);
+    const result = await stopZendeskSyncWorkflow(this.connectorId);
     return result.isErr() ? result : new Ok(undefined);
   }
 

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -110,7 +110,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
   }
 
   async resume(): Promise<Result<undefined, Error>> {
-    const connectorId = this.connectorId;
+    const {connectorId} = this;
     const connector = await ConnectorResource.fetchById(connectorId);
     if (!connector) {
       logger.error({ connectorId }, "[Zendesk] Connector not found.");

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -73,7 +73,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     );
 
     const workflowStartResult = await launchZendeskSyncWorkflow({
-      connectorId: connector.id,
+      connector,
     });
 
     if (workflowStartResult.isErr()) {
@@ -119,7 +119,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
 
     const dataSourceConfig = dataSourceConfigFromConnector(connector);
     try {
-      await launchZendeskSyncWorkflow({ connectorId });
+      await launchZendeskSyncWorkflow({ connector });
     } catch (e) {
       logger.error(
         {
@@ -145,7 +145,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
       connectorId,
     });
     const result = await launchZendeskSyncWorkflow({
-      connectorId,
+      connector,
       brandIds,
       forceResync: true,
     });
@@ -338,7 +338,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
       toBeSignaledCategoryIds.size > 0
     ) {
       const sendSignalToWorkflowResult = await launchZendeskSyncWorkflow({
-        connectorId,
+        connector,
         brandIds: [...toBeSignaledBrandIds],
         ticketsBrandIds: [...toBeSignaledTicketsIds],
         helpCenterBrandIds: [...toBeSignaledHelpCenterIds],
@@ -564,7 +564,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     const brandIds = await ZendeskBrandResource.fetchAllBrandIds({
       connectorId,
     });
-    const result = await launchZendeskSyncWorkflow({ connectorId, brandIds });
+    const result = await launchZendeskSyncWorkflow({ connector, brandIds });
 
     return result.isErr() ? result : new Ok(undefined);
   }

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -133,7 +133,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
   }
 
   async sync(): Promise<Result<string, Error>> {
-    const connectorId = this.connectorId;
+    const { connectorId } = this;
     const connector = await ConnectorResource.fetchById(connectorId);
     if (!connector) {
       logger.error({ connectorId }, "[Zendesk] Connector not found.");
@@ -160,7 +160,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     filterPermission: ConnectorPermission | null;
     viewType: ContentNodesViewType;
   }): Promise<Result<ContentNode[], Error>> {
-    const connectorId = this.connectorId;
+    const { connectorId } = this;
     const connector = await ConnectorResource.fetchById(connectorId);
     if (!connector) {
       logger.error({ connectorId }, "[Zendesk] Connector not found.");
@@ -192,7 +192,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
   }: {
     permissions: Record<string, ConnectorPermission>;
   }): Promise<Result<void, Error>> {
-    const connectorId = this.connectorId;
+    const { connectorId } = this;
 
     const connector = await ConnectorResource.fetchById(this.connectorId);
     if (!connector) {
@@ -397,7 +397,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
       }
     });
 
-    const connectorId = this.connectorId;
+    const { connectorId } = this;
 
     const allBrandIds = [
       ...new Set([...brandIds, ...brandTicketsIds, ...brandHelpCenterIds]),
@@ -441,7 +441,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     internalId: string;
     memoizationKey?: string;
   }): Promise<Result<string[], Error>> {
-    const connectorId = this.connectorId;
+    const { connectorId } = this;
 
     const { type, objectId } = getIdFromInternalId(connectorId, internalId);
     switch (type) {
@@ -539,7 +539,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
   }
 
   async pause(): Promise<Result<undefined, Error>> {
-    const connectorId = this.connectorId;
+    const { connectorId } = this;
     const connector = await ConnectorResource.fetchById(connectorId);
     if (!connector) {
       logger.error({ connectorId }, "[Zendesk] Connector not found.");
@@ -552,7 +552,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
   }
 
   async unpause(): Promise<Result<undefined, Error>> {
-    const connectorId = this.connectorId;
+    const { connectorId } = this;
     const connector = await ConnectorResource.fetchById(connectorId);
     if (!connector) {
       logger.error({ connectorId }, "[Zendesk] Connector not found.");

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -72,9 +72,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
       { subdomain: "d3v-dust", conversationsSlidingWindow: 90 }
     );
 
-    const workflowStartResult = await launchZendeskSyncWorkflow({
-      connector,
-    });
+    const workflowStartResult = await launchZendeskSyncWorkflow(connector);
 
     if (workflowStartResult.isErr()) {
       await connector.delete();
@@ -117,7 +115,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     }
 
     const dataSourceConfig = dataSourceConfigFromConnector(connector);
-    const result = await launchZendeskSyncWorkflow({ connector });
+    const result = await launchZendeskSyncWorkflow(connector);
     if (result.isErr()) {
       logger.error(
         {
@@ -143,8 +141,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     const brandIds = await ZendeskBrandResource.fetchAllBrandIds({
       connectorId,
     });
-    const result = await launchZendeskSyncWorkflow({
-      connector,
+    const result = await launchZendeskSyncWorkflow(connector, {
       brandIds,
       forceResync: true,
     });
@@ -336,8 +333,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
       toBeSignaledHelpCenterIds.size > 0 ||
       toBeSignaledCategoryIds.size > 0
     ) {
-      return launchZendeskSyncWorkflow({
-        connector,
+      return launchZendeskSyncWorkflow(connector, {
         brandIds: [...toBeSignaledBrandIds],
         ticketsBrandIds: [...toBeSignaledTicketsIds],
         helpCenterBrandIds: [...toBeSignaledHelpCenterIds],
@@ -558,7 +554,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     const brandIds = await ZendeskBrandResource.fetchAllBrandIds({
       connectorId,
     });
-    return launchZendeskSyncWorkflow({ connector, brandIds });
+    return launchZendeskSyncWorkflow(connector, { brandIds });
   }
 
   async garbageCollect(): Promise<Result<string, Error>> {

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -137,19 +137,16 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
       return new Err(new Error("Connector not found"));
     }
 
-    const brands = await ZendeskBrandResource.fetchByConnectorId({
+    const brandIds = await ZendeskBrandResource.fetchAllBrandIds({
       connectorId,
     });
-
-    const sendSignalToWorkflowResult = await launchZendeskSyncWorkflow({
+    const result = await launchZendeskSyncWorkflow({
       connectorId,
-      brandIds: brands.map((brand) => brand.brandId),
+      brandIds,
       forceResync: true,
     });
-    if (sendSignalToWorkflowResult.isErr()) {
-      return new Err(sendSignalToWorkflowResult.error);
-    }
-    return new Ok(connector.id.toString());
+
+    return result.isErr() ? result : new Ok(connector.id.toString());
   }
 
   async retrievePermissions({

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -546,9 +546,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
       return new Err(new Error("Connector not found"));
     }
     await connector.markAsPaused();
-    const result = await this.stop();
-
-    return result.isErr() ? result : new Ok(undefined);
+    return this.stop();
   }
 
   async unpause(): Promise<Result<undefined, Error>> {

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -35,7 +35,7 @@ async function _getZendeskConnectorOrRaise(connectorId: ModelId) {
 
 async function _getZendeskConfigurationOrRaise(connectorId: ModelId) {
   const configuration =
-    await ZendeskConfigurationResource.fetchById(connectorId);
+    await ZendeskConfigurationResource.fetchByConnectorId(connectorId);
   if (!configuration) {
     throw new Error("[Zendesk] Configuration not found.");
   }

--- a/connectors/src/connectors/zendesk/temporal/client.ts
+++ b/connectors/src/connectors/zendesk/temporal/client.ts
@@ -15,23 +15,24 @@ export function getZendeskSyncWorkflowId(connectorId: ModelId): string {
   return `zendesk-sync-${connectorId}`;
 }
 
-export async function launchZendeskSyncWorkflow({
-  connector,
-  startFromTs = null,
-  brandIds = [],
-  ticketsBrandIds = [],
-  helpCenterBrandIds = [],
-  categoryIds = [],
-  forceResync = false,
-}: {
-  connector: ConnectorResource;
-  startFromTs?: number | null;
-  brandIds?: number[];
-  ticketsBrandIds?: number[];
-  helpCenterBrandIds?: number[];
-  categoryIds?: number[];
-  forceResync?: boolean;
-}): Promise<Result<undefined, Error>> {
+export async function launchZendeskSyncWorkflow(
+  connector: ConnectorResource,
+  {
+    startFromTs = null,
+    brandIds = [],
+    ticketsBrandIds = [],
+    helpCenterBrandIds = [],
+    categoryIds = [],
+    forceResync = false,
+  }: {
+    startFromTs?: number | null;
+    brandIds?: number[];
+    ticketsBrandIds?: number[];
+    helpCenterBrandIds?: number[];
+    categoryIds?: number[];
+    forceResync?: boolean;
+  } = {}
+): Promise<Result<undefined, Error>> {
   if (startFromTs) {
     throw new Error("[Zendesk] startFromTs not implemented yet.");
   }

--- a/connectors/src/connectors/zendesk/temporal/client.ts
+++ b/connectors/src/connectors/zendesk/temporal/client.ts
@@ -31,7 +31,7 @@ export async function launchZendeskSyncWorkflow({
   helpCenterBrandIds?: number[];
   categoryIds?: number[];
   forceResync?: boolean;
-}): Promise<Result<string, Error>> {
+}): Promise<Result<undefined, Error>> {
   if (startFromTs) {
     throw new Error("[Zendesk] startFromTs not implemented yet.");
   }
@@ -85,7 +85,7 @@ export async function launchZendeskSyncWorkflow({
     return new Err(err as Error);
   }
 
-  return new Ok(workflowId);
+  return new Ok(undefined);
 }
 
 export async function stopZendeskSyncWorkflow(

--- a/connectors/src/connectors/zendesk/temporal/client.ts
+++ b/connectors/src/connectors/zendesk/temporal/client.ts
@@ -90,7 +90,7 @@ export async function launchZendeskSyncWorkflow({
 
 export async function stopZendeskSyncWorkflow(
   connectorId: ModelId
-): Promise<Result<void, Error>> {
+): Promise<Result<undefined, Error>> {
   const client = await getTemporalClient();
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -1,7 +1,4 @@
-import type { ModelId, Result } from "@dust-tt/types";
-import { Err, Ok } from "@dust-tt/types";
-import type { WorkflowHandle } from "@temporalio/client";
-import { WorkflowNotFoundError } from "@temporalio/client";
+import type { ModelId } from "@dust-tt/types";
 import { assertNever } from "@temporalio/common/lib/type-helpers";
 import {
   executeChild,
@@ -11,12 +8,8 @@ import {
 } from "@temporalio/workflow";
 
 import type * as activities from "@connectors/connectors/zendesk/temporal/activities";
-import { getZendeskSyncWorkflowId } from "@connectors/connectors/zendesk/temporal/client";
 import type { ZendeskUpdateSignal } from "@connectors/connectors/zendesk/temporal/signals";
 import { zendeskUpdatesSignal } from "@connectors/connectors/zendesk/temporal/signals";
-import { getTemporalClient } from "@connectors/lib/temporal";
-import logger from "@connectors/logger/logger";
-import { ConnectorResource } from "@connectors/resources/connector_resource";
 
 const {
   getZendeskCategoriesActivity,
@@ -383,37 +376,4 @@ async function runZendeskBrandTicketsSyncActivities({
     currentSyncDateMs,
     forceResync,
   });
-}
-
-export async function zendeskStopSyncWorkflow(
-  connectorId: ModelId
-): Promise<Result<void, Error>> {
-  const client = await getTemporalClient();
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    throw new Error(
-      `[Zendesk] Connector not found, connectorId: ${connectorId}`
-    );
-  }
-
-  const workflowId = getZendeskSyncWorkflowId(connectorId);
-
-  try {
-    const handle: WorkflowHandle<typeof zendeskSyncWorkflow> =
-      client.workflow.getHandle(workflowId);
-    try {
-      await handle.terminate();
-    } catch (e) {
-      if (!(e instanceof WorkflowNotFoundError)) {
-        throw e;
-      }
-    }
-    return new Ok(undefined);
-  } catch (error) {
-    logger.error(
-      { workflowId, error },
-      "[Zendesk] Failed to stop the sync workflow."
-    );
-    return new Err(error as Error);
-  }
 }

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -215,6 +215,15 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
     return brands.map((brand) => new this(this.model, brand.get()));
   }
 
+  static async fetchByConnectorId({
+    connectorId,
+  }: {
+    connectorId: number;
+  }): Promise<ZendeskBrandResource[]> {
+    const brands = await ZendeskBrand.findAll({ where: { connectorId } });
+    return brands.map((brand) => new this(this.model, brand.get()));
+  }
+
   static async fetchAllWithHelpCenter({
     connectorId,
   }: {

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -215,13 +215,16 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
     return brands.map((brand) => new this(this.model, brand.get()));
   }
 
-  static async fetchByConnectorId({
+  static async fetchAllBrandIds({
     connectorId,
   }: {
     connectorId: number;
-  }): Promise<ZendeskBrandResource[]> {
-    const brands = await ZendeskBrand.findAll({ where: { connectorId } });
-    return brands.map((brand) => new this(this.model, brand.get()));
+  }): Promise<number[]> {
+    const brands = await ZendeskBrand.findAll({
+      where: { connectorId },
+      attributes: ["brandId"],
+    });
+    return brands.map((brand) => brand.brandId);
   }
 
   static async fetchAllWithHelpCenter({


### PR DESCRIPTION
## Description

- Close [#1523](https://github.com/dust-tt/tasks/issues/1523)
- Close #8389 
- Trigger workflows when creating a connector, setting permissions, resuming.
- Add a pause workflow.
- Implement the pause/unpause and sync.
- Fix the fetching of `ZendeskConfigurations` (`fetchById` mistook for `fetchByConnectorId`).

## Risk

## Deploy Plan

- Deploy connectors.