### PR TITLE
[sparkle] - refactor: streamline LinkWrapper rendering logic

### DIFF
--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -3,6 +3,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
 import { Icon } from "@sparkle/components/Icon";
+import { LinkWrapper, LinkWrapperProps } from "@sparkle/components/LinkWrapper";
 import Spinner, { SpinnerProps } from "@sparkle/components/Spinner";
 import {
   TooltipContent,
@@ -103,7 +104,9 @@ const MetaButton = React.forwardRef<HTMLButtonElement, MetaButtonProps>(
 );
 MetaButton.displayName = "MetaButton";
 
-export interface ButtonProps extends MetaButtonProps {
+export interface ButtonProps
+  extends MetaButtonProps,
+    Omit<LinkWrapperProps, "children" | "className"> {
   label?: string;
   icon?: React.ComponentType;
   isSelect?: boolean;
@@ -123,6 +126,11 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       isSelect = false,
       isPulsing = false,
       size,
+      href,
+      target,
+      rel,
+      replace,
+      shallow,
       "aria-label": ariaLabel,
       ...props
     },
@@ -152,23 +160,31 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     );
 
     const buttonElement = (
-      <MetaButton
-        ref={ref}
-        size={buttonSize}
-        variant={variant}
-        disabled={isLoading || props.disabled}
-        className={isPulsing ? "s-animate-pulse" : ""}
-        aria-label={ariaLabel || tooltip || label}
-        style={
-          {
-            "--pulse-color": "#93C5FD",
-            "--duration": "1.5s",
-          } as React.CSSProperties
-        }
-        {...props}
+      <LinkWrapper
+        href={href}
+        target={target}
+        rel={rel}
+        replace={replace}
+        shallow={shallow}
       >
-        {content}
-      </MetaButton>
+        <MetaButton
+          ref={ref}
+          size={buttonSize}
+          variant={variant}
+          disabled={isLoading || props.disabled}
+          className={isPulsing ? "s-animate-pulse" : ""}
+          aria-label={ariaLabel || tooltip || label}
+          style={
+            {
+              "--pulse-color": "#93C5FD",
+              "--duration": "1.5s",
+            } as React.CSSProperties
+          }
+          {...props}
+        >
+          {content}
+        </MetaButton>
+      </LinkWrapper>
     );
 
     return tooltip ? (

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -80,7 +80,7 @@ const NavigationListItem = React.forwardRef<
       }
     };
 
-    const content = (
+    return (
       <div className={className} ref={ref} {...props}>
         <div
           className={listStyles({
@@ -93,31 +93,27 @@ const NavigationListItem = React.forwardRef<
           onMouseDown={handleMouseDown}
           onMouseUp={() => setIsPressed(false)}
         >
-          {icon && <Icon visual={icon} size="sm" />}
-          {label && (
-            <span className="s-grow s-overflow-hidden s-text-ellipsis s-whitespace-nowrap">
-              {label}
-            </span>
-          )}
-          {selected && moreMenu && (
-            <div className="-s-mr-2 s-flex s-h-4 s-items-center">
-              {moreMenu}
-            </div>
-          )}
+          <LinkWrapper
+            href={href}
+            target={target}
+            rel={rel}
+            replace={replace}
+            shallow={shallow}
+          >
+            {icon && <Icon visual={icon} size="sm" />}
+            {label && (
+              <span className="s-grow s-overflow-hidden s-text-ellipsis s-whitespace-nowrap">
+                {label}
+              </span>
+            )}
+            {selected && moreMenu && (
+              <div className="-s-mr-2 s-flex s-h-4 s-items-center">
+                {moreMenu}
+              </div>
+            )}
+          </LinkWrapper>
         </div>
       </div>
-    );
-
-    return (
-      <LinkWrapper
-        href={href}
-        target={target}
-        rel={rel}
-        replace={replace}
-        shallow={shallow}
-      >
-        {content}
-      </LinkWrapper>
     );
   }
 );

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -82,23 +82,27 @@ const NavigationListItem = React.forwardRef<
 
     return (
       <div className={className} ref={ref} {...props}>
-        <div
-          className={listStyles({
-            layout: "item",
-            state: selected ? "selected" : isPressed ? "active" : "unselected",
-          })}
-          onMouseLeave={() => {
-            setIsPressed(false);
-          }}
-          onMouseDown={handleMouseDown}
-          onMouseUp={() => setIsPressed(false)}
+        <LinkWrapper
+          href={href}
+          target={target}
+          rel={rel}
+          replace={replace}
+          shallow={shallow}
         >
-          <LinkWrapper
-            href={href}
-            target={target}
-            rel={rel}
-            replace={replace}
-            shallow={shallow}
+          <div
+            className={listStyles({
+              layout: "item",
+              state: selected
+                ? "selected"
+                : isPressed
+                  ? "active"
+                  : "unselected",
+            })}
+            onMouseLeave={() => {
+              setIsPressed(false);
+            }}
+            onMouseDown={handleMouseDown}
+            onMouseUp={() => setIsPressed(false)}
           >
             {icon && <Icon visual={icon} size="sm" />}
             {label && (
@@ -111,8 +115,8 @@ const NavigationListItem = React.forwardRef<
                 {moreMenu}
               </div>
             )}
-          </LinkWrapper>
-        </div>
+          </div>
+        </LinkWrapper>
       </div>
     );
   }

--- a/sparkle/src/components/Tabs.tsx
+++ b/sparkle/src/components/Tabs.tsx
@@ -2,7 +2,7 @@ import * as TabsPrimitive from "@radix-ui/react-tabs";
 import * as React from "react";
 
 import { Button } from "@sparkle/components/Button";
-import { LinkWrapper, LinkWrapperProps } from "@sparkle/components/LinkWrapper";
+import { LinkWrapperProps } from "@sparkle/components/LinkWrapper";
 import { cn } from "@sparkle/lib/utils";
 
 const Tabs = TabsPrimitive.Root;
@@ -60,26 +60,20 @@ const TabsTrigger = React.forwardRef<
           className
         )}
         disabled={disabled}
