### PR TITLE
[connectors] Implement incremental sync for the Zendesk articles

### DIFF
--- a/connectors/src/connectors/zendesk/lib/sync_article.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_article.ts
@@ -8,6 +8,7 @@ import type {
 } from "@connectors/@types/node-zendesk";
 import { getArticleInternalId } from "@connectors/connectors/zendesk/lib/id_conversions";
 import {
+  deleteFromDataSource,
   renderDocumentTitleAndContent,
   renderMarkdownSection,
   upsertToDatasource,
@@ -18,6 +19,36 @@ import { ZendeskArticleResource } from "@connectors/resources/zendesk_resources"
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
 const turndownService = new TurndownService();
+
+/**
+ * Deletes an article from the db and the data sources.
+ */
+export async function deleteArticle(
+  connectorId: ModelId,
+  article: ZendeskFetchedArticle,
+  dataSourceConfig: DataSourceConfig,
+  loggerArgs: Record<string, string | number | null>
+): Promise<void> {
+  logger.info(
+    {
+      ...loggerArgs,
+      connectorId,
+      articleId: article.id,
+      name: article.name,
+    },
+    "[Zendesk] Deleting article."
+  );
+  await Promise.all([
+    ZendeskArticleResource.deleteByArticleId({
+      connectorId,
+      articleId: article.id,
+    }),
+    deleteFromDataSource(
+      dataSourceConfig,
+      getArticleInternalId(connectorId, article.id)
+    ),
+  ]);
+}
 
 /**
  * Syncs an article from Zendesk to the postgres db and to the data sources.

--- a/connectors/src/connectors/zendesk/lib/sync_article.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_article.ts
@@ -38,16 +38,14 @@ export async function deleteArticle(
     },
     "[Zendesk] Deleting article."
   );
-  await Promise.all([
-    ZendeskArticleResource.deleteByArticleId({
-      connectorId,
-      articleId: article.id,
-    }),
-    deleteFromDataSource(
-      dataSourceConfig,
-      getArticleInternalId(connectorId, article.id)
-    ),
-  ]);
+  await deleteFromDataSource(
+    dataSourceConfig,
+    getArticleInternalId(connectorId, article.id)
+  );
+  await ZendeskArticleResource.deleteByArticleId({
+    connectorId,
+    articleId: article.id,
+  });
 }
 
 /**

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -37,16 +37,14 @@ export async function deleteTicket(
     },
     "[Zendesk] Deleting ticket."
   );
-  await Promise.all([
-    ZendeskTicketResource.deleteByTicketId({
-      connectorId,
-      ticketId: ticket.id,
-    }),
-    deleteFromDataSource(
-      dataSourceConfig,
-      getTicketInternalId(connectorId, ticket.id)
-    ),
-  ]);
+  await deleteFromDataSource(
+    dataSourceConfig,
+    getTicketInternalId(connectorId, ticket.id)
+  );
+  await ZendeskTicketResource.deleteByTicketId({
+    connectorId,
+    ticketId: ticket.id,
+  });
 }
 
 /**

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -155,7 +155,7 @@ async function fetchFromZendeskWithRetries({
 export async function fetchRecentlyUpdatedArticles({
   subdomain,
   accessToken,
-  startTime = null,
+  startTime = null, // start time in Unix epoch time, in seconds
   cursor = null,
 }:
   | {

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -166,6 +166,7 @@ export async function fetchRecentlyUpdatedArticles({
   end_time: number;
 }> {
   startTime &&= Math.min(startTime || Math.floor(Date.now() / 1000) - 60); // we get a StartTimeTooRecent error before 1 minute
+  // this endpoint retrieves changes in content despite what is mentioned in the documentation.
   const response = await fetchFromZendeskWithRetries({
     url: `https://${subdomain}.zendesk.com/api/v2/help_center/incremental/articles.json?start_time=${startTime}`,
     accessToken,

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -155,35 +155,25 @@ async function fetchFromZendeskWithRetries({
 export async function fetchRecentlyUpdatedArticles({
   subdomain,
   accessToken,
-  startTime = null, // start time in Unix epoch time, in seconds
-  cursor = null,
-}:
-  | {
-      subdomain: string;
-      accessToken: string;
-      startTime: number | null;
-      cursor?: never;
-    }
-  | {
-      subdomain: string;
-      accessToken: string;
-      startTime?: never;
-      cursor: string | null;
-    }): Promise<{
+  startTime, // start time in Unix epoch time, in seconds
+}: {
+  subdomain: string;
+  accessToken: string;
+  startTime: number;
+}): Promise<{
   articles: ZendeskFetchedArticle[];
-  meta: { end_of_stream: boolean; after_cursor: string };
+  next_page: string | null;
+  end_time: number;
 }> {
-  const response = await fetchWithRetries({
-    url:
-      `https://${subdomain}.zendesk.com/api/v2/help_center/incremental/articles.json` +
-      (cursor ? `?cursor=${cursor}` : "") +
-      (startTime ? `?start_time=${startTime}` : ""),
+  const response = await fetchFromZendeskWithRetries({
+    url: `https://${subdomain}.zendesk.com/api/v2/help_center/incremental/articles.json?start_time=${startTime}`,
     accessToken,
   });
   return (
     response || {
       articles: [],
-      meta: { end_of_stream: false, after_cursor: "" },
+      next_page: null,
+      end_time: startTime,
     }
   );
 }

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -165,7 +165,6 @@ export async function fetchRecentlyUpdatedArticles({
   next_page: string | null;
   end_time: number;
 }> {
-  startTime &&= Math.min(startTime || Math.floor(Date.now() / 1000) - 60); // we get a StartTimeTooRecent error before 1 minute
   // this endpoint retrieves changes in content despite what is mentioned in the documentation.
   const response = await fetchFromZendeskWithRetries({
     url: `https://${subdomain}.zendesk.com/api/v2/help_center/incremental/articles.json?start_time=${startTime}`,

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -150,6 +150,45 @@ async function fetchFromZendeskWithRetries({
 }
 
 /**
+ * Fetches a batch of the recently updated articles from the Zendesk API using the incremental API endpoint.
+ */
+export async function fetchRecentlyUpdatedArticles({
+  subdomain,
+  accessToken,
+  startTime = null,
+  cursor = null,
+}:
+  | {
+      subdomain: string;
+      accessToken: string;
+      startTime: number | null;
+      cursor?: never;
+    }
+  | {
+      subdomain: string;
+      accessToken: string;
+      startTime?: never;
+      cursor: string | null;
+    }): Promise<{
+  articles: ZendeskFetchedArticle[];
+  meta: { end_of_stream: boolean; after_cursor: string };
+}> {
+  const response = await fetchWithRetries({
+    url:
+      `https://${subdomain}.zendesk.com/api/v2/help_center/incremental/articles.json` +
+      (cursor ? `?cursor=${cursor}` : "") +
+      (startTime ? `?start_time=${startTime}` : ""),
+    accessToken,
+  });
+  return (
+    response || {
+      articles: [],
+      meta: { end_of_stream: false, after_cursor: "" },
+    }
+  );
+}
+
+/**
  * Fetches a batch of articles in a category from the Zendesk API.
  */
 export async function fetchZendeskArticlesInCategory({

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -165,6 +165,7 @@ export async function fetchRecentlyUpdatedArticles({
   next_page: string | null;
   end_time: number;
 }> {
+  startTime &&= Math.min(startTime || Math.floor(Date.now() / 1000) - 60); // we get a StartTimeTooRecent error before 1 minute
   const response = await fetchFromZendeskWithRetries({
     url: `https://${subdomain}.zendesk.com/api/v2/help_center/incremental/articles.json?start_time=${startTime}`,
     accessToken,

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -258,10 +258,10 @@ export async function getZendeskTimestampCursorActivity(
 /**
  * Retrieves the IDs of every brand stored in db that has read permissions on their Help Center.
  */
-export async function getZendeskHelpCenterReadPermissionedBrandIdsActivity(
+export async function getZendeskHelpCenterReadAllowedBrandIdsActivity(
   connectorId: ModelId
 ): Promise<number[]> {
-  return ZendeskBrandResource.fetchHelpCenterReadPermissionedBrandIds({
+  return ZendeskBrandResource.fetchHelpCenterReadAllowedBrandIds({
     connectorId,
   });
 }

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -223,17 +223,6 @@ export async function checkZendeskTicketsPermissionsActivity({
 }
 
 /**
- * Retrieves the IDs of every brand stored in db.
- */
-export async function getAllZendeskBrandsIdsActivity({
-  connectorId,
-}: {
-  connectorId: ModelId;
-}): Promise<number[]> {
-  return ZendeskBrandResource.fetchAllBrandIds({ connectorId });
-}
-
-/**
  * Retrieves the timestamp cursor, which is the start date of the last successful sync.
  */
 export async function getZendeskTimestampCursorActivity(

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -576,7 +576,9 @@ export async function syncZendeskArticleUpdateBatchActivity({
   } = await fetchRecentlyUpdatedArticles({
     subdomain: brandSubdomain,
     accessToken,
-    ...(cursor ? { cursor } : { startTime: currentSyncDateMs - 1000 * 60 * 5 }), // 5 min ago, previous scheduled execution
+    ...(cursor
+      ? { cursor }
+      : { startTime: Math.floor(currentSyncDateMs / 1000 - 60 * 5) }), // 5 min ago, previous scheduled execution
   });
 
   await concurrentExecutor(

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -538,7 +538,7 @@ export async function syncZendeskTicketBatchActivity({
  * This activity is responsible for syncing the next batch of recently updated articles to process.
  * It is based on the incremental endpoint, which returns a diff.
  */
-export async function syncZendeskRecentlyUpdatedArticleBatchActivity({
+export async function syncZendeskArticleUpdateBatchActivity({
   connectorId,
   brandId,
   currentSyncDateMs,

--- a/connectors/src/connectors/zendesk/temporal/config.ts
+++ b/connectors/src/connectors/zendesk/temporal/config.ts
@@ -1,2 +1,2 @@
-export const WORKFLOW_VERSION = 3;
+export const WORKFLOW_VERSION = 4;
 export const QUEUE_NAME = `zendesk-queue-v${WORKFLOW_VERSION}`;

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -21,7 +21,7 @@ const {
   syncZendeskArticleBatchActivity,
   syncZendeskTicketBatchActivity,
   syncZendeskTicketUpdateBatchActivity,
-  syncZendeskRecentlyUpdatedArticleBatchActivity,
+  syncZendeskArticleUpdateBatchActivity,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "5 minutes",
 });
@@ -233,7 +233,7 @@ export async function zendeskIncrementalSyncWorkflow({
 
   for (const brandId of helpCenterBrandIds) {
     await runZendeskActivityWithPagination((cursor) =>
-      syncZendeskRecentlyUpdatedArticleBatchActivity({
+      syncZendeskArticleUpdateBatchActivity({
         connectorId,
         brandId,
         currentSyncDateMs,

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -232,14 +232,15 @@ export async function zendeskIncrementalSyncWorkflow({
   const startTime = Math.floor(startTimeMs / 1000);
 
   for (const brandId of helpCenterBrandIds) {
-    await runZendeskActivityWithPagination((cursor) =>
-      syncZendeskArticleUpdateBatchActivity({
+    let articleSyncStartTime: number | null = startTime;
+    while (articleSyncStartTime !== null) {
+      articleSyncStartTime = await syncZendeskArticleUpdateBatchActivity({
         connectorId,
         brandId,
         currentSyncDateMs,
-        cursor,
-      })
-    );
+        startTime: articleSyncStartTime,
+      });
+    }
   }
 
   for (const brandId of ticketBrandIds) {

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -29,11 +29,11 @@ const {
 const {
   checkZendeskHelpCenterPermissionsActivity,
   checkZendeskTicketsPermissionsActivity,
+  getZendeskHelpCenterReadAllowedBrandIdsActivity,
   saveZendeskConnectorStartSync,
   saveZendeskConnectorSuccessSync,
   getZendeskTicketsAllowedBrandIdsActivity,
   getZendeskTimestampCursorActivity,
-  getZendeskHelpCenterReadPermissionedBrandIdsActivity,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "1 minute",
 });
@@ -223,7 +223,7 @@ export async function zendeskIncrementalSyncWorkflow({
   const [cursor, ticketBrandIds, helpCenterBrandIds] = await Promise.all([
     getZendeskTimestampCursorActivity(connectorId),
     getZendeskTicketsAllowedBrandIdsActivity(connectorId),
-    getZendeskHelpCenterReadPermissionedBrandIdsActivity(connectorId),
+    getZendeskHelpCenterReadAllowedBrandIdsActivity(connectorId),
   ]);
 
   const startTimeMs = cursor

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -248,6 +248,18 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
     return brands.map((brand) => brand.get().brandId);
   }
 
+  static async fetchHelpCenterReadPermissionedBrandIds({
+    connectorId,
+  }: {
+    connectorId: number;
+  }): Promise<number[]> {
+    const brands = await ZendeskBrand.findAll({
+      where: { connectorId, helpCenterPermission: "read" },
+      attributes: ["brandId"],
+    });
+    return brands.map((brand) => brand.get().brandId);
+  }
+
   static async fetchAllWithHelpCenter({
     connectorId,
   }: {

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -868,6 +868,15 @@ export class ZendeskArticleResource extends BaseResource<ZendeskArticle> {
     return articles.map((article) => new this(this.model, article.get()));
   }
 
+  static async deleteByArticleId({
+    connectorId,
+    articleId,
+  }: {
+    connectorId: number;
+    articleId: number;
+  }) {
+    await ZendeskArticle.destroy({ where: { connectorId, articleId } });
+  }
   static async deleteByCategoryId({
     connectorId,
     categoryId,

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -248,7 +248,7 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
     return brands.map((brand) => brand.get().brandId);
   }
 
-  static async fetchHelpCenterReadPermissionedBrandIds({
+  static async fetchHelpCenterReadAllowedBrandIds({
     connectorId,
   }: {
     connectorId: number;


### PR DESCRIPTION
## Description

- Close [#8548](https://github.com/dust-tt/dust/issues/8548)
- On a cron execution (meaning not one triggered by a signal), the current workflow only updates the tickets currently.
- The incremental endpoint can be used to retrieve the diff starting from a certain date, which can be leveraged in the cron schedule to sync what changed since the previous cron execution.
- Tests performed:
  - Add an article to a category that is allowed and check that is appears in qdrant and postgres.
  - Do the same for an article in a category that is not allowed and check that nothing happens.

## Risk

Low.

## Deploy Plan

- Deploy connectors.