### PR TITLE
[connectors] Sync Zendesk articles in newly created categories

### DIFF
--- a/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
@@ -94,11 +94,9 @@ export async function allowSyncZendeskHelpCenter({
 export async function forbidSyncZendeskHelpCenter({
   connectorId,
   brandId,
-  withChildren = true,
 }: {
   connectorId: ModelId;
   brandId: number;
-  withChildren?: boolean;
 }): Promise<ZendeskBrandResource | null> {
   const brand = await ZendeskBrandResource.fetchByBrandId({
     connectorId,
@@ -116,16 +114,14 @@ export async function forbidSyncZendeskHelpCenter({
   await brand.revokeHelpCenterPermissions();
 
   // revoking the permissions for all the children categories and articles
-  if (withChildren) {
-    await ZendeskCategoryResource.revokePermissionsForBrand({
-      connectorId,
-      brandId,
-    });
-    await ZendeskArticleResource.revokePermissionsForBrand({
-      connectorId,
-      brandId,
-    });
-  }
+  await ZendeskCategoryResource.revokePermissionsForBrand({
+    connectorId,
+    brandId,
+  });
+  await ZendeskArticleResource.revokePermissionsForBrand({
+    connectorId,
+    brandId,
+  });
 
   return brand;
 }


### PR DESCRIPTION
## Description

- Previous behavior: only existing and selected categories were synced.
- New behavior: articles in newly created categories will be synced if the Help Center is selected.
- Fix: revoking the permissions on a category does not revoke the Help Center's, same for allow.

## Risk

Low.

## Deploy Plan

- Deploy connectors.