### PR TITLE
[connectors] Recast data stored for Zendesk as BIGINT into JS numbers

### DIFF
--- a/connectors/src/lib/models/zendesk.ts
+++ b/connectors/src/lib/models/zendesk.ts
@@ -9,6 +9,12 @@ import { DataTypes, Model } from "sequelize";
 import { sequelizeConnection } from "@connectors/resources/storage";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 
+function throwOnUnsafeInteger(value: number) {
+  if (!Number.isSafeInteger(value)) {
+    throw new Error(`Value must be a safe integer: ${value}`);
+  }
+}
+
 export class ZendeskTimestampCursors extends Model<
   InferAttributes<ZendeskTimestampCursors>,
   InferCreationAttributes<ZendeskTimestampCursors>
@@ -152,6 +158,7 @@ ZendeskBrand.init(
     brandId: {
       type: DataTypes.BIGINT,
       allowNull: false,
+      validate: { throwOnUnsafeInteger },
     },
     name: {
       type: DataTypes.STRING,
@@ -242,10 +249,12 @@ ZendeskCategory.init(
     categoryId: {
       type: DataTypes.BIGINT,
       allowNull: false,
+      validate: { throwOnUnsafeInteger },
     },
     brandId: {
       type: DataTypes.BIGINT,
       allowNull: false,
+      validate: { throwOnUnsafeInteger },
     },
     name: {
       type: DataTypes.STRING,
@@ -328,14 +337,17 @@ ZendeskArticle.init(
     articleId: {
       type: DataTypes.BIGINT,
       allowNull: false,
+      validate: { throwOnUnsafeInteger },
     },
     brandId: {
       type: DataTypes.BIGINT,
       allowNull: false,
+      validate: { throwOnUnsafeInteger },
     },
     categoryId: {
       type: DataTypes.BIGINT,
       allowNull: false,
+      validate: { throwOnUnsafeInteger },
     },
     name: {
       type: DataTypes.STRING,
@@ -426,22 +438,27 @@ ZendeskTicket.init(
     ticketId: {
       type: DataTypes.BIGINT,
       allowNull: false,
+      validate: { throwOnUnsafeInteger },
     },
     brandId: {
       type: DataTypes.BIGINT,
       allowNull: false,
+      validate: { throwOnUnsafeInteger },
     },
     groupId: {
       type: DataTypes.BIGINT,
       allowNull: true,
+      validate: { throwOnUnsafeInteger },
     },
     assigneeId: {
       type: DataTypes.BIGINT,
       allowNull: true,
+      validate: { throwOnUnsafeInteger },
     },
     organizationId: {
       type: DataTypes.BIGINT,
       allowNull: true,
+      validate: { throwOnUnsafeInteger },
     },
     permission: {
       type: DataTypes.STRING,

--- a/connectors/src/lib/models/zendesk.ts
+++ b/connectors/src/lib/models/zendesk.ts
@@ -9,8 +9,8 @@ import { DataTypes, Model } from "sequelize";
 import { sequelizeConnection } from "@connectors/resources/storage";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 
-function throwOnUnsafeInteger(value: number) {
-  if (!Number.isSafeInteger(value)) {
+function throwOnUnsafeInteger(value: number | null) {
+  if (value !== null && !Number.isSafeInteger(value)) {
     throw new Error(`Value must be a safe integer: ${value}`);
   }
 }
@@ -397,9 +397,9 @@ export class ZendeskTicket extends Model<
   declare brandId: number;
   declare permission: "read" | "none";
 
-  declare assigneeId: number;
-  declare groupId: number;
-  declare organizationId: number;
+  declare assigneeId: number | null;
+  declare groupId: number | null;
+  declare organizationId: number | null;
 
   declare subject: string;
   declare url: string;

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -241,7 +241,7 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
       where: { connectorId },
       attributes: ["brandId"],
     });
-    return brands.map((brand) => brand.get().brandId);
+    return brands.map((brand) => Number(brand.get().brandId));
   }
 
   static async fetchHelpCenterReadAllowedBrandIds({
@@ -253,7 +253,7 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
       where: { connectorId, helpCenterPermission: "read" },
       attributes: ["brandId"],
     });
-    return brands.map((brand) => brand.get().brandId);
+    return brands.map((brand) => Number(brand.get().brandId));
   }
 
   static async fetchAllWithHelpCenter({
@@ -280,7 +280,7 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
       where: { connectorId, ticketsPermission: "read" },
       attributes: ["brandId"],
     });
-    return brands.map((brand) => brand.get().brandId);
+    return brands.map((brand) => Number(brand.get().brandId));
   }
 
   static async deleteByConnectorId(
@@ -649,7 +649,7 @@ export class ZendeskTicketResource extends BaseResource<ZendeskTicket> {
       where: { connectorId, ticketUpdatedAt: { [Op.lt]: expirationDate } },
       limit: batchSize,
     });
-    return tickets.map((ticket) => ticket.ticketId);
+    return tickets.map((ticket) => Number(ticket.get().ticketId));
   }
 
   static async fetchByTicketId({

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -115,7 +115,8 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
     model: ModelStatic<ZendeskBrand>,
     blob: Attributes<ZendeskBrand>
   ) {
-    super(ZendeskBrand, blob);
+    // the IDs used here are stored as BigInts and are between JS max int and PSQL's max INTEGER
+    super(ZendeskBrand, { ...blob, brandId: Number(blob.brandId) });
   }
 
   async postFetchHook(): Promise<void> {
@@ -352,7 +353,11 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
     model: ModelStatic<ZendeskCategory>,
     blob: Attributes<ZendeskCategory>
   ) {
-    super(ZendeskCategory, blob);
+    super(ZendeskCategory, {
+      ...blob,
+      brandId: Number(blob.brandId), // the IDs used here are stored as BigInts and are between JS max int and PSQL's max INTEGER
+      categoryId: Number(blob.categoryId),
+    });
   }
 
   static async makeNew({
@@ -553,7 +558,14 @@ export class ZendeskTicketResource extends BaseResource<ZendeskTicket> {
     model: ModelStatic<ZendeskTicket>,
     blob: Attributes<ZendeskTicket>
   ) {
-    super(ZendeskTicket, blob);
+    super(ZendeskTicket, {
+      ...blob,
+      brandId: Number(blob.brandId), // the IDs used here are stored as BigInts and are between JS max int and PSQL's max INTEGER
+      ticketId: Number(blob.ticketId),
+      assigneeId: Number(blob.assigneeId),
+      groupId: blob.groupId && Number(blob.groupId),
+      organizationId: blob.organizationId && Number(blob.organizationId),
+    });
   }
 
   static async makeNew({
@@ -746,7 +758,11 @@ export class ZendeskArticleResource extends BaseResource<ZendeskArticle> {
     model: ModelStatic<ZendeskArticle>,
     blob: Attributes<ZendeskArticle>
   ) {
-    super(ZendeskArticle, blob);
+    super(ZendeskArticle, {
+      ...blob,
+      brandId: Number(blob.brandId), // the IDs used here are stored as BIGINTs and are between JS max int and PSQL's max INTEGER
+      articleId: Number(blob.articleId),
+    });
   }
 
   static async makeNew({


### PR DESCRIPTION
## Description

- The IDs returned by Zendesk's API are too big to be stored in db as `INTEGER`s (> 2^31) but can always be represented as JS `number`s (< 2^53) as per [Zendesk's doc](https://developer.zendesk.com/api-reference/introduction/data-types/)).
- They are currently stored as `BIGINT`s, which is more practical than storing them as `VARCHAR` since we are using a [SDK](https://blakmatrix.github.io/node-zendesk/) that wraps Zendesk's API and returns them as numbers.
- This PR aims at adding validation on save and recasting these values into numbers on fetch.
- Open to suggestions regarding the approach and the implementation.

Example `brandId`: 24050113285393.

Update: we should override the type parser of Sequalize since we are going to need `BIGINT`s in other projects (sharding notably). However it does not seem to be easy, we use and outdated version and can't seem to be able to choose between `node-postgres` and `pg`. This will be handled at another time, for the moment we are going to cast in the Resource after fetching.
https://github.com/brianc/node-postgres/pull/353
https://github.com/sequelize/sequelize/issues/9074

## Risk

Low.

## Deploy Plan

- Deploy connectors.