### PR TITLE
[connectors] Cleanup permissions in Zendesk

### DIFF
--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -11,13 +11,13 @@ import type { ConnectorManagerError } from "@connectors/connectors/interface";
 import { BaseConnectorManager } from "@connectors/connectors/interface";
 import {
   allowSyncZendeskBrand,
-  revokeSyncZendeskBrand,
+  forbidSyncZendeskBrand,
 } from "@connectors/connectors/zendesk/lib/brand_permissions";
 import {
   allowSyncZendeskCategory,
   allowSyncZendeskHelpCenter,
-  revokeSyncZendeskCategory,
-  revokeSyncZendeskHelpCenter,
+  forbidSyncZendeskCategory,
+  forbidSyncZendeskHelpCenter,
 } from "@connectors/connectors/zendesk/lib/help_center_permissions";
 import {
   getBrandInternalId,
@@ -29,7 +29,7 @@ import {
 } from "@connectors/connectors/zendesk/lib/permissions";
 import {
   allowSyncZendeskTickets,
-  revokeSyncZendeskTickets,
+  forbidSyncZendeskTickets,
 } from "@connectors/connectors/zendesk/lib/ticket_permissions";
 import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
 import {
@@ -258,8 +258,8 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
       logger.error({ connectorId }, "[Zendesk] Connector not found.");
       return new Err(new Error("Connector not found"));
     }
+    const { connectionId } = connector;
 
-    const connectionId = connector.connectionId;
     const toBeSignaledBrandIds = new Set<number>();
     const toBeSignaledTicketsIds = new Set<number>();
     const toBeSignaledHelpCenterIds = new Set<number>();
@@ -279,11 +279,11 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
       switch (type) {
         case "brand": {
           if (permission === "none") {
-            const revokedBrand = await revokeSyncZendeskBrand({
+            const updatedBrand = await forbidSyncZendeskBrand({
               connectorId,
               brandId: objectId,
             });
-            if (revokedBrand) {
+            if (updatedBrand) {
               toBeSignaledBrandIds.add(objectId);
             }
           }
@@ -301,12 +301,12 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         }
         case "help-center": {
           if (permission === "none") {
-            const revokedBrandHelpCenter = await revokeSyncZendeskHelpCenter({
+            const updatedBrandHelpCenter = await forbidSyncZendeskHelpCenter({
               connectorId,
               brandId: objectId,
             });
-            if (revokedBrandHelpCenter) {
-              toBeSignaledHelpCenterIds.add(revokedBrandHelpCenter.brandId);
+            if (updatedBrandHelpCenter) {
+              toBeSignaledHelpCenterIds.add(updatedBrandHelpCenter.brandId);
             }
           }
           if (permission === "read") {
@@ -323,12 +323,12 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         }
         case "tickets": {
           if (permission === "none") {
-            const revokedBrandTickets = await revokeSyncZendeskTickets({
+            const updatedBrandTickets = await forbidSyncZendeskTickets({
               connectorId,
               brandId: objectId,
             });
-            if (revokedBrandTickets) {
-              toBeSignaledTicketsIds.add(revokedBrandTickets.brandId);
+            if (updatedBrandTickets) {
+              toBeSignaledTicketsIds.add(updatedBrandTickets.brandId);
             }
           }
           if (permission === "read") {
@@ -345,14 +345,14 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         }
         case "category": {
           if (permission === "none") {
-            const revokedCategory = await revokeSyncZendeskCategory({
+            const updatedCategory = await forbidSyncZendeskCategory({
               connectorId,
               categoryId: objectId.categoryId,
             });
-            if (revokedCategory) {
-              toBeSignaledCategoryIds.add(revokedCategory.categoryId);
-              categoryBrandIds[revokedCategory.categoryId] =
-                revokedCategory.brandId;
+            if (updatedCategory) {
+              toBeSignaledCategoryIds.add(updatedCategory.categoryId);
+              categoryBrandIds[updatedCategory.categoryId] =
+                updatedCategory.brandId;
             }
           }
           if (permission === "read") {

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -376,8 +376,8 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
             { connectorId, objectId },
             "[Zendesk] Cannot set permissions for a single article or ticket"
           );
-          throw new Error(
-            "Cannot set permissions for a single article or ticket"
+          return new Err(
+            new Error("Cannot set permissions for a single article or ticket")
           );
         default:
           assertNever(type);

--- a/connectors/src/connectors/zendesk/lib/brand_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/brand_permissions.ts
@@ -101,11 +101,7 @@ export async function forbidSyncZendeskBrand({
     return null;
   }
 
-  // revoke permissions for the brand
-  await brand.revokeHelpCenterPermissions();
-  await brand.revokeTicketsPermissions();
-
-  // revoke permissions for all the children resources (help center and tickets)
+  // revoke permissions for the two children resources (help center and tickets + respective children)
   await forbidSyncZendeskHelpCenter({ connectorId, brandId });
   await forbidSyncZendeskTickets({ connectorId, brandId });
 

--- a/connectors/src/connectors/zendesk/lib/brand_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/brand_permissions.ts
@@ -2,11 +2,11 @@ import type { ModelId } from "@dust-tt/types";
 
 import {
   allowSyncZendeskHelpCenter,
-  revokeSyncZendeskHelpCenter,
+  forbidSyncZendeskHelpCenter,
 } from "@connectors/connectors/zendesk/lib/help_center_permissions";
 import {
   allowSyncZendeskTickets,
-  revokeSyncZendeskTickets,
+  forbidSyncZendeskTickets,
 } from "@connectors/connectors/zendesk/lib/ticket_permissions";
 import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
 import { createZendeskClient } from "@connectors/connectors/zendesk/lib/zendesk_api";
@@ -82,7 +82,7 @@ export async function allowSyncZendeskBrand({
 /**
  * Mark a brand as permission "none", with all its children (help center and tickets + children).
  */
-export async function revokeSyncZendeskBrand({
+export async function forbidSyncZendeskBrand({
   connectorId,
   brandId,
 }: {
@@ -96,7 +96,7 @@ export async function revokeSyncZendeskBrand({
   if (!brand) {
     logger.error(
       { brandId },
-      "[Zendesk] Brand not found, could not revoke sync."
+      "[Zendesk] Brand not found, could not disable sync."
     );
     return null;
   }
@@ -106,8 +106,8 @@ export async function revokeSyncZendeskBrand({
   await brand.revokeTicketsPermissions();
 
   // revoke permissions for all the children resources (help center and tickets)
-  await revokeSyncZendeskHelpCenter({ connectorId, brandId });
-  await revokeSyncZendeskTickets({ connectorId, brandId });
+  await forbidSyncZendeskHelpCenter({ connectorId, brandId });
+  await forbidSyncZendeskTickets({ connectorId, brandId });
 
   return brand;
 }

--- a/connectors/src/connectors/zendesk/lib/brand_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/brand_permissions.ts
@@ -73,7 +73,7 @@ export async function allowSyncZendeskBrand({
 }
 
 /**
- * Mark a help center as permission "none" and all children (collections and articles).
+ * Mark a brand as permission "none" (help center and tickets).
  */
 export async function revokeSyncZendeskBrand({
   connectorId,
@@ -94,6 +94,8 @@ export async function revokeSyncZendeskBrand({
     return null;
   }
 
-  await brand.revokeAllPermissions();
+  await brand.revokeHelpCenterPermissions();
+  await brand.revokeTicketsPermissions();
+
   return brand;
 }

--- a/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
@@ -93,7 +93,7 @@ export async function allowSyncZendeskHelpCenter({
 }
 
 /**
- * Mark a help center as permission "none" and all children (collections and articles).
+ * Mark a help center as permission "none", optionally alongside all its children (categories and articles).
  */
 export async function forbidSyncZendeskHelpCenter({
   connectorId,

--- a/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
@@ -152,11 +152,10 @@ export async function allowSyncZendeskCategory({
     connectorId,
     categoryId,
   });
-  if (category?.permission === "none") {
-    await category.update({ permission: "read" });
-  }
 
-  if (!category) {
+  if (category) {
+    await category.grantPermissions();
+  } else {
     const zendeskApiClient = createZendeskClient(
       await getZendeskSubdomainAndAccessToken(connectionId)
     );

--- a/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
@@ -95,7 +95,7 @@ export async function allowSyncZendeskHelpCenter({
 /**
  * Mark a help center as permission "none" and all children (collections and articles).
  */
-export async function revokeSyncZendeskHelpCenter({
+export async function forbidSyncZendeskHelpCenter({
   connectorId,
   brandId,
   withChildren = true,
@@ -111,7 +111,7 @@ export async function revokeSyncZendeskHelpCenter({
   if (!brand) {
     logger.error(
       { brandId },
-      "[Zendesk] Brand not found, could not revoke sync."
+      "[Zendesk] Brand not found, could not disable sync."
     );
     return null;
   }
@@ -197,7 +197,7 @@ export async function allowSyncZendeskCategory({
 /**
  * Mark a category with "none" permissions alongside all its children articles.
  */
-export async function revokeSyncZendeskCategory({
+export async function forbidSyncZendeskCategory({
   connectorId,
   categoryId,
 }: {
@@ -212,7 +212,7 @@ export async function revokeSyncZendeskCategory({
   if (!category) {
     logger.error(
       { categoryId },
-      "[Zendesk] Category not found, could not revoke sync."
+      "[Zendesk] Category not found, could not disable sync."
     );
     return null;
   }
@@ -230,7 +230,7 @@ export async function revokeSyncZendeskCategory({
     brandId: category.brandId,
   });
   if (categories.length === 0) {
-    await revokeSyncZendeskHelpCenter({
+    await forbidSyncZendeskHelpCenter({
       connectorId,
       brandId: category.brandId,
       withChildren: false,

--- a/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
@@ -62,7 +62,7 @@ export async function allowSyncZendeskTickets({
 /**
  * Mark the node "Tickets" and all the children tickets for a Brand as permission "none".
  */
-export async function revokeSyncZendeskTickets({
+export async function forbidSyncZendeskTickets({
   connectorId,
   brandId,
 }: {
@@ -76,7 +76,7 @@ export async function revokeSyncZendeskTickets({
   if (!brand) {
     logger.error(
       { brandId },
-      "[Zendesk] Brand not found, could not revoke sync."
+      "[Zendesk] Brand not found, could not disable sync."
     );
     return null;
   }

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -176,11 +176,6 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
     }
   }
 
-  async revokeAllPermissions(): Promise<void> {
-    await this.revokeHelpCenterPermissions();
-    await this.revokeTicketsPermissions();
-  }
-
   async revokeHelpCenterPermissions(): Promise<void> {
     if (this.helpCenterPermission === "read") {
       await this.update({ helpCenterPermission: "none" });

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -496,6 +496,12 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
     );
   }
 
+  async grantPermissions(): Promise<void> {
+    if (this.permission === "none") {
+      await this.update({ permission: "read" });
+    }
+  }
+
   async revokePermissions(): Promise<void> {
     if (this.permission === "read") {
       await this.update({ permission: "none" });


### PR DESCRIPTION
## Description

- Cleanup the permission handling in Zendesk.
  - Change the wording from revoke/allow sync to forbid/allow sync (keeping revoke/grant permissions).
  - Update descriptions and comments.
- Fix: revoking permissions for a brand now correctly revokes them for its tickets and help center.

The target end state of the PR is:
- The permissions setting is all OK.
- In an upcoming PR I will mv the garbage collection currently done in the sync workflow to the garbage collection workflow (e.g. cleaning help centers with 0 category, brand with 0 permission).

## Risk

Low.

## Deploy Plan

- Deploy connectors.
