### PR TITLE
Bump react-cookie to fix vuln in dependency

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -6385,9 +6385,9 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -7557,16 +7557,16 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
-      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
+      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
         "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.6.0",
+        "cookie": "0.7.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "front",
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
@@ -86,7 +87,7 @@
         "react-accessible-treeview": "^2.6.0",
         "react-beforeunload": "^2.5.3",
         "react-confetti": "^6.1.0",
-        "react-cookie": "^6.1.1",
+        "react-cookie": "^7.2.2",
         "react-cropper": "^2.3.3",
         "react-dom": "^18.3.1",
         "react-dropzone": "^14.2.3",
@@ -33274,13 +33275,13 @@
       }
     },
     "node_modules/react-cookie": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-6.1.3.tgz",
-      "integrity": "sha512-cOToXQPdxvLfK0MH4ZFrrL3cOpDwbboKupFS96MCvrHsHMABMk48vdd1fRWkNG6F5D1JZMvoI5Y74sj8vtHGpA==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-7.2.2.tgz",
+      "integrity": "sha512-e+hi6axHcw9VODoeVu8WyMWyoosa1pzpyjfvrLdF7CexfU+WSGZdDuRfHa4RJgTpfv3ZjdIpHE14HpYBieHFhg==",
       "dependencies": {
         "@types/hoist-non-react-statics": "^3.3.5",
         "hoist-non-react-statics": "^3.3.2",
-        "universal-cookie": "^6.0.0"
+        "universal-cookie": "^7.0.0"
       },
       "peerDependencies": {
         "react": ">= 16.3.0"
@@ -36635,12 +36636,20 @@
       }
     },
     "node_modules/universal-cookie": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-6.1.3.tgz",
-      "integrity": "sha512-AETYRrhpRgl9T1YtnODmQE32G81U3A+f3HO3ZeK7efbXqe3x+RNOW4RTpV0iff7zJWhGYJA6EI0Mm+w50aFTAw==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-7.2.2.tgz",
+      "integrity": "sha512-fMiOcS3TmzP2x5QV26pIH3mvhexLIT0HmPa3V7Q7knRfT9HG6kTwq02HZGLPw0sAOXrAmotElGRvTLCMbJsvxQ==",
       "dependencies": {
         "@types/cookie": "^0.6.0",
-        "cookie": "^0.6.0"
+        "cookie": "^0.7.2"
+      }
+    },
+    "node_modules/universal-cookie/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/universal-user-agent": {

--- a/front/package.json
+++ b/front/package.json
@@ -104,7 +104,7 @@
     "react-accessible-treeview": "^2.6.0",
     "react-beforeunload": "^2.5.3",
     "react-confetti": "^6.1.0",
-    "react-cookie": "^6.1.1",
+    "react-cookie": "^7.2.2",
     "react-cropper": "^2.3.3",
     "react-dom": "^18.3.1",
     "react-dropzone": "^14.2.3",


### PR DESCRIPTION
## Description

Bump react-cookie used on the landing page only to fix vuln related to imported library cookie

## Risk

N/A Tested in dev

## Deploy Plan

- deploy `front`