### PR TITLE
Use FF to capture all Gong transcripts

### DIFF
--- a/front/lib/resources/labs_transcripts_resource.ts
+++ b/front/lib/resources/labs_transcripts_resource.ts
@@ -132,6 +132,26 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
     return this.update({ isActive });
   }
 
+  async setIsDefaultFullStorage(isDefaultFullStorage: boolean) {
+    if (this.isDefaultFullStorage === isDefaultFullStorage) {
+      return;
+    }
+
+    // Update all other configurations to be false.
+    if (isDefaultFullStorage) {
+      await LabsTranscriptsConfigurationModel.update(
+        { isDefaultFullStorage: false },
+        {
+          where: {
+            workspaceId: this.workspaceId,
+          },
+        }
+      );
+    }
+
+    return this.update({ isDefaultFullStorage });
+  }
+
   async setDataSourceViewId(
     auth: Authenticator,
     dataSourceViewId: string | null

--- a/front/lib/resources/labs_transcripts_resource.ts
+++ b/front/lib/resources/labs_transcripts_resource.ts
@@ -1,12 +1,13 @@
 import type { LabsConnectorProvider, Result } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
+import type { CreationAttributes } from "sequelize";
 import type {
   Attributes,
   InferAttributes,
   ModelStatic,
   Transaction,
 } from "sequelize";
-import type { CreationAttributes } from "sequelize";
+import { Op } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
@@ -153,6 +154,29 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
     }
 
     return this.update({ dataSourceViewId: dataSourceView.id });
+  }
+
+  static async fetchFirstConfigurationWithDatasourceViewForWorkspace(
+    auth: Authenticator
+  ): Promise<LabsTranscriptsConfigurationResource | null> {
+    const configuration = await LabsTranscriptsConfigurationModel.findOne({
+      where: {
+        workspaceId: auth.workspace()?.id,
+        dataSourceViewId: {
+          [Op.ne]: null,
+        },
+      },
+      order: [["id", "ASC"]],
+    });
+
+    if (!configuration) {
+      return null;
+    }
+
+    return new LabsTranscriptsConfigurationResource(
+      LabsTranscriptsConfigurationModel,
+      configuration.get()
+    );
   }
 
   async delete(

--- a/front/lib/resources/storage/models/labs_transcripts.ts
+++ b/front/lib/resources/storage/models/labs_transcripts.ts
@@ -26,6 +26,7 @@ export class LabsTranscriptsConfigurationModel extends Model<
   declare provider: LabsTranscriptsProviderType;
   declare agentConfigurationId: ForeignKey<AgentConfiguration["sId"]> | null;
   declare isActive: boolean;
+  declare isDefaultFullStorage: boolean;
 
   declare userId: ForeignKey<User["id"]>;
   declare workspaceId: ForeignKey<Workspace["id"]>;
@@ -62,6 +63,11 @@ LabsTranscriptsConfigurationModel.init(
       allowNull: true,
     },
     isActive: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    isDefaultFullStorage: {
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: false,

--- a/front/migrations/db/migration_115.sql
+++ b/front/migrations/db/migration_115.sql
@@ -1,0 +1,2 @@
+-- Migration created on Nov 19, 2024
+ALTER TABLE "public"."labs_transcripts_configurations" ADD COLUMN "isDefaultFullStorage" BOOLEAN NOT NULL DEFAULT false;

--- a/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
@@ -132,6 +132,13 @@ async function handler(
           auth,
           dataSourceViewId
         );
+
+        const flags = await getFeatureFlags(owner);
+        if (flags.includes("labs_transcripts_gong_full_storage")) {
+          await transcriptsConfiguration.setIsDefaultFullStorage(
+            !!dataSourceViewId
+          );
+        }
       }
 
       const updatedTranscriptsConfiguration =

--- a/front/temporal/labs/activities.ts
+++ b/front/temporal/labs/activities.ts
@@ -273,23 +273,14 @@ export async function processTranscriptActivity(
           auth
         );
 
-      if (!defaultGongTranscriptsStorageConfiguration) {
-        localLogger.error(
-          {},
-          "[processTranscriptActivity] No default transcript configuration for Gong storage enabled. Stopping."
-        );
-        await stopRetrieveTranscriptsWorkflow(transcriptsConfiguration);
-        return;
-      }
-
       gongFullStorageDataSourceViewId =
-        defaultGongTranscriptsStorageConfiguration.dataSourceViewId;
+        defaultGongTranscriptsStorageConfiguration?.dataSourceViewId;
     }
   }
 
   // Decide to store transcript or not (user might not have participated)
   const storeTranscript =
