### PR TITLE
enh: heartbeat in notion get parents

### DIFF
--- a/connectors/migrations/20240802_table_parents.ts
+++ b/connectors/migrations/20240802_table_parents.ts
@@ -171,7 +171,8 @@ export async function notionTables(
       connectorId as number,
       notionDatabaseId as string,
       [],
-      memo
+      memo,
+      undefined
     );
 
     await updateParents({

--- a/connectors/migrations/20241030_fix_notion_parents.ts
+++ b/connectors/migrations/20241030_fix_notion_parents.ts
@@ -124,6 +124,7 @@ async function updateParentsFieldForConnector(
             connector.id,
             "notionPageId" in node ? node.notionPageId : node.notionDatabaseId,
             [],
+            undefined,
             undefined
           );
         } catch (e) {

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -597,7 +597,13 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
     const memo = memoizationKey || uuidv4();
 
     try {
-      const parents = await getParents(this.connectorId, internalId, [], memo);
+      const parents = await getParents(
+        this.connectorId,
+        internalId,
+        [],
+        memo,
+        undefined
+      );
 
       return new Ok(parents);
     } catch (e) {

--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -452,7 +452,8 @@ export async function isAccessibleAndUnarchived(
 async function getBlockParent(
   notionAccessToken: string,
   blockId: string,
-  localLogger: Logger
+  localLogger: Logger,
+  onProgress?: () => Promise<void>
 ): Promise<{
   parentId: string;
   parentType: "database" | "page" | "workspace";
@@ -472,6 +473,9 @@ async function getBlockParent(
   let transient_errors = 0;
 
   for (;;) {
+    if (onProgress) {
+      await onProgress();
+    }
     localLogger.info({ blockId }, "Looking up block parent");
     try {
       const block = await wrapNotionAPITokenErrors(async () =>
@@ -526,7 +530,14 @@ async function getBlockParent(
 
 export const getBlockParentMemoized = cacheWithRedis(
   getBlockParent,
-  (notionAccessToken: string, blockId: string) => {
+  (
+    notionAccessToken: string,
+    blockId: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- used for memoization
+    localLogger: Logger,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- used for memoization
+    onProgress?: () => Promise<void>
+  ) => {
     return blockId;
   },
   60 * 10 * 1000

--- a/connectors/src/connectors/notion/lib/parents.ts
+++ b/connectors/src/connectors/notion/lib/parents.ts
@@ -12,7 +12,6 @@ import {
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { updateDocumentParentsField } from "@connectors/lib/data_sources";
 import { NotionDatabase, NotionPage } from "@connectors/lib/models/notion";
-import { heartbeat } from "@connectors/lib/temporal";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 
@@ -30,12 +29,14 @@ async function _getParents(
   pageOrDbId: string,
   seen: string[],
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- used for memoization
-  memoizationKey?: string
+  memoizationKey?: string,
+  onProgress?: () => Promise<void>
 ): Promise<string[]> {
   const parents: string[] = [pageOrDbId];
   const pageOrDb =
     (await getNotionPageFromConnectorsDb(connectorId, pageOrDbId)) ||
     (await getNotionDatabaseFromConnectorsDb(connectorId, pageOrDbId));
+
   if (!pageOrDb) {
     // pageOrDb is either not synced yet (not an issue, see design doc) or
     // is not in Dust's scope, in both cases we can just return the page id
@@ -87,12 +88,21 @@ async function _getParents(
         );
         throw new Error("getParent parentId is undefined");
       }
+      if (onProgress) {
+        await onProgress();
+      }
       return parents.concat(
         // parentId cannot be undefined if parentType is page or database as per
         // Notion API
         //
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        await getParents(connectorId, pageOrDb.parentId, seen, memoizationKey)
+        await getParents(
+          connectorId,
+          pageOrDb.parentId,
+          seen,
+          memoizationKey,
+          onProgress
+        )
       );
     }
     default:
@@ -102,7 +112,8 @@ async function _getParents(
 
 export const getParents = cacheWithRedis(
   _getParents,
-  (connectorId, pageOrDbId, seen, memoizationKey) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- used for memoization
+  (connectorId, pageOrDbId, seen, memoizationKey, onProgress) => {
     return `${connectorId}:${pageOrDbId}:${memoizationKey}`;
   },
   60 * 10 * 1000
@@ -113,7 +124,7 @@ export async function updateAllParentsFields(
   createdOrMovedNotionPageIds: string[],
   createdOrMovedNotionDatabaseIds: string[],
   memoizationKey?: string,
-  shouldHeartbeat = false
+  onProgress?: () => Promise<void>
 ): Promise<number> {
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
@@ -148,7 +159,8 @@ export async function updateAllParentsFields(
           connectorId,
           pageId,
           [],
-          memoizationKey
+          memoizationKey,
+          onProgress
         );
         logger.info(
           {
@@ -162,8 +174,8 @@ export async function updateAllParentsFields(
           documentId: `notion-${pageId}`,
           parents,
         });
-        if (shouldHeartbeat) {
-          await heartbeat();
+        if (onProgress) {
+          await onProgress();
         }
       })
     );

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1193,7 +1193,8 @@ export async function updateParentsFields(connectorId: ModelId) {
     connectorId,
     notionPageIds,
     notionDatabaseIds,
-    newParentsLastUpdatedAt.getTime().toString()
+    newParentsLastUpdatedAt.getTime().toString(),
+    async () => heartbeat()
   );
 
   await notionConnectorState.update({
@@ -1793,7 +1794,10 @@ export async function renderAndUpsertPageFromCache({
           connector.id,
           parentDb.notionDatabaseId,
           [],
-          runTimestamp.toString()
+          runTimestamp.toString(),
+          async () => {
+            await heartbeat();
+          }
         );
 
         await ignoreTablesError(
@@ -1892,7 +1896,10 @@ export async function renderAndUpsertPageFromCache({
       const blockParent = await getBlockParentMemoized(
         accessToken,
         parentId,
-        localLogger
+        localLogger,
+        async () => {
+          await heartbeat();
+        }
       );
       if (blockParent) {
         parentType = blockParent.parentType;
@@ -1985,7 +1992,10 @@ export async function renderAndUpsertPageFromCache({
       connectorId,
       pageId,
       [],
-      runTimestamp.toString()
+      runTimestamp.toString(),
+      async () => {
+        await heartbeat();
+      }
     );
 
     const content = await renderDocumentTitleAndContent({
@@ -2495,7 +2505,8 @@ export async function upsertDatabaseStructuredDataFromCache({
     connector.id,
     databaseId,
     [],
-    runTimestamp.toString()
+    runTimestamp.toString(),
+    async () => heartbeat()
   );
 
   localLogger.info("Upserting Notion Database as Table.");


### PR DESCRIPTION
## Description

We're seeing timeouts on notion's `renderAndUpsertPageFromCache` activity. The zombie activities end up taking all the available worker slots.

Adding the heartbeat will stop execution on timeout.

## Risk

blast radius limited to notion

## Deploy Plan

Deploy connectors