-        asChild
         {...props}
       >
-        <div>
-          <LinkWrapper
-            href={href}
-            target={target}
-            rel={rel}
-            replace={replace}
-            shallow={shallow}
-          >
-            <Button
-              variant="ghost"
-              size="sm"
-              label={label}
-              icon={icon}
-              disabled={disabled}
-            />
-          </LinkWrapper>
-        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          label={label}
+          icon={icon}
+          disabled={disabled}
+          href={href}
+          target={target}
+          rel={rel}
+          replace={replace}
+          shallow={shallow}
+        />
       </TabsPrimitive.Trigger>
     );
   }

--- a/sparkle/src/components/Tabs.tsx
+++ b/sparkle/src/components/Tabs.tsx
@@ -52,7 +52,7 @@ const TabsTrigger = React.forwardRef<
     },
     ref
   ) => {
-    const content = (
+    return (
       <TabsPrimitive.Trigger
         ref={ref}
         className={cn(
@@ -64,27 +64,23 @@ const TabsTrigger = React.forwardRef<
         {...props}
       >
         <div>
-          <Button
-            variant="ghost"
-            size="sm"
-            label={label}
-            icon={icon}
-            disabled={disabled}
-          />
+          <LinkWrapper
+            href={href}
+            target={target}
+            rel={rel}
+            replace={replace}
+            shallow={shallow}
+          >
+            <Button
+              variant="ghost"
+              size="sm"
+              label={label}
+              icon={icon}
+              disabled={disabled}
+            />
+          </LinkWrapper>
         </div>
       </TabsPrimitive.Trigger>
-    );
-
-    return (
-      <LinkWrapper
-        href={href}
-        target={target}
-        rel={rel}
-        replace={replace}
-        shallow={shallow}
-      >
-        {content}
-      </LinkWrapper>
     );
   }
 );

--- a/sparkle/src/stories/Button.stories.tsx
+++ b/sparkle/src/stories/Button.stories.tsx
@@ -51,6 +51,12 @@ const ButtonExamplesBySize = ({
       <Button size={size} variant="highlight" label="Button" />
       <Button size={size} variant="warning" label="Button" />
       <Button size={size} variant="ghost" label="Button" />
+      <Button
+        size={size}
+        variant="primary"
+        label="Button with href"
+        href="hello"
+      />
     </div>
     <div className="s-flex s-items-center s-gap-4">
       <Button size={size} label="Button" isLoading />

--- a/sparkle/src/stories/NavigationList.stories.tsx
+++ b/sparkle/src/stories/NavigationList.stories.tsx
@@ -76,6 +76,7 @@ export const NewNavigationListDemo = () => {
                 return (
                   <NavigationListItem
                     key={index}
+                    href={index / 2 === 0 ? "title" : undefined}
                     selected={itemIndex === selectedIndex}
                     onClick={() => setSelectedIndex(itemIndex)}
                     label={title}

--- a/sparkle/src/stories/NavigationList.stories.tsx
+++ b/sparkle/src/stories/NavigationList.stories.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 
 import {
   Button,
+  LockIcon,
   MoreIcon,
   NavigationList,
   NavigationListItem,
@@ -76,12 +77,13 @@ export const NewNavigationListDemo = () => {
                 return (
                   <NavigationListItem
                     key={index}
-                    href={index / 2 === 0 ? "title" : undefined}
+                    href={index % 2 === 0 ? "title" : undefined}
                     selected={itemIndex === selectedIndex}
                     onClick={() => setSelectedIndex(itemIndex)}
                     label={title}
                     className="s-w-full"
                     moreMenu={getMoreMenu(title)}
+                    icon={LockIcon}
                   />
                 );
               })}


### PR DESCRIPTION
## Description

This PR refactors the `LinkWrapper` component integration in navigation components to improve rendering logic. Instead of wrapping entire content blocks with `LinkWrapper`, it now wraps only the interactive elements within `NavigationListItem` and `TabsTrigger`. It is also now being used within the `Button` component.

## Risk

Low

## Deploy Plan

Publish `sparkle`