### PR TITLE
[front] - enh(AssistantPicker): prettify

### DIFF
--- a/front/components/assistant/AssistantPicker.tsx
+++ b/front/components/assistant/AssistantPicker.tsx
@@ -1,8 +1,7 @@
 import {
   Avatar,
-  Button, EyeIcon,
+  Button,
   IconButton,
-  Item,
   MoreIcon,
   NewDropdownMenu,
   NewDropdownMenuContent,
@@ -10,19 +9,13 @@ import {
   NewDropdownMenuSeparator,
   NewDropdownMenuTrigger,
   PlusIcon,
-  PopoverContent,
-  PopoverRoot,
-  PopoverTrigger,
   RobotIcon,
   ScrollArea,
-  Searchbar,
-  Separator,
 } from "@dust-tt/sparkle";
 import type {
   LightAgentConfigurationType,
   WorkspaceType,
 } from "@dust-tt/types";
-import Link from "next/link";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useState } from "react";
 
@@ -140,18 +133,15 @@ export function AssistantPicker({
         {showFooterButtons && (
           <>
             <NewDropdownMenuSeparator />
-            <div className="py-1 flex justify-end">
-              <Link
-                href={`/w/${owner.sId}/builder/assistants/create?flow=personal_assistants`}
-              >
+            <div className="flex justify-end">
                 <Button
                   label="Create"
                   size="xs"
                   variant="primary"
                   icon={PlusIcon}
                   className="mr-2"
+                  href={`/w/${owner.sId}/builder/assistants/create?flow=personal_assistants`}
                 />
-              </Link>
             </div>
           </>
         )}

--- a/front/components/assistant/AssistantPicker.tsx
+++ b/front/components/assistant/AssistantPicker.tsx
@@ -1,11 +1,10 @@
 import {
   Avatar,
   Button,
-  IconButton,
-  MoreIcon,
   NewDropdownMenu,
   NewDropdownMenuContent,
-  NewDropdownMenuItem, NewDropdownMenuSearchbar,
+  NewDropdownMenuItem,
+  NewDropdownMenuSearchbar,
   NewDropdownMenuSeparator,
   NewDropdownMenuTrigger,
   PlusIcon,
@@ -16,44 +15,15 @@ import type {
   LightAgentConfigurationType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { useRouter } from "next/router";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { filterAndSortAgents } from "@app/lib/utils";
-import { setQueryParam } from "@app/lib/utils/router";
-
-const ShowAssistantDetailsButton = ({
-  assistant,
-}: {
-  assistant: LightAgentConfigurationType;
-}) => {
-  const router = useRouter();
-
-  const showAssistantDetails = useCallback(
-    (agentConfiguration: LightAgentConfigurationType) => {
-      setQueryParam(router, "assistantDetails", agentConfiguration.sId);
-    },
-    [router]
-  );
-  return (
-    <IconButton
-      icon={MoreIcon}
-      onClick={() => {
-        close();
-        showAssistantDetails(assistant);
-      }}
-      variant="ghost"
-      size="sm"
-    />
-  );
-};
 
 export function AssistantPicker({
   owner,
   assistants,
   onItemClick,
   pickerButton,
-  showMoreDetailsButtons = true,
   showFooterButtons = true,
   size = "md",
 }: {
@@ -111,17 +81,12 @@ export function AssistantPicker({
             }
           }}
         />
-        <NewDropdownMenuSeparator className="mt-2"/>
+        <NewDropdownMenuSeparator className="mt-2" />
         <ScrollArea className="mt-1 h-[300px]">
           {searchedAssistants.map((c) => (
             <NewDropdownMenuItem
               key={`assistant-picker-${c.sId}`}
-              icon={() => (
-                <Avatar
-                  size="xs"
-                  visual={c.pictureUrl}
-                />
-              )}
+              icon={() => <Avatar size="xs" visual={c.pictureUrl} />}
               label={c.name}
               onClick={() => {
                 onItemClick(c);
@@ -134,20 +99,18 @@ export function AssistantPicker({
           <>
             <NewDropdownMenuSeparator />
             <div className="flex justify-end">
-                <Button
-                  label="Create"
-                  size="xs"
-                  variant="primary"
-                  icon={PlusIcon}
-                  className="mr-2"
-                  href={`/w/${owner.sId}/builder/assistants/create?flow=personal_assistants`}
-                />
+              <Button
+                label="Create"
+                size="xs"
+                variant="primary"
+                icon={PlusIcon}
+                className="mr-2"
+                href={`/w/${owner.sId}/builder/assistants/create?flow=personal_assistants`}
+              />
             </div>
           </>
         )}
       </NewDropdownMenuContent>
     </NewDropdownMenu>
-
-
   );
 }

--- a/front/components/assistant/AssistantPicker.tsx
+++ b/front/components/assistant/AssistantPicker.tsx
@@ -1,8 +1,14 @@
 import {
-  Button,
+  Avatar,
+  Button, EyeIcon,
   IconButton,
   Item,
   MoreIcon,
+  NewDropdownMenu,
+  NewDropdownMenuContent,
+  NewDropdownMenuItem, NewDropdownMenuSearchbar,
+  NewDropdownMenuSeparator,
+  NewDropdownMenuTrigger,
   PlusIcon,
   PopoverContent,
   PopoverRoot,
@@ -82,8 +88,8 @@ export function AssistantPicker({
   };
 
   return (
-    <PopoverRoot>
-      <PopoverTrigger asChild>
+    <NewDropdownMenu>
+      <NewDropdownMenuTrigger asChild>
         {pickerButton ? (
           pickerButton
         ) : (
@@ -95,9 +101,9 @@ export function AssistantPicker({
             tooltip="Pick an assistant"
           />
         )}
-      </PopoverTrigger>
-      <PopoverContent className="mr-2 p-2">
-        <Searchbar
+      </NewDropdownMenuTrigger>
+      <NewDropdownMenuContent className="min-w-[300px]">
+        <NewDropdownMenuSearchbar
           ref={searchbarRef}
           placeholder="Search"
           name="input"
@@ -112,33 +118,29 @@ export function AssistantPicker({
             }
           }}
         />
-        <ScrollArea className="mt-2 h-[300px]">
+        <NewDropdownMenuSeparator className="mt-2"/>
+        <ScrollArea className="mt-1 h-[300px]">
           {searchedAssistants.map((c) => (
-            <div
-              key={`assistant-picker-container-${c.sId}`}
-              className="flex flex-row items-center justify-between px-2"
-            >
-              <Item.Avatar
-                key={`assistant-picker-${c.sId}`}
-                label={c.name}
-                visual={c.pictureUrl}
-                hasAction={false}
-                onClick={() => {
-                  onItemClick(c);
-                  setSearchText("");
-                }}
-                className="truncate"
-              />
-              {showMoreDetailsButtons && (
-                <ShowAssistantDetailsButton assistant={c} />
+            <NewDropdownMenuItem
+              key={`assistant-picker-${c.sId}`}
+              icon={() => (
+                <Avatar
+                  size="xs"
+                  visual={c.pictureUrl}
+                />
               )}
-            </div>
+              label={c.name}
+              onClick={() => {
+                onItemClick(c);
+                setSearchText("");
+              }}
+            />
           ))}
         </ScrollArea>
         {showFooterButtons && (
           <>
-            <Separator />
-            <div className="mt-2 flex justify-end">
+            <NewDropdownMenuSeparator />
+            <div className="py-1 flex justify-end">
               <Link
                 href={`/w/${owner.sId}/builder/assistants/create?flow=personal_assistants`}
               >
@@ -153,7 +155,9 @@ export function AssistantPicker({
             </div>
           </>
         )}
-      </PopoverContent>
-    </PopoverRoot>
+      </NewDropdownMenuContent>
+    </NewDropdownMenu>
+
+
   );
 }

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -161,9 +161,6 @@ const InputBarContainer = ({
               showFooterButtons={actions.includes(
                 "assistants-list-with-actions"
               )}
-              showMoreDetailsButtons={actions.includes(
-                "assistants-list-with-actions"
-              )}
             />
           )}
           {actions.includes("fullscreen") && (

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.291",
+        "@dust-tt/sparkle": "^0.2.292",
         "@dust-tt/types": "file:../types",
         "@headlessui/react": "^1.7.7",
         "@heroicons/react": "^2.0.11",
@@ -11483,9 +11483,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.291",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.291.tgz",
-      "integrity": "sha512-Lxkc+onMI/DbpD/NyrAo6sLKqmKfh952lqzR6opKsgDJiufiSSl2FUSV9shhFnkA0xkztR4HCTHTrNERBea5VQ==",
+      "version": "0.2.292",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.292.tgz",
+      "integrity": "sha512-oPmYNBepIWmpmIgD1UFw5qcmXvHa6JTDhKYy4eiZQoyZH6VGyzv8NmhmgCZgwYXNrhXtBkRahzo5p6cvJT3YHA==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.291",
+    "@dust-tt/sparkle": "^0.2.292",
     "@dust-tt/types": "file:../types",
     "@headlessui/react": "^1.7.7",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description

This PR aims at prettifying the `AssistantPicker` to use the `NewDropdownMenu` components. It enables to navigate the assistants with arrows. The autofocus is also directly put on the searchbar when the dropdown opens.

## Risk

Low

## Deploy Plan

Deploy `front`