### PR TITLE
Extension: Better UX navigation headers

### DIFF
--- a/front/extension/app/src/components/auth/ProtectedRoute.tsx
+++ b/front/extension/app/src/components/auth/ProtectedRoute.tsx
@@ -53,7 +53,7 @@ export const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
   return (
     <div className="flex h-screen flex-col gap-2 p-4">
       <div className="flex items-start justify-between">
-        <div className="flex items-center gap-2 pb-10">
+        <div className="flex items-center gap-2 pb-16">
           <LogoHorizontalColorLogo className="h-4 w-16" />
           <a href="https://dust.tt" target="_blank">
             <ExternalLinkIcon color="#64748B" />
@@ -64,7 +64,7 @@ export const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
           variant="outline"
           label="Sign out"
           onClick={handleLogout}
-          size="sm"
+          size="xs"
         />
       </div>
       <>

--- a/front/extension/app/src/pages/ConversationPage.tsx
+++ b/front/extension/app/src/pages/ConversationPage.tsx
@@ -1,7 +1,8 @@
-import { BarHeader, ChevronLeftIcon, Page } from "@dust-tt/sparkle";
+import { usePublicConversation } from "@app/extension/app/src/components/conversation/usePublicConversation";
+import { BarHeader, ExternalLinkIcon, IconButton } from "@dust-tt/sparkle";
 import type { ProtectedRouteChildrenProps } from "@extension/components/auth/ProtectedRoute";
 import { ConversationContainer } from "@extension/components/conversation/ConversationContainer";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
 export const ConversationPage = ({
   workspace,
@@ -9,6 +10,11 @@ export const ConversationPage = ({
 }: ProtectedRouteChildrenProps) => {
   const navigate = useNavigate();
   const { conversationId } = useParams();
+
+  const { conversation } = usePublicConversation({
+    conversationId: conversationId ?? null,
+    workspaceId: workspace.sId,
+  });
 
   if (!conversationId) {
     navigate("/");
@@ -18,15 +24,23 @@ export const ConversationPage = ({
   return (
     <>
       <BarHeader
-        title="Home"
-        leftActions={
-          <Link to="/">
-            <ChevronLeftIcon />
-          </Link>
+        title={conversation?.title || "Conversation"}
+        rightActions={
+          <div>
+            <a
+              href={`${process.env.DUST_DOMAIN}/w/${workspace.sId}/assistant/${conversationId}`}
+              target="_blank"
+            >
+              <IconButton icon={ExternalLinkIcon} />
+            </a>
+            <BarHeader.ButtonBar
+              variant="close"
+              onClose={() => navigate("/")}
+            />
+          </div>
         }
       />
       <div className="h-full w-full pt-4">
-        <Page.SectionHeader title="Conversation" />
         <ConversationContainer
           owner={workspace}
           conversationId={conversationId}

--- a/front/extension/app/src/pages/ConversationsPage.tsx
+++ b/front/extension/app/src/pages/ConversationsPage.tsx
@@ -1,16 +1,16 @@
 import {
   BarHeader,
-  ChevronLeftIcon,
+  ExternalLinkIcon,
+  IconButton,
   NavigationList,
   NavigationListItem,
   NavigationListLabel,
-  Page,
 } from "@dust-tt/sparkle";
 import type { ConversationWithoutContentType } from "@dust-tt/types";
 import type { ProtectedRouteChildrenProps } from "@extension/components/auth/ProtectedRoute";
 import { useConversations } from "@extension/components/conversation/useConversations";
 import moment from "moment";
-import { Link, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 type GroupLabel =
   | "Today"
@@ -71,16 +71,23 @@ export const ConversationsPage = ({
   return (
     <>
       <BarHeader
-        title="Home"
-        leftActions={
-          <Link to="/">
-            <ChevronLeftIcon />
-          </Link>
+        title="Conversations"
+        rightActions={
+          <div>
+            <a
+              href={`${process.env.DUST_DOMAIN}/w/${workspace.sId}`}
+              target="_blank"
+            >
+              <IconButton icon={ExternalLinkIcon} />
+            </a>
+            <BarHeader.ButtonBar
+              variant="close"
+              onClose={() => navigate("/")}
+            />
+          </div>
         }
       />
       <div className="h-full w-full pt-4">
-        <Page.SectionHeader title="Conversations" />
-
         {conversationsByDate &&
           Object.keys(conversationsByDate).map((dateLabel) => (
             <RenderConversations


### PR DESCRIPTION
## Description

Rework a bit the navigation to harmonize the header -> display the title on the right and on the left a link to the web app + a close button. 

I think this looks better since it avoids duplicating the title and consistently allows to go to the web app. WDYT? 

### Homepage: 
<kbd>
<img width="712" alt="Screenshot 2024-10-30 at 21 38 28" src="https://github.com/user-attachments/assets/5844eaca-61a4-441c-9374-9f83a766aa53">
</kbd>
<br />
<br />

### Conversation history page: 
The link redirect to the web app in a new tab, on the chat homepage. 
The close button go back to the extension home page.
<kbd>
<img width="712" alt="Screenshot 2024-10-30 at 21 38 42" src="https://github.com/user-attachments/assets/086902e9-fdb5-4229-bb5f-284b77e113ad">
</kbd>
<br />
<br />

### Conversation page: 
The link redirect to conversation on the web app in a new tab.
The close button go back to the extension home page.
<kbd>
<img width="712" alt="Screenshot 2024-10-30 at 21 46 38" src="https://github.com/user-attachments/assets/281c4c85-16e5-4070-b41c-82b9edf0d204">
</kbd>

## Risk

Extension code only. 

## Deploy Plan

No deploy. 
