### PR TITLE
Ext: fix back nav from convo

### DIFF
--- a/extension/app/src/pages/ConversationPage.tsx
+++ b/extension/app/src/pages/ConversationPage.tsx
@@ -8,14 +8,24 @@ import type { ProtectedRouteChildrenProps } from "@extension/components/auth/Pro
 import { ConversationContainer } from "@extension/components/conversation/ConversationContainer";
 import { FileDropProvider } from "@extension/components/conversation/FileUploaderContext";
 import { usePublicConversation } from "@extension/components/conversation/usePublicConversation";
-import { useNavigate, useParams } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
 
 export const ConversationPage = ({
   workspace,
   user,
 }: ProtectedRouteChildrenProps) => {
   const navigate = useNavigate();
+  const location = useLocation();
   const { conversationId } = useParams();
+
+  const [origin, setOrigin] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (location.state?.origin) {
+      setOrigin(location.state.origin);
+    }
+  }, [location.state?.origin]);
 
   const { conversation } = usePublicConversation({
     conversationId: conversationId ?? null,
@@ -35,7 +45,13 @@ export const ConversationPage = ({
           <Button
             icon={ChevronLeftIcon}
             variant="ghost"
-            onClick={() => navigate(-1)}
+            onClick={() => {
+              if (origin === "conversations") {
+                navigate("/conversations");
+              } else {
+                navigate("/");
+              }
+            }}
             size="md"
           />
         }

--- a/extension/app/src/pages/ConversationsPage.tsx
+++ b/extension/app/src/pages/ConversationsPage.tsx
@@ -10,6 +10,7 @@ import {
 } from "@dust-tt/sparkle";
 import { useConversations } from "@extension/components/conversation/useConversations";
 import moment from "moment";
+import type { NavigateFunction } from "react-router-dom";
 import { useNavigate } from "react-router-dom";
 
 type GroupLabel =
@@ -111,7 +112,7 @@ const RenderConversations = ({
 }: {
   conversations: ConversationWithoutContentPublicType[];
   dateLabel: string;
-  navigate: (path: string) => void;
+  navigate: NavigateFunction;
 }) => {
   if (!conversations.length) {
     return null;
@@ -137,7 +138,11 @@ const RenderConversations = ({
           <NavigationListItem
             key={conversation.sId}
             label={getLabel(conversation)}
-            onClick={() => navigate(`/conversations/${conversation.sId}`)}
+            onClick={() => {
+              navigate(`/conversations/${conversation.sId}`, {
+                state: { origin: "conversations" },
+              });
+            }}
           />
         ))}
       </NavigationList>


### PR DESCRIPTION
## Description

The navigate(-1) was not working properly when the convo was opened from a context menu. 
This will be more robust even though it's annoying to have added a state for it. 

## Risk

Extension only. 

## Deploy Plan

Nothing. 
