### PR TITLE
[sparkle] Allow to control SplitButton with onActionChange/action props

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.306",
+  "version": "0.2.307",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.306",
+      "version": "0.2.307",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.306",
+  "version": "0.2.307",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/SplitButton.tsx
+++ b/sparkle/src/components/SplitButton.tsx
@@ -36,55 +36,79 @@ interface SplitButtonActionProps {
   onClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
 }
 
-export interface SplitButtonProps extends Omit<MetaButtonProps, "children"> {
+export interface SplitButtonProps
+  extends Omit<MetaButtonProps, "children" | "onClick"> {
   actions: SplitButtonActionProps[];
-  defaultAction: SplitButtonActionProps;
+  action?: SplitButtonActionProps;
+  defaultAction?: SplitButtonActionProps;
+  onActionChange?: (action: SplitButtonActionProps) => void;
 }
 
 export const SplitButton = React.forwardRef<
   HTMLButtonElement,
   SplitButtonProps
->(({ actions, className, size, variant, disabled, ...props }, ref) => {
-  const [current, setCurrent] = useState(props.defaultAction);
-  return (
-    <div className="s-flex s-items-center">
-      <Button
-        {...props}
-        size={size}
-        variant={variant}
-        label={current.label}
-        icon={current.icon}
-        disabled={disabled || current.disabled}
-        onClick={(e) => current.onClick && current.onClick(e)}
-        ref={ref}
-        className={cn("s-rounded-r-none s-border-r-0", className)}
-      />
-      <div className={separatorVariants({ size })}>
-        <Separator orientation="vertical" />
-      </div>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            {...props}
-            size={size}
-            variant={variant}
-            icon={ChevronDownIcon}
-            disabled={disabled}
-            className={cn("s-rounded-l-none s-border-l-0", className)}
-          />
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          {actions.map((action, index) => (
-            <DropdownMenuItem
-              key={index}
-              label={action.label}
-              icon={action.icon}
-              disabled={action.disabled}
-              onClick={() => setCurrent(action)}
+>(
+  (
+    {
+      actions,
+      className,
+      size,
+      variant,
+      disabled,
+      action,
+      defaultAction,
+      onActionChange,
+      ...props
+    },
+    ref
+  ) => {
+    const [localAction, setLocalAction] = useState(defaultAction ?? actions[0]);
+    const actionToUse = action ?? localAction;
+    return (
+      <div className="s-flex s-items-center">
+        <Button
+          {...props}
+          size={size}
+          variant={variant}
+          label={actionToUse?.label}
+          icon={actionToUse?.icon}
+          disabled={disabled || actionToUse?.disabled}
+          onClick={(e) => actionToUse?.onClick && actionToUse?.onClick(e)}
+          ref={ref}
+          className={cn("s-rounded-r-none s-border-r-0", className)}
+        />
+        <div className={separatorVariants({ size })}>
+          <Separator orientation="vertical" />
+        </div>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              {...props}
+              size={size}
+              variant={variant}
+              icon={ChevronDownIcon}
+              disabled={disabled}
+              className={cn("s-rounded-l-none s-border-l-0", className)}
             />
-          ))}
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </div>
-  );
-});
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {actions.map((action, index) => (
+              <DropdownMenuItem
+                key={index}
+                label={action.label}
+                icon={action.icon}
+                disabled={action.disabled}
+                onClick={() => {
+                  setLocalAction(action);
+                  if (onActionChange) {
+                    onActionChange(action);
+                  }
+                }}
+              />
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    );
+  }
+);

--- a/sparkle/src/components/SplitButton.tsx
+++ b/sparkle/src/components/SplitButton.tsx
@@ -38,9 +38,24 @@ interface SplitButtonActionProps {
 
 export interface SplitButtonProps
   extends Omit<MetaButtonProps, "children" | "onClick"> {
+  /**
+   * List of possible actions, will be displayed in dropdown
+   */
   actions: SplitButtonActionProps[];
+
+  /**
+   * Current action to use (controlled mode)
+   */
   action?: SplitButtonActionProps;
+
+  /**
+   * default action to use in uncontrolled mode. If not specified, the first action will be used.
+   */
   defaultAction?: SplitButtonActionProps;
+
+  /**
+   * Event handler for action change
+   */
   onActionChange?: (action: SplitButtonActionProps) => void;
 }
 
@@ -62,18 +77,27 @@ export const SplitButton = React.forwardRef<
     },
     ref
   ) => {
+    // If there are no actions, do not display anything
+    if (actions.length === 0) {
+      return null;
+    }
+
+    // Local state in uncontrolled mode, set to defaultAction or first action
     const [localAction, setLocalAction] = useState(defaultAction ?? actions[0]);
+
+    // Override and ignore if controlled
     const actionToUse = action ?? localAction;
+
     return (
       <div className="s-flex s-items-center">
         <Button
           {...props}
           size={size}
           variant={variant}
-          label={actionToUse?.label}
-          icon={actionToUse?.icon}
-          disabled={disabled || actionToUse?.disabled}
-          onClick={(e) => actionToUse?.onClick && actionToUse?.onClick(e)}
+          label={actionToUse.label}
+          icon={actionToUse.icon}
+          disabled={disabled || actionToUse.disabled}
+          onClick={(e) => actionToUse.onClick && actionToUse.onClick(e)}
           ref={ref}
           className={cn("s-rounded-r-none s-border-r-0", className)}
         />


### PR DESCRIPTION
## Description

- Add `onActionChange` event
- Control state with `action`

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

publish sparkle
