### PR TITLE
Improve visualization prompt to better support screenshot

### DIFF
--- a/front/lib/api/assistant/visualization.ts
+++ b/front/lib/api/assistant/visualization.ts
@@ -136,7 +136,10 @@ Guidelines using the :::visualization tag:
 - Props:
   - The generated component should not have any required props / parameters
 - Responsiveness:
-  - The content should be responsive
+  - Use ResponsiveContainer for charts to adapt to parent dimensions
+  - Leave adequate padding around charts for labels and legends
+  - Content should adapt gracefully to different widths
+  - For multi-chart layouts, use flex or grid to maintain spacing
   - The outermost container should have a fixed height between 200 and 600 pixels, set using the \`style\` prop such as \`<div style={{height: "600px"}}>\`
   - The component should be able to adapt to different screen sizes
   - The content should never overflow the viewport and should never have horizontal or vertical scrollbars

--- a/front/lib/api/assistant/visualization.ts
+++ b/front/lib/api/assistant/visualization.ts
@@ -140,7 +140,6 @@ Guidelines using the :::visualization tag:
   - Leave adequate padding around charts for labels and legends
   - Content should adapt gracefully to different widths
   - For multi-chart layouts, use flex or grid to maintain spacing
-  - The outermost container should have a fixed height between 200 and 600 pixels, set using the \`style\` prop such as \`<div style={{height: "600px"}}>\`
   - The component should be able to adapt to different screen sizes
   - The content should never overflow the viewport and should never have horizontal or vertical scrollbars
 - Styling:

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -251,7 +251,7 @@ export function VisualizationWrapper({
     <div className="relative group/viz">
       <button
         onClick={handleDownload}
-        className="absolute top-2 right-2 bg-white p-2 rounded shadow hover:bg-gray-100 transition opacity-0 group-hover/viz:opacity-100"
+        className="absolute top-2 right-2 bg-white p-2 rounded shadow hover:bg-gray-100 transition opacity-0 group-hover/viz:opacity-100 z-50"
       >
         <Download size={20} />
       </button>


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We got several reports that when assistant generates visualization that overcomes the max iframe height (600px) when taking the screenshot the view is cropped.

The LLM was previously instructed to set fixed heights on visualization containers. When using html-to-image's `toBlob()`, it only captures the visible content of the element. Since some charts were getting cropped by their container's fixed height + overflow handling, the screenshots were incomplete. By letting the container expand to its content's natural height, we ensure the full visualization is visible and therefore captured in the screenshot.

Example:
![visualization-viz-ieWGiwyusA-3](https://github.com/user-attachments/assets/61ee56b8-4c5c-4162-adfc-9ce20cc96b41)

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
