### PR TITLE
core: add 'any' option to function_call

### DIFF
--- a/core/src/blocks/chat.rs
+++ b/core/src/blocks/chat.rs
@@ -381,12 +381,12 @@ impl Block for Chat {
         match function_call.as_ref() {
             None => (),
             Some(s) => match s.as_str() {
-                "auto" | "none" => (),
+                "auto" | "none" | "any" => (),
                 s => {
                     functions.iter().find(|f| f.name == s).ok_or(anyhow!(
                         "Invalid `function_call` in configuration for chat block `{}`: \
                          function name `{}` not found in functions. Possible values are \
-                         'auto', 'none' or the name of one of the functions.",
+                         'auto', 'none', 'any' or the name of one of the functions.",
                         name,
                         s
                     ))?;


### PR DESCRIPTION
## Description

We do support `any` for all providers but fail to accept it in the chat.rs block.

## Risk

None, purely additive

## Deploy Plan

- deploy `core`