### PR TITLE
[JIT Datasources] Create conversations space

### DIFF
--- a/front/components/assistant_builder/spaces/SpaceSelector.tsx
+++ b/front/components/assistant_builder/spaces/SpaceSelector.tsx
@@ -8,7 +8,11 @@ import {
 import type { SpaceType } from "@dust-tt/types";
 import React, { useState } from "react";
 
-import { getSpaceIcon, getSpaceName, groupSpaces } from "@app/lib/spaces";
+import {
+  getSpaceIcon,
+  getSpaceName,
+  groupSpacesForDisplay,
+} from "@app/lib/spaces";
 import { classNames } from "@app/lib/utils";
 
 interface SpaceSelectorProps {
@@ -39,7 +43,7 @@ export function SpaceSelector({
   }
 
   // Group by kind and sort.
-  const sortedSpaces = groupSpaces(spaces)
+  const sortedSpaces = groupSpacesForDisplay(spaces)
     .filter((i) => i.section !== "system")
     .map((i) =>
       i.spaces.sort((a, b) => {

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -28,7 +28,11 @@ import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_provide
 import { getVisualForContentNode } from "@app/lib/content_nodes";
 import { getDataSourceNameFromView } from "@app/lib/data_sources";
 import type { SpaceSectionGroupType } from "@app/lib/spaces";
-import { getSpaceIcon, getSpaceName, groupSpaces } from "@app/lib/spaces";
+import {
+  getSpaceIcon,
+  getSpaceName,
+  groupSpacesForDisplay,
+} from "@app/lib/spaces";
 import { useApps } from "@app/lib/swr/apps";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import {
@@ -88,7 +92,7 @@ export default function SpaceSideBarMenu({
     return <></>;
   }
 
-  const sortedGroupedSpaces = groupSpaces(spaces).filter(
+  const sortedGroupedSpaces = groupSpacesForDisplay(spaces).filter(
     ({ section, spaces }) => section !== "system" || spaces.length !== 0
   );
 

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -112,9 +112,21 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         [globalGroup]
       ));
 
+    const conversationsSpace =
+      existingSpaces.find((s) => s.kind === "conversations") ||
+      (await SpaceResource.makeNew(
+        {
+          name: "Conversations",
+          kind: "conversations",
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+        [globalGroup]
+      ));
+
     return {
       systemSpace,
       globalSpace,
+      conversationsSpace,
     };
   }
 
@@ -188,7 +200,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return this.baseFetch(auth, {
       where: {
         kind: {
-          [Op.in]: ["system", "global"],
+          [Op.in]: ["system", "global", "conversations"],
         },
       },
     });
@@ -470,8 +482,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       ];
     }
 
-    // Default Workspace space.
-    if (this.isGlobal()) {
+    // Default Workspace space and Conversations space.
+    if (this.isGlobal() || this.isConversations()) {
       return [
         {
           workspaceId: this.workspaceId,
@@ -565,6 +577,10 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
   isSystem() {
     return this.kind === "system";
+  }
+
+  isConversations() {
+    return this.kind === "conversations";
   }
 
   isRegular() {

--- a/front/lib/resources/storage/models/spaces.ts
+++ b/front/lib/resources/storage/models/spaces.ts
@@ -1,5 +1,10 @@
 import type { SpaceKind } from "@dust-tt/types";
-import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
+import type {
+  CreationOptional,
+  ForeignKey,
+  NonAttribute,
+  Transaction,
+} from "sequelize";
 import { DataTypes } from "sequelize";
 
 import { Workspace } from "@app/lib/models/workspace";
@@ -66,3 +71,25 @@ SpaceModel.belongsTo(Workspace, {
   foreignKey: { allowNull: false },
   onDelete: "RESTRICT",
 });
+
+SpaceModel.addHook(
+  "beforeCreate",
+  "enforce_one_special_space_per_workspace",
+  async (space: SpaceModel, options: { transaction: Transaction }) => {
+    if (["global", "system", "conversations"].includes(space.kind)) {
+      const existingSpace = await SpaceModel.findOne({
+        where: {
+          workspaceId: space.workspaceId,
+          kind: space.kind,
+        },
+        transaction: options.transaction,
+      });
+
+      if (existingSpace) {
+        throw new Error(`A ${space.kind} space exists for this workspace.`, {
+          cause: `enforce_one_${space.kind}_space_per_workspace`,
+        });
+      }
+    }
+  }
+);

--- a/front/lib/resources/storage/models/spaces.ts
+++ b/front/lib/resources/storage/models/spaces.ts
@@ -1,4 +1,8 @@
-import type { SpaceKind, UNIQUE_SPACE_KINDS } from "@dust-tt/types";
+import {
+  isUniqueSpaceKind,
+  UNIQUE_SPACE_KINDS,
+  type SpaceKind,
+} from "@dust-tt/types";
 import type {
   CreationOptional,
   ForeignKey,
@@ -76,7 +80,7 @@ SpaceModel.addHook(
   "beforeCreate",
   "enforce_one_special_space_per_workspace",
   async (space: SpaceModel, options: { transaction: Transaction }) => {
-    if (UNIQUE_SPACE_KINDS.includes(space.kind)) {
+    if (isUniqueSpaceKind(space.kind)) {
       const existingSpace = await SpaceModel.findOne({
         where: {
           workspaceId: space.workspaceId,

--- a/front/lib/resources/storage/models/spaces.ts
+++ b/front/lib/resources/storage/models/spaces.ts
@@ -1,8 +1,5 @@
-import {
-  isUniqueSpaceKind,
-  UNIQUE_SPACE_KINDS,
-  type SpaceKind,
-} from "@dust-tt/types";
+import type { SpaceKind } from "@dust-tt/types";
+import { isUniqueSpaceKind } from "@dust-tt/types";
 import type {
   CreationOptional,
   ForeignKey,

--- a/front/lib/resources/storage/models/spaces.ts
+++ b/front/lib/resources/storage/models/spaces.ts
@@ -1,4 +1,4 @@
-import type { SpaceKind } from "@dust-tt/types";
+import type { SpaceKind, UNIQUE_SPACE_KINDS } from "@dust-tt/types";
 import type {
   CreationOptional,
   ForeignKey,
@@ -76,7 +76,7 @@ SpaceModel.addHook(
   "beforeCreate",
   "enforce_one_special_space_per_workspace",
   async (space: SpaceModel, options: { transaction: Transaction }) => {
-    if (["global", "system", "conversations"].includes(space.kind)) {
+    if (UNIQUE_SPACE_KINDS.includes(space.kind)) {
       const existingSpace = await SpaceModel.findOne({
         where: {
           workspaceId: space.workspaceId,

--- a/front/lib/spaces.ts
+++ b/front/lib/spaces.ts
@@ -1,8 +1,6 @@
 import { LockIcon, PlanetIcon, ServerIcon } from "@dust-tt/sparkle";
-import type {PlanType, SpaceType, WorkspaceType} from "@dust-tt/types";
-import {
-  assertNever
-} from "@dust-tt/types";
+import type { PlanType, SpaceType, WorkspaceType } from "@dust-tt/types";
+import { assertNever } from "@dust-tt/types";
 import { groupBy } from "lodash";
 import type React from "react";
 

--- a/front/lib/spaces.ts
+++ b/front/lib/spaces.ts
@@ -1,5 +1,8 @@
 import { LockIcon, PlanetIcon, ServerIcon } from "@dust-tt/sparkle";
-import type { PlanType, SpaceType, WorkspaceType } from "@dust-tt/types";
+import type {PlanType, SpaceType, WorkspaceType} from "@dust-tt/types";
+import {
+  assertNever
+} from "@dust-tt/types";
 import { groupBy } from "lodash";
 import type React from "react";
 
@@ -37,19 +40,34 @@ export const dustAppsListUrl = (
   return `/w/${owner.sId}/spaces/${space.sId}/categories/apps`;
 };
 
-export const groupSpaces = (spaces: SpaceType[]) => {
+export const groupSpacesForDisplay = (spaces: SpaceType[]) => {
+  // Conversations space should never be displayed
+  const spacesWithoutConversations = spaces.filter(
+    (space) => space.kind !== "conversations"
+  );
   // Group by kind and sort.
-  const groupedSpaces = groupBy(spaces, (space): SpaceSectionGroupType => {
-    switch (space.kind) {
-      case "public":
-      case "system":
-        return space.kind;
+  const groupedSpaces = groupBy(
+    spacesWithoutConversations,
+    (space): SpaceSectionGroupType => {
+      // please ts
+      if (space.kind === "conversations") {
+        throw new Error("Conversations space should never be displayed");
+      }
 
-      case "global":
-      case "regular":
-        return space.isRestricted ? "restricted" : "shared";
+      switch (space.kind) {
+        case "public":
+        case "system":
+          return space.kind;
+
+        case "global":
+        case "regular":
+          return space.isRestricted ? "restricted" : "shared";
+
+        default:
+          assertNever(space.kind);
+      }
     }
-  });
+  );
 
   return SPACE_SECTION_GROUP_ORDER.map((section) => ({
     section,

--- a/front/migrations/20241114_conversations_spaces_backfill.ts
+++ b/front/migrations/20241114_conversations_spaces_backfill.ts
@@ -1,0 +1,60 @@
+import _ from "lodash";
+
+import { Workspace } from "@app/lib/models/workspace";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { makeScript } from "@app/scripts/helpers";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+
+async function backfillWorkspacesGroup(execute: boolean) {
+  const workspaces = await Workspace.findAll();
+
+  const chunks = _.chunk(workspaces, 16);
+  for (const [i, c] of chunks.entries()) {
+    console.log(
+      `[execute=${execute}] Processing chunk of ${c.length} workspaces... (${
+        i + 1
+      }/${chunks.length})`
+    );
+    if (execute) {
+      await Promise.all(
+        c.map((w) =>
+          (async () => {
+            try {
+              const workspaceGroup =
+                await GroupResource.internalFetchWorkspaceGlobalGroup(w.id);
+              if (!workspaceGroup) {
+                throw new Error("Workspace group not found");
+              }
+              await SpaceResource.makeNew(
+                {
+                  name: "Conversations",
+                  kind: "conversations",
+                  workspaceId: w.id,
+                },
+                [workspaceGroup]
+              );
+            } catch (error) {
+              if (
+                error instanceof Error &&
+                error.cause &&
+                error.cause === "enforce_one_conversations_space_per_workspace"
+              ) {
+                console.log(
+                  `Conversation already exists for workspace ${w.id}`
+                );
+              } else {
+                throw error;
+              }
+            }
+          })()
+        )
+      );
+    }
+  }
+
+  console.log(`Done.`);
+}
+
+makeScript({}, async ({ execute }) => {
+  await backfillWorkspacesGroup(execute);
+});

--- a/front/migrations/20241114_conversations_spaces_backfill.ts
+++ b/front/migrations/20241114_conversations_spaces_backfill.ts
@@ -2,8 +2,8 @@ import _ from "lodash";
 
 import { Workspace } from "@app/lib/models/workspace";
 import { GroupResource } from "@app/lib/resources/group_resource";
-import { makeScript } from "@app/scripts/helpers";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import { makeScript } from "@app/scripts/helpers";
 
 async function backfillWorkspacesGroup(execute: boolean) {
   const workspaces = await Workspace.findAll();

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/index.ts
@@ -95,6 +95,16 @@ async function handler(
     });
   }
 
+  if (app.space.kind === "conversations") {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   switch (req.method) {
     case "GET":
       const runId = req.query.runId as string;

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -207,6 +207,16 @@ async function handler(
     });
   }
 
+  if (app.space.kind === "conversations") {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   if (!app.canRead(keyAuth)) {
     return apiError(req, res, {
       status_code: 403,

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/index.ts
@@ -104,6 +104,16 @@ async function handler(
     });
   }
 
+  if (space.kind === "conversations") {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   switch (req.method) {
     case "GET":
       const apps = await AppResource.listBySpace(auth, space);

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
@@ -186,6 +186,16 @@ async function handler(
     });
   }
 
+  if (dataSourceView.space.kind === "conversations") {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   switch (req.method) {
     case "GET":
       return res.status(200).json({

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/search.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/search.ts
@@ -172,6 +172,16 @@ async function handler(
     });
   }
 
+  if (dataSourceView.space.kind === "conversations") {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   switch (req.method) {
     case "GET": {
       // I could not find a way to make the query params be an array if there is only one tag.

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
@@ -78,6 +78,16 @@ async function handler(
     });
   }
 
+  if (space.kind === "conversations") {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   switch (req.method) {
     case "GET":
       const dataSourceViews = await DataSourceViewResource.listBySpace(

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -295,6 +295,16 @@ async function handler(
     });
   }
 
+  if (dataSource.space.kind === "conversations") {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   const owner = auth.getNonNullableWorkspace();
   const plan = auth.getNonNullablePlan();
 

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/parents.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/parents.ts
@@ -121,6 +121,16 @@ async function handler(
     });
   }
 
+  if (dataSource.space.kind === "conversations") {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   switch (req.method) {
     case "POST":
       if (

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/index.ts
@@ -117,6 +117,16 @@ async function handler(
     });
   }
 
+  if (dataSource.space.kind === "conversations") {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
   switch (req.method) {
     case "GET":

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/search.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/search.ts
@@ -194,6 +194,16 @@ async function handler(
     });
   }
 
+  if (dataSource.space.kind === "conversations") {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   switch (req.method) {
     case "GET": {
       // I could not find a way to make the query params be an array if there is only one tag.

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/index.ts
@@ -149,6 +149,16 @@ async function handler(
     });
   }
 
+  if (dataSource.space.kind === "conversations") {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   switch (req.method) {
     case "GET":
       const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/parents.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/parents.ts
@@ -75,6 +75,16 @@ async function handler(
     });
   }
 
+  if (dataSource.space.kind === "conversations") {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   switch (req.method) {
     case "POST":
       const r = await PostTableParentsRequestSchema.safeParse(req.body);

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/rows/[rId].ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/rows/[rId].ts
@@ -166,6 +166,16 @@ async function handler(
     });
   }
 
+  if (dataSource.space.kind === "conversations") {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 
   switch (req.method) {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/rows/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/rows/index.ts
@@ -210,6 +210,16 @@ async function handler(
     });
   }
 
+  if (dataSource.space.kind === "conversations") {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
   switch (req.method) {
     case "GET":

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.ts
@@ -89,6 +89,16 @@ async function handler(
     });
   }
 
+  if (dataSource.space.kind === "conversations") {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   switch (req.method) {
     case "POST": {
       const r = UpsertTableFromCsvRequestSchema.safeParse(req.body);

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -176,6 +176,16 @@ async function handler(
     });
   }
 
+  if (dataSource.space.kind === "conversations") {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 
   switch (req.method) {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tokenize.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tokenize.ts
@@ -79,6 +79,16 @@ async function handler(
     });
   }
 
+  if (dataSource.space.kind === "conversations") {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   switch (req.method) {
     case "POST": {
       const bodyValidation = PostDatasourceTokenizeBodySchema.decode(req.body);

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/index.ts
@@ -73,6 +73,16 @@ async function handler(
     });
   }
 
+  if (space.kind === "conversations") {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   const dataSources = await DataSourceResource.listBySpace(auth, space);
 
   switch (req.method) {

--- a/front/pages/api/v1/w/[wId]/spaces/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/index.ts
@@ -65,7 +65,12 @@ async function handler(
 ): Promise<void> {
   switch (req.method) {
     case "GET":
-      const spaces = await SpaceResource.listWorkspaceSpaces(auth);
+      const allSpaces = await SpaceResource.listWorkspaceSpaces(auth);
+
+      // conversations space should not be shown
+      const spaces = allSpaces.filter(
+        (space) => space.kind !== "conversations"
+      );
 
       const isLegacyRequest = req.url?.includes("/vaults");
       if (isLegacyRequest) {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/[name]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/[name]/index.ts
@@ -56,6 +56,16 @@ async function handler(
     });
   }
 
+  if (app.space.isConversations()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   if (!app.canRead(auth)) {
     return apiError(req, res, {
       status_code: 403,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/index.ts
@@ -74,6 +74,16 @@ async function handler(
     });
   }
 
+  if (app.space.isConversations()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   if (!app.canWrite(auth)) {
     return apiError(req, res, {
       status_code: 403,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/index.ts
@@ -47,6 +47,16 @@ async function handler(
     });
   }
 
+  if (app.space.isConversations()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   switch (req.method) {
     case "GET":
       res.status(200).json({

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]/index.ts
@@ -46,6 +46,16 @@ async function handler(
     });
   }
 
+  if (app.space.isConversations()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   if (!app.canWrite(auth)) {
     return apiError(req, res, {
       status_code: 403,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/status.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/status.ts
@@ -50,6 +50,16 @@ async function handler(
     });
   }
 
+  if (app.space.isConversations()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   let runId: string | null =
     typeof req.query.runId === "string" ? req.query.runId : null;
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -57,6 +57,16 @@ async function handler(
     });
   }
 
+  if (app.space.isConversations()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   if (!app.canWrite(auth)) {
     return apiError(req, res, {
       status_code: 403,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/state.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/state.ts
@@ -37,6 +37,16 @@ async function handler(
     });
   }
 
+  if (app.space.isConversations()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   if (!app.canWrite(auth)) {
     return apiError(req, res, {
       status_code: 403,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/index.ts
@@ -37,7 +37,7 @@ async function handler(
     });
   }
   const space = await SpaceResource.fetchById(auth, spaceId);
-  if (!space || !space.canList(auth)) {
+  if (!space || !space.canList(auth) || space.isConversations()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
@@ -62,6 +62,16 @@ async function handler(
     });
   }
 
+  if (dataSourceView.space.isConversations()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   if (req.method !== "POST") {
     return apiError(req, res, {
       status_code: 405,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/documents/[documentId]/index.ts
@@ -49,6 +49,17 @@ async function handler(
       },
     });
   }
+
+  if (dataSourceView.space.isConversations()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   const coreAPI = new CoreAPI(apiConfig.getCoreAPIConfig(), logger);
 
   switch (req.method) {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
@@ -49,6 +49,17 @@ async function handler(
       },
     });
   }
+
+  if (dataSourceView.space.isConversations()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   switch (req.method) {
     case "GET": {
       return res.status(200).json({

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/[tableId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/[tableId]/index.ts
@@ -51,6 +51,16 @@ async function handler(
     });
   }
 
+  if (dataSourceView.space.isConversations()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   switch (req.method) {
     case "GET":
       const coreAPI = new CoreAPI(apiConfig.getCoreAPIConfig(), logger);

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/index.ts
@@ -47,6 +47,16 @@ async function handler(
     });
   }
 
+  if (dataSourceView.space.isConversations()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   switch (req.method) {
     case "GET":
       const paginationRes = getOffsetPaginationParams(req);

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
@@ -68,6 +68,16 @@ async function handler(
     });
   }
 
+  if (space.isConversations()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   switch (req.method) {
     case "GET": {
       const category =

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/configuration.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/configuration.ts
@@ -67,6 +67,16 @@ async function handler(
     });
   }
 
+  if (dataSource.space.isConversations()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   // Only Slack & Webcrawler connectors have configurations.
   // SlackConfiguration.botEnabled can only be updated from a Poke route.
   // So these routes are currently only for Webcrawler connectors.

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -68,6 +68,16 @@ async function handler(
     });
   }
 
+  if (dataSource.space.isConversations()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   switch (req.method) {
     case "PATCH":
       if (!dataSource.canWrite(auth)) {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/index.ts
@@ -57,6 +57,16 @@ async function handler(
     });
   }
 
+  if (dataSource.space.isConversations()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   switch (req.method) {
     case "POST":
       if (!dataSource.canWrite(auth)) {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/index.ts
@@ -39,7 +39,7 @@ async function handler(
   }
 
   const space = await SpaceResource.fetchById(auth, spaceId);
-  if (!space) {
+  if (!space || space.isConversations()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tableId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tableId]/index.ts
@@ -63,6 +63,16 @@ async function handler(
     });
   }
 
+  if (dataSource.space.isConversations()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   switch (req.method) {
     case "PATCH":
       if (!dataSource.canWrite(auth)) {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -53,6 +53,16 @@ async function handler(
     });
   }
 
+  if (dataSource.space.isConversations()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space you're trying to access was not found",
+      },
+    });
+  }
+
   switch (req.method) {
     case "POST":
       if (!dataSource.canWrite(auth)) {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
@@ -103,7 +103,7 @@ async function handler(
   }
 
   const space = await SpaceResource.fetchById(auth, spaceId);
-  if (!space) {
+  if (!space || space.isConversations()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
@@ -58,7 +58,7 @@ async function handler(
   }
 
   const space = await SpaceResource.fetchById(auth, spaceId);
-  if (!space || !space.canList(auth)) {
+  if (!space || space.isConversations()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/members.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/members.ts
@@ -31,7 +31,7 @@ async function handler(
   }
 
   const space = await SpaceResource.fetchById(auth, spaceId);
-  if (!space) {
+  if (!space || space.isConversations()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/api/w/[wId]/spaces/index.ts
+++ b/front/pages/api/w/[wId]/spaces/index.ts
@@ -68,6 +68,9 @@ async function handler(
         spaces = await SpaceResource.listWorkspaceSpacesAsMember(auth);
       }
 
+      // Filter out conversation spaces.
+      spaces = spaces.filter((s) => s.kind !== "conversations");
+
       return res.status(200).json({
         spaces: spaces.map((s) => s.toJSON()),
       });

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -152,8 +152,10 @@ async function archiveAssistants(auth: Authenticator) {
 }
 
 async function deleteDatasources(auth: Authenticator) {
-  const globalAndSystemSpaces =
-    await SpaceResource.listWorkspaceDefaultSpaces(auth);
+  const globalAndSystemSpaces = await SpaceResource.listWorkspaceDefaultSpaces(
+    auth,
+    { includeConversationsSpace: true }
+  );
 
   // Retrieve and delete all data sources associated with the system and global spaces.
   // Others will be deleted when deleting the spaces.

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1386,6 +1386,7 @@ const SpaceKindSchema = FlexibleEnumSchema([
   "global",
   "system",
   "public",
+  "conversations",
 ]);
 
 const SpaceTypeSchema = z.object({

--- a/types/src/front/space.ts
+++ b/types/src/front/space.ts
@@ -8,6 +8,7 @@ const SPACE_KINDS = [...UNIQUE_SPACE_KINDS, "public", "regular"] as const;
 
 export type SpaceKind = (typeof SPACE_KINDS)[number];
 
+export type UniqueSpaceKind = (typeof UNIQUE_SPACE_KINDS)[number];
 export type SpaceType = {
   createdAt: number;
   groupIds: string[];
@@ -17,3 +18,7 @@ export type SpaceType = {
   sId: string;
   updatedAt: number;
 };
+
+export function isUniqueSpaceKind(kind: SpaceKind): kind is UniqueSpaceKind {
+  return UNIQUE_SPACE_KINDS.includes(kind as UniqueSpaceKind);
+}

--- a/types/src/front/space.ts
+++ b/types/src/front/space.ts
@@ -1,4 +1,10 @@
-const SPACE_KINDS = ["regular", "global", "system", "public"] as const;
+const SPACE_KINDS = [
+  "regular",
+  "global",
+  "system",
+  "public",
+  "conversations",
+] as const;
 export type SpaceKind = (typeof SPACE_KINDS)[number];
 
 export type SpaceType = {

--- a/types/src/front/space.ts
+++ b/types/src/front/space.ts
@@ -1,10 +1,11 @@
-const SPACE_KINDS = [
-  "regular",
+export const UNIQUE_SPACE_KINDS = [
   "global",
   "system",
-  "public",
   "conversations",
 ] as const;
+
+const SPACE_KINDS = [...UNIQUE_SPACE_KINDS, "public", "regular"] as const;
+
 export type SpaceKind = (typeof SPACE_KINDS)[number];
 
 export type SpaceType = {


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/1569

- new "conversations" kind created by default at workspace creation
- backfill
- sql unicity constraint on spaces, just like on groups cc @flvndvd
- not visible in UX
- security: blocked use at API level, both public and internal => cannot query "conversations" space or any related resource by API directly---it should be accessed indirectly via other authed endpoints that can check conversation permissions

On last point: 
- checks at endpoints are used to restrict access to the space, rather than permissions. This is because any user must be able to access their conversation's content so the permissions of the space have to be open.
- all access is blocked, and we'll open some carefully if needed, rather than the reverse

Potential app security leak to be adressed by an immediately following PR; card [here](https://github.com/dust-tt/tasks/issues/1658) cc @spolu

Risks
---
low, the space is unused
worst case: an empty space appears somewhere in the UX
tested locally

## Deploy plan
- front
- run backfill

