### PR TITLE
[core] - fix: strip NULL bytes from text sections in DataSource

### DIFF
--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -588,7 +588,13 @@ impl DataSource {
         text: Section,
         preserve_system_tags: bool,
     ) -> Result<Document> {
-        let full_text = text.full_text();
+        // converting NULL byte ('\0') to an empty string ("")
+        let full_text = text.full_text().replace('\0', "");
+        let text = Section {
+            prefix: text.prefix.map(|p| p.replace('\0', "")),
+            content: text.content.map(|c| c.replace('\0', "")),
+            sections: text.sections,
+        };
         // Disallow preserve_system_tags=true if tags contains a string starting with the system
         // tag prefix prevents having duplicate system tags or have users accidentally add system
         // tags (from UI/API).


### PR DESCRIPTION
## Description

This PR replaces NULL bytes with an empty string to ensure text integrity during data manipulation because Postgres refuses to store null bytes.

More context [here](https://dust4ai.slack.com/archives/C05F84CFP0E/p1732430682687919)

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
