### PR TITLE
[connectors] Enrich the data upserted to ds within articles

### DIFF
--- a/connectors/src/connectors/zendesk/lib/node-zendesk-types.d.ts
+++ b/connectors/src/connectors/zendesk/lib/node-zendesk-types.d.ts
@@ -130,6 +130,21 @@ interface ZendeskFetchedTicket {
   };
 }
 
+interface ZendeskFetchedTicketComment {
+  id: number;
+  body: string;
+  html_body: string;
+  plain_body: string;
+  public: boolean;
+  author_id: number;
+  created_at: string;
+  attachments: {
+    id: number;
+    file_name: string;
+    content_url: string;
+  }[];
+}
+
 interface ZendeskFetchedUser {
   active?: boolean;
   alias?: string;
@@ -170,21 +185,6 @@ interface ZendeskFetchedUser {
   url?: string;
   user_fields?: object;
   verified?: boolean;
-}
-
-interface ZendeskFetchedTicketComment {
-  id: number;
-  body: string;
-  html_body: string;
-  plain_body: string;
-  public: boolean;
-  author_id: number;
-  created_at: string;
-  attachments: {
-    id: number;
-    file_name: string;
-    content_url: string;
-  }[];
 }
 
 declare module "node-zendesk" {

--- a/connectors/src/connectors/zendesk/lib/node-zendesk-types.d.ts
+++ b/connectors/src/connectors/zendesk/lib/node-zendesk-types.d.ts
@@ -208,6 +208,7 @@ declare module "node-zendesk" {
         ) => Promise<{ response: Response; result: ZendeskFetchedCategory }>;
       };
       sections: {
+        list: () => Promise<ZendeskFetchedSection[]>;
         show: (
           sectionId: number
         ) => Promise<{ response: Response; result: ZendeskFetchedSection }>;

--- a/connectors/src/connectors/zendesk/lib/node-zendesk-types.d.ts
+++ b/connectors/src/connectors/zendesk/lib/node-zendesk-types.d.ts
@@ -83,7 +83,7 @@ export interface ZendeskFetchedArticle {
   permission_group_id: number;
   content_tag_ids: number[];
   label_names: string[];
-  body: string;
+  body: string | undefined;
   user_segment_ids: number[];
 }
 

--- a/connectors/src/connectors/zendesk/lib/node-zendesk-types.d.ts
+++ b/connectors/src/connectors/zendesk/lib/node-zendesk-types.d.ts
@@ -146,45 +146,46 @@ interface ZendeskFetchedTicketComment {
 }
 
 interface ZendeskFetchedUser {
-  active?: boolean;
-  alias?: string;
-  chat_only?: boolean;
-  created_at?: string;
-  custom_role_id?: number;
-  default_group_id?: number;
-  details?: string;
-  email?: string;
-  external_id?: string;
-  iana_time_zone?: string;
-  id?: number;
-  last_login_at?: string;
-  locale?: string;
-  locale_id?: number;
-  moderator?: boolean;
+  active: boolean;
+  alias: string;
+  chat_only: boolean;
+  created_at: string; // ISO 8601 date string
+  custom_role_id: number;
+  default_group_id: number;
+  details: string;
+  email: string;
+  external_id: string;
+  id: number;
+  last_login_at: string; // ISO 8601 date string
+  locale: string;
+  locale_id: number;
+  moderator: boolean;
   name: string;
-  notes?: string;
-  only_private_comments?: boolean;
-  organization_id?: number;
-  phone?: string;
-  photo?: object;
-  remote_photo_url?: string;
-  report_csv?: boolean;
-  restricted_agent?: boolean;
-  role?: string;
-  role_type?: number;
-  shared?: boolean;
-  shared_agent?: boolean;
-  shared_phone_number?: boolean;
-  signature?: string;
-  suspended?: boolean;
-  tags?: string[];
-  ticket_restriction?: string;
-  time_zone?: string;
-  two_factor_auth_enabled?: boolean;
-  updated_at?: string;
-  url?: string;
-  user_fields?: object;
-  verified?: boolean;
+  notes: string;
+  only_private_comments: boolean;
+  organization_id: number;
+  phone: string;
+  photo: {
+    url: string;
+    id: number;
+    file_name: string;
+    content_url: string;
+    mapped_content_url: string;
+  };
+  report_csv: boolean;
+  restricted_agent: boolean;
+  role: "end-user" | "agent" | "admin";
+  shared: boolean;
+  shared_agent: boolean;
+  signature: string;
+  suspended: boolean;
+  tags: string[];
+  ticket_restriction: "requested" | "none" | "organization";
+  time_zone: string;
+  two_factor_auth_enabled: boolean;
+  updated_at: string; // ISO 8601 date string
+  url: string;
+  verified: boolean;
 }
 
 declare module "node-zendesk" {

--- a/connectors/src/connectors/zendesk/lib/node-zendesk-types.d.ts
+++ b/connectors/src/connectors/zendesk/lib/node-zendesk-types.d.ts
@@ -27,6 +27,23 @@ interface Response {
   statusText: string;
 }
 
+interface ZendeskFetchedSection {
+  category_id?: number;
+  created_at?: string;
+  description?: string;
+  html_url?: string;
+  id?: number;
+  locale: string;
+  name: string;
+  outdated?: boolean;
+  parent_section_id?: number;
+  position?: number;
+  source_locale?: string;
+  theme_template?: string;
+  updated_at?: string;
+  url?: string;
+}
+
 interface ZendeskFetchedCategory {
   id: number;
   url: string;
@@ -190,6 +207,11 @@ declare module "node-zendesk" {
         show: (
           categoryId: number
         ) => Promise<{ response: Response; result: ZendeskFetchedCategory }>;
+      };
+      sections: {
+        show: (
+          sectionId: number
+        ) => Promise<{ response: Response; result: ZendeskFetchedSection }>;
       };
       articles: {
         list: () => Promise<ZendeskFetchedArticle[]>;

--- a/connectors/src/connectors/zendesk/lib/node-zendesk-types.d.ts
+++ b/connectors/src/connectors/zendesk/lib/node-zendesk-types.d.ts
@@ -83,7 +83,7 @@ export interface ZendeskFetchedArticle {
   permission_group_id: number;
   content_tag_ids: number[];
   label_names: string[];
-  body: string | undefined;
+  body: string | null;
   user_segment_ids: number[];
 }
 

--- a/connectors/src/connectors/zendesk/lib/node-zendesk-types.d.ts
+++ b/connectors/src/connectors/zendesk/lib/node-zendesk-types.d.ts
@@ -130,6 +130,48 @@ interface ZendeskFetchedTicket {
   };
 }
 
+interface ZendeskFetchedUser {
+  active?: boolean;
+  alias?: string;
+  chat_only?: boolean;
+  created_at?: string;
+  custom_role_id?: number;
+  default_group_id?: number;
+  details?: string;
+  email?: string;
+  external_id?: string;
+  iana_time_zone?: string;
+  id?: number;
+  last_login_at?: string;
+  locale?: string;
+  locale_id?: number;
+  moderator?: boolean;
+  name: string;
+  notes?: string;
+  only_private_comments?: boolean;
+  organization_id?: number;
+  phone?: string;
+  photo?: object;
+  remote_photo_url?: string;
+  report_csv?: boolean;
+  restricted_agent?: boolean;
+  role?: string;
+  role_type?: number;
+  shared?: boolean;
+  shared_agent?: boolean;
+  shared_phone_number?: boolean;
+  signature?: string;
+  suspended?: boolean;
+  tags?: string[];
+  ticket_restriction?: string;
+  time_zone?: string;
+  two_factor_auth_enabled?: boolean;
+  updated_at?: string;
+  url?: string;
+  user_fields?: object;
+  verified?: boolean;
+}
+
 interface ZendeskFetchedTicketComment {
   id: number;
   body: string;
@@ -143,49 +185,6 @@ interface ZendeskFetchedTicketComment {
     file_name: string;
     content_url: string;
   }[];
-}
-
-interface ZendeskFetchedUser {
-  active: boolean;
-  alias: string;
-  chat_only: boolean;
-  created_at: string; // ISO 8601 date string
-  custom_role_id: number;
-  default_group_id: number;
-  details: string;
-  email: string;
-  external_id: string;
-  id: number;
-  last_login_at: string; // ISO 8601 date string
-  locale: string;
-  locale_id: number;
-  moderator: boolean;
-  name: string;
-  notes: string;
-  only_private_comments: boolean;
-  organization_id: number;
-  phone: string;
-  photo: {
-    url: string;
-    id: number;
-    file_name: string;
-    content_url: string;
-    mapped_content_url: string;
-  };
-  report_csv: boolean;
-  restricted_agent: boolean;
-  role: "end-user" | "agent" | "admin";
-  shared: boolean;
-  shared_agent: boolean;
-  signature: string;
-  suspended: boolean;
-  tags: string[];
-  ticket_restriction: "requested" | "none" | "organization";
-  time_zone: string;
-  two_factor_auth_enabled: boolean;
-  updated_at: string; // ISO 8601 date string
-  url: string;
-  verified: boolean;
 }
 
 declare module "node-zendesk" {

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -25,22 +25,24 @@ export function createZendeskClient({
 /**
  * Returns a Zendesk client with the subdomain set to the one in the brand.
  * Retrieves the brand from the database if it exists, fetches it from the Zendesk API otherwise.
+ * @returns The subdomain of the brand the client was scoped to.
  */
 export async function changeZendeskClientSubdomain(
   client: Client,
   { connectorId, brandId }: { connectorId: ModelId; brandId: number }
-) {
-  client.config.subdomain = await getZendeskBrandSubdomain(client, {
+): Promise<string> {
+  const brandSubdomain = await getZendeskBrandSubdomain(client, {
     connectorId,
     brandId,
   });
-  return client;
+  client.config.subdomain = brandSubdomain;
+  return brandSubdomain;
 }
 
 /**
  * Retrieves a brand's subdomain from the database if it exists, fetches it from the Zendesk API otherwise.
  */
-export async function getZendeskBrandSubdomain(
+async function getZendeskBrandSubdomain(
   client: Client,
   { connectorId, brandId }: { connectorId: ModelId; brandId: number }
 ): Promise<string> {

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -347,6 +347,7 @@ export async function syncZendeskArticleBatchActivity({
     brandId: category.brandId,
     connectorId,
   });
+  zendeskApiClient.config.subdomain = brandSubdomain;
 
   const {
     articles,
@@ -363,6 +364,7 @@ export async function syncZendeskArticleBatchActivity({
     articles,
     (article) =>
       syncArticle({
+        zendeskApiClient,
         connectorId,
         category,
         article,

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -360,14 +360,18 @@ export async function syncZendeskArticleBatchActivity({
     cursor,
   });
 
+  const sections = await zendeskApiClient.helpcenter.sections.list();
+  const users = await zendeskApiClient.users.list();
+
   await concurrentExecutor(
     articles,
     (article) =>
       syncArticle({
-        zendeskApiClient,
         connectorId,
         category,
         article,
+        section: sections.find((section) => section.id === article.section_id),
+        user: users.find((user) => user.id === article.author_id),
         dataSourceConfig,
         currentSyncDateMs,
         loggerArgs,

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -9,7 +9,6 @@ import {
   changeZendeskClientSubdomain,
   createZendeskClient,
   fetchZendeskArticlesInCategory,
-  getZendeskBrandSubdomain,
 } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import { syncArticle } from "@connectors/connectors/zendesk/temporal/sync_article";
 import { syncTicket } from "@connectors/connectors/zendesk/temporal/sync_ticket";
@@ -343,11 +342,10 @@ export async function syncZendeskArticleBatchActivity({
     connector.connectionId
   );
   const zendeskApiClient = createZendeskClient({ accessToken, subdomain });
-  const brandSubdomain = await getZendeskBrandSubdomain(zendeskApiClient, {
+  const brandSubdomain = await changeZendeskClientSubdomain(zendeskApiClient, {
     brandId: category.brandId,
     connectorId,
   });
-  zendeskApiClient.config.subdomain = brandSubdomain;
 
   const {
     articles,

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -370,8 +370,9 @@ export async function syncZendeskArticleBatchActivity({
         connectorId,
         category,
         article,
-        section: sections.find((section) => section.id === article.section_id),
-        user: users.find((user) => user.id === article.author_id),
+        section:
+          sections.find((section) => section.id === article.section_id) || null,
+        user: users.find((user) => user.id === article.author_id) || null,
         dataSourceConfig,
         currentSyncDateMs,
         loggerArgs,

--- a/connectors/src/connectors/zendesk/temporal/sync_article.ts
+++ b/connectors/src/connectors/zendesk/temporal/sync_article.ts
@@ -108,7 +108,7 @@ export async function syncArticle({
       section &&
         `SECTION: ${section.name} ${section?.description ? ` - ${section.description}` : ""}`,
       user && `USER: ${user.name} ${user?.email ? ` - ${user.email}` : ""}`,
-      `VOTE_SUM: ${article.vote_sum}`,
+      `VOTE OF SUM: ${article.vote_sum}`,
       article.label_names.length ? `LABELS: ${article.label_names.join()}` : "",
     ]
       .filter(Boolean)

--- a/connectors/src/connectors/zendesk/temporal/sync_article.ts
+++ b/connectors/src/connectors/zendesk/temporal/sync_article.ts
@@ -93,9 +93,13 @@ export async function syncArticle({
     typeof article.body === "string"
       ? turndownService.turndown(article.body)
       : "";
+
+  // fetching the section to get the section description
   const { result: section } = await zendeskApiClient.helpcenter.sections.show(
     article.section_id
   );
+  // fetching the user to get the user's name and email
+  const { result: user } = await zendeskApiClient.users.show(article.author_id);
 
   const labels = article.label_names
     ? `LABELS: ${article.label_names.join()}`
@@ -103,6 +107,7 @@ export async function syncArticle({
   // append the collection description at the beginning of the article
   const markdown = `
 CATEGORY: ${category.name} ${category?.description ? ` - ${category.description}` : ""}
+USER: ${user.name} ${user?.email ? ` - ${user.email}` : ""}
 SECTION: ${section.name} ${section?.description ? ` - ${section.description}` : ""}
 VOTE_SUM: ${article.vote_sum}${labels}\n
 ${articleContentInMarkdown}`; // extra newline to separate the content from the metadata

--- a/connectors/src/connectors/zendesk/temporal/sync_article.ts
+++ b/connectors/src/connectors/zendesk/temporal/sync_article.ts
@@ -36,9 +36,9 @@ export async function syncArticle({
   connectorId: ModelId;
   dataSourceConfig: DataSourceConfig;
   article: ZendeskFetchedArticle;
-  section: ZendeskFetchedSection | undefined;
+  section: ZendeskFetchedSection | null;
   category: ZendeskCategoryResource;
-  user: ZendeskFetchedUser | undefined;
+  user: ZendeskFetchedUser | null;
   currentSyncDateMs: number;
   loggerArgs: Record<string, string | number | null>;
   forceResync: boolean;

--- a/connectors/src/connectors/zendesk/temporal/sync_article.ts
+++ b/connectors/src/connectors/zendesk/temporal/sync_article.ts
@@ -99,26 +99,24 @@ export async function syncArticle({
       ? turndownService.turndown(article.body)
       : "";
 
-  const header = [
-    `CATEGORY: ${category.name} ${category?.description ? ` - ${category.description}` : ""}`,
-    section &&
-      `SECTION: ${section.name} ${section?.description ? ` - ${section.description}` : ""}`,
-    user && `USER: ${user.name} ${user?.email ? ` - ${user.email}` : ""}`,
-    `VOTE_SUM: ${article.vote_sum}`,
-    article.label_names.length ? `LABELS: ${article.label_names.join()}` : "",
-  ]
-    .filter(Boolean)
-    .join("\n");
-
-  const markdown = `${header}\n\n${articleContentInMarkdown}`;
-
   if (articleContentInMarkdown) {
     const createdAt = new Date(article.created_at);
     const updatedAt = new Date(article.updated_at);
 
+    const header = [
+      `CATEGORY: ${category.name} ${category?.description ? ` - ${category.description}` : ""}`,
+      section &&
+        `SECTION: ${section.name} ${section?.description ? ` - ${section.description}` : ""}`,
+      user && `USER: ${user.name} ${user?.email ? ` - ${user.email}` : ""}`,
+      `VOTE_SUM: ${article.vote_sum}`,
+      article.label_names.length ? `LABELS: ${article.label_names.join()}` : "",
+    ]
+      .filter(Boolean)
+      .join("\n");
+
     const renderedMarkdown = await renderMarkdownSection(
       dataSourceConfig,
-      markdown
+      `${header}\n\n${articleContentInMarkdown}`
     );
     const documentContent = await renderDocumentTitleAndContent({
       dataSourceConfig,

--- a/connectors/src/connectors/zendesk/temporal/sync_article.ts
+++ b/connectors/src/connectors/zendesk/temporal/sync_article.ts
@@ -108,7 +108,7 @@ export async function syncArticle({
       section &&
         `SECTION: ${section.name} ${section?.description ? ` - ${section.description}` : ""}`,
       user && `USER: ${user.name} ${user?.email ? ` - ${user.email}` : ""}`,
-      `VOTE OF SUM: ${article.vote_sum}`,
+      `SUM OF VOTES: ${article.vote_sum}`,
       article.label_names.length ? `LABELS: ${article.label_names.join()}` : "",
     ]
       .filter(Boolean)

--- a/connectors/src/connectors/zendesk/temporal/sync_article.ts
+++ b/connectors/src/connectors/zendesk/temporal/sync_article.ts
@@ -101,7 +101,7 @@ export async function syncArticle({
   // fetching the user to get the user's name and email
   const { result: user } = await zendeskApiClient.users.show(article.author_id);
 
-  const labels = article.label_names
+  const labels = article.label_names.length
     ? `LABELS: ${article.label_names.join()}`
     : "";
   // append the collection description at the beginning of the article


### PR DESCRIPTION
## Description

- Close [#8477](https://github.com/dust-tt/dust/issues/8477)
- Add data relative to the `Section`, the `User`, the label names and the vote sum to the upserted articles.

## Risk

Low, retrocompatible and connector not in use.

## Deploy Plan

- Deploy connectors