### PR TITLE
upload tab content on every post

### DIFF
--- a/extension/app/background.ts
+++ b/extension/app/background.ts
@@ -74,6 +74,7 @@ chrome.runtime.onMessage.addListener(
                 func: () => document.documentElement.innerText,
               });
               sendResponse({
+                title: tab.title || "",
                 url: tab.url || "",
                 content: result.result ?? "no content.",
               });

--- a/extension/app/background.ts
+++ b/extension/app/background.ts
@@ -64,7 +64,7 @@ chrome.runtime.onMessage.addListener(
             const tab = tabs[0];
             if (!tab?.id) {
               log("No active tab found.");
-              sendResponse({ url: "", content: "" });
+              sendResponse({ url: "", content: "", title: "" });
               return;
             }
 
@@ -80,7 +80,7 @@ chrome.runtime.onMessage.addListener(
               });
             } catch (error) {
               log("Error getting active tab content:", error);
-              sendResponse({ url: tab.url || "", content: "" });
+              sendResponse({ url: tab.url || "", content: "", title: "" });
             }
           }
         );

--- a/extension/app/src/components/auth/ProtectedRoute.tsx
+++ b/extension/app/src/components/auth/ProtectedRoute.tsx
@@ -1,15 +1,4 @@
-import {
-  Avatar,
-  Button,
-  ExternalLinkIcon,
-  LogoHorizontalColorLogo,
-  LogoutIcon,
-  NewDropdownMenu,
-  NewDropdownMenuContent,
-  NewDropdownMenuItem,
-  NewDropdownMenuTrigger,
-  Spinner,
-} from "@dust-tt/sparkle";
+import { Spinner } from "@dust-tt/sparkle";
 import type { LightWorkspaceType } from "@dust-tt/types";
 import { useAuth } from "@extension/components/auth/AuthProvider";
 import type { StoredUser } from "@extension/lib/storage";

--- a/extension/app/src/components/auth/ProtectedRoute.tsx
+++ b/extension/app/src/components/auth/ProtectedRoute.tsx
@@ -24,6 +24,7 @@ type ProtectedRouteProps = {
 export type ProtectedRouteChildrenProps = {
   user: StoredUser;
   workspace: LightWorkspaceType;
+  handleLogout: () => void;
 };
 
 export const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
@@ -57,47 +58,9 @@ export const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
 
   return (
     <div className="flex h-screen flex-col gap-2 p-4">
-      <div className="flex items-start justify-between">
-        <div className="flex items-center gap-2 pb-6">
-          <LogoHorizontalColorLogo className="h-4 w-16" />
-          <Button
-            icon={ExternalLinkIcon}
-            variant="ghost"
-            href="https://dust.tt"
-            target="_blank"
-          />
-        </div>
-        <NewDropdownMenu>
-          <NewDropdownMenuTrigger>
-            <>
-              <span className="sr-only">Open user menu</span>
-              <Avatar
-                size="md"
-                visual={
-                  user.image
-                    ? user.image
-                    : "https://gravatar.com/avatar/anonymous?d=mp"
-                }
-                onClick={() => {
-                  "clickable";
-                }}
-              />
-            </>
-          </NewDropdownMenuTrigger>
-          <NewDropdownMenuContent>
-            <NewDropdownMenuItem
-              icon={LogoutIcon}
-              label="Sign out"
-              onClick={handleLogout}
-            />
-          </NewDropdownMenuContent>
-        </NewDropdownMenu>
-      </div>
-      <>
-        {typeof children === "function"
-          ? children({ user, workspace })
-          : children}
-      </>
+      {typeof children === "function"
+        ? children({ user, workspace, handleLogout })
+        : children}
     </div>
   );
 };

--- a/extension/app/src/components/conversation/ConversationContainer.tsx
+++ b/extension/app/src/components/conversation/ConversationContainer.tsx
@@ -10,7 +10,6 @@ import type {
   LightWorkspaceType,
   MentionType,
 } from "@dust-tt/types";
