### PR TITLE
[front] - fix: add horizontal padding to website modal

### DIFF
--- a/front/components/spaces/SpaceWebsiteModal.tsx
+++ b/front/components/spaces/SpaceWebsiteModal.tsx
@@ -390,7 +390,7 @@ export default function SpaceWebsiteModal({
       }
     >
       <div className="w-full pt-6">
-        <div className="overflow-x-auto">
+        <div className="overflow-x-auto px-1">
           <AdvancedSettingsModal
             advancedSettingsOpened={advancedSettingsOpened}
             setAdvancedSettingsOpened={setAdvancedSettingsOpened}


### PR DESCRIPTION
## Description

This PR adds padding to the website modal to avoid the inputs' ring being cropped:

<img width="735" alt="Screenshot 2024-11-17 at 10 39 59" src="https://github.com/user-attachments/assets/2047a435-0129-4347-a1d4-080992c43bd3">


## Risk

None

## Deploy Plan

Deploy `front`