### PR TITLE
Fix: multiple-upload allow re-uploading the same file, can be re-opened after cancelling the dialog

### DIFF
--- a/front/components/spaces/ContentActions.tsx
+++ b/front/components/spaces/ContentActions.tsx
@@ -15,7 +15,12 @@ import type {
 } from "@dust-tt/types";
 import { capitalize } from "lodash";
 import type { ComponentProps, RefObject } from "react";
-import React, { useEffect, useImperativeHandle, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useState,
+} from "react";
 
 import { DocumentOrTableDeleteDialog } from "@app/components/data_source/DocumentOrTableDeleteDialog";
 import { DocumentOrTableUploadOrEditModal } from "@app/components/data_source/DocumentOrTableUploadOrEditModal";
@@ -98,16 +103,19 @@ export const ContentActions = React.forwardRef<
       }
     }, [currentAction, setCurrentDocumentId]);
 
-    const onClose = (save: boolean) => {
-      const action = currentAction.action;
+    const onClose = useCallback(
+      (save: boolean) => {
+        const action = currentAction.action;
 
-      // Clear the action
-      setCurrentAction({ contentNode: currentAction.contentNode });
+        // Clear the action
+        setCurrentAction({ contentNode: currentAction.contentNode });
 
-      if (save) {
-        onSave(action);
-      }
-    };
+        if (save) {
+          onSave(action);
+        }
+      },
+      [currentAction, onSave]
+    );
 
     return (
       <>

--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -325,6 +325,21 @@ export const SpaceDataSourceViewContentList = ({
     await mutateContentNodes();
   }, [mutateContentNodes]);
 
+  const onSaveAction = useCallback(
+    async (action?: ContentActionKey) => {
+      await mutateContentNodes();
+      if (
+        action === "DocumentUploadOrEdit" ||
+        action === "MultipleDocumentsUpload"
+      ) {
+        handleViewTypeChange("documents");
+      } else if (action === "TableUploadOrEdit") {
+        handleViewTypeChange("tables");
+      }
+    },
+    [handleViewTypeChange, mutateContentNodes]
+  );
+
   const emptySpaceContent =
     isManaged(dataSourceView.dataSource) && space.kind !== "system" ? (
       isAdmin ? (
@@ -488,17 +503,7 @@ export const SpaceDataSourceViewContentList = ({
         totalNodesCount={totalNodesCount}
         owner={owner}
         plan={plan}
-        onSave={async (action?: ContentActionKey) => {
-          await mutateContentNodes();
-          if (
-            action === "DocumentUploadOrEdit" ||
-            action === "MultipleDocumentsUpload"
-          ) {
-            handleViewTypeChange("documents");
-          } else if (action === "TableUploadOrEdit") {
-            handleViewTypeChange("tables");
-          }
-        }}
+        onSave={onSaveAction}
       />
     </>
   );


### PR DESCRIPTION
## Description

Fixes:
- Couldn't open the dialog twice without reloading the page.
- Couldn't re-upload twice the same file without reloading the page (upload A, delete A, upload A)

## Risk

None

## Deploy Plan

Deploy `front`