### PR TITLE
[connectors] Increase `ZENDESK_BATCH_SIZE` 🔧 

### DIFF
--- a/connectors/src/connectors/zendesk/temporal/config.ts
+++ b/connectors/src/connectors/zendesk/temporal/config.ts
@@ -3,4 +3,4 @@ export const QUEUE_NAME = `zendesk-queue-v${WORKFLOW_VERSION}`;
 
 // Batch size used when fetching from Zendesk API or from the database
 // 100 is the maximum value allowed for most endpoints in Zendesk: https://developer.zendesk.com/api-reference/introduction/pagination/
-export const ZENDESK_BATCH_SIZE = 30;
+export const ZENDESK_BATCH_SIZE = 50;


### PR DESCRIPTION
## Description

- One batch of articles/tickets [typically takes 6 min to get processed](https://cloud.temporal.io/namespaces/dust-prod.gmnlm/workflows/zendesk-sync-10672-brand-454645/867dfb4f-13ca-49a1-bba7-ac5613d4834d/history).
- This PR brings up the batch size from 30 to 50 for a faster processing.

## Risk

Low.

## Deploy Plan

- Deploy connectors.