### PR TITLE
process: hammer v2

### DIFF
--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -95,7 +95,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "953b79fe89",
       appHash:
-        "b652dccc2346a1ba9cf04754419fa5f65f3339c19f006cb4464024e0eab956d3",
+        "467e1beda5e447dffa7515479d1457778575eb7fe2002e40dc12fe63ffb1f091",
       appSpaceId: PRODUCTION_DUST_APPS_SPACE_ID,
     },
     config: {

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -502,9 +502,6 @@ const ProcessActionOutputsSchema = z.object({
   total_documents: z.number(),
   total_chunks: z.number(),
   total_tokens: z.number(),
-  skip_documents: z.number(),
-  skip_chunks: z.number(),
-  skip_tokens: z.number(),
 });
 
 const ProcessActionTypeSchema = BaseActionSchema.extend({

--- a/types/src/front/assistant/actions/process.ts
+++ b/types/src/front/assistant/actions/process.ts
@@ -71,9 +71,6 @@ export type ProcessActionOutputsType = {
   total_documents: number;
   total_chunks: number;
   total_tokens: number;
-  skip_documents: number;
-  skip_chunks: number;
-  skip_tokens: number;
 };
 
 // Use top_k of 768 as 512 worked really smoothly during initial tests. Might update to 1024 in the


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/1582

Changes the way we split docs:
- Simply operate at the chunk level relying on the fact that without query we get ~topk chunks (possibly a bit more if we have too much data, otherwise less) and group them in 32 groups. We use topK = 768 so each group have `12288` tokens at most (with a few injected tags), which is guaranteed to hold in context size for models we use for our assistants.
- The fact that we do split in 32 groups helps the model generate more extracted data points and it also seems to follow objective well now.

Overall should create a much better experience. Risk is that we go full 32 parallel call to model providers at each extract execution. To be monitored. 

Dust-app: https://dust.tt/w/78bda07b39/spaces/vlt_rICtlrSEpWqX/apps/953b79fe89

## Risk

Described above, increased concurrency.

## Deploy Plan

- deploy `front`