### PR TITLE
nit: refer to actual action names when file too big to include

### DIFF
--- a/front/lib/api/assistant/actions/conversation/include_file.ts
+++ b/front/lib/api/assistant/actions/conversation/include_file.ts
@@ -26,6 +26,8 @@ import {
 import {
   DEFAULT_CONVERSATION_INCLUDE_FILE_ACTION_DESCRIPTION,
   DEFAULT_CONVERSATION_INCLUDE_FILE_ACTION_NAME,
+  DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME,
+  DEFAULT_CONVERSATION_SEARCH_ACTION_NAME,
 } from "@app/lib/api/assistant/actions/constants";
 import type { BaseActionRunParams } from "@app/lib/api/assistant/actions/types";
 import { BaseActionConfigurationServerRunner } from "@app/lib/api/assistant/actions/types";
@@ -209,8 +211,9 @@ export class ConversationIncludeFileAction extends BaseAction {
       model.contextSize / CONTEXT_SIZE_DIVISOR_FOR_INCLUDE
     ) {
       return finalize(
-        // TODO(spolu): refer to the tool exactly
-        `Error: File \`${this.params.fileId}\` has too many tokens to be included, use semantic search on the conversation files instead.`
+        `Error: File \`${this.params.fileId}\` has too many tokens to be included, ` +
+          `use the \`${DEFAULT_CONVERSATION_SEARCH_ACTION_NAME}\` or ` +
+          `\`${DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME}\` actions instead.`
       );
     }
 


### PR DESCRIPTION
## Description

When the file overflows the amount of context we allocate for inclusion, we show an error to the model inviting it to use semantic search or query tables on conversation files. This fixes the error message to refer to the actual action name specifically.

## Risk

N/A

## Deploy Plan

N/A