### PR TITLE
[Slack] Allow indexing private channels

### DIFF
--- a/connectors/migrations/20230725_slack_channel_permissions.ts
+++ b/connectors/migrations/20230725_slack_channel_permissions.ts
@@ -63,6 +63,7 @@ async function main() {
           slackChannelId: channel.id,
           slackChannelName: channel.name,
           permission: "read_write",
+          private: !!channel.is_private,
         });
       }
     }

--- a/connectors/migrations/db/migration_32.sql
+++ b/connectors/migrations/db/migration_32.sql
@@ -1,0 +1,2 @@
+-- Migration created on Nov 08, 2024
+ALTER TABLE "public"."slack_channels" ADD COLUMN "private" BOOLEAN NOT NULL DEFAULT false;

--- a/connectors/migrations/db/migration_33.sql
+++ b/connectors/migrations/db/migration_33.sql
@@ -1,0 +1,2 @@
+-- Migration created on Nov 08, 2024
+ALTER TABLE "public"."slack_channels" ALTER COLUMN "private" DROP DEFAULT;

--- a/connectors/src/api/slack_channels_linked_with_agent.ts
+++ b/connectors/src/api/slack_channels_linked_with_agent.ts
@@ -73,13 +73,17 @@ const _patchSlackChannelsLinkedWithAgentHandler = async (
     if (missingSlackChannelIds.length) {
       const remoteChannels = (
         await getChannels(parseInt(connectorId), false)
-      ).flatMap((c) => (c.id && c.name ? [{ id: c.id, name: c.name }] : []));
+      ).flatMap((c) =>
+        c.id && c.name
+          ? [{ id: c.id, name: c.name, private: !!c.is_private }]
+          : []
+      );
       const remoteChannelsById = remoteChannels.reduce(
         (acc, ch) => {
           acc[ch.id] = ch;
           return acc;
         },
-        {} as Record<string, { id: string; name: string }>
+        {} as Record<string, { id: string; name: string; private: boolean }>
       );
       const createdChannels = await Promise.all(
         missingSlackChannelIds.map((slackChannelId) => {
@@ -96,6 +100,7 @@ const _patchSlackChannelsLinkedWithAgentHandler = async (
               slackChannelName: remoteChannel.name,
               agentConfigurationId,
               permission: "write",
+              private: remoteChannel.private,
             },
             {
               transaction: t,

--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -7,6 +7,7 @@ import {
   onChannelCreation,
 } from "@connectors/api/webhooks/slack/created_channel";
 import { botAnswerMessage } from "@connectors/connectors/slack/bot";
+import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
 import { getBotUserIdMemoized } from "@connectors/connectors/slack/temporal/activities";
 import {
   launchSlackSyncOneMessageWorkflow,
@@ -19,7 +20,6 @@ import mainLogger from "@connectors/logger/logger";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
-import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
 
 export interface SlackWebhookEvent<T = string> {
   bot_id?: string;

--- a/connectors/src/connectors/slack/auto_read_channel.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.ts
@@ -88,6 +88,7 @@ export async function autoReadChannel(
         slackChannelId,
         slackChannelName: remoteChannelName,
         permission: "read_write",
+        private: remoteChannel.channel?.is_private ?? false,
       });
     } else {
       await channel.update({

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -317,6 +317,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
       slackChannelId: string;
       slackChannelName: string;
       permission: ConnectorPermission;
+      private: boolean;
     }[] = [];
 
     try {
@@ -332,6 +333,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
             slackChannelId: channel.slackChannelId,
             slackChannelName: channel.slackChannelName,
             permission: channel.permission,
+            private: channel.private,
           }))
         );
       } else {
@@ -369,6 +371,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
               slackChannelId: remoteChannel.id,
               slackChannelName: remoteChannel.name,
               permission: permissions,
+              private: !!remoteChannel.is_private,
             });
           }
         }
@@ -386,6 +389,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
         dustDocumentId: null,
         lastUpdatedAt: null,
         dustTableId: null,
+        providerVisibility: ch.private ? "private" : "public",
       }));
 
       resources.sort((a, b) => {
@@ -586,6 +590,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
       dustDocumentId: null,
       lastUpdatedAt: null,
       dustTableId: null,
+      providerVisibility: ch.private ? "private" : "public",
     }));
 
     return new Ok(contentNodes);

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -491,6 +491,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
             slackChannelId: id,
             slackChannelName: remoteChannel.channel.name,
             permission: "none",
