### PR TITLE
[sparkle] Refactor IconButton

### DIFF
--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.288",
+  "version": "0.2.290",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.290",
+  "version": "0.2.288",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -86,7 +86,7 @@ interface MetaButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
-  variant?: ButtonVariantType;
+  variant?: ButtonVariantType | null;
 }
 
 const MetaButton = React.forwardRef<HTMLButtonElement, MetaButtonProps>(
@@ -98,7 +98,7 @@ const MetaButton = React.forwardRef<HTMLButtonElement, MetaButtonProps>(
 
     return (
       <Comp
-        className={cn(buttonVariants({ variant, size }), className)}
+        className={cn(variant && buttonVariants({ variant, size }), className)}
         ref={ref}
         {...props}
       >
@@ -136,8 +136,8 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ) => {
     const buttonSize = size || "sm";
     const spinnerVariant = isLoading
-      ? spinnerVariantsMapIsLoading[variant] || "slate400"
-      : spinnerVariantsMap[variant] || "slate400";
+      ? (variant && spinnerVariantsMapIsLoading[variant]) || "slate400"
+      : (variant && spinnerVariantsMap[variant]) || "slate400";
 
     const renderIcon = (visual: React.ComponentType, extraClass = "") => (
       <Icon visual={visual} size={buttonSize} className={extraClass} />

--- a/sparkle/src/components/IconButton.tsx
+++ b/sparkle/src/components/IconButton.tsx
@@ -16,9 +16,6 @@ type IconButtonProps = {
   disabled?: boolean;
 };
 
-const baseClasses =
-  "s-transition-all s-ease-out s-duration-300 s-cursor-pointer hover:s-scale-110";
-
 const styleVariants: Record<ButtonVariantType, string> = {
   primary:
     "s-text-action-500 dark:s-text-action-500-dark" +
@@ -52,18 +49,21 @@ const styleVariants: Record<ButtonVariantType, string> = {
     "s-text-element-500 dark:s-text-element-500-dark",
 };
 
-const iconButtonVariants = cva(baseClasses, {
-  variants: {
-    variant: styleVariants,
-    disabled: {
-      true: "s-text-element-500 s-cursor-default hover:s-scale-100",
+const iconButtonVariants = cva(
+  "s-transition-all s-ease-out s-duration-300 s-cursor-pointer hover:s-scale-110",
+  {
+    variants: {
+      variant: styleVariants,
+      disabled: {
+        true: "s-text-element-500 s-cursor-default hover:s-scale-100",
+      },
     },
-  },
-  defaultVariants: {
-    variant: "outline",
-    disabled: false,
-  },
-});
+    defaultVariants: {
+      variant: "outline",
+      disabled: false,
+    },
+  }
+);
 
 const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
   (

--- a/sparkle/src/components/IconButton.tsx
+++ b/sparkle/src/components/IconButton.tsx
@@ -1,10 +1,9 @@
 import { cva } from "class-variance-authority";
 import React, { ComponentType, MouseEventHandler } from "react";
 
+import { Tooltip } from "@sparkle/components";
 import { Button, ButtonVariantType } from "@sparkle/components/Button";
-
-import { Icon } from "./Icon";
-import { Tooltip } from "./Tooltip";
+import { cn } from "@sparkle/lib/utils";
 
 type IconButtonProps = {
   variant?: React.ComponentProps<typeof Button>["variant"];
@@ -66,33 +65,32 @@ const iconButtonVariants = cva(baseClasses, {
   },
 });
 
-export function IconButton({
-  variant,
-  onClick,
-  disabled = false,
-  tooltip,
-  tooltipPosition,
-  icon,
-  className,
-  size,
-}: IconButtonProps) {
-  const iconSize = size || "sm";
-  const buttonClasses = iconButtonVariants({ variant, disabled, className });
-
-  const IconButtonContent = (
-    <button className={buttonClasses} onClick={onClick} disabled={disabled}>
-      <Icon visual={icon} size={iconSize} />
-    </button>
-  );
-
-  return tooltip ? (
-    <Tooltip
-      trigger={IconButtonContent}
-      label={tooltip}
-      side={tooltipPosition}
-      tooltipTriggerAsChild
+const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
+  (
+    {
+      variant = "outline",
+      onClick,
+      disabled = false,
+      tooltip,
+      icon,
+      className,
+      size = "sm",
+      ...props
+    },
+    ref
+  ) => (
+    <Button
+      tooltip={tooltip}
+      className={cn(iconButtonVariants({ variant, disabled }), className)}
+      onClick={onClick}
+      disabled={disabled}
+      ref={ref}
+      size={size}
+      icon={icon}
+      variant={null}
+      {...props}
     />
-  ) : (
-    IconButtonContent
-  );
-}
+  )
+);
+
+export { IconButton };

--- a/sparkle/src/stories/IconButton.stories.tsx
+++ b/sparkle/src/stories/IconButton.stories.tsx
@@ -22,7 +22,6 @@ export const IconButtonWithTooltip: Story = {
   args: {
     variant: "primary",
     tooltip: "Your settings",
-    tooltipPosition: "bottom",
     icon: Cog6ToothIcon,
   },
 };
@@ -31,7 +30,6 @@ export const IconButtonSecondary: Story = {
   args: {
     variant: "highlight",
     tooltip: "This a highlight IconButton",
-    tooltipPosition: "bottom",
     icon: Cog6ToothIcon,
   },
 };
@@ -40,7 +38,6 @@ export const IconButtonTertiary: Story = {
   args: {
     variant: "ghost",
     tooltip: "This a ghost IconButton",
-    tooltipPosition: "bottom",
     icon: Cog6ToothIcon,
   },
 };


### PR DESCRIPTION
## Description

- Close [#8243](https://github.com/dust-tt/dust/issues/8243) (refactor the IconButton component to use the new Button component under the hood).
- Make the `variant` prop of the `Button` nullable to allow not setting any style.
- Remove the `tooltipPosition` prop on the `IconButton` (not used anywhere in front).
- Turn the `IconButton` into a `forwardRef`.

## Risk

Low - The changes are strictly refactoring with no functional changes.

## Deploy Plan
