### PR TITLE
[front] - refactor: migrate old DropdownMenu

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -9,8 +9,16 @@ import {
   Icon,
   IconButton,
   Input,
+  Label,
   Modal,
   MoreIcon,
+  NewDropdownMenu,
+  NewDropdownMenuContent,
+  NewDropdownMenuGroup,
+  NewDropdownMenuItem,
+  NewDropdownMenuLabel,
+  NewDropdownMenuSeparator,
+  NewDropdownMenuTrigger,
   Page,
   PlusIcon,
   Popover,
@@ -1007,50 +1015,69 @@ interface AddActionProps {
 
 function AddAction({ onAddAction }: AddActionProps) {
   return (
-    <DropdownMenu>
-      <DropdownMenu.Button>
+    <NewDropdownMenu>
+      <NewDropdownMenuTrigger asChild>
         <Button variant="primary" label="Add a tool" icon={PlusIcon} />
-      </DropdownMenu.Button>
-      <DropdownMenu.Items origin="topLeft" width={320} overflow="visible">
-        <DropdownMenu.SectionHeader label="DATA SOURCES" />
-        {DATA_SOURCES_ACTION_CATEGORIES.map((key) => {
-          const spec = ACTION_SPECIFICATIONS[key];
-          const defaultAction = getDefaultActionConfiguration(key);
-          if (!defaultAction) {
-            // Unreachable
-            return null;
-          }
-          return (
-            <DropdownMenu.Item
-              key={key}
-              label={spec.label}
-              icon={spec.dropDownIcon}
-              description={spec.description}
-              onClick={() => onAddAction(defaultAction)}
-            />
-          );
-        })}
+      </NewDropdownMenuTrigger>
 
-        <DropdownMenu.SectionHeader label="ADVANCED ACTIONS" />
-        {ADVANCED_ACTION_CATEGORIES.map((key) => {
-          const spec = ACTION_SPECIFICATIONS[key];
-          const defaultAction = getDefaultActionConfiguration(key);
-          if (!defaultAction) {
-            // Unreachable
-            return null;
-          }
-          return (
-            <DropdownMenu.Item
-              key={key}
-              label={spec.label}
-              icon={spec.dropDownIcon}
-              description={spec.description}
-              onClick={() => onAddAction(defaultAction)}
-            />
-          );
-        })}
-      </DropdownMenu.Items>
-    </DropdownMenu>
+      <NewDropdownMenuContent className="w-[320px]">
+        <NewDropdownMenuGroup>
+          <NewDropdownMenuLabel>Data Sources</NewDropdownMenuLabel>
+          {DATA_SOURCES_ACTION_CATEGORIES.map((key) => {
+            const spec = ACTION_SPECIFICATIONS[key];
+            const defaultAction = getDefaultActionConfiguration(key);
+            if (!defaultAction) {
+              return null;
+            }
+
+            return (
+              <NewDropdownMenuItem
+                key={key}
+                onClick={() => onAddAction(defaultAction)}
+              >
+                <div className="flex flex-col gap-1">
+                  <div className="flex items-center gap-2">
+                    <Icon visual={spec.dropDownIcon} />
+                    <Label>{spec.label}</Label>
+                  </div>
+                  <span className="text-sm text-element-700">
+                    {spec.description}
+                  </span>
+                </div>
+              </NewDropdownMenuItem>
+            );
+          })}
+        </NewDropdownMenuGroup>
+        <NewDropdownMenuSeparator />
+        <NewDropdownMenuGroup>
+          <NewDropdownMenuLabel>Advanced Actions</NewDropdownMenuLabel>
+          {ADVANCED_ACTION_CATEGORIES.map((key) => {
+            const spec = ACTION_SPECIFICATIONS[key];
+            const defaultAction = getDefaultActionConfiguration(key);
+            if (!defaultAction) {
+              return null;
+            }
+
+            return (
+              <NewDropdownMenuItem
+                key={key}
+                onClick={() => onAddAction(defaultAction)}
+              >
+                <div className="flex flex-col gap-1">
+                  <div className="flex items-center gap-2">
+                    <Icon visual={spec.dropDownIcon} />
+                    <Label>{spec.label}</Label>
+                  </div>
+                  <span className="text-sm text-element-700">
+                    {spec.description}
+                  </span>
+                </div>
+              </NewDropdownMenuItem>
+            );
+          })}
+        </NewDropdownMenuGroup>
+      </NewDropdownMenuContent>
+    </NewDropdownMenu>
   );
 }
 

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -1020,9 +1020,9 @@ function AddAction({ onAddAction }: AddActionProps) {
         <Button variant="primary" label="Add a tool" icon={PlusIcon} />
       </NewDropdownMenuTrigger>
 
-      <NewDropdownMenuContent className="w-[320px]">
+      <NewDropdownMenuContent>
         <NewDropdownMenuGroup>
-          <NewDropdownMenuLabel>Data Sources</NewDropdownMenuLabel>
+          <NewDropdownMenuLabel label="Data Sources" />
           {DATA_SOURCES_ACTION_CATEGORIES.map((key) => {
             const spec = ACTION_SPECIFICATIONS[key];
             const defaultAction = getDefaultActionConfiguration(key);
@@ -1034,23 +1034,16 @@ function AddAction({ onAddAction }: AddActionProps) {
               <NewDropdownMenuItem
                 key={key}
                 onClick={() => onAddAction(defaultAction)}
-              >
-                <div className="flex flex-col gap-1">
-                  <div className="flex items-center gap-2">
-                    <Icon visual={spec.dropDownIcon} />
-                    <Label>{spec.label}</Label>
-                  </div>
-                  <span className="text-sm text-element-700">
-                    {spec.description}
-                  </span>
-                </div>
-              </NewDropdownMenuItem>
+                icon={spec.dropDownIcon}
+                label={spec.label}
+                description={spec.description}
+              />
             );
           })}
         </NewDropdownMenuGroup>
         <NewDropdownMenuSeparator />
         <NewDropdownMenuGroup>
-          <NewDropdownMenuLabel>Advanced Actions</NewDropdownMenuLabel>
+          <NewDropdownMenuLabel label="Advanced Actions" />
           {ADVANCED_ACTION_CATEGORIES.map((key) => {
             const spec = ACTION_SPECIFICATIONS[key];
             const defaultAction = getDefaultActionConfiguration(key);
@@ -1062,17 +1055,10 @@ function AddAction({ onAddAction }: AddActionProps) {
               <NewDropdownMenuItem
                 key={key}
                 onClick={() => onAddAction(defaultAction)}
-              >
-                <div className="flex flex-col gap-1">
-                  <div className="flex items-center gap-2">
-                    <Icon visual={spec.dropDownIcon} />
-                    <Label>{spec.label}</Label>
-                  </div>
-                  <span className="text-sm text-element-700">
-                    {spec.description}
-                  </span>
-                </div>
-              </NewDropdownMenuItem>
+                icon={spec.dropDownIcon}
+                label={spec.label}
+                description={spec.description}
+              />
             );
           })}
         </NewDropdownMenuGroup>

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -9,7 +9,6 @@ import {
   Icon,
   IconButton,
   Input,
-  Label,
   Modal,
   MoreIcon,
   NewDropdownMenu,

--- a/front/components/data_source/DataSourcePicker.tsx
+++ b/front/components/data_source/DataSourcePicker.tsx
@@ -1,4 +1,12 @@
-import { DropdownMenu, Input } from "@dust-tt/sparkle";
+import {
+  Button,
+  PopoverContent,
+  PopoverRoot,
+  PopoverTrigger,
+  ScrollArea,
+  Searchbar,
+  Separator,
+} from "@dust-tt/sparkle";
 import type {
   DataSourceViewType,
   SpaceType,
@@ -109,58 +117,50 @@ export default function DataSourcePicker({
             "No DataSource"
           )
         ) : (
-          <DropdownMenu>
-            <div>
-              <DropdownMenu.Button
-                className={classNames(
-                  "inline-flex items-center rounded-md py-1 text-sm font-normal text-gray-700",
-                  selectedDataSourceView ? "px-0" : "border px-3",
-                  readOnly
-                    ? "border-white text-gray-300"
-                    : "border-orange-400 text-gray-700",
-                  "focus:outline-none focus:ring-0"
-                )}
-              >
-                {selectedDataSourceView ? (
-                  <>
-                    <Link href={getEditLink(selectedDataSourceView)}>
-                      <div className="mr-1 max-w-xs truncate text-sm font-bold text-action-500">
-                        {selectedDataSourceView.dataSource.name}
-                      </div>
-                    </Link>
-                    <ChevronDownIcon className="mt-0.5 h-4 w-4 hover:text-gray-700" />
-                  </>
-                ) : spaceDataSourceViews && spaceDataSourceViews.length > 0 ? (
-                  "Select DataSource"
-                ) : (
-                  <Link
-                    href={`/w/${owner.sId}/data-sources/vaults`}
-                    className={classNames(
-                      readOnly
-                        ? "border-white text-gray-300"
-                        : "border-orange-400 text-gray-700"
-                    )}
-                  >
-                    Create DataSource
+          <PopoverRoot>
+            <PopoverTrigger>
+              {selectedDataSourceView ? (
+                <div
+                  className={classNames(
+                    "inline-flex items-center rounded-md py-1 text-sm font-normal",
+                    readOnly ? "text-gray-300" : "text-gray-700",
+                    "focus:outline-none focus:ring-0"
+                  )}
+                >
+                  <Link href={getEditLink(selectedDataSourceView)}>
+                    <div className="mr-1 max-w-xs truncate text-sm font-bold text-action-500">
+                      {selectedDataSourceView.dataSource.name}
+                    </div>
                   </Link>
-                )}
-              </DropdownMenu.Button>
-            </div>
+                  <ChevronDownIcon className="mt-0.5 h-4 w-4 hover:text-gray-700" />
+                </div>
+              ) : spaceDataSourceViews && spaceDataSourceViews.length > 0 ? (
+                <Button variant="outline" label="Select DataSource" isSelect />
+              ) : (
+                <Link
+                  href={`/w/${owner.sId}/data-sources/vaults`}
+                  className={classNames(
+                    readOnly ? "text-gray-300" : "text-gray-700"
+                  )}
+                >
+                  Create DataSource
+                </Link>
+              )}
+            </PopoverTrigger>
 
-            {(spaceDataSourceViews || []).length > 0 ? (
-              <DropdownMenu.Items width={300}>
-                <Input
+            {(spaceDataSourceViews || []).length > 0 && (
+              <PopoverContent className="mr-2 p-4">
+                <Searchbar
                   name="search"
                   placeholder="Search"
                   value={searchFilter}
-                  onChange={(e) => setSearchFilter(e.target.value)}
-                  className="mt-4 w-full"
+                  onChange={(e) => setSearchFilter(e)}
                 />
-                {(filteredDataSourceViews || []).map((dsv) => {
-                  return (
-                    <DropdownMenu.Item
+                <ScrollArea className="mt-2 h-[300px]">
+                  {(filteredDataSourceViews || []).map((dsv) => (
+                    <div
                       key={dsv.sId}
-                      label={dsv.dataSource.name}
+                      className="flex cursor-pointer flex-col items-start hover:opacity-80"
                       onClick={() => {
                         onDataSourcesUpdate([
                           {
@@ -170,18 +170,22 @@ export default function DataSourcePicker({
                         ]);
                         setSearchFilter("");
                       }}
-                    />
-                  );
-                })}
-                {filteredDataSourceViews.length === 0 && (
-                  <span className="block px-4 py-2 text-sm text-gray-700">
-                    No datasources found
-                  </span>
-                )}
-                {/* </div> */}
-              </DropdownMenu.Items>
-            ) : null}
-          </DropdownMenu>
+                    >
+                      <div className="my-1">
+                        <div className="text-sm">{dsv.dataSource.name}</div>
+                      </div>
+                      <Separator />
+                    </div>
+                  ))}
+                  {filteredDataSourceViews.length === 0 && (
+                    <span className="block px-4 py-2 text-sm text-gray-700">
+                      No datasources found
+                    </span>
+                  )}
+                </ScrollArea>
+              </PopoverContent>
+            )}
+          </PopoverRoot>
         )}
       </div>
     </div>

--- a/front/components/tables/TablePicker.tsx
+++ b/front/components/tables/TablePicker.tsx
@@ -1,4 +1,11 @@
-import { DropdownMenu, Input } from "@dust-tt/sparkle";
+import {
+  PopoverContent,
+  PopoverRoot,
+  PopoverTrigger,
+  ScrollArea,
+  Searchbar,
+  Separator,
+} from "@dust-tt/sparkle";
 import type {
   DataSourceViewContentNode,
   LightWorkspaceType,
@@ -81,15 +88,13 @@ export default function TablePicker({
             "No Table"
           )
         ) : (
-          <DropdownMenu>
-            <div>
-              <DropdownMenu.Button
+          <PopoverRoot>
+            <PopoverTrigger asChild>
+              <div
                 className={classNames(
-                  "inline-flex items-center rounded-md py-1 text-sm font-normal text-gray-700",
+                  "inline-flex items-center rounded-md py-1 text-sm font-normal",
                   currentTable ? "px-0" : "border px-3",
-                  readOnly
-                    ? "border-white text-gray-300"
-                    : "border-orange-400 text-gray-700",
+                  readOnly ? "text-gray-300" : "text-gray-700",
                   "focus:outline-none focus:ring-0"
                 )}
               >
@@ -101,42 +106,46 @@ export default function TablePicker({
                     <ChevronDownIcon className="mt-0.5 h-4 w-4 hover:text-gray-700" />
                   </>
                 ) : tables && tables.length > 0 ? (
-                  "Select Table"
+                  <span>Select Table</span>
                 ) : (
-                  "No Tables"
+                  <span>No Tables</span>
                 )}
-              </DropdownMenu.Button>
-            </div>
+              </div>
+            </PopoverTrigger>
 
-            {(tables || []).length > 0 ? (
-              <DropdownMenu.Items width={300}>
-                <Input
+            {(tables || []).length > 0 && (
+              <PopoverContent className="mr-2 p-4">
+                <Searchbar
                   name="search"
                   placeholder="Search"
                   value={searchFilter}
-                  onChange={(e) => setSearchFilter(e.target.value)}
-                  className="mt-4 w-full"
+                  onChange={(e) => setSearchFilter(e)}
                 />
-                {(filteredTables || []).map((t) => {
-                  return (
-                    <DropdownMenu.Item
+                <ScrollArea className="mt-2 h-[300px]">
+                  {(filteredTables || []).map((t) => (
+                    <div
                       key={t.dustDocumentId}
-                      label={t.title}
+                      className="flex cursor-pointer flex-col items-start hover:opacity-80"
                       onClick={() => {
                         onTableUpdate(t);
                         setSearchFilter("");
                       }}
-                    />
-                  );
-                })}
-                {filteredTables.length === 0 && (
-                  <span className="block px-4 py-2 text-sm text-gray-700">
-                    No tables found
-                  </span>
-                )}
-              </DropdownMenu.Items>
-            ) : null}
-          </DropdownMenu>
+                    >
+                      <div className="my-1">
+                        <div className="text-sm">{t.title}</div>
+                      </div>
+                      <Separator />
+                    </div>
+                  ))}
+                  {filteredTables.length === 0 && (
+                    <span className="block px-4 py-2 text-sm text-gray-700">
+                      No tables found
+                    </span>
+                  )}
+                </ScrollArea>
+              </PopoverContent>
+            )}
+          </PopoverRoot>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Description

This PR aims at migrate the last few components using the old `DropdownMenu` to either `Popover` or `NewDropdownMenu`.

The combined work of this PR and https://github.com/dust-tt/dust/pull/8185 result in having moved all old components.

## Risk

Low, only UI breaking changes

## Deploy Plan

Deploy `front`