### PR TITLE
core: fix ordering of documents when no query is specified

### DIFF
--- a/core/src/blocks/data_source.rs
+++ b/core/src/blocks/data_source.rs
@@ -77,6 +77,7 @@ impl DataSource {
         env: &Env,
         workspace_id: String,
         data_source_or_data_source_view_id: String,
+        q: Option<String>,
         top_k: usize,
         filter: Option<SearchFilter>,
         target_document_tokens: Option<usize>,
@@ -98,14 +99,12 @@ impl DataSource {
             None => Err(anyhow!("Data source `{}` not found", data_source_id))?,
         };
 
-        let q = self.query(env)?;
-
         let documents = ds
             .search(
                 env.credentials.clone(),
                 env.store.clone(),
                 env.qdrant_clients.clone(),
-                &Some(q.to_string()),
+                &q,
                 top_k,
                 match filter {
                     Some(filter) => Some(filter.postprocess_for_data_source(&data_source_id)),
@@ -122,17 +121,30 @@ impl DataSource {
 
     /// This function is in charge given a set of Documents with scored chunks possibly coming from
     /// multiple data sources, to return the documents associated with the `top_k` chunks (including
-    /// only these `top_k` chunks), sorted by top chunk.
-    fn top_k_sorted_documents(top_k: usize, documents: &Vec<Document>) -> Vec<Document> {
-        // Extract all chunks, keeping their source `document_id`.
+    /// only these `top_k` chunks), sorted by top chunk. We pass the query as we want a date
+    /// ordering if the query is not specified.
+    fn top_k_sorted_documents(
+        query: &Option<String>,
+        top_k: usize,
+        documents: &Vec<Document>,
+    ) -> Vec<Document> {
+        // Extract all chunks, keeping their source `document_id` and document timestamp.
         let mut chunks = documents
             .iter()
-            .map(|d| d.chunks.iter().map(|c| (d.document_id.clone(), c.clone())))
+            .map(|d| {
+                d.chunks
+                    .iter()
+                    .map(|c| (d.document_id.clone(), d.timestamp, c.clone()))
+            })
             .flatten()
             .collect::<Vec<_>>();
 
-        // Sort them by score and truncate to `top_k`
-        chunks.sort_by(|a, b| b.1.score.partial_cmp(&a.1.score).unwrap());
+        // Sort them by score or timestamp and truncate to `top_k`
+        if !query.is_none() {
+            chunks.sort_by(|a, b| b.2.score.partial_cmp(&a.2.score).unwrap());
+        } else {
+            chunks.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        }
         chunks.truncate(top_k);
 
         // Get the documents without chunks.
@@ -146,7 +158,7 @@ impl DataSource {
             .collect::<HashMap<_, _>>();
 
         // Reinsert the `top_k` chunks in their respective documents.
-        for (document_id, chunk) in chunks {
+        for (document_id, _, chunk) in chunks {
             documents.get_mut(&document_id).unwrap().chunks.push(chunk);
         }
 
@@ -157,8 +169,12 @@ impl DataSource {
             .map(|(_, d)| d)
             .collect::<Vec<_>>();
 
-        // Order documents by top chunk score.
-        d.sort_by(|a, b| b.chunks[0].score.partial_cmp(&a.chunks[0].score).unwrap());
+        // Order documents by top chunk score or timestamp if no query.
+        if !query.is_none() {
+            d.sort_by(|a, b| b.chunks[0].score.partial_cmp(&a.chunks[0].score).unwrap());
+        } else {
+            d.sort_by(|a, b| b.timestamp.partial_cmp(&a.timestamp).unwrap());
+        }
         d.truncate(top_k);
 
         return d;
@@ -319,6 +335,13 @@ impl Block for DataSource {
             _ => (),
         };
 
+        // If the query is an empty string (no query) we set it to None.
+        let q_raw = self.query(env)?;
+        let q = match q_raw.len() {
+            0 => None,
+            _ => Some(q_raw),
+        };
+
         // For each data_sources, retrieve documents concurrently.
         let mut futures = Vec::new();
         for (w_id, ds) in data_sources {
@@ -326,6 +349,7 @@ impl Block for DataSource {
                 env,
                 w_id.clone(),
                 ds.clone(),
+                q.clone(),
                 top_k,
                 filter.clone(),
                 target_document_tokens,
@@ -343,7 +367,7 @@ impl Block for DataSource {
         }
 
         Ok(BlockResult {
-            value: serde_json::to_value(Self::top_k_sorted_documents(top_k, &documents))?,
+            value: serde_json::to_value(Self::top_k_sorted_documents(&q, top_k, &documents))?,
             meta: Some(json!({
                 "logs": filter_logs,
             })),

--- a/core/src/blocks/data_source.rs
+++ b/core/src/blocks/data_source.rs
@@ -140,7 +140,7 @@ impl DataSource {
             .collect::<Vec<_>>();
 
         // Sort them by score or timestamp and truncate to `top_k`
-        if !query.is_none() {
+        if query.is_some() {
             chunks.sort_by(|a, b| b.2.score.partial_cmp(&a.2.score).unwrap());
         } else {
             chunks.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
@@ -170,7 +170,7 @@ impl DataSource {
             .collect::<Vec<_>>();
 
         // Order documents by top chunk score or timestamp if no query.
-        if !query.is_none() {
+        if query.is_some() {
             d.sort_by(|a, b| b.chunks[0].score.partial_cmp(&a.chunks[0].score).unwrap());
         } else {
             d.sort_by(|a, b| b.timestamp.partial_cmp(&a.timestamp).unwrap());


### PR DESCRIPTION
## Description

As we merge documents from multiple data source in the data source core block, we always ordered by score (which may be undefined) resulting in inconsistent ordering when using the block without query (most recent data, extract).

We make sure to support query-less ordering based on document timestamp in the data source block

## Risk

None tested locally

## Deploy Plan

- deploy `core`