### PR TITLE
[connectors] Implement garbage collection for Zendesk articles

### DIFF
--- a/connectors/src/connectors/zendesk/temporal/config.ts
+++ b/connectors/src/connectors/zendesk/temporal/config.ts
@@ -1,2 +1,4 @@
 export const WORKFLOW_VERSION = 4;
 export const QUEUE_NAME = `zendesk-queue-v${WORKFLOW_VERSION}`;
+
+export const ZENDESK_BATCH_SIZE = 100;

--- a/connectors/src/connectors/zendesk/temporal/config.ts
+++ b/connectors/src/connectors/zendesk/temporal/config.ts
@@ -1,4 +1,5 @@
 export const WORKFLOW_VERSION = 4;
 export const QUEUE_NAME = `zendesk-queue-v${WORKFLOW_VERSION}`;
+export const GARBAGE_COLLECT_QUEUE_NAME = `zendesk-gc-queue-v${WORKFLOW_VERSION}`;
 
 export const ZENDESK_BATCH_SIZE = 100;

--- a/connectors/src/connectors/zendesk/temporal/gc_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/gc_activities.ts
@@ -67,6 +67,7 @@ export async function garbageCollectTicketBatchActivity(
 
 /**
  * This activity is responsible for fetching and garbage collecting a batch of articles.
+ * Here, garbage collection means deleting articles that are no longer present in Zendesk.
  */
 export async function garbageCollectArticleBatchActivity({
   connectorId,

--- a/connectors/src/connectors/zendesk/temporal/gc_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/gc_activities.ts
@@ -1,0 +1,61 @@
+import type { ModelId } from "@dust-tt/types";
+
+import { deleteTicket } from "@connectors/connectors/zendesk/lib/sync_ticket";
+import { ZENDESK_BATCH_SIZE } from "@connectors/connectors/zendesk/temporal/config";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { concurrentExecutor } from "@connectors/lib/async_utils";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import {
+  ZendeskConfigurationResource,
+  ZendeskTicketResource,
+} from "@connectors/resources/zendesk_resources";
+
+/**
+ * This activity is responsible for fetching a batch of tickets
+ * that are older than the retention period and ready to be deleted.
+ */
+export async function getNextOldTicketBatchActivity(
+  connectorId: ModelId
+): Promise<number[]> {
+  const configuration =
+    await ZendeskConfigurationResource.fetchByConnectorId(connectorId);
+  if (!configuration) {
+    throw new Error(
+      `[Zendesk] Configuration not found, connectorId: ${connectorId}`
+    );
+  }
+  return ZendeskTicketResource.fetchOutdatedTicketIds({
+    connectorId,
+    expirationDate: new Date(
+      Date.now() - configuration.retentionPeriodDays * 24 * 60 * 60 * 1000 // conversion from days to ms
+    ),
+    batchSize: ZENDESK_BATCH_SIZE,
+  });
+}
+
+/**
+ * This activity is responsible for deleting a batch of tickets given their IDs.
+ */
+export async function deleteTicketBatchActivity(
+  connectorId: ModelId,
+  ticketIds: number[]
+): Promise<void> {
+  const connector = await ConnectorResource.fetchById(connectorId);
+  if (!connector) {
+    throw new Error("[Zendesk] Connector not found.");
+  }
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+  const loggerArgs = {
+    workspaceId: dataSourceConfig.workspaceId,
+    connectorId,
+    provider: "zendesk",
+    dataSourceId: dataSourceConfig.dataSourceId,
+  };
+
+  await concurrentExecutor(
+    ticketIds,
+    (ticketId) =>
+      deleteTicket({ connectorId, ticketId, dataSourceConfig, loggerArgs }),
+    { concurrency: 10 }
+  );
+}

--- a/connectors/src/connectors/zendesk/temporal/gc_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/gc_activities.ts
@@ -119,7 +119,7 @@ export async function garbageCollectArticleBatchActivity({
     brandId,
   });
 
-  // TODO(2024-11-18 aubin): see if we need to delete in batch
+  // not deleting in batch for now, assuming we won't have that many articles to delete at once
   await concurrentExecutor(
     articleIds,
     async (articleId) => {

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -9,10 +9,7 @@ import {
 
 import type * as activities from "@connectors/connectors/zendesk/temporal/activities";
 import type * as gc_activities from "@connectors/connectors/zendesk/temporal/gc_activities";
-import {
-  garbageCollectArticleBatchActivity,
-  getNextArticleBatchActivity,
-} from "@connectors/connectors/zendesk/temporal/gc_activities";
+import { garbageCollectArticleBatchActivity } from "@connectors/connectors/zendesk/temporal/gc_activities";
 import type {
   ZendeskCategoryUpdateSignal,
   ZendeskUpdateSignal,
@@ -422,18 +419,11 @@ export async function zendeskGarbageCollectionWorkflow({
     let cursor = null;
 
     do {
-      const { articleIds, cursor: newCursor } =
-        await getNextArticleBatchActivity({
-          connectorId,
-          brandId,
-          cursor,
-        });
-      await garbageCollectArticleBatchActivity({
+      cursor = await garbageCollectArticleBatchActivity({
         connectorId,
         brandId,
-        articleIds,
+        cursor,
       });
-      cursor = newCursor;
     } while (cursor !== null);
   }
 }

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -8,6 +8,7 @@ import {
 } from "@temporalio/workflow";
 
 import type * as activities from "@connectors/connectors/zendesk/temporal/activities";
+import type * as gc_activities from "@connectors/connectors/zendesk/temporal/gc_activities";
 import type {
   ZendeskCategoryUpdateSignal,
   ZendeskUpdateSignal,
@@ -22,10 +23,14 @@ const {
   syncZendeskTicketBatchActivity,
   syncZendeskTicketUpdateBatchActivity,
   syncZendeskArticleUpdateBatchActivity,
-  deleteTicketBatchActivity,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "5 minutes",
 });
+
+const { deleteTicketBatchActivity, getNextOldTicketBatchActivity } =
+  proxyActivities<typeof gc_activities>({
+    startToCloseTimeout: "5 minutes",
+  });
 
 const {
   getZendeskHelpCenterReadAllowedBrandIdsActivity,
@@ -33,7 +38,6 @@ const {
   saveZendeskConnectorSuccessSync,
   getZendeskTicketsAllowedBrandIdsActivity,
   getZendeskTimestampCursorActivity,
-  getNextOldTicketBatchActivity,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "1 minute",
 });

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -403,17 +403,19 @@ export async function zendeskCategorySyncWorkflow({
  * - Categories that have no article anymore.
  * - Brands that have no permission on tickets and Help Center anymore.
  */
-export async function zendeskGarbageCollectWorkflow({
+export async function zendeskGarbageCollectionWorkflow({
   connectorId,
 }: {
   connectorId: ModelId;
 }) {
+  // deleting the outdated tickets
   let ticketIds = await getNextOldTicketBatchActivity(connectorId);
   while (ticketIds.length > 0) {
     await deleteTicketBatchActivity(connectorId, ticketIds);
     ticketIds = await getNextOldTicketBatchActivity(connectorId);
   }
 
+  // deleting the articles that cannot be found anymore in the Zendesk API
   const brandIds =
     await getZendeskHelpCenterReadAllowedBrandIdsActivity(connectorId);
   for (const brandId of brandIds) {

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -820,6 +820,32 @@ export class ZendeskArticleResource extends BaseResource<ZendeskArticle> {
     ];
   }
 
+  /**
+   * Fetches a batch of article IDs.
+   */
+  static async fetchBatchByBrandId({
+    connectorId,
+    brandId,
+    batchSize,
+    cursor,
+  }: {
+    connectorId: number;
+    brandId: number;
+    batchSize: number;
+    cursor: number | null;
+  }): Promise<{ articleIds: number[]; cursor: number | null }> {
+    const articles = await ZendeskArticle.findAll({
+      where: { connectorId, brandId },
+      order: [["id", "ASC"]],
+      ...(cursor && { where: { id: { [Op.gt]: cursor } } }),
+      limit: batchSize,
+    });
+    return {
+      articleIds: articles.map((article) => article.get().articleId),
+      cursor: articles[batchSize - 1]?.get().id || null, // returning the last ID if it's a complete batch
+    };
+  }
+
   static async fetchByArticleId({
     connectorId,
     articleId,


### PR DESCRIPTION
## Description

- Close [#8656](https://github.com/dust-tt/dust/issues/8656)
- Add a garbage collection workflow that runs on a cron schedule every day at 3 am.
- Move the outdated ticket cleanup to this workflow.
- Add to this workflow activities to go over all the articles in batch and fetch them from the Zendesk API to check they still exist, deleting them if they don't.
- Other garbage collection activities (cleaning up whole brands for instance) will be added in an upcoming PR.

## Risk

Low.

## Deploy Plan

- Deploy connectors.