### PR TITLE
[front] - fix: conditionally display select all button in ContentNodeTree

### DIFF
--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -280,12 +280,12 @@ function ContentNodeTreeChildren({
               />
             </div>
 
-            <div className="p-1">
+            {search.trim().length > 0 && (
               <Button
-                disabled={search.trim().length === 0}
                 icon={ListCheckIcon}
                 label={selectAllClicked ? "Unselect All" : "Select All"}
                 size="sm"
+                className="m-1"
                 variant="ghost"
                 onClick={() => {
                   const isSelected = !selectAllClicked;
@@ -303,7 +303,7 @@ function ContentNodeTreeChildren({
                   });
                 }}
               />
-            </div>
+            )}
           </div>
         </>
       )}


### PR DESCRIPTION
## Description

This PR only show 'Select All' button when there is a non-empty search query to avoid user confusion and interaction with an unnecessary button

**References:**
- [Slack thread](https://dustcommunity.slack.com/archives/C06SHT0F20G/p1731350455898829)

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
