### PR TITLE
[connectors] Run both Zendesk workers together

### DIFF
--- a/connectors/src/connectors/zendesk/temporal/worker.ts
+++ b/connectors/src/connectors/zendesk/temporal/worker.ts
@@ -9,9 +9,9 @@ import logger from "@connectors/logger/logger";
 import * as activities from "./activities";
 import { GARBAGE_COLLECT_QUEUE_NAME, QUEUE_NAME } from "./config";
 
-export async function runZendeskWorker() {
+export async function runZendeskWorkers() {
   const { connection, namespace } = await getTemporalWorkerConnection();
-  const worker = await Worker.create({
+  const syncWorker = await Worker.create({
     workflowsPath: require.resolve("./workflows"),
     activities,
     taskQueue: QUEUE_NAME,
@@ -35,12 +35,9 @@ export async function runZendeskWorker() {
     },
   });
 
-  await worker.run();
-}
+  await syncWorker.run();
 
-export async function runZendeskGarbageCollectionWorker() {
-  const { connection, namespace } = await getTemporalWorkerConnection();
-  const worker = await Worker.create({
+  const gcWorker = await Worker.create({
     workflowsPath: require.resolve("./workflows"),
     activities,
     taskQueue: GARBAGE_COLLECT_QUEUE_NAME,
@@ -64,5 +61,5 @@ export async function runZendeskGarbageCollectionWorker() {
     },
   });
 
-  await worker.run();
+  await gcWorker.run();
 }

--- a/connectors/src/start.ts
+++ b/connectors/src/start.ts
@@ -11,10 +11,7 @@ import { runIntercomWorker } from "./connectors/intercom/temporal/worker";
 import { runNotionWorker } from "./connectors/notion/temporal/worker";
 import { runSlackWorker } from "./connectors/slack/temporal/worker";
 import { runWebCrawlerWorker } from "./connectors/webcrawler/temporal/worker";
-import {
-  runZendeskGarbageCollectionWorker,
-  runZendeskWorker,
-} from "./connectors/zendesk/temporal/worker";
+import { runZendeskWorkers } from "./connectors/zendesk/temporal/worker";
 import { errorFromAny } from "./lib/error";
 import logger from "./logger/logger";
 
@@ -48,11 +45,8 @@ runGoogleWorkers().catch((err) =>
 runIntercomWorker().catch((err) =>
   logger.error(errorFromAny(err), "Error running intercom worker")
 );
-runZendeskWorker().catch((err) =>
+runZendeskWorkers().catch((err) =>
   logger.error(errorFromAny(err), "Error running zendesk worker")
-);
-runZendeskGarbageCollectionWorker().catch((err) =>
-  logger.error(errorFromAny(err), "Error running zendesk gc worker")
 );
 runWebCrawlerWorker().catch((err) =>
   logger.error(errorFromAny(err), "Error running webcrawler worker")

--- a/connectors/src/start_worker.ts
+++ b/connectors/src/start_worker.ts
@@ -16,19 +16,13 @@ import {
   runNotionWorker,
 } from "./connectors/notion/temporal/worker";
 import { runSlackWorker } from "./connectors/slack/temporal/worker";
-import {
-  runZendeskGarbageCollectionWorker,
-  runZendeskWorker,
-} from "./connectors/zendesk/temporal/worker";
+import { runZendeskWorkers } from "./connectors/zendesk/temporal/worker";
 import { errorFromAny } from "./lib/error";
 import logger from "./logger/logger";
 
 setupGlobalErrorHandler(logger);
 
-type WorkerType =
-  | ConnectorProvider
-  | "notion_garbage_collector"
-  | "zendesk_garbage_collector";
+type WorkerType = ConnectorProvider | "notion_garbage_collector";
 
 const workerFunctions: Record<WorkerType, () => Promise<void>> = {
   confluence: runConfluenceWorker,
@@ -41,8 +35,7 @@ const workerFunctions: Record<WorkerType, () => Promise<void>> = {
   slack: runSlackWorker,
   webcrawler: runWebCrawlerWorker,
   snowflake: runSnowflakeWorker,
-  zendesk: runZendeskWorker,
-  zendesk_garbage_collector: runZendeskGarbageCollectionWorker,
+  zendesk: runZendeskWorkers,
 };
 
 const ALL_WORKERS = Object.keys(workerFunctions) as WorkerType[];


### PR DESCRIPTION
## Description

- This PR changes `start_worker.ts` and `start.ts` to run the sync worker and the garbage collection workers when calling `npm run start:worker --workers zendesk`.
- This change allows running both without the [need for an additional deployment](https://github.com/dust-tt/dust-infra/pull/66/files) (same pod).

## Risk

Low.

## Deploy Plan

- Deploy connectors.