### PR TITLE
Conversation IncludeFileAction: move tokens counting to action run 

### DIFF
--- a/front/lib/models/assistant/actions/conversation/include_file.ts
+++ b/front/lib/models/assistant/actions/conversation/include_file.ts
@@ -21,6 +21,7 @@ export class AgentConversationIncludeFileAction extends Model<
   declare updatedAt: CreationOptional<Date>;
 
   declare fileId: string;
+  declare tokensCount: number | null;
   declare functionCallId: string | null;
   declare functionCallName: string | null;
 
@@ -47,6 +48,10 @@ AgentConversationIncludeFileAction.init(
     fileId: {
       type: DataTypes.STRING,
       allowNull: false,
+    },
+    tokensCount: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
     },
     functionCallId: {
       type: DataTypes.STRING,

--- a/front/migrations/db/migration_119.sql
+++ b/front/migrations/db/migration_119.sql
@@ -1,0 +1,2 @@
+-- Migration created on Nov 21, 2024
+ALTER TABLE "public"."agent_conversation_include_file_actions" ADD COLUMN "tokensCount" INTEGER;

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -465,14 +465,12 @@ const ConversationIncludeFileActionTypeSchema = BaseActionSchema.extend({
   params: z.object({
     fileId: z.string(),
   }),
+  tokensCount: z.number().nullable(),
   functionCallId: z.string().nullable(),
   functionCallName: z.string().nullable(),
   step: z.number(),
   type: z.literal("conversation_include_file_action"),
 });
-type ConversationIncludeFileActionPublicType = z.infer<
-  typeof ConversationIncludeFileActionTypeSchema
->;
 
 const ConversationFileTypeSchema = z.object({
   fileId: z.string(),


### PR DESCRIPTION
## Description

Move tokensCount computation to the action run instead of at each rendering.

## Risk

Low (assuming migration is run) not used yet

## Deploy Plan

- run migration
- deploy `front`