### PR TITLE
[connectors] Fix timeouts when syncing Zendesk articles

### DIFF
--- a/connectors/src/@types/node-zendesk.d.ts
+++ b/connectors/src/@types/node-zendesk.d.ts
@@ -208,6 +208,9 @@ declare module "node-zendesk" {
       };
       sections: {
         list: () => Promise<ZendeskFetchedSection[]>;
+        listByCategory: (
+          categoryId: number
+        ) => Promise<ZendeskFetchedSection[]>;
         show: (
           sectionId: number
         ) => Promise<{ response: Response; result: ZendeskFetchedSection }>;

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -333,7 +333,9 @@ export async function syncZendeskArticleBatchActivity({
 
   const sections =
     await zendeskApiClient.helpcenter.sections.listByCategory(categoryId);
-  const users = await zendeskApiClient.users.list();
+  const { result: users } = await zendeskApiClient.users.showMany(
+    articles.map((article) => article.author_id)
+  );
 
   await concurrentExecutor(
     articles,

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -331,7 +331,8 @@ export async function syncZendeskArticleBatchActivity({
     `[Zendesk] Processing ${articles.length} articles in batch`
   );
 
-  const sections = await zendeskApiClient.helpcenter.sections.list();
+  const sections =
+    await zendeskApiClient.helpcenter.sections.listByCategory(categoryId);
   const users = await zendeskApiClient.users.list();
 
   await concurrentExecutor(


### PR DESCRIPTION
## Description

- We have [Zendesk article sync activities that time out](https://cloud.temporal.io/namespaces/dust-prod.gmnlm/workflows/zendesk-sync-10675-help-center-23166858766481/83c93296-0f60-4bc1-947e-908816761606/pending-activities).
- These activities are stuck after `[Zendesk] Processing ${articles.length} articles in batch` and before we ever get into `syncArticle`.
- We run two absolutely HUGE queries for no particular reason between these two logs.
- This PR aims at fetching less data: instead of retrieving all the Sections and all the Users we only retrieve:
  - The users we need (there is an [endpoint for retrieving a batch of users given their ID](https://developer.zendesk.com/api-reference/ticketing/users/users/#show-many-users)).
  - The sections for the category considered, which is still too much and should be evaluated against fetching each section required individually.

## Risk

Low.

## Deploy Plan

- Deploy connectors