### PR TITLE
[sparkle] Add split button

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.304",
+  "version": "0.2.305",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.304",
+      "version": "0.2.305",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.304",
+  "version": "0.2.305",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -26,7 +26,7 @@ export type ButtonVariantType = (typeof BUTTON_VARIANTS)[number];
 
 export const BUTTON_SIZES = ["xs", "sm", "md"] as const;
 
-type ButtonSizeType = (typeof BUTTON_SIZES)[number];
+export type ButtonSizeType = (typeof BUTTON_SIZES)[number];
 
 const styleVariants: Record<ButtonVariantType, string> = {
   primary:

--- a/sparkle/src/components/SplitButton.tsx
+++ b/sparkle/src/components/SplitButton.tsx
@@ -27,22 +27,25 @@ const separatorVariants = cva("s--ml-[1px]", {
     size: separatorSizeVariants,
   },
 });
-type LabelProps = {
+
+interface SplitButtonActionProps {
   label: string;
   icon?: React.ComponentType;
   tooltip?: string;
   disabled?: boolean;
   onClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
-};
-type SplitButtonProps = MetaButtonProps & {
-  values: LabelProps[];
-};
+}
+
+export interface SplitButtonProps extends Omit<MetaButtonProps, "children"> {
+  actions: SplitButtonActionProps[];
+  defaultAction: SplitButtonActionProps;
+}
 
 export const SplitButton = React.forwardRef<
   HTMLButtonElement,
   SplitButtonProps
