### PR TITLE
Add: expose files as a simulated function call for JIT actions

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -8,7 +8,10 @@ import parseArgs from "minimist";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
 import { renderConversationForModel } from "@app/lib/api/assistant/generation";
-import { getTextContentFromMessage } from "@app/lib/api/assistant/utils";
+import {
+  getTextContentFromMessage,
+  getTextRepresentationFromMessages,
+} from "@app/lib/api/assistant/utils";
 import config from "@app/lib/api/config";
 import { getDataSources } from "@app/lib/api/data_sources";
 import { garbageCollectGoogleDriveDocument } from "@app/lib/api/poke/plugins/data_sources/garbage_collect_google_drive_document";
@@ -347,17 +350,7 @@ const conversation = async (command: string, args: parseArgs.ParsedArgs) => {
       const messages = renderedConvo.modelConversation.messages;
 
       const tokenCountRes = await tokenCountForTexts(
-        [
-          ...messages.map((m) => {
-            let text = `${m.role} ${"name" in m ? m.name : ""} ${getTextContentFromMessage(m)}`;
-            if ("function_calls" in m) {
-              text += m.function_calls
-                .map((f) => `${f.name} ${f.arguments}`)
-                .join(" ");
-            }
-            return text;
-          }),
-        ],
+        getTextRepresentationFromMessages(messages),
         model
       );
       if (tokenCountRes.isErr()) {

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -32,7 +32,10 @@ import {
   isJITActionsEnabled,
   renderConversationForModelJIT,
 } from "@app/lib/api/assistant/jit_actions";
-import { getTextContentFromMessage } from "@app/lib/api/assistant/utils";
+import {
+  getTextContentFromMessage,
+  getTextRepresentationFromMessages,
+} from "@app/lib/api/assistant/utils";
 import { getVisualizationPrompt } from "@app/lib/api/assistant/visualization";
 import type { Authenticator } from "@app/lib/auth";
 import { renderContentFragmentForModel } from "@app/lib/resources/content_fragment_resource";
@@ -386,18 +389,7 @@ async function renderConversationForModelMultiActions({
 
   // Compute in parallel the token count for each message and the prompt.
   const res = await tokenCountForTexts(
-    [
-      prompt,
-      ...messages.map((m) => {
-        let text = `${m.role} ${"name" in m ? m.name : ""} ${getTextContentFromMessage(m)}`;
-        if ("function_calls" in m) {
-          text += m.function_calls
-            .map((f) => `${f.name} ${f.arguments}`)
-            .join(" ");
-        }
-        return text;
-      }),
-    ],
+    [prompt, ...getTextRepresentationFromMessages(messages)],
     model
   );
 

--- a/front/lib/api/assistant/utils.ts
+++ b/front/lib/api/assistant/utils.ts
@@ -24,3 +24,20 @@ export function getTextContentFromMessage(
     })
     .join("\n");
 }
+
+// This function is used to get the text representation of the messages to calculate the token amount
+export function getTextRepresentationFromMessages(
+  messages: ModelMessageTypeMultiActions[]
+): string[] {
+  return [
+    ...messages.map((m) => {
+      let text = `${m.role} ${"name" in m ? m.name : ""} ${getTextContentFromMessage(m)}`;
+      if ("function_calls" in m) {
+        text += m.function_calls
+          .map((f) => `${f.name} ${f.arguments}`)
+          .join(" ");
+      }
+      return text;
+    }),
+  ];
+}

--- a/front/lib/api/assistant/visualization.ts
+++ b/front/lib/api/assistant/visualization.ts
@@ -19,7 +19,7 @@ export async function getVisualizationPrompt({
   auth: Authenticator;
   conversation: ConversationType;
 }) {
-  const isJITEnabled = !(await isJITActionsEnabled(auth));
+  const isJITEnabled = await isJITActionsEnabled(auth);
 
   // When JIT is enabled, we return the visualization prompt directly without listing the files as the files will be made available to the model via another mechanism (simulated function call).
   if (isJITEnabled) {

--- a/front/lib/api/assistant/visualization.ts
+++ b/front/lib/api/assistant/visualization.ts
@@ -7,9 +7,8 @@ import {
   removeNulls,
 } from "@dust-tt/types";
 import _ from "lodash";
-import * as readline from "readline"; // Add this line
-import type { Readable } from "stream";
 
+import { isJITActionsEnabled } from "@app/lib/api/assistant/jit_actions";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 
@@ -20,104 +19,65 @@ export async function getVisualizationPrompt({
   auth: Authenticator;
   conversation: ConversationType;
 }) {
-  const readFirstFiveLines = (inputStream: Readable): Promise<string[]> => {
-    return new Promise((resolve, reject) => {
-      const rl: readline.Interface = readline.createInterface({
-        input: inputStream,
-        crlfDelay: Infinity,
-      });
+  const isJITEnabled = !(await isJITActionsEnabled(auth));
 
-      let lineCount: number = 0;
-      const lines: string[] = [];
-
-      rl.on("line", (line: string) => {
-        lines.push(line);
-        lineCount++;
-        if (lineCount === 5) {
-          rl.close();
-        }
-      });
-
-      rl.on("close", () => {
-        resolve(lines);
-      });
-
-      rl.on("error", (err: Error) => {
-        reject(err);
-      });
-    });
-  };
-
-  const contentFragmentMessages: Array<ContentFragmentType> = [];
-  for (const m of conversation.content.flat(1)) {
-    if (isContentFragmentType(m)) {
-      contentFragmentMessages.push(m);
-    }
-  }
-  const contentFragmentFileBySid = _.keyBy(
-    await FileResource.fetchByIds(
-      auth,
-      removeNulls(contentFragmentMessages.map((m) => m.fileId))
-    ),
-    "sId"
-  );
-
-  const contentFragmentTextByMessageId: Record<string, string[]> = {};
-  for (const m of contentFragmentMessages) {
-    if (!m.fileId || !m.contentType.startsWith("text/")) {
-      continue;
-    }
-
-    const file = contentFragmentFileBySid[m.fileId];
-    if (!file) {
-      continue;
-    }
-    const readStream = file.getReadStream({
-      auth,
-      version: "original",
-    });
-    contentFragmentTextByMessageId[m.sId] =
-      await readFirstFiveLines(readStream);
-  }
-
-  let prompt = visualizationSystemPrompt.trim() + "\n\n";
-
-  const fileAttachments: string[] = [];
-  for (const m of conversation.content.flat(1)) {
-    if (isContentFragmentType(m)) {
-      if (!m.fileId || !contentFragmentFileBySid[m.fileId]) {
-        continue;
+  // When JIT is enabled, we return the visualization prompt directly without listing the files as the files will be made available to the model via another mechanism (simulated function call).
+  if (isJITEnabled) {
+    return visualizationSystemPrompt.trim();
+  } else {
+    const contentFragmentMessages: Array<ContentFragmentType> = [];
+    for (const m of conversation.content.flat(1)) {
+      if (isContentFragmentType(m)) {
+        contentFragmentMessages.push(m);
       }
-      fileAttachments.push(
-        `<file id="${m.fileId}" name="${m.title}" type="${m.contentType}" />`
-      );
-    } else if (isAgentMessageType(m)) {
-      for (const a of m.actions) {
-        if (isTablesQueryActionType(a)) {
-          const attachment = getTablesQueryResultsFileAttachment({
-            resultsFileId: a.resultsFileId,
-            resultsFileSnippet: a.resultsFileSnippet,
-            output: a.output,
-            includeSnippet: false,
-          });
-          if (attachment) {
-            fileAttachments.push(attachment);
+    }
+    const contentFragmentFileBySid = _.keyBy(
+      await FileResource.fetchByIds(
+        auth,
+        removeNulls(contentFragmentMessages.map((m) => m.fileId))
+      ),
+      "sId"
+    );
+
+    let prompt = visualizationSystemPrompt.trim() + "\n\n";
+
+    const fileAttachments: string[] = [];
+    for (const m of conversation.content.flat(1)) {
+      if (isContentFragmentType(m)) {
+        if (!m.fileId || !contentFragmentFileBySid[m.fileId]) {
+          continue;
+        }
+        fileAttachments.push(
+          `<file id="${m.fileId}" name="${m.title}" type="${m.contentType}" />`
+        );
+      } else if (isAgentMessageType(m)) {
+        for (const a of m.actions) {
+          if (isTablesQueryActionType(a)) {
+            const attachment = getTablesQueryResultsFileAttachment({
+              resultsFileId: a.resultsFileId,
+              resultsFileSnippet: a.resultsFileSnippet,
+              output: a.output,
+              includeSnippet: false,
+            });
+            if (attachment) {
+              fileAttachments.push(attachment);
+            }
           }
         }
       }
     }
-  }
 
-  if (fileAttachments.length > 0) {
-    prompt +=
-      "Files accessible to the :::visualization directive environment:\n";
-    prompt += fileAttachments.join("\n");
-  } else {
-    prompt +=
-      "No files are currently accessible to the :::visualization directive environment in this conversation.";
-  }
+    if (fileAttachments.length > 0) {
+      prompt +=
+        "Files accessible to the :::visualization directive environment:\n";
+      prompt += fileAttachments.join("\n");
+    } else {
+      prompt +=
+        "No files are currently accessible to the :::visualization directive environment in this conversation.";
+    }
 
-  return prompt;
+    return prompt;
+  }
 }
 
 export const visualizationSystemPrompt = `\

--- a/front/pages/poke/[wId]/conversations/[cId]/index.tsx
+++ b/front/pages/poke/[wId]/conversations/[cId]/index.tsx
@@ -1,4 +1,4 @@
-import { Page } from "@dust-tt/sparkle";
+import { Button, Page } from "@dust-tt/sparkle";
 import type {
   AgentMessageType,
   ContentFragmentType,
@@ -9,6 +9,7 @@ import type { InferGetServerSidePropsType } from "next";
 
 import PokeNavbar from "@app/components/poke/PokeNavbar";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
+import { DustProdActionRegistry } from "@app/lib/registry";
 import { useConversation } from "@app/poke/swr";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
@@ -67,7 +68,9 @@ const AgentMessageView = ({ message }: { message: AgentMessageType }) => {
         </a>
         {")"}
       </div>
-      <div className="text-element-600">version={message.version}</div>
+      <div className="text-element-600">
+        version={message.version} {message.actions.length}
+      </div>
       {message.actions.map((a, i) => {
         return (
           <div key={`action-${i}`} className="pl-2 text-element-600">
@@ -111,21 +114,29 @@ const ConversationPage = ({
   conversationId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const { conversation } = useConversation({ workspaceId, conversationId });
-
+  const multiActionsApp =
+    DustProdActionRegistry["assistant-v2-multi-actions-agent"];
   return (
     <div className="min-h-screen bg-structure-50">
       <PokeNavbar />
       {conversation && (
         <div className="mx-auto max-w-4xl pt-8">
           <Page.Vertical align="stretch">
-            <div className="ml-4 text-sm text-element-600">
-              <a
+            <div className="flex space-x-2">
+              <Button
                 href={`http://go/trace-conversation/${conversation.sId}`}
+                label="Trace Conversation"
+                variant="primary"
+                size="xs"
                 target="_blank"
-                className="text-action-500"
-              >
-                [trace-conversation]
-              </a>
+              />
+              <Button
+                href={`/w/${multiActionsApp.app.workspaceId}/spaces/${multiActionsApp.app.appSpaceId}/apps/${multiActionsApp.app.appId}/runs?wIdTarget=${workspaceId}`}
+                label="Dust apps logs for workspace"
+                variant="primary"
+                size="xs"
+                target="_blank"
+              />
             </div>
             {conversation.content.map((messages, i) => {
               return (

--- a/types/src/front/lib/api/assistant/generation.ts
+++ b/types/src/front/lib/api/assistant/generation.ts
@@ -41,13 +41,13 @@ export interface UserMessageTypeModel {
   name: string;
   content: Content[];
 }
-
 export interface FunctionCallType {
   id: string;
   name: string;
-  arguments: string;
+  arguments: string; // Empty is not valid, should be at least "{}"
 }
 
+// Assistant requiring usage of function(s) call(s)
 export interface AssistantFunctionCallMessageTypeModel {
   role: "assistant";
   content?: string;
@@ -60,6 +60,7 @@ export interface AssistantContentMessageTypeModel {
   content: string;
 }
 
+// This is the output of one function call
 export interface FunctionMessageTypeModel {
   role: "function";
   name: string;

--- a/viz/package-lock.json
+++ b/viz/package-lock.json
@@ -40,8 +40,6 @@
         "@notionhq/client": "^2.2.4",
         "csv-parse": "^5.5.6",
         "csv-stringify": "^6.5.0",
-        "dts-cli": "^2.0.5",
-        "eslint-plugin-simple-import-sort": "^12.1.0",
         "eventsource-parser": "^1.1.1",
         "hot-shots": "^10.0.0",
         "htmlparser2": "^9.1.0",
@@ -55,6 +53,8 @@
       "devDependencies": {
         "@tsconfig/recommended": "^1.0.3",
         "@types/uuid": "^9.0.7",
+        "dts-cli": "^2.0.5",
+        "eslint-plugin-simple-import-sort": "^12.1.0",
         "tslib": "^2.6.2",
         "typescript": "^5.4.5"
       },


### PR DESCRIPTION
## Description

To expose the files to the model for JIT actions & visualization, when JIT ff flag is enabled:
- if we have files, we simulate a function call from the model asking to list the files.
- we remove the list of files from the visualization prompt

I tested by also removing the fileId & content from the user message with the original attachment, to make sure the model rely on the list of files.

## Risk

Could confuse the model & affect visualization, mitigated by putting it behind a FF.

## Deploy Plan

Deploy `front`