### PR TITLE
[connectors] Handle Zendesk brands that have no help center

### DIFF
--- a/connectors/src/connectors/zendesk/lib/brand_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/brand_permissions.ts
@@ -58,7 +58,7 @@ export async function allowSyncZendeskBrand({
         brandId: fetchedBrand.id,
         name: fetchedBrand.name || "Brand",
         ticketsPermission: "read",
-        helpCenterPermission: "read",
+        helpCenterPermission: fetchedBrand.has_help_center ? "read" : "none",
         hasHelpCenter: fetchedBrand.has_help_center,
         url: fetchedBrand.url,
       },

--- a/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
@@ -32,7 +32,7 @@ export async function allowSyncZendeskHelpCenter({
     brandId,
   });
 
-  if (brand) {
+  if (brand && brand.hasHelpCenter) {
     await brand.grantHelpCenterPermissions();
   } else {
     // fetching the brand from Zendesk
@@ -55,7 +55,7 @@ export async function allowSyncZendeskHelpCenter({
         brandId: fetchedBrand.id,
         name: fetchedBrand.name || "Brand",
         ticketsPermission: "none",
-        helpCenterPermission: "read",
+        helpCenterPermission: fetchedBrand.has_help_center ? "read" : "none",
         hasHelpCenter: fetchedBrand.has_help_center,
         url: fetchedBrand.url,
       },

--- a/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
@@ -32,7 +32,7 @@ export async function allowSyncZendeskHelpCenter({
     brandId,
   });
 
-  if (brand && brand.hasHelpCenter) {
+  if (brand) {
     await brand.grantHelpCenterPermissions();
   } else {
     // fetching the brand from Zendesk
@@ -55,7 +55,7 @@ export async function allowSyncZendeskHelpCenter({
         brandId: fetchedBrand.id,
         name: fetchedBrand.name || "Brand",
         ticketsPermission: "none",
-        helpCenterPermission: fetchedBrand.has_help_center ? "read" : "none",
+        helpCenterPermission: "read",
         hasHelpCenter: fetchedBrand.has_help_center,
         url: fetchedBrand.url,
       },


### PR DESCRIPTION
## Description

- Previously, we got [404](https://app.datadoghq.eu/logs?query=%40dd.service%3Aconnectors-worker%20%40dd.env%3Aprod%20%40hostname%3Aconnectors-worker-zendesk-deployment-7c78bf5677-h8zld&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZNT2AYUpizadQAAABhBWk5UMkJMcUFBQU42UFo1ZFpCVWt3QUEAAAAkMDE5MzUzZDgtOWFmMi00NGUxLTlhMjMtOGQ0MmYxMGJiMjdmAAAMog&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=7335969944735129240&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1732187374713&to_ts=1732273774713&live=true) when selecting a whole brand that had no help center.
- This issue occurred because selecting a whole brand sets its help center permissions to true, which led to a sync that would query its categories (ergo the 404).
- This PR prevents the `helpCenterPermissions` from being set to `read` if the brand has no help center.

## Risk

Very low, no customer ever has a brand without a help center, and the errors do no harm.

## Deploy Plan

- Deploy connectors.
