### PR TITLE
[Slack] Copy for message on private join channel

### DIFF
--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -463,7 +463,7 @@ const _webhookSlackAPIHandler = async (
         if (channelInfo?.channel?.is_private) {
           await slackClient.chat.postMessage({
             channel: event.channel,
-            text: "You can now talk to Dust in this channel. ⚠️ Admins of your Dust workspace will also be able to synchronize data from this channel.",
+            text: "You can now talk to Dust in this channel. ⚠️ If private channel synchronization has been allowed on your Dust workspace, admins will now be able to synchronize data from this channel.",
           });
         }
 


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/1666

Not easy to avoid displaying if feature flag is off, so we change message copy instead

cc @ahammour 

Risk
---
none

Deploy
---
Connectors
