### PR TITLE
convert ticket api URL to web url

### DIFF
--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -85,9 +85,12 @@ export async function syncTicket({
     !ticketInDb.lastUpsertedTs ||
     ticketInDb.lastUpsertedTs < updatedAtDate;
 
+  // ticket.url is the json api url, we need to convert it to the web url
+  const ticketUrl = ticket.url.replace("/api/v2/", "/").replace(".json", "");
+
   const commonTicketData = {
     subject: ticket.subject,
-    url: ticket.url,
+    url: ticketUrl,
     assigneeId: ticket.assignee_id,
     groupId: ticket.group_id,
     organizationId: ticket.organization_id,


### PR DESCRIPTION
## Description

Currently the source URL we store is the API url of the tickets, so when clicking on the footnotes we end up looking at JSON 
We want to convert that URL the a web URL by removing the API parts of the URL
We don't need to add the /agent as it's redirected automatically by zendesk

<img width="1029" alt="Screenshot 2024-11-21 at 10 34 30" src="https://github.com/user-attachments/assets/30f3612e-ae02-47a4-ab9e-2debe6335687">
<img width="1166" alt="Screenshot 2024-11-21 at 10 34 20" src="https://github.com/user-attachments/assets/eecfa5d1-076e-4405-86c4-1de747953ba9">
<img width="1142" alt="Screenshot 2024-11-21 at 10 34 15" src="https://github.com/user-attachments/assets/58e9120e-59ca-41d8-bc10-890c7ddcc7df">


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
