### PR TITLE
feat(browser-ext): supersede tab content content fragments

### DIFF
--- a/extension/app/src/components/conversation/ConversationContainer.tsx
+++ b/extension/app/src/components/conversation/ConversationContainer.tsx
@@ -2,7 +2,6 @@ import type {
   AgentMentionType,
   ContentFragmentType,
   LightWorkspaceType,
-  UploadedContentFragmentType,
 } from "@dust-tt/client";
 import { Page, useSendNotification } from "@dust-tt/sparkle";
 import { ConversationViewer } from "@extension/components/conversation/ConversationViewer";
@@ -31,7 +30,10 @@ import {
   saveFilesContentFragmentIds,
   setConversationsContext,
 } from "@extension/lib/storage";
-import type { UploadedFileWithKind } from "@extension/lib/types";
+import type {
+  UploadedFileWithKind,
+  UploadedFileWithSupersededContentFragmentId,
+} from "@extension/lib/types";
 import { useCallback, useContext, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
@@ -110,9 +112,8 @@ export function ConversationContainer({
     try {
       await mutateConversation(
         async (currentConversation) => {
-          const contentFragmentFiles: (UploadedContentFragmentType & {
-            supersededContentFragmentId?: string;
-          })[] = [];
+          const contentFragmentFiles: UploadedFileWithSupersededContentFragmentId[] =
+            [];
 
           for (const file of files) {
             // Get the content fragment ID to supersede for a given file.

--- a/extension/app/src/components/conversation/ConversationContainer.tsx
+++ b/extension/app/src/components/conversation/ConversationContainer.tsx
@@ -219,7 +219,7 @@ export function ConversationContainer({
             });
           }
         } else {
-          // Save the content fragment IDs for tab contents to the local storage.
+          // Get all content fragments from the conversation.
           const contentFragments: ContentFragmentType[] = [];
           for (const versions of conversationRes.value.content) {
             const latestVersion = versions[versions.length - 1];
@@ -227,7 +227,7 @@ export function ConversationContainer({
               contentFragments.push(latestVersion);
             }
           }
-
+          // Save the content fragment IDs for tab contents to the local storage.
           await saveFilesContentFragmentIds({
             conversationId: conversationRes.value.sId,
             uploadedFiles: files,

--- a/extension/app/src/components/conversation/ConversationContainer.tsx
+++ b/extension/app/src/components/conversation/ConversationContainer.tsx
@@ -31,6 +31,7 @@ import {
   saveFilesContentFragmentIds,
   setConversationsContext,
 } from "@extension/lib/storage";
+import type { UploadedFileWithKind } from "@extension/lib/types";
 import { useCallback, useContext, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
@@ -100,9 +101,7 @@ export function ConversationContainer({
   const handlePostMessage = async (
     input: string,
     mentions: AgentMentionType[],
-    files: (UploadedContentFragmentType & {
-      kind: "attachment" | "tab_content";
-    })[]
+    files: UploadedFileWithKind[]
   ) => {
     if (!activeConversationId) {
       return null;
@@ -195,9 +194,7 @@ export function ConversationContainer({
       async (
         input: string,
         mentions: AgentMentionType[],
-        files: (UploadedContentFragmentType & {
-          kind: "attachment" | "tab_content";
-        })[]
+        files: UploadedFileWithKind[]
       ) => {
         const conversationRes = await postConversation({
           dustAPI,
@@ -289,9 +286,7 @@ export function ConversationContainer({
               onSubmit={async (
                 input,
                 mentions,
-                files: (UploadedContentFragmentType & {
-                  kind: "attachment" | "tab_content";
-                })[]
+                files: UploadedFileWithKind[]
               ) => {
                 void (activeConversationId
                   ? handlePostMessage(input, mentions, files)

--- a/extension/app/src/components/conversation/ConversationContainer.tsx
+++ b/extension/app/src/components/conversation/ConversationContainer.tsx
@@ -283,15 +283,11 @@ export function ConversationContainer({
             )}
             <AssistantInputBar
               owner={owner}
-              onSubmit={async (
-                input,
-                mentions,
-                files: UploadedFileWithKind[]
-              ) => {
-                void (activeConversationId
-                  ? handlePostMessage(input, mentions, files)
-                  : handlePostConversation(input, mentions, files));
-              }}
+              onSubmit={
+                activeConversationId
+                  ? handlePostMessage
+                  : handlePostConversation
+              }
               stickyMentions={stickyMentions}
               isTabIncluded={!!includeContent}
               setIncludeTab={(includeTab) => {

--- a/extension/app/src/components/input_bar/InputBar.tsx
+++ b/extension/app/src/components/input_bar/InputBar.tsx
@@ -3,7 +3,6 @@ import type {
   ConversationPublicType,
   LightAgentConfigurationType,
   LightWorkspaceType,
-  UploadedContentFragmentType,
 } from "@dust-tt/client";
 import { Button, StopIcon } from "@dust-tt/sparkle";
 import { usePublicAgentConfigurations } from "@extension/components/assistants/usePublicAgentConfigurations";
@@ -18,6 +17,7 @@ import { useFileUploaderService } from "@extension/hooks/useFileUploaderService"
 import { useDustAPI } from "@extension/lib/dust_api";
 import type { AttachSelectionMessage } from "@extension/lib/messages";
 import { sendInputBarStatus } from "@extension/lib/messages";
+import type { UploadedFileWithKind } from "@extension/lib/types";
 import { classNames, compareAgentsForSort } from "@extension/lib/utils";
 import { useContext, useEffect, useMemo, useRef, useState } from "react";
 
@@ -41,9 +41,7 @@ export function AssistantInputBar({
   onSubmit: (
     input: string,
     mentions: AgentMentionType[],
-    contentFragments: (UploadedContentFragmentType & {
-      kind: "attachment" | "tab_content";
-    })[]
+    contentFragments: UploadedFileWithKind[]
   ) => void;
   stickyMentions?: AgentMentionType[];
   additionalAgentConfiguration?: LightAgentConfigurationType;

--- a/extension/app/src/components/input_bar/InputBar.tsx
+++ b/extension/app/src/components/input_bar/InputBar.tsx
@@ -41,7 +41,9 @@ export function AssistantInputBar({
   onSubmit: (
     input: string,
     mentions: AgentMentionType[],
-    contentFragments: UploadedContentFragmentType[]
+    contentFragments: (UploadedContentFragmentType & {
+      kind: "attachment" | "tab_content";
+    })[]
   ) => void;
   stickyMentions?: AgentMentionType[];
   additionalAgentConfiguration?: LightAgentConfigurationType;
@@ -81,7 +83,10 @@ export function AssistantInputBar({
   useEffect(() => {
     if (droppedFiles.length > 0) {
       // Handle the dropped files.
-      void fileUploaderService.handleFilesUpload(droppedFiles);
+      void fileUploaderService.handleFilesUpload({
+        files: droppedFiles,
+        kind: "attachment",
+      });
 
       // Clear the dropped files after handling them.
       setDroppedFiles([]);
@@ -193,6 +198,7 @@ export function AssistantInputBar({
       title: cf.filename,
       fileId: cf.fileId,
       url: cf.publicUrl,
+      kind: cf.kind,
     }));
 
     resetEditorText();
@@ -213,10 +219,12 @@ export function AssistantInputBar({
             title: cf.filename,
             fileId: cf.fileId || "",
             url: cf.publicUrl,
+            kind: cf.kind,
           }))
         );
       }
     }
+
     onSubmit(text, mentions, newFiles);
     fileUploaderService.resetUpload();
   };

--- a/extension/app/src/hooks/useFileUploaderService.ts
+++ b/extension/app/src/hooks/useFileUploaderService.ts
@@ -13,13 +13,12 @@ import { useSendNotification } from "@dust-tt/sparkle";
 import { getIncludeCurrentTab } from "@extension/lib/conversation";
 import { useDustAPI } from "@extension/lib/dust_api";
 import type { GetActiveTabOptions } from "@extension/lib/messages";
+import type { UploadedFileKind } from "@extension/lib/types";
 import { useState } from "react";
-
-type FileBlobKind = "attachment" | "tab_content";
 
 interface FileBlob {
   contentType: SupportedFileContentType;
-  kind: FileBlobKind;
+  kind: UploadedFileKind;
   file: File;
   filename: string;
   id: string;
@@ -74,7 +73,7 @@ export function useFileUploaderService() {
   }: {
     files: File[];
     updateBlobs?: boolean;
-    kind: FileBlobKind;
+    kind: UploadedFileKind;
   }): Promise<FileBlob[] | undefined> => {
     setIsProcessingFiles(true);
 
@@ -132,7 +131,7 @@ export function useFileUploaderService() {
 
   const processSelectedFiles = (
     selectedFiles: File[],
-    kind: FileBlobKind
+    kind: UploadedFileKind
   ): Result<FileBlob, FileBlobUploadError>[] => {
     return selectedFiles.reduce(
       (acc, file) => {
@@ -416,7 +415,7 @@ const createFileBlob = ({
 }: {
   file: File;
   contentType: SupportedFileContentType;
-  kind: "attachment" | "tab_content";
+  kind: UploadedFileKind;
   preview?: string;
 }): FileBlob => ({
   contentType,

--- a/extension/app/src/hooks/useFileUploaderService.ts
+++ b/extension/app/src/hooks/useFileUploaderService.ts
@@ -340,7 +340,7 @@ export function useFileUploaderService() {
         const fragments = await handleFilesUpload({
           files: [file],
           updateBlobs,
-          kind: "tab_content",
+          kind: includeSelectionOnly ? "selection" : "tab_content",
         });
         if (fragments) {
           fragments.forEach((f) => {

--- a/extension/app/src/lib/conversation.ts
+++ b/extension/app/src/lib/conversation.ts
@@ -18,6 +18,7 @@ import { Err, Ok } from "@dust-tt/client";
 import type { GetActiveTabOptions } from "@extension/lib/messages";
 import { sendGetActiveTabMessage } from "@extension/lib/messages";
 import { getAccessToken, getStoredUser } from "@extension/lib/storage";
+import type { UploadedFileWithSupersededContentFragmentId } from "@extension/lib/types";
 
 type SubmitMessageError = {
   type:
@@ -202,9 +203,7 @@ export async function postMessage({
     input: string;
     mentions: AgentMentionType[];
   };
-  files: (UploadedContentFragmentType & {
-    supersededContentFragmentId?: string;
-  })[];
+  files: UploadedFileWithSupersededContentFragmentId[];
 }): Promise<
   Result<
     { message: UserMessageType; contentFragments: ContentFragmentType[] },

--- a/extension/app/src/lib/conversation.ts
+++ b/extension/app/src/lib/conversation.ts
@@ -194,7 +194,7 @@ export async function postMessage({
   dustAPI,
   conversationId,
   messageData,
-  contentFragments,
+  files,
 }: {
   dustAPI: DustAPI;
   conversationId: string;
@@ -202,8 +202,15 @@ export async function postMessage({
     input: string;
     mentions: AgentMentionType[];
   };
-  contentFragments: UploadedContentFragmentType[];
-}): Promise<Result<{ message: UserMessageType }, SubmitMessageError>> {
+  files: (UploadedContentFragmentType & {
+    supersededContentFragmentId?: string;
+  })[];
+}): Promise<
+  Result<
+    { message: UserMessageType; contentFragments: ContentFragmentType[] },
+    SubmitMessageError
+  >
+> {
   const { input, mentions } = messageData;
   const user = await getStoredUser();
 
@@ -215,22 +222,32 @@ export async function postMessage({
       message: "Please log in again.",
     });
   }
-
-  for (const contentFragment of contentFragments) {
-    await dustAPI.postContentFragment({
+  const contentFragments: ContentFragmentType[] = [];
+  for (const file of files) {
+    const res = await dustAPI.postContentFragment({
       conversationId,
       contentFragment: {
-        title: contentFragment.title,
-        fileId: contentFragment.fileId,
-        url: null,
+        title: file.title,
+        fileId: file.fileId,
+        url: file.url ?? null,
         context: {
           username: user.username,
           email: user.email,
           fullName: user.fullName,
           profilePictureUrl: user.image,
         },
+        supersededContentFragmentId: file.supersededContentFragmentId,
       },
     });
+    if (res.isOk()) {
+      contentFragments.push(res.value);
+    } else {
+      return new Err({
+        type: "attachment_upload_error",
+        title: "Your message could not be sent.",
+        message: res.error.message || "Please try again or contact us.",
+      });
+    }
   }
 
   const mRes = await dustAPI.postUserMessage({
@@ -267,7 +284,7 @@ export async function postMessage({
     });
   }
 
-  return new Ok({ message: mRes.value });
+  return new Ok({ message: mRes.value, contentFragments });
 }
 
 export async function retryMessage({

--- a/extension/app/src/lib/storage.ts
+++ b/extension/app/src/lib/storage.ts
@@ -1,9 +1,6 @@
-import type {
-  ContentFragmentType,
-  MeResponseType,
-  UploadedContentFragmentType,
-} from "@dust-tt/client";
+import type { ContentFragmentType, MeResponseType } from "@dust-tt/client";
 import type { Auth0AuthorizeResponse } from "@extension/lib/messages";
+import type { UploadedFileWithKind } from "@extension/lib/types";
 
 export type UserTypeWithWorkspaces = MeResponseType["user"];
 
@@ -171,9 +168,7 @@ export const saveFilesContentFragmentIds = async ({
   createdContentFragments,
 }: {
   conversationId: string;
-  uploadedFiles: (UploadedContentFragmentType & {
-    kind: "attachment" | "tab_content";
-  })[];
+  uploadedFiles: UploadedFileWithKind[];
   createdContentFragments: ContentFragmentType[];
 }) => {
   const tabContentFileIds = new Set(
@@ -204,9 +199,7 @@ export const saveFilesContentFragmentIds = async ({
  */
 export const getFileContentFragmentId = async (
   conversationId: string,
-  file: UploadedContentFragmentType & {
-    kind: "attachment" | "tab_content";
-  }
+  file: UploadedFileWithKind
 ): Promise<string | null> => {
   if (file.kind !== "tab_content" || !file.url) {
     return null;

--- a/extension/app/src/lib/storage.ts
+++ b/extension/app/src/lib/storage.ts
@@ -145,10 +145,12 @@ export const clearStoredData = async (): Promise<void> => {
   });
 };
 
-function getTabContentKey(conversationId: string, rawUrl: string) {
-  const url = new URL(rawUrl);
-  const urlKey = `${url.hostname}${url.pathname}`;
-  return `tabContentContentFragmentId_${conversationId}_${urlKey}`;
+function getTabContentKey(
+  conversationId: string,
+  rawUrl: string,
+  title: string
+) {
+  return `tabContentContentFragmentId_${conversationId}_${rawUrl}_${title}`;
 }
 
 /**
@@ -189,7 +191,7 @@ export const saveFilesContentFragmentIds = async ({
     if (!cf.sourceUrl) {
       continue;
     }
-    const key = getTabContentKey(conversationId, cf.sourceUrl);
+    const key = getTabContentKey(conversationId, cf.sourceUrl, cf.title);
     await chrome.storage.local.set({
       [key]: cf.contentFragmentId,
     });
@@ -207,7 +209,7 @@ export const getFileContentFragmentId = async (
   if (file.kind !== "tab_content" || !file.url) {
     return null;
   }
-  const key = getTabContentKey(conversationId, file.url);
+  const key = getTabContentKey(conversationId, file.url, file.title);
   const result = await chrome.storage.local.get([key]);
   return result[key] ?? null;
 };

--- a/extension/app/src/lib/storage.ts
+++ b/extension/app/src/lib/storage.ts
@@ -174,6 +174,9 @@ export const saveFilesContentFragmentIds = async ({
   const tabContentFileIds = new Set(
     uploadedFiles.filter((f) => f.kind === "tab_content").map((f) => f.fileId)
   );
+  if (tabContentFileIds.size === 0) {
+    return;
+  }
 
   const tabContentContentFragments = createdContentFragments.filter(
     (cf) =>

--- a/extension/app/src/lib/types.ts
+++ b/extension/app/src/lib/types.ts
@@ -5,3 +5,8 @@ export type UploadedFileKind = "attachment" | "tab_content";
 export type UploadedFileWithKind = UploadedContentFragmentType & {
   kind: UploadedFileKind;
 };
+
+export type UploadedFileWithSupersededContentFragmentId =
+  UploadedContentFragmentType & {
+    supersededContentFragmentId?: string;
+  };

--- a/extension/app/src/lib/types.ts
+++ b/extension/app/src/lib/types.ts
@@ -1,0 +1,7 @@
+import type { UploadedContentFragmentType } from "@dust-tt/client";
+
+export type UploadedFileKind = "attachment" | "tab_content";
+
+export type UploadedFileWithKind = UploadedContentFragmentType & {
+  kind: UploadedFileKind;
+};

--- a/extension/app/src/lib/types.ts
+++ b/extension/app/src/lib/types.ts
@@ -1,6 +1,6 @@
 import type { UploadedContentFragmentType } from "@dust-tt/client";
 
-export type UploadedFileKind = "attachment" | "tab_content";
+export type UploadedFileKind = "attachment" | "tab_content" | "selection";
 
 export type UploadedFileWithKind = UploadedContentFragmentType & {
   kind: UploadedFileKind;

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -803,6 +803,11 @@ const ContentFragmentSchema = z.object({
   title: z.string(),
   contentType: SupportedContentFragmentTypeSchema,
   context: ContentFragmentContextSchema,
+  contentFragmentId: z.string(),
+  contentFragmentVersion: z.union([
+    z.literal("latest"),
+    z.literal("superseded"),
+  ]),
 });
 export type ContentFragmentType = z.infer<typeof ContentFragmentSchema>;
 


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/tasks/issues/1618

Browser extension will now save to local storage the tab content content fragment SID. This is used to "upsert" the content fragment instead of creating a brand new one, such that we only render the latest one to the model (superseded versions get rendered without content as "outdated").

We store content fragement sIds to supersede base on conversation ID and "base  URL", i.e hostname + path:
- `https://example.com/a` and `https://example.com/b` are **not** the same content fragments
- `https://example.com/a?x=y` and `https://example.com/a?y=z` **are** the same content fragments

## Risk

could be confusing to the model as we're re-writing conversation history
=> intitial tests with claude sonnet work well


## Deploy Plan

N/A