### PR TITLE
[connectors] Fix node retrieval for Zendesk

### DIFF
--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -168,22 +168,9 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     filterPermission: ConnectorPermission | null;
     viewType: ContentNodesViewType;
   }): Promise<Result<ContentNode[], Error>> {
-    const { connectorId } = this;
-
-    if (filterPermission === "read" && parentInternalId === null) {
-      /// we only show brands at the root level
-      const brands = await ZendeskBrandResource.fetchAllReadOnly({
-        connectorId,
-      });
-      const brandNodes: ContentNode[] = brands.map((brand) =>
-        brand.toContentNode(connectorId)
-      );
-      return new Ok(brandNodes);
-    }
-
     try {
       const nodes = await retrieveChildrenNodes({
-        connectorId,
+        connectorId: this.connectorId,
         parentInternalId,
         filterPermission,
         viewType: "documents",

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -23,10 +23,7 @@ import {
   getBrandInternalId,
   getIdFromInternalId,
 } from "@connectors/connectors/zendesk/lib/id_conversions";
-import {
-  retrieveChildrenNodes,
-  retrieveSelectedNodes,
-} from "@connectors/connectors/zendesk/lib/permissions";
+import { retrieveChildrenNodes } from "@connectors/connectors/zendesk/lib/permissions";
 import {
   allowSyncZendeskTickets,
   revokeSyncZendeskTickets,
@@ -174,9 +171,14 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     const { connectorId } = this;
 
     if (filterPermission === "read" && parentInternalId === null) {
-      // We want all selected nodes despite the hierarchy
-      const selectedNodes = await retrieveSelectedNodes({ connectorId });
-      return new Ok(selectedNodes);
+      /// we only show brands at the root level
+      const brands = await ZendeskBrandResource.fetchAllReadOnly({
+        connectorId,
+      });
+      const brandNodes: ContentNode[] = brands.map((brand) =>
+        brand.toContentNode({ connectorId })
+      );
+      return new Ok(brandNodes);
     }
 
     try {

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -23,7 +23,10 @@ import {
   getBrandInternalId,
   getIdFromInternalId,
 } from "@connectors/connectors/zendesk/lib/id_conversions";
-import { retrieveChildrenNodes } from "@connectors/connectors/zendesk/lib/permissions";
+import {
+  retrieveAllSelectedNodes,
+  retrieveChildrenNodes,
+} from "@connectors/connectors/zendesk/lib/permissions";
 import {
   allowSyncZendeskTickets,
   revokeSyncZendeskTickets,
@@ -168,6 +171,11 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     filterPermission: ConnectorPermission | null;
     viewType: ContentNodesViewType;
   }): Promise<Result<ContentNode[], Error>> {
+    if (filterPermission === "read" && parentInternalId === null) {
+      // retrieving all the selected nodes despite the hierarchy
+      return new Ok(await retrieveAllSelectedNodes(this.connectorId));
+    }
+
     try {
       const nodes = await retrieveChildrenNodes({
         connectorId: this.connectorId,

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -182,14 +182,14 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     }
 
     try {
-      return new Ok(
-        await retrieveChildrenNodes({
-          connectorId,
-          parentInternalId,
-          filterPermission,
-          viewType: "documents",
-        })
-      );
+      const nodes = await retrieveChildrenNodes({
+        connectorId,
+        parentInternalId,
+        filterPermission,
+        viewType: "documents",
+      });
+      nodes.sort((a, b) => a.title.localeCompare(b.title));
+      return new Ok(nodes);
     } catch (e) {
       return new Err(e as Error);
     }

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -176,7 +176,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         connectorId,
       });
       const brandNodes: ContentNode[] = brands.map((brand) =>
-        brand.toContentNode({ connectorId })
+        brand.toContentNode(connectorId)
       );
       return new Ok(brandNodes);
     }
@@ -429,13 +429,11 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     });
 
     return new Ok([
-      ...brands.map((brand) => brand.toContentNode({ connectorId })),
+      ...brands.map((brand) => brand.toContentNode(connectorId)),
       ...brandHelpCenters.map((brand) =>
-        brand.getHelpCenterContentNode({ connectorId })
+        brand.getHelpCenterContentNode(connectorId)
       ),
-      ...brandTickets.map((brand) =>
-        brand.getTicketsContentNode({ connectorId })
-      ),
+      ...brandTickets.map((brand) => brand.getTicketsContentNode(connectorId)),
       ...categories.map((category) => category.toContentNode({ connectorId })),
       ...articles.map((article) => article.toContentNode({ connectorId })),
       ...tickets.map((ticket) => ticket.toContentNode({ connectorId })),

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -434,9 +434,9 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         brand.getHelpCenterContentNode(connectorId)
       ),
       ...brandTickets.map((brand) => brand.getTicketsContentNode(connectorId)),
-      ...categories.map((category) => category.toContentNode({ connectorId })),
-      ...articles.map((article) => article.toContentNode({ connectorId })),
-      ...tickets.map((ticket) => ticket.toContentNode({ connectorId })),
+      ...categories.map((category) => category.toContentNode(connectorId)),
+      ...articles.map((article) => article.toContentNode(connectorId)),
+      ...tickets.map((ticket) => ticket.toContentNode(connectorId)),
     ]);
   }
 

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -80,11 +80,11 @@ export async function retrieveChildrenNodes({
     switch (type) {
       // If the parent is a Brand, we return a node for its tickets and one for its help center.
       case "brand": {
+        const brandInDb = await ZendeskBrandResource.fetchByBrandId({
+          connectorId,
+          brandId: objectId,
+        });
         if (isReadPermissionsOnly) {
-          const brandInDb = await ZendeskBrandResource.fetchByBrandId({
-            connectorId,
-            brandId: objectId,
-          });
           if (brandInDb?.ticketsPermission === "read") {
             nodes.push(brandInDb.getTicketsContentNode(connectorId));
           }
@@ -104,7 +104,8 @@ export async function retrieveChildrenNodes({
             title: "Tickets",
             sourceUrl: null,
             expandable: false,
-            permission: "none",
+            permission:
+              brandInDb?.ticketsPermission === "read" ? "read" : "none",
             dustDocumentId: null,
             lastUpdatedAt: null,
           };
@@ -121,7 +122,8 @@ export async function retrieveChildrenNodes({
               title: "Help Center",
               sourceUrl: null,
               expandable: true,
-              permission: "none",
+              permission:
+                brandInDb?.helpCenterPermission === "read" ? "read" : "none",
               dustDocumentId: null,
               lastUpdatedAt: null,
             };

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -179,7 +179,8 @@ export async function retrieveChildrenNodes({
               sourceUrl: category.html_url,
 
               expandable: false,
-              permission: matchingDbEntry ? "read" : "none",
+              permission:
+                matchingDbEntry?.permission === "read" ? "read" : "none",
               dustDocumentId: null,
               lastUpdatedAt: matchingDbEntry?.updatedAt.getTime() ?? null,
             };

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -29,6 +29,26 @@ import {
 } from "@connectors/resources/zendesk_resources";
 
 /**
+ * Retrieve all nodes selected by the admin when setting permissions.
+ */
+export async function retrieveAllSelectedNodes(
+  connectorId: ModelId
+): Promise<ContentNode[]> {
+  const brands = await ZendeskBrandResource.fetchAllReadOnly({ connectorId });
+  const helpCenterNodes: ContentNode[] = brands
+    .filter(
+      (brand) => brand.hasHelpCenter && brand.helpCenterPermission === "read"
+    )
+    .map((brand) => brand.getHelpCenterContentNode(connectorId));
+
+  const ticketNodes: ContentNode[] = brands
+    .filter((brand) => brand.ticketsPermission === "read")
+    .map((brand) => brand.getTicketsContentNode(connectorId));
+
+  return [...helpCenterNodes, ...ticketNodes];
+}
+
+/**
  * Retrieves the Brand content nodes, which populate the root level.
  */
 async function getRootLevelContentNodes(

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -139,7 +139,7 @@ export async function retrieveChildrenNodes({
               brandId: objectId,
             });
           nodes = ticketsInDb.map((ticket) =>
-            ticket.toContentNode({ connectorId })
+            ticket.toContentNode(connectorId)
           );
         }
         break;
@@ -153,7 +153,7 @@ export async function retrieveChildrenNodes({
           });
         if (isReadPermissionsOnly) {
           nodes = categoriesInDatabase.map((category) =>
-            category.toContentNode({ connectorId, expandable: true })
+            category.toContentNode(connectorId, { expandable: true })
           );
         } else {
           await changeZendeskClientSubdomain(zendeskApiClient, {
@@ -196,7 +196,7 @@ export async function retrieveChildrenNodes({
               categoryId: objectId.categoryId,
             });
           nodes = articlesInDb.map((article) =>
-            article.toContentNode({ connectorId })
+            article.toContentNode(connectorId)
           );
         }
         break;

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -150,6 +150,8 @@ export async function retrieveChildrenNodes({
       }
       // If the parent is a brand's help center, we retrieve the list of Categories for this brand.
       case "help-center": {
+        /// it's ok to fetch read-only data here, if !isReadPermissionsOnly, we are only using the categories in db to
+        // check if they have read permissions
         const categoriesInDatabase =
           await ZendeskCategoryResource.fetchByBrandIdReadOnly({
             connectorId,
@@ -181,7 +183,6 @@ export async function retrieveChildrenNodes({
               type: "folder",
               title: category.name,
               sourceUrl: category.html_url,
-
               expandable: false,
               permission:
                 matchingDbEntry?.permission === "read" ? "read" : "none",

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -111,9 +111,11 @@ export async function retrieveChildrenNodes({
           };
           nodes.push(ticketsNode);
 
-          /// fetching the brand to check if it has a help center
-          const fetchedBrand = await zendeskApiClient.brand.show(objectId);
-          if (fetchedBrand.result.brand.has_help_center) {
+          const hasHelpCenter =
+            brandInDb?.hasHelpCenter ||
+            (await zendeskApiClient.brand.show(objectId)).result.brand
+              .has_help_center;
+          if (hasHelpCenter) {
             const helpCenterNode: ContentNode = {
               provider: connector.type,
               internalId: getHelpCenterInternalId(connectorId, objectId),

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -5,6 +5,7 @@ import type {
   ModelId,
 } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
+import type { Client } from "node-zendesk";
 
 import {
   getBrandInternalId,
@@ -27,6 +28,176 @@ import {
   ZendeskTicketResource,
 } from "@connectors/resources/zendesk_resources";
 
+/**
+ * Retrieves the Brand content nodes, which populate the root level.
+ */
+async function getRootLevelContentNodes(
+  zendeskApiClient: Client,
+  {
+    connectorId,
+    isReadPermissionsOnly,
+  }: {
+    connectorId: ModelId;
+    isReadPermissionsOnly: boolean;
+  }
+): Promise<ContentNode[]> {
+  const brandsInDatabase = await ZendeskBrandResource.fetchAllReadOnly({
+    connectorId,
+  });
+  if (isReadPermissionsOnly) {
+    return brandsInDatabase.map((brand) => brand.toContentNode(connectorId));
+  } else {
+    const { result: brands } = await zendeskApiClient.brand.list();
+    return brands.map(
+      (brand) =>
+        brandsInDatabase
+          .find((b) => b.brandId === brand.id)
+          ?.toContentNode(connectorId) ?? {
+          provider: "zendesk",
+          internalId: getBrandInternalId(connectorId, brand.id),
+          parentInternalId: null,
+          type: "folder",
+          title: brand.name || "Brand",
+          sourceUrl: brand.brand_url,
+          expandable: true,
+          permission: "none",
+          dustDocumentId: null,
+          lastUpdatedAt: null,
+        }
+    );
+  }
+}
+
+/**
+ * Retrieves the two children node of a Brand, one for its tickets and one for its help center.
+ */
+async function getBrandChildren(
+  zendeskApiClient: Client,
+  {
+    connectorId,
+    brandId,
+    isReadPermissionsOnly,
+    parentInternalId,
+  }: {
+    connectorId: ModelId;
+    brandId: number;
+    parentInternalId: string;
+    isReadPermissionsOnly: boolean;
+  }
+): Promise<ContentNode[]> {
+  const nodes = [];
+  const brandInDb = await ZendeskBrandResource.fetchByBrandId({
+    connectorId,
+    brandId,
+  });
+  if (isReadPermissionsOnly) {
+    if (brandInDb?.ticketsPermission === "read") {
+      nodes.push(brandInDb.getTicketsContentNode(connectorId));
+    }
+    if (
+      brandInDb?.hasHelpCenter &&
+      brandInDb?.helpCenterPermission === "read"
+    ) {
+      nodes.push(brandInDb.getHelpCenterContentNode(connectorId));
+    }
+    // if we don't have data for the brand in db, we should not show anything
+  } else {
+    const ticketsNode: ContentNode = {
+      provider: "zendesk",
+      internalId: getTicketsInternalId(connectorId, brandId),
+      parentInternalId: parentInternalId,
+      type: "folder",
+      title: "Tickets",
+      sourceUrl: null,
+      expandable: false,
+      permission: brandInDb?.ticketsPermission === "read" ? "read" : "none",
+      dustDocumentId: null,
+      lastUpdatedAt: null,
+    };
+    nodes.push(ticketsNode);
+
+    const hasHelpCenter =
+      brandInDb?.hasHelpCenter ||
+      (await zendeskApiClient.brand.show(brandId)).result.brand.has_help_center;
+    if (hasHelpCenter) {
+      const helpCenterNode: ContentNode = {
+        provider: "zendesk",
+        internalId: getHelpCenterInternalId(connectorId, brandId),
+        parentInternalId: parentInternalId,
+        type: "folder",
+        title: "Help Center",
+        sourceUrl: null,
+        expandable: true,
+        permission:
+          brandInDb?.helpCenterPermission === "read" ? "read" : "none",
+        dustDocumentId: null,
+        lastUpdatedAt: null,
+      };
+      nodes.push(helpCenterNode);
+    }
+  }
+  return nodes;
+}
+
+/**
+ * Retrieves the children nodes of a Help Center, which are the categories.
+ */
+async function getHelpCenterChildren(
+  zendeskApiClient: Client,
+  {
+    connectorId,
+    brandId,
+    isReadPermissionsOnly,
+    parentInternalId,
+  }: {
+    connectorId: ModelId;
+    brandId: number;
+    parentInternalId: string;
+    isReadPermissionsOnly: boolean;
+  }
+): Promise<ContentNode[]> {
+  /// it's ok to fetch read-only data here, if !isReadPermissionsOnly, we are only using the categories in db to
+  // check if they have read permissions
+  const categoriesInDatabase =
+    await ZendeskCategoryResource.fetchByBrandIdReadOnly({
+      connectorId,
+      brandId,
+    });
+  if (isReadPermissionsOnly) {
+    return categoriesInDatabase.map((category) =>
+      category.toContentNode(connectorId, { expandable: true })
+    );
+  } else {
+    // fetching the categories
+    await changeZendeskClientSubdomain(zendeskApiClient, {
+      connectorId,
+      brandId,
+    });
+    const categories = await zendeskApiClient.helpcenter.categories.list();
+
+    return categories.map((category) => {
+      const matchingDbEntry = categoriesInDatabase.find(
+        (c) => c.categoryId === category.id
+      );
+      return {
+        provider: "zendesk",
+        internalId: getCategoryInternalId(connectorId, brandId, category.id),
+        parentInternalId: parentInternalId,
+        type: "folder",
+        title: category.name,
+        sourceUrl: category.html_url,
+        expandable: false,
+        permission: matchingDbEntry?.permission === "read" ? "read" : "none",
+        dustDocumentId: null,
+        lastUpdatedAt: matchingDbEntry?.updatedAt.getTime() ?? null,
+      };
+    });
+  }
+}
+
+/**
+ * Retrieves the children nodes of a node identified by its internal ID.
+ */
 export async function retrieveChildrenNodes({
   connectorId,
   parentInternalId,
@@ -42,181 +213,65 @@ export async function retrieveChildrenNodes({
     logger.error({ connectorId }, "[Zendesk] Connector not found.");
     throw new Error("Connector not found");
   }
-
-  const isReadPermissionsOnly = filterPermission === "read";
-
   const zendeskApiClient = createZendeskClient(
     await getZendeskSubdomainAndAccessToken(connector.connectionId)
   );
+  const isReadPermissionsOnly = filterPermission === "read";
 
-  // At the root level, we show one node for each brand.
   if (!parentInternalId) {
-    const brandsInDatabase = await ZendeskBrandResource.fetchAllReadOnly({
+    return getRootLevelContentNodes(zendeskApiClient, {
       connectorId,
+      isReadPermissionsOnly,
     });
-    if (isReadPermissionsOnly) {
-      return brandsInDatabase.map((brand) => brand.toContentNode(connectorId));
-    } else {
-      const { result: brands } = await zendeskApiClient.brand.list();
-      return brands.map(
-        (brand) =>
-          brandsInDatabase
-            .find((b) => b.brandId === brand.id)
-            ?.toContentNode(connectorId) ?? {
-            provider: connector.type,
-            internalId: getBrandInternalId(connectorId, brand.id),
-            parentInternalId: null,
-            type: "folder",
-            title: brand.name || "Brand",
-            sourceUrl: brand.brand_url,
-            expandable: true,
-            permission: "none",
-            dustDocumentId: null,
-            lastUpdatedAt: null,
-          }
-      );
+  }
+  const { type, objectId } = getIdFromInternalId(connectorId, parentInternalId);
+  switch (type) {
+    case "brand": {
+      return getBrandChildren(zendeskApiClient, {
+        connectorId,
+        brandId: objectId,
+        isReadPermissionsOnly,
+        parentInternalId,
+      });
     }
-  } else {
-    const { type, objectId } = getIdFromInternalId(
-      connectorId,
-      parentInternalId
-    );
-    switch (type) {
-      // If the parent is a Brand, we return a node for its tickets and one for its help center.
-      case "brand": {
-        const nodes = [];
-        const brandInDb = await ZendeskBrandResource.fetchByBrandId({
+    case "help-center": {
+      return getHelpCenterChildren(zendeskApiClient, {
+        connectorId,
+        brandId: objectId,
+        isReadPermissionsOnly,
+        parentInternalId,
+      });
+    }
+    // If the parent is a brand's tickets, we retrieve the list of tickets for the brand.
+    case "tickets": {
+      if (isReadPermissionsOnly) {
+        const ticketsInDb = await ZendeskTicketResource.fetchByBrandIdReadOnly({
           connectorId,
           brandId: objectId,
         });
-        if (isReadPermissionsOnly) {
-          if (brandInDb?.ticketsPermission === "read") {
-            nodes.push(brandInDb.getTicketsContentNode(connectorId));
-          }
-          if (
-            brandInDb?.hasHelpCenter &&
-            brandInDb?.helpCenterPermission === "read"
-          ) {
-            nodes.push(brandInDb.getHelpCenterContentNode(connectorId));
-          }
-          // if we don't have data for the brand in db, we should not show anything
-        } else {
-          const ticketsNode: ContentNode = {
-            provider: connector.type,
-            internalId: getTicketsInternalId(connectorId, objectId),
-            parentInternalId: parentInternalId,
-            type: "folder",
-            title: "Tickets",
-            sourceUrl: null,
-            expandable: false,
-            permission:
-              brandInDb?.ticketsPermission === "read" ? "read" : "none",
-            dustDocumentId: null,
-            lastUpdatedAt: null,
-          };
-          nodes.push(ticketsNode);
-
-          const hasHelpCenter =
-            brandInDb?.hasHelpCenter ||
-            (await zendeskApiClient.brand.show(objectId)).result.brand
-              .has_help_center;
-          if (hasHelpCenter) {
-            const helpCenterNode: ContentNode = {
-              provider: connector.type,
-              internalId: getHelpCenterInternalId(connectorId, objectId),
-              parentInternalId: parentInternalId,
-              type: "folder",
-              title: "Help Center",
-              sourceUrl: null,
-              expandable: true,
-              permission:
-                brandInDb?.helpCenterPermission === "read" ? "read" : "none",
-              dustDocumentId: null,
-              lastUpdatedAt: null,
-            };
-            nodes.push(helpCenterNode);
-          }
-        }
-        return nodes;
+        return ticketsInDb.map((ticket) => ticket.toContentNode(connectorId));
       }
-      // If the parent is a brand's tickets, we retrieve the list of tickets for the brand.
-      case "tickets": {
-        if (isReadPermissionsOnly) {
-          const ticketsInDb =
-            await ZendeskTicketResource.fetchByBrandIdReadOnly({
-              connectorId,
-              brandId: objectId,
-            });
-          return ticketsInDb.map((ticket) => ticket.toContentNode(connectorId));
-        }
-        return [];
-      }
-      // If the parent is a brand's help center, we retrieve the list of Categories for this brand.
-      case "help-center": {
-        /// it's ok to fetch read-only data here, if !isReadPermissionsOnly, we are only using the categories in db to
-        // check if they have read permissions
-        const categoriesInDatabase =
-          await ZendeskCategoryResource.fetchByBrandIdReadOnly({
-            connectorId,
-            brandId: objectId,
-          });
-        if (isReadPermissionsOnly) {
-          return categoriesInDatabase.map((category) =>
-            category.toContentNode(connectorId, { expandable: true })
-          );
-        } else {
-          // fetching the categories
-          await changeZendeskClientSubdomain(zendeskApiClient, {
-            connectorId,
-            brandId: objectId,
-          });
-          const categories =
-            await zendeskApiClient.helpcenter.categories.list();
-
-          return categories.map((category) => {
-            const matchingDbEntry = categoriesInDatabase.find(
-              (c) => c.categoryId === category.id
-            );
-            return {
-              provider: connector.type,
-              internalId: getCategoryInternalId(
-                connectorId,
-                objectId,
-                category.id
-              ),
-              parentInternalId: parentInternalId,
-              type: "folder",
-              title: category.name,
-              sourceUrl: category.html_url,
-              expandable: false,
-              permission:
-                matchingDbEntry?.permission === "read" ? "read" : "none",
-              dustDocumentId: null,
-              lastUpdatedAt: matchingDbEntry?.updatedAt.getTime() ?? null,
-            };
-          });
-        }
-      }
-      // If the parent is a category, we retrieve the list of articles for this category.
-      case "category": {
-        if (isReadPermissionsOnly) {
-          const articlesInDb =
-            await ZendeskArticleResource.fetchByCategoryIdReadOnly({
-              connectorId,
-              categoryId: objectId.categoryId,
-            });
-          return articlesInDb.map((article) =>
-            article.toContentNode(connectorId)
-          );
-        }
-        return [];
-      }
-      // Single tickets and articles have no children.
-      case "ticket":
-      case "article":
-        return [];
-      default:
-        assertNever(type);
+      return [];
     }
+    // If the parent is a category, we retrieve the list of articles for this category.
+    case "category": {
+      if (isReadPermissionsOnly) {
+        const articlesInDb =
+          await ZendeskArticleResource.fetchByCategoryIdReadOnly({
+            connectorId,
+            categoryId: objectId.categoryId,
+          });
+        return articlesInDb.map((article) =>
+          article.toContentNode(connectorId)
+        );
+      }
+      return [];
+    }
+    // Single tickets and articles have no children.
+    case "ticket":
+    case "article":
+      return [];
+    default:
+      assertNever(type);
   }
 }

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -27,38 +27,6 @@ import {
   ZendeskTicketResource,
 } from "@connectors/resources/zendesk_resources";
 
-/**
- * Retrieve all selected nodes by the admin when setting permissions.
- * For Zendesk, the admin can set:
- * - all the tickets/whole help center
- * - brands, categories within a help center
- * - brands' tickets
- */
-export async function retrieveSelectedNodes({
-  connectorId,
-}: {
-  connectorId: ModelId;
-}): Promise<ContentNode[]> {
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    logger.error({ connectorId }, "[Zendesk] Connector not found.");
-    throw new Error("Connector not found");
-  }
-
-  const brands = await ZendeskBrandResource.fetchAllReadOnly({ connectorId });
-  const helpCenterNodes: ContentNode[] = brands
-    .filter(
-      (brand) => brand.hasHelpCenter && brand.helpCenterPermission === "read"
-    )
-    .map((brand) => brand.getHelpCenterContentNode({ connectorId }));
-
-  const ticketNodes: ContentNode[] = brands
-    .filter((brand) => brand.ticketsPermission === "read")
-    .map((brand) => brand.getTicketsContentNode({ connectorId }));
-
-  return [...helpCenterNodes, ...ticketNodes];
-}
-
 export async function retrieveChildrenNodes({
   connectorId,
   parentInternalId,

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -56,9 +56,7 @@ export async function retrieveChildrenNodes({
       const brandsInDatabase = await ZendeskBrandResource.fetchAllReadOnly({
         connectorId,
       });
-      nodes = brandsInDatabase.map((brand) =>
-        brand.toContentNode({ connectorId })
-      );
+      nodes = brandsInDatabase.map((brand) => brand.toContentNode(connectorId));
     } else {
       const { result: brands } = await zendeskApiClient.brand.list();
       nodes = brands.map((brand) => ({
@@ -88,13 +86,13 @@ export async function retrieveChildrenNodes({
             brandId: objectId,
           });
           if (brandInDb?.ticketsPermission === "read") {
-            nodes.push(brandInDb.getTicketsContentNode({ connectorId }));
+            nodes.push(brandInDb.getTicketsContentNode(connectorId));
           }
           if (
             brandInDb?.hasHelpCenter &&
             brandInDb?.helpCenterPermission === "read"
           ) {
-            nodes.push(brandInDb.getHelpCenterContentNode({ connectorId }));
+            nodes.push(brandInDb.getHelpCenterContentNode(connectorId));
           }
           // if we don't have data for the brand in db, we should not show anything
         } else {

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -39,11 +39,17 @@ export async function retrieveAllSelectedNodes(
     .filter(
       (brand) => brand.hasHelpCenter && brand.helpCenterPermission === "read"
     )
-    .map((brand) => brand.getHelpCenterContentNode(connectorId));
+    .map((brand) => ({
+      ...brand.getHelpCenterContentNode(connectorId),
+      title: `${brand.name} - Help Center`, // adding the name of the brand since this will be named "Help Center" otherwise
+    }));
 
   const ticketNodes: ContentNode[] = brands
     .filter((brand) => brand.ticketsPermission === "read")
-    .map((brand) => brand.getTicketsContentNode(connectorId));
+    .map((brand) => ({
+      ...brand.getTicketsContentNode(connectorId),
+      title: `${brand.name} - Tickets`, // adding the name of the brand since this will be named "Tickets" otherwise
+    }));
 
   return [...helpCenterNodes, ...ticketNodes];
 }

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -280,7 +280,7 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
       sourceUrl: this.url,
       expandable: true,
       permission:
-        this.helpCenterPermission === "read" ||
+        this.helpCenterPermission === "read" &&
         this.ticketsPermission === "read"
           ? "read"
           : "none",

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -270,7 +270,7 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
     await ZendeskBrand.destroy({ where: { connectorId }, transaction });
   }
 
-  toContentNode({ connectorId }: { connectorId: number }): ContentNode {
+  toContentNode(connectorId: number): ContentNode {
     return {
       provider: "zendesk",
       internalId: getBrandInternalId(connectorId, this.brandId),
@@ -289,11 +289,7 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
     };
   }
 
-  getHelpCenterContentNode({
-    connectorId,
-  }: {
-    connectorId: number;
-  }): ContentNode {
+  getHelpCenterContentNode(connectorId: number): ContentNode {
     return {
       provider: "zendesk",
       internalId: getHelpCenterInternalId(connectorId, this.brandId),
@@ -308,7 +304,7 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
     };
   }
 
-  getTicketsContentNode({ connectorId }: { connectorId: number }): ContentNode {
+  getTicketsContentNode(connectorId: number): ContentNode {
     return {
       provider: "zendesk",
       internalId: getTicketsInternalId(connectorId, this.brandId),

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -483,13 +483,10 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
     }
   }
 
-  toContentNode({
-    connectorId,
-    expandable = false,
-  }: {
-    connectorId: number;
-    expandable?: boolean;
-  }): ContentNode {
+  toContentNode(
+    connectorId: number,
+    { expandable = false }: { expandable?: boolean } = {}
+  ): ContentNode {
     return {
       provider: "zendesk",
       internalId: getCategoryInternalId(
@@ -576,7 +573,7 @@ export class ZendeskTicketResource extends BaseResource<ZendeskTicket> {
     };
   }
 
-  toContentNode({ connectorId }: { connectorId: number }): ContentNode {
+  toContentNode(connectorId: number): ContentNode {
     return {
       provider: "zendesk",
       internalId: getTicketInternalId(connectorId, this.ticketId),
@@ -742,7 +739,7 @@ export class ZendeskArticleResource extends BaseResource<ZendeskArticle> {
     };
   }
 
-  toContentNode({ connectorId }: { connectorId: number }): ContentNode {
+  toContentNode(connectorId: number): ContentNode {
     return {
       provider: "zendesk",
       internalId: getArticleInternalId(connectorId, this.articleId),


### PR DESCRIPTION
## Description

- Permissions are not correctly retrieved from the db when not in read only mode (which causes inconsistencies in the `ContentNodeTree`), this PR fixes that.
- Refactor the `toContentNode` methods.

For context, the content tree has the following structure:
- Brand 1 (maps to an entry in the table `zendesk_brands`)
  - Help Center (built using the entry in `zendesk_brands`)
    - Category 1 (maps to an entry in the table `zendesk_category`)
    - ....
  - Tickets (built using the entry in `zendesk_brands`)
- ...

## Risk

Low, connector not in use.

## Deploy Plan

- Deploy connectors.