### PR TITLE
[front] - chore(sidebar): tabs dynamic sizing

### DIFF
--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -23,6 +23,7 @@ import { UserMenu } from "@app/components/UserMenu";
 import WorkspacePicker from "@app/components/WorkspacePicker";
 import { useAppStatus } from "@app/lib/swr/useAppStatus";
 import { useUser } from "@app/lib/swr/user";
+import { classNames } from "@app/lib/utils";
 
 interface NavigationSidebarProps {
   children: React.ReactNode;
@@ -121,9 +122,13 @@ export const NavigationSidebar = React.forwardRef<
               <TabsList>
                 {navs.map((tab) => (
                   <TabsTrigger
+                    className={classNames(
+                      tab.sizing === "expand" ? "grow" : "shrink",
+                      "px-1"
+                    )}
                     key={tab.id}
                     value={tab.id}
-                    label={tab.label}
+                    label={tab.hideLabel ? undefined : tab.label}
                     icon={tab.icon}
                     onClick={() => {
                       if (tab.href) {


### PR DESCRIPTION
## Description

This PR aims at enhancing the `NavigationSidebar` UI, it introduces the following changes:
 - Add conditional class application for navigation tabs to allow dynamic sizing behavior
 - Hide labels on tabs when `hideLabel` property is set, enhancing the display options for navigation items

![Screenshot 2024-11-04 at 14 14 38](https://github.com/user-attachments/assets/8a6f0d01-e090-4a02-a8cd-33d565030ea4)

## Risk

Low, only adds UI logic 

## Deploy Plan

Deploy `front`
