### PR TITLE
[front/sparkle] - fix: Input / TextArea

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -859,7 +859,7 @@ function ActionEditor({
   );
 
   return (
-    <>
+    <div className="px-1">
       <ActionModeSection show={true}>
         <div className="flex w-full flex-row items-center justify-between px-1">
           <Page.Header
@@ -965,7 +965,7 @@ function ActionEditor({
           />
         </div>
       )}
-    </>
+    </div>
   );
 }
 

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -208,7 +208,7 @@ export function CreateOrEditSpaceModal({
       onSave={onSave}
     >
       <Page.Vertical gap="md" sizing="grow">
-        <div className="flex w-full flex-col gap-y-4 overflow-y-hidden">
+        <div className="flex w-full flex-col gap-y-4 overflow-y-hidden px-1">
           <div className="mb-4 flex w-full flex-col gap-y-2 pt-2">
             <Page.SectionHeader title="Name" />
             <Input

--- a/front/components/spaces/SpaceWebsiteModal.tsx
+++ b/front/components/spaces/SpaceWebsiteModal.tsx
@@ -654,7 +654,7 @@ const AdvancedSettingsModal = ({
           <div className="flex flex-col gap-4">
             {headers.map((header, index) => (
               <div key={index} className="flex gap-2">
-                <div className="flex grow flex-col gap-1">
+                <div className="flex grow flex-col gap-1 px-1">
                   <Input
                     placeholder="Header Name"
                     value={header.key}

--- a/sparkle/src/components/TextArea.tsx
+++ b/sparkle/src/components/TextArea.tsx
@@ -29,7 +29,7 @@ const textAreaVariants = cva(
       error: {
         true: "s-ring-warning-200 focus:s-ring-warning-300 dark:s-ring-warning-200-dark dark:focus:s-ring-warning-300-dark",
         false:
-          "s-ring-structure-200 focus:s-ring-action-300 dark:s-ring-structure-300-dark dark:focus:s-ring-action-300-dark",
+          "s-ring-structure-200 dark:s-ring-structure-300-dark dark:focus:s-ring-action-300-dark",
       },
       disabled: {
         true: "disabled:s-cursor-not-allowed disabled:s-text-muted-foreground",


### PR DESCRIPTION
## Description

This PR aims at fixing the modal `x` padding which was causing some inputs' rings to be cropped. It also removes an unwanted tailwind class on the `TextArea` component which was overriding the desired one.

## Risk

Low

## Deploy Plan

N/A
