### PR TITLE
Extension: Bump Sparkle

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.294",
+        "@dust-tt/sparkle": "^0.2.296",
         "@dust-tt/types": "file:../types",
         "@tailwindcss/forms": "^0.5.9",
         "@tiptap/extension-character-count": "^2.9.1",
@@ -269,9 +269,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.295",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.295.tgz",
-      "integrity": "sha512-9LCxqHr/QWSiEoWiEt0m6eOEU1QBJ50Ii88h/o6wRxwty0gvyQ0+T8O0jKhc6za+hMPOXeA2TXhwnc4PAWa0Sg==",
+      "version": "0.2.296",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.296.tgz",
+      "integrity": "sha512-QbmORtWwFqSy71I+QoxxnL3urQ11MBIDHQ2Myzu8eGOQ/PCDU91Z0sdU/RgTo2S5y+Q9r0RA2P3FrM9Mwo2Uww==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.295",
+    "@dust-tt/sparkle": "^0.2.296",
     "@dust-tt/types": "file:../types",
     "@tailwindcss/forms": "^0.5.9",
     "@tiptap/extension-character-count": "^2.9.1",


### PR DESCRIPTION
## Description

Just using the last sparkle version to get rid of the annoying js error on the Assistant Picker. 

## Risk

none

## Deploy Plan

nothing
