### PR TITLE
Ext: Logout when user not found

### DIFF
--- a/extension/app/src/components/conversation/ConversationContainer.tsx
+++ b/extension/app/src/components/conversation/ConversationContainer.tsx
@@ -192,7 +192,7 @@ export function ConversationContainer({
           onStickyMentionsChange={onStickyMentionsChange}
         />
       )}
-      <div className="sticky bottom-0 z-20 flex flex-col max-h-screen w-full max-w-4xl sm:pb-8">
+      <div className="sticky bottom-0 z-20 flex flex-col max-h-screen w-full max-w-4xl pb-4">
         <div className="flex justify-end space-x-1 pb-2">
           {!activeConversationId && (
             <Tooltip

--- a/extension/app/src/components/input_bar/InputBar.tsx
+++ b/extension/app/src/components/input_bar/InputBar.tsx
@@ -123,10 +123,10 @@ export function AssistantInputBar({
   return (
     <div className="flex w-full flex-col">
       <div className="flex flex-1 px-0">
-        <div className="flex w-full flex-1 flex-col items-end self-stretch sm:flex-row">
+        <div className="flex w-full flex-1 flex-col items-end self-stretch">
           <div
             className={classNames(
-              "relative flex w-full flex-1 flex-col items-stretch gap-0 self-stretch pl-4 sm:flex-row",
+              "relative flex w-full flex-1 flex-col items-stretch gap-0 self-stretch pl-4",
               "border-struture-200 border-t bg-white/90 backdrop-blur focus-within:border-structure-300",
               "transition-all",
               "rounded-2xl border-b border-l border-r border-element-500 focus-within:border-action-300 focus-within:shadow-md focus-within:ring-1",


### PR DESCRIPTION
## Description

When front API is answering with "user_not_found", we log out. 
Occurs when we have a token and we switch env. 

Also fixes a margin in input bar. 

## Risk

Code of extension only.

## Deploy Plan

Nothing. 
