### PR TITLE
Fix content nodes sorting take 2

### DIFF
--- a/connectors/src/api/get_content_nodes.ts
+++ b/connectors/src/api/get_content_nodes.ts
@@ -4,7 +4,7 @@ import type {
   Result,
   WithConnectorsAPIErrorReponse,
 } from "@dust-tt/types";
-import { removeNulls } from "@dust-tt/types";
+import { contentNodeTypeSortOrder, removeNulls } from "@dust-tt/types";
 import type { Request, Response } from "express";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -92,7 +92,7 @@ const _getContentNodes = async (
 
   const contentNodes = sortBy(
     removeNulls(internalIds.map((internalId) => contentNodesMap[internalId])),
-    (e) => e.title.toLowerCase()
+    (c) => [contentNodeTypeSortOrder[c.type], c.title.toLowerCase()]
   );
 
   if (includeParents) {

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -55,6 +55,11 @@ export type ConnectorType = {
 export type ConnectorPermission = "read" | "write" | "read_write" | "none";
 export type ContentNodeType = "file" | "folder" | "database" | "channel";
 
+/*
+ * This constant defines the priority order for sorting content nodes by their type.
+ * The types are sorted in the following order: folder first, then file, database, and channel.
+ * This mapping is used to provide a numerical value representing the priority of each content node type.
+ */
 export const contentNodeTypeSortOrder: Record<ContentNodeType, number> = {
   folder: 1,
   file: 2,

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -55,6 +55,13 @@ export type ConnectorType = {
 export type ConnectorPermission = "read" | "write" | "read_write" | "none";
 export type ContentNodeType = "file" | "folder" | "database" | "channel";
 
+export const contentNodeTypeSortOrder: Record<ContentNodeType, number> = {
+  folder: 1,
+  file: 2,
+  database: 3,
+  channel: 4,
+};
+
 /**
  * A ContentNode represents a connector related node. As an example:
  * - Notion: Top-level pages (possibly manually added lower level ones)


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Take 2️⃣ of https://github.com/dust-tt/dust/pull/8580.

Oversaw that some connectors were implementing their own sorting. This PR standardize sorting for all connectors.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
