### PR TITLE
[connectors] Add logs on Zendesk API response parsing

### DIFF
--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -131,8 +131,13 @@ async function fetchFromZendeskWithRetries({
     }
   }
   const text = await rawResponse.text();
-  const response = JSON.parse(text);
-
+  let response;
+  try {
+    response = JSON.parse(text);
+  } catch (e) {
+    logger.error({ text }, "[Zendesk] Error parsing Zendesk API response");
+    throw new Error(`Error parsing Zendesk API response: ${text}`);
+  }
   if (!rawResponse.ok) {
     if (response.type === "error.list" && response.errors?.length) {
       const error = response.errors[0];

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -130,13 +130,15 @@ async function fetchFromZendeskWithRetries({
       );
     }
   }
-  const text = await rawResponse.text();
   let response;
   try {
-    response = JSON.parse(text);
+    response = await rawResponse.json();
   } catch (e) {
-    logger.error({ text }, "[Zendesk] Error parsing Zendesk API response");
-    throw new Error(`Error parsing Zendesk API response: ${text}`);
+    logger.error(
+      { rawResponse },
+      "[Zendesk] Error parsing Zendesk API response"
+    );
+    throw new Error("Error parsing Zendesk API response");
   }
   if (!rawResponse.ok) {
     if (response.type === "error.list" && response.errors?.length) {
@@ -148,8 +150,8 @@ async function fetchFromZendeskWithRetries({
         return null;
       }
     }
-    logger.error({ response }, "[Zendesk] Zendesk API error");
-    throw new Error(`Zendesk API error: ${text}`);
+    logger.error({ rawResponse }, "[Zendesk] Zendesk API error");
+    throw new Error("Zendesk API error.");
   }
 
   return response;


### PR DESCRIPTION
## Description

- Add logging when the parsing of a response from Zendesk API fails.

## Risk

Low.

## Deploy Plan

- Deploy connectors.