### PR TITLE
[front] - feature(assistant-browser): tabs horizontal scrolling

### DIFF
--- a/front/components/assistant/AssistantBrowser.tsx
+++ b/front/components/assistant/AssistantBrowser.tsx
@@ -194,10 +194,10 @@ export function AssistantBrowser({
       </div>
 
       {/* Assistant tabs */}
-      <div className="relative w-full px-4">
-        <ScrollArea className="w-full" aria-orientation="horizontal">
+      <div className="w-full px-4">
+        <ScrollArea aria-orientation="horizontal">
           <Tabs value={viewTab} onValueChange={setSelectedTab}>
-            <TabsList className="inline-flex h-10 items-center gap-2 border-b border-separator">
+            <TabsList>
               {visibleTabs.map((tab) => (
                 <TabsTrigger
                   key={tab.id}

--- a/front/components/assistant/AssistantBrowser.tsx
+++ b/front/components/assistant/AssistantBrowser.tsx
@@ -7,6 +7,8 @@ import {
   PlusIcon,
   RobotIcon,
   RocketIcon,
+  ScrollArea,
+  ScrollBar,
   Searchbar,
   StarIcon,
   Tabs,
@@ -192,25 +194,29 @@ export function AssistantBrowser({
       </div>
 
       {/* Assistant tabs */}
-      <div className="flex flex-row space-x-4 px-4">
-        <Tabs className="w-full" value={viewTab} onValueChange={setSelectedTab}>
-          <TabsList className="inline-flex h-10 items-center gap-2 border-b border-separator">
-            {visibleTabs.map((tab) => (
-              <TabsTrigger
-                key={tab.id}
-                value={tab.id}
-                label={tab.label}
-                icon={tab.icon}
-                className={
-                  assistantSearch !== ""
-                    ? "border-element-700 text-element-700"
-                    : ""
-                }
-              />
-            ))}
-          </TabsList>
-        </Tabs>
+      <div className="relative w-full px-4">
+        <ScrollArea className="w-full" aria-orientation="horizontal">
+          <Tabs value={viewTab} onValueChange={setSelectedTab}>
+            <TabsList className="inline-flex h-10 items-center gap-2 border-b border-separator">
+              {visibleTabs.map((tab) => (
+                <TabsTrigger
+                  key={tab.id}
+                  value={tab.id}
+                  label={tab.label}
+                  icon={tab.icon}
+                  className={
+                    assistantSearch !== ""
+                      ? "border-element-700 text-element-700"
+                      : ""
+                  }
+                />
+              ))}
+            </TabsList>
+          </Tabs>
+          <ScrollBar orientation="horizontal" className="hidden" />
+        </ScrollArea>
       </div>
+
       {!viewTab && (
         <div className="text-center">
           No assistants found. Try adjusting your search criteria.


### PR DESCRIPTION
## Description

This PR introduces horizontal scrolling on the assistant browser tabs when the view screen isn't large enough to display all of them.

![Screenshot 2024-11-04 at 13 25 42](https://github.com/user-attachments/assets/6bb5e683-e5d2-491f-b903-69cf35f7978a)


## Risk

Low, UI regressions

## Deploy Plan

Deploy `front`