### PR TITLE
Extension: Proper login screen + polish

### DIFF
--- a/extension/app/src/css/custom.css
+++ b/extension/app/src/css/custom.css
@@ -1,4 +1,4 @@
 body {
   font-family: darkmode-off-cc, sans-serif;
-  font-size: 14px !important;
+  font-size: 14px;
 }

--- a/extension/app/src/css/custom.css
+++ b/extension/app/src/css/custom.css
@@ -1,4 +1,4 @@
 body {
   font-family: darkmode-off-cc, sans-serif;
-  font-size: 100%;
+  font-size: 14px !important;
 }

--- a/extension/app/src/pages/ConversationsPage.tsx
+++ b/extension/app/src/pages/ConversationsPage.tsx
@@ -6,6 +6,7 @@ import {
   NavigationList,
   NavigationListItem,
   NavigationListLabel,
+  Spinner,
 } from "@dust-tt/sparkle";
 import type { ProtectedRouteChildrenProps } from "@extension/components/auth/ProtectedRoute";
 import { useConversations } from "@extension/components/conversation/useConversations";
@@ -24,7 +25,15 @@ export const ConversationsPage = ({
   workspace,
 }: ProtectedRouteChildrenProps) => {
   const navigate = useNavigate();
-  const conversations = useConversations();
+  const { conversations, isConversationsLoading } = useConversations();
+
+  if (isConversationsLoading) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
 
   const groupConversationsByDate = (
     conversations: ConversationWithoutContentPublicType[]
@@ -64,8 +73,8 @@ export const ConversationsPage = ({
     return groups;
   };
 
-  const conversationsByDate = conversations.conversations.length
-    ? groupConversationsByDate(conversations.conversations)
+  const conversationsByDate = conversations.length
+    ? groupConversationsByDate(conversations)
     : ({} as Record<GroupLabel, ConversationWithoutContentPublicType[]>);
 
   return (

--- a/extension/app/src/pages/LoginPage.tsx
+++ b/extension/app/src/pages/LoginPage.tsx
@@ -1,14 +1,18 @@
 import {
   Button,
+  ChevronDownIcon,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
   LoginIcon,
+  LogoHorizontalColorLogo,
+  Page,
+  Spinner,
 } from "@dust-tt/sparkle";
 import { useAuth } from "@extension/components/auth/AuthProvider";
 import { useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 export const LoginPage = () => {
   const navigate = useNavigate();
@@ -27,22 +31,64 @@ export const LoginPage = () => {
     }
   }, [navigate, user, isAuthenticated, isUserSetup]);
 
-  return (
-    <div className="flex h-screen flex-col gap-2 p-4">
-      <div className="flex h-full w-full items-center justify-center">
-        {!isAuthenticated && (
-          <Button
-            icon={LoginIcon}
-            variant="primary"
-            label="Sign in"
-            onClick={handleLogin}
-            disabled={isLoading}
-          />
-        )}
-        {isAuthenticated && !isUserSetup && user?.workspaces.length && (
+  const PRIVACY_POLICY_URL =
+    "https://dust-tt.notion.site/Website-Privacy-Policy-a118bb3472f945a1be8e11fbfb733084";
+  const TERMS_OF_USE_URL =
+    "https://dust-tt.notion.site/Website-Terms-of-Use-ff8665f52c454e0daf02195ec0d6bafb";
+
+  if (isLoading) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <div className="flex h-screen flex-col p-4">
+        <div className="flex flex-1 flex-col items-center justify-center gap-8">
+          <div className="flex flex-col items-center text-center space-y-4">
+            <LogoHorizontalColorLogo className="h-6 w-24" />
+            <Page.Header title="Get more done, faster, with the power of your assistants at your fingertips." />
+          </div>
+          <div className="text-center">
+            <Button
+              icon={LoginIcon}
+              variant="primary"
+              label="Sign in"
+              onClick={handleLogin}
+              disabled={isLoading}
+            />
+          </div>
+        </div>
+        <p className="text-center text-element-700">
+          By logging in, you agree to Dust's{" "}
+          <Link to={TERMS_OF_USE_URL} target="_blank" className="underline">
+            Terms of Use
+          </Link>{" "}
+          and{" "}
+          <Link to={PRIVACY_POLICY_URL} target="_blank" className="underline">
+            Privacy Policy
+          </Link>
+          .
+        </p>
+      </div>
+    );
+  }
+
+  if (isAuthenticated && !isUserSetup && user?.workspaces.length) {
+    return (
+      <div className="flex h-screen flex-col gap-2 p-4">
+        <div className="flex h-full w-full flex-col items-center justify-center gap-4 text-center">
+          <Page.Header title="Almost there" />
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button label="Select workspace" variant="ghost" />
+              <Button
+                label="Pick a workspace"
+                variant="outline"
+                icon={ChevronDownIcon}
+              />
             </DropdownMenuTrigger>
             <DropdownMenuContent>
               {user.workspaces.map((w) => {
@@ -56,8 +102,15 @@ export const LoginPage = () => {
               })}
             </DropdownMenuContent>
           </DropdownMenu>
-        )}
+        </div>
       </div>
+    );
+  }
+
+  // Should never happen.
+  return (
+    <div className="flex h-screen items-center justify-center text-center">
+      <Page.SectionHeader title="Something unexpected occured, please contact us at team@dust.tt!" />
     </div>
   );
 };

--- a/extension/app/src/pages/MainPage.tsx
+++ b/extension/app/src/pages/MainPage.tsx
@@ -1,11 +1,9 @@
 import {
   Avatar,
-  Button,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-  ExternalLinkIcon,
   LogoHorizontalColorLogo,
   LogoutIcon,
 } from "@dust-tt/sparkle";
@@ -27,12 +25,6 @@ export const MainPage = ({
           <Link to="https://dust.tt" target="_blank">
             <LogoHorizontalColorLogo className="h-4 w-16" />
           </Link>
-          <Button
-            icon={ExternalLinkIcon}
-            variant="ghost"
-            href="https://dust.tt"
-            target="_blank"
-          />
         </div>
         <div className="flex items-center gap-2">
           <ConversationsListButton size="md" />

--- a/front/components/home/menu/config.ts
+++ b/front/components/home/menu/config.ts
@@ -57,6 +57,7 @@ const AboutMenuConfig: MenuConfig = {
   ],
 };
 
+// If you change this, make sure to update the links in the extension as well.
 const LegalMenuConfig: MenuConfig = {
   title: "Legal",
   items: [


### PR DESCRIPTION
## Description

- Styling of login screen following Figma (login button + screen to select workspace). 
- Set font size to 14px (instead of 16px). 
- Add loader screens in multiple screens. 
- Remove external link icon from main screen. 

<kbd>
<img width="474" alt="Screenshot 2024-11-09 at 11 09 29" src="https://github.com/user-attachments/assets/cd5004bc-c2a1-4748-b370-24f11efd9ed9">
</kbd>
<kbd>
<img width="474" alt="Screenshot 2024-11-09 at 11 09 43" src="https://github.com/user-attachments/assets/3f542b42-dfd0-4247-be1a-2f00d8e477f9">
</kbd>

## Risk

Extension code only. 

## Deploy Plan

No deploy
