### PR TITLE
Conversation actions: stop rendering content fragments

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -176,7 +176,6 @@ export async function renderConversationForModel(
     allowedTokenCount,
     excludeActions,
     excludeImages,
-    excludeContentFragments,
   }: {
     conversation: ConversationType;
     model: ModelConfigurationType;
@@ -184,7 +183,6 @@ export async function renderConversationForModel(
     allowedTokenCount: number;
     excludeActions?: boolean;
     excludeImages?: boolean;
-    excludeContentFragments?: boolean;
   }
 ): Promise<
   Result<
@@ -203,7 +201,6 @@ export async function renderConversationForModel(
       allowedTokenCount,
       excludeActions,
       excludeImages,
-      excludeContentFragments,
     });
   } else {
     return renderConversationForModelJIT({
@@ -213,7 +210,6 @@ export async function renderConversationForModel(
       allowedTokenCount,
       excludeActions,
       excludeImages,
-      excludeContentFragments,
     });
   }
 }
@@ -225,7 +221,6 @@ async function renderConversationForModelMultiActions({
   allowedTokenCount,
   excludeActions,
   excludeImages,
-  excludeContentFragments,
 }: {
   conversation: ConversationType;
   model: ModelConfigurationType;
@@ -233,7 +228,6 @@ async function renderConversationForModelMultiActions({
   allowedTokenCount: number;
   excludeActions?: boolean;
   excludeImages?: boolean;
-  excludeContentFragments?: boolean;
 }): Promise<
   Result<
     {
@@ -384,9 +378,7 @@ async function renderConversationForModelMultiActions({
       if (res.isErr()) {
         return new Err(res.error);
       }
-      if (!excludeContentFragments) {
-        messages.push(res.value);
-      }
+      messages.push(res.value);
     } else {
       assertNever(m);
     }

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -25,7 +25,6 @@ import {
   isDevelopment,
   isSupportedPlainTextContentType,
   isTablesQueryActionType,
-  isTextContent,
   isUserMessageType,
   Ok,
   removeNulls,
@@ -44,10 +43,10 @@ import {
 } from "@app/lib/api/assistant/utils";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
-import { renderContentFragmentForModel } from "@app/lib/resources/content_fragment_resource";
+import { renderLightContentFragmentForModel } from "@app/lib/resources/content_fragment_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
-import { tokenCountForTexts, tokenSplit } from "@app/lib/tokenization";
+import { tokenCountForTexts } from "@app/lib/tokenization";
 import logger from "@app/logger/logger";
 
 export async function isJITActionsEnabled(
@@ -226,7 +225,6 @@ export async function renderConversationForModelJIT({
   allowedTokenCount,
   excludeActions,
   excludeImages,
-  excludeContentFragments,
 }: {
   conversation: ConversationType;
   model: ModelConfigurationType;
@@ -234,7 +232,6 @@ export async function renderConversationForModelJIT({
   allowedTokenCount: number;
   excludeActions?: boolean;
   excludeImages?: boolean;
-  excludeContentFragments?: boolean;
 }): Promise<
   Result<
     {
@@ -387,16 +384,11 @@ export async function renderConversationForModelJIT({
         ],
       });
     } else if (isContentFragmentType(m)) {
-      const res = await renderContentFragmentForModel(m, conversation, model, {
-        excludeImages: Boolean(excludeImages),
-      });
-
-      if (res.isErr()) {
-        return new Err(res.error);
-      }
-      if (!excludeContentFragments) {
-        messages.push(res.value);
-      }
+      messages.push(
+        await renderLightContentFragmentForModel(m, conversation, model, {
+          excludeImages: Boolean(excludeImages),
+        })
+      );
     } else {
       assertNever(m);
     }
@@ -407,7 +399,6 @@ export async function renderConversationForModelJIT({
     [prompt, ...getTextRepresentationFromMessages(messages)],
     model
   );
-
   if (res.isErr()) {
     return new Err(res.error);
   }
@@ -415,14 +406,12 @@ export async function renderConversationForModelJIT({
   const [promptCount, ...messagesCount] = res.value;
 
   // We initialize `tokensUsed` to the prompt tokens + a bit of buffer for message rendering
-  // approximations, 64 tokens seems small enough and ample enough.
+  // approximations.
   const tokensMargin = 1024;
   let tokensUsed = promptCount + tokensMargin;
 
   // Go backward and accumulate as much as we can within allowedTokenCount.
   const selected: ModelMessageTypeMultiActions[] = [];
-  const truncationMessage = `... (content truncated)`;
-  const approxTruncMsgTokenCount = truncationMessage.length / 3;
 
   // Selection loop.
   for (let i = messages.length - 1; i >= 0; i--) {
@@ -433,57 +422,12 @@ export async function renderConversationForModelJIT({
     if (tokensUsed + c <= allowedTokenCount) {
       tokensUsed += c;
       selected.unshift(currentMessage);
-    } else if (
-      // When a content fragment has more than the remaining number of tokens, we split it.
-      isContentFragmentMessageTypeModel(currentMessage) &&
-      // Allow at least tokensMargin tokens in addition to the truncation message.
-      tokensUsed + approxTruncMsgTokenCount + tokensMargin < allowedTokenCount
-    ) {
-      const remainingTokens =
-        allowedTokenCount - tokensUsed - approxTruncMsgTokenCount;
-
-      const updatedContent = [];
-      for (const c of currentMessage.content) {
-        if (!isTextContent(c)) {
-          // If there is not enough room and it's an image, we simply ignore it.
-          continue;
-        }
-
-        // Remove only if it ends with "</attachment>".
-        const textWithoutClosingAttachmentTag = c.text.replace(
-          /<\/attachment>$/,
-          ""
-        );
-
-        const contentRes = await tokenSplit(
-          textWithoutClosingAttachmentTag,
-          model,
-          remainingTokens
-        );
-        if (contentRes.isErr()) {
-          return new Err(contentRes.error);
-        }
-
-        updatedContent.push({
-          ...c,
-          text: `${contentRes.value}${truncationMessage}</attachment>`,
-        });
-      }
-
-      selected.unshift({
-        ...currentMessage,
-        content: updatedContent,
-      });
-
-      tokensUsed += remainingTokens;
-      break;
     } else {
       break;
     }
   }
 
-  // Merging loop.
-  // Merging content fragments into the upcoming user message.
+  // Merging loop: merging content fragments into the upcoming user message.
   // Eg: [CF1, CF2, UserMessage, AgentMessage] => [CF1-CF2-UserMessage, AgentMessage]
   for (let i = selected.length - 1; i >= 0; i--) {
     const cfMessage = selected[i];


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/1574

Final step of include actions, stop rendering content fragments in the conversation.
Follow-up work: thorough dev testing and iterations

## Risk

Low, behind flag

## Deploy Plan

- deploy `front`