### PR TITLE
Extension: reset convo context for new after posting a new convo

### DIFF
--- a/extension/app/src/components/conversation/ConversationContainer.tsx
+++ b/extension/app/src/components/conversation/ConversationContainer.tsx
@@ -23,7 +23,7 @@ import { getRandomGreetingForName } from "@extension/lib/greetings";
 import type { StoredUser } from "@extension/lib/storage";
 import {
   getConversationContext,
-  setConversationContext,
+  setConversationsContext,
 } from "@extension/lib/storage";
 import { useCallback, useContext, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -49,9 +49,10 @@ export function ConversationContainer({
     if (includeContent === undefined) {
       return;
     }
-
-    void setConversationContext(activeConversationId ?? "new", {
-      includeCurrentPage: includeContent,
+    void setConversationsContext({
+      [activeConversationId ?? "new"]: {
+        includeCurrentPage: includeContent,
+      },
     });
   }, [includeContent]);
 
@@ -181,8 +182,11 @@ export function ConversationContainer({
             });
           }
         } else {
-          await setConversationContext(conversationRes.value.sId, {
-            includeCurrentPage: !!includeContent,
+          await setConversationsContext({
+            [conversationRes.value.sId]: {
+              includeCurrentPage: !!includeContent,
+            },
+            new: { includeCurrentPage: false },
           });
           setActiveConversationId(conversationRes.value.sId);
         }

--- a/extension/app/src/lib/storage.ts
+++ b/extension/app/src/lib/storage.ts
@@ -68,6 +68,7 @@ export const setConversationsContext = async (
   const result = await chrome.storage.local.get(["conversationContext"]);
   const v = result.conversationContext ?? {};
   Object.assign(v, conversationsWithContext);
+  await chrome.storage.local.set({ conversationContext: v });
 };
 
 /**

--- a/extension/app/src/lib/storage.ts
+++ b/extension/app/src/lib/storage.ts
@@ -62,14 +62,12 @@ export const getConversationContext = async (
   return conversationContext[conversationId] ?? { includeCurrentPage: false };
 };
 
-export const setConversationContext = async (
-  conversationId: string,
-  context: ConversationContext
-): Promise<void> => {
+export const setConversationsContext = async (
+  conversationsWithContext: Record<string, ConversationContext>
+) => {
   const result = await chrome.storage.local.get(["conversationContext"]);
   const v = result.conversationContext ?? {};
-  v[conversationId] = context;
-  await chrome.storage.local.set({ conversationContext: v });
+  Object.assign(v, conversationsWithContext);
 };
 
 /**


### PR DESCRIPTION
## Description

If I share tab content for a new convo, we set "new" -> includeCurrentPage = true. 
When I post my convo we set this state for the id of this convo, but we forgot to reset the state for new. 

So the change is: when posting a new convo, we also reset the state for new. 

## Risk

Only in extension. 

## Deploy Plan

No deploy. 
