### PR TITLE
Move some types to types to easily share them between front & extension

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -3,11 +3,11 @@ import type {
   AgentGenerationCancelledEvent,
   AgentMention,
   AgentMessageNewEvent,
-  AgentMessageType,
   ContentFragmentType,
   ConversationTitleEvent,
+  FetchConversationMessagesResponse,
+  MessageWithContentFragmentsType,
   UserMessageNewEvent,
-  UserMessageType,
   UserType,
   WorkspaceType,
 } from "@dust-tt/types";
@@ -22,7 +22,6 @@ import { CONVERSATION_PARENT_SCROLL_DIV_ID } from "@app/components/assistant/con
 import MessageGroup from "@app/components/assistant/conversation/MessageGroup";
 import { useEventSource } from "@app/hooks/useEventSource";
 import { useLastMessageGroupObserver } from "@app/hooks/useLastMessageGroupObserver";
-import type { FetchConversationMessagesResponse } from "@app/lib/api/assistant/messages";
 import {
   getUpdatedMessagesFromEvent,
   getUpdatedParticipantsFromEvent,
@@ -37,12 +36,6 @@ import {
 import { classNames } from "@app/lib/utils";
 
 const DEFAULT_PAGE_LIMIT = 50;
-
-export type MessageWithContentFragmentsType =
-  | AgentMessageType
-  | (UserMessageType & {
-      contenFragments?: ContentFragmentType[];
-    });
 
 interface ConversationViewerProps {
   conversationId: string;

--- a/front/components/assistant/conversation/MessageGroup.tsx
+++ b/front/components/assistant/conversation/MessageGroup.tsx
@@ -1,13 +1,13 @@
 import type {
   ConversationMessageReactions,
+  FetchConversationMessagesResponse,
+  MessageWithContentFragmentsType,
   UserType,
   WorkspaceType,
 } from "@dust-tt/types";
 import React, { useEffect, useRef } from "react";
 
-import type { MessageWithContentFragmentsType } from "@app/components/assistant/conversation/ConversationViewer";
 import MessageItem from "@app/components/assistant/conversation/MessageItem";
-import type { FetchConversationMessagesResponse } from "@app/lib/api/assistant/messages";
 
 interface MessageGroupProps {
   messages: MessageWithContentFragmentsType[][];

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -2,6 +2,7 @@ import { Citation, ZoomableImageCitationWrapper } from "@dust-tt/sparkle";
 import type { CitationType } from "@dust-tt/sparkle/dist/esm/components/Citation";
 import type {
   ConversationMessageReactions,
+  MessageWithContentFragmentsType,
   UserType,
   WorkspaceType,
 } from "@dust-tt/types";
@@ -10,7 +11,6 @@ import React from "react";
 import { useSWRConfig } from "swr";
 
 import { AgentMessage } from "@app/components/assistant/conversation/AgentMessage";
-import type { MessageWithContentFragmentsType } from "@app/components/assistant/conversation/ConversationViewer";
 import { UserMessage } from "@app/components/assistant/conversation/UserMessage";
 import { useSubmitFunction } from "@app/lib/client/utils";
 

--- a/front/extension/app/src/components/conversation/ConversationViewer.tsx
+++ b/front/extension/app/src/components/conversation/ConversationViewer.tsx
@@ -1,8 +1,8 @@
-import type { MessageWithContentFragmentsType } from "@app/components/assistant/conversation/ConversationViewer";
 import type {
   AgentMessageType,
   ContentFragmentType,
   LightWorkspaceType,
+  MessageWithContentFragmentsType,
   UserMessageType,
 } from "@dust-tt/types";
 import { isContentFragmentType, isUserMessageType } from "@dust-tt/types";

--- a/front/extension/app/src/components/conversation/MessageGroup.tsx
+++ b/front/extension/app/src/components/conversation/MessageGroup.tsx
@@ -1,8 +1,8 @@
-import type { MessageWithContentFragmentsType } from "@app/components/assistant/conversation/ConversationViewer";
-import type { FetchConversationMessagesResponse } from "@app/lib/api/assistant/messages";
 import type {
   ConversationMessageReactions,
+  FetchConversationMessagesResponse,
   LightWorkspaceType,
+  MessageWithContentFragmentsType,
 } from "@dust-tt/types";
 import MessageItem from "@extension/components/conversation/MessageItem";
 import type { StoredUser } from "@extension/lib/storage";

--- a/front/extension/app/src/components/conversation/MessageItem.tsx
+++ b/front/extension/app/src/components/conversation/MessageItem.tsx
@@ -1,9 +1,9 @@
-import type { MessageWithContentFragmentsType } from "@app/components/assistant/conversation/ConversationViewer";
 import { Citation, ZoomableImageCitationWrapper } from "@dust-tt/sparkle";
 import type { CitationType } from "@dust-tt/sparkle/dist/esm/components/Citation";
 import type {
   ConversationMessageReactions,
   LightWorkspaceType,
+  MessageWithContentFragmentsType,
 } from "@dust-tt/types";
 import { isSupportedImageContentType } from "@dust-tt/types";
 import { AgentMessage } from "@extension/components/conversation/AgentMessage";

--- a/front/extension/app/src/components/conversation/usePublicConversation.ts
+++ b/front/extension/app/src/components/conversation/usePublicConversation.ts
@@ -1,8 +1,8 @@
-import type { FetchConversationMessagesResponse } from "@app/lib/api/assistant/messages";
 import type {
   ConversationError,
   ConversationMessageReactions,
   ConversationType,
+  FetchConversationMessagesResponse,
 } from "@dust-tt/types";
 import {
   fetcher,

--- a/front/extension/app/src/pages/ConversationPage.tsx
+++ b/front/extension/app/src/pages/ConversationPage.tsx
@@ -1,7 +1,7 @@
-import { usePublicConversation } from "@app/extension/app/src/components/conversation/usePublicConversation";
 import { BarHeader, ExternalLinkIcon, IconButton } from "@dust-tt/sparkle";
 import type { ProtectedRouteChildrenProps } from "@extension/components/auth/ProtectedRoute";
 import { ConversationContainer } from "@extension/components/conversation/ConversationContainer";
+import { usePublicConversation } from "@extension/components/conversation/usePublicConversation";
 import { useNavigate, useParams } from "react-router-dom";
 
 export const ConversationPage = ({

--- a/front/hooks/useLastMessageGroupObserver.ts
+++ b/front/hooks/useLastMessageGroupObserver.ts
@@ -1,6 +1,6 @@
+import type { MessageWithContentFragmentsType } from "@dust-tt/types";
 import { useEffect } from "react";
 
-import type { MessageWithContentFragmentsType } from "@app/components/assistant/conversation/ConversationViewer";
 import { LAST_MESSAGE_GROUP_ID } from "@app/components/assistant/conversation/MessageGroup";
 
 /**

--- a/types/src/front/assistant/conversation.ts
+++ b/types/src/front/assistant/conversation.ts
@@ -44,6 +44,12 @@ export type MessageType =
   | UserMessageType
   | ContentFragmentType;
 
+export type MessageWithContentFragmentsType =
+  | AgentMessageType
+  | (UserMessageType & {
+      contenFragments?: ContentFragmentType[];
+    });
+
 export type WithRank<T> = T & {
   rank: number;
 };
@@ -248,3 +254,9 @@ export type SubmitMessageError = {
   title: string;
   message: string;
 };
+
+export interface FetchConversationMessagesResponse {
+  hasMore: boolean;
+  lastValue: number | null;
+  messages: MessageWithRankType[];
+}


### PR DESCRIPTION
## Description

`FetchConversationMessagesResponse` & `MessageWithContentFragmentsType` are moved to `types/src/front/assistant/conversation.ts`. 
The rest is only update of the imports. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
