### PR TITLE
[connectors] - fix: handle missing error message for large file uploads

### DIFF
--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -858,7 +858,8 @@ export async function upsertTableFromCsv({
     if (dustRequestResult.status === 413) {
       throw new TablesError(
         "file_too_large",
-        dustRequestResult.data.error.message
+        dustRequestResult.data.error?.message ||
+          "File size exceeds the maximum limit"
       );
     }
     throw new Error(


### PR DESCRIPTION
## Description

Adds default error message for when the file size exceeds the maximum limit. Body size limit error is handled by next directly.

This aims to fix the following error:
```
TypeError: Cannot read properties of undefined (reading 'message')
    at upsertTableFromCsv (/app/src/lib/data_sources.ts:861:38)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at upsertGdriveTable (/app/src/connectors/google_drive/temporal/spreadsheets.ts:72:3)
    at processSheet (/app/src/connectors/google_drive/temporal/spreadsheets.ts:185:7)
    at <anonymous> (/app/src/connectors/google_drive/temporal/spreadsheets.ts:493:28)
    at syncOneFileTable (/app/src/connectors/google_drive/temporal/file.ts:329:17)
    at <anonymous> (/app/node_modules/p-queue/dist/index.js:118:36)
```

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
