### PR TITLE
enh: give more RAM to sqlite workers

### DIFF
--- a/k8s/dust-kube/deployments/core-sqlite-worker-deployment.yaml
+++ b/k8s/dust-kube/deployments/core-sqlite-worker-deployment.yaml
@@ -47,7 +47,7 @@ spec:
           resources:
             requests:
               cpu: 1000m
-              memory: 4Gi
+              memory: 16Gi
             limits:
               cpu: 1000m
-              memory: 4Gi
+              memory: 16Gi


### PR DESCRIPTION
## Description

Big databases are crashing the pods.
We limit DB size for connected tables, but we don't enforce any limits on self-managed tables, and we start to have very large ones.

This is only a partial fix, we need to:
- remove the need for holding every row in memory several times ("stream" data into the sqlite db, instead of fetching all rows and creating all SQL)
- enforce limits at query time

## Risk

- Might still crash
- increase time to deploy due to auto-scaled cluster

## Deploy Plan

Apply infra