### PR TITLE
[front] - chore(SidebarMenu): keep action buttons visible

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -17,6 +17,7 @@ import {
   PlusIcon,
   RobotIcon,
   ScrollArea,
+  Separator,
   TrashIcon,
   XMarkIcon,
 } from "@dust-tt/sparkle";
@@ -200,95 +201,90 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
         )}
       >
         <div className="flex h-0 min-h-full w-full overflow-y-auto">
-          <ScrollArea className="w-full">
-            <div className="flex w-full flex-col px-2">
-              {isMultiSelect ? (
-                <div className={classNames("flex items-center pt-2")}>
-                  <div className="flex-grow" />
-                  <Button
-                    size="sm"
-                    icon={MoreIcon}
-                    variant="ghost"
-                    className="invisible"
-                  />
-                  <Button
-                    size="xs"
-                    variant="outline"
-                    icon={XMarkIcon}
-                    onClick={toggleMultiSelect}
-                    className="mr-2"
-                  />
-                  <Button
-                    icon={TrashIcon}
-                    size="xs"
-                    variant={
-                      selectedConversations.length === 0 ? "outline" : "warning"
-                    }
-                    disabled={selectedConversations.length === 0}
-                    onClick={() => setShowDeleteDialog("selection")}
-                  />
-                </div>
-              ) : (
-                <div className={classNames("flex justify-end gap-2 pt-2")}>
-                  <Button
-                    href={`/w/${owner.sId}/assistant/new`}
-                    label="New"
-                    icon={ChatBubbleBottomCenterPlusIcon}
-                    className="shrink"
-                    tooltip="Create a new conversation"
-                    onClick={() => {
-                      setSidebarOpen(false);
-                      const { cId } = router.query;
-                      const isNewConversation =
-                        router.pathname === "/w/[wId]/assistant/[cId]" &&
-                        typeof cId === "string" &&
-                        cId === "new";
+          <div className="flex w-full flex-col pl-2">
+            {isMultiSelect ? (
+              <div className="flex w-full items-center justify-end py-2 pr-2">
+                <Button
+                  size="xs"
+                  variant="outline"
+                  icon={XMarkIcon}
+                  onClick={toggleMultiSelect}
+                  className="mr-2"
+                />
+                <Button
+                  icon={TrashIcon}
+                  size="xs"
+                  variant={
+                    selectedConversations.length === 0 ? "outline" : "warning"
+                  }
+                  tooltip="Delete conversations"
+                  disabled={selectedConversations.length === 0}
+                  onClick={() => setShowDeleteDialog("selection")}
+                />
+              </div>
+            ) : (
+              <div className={classNames("flex justify-end gap-2 py-2 pr-2")}>
+                <Button
+                  href={`/w/${owner.sId}/assistant/new`}
+                  label="New"
+                  icon={ChatBubbleBottomCenterPlusIcon}
+                  className="shrink"
+                  tooltip="Create a new conversation"
+                  onClick={() => {
+                    setSidebarOpen(false);
+                    const { cId } = router.query;
+                    const isNewConversation =
+                      router.pathname === "/w/[wId]/assistant/[cId]" &&
+                      typeof cId === "string" &&
+                      cId === "new";
 
-                      if (isNewConversation && triggerInputAnimation) {
-                        triggerInputAnimation();
-                      }
-                    }}
-                  />
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button size="sm" icon={MoreIcon} variant="outline" />
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent>
-                      <DropdownMenuLabel>Assistants</DropdownMenuLabel>
+                    if (isNewConversation && triggerInputAnimation) {
+                      triggerInputAnimation();
+                    }
+                  }}
+                />
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button size="sm" icon={MoreIcon} variant="outline" />
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent>
+                    <DropdownMenuLabel>Assistants</DropdownMenuLabel>
+                    <DropdownMenuItem
+                      label="Create new assistant"
+                      href={`/w/${owner.sId}/builder/assistants/create`}
+                      icon={PlusIcon}
+                    />
+                    {isBuilder(owner) && (
                       <DropdownMenuItem
-                        label="Create new assistant"
-                        href={`/w/${owner.sId}/builder/assistants/create`}
-                        icon={PlusIcon}
+                        href={`/w/${owner.sId}/builder/assistants`}
+                        label="Manage assistants"
+                        icon={RobotIcon}
                       />
-                      {isBuilder(owner) && (
-                        <DropdownMenuItem
-                          href={`/w/${owner.sId}/builder/assistants`}
-                          label="Manage assistants"
-                          icon={RobotIcon}
-                        />
-                      )}
-                      <DropdownMenuLabel>Conversations</DropdownMenuLabel>
-                      <DropdownMenuItem
-                        label="Edit conversations"
-                        onClick={toggleMultiSelect}
-                        icon={ListCheckIcon}
-                        disabled={conversations.length === 0}
-                      />
-                      <DropdownMenuItem
-                        label="Clear conversation history"
-                        onClick={() => setShowDeleteDialog("all")}
-                        icon={TrashIcon}
-                        disabled={conversations.length === 0}
-                      />
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </div>
-              )}
-              {isConversationsError && (
-                <Label className="py-1 text-xs font-medium text-element-800">
-                  Error loading conversations
-                </Label>
-              )}
+                    )}
+                    <DropdownMenuLabel>Conversations</DropdownMenuLabel>
+                    <DropdownMenuItem
+                      label="Edit conversations"
+                      onClick={toggleMultiSelect}
+                      icon={ListCheckIcon}
+                      disabled={conversations.length === 0}
+                    />
+                    <DropdownMenuItem
+                      label="Clear conversation history"
+                      onClick={() => setShowDeleteDialog("all")}
+                      icon={TrashIcon}
+                      disabled={conversations.length === 0}
+                    />
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            )}
+            {isConversationsError && (
+              <Label className="py-1 text-xs font-medium text-element-800">
+                Error loading conversations
+              </Label>
+            )}
+            <Separator />
+            <ScrollArea className="w-full">
               {conversationsByDate &&
                 Object.keys(conversationsByDate).map((dateLabel) => (
                   <RenderConversations
@@ -302,8 +298,8 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
                     owner={owner}
                   />
                 ))}
-            </div>
-          </ScrollArea>
+            </ScrollArea>
+          </div>
         </div>
       </div>
     </>


### PR DESCRIPTION
## Description

This PR aims at keeping the action button sticky when editing conversations

![Screenshot 2024-11-25 at 13 30 12](https://github.com/user-attachments/assets/72a108eb-df5f-48ef-b700-42dff902235a)

**References:**
- https://github.com/dust-tt/tasks/issues/1691
 
## Risk

Low

## Deploy Plan

Deploy `front`