### PR TITLE
feat: include data action

### DIFF
--- a/front/components/assistant_builder/actions/ProcessAction.tsx
+++ b/front/components/assistant_builder/actions/ProcessAction.tsx
@@ -567,7 +567,7 @@ export function ActionProcess({
           }}
         />
         <TimeUnitDropdown
-          actionConfiguration={actionConfiguration}
+          timeFrame={actionConfiguration.timeFrame}
           updateAction={updateAction}
           onEdit={() => setEdited(true)}
         />

--- a/front/components/assistant_builder/actions/TimeDropdown.tsx
+++ b/front/components/assistant_builder/actions/TimeDropdown.tsx
@@ -8,27 +8,29 @@ import {
 import type { TimeframeUnit } from "@dust-tt/types";
 
 import { TIME_FRAME_UNIT_TO_LABEL } from "@app/components/assistant_builder/shared";
-import type { AssistantBuilderBaseConfiguration } from "@app/components/assistant_builder/types";
+import type { AssistantBuilderTimeFrame } from "@app/components/assistant_builder/types";
 
-interface TimeUnitDropdownProps<T extends AssistantBuilderBaseConfiguration> {
-  actionConfiguration: T;
+interface TimeUnitDropdownProps<
+  T extends { timeFrame?: AssistantBuilderTimeFrame },
+> {
+  timeFrame: AssistantBuilderTimeFrame;
+  disabled?: boolean;
   onEdit: () => void;
   updateAction: (setNewAction: (previousAction: T) => T) => void;
 }
 
-export function TimeUnitDropdown<T extends AssistantBuilderBaseConfiguration>({
-  actionConfiguration,
-  updateAction,
-  onEdit,
-}: TimeUnitDropdownProps<T>) {
+export function TimeUnitDropdown<
+  T extends { timeFrame?: AssistantBuilderTimeFrame },
+>({ timeFrame, updateAction, onEdit, disabled }: TimeUnitDropdownProps<T>) {
   return (
     <NewDropdownMenu>
       <NewDropdownMenuTrigger asChild>
         <Button
           isSelect
-          label={TIME_FRAME_UNIT_TO_LABEL[actionConfiguration.timeFrame.unit]}
+          label={TIME_FRAME_UNIT_TO_LABEL[timeFrame.unit]}
           variant="outline"
           size="sm"
+          disabled={disabled}
         />
       </NewDropdownMenuTrigger>
       <NewDropdownMenuContent>
@@ -41,7 +43,7 @@ export function TimeUnitDropdown<T extends AssistantBuilderBaseConfiguration>({
               updateAction((previousAction) => ({
                 ...previousAction,
                 timeFrame: {
-                  value: previousAction.timeFrame.value,
+                  value: timeFrame.value,
                   unit: key as TimeframeUnit,
                 },
               }));

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -120,9 +120,10 @@ async function getRetrievalActionConfiguration(
       : getDefaultRetrievalExhaustiveActionConfiguration();
   if (
     action.relativeTimeFrame !== "auto" &&
-    action.relativeTimeFrame !== "none"
+    action.relativeTimeFrame !== "none" &&
+    "timeFrame" in retrievalConfiguration
   ) {
-    retrievalConfiguration.configuration.timeFrame = {
+    retrievalConfiguration.timeFrame = {
       value: action.relativeTimeFrame.duration,
       unit: action.relativeTimeFrame.unit,
     };

--- a/front/components/assistant_builder/submitAssistantBuilderForm.ts
+++ b/front/components/assistant_builder/submitAssistantBuilderForm.ts
@@ -3,6 +3,7 @@ import type {
   LightAgentConfigurationType,
   PostOrPatchAgentConfigurationRequestBody,
   Result,
+  RetrievalTimeframe,
   WorkspaceType,
 } from "@dust-tt/types";
 import { assertNever, Err, Ok } from "@dust-tt/types";
@@ -61,6 +62,24 @@ export async function submitAssistantBuilderForm({
   >;
 
   const map: (a: AssistantBuilderActionConfiguration) => ActionsType = (a) => {
+    let timeFrame: RetrievalTimeframe = "auto";
+
+    if (a.type === "RETRIEVAL_EXHAUSTIVE") {
+      if (a.configuration.timeFrame) {
+        timeFrame = {
+          duration: a.configuration.timeFrame.value,
+          unit: a.configuration.timeFrame.unit,
+        };
+      } else {
+        timeFrame = "none";
+      }
+    } else if (a.type === "PROCESS") {
+      timeFrame = {
+        duration: a.configuration.timeFrame.value,
+        unit: a.configuration.timeFrame.unit,
+      };
+    }
+
     switch (a.type) {
       case "RETRIEVAL_SEARCH":
       case "RETRIEVAL_EXHAUSTIVE":
@@ -70,13 +89,7 @@ export async function submitAssistantBuilderForm({
             name: a.name,
             description: a.description,
             query: a.type === "RETRIEVAL_SEARCH" ? "auto" : "none",
-            relativeTimeFrame:
-              a.type === "RETRIEVAL_EXHAUSTIVE"
-                ? {
-                    duration: a.configuration.timeFrame.value,
-                    unit: a.configuration.timeFrame.unit,
-                  }
-                : "auto",
+            relativeTimeFrame: timeFrame,
             topK: "auto",
             dataSources: Object.values(
               a.configuration.dataSourceConfigurations
@@ -173,10 +186,7 @@ export async function submitAssistantBuilderForm({
               },
             })),
             tagsFilter: a.configuration.tagsFilter,
-            relativeTimeFrame: {
-              duration: a.configuration.timeFrame.value,
-              unit: a.configuration.timeFrame.unit,
-            },
+            relativeTimeFrame: timeFrame,
             schema: a.configuration.schema,
           },
         ];

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -38,10 +38,6 @@ export const ACTION_MODES = [
 
 // Retrieval configuration
 
-export interface AssistantBuilderBaseConfiguration {
-  timeFrame: AssistantBuilderTimeFrame;
-}
-
 export type AssistantBuilderTimeFrame = {
   value: number;
   unit: TimeframeUnit;
@@ -51,10 +47,13 @@ export type AssistantBuilderTagsFilter = {
   in: string[];
 };
 
-export type AssistantBuilderRetrievalConfiguration =
-  AssistantBuilderBaseConfiguration & {
-    dataSourceConfigurations: DataSourceViewSelectionConfigurations;
-  };
+export type AssistantBuilderRetrievalConfiguration = {
+  dataSourceConfigurations: DataSourceViewSelectionConfigurations;
+};
+
+export type AssistantBuilderRetrievalExhaustiveConfiguration = {
+  timeFrame?: AssistantBuilderTimeFrame;
+} & AssistantBuilderRetrievalConfiguration;
 
 // DustAppRun configuration
 
@@ -69,12 +68,13 @@ export type AssistantBuilderTableConfiguration =
 
 // Process configuration
 
-export type AssistantBuilderProcessConfiguration =
-  AssistantBuilderBaseConfiguration & {
-    dataSourceConfigurations: DataSourceViewSelectionConfigurations;
-    tagsFilter: AssistantBuilderTagsFilter | null;
-    schema: ProcessSchemaPropertyType[];
-  };
+export type AssistantBuilderProcessConfiguration = {
+  timeFrame: AssistantBuilderTimeFrame;
+} & {
+  dataSourceConfigurations: DataSourceViewSelectionConfigurations;
+  tagsFilter: AssistantBuilderTagsFilter | null;
+  schema: ProcessSchemaPropertyType[];
+};
 
 // Websearch configuration
 export type AssistantBuilderWebNavigationConfiguration = Record<string, never>; // no relevant params identified yet
@@ -85,8 +85,12 @@ export type AssistantBuilderVisualizationConfiguration = Record<string, never>; 
 
 export type AssistantBuilderActionConfiguration = (
   | {
-      type: "RETRIEVAL_SEARCH" | "RETRIEVAL_EXHAUSTIVE";
+      type: "RETRIEVAL_SEARCH";
       configuration: AssistantBuilderRetrievalConfiguration;
+    }
+  | {
+      type: "RETRIEVAL_EXHAUSTIVE";
+      configuration: AssistantBuilderRetrievalExhaustiveConfiguration;
     }
   | {
       type: "DUST_APP_RUN";
@@ -221,11 +225,7 @@ export function getDefaultRetrievalExhaustiveActionConfiguration() {
     type: "RETRIEVAL_EXHAUSTIVE",
     configuration: {
       dataSourceConfigurations: {},
-      timeFrame: {
-        value: 1,
-        unit: "month",
-      },
-    } as AssistantBuilderRetrievalConfiguration,
+    } as AssistantBuilderRetrievalExhaustiveConfiguration,
     name: DEFAULT_RETRIEVAL_NO_QUERY_ACTION_NAME,
     description: "",
   } satisfies AssistantBuilderActionConfiguration;

--- a/front/lib/api/assistant/actions/names.ts
+++ b/front/lib/api/assistant/actions/names.ts
@@ -3,7 +3,7 @@ export const DEFAULT_BROWSE_ACTION_NAME = "browse";
 export const DEFAULT_PROCESS_ACTION_NAME =
   "extract_structured_data_from_data_sources";
 export const DEFAULT_RETRIEVAL_ACTION_NAME = "search_data_sources";
-// The name below is used by the assistant builder when the user selects "Most recent data".
+// The name below is used by the assistant builder when the user selects "Include data".
 export const DEFAULT_RETRIEVAL_NO_QUERY_ACTION_NAME =
   "most_recent_in_data_sources";
 export const DEFAULT_WEBSEARCH_ACTION_NAME = "web_search";

--- a/front/lib/api/assistant/actions/utils.ts
+++ b/front/lib/api/assistant/actions/utils.ts
@@ -33,7 +33,7 @@ export const ACTION_SPECIFICATIONS: Record<
   }
 > = {
   RETRIEVAL_EXHAUSTIVE: {
-    label: "Most recent data",
+    label: "Include data",
     description: "Include as much data as possible",
     cardIcon: TimeIcon,
     dropDownIcon: TimeIcon,

--- a/types/src/front/assistant/actions/guards.ts
+++ b/types/src/front/assistant/actions/guards.ts
@@ -135,20 +135,6 @@ export function throwIfInvalidAgentConfiguration(
   configation: AgentConfigurationType | TemplateAgentConfigurationType
 ) {
   configation.actions.forEach((action) => {
-    if (isRetrievalConfiguration(action)) {
-      if (action.query === "none") {
-        if (
-          action.relativeTimeFrame === "auto" ||
-          action.relativeTimeFrame === "none"
-        ) {
-          /** Should never happen. Throw loudly if it does */
-          throw new Error(
-            "Invalid configuration: exhaustive retrieval must have a definite time frame"
-          );
-        }
-      }
-    }
-
     if (isProcessConfiguration(action)) {
       if (
         action.relativeTimeFrame === "auto" ||


### PR DESCRIPTION
## Description

https://www.notion.so/dust-tt/Tool-Include-c6f4310246b44c93bd61e1fe7ef6dff4?pvs=4

Basically, rename the "Most Recent Data" action into "Include Data". The timeframe is made optional, and by default disabled.

<img width="954" alt="Screenshot 2024-11-08 at 17 51 48" src="https://github.com/user-attachments/assets/f6833a46-0ef1-4bc8-91cd-c414cc5c7408">


<img width="725" alt="Screenshot 2024-11-08 at 17 52 16" src="https://github.com/user-attachments/assets/37000272-275d-4f7a-882b-f4adfdc302e8">

<img width="728" alt="Screenshot 2024-11-08 at 17 52 29" src="https://github.com/user-attachments/assets/8fbda63c-5fbd-45d8-8b19-db3cc74294da">


## Risk

Well tested, but on assistant builder critical path and touches code that could affect Retrieval and Process on top of Most Recent.

## Deploy Plan

Deploy front