### PR TITLE
[connectors] Implement articles pagination for Zendesk

### DIFF
--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -252,13 +252,13 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
             }
           }
           if (permission === "read") {
-            const newBrand = await allowSyncZendeskHelpCenter({
+            const wasBrandUpdated = await allowSyncZendeskHelpCenter({
               connectorId,
               connectionId,
               brandId: objectId,
             });
-            if (newBrand) {
-              toBeSignaledHelpCenterIds.add(newBrand.brandId);
+            if (wasBrandUpdated) {
+              toBeSignaledHelpCenterIds.add(objectId);
             }
           }
           break;
@@ -274,13 +274,13 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
             }
           }
           if (permission === "read") {
-            const newBrand = await allowSyncZendeskTickets({
+            const wasBrandUpdated = await allowSyncZendeskTickets({
               connectorId,
               connectionId,
               brandId: objectId,
             });
-            if (newBrand) {
-              toBeSignaledTicketsIds.add(newBrand.brandId);
+            if (wasBrandUpdated) {
+              toBeSignaledTicketsIds.add(objectId);
             }
           }
           break;

--- a/connectors/src/connectors/zendesk/lib/brand_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/brand_permissions.ts
@@ -30,12 +30,9 @@ export async function allowSyncZendeskBrand({
     await brand.update({ ticketsPermission: "read" });
   }
 
-  const { accessToken, subdomain } =
-    await getZendeskSubdomainAndAccessToken(connectionId);
-  const zendeskApiClient = createZendeskClient({
-    token: accessToken,
-    subdomain,
-  });
+  const zendeskApiClient = createZendeskClient(
+    await getZendeskSubdomainAndAccessToken(connectionId)
+  );
 
   if (!brand) {
     const {

--- a/connectors/src/connectors/zendesk/lib/brand_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/brand_permissions.ts
@@ -3,8 +3,6 @@ import type { ModelId } from "@dust-tt/types";
 import { allowSyncZendeskHelpCenter } from "@connectors/connectors/zendesk/lib/help_center_permissions";
 import { allowSyncZendeskTickets } from "@connectors/connectors/zendesk/lib/ticket_permissions";
 import { syncBrandWithPermissions } from "@connectors/connectors/zendesk/lib/utils";
-import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
-import { createZendeskClient } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import logger from "@connectors/logger/logger";
 import { ZendeskBrandResource } from "@connectors/resources/zendesk_resources";
 
@@ -20,12 +18,9 @@ export async function allowSyncZendeskBrand({
   connectionId: string;
   brandId: number;
 }): Promise<boolean> {
-  const zendeskApiClient = createZendeskClient(
-    await getZendeskSubdomainAndAccessToken(connectionId)
-  );
-
-  const syncSuccess = await syncBrandWithPermissions(zendeskApiClient, {
+  const syncSuccess = await syncBrandWithPermissions({
     connectorId,
+    connectionId,
     brandId,
     permissions: {
       ticketsPermission: "none",

--- a/connectors/src/connectors/zendesk/lib/brand_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/brand_permissions.ts
@@ -18,8 +18,8 @@ export async function allowSyncZendeskBrand({
   connectorId: ModelId;
   connectionId: string;
   brandId: number;
-}): Promise<ZendeskBrandResource | null> {
-  let brand = await ZendeskBrandResource.fetchByBrandId({
+}): Promise<boolean> {
+  const brand = await ZendeskBrandResource.fetchByBrandId({
     connectorId,
     brandId,
   });
@@ -39,7 +39,7 @@ export async function allowSyncZendeskBrand({
       result: { brand: fetchedBrand },
     } = await zendeskApiClient.brand.show(brandId);
     if (fetchedBrand) {
-      brand = await ZendeskBrandResource.makeNew({
+      await ZendeskBrandResource.makeNew({
         blob: {
           subdomain: fetchedBrand.subdomain,
           connectorId: connectorId,
@@ -53,7 +53,7 @@ export async function allowSyncZendeskBrand({
       });
     } else {
       logger.error({ brandId }, "[Zendesk] Brand could not be fetched.");
-      return null;
+      return false;
     }
   }
 
@@ -68,7 +68,7 @@ export async function allowSyncZendeskBrand({
     brandId,
   });
 
-  return brand;
+  return true;
 }
 
 /**

--- a/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
@@ -35,12 +35,9 @@ export async function allowSyncZendeskHelpCenter({
     await brand.update({ helpCenterPermission: "read" });
   }
 
-  const { accessToken, subdomain } =
-    await getZendeskSubdomainAndAccessToken(connectionId);
-  const zendeskApiClient = createZendeskClient({
-    token: accessToken,
-    subdomain,
-  });
+  const zendeskApiClient = createZendeskClient(
+    await getZendeskSubdomainAndAccessToken(connectionId)
+  );
 
   if (!brand) {
     const {
@@ -160,12 +157,9 @@ export async function allowSyncZendeskCategory({
     await category.update({ permission: "read" });
   }
 
-  const { accessToken, subdomain } =
-    await getZendeskSubdomainAndAccessToken(connectionId);
-  const zendeskApiClient = createZendeskClient({
-    token: accessToken,
-    subdomain,
-  });
+  const zendeskApiClient = createZendeskClient(
+    await getZendeskSubdomainAndAccessToken(connectionId)
+  );
 
   if (!category) {
     await changeZendeskClientSubdomain(zendeskApiClient, {

--- a/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
@@ -31,7 +31,9 @@ export async function allowSyncZendeskHelpCenter({
     await getZendeskSubdomainAndAccessToken(connectionId)
   );
 
-  const syncSuccess = await syncBrandWithPermissions(zendeskApiClient, {
+  const syncSuccess = await syncBrandWithPermissions({
+    zendeskApiClient,
+    connectionId,
     connectorId,
     brandId,
     permissions: {

--- a/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
@@ -25,8 +25,8 @@ export async function allowSyncZendeskHelpCenter({
   connectionId: string;
   brandId: number;
   withChildren?: boolean;
-}): Promise<ZendeskBrandResource | null> {
-  let brand = await ZendeskBrandResource.fetchByBrandId({
+}): Promise<boolean> {
+  const brand = await ZendeskBrandResource.fetchByBrandId({
     connectorId,
     brandId,
   });
@@ -44,7 +44,7 @@ export async function allowSyncZendeskHelpCenter({
       result: { brand: fetchedBrand },
     } = await zendeskApiClient.brand.show(brandId);
     if (fetchedBrand) {
-      brand = await ZendeskBrandResource.makeNew({
+      await ZendeskBrandResource.makeNew({
         blob: {
           subdomain: fetchedBrand.subdomain,
           connectorId: connectorId,
@@ -61,7 +61,7 @@ export async function allowSyncZendeskHelpCenter({
         { connectorId, brandId },
         "[Zendesk] Brand could not be fetched."
       );
-      return null;
+      return false;
     }
   }
 
@@ -86,11 +86,11 @@ export async function allowSyncZendeskHelpCenter({
         { connectorId, brandId },
         "[Zendesk] Categories could not be fetched."
       );
-      return null;
+      return false;
     }
   }
 
-  return brand;
+  return true;
 }
 
 /**

--- a/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
@@ -12,11 +12,11 @@ import {
   ZendeskCategoryResource,
 } from "@connectors/resources/zendesk_resources";
 
-export async function allowSyncZendeskHelpCenter({
-  connectorId,
 /**
  * Marks a help center as permission "read", optionally alongside all its children (categories and articles).
  */
+export async function allowSyncZendeskHelpCenter({
+  connectorId,
   connectionId,
   brandId,
   withChildren = true,
@@ -157,11 +157,10 @@ export async function allowSyncZendeskCategory({
     await category.update({ permission: "read" });
   }
 
-  const zendeskApiClient = createZendeskClient(
-    await getZendeskSubdomainAndAccessToken(connectionId)
-  );
-
   if (!category) {
+    const zendeskApiClient = createZendeskClient(
+      await getZendeskSubdomainAndAccessToken(connectionId)
+    );
     await changeZendeskClientSubdomain(zendeskApiClient, {
       connectorId,
       brandId,

--- a/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
@@ -12,11 +12,11 @@ import {
   ZendeskCategoryResource,
 } from "@connectors/resources/zendesk_resources";
 
+export async function allowSyncZendeskHelpCenter({
+  connectorId,
 /**
  * Marks a help center as permission "read", optionally alongside all its children (categories and articles).
  */
-export async function allowSyncZendeskHelpCenter({
-  connectorId,
   connectionId,
   brandId,
   withChildren = true,
@@ -70,7 +70,10 @@ export async function allowSyncZendeskHelpCenter({
 
   // updating permissions for all the children categories
   if (withChildren) {
-    await changeZendeskClientSubdomain({ client: zendeskApiClient, brandId });
+    await changeZendeskClientSubdomain(zendeskApiClient, {
+      connectorId,
+      brandId,
+    });
     try {
       const categories = await zendeskApiClient.helpcenter.categories.list();
       categories.forEach((category) =>
@@ -165,7 +168,10 @@ export async function allowSyncZendeskCategory({
   });
 
   if (!category) {
-    await changeZendeskClientSubdomain({ client: zendeskApiClient, brandId });
+    await changeZendeskClientSubdomain(zendeskApiClient, {
+      connectorId,
+      brandId,
+    });
     const { result: fetchedCategory } =
       await zendeskApiClient.helpcenter.categories.show(categoryId);
     if (fetchedCategory) {

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -85,8 +85,9 @@ export async function retrieveChildrenNodes({
   // At the root level, we show one node for each brand.
   if (!parentInternalId) {
     if (isReadPermissionsOnly) {
-      const brandsInDatabase =
-        await ZendeskBrandResource.fetchAllWithHelpCenter({ connectorId });
+      const brandsInDatabase = await ZendeskBrandResource.fetchAllReadOnly({
+        connectorId,
+      });
       nodes = brandsInDatabase.map((brand) =>
         brand.toContentNode({ connectorId })
       );

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -93,20 +93,18 @@ export async function retrieveChildrenNodes({
       );
     } else {
       const { result: brands } = await zendeskApiClient.brand.list();
-      nodes = brands
-        .filter((brand) => brand.has_help_center)
-        .map((brand) => ({
-          provider: connector.type,
-          internalId: getBrandInternalId(connectorId, brand.id),
-          parentInternalId: null,
-          type: "folder",
-          title: brand.name || "Brand",
-          sourceUrl: brand.brand_url,
-          expandable: true,
-          permission: "none",
-          dustDocumentId: null,
-          lastUpdatedAt: null,
-        }));
+      nodes = brands.map((brand) => ({
+        provider: connector.type,
+        internalId: getBrandInternalId(connectorId, brand.id),
+        parentInternalId: null,
+        type: "folder",
+        title: brand.name || "Brand",
+        sourceUrl: brand.brand_url,
+        expandable: true,
+        permission: "none",
+        dustDocumentId: null,
+        lastUpdatedAt: null,
+      }));
     }
   } else {
     const { type, objectId } = getIdFromInternalId(

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -188,8 +188,8 @@ export async function retrieveChildrenNodes({
             category.toContentNode({ connectorId, expandable: true })
           );
         } else {
-          await changeZendeskClientSubdomain({
-            client: zendeskApiClient,
+          await changeZendeskClientSubdomain(zendeskApiClient, {
+            connectorId,
             brandId: objectId,
           });
           const categories =

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -78,13 +78,9 @@ export async function retrieveChildrenNodes({
   const isReadPermissionsOnly = filterPermission === "read";
   let nodes: ContentNode[] = [];
 
-  const { accessToken, subdomain } = await getZendeskSubdomainAndAccessToken(
-    connector.connectionId
+  const zendeskApiClient = createZendeskClient(
+    await getZendeskSubdomainAndAccessToken(connector.connectionId)
   );
-  const zendeskApiClient = createZendeskClient({
-    token: accessToken,
-    subdomain,
-  });
 
   // At the root level, we show one node for each brand.
   if (!parentInternalId) {

--- a/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
@@ -25,11 +25,10 @@ export async function allowSyncZendeskTickets({
     await brand.update({ ticketsPermission: "read" });
   }
 
-  const zendeskApiClient = createZendeskClient(
-    await getZendeskSubdomainAndAccessToken(connectionId)
-  );
-
   if (!brand) {
+    const zendeskApiClient = createZendeskClient(
+      await getZendeskSubdomainAndAccessToken(connectionId)
+    );
     const {
       result: { brand: fetchedBrand },
     } = await zendeskApiClient.brand.show(brandId);

--- a/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
@@ -1,8 +1,6 @@
 import type { ModelId } from "@dust-tt/types";
 
 import { syncBrandWithPermissions } from "@connectors/connectors/zendesk/lib/utils";
-import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
-import { createZendeskClient } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import logger from "@connectors/logger/logger";
 import {
   ZendeskBrandResource,
@@ -21,11 +19,9 @@ export async function allowSyncZendeskTickets({
   connectionId: string;
   brandId: number;
 }): Promise<boolean> {
-  const zendeskApiClient = createZendeskClient(
-    await getZendeskSubdomainAndAccessToken(connectionId)
-  );
-  return syncBrandWithPermissions(zendeskApiClient, {
+  return syncBrandWithPermissions({
     connectorId,
+    connectionId,
     brandId,
     permissions: {
       ticketsPermission: "read",

--- a/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
@@ -1,5 +1,6 @@
 import type { ModelId } from "@dust-tt/types";
 
+import { fetchBrandAndSync } from "@connectors/connectors/zendesk/lib/utils";
 import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
 import { createZendeskClient } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import logger from "@connectors/logger/logger";
@@ -28,33 +29,21 @@ export async function allowSyncZendeskTickets({
     await brand.update({ ticketsPermission: "read" });
   }
 
-  if (!brand) {
-    const zendeskApiClient = createZendeskClient(
-      await getZendeskSubdomainAndAccessToken(connectionId)
-    );
-    const {
-      result: { brand: fetchedBrand },
-    } = await zendeskApiClient.brand.show(brandId);
-    if (fetchedBrand) {
-      await ZendeskBrandResource.makeNew({
-        blob: {
-          subdomain: fetchedBrand.subdomain,
-          connectorId: connectorId,
-          brandId: fetchedBrand.id,
-          name: fetchedBrand.name || "Brand",
-          helpCenterPermission: "none",
-          ticketsPermission: "read",
-          hasHelpCenter: fetchedBrand.has_help_center,
-          url: fetchedBrand.url,
-        },
-      });
-    } else {
-      logger.error({ brandId }, "[Zendesk] Brand could not be fetched.");
-      return false;
-    }
+  if (brand) {
+    return true;
   }
 
-  return true;
+  const zendeskApiClient = createZendeskClient(
+    await getZendeskSubdomainAndAccessToken(connectionId)
+  );
+  return fetchBrandAndSync(zendeskApiClient, {
+    connectorId,
+    brandId,
+    permissions: {
+      ticketsPermission: "read",
+      helpCenterPermission: "none",
+    },
+  });
 }
 
 /**

--- a/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
@@ -1,6 +1,6 @@
 import type { ModelId } from "@dust-tt/types";
 
-import { fetchBrandAndSync } from "@connectors/connectors/zendesk/lib/utils";
+import { syncBrandWithPermissions } from "@connectors/connectors/zendesk/lib/utils";
 import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
 import { createZendeskClient } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import logger from "@connectors/logger/logger";
@@ -21,22 +21,10 @@ export async function allowSyncZendeskTickets({
   connectionId: string;
   brandId: number;
 }): Promise<boolean> {
-  const brand = await ZendeskBrandResource.fetchByBrandId({
-    connectorId,
-    brandId,
-  });
-  if (brand?.ticketsPermission === "none") {
-    await brand.update({ ticketsPermission: "read" });
-  }
-
-  if (brand) {
-    return true;
-  }
-
   const zendeskApiClient = createZendeskClient(
     await getZendeskSubdomainAndAccessToken(connectionId)
   );
-  return fetchBrandAndSync(zendeskApiClient, {
+  return syncBrandWithPermissions(zendeskApiClient, {
     connectorId,
     brandId,
     permissions: {

--- a/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
@@ -25,12 +25,9 @@ export async function allowSyncZendeskTickets({
     await brand.update({ ticketsPermission: "read" });
   }
 
-  const { accessToken, subdomain } =
-    await getZendeskSubdomainAndAccessToken(connectionId);
-  const zendeskApiClient = createZendeskClient({
-    token: accessToken,
-    subdomain,
-  });
+  const zendeskApiClient = createZendeskClient(
+    await getZendeskSubdomainAndAccessToken(connectionId)
+  );
 
   if (!brand) {
     const {

--- a/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
@@ -8,6 +8,9 @@ import {
   ZendeskTicketResource,
 } from "@connectors/resources/zendesk_resources";
 
+/**
+ * Marks the node "Tickets" of a Brand as permission "read".
+ */
 export async function allowSyncZendeskTickets({
   connectorId,
   connectionId,
@@ -55,7 +58,7 @@ export async function allowSyncZendeskTickets({
 }
 
 /**
- * Mark a help center as permission "none" and all children (collections and articles).
+ * Mark the node "Tickets" and all the children tickets for a Brand as permission "none".
  */
 export async function revokeSyncZendeskTickets({
   connectorId,

--- a/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
@@ -19,8 +19,8 @@ export async function allowSyncZendeskTickets({
   connectorId: ModelId;
   connectionId: string;
   brandId: number;
-}): Promise<ZendeskBrandResource | null> {
-  let brand = await ZendeskBrandResource.fetchByBrandId({
+}): Promise<boolean> {
+  const brand = await ZendeskBrandResource.fetchByBrandId({
     connectorId,
     brandId,
   });
@@ -36,7 +36,7 @@ export async function allowSyncZendeskTickets({
       result: { brand: fetchedBrand },
     } = await zendeskApiClient.brand.show(brandId);
     if (fetchedBrand) {
-      brand = await ZendeskBrandResource.makeNew({
+      await ZendeskBrandResource.makeNew({
         blob: {
           subdomain: fetchedBrand.subdomain,
           connectorId: connectorId,
@@ -50,11 +50,11 @@ export async function allowSyncZendeskTickets({
       });
     } else {
       logger.error({ brandId }, "[Zendesk] Brand could not be fetched.");
-      return null;
+      return false;
     }
   }
 
-  return brand;
+  return true;
 }
 
 /**

--- a/connectors/src/connectors/zendesk/lib/utils.ts
+++ b/connectors/src/connectors/zendesk/lib/utils.ts
@@ -1,0 +1,49 @@
+import type { ModelId } from "@dust-tt/types";
+import type { Client } from "node-zendesk";
+
+import logger from "@connectors/logger/logger";
+import { ZendeskBrandResource } from "@connectors/resources/zendesk_resources";
+
+/**
+ * Fetches a brand and syncs it with the db.
+ * @returns True if the fetch succeeded, false otherwise.
+ */
+export async function fetchBrandAndSync(
+  zendeskApiClient: Client,
+  {
+    connectorId,
+    brandId,
+    permissions,
+  }: {
+    connectorId: ModelId;
+    brandId: number;
+    permissions: {
+      ticketsPermission: "read" | "none";
+      helpCenterPermission: "read" | "none";
+    };
+  }
+): Promise<boolean> {
+  const {
+    result: { brand: fetchedBrand },
+  } = await zendeskApiClient.brand.show(brandId);
+  if (fetchedBrand) {
+    await ZendeskBrandResource.makeNew({
+      blob: {
+        subdomain: fetchedBrand.subdomain,
+        connectorId: connectorId,
+        brandId: fetchedBrand.id,
+        name: fetchedBrand.name || "Brand",
+        ...permissions,
+        hasHelpCenter: fetchedBrand.has_help_center,
+        url: fetchedBrand.url,
+      },
+    });
+    return true;
+  } else {
+    logger.error(
+      { connectorId, brandId },
+      "[Zendesk] Brand could not be fetched."
+    );
+    return false;
+  }
+}

--- a/connectors/src/connectors/zendesk/lib/utils.ts
+++ b/connectors/src/connectors/zendesk/lib/utils.ts
@@ -32,14 +32,14 @@ export async function syncBrandWithPermissions({
     brandId,
   });
 
-  if (permissions.helpCenterPermission === "read") {
-    await brand?.grantHelpCenterPermissions();
-  }
-  if (permissions.ticketsPermission === "read") {
-    await brand?.grantTicketsPermissions();
-  }
-
   if (brand) {
+    if (permissions.helpCenterPermission === "read") {
+      await brand.grantHelpCenterPermissions();
+    }
+    if (permissions.ticketsPermission === "read") {
+      await brand.grantTicketsPermissions();
+    }
+
     return true;
   }
 

--- a/connectors/src/connectors/zendesk/lib/utils.ts
+++ b/connectors/src/connectors/zendesk/lib/utils.ts
@@ -28,17 +28,11 @@ export async function syncBrandWithPermissions(
     brandId,
   });
 
-  if (
-    permissions.helpCenterPermission === "read" &&
-    brand?.helpCenterPermission === "none"
-  ) {
-    await brand.update({ helpCenterPermission: "read" });
+  if (permissions.helpCenterPermission === "read") {
+    await brand?.grantHelpCenterPermissions();
   }
-  if (
-    permissions.ticketsPermission === "read" &&
-    brand?.ticketsPermission === "none"
-  ) {
-    await brand.update({ ticketsPermission: "read" });
+  if (permissions.ticketsPermission === "read") {
+    await brand?.grantTicketsPermissions();
   }
 
   if (brand) {

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -1,3 +1,6 @@
+import assert from "node:assert";
+
+import type { ModelId } from "@dust-tt/types";
 import type { Client } from "node-zendesk";
 import { createClient } from "node-zendesk";
 
@@ -11,17 +14,34 @@ export function createZendeskClient({
   return createClient({ oauth: true, token, subdomain });
 }
 
-export async function changeZendeskClientSubdomain({
-  client,
-  brandId,
-}: {
-  client: Client;
-  brandId: number;
-}) {
-  // TODO(2024-10-29 aubin): in some cases the brand in db is available and can be used to retrieve the subdomain
+/**
+ * Returns a Zendesk client with the subdomain set to the one in the brand.
+ * Retrieves the brand from the database if it exists, fetches it from the Zendesk API otherwise.
+ */
+export async function changeZendeskClientSubdomain(
+  client: Client,
+  {
+    connectorId = null,
+    brandId,
+  }: {
+    connectorId?: ModelId | null;
+    brandId: number;
+  }
+) {
+  if (connectorId) {
+    const brandInDb = await ZendeskBrandResource.fetchByBrandId({
+      connectorId,
+      brandId,
+    });
+    if (brandInDb) {
+      client.config.subdomain = brandInDb.subdomain;
+      return client;
+    }
+  }
   const {
     result: { brand },
   } = await client.brand.show(brandId);
   client.config.subdomain = brand.subdomain;
+
   return client;
 }

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -8,6 +8,8 @@ import type { ZendeskFetchedArticle } from "@connectors/connectors/zendesk/lib/n
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import { ZendeskBrandResource } from "@connectors/resources/zendesk_resources";
 
+const ZENDESK_RATE_LIMIT_TIMEOUT_SECONDS = 60;
+
 export function createZendeskClient({
   accessToken,
   subdomain,
@@ -62,7 +64,11 @@ export async function getZendeskBrandSubdomain(
  */
 async function handleZendeskRateLimit(response: Response): Promise<boolean> {
   if (response.status === 429) {
-    const retryAfter = Number(response.headers.get("Retry-After")) || 60;
+    const retryAfter = Math.min(
+      Number(response.headers.get("Retry-After")) ||
+        ZENDESK_RATE_LIMIT_TIMEOUT_SECONDS,
+      ZENDESK_RATE_LIMIT_TIMEOUT_SECONDS
+    );
     await new Promise((resolve) => setTimeout(resolve, retryAfter * 1000));
     return true;
   }

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -6,6 +6,7 @@ import { createClient } from "node-zendesk";
 
 import type { ZendeskFetchedArticle } from "@connectors/connectors/zendesk/lib/node-zendesk-types";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
+import logger from "@connectors/logger/logger";
 import { ZendeskBrandResource } from "@connectors/resources/zendesk_resources";
 
 const ZENDESK_RATE_LIMIT_TIMEOUT_SECONDS = 60;
@@ -68,6 +69,10 @@ async function handleZendeskRateLimit(response: Response): Promise<boolean> {
       Number(response.headers.get("Retry-After")) ||
         ZENDESK_RATE_LIMIT_TIMEOUT_SECONDS,
       ZENDESK_RATE_LIMIT_TIMEOUT_SECONDS
+    );
+    logger.info(
+      { response, retryAfter },
+      "[Zendesk] Rate limit hit, waiting before retrying."
     );
     await new Promise((resolve) => setTimeout(resolve, retryAfter * 1000));
     return true;

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -4,6 +4,10 @@ import type { ModelId } from "@dust-tt/types";
 import type { Client } from "node-zendesk";
 import { createClient } from "node-zendesk";
 
+import type { ZendeskFetchedArticle } from "@connectors/connectors/zendesk/lib/node-zendesk-types";
+import { ExternalOAuthTokenError } from "@connectors/lib/error";
+import { ZendeskBrandResource } from "@connectors/resources/zendesk_resources";
+
 export function createZendeskClient({
   token,
   subdomain,
@@ -28,20 +32,112 @@ export async function changeZendeskClientSubdomain(
     brandId: number;
   }
 ) {
+  client.config.subdomain = await getZendeskBrandSubdomain(client, {
+    connectorId,
+    brandId,
+  });
+  return client;
+}
+
+/**
+ * Retrieves a brand's subdomain from the database if it exists, fetches it from the Zendesk API otherwise.
+ */
+export async function getZendeskBrandSubdomain(
+  client: Client,
+  {
+    connectorId = null,
+    brandId,
+  }: {
+    connectorId?: ModelId | null;
+    brandId: number;
+  }
+): Promise<string> {
   if (connectorId) {
     const brandInDb = await ZendeskBrandResource.fetchByBrandId({
       connectorId,
       brandId,
     });
     if (brandInDb) {
-      client.config.subdomain = brandInDb.subdomain;
-      return client;
+      return brandInDb.subdomain;
     }
   }
   const {
     result: { brand },
   } = await client.brand.show(brandId);
-  client.config.subdomain = brand.subdomain;
+  return brand.subdomain;
+}
 
-  return client;
+/**
+ * Handles rate limit responses from Zendesk API.
+ * Expects to find the header `Retry-After` in the response.
+ * https://developer.zendesk.com/api-reference/introduction/rate-limits/
+ * @returns true if the rate limit was handled and the request should be retried, false otherwise.
+ */
+async function handleZendeskRateLimit(response: Response): Promise<boolean> {
+  if (response.status === 429) {
+    const retryAfter = Number(response.headers.get("Retry-After")) || 60;
+    await new Promise((resolve) => setTimeout(resolve, retryAfter * 1000));
+    return true;
+  }
+  return false;
+}
+
+export async function fetchZendeskArticlesInCategory({
+  subdomain,
+  accessToken,
+  categoryId,
+  pageSize = 100,
+  cursor = null,
+}: {
+  subdomain: string;
+  accessToken: string;
+  categoryId: number;
+  pageSize?: number;
+  cursor?: string | null;
+}): Promise<{
+  articles: ZendeskFetchedArticle[];
+  meta: { hasMore: boolean; after_cursor: string };
+}> {
+  assert(
+    pageSize <= 100,
+    `pageSize must be at most 100 (current value: ${pageSize})` // https://developer.zendesk.com/api-reference/introduction/pagination
+  );
+  const runFetch = async () =>
+    fetch(
+      `https://${subdomain}.zendesk.com/api/v2/help_center/categories/${categoryId}/articles?page[size]=${pageSize}` +
+        (cursor ? `&page[after]=${cursor}` : ""),
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/json",
+        },
+      }
+    );
+
+  let rawResponse = await runFetch();
+  while (await handleZendeskRateLimit(rawResponse)) {
+    rawResponse = await runFetch();
+  }
+
+  const text = await rawResponse.text();
+  const response = JSON.parse(text);
+
+  if (!rawResponse.ok) {
+    if (
+      response.type === "error.list" &&
+      response.errors &&
+      response.errors.length > 0
+    ) {
+      const error = response.errors[0];
+      if (error.code === "unauthorized") {
+        throw new ExternalOAuthTokenError();
+      }
+      if (error.code === "not_found") {
+        return { articles: [], meta: { hasMore: false, after_cursor: "" } };
+      }
+    }
+  }
+
+  return response;
 }

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -24,13 +24,7 @@ export function createZendeskClient({
  */
 export async function changeZendeskClientSubdomain(
   client: Client,
-  {
-    connectorId = null,
-    brandId,
-  }: {
-    connectorId?: ModelId | null;
-    brandId: number;
-  }
+  { connectorId, brandId }: { connectorId: ModelId; brandId: number }
 ) {
   client.config.subdomain = await getZendeskBrandSubdomain(client, {
     connectorId,
@@ -44,23 +38,16 @@ export async function changeZendeskClientSubdomain(
  */
 export async function getZendeskBrandSubdomain(
   client: Client,
-  {
-    connectorId = null,
-    brandId,
-  }: {
-    connectorId?: ModelId | null;
-    brandId: number;
-  }
+  { connectorId, brandId }: { connectorId: ModelId; brandId: number }
 ): Promise<string> {
-  if (connectorId) {
-    const brandInDb = await ZendeskBrandResource.fetchByBrandId({
-      connectorId,
-      brandId,
-    });
-    if (brandInDb) {
-      return brandInDb.subdomain;
-    }
+  const brandInDb = await ZendeskBrandResource.fetchByBrandId({
+    connectorId,
+    brandId,
+  });
+  if (brandInDb) {
+    return brandInDb.subdomain;
   }
+
   const {
     result: { brand },
   } = await client.brand.show(brandId);

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -98,7 +98,7 @@ export async function fetchZendeskArticlesInCategory({
   cursor?: string | null;
 }): Promise<{
   articles: ZendeskFetchedArticle[];
-  meta: { hasMore: boolean; after_cursor: string };
+  meta: { has_more: boolean; after_cursor: string };
 }> {
   assert(
     pageSize <= 100,
@@ -148,7 +148,7 @@ export async function fetchZendeskArticlesInCategory({
         throw new ExternalOAuthTokenError();
       }
       if (error.code === "not_found") {
-        return { articles: [], meta: { hasMore: false, after_cursor: "" } };
+        return { articles: [], meta: { has_more: false, after_cursor: "" } };
       }
     }
   }

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -9,13 +9,13 @@ import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import { ZendeskBrandResource } from "@connectors/resources/zendesk_resources";
 
 export function createZendeskClient({
-  token,
+  accessToken,
   subdomain,
 }: {
-  token: string;
+  accessToken: string;
   subdomain: string;
 }) {
-  return createClient({ oauth: true, token, subdomain });
+  return createClient({ oauth: true, token: accessToken, subdomain });
 }
 
 /**

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -82,6 +82,9 @@ async function handleZendeskRateLimit(response: Response): Promise<boolean> {
   return false;
 }
 
+/**
+ * Fetches a batch of articles in a category from the Zendesk API.
+ */
 export async function fetchZendeskArticlesInCategory({
   subdomain,
   accessToken,

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -126,13 +126,9 @@ export async function syncZendeskBrandActivity({
     return { helpCenterAllowed: false, ticketsAllowed: false };
   }
 
-  const { accessToken, subdomain } = await getZendeskSubdomainAndAccessToken(
-    connector.connectionId
+  const zendeskApiClient = createZendeskClient(
+    await getZendeskSubdomainAndAccessToken(connector.connectionId)
   );
-  const zendeskApiClient = createZendeskClient({
-    token: accessToken,
-    subdomain,
-  });
 
   // if the brand is not on Zendesk anymore, we delete it
   const {
@@ -243,13 +239,9 @@ export async function getZendeskCategoriesActivity({
   brandId: number;
 }): Promise<number[]> {
   const connector = await _getZendeskConnectorOrRaise(connectorId);
-  const { accessToken, subdomain } = await getZendeskSubdomainAndAccessToken(
-    connector.connectionId
+  const client = createZendeskClient(
+    await getZendeskSubdomainAndAccessToken(connector.connectionId)
   );
-  const client = createZendeskClient({
-    token: accessToken,
-    subdomain,
-  });
   await changeZendeskClientSubdomain(client, { connectorId, brandId });
   const categories = await client.helpcenter.categories.list();
 
@@ -291,13 +283,9 @@ export async function syncZendeskCategoryActivity({
     return false;
   }
 
-  const { accessToken, subdomain } = await getZendeskSubdomainAndAccessToken(
-    connector.connectionId
+  const zendeskApiClient = createZendeskClient(
+    await getZendeskSubdomainAndAccessToken(connector.connectionId)
   );
-  const zendeskApiClient = createZendeskClient({
-    token: accessToken,
-    subdomain,
-  });
   await changeZendeskClientSubdomain(zendeskApiClient, {
     connectorId,
     brandId,
@@ -353,10 +341,7 @@ export async function syncZendeskArticleBatchActivity({
   const { accessToken, subdomain } = await getZendeskSubdomainAndAccessToken(
     connector.connectionId
   );
-  const zendeskApiClient = createZendeskClient({
-    token: accessToken,
-    subdomain,
-  });
+  const zendeskApiClient = createZendeskClient({ accessToken, subdomain });
   const brandSubdomain = await getZendeskBrandSubdomain(zendeskApiClient, {
     brandId: category.brandId,
     connectorId,
@@ -413,13 +398,9 @@ export async function syncZendeskTicketsActivity({
     dataSourceId: dataSourceConfig.dataSourceId,
   };
 
-  const { accessToken, subdomain } = await getZendeskSubdomainAndAccessToken(
-    connector.connectionId
+  const zendeskApiClient = createZendeskClient(
+    await getZendeskSubdomainAndAccessToken(connector.connectionId)
   );
-  const zendeskApiClient = createZendeskClient({
-    token: accessToken,
-    subdomain,
-  });
   await changeZendeskClientSubdomain(zendeskApiClient, {
     connectorId,
     brandId,

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -246,7 +246,7 @@ export async function getZendeskCategoriesActivity({
     token: accessToken,
     subdomain,
   });
-  await changeZendeskClientSubdomain({ client, brandId });
+  await changeZendeskClientSubdomain(client, { connectorId, brandId });
   const categories = await client.helpcenter.categories.list();
 
   return categories.map((category) => category.id);
@@ -294,7 +294,10 @@ export async function syncZendeskCategoryActivity({
     token: accessToken,
     subdomain,
   });
-  await changeZendeskClientSubdomain({ client: zendeskApiClient, brandId });
+  await changeZendeskClientSubdomain(zendeskApiClient, {
+    connectorId,
+    brandId,
+  });
 
   // if the category is not on Zendesk anymore, we delete it
   const { result: fetchedCategory } =
@@ -395,7 +398,10 @@ export async function syncZendeskTicketsActivity({
     token: accessToken,
     subdomain,
   });
-  await changeZendeskClientSubdomain({ client: zendeskApiClient, brandId });
+  await changeZendeskClientSubdomain(zendeskApiClient, {
+    connectorId,
+    brandId,
+  });
   const tickets = await zendeskApiClient.tickets.list();
 
   await concurrentExecutor(

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -349,7 +349,7 @@ export async function syncZendeskArticleBatchActivity({
 
   const {
     articles,
-    meta: { after_cursor, hasMore },
+    meta: { after_cursor, has_more },
   } = await fetchZendeskArticlesInCategory({
     subdomain: brandSubdomain,
     accessToken,
@@ -372,7 +372,7 @@ export async function syncZendeskArticleBatchActivity({
       }),
     { concurrency: 10 }
   );
-  return { hasMore, afterCursor: after_cursor };
+  return { hasMore: has_more, afterCursor: after_cursor };
 }
 
 /**

--- a/connectors/src/connectors/zendesk/temporal/config.ts
+++ b/connectors/src/connectors/zendesk/temporal/config.ts
@@ -1,2 +1,2 @@
-export const WORKFLOW_VERSION = 2;
+export const WORKFLOW_VERSION = 3;
 export const QUEUE_NAME = `zendesk-queue-v${WORKFLOW_VERSION}`;

--- a/connectors/src/connectors/zendesk/temporal/sync_article.ts
+++ b/connectors/src/connectors/zendesk/temporal/sync_article.ts
@@ -67,7 +67,7 @@ export async function syncArticle({
       updatedAt: updatedAtDate,
       categoryId: category.categoryId, // an article can be moved from one category to another, which does not apply to brands
       name: article.name,
-      url: article.url,
+      url: article.html_url,
     });
   }
 

--- a/connectors/src/connectors/zendesk/temporal/sync_article.ts
+++ b/connectors/src/connectors/zendesk/temporal/sync_article.ts
@@ -47,28 +47,26 @@ export async function syncArticle({
     !articleInDb.lastUpsertedTs ||
     articleInDb.lastUpsertedTs < articleUpdatedAtDate; // upserting if the article was updated after the last upsert
 
+  const updatableFields = {
+    createdAt: createdAtDate,
+    updatedAt: updatedAtDate,
+    categoryId: category.categoryId, // an article can be moved from one category to another, which does not apply to brands
+    name: article.name,
+    url: article.html_url,
+  };
+  // we either create a new article or update the existing one
   if (!articleInDb) {
     articleInDb = await ZendeskArticleResource.makeNew({
       blob: {
-        createdAt: createdAtDate,
-        updatedAt: updatedAtDate,
+        ...updatableFields,
         articleId: article.id,
         brandId: category.brandId,
-        categoryId: category.categoryId,
         permission: "read",
-        name: article.name,
-        url: article.html_url,
         connectorId,
       },
     });
   } else {
-    await articleInDb.update({
-      createdAt: createdAtDate,
-      updatedAt: updatedAtDate,
-      categoryId: category.categoryId, // an article can be moved from one category to another, which does not apply to brands
-      name: article.name,
-      url: article.html_url,
-    });
+    await articleInDb.update(updatableFields);
   }
 
   if (!shouldPerformUpsertion) {

--- a/connectors/src/connectors/zendesk/temporal/sync_article.ts
+++ b/connectors/src/connectors/zendesk/temporal/sync_article.ts
@@ -39,19 +39,16 @@ export async function syncArticle({
     connectorId,
     articleId: article.id,
   });
-  const createdAtDate = new Date(article.created_at);
   const updatedAtDate = new Date(article.updated_at);
-
-  const articleUpdatedAtDate = new Date(article.updated_at);
 
   const shouldPerformUpsertion =
     forceResync ||
     !articleInDb ||
     !articleInDb.lastUpsertedTs ||
-    articleInDb.lastUpsertedTs < articleUpdatedAtDate; // upserting if the article was updated after the last upsert
+    articleInDb.lastUpsertedTs < updatedAtDate; // upserting if the article was updated after the last upsert
 
   const updatableFields = {
-    createdAt: createdAtDate,
+    createdAt: new Date(article.created_at),
     updatedAt: updatedAtDate,
     categoryId: category.categoryId, // an article can be moved from one category to another, which does not apply to brands
     name: article.name,
@@ -77,7 +74,7 @@ export async function syncArticle({
       ...loggerArgs,
       connectorId,
       articleId: article.id,
-      articleUpdatedAt: articleUpdatedAtDate,
+      articleUpdatedAt: updatedAtDate,
       dataSourceLastUpsertedAt: articleInDb?.lastUpsertedTs ?? null,
     },
     shouldPerformUpsertion

--- a/connectors/src/connectors/zendesk/temporal/sync_article.ts
+++ b/connectors/src/connectors/zendesk/temporal/sync_article.ts
@@ -72,29 +72,21 @@ export async function syncArticle({
     await articleInDb.update(updatableFields);
   }
 
+  logger.info(
+    {
+      ...loggerArgs,
+      connectorId,
+      articleId: article.id,
+      articleUpdatedAt: articleUpdatedAtDate,
+      dataSourceLastUpsertedAt: articleInDb?.lastUpsertedTs ?? null,
+    },
+    shouldPerformUpsertion
+      ? "[Zendesk] Article to sync."
+      : "[Zendesk] Article already up to date. Skipping sync."
+  );
+
   if (!shouldPerformUpsertion) {
-    logger.info(
-      {
-        ...loggerArgs,
-        connectorId,
-        articleId: article.id,
-        articleUpdatedAt: articleUpdatedAtDate,
-        dataSourceLastUpsertedAt: articleInDb?.lastUpsertedTs ?? null,
-      },
-      "[Zendesk] Article already up to date. Skipping sync."
-    );
     return;
-  } else {
-    logger.info(
-      {
-        ...loggerArgs,
-        connectorId,
-        articleId: article.id,
-        articleUpdatedAt: articleUpdatedAtDate,
-        dataSourceLastUpsertedAt: articleInDb?.lastUpsertedTs ?? null,
-      },
-      "[Zendesk] Article to sync."
-    );
   }
 
   const categoryContent =

--- a/connectors/src/connectors/zendesk/temporal/sync_article.ts
+++ b/connectors/src/connectors/zendesk/temporal/sync_article.ts
@@ -15,6 +15,9 @@ import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
 const turndownService = new TurndownService();
 
+/**
+ * Syncs an article from Zendesk to the postgres db and to the data sources.
+ */
 export async function syncArticle({
   connectorId,
   article,

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -327,18 +327,18 @@ export async function zendeskCategorySyncWorkflow({
   }
 
   let cursor = null; // cursor involved in the pagination of the API
-  for (;;) {
-    const { hasMore, afterCursor } = await syncZendeskArticleBatchActivity({
+  let hasMore = true;
+
+  while (hasMore) {
+    const result = await syncZendeskArticleBatchActivity({
       connectorId,
       categoryId,
       currentSyncDateMs,
       forceResync,
       cursor,
     });
-    if (!hasMore) {
-      break;
-    }
-    cursor = afterCursor;
+    hasMore = result.hasMore || false;
+    cursor = result.afterCursor;
   }
 }
 
@@ -374,19 +374,19 @@ async function runZendeskBrandHelpCenterSyncActivities({
   }
 
   for (const categoryId of categoryIdsToSync) {
+    let hasMore = true;
     let cursor = null; // cursor involved in the pagination of the API
-    for (;;) {
-      const { hasMore, afterCursor } = await syncZendeskArticleBatchActivity({
+
+    while (hasMore) {
+      const result = await syncZendeskArticleBatchActivity({
         connectorId,
         categoryId,
         currentSyncDateMs,
         forceResync,
         cursor,
       });
-      if (!hasMore) {
-        break;
-      }
-      cursor = afterCursor;
+      hasMore = result.hasMore || false;
+      cursor = result.afterCursor;
     }
   }
 }

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -164,6 +164,18 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
     return new this(this.model, brand.get());
   }
 
+  async grantHelpCenterPermissions(): Promise<void> {
+    if (this.helpCenterPermission === "none") {
+      await this.update({ helpCenterPermission: "read" });
+    }
+  }
+
+  async grantTicketsPermissions(): Promise<void> {
+    if (this.ticketsPermission === "none") {
+      await this.update({ ticketsPermission: "read" });
+    }
+  }
+
   async revokeAllPermissions(): Promise<void> {
     await this.revokeHelpCenterPermissions();
     await this.revokeTicketsPermissions();


### PR DESCRIPTION
## Description

- Closes [#8423](https://github.com/dust-tt/dust/issues/8423)
- Processes articles by **batch** (1 batch <=> 1 activity).
- Each batch is fetched through the Zendesk API and then processed (synced with the db + datasource if applicable) before moving onto the next batch.
- **Cursor**-based pagination is used over of **offset**-based pagination.
- **Rate limits** enforced by Zendesk API are handled by waiting within each activity (the API specifies how much time to sleep for).
- Previous behavior: fetching all the articles at once and then processing all of them, all of this in a single activity.

### Additional changes

- Prevent category data from being exposed in Temporal workflows (replaced with IDs).
- Small refactoring changes such as renaming the parameter `token` into `accessToken` in the function `createZendeskClient`.

## Risk

Low.

## Deploy Plan

- Deploy connectors