### PR TITLE
[front] - chore(workspacePicker): UX tweak

### DIFF
--- a/front/components/WorkspacePicker.tsx
+++ b/front/components/WorkspacePicker.tsx
@@ -5,6 +5,7 @@ import {
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
+  Label,
 } from "@dust-tt/sparkle";
 import type {
   LightWorkspaceType,
@@ -24,7 +25,7 @@ export default function WorkspacePicker({
 }: WorkspacePickerProps) {
   return (
     <div className="flex flex-row items-center gap-1 px-3 py-2">
-      <p className="text-xs text-muted-foreground">Workspace:</p>
+      <Label className="text-xs text-muted-foreground">Workspace:</Label>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button

--- a/front/components/WorkspacePicker.tsx
+++ b/front/components/WorkspacePicker.tsx
@@ -2,7 +2,8 @@ import {
   Button,
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from "@dust-tt/sparkle";
 import type {
@@ -32,17 +33,20 @@ export default function WorkspacePicker({
             isSelect
           />
         </DropdownMenuTrigger>
-
         <DropdownMenuContent>
-          {user.workspaces.map((w) => {
-            return (
-              <DropdownMenuItem
-                key={w.sId}
-                onClick={() => void onWorkspaceUpdate(w)}
-                label={w.name}
-              />
-            );
-          })}
+          <DropdownMenuRadioGroup value={workspace.name}>
+            {user.workspaces.map((w) => {
+              return (
+                <DropdownMenuRadioItem
+                  key={w.sId}
+                  onClick={() => void onWorkspaceUpdate(w)}
+                  value={w.name}
+                >
+                  {w.name}
+                </DropdownMenuRadioItem>
+              );
+            })}
+          </DropdownMenuRadioGroup>
         </DropdownMenuContent>
       </DropdownMenu>
     </div>


### PR DESCRIPTION
## Description

This PR tweaks the design of the current current `WorkspacePicker` to use `DropdownRadioItems` instead of a regular `Dropdown`

**References:**
- https://github.com/dust-tt/tasks/issues/1670

## Risk

Low, only UX tweaks

## Deploy Plan

- Deploy `front`