### PR TITLE
[Utils] Remove lock optionality on `cacheWithRedis`

### DIFF
--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -513,8 +513,7 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
             getSpaceHierarchy,
             () => memoizationKey,
             60 * 60 * 1000,
-            undefined,
-            true
+            undefined
           )(this.connectorId, currentPage.spaceId)
         : undefined;
 


### PR DESCRIPTION
Description
---
Lock introduced in #8077 . Theoretically, locking should always apply here since if the key is being written in redis whatever the case, another caller of cacheWithRedis with the same key should wait and get from redis, not overwrite.

We made it optional to monitor potential issues. Now it's time to go live.

Risk
---
Relatively high, blast radius: google drive, notion, microsoft, a few minor front places
Mitigation:
- logical argument: locking mechanism is free resource-wise
- used for a month without issue on confluence
- easy to rollback

Deploy
---
connectors
front