### PR TITLE
[connectors] - fix: filter out non-numeric IDs in `fetchByIds` method

### DIFF
--- a/connectors/src/resources/connector_resource.ts
+++ b/connectors/src/resources/connector_resource.ts
@@ -136,9 +136,13 @@ export class ConnectorResource extends BaseResource<ConnectorModel> {
   }
 
   static async fetchByIds(type: ConnectorProvider, ids: (ModelId | string)[]) {
-    const parsedIds = ids.map((id) =>
-      typeof id === "string" ? parseInt(id, 10) : id
-    );
+    const parsedIds = ids
+      .map((id) => (typeof id === "string" ? parseInt(id, 10) : id))
+      .filter((id) => !isNaN(id));
+
+    if (parsedIds.length === 0) {
+      return [];
+    }
 
     const blobs = await ConnectorResource.model.findAll({
       where: {

--- a/connectors/src/resources/connector_resource.ts
+++ b/connectors/src/resources/connector_resource.ts
@@ -12,6 +12,7 @@ import type {
   WhereOptions,
 } from "sequelize";
 
+import logger from "@connectors/logger/logger";
 import { BaseResource } from "@connectors/resources/base_resource";
 import type {
   ConnectorProviderConfigurationResource,
@@ -23,7 +24,6 @@ import { getConnectorProviderStrategy } from "@connectors/resources/connector/st
 import { sequelizeConnection } from "@connectors/resources/storage";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 import type { ReadonlyAttributesType } from "@connectors/resources/storage/types";
-import logger from "@connectors/logger/logger";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.


### PR DESCRIPTION
## Description

This PR filter IDs to exclude any non-numeric values before querying the database

**References:**
- [Datadog logs](https://app.datadoghq.eu/logs?query=%22Unhandled%20API%20Error%22%20status%3Aerror%20%40dd.env%3Aprod%20%40error.parent.message%3A%22column%20%5C%22nan%5C%22%20does%20not%20exist%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1732186405035&to_ts=1732200805035&live=true)

## Risk

Low

## Deploy Plan

Deploy `connectors`