### PR TITLE
[connectors] Make Zendesk tickets node expandable where needed

### DIFF
--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -47,7 +47,7 @@ export async function retrieveAllSelectedNodes(
   const ticketNodes: ContentNode[] = brands
     .filter((brand) => brand.ticketsPermission === "read")
     .map((brand) => ({
-      ...brand.getTicketsContentNode(connectorId),
+      ...brand.getTicketsContentNode(connectorId, { expandable: true }),
       title: `${brand.name} - Tickets`, // adding the name of the brand since this will be named "Tickets" otherwise
     }));
 

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -117,7 +117,9 @@ async function getBrandChildren(
   });
   if (isReadPermissionsOnly) {
     if (brandInDb?.ticketsPermission === "read") {
-      nodes.push(brandInDb.getTicketsContentNode(connectorId));
+      nodes.push(
+        brandInDb.getTicketsContentNode(connectorId, { expandable: true })
+      );
     }
     if (
       brandInDb?.hasHelpCenter &&

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -345,7 +345,10 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
     };
   }
 
-  getTicketsContentNode(connectorId: number): ContentNode {
+  getTicketsContentNode(
+    connectorId: number,
+    { expandable = false }: { expandable?: boolean } = {}
+  ): ContentNode {
     const { brandId } = this;
     return {
       provider: "zendesk",
@@ -354,7 +357,7 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
       type: "folder",
       title: `Tickets`,
       sourceUrl: null,
-      expandable: false,
+      expandable: expandable,
       permission: this.ticketsPermission,
       dustDocumentId: null,
       lastUpdatedAt: null,


### PR DESCRIPTION
## Description

- The Tickets content node should not be expandable in the Connection Admin, but it should be when adding data to a Space.
- Currently it is never expandable.

<img width="433" alt="Screenshot 2024-11-20 at 7 15 00 PM" src="https://github.com/user-attachments/assets/5b45f7d1-06a7-4d6d-9770-f3247e81bb65">

<img width="433" alt="Screenshot 2024-11-20 at 7 14 46 PM" src="https://github.com/user-attachments/assets/de132378-673c-4e38-ae6c-270ec50717a6">

## Risk

Low.

## Deploy Plan

- Deploy connectors.