### PR TITLE
[connectors] Cleanup outdated tickets

### DIFF
--- a/connectors/migrations/db/migration_35.sql
+++ b/connectors/migrations/db/migration_35.sql
@@ -1,0 +1,3 @@
+-- Migration created on Nov 15, 2024
+ALTER TABLE "public"."zendesk_configurations" ADD COLUMN "retentionPeriodDays" INTEGER NOT NULL DEFAULT 180;
+ALTER TABLE "public"."zendesk_configurations" DROP COLUMN "conversationsSlidingWindow";

--- a/connectors/migrations/db/migration_35.sql
+++ b/connectors/migrations/db/migration_35.sql
@@ -1,3 +1,7 @@
 -- Migration created on Nov 15, 2024
 ALTER TABLE "public"."zendesk_configurations" ADD COLUMN "retentionPeriodDays" INTEGER NOT NULL DEFAULT 180;
 ALTER TABLE "public"."zendesk_configurations" DROP COLUMN "conversationsSlidingWindow";
+
+ALTER TABLE "public"."zendesk_tickets" ADD COLUMN "ticketCreatedAt" TIMESTAMP WITH TIME ZONE;
+UPDATE "public"."zendesk_tickets" SET "ticketCreatedAt" = "createdAt";
+ALTER TABLE "public"."zendesk_tickets" ALTER COLUMN "ticketCreatedAt" SET NOT NULL;

--- a/connectors/migrations/db/migration_35.sql
+++ b/connectors/migrations/db/migration_35.sql
@@ -2,6 +2,6 @@
 ALTER TABLE "public"."zendesk_configurations" ADD COLUMN "retentionPeriodDays" INTEGER NOT NULL DEFAULT 180;
 ALTER TABLE "public"."zendesk_configurations" DROP COLUMN "conversationsSlidingWindow";
 
-ALTER TABLE "public"."zendesk_tickets" ADD COLUMN "ticketCreatedAt" TIMESTAMP WITH TIME ZONE;
-UPDATE "public"."zendesk_tickets" SET "ticketCreatedAt" = "createdAt";
-ALTER TABLE "public"."zendesk_tickets" ALTER COLUMN "ticketCreatedAt" SET NOT NULL;
+ALTER TABLE "public"."zendesk_tickets" ADD COLUMN "ticketUpdatedAt" TIMESTAMP WITH TIME ZONE;
+UPDATE "public"."zendesk_tickets" SET "ticketUpdatedAt" = "createdAt";
+ALTER TABLE "public"."zendesk_tickets" ALTER COLUMN "ticketUpdatedAt" SET NOT NULL;

--- a/connectors/migrations/db/migration_36.sql
+++ b/connectors/migrations/db/migration_36.sql
@@ -1,3 +1,4 @@
 -- Migration created on Nov 15, 2024
-ALTER TABLE "public"."zendesk_tickets" ADD COLUMN "ticketCreatedAt" TIMESTAMP WITH TIME ZONE;
-ALTER TABLE "public"."zendesk_tickets" ALTER COLUMN "ticketCreatedAt" SET NOT NULL; -- empty table at time of migration
+ALTER TABLE public.zendesk_tickets ADD COLUMN "ticketCreatedAt" TIMESTAMP WITH TIME ZONE;
+UPDATE public.zendesk_tickets SET "ticketCreatedAt" = "createdAt";
+ALTER TABLE public.zendesk_tickets ALTER COLUMN "ticketCreatedAt" SET NOT NULL;

--- a/connectors/migrations/db/migration_36.sql
+++ b/connectors/migrations/db/migration_36.sql
@@ -1,4 +1,0 @@
--- Migration created on Nov 15, 2024
-ALTER TABLE public.zendesk_tickets ADD COLUMN "ticketCreatedAt" TIMESTAMP WITH TIME ZONE;
-UPDATE public.zendesk_tickets SET "ticketCreatedAt" = "createdAt";
-ALTER TABLE public.zendesk_tickets ALTER COLUMN "ticketCreatedAt" SET NOT NULL;

