### PR TITLE
[webcrawler] Add logging and stats around successful crawls

### DIFF
--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -42,6 +42,7 @@ import {
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { WebCrawlerConfigurationResource } from "@connectors/resources/webcrawler_resource";
+import { statsDClient } from "@connectors/logger/withlogging";
 
 const CONCURRENCY = 1;
 
@@ -159,7 +160,10 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
           await Context.current().sleep(1);
         } catch (e) {
           if (isCancellation(e)) {
-            childLogger.error("The activity was canceled. Aborting crawl.");
+            childLogger.error(
+              { error: e },
+              "The activity was canceled. Aborting crawl."
+            );
 
             // raise a panic flag if the activity is aborted because it exceeded the maximum time to crawl
             const isTooLongToCrawl =
@@ -172,10 +176,11 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
                   url,
                   configId: webCrawlerConfig.id,
                   panic: true,
+                  crawls_per_minute: Math.round(
+                    pageCount.valid / MAX_TIME_TO_CRAWL_MINUTES
+                  ),
                 },
-                `Website takes too long to crawl (crawls ${Math.round(
-                  pageCount.valid / MAX_TIME_TO_CRAWL_MINUTES
-                )} pages per minute)`
+                `Website takes too long to crawl`
               );
             }
 
@@ -282,6 +287,22 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
           depth: currentRequestDepth,
           lastSeenAt: new Date(),
         });
+
+        childLogger.info(
+          {
+            documentId,
+            configId: webCrawlerConfig.id,
+            documentLen: extracted.length,
+            url,
+          },
+          "Successfully crawled page"
+        );
+
+        statsDClient.increment("connectors_webcrawler_crawls.count", 1);
+        statsDClient.increment(
+          "connectors_webcrawler_crawls_bytes.count",
+          extracted.length
+        );
 
         Context.current().heartbeat({
           type: "upserting",

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -40,9 +40,9 @@ import {
   syncSucceeded,
 } from "@connectors/lib/sync_status";
 import logger from "@connectors/logger/logger";
+import { statsDClient } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { WebCrawlerConfigurationResource } from "@connectors/resources/webcrawler_resource";
-import { statsDClient } from "@connectors/logger/withlogging";
 
 const CONCURRENCY = 1;
 


### PR DESCRIPTION
## Description

Fix a few logs and adds one log per successful crawl + statsd metrics.
Goal is to evaluate our volume of crawling.

## Risk

None

## Deploy Plan

- deploy `connectors`