-import { isContentFragmentMessageTypeModel } from "@dust-tt/types";
 import { ConversationViewer } from "@extension/components/conversation/ConversationViewer";
 import { ReachedLimitPopup } from "@extension/components/conversation/ReachedLimitPopup";
 import { usePublicConversation } from "@extension/components/conversation/usePublicConversation";

--- a/extension/app/src/components/conversation/ConversationContainer.tsx
+++ b/extension/app/src/components/conversation/ConversationContainer.tsx
@@ -10,6 +10,7 @@ import type {
   LightWorkspaceType,
   MentionType,
 } from "@dust-tt/types";
+import { isContentFragmentMessageTypeModel } from "@dust-tt/types";
 import { ConversationViewer } from "@extension/components/conversation/ConversationViewer";
 import { ReachedLimitPopup } from "@extension/components/conversation/ReachedLimitPopup";
 import { usePublicConversation } from "@extension/components/conversation/usePublicConversation";
@@ -26,6 +27,10 @@ import { useDustAPI } from "@extension/lib/dust_api";
 import { getRandomGreetingForName } from "@extension/lib/greetings";
 import { sendGetActiveTabMessage } from "@extension/lib/messages";
 import type { StoredUser } from "@extension/lib/storage";
+import {
+  getConversationContext,
+  setConversationContext,
+} from "@extension/lib/storage";
 import { useCallback, useContext, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
@@ -44,11 +49,27 @@ export function ConversationContainer({
   const [activeConversationId, setActiveConversationId] =
     useState(conversationId);
 
-  const [tabContentToInclude, setTabContentToInclude] = useState<{
-    title: string;
-    content: string;
-    url: string;
-  } | null>(null);
+  const [includeContent, setIncludeContent] = useState<boolean | undefined>();
+
+  useEffect(() => {
+    if (includeContent === undefined) {
+      return;
+    }
+
+    void setConversationContext(activeConversationId ?? "new", {
+      includeCurrentPage: includeContent,
+    });
+  }, [includeContent]);
+
+  useEffect(() => {
+    const doAsync = async () => {
+      const context = await getConversationContext(
+        activeConversationId ?? "new"
+      );
+      setIncludeContent(context.includeCurrentPage);
+    };
+    void doAsync();
+  }, [conversationId]);
 
   const [planLimitReached, setPlanLimitReached] = useState(false);
   const [stickyMentions, setStickyMentions] = useState<AgentMention[]>([]);
@@ -57,7 +78,7 @@ export function ConversationContainer({
   const { animate, setAnimate } = useContext(InputBarContext);
   const sendNotification = useSendNotification();
 
-  const { mutateConversation } = usePublicConversation({
+  const { conversation, mutateConversation } = usePublicConversation({
     conversationId,
     workspaceId: owner.sId,
   });
@@ -76,17 +97,17 @@ export function ConversationContainer({
     }
   }, [activeConversationId, navigate]);
 
-  const handleIncludeCurrentTab = async () => {
+  const getIncludeCurrentTab = async () => {
     const backgroundRes = await sendGetActiveTabMessage();
     if (!backgroundRes.content || !backgroundRes.url) {
       console.error("Failed to get content from the current tab.");
-      return;
+      return null;
     }
-    setTabContentToInclude({
-      title: `Content from ${backgroundRes.url}`,
+    return {
+      title: backgroundRes.title,
       content: backgroundRes.content,
       url: backgroundRes.url,
-    });
+    };
   };
 
   const handlePostMessage = async (input: string, mentions: MentionType[]) => {
@@ -97,10 +118,26 @@ export function ConversationContainer({
     try {
       await mutateConversation(
         async (currentConversation) => {
+          const tabContent = includeContent
+            ? await getIncludeCurrentTab()
+            : null;
+          // Check if the content is already uploaded - compare the title and the size of the content.
+          const alreadyUploaded =
+            tabContent &&
+            conversation?.content
+              .map((m) => m[m.length - 1])
+              .some(
+                (m) =>
+                  m.type === "content_fragment" &&
+                  m.title === tabContent.title &&
+                  m.textBytes === new Blob([tabContent.content]).size
+              );
+
           const result = await postMessage({
             dustAPI,
             conversationId: activeConversationId,
             messageData,
+            tabContent: alreadyUploaded ? null : tabContent,
           });
 
           if (result.isOk()) {
@@ -152,13 +189,14 @@ export function ConversationContainer({
   const { submit: handlePostConversation } = useSubmitFunction(
     useCallback(
       async (input: string, mentions: MentionType[]) => {
+        const tabContent = includeContent ? await getIncludeCurrentTab() : null;
         const conversationRes = await postConversation({
           dustAPI,
           messageData: {
             input,
             mentions,
           },
-          tabContent: tabContentToInclude,
+          tabContent,
         });
         if (conversationRes.isErr()) {
           if (conversationRes.error.type === "plan_limit_reached_error") {
@@ -171,10 +209,13 @@ export function ConversationContainer({
             });
           }
         } else {
+          await setConversationContext(conversationRes.value.sId, {
+            includeCurrentPage: !!includeContent,
+          });
           setActiveConversationId(conversationRes.value.sId);
         }
       },
-      [owner, sendNotification, setActiveConversationId, tabContentToInclude]
+      [owner, sendNotification, setActiveConversationId, includeContent]
     )
   );
 
@@ -209,21 +250,23 @@ export function ConversationContainer({
             </div>
             <div className="flex space-x-1">
               <Button
-                tooltip={
-                  tabContentToInclude
-                    ? `Page included: ${tabContentToInclude.url}`
-                    : "Include content from the current tab"
-                }
+                label={includeContent ? `Page included` : "Include page"}
                 icon={CloudArrowDownIcon}
-                variant="outline"
-                onClick={handleIncludeCurrentTab}
-                disabled={tabContentToInclude !== null}
+                variant={includeContent ? "highlight" : "outline"}
+                onClick={() => setIncludeContent((v) => !v)}
               />
               <ConversationHistory />
             </div>
           </div>
         ) : (
-          <div className="flex justify-end items-end pb-2">
+          <div className="flex justify-end items-end pb-2 gap-1">
+            <Button
+              label={includeContent ? `Page included` : "Include page"}
+              icon={CloudArrowDownIcon}
+              variant={includeContent ? "highlight" : "outline"}
+              onClick={() => setIncludeContent((v) => !v)}
+            />
+
             <ConversationHistory />
           </div>
         )}

--- a/extension/app/src/lib/conversation.ts
+++ b/extension/app/src/lib/conversation.ts
@@ -146,7 +146,7 @@ export async function postConversation({
         email: user.email,
         fullName: user.fullName,
         timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
-        profilePictureUrl: null,
+        profilePictureUrl: user.image,
         origin: "extension",
       },
       mentions,
@@ -161,7 +161,7 @@ export async function postConversation({
             username: user.username,
             email: user.email,
             fullName: user.fullName,
-            profilePictureUrl: null,
+            profilePictureUrl: user.image,
           },
         }
       : undefined,
@@ -188,6 +188,7 @@ export async function postMessage({
   dustAPI,
   conversationId,
   messageData,
+  tabContent,
 }: {
   dustAPI: DustAPI;
   conversationId: string;
@@ -195,6 +196,11 @@ export async function postMessage({
     input: string;
     mentions: MentionType[];
   };
+  tabContent: {
+    title: string;
+    content: string;
+    url: string;
+  } | null;
 }): Promise<Result<{ message: UserMessageType }, SubmitMessageError>> {
   const { input, mentions } = messageData;
   const user = await getStoredUser();
@@ -208,6 +214,24 @@ export async function postMessage({
     });
   }
 
+  if (tabContent) {
+    await dustAPI.postContentFragment({
+      conversationId,
+      contentFragment: {
+        title: tabContent.title,
+        content: tabContent.content,
+        url: tabContent.url,
+        contentType: "text/plain",
+        context: {
+          username: user.username,
+          email: user.email,
+          fullName: user.fullName,
+          profilePictureUrl: user.image,
+        },
+      },
+    });
+  }
+
   const mRes = await dustAPI.postUserMessage({
     conversationId,
     message: {
@@ -217,7 +241,7 @@ export async function postMessage({
         email: user.email,
         fullName: user.fullName,
         timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
-        profilePictureUrl: null, // todo daph
+        profilePictureUrl: user.image,
         origin: "extension",
       },
       mentions,

--- a/extension/app/src/lib/messages.ts
+++ b/extension/app/src/lib/messages.ts
@@ -20,6 +20,7 @@ export type GetActiveTabBackgroundMessage = {
 };
 
 export type GetActiveTabBackgroundResponse = {
+  title: string;
   url: string;
   content: string;
 };

--- a/extension/app/src/lib/storage.ts
+++ b/extension/app/src/lib/storage.ts
@@ -49,6 +49,29 @@ export const getAccessToken = async (): Promise<string | null> => {
   return result.accessToken ?? null;
 };
 
+type ConversationContext = {
+  includeCurrentPage: boolean;
+};
+
+export const getConversationContext = async (
+  conversationId: string
+): Promise<ConversationContext> => {
+  const result = await chrome.storage.local.get(["conversationContext"]);
+  return result.conversationContext
+    ? result.conversationContext[conversationId]
+    : { includeCurrentPage: false };
+};
+
+export const setConversationContext = async (
+  conversationId: string,
+  context: ConversationContext
+): Promise<void> => {
+  const result = await chrome.storage.local.get(["conversationContext"]);
+  const v = result.conversationContext ?? {};
+  v[conversationId] = context;
+  await chrome.storage.local.set({ conversationContext: v });
+};
+
 /**
  * User.
  * We store the basic user information with list of workspaces and currently selected workspace in Chrome storage.

--- a/extension/app/src/pages/ConversationPage.tsx
+++ b/extension/app/src/pages/ConversationPage.tsx
@@ -40,7 +40,7 @@ export const ConversationPage = ({
           </div>
         }
       />
-      <div className="h-full w-full pt-4">
+      <div className="h-full w-full pt-4 mt-12">
         <ConversationContainer
           owner={workspace}
           conversationId={conversationId}

--- a/extension/app/src/pages/ConversationsPage.tsx
+++ b/extension/app/src/pages/ConversationsPage.tsx
@@ -87,7 +87,7 @@ export const ConversationsPage = ({
           </div>
         }
       />
-      <div className="h-full w-full">
+      <div className="h-full w-full mt-12">
         {conversationsByDate &&
           Object.keys(conversationsByDate).map((dateLabel) => (
             <RenderConversations

--- a/extension/app/src/pages/MainPage.tsx
+++ b/extension/app/src/pages/MainPage.tsx
@@ -1,14 +1,67 @@
+import {
+  Avatar,
+  Button,
+  ExternalLinkIcon,
+  LogoHorizontalColorLogo,
+  LogoutIcon,
+  NewDropdownMenu,
+  NewDropdownMenuContent,
+  NewDropdownMenuItem,
+  NewDropdownMenuTrigger,
+} from "@dust-tt/sparkle";
 import type { ProtectedRouteChildrenProps } from "@extension/components/auth/ProtectedRoute";
 import { ConversationContainer } from "@extension/components/conversation/ConversationContainer";
 
-export const MainPage = ({ user, workspace }: ProtectedRouteChildrenProps) => {
+export const MainPage = ({
+  user,
+  workspace,
+  handleLogout,
+}: ProtectedRouteChildrenProps) => {
   return (
-    <div className="h-full w-full pt-28">
-      <ConversationContainer
-        owner={workspace}
-        conversationId={null}
-        user={user}
-      />
-    </div>
+    <>
+      <div className="flex items-start justify-between">
+        <div className="flex items-center gap-2 pb-6">
+          <LogoHorizontalColorLogo className="h-4 w-16" />
+          <Button
+            icon={ExternalLinkIcon}
+            variant="ghost"
+            href="https://dust.tt"
+            target="_blank"
+          />
+        </div>
+        <NewDropdownMenu>
+          <NewDropdownMenuTrigger>
+            <>
+              <span className="sr-only">Open user menu</span>
+              <Avatar
+                size="md"
+                visual={
+                  user.image
+                    ? user.image
+                    : "https://gravatar.com/avatar/anonymous?d=mp"
+                }
+                onClick={() => {
+                  "clickable";
+                }}
+              />
+            </>
+          </NewDropdownMenuTrigger>
+          <NewDropdownMenuContent>
+            <NewDropdownMenuItem
+              icon={LogoutIcon}
+              label="Sign out"
+              onClick={handleLogout}
+            />
+          </NewDropdownMenuContent>
+        </NewDropdownMenu>
+      </div>
+      <div className="h-full w-full pt-28">
+        <ConversationContainer
+          owner={workspace}
+          conversationId={null}
+          user={user}
+        />
+      </div>
+    </>
   );
 };

--- a/extension/app/src/pages/routes.tsx
+++ b/extension/app/src/pages/routes.tsx
@@ -13,8 +13,12 @@ export const routes = [
     path: "*",
     element: (
       <ProtectedRoute>
-        {({ user, workspace }) => (
-          <MainPage user={user} workspace={workspace} />
+        {({ user, workspace, handleLogout }) => (
+          <MainPage
+            user={user}
+            workspace={workspace}
+            handleLogout={handleLogout}
+          />
         )}
       </ProtectedRoute>
     ),
@@ -23,8 +27,12 @@ export const routes = [
     path: "/conversations/:conversationId",
     element: (
       <ProtectedRoute>
-        {({ user, workspace }) => (
-          <ConversationPage user={user} workspace={workspace} />
+        {({ user, workspace, handleLogout }) => (
+          <ConversationPage
+            user={user}
+            workspace={workspace}
+            handleLogout={handleLogout}
+          />
         )}
       </ProtectedRoute>
     ),
@@ -33,8 +41,12 @@ export const routes = [
     path: "/conversations",
     element: (
       <ProtectedRoute>
-        {({ user, workspace }) => (
-          <ConversationsPage user={user} workspace={workspace} />
+        {({ user, workspace, handleLogout }) => (
+          <ConversationsPage
+            user={user}
+            workspace={workspace}
+            handleLogout={handleLogout}
+          />
         )}
       </ProtectedRoute>
     ),

--- a/front/lib/api/assistant/conversation/content_fragment.ts
+++ b/front/lib/api/assistant/conversation/content_fragment.ts
@@ -45,7 +45,7 @@ export async function getContentFragmentBlob(
           workspaceId: owner.sId,
           conversationId: conversation.sId,
           messageId,
-          contentFormat: "raw",
+          contentFormat: "text",
         }).downloadUrl
       : url;
 


### PR DESCRIPTION
## Description

Improve tab content upload functionality
The PR makes the following improvements to tab content handling in the Chrome extension:
- Add a persistent toggle to include/exclude the current page content per conversation 
- Store conversation context to remember user preferences
- Prevent duplicate content uploads by checking existing content fragments 
- Add page title to uploaded content metadata

This change improves the user experience by giving more control over when page content is included and avoiding unnecessary uploads.
 
Additional change on front/lib/api/assistant/conversation/content_fragment.ts : content_fragments uploaded with public api (not using files) are still using legacy content_fragment and are always uploaded as text ( with `storeContentFragmentText`, just below line 53)

<img width="655" alt="Screenshot 2024-11-07 at 09 18 43" src="https://github.com/user-attachments/assets/6c3e3cfd-3c63-4342-8fb0-d76f9180c786">

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
