### PR TITLE
[connectors] Improve logging on Zendesk API errors

### DIFF
--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -157,7 +157,7 @@ async function fetchFromZendeskWithRetries({
         return null;
       }
     }
-    logger.error({ rawResponse }, "[Zendesk] Zendesk API error");
+    logger.error({ rawResponse, response }, "[Zendesk] Zendesk API error");
     throw new Error("Zendesk API error.");
   }
 

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -157,7 +157,10 @@ async function fetchFromZendeskWithRetries({
         return null;
       }
     }
-    logger.error({ rawResponse, response }, "[Zendesk] Zendesk API error");
+    logger.error(
+      { rawResponse, response, status: rawResponse.status },
+      "[Zendesk] Zendesk API error"
+    );
     throw new Error("Zendesk API error.");
   }
 


### PR DESCRIPTION
## Description

- This PR adds the response and status to the logs on Zendesk API errors.
- I don't understand why we could not see the rawResponse in [the logs](https://app.datadoghq.eu/logs?query=%40dd.service%3Aconnectors-worker%20%40dd.env%3Aprod%20%40hostname%3Aconnectors-worker-zendesk-deployment-74995fb698-5cng9%20%22Zendesk%20API%20error%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZNUjglWU8448AAAABhBWk5VamhnSkFBQzZxNzRxME5uRnB3QUIAAAAkMDE5MzU0OGUtNDBmMC00N2RkLTkwZTktMGE4YjM1YWM2OGQxAAAgOQ&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=6000198897476506285&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1732283729307&to_ts=1732284629307&live=true).

## Risk

Low.

## Deploy Plan

- Deploy connectors.