### PR TITLE
[front] - fix(notion): see raw content

### DIFF
--- a/front/components/DataSourceViewDocumentModal.tsx
+++ b/front/components/DataSourceViewDocumentModal.tsx
@@ -19,11 +19,12 @@ export default function DataSourceViewDocumentModal({
   onClose,
   owner,
 }: DataSourceViewDocumentModalProps) {
-  const { document, isDocumentLoading } = useDataSourceViewDocument({
+  const { document, isDocumentLoading, isDocumentError } = useDataSourceViewDocument({
     documentId,
     dataSourceView,
     owner,
   });
+  console.log(isDocumentError)
 
   const { title, text } = useMemo(() => {
     if (!document) {
@@ -55,7 +56,7 @@ export default function DataSourceViewDocumentModal({
               <Spinner variant="dark" size="md" />
             </div>
           )}
-          {!isDocumentLoading && !document && (
+          {!isDocumentLoading && isDocumentError && (
             <div className="flex flex-col gap-2 py-8">
               <Label className="text-warning-500">
                 Unable to retrieve document.

--- a/front/components/DataSourceViewDocumentModal.tsx
+++ b/front/components/DataSourceViewDocumentModal.tsx
@@ -1,4 +1,4 @@
-import { Modal } from "@dust-tt/sparkle";
+import { Label, Modal, Spinner } from "@dust-tt/sparkle";
 import type { DataSourceViewType, LightWorkspaceType } from "@dust-tt/types";
 import { useMemo } from "react";
 
@@ -50,14 +50,32 @@ export default function DataSourceViewDocumentModal({
     >
       <div className="w-full">
         <div className="text-left">
-          <div className="mb-4 mt-8 text-sm text-element-900">
-            Content of the document:
-          </div>
-          {!isDocumentLoading && document ? (
-            <pre className="whitespace-pre-wrap bg-structure-100 py-8 pl-4 pr-2 text-sm text-element-800">
-              {text}
-            </pre>
-          ) : null}
+          {isDocumentLoading && (
+            <div className="flex justify-center py-8">
+              <Spinner variant="dark" size="md" />
+            </div>
+          )}
+          {!isDocumentLoading && !document && (
+            <div className="flex flex-col gap-2 py-8">
+              <Label className="text-warning-500">
+                Unable to retrieve document.
+              </Label>
+              <span className="text-sm text-element-700">
+                We were not able to synchronize this document. Please contact
+                support@dust.tt for assistance.
+              </span>
+            </div>
+          )}
+          {!isDocumentLoading && document && (
+            <>
+              <div className="mb-4 mt-8 text-sm text-element-900">
+                Content of the document:
+              </div>
+              <pre className="whitespace-pre-wrap bg-structure-100 py-8 pl-4 pr-2 text-sm text-element-800">
+                {text}
+              </pre>
+            </>
+          )}
         </div>
       </div>
     </Modal>

--- a/front/components/DataSourceViewDocumentModal.tsx
+++ b/front/components/DataSourceViewDocumentModal.tsx
@@ -19,12 +19,13 @@ export default function DataSourceViewDocumentModal({
   onClose,
   owner,
 }: DataSourceViewDocumentModalProps) {
-  const { document, isDocumentLoading, isDocumentError } = useDataSourceViewDocument({
-    documentId,
-    dataSourceView,
-    owner,
-  });
-  console.log(isDocumentError)
+  const { document, isDocumentLoading, isDocumentError } =
+    useDataSourceViewDocument({
+      documentId,
+      dataSourceView,
+      owner,
+    });
+  console.log(isDocumentError);
 
   const { title, text } = useMemo(() => {
     if (!document) {

--- a/front/components/spaces/ContentActions.tsx
+++ b/front/components/spaces/ContentActions.tsx
@@ -212,7 +212,7 @@ export const getMenuItems = (
       onClick: (e: ReactMouseEvent) => {
         e.stopPropagation();
         contentActionsRef.current &&
-          contentActionsRef.current?.callAction(
+          contentActionsRef.current.callAction(
             contentNode.type === "database"
               ? "TableUploadOrEdit"
               : "DocumentUploadOrEdit",
@@ -226,7 +226,7 @@ export const getMenuItems = (
       onClick: (e: ReactMouseEvent) => {
         e.stopPropagation();
         contentActionsRef.current &&
-          contentActionsRef.current?.callAction(
+          contentActionsRef.current.callAction(
             "DocumentOrTableDeleteDialog",
             contentNode
           );
@@ -246,10 +246,7 @@ export const getMenuItems = (
       onClick: (e: ReactMouseEvent) => {
         e.stopPropagation();
         contentActionsRef.current &&
-          contentActionsRef.current?.callAction(
-            "AddToSpaceDialog",
-            contentNode
-          );
+          contentActionsRef.current.callAction("AddToSpaceDialog", contentNode);
       },
     });
   }
@@ -290,7 +287,7 @@ const makeViewRawContentAction = (
     onClick: (e: ReactMouseEvent) => {
       e.stopPropagation();
       contentActionsRef.current &&
-        contentActionsRef.current?.callAction(
+        contentActionsRef.current.callAction(
           "DocumentViewRawContent",
           contentNode
         );


### PR DESCRIPTION
## Description

Improves the document viewing modal UX by adding a loading state and error handling when displaying raw content. Adds proper error messaging when document content cannot be retrieved.

**References:**
- https://github.com/dust-tt/tasks/issues/1675

## Risk

N/A

## Deploy Plan

Deploy `front`