### PR TITLE
[Slack] Exclude archived channels from api call rather than after

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -93,8 +93,19 @@ async function _getChannelsUncached(
       // we observed ~50 channels per call at times see https://github.com/dust-tt/tasks/issues/1655
       limit: 999,
       cursor: nextCursor,
+      exclude_archived: true,
     });
     nbCalls++;
+
+    logger.info(
+      {
+        connectorId,
+        returnedChannels: allChannels.length,
+        currentCursor: nextCursor,
+        nbCalls,
+      },
+      `[Slack] conversations.list called for getChannels (${nbCalls} calls)`
+    );
 
     nextCursor = c?.response_metadata?.next_cursor;
 
@@ -110,24 +121,12 @@ async function _getChannelsUncached(
     }
     for (const channel of c.channels) {
       if (channel && channel.id) {
-        if (channel.is_archived) {
-          continue;
-        }
         if (!joinedOnly || channel.is_member) {
           allChannels.push(channel);
         }
       }
     }
   } while (nextCursor);
-
-  logger.info(
-    {
-      connectorId,
-      returnedChannels: allChannels.length,
-      nbCalls,
-    },
-    `[Slack] conversations.list called for getChannels (${nbCalls} calls)`
-  );
 
   return allChannels;
 }


### PR DESCRIPTION
Description
---
We were including archived channels in `conversations.list` calls which are rate limited, and then excluding them in code

This PR fixes that and improves (back) the investigation log.

See issue https://github.com/dust-tt/tasks/issues/1655

Risks
---
low

Deploy
---
connectors