### PR TITLE
enh: clearer error when connector fails to retrieve token

### DIFF
--- a/connectors/src/lib/oauth.ts
+++ b/connectors/src/lib/oauth.ts
@@ -41,7 +41,9 @@ export async function getOAuthConnectionAccessTokenWithThrow({
     ) {
       throw new ExternalOAuthTokenError(new Error(tokRes.error.message));
     } else {
-      throw new Error(`Error retrieving access token from ${provider}`);
+      throw new Error(
+        `Error retrieving access token from ${provider}: code=${tokRes.error.code} message=${tokRes.error.message}`
+      );
     }
   }
 


### PR DESCRIPTION
## Description

Hard to tell why the connector is failing to retrieve the token as we're swallowing the real error

## Risk

N/A

## Deploy Plan

deploy connectors