### PR TITLE
[front] - chore: bump @dust-tt/sparkle version to fix dependencies

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.293",
+        "@dust-tt/sparkle": "^0.2.294",
         "@dust-tt/types": "file:../types",
         "@headlessui/react": "^1.7.7",
         "@heroicons/react": "^2.0.11",
@@ -11483,9 +11483,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.293",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.293.tgz",
-      "integrity": "sha512-260L3lQLkXT6KjJl9UTQpnNAHybUpsLUibNx14YhcNcPdneBkZpqITv/QxhWjEb0b/XCCTV69v07Dw4NYCZTkw==",
+      "version": "0.2.294",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.294.tgz",
+      "integrity": "sha512-rbF30ro6gaLNseshE9FQloyRvp3UfKSejmLIyEIZpmdX3wuVjfQl3C00bdWEXThp+IwS01DBKOpogQtQjfuxgw==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.293",
+    "@dust-tt/sparkle": "^0.2.294",
     "@dust-tt/types": "file:../types",
     "@headlessui/react": "^1.7.7",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description

This PR updates the front dependency to @dust-tt/sparkle to version 0.2.294 to include the latest related to the `Tabs` component.

## Risk

Low

## Deploy Plan

Deploy `front`