### PR TITLE
Extension: Display favorites

### DIFF
--- a/extension/app/src/components/assistants/AssistantFavorites.tsx
+++ b/extension/app/src/components/assistants/AssistantFavorites.tsx
@@ -1,0 +1,57 @@
+import { AssistantPreview, Page } from "@dust-tt/sparkle";
+import { usePublicAgentConfigurations } from "@extension/components/assistants/usePublicAgentConfigurations";
+import { InputBarContext } from "@extension/components/input_bar/InputBarContext";
+import { useCallback, useContext } from "react";
+
+export function AssistantFavorites() {
+  const {
+    agentConfigurations,
+    isAgentConfigurationsLoading,
+    isAgentConfigurationsError,
+  } = usePublicAgentConfigurations("favorites");
+
+  const { setSelectedAssistant } = useContext(InputBarContext);
+
+  const handleAssistantClick = useCallback(
+    (agentId: string) => {
+      const scrollContainer = document.getElementById("assistant-input-header");
+      if (!scrollContainer) {
+        console.error("Scroll container not found");
+        return;
+      }
+
+      const { top } = scrollContainer.getBoundingClientRect();
+      if (top < -2) {
+        scrollContainer.scrollIntoView({ behavior: "smooth" });
+      }
+
+      setSelectedAssistant({ configurationId: agentId });
+    },
+    [setSelectedAssistant]
+  );
+
+  if (isAgentConfigurationsError || isAgentConfigurationsLoading) {
+    return null;
+  }
+
+  return (
+    <div className="text-left w-full pt-2 pb-12">
+      <Page.SectionHeader title="Favorites" />
+      <div className="relative grid w-full grid-cols-1 gap-2 sm:grid-cols-2">
+        {agentConfigurations.map(
+          ({ sId, name, pictureUrl, lastAuthors, description }) => (
+            <AssistantPreview
+              key={sId}
+              title={name}
+              pictureUrl={pictureUrl}
+              subtitle={lastAuthors?.join(", ") ?? ""}
+              description={description}
+              variant="minimal"
+              onClick={() => handleAssistantClick(sId)}
+            />
+          )
+        )}
+      </div>
+    </div>
+  );
+}

--- a/extension/app/src/components/assistants/usePublicAgentConfigurations.ts
+++ b/extension/app/src/components/assistants/usePublicAgentConfigurations.ts
@@ -1,13 +1,16 @@
+import type { AgentConfigurationViewType } from "@dust-tt/client";
 import { logout } from "@extension/lib/auth";
 import { useDustAPI } from "@extension/lib/dust_api";
 import { useSWRWithDefaults } from "@extension/lib/swr";
 import { useEffect, useMemo } from "react";
 
