### PR TITLE
[front] - fix(poke): data source table button variant 

### DIFF
--- a/front/components/poke/data_sources/columns.tsx
+++ b/front/components/poke/data_sources/columns.tsx
@@ -93,7 +93,7 @@ export function makeColumnsForDataSources(
           <IconButton
             icon={TrashIcon}
             size="xs"
-            variant="ghost"
+            variant="outline"
             onClick={async () => {
               await deleteDataSource(owner, dataSource.sId, onDeleted);
             }}


### PR DESCRIPTION
## Description

This PR aims at fixing the IconButton variant used in the poke's data source table

## Risk

None

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
