### PR TITLE
[Zendesk] connector: use OAuthConnection metadata `zendesk_subdomain`

### DIFF
--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -94,6 +94,10 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     connectionId: string;
   }): Promise<Result<string, ConnectorsAPIError>> {
     logger.info({ connectionId }, "Updating Zendesk connector");
+
+    // Make sure to verify that the the new OAuth connection metadata.zendesk_subdomain matches the
+    // existing ZendeskConfiguration.subdomain (to prevent subdoamin switch as part of re-auth).
+
     throw new Error("Method not implemented.");
   }
 

--- a/connectors/src/connectors/zendesk/lib/brand_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/brand_permissions.ts
@@ -2,7 +2,7 @@ import type { ModelId } from "@dust-tt/types";
 
 import { allowSyncZendeskHelpCenter } from "@connectors/connectors/zendesk/lib/help_center_permissions";
 import { allowSyncZendeskTickets } from "@connectors/connectors/zendesk/lib/ticket_permissions";
-import { getZendeskAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
+import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
 import { createZendeskClient } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import logger from "@connectors/logger/logger";
 import { ZendeskBrandResource } from "@connectors/resources/zendesk_resources";
@@ -11,12 +11,10 @@ import { ZendeskBrandResource } from "@connectors/resources/zendesk_resources";
  * Mark a brand as permission "read" and all children (help center and tickets) if specified.
  */
 export async function allowSyncZendeskBrand({
-  subdomain,
   connectorId,
   connectionId,
   brandId,
 }: {
-  subdomain: string;
   connectorId: ModelId;
   connectionId: string;
   brandId: number;
@@ -32,8 +30,12 @@ export async function allowSyncZendeskBrand({
     await brand.update({ ticketsPermission: "read" });
   }
 
-  const token = await getZendeskAccessToken(connectionId);
-  const zendeskApiClient = createZendeskClient({ token, subdomain });
+  const { accessToken, subdomain } =
+    await getZendeskSubdomainAndAccessToken(connectionId);
+  const zendeskApiClient = createZendeskClient({
+    token: accessToken,
+    subdomain,
+  });
 
   if (!brand) {
     const {

--- a/connectors/src/connectors/zendesk/lib/brand_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/brand_permissions.ts
@@ -61,13 +61,11 @@ export async function allowSyncZendeskBrand({
   }
 
   await allowSyncZendeskHelpCenter({
-    subdomain,
     connectorId,
     connectionId,
     brandId,
   });
   await allowSyncZendeskTickets({
-    subdomain,
     connectorId,
     connectionId,
     brandId,

--- a/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
@@ -1,6 +1,6 @@
 import type { ModelId } from "@dust-tt/types";
 
-import { getZendeskAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
+import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
 import {
   changeZendeskClientSubdomain,
   createZendeskClient,
@@ -13,12 +13,10 @@ import {
 } from "@connectors/resources/zendesk_resources";
 
 export async function allowSyncZendeskHelpCenter({
-  subdomain,
   connectorId,
   connectionId,
   brandId,
 }: {
-  subdomain: string;
   connectorId: ModelId;
   connectionId: string;
   brandId: number;
@@ -32,8 +30,12 @@ export async function allowSyncZendeskHelpCenter({
     await brand.update({ helpCenterPermission: "read" });
   }
 
-  const token = await getZendeskAccessToken(connectionId);
-  const zendeskApiClient = createZendeskClient({ token, subdomain });
+  const { accessToken, subdomain } =
+    await getZendeskSubdomainAndAccessToken(connectionId);
+  const zendeskApiClient = createZendeskClient({
+    token: accessToken,
+    subdomain,
+  });
 
   if (!brand) {
     const {
@@ -66,7 +68,6 @@ export async function allowSyncZendeskHelpCenter({
     const categories = await zendeskApiClient.helpcenter.categories.list();
     categories.forEach((category) =>
       allowSyncZendeskCategory({
-        subdomain,
         connectionId,
         connectorId,
         categoryId: category.id,
@@ -120,12 +121,10 @@ export async function revokeSyncZendeskHelpCenter({
 }
 
 export async function allowSyncZendeskCategory({
-  subdomain,
   connectorId,
   connectionId,
   categoryId,
 }: {
-  subdomain: string;
   connectorId: ModelId;
   connectionId: string;
   categoryId: number;
@@ -138,8 +137,12 @@ export async function allowSyncZendeskCategory({
     await category.update({ permission: "read" });
   }
 
-  const token = await getZendeskAccessToken(connectionId);
-  const zendeskApiClient = createZendeskClient({ token, subdomain });
+  const { accessToken, subdomain } =
+    await getZendeskSubdomainAndAccessToken(connectionId);
+  const zendeskApiClient = createZendeskClient({
+    token: accessToken,
+    subdomain,
+  });
 
   if (!category) {
     const { result: fetchedCategory } =

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -13,7 +13,7 @@ import {
   getIdFromInternalId,
   getTicketsInternalId,
 } from "@connectors/connectors/zendesk/lib/id_conversions";
-import { getZendeskAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
+import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
 import {
   changeZendeskClientSubdomain,
   createZendeskClient,
@@ -106,8 +106,13 @@ export async function retrieveChildrenNodes({
   const isReadPermissionsOnly = filterPermission === "read";
   let nodes: ContentNode[] = [];
 
-  const token = await getZendeskAccessToken(connector.connectionId);
-  const zendeskApiClient = createZendeskClient({ token });
+  const { accessToken, subdomain } = await getZendeskSubdomainAndAccessToken(
+    connector.connectionId
+  );
+  const zendeskApiClient = createZendeskClient({
+    token: accessToken,
+    subdomain,
+  });
 
   // At the root level, we show one node for each brand.
   if (!parentInternalId) {

--- a/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
@@ -1,6 +1,6 @@
 import type { ModelId } from "@dust-tt/types";
 
-import { getZendeskAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
+import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
 import { createZendeskClient } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import logger from "@connectors/logger/logger";
 import {
@@ -9,13 +9,11 @@ import {
 } from "@connectors/resources/zendesk_resources";
 
 export async function allowSyncZendeskTickets({
-  subdomain,
   connectorId,
   connectionId,
   brandId,
   withChildren = false,
 }: {
-  subdomain: string;
   connectorId: ModelId;
   connectionId: string;
   brandId: number;
@@ -29,8 +27,12 @@ export async function allowSyncZendeskTickets({
     await brand.update({ ticketsPermission: "read" });
   }
 
-  const token = await getZendeskAccessToken(connectionId);
-  const zendeskApiClient = createZendeskClient({ token, subdomain });
+  const { accessToken, subdomain } =
+    await getZendeskSubdomainAndAccessToken(connectionId);
+  const zendeskApiClient = createZendeskClient({
+    token: accessToken,
+    subdomain,
+  });
 
   if (!brand) {
     const {

--- a/connectors/src/connectors/zendesk/lib/zendesk_access_token.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_access_token.ts
@@ -1,13 +1,26 @@
+import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import { getOAuthConnectionAccessTokenWithThrow } from "@connectors/lib/oauth";
 import logger from "@connectors/logger/logger";
 
-export async function getZendeskAccessToken(
+export async function getZendeskSubdomainAndAccessToken(
   connectionId: string
-): Promise<string> {
+): Promise<{ accessToken: string; subdomain: string }> {
   const token = await getOAuthConnectionAccessTokenWithThrow({
     logger,
     provider: "zendesk",
     connectionId,
   });
-  return token.access_token;
+  if (typeof token.connection.metadata.zendesk_subdomain !== "string") {
+    // If the zendesk connection metadata does not have a `zendesk_subdomain` entry we throw an
+    // ExternalOAuthTokenError since this it requires a re-authentication.
+    throw new ExternalOAuthTokenError(
+      new Error(
+        `Missing zendesk connection metadata subdomain: connectionId=${connectionId}`
+      )
+    );
+  }
+  return {
+    accessToken: token.access_token,
+    subdomain: token.connection.metadata.zendesk_subdomain,
+  };
 }

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -3,10 +3,10 @@ import { createClient } from "node-zendesk";
 
 export function createZendeskClient({
   token,
-  subdomain = "d3v-dust",
+  subdomain,
 }: {
   token: string;
-  subdomain?: string;
+  subdomain: string;
 }) {
   return createClient({ oauth: true, token, subdomain });
 }


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/dust/issues/8395

We now store the `zendesk_subdomain` as part of the OAuth connection metadata. We want to rely on it as we interact with Zendesk. We still store the subdomain on the `ZendeskConfiguration` (even if we don't use it anymore in practice) so that we will be able to prevent switching sub-domains during connection updates.

Removes all references to `d3v-dust`

## Risk

Low, not in production yet. Tested locally e2e

## Deploy Plan

- deploy `connectors`