### PR TITLE
Extension: Apply UX feedback

### DIFF
--- a/extension/app/src/components/conversation/AttachFragment.tsx
+++ b/extension/app/src/components/conversation/AttachFragment.tsx
@@ -3,7 +3,7 @@ import {
   AttachmentIcon,
   Button,
   CameraIcon,
-  DocumentTextIcon,
+  GlobeAltIcon,
 } from "@dust-tt/sparkle";
 import type { EditorService } from "@extension/components/input_bar/editor/useCustomEditor";
 import { InputBarContext } from "@extension/components/input_bar/InputBarContext";
@@ -51,7 +51,7 @@ export const AttachFragment = ({
       />
       <Button
         icon={AttachmentIcon}
-        tooltip={"Attach file"}
+        tooltip="Attach file"
         variant="ghost"
         size="xs"
         onClick={async () => {
@@ -59,8 +59,8 @@ export const AttachFragment = ({
         }}
       />
       <Button
-        icon={DocumentTextIcon}
-        tooltip={"Attach tab content"}
+        icon={GlobeAltIcon}
+        tooltip="Attach tab content"
         variant="ghost"
         size="xs"
         className={attachPageBlinking ? "animate-[bgblink_200ms_3]" : ""}
@@ -73,7 +73,7 @@ export const AttachFragment = ({
       />
       <Button
         icon={CameraIcon}
-        tooltip={"Attach tab screenshot"}
+        tooltip="Attach tab screenshot"
         variant="ghost"
         size="xs"
         onClick={() =>

--- a/extension/app/src/components/conversation/ConversationsListButton.tsx
+++ b/extension/app/src/components/conversation/ConversationsListButton.tsx
@@ -9,7 +9,7 @@ export const ConversationsListButton = ({
   const navigate = useNavigate();
   return (
     <Button
-      tooltip="View all conversations"
+      tooltip="View conversations"
       icon={ChatBubbleLeftRightIcon}
       variant="ghost"
       onClick={() => navigate("/conversations")}

--- a/extension/app/src/pages/ConversationPage.tsx
+++ b/extension/app/src/pages/ConversationPage.tsx
@@ -47,6 +47,7 @@ export const ConversationPage = ({
               href={`${process.env.DUST_DOMAIN}/w/${workspace.sId}/assistant/${conversationId}`}
               target="_blank"
               size="md"
+              tooltip="Open in Dust"
             />
           </div>
         }

--- a/extension/app/src/pages/MainPage.tsx
+++ b/extension/app/src/pages/MainPage.tsx
@@ -26,9 +26,6 @@ export const MainPage = ({
     <>
       <div className="flex items-start justify-between">
         <div className="flex flex-col gap-2 pb-6">
-          <Link to="https://dust.tt" target="_blank">
-            <LogoHorizontalColorLogo className="h-4 w-16" />
-          </Link>
           {user.workspaces.length > 1 && (
             <div className="flex flex-row items-center gap-2">
               <p className="text-sm text-slate-500">Workspace:</p>
@@ -54,6 +51,11 @@ export const MainPage = ({
               </DropdownMenu>
             </div>
           )}
+        </div>
+        <div className="fixed bottom-4 right-4">
+          <Link to="https://dust.tt" target="_blank">
+            <LogoHorizontalColorLogo className="h-6 w-24" />
+          </Link>
         </div>
         <div className="flex items-center gap-2">
           <ConversationsListButton size="md" />


### PR DESCRIPTION
## Description

Implements these requests: 
- To avoid double logos (extension layout + browser extension logo), place the Dust logo at the bottom right.
- Use globe-alt icon instead of document one for attaching page content.
- Add tooltips for the external link and conversation icon: "Open in Dust"; "View conversations".


![Screenshot 2024-11-19 at 13 46 13](https://github.com/user-attachments/assets/61871798-9dc7-4b3a-9a65-86617d871f74)

## Risk

Extension only. 

## Deploy Plan

Nothing. 
