### PR TITLE
core: move table/index creation to an init_db script

### DIFF
--- a/.github/workflows/build-and-test-core.yml
+++ b/.github/workflows/build-and-test-core.yml
@@ -22,12 +22,12 @@ jobs:
       - name: Install Redis
         uses: zhulik/redis-action@1.1.0
         with:
-          redis version: '7.2.5'
+          redis version: "7.2.5"
 
       - name: Install Postgres
         uses: harmon758/postgresql-action@v1
         with:
-          postgresql version: '14.13'  # See https://hub.docker.com/_/postgres for available versions
+          postgresql version: "14.13" # See https://hub.docker.com/_/postgres for available versions
           postgresql db: oauth
           postgresql user: test
           postgresql password: test
@@ -46,12 +46,17 @@ jobs:
         working-directory: core
         run: cargo fmt --all -- --check
 
+      - name: Setup Tables
+        working-directory: core
+        run: cargo run --bin init_db
+        env:
+          OAUTH_DATABASE_URI: "postgres://test:test@localhost:5432/oauth"
+
       - name: Test
         working-directory: core
         run: cargo test --all
         env:
-          DISABLE_API_KEY_CHECK: 'true'
-          OAUTH_DATABASE_URI: 'postgres://test:test@localhost:5432/oauth'
-          REDIS_URI: 'redis://localhost:6379'
+          DISABLE_API_KEY_CHECK: "true"
+          OAUTH_DATABASE_URI: "postgres://test:test@localhost:5432/oauth"
+          REDIS_URI: "redis://localhost:6379"
           OAUTH_ENCRYPTION_KEY: ${{ secrets.TEST_OAUTH_ENCRYPTION_KEY }}
-

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -3,37 +3,46 @@ name = "dust"
 version = "0.1.0"
 edition = "2021"
 
+# SERVICES
+
 [[bin]]
 name = "dust-api"
 path = "bin/dust_api.rs"
-
-[[bin]]
-name = "qdrant_migrator"
-path = "bin/qdrant/migrator.rs"
-
-[[bin]]
-name = "qdrant_migrate_embedder"
-path = "bin/qdrant/migrate_embedder.rs"
-
-[[bin]]
-name = "qdrant_create_collection"
-path = "bin/qdrant/create_collection.rs"
-
-[[bin]]
-name = "qdrant_delete_orphaned_points"
-path = "bin/qdrant/delete_orphaned_points.rs"
-
-[[bin]]
-name = "sqlite-worker"
-path = "bin/sqlite_worker.rs"
 
 [[bin]]
 name = "oauth"
 path = "bin/oauth.rs"
 
 [[bin]]
-name = "oauth_generate_key"
-path = "bin/oauth_generate_key.rs"
+name = "sqlite-worker"
+path = "bin/sqlite_worker.rs"
+
+# UTILS
+
+[[bin]]
+name = "init_db"
+path = "bin/init_db.rs"
+
+[[bin]]
+name = "qdrant_create_collection"
+path = "bin/qdrant/create_collection.rs"
+
+# [[bin]]
+# name = "qdrant_migrator"
+# path = "bin/qdrant/migrator.rs"
+
+# [[bin]]
+# name = "qdrant_migrate_embedder"
+# path = "bin/qdrant/migrate_embedder.rs"
+
+# [[bin]]
+# name = "qdrant_delete_orphaned_points"
+# path = "bin/qdrant/delete_orphaned_points.rs"
+
+
+# [[bin]]
+# name = "oauth_generate_key"
+# path = "bin/oauth_generate_key.rs"
 
 [[test]]
 name = "oauth_connections_test"

--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -41,7 +41,7 @@ use dust::{
         database::{execute_query, QueryDatabaseError},
         table::{LocalTable, Row, Table},
     },
-    databases_store::store::{self as databases_store, DatabasesStore},
+    databases_store::store::{self as databases_store},
     dataset,
     deno::js_executor::JSExecutor,
     project,
