### PR TITLE
[Connectors] Log the URL when getting 404 in Zendesk

### DIFF
--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -137,7 +137,7 @@ async function fetchFromZendeskWithRetries({
     if (rawResponse.status === 404) {
       logger.error(
         { rawResponse, text: rawResponse.text },
-        "[Zendesk] Zendesk API 404 error"
+        `[Zendesk] Zendesk API 404 error on: ${url}`
       );
       return null;
     }


### PR DESCRIPTION
## Description

- We get [404 errors](https://app.datadoghq.eu/logs?query=status%3Aerror%20%40dd.service%3Aconnectors-worker%20%40dd.env%3Aprod%20%40hostname%3Aconnectors-worker-zendesk-deployment-7ddf8577d5-wg4bt&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZNTotky9vZ6JQAAABhBWk5Ub3VXcUFBQ1o3ejRMOEY1QS13QUEAAAAkMDE5MzUzYTktNzZhYy00MDYyLWJhNTItYmIyNzZlN2RlNmNhAAAeUQ&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=7335969944735129240&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1732187374713&to_ts=1732273774713&live=true) in Zendesk API.
- We currently do not log enough information to investigate.
- This PR adds the URL queried.

## Risk

Wondering if this leaks too much data.

## Deploy Plan

- Deploy connectors.
