### PR TITLE
Support more Confluence space types

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -141,6 +141,15 @@ const ConfluenceReadOperationRestrictionsCodec = t.type({
   restrictions: RestrictionsCodec,
 });
 
+// Space types that we support indexing in Dust.
+export const CONFLUENCE_SUPPORTED_SPACE_TYPES = [
+  "global",
+  "collaboration",
+  "knowledge_base",
+];
+type ConfluenceSupportedSpaceType =
+  (typeof CONFLUENCE_SUPPORTED_SPACE_TYPES)[number];
+
 function extractCursorFromLinks(links: { next?: string }): string | null {
   if (!links.next) {
     return null;
@@ -361,10 +370,13 @@ export class ConfluenceClient {
     }
   }
 
-  async getGlobalSpaces(pageCursor: string | null) {
+  async getSpaces(
+    spaceType: ConfluenceSupportedSpaceType,
+    { pageCursor }: { pageCursor: string | null }
+  ) {
     const params = new URLSearchParams({
       limit: "250",
-      type: "global",
+      type: spaceType,
       sort: "name",
       status: "current",
     });


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR expands our Confluence space support beyond just `global` spaces to include `knowledge_base` and `collaboration` spaces. While Confluence has four space types (`global`, `knowledge_base`, `collaboration`, and `personal`), we're extending our listing and importing capabilities to three of these types, excluding `personal` spaces. (see API [documentation](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-space/#api-spaces-get))

The implementation leverages the existing infrastructure and restrictions we have in place for `global` spaces, applying them consistently to the newly supported space types. This ensures a uniform handling across these space categories.

Tested on our Developer account.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
