### PR TITLE
Add: generate summary of file for JIT on upsert

### DIFF
--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -76,12 +76,12 @@ async function generateSnippet(
   }
 
   const config = cloneBaseConfig(
-    DustProdActionRegistry["content-summarizer"].config
+    DustProdActionRegistry["conversation-file-summarizer"].config
   );
   config.MODEL.provider_id = model.providerId;
   config.MODEL.model_id = model.modelId;
 
-  const res = await runAction(auth, "content-summarizer", config, [
+  const res = await runAction(auth, "conversation-file-summarizer", config, [
     {
       content: content,
     },

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -4,10 +4,18 @@ import type {
   PlainTextContentType,
   Result,
 } from "@dust-tt/types";
-import { Err, isSupportedPlainTextContentType, Ok } from "@dust-tt/types";
+import {
+  assertNever,
+  Err,
+  getSmallWhitelistedModel,
+  isSupportedPlainTextContentType,
+  Ok,
+  removeNulls,
+} from "@dust-tt/types";
 import { Writable } from "stream";
 import { pipeline } from "stream/promises";
 
+import { runAction } from "@app/lib/actions/server";
 import { getConversation } from "@app/lib/api/assistant/conversation";
 import { isJITActionsEnabled } from "@app/lib/api/assistant/jit_actions";
 import {
@@ -17,6 +25,7 @@ import {
 } from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
+import { cloneBaseConfig, DustProdActionRegistry } from "@app/lib/registry";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -52,6 +61,64 @@ const notSupportedError: ProcessingFunction = async ({ file }) => {
     )
   );
 };
+
+async function generateSnippet(
+  auth: Authenticator,
+  content: string
+): Promise<Result<string, Error>> {
+  const owner = auth.getNonNullableWorkspace();
+
+  const model = getSmallWhitelistedModel(owner);
+  if (!model) {
+    return new Err(
+      new Error(`Failed to find a whitelisted model to generate title`)
+    );
+  }
+
+  const config = cloneBaseConfig(
+    DustProdActionRegistry["content-summarizer"].config
+  );
+  config.MODEL.provider_id = model.providerId;
+  config.MODEL.model_id = model.modelId;
+
+  const res = await runAction(auth, "content-summarizer", config, [
+    {
+      content: content,
+    },
+  ]);
+
+  if (res.isErr()) {
+    return new Err(new Error(`Error generating snippet: ${res.error}`));
+  }
+
+  const {
+    status: { run },
+    traces,
+    results,
+  } = res.value;
+
+  switch (run) {
+    case "errored":
+      const error = removeNulls(traces.map((t) => t[1][0][0].error)).join(", ");
+      return new Err(new Error(`Error generating snippet: ${error}`));
+    case "succeeded":
+      if (!results || results.length === 0) {
+        return new Err(
+          new Error(
+            `Error generating snippet: no results returned while run was successful`
+          )
+        );
+      }
+      const snippet = results[0][0].value as string;
+      return new Ok(snippet);
+    case "running":
+      return new Err(
+        new Error(`Snippet generation is still running, should never happen.`)
+      );
+    default:
+      assertNever(run);
+  }
+}
 
 // Upload to dataSource
 const upsertDocumentToDatasource: ProcessingFunction = async ({
@@ -216,6 +283,28 @@ const maybeApplyProcessing: ProcessingFunction = async ({
   return new Ok(undefined);
 };
 
+async function getFileContent(
+  auth: Authenticator,
+  file: FileResource
+): Promise<string> {
+  // Create a stream to hold the content of the file
+  const writableStream = new MemoryWritable();
+
+  // Read from the processed file
+  await pipeline(
+    file.getReadStream({ auth, version: "processed" }),
+    writableStream
+  );
+
+  const content = writableStream.getContent();
+
+  if (!content) {
+    throw new Error("No content extracted from file for JIT processing.");
+  }
+
+  return content;
+}
+
 export async function processAndUpsertToDataSource(
   auth: Authenticator,
   { file }: { file: FileResource }
@@ -262,16 +351,7 @@ export async function processAndUpsertToDataSource(
     });
   }
 
-  // Create a stream to hold the content of the file
-  const writableStream = new MemoryWritable();
-
-  // Read from the processed file
-  await pipeline(
-    file.getReadStream({ auth, version: "processed" }),
-    writableStream
-  );
-
-  const content = writableStream.getContent();
+  const content = await getFileContent(auth, file);
 
   if (!content) {
     return new Err({
@@ -326,12 +406,15 @@ export async function processAndUpsertToDataSource(
     dataSource = r.value.dataSource;
   }
 
-  const processingRes = await maybeApplyProcessing({
-    auth,
-    file,
-    content,
-    dataSource,
-  });
+  const [processingRes, snippetRes] = await Promise.all([
+    maybeApplyProcessing({
+      auth,
+      file,
+      content,
+      dataSource,
+    }),
+    generateSnippet(auth, content),
+  ]);
 
   if (processingRes.isErr()) {
     return new Err({
@@ -340,6 +423,17 @@ export async function processAndUpsertToDataSource(
       message: `Failed to process the file : ${processingRes.error}`,
     });
   }
+
+  if (snippetRes.isErr()) {
+    return new Err({
+      name: "dust_error",
+      code: "internal_server_error",
+      message: `Failed to generate snippet: ${snippetRes.error}`,
+    });
+  }
+
+  // If the snippet is present, it means the file is ready to use for JIT actions.
+  await file.setSnippet(snippetRes.value);
 
   return new Ok(file);
 }

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -307,6 +307,22 @@ export const DustProdActionRegistry = createActionRegistry({
       },
     },
   },
+  "content-summarizer": {
+    app: {
+      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
+      appId: "iy1pjLCMzZ",
+      appHash:
+        "0cd0a82dcfaa327b2d5d1f645a314ea885e995a12921a1024ee96b92e8f15768",
+      appSpaceId: PRODUCTION_DUST_APPS_SPACE_ID,
+    },
+    config: {
+      MODEL: {
+        // `provider_id` and `model_id` must be set by caller.
+        use_cache: false,
+        use_stream: false,
+      },
+    },
+  },
 });
 
 export type DustRegistryActionName = keyof typeof DustProdActionRegistry;

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -307,7 +307,7 @@ export const DustProdActionRegistry = createActionRegistry({
       },
     },
   },
-  "content-summarizer": {
+  "conversation-file-summarizer": {
     app: {
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "iy1pjLCMzZ",

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -289,6 +289,14 @@ export class FileResource extends BaseResource<FileModel> {
     return this.update({ useCaseMetadata: metadata });
   }
 
+  setSnippet(snippet: string) {
+    return this.update({ snippet });
+  }
+
+  isUsableForJITActions(): boolean {
+    return this.snippet !== null;
+  }
+
   // Serialization logic.
 
   toJSON(auth: Authenticator): FileType {


### PR DESCRIPTION
## Description

Generate snippet on the fly and store it on the file object.

## Risk

Small, behind a FF.

## Deploy Plan

Deploy `front` (the dust-app is already in prod)