### PR TITLE
[connectors] Fix permissions handling for Zendesk

### DIFF
--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -219,6 +219,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     const toBeSignaledTicketsIds = new Set<number>();
     const toBeSignaledHelpCenterIds = new Set<number>();
     const toBeSignaledCategoryIds = new Set<number>();
+    const categoryBrandIds: Record<number, number> = {};
 
     for (const [id, permission] of Object.entries(permissions)) {
       if (permission !== "none" && permission !== "read") {
@@ -300,6 +301,8 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
             });
             if (revokedCategory) {
               toBeSignaledCategoryIds.add(revokedCategory.categoryId);
+              categoryBrandIds[revokedCategory.categoryId] =
+                revokedCategory.brandId;
             }
           }
           if (permission === "read") {
@@ -311,6 +314,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
             });
             if (newCategory) {
               toBeSignaledCategoryIds.add(newCategory.categoryId);
+              categoryBrandIds[newCategory.categoryId] = newCategory.brandId;
             }
           }
           break;
@@ -340,7 +344,10 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         brandIds: [...toBeSignaledBrandIds],
         ticketsBrandIds: [...toBeSignaledTicketsIds],
         helpCenterBrandIds: [...toBeSignaledHelpCenterIds],
-        categoryIds: [...toBeSignaledCategoryIds],
+        categoryIds: [...toBeSignaledCategoryIds].map((categoryId) => ({
+          categoryId,
+          brandId: categoryBrandIds[categoryId] as number,
+        })),
       });
     }
 

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -296,7 +296,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
           if (permission === "none") {
             const revokedCategory = await revokeSyncZendeskCategory({
               connectorId,
-              categoryId: objectId,
+              categoryId: objectId.categoryId,
             });
             if (revokedCategory) {
               toBeSignaledCategoryIds.add(revokedCategory.categoryId);
@@ -306,7 +306,8 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
             const newCategory = await allowSyncZendeskCategory({
               connectorId,
               connectionId,
-              categoryId: objectId,
+              categoryId: objectId.categoryId,
+              brandId: objectId.brandId,
             });
             if (newCategory) {
               toBeSignaledCategoryIds.add(newCategory.categoryId);
@@ -375,7 +376,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
           return;
         }
         case "category": {
-          categoryIds.push(objectId);
+          categoryIds.push(objectId.categoryId);
           return;
         }
         case "article":
@@ -452,7 +453,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
       case "category": {
         const category = await ZendeskCategoryResource.fetchByCategoryId({
           connectorId,
-          categoryId: objectId,
+          categoryId: objectId.categoryId,
         });
         if (category) {
           return new Ok([
@@ -477,7 +478,11 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         if (article) {
           return new Ok([
             internalId,
-            getCategoryInternalId(connectorId, article.categoryId),
+            getCategoryInternalId(
+              connectorId,
+              article.brandId,
+              article.categoryId
+            ),
             getHelpCenterInternalId(connectorId, article.brandId),
             getBrandInternalId(connectorId, article.brandId),
           ]);

--- a/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
@@ -71,6 +71,7 @@ export async function allowSyncZendeskHelpCenter({
         connectionId,
         connectorId,
         categoryId: category.id,
+        brandId,
       })
     );
   } catch (e) {
@@ -123,10 +124,12 @@ export async function revokeSyncZendeskHelpCenter({
 export async function allowSyncZendeskCategory({
   connectorId,
   connectionId,
+  brandId,
   categoryId,
 }: {
   connectorId: ModelId;
   connectionId: string;
+  brandId: number;
   categoryId: number;
 }): Promise<ZendeskCategoryResource | null> {
   let category = await ZendeskCategoryResource.fetchByCategoryId({
@@ -145,17 +148,18 @@ export async function allowSyncZendeskCategory({
   });
 
   if (!category) {
+    await changeZendeskClientSubdomain({ client: zendeskApiClient, brandId });
     const { result: fetchedCategory } =
       await zendeskApiClient.helpcenter.categories.show(categoryId);
     if (fetchedCategory) {
       category = await ZendeskCategoryResource.makeNew({
         blob: {
-          connectorId: connectorId,
-          brandId: fetchedCategory.id,
-          name: fetchedCategory.name || "Brand",
-          categoryId: fetchedCategory.id,
+          connectorId,
+          brandId,
+          name: fetchedCategory.name || "Category",
+          categoryId,
           permission: "read",
-          url: fetchedCategory.url,
+          url: fetchedCategory.html_url,
         },
       });
     } else {

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -46,25 +46,6 @@ export async function retrieveSelectedNodes({
   }
 
   const brands = await ZendeskBrandResource.fetchAllReadOnly({ connectorId });
-  const brandNodes: ContentNode[] = brands.map((brand) => {
-    return {
-      provider: connector.type,
-      internalId: getBrandInternalId(connectorId, brand.brandId),
-      parentInternalId: null,
-      type: "folder",
-      title: brand.name,
-      sourceUrl: brand.url,
-      expandable: true,
-      permission:
-        brand.helpCenterPermission === "read" &&
-        brand.ticketsPermission === "read"
-          ? "read"
-          : "none",
-      dustDocumentId: null,
-      lastUpdatedAt: brand.updatedAt.getTime() ?? null,
-    };
-  });
-
   const helpCenterNodes: ContentNode[] = brands
     .filter(
       (brand) => brand.hasHelpCenter && brand.helpCenterPermission === "read"
@@ -81,12 +62,7 @@ export async function retrieveSelectedNodes({
     .filter((brand) => brand.ticketsPermission === "read")
     .map((brand) => brand.getTicketsContentNode({ connectorId }));
 
-  return [
-    ...brandNodes,
-    ...helpCenterNodes,
-    ...categoriesNodes,
-    ...ticketNodes,
-  ];
+  return [...helpCenterNodes, ...categoriesNodes, ...ticketNodes];
 }
 
 export async function retrieveChildrenNodes({

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -200,7 +200,11 @@ export async function retrieveChildrenNodes({
             );
             return {
               provider: connector.type,
-              internalId: getCategoryInternalId(connectorId, category.id),
+              internalId: getCategoryInternalId(
+                connectorId,
+                objectId,
+                category.id
+              ),
               parentInternalId: parentInternalId,
               type: "folder",
               title: category.name,
@@ -221,7 +225,7 @@ export async function retrieveChildrenNodes({
           const articlesInDb =
             await ZendeskArticleResource.fetchByCategoryIdReadOnly({
               connectorId,
-              categoryId: objectId,
+              categoryId: objectId.categoryId,
             });
           nodes = articlesInDb.map((article) =>
             article.toContentNode({ connectorId })

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -52,17 +52,11 @@ export async function retrieveSelectedNodes({
     )
     .map((brand) => brand.getHelpCenterContentNode({ connectorId }));
 
-  const categories = await ZendeskCategoryResource.fetchAllReadOnly({
-    connectorId,
-  });
-  const categoriesNodes: ContentNode[] = categories.map((category) =>
-    category.toContentNode({ connectorId })
-  );
   const ticketNodes: ContentNode[] = brands
     .filter((brand) => brand.ticketsPermission === "read")
     .map((brand) => brand.getTicketsContentNode({ connectorId }));
 
-  return [...helpCenterNodes, ...categoriesNodes, ...ticketNodes];
+  return [...helpCenterNodes, ...ticketNodes];
 }
 
 export async function retrieveChildrenNodes({

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -66,7 +66,9 @@ export async function retrieveSelectedNodes({
   });
 
   const helpCenterNodes: ContentNode[] = brands
-    .filter((brand) => brand.hasHelpCenter)
+    .filter(
+      (brand) => brand.hasHelpCenter && brand.helpCenterPermission === "read"
+    )
     .map((brand) => brand.getHelpCenterContentNode({ connectorId }));
 
   const categories = await ZendeskCategoryResource.fetchAllReadOnly({
@@ -75,9 +77,9 @@ export async function retrieveSelectedNodes({
   const categoriesNodes: ContentNode[] = categories.map((category) =>
     category.toContentNode({ connectorId })
   );
-  const ticketNodes: ContentNode[] = brands.map((brand) =>
-    brand.getTicketsContentNode({ connectorId })
-  );
+  const ticketNodes: ContentNode[] = brands
+    .filter((brand) => brand.ticketsPermission === "read")
+    .map((brand) => brand.getTicketsContentNode({ connectorId }));
 
   return [
     ...brandNodes,

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -254,10 +254,12 @@ export async function getZendeskCategoriesActivity({
 export async function syncZendeskCategoryActivity({
   connectorId,
   categoryId,
+  brandId,
   currentSyncDateMs,
 }: {
   connectorId: ModelId;
   categoryId: number;
+  brandId: number;
   currentSyncDateMs: number;
 }): Promise<boolean> {
   const connector = await _getZendeskConnectorOrRaise(connectorId);
@@ -281,6 +283,7 @@ export async function syncZendeskCategoryActivity({
     token: accessToken,
     subdomain,
   });
+  await changeZendeskClientSubdomain({ client: zendeskApiClient, brandId });
 
   // if the category is not on Zendesk anymore, we delete it
   const { result: fetchedCategory } =

--- a/connectors/src/connectors/zendesk/temporal/config.ts
+++ b/connectors/src/connectors/zendesk/temporal/config.ts
@@ -1,2 +1,2 @@
-export const WORKFLOW_VERSION = 0;
+export const WORKFLOW_VERSION = 2;
 export const QUEUE_NAME = `zendesk-queue-v${WORKFLOW_VERSION}`;

--- a/connectors/src/connectors/zendesk/temporal/signals.ts
+++ b/connectors/src/connectors/zendesk/temporal/signals.ts
@@ -2,10 +2,17 @@ import { defineSignal } from "@temporalio/workflow";
 
 export interface ZendeskUpdateSignal {
   zendeskId: number;
-  type: "brand" | "help-center" | "tickets" | "category";
+  type: "brand" | "help-center" | "tickets";
   forceResync: boolean;
 }
 
-export const zendeskUpdatesSignal = defineSignal<[ZendeskUpdateSignal[]]>(
-  "zendeskUpdatesSignal"
-);
+export interface ZendeskCategoryUpdateSignal {
+  brandId: number;
+  categoryId: number;
+  type: "category";
+  forceResync: boolean;
+}
+
+export const zendeskUpdatesSignal = defineSignal<
+  [(ZendeskUpdateSignal | ZendeskCategoryUpdateSignal)[]]
+>("zendeskUpdatesSignal");

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -8,7 +8,10 @@ import {
 } from "@temporalio/workflow";
 
 import type * as activities from "@connectors/connectors/zendesk/temporal/activities";
-import type { ZendeskUpdateSignal } from "@connectors/connectors/zendesk/temporal/signals";
+import type {
+  ZendeskCategoryUpdateSignal,
+  ZendeskUpdateSignal,
+} from "@connectors/connectors/zendesk/temporal/signals";
 import { zendeskUpdatesSignal } from "@connectors/connectors/zendesk/temporal/signals";
 
 const {
@@ -49,42 +52,48 @@ export async function zendeskSyncWorkflow({
   const brandHelpCenterSignals: ZendeskUpdateSignal[] = [];
   const brandTicketsIds = new Set<number>();
   const brandTicketSignals: ZendeskUpdateSignal[] = [];
+
   const categoryIds = new Set<number>();
-  const categorySignals: ZendeskUpdateSignal[] = [];
+  const categoryBrands: Record<number, number> = {};
+  const categorySignals: ZendeskCategoryUpdateSignal[] = [];
 
   // If we get a signal, update the workflow state by adding help center ids.
   // Signals are sent when permissions are updated by the admin.
-  setHandler(zendeskUpdatesSignal, (zendeskUpdates: ZendeskUpdateSignal[]) => {
-    zendeskUpdates.forEach((signal) => {
-      switch (signal.type) {
-        case "brand": {
-          brandIds.add(signal.zendeskId);
-          brandSignals.push(signal);
-          break;
+  setHandler(
+    zendeskUpdatesSignal,
+    (zendeskUpdates: (ZendeskUpdateSignal | ZendeskCategoryUpdateSignal)[]) => {
+      zendeskUpdates.forEach((signal) => {
+        switch (signal.type) {
+          case "brand": {
+            brandIds.add(signal.zendeskId);
+            brandSignals.push(signal);
+            break;
+          }
+          case "help-center": {
+            brandHelpCenterIds.add(signal.zendeskId);
+            brandHelpCenterSignals.push(signal);
+            break;
+          }
+          case "tickets": {
+            brandTicketsIds.add(signal.zendeskId);
+            brandTicketSignals.push(signal);
+            break;
+          }
+          case "category": {
+            categoryIds.add(signal.categoryId);
+            categoryBrands[signal.categoryId] = signal.brandId;
+            categorySignals.push(signal);
+            break;
+          }
+          default:
+            assertNever(
+              `Unexpected signal type received within Zendesk sync workflow.`,
+              signal
+            );
         }
-        case "help-center": {
-          brandHelpCenterIds.add(signal.zendeskId);
-          brandHelpCenterSignals.push(signal);
-          break;
-        }
-        case "tickets": {
-          brandTicketsIds.add(signal.zendeskId);
-          brandTicketSignals.push(signal);
-          break;
-        }
-        case "category": {
-          categoryIds.add(signal.zendeskId);
-          categorySignals.push(signal);
-          break;
-        }
-        default:
-          assertNever(
-            `Unexpected signal type ${signal.type} received within Zendesk sync workflow.`,
-            signal.type
-          );
-      }
-    });
-  });
+      });
+    }
+  );
 
   // If we got no signal, then we're on the scheduled execution
   if (
@@ -161,18 +170,21 @@ export async function zendeskSyncWorkflow({
   while (categoryIds.size > 0) {
     const categoryIdsToProcess = new Set(categoryIds);
     for (const categoryId of categoryIdsToProcess) {
-      if (!categoryIds.has(categoryId)) {
-        continue;
-      }
       const relatedSignal = categorySignals.find(
-        (signal) => signal.zendeskId === categoryId
+        (signal) => signal.categoryId === categoryId
       );
       const forceResync = relatedSignal?.forceResync || false;
+      const brandId = categoryBrands[categoryId];
+      if (!brandId) {
+        continue; // this is mostly for typing since we add to categoryBrands whenever we add to categoryIds
+      }
 
       await executeChild(zendeskCategorySyncWorkflow, {
         workflowId: `${workflowId}-category-${categoryId}`,
         searchAttributes: parentSearchAttributes,
-        args: [{ connectorId, categoryId, currentSyncDateMs, forceResync }],
+        args: [
+          { connectorId, categoryId, brandId, currentSyncDateMs, forceResync },
+        ],
         memo,
       });
       categoryIds.delete(categoryId);
@@ -290,11 +302,13 @@ export async function zendeskBrandTicketsSyncWorkflow({
 export async function zendeskCategorySyncWorkflow({
   connectorId,
   categoryId,
+  brandId,
   currentSyncDateMs,
   forceResync,
 }: {
   connectorId: ModelId;
   categoryId: number;
+  brandId: number;
   currentSyncDateMs: number;
   forceResync: boolean;
 }) {
@@ -302,6 +316,7 @@ export async function zendeskCategorySyncWorkflow({
     connectorId,
     categoryId,
     currentSyncDateMs,
+    brandId,
   });
   if (!isCategoryAllowed) {
     return; // nothing to sync
@@ -338,6 +353,7 @@ async function runZendeskBrandHelpCenterSyncActivities({
       connectorId,
       categoryId,
       currentSyncDateMs,
+      brandId,
     });
     if (wasCategoryUpdated) {
       categoriesToSync.add(categoryId);

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -176,7 +176,9 @@ export async function zendeskSyncWorkflow({
       const forceResync = relatedSignal?.forceResync || false;
       const brandId = categoryBrands[categoryId];
       if (!brandId) {
-        continue; // this is mostly for typing since we add to categoryBrands whenever we add to categoryIds
+        throw new Error(
+          "Unreachable: a category ID was pushed without a brand."
+        );
       }
 
       await executeChild(zendeskCategorySyncWorkflow, {

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -480,7 +480,11 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
   toContentNode({ connectorId }: { connectorId: number }): ContentNode {
     return {
       provider: "zendesk",
-      internalId: getCategoryInternalId(connectorId, this.categoryId),
+      internalId: getCategoryInternalId(
+        connectorId,
+        this.brandId,
+        this.categoryId
+      ),
       parentInternalId: getHelpCenterInternalId(connectorId, this.brandId),
       type: "folder",
       title: this.name,
@@ -703,7 +707,11 @@ export class ZendeskArticleResource extends BaseResource<ZendeskArticle> {
     return {
       provider: "zendesk",
       internalId: getArticleInternalId(connectorId, this.articleId),
-      parentInternalId: getCategoryInternalId(connectorId, this.categoryId),
+      parentInternalId: getCategoryInternalId(
+        connectorId,
+        this.brandId,
+        this.categoryId
+      ),
       type: "file",
       title: this.name,
       sourceUrl: this.url,
@@ -712,6 +720,15 @@ export class ZendeskArticleResource extends BaseResource<ZendeskArticle> {
       dustDocumentId: null,
       lastUpdatedAt: this.updatedAt.getTime(),
     };
+  }
+
+  getParentInternalIds(connectorId: number): string[] {
+    return [
+      getArticleInternalId(connectorId, this.articleId),
+      getCategoryInternalId(connectorId, this.brandId, this.categoryId),
+      getHelpCenterInternalId(connectorId, this.brandId),
+      getBrandInternalId(connectorId, this.brandId),
+    ];
   }
 
   static async fetchByArticleId({

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -215,8 +215,10 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
     const brands = await ZendeskBrand.findAll({
       where: {
         connectorId,
-        helpCenterPermission: "read",
-        ticketsPermission: "read",
+        [Op.or]: [
+          { helpCenterPermission: "read" },
+          { ticketsPermission: "read" },
+        ],
       },
     });
     return brands.map((brand) => new this(this.model, brand.get()));


### PR DESCRIPTION
## Description

- Node retrieval was broken and returned duplicate nodes.
- When setting permissions for a category, the brand was not known although it is needed to fetch the category. It was therefore included into the internal ID of a category.
- A refactoring PR is planned, in the meantime any suggestion is welcome!

## Risk

Low, connector not being used.

## Deploy Plan

- Deploy connectors