### PR TITLE
[sparkle] - feature: add disabled state support to TabsTrigger component

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.287",
+  "version": "0.2.288",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.287",
+      "version": "0.2.288",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.287",
+  "version": "0.2.288",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Tabs.tsx
+++ b/sparkle/src/components/Tabs.tsx
@@ -30,7 +30,18 @@ const TabsTrigger = React.forwardRef<
   } & Omit<LinkWrapperProps, "children" | "className">
 >(
   (
-    { className, label, icon, href, target, rel, replace, shallow, ...props },
+    {
+      className,
+      label,
+      icon,
+      href,
+      target,
+      rel,
+      replace,
+      shallow,
+      disabled,
+      ...props
+    },
     ref
   ) => {
     const content = (
@@ -40,11 +51,18 @@ const TabsTrigger = React.forwardRef<
           "s-border-0 s-border-b-2 s-border-primary-800/0 s-pb-1 disabled:s-pointer-events-none data-[state=active]:s-border-primary-800",
           className
         )}
+        disabled={disabled}
         asChild
         {...props}
       >
         <div>
-          <Button variant="ghost" size="sm" label={label} icon={icon} />
+          <Button
+            variant="ghost"
+            size="sm"
+            label={label}
+            icon={icon}
+            disabled={disabled}
+          />
         </div>
       </TabsPrimitive.Trigger>
     );

--- a/sparkle/src/stories/Tabs.stories.tsx
+++ b/sparkle/src/stories/Tabs.stories.tsx
@@ -27,7 +27,7 @@ export function TabExample() {
           href="hello"
           icon={CommandIcon}
         />
-        <TabsTrigger value="password" label="World" icon={LightbulbIcon} />
+        <TabsTrigger disabled value="password" label="World" icon={LightbulbIcon} />
         <TabsTrigger value="settings" icon={Cog6ToothIcon} />
       </TabsList>
       <TabsContent value="account">Hello</TabsContent>


### PR DESCRIPTION
## Description

This PR aims at propagating the "disabled" props to the `Button` used within the trigger

## Risk

Low

## Deploy Plan

Publish sparkle