### PR TITLE
[connectors] Move all Zendesk garbage collection to the gc workflow

### DIFF
--- a/connectors/src/connectors/zendesk/lib/data_cleanup.ts
+++ b/connectors/src/connectors/zendesk/lib/data_cleanup.ts
@@ -5,30 +5,10 @@ import {
 import { deleteFromDataSource } from "@connectors/lib/data_sources";
 import {
   ZendeskArticleResource,
-  ZendeskBrandResource,
   ZendeskCategoryResource,
   ZendeskTicketResource,
 } from "@connectors/resources/zendesk_resources";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
-
-/**
- * Deletes all the data relative to a brand (tickets, help center, categories, articles) in the data source and in the db.
- */
-export async function deleteBrand({
-  connectorId,
-  brandId,
-  dataSourceConfig,
-}: {
-  connectorId: number;
-  brandId: number;
-  dataSourceConfig: DataSourceConfig;
-}) {
-  await Promise.all([
-    deleteBrandHelpCenter({ connectorId, brandId, dataSourceConfig }),
-    deleteBrandTickets({ connectorId, brandId, dataSourceConfig }),
-  ]);
-  await ZendeskBrandResource.deleteByConnectorId(connectorId);
-}
 
 /**
  * Deletes all the tickets stored in the db and in the data source relative to a brand.

--- a/connectors/src/connectors/zendesk/lib/data_cleanup.ts
+++ b/connectors/src/connectors/zendesk/lib/data_cleanup.ts
@@ -1,0 +1,106 @@
+import {
+  getArticleInternalId,
+  getTicketInternalId,
+} from "@connectors/connectors/zendesk/lib/id_conversions";
+import { deleteFromDataSource } from "@connectors/lib/data_sources";
+import {
+  ZendeskArticleResource,
+  ZendeskCategoryResource,
+  ZendeskTicketResource,
+} from "@connectors/resources/zendesk_resources";
+import type { DataSourceConfig } from "@connectors/types/data_source_config";
+
+/**
+ * Deletes all the tickets stored in the db and in the data source relative to a brand.
+ */
+export async function deleteBrandTickets({
+  connectorId,
+  brandId,
+  dataSourceConfig,
+}: {
+  connectorId: number;
+  brandId: number;
+  dataSourceConfig: DataSourceConfig;
+}) {
+  const tickets = await ZendeskTicketResource.fetchByBrandId({
+    connectorId,
+    brandId,
+  });
+  /// deleting the tickets in the data source
+  await Promise.all(
+    tickets.map((ticket) =>
+      deleteFromDataSource(
+        dataSourceConfig,
+        getTicketInternalId(ticket.connectorId, ticket.ticketId)
+      )
+    )
+  );
+  /// deleting the tickets stored in the db
+  await ZendeskTicketResource.deleteByBrandId({ connectorId, brandId });
+}
+
+/**
+ * Deletes all the data stored in the db and in the data source relative to a brand's help center (category, articles).
+ */
+export async function deleteBrandHelpCenter({
+  connectorId,
+  brandId,
+  dataSourceConfig,
+}: {
+  connectorId: number;
+  brandId: number;
+  dataSourceConfig: DataSourceConfig;
+}) {
+  /// deleting the articles in the data source
+  const articles = await ZendeskArticleResource.fetchByBrandId({
+    connectorId,
+    brandId,
+  });
+  await Promise.all(
+    articles.map((article) =>
+      deleteFromDataSource(
+        dataSourceConfig,
+        getArticleInternalId(connectorId, article.articleId)
+      )
+    )
+  );
+  /// deleting the articles stored in the db
+  await ZendeskArticleResource.deleteByBrandId({
+    connectorId,
+    brandId,
+  });
+  /// deleting the categories stored in the db
+  await ZendeskCategoryResource.deleteByBrandId({ connectorId, brandId });
+}
+
+/**
+ * Deletes all the data stored in the db and in the data source relative to a category (articles).
+ */
+export async function deleteCategoryChildren({
+  connectorId,
+  categoryId,
+  dataSourceConfig,
+}: {
+  connectorId: number;
+  categoryId: number;
+  dataSourceConfig: DataSourceConfig;
+}) {
+  /// deleting the articles in the data source
+  const articles = await ZendeskArticleResource.fetchByCategoryId({
+    connectorId,
+    categoryId,
+  });
+  await Promise.all(
+    articles.map((article) =>
+      deleteFromDataSource(
+        dataSourceConfig,
+        getArticleInternalId(connectorId, article.articleId)
+      )
+    )
+  );
+  /// deleting the articles stored in the db
+  await ZendeskArticleResource.deleteByCategoryId({
+    connectorId,
+    categoryId,
+  });
+}

--- a/connectors/src/connectors/zendesk/lib/data_cleanup.ts
+++ b/connectors/src/connectors/zendesk/lib/data_cleanup.ts
@@ -96,7 +96,7 @@ export async function deleteBrandHelpCenter({
 /**
  * Deletes all the data stored in the db and in the data source relative to a category (articles).
  */
-export async function deleteCategoryChildren({
+export async function deleteCategory({
   connectorId,
   categoryId,
   dataSourceConfig,
@@ -123,4 +123,6 @@ export async function deleteCategoryChildren({
     connectorId,
     categoryId,
   });
+  // deleting the category stored in the db
+  await ZendeskCategoryResource.deleteByCategoryId({ connectorId, categoryId });
 }

--- a/connectors/src/connectors/zendesk/lib/data_cleanup.ts
+++ b/connectors/src/connectors/zendesk/lib/data_cleanup.ts
@@ -1,4 +1,5 @@
 import { getArticleInternalId } from "@connectors/connectors/zendesk/lib/id_conversions";
+import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { deleteFromDataSource } from "@connectors/lib/data_sources";
 import {
   ZendeskArticleResource,
@@ -23,13 +24,14 @@ export async function deleteCategory({
     connectorId,
     categoryId,
   });
-  await Promise.all(
-    articles.map((article) =>
+  await concurrentExecutor(
+    articles,
+    (article) =>
       deleteFromDataSource(
         dataSourceConfig,
         getArticleInternalId(connectorId, article.articleId)
-      )
-    )
+      ),
+    { concurrency: 10 }
   );
   /// deleting the articles stored in the db
   await ZendeskArticleResource.deleteByCategoryId({

--- a/connectors/src/connectors/zendesk/lib/data_cleanup.ts
+++ b/connectors/src/connectors/zendesk/lib/data_cleanup.ts
@@ -1,84 +1,10 @@
-import {
-  getArticleInternalId,
-  getTicketInternalId,
-} from "@connectors/connectors/zendesk/lib/id_conversions";
-import { ZENDESK_BATCH_SIZE } from "@connectors/connectors/zendesk/temporal/config";
+import { getArticleInternalId } from "@connectors/connectors/zendesk/lib/id_conversions";
 import { deleteFromDataSource } from "@connectors/lib/data_sources";
 import {
   ZendeskArticleResource,
   ZendeskCategoryResource,
-  ZendeskTicketResource,
 } from "@connectors/resources/zendesk_resources";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
-
-/**
- * Deletes all the tickets stored in the db and in the data source relative to a brand.
- *
- * @returns `true` if there are more tickets to process.
- */
-export async function deleteBrandTicketBatch({
-  connectorId,
-  brandId,
-  dataSourceConfig,
-}: {
-  connectorId: number;
-  brandId: number;
-  dataSourceConfig: DataSourceConfig;
-}): Promise<boolean> {
-  const ticketIds = await ZendeskTicketResource.fetchTicketIdsByBrandId({
-    connectorId,
-    brandId,
-    batchSize: ZENDESK_BATCH_SIZE,
-  });
-  /// deleting the tickets in the data source
-  await Promise.all(
-    ticketIds.map((ticketId) =>
-      deleteFromDataSource(
-        dataSourceConfig,
-        getTicketInternalId(connectorId, ticketId)
-      )
-    )
-  );
-  /// deleting the tickets stored in the db
-  await ZendeskTicketResource.deleteByTicketIds({ connectorId, ticketIds });
-
-  /// returning false if we know for sure there isn't any more ticket to process
-  return ticketIds.length === ZENDESK_BATCH_SIZE;
-}
-
-/**
- * Deletes all the data stored in the db and in the data source relative to a brand's help center (category, articles).
- */
-export async function deleteBrandHelpCenter({
-  connectorId,
-  brandId,
-  dataSourceConfig,
-}: {
-  connectorId: number;
-  brandId: number;
-  dataSourceConfig: DataSourceConfig;
-}) {
-  /// deleting the articles in the data source
-  const articles = await ZendeskArticleResource.fetchByBrandId({
-    connectorId,
-    brandId,
-  });
-  await Promise.all(
-    articles.map((article) =>
-      deleteFromDataSource(
-        dataSourceConfig,
-        getArticleInternalId(connectorId, article.articleId)
-      )
-    )
-  );
-  /// deleting the articles stored in the db
-  await ZendeskArticleResource.deleteByBrandId({
-    connectorId,
-    brandId,
-  });
-  /// deleting the categories stored in the db
-  await ZendeskCategoryResource.deleteByBrandId({ connectorId, brandId });
-}
 
 /**
  * Deletes all the data stored in the db and in the data source relative to a category (articles).

--- a/connectors/src/connectors/zendesk/lib/data_cleanup.ts
+++ b/connectors/src/connectors/zendesk/lib/data_cleanup.ts
@@ -5,10 +5,30 @@ import {
 import { deleteFromDataSource } from "@connectors/lib/data_sources";
 import {
   ZendeskArticleResource,
+  ZendeskBrandResource,
   ZendeskCategoryResource,
   ZendeskTicketResource,
 } from "@connectors/resources/zendesk_resources";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
+
+/**
+ * Deletes all the data relative to a brand (tickets, help center, categories, articles) in the data source and in the db.
+ */
+export async function deleteBrand({
+  connectorId,
+  brandId,
+  dataSourceConfig,
+}: {
+  connectorId: number;
+  brandId: number;
+  dataSourceConfig: DataSourceConfig;
+}) {
+  await Promise.all([
+    deleteBrandHelpCenter({ connectorId, brandId, dataSourceConfig }),
+    deleteBrandTickets({ connectorId, brandId, dataSourceConfig }),
+  ]);
+  await ZendeskBrandResource.deleteByConnectorId(connectorId);
+}
 
 /**
  * Deletes all the tickets stored in the db and in the data source relative to a brand.

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -1,9 +1,10 @@
 import type { ModelId } from "@dust-tt/types";
 
 import {
-  getArticleInternalId,
-  getTicketInternalId,
-} from "@connectors/connectors/zendesk/lib/id_conversions";
+  deleteBrandHelpCenter,
+  deleteBrandTickets,
+  deleteCategoryChildren,
+} from "@connectors/connectors/zendesk/lib/data_cleanup";
 import { syncArticle } from "@connectors/connectors/zendesk/lib/sync_article";
 import {
   deleteTicket,
@@ -27,13 +28,10 @@ import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import {
-  ZendeskArticleResource,
   ZendeskBrandResource,
   ZendeskCategoryResource,
   ZendeskConfigurationResource,
-  ZendeskTicketResource,
 } from "@connectors/resources/zendesk_resources";
-import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
 /**
  * This activity is responsible for updating the lastSyncStartTime of the connector to now.
@@ -80,14 +78,10 @@ export async function saveZendeskConnectorSuccessSync(
 
 /**
  * This activity is responsible for syncing a Brand.
- * It does not sync the content inside the Brand, only the Brand data in itself.
+ * It does not sync the content inside the Brand, only the Brand data in itself (name, url, subdomain, lastUpsertedTs).
+ * If the brand is not found in Zendesk, it deletes it.
  *
- * It is going to update the name of the Brand if it has changed.
- * If the Brand is not allowed anymore, it will delete all its data.
- * If the Brand is not present on Zendesk anymore, it will delete all its data as well.
- * If the Help Center has no readable category anymore, we delete the Help Center data.
- *
- * @returns the updated permissions of the Brand.
+ * @returns the permissions of the Brand.
  */
 export async function syncZendeskBrandActivity({
   connectorId,
@@ -114,30 +108,14 @@ export async function syncZendeskBrandActivity({
     );
   }
 
-  // deleting the tickets/help center if not allowed anymore
-  if (brandInDb.ticketsPermission === "none") {
-    await deleteBrandTickets({ connectorId, brandId, dataSourceConfig });
-  }
-  if (brandInDb.helpCenterPermission === "none") {
-    await deleteBrandHelpCenter({ connectorId, brandId, dataSourceConfig });
-  }
-
-  // if all rights were revoked, we delete the brand data.
-  if (
-    brandInDb.helpCenterPermission === "none" &&
-    brandInDb.ticketsPermission === "none"
-  ) {
-    await brandInDb.delete();
-    return { helpCenterAllowed: false, ticketsAllowed: false };
-  }
-
-  // if the brand is not on Zendesk anymore, we delete it
   const zendeskApiClient = createZendeskClient(
     await getZendeskSubdomainAndAccessToken(connector.connectionId)
   );
   const {
     result: { brand: fetchedBrand },
   } = await zendeskApiClient.brand.show(brandId);
+
+  // if the brand is not on Zendesk anymore, we delete it
   if (!fetchedBrand) {
     await Promise.all([
       deleteBrandHelpCenter({ connectorId, brandId, dataSourceConfig }),
@@ -147,29 +125,14 @@ export async function syncZendeskBrandActivity({
     return { helpCenterAllowed: false, ticketsAllowed: false };
   }
 
-  // if there are no read permissions on any category, we delete the help center
-  const categoriesWithReadPermissions =
-    await ZendeskCategoryResource.fetchByBrandIdReadOnly({
-      connectorId,
-      brandId,
-    });
-  const noMoreAllowedCategories = categoriesWithReadPermissions.length === 0;
-
-  if (noMoreAllowedCategories) {
-    await deleteBrandHelpCenter({ connectorId, brandId, dataSourceConfig });
-    // if the tickets and all children categories are not allowed anymore, we delete the brand data
-    if (brandInDb.ticketsPermission !== "read") {
-      await brandInDb.delete();
-      return { helpCenterAllowed: false, ticketsAllowed: false };
-    }
-    await brandInDb.revokeHelpCenterPermissions();
-  }
-
-  // otherwise, we update the brand name and lastUpsertedTs
+  // otherwise, we update the brand data and lastUpsertedTs
   await brandInDb.update({
     name: fetchedBrand.name || "Brand",
+    url: fetchedBrand?.url || brandInDb.url,
+    subdomain: fetchedBrand?.subdomain || brandInDb.subdomain,
     lastUpsertedTs: new Date(currentSyncDateMs),
   });
+
   return {
     helpCenterAllowed: brandInDb.helpCenterPermission === "read",
     ticketsAllowed: brandInDb.ticketsPermission === "read",
@@ -196,6 +159,15 @@ export async function getZendeskTimestampCursorActivity(
   return cursors.timestampCursor
     ? new Date(Math.min(cursors.timestampCursor.getTime(), minAgo))
     : new Date(minAgo);
+}
+
+/**
+ * Retrieves the IDs of every brand stored in db.
+ */
+export async function getZendeskBrandIdsActivity(
+  connectorId: ModelId
+): Promise<number[]> {
+  return ZendeskBrandResource.fetchAllBrandIds({ connectorId });
 }
 
 /**
@@ -657,99 +629,4 @@ export async function syncZendeskTicketUpdateBatchActivity({
     { concurrency: 10 }
   );
   return { hasMore: !end_of_stream, afterCursor: after_cursor };
-}
-
-/**
- * Deletes all the tickets stored in the db and in the data source relative to a brand.
- */
-async function deleteBrandTickets({
-  connectorId,
-  brandId,
-  dataSourceConfig,
-}: {
-  connectorId: number;
-  brandId: number;
-  dataSourceConfig: DataSourceConfig;
-}) {
-  const tickets = await ZendeskTicketResource.fetchByBrandId({
-    connectorId,
-    brandId,
-  });
-  /// deleting the tickets in the data source
-  await Promise.all(
-    tickets.map((ticket) =>
-      deleteFromDataSource(
-        dataSourceConfig,
-        getTicketInternalId(ticket.connectorId, ticket.ticketId)
-      )
-    )
-  );
-  /// deleting the tickets stored in the db
-  await ZendeskTicketResource.deleteByBrandId({ connectorId, brandId });
-}
-
-/**
- * Deletes all the data stored in the db and in the data source relative to a brand's help center (category, articles).
- */
-async function deleteBrandHelpCenter({
-  connectorId,
-  brandId,
-  dataSourceConfig,
-}: {
-  connectorId: number;
-  brandId: number;
-  dataSourceConfig: DataSourceConfig;
-}) {
-  /// deleting the articles in the data source
-  const articles = await ZendeskArticleResource.fetchByBrandId({
-    connectorId,
-    brandId,
-  });
-  await Promise.all(
-    articles.map((article) =>
-      deleteFromDataSource(
-        dataSourceConfig,
-        getArticleInternalId(connectorId, article.articleId)
-      )
-    )
-  );
-  /// deleting the articles stored in the db
-  await ZendeskArticleResource.deleteByBrandId({
-    connectorId,
-    brandId,
-  });
-  /// deleting the categories stored in the db
-  await ZendeskCategoryResource.deleteByBrandId({ connectorId, brandId });
-}
-
-/**
- * Deletes all the data stored in the db and in the data source relative to a category (articles).
- */
-async function deleteCategoryChildren({
-  connectorId,
-  categoryId,
-  dataSourceConfig,
-}: {
-  connectorId: number;
-  categoryId: number;
-  dataSourceConfig: DataSourceConfig;
-}) {
-  /// deleting the articles in the data source
-  const articles = await ZendeskArticleResource.fetchByCategoryId({
-    connectorId,
-    categoryId,
-  });
-  await Promise.all(
-    articles.map((article) =>
-      deleteFromDataSource(
-        dataSourceConfig,
-        getArticleInternalId(connectorId, article.articleId)
-      )
-    )
-  );
-  /// deleting the articles stored in the db
-  await ZendeskArticleResource.deleteByCategoryId({
-    connectorId,
-    categoryId,
-  });
 }

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -21,7 +21,6 @@ import {
 import { ZENDESK_BATCH_SIZE } from "@connectors/connectors/zendesk/temporal/config";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
-import { deleteFromDataSource } from "@connectors/lib/data_sources";
 import { ZendeskTimestampCursors } from "@connectors/lib/models/zendesk";
 import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
 import logger from "@connectors/logger/logger";

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -2,7 +2,7 @@ import type { ModelId } from "@dust-tt/types";
 
 import {
   deleteBrand,
-  deleteCategoryChildren,
+  deleteCategory,
 } from "@connectors/connectors/zendesk/lib/data_cleanup";
 import { syncArticle } from "@connectors/connectors/zendesk/lib/sync_article";
 import {
@@ -269,8 +269,7 @@ export async function syncZendeskCategoryActivity({
 
   // if all rights were revoked, we delete the category data.
   if (categoryInDb.permission === "none") {
-    await deleteCategoryChildren({ connectorId, dataSourceConfig, categoryId });
-    await categoryInDb.delete();
+    await deleteCategory({ connectorId, dataSourceConfig, categoryId });
     return false;
   }
 
@@ -286,8 +285,7 @@ export async function syncZendeskCategoryActivity({
   const { result: fetchedCategory } =
     await zendeskApiClient.helpcenter.categories.show(categoryId);
   if (!fetchedCategory) {
-    await deleteCategoryChildren({ connectorId, categoryId, dataSourceConfig });
-    await categoryInDb.delete();
+    await deleteCategory({ connectorId, categoryId, dataSourceConfig });
     return false;
   }
 

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -1,8 +1,7 @@
 import type { ModelId } from "@dust-tt/types";
 
 import {
-  deleteBrandHelpCenter,
-  deleteBrandTickets,
+  deleteBrand,
   deleteCategoryChildren,
 } from "@connectors/connectors/zendesk/lib/data_cleanup";
 import { syncArticle } from "@connectors/connectors/zendesk/lib/sync_article";
@@ -117,11 +116,7 @@ export async function syncZendeskBrandActivity({
 
   // if the brand is not on Zendesk anymore, we delete it
   if (!fetchedBrand) {
-    await Promise.all([
-      deleteBrandHelpCenter({ connectorId, brandId, dataSourceConfig }),
-      deleteBrandTickets({ connectorId, brandId, dataSourceConfig }),
-    ]);
-    await brandInDb.delete();
+    await deleteBrand({ connectorId, brandId, dataSourceConfig });
     return { helpCenterAllowed: false, ticketsAllowed: false };
   }
 

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -211,7 +211,7 @@ export async function getZendeskTicketsAllowedBrandIdsActivity(
 /**
  * Retrieves the categories for a given Brand.
  */
-export async function getZendeskCategoriesActivity({
+export async function fetchZendeskCategoriesActivity({
   connectorId,
   brandId,
 }: {

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -1,9 +1,6 @@
 import type { ModelId } from "@dust-tt/types";
 
-import {
-  deleteBrand,
-  deleteCategory,
-} from "@connectors/connectors/zendesk/lib/data_cleanup";
+import { deleteCategory } from "@connectors/connectors/zendesk/lib/data_cleanup";
 import { syncArticle } from "@connectors/connectors/zendesk/lib/sync_article";
 import {
   deleteTicket,
@@ -94,7 +91,6 @@ export async function syncZendeskBrandActivity({
   if (!connector) {
     throw new Error("[Zendesk] Connector not found.");
   }
-  const dataSourceConfig = dataSourceConfigFromConnector(connector);
 
   const brandInDb = await ZendeskBrandResource.fetchByBrandId({
     connectorId,
@@ -115,7 +111,8 @@ export async function syncZendeskBrandActivity({
 
   // if the brand is not on Zendesk anymore, we delete it
   if (!fetchedBrand) {
-    await deleteBrand({ connectorId, brandId, dataSourceConfig });
+    await brandInDb.revokeTicketsPermissions();
+    await brandInDb.revokeHelpCenterPermissions();
     return { helpCenterAllowed: false, ticketsAllowed: false };
   }
 

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -153,15 +153,6 @@ export async function getZendeskTimestampCursorActivity(
 }
 
 /**
- * Retrieves the IDs of every brand stored in db.
- */
-export async function getZendeskBrandIdsActivity(
-  connectorId: ModelId
-): Promise<number[]> {
-  return ZendeskBrandResource.fetchAllBrandIds({ connectorId });
-}
-
-/**
  * Sets the timestamp cursor to the start date of the last successful incremental sync.
  */
 export async function setZendeskTimestampCursorActivity({

--- a/connectors/src/connectors/zendesk/temporal/config.ts
+++ b/connectors/src/connectors/zendesk/temporal/config.ts
@@ -1,4 +1,4 @@
-export const WORKFLOW_VERSION = 5;
+export const WORKFLOW_VERSION = 6;
 export const QUEUE_NAME = `zendesk-queue-v${WORKFLOW_VERSION}`;
 export const GARBAGE_COLLECT_QUEUE_NAME = `zendesk-gc-queue-v${WORKFLOW_VERSION}`;
 

--- a/connectors/src/connectors/zendesk/temporal/gc_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/gc_activities.ts
@@ -175,7 +175,7 @@ export async function garbageCollectArticleBatchActivity({
 /**
  * This activity is responsible for removing all the empty categories (category with no readable article).
  */
-export async function garbageCollectCategoriesActivity(connectorId: number) {
+export async function removeEmptyCategoriesActivity(connectorId: number) {
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
     throw new Error("[Zendesk] Connector not found.");

--- a/connectors/src/connectors/zendesk/temporal/gc_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/gc_activities.ts
@@ -239,13 +239,14 @@ export async function deleteTicketBatchActivity({
     batchSize: ZENDESK_BATCH_SIZE,
   });
   /// deleting the tickets in the data source
-  await Promise.all(
-    ticketIds.map((ticketId) =>
+  await concurrentExecutor(
+    ticketIds,
+    (ticketId) =>
       deleteFromDataSource(
         dataSourceConfig,
         getTicketInternalId(connectorId, ticketId)
-      )
-    )
+      ),
+    { concurrency: 10 }
   );
   /// deleting the tickets stored in the db
   await ZendeskTicketResource.deleteByTicketIds({ connectorId, ticketIds });
@@ -278,13 +279,14 @@ export async function deleteArticleBatchActivity({
     brandId,
     batchSize: ZENDESK_BATCH_SIZE,
   });
-  await Promise.all(
-    articleIds.map((articleId) =>
+  await concurrentExecutor(
+    articleIds,
+    (articleId) =>
       deleteFromDataSource(
         dataSourceConfig,
         getArticleInternalId(connectorId, articleId)
-      )
-    )
+      ),
+    { concurrency: 10 }
   );
   /// deleting the articles stored in the db
   await ZendeskArticleResource.deleteByArticleIds({ connectorId, articleIds });

--- a/connectors/src/connectors/zendesk/temporal/gc_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/gc_activities.ts
@@ -292,3 +292,24 @@ export async function deleteBrandArticleBatchActivity({
   /// returning false if we know for sure there isn't any more article to process
   return articleIds.length === ZENDESK_BATCH_SIZE;
 }
+
+/**
+ * Deletes a batch of categories from the db.
+ *
+ * @returns `false` if there is no more category to process.
+ */
+export async function deleteBrandCategoryBatchActivity({
+  connectorId,
+  brandId,
+}: {
+  connectorId: number;
+  brandId: number;
+}): Promise<boolean> {
+  const deletedCount = await ZendeskCategoryResource.deleteByBrandId({
+    connectorId,
+    brandId,
+    batchSize: ZENDESK_BATCH_SIZE,
+  });
+
+  return deletedCount === ZENDESK_BATCH_SIZE;
+}

--- a/connectors/src/connectors/zendesk/temporal/gc_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/gc_activities.ts
@@ -48,6 +48,9 @@ export async function checkEmptyHelpCentersActivity(
   }
 }
 
+/**
+ * Retrieves the IDs of the Brands whose tickets are to be deleted.
+ */
 export async function getZendeskBrandsWithTicketsToDeleteActivity(
   connectorId: ModelId
 ): Promise<number[]> {
@@ -56,6 +59,9 @@ export async function getZendeskBrandsWithTicketsToDeleteActivity(
   });
 }
 
+/**
+ * Retrieves the IDs of the Brands whose Help Center is to be deleted.
+ */
 export async function getZendeskBrandsWithHelpCenterToDeleteActivity(
   connectorId: ModelId
 ): Promise<number[]> {

--- a/connectors/src/connectors/zendesk/temporal/gc_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/gc_activities.ts
@@ -68,7 +68,7 @@ export async function getZendeskBrandsWithHelpCenterToDeleteActivity(
  * This activity is responsible for fetching and cleaning up a batch of tickets
  * that are older than the retention period and ready to be deleted.
  */
-export async function garbageCollectTicketBatchActivity(
+export async function removeOutdatedTicketBatchActivity(
   connectorId: ModelId
 ): Promise<boolean> {
   const configuration =
@@ -116,7 +116,7 @@ export async function garbageCollectTicketBatchActivity(
  * This activity is responsible for fetching and garbage collecting a batch of articles.
  * Here, garbage collection means deleting articles that are no longer present in Zendesk.
  */
-export async function garbageCollectArticleBatchActivity({
+export async function removeMissingArticleBatchActivity({
   connectorId,
   brandId,
   cursor,

--- a/connectors/src/connectors/zendesk/temporal/gc_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/gc_activities.ts
@@ -220,7 +220,7 @@ export async function deleteBrandsWithNoPermissionActivity(
  *
  * @returns `false` if there is no more ticket to process.
  */
-export async function deleteBrandTicketBatchActivity({
+export async function deleteTicketBatchActivity({
   connectorId,
   brandId,
 }: {
@@ -259,7 +259,7 @@ export async function deleteBrandTicketBatchActivity({
  *
  * @returns `false` if there is no more article to process.
  */
-export async function deleteBrandArticleBatchActivity({
+export async function deleteArticleBatchActivity({
   connectorId,
   brandId,
 }: {
@@ -298,7 +298,7 @@ export async function deleteBrandArticleBatchActivity({
  *
  * @returns `false` if there is no more category to process.
  */
-export async function deleteBrandCategoryBatchActivity({
+export async function deleteCategoryBatchActivity({
   connectorId,
   brandId,
 }: {

--- a/connectors/src/connectors/zendesk/temporal/gc_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/gc_activities.ts
@@ -2,7 +2,7 @@ import type { ModelId } from "@dust-tt/types";
 
 import {
   deleteBrandHelpCenter,
-  deleteBrandTickets,
+  deleteBrandTicketBatch,
   deleteCategory,
 } from "@connectors/connectors/zendesk/lib/data_cleanup";
 import { deleteArticle } from "@connectors/connectors/zendesk/lib/sync_article";
@@ -193,7 +193,7 @@ export async function garbageCollectBrandActivity({
 
   // deleting the tickets/help center if not allowed anymore
   if (brandInDb.ticketsPermission === "none") {
-    await deleteBrandTickets({ connectorId, brandId, dataSourceConfig });
+    await deleteBrandTicketBatch({ connectorId, brandId, dataSourceConfig });
   }
   if (brandInDb.helpCenterPermission === "none") {
     await deleteBrandHelpCenter({ connectorId, brandId, dataSourceConfig });

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -34,6 +34,7 @@ const {
   getZendeskBrandsWithTicketsToDeleteActivity,
   checkEmptyHelpCentersActivity,
   deleteBrandsWithNoPermissionActivity,
+  deleteBrandCategoryBatchActivity,
 } = proxyActivities<typeof gc_activities>({
   startToCloseTimeout: "2 minutes",
 });
@@ -450,12 +451,19 @@ export async function zendeskGarbageCollectionWorkflow({
   // updating the permissions of the Help Centers that have no category anymore for a cleanup at the next step
   await checkEmptyHelpCentersActivity(connectorId);
 
-  // cleaning the articles of the brands that have no permission on their Help Center anymore
+  // cleaning the articles and categories of the brands that have no permission on their Help Center anymore
   brandIds = await getZendeskBrandsWithHelpCenterToDeleteActivity(connectorId);
   for (const brandId of brandIds) {
     hasMore = true;
     while (hasMore) {
       hasMore = await deleteBrandArticleBatchActivity({ connectorId, brandId });
+    }
+    hasMore = true;
+    while (hasMore) {
+      hasMore = await deleteBrandCategoryBatchActivity({
+        connectorId,
+        brandId,
+      });
     }
   }
 

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -34,9 +34,10 @@ const {
   startToCloseTimeout: "2 minutes",
 });
 
-const { garbageCollectBrandActivity } = proxyActivities<typeof gc_activities>({
-  startToCloseTimeout: "5 minutes",
-});
+const { garbageCollectBrandActivity, garbageCollectCategoriesActivity } =
+  proxyActivities<typeof gc_activities>({
+    startToCloseTimeout: "5 minutes",
+  });
 
 const {
   getZendeskHelpCenterReadAllowedBrandIdsActivity,
@@ -433,6 +434,9 @@ export async function zendeskGarbageCollectionWorkflow({
       });
     } while (cursor !== null);
   }
+
+  // deleting the categories that have no article anymore
+  await garbageCollectCategoriesActivity(connectorId);
 
   // cleaning the brands that have no permission on tickets and Help Center or are not on Zendesk anymore
   brandIds = await getZendeskBrandIdsActivity(connectorId);

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -16,7 +16,7 @@ import type {
 import { zendeskUpdatesSignal } from "@connectors/connectors/zendesk/temporal/signals";
 
 const {
-  getZendeskCategoriesActivity,
+  fetchZendeskCategoriesActivity,
   syncZendeskBrandActivity,
   syncZendeskCategoryActivity,
   syncZendeskArticleBatchActivity,
@@ -455,7 +455,7 @@ async function runZendeskBrandHelpCenterSyncActivities({
   currentSyncDateMs: number;
   forceResync: boolean;
 }) {
-  const categoryIds = await getZendeskCategoriesActivity({
+  const categoryIds = await fetchZendeskCategoriesActivity({
     connectorId,
     brandId,
   });

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -41,7 +41,7 @@ const {
 const {
   deleteBrandTicketBatchActivity,
   deleteBrandArticleBatchActivity,
-  garbageCollectCategoriesActivity,
+  removeEmptyCategoriesActivity,
 } = proxyActivities<typeof gc_activities>({
   startToCloseTimeout: "5 minutes",
 });
@@ -445,7 +445,7 @@ export async function zendeskGarbageCollectionWorkflow({
   }
 
   // deleting the categories that have no article anymore
-  await garbageCollectCategoriesActivity(connectorId);
+  await removeEmptyCategoriesActivity(connectorId);
 
   // updating the permissions of the Help Centers that have no category anymore for a cleanup at the next step
   await checkEmptyHelpCentersActivity(connectorId);

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -34,14 +34,14 @@ const {
   getZendeskBrandsWithTicketsToDeleteActivity,
   checkEmptyHelpCentersActivity,
   deleteBrandsWithNoPermissionActivity,
-  deleteBrandCategoryBatchActivity,
+  deleteCategoryBatchActivity,
 } = proxyActivities<typeof gc_activities>({
   startToCloseTimeout: "2 minutes",
 });
 
 const {
-  deleteBrandTicketBatchActivity,
-  deleteBrandArticleBatchActivity,
+  deleteTicketBatchActivity,
+  deleteArticleBatchActivity,
   removeEmptyCategoriesActivity,
 } = proxyActivities<typeof gc_activities>({
   startToCloseTimeout: "5 minutes",
@@ -456,14 +456,11 @@ export async function zendeskGarbageCollectionWorkflow({
   for (const brandId of brandIds) {
     hasMore = true;
     while (hasMore) {
-      hasMore = await deleteBrandArticleBatchActivity({ connectorId, brandId });
+      hasMore = await deleteArticleBatchActivity({ connectorId, brandId });
     }
     hasMore = true;
     while (hasMore) {
-      hasMore = await deleteBrandCategoryBatchActivity({
-        connectorId,
-        brandId,
-      });
+      hasMore = await deleteCategoryBatchActivity({ connectorId, brandId });
     }
   }
 
@@ -472,7 +469,7 @@ export async function zendeskGarbageCollectionWorkflow({
   for (const brandId of brandIds) {
     let hasMore = true;
     while (hasMore) {
-      hasMore = await deleteBrandTicketBatchActivity({ connectorId, brandId });
+      hasMore = await deleteTicketBatchActivity({ connectorId, brandId });
     }
   }
 

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -28,8 +28,8 @@ const {
 });
 
 const {
-  garbageCollectTicketBatchActivity,
-  garbageCollectArticleBatchActivity,
+  removeOutdatedTicketBatchActivity,
+  removeMissingArticleBatchActivity,
   getZendeskBrandsWithHelpCenterToDeleteActivity,
   getZendeskBrandsWithTicketsToDeleteActivity,
   checkEmptyHelpCentersActivity,
@@ -427,7 +427,7 @@ export async function zendeskGarbageCollectionWorkflow({
   // deleting the outdated tickets (deleted tickets are cleaned in the incremental sync)
   let hasMore = true;
   while (hasMore) {
-    hasMore = await garbageCollectTicketBatchActivity(connectorId);
+    hasMore = await removeOutdatedTicketBatchActivity(connectorId);
   }
 
   // deleting the articles that cannot be found anymore in the Zendesk API
@@ -436,7 +436,7 @@ export async function zendeskGarbageCollectionWorkflow({
   for (const brandId of brandIds) {
     let cursor = null;
     do {
-      cursor = await garbageCollectArticleBatchActivity({
+      cursor = await removeMissingArticleBatchActivity({
         connectorId,
         brandId,
         cursor,

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -397,6 +397,15 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
     };
   }
 
+  static async fetchCategoryIdsForConnector(
+    connectorId: number
+  ): Promise<number[]> {
+    const categories = await ZendeskCategory.findAll({
+      where: { connectorId },
+    });
+    return categories.map((category) => category.get().categoryId);
+  }
+
   static async fetchByCategoryId({
     connectorId,
     categoryId,

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -523,11 +523,16 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
   static async deleteByBrandId({
     connectorId,
     brandId,
+    batchSize = null,
   }: {
     connectorId: number;
     brandId: number;
-  }): Promise<void> {
-    await ZendeskCategory.destroy({ where: { connectorId, brandId } });
+    batchSize?: number | null;
+  }): Promise<number> {
+    return ZendeskCategory.destroy({
+      where: { connectorId, brandId },
+      ...(batchSize && { limit: batchSize }),
+    });
   }
 
   static async deleteByConnectorId(

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -698,17 +698,21 @@ export class ZendeskTicketResource extends BaseResource<ZendeskTicket> {
     return tickets.map((ticket) => new this(this.model, ticket.get()));
   }
 
-  static async fetchByBrandId({
+  static async fetchTicketIdsByBrandId({
     connectorId,
     brandId,
+    batchSize = null,
   }: {
     connectorId: number;
     brandId: number;
-  }): Promise<ZendeskTicketResource[]> {
+    batchSize?: number | null;
+  }): Promise<number[]> {
     const tickets = await ZendeskTicket.findAll({
       where: { connectorId, brandId },
+      attributes: ["ticketId"],
+      ...(batchSize && { limit: batchSize }),
     });
-    return tickets.map((ticket) => new this(this.model, ticket.get()));
+    return tickets.map((ticket) => ticket.get().ticketId);
   }
 
   static async deleteByTicketId({
@@ -721,14 +725,16 @@ export class ZendeskTicketResource extends BaseResource<ZendeskTicket> {
     await ZendeskTicket.destroy({ where: { connectorId, ticketId } });
   }
 
-  static async deleteByBrandId({
+  static async deleteByTicketIds({
     connectorId,
-    brandId,
+    ticketIds,
   }: {
     connectorId: number;
-    brandId: number;
+    ticketIds: number[];
   }): Promise<void> {
-    await ZendeskTicket.destroy({ where: { connectorId, brandId } });
+    await ZendeskTicket.destroy({
+      where: { connectorId, ticketId: { [Op.in]: ticketIds } },
+    });
   }
 
   static async deleteByConnectorId(

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -466,6 +466,16 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
     return categories.map((category) => new this(this.model, category.get()));
   }
 
+  static async deleteByCategoryId({
+    connectorId,
+    categoryId,
+  }: {
+    connectorId: number;
+    categoryId: number;
+  }): Promise<void> {
+    await ZendeskCategory.destroy({ where: { connectorId, categoryId } });
+  }
+
   static async deleteByBrandId({
     connectorId,
     brandId,

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -855,9 +855,12 @@ export class ZendeskArticleResource extends BaseResource<ZendeskArticle> {
     cursor: number | null;
   }): Promise<{ articleIds: number[]; cursor: number | null }> {
     const articles = await ZendeskArticle.findAll({
-      where: { connectorId, brandId },
+      where: {
+        connectorId,
+        brandId,
+        ...(cursor && { id: { [Op.gt]: cursor } }),
+      },
       order: [["id", "ASC"]],
-      ...(cursor && { where: { id: { [Op.gt]: cursor } } }),
       limit: batchSize,
     });
     return {

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -284,7 +284,7 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
 
   static async deleteByConnectorId(
     connectorId: number,
-    transaction: Transaction
+    transaction?: Transaction
   ) {
     await ZendeskBrand.destroy({ where: { connectorId }, transaction });
   }


### PR DESCRIPTION
## Description

- Move actions relative to the garbage collection from the sync workflow to the garbage collection workflow.
- The garbage collection workflow now cleans the following:
  - Outdated tickets.
  - Articles that cannot be found anymore in the Zendesk API.
  - Categories that have no article anymore.
  - Permissions of the Help Centers that have no category anymore (allows a cleanup of the brand).
  - Articles and tickets of the brands that have no permission on their Help Center anymore.
  - Brands that have no permission on tickets and Help Center anymore.

## Risk

Low.

## Deploy Plan

- Deploy connectors.