### PR TITLE
chore: rename `generateLegacyModelSId` into `generateRandomModelSId`

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -25,7 +25,7 @@ import { GroupResource } from "@app/lib/resources/group_resource";
 import { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { generateLegacyModelSId } from "@app/lib/resources/string_ids";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { tokenCountForTexts } from "@app/lib/tokenization";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
@@ -45,7 +45,7 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
       }
 
       const w = await Workspace.create({
-        sId: generateLegacyModelSId(),
+        sId: generateRandomModelSId(),
         name: args.name,
       });
 

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -68,7 +68,7 @@ import {
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
-import { generateLegacyModelSId } from "@app/lib/resources/string_ids";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { TemplateResource } from "@app/lib/resources/template_resource";
 
 type SortStrategyType = "alphabetical" | "priority" | "updatedAt";
@@ -723,7 +723,7 @@ export async function createAgentConfiguration(
           userFavorite = userRelation?.favorite ?? false;
         }
 
-        const sId = agentConfigurationId || generateLegacyModelSId();
+        const sId = agentConfigurationId || generateRandomModelSId();
 
         // Create Agent config.
         return AgentConfiguration.create(
@@ -913,7 +913,7 @@ export async function createAgentActionConfiguration(
       return frontSequelize.transaction(async (t) => {
         const retrievalConfig = await AgentRetrievalConfiguration.create(
           {
-            sId: generateLegacyModelSId(),
+            sId: generateRandomModelSId(),
             query: action.query,
             relativeTimeFrame: isTimeFrame(action.relativeTimeFrame)
               ? "custom"
@@ -953,7 +953,7 @@ export async function createAgentActionConfiguration(
     }
     case "dust_app_run_configuration": {
       const dustAppRunConfig = await AgentDustAppRunConfiguration.create({
-        sId: generateLegacyModelSId(),
+        sId: generateRandomModelSId(),
         appWorkspaceId: action.appWorkspaceId,
         appId: action.appId,
         agentConfigurationId: agentConfiguration.id,
@@ -973,7 +973,7 @@ export async function createAgentActionConfiguration(
       return frontSequelize.transaction(async (t) => {
         const tablesQueryConfig = await AgentTablesQueryConfiguration.create(
           {
-            sId: generateLegacyModelSId(),
+            sId: generateRandomModelSId(),
             agentConfigurationId: agentConfiguration.id,
             name: action.name,
             description: action.description,
@@ -1002,7 +1002,7 @@ export async function createAgentActionConfiguration(
       return frontSequelize.transaction(async (t) => {
         const processConfig = await AgentProcessConfiguration.create(
           {
-            sId: generateLegacyModelSId(),
+            sId: generateRandomModelSId(),
             relativeTimeFrame: isTimeFrame(action.relativeTimeFrame)
               ? "custom"
               : action.relativeTimeFrame,
@@ -1041,7 +1041,7 @@ export async function createAgentActionConfiguration(
     }
     case "websearch_configuration": {
       const websearchConfig = await AgentWebsearchConfiguration.create({
-        sId: generateLegacyModelSId(),
+        sId: generateRandomModelSId(),
         agentConfigurationId: agentConfiguration.id,
         name: action.name,
         description: action.description,
@@ -1057,7 +1057,7 @@ export async function createAgentActionConfiguration(
     }
     case "browse_configuration": {
       const browseConfig = await AgentBrowseConfiguration.create({
-        sId: generateLegacyModelSId(),
+        sId: generateRandomModelSId(),
         agentConfigurationId: agentConfiguration.id,
         name: action.name,
         description: action.description,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -83,7 +83,7 @@ import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import {
-  generateLegacyModelSId,
+  generateRandomModelSId,
   getResourceIdFromSId,
 } from "@app/lib/resources/string_ids";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -112,7 +112,7 @@ export async function createConversation(
   }
 
   const conversation = await Conversation.create({
-    sId: generateLegacyModelSId(),
+    sId: generateRandomModelSId(),
     workspaceId: owner.id,
     title: title,
     visibility: visibility,
@@ -791,7 +791,7 @@ export async function* postUserMessage(
       async function createMessageAndUserMessage() {
         return Message.create(
           {
-            sId: generateLegacyModelSId(),
+            sId: generateRandomModelSId(),
             rank: nextMessageRank++,
             conversationId: conversation.id,
             parentId: null,
@@ -871,7 +871,7 @@ export async function* postUserMessage(
               );
               const messageRow = await Message.create(
                 {
-                  sId: generateLegacyModelSId(),
+                  sId: generateRandomModelSId(),
                   rank: nextMessageRank++,
                   conversationId: conversation.id,
                   parentId: userMessage.id,
@@ -1260,7 +1260,7 @@ export async function* editUserMessage(
       async function createMessageAndUserMessage(messageRow: Message) {
         return Message.create(
           {
-            sId: generateLegacyModelSId(),
+            sId: generateRandomModelSId(),
             rank: messageRow.rank,
             conversationId: conversation.id,
             parentId: messageRow.parentId,
@@ -1355,7 +1355,7 @@ export async function* editUserMessage(
             );
             const messageRow = await Message.create(
               {
-                sId: generateLegacyModelSId(),
+                sId: generateRandomModelSId(),
                 rank: nextMessageRank++,
                 conversationId: conversation.id,
                 parentId: userMessage.id,
@@ -1603,7 +1603,7 @@ export async function* retryAgentMessage(
       );
       const m = await Message.create(
         {
-          sId: generateLegacyModelSId(),
+          sId: generateRandomModelSId(),
           rank: messageRow.rank,
           conversationId: conversation.id,
           parentId: messageRow.parentId,
@@ -1756,7 +1756,7 @@ export async function postNewContentFragment(
     return new Err(new ConversationError("conversation_access_restricted"));
   }
 
-  const messageId = generateLegacyModelSId();
+  const messageId = generateRandomModelSId();
 
   const cfBlobRes = await getContentFragmentBlob(
     auth,

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -37,7 +37,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import { generateLegacyModelSId } from "@app/lib/resources/string_ids";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { enqueueUpsertTable } from "@app/lib/upsert_queue";
 import { validateUrl } from "@app/lib/utils";
 import logger from "@app/logger/logger";
@@ -408,7 +408,7 @@ export async function upsertTable({
   auth: Authenticator;
   useAppForHeaderDetection?: boolean;
 }) {
-  const nonNullTableId = tableId ?? generateLegacyModelSId();
+  const nonNullTableId = tableId ?? generateRandomModelSId();
   const tableParents: string[] = parents ?? [];
 
   if (!tableParents.includes(nonNullTableId)) {
@@ -565,7 +565,7 @@ export async function handleDataSourceTableCSVUpsert({
     });
   }
 
-  const tableId = params.tableId ?? generateLegacyModelSId();
+  const tableId = params.tableId ?? generateRandomModelSId();
   const tableParents: string[] = params.parents ?? [];
 
   if (!tableParents.includes(tableId)) {

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -19,7 +19,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { MAX_UNCONSUMED_INVITATIONS_PER_WORKSPACE_PER_DAY } from "@app/lib/invitations";
 import { MembershipInvitation } from "@app/lib/models/workspace";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
-import { generateLegacyModelSId } from "@app/lib/resources/string_ids";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { isEmailValid } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 
@@ -128,7 +128,7 @@ export async function updateOrCreateInvitation(
   return typeFromModel(
     owner,
     await MembershipInvitation.create({
-      sId: generateLegacyModelSId(),
+      sId: generateRandomModelSId(),
       workspaceId: owner.id,
       inviteEmail: sanitizeString(inviteEmail),
       status: "pending",

--- a/front/lib/iam/users.ts
+++ b/front/lib/iam/users.ts
@@ -4,7 +4,7 @@ import { sanitizeString } from "@dust-tt/types";
 
 import type { ExternalUser, SessionWithUser } from "@app/lib/iam/provider";
 import { User } from "@app/lib/models/user";
-import { generateLegacyModelSId } from "@app/lib/resources/string_ids";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { guessFirstAndLastNameFromFullName } from "@app/lib/user";
@@ -140,7 +140,7 @@ export async function createOrUpdateUser(
     );
 
     const u = await UserResource.makeNew({
-      sId: generateLegacyModelSId(),
+      sId: generateRandomModelSId(),
       auth0Sub: externalUser.sub,
       provider: mapAuth0ProviderToLegacy(session)?.provider ?? null,
       username: externalUser.nickname,

--- a/front/lib/iam/workspaces.ts
+++ b/front/lib/iam/workspaces.ts
@@ -3,7 +3,7 @@ import type { SessionWithUser } from "@app/lib/iam/provider";
 import { Workspace, WorkspaceHasDomain } from "@app/lib/models/workspace";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { generateLegacyModelSId } from "@app/lib/resources/string_ids";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { isDisposableEmailDomain } from "@app/lib/utils/disposable_email_domains";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 
@@ -33,7 +33,7 @@ export async function createWorkspaceInternal({
     isVerified && !isDisposableEmailDomain(emailDomain) ? emailDomain : null;
 
   const workspace = await Workspace.create({
-    sId: generateLegacyModelSId(),
+    sId: generateRandomModelSId(),
     name: name,
   });
 

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -34,7 +34,7 @@ import { getTrialVersionForPlan, isTrial } from "@app/lib/plans/trial";
 import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
 import { REPORT_USAGE_METADATA_KEY } from "@app/lib/plans/usage/types";
 import { frontSequelize } from "@app/lib/resources/storage";
-import { generateLegacyModelSId } from "@app/lib/resources/string_ids";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { getWorkspaceFirstAdmin } from "@app/lib/workspace";
 import { checkWorkspaceActivity } from "@app/lib/workspace_usage";
 import logger from "@app/logger/logger";
@@ -255,7 +255,7 @@ export const internalSubscribeWorkspaceToFreePlan = async ({
 
     return Subscription.create(
       {
-        sId: generateLegacyModelSId(),
+        sId: generateRandomModelSId(),
         workspaceId: workspace.id,
         planId: newPlan.id,
         status: "active",

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -137,7 +137,7 @@ export function getResourceNameAndIdFromSId(
 /**
  * Generates 10-character long model SId from [A-Za-z0-9] characters.
  */
-export function generateLegacyModelSId(prefix?: string): string {
+export function generateRandomModelSId(prefix?: string): string {
   const u = uuidv4();
   const b = blake3(u, { length: 10 });
   const sId = Buffer.from(b)

--- a/front/migrations/20231023_create_plan_subscriptions.ts
+++ b/front/migrations/20231023_create_plan_subscriptions.ts
@@ -3,7 +3,7 @@
 // import { Plan, Subscription } from "@app/lib/models/plan";
 // import { Workspace } from "@app/lib/models/workspace";
 // import { FREE_UPGRADED_PLAN_CODE } from "@app/lib/plans/plan_codes";
-// import { generateLegacyModelSId } from "@app/lib/resources/string_ids";
+// import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 //
 // async function main() {
 //   const workspaces = await Workspace.findAll({
@@ -47,7 +47,7 @@
 //         if (workspace.upgradedAt) {
 //           // We subscribe to Free Trial plan
 //           await Subscription.create({
-//             sId: generateLegacyModelSId(),
+//             sId: generateRandomModelSId(),
 //             workspaceId: workspace.id,
 //             planId: freeUpgradedPlan.id,
 //             status: "active",

--- a/front/migrations/20240404_backfill_users_and_invitations_sid.ts
+++ b/front/migrations/20240404_backfill_users_and_invitations_sid.ts
@@ -1,6 +1,6 @@
 import { User } from "@app/lib/models/user";
 import { MembershipInvitation } from "@app/lib/models/workspace";
-import { generateLegacyModelSId } from "@app/lib/resources/string_ids";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 
@@ -22,7 +22,7 @@ const backfillUsers = async (execute: boolean) => {
     await Promise.all(
       chunk.map((u) => {
         return (async () => {
-          const sId = generateLegacyModelSId();
+          const sId = generateRandomModelSId();
           logger.info(
             `Backfilling user ${u.id} with \`sId=${sId}\` [execute: ${execute}]`
           );
@@ -54,7 +54,7 @@ const backfillInvitations = async (execute: boolean) => {
     await Promise.all(
       chunk.map((i) => {
         return (async () => {
-          const sId = generateLegacyModelSId();
+          const sId = generateRandomModelSId();
           logger.info(
             `Backfilling invitation ${i.id} with \`sId=${sId}\` [execute: ${execute}]`
           );

--- a/front/pages/api/poke/templates/index.ts
+++ b/front/pages/api/poke/templates/index.ts
@@ -10,7 +10,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { USED_MODEL_CONFIGS } from "@app/components/providers/types";
 import { withSessionAuthentication } from "@app/lib/api/wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { generateLegacyModelSId } from "@app/lib/resources/string_ids";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { TemplateResource } from "@app/lib/resources/template_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { AssistantTemplateListType } from "@app/pages/api/w/[wId]/assistant/builder/templates";
@@ -104,7 +104,7 @@ async function handler(
         presetModelId: model.modelId,
         presetProviderId: model.providerId,
         presetTemperature: body.presetTemperature ?? null,
-        sId: generateLegacyModelSId(),
+        sId: generateRandomModelSId(),
         tags: body.tags,
         visibility: body.visibility,
       });

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -24,7 +24,7 @@ import {
 import { maybeCancelInactiveTrials } from "@app/lib/plans/subscription";
 import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
 import { frontSequelize } from "@app/lib/resources/storage";
-import { generateLegacyModelSId } from "@app/lib/resources/string_ids";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
@@ -223,7 +223,7 @@ async function handler(
 
               await Subscription.create(
                 {
-                  sId: generateLegacyModelSId(),
+                  sId: generateRandomModelSId(),
                   workspaceId: workspace.id,
                   planId: plan.id,
                   status: "active",

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -12,7 +12,7 @@ import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { generateLegacyModelSId } from "@app/lib/resources/string_ids";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 
@@ -244,7 +244,7 @@ async function handler(
         remote_database_secret_id: remoteDatabaseSecretId,
       } = r.data;
 
-      const tableId = maybeTableId || generateLegacyModelSId();
+      const tableId = maybeTableId || generateRandomModelSId();
 
       const tRes = await coreAPI.getTables({
         projectId: dataSource.dustAPIProjectId,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/index.ts
@@ -7,7 +7,7 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { generateLegacyModelSId } from "@app/lib/resources/string_ids";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 
@@ -108,7 +108,7 @@ async function handler(
 
       const app = await AppResource.makeNew(
         {
-          sId: generateLegacyModelSId(),
+          sId: generateRandomModelSId(),
           name: req.body.name,
           description,
           dustAPIProjectId: p.value.project.project_id.toString(),

--- a/front/scripts/dev/create_test_workspaces.ts
+++ b/front/scripts/dev/create_test_workspaces.ts
@@ -3,7 +3,7 @@ import { createWorkspaceInternal } from "@app/lib/iam/workspaces";
 import { Plan } from "@app/lib/models/plan";
 import { FREE_UPGRADED_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { pokeUpgradeWorkspaceToPlan } from "@app/lib/plans/subscription";
-import { generateLegacyModelSId } from "@app/lib/resources/string_ids";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { Logger } from "@app/logger/logger";
 import { createAndLogMembership } from "@app/pages/api/login";
@@ -55,7 +55,7 @@ async function createTestWorkspaces(
   );
 
   for (let i = 0; i < count; i++) {
-    const name = `${user.firstName} ${generateLegacyModelSId()}`;
+    const name = `${user.firstName} ${generateRandomModelSId()}`;
     const workspace = await createWorkspaceInternal({
       email: user.email,
       name: name,


### PR DESCRIPTION
## Description

Making this its own PR as it touches lots of files and clutters the diff.

I'm going to need a good old random sIds for the versioned content fragments. In fact, any type of versioned table is a legitimate use  case for random non-sqid sIds, so the function shouldn't be called "legacy".

## Risk

N/A (pure search and replace)

## Deploy Plan

N/A