### PR TITLE
Add: ability to do a table query on attachment

### DIFF
--- a/front/lib/api/assistant/actions/conversation/include_file.ts
+++ b/front/lib/api/assistant/actions/conversation/include_file.ts
@@ -141,6 +141,7 @@ export class ConversationIncludeFileAction extends BaseAction {
         fileId,
         title: m.title,
         contentType: m.contentType,
+        snippet: m.snippet,
       },
       content: text,
     });

--- a/front/lib/api/assistant/actions/conversation/list_files.ts
+++ b/front/lib/api/assistant/actions/conversation/list_files.ts
@@ -12,7 +12,6 @@ import _ from "lodash";
 
 import { isConversationIncludableFileContentType } from "@app/lib/api/assistant/actions/conversation/include_file";
 import { listFiles } from "@app/lib/api/assistant/jit_actions";
-import type { Authenticator } from "@app/lib/auth";
 
 interface ConversationListFilesActionBlob {
   agentMessageId: ModelId;
@@ -74,14 +73,14 @@ export class ConversationListFilesAction extends BaseAction {
   }
 }
 
-export async function makeConversationListFilesAction(
-  auth: Authenticator,
-  {
-    agentMessage,
-    conversation,
-  }: { agentMessage: AgentMessageType; conversation: ConversationType }
-): Promise<ConversationListFilesActionType | null> {
-  const files: ConversationFileType[] = await listFiles(auth, { conversation });
+export function makeConversationListFilesAction({
+  agentMessage,
+  conversation,
+}: {
+  agentMessage: AgentMessageType;
+  conversation: ConversationType;
+}): ConversationListFilesActionType | null {
+  const files: ConversationFileType[] = listFiles(conversation);
 
   if (files.length === 0) {
     return null;

--- a/front/lib/api/assistant/actions/conversation/list_files.ts
+++ b/front/lib/api/assistant/actions/conversation/list_files.ts
@@ -7,16 +7,12 @@ import type {
   FunctionMessageTypeModel,
   ModelId,
 } from "@dust-tt/types";
-import {
-  BaseAction,
-  getTablesQueryResultsFileTitle,
-  isAgentMessageType,
-  isContentFragmentType,
-  isSupportedPlainTextContentType,
-  isTablesQueryActionType,
-} from "@dust-tt/types";
+import { BaseAction } from "@dust-tt/types";
+import _ from "lodash";
 
 import { isConversationIncludableFileContentType } from "@app/lib/api/assistant/actions/conversation/include_file";
+import { listFiles } from "@app/lib/api/assistant/jit_actions";
+import type { Authenticator } from "@app/lib/auth";
 
 interface ConversationListFilesActionBlob {
   agentMessageId: ModelId;
@@ -59,8 +55,14 @@ export class ConversationListFilesAction extends BaseAction {
       `\n`;
     for (const f of this.files) {
       content +=
-        `<file id="${f.fileId}" name="${f.title}" type="${f.contentType}" ` +
-        `includable="${isConversationIncludableFileContentType(f.contentType)}"/>\n`;
+        `<file id="${f.fileId}" name="${_.escape(f.title)}" type="${f.contentType}" ` +
+        `includable="${isConversationIncludableFileContentType(f.contentType)}" queryable="${!!f.snippet}"`;
+
+      if (f.snippet) {
+        content += ` snippet="${_.escape(f.snippet)}"`;
+      }
+
+      content += "/>\n";
     }
 
     return {
@@ -72,39 +74,14 @@ export class ConversationListFilesAction extends BaseAction {
   }
 }
 
-export function makeConversationListFilesAction(
-  agentMessage: AgentMessageType,
-  conversation: ConversationType
-): ConversationListFilesActionType | null {
-  const files: ConversationFileType[] = [];
-
-  for (const m of conversation.content.flat(1)) {
-    if (
-      isContentFragmentType(m) &&
-      isSupportedPlainTextContentType(m.contentType) &&
-      m.contentFragmentVersion === "latest"
-    ) {
-      if (m.fileId) {
-        files.push({
-          fileId: m.fileId,
-          title: m.title,
-          contentType: m.contentType,
-        });
-      }
-    } else if (isAgentMessageType(m)) {
-      for (const a of m.actions) {
-        if (isTablesQueryActionType(a)) {
-          if (a.resultsFileId && a.resultsFileSnippet) {
-            files.push({
-              fileId: a.resultsFileId,
-              contentType: "text/csv",
-              title: getTablesQueryResultsFileTitle({ output: a.output }),
-            });
-          }
-        }
-      }
-    }
-  }
+export async function makeConversationListFilesAction(
+  auth: Authenticator,
+  {
+    agentMessage,
+    conversation,
+  }: { agentMessage: AgentMessageType; conversation: ConversationType }
+): Promise<ConversationListFilesActionType | null> {
+  const files: ConversationFileType[] = await listFiles(auth, { conversation });
 
   if (files.length === 0) {
     return null;

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -95,9 +95,11 @@ export async function* runAgent(
   }
 
   // Add JIT actions for available files in the conversation.
-  fullConfiguration.actions = fullConfiguration.actions.concat(
-    await getJITActions(auth, { conversation })
-  );
+  if (await isJITActionsEnabled(auth)) {
+    fullConfiguration.actions = fullConfiguration.actions.concat(
+      await getJITActions(auth, { conversation })
+    );
+  }
 
   const stream = runMultiActionsAgentLoop(
     auth,
@@ -314,7 +316,7 @@ async function getEmulatedAgentMessageActions(
 ): Promise<AgentActionType[]> {
   const actions: AgentActionType[] = [];
   if (await isJITActionsEnabled(auth)) {
-    const a = await makeConversationListFilesAction(auth, {
+    const a = makeConversationListFilesAction({
       agentMessage,
       conversation,
     });

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1832,14 +1832,13 @@ export async function postNewContentFragment(
       return { contentFragment, messageRow };
     }
   );
+  const render = await contentFragment.renderFromMessage({
+    auth,
+    conversationId: conversation.sId,
+    message: messageRow,
+  });
 
-  return new Ok(
-    contentFragment.renderFromMessage({
-      auth,
-      conversationId: conversation.sId,
-      message: messageRow,
-    })
-  );
+  return new Ok(render);
 }
 
 async function* streamRunAgentEvents(

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -259,15 +259,22 @@ async function batchRenderContentFragment(
     );
   }
 
-  return messagesWithContentFragment.map((message: Message) => {
-    const contentFragment = ContentFragmentResource.fromMessage(message);
+  return Promise.all(
+    messagesWithContentFragment.map(async (message: Message) => {
+      const contentFragment = ContentFragmentResource.fromMessage(message);
+      const render = await contentFragment.renderFromMessage({
+        auth,
+        conversationId,
+        message,
+      });
 
-    return {
-      m: contentFragment.renderFromMessage({ auth, conversationId, message }),
-      rank: message.rank,
-      version: message.version,
-    };
-  });
+      return {
+        m: render,
+        rank: message.rank,
+        version: message.version,
+      };
+    })
+  );
 }
 
 /**

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -11,6 +11,7 @@ import {
   isSupportedPlainTextContentType,
   Ok,
   removeNulls,
+  slugify,
 } from "@dust-tt/types";
 import { Writable } from "stream";
 import { pipeline } from "stream/promises";
@@ -163,7 +164,7 @@ const upsertTableToDatasource: ProcessingFunction = async ({
   const tableId = file.sId; // Use the file sId as the table id to make it easy to track the table back to the file.
   const upsertTableRes = await upsertTable({
     tableId,
-    name: file.fileName,
+    name: slugify(file.fileName),
     description: "Table uploaded from file",
     truncate: true,
     csv: content,

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -2,6 +2,7 @@
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 import type {
+  ConversationType,
   DataSourceViewCategory,
   DataSourceViewType,
   ModelId,
@@ -355,6 +356,33 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     );
 
     return dataSourceViews ?? null;
+  }
+
+  static async fetchByConversation(
+    auth: Authenticator,
+    conversation: ConversationType
+  ): Promise<DataSourceViewResource | null> {
+    // Fetch the data source view associated with the datasource that is associated with the conversation.
+    const dataSource = await DataSourceResource.fetchByConversationId(
+      auth,
+      conversation.id
+    );
+    if (!dataSource) {
+      return null;
+    }
+
+    const dataSourceViews = await this.baseFetch(
+      auth,
+      {},
+      {
+        where: {
+          kind: "default",
+          dataSourceId: dataSource.id,
+        },
+      }
+    );
+
+    return dataSourceViews[0] ?? null;
   }
 
   static async search(

--- a/types/src/front/assistant/actions/conversation/list_files.ts
+++ b/types/src/front/assistant/actions/conversation/list_files.ts
@@ -6,6 +6,7 @@ export type ConversationFileType = {
   fileId: string;
   title: string;
   contentType: SupportedContentFragmentType;
+  snippet?: string;
 };
 
 export interface ConversationListFilesActionType extends BaseAction {

--- a/types/src/front/assistant/actions/conversation/list_files.ts
+++ b/types/src/front/assistant/actions/conversation/list_files.ts
@@ -6,7 +6,7 @@ export type ConversationFileType = {
   fileId: string;
   title: string;
   contentType: SupportedContentFragmentType;
-  snippet?: string;
+  snippet: string | null;
 };
 
 export interface ConversationListFilesActionType extends BaseAction {

--- a/types/src/front/content_fragment.ts
+++ b/types/src/front/content_fragment.ts
@@ -41,6 +41,7 @@ export type ContentFragmentType = {
   id: ModelId;
   sId: string;
   fileId: string | null;
+  snippet: string | null;
   created: number;
   type: "content_fragment";
   visibility: MessageVisibility;


### PR DESCRIPTION
## Description

Add the JIT action to table query an attachment.

- Moved the `listFiles()` method to jit_actions.ts and added the snippet in the output.
- Updated the `renderForMultiActionsModel()` to include the snippet as well as a "queryable" attribute (GPT4 was confused by includable="false", _maybe because the `include_file_action` function is not yet presented to it_) 
- Add the actions to the agent configuration before the `runMultiActionsAgentLoop()`
- `slugify` name of table

## Risk

Low, everything is behind FF.

## Deploy Plan

Deploy `front`.
