### PR TITLE
[slack] Add attached  filenames in slack messages

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -800,11 +800,20 @@ export async function formatMessagesForUpsert({
       const messageDate = new Date(parseInt(message.ts as string, 10) * 1000);
       const messageDateStr = formatDateForUpsert(messageDate);
 
+      const filesInfo = message.files
+        ? "\n" +
+          message.files
+            .map((file) => {
+              return `Attached file : ${file.name} ( ${file.mimetype} )`;
+            })
+            .join("\n")
+        : "";
+
       return {
         messageDate,
         dateStr: messageDateStr,
         userName,
-        text: text,
+        text: text + filesInfo,
         content: text + "\n",
         sections: [],
       };


### PR DESCRIPTION
## Description

fixes: https://github.com/dust-tt/tasks/issues/1640

Just add the names of all files attached to a message

## Risk

none

## Deploy Plan

deploy connectors
