### PR TITLE
[connectors] Remove unnecessary columns in zendesk_tickets

### DIFF
--- a/connectors/migrations/db/migration_38.sql
+++ b/connectors/migrations/db/migration_38.sql
@@ -1,0 +1,4 @@
+-- Migration created on Nov 22, 2024
+ALTER TABLE "zendesk_tickets" DROP COLUMN "assigneeId";
+ALTER TABLE "zendesk_tickets" DROP COLUMN "groupId";
+ALTER TABLE "zendesk_tickets" DROP COLUMN "organizationId";

--- a/connectors/src/connectors/zendesk/lib/sync_article.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_article.ts
@@ -84,16 +84,13 @@ export async function syncArticle({
     !articleInDb.lastUpsertedTs ||
     articleInDb.lastUpsertedTs < updatedAtDate; // upserting if the article was updated after the last upsert
 
-  const updatableFields = {
-    categoryId: category.categoryId, // an article can be moved from one category to another, which does not apply to brands
-    name: article.name,
-    url: article.html_url,
-  };
   // we either create a new article or update the existing one
   if (!articleInDb) {
     articleInDb = await ZendeskArticleResource.makeNew({
       blob: {
-        ...updatableFields,
+        categoryId: category.categoryId, // an article can be moved from one category to another, which does not apply to brands
+        name: article.name,
+        url: article.html_url,
         articleId: article.id,
         brandId: category.brandId,
         permission: "read",
@@ -101,7 +98,11 @@ export async function syncArticle({
       },
     });
   } else {
-    await articleInDb.update(updatableFields);
+    await articleInDb.update({
+      categoryId: category.categoryId, // an article can be moved from one category to another, which does not apply to brands
+      name: article.name,
+      url: article.html_url,
+    });
   }
 
   logger.info(

--- a/connectors/src/connectors/zendesk/lib/sync_category.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_category.ts
@@ -63,16 +63,13 @@ export async function syncCategory({
     connectorId,
     categoryId: category.id,
   });
-  const updatableFields = {
-    name: category.name || "Category",
-    url: category.html_url,
-    description: category.description,
-    lastUpsertedTs: new Date(currentSyncDateMs),
-  };
   if (!categoryInDb) {
     await ZendeskCategoryResource.makeNew({
       blob: {
-        ...updatableFields,
+        name: category.name || "Category",
+        url: category.html_url,
+        description: category.description,
+        lastUpsertedTs: new Date(currentSyncDateMs),
         connectorId,
         brandId,
         categoryId: category.id,
@@ -80,6 +77,11 @@ export async function syncCategory({
       },
     });
   } else {
-    await categoryInDb.update(updatableFields);
+    await categoryInDb.update({
+      name: category.name || "Category",
+      url: category.html_url,
+      description: category.description,
+      lastUpsertedTs: new Date(currentSyncDateMs),
+    });
   }
 }

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -85,17 +85,13 @@ export async function syncTicket({
     !ticketInDb.lastUpsertedTs ||
     ticketInDb.lastUpsertedTs < updatedAtDate;
 
-  const commonTicketData = {
-    subject: ticket.subject,
-    url: ticket.url.replace("/api/v2/", "/").replace(".json", ""), // converting the API URL into the web URL
-    lastUpsertedTs: new Date(currentSyncDateMs),
-    ticketUpdatedAt: updatedAtDate,
-  };
-
   if (!ticketInDb) {
     ticketInDb = await ZendeskTicketResource.makeNew({
       blob: {
-        ...commonTicketData,
+        subject: ticket.subject,
+        url: ticket.url.replace("/api/v2/", "/").replace(".json", ""), // converting the API URL into the web URL
+        lastUpsertedTs: new Date(currentSyncDateMs),
+        ticketUpdatedAt: updatedAtDate,
         ticketId: ticket.id,
         brandId,
         permission: "read",
@@ -103,7 +99,13 @@ export async function syncTicket({
       },
     });
   } else {
-    await ticketInDb.update({ ...commonTicketData, permission: "read" });
+    await ticketInDb.update({
+      subject: ticket.subject,
+      url: ticket.url.replace("/api/v2/", "/").replace(".json", ""), // converting the API URL into the web URL
+      lastUpsertedTs: new Date(currentSyncDateMs),
+      ticketUpdatedAt: updatedAtDate,
+      permission: "read",
+    });
   }
 
   if (!shouldPerformUpsertion) {

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -85,15 +85,9 @@ export async function syncTicket({
     !ticketInDb.lastUpsertedTs ||
     ticketInDb.lastUpsertedTs < updatedAtDate;
 
-  // ticket.url is the json api url, we need to convert it to the web url
-  const ticketUrl = ticket.url.replace("/api/v2/", "/").replace(".json", "");
-
   const commonTicketData = {
     subject: ticket.subject,
-    url: ticketUrl,
-    assigneeId: ticket.assignee_id,
-    groupId: ticket.group_id,
-    organizationId: ticket.organization_id,
+    url: ticket.url.replace("/api/v2/", "/").replace(".json", ""), // converting the API URL into the web URL
     lastUpsertedTs: new Date(currentSyncDateMs),
     ticketUpdatedAt: updatedAtDate,
   };

--- a/connectors/src/lib/models/zendesk.ts
+++ b/connectors/src/lib/models/zendesk.ts
@@ -397,10 +397,6 @@ export class ZendeskTicket extends Model<
   declare brandId: number;
   declare permission: "read" | "none";
 
-  declare assigneeId: number | null;
-  declare groupId: number | null;
-  declare organizationId: number | null;
-
   declare subject: string;
   declare url: string;
 
@@ -443,21 +439,6 @@ ZendeskTicket.init(
     brandId: {
       type: DataTypes.BIGINT,
       allowNull: false,
-      validate: { throwOnUnsafeInteger },
-    },
-    groupId: {
-      type: DataTypes.BIGINT,
-      allowNull: true,
-      validate: { throwOnUnsafeInteger },
-    },
-    assigneeId: {
-      type: DataTypes.BIGINT,
-      allowNull: true,
-      validate: { throwOnUnsafeInteger },
-    },
-    organizationId: {
-      type: DataTypes.BIGINT,
-      allowNull: true,
       validate: { throwOnUnsafeInteger },
     },
     permission: {


### PR DESCRIPTION
## Description

- Remove the columns `assigneeId`, `groupId`, `organizationId` from the table `zendesk_tickets` (not used anywhere).

## Risk

Low.

## Deploy Plan

- Deploy connectors.
- Run migration