### PR TITLE
fix: Google Drive full resync is broken

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -78,7 +78,7 @@ export async function googleDriveFullSync({
 
   let nextPageToken: string | undefined = undefined;
 
-  if (!foldersToBrowse) {
+  if (!foldersToBrowse.length) {
     foldersToBrowse = await getFoldersToSync(connectorId);
   }
 


### PR DESCRIPTION
## Description

Fully re-syncing a GDrive connector without specifying a list of folders (which is what happens when we full resync, eg when whitelisting a connector for PDFs) has been broken since https://github.com/dust-tt/dust/pull/6711

The condition checked for a falsy `foldersToBrowse` which was never possible due to it being initialized to an empty array (truthy in JS)

## Risk

N/A

## Deploy Plan

Deploy connectors