### PR TITLE
Extension: Agent message retry

### DIFF
--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
@@ -1,0 +1,115 @@
+import type { AgentMessageType, WithAPIErrorResponse } from "@dust-tt/types";
+import { isAgentMessageType } from "@dust-tt/types";
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getConversation } from "@app/lib/api/assistant/conversation";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
+import { retryAgentMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
+import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+
+export const PostRetryRequestBodySchema = t.union([
+  t.null,
+  t.undefined,
+  t.literal(""),
+  t.type({}),
+]);
+
+/**
+ * @ignoreswagger
+ * Not documented yet.
+ * TODO(Ext)
+ */
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<{ message: AgentMessageType }>>,
+  auth: Authenticator
+): Promise<void> {
+  if (!(typeof req.query.cId === "string")) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `cId` (string) is required.",
+      },
+    });
+  }
+
+  const conversationId = req.query.cId;
+  const conversationRes = await getConversation(auth, conversationId);
+
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
+  }
+
+  const conversation = conversationRes.value;
+
+  if (!(typeof req.query.mId === "string")) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `mId` (string) is required.",
+      },
+    });
+  }
+  const messageId = req.query.mId;
+
+  switch (req.method) {
+    case "POST":
+      const bodyValidation = PostRetryRequestBodySchema.decode(req.body);
+
+      if (isLeft(bodyValidation)) {
+        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${pathError}`,
+          },
+        });
+      }
+
+      const message = conversation.content
+        .flat()
+        .find((m) => m.sId === messageId);
+      if (!message || !isAgentMessageType(message)) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "The message you're trying to retry does not exist or is not an agent message.",
+          },
+        });
+      }
+
+      const retriedMessageRes = await retryAgentMessageWithPubSub(auth, {
+        conversation,
+        message,
+      });
+      if (retriedMessageRes.isErr()) {
+        return apiError(req, res, retriedMessageRes.error);
+      }
+
+      res.status(200).json({ message: retriedMessageRes.value });
+      return;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withPublicAPIAuthentication(handler, { isStreaming: true });


### PR DESCRIPTION
## Description

This PR adds the ability to copy the content of an agent message and retry its generation. 
It creates a new public api route undocumented yet (adapted from the private api route).
New route is using `withPublicAPIAuthentication` wrapper.

## Risk

Should not break anything since it's only a new route. 

## Deploy Plan

Deploy front.

