### PR TITLE
Sparkle exports MetaButton

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.299",
+  "version": "0.2.300",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.299",
+      "version": "0.2.300",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.299",
+  "version": "0.2.300",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -77,7 +77,7 @@ const spinnerVariantsMapIsLoading: Record<ButtonVariantType, SpinnerVariant> = {
   ghost: "slate400",
 };
 
-interface MetaButtonProps
+export interface MetaButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -5,7 +5,9 @@ export { Banner } from "./Banner";
 export { BarHeader } from "./BarHeader";
 export { Breadcrumbs } from "./Breadcrumbs";
 export type { ButtonProps } from "./Button";
+export type { MetaButtonProps } from "./Button";
 export { Button } from "./Button";
+export { MetaButton } from "./Button";
 export { CardButton } from "./CardButton";
 export type { CheckboxProps } from "./Checkbox";
 export {


### PR DESCRIPTION
## Description

Sparkle exports MetaButton.
I need it in the extension 🪄 

## Risk

/

## Deploy Plan

Publish Sparkle. 
