### PR TITLE
Use `requestedGroupIds` column for conversation and agent_configurations

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -577,7 +577,9 @@ export async function getAgentConfigurations<V extends "light" | "full">({
         .flat()
         .filter((a) =>
           auth.canRead(
-            Authenticator.createResourcePermissionsFromGroupIds(a.groupIds)
+            Authenticator.createResourcePermissionsFromGroupIds(
+              a.requestedGroupIds
+            )
           )
         );
 

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2170,12 +2170,12 @@ export function canAccessConversation(
 ): boolean {
   const owner = auth.getNonNullableWorkspace();
 
-  const groupIds =
+  const requestedGroupIds =
     conversation instanceof Conversation
-      ? getConversationGroupIdsFromModel(owner, conversation)
-      : conversation.groupIds;
+      ? getConversationRequestedGroupIdsFromModel(owner, conversation)
+      : conversation.requestedGroupIds;
 
   return auth.canRead(
-    Authenticator.createResourcePermissionsFromGroupIds(groupIds)
+    Authenticator.createResourcePermissionsFromGroupIds(requestedGroupIds)
   );
 }

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -434,7 +434,7 @@ export async function fetchConversationMessages(
 export function canReadMessage(auth: Authenticator, message: AgentMessageType) {
   return auth.canRead(
     Authenticator.createResourcePermissionsFromGroupIds(
-      message.configuration.groupIds
+      message.configuration.requestedGroupIds
     )
   );
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR switches the read to check if an authenticator has access to either an agent configuration or a conversation to use the newly introduced column `requestedGroupIds`.

Tested locally, works like a charm.

Follow-up items:
- Remove legacy columns
- Fix 404 (unreachable error) on conversation participants and messages

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
