### PR TITLE
Extension: remove unused permission

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -22,7 +22,6 @@
     "sidePanel",
     "identity",
     "storage",
-    "activeTab",
     "tabs",
     "scripting",
     "contextMenus"


### PR DESCRIPTION
## Description

We don't use activeTab. 
I'm afraid it would be better for the submission to use this over tabs since we currently don't use other tab than the active one but since this is something we want to offer to users trying as is. 

## Risk

/ 

## Deploy Plan

/ 
