### PR TITLE
Remove admin write permissions on system vault

### DIFF
--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -6,6 +6,7 @@ import type {
   Result,
 } from "@dust-tt/types";
 import { formatUserFullName, Ok, removeNulls } from "@dust-tt/types";
+import { Auth } from "googleapis";
 import type {
   Attributes,
   CreationAttributes,
@@ -495,6 +496,10 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
 
   canWrite(auth: Authenticator) {
     return this.space.canWrite(auth);
+  }
+
+  canAdministrate(auth: Authenticator) {
+    return this.space.canAdministrate(auth);
   }
 
   // sId logic.

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -6,7 +6,6 @@ import type {
   Result,
 } from "@dust-tt/types";
 import { formatUserFullName, Ok, removeNulls } from "@dust-tt/types";
-import { Auth } from "googleapis";
 import type {
   Attributes,
   CreationAttributes,

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions/index.ts
@@ -56,17 +56,6 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isAdmin()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "data_source_auth_error",
-        message:
-          "Only the users that are `admins` for the current workspace can see or edit the permissions of a data source.",
-      },
-    });
-  }
-
   const { dsId } = req.query;
   if (typeof dsId !== "string") {
     return apiError(req, res, {
@@ -95,6 +84,17 @@ async function handler(
       api_error: {
         type: "data_source_not_managed",
         message: "The data source you requested is not managed.",
+      },
+    });
+  }
+
+  if (!dataSource.canAdministrate(auth)) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "data_source_auth_error",
+        message:
+          "Only the users that are `admins` for the current workspace can administrate a data source.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/[dsvId]/index.ts
@@ -19,7 +19,7 @@ export async function handlePatchDataSourceView(
   auth: Authenticator,
   dataSourceView: DataSourceViewResource
 ) {
-  if (!auth.isAdmin() && !auth.isBuilder()) {
+  if (!dataSourceView.canWrite(auth)) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {
@@ -114,8 +114,8 @@ async function handler(
     }
 
     case "DELETE": {
-      if (!auth.isAdmin() || !auth.isBuilder()) {
-        // Only admins, or builders who have to the vault, can patch
+      if (!dataSourceView.canWrite(auth)) {
+        // Only admins, or builders who have to the space, can patch.
         return apiError(req, res, {
           status_code: 403,
           api_error: {

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_source_views/index.ts
@@ -152,7 +152,7 @@ async function handler(
     }
 
     case "POST": {
-      if (!auth.isAdmin() || !auth.isBuilder()) {
+      if (!vault.canWrite(auth)) {
         // Only admins, or builders who have to the vault, can create a new view
         return apiError(req, res, {
           status_code: 403,

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/[dsId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/[dsId]/index.ts
@@ -49,7 +49,7 @@ async function handler(
     });
   }
 
-  if (vault.isSystem() && !auth.isAdmin()) {
+  if (vault.isSystem() && !vault.canAdministrate(auth)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -58,7 +58,7 @@ async function handler(
           "Only the users that are `admins` for the current workspace can update a data source.",
       },
     });
-  } else if (vault.isGlobal() && !auth.isBuilder()) {
+  } else if (vault.isGlobal() && !vault.canWrite(auth)) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {
@@ -82,17 +82,6 @@ async function handler(
 
   switch (req.method) {
     case "PATCH": {
-      if (!vault.canWrite(auth)) {
-        return apiError(req, res, {
-          status_code: 403,
-          api_error: {
-            type: "data_source_auth_error",
-            message:
-              "Only the users that have `write` permission for the current vault can update a data source.",
-          },
-        });
-      }
-
       if (dataSource.connectorId) {
         // Not implemented yet, next PR will allow patching a website.
         return apiError(req, res, {
@@ -127,6 +116,7 @@ async function handler(
     case "DELETE": {
       const isAuthorized =
         vault.canWrite(auth) ||
+        // Only allow to delete Snowflake connectors if the user is an admin.
         (vault.isSystem() &&
           auth.isAdmin() &&
           dataSource.connectorProvider === "snowflake");

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/[dsId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/[dsId]/index.ts
@@ -118,7 +118,7 @@ async function handler(
         vault.canWrite(auth) ||
         // Only allow to delete Snowflake connectors if the user is an admin.
         (vault.isSystem() &&
-          auth.isAdmin() &&
+          vault.canAdministrate(auth) &&
           dataSource.connectorProvider === "snowflake");
 
       if (!isAuthorized) {

--- a/front/pages/api/w/[wId]/vaults/[vId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/data_sources/index.ts
@@ -91,7 +91,8 @@ async function handler(
   const owner = auth.getNonNullableWorkspace();
   const plan = auth.getNonNullablePlan();
 
-  if (typeof req.query.vId !== "string") {
+  const { vId } = req.query;
+  if (typeof vId !== "string") {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -100,8 +101,8 @@ async function handler(
       },
     });
   }
-  const space = await SpaceResource.fetchById(auth, req.query.vId);
 
+  const space = await SpaceResource.fetchById(auth, vId);
   if (!space) {
     return apiError(req, res, {
       status_code: 404,
@@ -113,7 +114,7 @@ async function handler(
   }
 
   if (space.isSystem()) {
-    if (!auth.isAdmin()) {
+    if (!space.canAdministrate(auth)) {
       return apiError(req, res, {
         status_code: 403,
         api_error: {

--- a/front/pages/api/w/[wId]/vaults/[vId]/index.ts
+++ b/front/pages/api/w/[wId]/vaults/[vId]/index.ts
@@ -132,7 +132,7 @@ async function handler(
     }
 
     case "PATCH": {
-      if (!auth.isAdmin()) {
+      if (!vault.canAdministrate(auth)) {
         // Only admins can update.
         return apiError(req, res, {
           status_code: 403,
@@ -211,7 +211,7 @@ async function handler(
     }
 
     case "DELETE": {
-      if (!auth.isAdmin()) {
+      if (!vault.canAdministrate(auth)) {
         // Only admins, who have access to the vault, can delete.
         return apiError(req, res, {
           status_code: 403,

--- a/front/pages/api/w/[wId]/vaults/index.ts
+++ b/front/pages/api/w/[wId]/vaults/index.ts
@@ -76,13 +76,12 @@ async function handler(
       });
 
     case "POST":
-      if (!auth.isAdmin() || !auth.isBuilder()) {
+      if (!auth.isAdmin()) {
         return apiError(req, res, {
           status_code: 403,
           api_error: {
             type: "workspace_auth_error",
-            message:
-              "Only users that are `admins` or `builder` can administrate spaces.",
+            message: "Only users that are `admins` can administrate spaces.",
           },
         });
       }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes https://github.com/dust-tt/dust/issues/8269.

This PR removes the "write" permission for admin on the system vault and refactors some permission logic to consolidate around `canAdministrate`. This need is now covered by the "admin" permission.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
