### PR TITLE
Improve connectors deploy notification

### DIFF
--- a/.github/workflows/deploy-connectors.yml
+++ b/.github/workflows/deploy-connectors.yml
@@ -24,6 +24,25 @@ jobs:
         id: short_sha
         run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
+      - name: Initiate a deployment
+        id: build_message
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: |
+              🚀 Starting deployment of connectors `${{ steps.short_sha.outputs.short_sha }}`
+              • Commit: <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ steps.short_sha.outputs.short_sha }}>
+              • Workflow: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View build>
+              • Author: ${{ github.actor }}
+
+              Building image...
+
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
       - name: "Authenticate with Google Cloud"
         uses: "google-github-actions/auth@v1"
         with:
@@ -40,6 +59,19 @@ jobs:
             --dockerfile-path=./connectors/Dockerfile \
             --working-dir=./ \
             --dust-client-facing-url=https://dust.tt
+
+      - name: Notify Deploy Start
+        id: deployment_message
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            thread_ts: "${{ steps.build_message.outputs.ts }}"
+            text: |
+              ✅ Image build completed
+              Starting deployment to regions: us-central1
 
       - name: Generate a token
         id: generate-token
@@ -63,6 +95,21 @@ jobs:
               client_payload: {
                 regions: 'us-central1',
                 component: 'connectors',
-                image_tag: '${{ steps.short_sha.outputs.short_sha }}'
+                image_tag: '${{ steps.short_sha.outputs.short_sha }}',
+                slack_thread_ts: "${{ steps.build_message.outputs.ts }}",
+                slack_channel: '${{ secrets.SLACK_CHANNEL_ID }}'
               }
             });
+
+      - name: Notify Failure
+        if: failure()
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            thread_ts: "${{ steps.build_message.outputs.ts }}"
+            text: |
+              ❌ Build pipeline failed
+              Check the workflow logs: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Improve the Slack notifications for connector deployment.

Sadly we can't do a re-usable workflow because we can't call it within `jobs.steps` but only in `jobs`:
> You call a reusable workflow by using the uses keyword. Unlike when you are using actions within a workflow, you call reusable workflows directly within a job, and not from within job steps.

(documentation [link](https://docs.github.com/en/actions/sharing-automations/reusing-workflows#calling-a-reusable-workflow))

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Add both `SLACK_BOT_TOKEN` and `SLACK_CHANNEL_ID` in Github secrets