--- a/connectors/migrations/db/migration_36.sql
+++ b/connectors/migrations/db/migration_36.sql
@@ -1,0 +1,3 @@
+-- Migration created on Nov 15, 2024
+ALTER TABLE "public"."zendesk_tickets" ADD COLUMN "ticketCreatedAt" TIMESTAMP WITH TIME ZONE;
+ALTER TABLE "public"."zendesk_tickets" ALTER COLUMN "ticketCreatedAt" SET NOT NULL; -- empty table at time of migration

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -66,7 +66,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         workspaceId: dataSourceConfig.workspaceId,
         dataSourceId: dataSourceConfig.dataSourceId,
       },
-      { subdomain, conversationsSlidingWindow: 90 }
+      { subdomain, conversationsSlidingWindow: 180 }
     );
 
     const workflowStartResult = await launchZendeskSyncWorkflow(connector);

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -66,7 +66,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         workspaceId: dataSourceConfig.workspaceId,
         dataSourceId: dataSourceConfig.dataSourceId,
       },
-      { subdomain, conversationsSlidingWindow: 180 }
+      { subdomain, retentionPeriodDays: 180 }
     );
 
     const workflowStartResult = await launchZendeskSyncWorkflow(connector);

--- a/connectors/src/connectors/zendesk/lib/sync_article.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_article.ts
@@ -85,8 +85,6 @@ export async function syncArticle({
     articleInDb.lastUpsertedTs < updatedAtDate; // upserting if the article was updated after the last upsert
 
   const updatableFields = {
-    createdAt: new Date(article.created_at),
-    updatedAt: updatedAtDate,
     categoryId: category.categoryId, // an article can be moved from one category to another, which does not apply to brands
     name: article.name,
     url: article.html_url,

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -22,28 +22,28 @@ const turndownService = new TurndownService();
 /**
  * Deletes a ticket from the db and the data sources.
  */
-export async function deleteTicket(
-  connectorId: ModelId,
-  ticket: ZendeskFetchedTicket,
-  dataSourceConfig: DataSourceConfig,
-  loggerArgs: Record<string, string | number | null>
-): Promise<void> {
+export async function deleteTicket({
+  connectorId,
+  ticketId,
+  dataSourceConfig,
+  loggerArgs,
+}: {
+  connectorId: ModelId;
+  ticketId: number;
+  dataSourceConfig: DataSourceConfig;
+  loggerArgs: Record<string, string | number | null>;
+}): Promise<void> {
   logger.info(
-    {
-      ...loggerArgs,
-      connectorId,
-      ticketId: ticket.id,
-      subject: ticket.subject,
-    },
+    { ...loggerArgs, connectorId, ticketId },
     "[Zendesk] Deleting ticket."
   );
   await deleteFromDataSource(
     dataSourceConfig,
-    getTicketInternalId(connectorId, ticket.id)
+    getTicketInternalId(connectorId, ticketId)
   );
   await ZendeskTicketResource.deleteByTicketId({
     connectorId,
-    ticketId: ticket.id,
+    ticketId,
   });
 }
 

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -98,6 +98,7 @@ export async function syncTicket({
     ticketInDb = await ZendeskTicketResource.makeNew({
       blob: {
         ...commonTicketData,
+        ticketCreatedAt: createdAtDate,
         ticketId: ticket.id,
         brandId,
         permission: "read",

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -88,8 +88,6 @@ export async function syncTicket({
   const commonTicketData = {
     subject: ticket.subject,
     url: ticket.url,
-    createdAt: createdAtDate,
-    updatedAt: updatedAtDate,
     assigneeId: ticket.assignee_id,
     groupId: ticket.group_id,
     organizationId: ticket.organization_id,

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -92,13 +92,13 @@ export async function syncTicket({
     groupId: ticket.group_id,
     organizationId: ticket.organization_id,
     lastUpsertedTs: new Date(currentSyncDateMs),
+    ticketUpdatedAt: updatedAtDate,
   };
 
   if (!ticketInDb) {
     ticketInDb = await ZendeskTicketResource.makeNew({
       blob: {
         ...commonTicketData,
-        ticketCreatedAt: createdAtDate,
         ticketId: ticket.id,
         brandId,
         permission: "read",

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -281,7 +281,7 @@ export async function fetchZendeskTicketsInBrand({
   );
 
   const searchQuery = encodeURIComponent(
-    `status:solved created>${retentionPeriodDays}days`
+    `status:solved updated>${retentionPeriodDays}days`
   );
   const response = await fetchFromZendeskWithRetries({
     url:

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -257,7 +257,7 @@ export async function fetchRecentlyUpdatedTickets({
 
 /**
  * Fetches a batch of tickets from the Zendesk API.
- * Only fetches tickets that have been solved, and that were created within the retention period.
+ * Only fetches tickets that have been solved, and that were updated within the retention period.
  */
 export async function fetchZendeskTicketsInBrand({
   brandSubdomain,

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -255,7 +255,11 @@ export async function fetchRecentlyUpdatedTickets({
   );
 }
 
-export async function fetchSolvedZendeskTicketsInBrand({
+/**
+ * Fetches a batch of tickets from the Zendesk API.
+ * Only fetches tickets that have been solved, and that were created within the retention period.
+ */
+export async function fetchZendeskTicketsInBrand({
   brandSubdomain,
   accessToken,
   pageSize,

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -260,11 +260,13 @@ export async function fetchSolvedZendeskTicketsInBrand({
   accessToken,
   pageSize,
   cursor,
+  retentionPeriodDays,
 }: {
   brandSubdomain: string;
   accessToken: string;
   pageSize: number;
   cursor: string | null;
+  retentionPeriodDays: number;
 }): Promise<{
   tickets: ZendeskFetchedTicket[];
   meta: { has_more: boolean; after_cursor: string };
@@ -274,7 +276,9 @@ export async function fetchSolvedZendeskTicketsInBrand({
     `pageSize must be at most 100 (current value: ${pageSize})`
   );
 
-  const searchQuery = encodeURIComponent("status:solved");
+  const searchQuery = encodeURIComponent(
+    `status:solved created>${retentionPeriodDays}days`
+  );
   const response = await fetchFromZendeskWithRetries({
     url:
       `https://${brandSubdomain}.zendesk.com/api/v2/search/export.json?query=${searchQuery}&filter[type]=ticket&page[size]=${pageSize}` +

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -29,6 +29,7 @@ import {
   ZendeskArticleResource,
   ZendeskBrandResource,
   ZendeskCategoryResource,
+  ZendeskConfigurationResource,
   ZendeskTicketResource,
 } from "@connectors/resources/zendesk_resources";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
@@ -183,6 +184,57 @@ export async function syncZendeskBrandActivity({
     helpCenterAllowed: brandInDb.helpCenterPermission === "read",
     ticketsAllowed: brandInDb.ticketsPermission === "read",
   };
+}
+
+/**
+ * This activity is responsible for fetching a batch of tickets
+ * that are older than the conversationsSlidingWindow and ready to be deleted.
+ */
+export async function getNextOldTicketBatchActivity(
+  connectorId: ModelId
+): Promise<number[]> {
+  const configuration =
+    await ZendeskConfigurationResource.fetchByConnectorId(connectorId);
+  if (!configuration) {
+    throw new Error(
+      `[Zendesk] Configuration not found, connectorId: ${connectorId}`
+    );
+  }
+  return ZendeskTicketResource.fetchOutdatedTicketIds({
+    connectorId,
+    expirationDate: new Date(
+      Date.now() -
+      configuration.conversationsSlidingWindow * 24 * 60 * 60 * 1000 // conversion from days to ms
+    ),
+    batchSize: ZENDESK_BATCH_SIZE,
+  });
+}
+
+/**
+ * This activity is responsible for deleting a batch of tickets given their IDs.
+ */
+export async function deleteTicketBatchActivity(
+  connectorId: ModelId,
+  ticketIds: number[]
+): Promise<void> {
+  const connector = await ConnectorResource.fetchById(connectorId);
+  if (!connector) {
+    throw new Error("[Zendesk] Connector not found.");
+  }
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+  const loggerArgs = {
+    workspaceId: dataSourceConfig.workspaceId,
+    connectorId,
+    provider: "zendesk",
+    dataSourceId: dataSourceConfig.dataSourceId,
+  };
+
+  await concurrentExecutor(
+    ticketIds,
+    (ticketId) =>
+      deleteTicket({ connectorId, ticketId, dataSourceConfig, loggerArgs }),
+    { concurrency: 10 }
+  );
 }
 
 /**
@@ -612,7 +664,12 @@ export async function syncZendeskTicketUpdateBatchActivity({
     tickets,
     async (ticket) => {
       if (ticket.status === "deleted") {
-        return deleteTicket(connectorId, ticket, dataSourceConfig, loggerArgs);
+        return deleteTicket({
+          connectorId,
+          ticketId: ticket.id,
+          dataSourceConfig,
+          loggerArgs,
+        });
       } else if (ticket.status === "solved") {
         const comments = await zendeskApiClient.tickets.getComments(ticket.id);
         const { result: users } = await zendeskApiClient.users.showMany(

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -15,8 +15,8 @@ import {
   createZendeskClient,
   fetchRecentlyUpdatedArticles,
   fetchRecentlyUpdatedTickets,
-  fetchSolvedZendeskTicketsInBrand,
   fetchZendeskArticlesInCategory,
+  fetchZendeskTicketsInBrand,
 } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
@@ -494,7 +494,7 @@ export async function syncZendeskTicketBatchActivity({
     brandId,
   });
 
-  const { tickets, meta } = await fetchSolvedZendeskTicketsInBrand({
+  const { tickets, meta } = await fetchZendeskTicketsInBrand({
     brandSubdomain,
     accessToken,
     pageSize: ZENDESK_BATCH_SIZE,

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -203,8 +203,7 @@ export async function getNextOldTicketBatchActivity(
   return ZendeskTicketResource.fetchOutdatedTicketIds({
     connectorId,
     expirationDate: new Date(
-      Date.now() -
-      configuration.conversationsSlidingWindow * 24 * 60 * 60 * 1000 // conversion from days to ms
+      Date.now() - configuration.retentionPeriodDays * 24 * 60 * 60 * 1000 // conversion from days to ms
     ),
     batchSize: ZENDESK_BATCH_SIZE,
   });

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -472,6 +472,11 @@ export async function syncZendeskTicketBatchActivity({
   if (!connector) {
     throw new Error("[Zendesk] Connector not found.");
   }
+  const configuration =
+    await ZendeskConfigurationResource.fetchByConnectorId(connectorId);
+  if (!configuration) {
+    throw new Error(`[Zendesk] Configuration not found.`);
+  }
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
   const loggerArgs = {
     workspaceId: dataSourceConfig.workspaceId,
@@ -494,6 +499,7 @@ export async function syncZendeskTicketBatchActivity({
     accessToken,
     pageSize: ZENDESK_BATCH_SIZE,
     cursor,
+    retentionPeriodDays: configuration.retentionPeriodDays,
   });
 
   if (tickets.length === 0) {

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -188,7 +188,7 @@ export async function syncZendeskBrandActivity({
 
 /**
  * This activity is responsible for fetching a batch of tickets
- * that are older than the conversationsSlidingWindow and ready to be deleted.
+ * that are older than the retention period and ready to be deleted.
  */
 export async function getNextOldTicketBatchActivity(
   connectorId: ModelId

--- a/connectors/src/lib/models/zendesk.ts
+++ b/connectors/src/lib/models/zendesk.ts
@@ -66,7 +66,7 @@ export class ZendeskConfiguration extends Model<
   declare updatedAt: CreationOptional<Date>;
 
   declare subdomain: string;
-  declare conversationsSlidingWindow: number;
+  declare conversationsSlidingWindow: number; // in days
 
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
 }
@@ -95,7 +95,7 @@ ZendeskConfiguration.init(
     conversationsSlidingWindow: {
       type: DataTypes.INTEGER,
       allowNull: false,
-      defaultValue: 90,
+      defaultValue: 180, // approximately 6 months
     },
   },
   {

--- a/connectors/src/lib/models/zendesk.ts
+++ b/connectors/src/lib/models/zendesk.ts
@@ -392,6 +392,7 @@ export class ZendeskTicket extends Model<
   declare subject: string;
   declare url: string;
 
+  declare ticketCreatedAt: Date;
   declare lastUpsertedTs: Date;
 
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
@@ -444,6 +445,10 @@ ZendeskTicket.init(
     },
     permission: {
       type: DataTypes.STRING,
+      allowNull: false,
+    },
+    ticketCreatedAt: {
+      type: DataTypes.DATE,
       allowNull: false,
     },
     lastUpsertedTs: {

--- a/connectors/src/lib/models/zendesk.ts
+++ b/connectors/src/lib/models/zendesk.ts
@@ -66,7 +66,7 @@ export class ZendeskConfiguration extends Model<
   declare updatedAt: CreationOptional<Date>;
 
   declare subdomain: string;
-  declare conversationsSlidingWindow: number; // in days
+  declare retentionPeriodDays: number;
 
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
 }
@@ -92,7 +92,7 @@ ZendeskConfiguration.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
-    conversationsSlidingWindow: {
+    retentionPeriodDays: {
       type: DataTypes.INTEGER,
       allowNull: false,
       defaultValue: 180, // approximately 6 months

--- a/connectors/src/lib/models/zendesk.ts
+++ b/connectors/src/lib/models/zendesk.ts
@@ -392,7 +392,7 @@ export class ZendeskTicket extends Model<
   declare subject: string;
   declare url: string;
 
-  declare ticketCreatedAt: Date;
+  declare ticketUpdatedAt: Date;
   declare lastUpsertedTs: Date;
 
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
@@ -447,7 +447,7 @@ ZendeskTicket.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
-    ticketCreatedAt: {
+    ticketUpdatedAt: {
       type: DataTypes.DATE,
       allowNull: false,
     },

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -622,6 +622,23 @@ export class ZendeskTicketResource extends BaseResource<ZendeskTicket> {
     ];
   }
 
+  static async fetchOutdatedTicketIds({
+    connectorId,
+    expirationDate,
+    batchSize,
+  }: {
+    connectorId: number;
+    expirationDate: Date;
+    batchSize: number;
+  }): Promise<number[]> {
+    const tickets = await ZendeskTicket.findAll({
+      attributes: ["ticketId"],
+      where: { connectorId, updatedAt: { [Op.lt]: expirationDate } },
+      limit: batchSize,
+    });
+    return tickets.map((ticket) => ticket.ticketId);
+  }
+
   static async fetchByTicketId({
     connectorId,
     ticketId,

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -633,7 +633,7 @@ export class ZendeskTicketResource extends BaseResource<ZendeskTicket> {
   }): Promise<number[]> {
     const tickets = await ZendeskTicket.findAll({
       attributes: ["ticketId"],
-      where: { connectorId, ticketCreatedAt: { [Op.lt]: expirationDate } },
+      where: { connectorId, ticketUpdatedAt: { [Op.lt]: expirationDate } },
       limit: batchSize,
     });
     return tickets.map((ticket) => ticket.ticketId);

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -633,7 +633,7 @@ export class ZendeskTicketResource extends BaseResource<ZendeskTicket> {
   }): Promise<number[]> {
     const tickets = await ZendeskTicket.findAll({
       attributes: ["ticketId"],
-      where: { connectorId, updatedAt: { [Op.lt]: expirationDate } },
+      where: { connectorId, ticketCreatedAt: { [Op.lt]: expirationDate } },
       limit: batchSize,
     });
     return tickets.map((ticket) => ticket.ticketId);

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -95,7 +95,7 @@ export class ZendeskConfigurationResource extends BaseResource<ZendeskConfigurat
       updatedAt: this.updatedAt,
 
       subdomain: this.subdomain,
-      conversationsSlidingWindow: this.conversationsSlidingWindow,
+      retentionPeriodDays: this.retentionPeriodDays,
 
       connectorId: this.connectorId,
     };


### PR DESCRIPTION
## Description

- Close [#8622](https://github.com/dust-tt/dust/issues/8622)
- Update the default retention period from 90 days to 6 months (actually 180 days).
- Clean up outdated tickets.
  - Add a column `ticketUpdatedAt` in `zendesk_tickets` to store update dates.
- Prevent outdated tickets from being fetched.
- Rename the column for the retention period from `conversationSlidingWindow` to `retentionPeriodDays`.


## Risk

Low.

## Deploy Plan

- Run migration and deploy connectors.