### PR TITLE
[sparkle] - fix(Tabs): console errors

### DIFF
--- a/sparkle/src/components/Tabs.tsx
+++ b/sparkle/src/components/Tabs.tsx
@@ -22,7 +22,7 @@ const TabsList = React.forwardRef<
     <TabsPrimitive.List
       ref={ref}
       className={cn(
-        "s-inline-flex s-h-12 s-gap-2 s-border-b s-border-separator",
+        "s-inline-flex s-h-11 s-gap-2 s-border-b s-border-separator",
         isFullSize && "s-w-full",
         className
       )}
@@ -62,26 +62,29 @@ const TabsTrigger = React.forwardRef<
       <TabsPrimitive.Trigger
         ref={ref}
         className={cn(
-          "s-h-12",
+          "s-h-11",
           "disabled:s-pointer-events-none data-[state=active]:s-shadow-inner-border",
           className
         )}
         disabled={disabled}
+        asChild
         {...props}
       >
-        <Button
-          variant="ghost"
-          size="sm"
-          label={label}
-          tooltip={tooltip}
-          icon={icon}
-          disabled={disabled}
-          href={href}
-          target={target}
-          rel={rel}
-          replace={replace}
-          shallow={shallow}
-        />
+        <div>
+          <Button
+            variant="ghost"
+            size="sm"
+            label={label}
+            tooltip={tooltip}
+            icon={icon}
+            disabled={disabled}
+            href={href}
+            target={target}
+            rel={rel}
+            replace={replace}
+            shallow={shallow}
+          />
+        </div>
       </TabsPrimitive.Trigger>
     );
   }


### PR DESCRIPTION
## Description

This PR aims at fixing the console errors caused by the recent changes in the Tabs component. Since `TabsPrimitive.Trigger` renders a button and we render a button within the component we could pass a "asChild" parameter and simply pass the props to the button however it totally breaks the style. 

## Risk

Low

## Deploy Plan
