### PR TITLE
[front] - fix(poke): update IconButton variant from ghost to outline

### DIFF
--- a/front/components/poke/assistants/columns.tsx
+++ b/front/components/poke/assistants/columns.tsx
@@ -37,7 +37,7 @@ export function makeColumnsForAssistants(
           <div className="flex space-x-2">
             <p>Id</p>
             <IconButton
-              variant="ghost"
+              variant="outline"
               icon={ArrowsUpDownIcon}
               onClick={() =>
                 column.toggleSorting(column.getIsSorted() === "asc")
@@ -54,7 +54,7 @@ export function makeColumnsForAssistants(
           <div className="flex space-x-2">
             <p>Name</p>
             <IconButton
-              variant="ghost"
+              variant="outline"
               icon={ArrowsUpDownIcon}
               onClick={() =>
                 column.toggleSorting(column.getIsSorted() === "asc")
@@ -96,7 +96,7 @@ export function makeColumnsForAssistants(
               assistant.status !== "archived" ? TrashIcon : EmotionLaughIcon
             }
             size="xs"
-            variant="ghost"
+            variant="outline"
             onClick={async () => {
               await (assistant.status !== "archived"
                 ? archiveAssistant(owner, reload, assistant)

--- a/front/components/poke/data_source_views/columns.tsx
+++ b/front/components/poke/data_source_views/columns.tsx
@@ -29,7 +29,7 @@ export function makeColumnsForDataSourceViews(): ColumnDef<DataSourceView>[] {
           <div className="flex space-x-2">
             <p>sId</p>
             <IconButton
-              variant="ghost"
+              variant="outline"
               icon={ArrowsUpDownIcon}
               onClick={() =>
                 column.toggleSorting(column.getIsSorted() === "asc")
@@ -51,7 +51,7 @@ export function makeColumnsForDataSourceViews(): ColumnDef<DataSourceView>[] {
           <div className="flex space-x-2">
             <p>Data Source</p>
             <IconButton
-              variant="ghost"
+              variant="outline"
               icon={ArrowsUpDownIcon}
               onClick={() =>
                 column.toggleSorting(column.getIsSorted() === "asc")

--- a/front/components/poke/data_sources/columns.tsx
+++ b/front/components/poke/data_sources/columns.tsx
@@ -36,7 +36,7 @@ export function makeColumnsForDataSources(
           <div className="flex space-x-2">
             <p>sId</p>
             <IconButton
-              variant="ghost"
+              variant="outline"
               icon={ArrowsUpDownIcon}
               onClick={() =>
                 column.toggleSorting(column.getIsSorted() === "asc")
@@ -53,7 +53,7 @@ export function makeColumnsForDataSources(
           <div className="flex space-x-2">
             <p>Name</p>
             <IconButton
-              variant="ghost"
+              variant="outline"
               icon={ArrowsUpDownIcon}
               onClick={() =>
                 column.toggleSorting(column.getIsSorted() === "asc")

--- a/front/components/poke/features/columns.tsx
+++ b/front/components/poke/features/columns.tsx
@@ -22,7 +22,7 @@ export function makeColumnsForFeatureFlags(
           <div className="flex space-x-2">
             <p>Name</p>
             <IconButton
-              variant="ghost"
+              variant="outline"
               icon={ArrowsUpDownIcon}
               onClick={() =>
                 column.toggleSorting(column.getIsSorted() === "asc")

--- a/front/components/poke/invitations/columns.tsx
+++ b/front/components/poke/invitations/columns.tsx
@@ -32,6 +32,7 @@ export function makeColumnsForInvitations(
             &nbsp;
             <IconButton
               icon={ClipboardIcon}
+              variant="outline"
               tooltip="Copy invite link to clipboard"
               size="xs"
               onClick={() =>
@@ -74,7 +75,7 @@ export function makeColumnsForInvitations(
           <IconButton
             icon={TrashIcon}
             size="xs"
-            variant="ghost"
+            variant="outline"
             onClick={async () => {
               await onRevokeInvitation(invitation.inviteEmail);
             }}

--- a/front/components/poke/members/columns.tsx
+++ b/front/components/poke/members/columns.tsx
@@ -33,7 +33,7 @@ export function makeColumnsForMembers({
           <div className="flex space-x-2">
             <p>Id</p>
             <IconButton
-              variant="ghost"
+              variant="outline"
               icon={ArrowsUpDownIcon}
               onClick={() =>
                 column.toggleSorting(column.getIsSorted() === "asc")
@@ -50,7 +50,7 @@ export function makeColumnsForMembers({
           <div className="flex space-x-2">
             <p>Name</p>
             <IconButton
-              variant="ghost"
+              variant="outline"
               icon={ArrowsUpDownIcon}
               onClick={() =>
                 column.toggleSorting(column.getIsSorted() === "asc")
@@ -88,7 +88,7 @@ export function makeColumnsForMembers({
           <div className="flex space-x-2">
             <p>Role</p>
             <IconButton
-              variant="ghost"
+              variant="outline"
               icon={ArrowsUpDownIcon}
               onClick={() =>
                 column.toggleSorting(column.getIsSorted() === "asc")
@@ -134,7 +134,7 @@ export function makeColumnsForMembers({
           <IconButton
             icon={TrashIcon}
             size="xs"
-            variant="ghost"
+            variant="outline"
             onClick={async () => {
               await onRevokeMember(member);
             }}


### PR DESCRIPTION
## Description

This PR aims at fixing the styles of the `IconButton` used in poke from "ghost" to "outline" to make them more visible

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
