### PR TITLE
[connectors] Override the type parser for Sequelize BIGINTs

### DIFF
--- a/connectors/src/resources/storage/index.ts
+++ b/connectors/src/resources/storage/index.ts
@@ -1,4 +1,7 @@
+import assert from "node:assert";
+
 import { isDevelopment } from "@dust-tt/types";
+import types, { builtins } from "pg-types";
 import { Sequelize } from "sequelize";
 
 import logger from "@connectors/logger/logger";
@@ -11,6 +14,14 @@ const { DB_LOGGING_ENABLED = false } = process.env;
 function sequelizeLogger(message: string) {
   console.log(message.replace("Executing (default): ", ""));
 }
+
+types.setTypeParser(builtins.INT8, function (val) {
+  assert(
+    Number.isSafeInteger(Number(val)),
+    `Found a value stored as a BIGINT that is not a safe integer: ${val}`
+  );
+  return Number(val);
+});
 
 export const sequelizeConnection = new Sequelize(
   dbConfig.getRequiredDatabaseURI(),

--- a/connectors/src/resources/storage/index.ts
+++ b/connectors/src/resources/storage/index.ts
@@ -15,6 +15,11 @@ function sequelizeLogger(message: string) {
   console.log(message.replace("Executing (default): ", ""));
 }
 
+// Parse PostgreSQL BIGINT (INT8) values into JavaScript numbers, but only if they
+// fall within JavaScript's safe integer range (-(2^53 - 1) to 2^53 - 1). This
+// prevents silent precision loss when handling large integers from the database.
+// Throws an assertion error if a BIGINT value exceeds JavaScript's safe integer
+// limits.
 types.setTypeParser(builtins.INT8, function (val) {
   assert(
     Number.isSafeInteger(Number(val)),

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -115,8 +115,7 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
     model: ModelStatic<ZendeskBrand>,
     blob: Attributes<ZendeskBrand>
   ) {
-    // the IDs used here are stored as BigInts and are between JS max int and PSQL's max INTEGER
-    super(ZendeskBrand, { ...blob, brandId: Number(blob.brandId) });
+    super(ZendeskBrand, blob);
   }
 
   async postFetchHook(): Promise<void> {
@@ -378,11 +377,7 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
     model: ModelStatic<ZendeskCategory>,
     blob: Attributes<ZendeskCategory>
   ) {
-    super(ZendeskCategory, {
-      ...blob,
-      brandId: Number(blob.brandId), // the IDs used here are stored as BigInts and are between JS max int and PSQL's max INTEGER
-      categoryId: Number(blob.categoryId),
-    });
+    super(ZendeskCategory, blob);
   }
 
   static async makeNew({
@@ -594,14 +589,7 @@ export class ZendeskTicketResource extends BaseResource<ZendeskTicket> {
     model: ModelStatic<ZendeskTicket>,
     blob: Attributes<ZendeskTicket>
   ) {
-    super(ZendeskTicket, {
-      ...blob,
-      brandId: Number(blob.brandId), // the IDs used here are stored as BigInts and are between JS max int and PSQL's max INTEGER
-      ticketId: Number(blob.ticketId),
-      assigneeId: Number(blob.assigneeId),
-      groupId: blob.groupId && Number(blob.groupId),
-      organizationId: blob.organizationId && Number(blob.organizationId),
-    });
+    super(ZendeskTicket, blob);
   }
 
   static async makeNew({
@@ -802,11 +790,7 @@ export class ZendeskArticleResource extends BaseResource<ZendeskArticle> {
     model: ModelStatic<ZendeskArticle>,
     blob: Attributes<ZendeskArticle>
   ) {
-    super(ZendeskArticle, {
-      ...blob,
-      brandId: Number(blob.brandId), // the IDs used here are stored as BIGINTs and are between JS max int and PSQL's max INTEGER
-      articleId: Number(blob.articleId),
-    });
+    super(ZendeskArticle, blob);
   }
 
   static async makeNew({


### PR DESCRIPTION
## Description

- Follow up of #8771.
- When parsing a BIGINTs coming from the db, throws if it is not a safe integer and return a value cast as a number.
- Remove custom casts in Zendesk resources.
- Tested on Zendesk: we do retrieve numbers and the function is correctly called at fetch time. 

## Risk

Affects all interactions with BIGINTs in connectors db (not added to the other db for now).

## Deploy Plan

- Deploy connectors.
