### PR TITLE
[sparkle] - fix(Button):  tooltip

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.295",
+  "version": "0.2.296",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.295",
+      "version": "0.2.296",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.295",
+  "version": "0.2.296",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -1,5 +1,4 @@
 import { Slot } from "@radix-ui/react-slot";
-import { TooltipPortal } from "@radix-ui/react-tooltip";
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
@@ -160,7 +159,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       </>
     );
 
-    const buttonElement = (
+    const innerButton = (
       <MetaButton
         ref={ref}
         size={buttonSize}
@@ -180,7 +179,18 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       </MetaButton>
     );
 
-    const wrappedButton = href ? (
+    const wrappedContent = tooltip ? (
+      <TooltipProvider>
+        <TooltipRoot>
+          <TooltipTrigger asChild>{innerButton}</TooltipTrigger>
+          <TooltipContent>{tooltip}</TooltipContent>
+        </TooltipRoot>
+      </TooltipProvider>
+    ) : (
+      innerButton
+    );
+
+    return href ? (
       <LinkWrapper
         href={href}
         target={target}
@@ -188,25 +198,10 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         replace={replace}
         shallow={shallow}
       >
-        {buttonElement}
+        {wrappedContent}
       </LinkWrapper>
     ) : (
-      buttonElement
-    );
-
-    if (!tooltip) {
-      return wrappedButton;
-    }
-
-    return (
-      <TooltipProvider>
-        <TooltipRoot>
-          <TooltipTrigger asChild>{wrappedButton}</TooltipTrigger>
-          <TooltipPortal>
-            <TooltipContent>{tooltip}</TooltipContent>
-          </TooltipPortal>
-        </TooltipRoot>
-      </TooltipProvider>
+      wrappedContent
     );
   }
 );

--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -1,4 +1,5 @@
 import { Slot } from "@radix-ui/react-slot";
+import { TooltipPortal } from "@radix-ui/react-tooltip";
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
@@ -160,6 +161,26 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     );
 
     const buttonElement = (
+      <MetaButton
+        ref={ref}
+        size={buttonSize}
+        variant={variant}
+        disabled={isLoading || props.disabled}
+        className={isPulsing ? "s-animate-pulse" : ""}
+        aria-label={ariaLabel || tooltip || label}
+        style={
+          {
+            "--pulse-color": "#93C5FD",
+            "--duration": "1.5s",
+          } as React.CSSProperties
+        }
+        {...props}
+      >
+        {content}
+      </MetaButton>
+    );
+
+    const wrappedButton = href ? (
       <LinkWrapper
         href={href}
         target={target}
@@ -167,37 +188,25 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         replace={replace}
         shallow={shallow}
       >
-        <MetaButton
-          ref={ref}
-          size={buttonSize}
-          variant={variant}
-          disabled={isLoading || props.disabled}
-          className={isPulsing ? "s-animate-pulse" : ""}
-          aria-label={ariaLabel || tooltip || label}
-          style={
-            {
-              "--pulse-color": "#93C5FD",
-              "--duration": "1.5s",
-            } as React.CSSProperties
-          }
-          {...props}
-        >
-          {content}
-        </MetaButton>
+        {buttonElement}
       </LinkWrapper>
-    );
-
-    return tooltip ? (
-      <TooltipProvider>
-        <TooltipRoot>
-          <TooltipTrigger asChild ref={ref}>
-            {buttonElement}
-          </TooltipTrigger>
-          <TooltipContent>{tooltip}</TooltipContent>
-        </TooltipRoot>
-      </TooltipProvider>
     ) : (
       buttonElement
+    );
+
+    if (!tooltip) {
+      return wrappedButton;
+    }
+
+    return (
+      <TooltipProvider>
+        <TooltipRoot>
+          <TooltipTrigger asChild>{wrappedButton}</TooltipTrigger>
+          <TooltipPortal>
+            <TooltipContent>{tooltip}</TooltipContent>
+          </TooltipPortal>
+        </TooltipRoot>
+      </TooltipProvider>
     );
   }
 );

--- a/sparkle/src/components/Tabs.tsx
+++ b/sparkle/src/components/Tabs.tsx
@@ -63,7 +63,7 @@ const TabsTrigger = React.forwardRef<
         ref={ref}
         className={cn(
           "s-h-12",
-          "data-[state=active]:s-shadow-inner-border disabled:s-pointer-events-none",
+          "disabled:s-pointer-events-none data-[state=active]:s-shadow-inner-border",
           className
         )}
         disabled={disabled}

--- a/sparkle/src/stories/Button.stories.tsx
+++ b/sparkle/src/stories/Button.stories.tsx
@@ -104,6 +104,12 @@ export const TooltipButtonExample = () => (
       variant="outline"
     />
     <Button
+      href="hello"
+      tooltip="This is a tooltip message"
+      icon={RobotIcon}
+      variant="primary"
+    />
+    <Button
       tooltip="This shouldn't be visible"
       icon={RobotIcon}
       variant="outline"

--- a/sparkle/src/stories/Button.stories.tsx
+++ b/sparkle/src/stories/Button.stories.tsx
@@ -95,3 +95,19 @@ export const DisabledButtonExample = () => (
     <Button icon={RobotIcon} variant="outline" isSelect disabled={true} />
   </div>
 );
+
+export const TooltipButtonExample = () => (
+  <div className="s-flex s-items-center s-gap-4">
+    <Button
+      tooltip="This is a tooltip message"
+      icon={RobotIcon}
+      variant="outline"
+    />
+    <Button
+      tooltip="This shouldn't be visible"
+      icon={RobotIcon}
+      variant="outline"
+      disabled
+    />
+  </div>
+);


### PR DESCRIPTION
## Description

This PR aims at fixing the Button's tooltip props that was broken by the Linkwrapper.

**References:**
- https://github.com/dust-tt/dust/issues/8453

## Risk

Low UI breaking changes mainly

## Deploy Plan

Deploy `front`