### PR TITLE
Upg: increase chunks count batch per embedding request (8->128)

### DIFF
--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -852,9 +852,9 @@ impl DataSource {
             .filter(|ci| !embeddings.contains_key(&ci.hash))
             .collect::<Vec<_>>();
 
-        // Chunk splits into a vectors of 8 chunks (Vec<Vec<String>>)
+        // Chunk splits into a vectors of 128 chunks (Vec<Vec<String>>)
         let chunked_splits = splits_to_embbed
-            .chunks(8)
+            .chunks(128)
             .map(|chunk| chunk.to_vec())
             .collect::<Vec<_>>();
 


### PR DESCRIPTION
## Description

Increase size of batch per embedding request to make the process much faster for large documents.

## Risk

More timeout on ~10% of our embedding requests, will monitor.

## Deploy Plan

Deploy `core`
