### PR TITLE
Ext: logout when user not found

### DIFF
--- a/extension/app/src/components/assistants/usePublicAgentConfigurations.ts
+++ b/extension/app/src/components/assistants/usePublicAgentConfigurations.ts
@@ -1,6 +1,7 @@
+import { logout } from "@extension/lib/auth";
 import { useDustAPI } from "@extension/lib/dust_api";
 import { useSWRWithDefaults } from "@extension/lib/swr";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 
 export function usePublicAgentConfigurations() {
   const dustAPI = useDustAPI();
@@ -18,6 +19,15 @@ export function usePublicAgentConfigurations() {
       ["getAgentConfigurations", dustAPI.workspaceId()],
       agentConfigurationsFetcher
     );
+
+  useEffect(() => {
+    if (
+      typeof error?.message === "string" &&
+      error?.message.includes("User not found")
+    ) {
+      void logout();
+    }
+  }, [error]);
 
   return {
     agentConfigurations: useMemo(() => data ?? [], [data]),

--- a/extension/app/src/components/conversation/useConversations.ts
+++ b/extension/app/src/components/conversation/useConversations.ts
@@ -1,6 +1,7 @@
+import { logout } from "@extension/lib/auth";
 import { useDustAPI } from "@extension/lib/dust_api";
 import { useSWRWithDefaults } from "@extension/lib/swr";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 
 export function useConversations() {
   const dustAPI = useDustAPI();
@@ -16,6 +17,15 @@ export function useConversations() {
     ["getConversations", dustAPI.workspaceId()],
     conversationsFetcher
   );
+
+  useEffect(() => {
+    if (
+      typeof error?.message === "string" &&
+      error?.message.includes("User not found")
+    ) {
+      void logout();
+    }
+  }, [error]);
 
   return {
     conversations: useMemo(() => data ?? [], [data]),

--- a/extension/app/src/components/conversation/usePublicConversation.ts
+++ b/extension/app/src/components/conversation/usePublicConversation.ts
@@ -1,6 +1,8 @@
 import type { ConversationPublicType } from "@dust-tt/client";
+import { logout } from "@extension/lib/auth";
 import { useDustAPI } from "@extension/lib/dust_api";
 import { useSWRWithDefaults } from "@extension/lib/swr";
+import { useEffect } from "react";
 import type { KeyedMutator } from "swr";
 
 export function usePublicConversation({
@@ -33,6 +35,15 @@ export function usePublicConversation({
       : null,
     conversationFetcher
   );
+
+  useEffect(() => {
+    if (
+      typeof error?.message === "string" &&
+      error?.message.includes("User not found")
+    ) {
+      void logout();
+    }
+  }, [error]);
 
   return {
     conversation: data ? data : null,

--- a/extension/app/src/lib/swr.ts
+++ b/extension/app/src/lib/swr.ts
@@ -3,11 +3,6 @@ import { getAccessToken } from "@extension/lib/storage";
 import { useCallback } from "react";
 import type { Fetcher, Key, SWRConfiguration } from "swr";
 import useSWR, { useSWRConfig } from "swr";
-import type {
-  SWRInfiniteConfiguration,
-  SWRInfiniteKeyLoader,
-} from "swr/infinite";
-import useSWRInfinite from "swr/infinite";
 
 const DEFAULT_SWR_CONFIG: SWRConfiguration = {
   errorRetryCount: 16,
@@ -95,15 +90,6 @@ export function useSWRWithDefaults<TKey extends Key, TData>(
       mutateRegardlessOfQueryParams: myMutateRegardlessOfQueryParams,
     };
   }
-}
-
-export function useSWRInfiniteWithDefaults<TKey extends Key, TData>(
-  getKey: SWRInfiniteKeyLoader<TData, TKey>,
-  fetcher: Fetcher<TData, TKey> | null,
-  config?: SWRInfiniteConfiguration
-) {
-  const mergedConfig = { ...DEFAULT_SWR_CONFIG, ...config };
-  return useSWRInfinite<TData>(getKey, fetcher, mergedConfig);
 }
 
 const resHandler = async (res: Response) => {


### PR DESCRIPTION
## Description

If we have a user not found error we want to log out the user. 
It was initially handled it: https://github.com/dust-tt/dust/pull/8444/files#diff-ba553a35160ee751f317c0f7232faa056c07d6ad96e92e8e646527224ba2d5c4

But since we're not using this handler anymore to call the API from Dust Client directly from hooks, this is not called anymore. 

So in this PR: 
-> Add hooks to log out if user not found
-> remove useSWRInfiniteWithDefaults which was not used. 

## Risk

Extension only. 

## Deploy Plan

Nothing. 
