### PR TITLE
[front] - fix(PlansTable): trigger button variant

### DIFF
--- a/front/components/plans/PlansTables.tsx
+++ b/front/components/plans/PlansTables.tsx
@@ -326,8 +326,12 @@ export function PricePlans({
       >
         <Tabs defaultValue="pro">
           <TabsList>
-            <TabsTrigger value="pro" label="Pro" />
-            <TabsTrigger value="enterprise" label="Enterprise" />
+            <TabsTrigger value="pro" label="Pro" buttonVariant="outline" />
+            <TabsTrigger
+              value="enterprise"
+              label="Enterprise"
+              buttonVariant="outline"
+            />
           </TabsList>
           <div className="mt-8">
             <TabsContent value="pro">

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.302",
+        "@dust-tt/sparkle": "^0.2.303",
         "@dust-tt/types": "file:../types",
         "@headlessui/react": "^1.7.7",
         "@heroicons/react": "^2.0.11",
@@ -11485,9 +11485,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.302",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.302.tgz",
-      "integrity": "sha512-LQph9hmnrBsDzarobZm1YHHp4no2S8I9qKeYfbAZCj53lWEgJItjryeVLzYu3Htzg3FrlYaBzQO2QSdd5DcHpw==",
+      "version": "0.2.303",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.303.tgz",
+      "integrity": "sha512-zcEbu17PoUR8SXE0yKuNfau8tr9eloPDYzuYXlGiVRhH0+xUqQbOtS3sq/iV9safvvBG5HvbMcW9HxtGSEOJlw==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.302",
+    "@dust-tt/sparkle": "^0.2.303",
     "@dust-tt/types": "file:../types",
     "@headlessui/react": "^1.7.7",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description

This PR aims at fixing the button variant used in the plans table tabs triggers on mobile.
![Screenshot 2024-11-08 at 18 08 10](https://github.com/user-attachments/assets/a6205c26-619d-49e3-b386-92d125af850f)

Note: as seen IRL this is a temporary fix and we will go for a shadcn-like look.

## Risk

Low

## Deploy Plan

Deploy `front`