### PR TITLE
More robust connector update

### DIFF
--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -157,7 +157,7 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
 
         // If connector was previously paused, unpause it.
         if (connector.isPaused()) {
-          await connector.markAsUnpaused();
+          await this.unpause();
         }
       } else {
         logger.info(

--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -154,6 +154,11 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
         newConfluenceCloudInformation.id === currentCloudInformation.cloudId
       ) {
         await connector.update({ connectionId });
+
+        // If connector was previously paused, unpause it.
+        if (connector.isPaused()) {
+          await connector.markAsUnpaused();
+        }
       } else {
         logger.info(
           {

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -494,6 +494,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
       async (repoId) => {
         const repoRes = await getRepo(connectionId, repoId);
         if (repoRes.isErr()) {
+          // We need to throw the error to stop the execution of the concurrentExecutor.
           throw repoRes.error;
         }
 

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -98,7 +98,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
 
       // If connector was previously paused, unpause it.
       if (c.isPaused()) {
-        await c.markAsUnpaused();
+        await this.unpause();
       }
 
       await launchGithubFullSyncWorkflow({

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -96,6 +96,11 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
 
       await c.update({ connectionId });
 
+      // If connector was previously paused, unpause it.
+      if (c.isPaused()) {
+        await c.markAsUnpaused();
+      }
+
       await launchGithubFullSyncWorkflow({
         connectorId: this.connectorId,
         syncCodeOnly: false,

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -494,7 +494,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
       async (repoId) => {
         const repoRes = await getRepo(connectionId, repoId);
         if (repoRes.isErr()) {
-          return repoRes;
+          throw repoRes.error;
         }
 
         uniqueRepos[repoId] = repoRes.value;

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -192,6 +192,11 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
       }
 
       await connector.update({ connectionId });
+
+      // If connector was previously paused, unpause it.
+      if (connector.isPaused()) {
+        await connector.markAsUnpaused();
+      }
     }
 
     return new Ok(connector.id.toString());

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -195,7 +195,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
 
       // If connector was previously paused, unpause it.
       if (connector.isPaused()) {
-        await connector.markAsUnpaused();
+        await this.unpause();
       }
     }
 

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -163,6 +163,11 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
 
       await connector.update({ connectionId: newConnectionId });
 
+      // If connector was previously paused, unpause it.
+      if (connector.isPaused()) {
+        await connector.markAsUnpaused();
+      }
+
       await IntercomWorkspace.update(
         {
           intercomWorkspaceId: newIntercomWorkspace.id,

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -165,7 +165,7 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
 
       // If connector was previously paused, unpause it.
       if (connector.isPaused()) {
-        await connector.markAsUnpaused();
+        await this.unpause();
       }
 
       await IntercomWorkspace.update(

--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -150,10 +150,16 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
           {
             error: e,
           },
-          `Error checking Microsoft organization - lets update the connector regardless`
+          "Error checking Microsoft organization - lets update the connector regardless"
         );
       }
+
       await connector.update({ connectionId });
+
+      // If connector was previously paused, unpause it.
+      if (connector.isPaused()) {
+        await connector.markAsUnpaused();
+      }
     }
 
     return new Ok(connector.id.toString());

--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -158,7 +158,7 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
 
       // If connector was previously paused, unpause it.
       if (connector.isPaused()) {
-        await connector.markAsUnpaused();
+        await this.unpause();
       }
     }
 

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -170,7 +170,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
 
       // If connector was previously paused, unpause it.
       if (c.isPaused()) {
-        await c.markAsUnpaused();
+        await this.unpause();
       }
 
       const dataSourceConfig = dataSourceConfigFromConnector(c);

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -168,6 +168,11 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
 
       await c.update({ connectionId });
 
+      // If connector was previously paused, unpause it.
+      if (c.isPaused()) {
+        await c.markAsUnpaused();
+      }
+
       const dataSourceConfig = dataSourceConfigFromConnector(c);
       try {
         await launchNotionSyncWorkflow(c.id);

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -171,6 +171,11 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
 
     await c.update(updateParams);
 
+    // If connector was previously paused, unpause it.
+    if (c.isPaused()) {
+      await c.markAsUnpaused();
+    }
+
     return new Ok(c.id.toString());
   }
 

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -173,7 +173,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
 
     // If connector was previously paused, unpause it.
     if (c.isPaused()) {
-      await c.markAsUnpaused();
+      await this.unpause();
     }
 
     return new Ok(c.id.toString());

--- a/connectors/src/lib/temporal.ts
+++ b/connectors/src/lib/temporal.ts
@@ -5,6 +5,8 @@ import { Client, Connection, WorkflowNotFoundError } from "@temporalio/client";
 import { NativeConnection } from "@temporalio/worker";
 import fs from "fs-extra";
 
+import logger from "@connectors/logger/logger";
+
 // Assuming one cached workflows takes 2MB on average,
 // we can cache 292 workflows in 4096MB, which is the max heap size
 // we give to our temporal workers.
@@ -135,7 +137,19 @@ export async function terminateAllWorkflowsForConnectorId(
     query: `ExecutionStatus = 'Running' AND connectorId = ${connectorId}`,
   });
 
+  logger.info(
+    {
+      connectorId,
+    },
+    "About to terminate all workflows for connectorId"
+  );
+
   for await (const handle of workflowInfos) {
+    logger.info(
+      { connectorId, workflowId: handle.workflowId },
+      "Terminating Temporal workflow"
+    );
+
     const workflowHandle = client.workflow.getHandle(handle.workflowId);
     try {
       await workflowHandle.terminate();


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We have monitors triggered because some paused connectors still have running workflows (see [logs](https://app.datadoghq.eu/logs?query=%22Production%20check%20failed%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZMB33hc0hSyIQAAABhBWk1CMzN0MkFBQmpZVmx1WU41aDZRQV8AAAAkMDE5MzAxZTQtOWRhNy00N2QzLTg2MGMtODIxYjM4NWYxNjhlAAQgbA&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1730902049000&to_ts=1730903249000&live=false)).

This change addresses connector state management during authentication updates. When a connector encounters an `ExternalOAuthTokenError`, it is automatically paused and all associated Temporal workflows are terminated. When users re-authenticated through the UI by calling `POST /connectors/:connectorId/update` to update the `connectionId`, the connector remained in a paused state.

This update ensures that updating a connector's connection automatically unpauses it, which:
- Clears the paused state in the database
- Restarts the previously terminated Temporal workflows

Note: The current implementation duplicates this logic across multiple places. A design document and refactoring effort is planned to consolidate this common functionality.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
