### PR TITLE
[sparkle] - fix(RadioGroup): alignment

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.303",
+  "version": "0.2.304",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.303",
+      "version": "0.2.304",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.303",
+  "version": "0.2.304",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/RadioGroup.tsx
+++ b/sparkle/src/components/RadioGroup.tsx
@@ -8,6 +8,7 @@ import { cn } from "@sparkle/lib/utils";
 const radioStyles = cva(
   cn(
     "s-aspect-square s-rounded-full s-border s-border-border-darker s-text-foreground",
+    "s-flex s-items-center s-justify-center",
     "focus-visible:s-outline-none focus-visible:s-ring-2 focus-visible:s-ring-offset-2 focus-visible:s-ring-ring",
     "disabled:s-cursor-not-allowed disabled:s-opacity-50",
     "checked:s-ring-0 checked:s-bg-action-500"
@@ -30,8 +31,8 @@ const radioIndicatorStyles = cva(
   {
     variants: {
       size: {
-        xs: "s-h-2 s-w-2 s-ml-[3px]",
-        sm: "s-h-2.5 s-w-2.5 s-ml-1",
+        xs: "s-h-2 s-w-2",
+        sm: "s-h-2.5 s-w-2.5",
       },
     },
     defaultVariants: {
@@ -82,10 +83,7 @@ const RadioGroupItem = React.forwardRef<
     );
     return (
       <div
-        className={cn(
-          "s-group",
-          size === "sm" ? "s-h-5 s-w-5" : "-s-mt-1.5 s-h-4 s-w-4"
-        )}
+        className={cn("s-group", size === "sm" ? "s-h-5 s-w-5" : "s-h-4 s-w-4")}
       >
         {tooltipMessage ? (
           <Tooltip

--- a/sparkle/src/components/Tabs.tsx
+++ b/sparkle/src/components/Tabs.tsx
@@ -40,7 +40,7 @@ const TabsTrigger = React.forwardRef<
     tooltip?: string;
     icon?: React.ComponentType;
     isLoading?: boolean;
-    buttonVariant?: React.ComponentProps<typeof Button>["variant"]
+    buttonVariant?: React.ComponentProps<typeof Button>["variant"];
   } & Omit<LinkWrapperProps, "children" | "className">
 >(
   (

--- a/sparkle/src/stories/RadioGroup.stories.tsx
+++ b/sparkle/src/stories/RadioGroup.stories.tsx
@@ -77,8 +77,8 @@ export const RadioGroupWithChildrenExample = () => {
         onValueChange={(value) => setSelectedChoice(value)}
       >
         {choices.map((choice) => (
-          <RadioGroupChoice value={choice.id}>
-            <div className="s-flex s-items-center s-gap-2 s-p-2">
+          <RadioGroupChoice value={choice.id} iconPosition="start">
+            <div className="s-flex s-items-center s-gap-2 s-border s-border-red-500 s-p-2">
               <Icon visual={LockIcon} />
               <Label>{choice.label}</Label>
               <Button label="Click me" />


### PR DESCRIPTION
## Description

This PR aims at fixing the alignment of the indicator within the radio button.

Now:
<img width="197" alt="Screenshot 2024-11-09 at 08 30 23" src="https://github.com/user-attachments/assets/d9273011-75b5-4c4c-841e-a946c3441a51">

Before:
<img width="185" alt="Screenshot 2024-11-09 at 08 30 43" src="https://github.com/user-attachments/assets/70a3c593-cf44-4758-8941-40b2eb230f09">

## Risk

Low

## Deploy Plan

Publish sparkle