### PR TITLE
Set default pagination on static data source for content nodes

### DIFF
--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -150,7 +150,8 @@ async function getContentNodesForStaticDataSourceView(
 > {
   const { dataSource } = dataSourceView;
 
-  // Always set a limit for pagination of static data sources.
+  // Use a high pagination limit since the product UI doesn't support pagination yet,
+  // even though static data sources can contain many documents via API ingestion.
   const paginationParams = pagination ?? {
     limit: DEFAULT_STATIC_DATA_SOURCE_PAGINATION_LIMIT,
     offset: 0,

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -14,6 +14,8 @@ import type { OffsetPaginationParams } from "@app/lib/api/pagination";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import logger from "@app/logger/logger";
 
+const DEFAULT_STATIC_DATA_SOURCE_PAGINATION_LIMIT = 10_000;
+
 export function filterAndCropContentNodesByView(
   dataSourceView: DataSourceViewResource,
   contentNodes: DataSourceViewContentNode[]
@@ -148,6 +150,12 @@ async function getContentNodesForStaticDataSourceView(
 > {
   const { dataSource } = dataSourceView;
 
+  // Always set a limit for pagination of static data sources.
+  const paginationParams = pagination ?? {
+    limit: DEFAULT_STATIC_DATA_SOURCE_PAGINATION_LIMIT,
+    offset: 0,
+  };
+
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 
   // Early return if there are no internalIds.
@@ -166,7 +174,7 @@ async function getContentNodesForStaticDataSourceView(
         projectId: dataSource.dustAPIProjectId,
         viewFilter: dataSourceView.toViewFilter(),
       },
-      pagination
+      paginationParams
     );
 
     if (documentsRes.isErr()) {
@@ -209,7 +217,7 @@ async function getContentNodesForStaticDataSourceView(
         tableIds: internalIds,
         viewFilter: dataSourceView.toViewFilter(),
       },
-      pagination
+      paginationParams
     );
 
     if (tablesRes.isErr()) {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See [thread](https://dust4ai.slack.com/archives/C05F84CFP0E/p1730391021103279).

This PR sets a default limit when fetching content nodes from a static data source view. Most of those are being loaded with thousands of documents from the Public API. This is a temporary fix until we refactor the UI to pagination + search.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
