### PR TITLE
Handle error user not found from public api

### DIFF
--- a/extension/app/src/components/assistants/usePublicAgentConfigurations.ts
+++ b/extension/app/src/components/assistants/usePublicAgentConfigurations.ts
@@ -11,7 +11,7 @@ export function usePublicAgentConfigurations() {
     if (res.isOk()) {
       return res.value;
     }
-    throw new Error(res.error.message);
+    throw res.error;
   };
 
   const { data, error, mutate, mutateRegardlessOfQueryParams } =
@@ -21,10 +21,7 @@ export function usePublicAgentConfigurations() {
     );
 
   useEffect(() => {
-    if (
-      typeof error?.message === "string" &&
-      error?.message.includes("User not found")
-    ) {
+    if (error?.type === "not_authenticated") {
       void logout();
     }
   }, [error]);

--- a/extension/app/src/components/auth/useAuth.ts
+++ b/extension/app/src/components/auth/useAuth.ts
@@ -58,6 +58,22 @@ export const useAuthHook = () => {
     [handleRefreshToken]
   );
 
+  // Listen for changes in storage to make sure we always have the latest user and tokens.
+  useEffect(() => {
+    const handleStorageChange = (changes: {
+      [key: string]: chrome.storage.StorageChange;
+    }) => {
+      if (changes.accessToken && !changes.accessToken.newValue) {
+        console.log("Access token removed from storage.");
+        setTokens(null);
+        setUser(null);
+      }
+    };
+    chrome.storage.local.onChanged.addListener(handleStorageChange);
+    return () =>
+      chrome.storage.local.onChanged.removeListener(handleStorageChange);
+  }, []);
+
   useEffect(() => {
     void (async () => {
       setIsLoading(true);

--- a/extension/app/src/components/conversation/useConversations.ts
+++ b/extension/app/src/components/conversation/useConversations.ts
@@ -10,7 +10,7 @@ export function useConversations() {
     if (res.isOk()) {
       return res.value;
     }
-    throw new Error(res.error.message);
+    throw res.error;
   };
 
   const { data, error, mutate } = useSWRWithDefaults(
@@ -19,10 +19,7 @@ export function useConversations() {
   );
 
   useEffect(() => {
-    if (
-      typeof error?.message === "string" &&
-      error?.message.includes("User not found")
-    ) {
+    if (error?.type === "not_authenticated") {
       void logout();
     }
   }, [error]);

--- a/extension/app/src/components/conversation/usePublicConversation.ts
+++ b/extension/app/src/components/conversation/usePublicConversation.ts
@@ -26,7 +26,7 @@ export function usePublicConversation({
     if (res.isOk()) {
       return res.value;
     }
-    throw new Error(res.error.message);
+    throw res.error;
   };
 
   const { data, error, mutate } = useSWRWithDefaults(
@@ -37,10 +37,7 @@ export function usePublicConversation({
   );
 
   useEffect(() => {
-    if (
-      typeof error?.message === "string" &&
-      error?.message.includes("User not found")
-    ) {
+    if (error?.type === "not_authenticated") {
       void logout();
     }
   }, [error]);

--- a/extension/app/src/lib/swr.ts
+++ b/extension/app/src/lib/swr.ts
@@ -97,28 +97,28 @@ const resHandler = async (res: Response) => {
     return res.json();
   }
 
-  let errorText;
+  let error;
 
   try {
     const resJson = await res.json();
-    errorText = resJson.error?.message;
+    error = resJson.error;
 
-    if (errorText.includes("User not found")) {
-      errorText = "User not found, logging out.";
+    if (error?.type === "not_authenticated") {
+      error = "User not found, logging out.";
       await logout();
     }
   } catch (e) {
     console.error("Error parsing response: ", e);
-    errorText = await res.text();
+    error = await res.text();
   }
 
   console.error(
     "Error returned by the front API: ",
     res.status,
     res.headers,
-    errorText
+    error
   );
-  throw new Error(errorText);
+  throw new Error(error);
 };
 
 export const fetcher = async (...args: Parameters<typeof fetch>) => {

--- a/front/lib/api/wrappers.ts
+++ b/front/lib/api/wrappers.ts
@@ -205,6 +205,16 @@ export function withPublicAPIAuthentication<T, U extends boolean>(
           token,
           wId,
         });
+        if (auth.user() === null) {
+          return apiError(req, res, {
+            status_code: 401,
+            api_error: {
+              type: "not_authenticated",
+              message:
+                "The user does not have an active session or is not authenticated.",
+            },
+          });
+        }
         if (!auth.isUser()) {
           return apiError(req, res, {
             status_code: 401,
@@ -347,10 +357,11 @@ export function withAuth0TokenAuthentication<T>(
       const user = await getUserFromAuth0Token(bearerToken);
       if (!user) {
         return apiError(req, res, {
-          status_code: 404,
+          status_code: 401,
           api_error: {
-            type: "user_not_found",
-            message: "Could not find the user.",
+            type: "not_authenticated",
+            message:
+              "The user does not have an active session or is not authenticated.",
           },
         });
       }

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -304,7 +304,13 @@ export class Authenticator {
   }): Promise<Authenticator> {
     const user = await getUserFromAuth0Token(token);
     if (!user) {
-      throw new Error("User not found.");
+      return new Authenticator({
+        role: "none",
+        groups: [],
+        user: null,
+        subscription: null,
+        workspace: null,
+      });
     }
 
     const workspace = await Workspace.findOne({


### PR DESCRIPTION
## Description

**Changes in front api:** 
`Auth.fromAuth0Token` returns an empty authenticator if it does not find a user. 
The 2 API wrappers using this (one for /me, and the other for all /api/v1/w/[wId]) are now answering with a 401 `not_authenticated` if the user from authenticator is null.


**Changes in extension:** 
Update hooks calling public api to call for logout based on the new error returned by front. 
Update our `useAuthHook` to listen for changes in the chrome storage to make sure we immediately have an `isAuthenticated` = false when the storage is emptied by calling logout. 


I will check with Seb if this change is okay for the Raycast extension. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
