### PR TITLE
Extension: Fix font size in Input bar

### DIFF
--- a/extension/app/src/css/custom.css
+++ b/extension/app/src/css/custom.css
@@ -1,3 +1,4 @@
 body {
   font-family: darkmode-off-cc, sans-serif;
+  font-size: 100%;
 }


### PR DESCRIPTION
## Description

The font size in the input bar was set by a css rule set to 75%, this was injected css from the extension. 
I'm adding a rule in our custom css to set that font size is always 100%. 

<kbd>
<img width="474" alt="Screenshot 2024-11-06 at 22 46 28" src="https://github.com/user-attachments/assets/12c0e1ae-6e69-4eca-a502-2041273b4f56">
</kbd>

## Risk

None.

## Deploy Plan

No deploy. 