### PR TITLE
[sparkle] enh: support un-indented numbered lists (port commit addfd9c)

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.289",
+  "version": "0.2.290",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.289",
+      "version": "0.2.290",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.289",
+  "version": "0.2.290",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/markdown/Markdown.tsx
+++ b/sparkle/src/components/markdown/Markdown.tsx
@@ -109,8 +109,8 @@ export function Markdown({
           {children}
         </UlBlock>
       ),
-      ol: ({ children }) => (
-        <OlBlock textSize={textSize} textColor={textColor}>
+      ol: ({ children, start }) => (
+        <OlBlock start={start} textSize={textSize} textColor={textColor}>
           {children}
         </OlBlock>
       ),
@@ -307,15 +307,18 @@ function UlBlock({
 }
 function OlBlock({
   children,
+  start,
   textColor,
   textSize,
 }: {
   children: React.ReactNode;
+  start?: number;
   textColor: string;
   textSize: TextSize;
 }) {
   return (
     <ol
+      start={start}
       className={cn(
         "s-list-decimal s-py-3 s-pl-8 first:s-pt-0 last:s-pb-0",
         textColor,
@@ -330,10 +333,12 @@ function LiBlock({
   children,
   textColor,
   textSize,
+  className = "",
 }: {
   children: React.ReactNode;
   textColor: string;
   textSize: TextSize;
+  className?: string;
 }) {
   return (
     <li
@@ -341,7 +346,8 @@ function LiBlock({
         "s-break-words first:s-pt-0 last:s-pb-0",
         textSize === "sm" ? "s-py-1" : "s-py-2",
         textColor,
-        sizes[textSize].p
+        sizes[textSize].p,
+        className
       )}
     >
       {children}


### PR DESCRIPTION
## Description

Porting fix addfd9c into sparkle

## Risk



## Deploy Plan

publish sparkle
