### PR TITLE
[connectors] - fix: handle invalid string ids in base resource

### DIFF
--- a/connectors/src/resources/base_resource.ts
+++ b/connectors/src/resources/base_resource.ts
@@ -36,9 +36,7 @@ export abstract class BaseResource<M extends Model> {
     id: number | string
   ): Promise<T | null> {
     const parsedId = typeof id === "string" ? parseInt(id, 10) : id;
-    if (isNaN(parsedId)) {
-      return null;
-    }
+
     const blob = await this.model.findByPk(parsedId);
     if (!blob) {
       return null;

--- a/connectors/src/resources/base_resource.ts
+++ b/connectors/src/resources/base_resource.ts
@@ -36,6 +36,9 @@ export abstract class BaseResource<M extends Model> {
     id: number | string
   ): Promise<T | null> {
     const parsedId = typeof id === "string" ? parseInt(id, 10) : id;
+    if (isNaN(parsedId)) {
+      return null;
+    }
     const blob = await this.model.findByPk(parsedId);
     if (!blob) {
       return null;

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -390,6 +390,15 @@ export class ConnectorsAPI {
   async getConnector(
     connectorId: string
   ): Promise<ConnectorsAPIResponse<ConnectorType>> {
+    const parsedId = parseInt(connectorId, 10);
+    if (isNaN(parsedId)) {
+      const err: ConnectorsAPIError = {
+          type: "invalid_request_error",
+          message: "Invalid connector ID",
+      };
+      return new Err(err);
+    }
+
     const res = await this._fetchWithError(
       `${this._url}/connectors/${encodeURIComponent(connectorId)}`,
       {

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -393,8 +393,8 @@ export class ConnectorsAPI {
     const parsedId = parseInt(connectorId, 10);
     if (isNaN(parsedId)) {
       const err: ConnectorsAPIError = {
-          type: "invalid_request_error",
-          message: "Invalid connector ID",
+        type: "invalid_request_error",
+        message: "Invalid connector ID",
       };
       return new Err(err);
     }


### PR DESCRIPTION
## Description

This PR aims at fixing a few errors caused by a wrong id that cannot be parsed as int:
```
DatabaseError: column "nan" does not exist Error at Query.run (/app/node_modules/sequelize/src/dialects/postgres/query.js:76:25) at <anonymous> (/app/node_modules/sequelize/src/sequelize.js:650:28) at process.processTicksAndRejections (node:internal/process/task_queues:95:5) at PostgresQueryInterface.select (/app/node_modules/sequelize/src/dialects/abstract/query-interface.js:1001:12) at Function.findAll (/app/node_modules/sequelize/src/model.js:1824:21) at Function.findOne (/app/node_modules/sequelize/src/model.js:1998:12) at Function.findByPk (/app/node_modules/sequelize/src/model.js:1955:12) at Function.fetchById (/app/src/resources/base_resource.ts:39:18) at _getConnector (/app/src/api/get_connector.ts:29:21) at <anonymous> (/app/src/logger/withlogging.ts:17:7)
```

**References:**
 - [Logs](https://app.datadoghq.eu/logs?query=%40error.original.message%3A%22column%20%5C%22nan%5C%22%20does%20not%20exist%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZNUi3kX-Eg5IwAAABhBWk5VaTNfRUFBQVVVX1FBYUc3Z0lRQVYAAAAkMDE5MzU0OTQtOTY2MC00OTliLThlMTctN2E5NzY1YjczNmY3AAAl7A&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1731240406636&to_ts=1732536406636&live=true)
## Risk

Low

## Deploy Plan

Deploy connectors
