### PR TITLE
Ext: Basic poc content fragment page

### DIFF
--- a/extension/app/src/lib/conversation.ts
+++ b/extension/app/src/lib/conversation.ts
@@ -106,7 +106,7 @@ export async function postConversation({
   owner,
   messageData,
   visibility = "unlisted",
-  title,
+  tabContent,
 }: {
   owner: LightWorkspaceType;
   messageData: {
@@ -114,7 +114,11 @@ export async function postConversation({
     mentions: MentionType[];
   };
   visibility?: ConversationVisibility;
-  title?: string;
+  tabContent: {
+    title: string;
+    content: string;
+    url: string;
+  } | null;
 }): Promise<Result<ConversationType, SubmitMessageError>> {
   const { input, mentions } = messageData;
   const token = await getAccessToken();
@@ -130,7 +134,7 @@ export async function postConversation({
   }
 
   const body: PublicPostConversationsRequestBody = {
-    title: title ?? null,
+    title: null,
     visibility,
     message: {
       content: input,
@@ -144,7 +148,20 @@ export async function postConversation({
       },
       mentions,
     },
-    contentFragment: undefined,
+    contentFragment: tabContent
+      ? {
+          title: tabContent.title,
+          content: tabContent.content,
+          url: tabContent.url,
+          contentType: "text/plain",
+          context: {
+            username: user.username,
+            email: user.email,
+            fullName: user.fullName,
+            profilePictureUrl: null,
+          },
+        }
+      : undefined,
     blocking: false, // We want streaming.
   };
 
@@ -178,7 +195,6 @@ export async function postConversation({
   return new Ok(conversationData.conversation);
 }
 
-// Not called yet so not tested
 export async function postMessage({
   owner,
   conversationId,

--- a/extension/app/src/lib/messages.ts
+++ b/extension/app/src/lib/messages.ts
@@ -15,6 +15,15 @@ export type AuthBackroundMessage = {
   refreshToken?: string;
 };
 
+export type GetActiveTabBackgroundMessage = {
+  type: "GET_ACTIVE_TAB";
+};
+
+export type GetActiveTabBackgroundResponse = {
+  url: string;
+  content: string;
+};
+
 /**
  * Messages to the background script to authenticate, refresh tokens, and logout.
  */
@@ -104,3 +113,26 @@ export const sentLogoutMessage = (): Promise<AuthBackgroundResponse> => {
     );
   });
 };
+
+/**
+ * Message to the background script to get the active tab content.
+ */
+
+export const sendGetActiveTabMessage =
+  (): Promise<GetActiveTabBackgroundResponse> => {
+    return new Promise((resolve, reject) => {
+      const message: GetActiveTabBackgroundMessage = { type: "GET_ACTIVE_TAB" };
+      chrome.runtime.sendMessage(
+        message,
+        (response: GetActiveTabBackgroundResponse | undefined) => {
+          if (chrome.runtime.lastError) {
+            return reject(chrome.runtime.lastError);
+          }
+          if (!response) {
+            return reject(new Error("No response received."));
+          }
+          return resolve(response);
+        }
+      );
+    });
+  };

--- a/extension/app/src/pages/MainPage.tsx
+++ b/extension/app/src/pages/MainPage.tsx
@@ -1,22 +1,9 @@
-import { Button, HistoryIcon, Page } from "@dust-tt/sparkle";
 import type { ProtectedRouteChildrenProps } from "@extension/components/auth/ProtectedRoute";
 import { ConversationContainer } from "@extension/components/conversation/ConversationContainer";
-import { useNavigate } from "react-router-dom";
 
 export const MainPage = ({ user, workspace }: ProtectedRouteChildrenProps) => {
-  const navigate = useNavigate();
-
   return (
     <div className="h-full w-full pt-4">
-      <div className="flex items-center justify-between pb-2">
-        <Page.SectionHeader title={`Hi ${user.firstName},`} />
-        <Button
-          icon={HistoryIcon}
-          variant="outline"
-          onClick={() => navigate("/conversations")}
-          size="xs"
-        />
-      </div>
       <ConversationContainer
         owner={workspace}
         conversationId={null}

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -15,7 +15,14 @@
   "side_panel": {
     "default_path": "main.html"
   },
-  "permissions": ["sidePanel", "identity", "storage", "tabs"],
-  "host_permissions": ["http://localhost:3000/*", "https://dust.tt/*"],
+  "permissions": [
+    "sidePanel",
+    "identity",
+    "storage",
+    "activeTab",
+    "tabs",
+    "scripting"
+  ],
+  "host_permissions": ["<all_urls>"],
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu2kn2r/3emY/9AwPzAH0qb1KskhZCqLp4PE3o1PqD1hyLTf9fJ+VC0CPyy3F6bep/6mjVZaN+Ufw7bTn3XFoj3TW+Xg5e/KLg+qUn2pUS973j68IyhyIamydfx90ZZajCU1XwB666+8dFwgB6sy4sGe86WNKu0Be+EDhhVFCFVI2D7CyJjlmQXUXTYDr6U41MsdI1DlDK6jrv6N9IkHKhvq1o06GN0W8CpoPJ554iBHWcw5UYNHi6ySxA+u7OoV58tDkTyVOS9sQ8WGIge3hDmhc2jcUhsJTzkeAS3ijShKVdYC0i+5n5g6SnQ4N7y2xehEYsms0ARqkUkF/QPwmTQIDAQAB"
 }


### PR DESCRIPTION
## Description

Very basic poc to post as a content fragment the content of the current page when we create a convo. 
It adds a new button next to the history button, and if we click on it when we post the convo we also post the content of the current tab as content fragment. 

This is not meant to be the final feature, we want it to test rapidly having access to the current page but this is code to be dropped when we have a proper tool to include the page (assistant tool). 

## Risk

Only extension code. 

## Deploy Plan

No deploy. 
