### PR TITLE
[sparkle] - fix: adjust leaf item width in Tree component

### DIFF
--- a/sparkle/src/components/Tree.tsx
+++ b/sparkle/src/components/Tree.tsx
@@ -172,7 +172,7 @@ Tree.Item = function ({
             }}
           />
         )}
-        {type === "leaf" && <div className="s-w-4 s-flex-shrink-0"></div>}
+        {type === "leaf" && <div className="s-w-3 s-flex-shrink-0"></div>}
         {checkbox && <Checkbox {...checkbox} size="xs" />}
         <Icon visual={visual} size="sm" className={tailwindIconTextColor} />
         <div


### PR DESCRIPTION
## Description

This PR aims at fixing the checkboxes alignment in the contentNode tree, see [thread](https://dust4ai.slack.com/archives/C050A0S2Z7F/p1731599390590419)

## Risk

UI breaking changes

## Deploy Plan

