### PR TITLE
[front] - fix: prevent navigation event on content action clicks

### DIFF
--- a/front/components/spaces/ContentActions.tsx
+++ b/front/components/spaces/ContentActions.tsx
@@ -21,6 +21,7 @@ import React, {
   useImperativeHandle,
   useState,
 } from "react";
+import type { MouseEvent as ReactMouseEvent } from "react";
 
 import { DocumentOrTableDeleteDialog } from "@app/components/data_source/DocumentOrTableDeleteDialog";
 import { DocumentOrTableUploadOrEditModal } from "@app/components/data_source/DocumentOrTableUploadOrEditModal";
@@ -208,7 +209,8 @@ export const getMenuItems = (
     actions.push({
       label: "Edit",
       icon: PencilSquareIcon,
-      onClick: () => {
+      onClick: (e: ReactMouseEvent) => {
+        e.stopPropagation();
         contentActionsRef.current &&
           contentActionsRef.current?.callAction(
             contentNode.type === "database"
@@ -221,7 +223,8 @@ export const getMenuItems = (
     actions.push({
       label: "Delete",
       icon: TrashIcon,
-      onClick: () => {
+      onClick: (e: ReactMouseEvent) => {
+        e.stopPropagation();
         contentActionsRef.current &&
           contentActionsRef.current?.callAction(
             "DocumentOrTableDeleteDialog",
@@ -240,7 +243,8 @@ export const getMenuItems = (
     actions.push({
       label: "Add to space",
       icon: PlusIcon,
-      onClick: () => {
+      onClick: (e: ReactMouseEvent) => {
+        e.stopPropagation();
         contentActionsRef.current &&
           contentActionsRef.current?.callAction(
             "AddToSpaceDialog",
@@ -267,7 +271,8 @@ const makeViewSourceUrlContentAction = (
     label,
     icon: ExternalLinkIcon,
     disabled: contentNode.sourceUrl === null,
-    onClick: () => {
+    onClick: (e: ReactMouseEvent) => {
+      e.stopPropagation();
       if (contentNode.sourceUrl) {
         window.open(contentNode.sourceUrl, "_blank");
       }
@@ -282,7 +287,8 @@ const makeViewRawContentAction = (
   return {
     label: "View raw content",
     icon: EyeIcon,
-    onClick: () => {
+    onClick: (e: ReactMouseEvent) => {
+      e.stopPropagation();
       contentActionsRef.current &&
         contentActionsRef.current?.callAction(
           "DocumentViewRawContent",

--- a/front/components/spaces/ContentActions.tsx
+++ b/front/components/spaces/ContentActions.tsx
@@ -15,13 +15,13 @@ import type {
 } from "@dust-tt/types";
 import { capitalize } from "lodash";
 import type { ComponentProps, RefObject } from "react";
+import type { MouseEvent as ReactMouseEvent } from "react";
 import React, {
   useCallback,
   useEffect,
   useImperativeHandle,
   useState,
 } from "react";
-import type { MouseEvent as ReactMouseEvent } from "react";
 
 import { DocumentOrTableDeleteDialog } from "@app/components/data_source/DocumentOrTableDeleteDialog";
 import { DocumentOrTableUploadOrEditModal } from "@app/components/data_source/DocumentOrTableUploadOrEditModal";

--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -211,8 +211,7 @@ export const SpaceDataSourceViewContentList = ({
     [setPagination, setViewType, viewType, pagination.pageSize]
   );
 
-  const isServerPagination =
-    !isManaged(dataSourceView.dataSource) && !dataSourceSearch;
+  const isServerPagination = !isManaged(dataSourceView.dataSource);
 
   const columns = useMemo(
     () => getTableColumns(showSpaceUsage),

--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -211,7 +211,8 @@ export const SpaceDataSourceViewContentList = ({
     [setPagination, setViewType, viewType, pagination.pageSize]
   );
 
-  const isServerPagination = !isManaged(dataSourceView.dataSource);
+  const isServerPagination =
+    !isManaged(dataSourceView.dataSource) && !dataSourceSearch;
 
   const columns = useMemo(
     () => getTableColumns(showSpaceUsage),


### PR DESCRIPTION
## Description

This PR adds `stopPropagation` to onClick event handlers in content actions to avoid triggering parent event listeners. When on `SpaceDataSourceViewContentList` it prevents from clicking the datatable row when clicking the more menu items.

## Risk

Low, UI breaking changes

## Deploy Plan

Deploy `front`