### PR TITLE
enh: support un-indented numbered lists

### DIFF
--- a/front/components/assistant/markdown/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/markdown/RenderMessageMarkdown.tsx
@@ -420,26 +420,37 @@ function UlBlock({ children }: { children: React.ReactNode }) {
     <ul className="list-disc py-2 pl-8 first:pt-0 last:pb-0">{children}</ul>
   );
 }
-function OlBlock({ children }: { children: React.ReactNode }) {
+function OlBlock({
+  children,
+  start,
+}: {
+  children: React.ReactNode;
+  start?: number;
+}) {
   return (
-    <ol className="list-decimal py-3 pl-8 first:pt-0 last:pb-0">{children}</ol>
+    <ol start={start} className="list-decimal py-3 pl-8 first:pt-0 last:pb-0">
+      {children}
+    </ol>
   );
 }
 function LiBlock({
   textSize,
   textColor,
   children,
+  className = "",
 }: {
   textSize?: string;
   textColor?: string;
   children: React.ReactNode;
+  className?: string;
 }) {
   return (
     <li
       className={classNames(
         "break-words first:pt-0 last:pb-0",
         textSize === "sm" ? "py-1" : "py-2",
-        textColor ? textColor : "text-element-800"
+        textColor ? textColor : "text-element-800",
+        className
       )}
     >
       {children}

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -471,10 +471,6 @@ export async function constructPromptMultiActions(
   additionalInstructions +=
     "\nWhen generating latex formulas, solely rely on the $$ escape sequence, single $ latex sequences are not supported.\n";
 
-  additionalInstructions +=
-    "\nIn numbered lists, align all content with the item's text to preserve list continuity " +
-    "in markdown - otherwise the list numbering breaks and restarts when rendered.\n";
-
   let prompt = `${context}\n${instructions}`;
   if (additionalInstructions) {
     prompt += `\nADDITIONAL INSTRUCTIONS:\n${additionalInstructions}`;


### PR DESCRIPTION
## Description

Some models generate markdown numbered lists with un-indented content in between list items, which causes our UI to reset the number to 1 for each list item. 

We have tried prompting against this, but the latest Sonnet really likes to do this. A better solution is to handle the `start` parameter passed to `old`.

I removed the meta prompt we added.

## Risk

N/A

## Deploy Plan

Deploy front