### PR TITLE
[connectors] Fix data deletion in Zendesk

### DIFF
--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -281,12 +281,12 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         }
         case "help-center": {
           if (permission === "none") {
-            const revokedBrand = await revokeSyncZendeskHelpCenter({
+            const revokedBrandHelpCenter = await revokeSyncZendeskHelpCenter({
               connectorId,
               brandId: objectId,
             });
-            if (revokedBrand) {
-              toBeSignaledHelpCenterIds.add(revokedBrand.brandId);
+            if (revokedBrandHelpCenter) {
+              toBeSignaledHelpCenterIds.add(revokedBrandHelpCenter.brandId);
             }
           }
           if (permission === "read") {
@@ -303,12 +303,12 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         }
         case "tickets": {
           if (permission === "none") {
-            const revokedCollection = await revokeSyncZendeskTickets({
+            const revokedBrandTickets = await revokeSyncZendeskTickets({
               connectorId,
               brandId: objectId,
             });
-            if (revokedCollection) {
-              toBeSignaledTicketsIds.add(revokedCollection.brandId);
+            if (revokedBrandTickets) {
+              toBeSignaledTicketsIds.add(revokedBrandTickets.brandId);
             }
           }
           if (permission === "read") {

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -258,30 +258,35 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
       const { type, objectId } = getIdFromInternalId(connectorId, id);
       switch (type) {
         case "brand": {
-          toBeSignaledBrandIds.add(objectId);
           if (permission === "none") {
-            await revokeSyncZendeskBrand({
+            const revokedBrand = await revokeSyncZendeskBrand({
               connectorId,
               brandId: objectId,
             });
+            if (revokedBrand) {
+              toBeSignaledBrandIds.add(objectId);
+            }
           }
           if (permission === "read") {
-            await allowSyncZendeskBrand({
+            const wasBrandUpdated = await allowSyncZendeskBrand({
               connectorId,
               connectionId,
               brandId: objectId,
             });
+            if (wasBrandUpdated) {
+              toBeSignaledBrandIds.add(objectId);
+            }
           }
           break;
         }
         case "help-center": {
           if (permission === "none") {
-            const revokedCollection = await revokeSyncZendeskHelpCenter({
+            const revokedBrand = await revokeSyncZendeskHelpCenter({
               connectorId,
               brandId: objectId,
             });
-            if (revokedCollection) {
-              toBeSignaledHelpCenterIds.add(revokedCollection.brandId);
+            if (revokedBrand) {
+              toBeSignaledHelpCenterIds.add(revokedBrand.brandId);
             }
           }
           if (permission === "read") {

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -123,7 +123,7 @@ export async function syncZendeskBrandActivity({
     );
   }
 
-  // deleting the data not allowed anymore
+  // deleting the tickets/help center if not allowed anymore
   if (brandInDb.ticketsPermission === "none") {
     await deleteBrandTickets({ connectorId, brandId, dataSourceConfig });
   }

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -168,7 +168,7 @@ export async function syncZendeskBrandActivity({
       await brandInDb.delete();
       return { helpCenterAllowed: false, ticketsAllowed: false };
     }
-    await brandInDb.update({ helpCenterPermission: "none" });
+    await brandInDb.revokeHelpCenterPermissions();
   }
 
   // otherwise, we update the brand name and lastUpsertedTs

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -181,56 +181,6 @@ export async function syncZendeskBrandActivity({
 }
 
 /**
- * This activity is responsible for checking the permissions for a Brand's Help Center.
- *
- * @returns true if the Help Center has read permissions enabled.
- */
-export async function checkZendeskHelpCenterPermissionsActivity({
-  connectorId,
-  brandId,
-}: {
-  connectorId: ModelId;
-  brandId: number;
-}): Promise<boolean> {
-  const brandInDb = await ZendeskBrandResource.fetchByBrandId({
-    connectorId,
-    brandId,
-  });
-  if (!brandInDb) {
-    throw new Error(
-      `[Zendesk] Brand not found, connectorId: ${connectorId}, brandId: ${brandId}`
-    );
-  }
-
-  return brandInDb.helpCenterPermission === "read";
-}
-
-/**
- * This activity is responsible for checking the permissions for a Brand's Tickets.
- *
- * @returns true if the Brand has read permissions enabled on tickets.
- */
-export async function checkZendeskTicketsPermissionsActivity({
-  connectorId,
-  brandId,
-}: {
-  connectorId: ModelId;
-  brandId: number;
-}): Promise<boolean> {
-  const brandInDb = await ZendeskBrandResource.fetchByBrandId({
-    connectorId,
-    brandId,
-  });
-  if (!brandInDb) {
-    throw new Error(
-      `[Zendesk] Brand not found, connectorId: ${connectorId}, brandId: ${brandId}`
-    );
-  }
-
-  return brandInDb.ticketsPermission === "read";
-}
-
-/**
  * Retrieves the timestamp cursor, which is the start date of the last successful sync.
  */
 export async function getZendeskTimestampCursorActivity(

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -94,8 +94,9 @@ export async function saveZendeskConnectorSuccessSync({
  * It is going to update the name of the Brand if it has changed.
  * If the Brand is not allowed anymore, it will delete all its data.
  * If the Brand is not present on Zendesk anymore, it will delete all its data as well.
+ * If the Help Center has no readable category anymore, we delete the Help Center data.
  *
- * @returns true if the Brand was updated, false if it was deleted.
+ * @returns the updated permissions of the Brand.
  */
 export async function syncZendeskBrandActivity({
   connectorId,
@@ -122,6 +123,7 @@ export async function syncZendeskBrandActivity({
     );
   }
 
+  // deleting the data not allowed anymore
   if (brandInDb.ticketsPermission === "none") {
     await deleteBrandTickets({ connectorId, brandId, dataSourceConfig });
   }
@@ -154,6 +156,7 @@ export async function syncZendeskBrandActivity({
     return { helpCenterAllowed: false, ticketsAllowed: false };
   }
 
+  // if there are no read permissions on any category, we delete the help center
   const categoriesWithReadPermissions =
     await ZendeskCategoryResource.fetchByBrandIdReadOnly({
       connectorId,

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -127,7 +127,10 @@ export async function syncZendeskBrandActivity({
     brandInDb.helpCenterPermission === "none" &&
     brandInDb.ticketsPermission === "none"
   ) {
-    await brandInDb.delete();
+    await Promise.all([
+      brandInDb.delete(),
+      deleteBrandChildren({ connectorId, brandId, dataSourceConfig }),
+    ]);
     return { helpCenterAllowed: false, ticketsAllowed: false };
   }
 
@@ -140,8 +143,10 @@ export async function syncZendeskBrandActivity({
     result: { brand: fetchedBrand },
   } = await zendeskApiClient.brand.show(brandId);
   if (!fetchedBrand) {
-    await deleteBrandChildren({ connectorId, brandId, dataSourceConfig });
-    await brandInDb.delete();
+    await Promise.all([
+      brandInDb.delete(),
+      deleteBrandChildren({ connectorId, brandId, dataSourceConfig }),
+    ]);
     return { helpCenterAllowed: false, ticketsAllowed: false };
   }
 
@@ -155,7 +160,10 @@ export async function syncZendeskBrandActivity({
   if (noMoreAllowedCategories) {
     // if the tickets and all children categories are not allowed anymore, we delete the brand data
     if (brandInDb.ticketsPermission !== "read") {
-      await deleteBrandChildren({ connectorId, brandId, dataSourceConfig });
+      await Promise.all([
+        brandInDb.delete(),
+        deleteBrandChildren({ connectorId, brandId, dataSourceConfig }),
+      ]);
       return { helpCenterAllowed: false, ticketsAllowed: false };
     }
     await brandInDb.update({ helpCenterPermission: "none" });

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -149,10 +149,10 @@ export async function syncZendeskBrandActivity({
   } = await zendeskApiClient.brand.show(brandId);
   if (!fetchedBrand) {
     await Promise.all([
-      brandInDb.delete(),
       deleteBrandHelpCenter({ connectorId, brandId, dataSourceConfig }),
       deleteBrandTickets({ connectorId, brandId, dataSourceConfig }),
     ]);
+    await brandInDb.delete();
     return { helpCenterAllowed: false, ticketsAllowed: false };
   }
 

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -27,8 +27,6 @@ const {
 });
 
 const {
-  checkZendeskHelpCenterPermissionsActivity,
-  checkZendeskTicketsPermissionsActivity,
   getZendeskHelpCenterReadAllowedBrandIdsActivity,
   saveZendeskConnectorStartSync,
   saveZendeskConnectorSuccessSync,
@@ -308,11 +306,12 @@ export async function zendeskBrandHelpCenterSyncWorkflow({
   currentSyncDateMs: number;
   forceResync: boolean;
 }) {
-  const isHelpCenterAllowed = await checkZendeskHelpCenterPermissionsActivity({
+  const { helpCenterAllowed } = await syncZendeskBrandActivity({
     connectorId,
     brandId,
+    currentSyncDateMs,
   });
-  if (isHelpCenterAllowed) {
+  if (helpCenterAllowed) {
     await runZendeskBrandHelpCenterSyncActivities({
       connectorId,
       brandId,
@@ -336,11 +335,12 @@ export async function zendeskBrandTicketsSyncWorkflow({
   currentSyncDateMs: number;
   forceResync: boolean;
 }) {
-  const areTicketsAllowed = await checkZendeskTicketsPermissionsActivity({
+  const { ticketsAllowed } = await syncZendeskBrandActivity({
     connectorId,
     brandId,
+    currentSyncDateMs,
   });
-  if (areTicketsAllowed) {
+  if (ticketsAllowed) {
     await runZendeskBrandTicketsSyncActivities({
       connectorId,
       brandId,


### PR DESCRIPTION
## Description

- Previous behavior: unselecting a help center or tickets did not delete data, only unselecting the brand did.
- New behavior: changing permissions on a help center or tickets syncs the brand:
  - Checks that it still exists on Zendesk
  - Checks that it still has permissions
  - Checks that it still has at least 1 category with read permissions, otherwise revoking permissions for the help center and deleting it.

## Risk

Low.

## Deploy Plan

- Deploy connectors.