### PR TITLE
[connectors] Fix start date of Zendesk incremental syncs

### DIFF
--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -38,11 +38,7 @@ import type { DataSourceConfig } from "@connectors/types/data_source_config";
 /**
  * This activity is responsible for updating the lastSyncStartTime of the connector to now.
  */
-export async function saveZendeskConnectorStartSync({
-  connectorId,
-}: {
-  connectorId: ModelId;
-}) {
+export async function saveZendeskConnectorStartSync(connectorId: ModelId) {
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
     throw new Error("[Zendesk] Connector not found.");
@@ -56,11 +52,7 @@ export async function saveZendeskConnectorStartSync({
 /**
  * This activity is responsible for updating the sync status of the connector to "success".
  */
-export async function saveZendeskConnectorSuccessSync({
-  connectorId,
-}: {
-  connectorId: ModelId;
-}) {
+export async function saveZendeskConnectorSuccessSync(connectorId: ModelId) {
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
     throw new Error("[Zendesk] Connector not found.");

--- a/connectors/src/connectors/zendesk/temporal/config.ts
+++ b/connectors/src/connectors/zendesk/temporal/config.ts
@@ -1,4 +1,4 @@
-export const WORKFLOW_VERSION = 4;
+export const WORKFLOW_VERSION = 5;
 export const QUEUE_NAME = `zendesk-queue-v${WORKFLOW_VERSION}`;
 export const GARBAGE_COLLECT_QUEUE_NAME = `zendesk-gc-queue-v${WORKFLOW_VERSION}`;
 

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -212,7 +212,7 @@ export async function zendeskSyncWorkflow({
     }
   }
 
-  await saveZendeskConnectorSuccessSync(connectorId);
+  await saveZendeskConnectorSuccessSync(connectorId, currentSyncDateMs);
 }
 
 /**
@@ -376,13 +376,13 @@ export async function zendeskCategorySyncWorkflow({
   currentSyncDateMs: number;
   forceResync: boolean;
 }) {
-  const wasCategoryUpdated = await syncZendeskCategoryActivity({
+  const shouldSyncArticles = await syncZendeskCategoryActivity({
     connectorId,
     categoryId,
     currentSyncDateMs,
     brandId,
   });
-  if (wasCategoryUpdated) {
+  if (shouldSyncArticles) {
     await runZendeskActivityWithPagination((cursor) =>
       syncZendeskArticleBatchActivity({
         connectorId,

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -515,15 +515,3 @@ async function runZendeskActivityWithPagination(
     cursor = result.afterCursor;
   }
 }
-
-/**
- * Removes the outdated tickets.
- * The retention period is defined in the zendesk_configurations table (in number of days).
- */
-async function cleanupOldZendeskTickets(connectorId: ModelId) {
-  let ticketIds = await getNextOldTicketBatchActivity(connectorId);
-  while (ticketIds.length > 0) {
-    await deleteTicketBatchActivity(connectorId, ticketIds);
-    ticketIds = await getNextOldTicketBatchActivity(connectorId);
-  }
-}

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -56,7 +56,7 @@ export async function zendeskSyncWorkflow({
 }: {
   connectorId: ModelId;
 }) {
-  await saveZendeskConnectorStartSync({ connectorId });
+  await saveZendeskConnectorStartSync(connectorId);
 
   const brandIds = new Set<number>();
   const brandSignals: ZendeskUpdateSignal[] = [];
@@ -212,7 +212,7 @@ export async function zendeskSyncWorkflow({
     }
   }
 
-  await saveZendeskConnectorSuccessSync({ connectorId });
+  await saveZendeskConnectorSuccessSync(connectorId);
 }
 
 /**


### PR DESCRIPTION
## Description

- Previously, the incremental syncs for Zendesk fetched the updates since the last successful sync (incremental or not).
- This behavior is problematic in that if I just full synced Brand A then it does not mean that Brand B can be synced starting from now on (changes between the last sync of B and the current sync of A are lost).
- New behavior:
  - The cursor is specific to incremental syncs.
  - When setting up the connector, we set the cursor to the star of the first sync, which is not an incremental one. It is then used in incremental syncs from now on.
- Tiny refactor: replace `function f({ connectorId }: { connectorId: ModelId; })` with `function f(connectorId: ModelId))` on two occurrences.

## Risk

Low.

## Deploy Plan

- Deploy connectors.