### PR TITLE
Add: upsert table query output to use in JIT actions

### DIFF
--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -11,8 +11,11 @@ import {
   TrashIcon,
   XMarkIcon,
 } from "@dust-tt/sparkle";
-import type { WorkspaceType } from "@dust-tt/types";
 import type { ConversationType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
+import { isDevelopment } from "@dust-tt/types";
+import { BugIcon } from "lucide-react";
+import { useRouter } from "next/router";
 import type { MouseEvent } from "react";
 import React, { useRef, useState } from "react";
 import { useSWRConfig } from "swr";
@@ -31,6 +34,7 @@ export function ConversationTitle({
   shareLink: string;
   onDelete?: (conversationId: string) => void;
 }) {
+  const router = useRouter();
   const { mutate } = useSWRConfig();
 
   const [copyLinkSuccess, setCopyLinkSuccess] = useState<boolean>(false);
@@ -189,6 +193,21 @@ export function ConversationTitle({
                 />
               )}
             </div>
+            {isDevelopment() && (
+              <div className="hidden lg:flex">
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  tooltip="Debug in Poke"
+                  icon={BugIcon}
+                  onClick={() =>
+                    void router.push(
+                      `/poke/${conversation.owner.sId}/conversations/${conversation.sId}`
+                    )
+                  }
+                />
+              </div>
+            )}
             <Popover
               popoverTriggerAsChild
               trigger={

--- a/front/lib/api/assistant/actions/conversation/include_file.ts
+++ b/front/lib/api/assistant/actions/conversation/include_file.ts
@@ -53,10 +53,10 @@ export function isConversationIncludableFileContentType(
     case "text/markdown":
     case "text/plain":
     case "dust-application/slack":
-      return true;
-
     case "text/comma-separated-values":
     case "text/csv":
+      return true;
+
     case "text/tab-separated-values":
     case "text/tsv":
       return false;

--- a/front/lib/api/csv.ts
+++ b/front/lib/api/csv.ts
@@ -1,3 +1,6 @@
+import { parse } from "csv-parse/sync";
+import { stringify } from "csv-stringify/sync";
+
 const POSSIBLE_VALUES_MAX_LEN = 32;
 const POSSIBLE_VALUES_MAX_COUNT = 16;
 
@@ -97,4 +100,67 @@ export function analyzeCSVColumns(
   });
 
   return columnTypes;
+}
+
+export function generateCSVSnippet(content: string): string {
+  // Max number of characters in the snippet.
+  const MAX_SNIPPET_CHARS = 16384;
+
+  const records = parse(content, {
+    columns: true,
+    skip_empty_lines: true,
+    trim: true,
+  });
+
+  if (records.length === 0) {
+    return "TOTAL_LINES: 0\n(empty result set)\n";
+  }
+
+  let snippetOutput = `TOTAL_LINES: ${records.length}\n`;
+  let currentCharCount = snippetOutput.length;
+  let linesIncluded = 0;
+
+  const truncationString = "(...truncated)";
+  const endOfSnippetString = (omitted: number) =>
+    omitted > 0 ? `\n(${omitted} lines omitted)\n` : "\n(end of file)\n";
+
+  // Process header
+  const header = stringify([records[0]], { header: true }).split("\n")[0];
+  if (currentCharCount + header.length + 1 <= MAX_SNIPPET_CHARS) {
+    snippetOutput += header + "\n";
+    currentCharCount += header.length + 1;
+  } else {
+    const remainingChars =
+      MAX_SNIPPET_CHARS - currentCharCount - truncationString.length;
+    if (remainingChars > 0) {
+      snippetOutput += header.slice(0, remainingChars) + truncationString;
+    }
+    snippetOutput += endOfSnippetString(records.length);
+    return snippetOutput;
+  }
+
+  // Process data rows
+  for (const row of records) {
+    const rowCsv = stringify([row], { header: false });
+    const trimmedRowCsv = rowCsv.trim(); // Remove trailing newline
+    if (currentCharCount + trimmedRowCsv.length + 1 <= MAX_SNIPPET_CHARS) {
+      snippetOutput += trimmedRowCsv + "\n";
+      currentCharCount += trimmedRowCsv.length + 1;
+      linesIncluded++;
+    } else {
+      const remainingChars =
+        MAX_SNIPPET_CHARS - currentCharCount - truncationString.length;
+      if (remainingChars > 0) {
+        snippetOutput +=
+          trimmedRowCsv.slice(0, remainingChars) + truncationString;
+        linesIncluded++;
+      }
+      break;
+    }
+  }
+
+  const linesOmitted = records.length - linesIncluded;
+  snippetOutput += endOfSnippetString(linesOmitted);
+
+  return snippetOutput;
 }

--- a/front/lib/api/csv.ts
+++ b/front/lib/api/csv.ts
@@ -106,17 +106,19 @@ export function generateCSVSnippet(content: string): string {
   // Max number of characters in the snippet.
   const MAX_SNIPPET_CHARS = 16384;
 
+  const totalRecords = content.split("\n").length - 1; // Avoid parsing the whole file before truncating
   const records = parse(content, {
     columns: true,
     skip_empty_lines: true,
     trim: true,
+    to: 256, // Limit the number of records to parse
   });
 
-  if (records.length === 0) {
+  if (totalRecords === 0) {
     return "TOTAL_LINES: 0\n(empty result set)\n";
   }
 
-  let snippetOutput = `TOTAL_LINES: ${records.length}\n`;
+  let snippetOutput = `TOTAL_LINES: ${totalRecords}\n`;
   let currentCharCount = snippetOutput.length;
   let linesIncluded = 0;
 
@@ -135,7 +137,7 @@ export function generateCSVSnippet(content: string): string {
     if (remainingChars > 0) {
       snippetOutput += header.slice(0, remainingChars) + truncationString;
     }
-    snippetOutput += endOfSnippetString(records.length);
+    snippetOutput += endOfSnippetString(totalRecords);
     return snippetOutput;
   }
 
@@ -159,7 +161,7 @@ export function generateCSVSnippet(content: string): string {
     }
   }
 
-  const linesOmitted = records.length - linesIncluded;
+  const linesOmitted = totalRecords - linesIncluded;
   snippetOutput += endOfSnippetString(linesOmitted);
 
   return snippetOutput;

--- a/front/lib/api/csv.ts
+++ b/front/lib/api/csv.ts
@@ -106,7 +106,7 @@ export function generateCSVSnippet(content: string): string {
   // Max number of characters in the snippet.
   const MAX_SNIPPET_CHARS = 16384;
 
-  const totalRecords = content.split("\n").length - 1; // Avoid parsing the whole file before truncating
+  const totalRecords = content.trim().split("\n").length - 1; // Avoid parsing the whole file before truncating
   const records = parse(content, {
     columns: true,
     skip_empty_lines: true,

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -5,7 +5,6 @@ import type {
 import type {
   ConnectorProvider,
   ConnectorType,
-  ConversationType,
   CoreAPIDataSource,
   CoreAPIDocument,
   CoreAPIError,
@@ -14,6 +13,7 @@ import type {
   DataSourceType,
   DataSourceWithConnectorDetailsType,
   FrontDataSourceDocumentSectionType,
+  ModelId,
   PlanType,
   Result,
   UpsertTableFromCsvRequestType,
@@ -729,14 +729,14 @@ export async function createDataSourceWithoutProvider(
     space,
     name,
     description,
-    conversation,
+    conversationId,
   }: {
     plan: PlanType;
     owner: WorkspaceType;
     space: SpaceResource;
     name: string;
     description: string | null;
-    conversation?: ConversationType;
+    conversationId?: ModelId;
   }
 ): Promise<
   Result<
@@ -829,7 +829,7 @@ export async function createDataSourceWithoutProvider(
         dustAPIDataSourceId: dustDataSource.value.data_source.data_source_id,
         workspaceId: owner.id,
         assistantDefaultSelected: false,
-        conversationId: conversation?.id,
+        conversationId: conversationId,
       },
       space
     );

--- a/front/lib/api/files/tool_output.ts
+++ b/front/lib/api/files/tool_output.ts
@@ -1,6 +1,8 @@
 import { Readable } from "stream";
 import { pipeline } from "stream/promises";
 
+import { isJITActionsEnabled } from "@app/lib/api/assistant/jit_actions";
+import { processAndUpsertToDataSource } from "@app/lib/api/files/upsert";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 
@@ -48,6 +50,13 @@ export async function internalCreateToolOutputCsvFile(
   ]);
 
   await fileResource.markAsReady();
+
+  if (await isJITActionsEnabled(auth)) {
+    await processAndUpsertToDataSource(auth, {
+      file: fileResource,
+      optionalContent: content,
+    });
+  }
 
   return fileResource;
 }

--- a/front/lib/api/files/tool_output.ts
+++ b/front/lib/api/files/tool_output.ts
@@ -5,15 +5,18 @@ import { isJITActionsEnabled } from "@app/lib/api/assistant/jit_actions";
 import { processAndUpsertToDataSource } from "@app/lib/api/files/upsert";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
+import logger from "@app/logger/logger";
 
 export async function internalCreateToolOutputCsvFile(
   auth: Authenticator,
   {
     title,
+    conversationId,
     content,
     contentType,
   }: {
     title: string;
+    conversationId: string;
     content: string;
     contentType: "text/csv";
   }
@@ -28,6 +31,9 @@ export async function internalCreateToolOutputCsvFile(
     fileName: title,
     fileSize: Buffer.byteLength(content),
     useCase: "tool_output",
+    useCaseMetadata: {
+      conversationId,
+    },
   });
 
   // Write both the "original" and "processed" versions simultaneously
@@ -52,10 +58,19 @@ export async function internalCreateToolOutputCsvFile(
   await fileResource.markAsReady();
 
   if (await isJITActionsEnabled(auth)) {
-    await processAndUpsertToDataSource(auth, {
+    const r = await processAndUpsertToDataSource(auth, {
       file: fileResource,
       optionalContent: content,
     });
+    if (r.isErr()) {
+      logger.error(
+        {
+          code: r.error.code,
+          message: r.error.message,
+        },
+        "Failed to process and upsert to data source"
+      );
+    }
   }
 
   return fileResource;

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -1,8 +1,8 @@
 import type {
-  ConversationType,
   FileUseCase,
   PlainTextContentType,
   Result,
+  SupportedFileContentType,
 } from "@dust-tt/types";
 import {
   assertNever,
@@ -18,9 +18,9 @@ import { Writable } from "stream";
 import { pipeline } from "stream/promises";
 
 import { runAction } from "@app/lib/actions/server";
-import { getConversation } from "@app/lib/api/assistant/conversation";
 import { isJITActionsEnabled } from "@app/lib/api/assistant/jit_actions";
 import config from "@app/lib/api/config";
+import { generateCSVSnippet } from "@app/lib/api/csv";
 import {
   createDataSourceWithoutProvider,
   upsertDocument,
@@ -28,6 +28,7 @@ import {
 } from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
+import { Conversation } from "@app/lib/models/assistant/conversation";
 import { cloneBaseConfig, DustProdActionRegistry } from "@app/lib/registry";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import type { FileResource } from "@app/lib/resources/file_resource";
@@ -68,98 +69,115 @@ const notSupportedError: ProcessingFunction = async ({ file }) => {
 
 async function generateSnippet(
   auth: Authenticator,
-  content: string
+  content: string,
+  contentType: SupportedFileContentType
 ): Promise<Result<string, Error>> {
   const owner = auth.getNonNullableWorkspace();
 
-  const model = getSmallWhitelistedModel(owner);
-  if (!model) {
-    return new Err(
-      new Error(`Failed to find a whitelisted model to generate title`)
-    );
-  }
+  if (
+    contentType === "text/csv" ||
+    contentType === "text/comma-separated-values"
+  ) {
+    const snippet = generateCSVSnippet(content);
 
-  const appConfig = cloneBaseConfig(
-    DustProdActionRegistry["conversation-file-summarizer"].config
-  );
-  appConfig.MODEL.provider_id = model.providerId;
-  appConfig.MODEL.model_id = model.modelId;
-
-  const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-  const resTokenize = await coreAPI.tokenize({
-    text: content,
-    providerId: model.providerId,
-    modelId: model.modelId,
-  });
-
-  if (resTokenize.isErr()) {
-    return new Err(
-      new Error(
-        `Error tokenizing content: ${resTokenize.error.code} ${resTokenize.error.message}`
-      )
-    );
-  }
-
-  const tokensCount = resTokenize.value.tokens.length;
-  const allowedTokens = model.contextSize * 0.9;
-  if (tokensCount > allowedTokens) {
-    // Truncate the content to the context size * 0.9 using cross product
-    const truncateLength = Math.floor(
-      (allowedTokens * content.length) / tokensCount
-    );
-
-    logger.warn(
-      {
-        tokensCount,
-        contentLength: content.length,
-        contextSize: model.contextSize,
-      },
-      `Truncating content to ${truncateLength} characters`
-    );
-
-    content = content.slice(0, truncateLength);
-  }
-
-  const res = await runAction(auth, "conversation-file-summarizer", appConfig, [
-    {
-      content: content,
-    },
-  ]);
-
-  if (res.isErr()) {
-    return new Err(
-      new Error(
-        `Error generating snippet: ${res.error.type} ${res.error.message}`
-      )
-    );
-  }
-
-  const {
-    status: { run },
-    traces,
-    results,
-  } = res.value;
-
-  switch (run) {
-    case "errored":
-      const error = removeNulls(traces.map((t) => t[1][0][0].error)).join(", ");
-      return new Err(new Error(`Error generating snippet: ${error}`));
-    case "succeeded":
-      if (!results || results.length === 0) {
-        return new Err(
-          new Error(
-            `Error generating snippet: no results returned while run was successful`
-          )
-        );
-      }
-      const snippet = results[0][0].value as string;
-      return new Ok(snippet);
-    case "running":
+    return new Ok(snippet);
+  } else {
+    const model = getSmallWhitelistedModel(owner);
+    if (!model) {
       return new Err(
-        new Error(`Snippet generation is still running, should never happen.`)
+        new Error(`Failed to find a whitelisted model to generate title`)
       );
-    default:
-      assertNever(run);
+    }
+
+    const appConfig = cloneBaseConfig(
+      DustProdActionRegistry["conversation-file-summarizer"].config
+    );
+    appConfig.MODEL.provider_id = model.providerId;
+    appConfig.MODEL.model_id = model.modelId;
+
+    const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+    const resTokenize = await coreAPI.tokenize({
+      text: content,
+      providerId: model.providerId,
+      modelId: model.modelId,
+    });
+
+    if (resTokenize.isErr()) {
+      return new Err(
+        new Error(
+          `Error tokenizing content: ${resTokenize.error.code} ${resTokenize.error.message}`
+        )
+      );
+    }
+
+    const tokensCount = resTokenize.value.tokens.length;
+    const allowedTokens = model.contextSize * 0.9;
+    if (tokensCount > allowedTokens) {
+      // Truncate the content to the context size * 0.9 using cross product
+      const truncateLength = Math.floor(
+        (allowedTokens * content.length) / tokensCount
+      );
+
+      logger.warn(
+        {
+          tokensCount,
+          contentLength: content.length,
+          contextSize: model.contextSize,
+        },
+        `Truncating content to ${truncateLength} characters`
+      );
+
+      content = content.slice(0, truncateLength);
+    }
+
+    const res = await runAction(
+      auth,
+      "conversation-file-summarizer",
+      appConfig,
+      [
+        {
+          content: content,
+        },
+      ]
+    );
+
+    if (res.isErr()) {
+      return new Err(
+        new Error(
+          `Error generating snippet: ${res.error.type} ${res.error.message}`
+        )
+      );
+    }
+
+    const {
+      status: { run },
+      traces,
+      results,
+    } = res.value;
+
+    switch (run) {
+      case "errored":
+        const error = removeNulls(traces.map((t) => t[1][0][0].error)).join(
+          ", "
+        );
+        return new Err(new Error(`Error generating snippet: ${error}`));
+      case "succeeded":
+        if (!results || results.length === 0) {
+          return new Err(
+            new Error(
+              `Error generating snippet: no results returned while run was successful`
+            )
+          );
+        }
+        const snippet = results[0][0].value as string;
+        return new Ok(snippet);
+      case "running":
+        return new Err(
+          new Error(`Snippet generation is still running, should never happen.`)
+        );
+      default:
+        assertNever(run);
+    }
   }
 }
 
@@ -350,7 +368,7 @@ async function getFileContent(
 
 export async function processAndUpsertToDataSource(
   auth: Authenticator,
-  { file }: { file: FileResource }
+  { file, optionalContent }: { file: FileResource; optionalContent?: string }
 ): Promise<
   Result<
     FileResource,
@@ -394,7 +412,9 @@ export async function processAndUpsertToDataSource(
     });
   }
 
-  const content = await getFileContent(auth, file);
+  const content = optionalContent
+    ? optionalContent
+    : await getFileContent(auth, file);
 
   if (!content) {
     return new Err({
@@ -404,17 +424,22 @@ export async function processAndUpsertToDataSource(
     });
   }
 
-  const r = await getConversation(auth, file.useCaseMetadata.conversationId);
+  const workspace = auth.getNonNullableWorkspace();
 
-  if (r.isErr()) {
+  const conversation = await Conversation.findOne({
+    where: {
+      sId: file.useCaseMetadata.conversationId,
+      workspaceId: workspace.id,
+    },
+  });
+
+  if (conversation === null) {
     return new Err({
       name: "dust_error",
       code: "internal_server_error",
-      message: `Failed to fetch conversation : ${r.error}`,
+      message: `Failed to fetch conversation.`,
     });
   }
-
-  const conversation: ConversationType = r.value;
 
   // Fetch the datasource linked to the conversation...
   let dataSource = await DataSourceResource.fetchByConversationId(
@@ -435,7 +460,7 @@ export async function processAndUpsertToDataSource(
       space: conversationsSpace,
       name: name,
       description: "Files uploaded to conversation",
-      conversation: conversation,
+      conversationId: conversation.id,
     });
 
     if (r.isErr()) {
@@ -456,7 +481,7 @@ export async function processAndUpsertToDataSource(
       content,
       dataSource,
     }),
-    generateSnippet(auth, content),
+    generateSnippet(auth, content, file.contentType),
   ]);
 
   if (processingRes.isErr()) {

--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -190,6 +190,8 @@ export class AgentTablesQueryAction extends Model<
 
   declare step: number;
   declare resultsFileId: ForeignKey<FileModel["id"]> | null;
+
+  declare resultsFile: NonAttribute<FileModel>;
 }
 
 AgentTablesQueryAction.init(
@@ -273,6 +275,7 @@ FileModel.hasMany(AgentTablesQueryAction, {
   onDelete: "SET NULL",
 });
 AgentTablesQueryAction.belongsTo(FileModel, {
+  as: "resultsFile",
   foreignKey: { name: "resultsFileId", allowNull: true },
   onDelete: "SET NULL",
 });

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -383,6 +383,7 @@ async function renderFromFileId(
     contentType,
     excludeImages,
     fileId,
+    forceFullCSVInclude,
     model,
     title,
     textBytes,
@@ -391,6 +392,7 @@ async function renderFromFileId(
     contentType: string;
     excludeImages: boolean;
     fileId: string;
+    forceFullCSVInclude: boolean;
     model: ModelConfigurationType;
     title: string;
     textBytes: number | null;
@@ -436,6 +438,7 @@ async function renderFromFileId(
   } else {
     const shouldRetrieveSnippetVersion =
       contentType === "text/csv" &&
+      !forceFullCSVInclude &&
       textBytes &&
       textBytes > MAX_BYTE_SIZE_CSV_RENDER_FULL_CONTENT;
 
@@ -579,6 +582,7 @@ export async function renderContentFragmentForModel(
         contentType,
         excludeImages,
         fileId,
+        forceFullCSVInclude: message.snippet != null, // JIT
         model,
         title,
         textBytes,

--- a/types/src/front/assistant/actions/conversation/list_files.ts
+++ b/types/src/front/assistant/actions/conversation/list_files.ts
@@ -7,7 +7,6 @@ export type ConversationFileType = {
   title: string;
   contentType: SupportedContentFragmentType;
   snippet: string | null;
-  isUsableForJIT: boolean;
   isIncludable: boolean;
   isSearchable: boolean;
   isQueryable: boolean;

--- a/types/src/front/assistant/actions/index.ts
+++ b/types/src/front/assistant/actions/index.ts
@@ -4,7 +4,15 @@ import {
 } from "../../../front/assistant/generation";
 import { ModelConfigurationType } from "../../../front/lib/assistant";
 import { ModelId } from "../../../shared/model_id";
+import { SupportedContentFragmentType } from "../../content_fragment";
 import { ConversationType } from "../conversation";
+
+export type ActionGeneratedFileType = {
+  fileId: string;
+  title: string;
+  contentType: SupportedContentFragmentType;
+  snippet: string | null;
+};
 
 type BaseActionType =
   | "dust_app_run_action"
@@ -20,10 +28,20 @@ type BaseActionType =
 export abstract class BaseAction {
   readonly id: ModelId;
   readonly type: BaseActionType;
+  readonly generatedFiles: ActionGeneratedFileType[];
 
-  constructor(id: ModelId, type: BaseActionType) {
+  constructor(
+    id: ModelId,
+    type: BaseActionType,
+    generatedFiles: ActionGeneratedFileType[] = []
+  ) {
     this.id = id;
     this.type = type;
+    this.generatedFiles = generatedFiles;
+  }
+
+  getGeneratedFiles(): ActionGeneratedFileType[] {
+    return this.generatedFiles;
   }
 
   abstract renderForFunctionCall(): FunctionCallType;


### PR DESCRIPTION
## Description

Upsert table query output as a table datasource for JIT actions.
- Updated `BaseAction` to support that any action could generate files.
- Refactored `TableQueryActionType` to make generated files available to `BaseAction`.
- Make it so in case of JIT, we only include the full version of CSV files (or error).
- Bonus: added a "debug" button to go from convo to poke rendering.

## Risk

Behind a FF.

## Deploy Plan

No need for migration. Deploy `front`