### PR TITLE
Front: Fix View in link in datasource view

### DIFF
--- a/front/components/spaces/ContentActions.tsx
+++ b/front/components/spaces/ContentActions.tsx
@@ -266,11 +266,12 @@ const makeViewSourceUrlContentAction = (
   return {
     label,
     icon: ExternalLinkIcon,
-    link: contentNode.sourceUrl
-      ? { href: contentNode.sourceUrl, target: "_blank" }
-      : undefined,
     disabled: contentNode.sourceUrl === null,
-    onClick: () => {},
+    onClick: () => {
+      if (contentNode.sourceUrl) {
+        window.open(contentNode.sourceUrl, "_blank");
+      }
+    },
   };
 };
 


### PR DESCRIPTION
## Description

Card: https://github.com/dust-tt/tasks/issues/1632

This is the link "View in [notion]" when navigating in datasource views. 
The link was not working, I'm using the onClick instead (that's what we do elsewhere).

## Risk

Tested locally, can be rolled back. 

## Deploy Plan

Deploy front. 
