### PR TITLE
Public API get agent configurations view filter

### DIFF
--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
@@ -1,11 +1,28 @@
 import type { GetAgentConfigurationsResponseType } from "@dust-tt/client";
 import type { WithAPIErrorResponse } from "@dust-tt/types";
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import { withPublicAPIAuthentication } from "@app/lib/api/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
+
+const GetAgentConfigurationsViewSchema = t.partial({
+  view: t.union([
+    t.literal("all"),
+    t.literal("list"),
+    t.literal("workspace"),
+    t.literal("published"),
+    t.literal("global"),
+    t.literal("favorites"),
+  ]),
+});
+
+const viewRequiresUser = (view?: string): boolean =>
+  view === "list" || view === "favorites";
 
 /**
  * @swagger
@@ -22,6 +39,20 @@ import { apiError } from "@app/logger/withlogging";
  *         description: ID of the workspace
  *         schema:
  *           type: string
+ *       - in: query
+ *         name: view
+ *         required: false
+ *         description: |
+ *           The view to use when retrieving agents:
+ *           - all: Retrieves all non-private agents (default if not authenticated)
+ *           - list: Retrieves all active agents accessible to the user (default if authenticated)
+ *           - workspace: Retrieves all agents with workspace scope
+ *           - published: Retrieves all agents with published scope
+ *           - global: Retrieves all global agents
+ *           - favorites: Retrieves all agents marked as favorites by the user (only available to authenticated users)
+ *         schema:
+ *           type: string
+ *           enum: [all, list, workspace, published, global, favorites]
  *     security:
  *       - BearerAuth: []
  *     responses:
@@ -54,11 +85,40 @@ async function handler(
 ): Promise<void> {
   switch (req.method) {
     case "GET": {
+      const queryValidation = GetAgentConfigurationsViewSchema.decode(
+        req.query
+      );
+
+      if (isLeft(queryValidation)) {
+        const pathError = reporter.formatValidationErrors(queryValidation.left);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid query parameters: ${pathError}`,
+          },
+        });
+      }
+
+      if (viewRequiresUser(queryValidation.right.view) && !auth.user()) {
+        return apiError(req, res, {
+          status_code: 401,
+          api_error: {
+            type: "invalid_request_error",
+            message: `The user must be authenticated with oAuth to retrieve ${queryValidation.right.view} agents.`,
+          },
+        });
+      }
+
+      const defaultAgentGetView = auth.user() ? "list" : "all";
+      const agentsGetView = queryValidation.right.view ?? defaultAgentGetView;
+
       const agentConfigurations = await getAgentConfigurations({
         auth,
-        agentsGetView: auth.user() ? "list" : "all",
+        agentsGetView,
         variant: "light",
       });
+
       return res.status(200).json({
         agentConfigurations,
       });

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -155,7 +155,8 @@ export type AgentsGetViewType =
   | "published"
   | "global"
   | "admin_internal"
-  | "archived";
+  | "archived"
+  | "favorites";
 
 export type AgentUsageType = {
   messageCount: number;


### PR DESCRIPTION
## Description

This PR adds support for filtering agent configurations in the public API. 

This feature is needed to display favorite assistants in the extension without having to load all assistants and filter them on the frontend.

Key changes:
- Added "favorites" as a new valid view option in the agent configurations API
- Updated the backend logic to filter configurations based on user's favorite state
- Added proper authentication checks since favorites view requires a user context
- Updated type definitions to include the new "favorites" view type

## Risk

Low risk changes as this is:
- Adding a new filtering option without modifying existing behavior
- Easy to rollback if needed

## Deploy Plan

Deploy front. 
Then I'll add the option on the SDK, then use it on the extension. 
