### PR TITLE
fix(docker-compose): use correct qdrant secondary version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       timeout: 10s
       retries: 1 # Only retry once to minimize delay
   qdrant_secondary:
-    image: "qdrant/qdrant:v1.7.2"
+    image: "qdrant/qdrant:v1.11.4"
     volumes:
       - qdrant_secondary:/qdrant/storage
     environment:


### PR DESCRIPTION
## Description

for some reason the secondary version was out of sync with the primary. This causes communication errors between the 2 instances.

 
## Risk

N/A

## Deploy Plan

None (local)