### PR TITLE
Upg: ApiClient use undici, refactor streamAgentAnswer a bit

### DIFF
--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -1,6 +1,5 @@
 import type {
   AgentActionPublicType,
-  AgentMessagePublicType,
   ConversationPublicType,
   DustAPI,
 } from "@dust-tt/client";
@@ -124,26 +123,9 @@ export async function streamConversationToSlack(
     { adhereToRateLimit: false }
   );
 
-  const agentMessages = conversation.content
-    .map((versions) => {
-      const m = versions[versions.length - 1];
-      return m;
-    })
-    .filter((m) => {
-      return (
-        m &&
-        m.type === "agent_message" &&
-        m.parentMessageId === userMessage?.sId
-      );
-    });
-  if (agentMessages.length === 0) {
-    return new Err(new Error("Failed to retrieve agent message"));
-  }
-  const agentMessage = agentMessages[0] as AgentMessagePublicType;
-
-  const streamRes = await dustAPI.streamAgentMessageEvents({
+  const streamRes = await dustAPI.streamAgentAnswerEvents({
     conversation,
-    message: agentMessage,
+    userMessageId: userMessage.sId,
   });
 
   if (streamRes.isErr()) {

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -175,10 +175,12 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.0.0",
+      "version": "1.0.5",
+      "license": "ISC",
       "dependencies": {
         "eventsource-parser": "^1.1.1",
         "moment-timezone": "^0.5.46",
+        "undici": "^6.20.1",
         "zod": "^3.23.8"
       },
       "devDependencies": {

--- a/sdks/js/package-lock.json
+++ b/sdks/js/package-lock.json
@@ -1,15 +1,17 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.0.0",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/client",
-      "version": "1.0.0",
+      "version": "1.0.5",
+      "license": "ISC",
       "dependencies": {
         "eventsource-parser": "^1.1.1",
         "moment-timezone": "^0.5.46",
+        "undici": "^6.20.1",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -10314,6 +10316,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.20.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.20.1.tgz",
+      "integrity": "sha512-AjQF1QsmqfJys+LXfGTNum+qw4S88CojRInG/6t31W/1fk6G59s92bnAvGz5Cmur+kQv2SURXEvvudLmbrE8QA==",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,7 +1,17 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.0.0",
-  "author": "Dust",
+  "version": "1.0.5",
+  "description": "Client for Dust API",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dust/dust-tt.git"
+  },
+  "author": "Dust (Permutation Labs SAS)",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/dust/dust-tt/issues"
+  },
+  "homepage": "https://github.com/dust/dust-tt#readme",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "module": "dist/types.esm.js",
@@ -32,6 +42,7 @@
   "dependencies": {
     "eventsource-parser": "^1.1.1",
     "moment-timezone": "^0.5.46",
+    "undici": "^6.20.1",
     "zod": "^3.23.8"
   },
   "browser": {

--- a/x/spolu/cli/index.ts
+++ b/x/spolu/cli/index.ts
@@ -1,4 +1,3 @@
-import type { AgentMessageType } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
 import { Command } from "commander";
 import * as readlinePromises from "readline/promises";
@@ -119,14 +118,11 @@ conversations
       throw new Error(`Failed to create conversation: ${res.error.message}`);
     }
 
-    const agentMessage = res.value.conversation.content.at(-1);
-    if (!agentMessage) {
-      throw new Error(`No agent message received`);
-    }
+    const { conversation, message } = res.value;
 
-    const streamRes = await state.dustAPI().streamAgentMessageEvents({
-      conversation: res.value.conversation,
-      message: agentMessage[0] as AgentMessageType,
+    const streamRes = await state.dustAPI().streamAgentAnswerEvents({
+      conversation: conversation,
+      userMessageId: message.sId,
     });
 
     if (streamRes.isErr()) {

--- a/x/spolu/cli/package-lock.json
+++ b/x/spolu/cli/package-lock.json
@@ -8,6 +8,7 @@
       "name": "cli",
       "version": "0.0.1",
       "dependencies": {
+        "@dust-tt/client": "^1.0.3",
         "@dust-tt/types": "file:../../../types",
         "commander": "^12.1.0",
         "talisman": "^1.1.4"
@@ -36,8 +37,6 @@
         "@notionhq/client": "^2.2.4",
         "csv-parse": "^5.5.6",
         "csv-stringify": "^6.5.0",
-        "dts-cli": "^2.0.5",
-        "eslint-plugin-simple-import-sort": "^12.1.0",
         "eventsource-parser": "^1.1.1",
         "hot-shots": "^10.0.0",
         "htmlparser2": "^9.1.0",
@@ -51,6 +50,8 @@
       "devDependencies": {
         "@tsconfig/recommended": "^1.0.3",
         "@types/uuid": "^9.0.7",
+        "dts-cli": "^2.0.5",
+        "eslint-plugin-simple-import-sort": "^12.1.0",
         "tslib": "^2.6.2",
         "typescript": "^5.4.5"
       },
@@ -60,6 +61,19 @@
     },
     "../types": {
       "extraneous": true
+    },
+    "node_modules/@dust-tt/client": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@dust-tt/client/-/client-1.0.3.tgz",
+      "integrity": "sha512-/WWxEtpJLHAUw4K3kwAzacu5MxaVXoAygR5difu96rPNxNgsTsVgU/Qz78lKgEEam/SQ0gMTNzOy5nUyA9/VKw==",
+      "dependencies": {
+        "eventsource-parser": "^1.1.1",
+        "moment-timezone": "^0.5.46",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@dust-tt/types": {
       "resolved": "../../../types",
@@ -1970,6 +1984,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventsource-parser": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-1.1.2.tgz",
+      "integrity": "sha512-v0eOBUbiaFojBu2s2NPBfYUoRR9GjcDNvCXVaqEf5vVfpIAh9f8RCo4vXTP8c63QRKCFwoLpMpTdPwwhEKVgzA==",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3114,6 +3136,25 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.4.tgz",
       "integrity": "sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ=="
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.46",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.46.tgz",
+      "integrity": "sha512-ZXm9b36esbe7OmdABqIWJuBBiLLwAjrN7CE+7sYdCCx82Nabt1wHDj8TVseS59QIlfFPbOoiBPm6ca9BioG4hw==",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -4524,6 +4565,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/x/spolu/cli/package.json
+++ b/x/spolu/cli/package.json
@@ -11,6 +11,7 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
+    "@dust-tt/client": "^1.0.5",
     "@dust-tt/types": "file:../../../types",
     "commander": "^12.1.0",
     "talisman": "^1.1.4"

--- a/x/spolu/cli/src/state.ts
+++ b/x/spolu/cli/src/state.ts
@@ -1,15 +1,14 @@
+import type { DustAPICredentials } from "@dust-tt/client";
+import { DustAPI } from "@dust-tt/client";
 import type {
   ConversationWithoutContentType,
-  DustAPICredentials,
   LightAgentConfigurationType,
 } from "@dust-tt/types";
-import { DustAPI } from "@dust-tt/types";
 import fs from "fs/promises";
 import path from "path";
 
 export class State {
   agents: LightAgentConfigurationType[] = [];
-  private conversations: ConversationWithoutContentType[] = [];
 
   private credentials: DustAPICredentials | null = null;
   private url: string = "https://dust.tt";


### PR DESCRIPTION
## Description

- Refactor DustAPI to use `undici` so fetch works everywhere.
- Refactor slightly the `streamAgentMessageEvents` => `streamAgentAnswerEvents` and find out the answering agentMessage id directly within the function (instead of doing it before calling the function).

## Risk

- Break fetching where we use the api (tested locally to talk to an assistant)
- Break slack bot answering.

## Deploy Plan

Deploy `front` and `connectors`