### PR TITLE
[connectors] Fix parameter order for Zendesk API

### DIFF
--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -196,11 +196,6 @@ export async function fetchZendeskCategoriesInBrand({
   categories: ZendeskFetchedCategory[];
   meta: { has_more: boolean; after_cursor: string };
 }> {
-  assert(
-    pageSize <= 100,
-    `pageSize must be at most 100 (current value: ${pageSize})` // https://developer.zendesk.com/api-reference/introduction/pagination
-  );
-
   const response = await fetchFromZendeskWithRetries({
     url:
       `https://${brandSubdomain}.zendesk.com/api/v2/help_center/categories?` +
@@ -262,11 +257,6 @@ export async function fetchZendeskArticlesInCategory({
   articles: ZendeskFetchedArticle[];
   meta: { has_more: boolean; after_cursor: string };
 }> {
-  assert(
-    pageSize <= 100,
-    `pageSize must be at most 100 (current value: ${pageSize})` // https://developer.zendesk.com/api-reference/introduction/pagination
-  );
-
   const response = await fetchFromZendeskWithRetries({
     url:
       `https://${brandSubdomain}.zendesk.com/api/v2/help_center/categories/${categoryId}/articles?` +
@@ -340,11 +330,6 @@ export async function fetchZendeskTicketsInBrand({
   tickets: ZendeskFetchedTicket[];
   meta: { has_more: boolean; after_cursor: string };
 }> {
-  assert(
-    pageSize <= 100,
-    `pageSize must be at most 100 (current value: ${pageSize})`
-  );
-
   const searchQuery = encodeURIComponent(
     `status:solved updated>${retentionPeriodDays}days`
   );

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -203,8 +203,9 @@ export async function fetchZendeskCategoriesInBrand({
 
   const response = await fetchFromZendeskWithRetries({
     url:
-      `https://${brandSubdomain}.zendesk.com/api/v2/help_center/categories?page[size]=${pageSize}` +
-      (cursor ? `&page[after]=${encodeURIComponent(cursor)}` : ""),
+      `https://${brandSubdomain}.zendesk.com/api/v2/help_center/categories?` +
+      (cursor ? `page[after]=${encodeURIComponent(cursor)}&` : "") +
+      `page[size]=${pageSize}`,
     accessToken,
   });
   return (
@@ -268,8 +269,9 @@ export async function fetchZendeskArticlesInCategory({
 
   const response = await fetchFromZendeskWithRetries({
     url:
-      `https://${brandSubdomain}.zendesk.com/api/v2/help_center/categories/${categoryId}/articles?page[size]=${pageSize}` +
-      (cursor ? `&page[after]=${encodeURIComponent(cursor)}` : ""),
+      `https://${brandSubdomain}.zendesk.com/api/v2/help_center/categories/${categoryId}/articles?` +
+      (cursor ? `page[after]=${encodeURIComponent(cursor)}&` : "") +
+      `page[size]=${pageSize}`,
     accessToken,
   });
   return (

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -1,5 +1,3 @@
-import assert from "node:assert";
-
 import type { ModelId } from "@dust-tt/types";
 import type { Client } from "node-zendesk";
 import { createClient } from "node-zendesk";

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -348,8 +348,9 @@ export async function fetchZendeskTicketsInBrand({
   );
   const response = await fetchFromZendeskWithRetries({
     url:
-      `https://${brandSubdomain}.zendesk.com/api/v2/search/export.json?query=${searchQuery}&filter[type]=ticket&page[size]=${pageSize}` +
-      (cursor ? `&page[after]=${encodeURIComponent(cursor)}` : ""),
+      `https://${brandSubdomain}.zendesk.com/api/v2/search/export.json?filter[type]=ticket` +
+      (cursor ? `&page[after]=${encodeURIComponent(cursor)}` : "") +
+      `&page[size]=${pageSize}&query=${searchQuery}`,
     accessToken,
   });
 


### PR DESCRIPTION
## Description

- This PR aims at fixing ["Invalid search: Request parameters do not match previous request parameters"](https://app.datadoghq.eu/logs?query=%40dd.service%3Aconnectors-worker%20%40dd.env%3Aprod%20%40hostname%3Aconnectors-worker-zendesk-deployment-%2A%20%22Zendesk%20API%20error%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZNebbklvRsAHAAAABhBWk5lYmNoakFBQlQ5MDRHby1BSkxBQUIAAAAkMDE5MzVlNzgtZGVmYi00OGU0LWEzMmYtZTNlZDhhNzM1ZTRmAAINEA&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=6000198897476506285&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1731920961786&to_ts=1732525761786&live=true) errors.
- A suspicion regarding these errors is that the order of the parameters matters in that we need to pass `page[size]` after `page[after]` since the latter circumvent the former. In the hypothesis that it does not, this PR could either be rolled back or kept as is.
- This PR also removes unused `asserts` (redundant with the place where the variable is defined).

## Risk

Low.

## Deploy Plan

- Deploy connectors.