### PR TITLE
[Spaces] Use `withResourceFetchingFromRoute` in spaces public enpoints

### DIFF
--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/index.ts
@@ -3,9 +3,10 @@ import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { AppResource } from "@app/lib/resources/app_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 
 /**
@@ -83,37 +84,9 @@ import { apiError } from "@app/logger/withlogging";
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<GetAppsResponseType>>,
-  auth: Authenticator
+  auth: Authenticator,
+  space: SpaceResource
 ): Promise<void> {
-  const { spaceId } = req.query;
-
-  // Handling the case where `spaceId` is undefined to keep support for the legacy endpoint (not under
-  // space, global space assumed).
-  const space =
-    typeof spaceId !== "string"
-      ? await SpaceResource.fetchWorkspaceGlobalSpace(auth)
-      : await SpaceResource.fetchById(auth, spaceId);
-
-  if (!space) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "space_not_found",
-        message: "The space you're trying to access was not found",
-      },
-    });
-  }
-
-  if (space.kind === "conversations") {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "space_not_found",
-        message: "The space you're trying to access was not found",
-      },
-    });
-  }
-
   switch (req.method) {
     case "GET":
       const apps = await AppResource.listBySpace(auth, space);
@@ -134,4 +107,6 @@ async function handler(
   }
 }
 
-export default withPublicAPIAuthentication(handler);
+export default withPublicAPIAuthentication(
+  withResourceFetchingFromRoute(handler, "space")
+);

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/search.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/search.ts
@@ -6,8 +6,10 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import { handleDataSourceSearch } from "@app/lib/api/data_sources";
+import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 
 /**
@@ -148,10 +150,11 @@ import { apiError } from "@app/logger/withlogging";
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<DataSourceSearchResponseType>>,
-  auth: Authenticator
+  auth: Authenticator,
+  space: SpaceResource
 ): Promise<void> {
-  const { dsvId, spaceId } = req.query;
-  if (typeof dsvId !== "string" || typeof spaceId !== "string") {
+  const { dsvId } = req.query;
+  if (typeof dsvId !== "string") {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -162,22 +165,12 @@ async function handler(
   }
 
   const dataSourceView = await DataSourceViewResource.fetchById(auth, dsvId);
-  if (!dataSourceView || dataSourceView.space.sId !== spaceId) {
+  if (!dataSourceView || dataSourceView.space.sId !== space.sId) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
         type: "data_source_not_found",
         message: "The data source you requested was not found.",
-      },
-    });
-  }
-
-  if (dataSourceView.space.kind === "conversations") {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "space_not_found",
-        message: "The space you're trying to access was not found",
       },
     });
   }
@@ -237,4 +230,6 @@ async function handler(
   }
 }
 
-export default withPublicAPIAuthentication(handler);
+export default withPublicAPIAuthentication(
+  withResourceFetchingFromRoute(handler, "space")
+);

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/index.ts
@@ -3,9 +3,10 @@ import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 
 /**
@@ -52,37 +53,9 @@ import { apiError } from "@app/logger/withlogging";
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<GetDataSourcesResponseType>>,
-  auth: Authenticator
+  auth: Authenticator,
+  space: SpaceResource
 ): Promise<void> {
-  const { spaceId } = req.query;
-
-  // Handling the case where `spaceId` is undefined to keep support for the legacy endpoint (not under
-  // space, global space assumed).
-  const space =
-    typeof spaceId !== "string"
-      ? await SpaceResource.fetchWorkspaceGlobalSpace(auth)
-      : await SpaceResource.fetchById(auth, spaceId);
-
-  if (!space) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "space_not_found",
-        message: "The space you're trying to access was not found",
-      },
-    });
-  }
-
-  if (space.kind === "conversations") {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "space_not_found",
-        message: "The space you're trying to access was not found",
-      },
-    });
-  }
-
   const dataSources = await DataSourceResource.listBySpace(auth, space);
 
   switch (req.method) {
@@ -103,4 +76,6 @@ async function handler(
   }
 }
 
-export default withPublicAPIAuthentication(handler);
+export default withPublicAPIAuthentication(
+  withResourceFetchingFromRoute(handler, "space")
+);


### PR DESCRIPTION
Description
---
Following PR #8731  , extends use of wrapper to public routes

Note: a few routes (namely /data_source ones) are not converted to the wrapper due to the connectors legacy compatibility

Risk
---
High blast radius due to the use by connectors
To be tested

Deploy
---
front
