### PR TITLE
[connectors] Fix permissions update for Zendesk

### DIFF
--- a/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
@@ -16,10 +16,12 @@ export async function allowSyncZendeskHelpCenter({
   connectorId,
   connectionId,
   brandId,
+  withChildren = true,
 }: {
   connectorId: ModelId;
   connectionId: string;
   brandId: number;
+  withChildren?: boolean;
 }): Promise<ZendeskBrandResource | null> {
   let brand = await ZendeskBrandResource.fetchByBrandId({
     connectorId,
@@ -61,6 +63,11 @@ export async function allowSyncZendeskHelpCenter({
       );
       return null;
     }
+  }
+
+  /// if we don't want to sync the children, we are done and can return here.
+  if (!withChildren) {
+    return brand;
   }
 
   await changeZendeskClientSubdomain({ client: zendeskApiClient, brandId });
@@ -169,7 +176,12 @@ export async function allowSyncZendeskCategory({
     }
   }
 
-  await allowSyncZendeskHelpCenter({ connectorId, connectionId, brandId });
+  await allowSyncZendeskHelpCenter({
+    connectorId,
+    connectionId,
+    brandId,
+    withChildren: false,
+  });
 
   return category;
 }

--- a/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
@@ -169,6 +169,8 @@ export async function allowSyncZendeskCategory({
     }
   }
 
+  await allowSyncZendeskHelpCenter({ connectorId, connectionId, brandId });
+
   return category;
 }
 

--- a/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
@@ -12,6 +12,9 @@ import {
   ZendeskCategoryResource,
 } from "@connectors/resources/zendesk_resources";
 
+/**
+ * Marks a help center as permission "read", optionally alongside all its children (categories and articles).
+ */
 export async function allowSyncZendeskHelpCenter({
   connectorId,
   connectionId,
@@ -128,6 +131,9 @@ export async function revokeSyncZendeskHelpCenter({
   return brand;
 }
 
+/**
+ * Marks a category with "read" permissions, alongside all its children articles.
+ */
 export async function allowSyncZendeskCategory({
   connectorId,
   connectionId,

--- a/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
@@ -12,12 +12,10 @@ export async function allowSyncZendeskTickets({
   connectorId,
   connectionId,
   brandId,
-  withChildren = false,
 }: {
   connectorId: ModelId;
   connectionId: string;
   brandId: number;
-  withChildren?: boolean;
 }): Promise<ZendeskBrandResource | null> {
   let brand = await ZendeskBrandResource.fetchByBrandId({
     connectorId,
@@ -55,10 +53,6 @@ export async function allowSyncZendeskTickets({
       logger.error({ brandId }, "[Zendesk] Brand could not be fetched.");
       return null;
     }
-  }
-
-  if (withChildren) {
-    throw new Error("withChildren not implemented yet.");
   }
 
   return brand;

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -268,7 +268,7 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
       sourceUrl: this.url,
       expandable: true,
       permission:
-        this.helpCenterPermission === "read" &&
+        this.helpCenterPermission === "read" ||
         this.ticketsPermission === "read"
           ? "read"
           : "none",

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -867,4 +867,17 @@ export class ZendeskArticleResource extends BaseResource<ZendeskArticle> {
       { where: { connectorId, brandId } }
     );
   }
+
+  static async revokePermissionsForCategory({
+    connectorId,
+    categoryId,
+  }: {
+    connectorId: number;
+    categoryId: number;
+  }) {
+    await ZendeskArticle.update(
+      { permission: "none" },
+      { where: { connectorId, categoryId } }
+    );
+  }
 }


### PR DESCRIPTION
## Description

- Even if I allow a Help Center when initially syncing Zendesk, the parent Brand does not show up in the vault (its permission are set to none).
- Same for a category, the parent Help Center does not show as having read permissions even if I allowed the child category.

## Risk

Low

## Deploy Plan

- Deploy connectors