### PR TITLE
[connectors] Handle 404 from Zendesk API by returning null objects

### DIFF
--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -134,6 +134,13 @@ async function fetchFromZendeskWithRetries({
   try {
     response = await rawResponse.json();
   } catch (e) {
+    if (rawResponse.status === 404) {
+      logger.error(
+        { rawResponse, text: rawResponse.text },
+        "[Zendesk] Zendesk API 404 error"
+      );
+      return null;
+    }
     logger.error(
       { rawResponse, status: rawResponse.status, text: rawResponse.text },
       "[Zendesk] Error parsing Zendesk API response"


### PR DESCRIPTION
## Description

- Handle 404 from Zendesk API by returning null objects instead of crashing.
- In most usage, this behavior will lead to stopping pagination loops.

## Risk

Low.

## Deploy Plan

- Deploy connectors.