### PR TITLE
Move folder datasource creation to lib

### DIFF
--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -688,11 +688,6 @@ export async function handleDataSourceTableCSVUpsert({
   return new Ok(tableRes.value);
 }
 
-type DataSourceWithoutProviderBodyType = {
-  name: string;
-  description: string | null;
-};
-
 /**
  * Data sources without provider = folders
  */
@@ -702,12 +697,14 @@ export async function createDataSourceWithoutProvider(
     plan,
     owner,
     space,
-    body,
+    name,
+    description,
   }: {
     plan: PlanType;
     owner: WorkspaceType;
     space: SpaceResource;
-    body: DataSourceWithoutProviderBodyType;
+    name: string;
+    description: string | null;
   }
 ): Promise<
   Result<
@@ -721,8 +718,6 @@ export async function createDataSourceWithoutProvider(
     }
   >
 > {
-  const { name, description } = body;
-
   if (name.startsWith("managed-")) {
     return new Err({
       name: "dust_error",

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -7,21 +7,28 @@ import type {
   ConnectorType,
   CoreAPIDataSource,
   CoreAPIDocument,
+  CoreAPIError,
   CoreAPILightDocument,
   CoreAPITable,
   DataSourceType,
   DataSourceWithConnectorDetailsType,
   FrontDataSourceDocumentSectionType,
+  PlanType,
   Result,
   UpsertTableFromCsvRequestType,
   WithConnector,
+  WorkspaceType,
 } from "@dust-tt/types";
 import {
   assertNever,
   ConnectorsAPI,
   CoreAPI,
+  DEFAULT_EMBEDDING_PROVIDER_ID,
+  DEFAULT_QDRANT_CLUSTER,
   dustManagedCredentials,
+  EMBEDDING_CONFIGS,
   Err,
+  isDataSourceNameValid,
   MANAGED_DS_DELETABLE,
   Ok,
   sectionFullText,
@@ -37,7 +44,10 @@ import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+import { ServerSideTracking } from "@app/lib/tracking/server";
 import { enqueueUpsertTable } from "@app/lib/upsert_queue";
 import { validateUrl } from "@app/lib/utils";
 import logger from "@app/logger/logger";
@@ -676,4 +686,141 @@ export async function handleDataSourceTableCSVUpsert({
   }
 
   return new Ok(tableRes.value);
+}
+
+type DataSourceWithoutProviderBodyType = {
+  name: string;
+  description: string | null;
+};
+
+/**
+ * Data sources without provider = folders
+ */
+export async function createDataSourceWithoutProvider(
+  auth: Authenticator,
+  {
+    plan,
+    owner,
+    space,
+    body,
+  }: {
+    plan: PlanType;
+    owner: WorkspaceType;
+    space: SpaceResource;
+    body: DataSourceWithoutProviderBodyType;
+  }
+): Promise<
+  Result<
+    DataSourceViewResource,
+    Omit<DustError, "code"> & {
+      code:
+        | "invalid_request_error"
+        | "plan_limit_error"
+        | "internal_server_error";
+      dataSourceError?: CoreAPIError;
+    }
+  >
+> {
+  const { name, description } = body;
+
+  if (name.startsWith("managed-")) {
+    return new Err({
+      name: "dust_error",
+      code: "invalid_request_error",
+      message: "The data source name cannot start with `managed-`.",
+    });
+  }
+  if (!isDataSourceNameValid(name)) {
+    return new Err({
+      name: "dust_error",
+      code: "invalid_request_error",
+      message: "Data source names cannot be empty.",
+    });
+  }
+  const dataSources = await DataSourceResource.listByWorkspace(auth);
+  if (
+    plan.limits.dataSources.count != -1 &&
+    dataSources.length >= plan.limits.dataSources.count
+  ) {
+    return new Err({
+      name: "dust_error",
+      code: "plan_limit_error",
+      message: "Your plan does not allow you to create more data sources.",
+    });
+  }
+
+  const dataSourceEmbedder =
+    owner.defaultEmbeddingProvider ?? DEFAULT_EMBEDDING_PROVIDER_ID;
+  const embedderConfig = EMBEDDING_CONFIGS[dataSourceEmbedder];
+  const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+
+  const dustProject = await coreAPI.createProject();
+  if (dustProject.isErr()) {
+    return new Err({
+      name: "dust_error",
+      code: "internal_server_error",
+      message: "Failed to create internal project for the data source.",
+      dataSourceError: dustProject.error,
+    });
+  }
+
+  const dustDataSource = await coreAPI.createDataSource({
+    projectId: dustProject.value.project.project_id.toString(),
+    config: {
+      qdrant_config: {
+        cluster: DEFAULT_QDRANT_CLUSTER,
+        shadow_write_cluster: null,
+      },
+      embedder_config: {
+        embedder: {
+          max_chunk_size: embedderConfig.max_chunk_size,
+          model_id: embedderConfig.model_id,
+          provider_id: embedderConfig.provider_id,
+          splitter_id: embedderConfig.splitter_id,
+        },
+      },
+    },
+    credentials: dustManagedCredentials(),
+  });
+
+  if (dustDataSource.isErr()) {
+    return new Err({
+      name: "dust_error",
+      code: "internal_server_error",
+      message: "Failed to create the data source.",
+      dataSourceError: dustDataSource.error,
+    });
+  }
+
+  const dataSourceView =
+    await DataSourceViewResource.createDataSourceAndDefaultView(
+      auth,
+      {
+        name,
+        description,
+        dustAPIProjectId: dustProject.value.project.project_id.toString(),
+        dustAPIDataSourceId: dustDataSource.value.data_source.data_source_id,
+        workspaceId: owner.id,
+        assistantDefaultSelected: false,
+      },
+      space
+    );
+
+  try {
+    // Asynchronous tracking without awaiting, handled safely
+    void ServerSideTracking.trackDataSourceCreated({
+      user: auth.getNonNullableUser(),
+      workspace: owner,
+      dataSource: dataSourceView.dataSource.toJSON(),
+    });
+  } catch (error) {
+    logger.error(
+      {
+        error,
+      },
+      "Failed to track data source creation"
+    );
+  }
+
+  return new Ok(dataSourceView);
 }

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
@@ -15,7 +15,6 @@ import {
   dustManagedCredentials,
   EMBEDDING_CONFIGS,
   ioTsParsePayload,
-  isDataSourceNameValid,
   sendUserOperationMessage,
   WebCrawlerConfigurationTypeSchema,
 } from "@dust-tt/types";
@@ -25,6 +24,7 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import config from "@app/lib/api/config";
+import { createDataSourceWithoutProvider } from "@app/lib/api/data_sources";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getOrCreateSystemApiKey } from "@app/lib/auth";
@@ -36,13 +36,22 @@ import {
   isConnectorProviderAssistantDefaultSelected,
   isValidConnectorSuffix,
 } from "@app/lib/connector_providers";
-import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { isDisposableEmailDomain } from "@app/lib/utils/disposable_email_domains";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
+
+// Sorcery: Create a union type with at least two elements to satisfy t.union
+function getConnectorProviderCodec(): t.Mixed {
+  const [first, second, ...rest] = CONNECTOR_PROVIDERS;
+  return t.union([
+    t.literal(first),
+    t.literal(second),
+    ...rest.map((value) => t.literal(value)),
+  ]);
+}
 
 export const PostDataSourceWithProviderRequestBodySchema = t.intersection([
   t.type({
@@ -54,15 +63,6 @@ export const PostDataSourceWithProviderRequestBodySchema = t.intersection([
     connectionId: t.string, // Required for some providers
   }),
 ]);
-// Sorcery: Create a union type with at least two elements to satisfy t.union
-export function getConnectorProviderCodec(): t.Mixed {
-  const [first, second, ...rest] = CONNECTOR_PROVIDERS;
-  return t.union([
-    t.literal(first),
-    t.literal(second),
-    ...rest.map((value) => t.literal(value)),
-  ]);
-}
 
 const PostDataSourceWithoutProviderRequestBodySchema = t.type({
   name: t.string,
@@ -179,14 +179,34 @@ async function handler(
         const body = bodyValidation.right as t.TypeOf<
           typeof PostDataSourceWithoutProviderRequestBodySchema
         >;
-        await handleDataSourceWithoutProvider({
-          auth,
+        const r = await createDataSourceWithoutProvider(auth, {
           plan,
           owner,
           space,
           body,
-          req,
-          res,
+        });
+
+        if (r.isErr()) {
+          return apiError(req, res, {
+            status_code:
+              r.error.code === "internal_server_error"
+                ? 500
+                : r.error.code === "plan_limit_error"
+                  ? 401
+                  : 400,
+            api_error: {
+              type: r.error.code,
+              message: r.error.message,
+              data_source_error: r.error.dataSourceError,
+            },
+          });
+        }
+
+        const dataSourceView = r.value;
+
+        return res.status(201).json({
+          dataSource: dataSourceView.dataSource.toJSON(),
+          dataSourceView: dataSourceView.toJSON(),
         });
       }
       break;
@@ -488,147 +508,6 @@ const handleDataSourceWithProvider = async ({
         }\``,
       });
     }
-  } catch (error) {
-    logger.error(
-      {
-        error,
-      },
-      "Failed to track data source creation"
-    );
-  }
-
-  return;
-};
-
-/**
- * Data sources without provider = folders
- */
-const handleDataSourceWithoutProvider = async ({
-  auth,
-  plan,
-  owner,
-  space,
-  body,
-  req,
-  res,
-}: {
-  auth: Authenticator;
-  plan: PlanType;
-  owner: WorkspaceType;
-  space: SpaceResource;
-  body: t.TypeOf<typeof PostDataSourceWithoutProviderRequestBodySchema>;
-  req: NextApiRequest;
-  res: NextApiResponse<WithAPIErrorResponse<PostSpaceDataSourceResponseBody>>;
-}) => {
-  const { name, description } = body;
-
-  if (name.startsWith("managed-")) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "The data source name cannot start with `managed-`.",
-      },
-    });
-  }
-  if (!isDataSourceNameValid(name)) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Data source names cannot be empty.",
-      },
-    });
-  }
-  const dataSources = await DataSourceResource.listByWorkspace(auth);
-  if (
-    plan.limits.dataSources.count != -1 &&
-    dataSources.length >= plan.limits.dataSources.count
-  ) {
-    return apiError(req, res, {
-      status_code: 401,
-      api_error: {
-        type: "plan_limit_error",
-        message: "Your plan does not allow you to create managed data sources.",
-      },
-    });
-  }
-
-  const dataSourceEmbedder =
-    owner.defaultEmbeddingProvider ?? DEFAULT_EMBEDDING_PROVIDER_ID;
-  const embedderConfig = EMBEDDING_CONFIGS[dataSourceEmbedder];
-  const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-
-  const dustProject = await coreAPI.createProject();
-  if (dustProject.isErr()) {
-    return apiError(req, res, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: `Failed to create internal project for the data source.`,
-        data_source_error: dustProject.error,
-      },
-    });
-  }
-
-  const dustDataSource = await coreAPI.createDataSource({
-    projectId: dustProject.value.project.project_id.toString(),
-    config: {
-      qdrant_config: {
-        cluster: DEFAULT_QDRANT_CLUSTER,
-        shadow_write_cluster: null,
-      },
-      embedder_config: {
-        embedder: {
-          max_chunk_size: embedderConfig.max_chunk_size,
-          model_id: embedderConfig.model_id,
-          provider_id: embedderConfig.provider_id,
-          splitter_id: embedderConfig.splitter_id,
-        },
-      },
-    },
-    credentials: dustManagedCredentials(),
-  });
-
-  if (dustDataSource.isErr()) {
-    return apiError(req, res, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: "Failed to create the data source.",
-        data_source_error: dustDataSource.error,
-      },
-    });
-  }
-
-  const dataSourceView =
-    await DataSourceViewResource.createDataSourceAndDefaultView(
-      auth,
-      {
-        name,
-        description,
-        dustAPIProjectId: dustProject.value.project.project_id.toString(),
-        dustAPIDataSourceId: dustDataSource.value.data_source.data_source_id,
-        workspaceId: owner.id,
-        assistantDefaultSelected: false,
-      },
-      space
-    );
-
-  const { dataSource } = dataSourceView;
-
-  res.status(201).json({
-    dataSource: dataSource.toJSON(),
-    dataSourceView: dataSourceView.toJSON(),
-  });
-
-  try {
-    // Asynchronous tracking without awaiting, handled safely
-    void ServerSideTracking.trackDataSourceCreated({
-      user: auth.getNonNullableUser(),
-      workspace: owner,
-      dataSource: dataSource.toJSON(),
-    });
   } catch (error) {
     logger.error(
       {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
@@ -183,7 +183,8 @@ async function handler(
           plan,
           owner,
           space,
-          body,
+          name: body.name,
+          description: body.description,
         });
 
         if (r.isErr()) {


### PR DESCRIPTION
## Description

Move creation of folder type datasource to a function in lib/ so I can re-use it to create the conversation datasource easily.

## Risk

Break folder creation but it's a straightforward refactoring (tested locally)

## Deploy Plan

Deploy `front`