### PR TITLE
Let admin to administrate connected data without being members

### DIFF
--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -487,20 +487,6 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
     return getDataSourceUsage({ auth, dataSource: this });
   }
 
-  // Permissions.
-
-  canRead(auth: Authenticator) {
-    return this.space.canRead(auth);
-  }
-
-  canWrite(auth: Authenticator) {
-    return this.space.canWrite(auth);
-  }
-
-  canAdministrate(auth: Authenticator) {
-    return this.space.canAdministrate(auth);
-  }
-
   // sId logic.
 
   get sId(): string {

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -547,7 +547,6 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
    * For non-managed data sources, requires write privileges.
    *
    * @param auth - The authenticator object for the current user
-   * @throws {Error} If authenticator is not provided
    * @returns boolean indicating whether the user has write permission
    */
   canWrite(auth: Authenticator) {

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -21,7 +21,7 @@ import { Op } from "sequelize";
 import { getDataSourceViewUsage } from "@app/lib/api/agent_data_sources";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
-import { isFolder, isWebsite } from "@app/lib/data_sources";
+import { isFolder, isManaged, isWebsite } from "@app/lib/data_sources";
 import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
 import { AgentTablesQueryConfigurationTable } from "@app/lib/models/assistant/actions/tables_query";
 import { User } from "@app/lib/models/user";
@@ -538,6 +538,25 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
   getUsagesByAgents = async (auth: Authenticator) => {
     return getDataSourceViewUsage({ auth, dataSourceView: this });
   };
+
+  // Permissions.
+
+  /**
+   * Determines if the current user has write permissions.
+   * For managed data sources, requires administrative privileges.
+   * For non-managed data sources, requires write privileges.
+   *
+   * @param auth - The authenticator object for the current user
+   * @throws {Error} If authenticator is not provided
+   * @returns boolean indicating whether the user has write permission
+   */
+  canWrite(auth: Authenticator) {
+    if (isManaged(this.dataSource)) {
+      return this.space.canAdministrate(auth);
+    }
+
+    return this.space.canWrite(auth);
+  }
 
   // Serialization.
 

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -539,24 +539,6 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     return getDataSourceViewUsage({ auth, dataSourceView: this });
   };
 
-  // Permissions.
-
-  /**
-   * Determines if the current user has write permissions.
-   * For managed data sources, requires administrative privileges.
-   * For non-managed data sources, requires write privileges.
-   *
-   * @param auth - The authenticator object for the current user
-   * @returns boolean indicating whether the user has write permission
-   */
-  canWrite(auth: Authenticator) {
-    if (isManaged(this.dataSource)) {
-      return this.space.canAdministrate(auth);
-    }
-
-    return this.space.canWrite(auth);
-  }
-
   // Serialization.
 
   toJSON(): DataSourceViewType {

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -21,7 +21,7 @@ import { Op } from "sequelize";
 import { getDataSourceViewUsage } from "@app/lib/api/agent_data_sources";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
-import { isFolder, isManaged, isWebsite } from "@app/lib/data_sources";
+import { isFolder, isWebsite } from "@app/lib/data_sources";
 import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
 import { AgentTablesQueryConfigurationTable } from "@app/lib/models/assistant/actions/tables_query";
 import { User } from "@app/lib/models/user";

--- a/front/lib/resources/resource_with_space.ts
+++ b/front/lib/resources/resource_with_space.ts
@@ -157,6 +157,10 @@ export abstract class ResourceWithSpace<
     return this.space.requestedPermissions(opts);
   }
 
+  canAdministrate(auth: Authenticator) {
+    return this.space.canAdministrate(auth);
+  }
+
   canList(auth: Authenticator) {
     return this.space.canList(auth);
   }

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -560,7 +560,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return [
       {
         workspaceId: this.workspaceId,
-        roles: [{ role: "admin", permissions: ["admin"] }],
+        roles: [{ role: "admin", permissions: ["admin", "write"] }],
         groups: this.groups.map((group) => ({
           id: group.id,
           permissions: ["read", "write"],

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
@@ -172,14 +172,14 @@ async function handler(
     }
 
     case "POST": {
-      if (!space.canWrite(auth) && !space.canAdministrate(auth)) {
-        // Only admins, or builders who have access to the space, can create a new view.
+      if (!space.canWrite(auth)) {
+        // Only admins, or builders who have to the space, can create a new view
         return apiError(req, res, {
           status_code: 403,
           api_error: {
             type: "workspace_auth_error",
             message:
-              "Access denied: Must be an administrator or builder with space access.",
+              "Only users that are `admins` or `builder` can administrate spaces.",
           },
         });
       }
@@ -210,29 +210,6 @@ async function handler(
           },
         });
       }
-
-      if (isManaged(dataSource) && !space.canAdministrate(auth)) {
-        return apiError(req, res, {
-          status_code: 403,
-          api_error: {
-            type: "workspace_auth_error",
-            message:
-              "Access denied: Must be an administrator to manage connected data sources.",
-          },
-        });
-      }
-
-      if (!isManaged(dataSource) && !space.canWrite(auth)) {
-        return apiError(req, res, {
-          status_code: 403,
-          api_error: {
-            type: "workspace_auth_error",
-            message:
-              "Access denied: Must be a builder with space access to create views.",
-          },
-        });
-      }
-
       const existing = await DataSourceViewResource.listForDataSourcesInSpace(
         auth,
         [dataSource],

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
@@ -179,7 +179,7 @@ async function handler(
           api_error: {
             type: "workspace_auth_error",
             message:
-              "Only users that are `admins` or `builder` can administrate spaces.",
+              "Access denied: Must be an administrator or builder with space access.",
           },
         });
       }
@@ -217,7 +217,7 @@ async function handler(
           api_error: {
             type: "workspace_auth_error",
             message:
-              "Insufficient permissions: Connected data sources can only be managed by administrators.",
+              "Access denied: Must be an administrator to manage connected data sources.",
           },
         });
       }
@@ -228,7 +228,7 @@ async function handler(
           api_error: {
             type: "workspace_auth_error",
             message:
-              "Insufficient permissions: View creation requires both space membership and builder role.",
+              "Access denied: Must be a builder with space access to create views.",
           },
         });
       }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Simplifies administrative workflow by allowing workspace administrators to manage connected data sources without requiring space membership.

## Background
Previously, administrators needed to temporarily join a space to add connected data, then remove themselves afterward. Multiple customers reported this workaround as cumbersome and inefficient.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
