### PR TITLE
[sparkle] Add flex sizing

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.300",
+  "version": "0.2.301",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.300",
+      "version": "0.2.301",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.300",
+  "version": "0.2.301",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Citation.tsx
+++ b/sparkle/src/components/Citation.tsx
@@ -160,7 +160,7 @@ export function Citation({
       variant="secondary"
       size="sm"
       className={classNames(
-        "s-relative s-flex s-w-48 s-flex-none s-flex-col s-gap-1",
+        "s-relative s-flex s-h-full s-w-48 s-flex-none s-flex-col s-gap-1",
         sizing === "fluid" ? typeSizing[sizing] : typeSizing[sizing][size],
         size === "sm" ? "sm:s-w-64" : "",
         isBlinking ? "s-animate-[bgblink_500ms_3]" : "",

--- a/sparkle/src/components/ZoomableImageCitationWrapper.tsx
+++ b/sparkle/src/components/ZoomableImageCitationWrapper.tsx
@@ -26,8 +26,17 @@ export function ZoomableImageCitationWrapper({
 
   return (
     <>
-      <div onClick={handleZoomToggle} className="s-min-h-76 s-group s-h-full">
-        <Citation title={title} size={size} type="image" imgSrc={imgSrc} />
+      <div
+        onClick={handleZoomToggle}
+        className="s-min-h-76 s-group s-flex s-h-full"
+      >
+        <Citation
+          title={title}
+          size={size}
+          type="image"
+          imgSrc={imgSrc}
+          sizing="fluid"
+        />
       </div>
 
       <Dialog


### PR DESCRIPTION
## Description

Make zoomable citations use the space in the grid

Before :   

<img width="746" alt="Screenshot 2024-11-08 at 15 59 18" src="https://github.com/user-attachments/assets/16752db8-fef4-4d25-8f66-21d56d113eba">


After : 

<img width="829" alt="Screenshot 2024-11-08 at 15 57 46" src="https://github.com/user-attachments/assets/3ef0ecce-fd99-4c69-8c4b-83ee690aac66">


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
publish sparkle
