### PR TITLE
Extension: Display history of conversation + add public api url to list convos

### DIFF
--- a/front/extension/app/src/components/conversation/useConversations.ts
+++ b/front/extension/app/src/components/conversation/useConversations.ts
@@ -1,0 +1,22 @@
+import { fetcher, useSWRWithDefaults } from "@app/extension/app/src/lib/swr";
+import type { ConversationWithoutContentType } from "@dust-tt/types";
+import { useMemo } from "react";
+import type { Fetcher } from "swr";
+
+export function useConversations({ workspaceId }: { workspaceId: string }) {
+  const conversationFetcher: Fetcher<{
+    conversations: ConversationWithoutContentType[];
+  }> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/v1/w/${workspaceId}/assistant/conversations`,
+    conversationFetcher
+  );
+
+  return {
+    conversations: useMemo(() => (data ? data.conversations : []), [data]),
+    isConversationsLoading: !error && !data,
+    isConversationsError: error,
+    mutateConversations: mutate,
+  };
+}

--- a/front/extension/app/src/pages/ConversationPage.tsx
+++ b/front/extension/app/src/pages/ConversationPage.tsx
@@ -17,7 +17,7 @@ export const ConversationPage = ({
   return (
     <>
       <BarHeader
-        title="Back"
+        title="Home"
         leftActions={
           <Link to="/">
             <ChevronLeftIcon />

--- a/front/extension/app/src/pages/ConversationsPage.tsx
+++ b/front/extension/app/src/pages/ConversationsPage.tsx
@@ -1,11 +1,72 @@
 import type { ProtectedRouteChildrenProps } from "@app/extension/app/src/components/auth/ProtectedRoute";
-import { BarHeader, ChevronLeftIcon, Page } from "@dust-tt/sparkle";
-import { Link } from "react-router-dom";
+import { useConversations } from "@app/extension/app/src/components/conversation/useConversations";
+import {
+  BarHeader,
+  ChevronLeftIcon,
+  NavigationList,
+  NavigationListItem,
+  NavigationListLabel,
+  Page,
+} from "@dust-tt/sparkle";
+import type { ConversationWithoutContentType } from "@dust-tt/types";
+import moment from "moment";
+import { Link, useNavigate } from "react-router-dom";
+
+type GroupLabel =
+  | "Today"
+  | "Yesterday"
+  | "Last Week"
+  | "Last Month"
+  | "Last 12 Months"
+  | "Older";
 
 export const ConversationsPage = ({
   workspace,
 }: ProtectedRouteChildrenProps) => {
-  console.log(workspace);
+  const navigate = useNavigate();
+  const conversations = useConversations({ workspaceId: workspace.sId });
+
+  const groupConversationsByDate = (
+    conversations: ConversationWithoutContentType[]
+  ) => {
+    const today = moment().startOf("day");
+    const yesterday = moment().subtract(1, "days").startOf("day");
+    const lastWeek = moment().subtract(1, "weeks").startOf("day");
+    const lastMonth = moment().subtract(1, "months").startOf("day");
+    const lastYear = moment().subtract(1, "years").startOf("day");
+
+    const groups: Record<GroupLabel, ConversationWithoutContentType[]> = {
+      Today: [],
+      Yesterday: [],
+      "Last Week": [],
+      "Last Month": [],
+      "Last 12 Months": [],
+      Older: [],
+    };
+
+    conversations.forEach((conversation: ConversationWithoutContentType) => {
+      const createdDate = moment(conversation.created);
+      if (createdDate.isSameOrAfter(today)) {
+        groups["Today"].push(conversation);
+      } else if (createdDate.isSameOrAfter(yesterday)) {
+        groups["Yesterday"].push(conversation);
+      } else if (createdDate.isSameOrAfter(lastWeek)) {
+        groups["Last Week"].push(conversation);
+      } else if (createdDate.isSameOrAfter(lastMonth)) {
+        groups["Last Month"].push(conversation);
+      } else if (createdDate.isSameOrAfter(lastYear)) {
+        groups["Last 12 Months"].push(conversation);
+      } else {
+        groups["Older"].push(conversation);
+      }
+    });
+
+    return groups;
+  };
+
+  const conversationsByDate = conversations.conversations.length
+    ? groupConversationsByDate(conversations.conversations)
+    : ({} as Record<GroupLabel, ConversationWithoutContentType[]>);
 
   return (
     <>
@@ -19,8 +80,56 @@ export const ConversationsPage = ({
       />
       <div className="h-full w-full pt-4">
         <Page.SectionHeader title="Conversations" />
-        Soupinou
+
+        {conversationsByDate &&
+          Object.keys(conversationsByDate).map((dateLabel) => (
+            <RenderConversations
+              key={dateLabel}
+              conversations={conversationsByDate[dateLabel as GroupLabel]}
+              dateLabel={dateLabel}
+              navigate={navigate}
+            />
+          ))}
       </div>
     </>
+  );
+};
+
+const RenderConversations = ({
+  conversations,
+  dateLabel,
+  navigate,
+}: {
+  conversations: ConversationWithoutContentType[];
+  dateLabel: string;
+  navigate: (path: string) => void;
+}) => {
+  if (!conversations.length) {
+    return null;
+  }
+
+  const getLabel = (conversation: ConversationWithoutContentType): string => {
+    const conversationLabel =
+      conversation.title ||
+      (moment(conversation.created).isSame(moment(), "day")
+        ? "New Conversation"
+        : `Conversation from ${new Date(conversation.created).toLocaleDateString()}`);
+
+    return conversationLabel;
+  };
+
+  return (
+    <div>
+      <NavigationListLabel label={dateLabel} />
+      <NavigationList>
+        {conversations.map((conversation) => (
+          <NavigationListItem
+            key={conversation.sId}
+            label={getLabel(conversation)}
+            onClick={() => navigate(`/conversations/${conversation.sId}`)}
+          />
+        ))}
+      </NavigationList>
+    </div>
   );
 };


### PR DESCRIPTION
## Description

- Add a public API route to list convo. It returns a list of `ConversationWithoutContentType`. 
- Extension: create a hook to fetch convos. 
- Extension: display the convos using this hook. 

I need to figure out how to update our api doc, I ran `npm run docs` but did not change anything, will dig. Can be reviewed already. 

<kbd>
<img width="530" alt="Screenshot 2024-10-30 at 17 19 59" src="https://github.com/user-attachments/assets/d1bc5590-d30b-4558-a883-b496f91ad128">
</kbd>

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front to get the new API route. 