-export function usePublicAgentConfigurations() {
+export function usePublicAgentConfigurations(
+  view?: AgentConfigurationViewType
+) {
   const dustAPI = useDustAPI();
 
   const agentConfigurationsFetcher = async () => {
-    const res = await dustAPI.getAgentConfigurations();
+    const res = await dustAPI.getAgentConfigurations(view);
     if (res.isOk()) {
       return res.value;
     }
@@ -16,7 +19,7 @@ export function usePublicAgentConfigurations() {
 
   const { data, error, mutate, mutateRegardlessOfQueryParams } =
     useSWRWithDefaults(
-      ["getAgentConfigurations", dustAPI.workspaceId()],
+      ["getAgentConfigurations", dustAPI.workspaceId(), view],
       agentConfigurationsFetcher
     );
 

--- a/extension/app/src/components/conversation/ConversationContainer.tsx
+++ b/extension/app/src/components/conversation/ConversationContainer.tsx
@@ -8,12 +8,8 @@ import { ConversationViewer } from "@extension/components/conversation/Conversat
 import { GenerationContextProvider } from "@extension/components/conversation/GenerationContextProvider";
 import { ReachedLimitPopup } from "@extension/components/conversation/ReachedLimitPopup";
 import { usePublicConversation } from "@extension/components/conversation/usePublicConversation";
-import { DropzoneContainer } from "@extension/components/DropzoneContainer";
 import { AssistantInputBar } from "@extension/components/input_bar/InputBar";
-import {
-  InputBarContext,
-  InputBarProvider,
-} from "@extension/components/input_bar/InputBarContext";
+import { InputBarContext } from "@extension/components/input_bar/InputBarContext";
 import { useSubmitFunction } from "@extension/components/utils/useSubmitFunction";
 import {
   createPlaceholderUserMessage,
@@ -261,49 +257,43 @@ export function ConversationContainer({
   }, [user]);
 
   return (
-    <InputBarProvider>
-      <GenerationContextProvider>
-        <DropzoneContainer
-          description="Drag and drop your text files (txt, doc, pdf) and image files (jpg, png) here."
-          title="Attach files to the conversation"
-        >
-          {activeConversationId && (
-            <ConversationViewer
-              conversationId={activeConversationId}
-              owner={owner}
-              user={user}
-              onStickyMentionsChange={onStickyMentionsChange}
-            />
-          )}
-          <div className="sticky bottom-0 z-20 flex flex-col max-h-screen w-full max-w-4xl pb-4">
-            {!activeConversationId && (
-              <div className="pb-2">
-                <Page.Header title={greeting} />
-                <Page.SectionHeader title="Start a conversation" />
-              </div>
-            )}
-            <AssistantInputBar
-              owner={owner}
-              onSubmit={
-                activeConversationId
-                  ? handlePostMessage
-                  : handlePostConversation
-              }
-              stickyMentions={stickyMentions}
-              isTabIncluded={!!includeContent}
-              setIncludeTab={(includeTab) => {
-                setIncludeContent(includeTab);
-              }}
-              conversation={conversation ?? undefined}
-            />
+    <GenerationContextProvider>
+      {activeConversationId && (
+        <ConversationViewer
+          conversationId={activeConversationId}
+          owner={owner}
+          user={user}
+          onStickyMentionsChange={onStickyMentionsChange}
+        />
+      )}
+      <div
+        id="assistant-input-header"
+        className="sticky bottom-0 z-20 flex flex-col max-h-screen w-full max-w-4xl pb-4"
+      >
+        {!activeConversationId && (
+          <div className="pb-2">
+            <Page.Header title={greeting} />
+            <Page.SectionHeader title="Start a conversation" />
           </div>
-          <ReachedLimitPopup
-            isOpened={planLimitReached}
-            onClose={() => setPlanLimitReached(false)}
-            isTrialing={false} // TODO(Ext): Properly handle this from loading the subscription.
-          />
-        </DropzoneContainer>
-      </GenerationContextProvider>
-    </InputBarProvider>
+        )}
+        <AssistantInputBar
+          owner={owner}
+          onSubmit={
+            activeConversationId ? handlePostMessage : handlePostConversation
+          }
+          stickyMentions={stickyMentions}
+          isTabIncluded={!!includeContent}
+          setIncludeTab={(includeTab) => {
+            setIncludeContent(includeTab);
+          }}
+          conversation={conversation ?? undefined}
+        />
+      </div>
+      <ReachedLimitPopup
+        isOpened={planLimitReached}
+        onClose={() => setPlanLimitReached(false)}
+        isTrialing={false} // TODO(Ext): Properly handle this from loading the subscription.
+      />
+    </GenerationContextProvider>
   );
 }

--- a/extension/app/src/pages/ConversationPage.tsx
+++ b/extension/app/src/pages/ConversationPage.tsx
@@ -8,6 +8,7 @@ import type { ProtectedRouteChildrenProps } from "@extension/components/auth/Pro
 import { ConversationContainer } from "@extension/components/conversation/ConversationContainer";
 import { FileDropProvider } from "@extension/components/conversation/FileUploaderContext";
 import { usePublicConversation } from "@extension/components/conversation/usePublicConversation";
+import { InputBarProvider } from "@extension/components/input_bar/InputBarContext";
 import { useEffect, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 
@@ -69,11 +70,13 @@ export const ConversationPage = ({
         }
       />
       <div className="h-full w-full pt-4 mt-12">
-        <ConversationContainer
-          owner={workspace}
-          conversationId={conversationId}
-          user={user}
-        />
+        <InputBarProvider>
+          <ConversationContainer
+            owner={workspace}
+            conversationId={conversationId}
+            user={user}
+          />
+        </InputBarProvider>
       </div>
     </FileDropProvider>
   );

--- a/extension/app/src/pages/MainPage.tsx
+++ b/extension/app/src/pages/MainPage.tsx
@@ -8,11 +8,14 @@ import {
   LogoHorizontalColorLogo,
   LogoutIcon,
 } from "@dust-tt/sparkle";
+import { AssistantFavorites } from "@extension/components/assistants/AssistantFavorites";
 import { useAuth } from "@extension/components/auth/AuthProvider";
 import type { ProtectedRouteChildrenProps } from "@extension/components/auth/ProtectedRoute";
 import { ConversationContainer } from "@extension/components/conversation/ConversationContainer";
 import { ConversationsListButton } from "@extension/components/conversation/ConversationsListButton";
 import { FileDropProvider } from "@extension/components/conversation/FileUploaderContext";
+import { DropzoneContainer } from "@extension/components/DropzoneContainer";
+import { InputBarProvider } from "@extension/components/input_bar/InputBarContext";
 import { Link } from "react-router-dom";
 
 export const MainPage = ({
@@ -86,14 +89,24 @@ export const MainPage = ({
           </DropdownMenu>
         </div>
       </div>
-      <div className="h-full w-full pt-28">
-        <FileDropProvider>
-          <ConversationContainer
-            owner={workspace}
-            conversationId={null}
-            user={user}
-          />
-        </FileDropProvider>
+      <div className="h-full w-full pt-28 max-w-4xl mx-auto flex justify-center">
+        <div className="flex flex-col items-center">
+          <FileDropProvider>
+            <DropzoneContainer
+              description="Drag and drop your text files (txt, doc, pdf) and image files (jpg, png) here."
+              title="Attach files to the conversation"
+            >
+              <InputBarProvider>
+                <ConversationContainer
+                  owner={workspace}
+                  conversationId={null}
+                  user={user}
+                />
+                <AssistantFavorites />
+              </InputBarProvider>
+            </DropzoneContainer>
+          </FileDropProvider>
+        </div>
       </div>
     </>
   );

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import type {
   AgentActionSpecificEvent,
   AgentActionSuccessEvent,
+  AgentConfigurationViewType,
   AgentErrorEvent,
   AgentMessageSuccessEvent,
   APIError,
@@ -482,9 +483,13 @@ export class DustAPI {
     return new Ok(r.value.data_sources);
   }
 
-  async getAgentConfigurations() {
+  async getAgentConfigurations(view?: AgentConfigurationViewType) {
+    const path = view
+      ? `assistant/agent_configurations?view=${view}`
+      : "assistant/agent_configurations";
+
     const res = await this.request({
-      path: "assistant/agent_configurations",
+      path,
       method: "GET",
     });
 

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -755,6 +755,19 @@ const AgentConfigurationScopeSchema = FlexibleEnumSchema([
   "private",
 ]);
 
+export const AgentConfigurationViewSchema = FlexibleEnumSchema([
+  "all",
+  "list",
+  "workspace",
+  "published",
+  "global",
+  "favorites",
+]);
+
+export type AgentConfigurationViewType = z.infer<
+  typeof AgentConfigurationViewSchema
+>;
+
 const AgentUsageTypeSchema = z.object({
   messageCount: z.number(),
   timePeriodSec: z.number(),


### PR DESCRIPTION
## Description

Following this https://github.com/dust-tt/dust/pull/8779

Displays the favorites on the extension. Clicking on an assistant will scroll up if necessary and set the mention. 
Design still to be discussed with Alex cause I'm not sure what exact scrolling behavior we want + the current component for preview in minimal still displays the 3 dots menu when we don't want it. 

I figured out this could already be submitted as is and will iterate on ongoing PRs. 

## Risk

This edits both the extension and the sdk to add a new optional param. 
Should be safe as param is optional but just in case, it can be rolled back. 

## Deploy Plan

No deploy. 