->(({ values, className, size, variant, disabled, ...props }, ref) => {
-  const [current, setCurrent] = useState(values[0]);
+>(({ actions, className, size, variant, disabled, ...props }, ref) => {
+  const [current, setCurrent] = useState(props.defaultAction);
   return (
     <div className="s-flex s-items-center">
       <Button
@@ -51,7 +54,7 @@ export const SplitButton = React.forwardRef<
         variant={variant}
         label={current.label}
         icon={current.icon}
-        disabled={disabled}
+        disabled={disabled || current.disabled}
         onClick={(e) => current.onClick && current.onClick(e)}
         ref={ref}
         className={cn("s-rounded-r-none s-border-r-0", className)}
@@ -71,13 +74,13 @@ export const SplitButton = React.forwardRef<
           />
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          {values.map((value, index) => (
+          {actions.map((action, index) => (
             <DropdownMenuItem
               key={index}
-              label={value.label}
-              icon={value.icon}
-              disabled={value.disabled}
-              onClick={() => setCurrent(value)}
+              label={action.label}
+              icon={action.icon}
+              disabled={action.disabled}
+              onClick={() => setCurrent(action)}
             />
           ))}
         </DropdownMenuContent>

--- a/sparkle/src/components/SplitButton.tsx
+++ b/sparkle/src/components/SplitButton.tsx
@@ -1,0 +1,87 @@
+import { cva } from "class-variance-authority";
+import React, { useState } from "react";
+
+import {
+  Button,
+  ButtonSizeType,
+  MetaButtonProps,
+} from "@sparkle/components/Button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@sparkle/components/Dropdown";
+import { Separator } from "@sparkle/components/Separator";
+import { ChevronDownIcon } from "@sparkle/icons";
+import { cn } from "@sparkle/lib";
+
+const separatorSizeVariants: Record<ButtonSizeType, string> = {
+  xs: "s-h-3",
+  sm: "s-h-5",
+  md: "s-h-7",
+};
+
+const separatorVariants = cva("s--ml-[1px]", {
+  variants: {
+    size: separatorSizeVariants,
+  },
+});
+type LabelProps = {
+  label: string;
+  icon?: React.ComponentType;
+  tooltip?: string;
+  disabled?: boolean;
+  onClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+};
+type SplitButtonProps = MetaButtonProps & {
+  values: LabelProps[];
+};
+
+export const SplitButton = React.forwardRef<
+  HTMLButtonElement,
+  SplitButtonProps
+>(({ values, className, size, variant, disabled, ...props }, ref) => {
+  const [current, setCurrent] = useState(values[0]);
+  return (
+    <div className="s-flex s-items-center">
+      <Button
+        {...props}
+        size={size}
+        variant={variant}
+        label={current.label}
+        icon={current.icon}
+        disabled={disabled}
+        onClick={(e) => current.onClick && current.onClick(e)}
+        ref={ref}
+        className={cn("s-rounded-r-none s-border-r-0", className)}
+      />
+      <div className={separatorVariants({ size })}>
+        <Separator orientation="vertical" />
+      </div>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            {...props}
+            size={size}
+            variant={variant}
+            icon={ChevronDownIcon}
+            disabled={disabled}
+            className={cn("s-rounded-l-none s-border-l-0", className)}
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          {values.map((value, index) => (
+            <DropdownMenuItem
+              key={index}
+              label={value.label}
+              icon={value.icon}
+              disabled={value.disabled}
+              onClick={() => setCurrent(value)}
+            />
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+});

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -93,6 +93,7 @@ export { Searchbar } from "./Searchbar";
 export { Separator } from "./Separator";
 export { SliderToggle } from "./SliderToggle";
 export { default as Spinner } from "./Spinner";
+export { SplitButton } from "./SplitButton";
 export { Tabs, TabsContent, TabsList, TabsTrigger } from "./Tabs";
 export { TextArea } from "./TextArea";
 export {

--- a/sparkle/src/stories/SplitButton.stories.tsx
+++ b/sparkle/src/stories/SplitButton.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+
+import { BUTTON_SIZES, BUTTON_VARIANTS } from "@sparkle/components/Button";
+
+import { PlusIcon, RobotIcon, SplitButton } from "../index_with_tw_base";
+
+const meta = {
+  title: "Primitives/SplitButton",
+  component: SplitButton,
+  argTypes: {
+    variant: {
+      description: "The visual style variant of the button",
+      options: BUTTON_VARIANTS,
+      control: { type: "select" },
+    },
+    size: {
+      description: "The size of the button",
+      options: BUTTON_SIZES,
+      control: { type: "select" },
+    },
+  },
+} satisfies Meta<React.ComponentProps<typeof SplitButton>>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ExampleButton: Story = {
+  args: {
+    variant: "outline",
+    size: "md",
+    values: [
+      {
+        label: "First",
+        icon: PlusIcon,
+        tooltip: "First tooltip",
+        disabled: true,
+      },
+      {
+        label: "Second",
+        icon: RobotIcon,
+        tooltip: "Second tooltip",
+      },
+      {
+        label: "Third",
+        icon: PlusIcon,
+        tooltip: "Third tooltip",
+      },
+    ],
+  },
+};

--- a/sparkle/src/stories/SplitButton.stories.tsx
+++ b/sparkle/src/stories/SplitButton.stories.tsx
@@ -5,7 +5,7 @@ import { BUTTON_SIZES, BUTTON_VARIANTS } from "@sparkle/components/Button";
 
 import { PlusIcon, RobotIcon, SplitButton } from "../index_with_tw_base";
 
-const meta = {
+const meta: Meta<React.ComponentProps<typeof SplitButton>> = {
   title: "Primitives/SplitButton",
   component: SplitButton,
   argTypes: {
@@ -20,7 +20,7 @@ const meta = {
       control: { type: "select" },
     },
   },
-} satisfies Meta<React.ComponentProps<typeof SplitButton>>;
+};
 
 export default meta;
 type Story = StoryObj<typeof meta>;
@@ -29,17 +29,22 @@ export const ExampleButton: Story = {
   args: {
     variant: "outline",
     size: "md",
-    values: [
+    defaultAction: {
+      label: "First",
+      icon: PlusIcon,
+      tooltip: "First tooltip",
+    },
+    actions: [
       {
         label: "First",
         icon: PlusIcon,
         tooltip: "First tooltip",
-        disabled: true,
       },
       {
         label: "Second",
         icon: RobotIcon,
         tooltip: "Second tooltip",
+        disabled: true,
       },
       {
         label: "Third",


### PR DESCRIPTION
## Description

context : https://github.com/dust-tt/tasks/issues/1643

New split button component

<img width="150" alt="Screenshot 2024-11-13 at 07 53 34" src="https://github.com/user-attachments/assets/58cba0ed-7c4c-4d3e-a118-b52369dbce74">
<img width="114" alt="Screenshot 2024-11-13 at 07 53 24" src="https://github.com/user-attachments/assets/777e7d7e-9170-4bd7-952f-0b365432b151">
<img width="136" alt="Screenshot 2024-11-13 at 07 53 18" src="https://github.com/user-attachments/assets/8d8adb11-8b7c-4afd-a0dc-c5df79151b58">
<img width="160" alt="Screenshot 2024-11-13 at 07 53 13" src="https://github.com/user-attachments/assets/b487950d-720d-4d01-b33f-ec8c16303262">
<img width="165" alt="Screenshot 2024-11-13 at 07 53 06" src="https://github.com/user-attachments/assets/086666d3-2cad-4924-9400-688f15d04f88">
<img width="167" alt="Screenshot 2024-11-13 at 07 52 59" src="https://github.com/user-attachments/assets/569453f8-1fe6-4e1e-bc34-ec692b0636b3">

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

publish sparkle