### PR TITLE
[connectors] Share the queue between Zendesk sync GC

### DIFF
--- a/connectors/src/connectors/zendesk/temporal/client.ts
+++ b/connectors/src/connectors/zendesk/temporal/client.ts
@@ -6,10 +6,7 @@ import {
   WorkflowNotFoundError,
 } from "@temporalio/client";
 
-import {
-  GARBAGE_COLLECT_QUEUE_NAME,
-  QUEUE_NAME,
-} from "@connectors/connectors/zendesk/temporal/config";
+import { QUEUE_NAME } from "@connectors/connectors/zendesk/temporal/config";
 import type {
   ZendeskCategoryUpdateSignal,
   ZendeskUpdateSignal,
@@ -153,7 +150,7 @@ export async function launchZendeskGarbageCollectionWorkflow(
   try {
     await client.workflow.start(zendeskGarbageCollectionWorkflow, {
       args: [{ connectorId: connector.id }],
-      taskQueue: GARBAGE_COLLECT_QUEUE_NAME,
+      taskQueue: QUEUE_NAME,
       workflowId,
       searchAttributes: { connectorId: [connector.id] },
       memo: { connectorId: connector.id },

--- a/connectors/src/connectors/zendesk/temporal/config.ts
+++ b/connectors/src/connectors/zendesk/temporal/config.ts
@@ -1,6 +1,5 @@
 export const WORKFLOW_VERSION = 9;
 export const QUEUE_NAME = `zendesk-queue-v${WORKFLOW_VERSION}`;
-export const GARBAGE_COLLECT_QUEUE_NAME = `zendesk-gc-queue-v${WORKFLOW_VERSION}`;
 
 // Batch size used when fetching from Zendesk API or from the database
 // 100 is the maximum value allowed for most endpoints in Zendesk: https://developer.zendesk.com/api-reference/introduction/pagination/


### PR DESCRIPTION
## Description

- This PR aims at using the same queue for the two Zendesk workflows.
- They will also share the same worker.
 
## Risk

Low, currently still in beta, downtimes are expected.

## Deploy Plan

- Deploy connectors.
