### PR TITLE
feat: allow superseding content fragments from public API

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1773,17 +1773,13 @@ export async function postNewContentFragment(
   // If the request is superseding an existing content fragment, we need to validate
   // that it exists and is part of the conversation.
   if (supersededContentFragmentId) {
-    let found = false;
-    for (const versions of conversation.content) {
+    const found = conversation.content.some((versions) => {
       const latest = versions[versions.length - 1];
-      if (
+      return (
         isContentFragmentType(latest) &&
         latest.contentFragmentId === supersededContentFragmentId
-      ) {
-        found = true;
-        break;
-      }
-    }
+      );
+    });
 
     if (!found) {
       return new Err(new Error("Superseded content fragment not found."));

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -34,6 +34,7 @@ import {
   assertNever,
   ConversationError,
   getSmallWhitelistedModel,
+  isContentFragmentType,
   isProviderWhitelisted,
   md5,
   removeNulls,
@@ -1768,22 +1769,52 @@ export async function postNewContentFragment(
     return cfBlobRes;
   }
 
+  const supersededContentFragmentId = cf.supersededContentFragmentId;
+  // If the request is superseding an existing content fragment, we need to validate
+  // that it exists and is part of the conversation.
+  if (supersededContentFragmentId) {
+    let found = false;
+    for (const versions of conversation.content) {
+      const latest = versions[versions.length - 1];
+      if (
+        isContentFragmentType(latest) &&
+        latest.contentFragmentId === supersededContentFragmentId
+      ) {
+        found = true;
+        break;
+      }
+    }
+
+    if (!found) {
+      return new Err(new Error("Superseded content fragment not found."));
+    }
+  }
+
   const { contentFragment, messageRow } = await frontSequelize.transaction(
     async (t) => {
       await getConversationRankVersionLock(conversation, t);
 
-      const contentFragment = await ContentFragmentResource.makeNew(
-        {
-          ...cfBlobRes.value,
-          userId: auth.user()?.id,
-          userContextProfilePictureUrl: context?.profilePictureUrl,
-          userContextEmail: context?.email,
-          userContextFullName: context?.fullName,
-          userContextUsername: context?.username,
-          version: "latest",
-        },
-        t
-      );
+      const fullBlob = {
+        ...cfBlobRes.value,
+        userId: auth.user()?.id,
+        userContextProfilePictureUrl: context?.profilePictureUrl,
+        userContextEmail: context?.email,
+        userContextFullName: context?.fullName,
+        userContextUsername: context?.username,
+      };
+
+      const contentFragment = await (() => {
+        if (supersededContentFragmentId) {
+          return ContentFragmentResource.makeNewVersion(
+            supersededContentFragmentId,
+            fullBlob,
+            t
+          );
+        } else {
+          return ContentFragmentResource.makeNew(fullBlob, t);
+        }
+      })();
+
       const nextMessageRank =
         ((await Message.max<number | null, Message>("rank", {
           where: {

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -93,7 +93,7 @@ async function destroyContentFragments(
   }
 
   const contentFragments =
-    await ContentFragmentResource.fetchMany(contentFragmentIds);
+    await ContentFragmentResource.fetchManyByModelIds(contentFragmentIds);
 
   for (const contentFragment of contentFragments) {
     const messageContentFragmentId = messageAndContentFragmentIds.find(

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -114,12 +114,14 @@ async function handler(
         r.data.contentType = normalizedContentType;
       }
       const { context, ...contentFragment } = r.data;
+
       const contentFragmentRes = await postNewContentFragment(
         auth,
         conversation,
         contentFragment,
         context
       );
+
       if (contentFragmentRes.isErr()) {
         return apiError(req, res, {
           status_code: 400,

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1581,6 +1581,8 @@ export const PublicContentFragmentWithContentSchema = z.object({
   contentType: SupportedContentFragmentTypeSchema,
   fileId: z.undefined().nullable(),
   context: ContentFragmentContextSchema.nullable(),
+  // Undocumented for now -- allows to supersede an existing content fragment.
+  supersededContentFragmentId: z.string().optional().nullable(),
 });
 
 export type PublicContentFragmentWithContent = z.infer<
@@ -1594,6 +1596,8 @@ export const PublicContentFragmentWithFileIdSchema = z.object({
   contentType: z.undefined().nullable(),
   fileId: z.string(),
   context: ContentFragmentContextSchema.nullable(),
+  // Undocumented for now -- allows to supersede an existing content fragment.
+  supersededContentFragmentId: z.string().optional().nullable(),
 });
 
 export type PublicContentFragmentWithFileId = z.infer<

--- a/types/src/front/api_handlers/internal/assistant.ts
+++ b/types/src/front/api_handlers/internal/assistant.ts
@@ -17,6 +17,7 @@ const ContentFragmentBaseSchema = t.intersection([
   }),
   t.partial({
     url: t.union([t.string, t.null]),
+    supersededContentFragmentId: t.union([t.string, t.null]),
   }),
 ]);
 


### PR DESCRIPTION
## Description

- Allows creating a new version of an existing content fragment, marking previous existing ones for that sId as "superseded"
- "superseded" content fragments get rendered without content in `renderConversationForModel`

## Risk

Critical path (blast radius: conversations that contain content fragment, uploading new content fragments)

## Deploy Plan

N/A