### PR TITLE
enh: add sId column on content fragments

### DIFF
--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -23,6 +23,7 @@ import { BaseResource } from "@app/lib/resources/base_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
 
 const MAX_BYTE_SIZE_CSV_RENDER_FULL_CONTENT = 500 * 1024; // 500 KB
@@ -45,12 +46,13 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
   }
 
   static async makeNew(
-    blob: CreationAttributes<ContentFragmentModel>,
+    blob: Omit<CreationAttributes<ContentFragmentModel>, "sId">,
     transaction?: Transaction
   ) {
     const contentFragment = await ContentFragmentModel.create(
       {
         ...blob,
+        sId: generateRandomModelSId("cf"),
       },
       {
         transaction,

--- a/front/lib/resources/storage/models/content_fragment.ts
+++ b/front/lib/resources/storage/models/content_fragment.ts
@@ -19,6 +19,7 @@ export class ContentFragmentModel extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
+  declare sId: string;
   declare title: string;
   declare contentType: SupportedContentFragmentType;
   declare sourceUrl: string | null; // GCS (upload) or Slack or ...
@@ -53,6 +54,10 @@ ContentFragmentModel.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
+    },
+    sId: {
+      type: DataTypes.STRING,
+      allowNull: false,
     },
     title: {
       type: DataTypes.TEXT,
@@ -90,7 +95,7 @@ ContentFragmentModel.init(
   {
     modelName: "content_fragment",
     sequelize: frontSequelize,
-    indexes: [{ fields: ["fileId"] }],
+    indexes: [{ fields: ["fileId"] }, { fields: ["sId"] }],
   }
 );
 

--- a/front/migrations/20241114_backfill_cf_sid.ts
+++ b/front/migrations/20241114_backfill_cf_sid.ts
@@ -1,0 +1,62 @@
+import { Op } from "sequelize";
+
+import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+import { makeScript } from "@app/scripts/helpers";
+
+makeScript({}, async ({ execute }, logger) => {
+  let lastSeenId = 0;
+  const batchSize = 1000;
+
+  for (;;) {
+    // Find content fragments without sId
+    const contentFragments: ContentFragmentModel[] =
+      await ContentFragmentModel.findAll({
+        // @ts-expect-error -- sequelize type for sId is not nullable (it temporarily is in db)
+        where: {
+          id: {
+            [Op.gt]: lastSeenId,
+          },
+          sId: {
+            [Op.is]: null,
+          },
+        },
+        order: [["id", "ASC"]],
+        limit: batchSize,
+      });
+
+    if (contentFragments.length === 0) {
+      break;
+    }
+
+    logger.info(
+      `Processing ${contentFragments.length} content fragments starting from ID ${lastSeenId}`
+    );
+
+    if (execute) {
+      await Promise.all(
+        contentFragments.map(async (cf) => {
+          const sId = generateRandomModelSId("cf");
+          await cf.update({ sId });
+          logger.info(
+            {
+              contentFragmentId: cf.id,
+              sId,
+            },
+            "Updated content fragment with sId"
+          );
+        })
+      );
+    } else {
+      logger.info(
+        {
+          lastSeenId,
+          count: contentFragments.length,
+        },
+        "Dry run - would have updated content fragments with sIds"
+      );
+    }
+
+    lastSeenId = contentFragments[contentFragments.length - 1].id;
+  }
+});

--- a/front/migrations/db/migration_111.sql
+++ b/front/migrations/db/migration_111.sql
@@ -4,4 +4,4 @@ ALTER TABLE
 ADD
     COLUMN "sId" VARCHAR(255);
 
-CREATE INDEX "content_fragments_s_id" ON "content_fragments" ("sId");
+CREATE INDEX CONCURRENTLY "content_fragments_s_id" ON "content_fragments" ("sId");

--- a/front/migrations/db/migration_111.sql
+++ b/front/migrations/db/migration_111.sql
@@ -1,0 +1,7 @@
+-- Migration created on Nov 14, 2024
+ALTER TABLE
+    "public"."content_fragments"
+ADD
+    COLUMN "sId" VARCHAR(255);
+
+CREATE INDEX "content_fragments_s_id" ON "content_fragments" ("sId");

--- a/front/migrations/db/migration_111.sql
+++ b/front/migrations/db/migration_111.sql
@@ -3,5 +3,3 @@ ALTER TABLE
     "public"."content_fragments"
 ADD
     COLUMN "sId" VARCHAR(255);
-
-CREATE INDEX CONCURRENTLY "content_fragments_s_id" ON "content_fragments" ("sId");

--- a/front/migrations/db/migration_112.sql
+++ b/front/migrations/db/migration_112.sql
@@ -1,0 +1,7 @@
+-- Migration created on Nov 14, 2024
+ALTER TABLE
+    "public"."content_fragments"
+ALTER COLUMN
+    "sId"
+SET
+    NOT NULL;

--- a/front/migrations/db/migration_112.sql
+++ b/front/migrations/db/migration_112.sql
@@ -1,4 +1,5 @@
 -- Migration created on Nov 14, 2024
+-- Backfill script that needs to be ran: 20241114_backfill_cf_sid.ts
 ALTER TABLE
     "public"."content_fragments"
 ALTER COLUMN

--- a/front/migrations/db/migration_112.sql
+++ b/front/migrations/db/migration_112.sql
@@ -6,3 +6,5 @@ ALTER COLUMN
     "sId"
 SET
     NOT NULL;
+
+CREATE INDEX CONCURRENTLY "content_fragments_s_id" ON "content_fragments" ("sId");


### PR DESCRIPTION
## Description

adds an `sId` column  on content fragments that is being populated with a random SID.

I need this as I am adding versioning to content fragment (ability to supersede a content fragment with a newer version). This will be used for the browser extension (new version of the webpage's content, instead of adding the whole new version as a separate attachment)

## Risk

Critical path, blast radius is:
- whole app (db schema migration)
- any conversation that has content fragments (slack-initiated, API, user uploaded attachments)

## Deploy Plan

- run migration 111
- deploy
- run backfill script
- run migration 112