### PR TITLE
[Slack] Prevent rate limit when retrieving permissions

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -124,7 +124,6 @@ async function _getChannelsUncached(
     {
       connectorId,
       returnedChannels: allChannels.length,
-      nextCursor,
       nbCalls,
     },
     `[Slack] conversations.list called for getChannels (${nbCalls} calls)`

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -91,7 +91,7 @@ async function _getChannelsUncached(
       types: "public_channel, private_channel",
       // despite the limit being 1000, slack may return fewer channels
       // we observed ~50 channels per call at times see https://github.com/dust-tt/tasks/issues/1655
-      limit: 1000,
+      limit: 999,
       cursor: nextCursor,
     });
     nbCalls++;

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -59,11 +59,26 @@ const MAX_SYNC_NON_THREAD_MESSAGES = 4000;
  * Broadly, you'll encounter limits like these, applied on a
  * "per API method per app per workspace" basis.
  * Tier 1: ~1 request per minute
- * Tier 2: ~20 request per minute (conversations.history)
+ * Tier 2: ~20 request per minute (conversations.history, conversation.list)
  * Tier 3: ~50 request per minute (conversations.replies)
  */
 
-export async function getChannels(
+/**
+ *  Call cached to avoid rate limits
+ *  ON RATE LIMIT ERRORS PERTAINING TO THIS FUNCTION:
+ * - the next step will be to paginate (overkill at time of writing)
+ * - see issue https://github.com/dust-tt/tasks/issues/1655
+ * - and related PR https://github.com/dust-tt/dust/pull/8709
+ * @param connectorId
+ * @param joinedOnly
+ */
+export const getChannels = cacheWithRedis(
+  _getChannelsUncached,
+  (connectorId, joinedOnly) => `slack-channels-${connectorId}-${joinedOnly}`,
+  5 * 60 * 1000
+);
+
+async function _getChannelsUncached(
   connectorId: ModelId,
   joinedOnly: boolean
 ): Promise<Channel[]> {
@@ -73,6 +88,8 @@ export async function getChannels(
   do {
     const c: ConversationsListResponse = await client.conversations.list({
       types: "public_channel, private_channel",
+      // despite the limit being 1000, slack may return fewer channels
+      // we observed ~50 channels per call at times see https://github.com/dust-tt/tasks/issues/1655
       limit: 1000,
       cursor: nextCursor,
     });


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/1655

As described in issue:
- conversations.list is limited to 20 calls / minute;
- getChannels sometimes return channels by batches of ~50 => a client with 500 channels will make 10 calls in a few seconds;
- this led to user-facing errors, see issue.

This PR caches the call to getChannels for 5 minutes, which will solve the issue satisfactorily for a good while. 

Preexisting log is kept but limited to 1 per `getChannels` call

Risk
---
Blast radius: retrievePermission modals and slack syncs 
Low risk, the code is standard
Tested locally

Deploy
---
connectors
