### PR TITLE
[.github] - fix: correct owner interpolation in dispatch event

### DIFF
--- a/.github/workflows/deploy-connectors-infra.yml
+++ b/.github/workflows/deploy-connectors-infra.yml
@@ -62,7 +62,7 @@ jobs:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             await github.rest.repos.createDispatchEvent({
-              owner: ${{ github.repository_owner }},
+              owner: '${{ github.repository_owner }}',
               repo: 'dust-infra',
               event_type: 'trigger-component-deploy',
               client_payload: {


### PR DESCRIPTION

## Description

 Ensure the 'owner' field in dispatchEvent uses proper string interpolation for the GitHub repository owner value
## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