+            private: !!remoteChannel.channel.is_private,
           });
           channels[id] = slackChannel;
           channel = slackChannel;

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -72,7 +72,7 @@ export async function getChannels(
   let nextCursor: string | undefined = undefined;
   do {
     const c: ConversationsListResponse = await client.conversations.list({
-      types: "public_channel",
+      types: "public_channel, private_channel",
       limit: 1000,
       cursor: nextCursor,
     });

--- a/connectors/src/lib/models/slack.ts
+++ b/connectors/src/lib/models/slack.ts
@@ -146,6 +146,8 @@ export class SlackChannel extends Model<
   declare slackChannelId: string;
   declare slackChannelName: string;
 
+  declare private: boolean;
+
   declare permission: ConnectorPermission;
   declare agentConfigurationId: CreationOptional<string | null>;
 }
@@ -176,6 +178,10 @@ SlackChannel.init(
     },
     slackChannelName: {
       type: DataTypes.STRING,
+      allowNull: false,
+    },
+    private: {
+      type: DataTypes.BOOLEAN,
       allowNull: false,
     },
     permission: {

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -32,6 +32,7 @@ import { InformationCircleIcon } from "@heroicons/react/20/solid";
 import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { useSWRConfig } from "swr";
 
+import { ConfirmContext } from "@app/components/Confirm";
 import { RequestDataSourceModal } from "@app/components/data_source/RequestDataSourceModal";
 import { setupConnection } from "@app/components/spaces/AddConnectionMenu";
 import { ConnectorDataUpdatedModal } from "@app/components/spaces/ConnectorDataUpdatedModal";
@@ -45,7 +46,6 @@ import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 
 import type { ContentNodeTreeItemStatus } from "./ContentNodeTree";
 import { ContentNodeTree } from "./ContentNodeTree";
-import { ConfirmContext } from "@app/components/Confirm";
 
 const PERMISSIONS_EDITABLE_CONNECTOR_TYPES: Set<ConnectorProvider> = new Set([
   "confluence",

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -638,10 +638,10 @@ export function ConnectorPermissionsModal({
 
     if (privateNodes.length > 0) {
       const confirmed = await confirm({
-        title: "Privacy heads up!",
-        message: `You are syncing private data from ${privateNodes
+        title: "Sensitive data synchronization",
+        message: `You are synchronizing data from ${privateNodes
           .map((node) => node.node.title)
-          .join(", ")}. Ensure the owners are aware. Is this okay?`,
+          .join(", ")}. Is this okay?`,
         validateVariant: "warning",
       });
       if (!confirmed) {

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -33,7 +33,8 @@ import { InformationCircleIcon } from "@heroicons/react/20/solid";
 import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { useSWRConfig } from "swr";
 
-import { ConfirmContext, ConfirmDataType } from "@app/components/Confirm";
+import type { ConfirmDataType } from "@app/components/Confirm";
+import { ConfirmContext } from "@app/components/Confirm";
 import { RequestDataSourceModal } from "@app/components/data_source/RequestDataSourceModal";
 import { setupConnection } from "@app/components/spaces/AddConnectionMenu";
 import { ConnectorDataUpdatedModal } from "@app/components/spaces/ConnectorDataUpdatedModal";

--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -170,6 +170,11 @@ function ContentNodeTreeChildren({
             key={n.internalId}
             type={n.expandable ? "node" : "leaf"}
             label={n.title}
+            labelClassName={
+              n.providerVisibility === "private"
+                ? "after:content-['(private)'] after:text-red-500 after:ml-1"
+                : ""
+            }
             visual={getVisualForContentNode(n)}
             className={`whitespace-nowrap tree-depth-${depth}`}
             checkbox={

--- a/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
+++ b/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
@@ -17,6 +17,7 @@ import { removeNulls } from "@dust-tt/types";
 import { useRouter } from "next/router";
 import React, { useContext, useMemo, useState } from "react";
 
+import { ConfirmContext } from "@app/components/Confirm";
 import { RequestDataSourceModal } from "@app/components/data_source/RequestDataSourceModal";
 import SpaceManagedDatasourcesViewsModal from "@app/components/spaces/SpaceManagedDatasourcesViewsModal";
 import { useAwaitableDialog } from "@app/hooks/useAwaitableDialog";
@@ -25,7 +26,6 @@ import {
   useSpaceDataSourceViews,
   useSpaceDataSourceViewsWithDetails,
 } from "@app/lib/swr/spaces";
-import { ConfirmContext } from "@app/components/Confirm";
 
 interface EditSpaceManagedDataSourcesViewsProps {
   dataSourceView?: DataSourceViewType;

--- a/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
+++ b/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
@@ -18,6 +18,7 @@ import { useRouter } from "next/router";
 import React, { useContext, useMemo, useState } from "react";
 
 import { ConfirmContext } from "@app/components/Confirm";
+import { confirmPrivateNodesSync } from "@app/components/ConnectorPermissionsModal";
 import { RequestDataSourceModal } from "@app/components/data_source/RequestDataSourceModal";
 import SpaceManagedDatasourcesViewsModal from "@app/components/spaces/SpaceManagedDatasourcesViewsModal";
 import { useAwaitableDialog } from "@app/hooks/useAwaitableDialog";
@@ -26,7 +27,6 @@ import {
   useSpaceDataSourceViews,
   useSpaceDataSourceViewsWithDetails,
 } from "@app/lib/swr/spaces";
-import { confirmPrivateNodesSync } from "@app/components/ConnectorPermissionsModal";
 
 interface EditSpaceManagedDataSourcesViewsProps {
   dataSourceView?: DataSourceViewType;
@@ -283,7 +283,7 @@ export function EditSpaceManagedDataSourcesViews({
               confirm,
             }))
           )
-            await updateSpaceDataSourceViews(selectionConfigurations);
+            {await updateSpaceDataSourceViews(selectionConfigurations);}
         }}
         initialSelectedDataSources={filteredDataSourceViews}
       />

--- a/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
+++ b/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
@@ -282,8 +282,9 @@ export function EditSpaceManagedDataSourcesViews({
                 .flat(),
               confirm,
             }))
-          )
-            {await updateSpaceDataSourceViews(selectionConfigurations);}
+          ) {
+            await updateSpaceDataSourceViews(selectionConfigurations);
+          }
         }}
         initialSelectedDataSources={filteredDataSourceViews}
       />

--- a/front/lib/content_nodes.ts
+++ b/front/lib/content_nodes.ts
@@ -3,6 +3,7 @@ import {
   DocumentIcon,
   DocumentPileIcon,
   FolderIcon,
+  LockIcon,
   Square3Stack3DIcon,
 } from "@dust-tt/sparkle";
 import type { BaseContentNode } from "@dust-tt/types";
@@ -19,6 +20,9 @@ function getVisualForFileContentNode(node: BaseContentNode & { type: "file" }) {
 export function getVisualForContentNode(node: BaseContentNode) {
   switch (node.type) {
     case "channel":
+      if (node.providerVisibility === "private") {
+        return LockIcon;
+      }
       return ChatBubbleLeftRightIcon;
 
     case "database":

--- a/front/lib/swr/connectors.ts
+++ b/front/lib/swr/connectors.ts
@@ -13,10 +13,10 @@ import {
   getErrorFromResponse,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { GetConnectorResponseBody } from "@app/pages/api/w/[wId]/data_sources/[dsId]/connector";
 import type { GetOrPostManagedDataSourceConfigResponseBody } from "@app/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]";
 import type { GetDataSourcePermissionsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions";
-import { useFeatureFlags } from "@app/lib/swr/workspaces";
 
 interface UseConnectorPermissionsReturn<IncludeParents extends boolean> {
   resources: GetDataSourcePermissionsResponseBody<IncludeParents>["resources"];

--- a/front/lib/swr/connectors.ts
+++ b/front/lib/swr/connectors.ts
@@ -73,7 +73,7 @@ export function useConnectorPermissions<IncludeParents extends boolean>({
                 featureFlags.includes("index_private_slack_channel")
             )
           : [],
-      [data]
+      [data, featureFlags]
     ),
     isResourcesLoading: !error && !data,
     isResourcesError: error,

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -605,6 +605,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema([
   "openai_o1_mini_feature",
   "snowflake_connector_feature",
   "zendesk_connector_feature",
+  "index_private_slack_channel",
 ]);
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -107,6 +107,7 @@ export interface BaseContentNode {
   permission: ConnectorPermission;
   dustDocumentId: string | null;
   lastUpdatedAt: number | null;
+  providerVisibility?: "public" | "private";
 }
 
 export type ContentNode = BaseContentNode & {

--- a/types/src/shared/feature_flags.ts
+++ b/types/src/shared/feature_flags.ts
@@ -7,6 +7,7 @@ export const WHITELISTABLE_FEATURES = [
   "openai_o1_feature",
   "openai_o1_mini_feature",
   "zendesk_connector_feature",
+  "index_private_slack_channel",
 ] as const;
 export type WhitelistableFeature = (typeof WHITELISTABLE_FEATURES)[number];
 export function isWhitelistableFeature(


### PR DESCRIPTION
## Description
Context threads [here](https://dust4ai.slack.com/archives/C050A0S2Z7F/p1731081357893739) and [here](https://dust4ai.slack.com/archives/C06QC8ZRL0N/p1730969867888119)

Private channels *in which the Dust bot has been invited* are now visible to sync by the admin, with warning.

Looks like this:
![image](https://github.com/user-attachments/assets/89ce5309-2f9a-4fc6-a27d-577feef5d876)

and this
![image](https://github.com/user-attachments/assets/07ff25d2-d275-422e-ac32-0d81fd92a5d2)

## Risk
The PR in itself is low risk (small code change + UX). The product risk is higher but has been discussed, see threads

## Deploy Plan
- deploy front
- migration_31
- deploy connectors
- migration_32
