### PR TITLE
fix: deadlock in notion getParents

### DIFF
--- a/connectors/src/connectors/notion/lib/parents.ts
+++ b/connectors/src/connectors/notion/lib/parents.ts
@@ -64,18 +64,6 @@ async function _getParents(
       return parents;
     case "page":
     case "database": {
-      if (seen.includes(pageOrDbId)) {
-        logger.error(
-          {
-            connectorId,
-            pageOrDbId,
-            seen,
-            parentId: pageOrDb.parentId,
-          },
-          "getParents infinite loop"
-        );
-        return parents.concat(seen);
-      }
       seen.push(pageOrDbId);
       if (!pageOrDb.parentId) {
         logger.error(
@@ -87,6 +75,18 @@ async function _getParents(
           "getParents parentId is undefined"
         );
         throw new Error("getParent parentId is undefined");
+      }
+      if (seen.includes(pageOrDb.parentId)) {
+        logger.error(
+          {
+            connectorId,
+            pageOrDbId,
+            seen,
+            parentId: pageOrDb.parentId,
+          },
+          "getParents infinite loop"
+        );
+        return parents.concat(seen);
       }
       if (onProgress) {
         await onProgress();


### PR DESCRIPTION
## Description

Now that we lock in `cacheWithRedis`, re-entrant calls can produce deadlocks.
A corner case in Notion `getParents` can cause this, when there is a cycle in the graph.

We already have a condition to handle this:
`if (seen.includes(myId))  { return } else { recursion(myParentId }`

but with this new locking mechanism, we need the condition to be:
`if (seen.include(myParentId) { return } else { recursion(myParentId }`

in order to avoid deadlocking.

## Risk

N/A

## Deploy Plan

deploy connectors