### PR TITLE
Fix extension - must install @dust-tt/client

### DIFF
--- a/extension/app/src/lib/conversation.ts
+++ b/extension/app/src/lib/conversation.ts
@@ -1,3 +1,4 @@
+import type { PublicPostConversationsRequestBody } from "@dust-tt/client";
 import type {
   AgentMessageNewEvent,
   AgentMessageType,
@@ -5,7 +6,6 @@ import type {
   ConversationVisibility,
   LightWorkspaceType,
   MentionType,
-  PublicPostConversationsRequestBody,
   Result,
   SubmitMessageError,
   UserMessageNewEvent,

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
+        "@dust-tt/client": "file:../sdks/js",
         "@dust-tt/sparkle": "^0.2.290",
         "@dust-tt/types": "file:../types",
         "@tailwindcss/forms": "^0.5.9",
@@ -64,6 +65,27 @@
         "webpack-ext-reloader": "^1.1.13",
         "webpackbar": "^6.0.1",
         "zip-webpack-plugin": "^4.0.1"
+      }
+    },
+    "../sdks/js": {
+      "name": "@dust-tt/client",
+      "version": "1.0.0",
+      "dependencies": {
+        "eventsource-parser": "^1.1.1",
+        "moment-timezone": "^0.5.46",
+        "zod": "^3.23.8"
+      },
+      "devDependencies": {
+        "@tsconfig/recommended": "^1.0.3",
+        "@types/node": "^22.7.5",
+        "@types/uuid": "^9.0.7",
+        "dts-cli": "^2.0.5",
+        "eslint-plugin-simple-import-sort": "^12.1.0",
+        "tslib": "^2.6.2",
+        "typescript": "^5.4.5"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "../types": {
@@ -241,6 +263,10 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/@dust-tt/client": {
+      "resolved": "../sdks/js",
+      "link": true
     },
     "node_modules/@dust-tt/sparkle": {
       "version": "0.2.290",

--- a/extension/package.json
+++ b/extension/package.json
@@ -48,6 +48,7 @@
     "zip-webpack-plugin": "^4.0.1"
   },
   "dependencies": {
+    "@dust-tt/client": "file:../sdks/js",
     "@dust-tt/sparkle": "^0.2.290",
     "@dust-tt/types": "file:../types",
     "@tailwindcss/forms": "^0.5.9",


### PR DESCRIPTION
## Description

To be able to call https://github.com/dust-tt/dust/pull/8384/files#diff-220b88bd1d5b62d747562b9077a7b77ea13d2577c4c7ad6fdfb9c07ebc382361L1 the extension must install "@dust-tt/client" in the dependencies. 

## Risk

Only extension code. 

## Deploy Plan

No deploy. 