-    transcriptsConfiguration.dataSourceViewId ||
+    (transcriptsConfiguration.dataSourceViewId && userParticipated) ||
     (gongFullStorageFF && gongFullStorageDataSourceViewId);
 
   // Decide to process transcript or not (user needs to have participated)

--- a/front/temporal/labs/activities.ts
+++ b/front/temporal/labs/activities.ts
@@ -259,15 +259,15 @@ export async function processTranscriptActivity(
   }
 
   // labs_transcripts_gong_full_storage FF enables storing all Gong transcripts in a single datasource view
-  let gongFullStorage = false;
+  let gongFullStorageFF = false;
   let gongFullStorageDataSourceViewId = null;
   if (transcriptsConfiguration.provider === "gong") {
     const featureFlags = await getFeatureFlags(owner);
-    gongFullStorage = featureFlags.includes(
+    gongFullStorageFF = featureFlags.includes(
       "labs_transcripts_gong_full_storage"
     );
 
-    if (gongFullStorage) {
+    if (gongFullStorageFF) {
       const defaultGongTranscriptsStorageConfiguration =
         await LabsTranscriptsConfigurationResource.fetchDefaultFullStorageConfigurationForWorkspace(
           auth
@@ -290,7 +290,7 @@ export async function processTranscriptActivity(
   // Decide to store transcript or not (user might not have participated)
   const storeTranscript =
     transcriptsConfiguration.dataSourceViewId ||
-    (gongFullStorage && gongFullStorageDataSourceViewId);
+    (gongFullStorageFF && gongFullStorageDataSourceViewId);
 
   // Decide to process transcript or not (user needs to have participated)
   const processTranscript =
@@ -300,7 +300,7 @@ export async function processTranscriptActivity(
     localLogger.info(
       {
         dataSourceViewId: transcriptsConfiguration.dataSourceViewId,
-        gongFullStorage,
+        gongFullStorageFF,
         gongFullStorageDataSourceViewId,
         transcriptsConfiguration,
       },

--- a/front/temporal/labs/activities.ts
+++ b/front/temporal/labs/activities.ts
@@ -276,7 +276,7 @@ export async function processTranscriptActivity(
       if (!defaultGongTranscriptsStorageConfiguration) {
         localLogger.error(
           {},
-          "[processTranscriptActivity] No default transcript configuration with a datasource view found while full Gong storage if enabled. Stopping."
+          "[processTranscriptActivity] No default transcript configuration for Gong storage enabled. Stopping."
         );
         await stopRetrieveTranscriptsWorkflow(transcriptsConfiguration);
         return;

--- a/front/temporal/labs/activities.ts
+++ b/front/temporal/labs/activities.ts
@@ -279,15 +279,15 @@ export async function processTranscriptActivity(
   }
 
   // Decide to store transcript or not (user might not have participated)
-  const storeTranscript =
+  const shouldStoreTranscript =
     (transcriptsConfiguration.dataSourceViewId && userParticipated) ||
     (gongFullStorageFF && gongFullStorageDataSourceViewId);
 
   // Decide to process transcript or not (user needs to have participated)
-  const processTranscript =
+  const shouldProcessTranscript =
     transcriptsConfiguration.isActive && userParticipated;
 
-  if (storeTranscript) {
+  if (shouldStoreTranscript) {
     localLogger.info(
       {
         dataSourceViewId: transcriptsConfiguration.dataSourceViewId,
@@ -381,7 +381,7 @@ export async function processTranscriptActivity(
     );
   }
 
-  if (processTranscript) {
+  if (shouldProcessTranscript) {
     localLogger.info(
       {
         transcriptTitle,

--- a/front/temporal/labs/utils/gong.ts
+++ b/front/temporal/labs/utils/gong.ts
@@ -2,6 +2,7 @@ import { getOAuthConnectionAccessToken } from "@dust-tt/types";
 
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import type { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
 import type { Logger } from "@app/logger/logger";
 
@@ -55,7 +56,15 @@ export async function retrieveGongTranscripts(
     localLogger
   );
 
-  const fromDateTime = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+  // TEMP: Get the last 2 weeks if labs_transcripts_gong_full_storage FF is enabled.
+  const flags = await getFeatureFlags(auth.getNonNullableWorkspace());
+  const daysOfHistory = flags.includes("labs_transcripts_gong_full_storage")
+    ? 14
+    : 1;
+
+  const fromDateTime = new Date(
+    Date.now() - daysOfHistory * 24 * 60 * 60 * 1000
+  ).toISOString();
   const newTranscripts = await fetch(
     `https://api.gong.io/v2/calls?fromDateTime=${fromDateTime}`,
     {

--- a/front/temporal/labs/utils/gong.ts
+++ b/front/temporal/labs/utils/gong.ts
@@ -125,7 +125,11 @@ export async function retrieveGongTranscriptContent(
   transcriptsConfiguration: LabsTranscriptsConfigurationResource,
   fileId: string,
   localLogger: Logger
-): Promise<{ transcriptTitle: string; transcriptContent: string } | null> {
+): Promise<{
+  transcriptTitle: string;
+  transcriptContent: string;
+  userParticipated: boolean;
+} | null> {
   if (!transcriptsConfiguration || !transcriptsConfiguration.connectionId) {
     localLogger.error(
       {},
@@ -248,12 +252,9 @@ export async function retrieveGongTranscriptContent(
     }
   }
 
+  let userParticipated = true;
   if (!participantsUsers[gongUser.id]) {
-    localLogger.info(
-      {},
-      "[processTranscriptActivity] User did not participate in this call. Skipping."
-    );
-    return null;
+    userParticipated = false;
   }
 
   const transcript = await fetch(`https://api.gong.io/v2/calls/transcript`, {
@@ -329,5 +330,5 @@ export async function retrieveGongTranscriptContent(
     }
   );
 
-  return { transcriptTitle, transcriptContent };
+  return { transcriptTitle, transcriptContent, userParticipated };
 }

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -629,7 +629,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema([
   "usage_data_api",
   "okta_enterprise_connection",
   "labs_transcripts",
-  "labs_transcripts_datasource",
+  "labs_transcripts_gong_full_storage",
   "document_tracker",
   "use_app_for_header_detection",
   "openai_o1_feature",

--- a/types/src/shared/feature_flags.ts
+++ b/types/src/shared/feature_flags.ts
@@ -2,6 +2,7 @@ export const WHITELISTABLE_FEATURES = [
   "usage_data_api",
   "okta_enterprise_connection",
   "labs_transcripts",
+  "labs_transcripts_gong_full_storage",
   "document_tracker",
   "use_app_for_header_detection",
   "openai_o1_feature",


### PR DESCRIPTION
## Description

- Use FF to capture all Gong transcripts
- Let only one user set up the default storage for everyone when the FF is set on a workspace. Show a message about it.
<img width="987" alt="Screenshot 2024-11-19 at 15 18 13" src="https://github.com/user-attachments/assets/55ea9080-28ca-4b1b-8e6a-b36e5f8fcda0">
- Add isDefaultFullStorage attribute to labs transcripts configuration

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Run migration 115
