### PR TITLE
[connectors] Add rich titles to Zendesk Help Centers and Tickets when necessary

### DIFF
--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -485,9 +485,11 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     return new Ok([
       ...brands.map((brand) => brand.toContentNode(connectorId)),
       ...brandHelpCenters.map((brand) =>
-        brand.getHelpCenterContentNode(connectorId)
+        brand.getHelpCenterContentNode(connectorId, { richTitle: true })
       ),
-      ...brandTickets.map((brand) => brand.getTicketsContentNode(connectorId)),
+      ...brandTickets.map((brand) =>
+        brand.getTicketsContentNode(connectorId, { richTitle: true })
+      ),
       ...categories.map((category) => category.toContentNode(connectorId)),
       ...articles.map((article) => article.toContentNode(connectorId)),
       ...tickets.map((ticket) => ticket.toContentNode(connectorId)),

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -39,18 +39,18 @@ export async function retrieveAllSelectedNodes(
     .filter(
       (brand) => brand.hasHelpCenter && brand.helpCenterPermission === "read"
     )
-    .map((brand) => ({
-      ...brand.getHelpCenterContentNode(connectorId, { richTitle: true }),
-    }));
+    .map((brand) =>
+      brand.getHelpCenterContentNode(connectorId, { richTitle: true })
+    );
 
   const ticketNodes: ContentNode[] = brands
     .filter((brand) => brand.ticketsPermission === "read")
-    .map((brand) => ({
-      ...brand.getTicketsContentNode(connectorId, {
+    .map((brand) =>
+      brand.getTicketsContentNode(connectorId, {
         expandable: true,
         richTitle: true,
-      }),
-    }));
+      })
+    );
 
   return [...helpCenterNodes, ...ticketNodes];
 }

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -40,15 +40,16 @@ export async function retrieveAllSelectedNodes(
       (brand) => brand.hasHelpCenter && brand.helpCenterPermission === "read"
     )
     .map((brand) => ({
-      ...brand.getHelpCenterContentNode(connectorId),
-      title: `${brand.name} - Help Center`, // adding the name of the brand since this will be named "Help Center" otherwise
+      ...brand.getHelpCenterContentNode(connectorId, { richTitle: true }),
     }));
 
   const ticketNodes: ContentNode[] = brands
     .filter((brand) => brand.ticketsPermission === "read")
     .map((brand) => ({
-      ...brand.getTicketsContentNode(connectorId, { expandable: true }),
-      title: `${brand.name} - Tickets`, // adding the name of the brand since this will be named "Tickets" otherwise
+      ...brand.getTicketsContentNode(connectorId, {
+        expandable: true,
+        richTitle: true,
+      }),
     }));
 
   return [...helpCenterNodes, ...ticketNodes];

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -328,14 +328,17 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
     };
   }
 
-  getHelpCenterContentNode(connectorId: number): ContentNode {
+  getHelpCenterContentNode(
+    connectorId: number,
+    { richTitle = false }: { richTitle?: boolean } = {}
+  ): ContentNode {
     const { brandId } = this;
     return {
       provider: "zendesk",
       internalId: getHelpCenterInternalId({ connectorId, brandId }),
       parentInternalId: getBrandInternalId({ connectorId, brandId }),
       type: "folder",
-      title: `Help Center`,
+      title: richTitle ? `${this.name} - Help Center` : "Help Center",
       sourceUrl: null,
       expandable: true,
       permission: this.helpCenterPermission,
@@ -346,7 +349,10 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
 
   getTicketsContentNode(
     connectorId: number,
-    { expandable = false }: { expandable?: boolean } = {}
+    {
+      expandable = false,
+      richTitle = false,
+    }: { expandable?: boolean; richTitle?: boolean } = {}
   ): ContentNode {
     const { brandId } = this;
     return {
@@ -354,7 +360,7 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
       internalId: getTicketsInternalId({ connectorId, brandId }),
       parentInternalId: getBrandInternalId({ connectorId, brandId }),
       type: "folder",
-      title: `Tickets`,
+      title: richTitle ? `${this.name} - Tickets` : "Tickets",
       sourceUrl: null,
       expandable: expandable,
       permission: this.ticketsPermission,


### PR DESCRIPTION
## Description

- Replace titles of the form `Help Center/Tickets` with `brandName - Help Center/Tickets` in the response of `/content_nodes`.

Before:
![image (2)](https://github.com/user-attachments/assets/39198377-b687-4990-85a2-8100bce44d9c)

After:
<img width="314" alt="Screenshot 2024-11-22 at 12 44 10 PM" src="https://github.com/user-attachments/assets/26216616-bb37-490b-9cf2-e6f988c52133">

## Risk

Low, at worst it shows the Brand name when not absolutely needed.

## Deploy Plan

- Deploy connectors.