### PR TITLE
[connectors] Add full resync for Zendesk connectors

### DIFF
--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -617,13 +617,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
       return new Err(new Error("Connector not found"));
     }
     await connector.markAsUnpaused();
-
-    const brandIds = await ZendeskBrandResource.fetchAllBrandIds(connectorId);
-    const result = await launchZendeskSyncWorkflow(connector, { brandIds });
-    if (result.isErr()) {
-      return result;
-    }
-    return launchZendeskGarbageCollectionWorkflow(connector);
+    return this.resume();
   }
 
   async garbageCollect(): Promise<Result<string, Error>> {

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -208,9 +208,15 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
       return new Err(new Error("Connector not found"));
     }
 
+    // syncing all the brands syncs tickets and whole help centers when selected
     const brandIds = await ZendeskBrandResource.fetchAllBrandIds(connectorId);
+    // syncing individual categories syncs all the categories that were selected
+    const categoryIds =
+      await ZendeskCategoryResource.fetchIdsForConnector(connectorId);
+
     const result = await launchZendeskSyncWorkflow(connector, {
       brandIds,
+      categoryIds,
       forceResync: true,
     });
 

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -181,21 +181,21 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
       dataSourceId: dataSourceConfig.dataSourceId,
     };
 
-    let result = await launchZendeskSyncWorkflow(connector);
-    if (result.isErr()) {
+    const syncResult = await this.sync();
+    if (syncResult.isErr()) {
       logger.error(
-        { ...loggerArgs, error: result.error },
+        { ...loggerArgs, error: syncResult.error },
         "[Zendesk] Error resuming the sync workflow."
       );
-      return result;
+      return syncResult;
     }
-    result = await launchZendeskGarbageCollectionWorkflow(connector);
-    if (result.isErr()) {
+    const gcResult = await launchZendeskGarbageCollectionWorkflow(connector);
+    if (gcResult.isErr()) {
       logger.error(
-        { ...loggerArgs, error: result.error },
+        { ...loggerArgs, error: gcResult.error },
         "[Zendesk] Error resuming the garbage collection workflow."
       );
-      return result;
+      return gcResult;
     }
     return new Ok(undefined);
   }

--- a/connectors/src/connectors/zendesk/temporal/gc_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/gc_activities.ts
@@ -207,8 +207,9 @@ export async function removeEmptyCategoriesActivity(connectorId: number) {
   }
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
 
-  const categoryIds =
-    await ZendeskCategoryResource.fetchCategoryIdsForConnector(connectorId);
+  const categoryIds = (
+    await ZendeskCategoryResource.fetchIdsForConnector(connectorId)
+  ).map(({ categoryId }) => categoryId);
 
   const categoriesToDelete = new Set<number>();
   await concurrentExecutor(

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -443,13 +443,17 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
     return categories.map((category) => Number(category.get().categoryId));
   }
 
-  static async fetchCategoryIdsForConnector(
+  static async fetchIdsForConnector(
     connectorId: number
-  ): Promise<number[]> {
+  ): Promise<{ categoryId: number; brandId: number }[]> {
     const categories = await ZendeskCategory.findAll({
       where: { connectorId },
+      attributes: ["categoryId", "brandId"],
     });
-    return categories.map((category) => Number(category.get().categoryId));
+    return categories.map((category) => {
+      const { categoryId, brandId } = category.get();
+      return { categoryId, brandId };
+    });
   }
 
   static async fetchByCategoryId({

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -484,21 +484,6 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
     );
   }
 
-  static async fetchByBrandId({
-    connectorId,
-    brandId,
-  }: {
-    connectorId: number;
-    brandId: number;
-  }): Promise<ZendeskCategoryResource[]> {
-    const categories = await ZendeskCategory.findAll({
-      where: { connectorId, brandId },
-    });
-    return categories.map(
-      (category) => category && new this(this.model, category.get())
-    );
-  }
-
   static async fetchReadOnlyCategoryIdsByBrandId({
     connectorId,
     brandId,

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -499,6 +499,20 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
     );
   }
 
+  static async fetchReadOnlyCategoryIdsByBrandId({
+    connectorId,
+    brandId,
+  }: {
+    connectorId: number;
+    brandId: number;
+  }): Promise<number[]> {
+    const categories = await ZendeskCategory.findAll({
+      where: { connectorId, brandId, permission: "read" },
+      attributes: ["categoryId"],
+    });
+    return categories.map((category) => category.get().categoryId);
+  }
+
   static async fetchByBrandIdReadOnly({
     connectorId,
     brandId,


### PR DESCRIPTION
## Description

- Close #8876.
- Make Zendesk connectors full-resyncable, and triggering such full resyncs on `resume` and `unpause`.
- Rationalize behavior for `pause`/`unpause`, `stop`/`resume`.
- Target behavior: a full resync launches a sync workflow with signals including all the brands and all the categories that would not be synced through the first signals (i.e. categories from brands whose Help Center is not selected and that are allowed for read).

## Risk

Low.

## Deploy Plan

- Deploy connectors.