### PR TITLE
Display specific error message if fail to retrieve permissions caused by rate limit

### DIFF
--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -21,7 +21,10 @@ import {
   getSlackClient,
 } from "@connectors/connectors/slack/lib/slack_client";
 import { launchSlackSyncWorkflow } from "@connectors/connectors/slack/temporal/client.js";
-import { ExternalOAuthTokenError } from "@connectors/lib/error";
+import {
+  ExternalOAuthTokenError,
+  ProviderWorkflowError,
+} from "@connectors/lib/error";
 import { SlackChannel } from "@connectors/lib/models/slack";
 import { terminateAllWorkflowsForConnectorId } from "@connectors/lib/temporal";
 import logger from "@connectors/logger/logger";
@@ -274,7 +277,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
     parentInternalId: string | null;
     filterPermission: ConnectorPermission | null;
     viewType: ContentNodesViewType;
-  }): Promise<Result<ContentNode[], Error>> {
+  }): Promise<Result<ContentNode[], Error | ProviderWorkflowError>> {
     if (parentInternalId) {
       return new Err(
         new Error(
@@ -403,6 +406,13 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
         return new Err(
           new Error("Slack token invalid. Please re-authorize Slack.")
         );
+      }
+      if (e instanceof ProviderWorkflowError && e.type === "rate_limit_error") {
+        logger.error(
+          { connectorId: this.connectorId, error: e },
+          "Slack rate limit when retrieving permissions."
+        );
+        return new Err(e);
       }
       throw e;
     }

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -277,7 +277,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
     parentInternalId: string | null;
     filterPermission: ConnectorPermission | null;
     viewType: ContentNodesViewType;
-  }): Promise<Result<ContentNode[], Error | ProviderWorkflowError>> {
+  }): Promise<Result<ContentNode[], Error>> {
     if (parentInternalId) {
       return new Err(
         new Error(

--- a/connectors/src/connectors/slack/lib/slack_client.ts
+++ b/connectors/src/connectors/slack/lib/slack_client.ts
@@ -65,10 +65,7 @@ export async function getSlackClient(
           // If we get rate limited, we throw a known error.
           // Note: a previous version using slackError.code === ErrorCode.RateLimitedError failed
           // see PR #2689 for details
-          if (
-            e instanceof Error &&
-            e.message.startsWith("A rate limit was exceeded")
-          ) {
+          if (e instanceof Error && e.message.includes("rate limit")) {
             try {
               Context.current().heartbeat();
               await Context.current().sleep("1 minute");

--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -154,10 +154,7 @@ function ContentNodeTreeChildren({
     return (
       <div className="text-sm text-warning">
         {resourcesError?.type === "rate_limit_error" ? (
-          <>
-            Failed to retrieve permissions, we are currently rate limited by the
-            provider API.
-          </>
+          <>Connected service's API limit reached. Please retry shortly.</>
         ) : (
           <>
             Failed to retrieve permissions likely due to a revoked

--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -8,7 +8,7 @@ import {
   Tooltip,
   Tree,
 } from "@dust-tt/sparkle";
-import type { BaseContentNode } from "@dust-tt/types";
+import type { APIError, BaseContentNode } from "@dust-tt/types";
 import type { ReactNode } from "react";
 import React, { useCallback, useContext, useState } from "react";
 
@@ -35,6 +35,7 @@ export type UseResourcesHook = (parentId: string | null) => {
   resources: BaseContentNode[];
   isResourcesLoading: boolean;
   isResourcesError: boolean;
+  resourcesError?: APIError | null;
 };
 
 export type ContentNodeTreeItemStatus = {
@@ -112,7 +113,7 @@ function ContentNodeTreeChildren({
 
   const { useResourcesHook, emptyComponent } = useContentNodeTreeContext();
 
-  const { resources, isResourcesLoading, isResourcesError } =
+  const { resources, isResourcesLoading, isResourcesError, resourcesError } =
     useResourcesHook(parentId);
 
   const filteredNodes = resources.filter(
@@ -152,7 +153,17 @@ function ContentNodeTreeChildren({
   if (isResourcesError) {
     return (
       <div className="text-sm text-warning">
-        Failed to retrieve permissions likely due to a revoked authorization.
+        {resourcesError?.type === "rate_limit_error" ? (
+          <>
+            Failed to retrieve permissions, we are currently rate limited by the
+            provider API.
+          </>
+        ) : (
+          <>
+            Failed to retrieve permissions likely due to a revoked
+            authorization.
+          </>
+        )}
       </div>
     );
   }

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -110,12 +110,7 @@ async function getContentNodesForManagedDataSourceView(
 
     if (connectorsRes.isErr()) {
       if (connectorsRes.error.type === "connector_rate_limit_error") {
-        return new Err(
-          new Error(
-            connectorsRes.error.message ??
-              "An error occurred while fetching the resources' content nodes."
-          )
-        );
+        return new Err(new Error(connectorsRes.error.message));
       }
       return new Err(
         new Error(

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -109,6 +109,14 @@ async function getContentNodesForManagedDataSourceView(
     });
 
     if (connectorsRes.isErr()) {
+      if (connectorsRes.error.type === "connector_rate_limit_error") {
+        return new Err(
+          new Error(
+            connectorsRes.error.message ??
+              "An error occurred while fetching the resources' content nodes."
+          )
+        );
+      }
       return new Err(
         new Error(
           "An error occurred while fetching the resources' children content nodes."

--- a/front/lib/swr/connectors.ts
+++ b/front/lib/swr/connectors.ts
@@ -1,5 +1,6 @@
 import { useSendNotification } from "@dust-tt/sparkle";
 import type {
+  APIError,
   ConnectorPermission,
   ContentNodesViewType,
   DataSourceType,
@@ -21,7 +22,8 @@ import type { GetDataSourcePermissionsResponseBody } from "@app/pages/api/w/[wId
 interface UseConnectorPermissionsReturn<IncludeParents extends boolean> {
   resources: GetDataSourcePermissionsResponseBody<IncludeParents>["resources"];
   isResourcesLoading: boolean;
-  isResourcesError: any;
+  isResourcesError: boolean;
+  resourcesError: APIError | null;
 }
 
 export function useConnectorPermissions<IncludeParents extends boolean>({
@@ -77,6 +79,7 @@ export function useConnectorPermissions<IncludeParents extends boolean>({
     ),
     isResourcesLoading: !error && !data,
     isResourcesError: error,
+    resourcesError: error ? (error.error as APIError) : null,
   };
 }
 

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions/index.ts
@@ -272,6 +272,16 @@ export async function getManagedDataSourcePermissionsHandler(
     includeParents,
   });
   if (permissionsRes.isErr()) {
+    if (permissionsRes.error.type === "connector_rate_limit_error") {
+      return apiError(req, res, {
+        status_code: 429,
+        api_error: {
+          type: "rate_limit_error",
+          message:
+            "Rate limit error while retrieving the data source permissions",
+        },
+      });
+    }
     return apiError(req, res, {
       status_code: 500,
       api_error: {


### PR DESCRIPTION
## Description

This is a change on the Slack connector. Currently, when there's an error while trying to retrieve permission (which we use on the permission modal + on the modal to set an assistant as default to answer in a Slack channel), we always display the wording "Failed to retrieve permissions likely due to a revoked authorization.", which is not necessarily true, the error can be something else such as hitting a rate limit from Slack: The goal of this PR is to display a proper message on these screens when the error we hit is a rate limit from Slack. 

To do so, in connectors, in case of a rate limit: 
- `SlackManager.retrievePermissions()` can return a `ProviderWorkflowError`.
- The connector API route to retrieve permission can return a `"connector_rate_limit_error"` which is an existing error code in connector. 

In front: 
- When calling connector API, if we get a `"connector_rate_limit_error"` we answer a ``"rate_limit_error"`` which is a frontAPI error type. 
- Update the hook `useConnectorPermissions` to also return the error (not just a boolean to know if there's an error). 
- Update `UseResourcesHook ` to have this optional new param with the error. 
- In `ContentNodeTreeChildren`, if there's an error and it's a rate limit error, we display a proper message. 


This is not fixing the why we get a rate limit, but this error message is much clearer and less scary for users (their token is not revoked, we are still syncing their data). 


![Screenshot 2024-11-15 at 09 27 41](https://github.com/user-attachments/assets/6c644179-e56c-4801-b1ef-7cc6c25275ff)


</kbd>

## Risk

Can be rolled back but since it's both front & connector it's annoying. 

## Deploy Plan

- Deploy front. 
- Deploy connectors.
