### PR TITLE
fix: tables rows upsert request parsing is broken

### DIFF
--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/rows/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/rows/index.ts
@@ -250,7 +250,7 @@ async function handler(
       return res.status(200).json({ rows: rowsList, offset, limit, total });
 
     case "POST":
-      const r = await UpsertTableRowsRequestSchema.safeParse(req.query);
+      const r = await UpsertTableRowsRequestSchema.safeParse(req.body);
 
       if (r.error) {
         return apiError(req, res, {


### PR DESCRIPTION
## Description

Currently not usable at all
Broken since https://github.com/dust-tt/dust/pull/8384, using `req.query` instead of `req.body`

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
