### PR TITLE
Fix and use conversation events

### DIFF
--- a/extension/app/src/components/conversation/AgentMessage.tsx
+++ b/extension/app/src/components/conversation/AgentMessage.tsx
@@ -392,8 +392,7 @@ export function AgentMessage({
         return (
           <div className="flex flex-row items-center gap-2">
             <div className="text-base font-medium">
-              {/* TODO(Ext) Any CTA here ? */}
-              {agentConfiguration.name}
+              {/* TODO(Ext) Any CTA here ? */}@{agentConfiguration.name}
             </div>
           </div>
         );

--- a/extension/app/src/components/conversation/ConversationViewer.tsx
+++ b/extension/app/src/components/conversation/ConversationViewer.tsx
@@ -89,39 +89,39 @@ export function ConversationViewer({
     [conversationId, owner.sId]
   );
 
-  const onEventCallback = useCallback((eventStr: string) => {
-    const eventPayload: {
-      eventId: string;
-      data:
-        | UserMessageNewEvent
-        | AgentMessageNewEvent
-        | AgentGenerationCancelledEvent
-        | ConversationTitleEvent;
-    } = JSON.parse(eventStr);
+  const onEventCallback = useCallback(
+    (eventStr: string) => {
+      const eventPayload: {
+        eventId: string;
+        data:
+          | UserMessageNewEvent
+          | AgentMessageNewEvent
+          | AgentGenerationCancelledEvent
+          | ConversationTitleEvent;
+      } = JSON.parse(eventStr);
 
-    const event = eventPayload.data;
+      const event = eventPayload.data;
 
-    if (!eventIds.current.includes(eventPayload.eventId)) {
-      console.log("Received event", event);
-      eventIds.current.push(eventPayload.eventId);
-      switch (event.type) {
-        case "user_message_new":
-        case "agent_message_new":
-        case "agent_generation_cancelled":
-        case "conversation_title": {
-          void mutateConversation();
-          break;
+      if (!eventIds.current.includes(eventPayload.eventId)) {
+        console.log("Received event", event);
+        eventIds.current.push(eventPayload.eventId);
+        switch (event.type) {
+          case "user_message_new":
+          case "agent_message_new":
+          case "agent_generation_cancelled":
+          case "conversation_title": {
+            void mutateConversation();
+            break;
+          }
+          default:
+            ((t: never) => {
+              console.error("Unknown event type", t);
+            })(event);
         }
-        default:
-          ((t: never) => {
-            console.error("Unknown event type", t);
-          })(event);
       }
-    }
-  },
-  [
-    mutateConversation,
-  ]);
+    },
+    [mutateConversation]
+  );
 
   useEventSource(
     buildEventSourceURL,
@@ -129,8 +129,7 @@ export function ConversationViewer({
     `conversation-${conversationId}`,
     {
       // We only start consuming the stream when the conversation has been loaded and we have a first page of message.
-      isReadyToConsumeStream: !isConversationLoading &&
-      messages.length !== 0,,
+      isReadyToConsumeStream: !isConversationLoading && messages.length !== 0,
     }
   );
   const eventIds = useRef<string[]>([]);

--- a/extension/app/src/components/conversation/ConversationViewer.tsx
+++ b/extension/app/src/components/conversation/ConversationViewer.tsx
@@ -1,9 +1,13 @@
 import type {
+  AgentGenerationCancelledEvent,
   AgentMention,
+  AgentMessageNewEvent,
   AgentMessageType,
   ContentFragmentType,
+  ConversationTitleEvent,
   LightWorkspaceType,
   MessageWithContentFragmentsType,
+  UserMessageNewEvent,
   UserMessageType,
 } from "@dust-tt/types";
 import {
@@ -13,9 +17,10 @@ import {
 } from "@dust-tt/types";
 import MessageGroup from "@extension/components/conversation/MessageGroup";
 import { usePublicConversation } from "@extension/components/conversation/usePublicConversation";
+import { useEventSource } from "@extension/hooks/useEventSource";
 import type { StoredUser } from "@extension/lib/storage";
 import { classNames } from "@extension/lib/utils";
-import { useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 
 interface ConversationViewerProps {
   conversationId: string;
@@ -30,10 +35,11 @@ export function ConversationViewer({
   owner,
   user,
 }: ConversationViewerProps) {
-  const { conversation } = usePublicConversation({
-    conversationId,
-    workspaceId: owner.sId,
-  });
+  const { conversation, isConversationLoading, mutateConversation } =
+    usePublicConversation({
+      conversationId,
+      workspaceId: owner.sId,
+    });
 
   const messages = (conversation?.content || []).flat();
 
@@ -63,6 +69,71 @@ export function ConversationViewer({
       onStickyMentionsChange(agentMentions);
     }
   }, [agentMentions, onStickyMentionsChange]);
+
+  // Hooks related to message streaming.
+
+  const buildEventSourceURL = useCallback(
+    (lastEvent: string | null) => {
+      const esURL = `${process.env.DUST_DOMAIN}/api/v1/w/${owner.sId}/assistant/conversations/${conversationId}/events`;
+      let lastEventId = "";
+      if (lastEvent) {
+        const eventPayload: {
+          eventId: string;
+        } = JSON.parse(lastEvent);
+        lastEventId = eventPayload.eventId;
+      }
+      const url = esURL + "?lastEventId=" + lastEventId;
+
+      return url;
+    },
+    [conversationId, owner.sId]
+  );
+
+  const onEventCallback = useCallback((eventStr: string) => {
+    const eventPayload: {
+      eventId: string;
+      data:
+        | UserMessageNewEvent
+        | AgentMessageNewEvent
+        | AgentGenerationCancelledEvent
+        | ConversationTitleEvent;
+    } = JSON.parse(eventStr);
+
+    const event = eventPayload.data;
+
+    if (!eventIds.current.includes(eventPayload.eventId)) {
+      console.log("Received event", event);
+      eventIds.current.push(eventPayload.eventId);
+      switch (event.type) {
+        case "user_message_new":
+        case "agent_message_new":
+        case "agent_generation_cancelled":
+        case "conversation_title": {
+          void mutateConversation();
+          break;
+        }
+        default:
+          ((t: never) => {
+            console.error("Unknown event type", t);
+          })(event);
+      }
+    }
+  },
+  [
+    mutateConversation,
+  ]);
+
+  useEventSource(
+    buildEventSourceURL,
+    onEventCallback,
+    `conversation-${conversationId}`,
+    {
+      // We only start consuming the stream when the conversation has been loaded and we have a first page of message.
+      isReadyToConsumeStream: !isConversationLoading &&
+      messages.length !== 0,,
+    }
+  );
+  const eventIds = useRef<string[]>([]);
 
   const typedGroupedMessages = useMemo(
     () => (messages ? groupMessagesByType(messages) : []),

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -77,9 +77,10 @@ async function handler(
         "Cache-Control": "no-cache",
         Connection: "keep-alive",
       });
+      res.flushHeaders();
 
       for await (const event of getConversationEvents(conversation.sId, null)) {
-        res.write(JSON.stringify(event));
+        res.write(`data: ${JSON.stringify(event)}\n\n`);
         // @ts-expect-error we need to flush for streaming but TS thinks flush() does not exists.
         res.flush();
       }


### PR DESCRIPTION
## Description

This listens to conversation events to reloads conversation messages. Fix the endpoint which was broken, not sending events in the correct format.

## Risk

none

## Deploy Plan

deploy `front` for endpoint
