### PR TITLE
Extension: Fix getting context of existing convo + history button in header

### DIFF
--- a/extension/app/src/components/conversation/ConversationContainer.tsx
+++ b/extension/app/src/components/conversation/ConversationContainer.tsx
@@ -1,9 +1,4 @@
-import {
-  Button,
-  HistoryIcon,
-  Page,
-  useSendNotification,
-} from "@dust-tt/sparkle";
+import { Page, useSendNotification } from "@dust-tt/sparkle";
 import type {
   AgentMention,
   LightWorkspaceType,
@@ -239,19 +234,10 @@ export function ConversationContainer({
         />
       )}
       <div className="sticky bottom-0 z-20 flex flex-col max-h-screen w-full max-w-4xl pb-4">
-        {!activeConversationId ? (
-          <div className="flex justify-between items-end pb-2">
-            <div>
-              <Page.Header title={greeting} />
-              <Page.SectionHeader title="Start a conversation" />
-            </div>
-            <div className="flex space-x-1">
-              <ConversationHistoryButton />
-            </div>
-          </div>
-        ) : (
-          <div className="flex justify-end items-end pb-2 gap-1">
-            <ConversationHistoryButton />
+        {!activeConversationId && (
+          <div className="pb-2">
+            <Page.Header title={greeting} />
+            <Page.SectionHeader title="Start a conversation" />
           </div>
         )}
         <AssistantInputBar
@@ -272,15 +258,3 @@ export function ConversationContainer({
     </>
   );
 }
-
-const ConversationHistoryButton = () => {
-  const navigate = useNavigate();
-  return (
-    <Button
-      tooltip="View all conversations"
-      icon={HistoryIcon}
-      variant="outline"
-      onClick={() => navigate("/conversations")}
-    />
-  );
-};

--- a/extension/app/src/components/input_bar/InputBarContainer.tsx
+++ b/extension/app/src/components/input_bar/InputBarContainer.tsx
@@ -99,7 +99,7 @@ export const InputBarContainer = ({
       />
 
       <div className="flex flex-row items-end justify-between gap-2 self-stretch pb-2 pr-2 sm:flex-col sm:border-0">
-        <div className="flex py-2">
+        <div className="flex py-2 space-x-1">
           <Button
             icon={isTabIncluded ? CheckCircleIcon : StopSignIcon}
             label={isTabIncluded ? "Tab sharing ON" : "Tab sharing OFF"}

--- a/extension/app/src/lib/storage.ts
+++ b/extension/app/src/lib/storage.ts
@@ -56,10 +56,10 @@ type ConversationContext = {
 export const getConversationContext = async (
   conversationId: string
 ): Promise<ConversationContext> => {
-  const result = await chrome.storage.local.get(["conversationContext"]);
-  return result.conversationContext
-    ? result.conversationContext[conversationId]
-    : { includeCurrentPage: false };
+  const { conversationContext = {} } = await chrome.storage.local.get([
+    "conversationContext",
+  ]);
+  return conversationContext[conversationId] ?? { includeCurrentPage: false };
 };
 
 export const setConversationContext = async (

--- a/extension/app/src/pages/ConversationPage.tsx
+++ b/extension/app/src/pages/ConversationPage.tsx
@@ -1,6 +1,7 @@
 import { BarHeader, Button, ExternalLinkIcon } from "@dust-tt/sparkle";
 import type { ProtectedRouteChildrenProps } from "@extension/components/auth/ProtectedRoute";
 import { ConversationContainer } from "@extension/components/conversation/ConversationContainer";
+import { ConversationsListButton } from "@extension/components/conversation/ConversationsListButton";
 import { usePublicConversation } from "@extension/components/conversation/usePublicConversation";
 import { useNavigate, useParams } from "react-router-dom";
 
@@ -26,6 +27,7 @@ export const ConversationPage = ({
         title={conversation?.title || "Conversation"}
         rightActions={
           <div className="flex flex-row items-right">
+            <ConversationsListButton />
             <Button
               icon={ExternalLinkIcon}
               variant="ghost"

--- a/extension/app/src/pages/MainPage.tsx
+++ b/extension/app/src/pages/MainPage.tsx
@@ -11,6 +11,8 @@ import {
 } from "@dust-tt/sparkle";
 import type { ProtectedRouteChildrenProps } from "@extension/components/auth/ProtectedRoute";
 import { ConversationContainer } from "@extension/components/conversation/ConversationContainer";
+import { ConversationsListButton } from "@extension/components/conversation/ConversationsListButton";
+import { Link } from "react-router-dom";
 
 export const MainPage = ({
   user,
@@ -21,7 +23,9 @@ export const MainPage = ({
     <>
       <div className="flex items-start justify-between">
         <div className="flex items-center gap-2 pb-6">
-          <LogoHorizontalColorLogo className="h-4 w-16" />
+          <Link to="https://dust.tt" target="_blank">
+            <LogoHorizontalColorLogo className="h-4 w-16" />
+          </Link>
           <Button
             icon={ExternalLinkIcon}
             variant="ghost"
@@ -29,31 +33,34 @@ export const MainPage = ({
             target="_blank"
           />
         </div>
-        <DropdownMenu>
-          <DropdownMenuTrigger>
-            <>
-              <span className="sr-only">Open user menu</span>
-              <Avatar
-                size="md"
-                visual={
-                  user.image
-                    ? user.image
-                    : "https://gravatar.com/avatar/anonymous?d=mp"
-                }
-                onClick={() => {
-                  "clickable";
-                }}
+        <div className="flex items-center gap-2">
+          <ConversationsListButton size="md" />
+          <DropdownMenu>
+            <DropdownMenuTrigger>
+              <>
+                <span className="sr-only">Open user menu</span>
+                <Avatar
+                  size="md"
+                  visual={
+                    user.image
+                      ? user.image
+                      : "https://gravatar.com/avatar/anonymous?d=mp"
+                  }
+                  onClick={() => {
+                    "clickable";
+                  }}
+                />
+              </>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+              <DropdownMenuItem
+                icon={LogoutIcon}
+                label="Sign out"
+                onClick={handleLogout}
               />
-            </>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent>
-            <DropdownMenuItem
-              icon={LogoutIcon}
-              label="Sign out"
-              onClick={handleLogout}
-            />
-          </DropdownMenuContent>
-        </DropdownMenu>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
       </div>
       <div className="h-full w-full pt-28">
         <ConversationContainer


### PR DESCRIPTION
## Description

- Fix js error when getting the context of a convo in storage, if the convo was not in storage we were returning undefined. 
- Put history button in header as discussed IRL. 

## Risk

Only extension code. 

## Deploy Plan

No deploy. 
