### PR TITLE
Sparkle - fix size of image citation for Safari

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.308",
+  "version": "0.2.309",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.308",
+      "version": "0.2.309",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.308",
+  "version": "0.2.309",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/ZoomableImageCitationWrapper.tsx
+++ b/sparkle/src/components/ZoomableImageCitationWrapper.tsx
@@ -26,10 +26,7 @@ export function ZoomableImageCitationWrapper({
 
   return (
     <>
-      <div
-        onClick={handleZoomToggle}
-        className="s-min-h-76 s-group s-flex s-h-full"
-      >
+      <div onClick={handleZoomToggle} className="s-min-h-76 s-group s-flex">
         <Citation
           title={title}
           size={size}

--- a/sparkle/src/stories/ConversationMessage.stories.tsx
+++ b/sparkle/src/stories/ConversationMessage.stories.tsx
@@ -66,6 +66,24 @@ export const ConversationExample = () => {
                 imgSrc="https://dust.tt/static/droidavatar/Droid_Lime_1.jpg"
                 alt={"Image"}
               />,
+              <ZoomableImageCitationWrapper
+                size="xs"
+                title="Title"
+                imgSrc="https://placecats.com/poppy/600/600" // Service that generates random cat images of a given size
+                alt={"Image"}
+              />,
+              <ZoomableImageCitationWrapper
+                size="xs"
+                title="Title"
+                imgSrc="https://placecats.com/neo/1200/700"
+                alt={"Image"}
+              />,
+              <ZoomableImageCitationWrapper
+                size="xs"
+                title="Title"
+                imgSrc="https://placecats.com/800/400"
+                alt={"Image"}
+              />,
             ]}
           >
             To conditionally render the citations only if a citations React node


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/1641
Display bug on Safari only.

### Before
<kbd>
<img width="666" alt="Screenshot 2024-11-13 at 15 11 56" src="https://github.com/user-attachments/assets/a1094535-ea3d-4cd3-8188-d602e806a11b">
</kbd>

### After
<kbd>
<img width="666" alt="Screenshot 2024-11-13 at 15 11 09" src="https://github.com/user-attachments/assets/ad4ae7da-3db8-492d-9e23-7fdc07ed6a7f">
</kbd>

## Risk



## Deploy Plan

Publish Sparkle, bump front, deploy front. 