@@ -2925,7 +2925,6 @@ fn main() {
         let store: Box<dyn store::Store + Sync + Send> = match std::env::var("CORE_DATABASE_URI") {
             Ok(db_uri) => {
                 let store = postgres::PostgresStore::new(&db_uri).await?;
-                store.init().await?;
                 Box::new(store)
             }
             Err(_) => Err(anyhow!("CORE_DATABASE_URI is required (postgres)"))?,
@@ -2934,7 +2933,6 @@ fn main() {
             match std::env::var("DATABASES_STORE_DATABASE_URI") {
                 Ok(db_uri) => {
                     let s = databases_store::PostgresDatabasesStore::new(&db_uri).await?;
-                    s.init().await?;
                     Box::new(s)
                 }
                 Err(_) => Err(anyhow!("DATABASES_STORE_DATABASE_URI not set."))?,

--- a/core/bin/init_db.rs
+++ b/core/bin/init_db.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use dust::{
     databases_store::store::PostgresDatabasesStore, oauth::store::PostgresOAuthStore,
     stores::postgres::PostgresStore,

--- a/core/bin/init_db.rs
+++ b/core/bin/init_db.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<(), anyhow::Error> {
             let s = PostgresStore::new(&db_uri).await?;
             s.init().await?;
         }
-        Err(_) => Err(anyhow!("CORE_DATABASE_URI is required (postgres)"))?,
+        Err(_) => print!("CORE_DATABASE_URI not set. Tables not initialized."),
     };
 
     match std::env::var("OAUTH_DATABASE_URI") {
@@ -20,14 +20,14 @@ async fn main() -> Result<(), anyhow::Error> {
             let s = PostgresOAuthStore::new(&db_uri).await?;
             s.init().await?;
         }
-        Err(_) => Err(anyhow!("OAUTH_DATABASE_URI not set."))?,
+        Err(_) => println!("OAUTH_DATABASE_URI not set. Tables not initialized."),
     };
     match std::env::var("DATABASES_STORE_DATABASE_URI") {
         Ok(db_uri) => {
             let s = PostgresDatabasesStore::new(&db_uri).await?;
             s.init().await?;
         }
-        Err(_) => Err(anyhow!("DATABASES_STORE_DATABASE_URI not set."))?,
+        Err(_) => println!("DATABASES_STORE_DATABASE_URI not set. Tables not initialized."),
     };
 
     Ok(())

--- a/core/bin/init_db.rs
+++ b/core/bin/init_db.rs
@@ -1,0 +1,34 @@
+use anyhow::{anyhow, Result};
+use dust::{
+    databases_store::store::PostgresDatabasesStore, oauth::store::PostgresOAuthStore,
+    stores::postgres::PostgresStore,
+};
+use tokio;
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    match std::env::var("CORE_DATABASE_URI") {
+        Ok(db_uri) => {
+            let s = PostgresStore::new(&db_uri).await?;
+            s.init().await?;
+        }
+        Err(_) => Err(anyhow!("CORE_DATABASE_URI is required (postgres)"))?,
+    };
+
+    match std::env::var("OAUTH_DATABASE_URI") {
+        Ok(db_uri) => {
+            let s = PostgresOAuthStore::new(&db_uri).await?;
+            s.init().await?;
+        }
+        Err(_) => Err(anyhow!("OAUTH_DATABASE_URI not set."))?,
+    };
+    match std::env::var("DATABASES_STORE_DATABASE_URI") {
+        Ok(db_uri) => {
+            let s = PostgresDatabasesStore::new(&db_uri).await?;
+            s.init().await?;
+        }
+        Err(_) => Err(anyhow!("DATABASES_STORE_DATABASE_URI not set."))?,
+    };
+
+    Ok(())
+}

--- a/core/bin/sqlite_worker.rs
+++ b/core/bin/sqlite_worker.rs
@@ -319,7 +319,6 @@ fn main() {
 
         let s = databases_store::store::PostgresDatabasesStore::new(&DATABASES_STORE_DATABASE_URI)
             .await?;
-        s.init().await?;
         let databases_store = Box::new(s);
 
         let state = Arc::new(WorkerState::new(databases_store));

--- a/core/bin/sqlite_worker.rs
+++ b/core/bin/sqlite_worker.rs
@@ -7,7 +7,7 @@ use axum::{
 };
 use dust::{
     databases::table::{LocalTable, Table},
-    databases_store::{self, store::DatabasesStore},
+    databases_store::{self},
     sqlite_workers::sqlite_database::{SqliteDatabase, SqliteDatabaseError},
     utils::{error_response, APIResponse, CoreRequestMakeSpan},
 };

--- a/core/src/databases_store/store.rs
+++ b/core/src/databases_store/store.rs
@@ -10,7 +10,6 @@ use crate::{databases::table::Row, utils};
 
 #[async_trait]
 pub trait DatabasesStore {
-    async fn init(&self) -> Result<()>;
     async fn load_table_row(&self, table_id: &str, row_id: &str) -> Result<Option<Row>>;
     async fn list_table_rows(
         &self,
@@ -46,11 +45,8 @@ impl PostgresDatabasesStore {
         let pool = Pool::builder().max_size(32).build(manager).await?;
         Ok(Self { pool })
     }
-}
 
-#[async_trait]
-impl DatabasesStore for PostgresDatabasesStore {
-    async fn init(&self) -> Result<()> {
+    pub async fn init(&self) -> Result<()> {
         let conn = self.pool.get().await?;
         for table in POSTGRES_TABLES {
             conn.execute(table, &[]).await?;
@@ -60,7 +56,10 @@ impl DatabasesStore for PostgresDatabasesStore {
         }
         Ok(())
     }
+}
 
+#[async_trait]
+impl DatabasesStore for PostgresDatabasesStore {
     async fn load_table_row(&self, table_id: &str, row_id: &str) -> Result<Option<Row>> {
         let pool = self.pool.clone();
         let c = pool.get().await?;

--- a/core/src/dataset.rs
+++ b/core/src/dataset.rs
@@ -142,7 +142,7 @@ impl Dataset {
             created: utils::now(),
             dataset_id: String::from(id),
             hash,
-            keys: keys,
+            keys,
             data,
         })
     }

--- a/core/src/oauth/app.rs
+++ b/core/src/oauth/app.rs
@@ -302,7 +302,6 @@ pub async fn create_app() -> Result<Router> {
     {
         Ok(db_uri) => {
             let s = store::PostgresOAuthStore::new(&db_uri).await?;
-            s.init().await?;
             Box::new(s)
         }
         Err(_) => Err(anyhow!("OAUTH_DATABASE_URI not set."))?,


### PR DESCRIPTION
## Description

Move table/index creation to a script (+ update dev setup)
Comments some rarely used binaries to speed up build

## Risk

Low (removes an init that was a no-op from prod pods)

## Deploy Plan

- deploy `core`
- deploy `oauth`