### PR TITLE
[extension] Use dedicated audience for dust api. Add scopes verification

### DIFF
--- a/extension/app/background.ts
+++ b/extension/app/background.ts
@@ -272,7 +272,6 @@ const authenticate = async (
     audience: DUST_API_AUDIENCE,
     code_challenge_method: "S256",
     code_challenge: codeChallenge,
-    prompt: "consent",
   };
 
   const queryString = new URLSearchParams(options).toString();

--- a/extension/app/background.ts
+++ b/extension/app/background.ts
@@ -2,9 +2,9 @@ import type { PendingUpdate } from "@extension/lib/storage";
 import { savePendingUpdate } from "@extension/lib/storage";
 
 import {
-  AUTH0_AUDIENCE,
   AUTH0_CLIENT_DOMAIN,
   AUTH0_CLIENT_ID,
+  DUST_API_AUDIENCE,
 } from "./src/lib/config";
 import { extractPage } from "./src/lib/extraction";
 import type {
@@ -266,12 +266,13 @@ const authenticate = async (
   const options = {
     client_id: AUTH0_CLIENT_ID,
     response_type: "code",
-    // "offline_access" to receive refresh tokens to maintain user sessions without re-prompting for authentication.
-    scope: "openid offline_access",
+    scope:
+      "offline_access read:user_profile read:conversation create:conversation",
     redirect_uri: redirectUrl,
-    audience: AUTH0_AUDIENCE,
+    audience: DUST_API_AUDIENCE,
     code_challenge_method: "S256",
     code_challenge: codeChallenge,
+    prompt: "consent",
   };
 
   const queryString = new URLSearchParams(options).toString();

--- a/extension/app/background.ts
+++ b/extension/app/background.ts
@@ -267,7 +267,7 @@ const authenticate = async (
     client_id: AUTH0_CLIENT_ID,
     response_type: "code",
     scope:
-      "offline_access read:user_profile read:conversation create:conversation update:conversation read:agent",
+      "offline_access read:user_profile read:conversation create:conversation update:conversation read:agent read:file create:file delete:file",
     redirect_uri: redirectUrl,
     audience: DUST_API_AUDIENCE,
     code_challenge_method: "S256",

--- a/extension/app/background.ts
+++ b/extension/app/background.ts
@@ -267,11 +267,12 @@ const authenticate = async (
     client_id: AUTH0_CLIENT_ID,
     response_type: "code",
     scope:
-      "offline_access read:user_profile read:conversation create:conversation",
+      "offline_access read:user_profile read:conversation create:conversation update:conversation read:agent",
     redirect_uri: redirectUrl,
     audience: DUST_API_AUDIENCE,
     code_challenge_method: "S256",
     code_challenge: codeChallenge,
+    prompt: "consent",
   };
 
   const queryString = new URLSearchParams(options).toString();

--- a/extension/app/src/lib/config.ts
+++ b/extension/app/src/lib/config.ts
@@ -3,3 +3,4 @@ export const AUTH0_CLIENT_DOMAIN = process.env.AUTH0_CLIENT_DOMAIN ?? "";
 export const AUTH0_CLIENT_ID = process.env.AUTH0_CLIENT_ID ?? "";
 export const AUTH0_AUDIENCE = `https://${AUTH0_CLIENT_DOMAIN}/api/v2/`;
 export const AUTH0_PROFILE_ROUTE = `https://${AUTH0_CLIENT_DOMAIN}/userinfo`;
+export const DUST_API_AUDIENCE = process.env.DUST_API_AUDIENCE ?? "";

--- a/front/lib/api/auth0.ts
+++ b/front/lib/api/auth0.ts
@@ -20,7 +20,8 @@ const Auth0JwtPayloadSchema = t.type({
   sub: t.string,
 });
 
-type Auth0JwtPayload = t.TypeOf<typeof Auth0JwtPayloadSchema> & jwt.JwtPayload;
+export type Auth0JwtPayload = t.TypeOf<typeof Auth0JwtPayloadSchema> &
+  jwt.JwtPayload;
 
 export function getRequiredScope(
   req: NextApiRequest,

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -11,6 +11,9 @@ const config = {
   getAuth0TenantUrl: (): string => {
     return EnvironmentConfig.getEnvVariable("AUTH0_TENANT_DOMAIN_URL");
   },
+  getDustApiAudience: (): string => {
+    return EnvironmentConfig.getEnvVariable("DUST_API_AUDIENCE");
+  },
   getAuth0M2MClientId: (): string => {
     return EnvironmentConfig.getEnvVariable("AUTH0_M2M_CLIENT_ID");
   },

--- a/front/lib/api/wrappers.ts
+++ b/front/lib/api/wrappers.ts
@@ -8,8 +8,6 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import {
   getRequiredScope,
   getUserFromAuth0Token,
-  METHOD_TO_VERB,
-  validateScopes,
   verifyAuth0Token,
 } from "@app/lib/api/auth0";
 import { getUserWithWorkspaces } from "@app/lib/api/user";

--- a/front/lib/api/wrappers.ts
+++ b/front/lib/api/wrappers.ts
@@ -170,7 +170,7 @@ export function withPublicAPIAuthentication<T, U extends boolean>(
   opts: {
     isStreaming?: boolean;
     allowUserOutsideCurrentWorkspace?: U;
-    resourceName?: string;
+    requiredScopes?: Record<string, string>;
   } = {}
 ) {
   const { allowUserOutsideCurrentWorkspace, isStreaming } = opts;
@@ -210,7 +210,7 @@ export function withPublicAPIAuthentication<T, U extends boolean>(
       if (authMethod === "access_token") {
         const decoded = await verifyAuth0Token(
           token,
-          getRequiredScope(req, opts)
+          getRequiredScope(req, opts.requiredScopes)
         );
         if (decoded.isErr()) {
           return apiError(req, res, {
@@ -346,7 +346,7 @@ export function withAuth0TokenAuthentication<T>(
     user: UserTypeWithWorkspaces
   ) => Promise<void> | void,
   opts: {
-    resourceName?: string;
+    requiredScopes?: Record<string, string>;
   } = {}
 ) {
   return withLogging(
@@ -381,7 +381,7 @@ export function withAuth0TokenAuthentication<T>(
 
       const decoded = await verifyAuth0Token(
         bearerToken,
-        getRequiredScope(req, opts)
+        getRequiredScope(req, opts.requiredScopes)
       );
       if (decoded.isErr()) {
         return apiError(req, res, {

--- a/front/lib/api/wrappers.ts
+++ b/front/lib/api/wrappers.ts
@@ -5,6 +5,7 @@ import type {
 } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { MethodType, ScopeType } from "@app/lib/api/auth0";
 import {
   getRequiredScope,
   getUserFromAuth0Token,
@@ -51,7 +52,7 @@ export function withSessionAuthentication<T>(
           api_error: {
             type: "not_authenticated",
             message:
-              "The user does not have an active session or is not authenticated",
+              "The user does not have an active session or is not authenticated.",
           },
         });
       }
@@ -168,7 +169,7 @@ export function withPublicAPIAuthentication<T, U extends boolean>(
   opts: {
     isStreaming?: boolean;
     allowUserOutsideCurrentWorkspace?: U;
-    requiredScopes?: Record<string, string>;
+    requiredScopes?: Partial<Record<MethodType, ScopeType>>;
   } = {}
 ) {
   const { allowUserOutsideCurrentWorkspace, isStreaming } = opts;
@@ -344,7 +345,7 @@ export function withAuth0TokenAuthentication<T>(
     user: UserTypeWithWorkspaces
   ) => Promise<void> | void,
   opts: {
-    requiredScopes?: Record<string, string>;
+    requiredScopes?: Partial<Record<MethodType, ScopeType>>;
   } = {}
 ) {
   return withLogging(
@@ -393,7 +394,7 @@ export function withAuth0TokenAuthentication<T>(
       }
 
       const user = await getUserFromAuth0Token(decoded.value);
-
+      // TODO(thomas): user not found : means the user is not registered, display a message to the user and redirects to site
       if (!user) {
         return apiError(req, res, {
           status_code: 401,

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -29,6 +29,7 @@ import type {
   NextApiResponse,
 } from "next";
 
+import type { Auth0JwtPayload } from "@app/lib/api/auth0";
 import { getUserFromAuth0Token } from "@app/lib/api/auth0";
 import config from "@app/lib/api/config";
 import type { SessionWithUser } from "@app/lib/iam/provider";
@@ -299,7 +300,7 @@ export class Authenticator {
     token,
     wId,
   }: {
-    token: string;
+    token: Auth0JwtPayload;
     wId: string;
   }): Promise<Authenticator> {
     const user = await getUserFromAuth0Token(token);

--- a/front/pages/api/v1/me.ts
+++ b/front/pages/api/v1/me.ts
@@ -34,4 +34,6 @@ async function handler(
   }
 }
 
-export default withAuth0TokenAuthentication(handler);
+export default withAuth0TokenAuthentication(handler, {
+  resourceName: "user_profile",
+});

--- a/front/pages/api/v1/me.ts
+++ b/front/pages/api/v1/me.ts
@@ -35,5 +35,5 @@ async function handler(
 }
 
 export default withAuth0TokenAuthentication(handler, {
-  resourceName: "user_profile",
+  requiredScopes: { GET: "read:user_profile" },
 });

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
@@ -74,4 +74,6 @@ async function handler(
   }
 }
 
-export default withPublicAPIAuthentication(handler);
+export default withPublicAPIAuthentication(handler, {
+  requiredScopes: { GET: "read:agent" },
+});

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/cancel.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/cancel.ts
@@ -116,4 +116,5 @@ async function handler(
 
 export default withPublicAPIAuthentication(handler, {
   isStreaming: true,
+  requiredScopes: { POST: "update:conversation" },
 });

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -142,4 +142,6 @@ async function handler(
   }
 }
 
-export default withPublicAPIAuthentication(handler);
+export default withPublicAPIAuthentication(handler, {
+  requiredScopes: { POST: "update:conversation" },
+});

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -108,4 +108,7 @@ async function handler(
   }
 }
 
-export default withPublicAPIAuthentication(handler, { isStreaming: true });
+export default withPublicAPIAuthentication(handler, {
+  isStreaming: true,
+  requiredScopes: { GET: "read:conversation" },
+});

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -91,4 +91,6 @@ async function handler(
   }
 }
 
-export default withPublicAPIAuthentication(handler);
+export default withPublicAPIAuthentication(handler, {
+  resourceName: "conversation",
+});

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -92,5 +92,5 @@ async function handler(
 }
 
 export default withPublicAPIAuthentication(handler, {
-  resourceName: "conversation",
+  requiredScopes: { GET: "read:conversation" },
 });

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
@@ -172,4 +172,6 @@ async function handler(
   }
 }
 
-export default withPublicAPIAuthentication(handler);
+export default withPublicAPIAuthentication(handler, {
+  requiredScopes: { POST: "update:conversation" },
+});

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
@@ -175,4 +175,7 @@ async function handler(
   }
 }
 
-export default withPublicAPIAuthentication(handler, { isStreaming: true });
+export default withPublicAPIAuthentication(handler, {
+  isStreaming: true,
+  requiredScopes: { GET: "read:conversation" },
+});

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
@@ -112,4 +112,7 @@ async function handler(
   }
 }
 
-export default withPublicAPIAuthentication(handler, { isStreaming: true });
+export default withPublicAPIAuthentication(handler, {
+  isStreaming: true,
+  requiredScopes: { POST: "update:conversation" },
+});

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -139,5 +139,5 @@ async function handler(
 }
 
 export default withPublicAPIAuthentication(handler, {
-  requiredScope: "update:conversation",
+  requiredScopes: { POST: "update:conversation" },
 });

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -138,4 +138,6 @@ async function handler(
   }
 }
 
-export default withPublicAPIAuthentication(handler);
+export default withPublicAPIAuthentication(handler, {
+  requiredScope: "update:conversation",
+});

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -279,5 +279,5 @@ async function handler(
 }
 
 export default withPublicAPIAuthentication(handler, {
-  resourceName: "conversation",
+  requiredScopes: { GET: "read:conversation", POST: "create:conversation" },
 });

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -278,4 +278,6 @@ async function handler(
   }
 }
 
-export default withPublicAPIAuthentication(handler);
+export default withPublicAPIAuthentication(handler, {
+  resourceName: "conversation",
+});

--- a/front/pages/api/v1/w/[wId]/files/[fileId].ts
+++ b/front/pages/api/v1/w/[wId]/files/[fileId].ts
@@ -123,4 +123,10 @@ async function handler(
   }
 }
 
-export default withPublicAPIAuthentication(handler);
+export default withPublicAPIAuthentication(handler, {
+  requiredScopes: {
+    GET: "read:file",
+    POST: "create:file",
+    DELETE: "delete:file",
+  },
+});

--- a/front/pages/api/v1/w/[wId]/files/index.ts
+++ b/front/pages/api/v1/w/[wId]/files/index.ts
@@ -167,4 +167,6 @@ async function handler(
   }
 }
 
-export default withPublicAPIAuthentication(handler);
+export default withPublicAPIAuthentication(handler, {
+  requiredScopes: { POST: "create:file" },
+});


### PR DESCRIPTION
## Description

This introduces the usage of a custom auth0 API for our public api. The audience is set in an env var , `DUST_API_AUDIENCE` which should be `https://dust-dev.tt/api/v1` in development or `https://dust.tt/api/v1` in production. 

This API defines scopes in auth0 configuration, that will need to be extended, for checking particular endpoints in the api. All scopes used by the app are set - we'll have to add/define other ones in another PR.

The scopes required by the app must be specified when requesting authorization, which will result in displaying a consent screen : 

<img width="425" alt="Screenshot 2024-11-18 at 16 07 01" src="https://github.com/user-attachments/assets/a2493520-5441-4326-8d79-c928dcf0145b">

(This consent screen can be skipped  for 1st party apps , i.e. our own apps registered in our auth0 tenant, but must be shown for 3rd party apps)

The 2 wrappers `withPublicAPIAuthentication` and `withAuth0TokenAuthentication` are extended to support new option "resourceName" that can be used to create the scope. 

Scope are only checked against oauth tokens . `sk-` keys are considered system and do not include any scope (no scope check).

## Risk

For oauth users, some routes now require scope. 

## Deploy Plan

- [x] Set up prod API on auth0
- [x] Set `DUST_API_AUDIENCE` env vars
- [ ] Deploy front
