### PR TITLE
[sparkle] Supports ref in LinkWrapper and forward to <a>

### DIFF
--- a/sparkle/src/components/LinkWrapper.tsx
+++ b/sparkle/src/components/LinkWrapper.tsx
@@ -11,19 +11,16 @@ export interface LinkWrapperProps {
   target?: string;
 }
 
-export function LinkWrapper({
-  children,
-  href,
-  rel,
-  replace,
-  shallow,
-  target,
-}: LinkWrapperProps) {
+export const LinkWrapper = React.forwardRef<
+  HTMLAnchorElement,
+  LinkWrapperProps
+>(({ children, href, rel, replace, shallow, target }, ref) => {
   const { components } = React.useContext(SparkleContext);
 
   if (href) {
     return (
       <components.link
+        ref={ref}
         href={href}
         target={target}
         rel={rel}
@@ -36,4 +33,4 @@ export function LinkWrapper({
   }
 
   return children;
-}
+});

--- a/sparkle/src/context.tsx
+++ b/sparkle/src/context.tsx
@@ -2,7 +2,7 @@ import React, { ComponentType, MouseEvent, ReactNode } from "react";
 import type { UrlObject } from "url";
 import url from "url";
 
-export type SparkleContextLinkType = ComponentType<{
+type SparkleLinkProps = {
   href: string | UrlObject;
   className?: string;
   children: ReactNode;
@@ -21,7 +21,11 @@ export type SparkleContextLinkType = ComponentType<{
   shallow?: boolean;
   target?: string;
   rel?: string;
-}>;
+};
+
+export type SparkleContextLinkType = ComponentType<
+  SparkleLinkProps & React.RefAttributes<HTMLAnchorElement>
+>;
 
 export type SparkleContextType = {
   components: {
@@ -29,41 +33,39 @@ export type SparkleContextType = {
   };
 };
 
-export const aLink: SparkleContextLinkType = ({
-  href,
-  className,
-  ariaCurrent,
-  ariaLabel,
-  onClick,
-  children,
-  target,
-  rel,
-}) => {
-  const hrefAsString = typeof href !== "string" ? url.format(href) : href;
+export const aLink: SparkleContextLinkType = React.forwardRef<
+  HTMLAnchorElement,
+  SparkleLinkProps
+>(
+  (
+    { href, className, ariaCurrent, ariaLabel, onClick, children, target, rel },
+    ref
+  ) => {
+    const hrefAsString = typeof href !== "string" ? url.format(href) : href;
 
-  return (
-    <a
-      href={hrefAsString}
-      className={className}
-      aria-current={ariaCurrent}
-      aria-label={ariaLabel}
-      onClick={onClick}
-      target={target}
-      rel={rel}
-    >
-      {children}
-    </a>
-  );
-};
+    return (
+      <a
+        ref={ref}
+        href={hrefAsString}
+        className={className}
+        aria-current={ariaCurrent}
+        aria-label={ariaLabel}
+        onClick={onClick}
+        target={target}
+        rel={rel}
+      >
+        {children}
+      </a>
+    );
+  }
+);
 
-export const noHrefLink: SparkleContextLinkType = ({
-  className,
-  ariaCurrent,
-  ariaLabel,
-  onClick,
-  children,
-}) => (
+export const noHrefLink: SparkleContextLinkType = React.forwardRef<
+  HTMLAnchorElement,
+  SparkleLinkProps
+>(({ className, ariaCurrent, ariaLabel, onClick, children }, ref) => (
   <a
+    ref={ref}
     className={className}
     aria-current={ariaCurrent}
     aria-label={ariaLabel}
@@ -71,7 +73,7 @@ export const noHrefLink: SparkleContextLinkType = ({
   >
     {children}
   </a>
-);
+));
 
 export const SparkleContext = React.createContext<SparkleContextType>({
   components: {


### PR DESCRIPTION
## Description

Support ref to link element in LinkWrapper

## Risk

none

## Deploy Plan

publish sparkle
we should then update front to also forward ref to next/link
