### PR TITLE
Zendesk: support user account subdomain configuration

### DIFF
--- a/core/src/oauth/providers/zendesk.rs
+++ b/core/src/oauth/providers/zendesk.rs
@@ -7,6 +7,7 @@ use crate::oauth::{
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use lazy_static::lazy_static;
+use regex::Regex;
 use serde_json::json;
 use std::env;
 
@@ -14,6 +15,8 @@ lazy_static! {
     static ref OAUTH_ZENDESK_CLIENT_ID: String = env::var("OAUTH_ZENDESK_CLIENT_ID").unwrap();
     static ref OAUTH_ZENDESK_CLIENT_SECRET: String =
         env::var("OAUTH_ZENDESK_CLIENT_SECRET").unwrap();
+    static ref ZENDESK_SUBDOMAIN_RE: Regex =
+        Regex::new(r"^[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$").unwrap();
 }
 
 pub struct ZendeskConnectionProvider {}
@@ -32,7 +35,7 @@ impl Provider for ZendeskConnectionProvider {
 
     async fn finalize(
         &self,
-        _connection: &Connection,
+        connection: &Connection,
         code: &str,
         redirect_uri: &str,
     ) -> Result<FinalizeResult, ProviderError> {
@@ -45,8 +48,20 @@ impl Provider for ZendeskConnectionProvider {
             "scope": "read"
         });
 
+        let sub_domain = match connection.metadata()["extra_config"].as_str() {
+            Some(c) => {
+                if !ZENDESK_SUBDOMAIN_RE.is_match(c) {
+                    Err(anyhow!("Zendesk extra_config subdomain format invalid"))?
+                }
+                c
+            }
+            None => Err(anyhow!("Zendesk extra_config subdomain is missing"))?,
+        };
+
+        let url = format!("https://{}.zendesk.com/oauth/tokens", sub_domain);
+
         let req = reqwest::Client::new()
-            .post("https://d3v-dust.zendesk.com/oauth/tokens")
+            .post(url)
             .header("Content-Type", "application/json")
             .json(&body);
 

--- a/core/src/oauth/providers/zendesk.rs
+++ b/core/src/oauth/providers/zendesk.rs
@@ -48,17 +48,17 @@ impl Provider for ZendeskConnectionProvider {
             "scope": "read"
         });
 
-        let sub_domain = match connection.metadata()["extra_config"].as_str() {
-            Some(c) => {
-                if !ZENDESK_SUBDOMAIN_RE.is_match(c) {
-                    Err(anyhow!("Zendesk extra_config subdomain format invalid"))?
+        let subdomain = match connection.metadata()["zendesk_subdomain"].as_str() {
+            Some(d) => {
+                if !ZENDESK_SUBDOMAIN_RE.is_match(d) {
+                    Err(anyhow!("Zendesk subdomain format invalid"))?
                 }
-                c
+                d
             }
-            None => Err(anyhow!("Zendesk extra_config subdomain is missing"))?,
+            None => Err(anyhow!("Zendesk subdomain is missing"))?,
         };
 
-        let url = format!("https://{}.zendesk.com/oauth/tokens", sub_domain);
+        let url = format!("https://{}.zendesk.com/oauth/tokens", subdomain);
 
         let req = reqwest::Client::new()
             .post(url)

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -126,6 +126,7 @@ export async function handleUpdatePermissions(
   const connectionIdRes = await setupConnection({
     owner,
     provider,
+    extraConfig: null,
   });
   if (connectionIdRes.isErr()) {
     sendNotification({

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -126,7 +126,7 @@ export async function handleUpdatePermissions(
   const connectionIdRes = await setupConnection({
     owner,
     provider,
-    extraConfig: null,
+    extraConfig: {},
   });
   if (connectionIdRes.isErr()) {
     sendNotification({

--- a/front/components/data_source/CreateConnectionConfirmationModal.tsx
+++ b/front/components/data_source/CreateConnectionConfirmationModal.tsx
@@ -6,6 +6,7 @@ import {
   Modal,
   Page,
 } from "@dust-tt/sparkle";
+import { isValidZendeskSubdomain } from "@dust-tt/types";
 import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
 
@@ -29,7 +30,7 @@ export function CreateConnectionConfirmationModal({
 
   const isExtraConfigValid = useCallback(() => {
     if (connectorProviderConfiguration.connectorProvider === "zendesk") {
-      return /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(extraConfig || "");
+      return isValidZendeskSubdomain(extraConfig);
     } else {
       return true;
     }

--- a/front/components/data_source/CreateConnectionConfirmationModal.tsx
+++ b/front/components/data_source/CreateConnectionConfirmationModal.tsx
@@ -16,7 +16,7 @@ type CreateConnectionConfirmationModalProps = {
   connectorProviderConfiguration: ConnectorProviderConfiguration;
   isOpen: boolean;
   onClose: () => void;
-  onConfirm: (extraConfig: string | null) => void;
+  onConfirm: (extraConfig: Record<string, string>) => void;
 };
 
 export function CreateConnectionConfirmationModal({
@@ -26,11 +26,11 @@ export function CreateConnectionConfirmationModal({
   onConfirm,
 }: CreateConnectionConfirmationModalProps) {
   const [isLoading, setIsLoading] = useState(false);
-  const [extraConfig, setExtraConfig] = useState<string | null>(null);
+  const [extraConfig, setExtraConfig] = useState<Record<string, string>>({});
 
   const isExtraConfigValid = useCallback(() => {
     if (connectorProviderConfiguration.connectorProvider === "zendesk") {
-      return isValidZendeskSubdomain(extraConfig);
+      return isValidZendeskSubdomain(extraConfig.zendesk_subdomain);
     } else {
       return true;
     }
@@ -39,6 +39,8 @@ export function CreateConnectionConfirmationModal({
   useEffect(() => {
     if (isOpen) {
       setIsLoading(false);
+      // Clean-up extraConfig at mount since the component is reused across providers.
+      setExtraConfig({});
     }
   }, [isOpen, setIsLoading]);
 
@@ -123,10 +125,10 @@ export function CreateConnectionConfirmationModal({
               message="The first part of your Zendesk account URL."
               messageStatus="info"
               name="subdomain"
-              value={extraConfig ?? ""}
+              value={extraConfig.zendesk_subdomain ?? ""}
               placeholder="my-subdomain"
               onChange={(e) => {
-                setExtraConfig(e.target.value);
+                setExtraConfig({ zendesk_subdomain: e.target.value });
               }}
             />
           )}

--- a/front/components/data_source/CreateConnectionConfirmationModal.tsx
+++ b/front/components/data_source/CreateConnectionConfirmationModal.tsx
@@ -105,26 +105,6 @@ export function CreateConnectionConfirmationModal({
             </>
           )}
 
-          {connectorProviderConfiguration.connectorProvider === "zendesk" && (
-            <>
-              <Page.SectionHeader title="Zendesk Configuration" />
-
-              <div className="w-full space-y-4">
-                <Input
-                  label="Zendesk account subdomain"
-                  message="The first part of your Zendesk account URL."
-                  messageStatus="info"
-                  name="subdomain"
-                  value={extraConfig ?? ""}
-                  placeholder="my-subdomain"
-                  onChange={(e) => {
-                    setExtraConfig(e.target.value);
-                  }}
-                />
-              </div>
-            </>
-          )}
-
           {connectorProviderConfiguration.limitations && (
             <div className="flex flex-col gap-y-2">
               <div className="grow text-sm font-medium text-element-800">
@@ -134,6 +114,20 @@ export function CreateConnectionConfirmationModal({
                 {connectorProviderConfiguration.limitations}
               </div>
             </div>
+          )}
+
+          {connectorProviderConfiguration.connectorProvider === "zendesk" && (
+            <Input
+              label="Zendesk account subdomain"
+              message="The first part of your Zendesk account URL."
+              messageStatus="info"
+              name="subdomain"
+              value={extraConfig ?? ""}
+              placeholder="my-subdomain"
+              onChange={(e) => {
+                setExtraConfig(e.target.value);
+              }}
+            />
           )}
 
           <div className="flex justify-center pt-2">

--- a/front/components/data_source/CreateConnectionSnowflakeModal.tsx
+++ b/front/components/data_source/CreateConnectionSnowflakeModal.tsx
@@ -163,7 +163,7 @@ export function CreateConnectionSnowflakeModal({
             <div className="w-full space-y-4">
               <Input
                 label="Snowflake Account identifier"
-                name="username"
+                name="account_identifier"
                 value={credentials.account}
                 placeholder="au12345.us-east-1"
                 onChange={(e) => {
@@ -173,7 +173,7 @@ export function CreateConnectionSnowflakeModal({
               />
               <Input
                 label="Role"
-                name="username"
+                name="role"
                 value={credentials.role}
                 placeholder="dev_role"
                 onChange={(e) => {

--- a/front/components/spaces/AddConnectionMenu.tsx
+++ b/front/components/spaces/AddConnectionMenu.tsx
@@ -56,7 +56,7 @@ export async function setupConnection({
 }: {
   owner: LightWorkspaceType;
   provider: ConnectorProvider;
-  extraConfig: string | null;
+  extraConfig: Record<string, string>;
 }): Promise<Result<string, Error>> {
   let connectionId: string;
 
@@ -158,7 +158,7 @@ export const AddConnectionMenu = ({
   const handleOauthProviderManagedDataSource = async (
     provider: ConnectorProvider,
     suffix: string | null,
-    extraConfig: string | null
+    extraConfig: Record<string, string>
   ) => {
     try {
       const connectionIdRes = await setupConnection({
@@ -326,7 +326,7 @@ export const AddConnectionMenu = ({
                   integration: prev.integration,
                 }))
               }
-              onConfirm={(extraConfig: string | null) => {
+              onConfirm={(extraConfig: Record<string, string>) => {
                 if (showConfirmConnection.integration) {
                   void handleOauthProviderManagedDataSource(
                     connectorProvider,

--- a/front/components/spaces/AddConnectionMenu.tsx
+++ b/front/components/spaces/AddConnectionMenu.tsx
@@ -52,9 +52,11 @@ type AddConnectionMenuProps = {
 export async function setupConnection({
   owner,
   provider,
+  extraConfig,
 }: {
   owner: LightWorkspaceType;
   provider: ConnectorProvider;
+  extraConfig: string | null;
 }): Promise<Result<string, Error>> {
   let connectionId: string;
 
@@ -65,6 +67,7 @@ export async function setupConnection({
       owner,
       provider,
       useCase: "connection",
+      extraConfig,
     });
     if (!cRes.isOk()) {
       return cRes;
@@ -154,12 +157,14 @@ export const AddConnectionMenu = ({
 
   const handleOauthProviderManagedDataSource = async (
     provider: ConnectorProvider,
-    suffix: string | null
+    suffix: string | null,
+    extraConfig: string | null
   ) => {
     try {
       const connectionIdRes = await setupConnection({
         owner,
         provider,
+        extraConfig,
       });
       if (connectionIdRes.isErr()) {
         throw connectionIdRes.error;
@@ -321,11 +326,12 @@ export const AddConnectionMenu = ({
                   integration: prev.integration,
                 }))
               }
-              onConfirm={() => {
+              onConfirm={(extraConfig: string | null) => {
                 if (showConfirmConnection.integration) {
                   void handleOauthProviderManagedDataSource(
                     connectorProvider,
-                    integration.setupWithSuffix
+                    integration.setupWithSuffix,
+                    extraConfig
                   );
                 }
               }}

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -247,12 +247,11 @@ const PROVIDER_STRATEGIES: Record<
   zendesk: {
     setupUri: (connection) => {
       const scopes = ["read"];
-      let subdomain = "not-valid-will-fail";
-      if (isValidZendeskSubdomain(connection.metadata.extra_config)) {
-        subdomain = connection.metadata.extra_config;
+      if (!isValidZendeskSubdomain(connection.metadata.extra_config)) {
+        throw "Invalid Zendesk subdomain";
       }
       return (
-        `https://${subdomain}.zendesk.com/oauth/authorizations/new?` +
+        `https://${connection.metadata.extra_config}.zendesk.com/oauth/authorizations/new?` +
         `client_id=${config.getOAuthZendeskClientId()}` +
         `&scope=${encodeURIComponent(scopes.join(" "))}` +
         `&response_type=code` +

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -4,7 +4,7 @@ import type {
   Result,
 } from "@dust-tt/types";
 import type { OAuthProvider, OAuthUseCase } from "@dust-tt/types";
-import { Err, OAuthAPI, Ok } from "@dust-tt/types";
+import { Err, isValidZendeskSubdomain, OAuthAPI, Ok } from "@dust-tt/types";
 import type { ParsedUrlQuery } from "querystring";
 import querystring from "querystring";
 
@@ -247,8 +247,12 @@ const PROVIDER_STRATEGIES: Record<
   zendesk: {
     setupUri: (connection) => {
       const scopes = ["read"];
+      let subdomain = "not-valid-will-fail";
+      if (isValidZendeskSubdomain(connection.metadata.extra_config)) {
+        subdomain = connection.metadata.extra_config;
+      }
       return (
-        `https://d3v-dust.zendesk.com/oauth/authorizations/new?` +
+        `https://${subdomain}.zendesk.com/oauth/authorizations/new?` +
         `client_id=${config.getOAuthZendeskClientId()}` +
         `&scope=${encodeURIComponent(scopes.join(" "))}` +
         `&response_type=code` +

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -39,6 +39,7 @@ const PROVIDER_STRATEGIES: Record<
     setupUri: (connection: OAuthConnectionType) => string;
     codeFromQuery: (query: ParsedUrlQuery) => string | null;
     connectionIdFromQuery: (query: ParsedUrlQuery) => string | null;
+    isExtraConfigValid: (extraConfig: Record<string, string>) => boolean;
   }
 > = {
   github: {
@@ -60,6 +61,9 @@ const PROVIDER_STRATEGIES: Record<
     },
     connectionIdFromQuery: (query) => {
       return getStringFromQuery(query, "state");
+    },
+    isExtraConfigValid: (extraConfig) => {
+      return Object.keys(extraConfig).length === 0;
     },
   },
   google_drive: {
@@ -85,6 +89,9 @@ const PROVIDER_STRATEGIES: Record<
     connectionIdFromQuery: (query) => {
       return getStringFromQuery(query, "state");
     },
+    isExtraConfigValid: (extraConfig) => {
+      return Object.keys(extraConfig).length === 0;
+    },
   },
   notion: {
     setupUri: (connection) => {
@@ -105,6 +112,9 @@ const PROVIDER_STRATEGIES: Record<
     },
     connectionIdFromQuery: (query) => {
       return getStringFromQuery(query, "state");
+    },
+    isExtraConfigValid: (extraConfig) => {
+      return Object.keys(extraConfig).length === 0;
     },
   },
   slack: {
@@ -138,6 +148,9 @@ const PROVIDER_STRATEGIES: Record<
     },
     connectionIdFromQuery: (query) => {
       return getStringFromQuery(query, "state");
+    },
+    isExtraConfigValid: (extraConfig) => {
+      return Object.keys(extraConfig).length === 0;
     },
   },
   confluence: {
@@ -175,6 +188,9 @@ const PROVIDER_STRATEGIES: Record<
     connectionIdFromQuery: (query) => {
       return getStringFromQuery(query, "state");
     },
+    isExtraConfigValid: (extraConfig) => {
+      return Object.keys(extraConfig).length === 0;
+    },
   },
   intercom: {
     setupUri: (connection) => {
@@ -190,6 +206,9 @@ const PROVIDER_STRATEGIES: Record<
     },
     connectionIdFromQuery: (connection) => {
       return getStringFromQuery(connection, "state");
+    },
+    isExtraConfigValid: (extraConfig) => {
+      return Object.keys(extraConfig).length === 0;
     },
   },
   gong: {
@@ -214,6 +233,9 @@ const PROVIDER_STRATEGIES: Record<
     },
     connectionIdFromQuery: (query) => {
       return getStringFromQuery(query, "state");
+    },
+    isExtraConfigValid: (extraConfig) => {
+      return Object.keys(extraConfig).length === 0;
     },
   },
   microsoft: {
@@ -243,6 +265,9 @@ const PROVIDER_STRATEGIES: Record<
     connectionIdFromQuery: (query) => {
       return getStringFromQuery(query, "state");
     },
+    isExtraConfigValid: (extraConfig) => {
+      return Object.keys(extraConfig).length === 0;
+    },
   },
   zendesk: {
     setupUri: (connection) => {
@@ -265,6 +290,13 @@ const PROVIDER_STRATEGIES: Record<
     connectionIdFromQuery: (query) => {
       return getStringFromQuery(query, "state");
     },
+    isExtraConfigValid: (extraConfig) => {
+      if (Object.keys(extraConfig).length !== 1) {
+        return false;
+      }
+      // Ensure the string is less than 63 characters.
+      return isValidZendeskSubdomain(extraConfig.zendesk_subdomain);
+    },
   },
 };
 
@@ -275,6 +307,17 @@ export async function createConnectionAndGetSetupUrl(
   extraConfig: Record<string, string>
 ): Promise<Result<string, OAuthError>> {
   const api = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+
+  if (!PROVIDER_STRATEGIES[provider].isExtraConfigValid(extraConfig)) {
+    logger.error(
+      { provider, useCase, extraConfig },
+      "OAuth: Invalid extraConfig"
+    );
+    return new Err({
+      code: "connection_creation_failed",
+      message: "Invalid OAuth connection extraConfig for provider",
+    });
+  }
 
   const metadata: Record<string, string> = {
     use_case: useCase,

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -268,17 +268,23 @@ const PROVIDER_STRATEGIES: Record<
 export async function createConnectionAndGetSetupUrl(
   auth: Authenticator,
   provider: OAuthProvider,
-  useCase: OAuthUseCase
+  useCase: OAuthUseCase,
+  extraConfig: string | null
 ): Promise<Result<string, OAuthError>> {
   const api = new OAuthAPI(config.getOAuthAPIConfig(), logger);
 
+  const metadata: Record<string, string> = {
+    use_case: useCase,
+    workspace_id: auth.getNonNullableWorkspace().sId,
+    user_id: auth.getNonNullableUser().sId,
+  };
+  if (extraConfig) {
+    metadata.extra_config = extraConfig;
+  }
+
   const cRes = await api.createConnection({
     provider,
-    metadata: {
-      use_case: useCase,
-      workspace_id: auth.getNonNullableWorkspace().sId,
-      user_id: auth.getNonNullableUser().sId,
-    },
+    metadata,
   });
   if (cRes.isErr()) {
     logger.error({ provider, useCase }, "OAuth: Failed to create connection");

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -247,11 +247,11 @@ const PROVIDER_STRATEGIES: Record<
   zendesk: {
     setupUri: (connection) => {
       const scopes = ["read"];
-      if (!isValidZendeskSubdomain(connection.metadata.extra_config)) {
+      if (!isValidZendeskSubdomain(connection.metadata.zendesk_subdomain)) {
         throw "Invalid Zendesk subdomain";
       }
       return (
-        `https://${connection.metadata.extra_config}.zendesk.com/oauth/authorizations/new?` +
+        `https://${connection.metadata.zendesk_subdomain}.zendesk.com/oauth/authorizations/new?` +
         `client_id=${config.getOAuthZendeskClientId()}` +
         `&scope=${encodeURIComponent(scopes.join(" "))}` +
         `&response_type=code` +
@@ -272,7 +272,7 @@ export async function createConnectionAndGetSetupUrl(
   auth: Authenticator,
   provider: OAuthProvider,
   useCase: OAuthUseCase,
-  extraConfig: string | null
+  extraConfig: Record<string, string>
 ): Promise<Result<string, OAuthError>> {
   const api = new OAuthAPI(config.getOAuthAPIConfig(), logger);
 
@@ -280,10 +280,8 @@ export async function createConnectionAndGetSetupUrl(
     use_case: useCase,
     workspace_id: auth.getNonNullableWorkspace().sId,
     user_id: auth.getNonNullableUser().sId,
+    ...extraConfig,
   };
-  if (extraConfig) {
-    metadata.extra_config = extraConfig;
-  }
 
   const cRes = await api.createConnection({
     provider,

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -187,7 +187,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
   zendesk: {
     name: "Zendesk",
     connectorProvider: "zendesk",
-    status: "preview",
+    status: "rolling_out",
     hide: false,
     description:
       "Authorize access to Zendesk for indexing tickets from your support center and articles from your help center.",

--- a/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
+++ b/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
@@ -386,6 +386,7 @@ export default function LabsTranscriptsIndex({
       owner,
       provider: "google_drive",
       useCase: "labs_transcripts",
+      extraConfig: null,
     });
 
     if (cRes.isErr()) {
@@ -440,6 +441,7 @@ export default function LabsTranscriptsIndex({
           owner,
           provider: "gong",
           useCase: "connection",
+          extraConfig: null,
         });
         if (!cRes.isOk()) {
           return cRes;

--- a/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
+++ b/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
@@ -386,7 +386,7 @@ export default function LabsTranscriptsIndex({
       owner,
       provider: "google_drive",
       useCase: "labs_transcripts",
-      extraConfig: null,
+      extraConfig: {},
     });
 
     if (cRes.isErr()) {
@@ -441,7 +441,7 @@ export default function LabsTranscriptsIndex({
           owner,
           provider: "gong",
           useCase: "connection",
-          extraConfig: null,
+          extraConfig: {},
         });
         if (!cRes.isOk()) {
           return cRes;

--- a/front/pages/w/[wId]/oauth/[provider]/setup.tsx
+++ b/front/pages/w/[wId]/oauth/[provider]/setup.tsx
@@ -11,15 +11,19 @@ export const getServerSideProps = withDefaultUserAuthRequirements<object>(
       };
     }
 
-    const provider = context.query.provider as string;
+    const { provider, useCase, extraConfig } = context.query;
+
     if (!isOAuthProvider(provider)) {
       return {
         notFound: true,
       };
     }
-
-    const useCase = context.query.useCase as string;
     if (!isOAuthUseCase(useCase)) {
+      return {
+        notFound: true,
+      };
+    }
+    if (extraConfig && typeof extraConfig !== "string") {
       return {
         notFound: true,
       };
@@ -28,7 +32,8 @@ export const getServerSideProps = withDefaultUserAuthRequirements<object>(
     const urlRes = await createConnectionAndGetSetupUrl(
       auth,
       provider,
-      useCase
+      useCase,
+      extraConfig || null
     );
 
     if (!urlRes.isOk()) {

--- a/types/src/oauth/client/setup.ts
+++ b/types/src/oauth/client/setup.ts
@@ -12,16 +12,20 @@ export async function setupOAuthConnection({
   owner,
   provider,
   useCase,
+  extraConfig,
 }: {
   dustClientFacingUrl: string;
   owner: LightWorkspaceType;
   provider: OAuthProvider;
   useCase: OAuthUseCase;
+  extraConfig: string | null;
 }): Promise<Result<OAuthConnectionType, Error>> {
   return new Promise((resolve) => {
-    const oauthPopup = window.open(
-      `${dustClientFacingUrl}/w/${owner.sId}/oauth/${provider}/setup?useCase=${useCase}`
-    );
+    let url = `${dustClientFacingUrl}/w/${owner.sId}/oauth/${provider}/setup?useCase=${useCase}`;
+    if (extraConfig) {
+      url += `&extraConfig=${extraConfig}`;
+    }
+    const oauthPopup = window.open(url);
     let authComplete = false;
 
     const popupMessageEventListener = (event: MessageEvent) => {

--- a/types/src/oauth/client/setup.ts
+++ b/types/src/oauth/client/setup.ts
@@ -18,12 +18,12 @@ export async function setupOAuthConnection({
   owner: LightWorkspaceType;
   provider: OAuthProvider;
   useCase: OAuthUseCase;
-  extraConfig: string | null;
+  extraConfig: Record<string, string>;
 }): Promise<Result<OAuthConnectionType, Error>> {
   return new Promise((resolve) => {
     let url = `${dustClientFacingUrl}/w/${owner.sId}/oauth/${provider}/setup?useCase=${useCase}`;
     if (extraConfig) {
-      url += `&extraConfig=${extraConfig}`;
+      url += `&extraConfig=${encodeURIComponent(JSON.stringify(extraConfig))}`;
     }
     const oauthPopup = window.open(url);
     let authComplete = false;

--- a/types/src/oauth/lib.ts
+++ b/types/src/oauth/lib.ts
@@ -29,7 +29,7 @@ export function isOAuthProvider(obj: unknown): obj is OAuthProvider {
 export type OAuthConnectionType = {
   connection_id: string;
   created: number;
-  metdata: Record<string, unknown>;
+  metadata: Record<string, unknown>;
   provider: OAuthProvider;
   status: "pending" | "finalized";
 };
@@ -43,6 +43,14 @@ export function isOAuthConnectionType(
     typeof connection.created === "number" &&
     isOAuthProvider(connection.provider) &&
     (connection.status === "pending" || connection.status === "finalized")
+  );
+}
+
+// OAuth Providers utils
+
+export function isValidZendeskSubdomain(s: unknown): s is string {
+  return (
+    typeof s === "string" && /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(s)
   );
 }
 

--- a/types/src/shared/utils/iots_utils.ts
+++ b/types/src/shared/utils/iots_utils.ts
@@ -46,7 +46,7 @@ export const SlugifiedString = t.brand(
 
 export function ioTsParsePayload<T>(
   payload: unknown,
-  codec: t.Type<T, T, unknown>
+  codec: t.Type<T>
 ): Result<T, string[]> {
   const bodyValidation = codec.decode(payload);
   if (isLeft(bodyValidation)) {

--- a/types/src/shared/utils/iots_utils.ts
+++ b/types/src/shared/utils/iots_utils.ts
@@ -46,7 +46,7 @@ export const SlugifiedString = t.brand(
 
 export function ioTsParsePayload<T>(
   payload: unknown,
-  codec: t.Type<T>
+  codec: t.Type<T, T, unknown>
 ): Result<T, string[]> {
   const bodyValidation = codec.decode(payload);
   if (isLeft(bodyValidation)) {


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/1517

- adds support for extra_config being passed through the setup redirect URL as metadata on the Connection
- Tweak Zendesk setup screen to capture the Zendesk account subdomain
- Change oauth zendesk adapter to pull the subdomain from the metadata of the Connection (and check it)
- Move zendesk to being rolling_out (feature flag based)

![Screenshot from 2024-10-31 15-59-05](https://github.com/user-attachments/assets/27e8d646-eb8f-4a87-bb79-c9ecc9a014a1)

## Risk

Low, not released yet. Did a successful setup in dev.

## Deploy Plan

- deploy `oauth
- deploy `front`

r? @aubin-tchoi cc @albandum 