### PR TITLE
[connectors] - fix(notion): missing 'not found' error codes

### DIFF
--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -556,6 +556,7 @@ export async function getParsedDatabase(
     if (
       APIResponseError.isAPIResponseError(e) &&
       (NOTION_UNAUTHORIZED_ACCESS_ERROR_CODES.includes(e.code) ||
+        NOTION_NOT_FOUND_ERROR_CODES.includes(e.code) ||
         // This happens if the database is a "linked" database - we can't query those so
         // it's not useful to retry.
         e.code === "validation_error")
@@ -956,6 +957,7 @@ export async function retrieveDatabaseChildrenResultPage({
     if (
       APIResponseError.isAPIResponseError(e) &&
       (NOTION_UNAUTHORIZED_ACCESS_ERROR_CODES.includes(e.code) ||
+        NOTION_NOT_FOUND_ERROR_CODES.includes(e.code) ||
         e.code === "validation_error")
     ) {
       localLogger.info(


### PR DESCRIPTION
## Description

Fixing missing 'object_not_found' error code from Notion when fetching databases or their children introduced by https://github.com/dust-tt/dust/pull/8770

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
