### PR TITLE
[extension] [front] chore: layout and fixes in message groups

### DIFF
--- a/extension/app/src/components/conversation/AgentMessage.tsx
+++ b/extension/app/src/components/conversation/AgentMessage.tsx
@@ -53,7 +53,23 @@ import { useSubmitFunction } from "@extension/components/utils/useSubmitFunction
 import { useEventSource } from "@extension/hooks/useEventSource";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Components } from "react-markdown";
+import type { ReactMarkdownProps } from "react-markdown/lib/complex-types";
 import type { PluggableList } from "react-markdown/lib/react-markdown";
+import { visit } from "unist-util-visit";
+
+export function visualizationDirective() {
+  return (tree: any) => {
+    visit(tree, ["containerDirective"], (node) => {
+      if (node.name === "visualization") {
+        const data = node.data || (node.data = {});
+        data.hName = "visualization";
+        data.hProperties = {
+          position: node.position,
+        };
+      }
+    });
+  };
+}
 
 export function makeDocumentCitation(
   document: RetrievalDocumentType
@@ -365,6 +381,18 @@ export function AgentMessage({
 
   const additionalMarkdownComponents: Components = useMemo(
     () => ({
+      visualization: (props: ReactMarkdownProps) => (
+        <div className="w-full flex justify-center">
+          <Button
+            label="Please check the visualization here"
+            onClick={() => {
+              window.open(
+                `${process.env.DUST_DOMAIN}/w/${owner.sId}/assistant/${conversationId}`
+              );
+            }}
+          />
+        </div>
+      ),
       sup: CiteBlock,
       mention: MentionBlock,
     }),
@@ -372,7 +400,7 @@ export function AgentMessage({
   );
 
   const additionalMarkdownPlugins: PluggableList = useMemo(
-    () => [mentionDirective, getCiteDirective()],
+    () => [mentionDirective, getCiteDirective(), visualizationDirective],
     []
   );
 

--- a/extension/app/src/components/conversation/ConversationContainer.tsx
+++ b/extension/app/src/components/conversation/ConversationContainer.tsx
@@ -10,7 +10,7 @@ import type {
 import { ConversationViewer } from "@extension/components/conversation/ConversationViewer";
 import { ReachedLimitPopup } from "@extension/components/conversation/ReachedLimitPopup";
 import { usePublicConversation } from "@extension/components/conversation/usePublicConversation";
-import { AssistantInputBar } from "@extension/components/input_bar/InputBar";
+import { FixedAssistantInputBar } from "@extension/components/input_bar/InputBar";
 import { InputBarContext } from "@extension/components/input_bar/InputBarContext";
 import { useSubmitFunction } from "@extension/components/utils/useSubmitFunction";
 import { postConversation, postMessage } from "@extension/lib/conversation";
@@ -162,13 +162,14 @@ export function ConversationContainer({
           onStickyMentionsChange={onStickyMentionsChange}
         />
       )}
-      <AssistantInputBar
+      <FixedAssistantInputBar
         owner={owner}
         onSubmit={
           activeConversationId ? handlePostMessage : handlePostConversation
         }
         stickyMentions={stickyMentions}
       />
+
       <ReachedLimitPopup
         isOpened={planLimitReached}
         onClose={() => setPlanLimitReached(false)}

--- a/extension/app/src/components/conversation/ConversationViewer.tsx
+++ b/extension/app/src/components/conversation/ConversationViewer.tsx
@@ -35,7 +35,9 @@ export function ConversationViewer({
     workspaceId: owner.sId,
   });
 
-  const messages = (conversation?.content || []).flat();
+  const messages = (conversation?.content || []).map(
+    (messages) => messages[messages.length - 1]
+  );
 
   const lastUserMessage = useMemo(() => {
     return messages.findLast(
@@ -106,15 +108,15 @@ export function ConversationViewer({
  * together.
  *
  * Example:
- * Input [[content_fragment, content_fragment], [user_message], [agent_message, agent_message]]
- * Output: [[user_message with content_fragment[]], [agent_message, agent_message]]
+ * Input [content_fragment, content_fragment, user_message, agent_message, agent_message, user_message, agent_message]
+ * Output: [[user_message with content_fragment[]], [agent_message, agent_message], [user_message, agent_message ]]
  * This structure enables layout customization for consecutive messages of the same type
  * and displays content_fragments within user_messages.
  */
 const groupMessagesByType = (
   messages: (ContentFragmentType | UserMessageType | AgentMessageType)[]
-): MessageWithContentFragmentsType[][][] => {
-  const groupedMessages: MessageWithContentFragmentsType[][][] = [];
+): MessageWithContentFragmentsType[][] => {
+  const groupedMessages: MessageWithContentFragmentsType[][] = [];
   let tempContentFragments: ContentFragmentType[] = [];
 
   messages.forEach((message) => {
@@ -131,17 +133,16 @@ const groupMessagesByType = (
         tempContentFragments = []; // Reset the collected content fragments.
 
         // Start a new group for user messages.
-        groupedMessages.push([[messageWithContentFragments]]);
+        groupedMessages.push([messageWithContentFragments]);
       } else {
         messageWithContentFragments = message;
 
         const lastGroup = groupedMessages[groupedMessages.length - 1];
 
         if (!lastGroup) {
-          groupedMessages.push([[messageWithContentFragments]]);
+          groupedMessages.push([messageWithContentFragments]);
         } else {
-          const [lastMessageGroup] = lastGroup;
-          lastMessageGroup.push(messageWithContentFragments); // Add agent messages to the last group.
+          lastGroup.push(messageWithContentFragments); // Add agent messages to the last group.
         }
       }
     }

--- a/extension/app/src/components/conversation/ConversationViewer.tsx
+++ b/extension/app/src/components/conversation/ConversationViewer.tsx
@@ -35,6 +35,7 @@ export function ConversationViewer({
     workspaceId: owner.sId,
   });
 
+  // We only keep the last version of each message.
   const messages = (conversation?.content || []).map(
     (messages) => messages[messages.length - 1]
   );
@@ -98,19 +99,20 @@ export function ConversationViewer({
     </div>
   );
 }
+
 /**
- * Groups and organizes messages by their type, associating content_fragments
- * with the following user_message.
- *
  * This function processes an array of messages, collecting content_fragments
- * and attaching them to subsequent user_messages, then groups these messages
- * with the previous user_message, ensuring consecutive messages are grouped
- * together.
+ * and attaching them to subsequent user_messages, then groups the agent messages
+ * with the previous user_message, ensuring question/answers are grouped
+ * together :
  *
- * Example:
+ * - user message + potential content fragments posted with the user message
+ * - one or multiple agent messages depending on the number of mentions in the user message.
+ *
+ * That means we want this:
  * Input [content_fragment, content_fragment, user_message, agent_message, agent_message, user_message, agent_message]
- * Output: [[user_message with content_fragment[]], [agent_message, agent_message], [user_message, agent_message ]]
- * This structure enables layout customization for consecutive messages of the same type
+ * Output [[user_message with content_fragment[], agent_message, agent_message], [user_message, agent_message ]]
+ * This structure enables layout customization for groups of question/answers
  * and displays content_fragments within user_messages.
  */
 const groupMessagesByType = (

--- a/extension/app/src/components/conversation/MessageGroup.tsx
+++ b/extension/app/src/components/conversation/MessageGroup.tsx
@@ -1,6 +1,5 @@
 import type {
   ConversationMessageReactions,
-  FetchConversationMessagesResponse,
   LightWorkspaceType,
   MessageWithContentFragmentsType,
 } from "@dust-tt/types";
@@ -9,7 +8,7 @@ import type { StoredUser } from "@extension/lib/storage";
 import React, { useEffect, useRef } from "react";
 
 interface MessageGroupProps {
-  messages: MessageWithContentFragmentsType[][];
+  messages: MessageWithContentFragmentsType[];
   isLastMessageGroup: boolean;
   conversationId: string;
   hideReactions: boolean;
@@ -17,7 +16,6 @@ interface MessageGroupProps {
   owner: LightWorkspaceType;
   reactions: ConversationMessageReactions;
   user: StoredUser;
-  latestPage?: FetchConversationMessagesResponse;
 }
 
 // arbitrary offset to scroll the last MessageGroup to
@@ -35,7 +33,6 @@ export default function MessageGroup({
   owner,
   reactions,
   user,
-  latestPage,
 }: MessageGroupProps) {
   const lastMessageGroupRef = useRef<HTMLDivElement>(null);
 
@@ -57,23 +54,21 @@ export default function MessageGroup({
       ref={isLastMessageGroup ? lastMessageGroupRef : undefined}
       style={{ minHeight }}
     >
-      {messages.map((group) => {
-        return group.map((message) => {
-          return (
-            <MessageItem
-              key={`message-${message.sId}`}
-              conversationId={conversationId}
-              hideReactions={hideReactions}
-              isInModal={isInModal}
-              message={message}
-              owner={owner}
-              reactions={reactions}
-              user={user}
-              isLastMessage={latestPage?.messages.at(-1)?.sId === message.sId}
-            />
-          );
-        });
-      })}
+      {messages.map((message) => (
+        <MessageItem
+          key={`message-${message.sId}`}
+          conversationId={conversationId}
+          hideReactions={hideReactions}
+          isInModal={isInModal}
+          message={message}
+          owner={owner}
+          reactions={reactions}
+          user={user}
+          isLastMessage={
+            isLastMessageGroup && messages.at(-1)?.sId === message.sId
+          }
+        />
+      ))}
     </div>
   );
 }

--- a/extension/app/src/components/input_bar/InputBar.tsx
+++ b/extension/app/src/components/input_bar/InputBar.tsx
@@ -150,3 +150,29 @@ export function AssistantInputBar({
     </div>
   );
 }
+
+export function FixedAssistantInputBar({
+  owner,
+  onSubmit,
+  stickyMentions,
+  additionalAgentConfiguration,
+  disableAutoFocus = false,
+}: {
+  owner: LightWorkspaceType;
+  onSubmit: (input: string, mentions: MentionType[]) => void;
+  stickyMentions?: AgentMention[];
+  additionalAgentConfiguration?: LightAgentConfigurationType;
+  disableAutoFocus?: boolean;
+}) {
+  return (
+    <div className="sticky bottom-0 z-20 flex max-h-screen w-full max-w-4xl sm:pb-8">
+      <AssistantInputBar
+        owner={owner}
+        onSubmit={onSubmit}
+        stickyMentions={stickyMentions}
+        additionalAgentConfiguration={additionalAgentConfiguration}
+        disableAutoFocus={disableAutoFocus}
+      />
+    </div>
+  );
+}

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -373,15 +373,15 @@ export default ConversationViewer;
  * together.
  *
  * Example:
- * Input [[content_fragment, content_fragment], [user_message], [agent_message, agent_message]]
- * Output: [[user_message with content_fragment[]], [agent_message, agent_message]]
+ * Input [[content_fragment, content_fragment], [user_message], [agent_message, agent_message], [user_message], [agent_message]]
+ * Output: [[user_message with content_fragment[], agent_message, agent_message], [user_message, agent_message]]
  * This structure enables layout customization for consecutive messages of the same type
  * and displays content_fragments within user_messages.
  */
 const groupMessagesByType = (
   messages: FetchConversationMessagesResponse[]
-): MessageWithContentFragmentsType[][][] => {
-  const groupedMessages: MessageWithContentFragmentsType[][][] = [];
+): MessageWithContentFragmentsType[][] => {
+  const groupedMessages: MessageWithContentFragmentsType[][] = [];
   let tempContentFragments: ContentFragmentType[] = [];
 
   messages
@@ -400,17 +400,16 @@ const groupMessagesByType = (
           tempContentFragments = []; // Reset the collected content fragments.
 
           // Start a new group for user messages.
-          groupedMessages.push([[messageWithContentFragments]]);
+          groupedMessages.push([messageWithContentFragments]);
         } else {
           messageWithContentFragments = message;
 
           const lastGroup = groupedMessages[groupedMessages.length - 1];
 
           if (!lastGroup) {
-            groupedMessages.push([[messageWithContentFragments]]);
+            groupedMessages.push([messageWithContentFragments]);
           } else {
-            const [lastMessageGroup] = lastGroup;
-            lastMessageGroup.push(messageWithContentFragments); // Add agent messages to the last group.
+            lastGroup.push(messageWithContentFragments); // Add agent messages to the last group.
           }
         }
       }

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -364,18 +364,18 @@ const ConversationViewer = React.forwardRef<
 export default ConversationViewer;
 
 /**
- * Groups and organizes messages by their type, associating content_fragments
- * with the following user_message.
- *
  * This function processes an array of messages, collecting content_fragments
- * and attaching them to subsequent user_messages, then groups these messages
- * with the previous user_message, ensuring consecutive messages are grouped
- * together.
+ * and attaching them to subsequent user_messages, then groups the agent messages
+ * with the previous user_message, ensuring question/answers are grouped
+ * together :
  *
- * Example:
- * Input [[content_fragment, content_fragment], [user_message], [agent_message, agent_message], [user_message], [agent_message]]
- * Output: [[user_message with content_fragment[], agent_message, agent_message], [user_message, agent_message]]
- * This structure enables layout customization for consecutive messages of the same type
+ * - user message + potential content fragments posted with the user message
+ * - one or multiple agent messages depending on the number of mentions in the user message.
+ *
+ * That means we want this:
+ * Input [content_fragment, content_fragment, user_message, agent_message, agent_message, user_message, agent_message]
+ * Output [[user_message with content_fragment[], agent_message, agent_message], [user_message, agent_message ]]
+ * This structure enables layout customization for groups of question/answers
  * and displays content_fragments within user_messages.
  */
 const groupMessagesByType = (

--- a/front/components/assistant/conversation/MessageGroup.tsx
+++ b/front/components/assistant/conversation/MessageGroup.tsx
@@ -10,7 +10,7 @@ import React, { useEffect, useRef } from "react";
 import MessageItem from "@app/components/assistant/conversation/MessageItem";
 
 interface MessageGroupProps {
-  messages: MessageWithContentFragmentsType[][];
+  messages: MessageWithContentFragmentsType[];
   isLastMessageGroup: boolean;
   conversationId: string;
   hideReactions: boolean;
@@ -62,28 +62,22 @@ export default function MessageGroup({
       ref={isLastMessageGroup ? lastMessageGroupRef : undefined}
       style={{ minHeight }}
     >
-      {messages.map((group) => {
-        return group.map((message) => {
-          return (
-            <MessageItem
-              key={`message-${message.sId}`}
-              conversationId={conversationId}
-              hideReactions={hideReactions}
-              isInModal={isInModal}
-              message={message}
-              owner={owner}
-              reactions={reactions}
-              ref={
-                message.sId === prevFirstMessageId
-                  ? prevFirstMessageRef
-                  : undefined
-              }
-              user={user}
-              isLastMessage={latestPage?.messages.at(-1)?.sId === message.sId}
-            />
-          );
-        });
-      })}
+      {messages.map((message) => (
+        <MessageItem
+          key={`message-${message.sId}`}
+          conversationId={conversationId}
+          hideReactions={hideReactions}
+          isInModal={isInModal}
+          message={message}
+          owner={owner}
+          reactions={reactions}
+          ref={
+            message.sId === prevFirstMessageId ? prevFirstMessageRef : undefined
+          }
+          user={user}
+          isLastMessage={latestPage?.messages.at(-1)?.sId === message.sId}
+        />
+      ))}
     </div>
   );
 }

--- a/front/hooks/useLastMessageGroupObserver.ts
+++ b/front/hooks/useLastMessageGroupObserver.ts
@@ -7,7 +7,7 @@ import { LAST_MESSAGE_GROUP_ID } from "@app/components/assistant/conversation/Me
  * A custom hook to observe when the last message group element becomes visible or not.
  */
 export function useLastMessageGroupObserver(
-  messages: MessageWithContentFragmentsType[][][]
+  messages: MessageWithContentFragmentsType[][]
 ) {
   useEffect(() => {
     const observer = new IntersectionObserver(


### PR DESCRIPTION
## Description

- Fixes message display - only shows last version of the message
- Remove unused array dimension in grouped messages ( **also in front** ). The created array was always `[nb of groups][1][nb of messages]`, second dimension was unused. A "group" is a user message with the associated agent responses.
- Use a fixed input bar
- Shows a button for visualization redirecting to conversation page

## Risk

Issue  in conversation rendering if I missed smthg in the 3-dim messages array

## Deploy Plan
