### PR TITLE
[connectors] Fix zendesk_tickets table

### DIFF
--- a/connectors/migrations/db/migration_36.sql
+++ b/connectors/migrations/db/migration_36.sql
@@ -1,0 +1,2 @@
+-- Migration created on Nov 18, 2024
+ALTER TABLE "public"."zendesk_tickets" DROP COLUMN IF EXISTS "name";


### PR DESCRIPTION
## Description

- The `zendesk_tickets` table has gone out of sync past `migration_31.sql`: a `RENAME COLUMN` was applied on a column that already existed.
- As a result, the column `name` still exists.

## Risk

Low.

## Deploy Plan

- Run `migration_36.sql`.
- Nothing to deploy.