### PR TITLE
[connectors] Lower `ZENDESK_BATCH_SIZE` :wrench:

### DIFF
--- a/connectors/src/connectors/zendesk/temporal/config.ts
+++ b/connectors/src/connectors/zendesk/temporal/config.ts
@@ -4,4 +4,4 @@ export const GARBAGE_COLLECT_QUEUE_NAME = `zendesk-gc-queue-v${WORKFLOW_VERSION}
 
 // Batch size used when fetching from Zendesk API or from the database
 // 100 is the maximum value allowed for most endpoints in Zendesk: https://developer.zendesk.com/api-reference/introduction/pagination/
-export const ZENDESK_BATCH_SIZE = 100;
+export const ZENDESK_BATCH_SIZE = 30;


### PR DESCRIPTION
## Description

- This PR aims at fixing errors in prod with `syncZendeskArticleBatchActivity` timing out repeatedly (the `startToTimeout` was increased in a previous PR).
- Lower `ZENDESK_BATCH_SIZE` from 100 to 30.
- This value controls the size of the batches of data fetched from Zendesk API or from the database
- Fetching 100 articles and parsing them concurrently seems to be quite huge in terms of memory load, which [https://app.datadoghq.eu/logs?query=host%3Agk3-dust-kube-pool-3-73178531-4d9l.c.or1g1[…]esc&viz=&from_ts=1732247380931&to_ts=1732261780931&live=true](https://app.datadoghq.eu/logs?query=host%3Agk3-dust-kube-pool-3-73178531-4d9l.c.or1g1n-186209.internal%20service%3Aconnectors-worker%20container_id%3A6bb3298f55ec5cd6491f720dbe5b8753028b3bf39dd7b86e9c764b99c8707e11&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&context_event=AZNSuUMxAAAN6PZ5dRHqsAAE&event=AwAAAZNSuTmSPEnahgAAABhBWk5TdVVNeEFBQU42UFo1ZFJIcXNBQVIAAAAkMDE5MzUyYmYtNzBkNy00NGE5LThmYTAtZTdhYjExZjAyN2Q0AAATJA&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=&from_ts=1732247380931&to_ts=1732261780931&live=true)
 
## Risk

Low.

## Deploy Plan

- Deploy connectors.