### PR TITLE
[connectors] Fix the Zendesk GC worker not polling

### DIFF
--- a/connectors/src/connectors/zendesk/temporal/worker.ts
+++ b/connectors/src/connectors/zendesk/temporal/worker.ts
@@ -37,8 +37,6 @@ export async function runZendeskWorkers() {
     },
   });
 
-  await syncWorker.run();
-
   const gcWorker = await Worker.create({
     workflowsPath: require.resolve("./workflows"),
     activities: { ...activities, ...gc_activities },
@@ -63,5 +61,6 @@ export async function runZendeskWorkers() {
     },
   });
 
-  await gcWorker.run();
+  // the run is blocking, we need to launch both workers in parallel
+  await Promise.all([syncWorker.run(), gcWorker.run()]);
 }


### PR DESCRIPTION
## Description

- The Zendesk GC workflow had no worker polling it in prod.
- This PR aims at fixing that by launching the two workers in parallel.

## Risk

Might increase the workload when the GC workflow is run.

## Deploy Plan

- Deploy connectors.
