### PR TITLE
Chrome extension: Force update

### DIFF
--- a/extension/app/background.ts
+++ b/extension/app/background.ts
@@ -1,3 +1,6 @@
+import type { PendingUpdate } from "@extension/lib/storage";
+import { savePendingUpdate } from "@extension/lib/storage";
+
 import {
   AUTH0_AUDIENCE,
   AUTH0_CLIENT_DOMAIN,
@@ -13,6 +16,17 @@ import type {
 import { generatePKCE } from "./src/lib/utils";
 
 const log = console.error;
+
+/**
+ * Listener for force update mechanism.
+ */
+chrome.runtime.onUpdateAvailable.addListener(async (details) => {
+  const pendingUpdate: PendingUpdate = {
+    version: details.version,
+    detectedAt: Date.now(),
+  };
+  await savePendingUpdate(pendingUpdate);
+});
 
 /**
  * Listener to open/close the side panel when the user clicks on the extension icon.

--- a/extension/app/src/components/auth/ProtectedRoute.tsx
+++ b/extension/app/src/components/auth/ProtectedRoute.tsx
@@ -1,4 +1,9 @@
-import { Button, Page, Spinner } from "@dust-tt/sparkle";
+import {
+  Button,
+  LogoHorizontalColorLogo,
+  Page,
+  Spinner,
+} from "@dust-tt/sparkle";
 import type { LightWorkspaceType } from "@dust-tt/types";
 import { useAuth } from "@extension/components/auth/AuthProvider";
 import type { StoredUser } from "@extension/lib/storage";
@@ -71,7 +76,11 @@ export const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
     return (
       <div className="flex h-screen flex-col gap-2 p-4">
         <div className="flex h-full w-full flex-col items-center justify-center gap-4 text-center">
-          <Page.SectionHeader title="The extension will update and you'll need to click the extension icon to reopen the panel." />
+          <div className="flex flex-col items-center text-center space-y-4">
+            <LogoHorizontalColorLogo className="h-6 w-24" />
+            <Page.Header title="Update required" />
+          </div>
+          <Page.SectionHeader title="Panel closes after update. Click Dust icon in toolbar to return." />
           <Button
             label="Update now"
             onClick={async () => {

--- a/extension/app/src/components/conversation/AgentMessage.tsx
+++ b/extension/app/src/components/conversation/AgentMessage.tsx
@@ -8,7 +8,6 @@ import type {
   AgentMessagePublicType,
   AgentMessageSuccessEvent,
   GenerationTokensEvent,
-  HeartbeatEvent,
   LightWorkspaceType,
   RetrievalActionPublicType,
   RetrievalDocumentPublicType,

--- a/extension/app/src/css/custom.css
+++ b/extension/app/src/css/custom.css
@@ -1,4 +1,8 @@
+html {
+  font-size: 14px;
+}
+
 body {
   font-family: darkmode-off-cc, sans-serif;
-  font-size: 14px;
+  font-size: 100%;
 }

--- a/extension/app/src/lib/storage.ts
+++ b/extension/app/src/lib/storage.ts
@@ -106,6 +106,25 @@ export const getStoredUser = async (): Promise<StoredUser | null> => {
 };
 
 /**
+ * Store version for force update.
+ */
+
+export type PendingUpdate = {
+  version: string;
+  detectedAt: number;
+};
+export const savePendingUpdate = async (
+  pendingUpdate: PendingUpdate
+): Promise<PendingUpdate> => {
+  await chrome.storage.local.set({ pendingUpdate });
+  return pendingUpdate;
+};
+export const getPendingUpdate = async (): Promise<PendingUpdate | null> => {
+  const result = await chrome.storage.local.get(["pendingUpdate"]);
+  return result.pendingUpdate ?? null;
+};
+
+/**
  * Clear all stored data.
  */
 


### PR DESCRIPTION
## Description

Basic mechanism to force update the extension. 

-> I read some docs and it seems Chrome Web is supposed to update the extension after they are published, so technically we don't need all that. Yet from past experiences when users are stuck on a previous extension it can be a real pain. 
-> When there's a new version we store it on the local storage. On the `ProtectedRoute` wrapper, we check if there's a version on storage that it's not > to our current version. If it is we display a button to update the extension. Only annoying thing is that updating the extension will close the panel. 

## Risk

Code of extension only. 

## Deploy Plan

No deploy. 
