### PR TITLE
[front] - fix(conversation): deletion notification message

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -96,17 +96,11 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
       type: "success",
       title: "Conversations successfully deleted",
       description:
-        conversations.length > 1
-          ? `${conversations.length} conversations have been deleted.`
-          : `${conversations.length} conversation has been deleted.`,
+        selectedConversations.length > 1
+          ? `${selectedConversations.length} conversations have been deleted.`
+          : `${selectedConversations.length} conversation has been deleted.`,
     });
-  }, [
-    conversations.length,
-    doDelete,
-    selectedConversations,
-    sendNotification,
-    toggleMultiSelect,
-  ]);
+  }, [doDelete, selectedConversations, sendNotification, toggleMultiSelect]);
 
   const deleteAll = useCallback(async () => {
     setIsDeleting(true);


### PR DESCRIPTION
## Description

This PR aims at fixing the conversation deletion notification message which was accessing the wrong variable to count the number of selected conversations.

**References:**
- [Slack thread](https://dust4ai.slack.com/archives/C07KY510DH7/p1730363841963779)

## Risk

None

## Deploy Plan

Deploy `front`