### PR TITLE
AgentMessageFeedbacks API

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1,5 +1,5 @@
 import type {
-  ConversationMessageEmojiSelectorProps,
+  ConversationMessageFeedbackSelectorProps,
   ConversationMessageSizeType,
 } from "@dust-tt/sparkle";
 import {
@@ -13,6 +13,7 @@ import {
   ConversationMessage,
   DocumentDuplicateIcon,
   EyeIcon,
+  FeedbackSelector,
   Markdown,
   Popover,
 } from "@dust-tt/sparkle";
@@ -83,7 +84,7 @@ interface AgentMessageProps {
   isInModal: boolean;
   isLastMessage: boolean;
   message: AgentMessageType;
-  messageEmoji?: ConversationMessageEmojiSelectorProps;
+  messageFeedback: ConversationMessageFeedbackSelectorProps;
   owner: WorkspaceType;
   user: UserType;
   size: ConversationMessageSizeType;
@@ -100,7 +101,7 @@ export function AgentMessage({
   isInModal,
   isLastMessage,
   message,
-  messageEmoji,
+  messageFeedback,
   owner,
   user,
   size,
@@ -368,6 +369,7 @@ export function AgentMessage({
             icon={ArrowPathIcon}
             disabled={isRetryHandlerProcessing || shouldStream}
           />,
+          <FeedbackSelector key="feedback-selector" {...messageFeedback} />,
         ];
 
   // References logic.
@@ -464,7 +466,6 @@ export function AgentMessage({
       name={`@${agentConfiguration.name}`}
       buttons={buttons}
       avatarBusy={agentMessageToRender.status === "created"}
-      messageEmoji={messageEmoji}
       renderName={() => {
         return (
           <div className="flex flex-row items-center gap-2">

--- a/front/components/assistant/conversation/ConversationLayout.tsx
+++ b/front/components/assistant/conversation/ConversationLayout.tsx
@@ -91,7 +91,7 @@ export default function ConversationLayout({
   ]);
 
   const { conversation, conversationError } = useConversation({
-    conversationId: activeConversationId,
+    conversationId: activeConversationId ?? "",
     workspaceId: owner.sId,
   });
 

--- a/front/components/assistant/conversation/ConversationLayout.tsx
+++ b/front/components/assistant/conversation/ConversationLayout.tsx
@@ -91,7 +91,7 @@ export default function ConversationLayout({
   ]);
 
   const { conversation, conversationError } = useConversation({
-    conversationId: activeConversationId ?? "",
+    conversationId: activeConversationId,
     workspaceId: owner.sId,
   });
 

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -28,9 +28,9 @@ import {
 } from "@app/lib/client/conversation/event_handlers";
 import {
   useConversation,
+  useConversationFeedbacks,
   useConversationMessages,
   useConversationParticipants,
-  useConversationReactions,
   useConversations,
 } from "@app/lib/swr/conversations";
 import { classNames } from "@app/lib/utils";
@@ -39,7 +39,6 @@ const DEFAULT_PAGE_LIMIT = 50;
 
 interface ConversationViewerProps {
   conversationId: string;
-  hideReactions?: boolean;
   isFading?: boolean;
   isInModal?: boolean;
   onStickyMentionsChange?: (mentions: AgentMention[]) => void;
@@ -62,7 +61,6 @@ const ConversationViewer = React.forwardRef<
     conversationId,
     onStickyMentionsChange,
     isInModal = false,
-    hideReactions = false,
     isFading = false,
   },
   ref
@@ -93,11 +91,6 @@ const ConversationViewer = React.forwardRef<
     conversationId,
     workspaceId: owner.sId,
     limit: DEFAULT_PAGE_LIMIT,
-  });
-
-  const { reactions } = useConversationReactions({
-    workspaceId: owner.sId,
-    conversationId,
   });
 
   const { mutateConversationParticipants } = useConversationParticipants({
@@ -191,6 +184,11 @@ const ConversationViewer = React.forwardRef<
   }, [agentMentions, onStickyMentionsChange]);
 
   const { ref: viewRef, inView: isTopOfListVisible } = useInView();
+
+  const { feedbacks } = useConversationFeedbacks({
+    conversationId: conversationId ?? "",
+    workspaceId: owner.sId,
+  });
 
   // On page load or when new data is loaded, check if the top of the list
   // is visible and there is more data to load. If so, set the current
@@ -346,10 +344,9 @@ const ConversationViewer = React.forwardRef<
               messages={typedGroup}
               isLastMessageGroup={isLastGroup}
               conversationId={conversationId}
-              hideReactions={hideReactions}
+              feedbacks={feedbacks}
               isInModal={isInModal}
               owner={owner}
-              reactions={reactions}
               prevFirstMessageId={prevFirstMessageId}
               prevFirstMessageRef={prevFirstMessageRef}
               user={user}

--- a/front/components/assistant/conversation/MessageGroup.tsx
+++ b/front/components/assistant/conversation/MessageGroup.tsx
@@ -1,5 +1,4 @@
 import type {
-  ConversationMessageReactions,
   FetchConversationMessagesResponse,
   MessageWithContentFragmentsType,
   UserType,
@@ -8,15 +7,15 @@ import type {
 import React, { useEffect, useRef } from "react";
 
 import MessageItem from "@app/components/assistant/conversation/MessageItem";
+import type { AgentMessageFeedbackType } from "@app/lib/api/assistant/feedback";
 
 interface MessageGroupProps {
   messages: MessageWithContentFragmentsType[];
   isLastMessageGroup: boolean;
   conversationId: string;
-  hideReactions: boolean;
+  feedbacks: AgentMessageFeedbackType[];
   isInModal: boolean;
   owner: WorkspaceType;
-  reactions: ConversationMessageReactions;
   prevFirstMessageId: string | null;
   prevFirstMessageRef: React.RefObject<HTMLDivElement>;
   user: UserType;
@@ -33,10 +32,9 @@ export default function MessageGroup({
   messages,
   isLastMessageGroup,
   conversationId,
-  hideReactions,
+  feedbacks,
   isInModal,
   owner,
-  reactions,
   prevFirstMessageId,
   prevFirstMessageRef,
   user,
@@ -66,11 +64,12 @@ export default function MessageGroup({
         <MessageItem
           key={`message-${message.sId}`}
           conversationId={conversationId}
-          hideReactions={hideReactions}
+          messageFeedback={feedbacks.find(
+            (feedback) => feedback.messageId === message.sId
+          )}
           isInModal={isInModal}
           message={message}
           owner={owner}
-          reactions={reactions}
           ref={
             message.sId === prevFirstMessageId ? prevFirstMessageRef : undefined
           }

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -1,7 +1,10 @@
-import type { CitationType } from "@dust-tt/sparkle";
-import { Citation, ZoomableImageCitationWrapper } from "@dust-tt/sparkle";
 import type {
-  ConversationMessageReactions,
+  CitationType,
+  ConversationMessageFeedbackSelectorProps,
+} from "@dust-tt/sparkle";
+import { Citation, ZoomableImageCitationWrapper } from "@dust-tt/sparkle";
+import { useSendNotification } from "@dust-tt/sparkle";
+import type {
   MessageWithContentFragmentsType,
   UserType,
   WorkspaceType,
@@ -12,16 +15,16 @@ import { useSWRConfig } from "swr";
 
 import { AgentMessage } from "@app/components/assistant/conversation/AgentMessage";
 import { UserMessage } from "@app/components/assistant/conversation/UserMessage";
+import type { AgentMessageFeedbackType } from "@app/lib/api/assistant/feedback";
 import { useSubmitFunction } from "@app/lib/client/utils";
 
 interface MessageItemProps {
   conversationId: string;
-  hideReactions: boolean;
+  messageFeedback: AgentMessageFeedbackType | undefined;
   isInModal: boolean;
   isLastMessage: boolean;
   message: MessageWithContentFragmentsType;
   owner: WorkspaceType;
-  reactions: ConversationMessageReactions;
   user: UserType;
 }
 
@@ -29,45 +32,54 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
   function MessageItem(
     {
       conversationId,
-      hideReactions,
+      messageFeedback,
       isInModal,
       isLastMessage,
       message,
       owner,
-      reactions,
       user,
     }: MessageItemProps,
     ref
   ) {
     const { sId, type } = message;
+    const sendNotification = useSendNotification();
 
-    const convoReactions = reactions.find((r) => r.messageId === sId);
-    const messageReactions = convoReactions?.reactions || [];
     const { mutate } = useSWRConfig();
-    const { submit: onSubmitEmoji, isSubmitting: isSubmittingEmoji } =
+    const { submit: onSubmitThumb, isSubmitting: isSubmittingThumb } =
       useSubmitFunction(
         async ({
-          emoji,
+          thumb,
           isToRemove,
+          feedbackContent,
         }: {
-          emoji: string;
+          thumb: string;
           isToRemove: boolean;
+          feedbackContent?: string | null;
         }) => {
           const res = await fetch(
-            `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages/${message.sId}/reactions`,
+            `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages/${message.sId}/feedbacks`,
             {
               method: isToRemove ? "DELETE" : "POST",
               headers: {
                 "Content-Type": "application/json",
               },
               body: JSON.stringify({
-                reaction: emoji,
+                thumbDirection: thumb,
+                feedbackContent,
               }),
             }
           );
           if (res.ok) {
+            if (feedbackContent && !isToRemove) {
+              sendNotification({
+                title: "Feedback submitted",
+                description:
+                  "Your comment has been submitted successfully to the Builder of this assistant. Thank you!",
+                type: "success",
+              });
+            }
             await mutate(
-              `/api/w/${owner.sId}/assistant/conversations/${conversationId}/reactions`
+              `/api/w/${owner.sId}/assistant/conversations/${conversationId}/feedbacks`
             );
           }
         }
@@ -77,17 +89,17 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
       return null;
     }
 
-    const messageEmoji = hideReactions
-      ? undefined
-      : {
-          reactions: messageReactions.map((reaction) => ({
-            emoji: reaction.emoji,
-            hasReacted: reaction.users.some((u) => u.userId === user.id),
-            count: reaction.users.length,
-          })),
-          onSubmitEmoji,
-          isSubmittingEmoji,
-        };
+    const messageFeedbackWithSubmit: ConversationMessageFeedbackSelectorProps =
+      {
+        feedback: messageFeedback
+          ? {
+              thumb: messageFeedback.thumbDirection,
+              feedbackContent: messageFeedback.content,
+            }
+          : null,
+        onSubmitThumb,
+        isSubmittingThumb,
+      };
 
     switch (type) {
       case "user_message":
@@ -152,7 +164,7 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
               isInModal={isInModal}
               isLastMessage={isLastMessage}
               message={message}
-              messageEmoji={messageEmoji}
+              messageFeedback={messageFeedbackWithSubmit}
               owner={owner}
               user={user}
               size={isInModal ? "compact" : "normal"}

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -1,7 +1,4 @@
-import type {
-  ConversationMessageEmojiSelectorProps,
-  ConversationMessageSizeType,
-} from "@dust-tt/sparkle";
+import type { ConversationMessageSizeType } from "@dust-tt/sparkle";
 import { ConversationMessage, Markdown } from "@dust-tt/sparkle";
 import type { UserMessageType, WorkspaceType } from "@dust-tt/types";
 import { useMemo } from "react";
@@ -23,7 +20,6 @@ interface UserMessageProps {
   conversationId: string;
   isLastMessage: boolean;
   message: UserMessageType;
-  messageEmoji?: ConversationMessageEmojiSelectorProps;
   owner: WorkspaceType;
   size: ConversationMessageSizeType;
 }
@@ -33,7 +29,6 @@ export function UserMessage({
   conversationId,
   isLastMessage,
   message,
-  messageEmoji,
   owner,
   size,
 }: UserMessageProps) {
@@ -54,7 +49,6 @@ export function UserMessage({
     <ConversationMessage
       pictureUrl={message.user?.image || message.context.profilePictureUrl}
       name={message.context.fullName}
-      messageEmoji={messageEmoji}
       renderName={(name) => <div className="text-base font-medium">{name}</div>}
       type="user"
       citations={citations}

--- a/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
+++ b/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
@@ -152,7 +152,6 @@ export default function AssistantBuilderRightPanel({
                         conversationId={conversation.sId}
                         onStickyMentionsChange={setStickyMentions}
                         isInModal
-                        hideReactions
                         isFading={isFading}
                         key={conversation.sId}
                       />

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -11,6 +11,7 @@ import { AgentWebsearchAction } from "@app/lib/models/assistant/actions/websearc
 import type { Conversation } from "@app/lib/models/assistant/conversation";
 import {
   AgentMessage,
+  AgentMessageFeedback,
   ConversationParticipant,
   Mention,
   Message,
@@ -153,6 +154,9 @@ export async function destroyConversation(
 
     await UserMessage.destroy({
       where: { id: userMessageIds },
+    });
+    await AgentMessageFeedback.destroy({
+      where: { agentMessageId: agentMessageIds },
     });
     await AgentMessage.destroy({
       where: { id: agentMessageIds },

--- a/front/lib/api/assistant/feedback.ts
+++ b/front/lib/api/assistant/feedback.ts
@@ -1,0 +1,244 @@
+import type {
+  ConversationType,
+  ConversationWithoutContentType,
+  Result,
+} from "@dust-tt/types";
+import type { UserType } from "@dust-tt/types";
+import { ConversationError, Err, GLOBAL_AGENTS_SID, Ok } from "@dust-tt/types";
+import { Op } from "sequelize";
+
+import { canAccessConversation } from "@app/lib/api/assistant/conversation";
+import type { AgentMessageFeedbackDirection } from "@app/lib/api/assistant/conversation/feedbacks";
+import type { Authenticator } from "@app/lib/auth";
+import { AgentConfiguration } from "@app/lib/models/assistant/agent";
+import {
+  AgentMessage,
+  AgentMessageFeedback,
+} from "@app/lib/models/assistant/conversation";
+import { Message } from "@app/lib/models/assistant/conversation";
+import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
+
+/**
+ * We retrieve the feedbacks for a whole conversation, not just a single message.
+ */
+
+export type AgentMessageFeedbackType = {
+  id: number;
+  messageId: string;
+  agentMessageId: number;
+  userId: number;
+  thumbDirection: AgentMessageFeedbackDirection;
+  content: string | null;
+};
+
+export async function getConversationFeedbacksForUser(
+  auth: Authenticator,
+  conversation: ConversationType | ConversationWithoutContentType
+): Promise<Result<AgentMessageFeedbackType[], ConversationError>> {
+  const owner = auth.workspace();
+  if (!owner) {
+    throw new Error("Unexpected `auth` without `workspace`.");
+  }
+  const user = auth.user();
+  if (!canAccessConversation(auth, conversation) || !user) {
+    return new Err(new ConversationError("conversation_access_restricted"));
+  }
+
+  const messages = await Message.findAll({
+    where: {
+      conversationId: conversation.id,
+      agentMessageId: {
+        [Op.ne]: null,
+      },
+    },
+    attributes: ["sId", "agentMessageId"],
+  });
+
+  const agentMessages = await AgentMessage.findAll({
+    where: {
+      id: {
+        [Op.in]: messages
+          .map((m) => m.agentMessageId)
+          .filter((id): id is number => id !== null),
+      },
+    },
+  });
+
+  const feedbacks = await AgentMessageFeedback.findAll({
+    where: {
+      userId: user.id,
+      agentMessageId: {
+        [Op.in]: agentMessages.map((m) => m.id),
+      },
+    },
+  });
+  const feedbacksByMessageId = feedbacks.map(
+    (feedback) =>
+      ({
+        id: feedback.id,
+        messageId: messages.find(
+          (m) => m.agentMessageId === feedback.agentMessageId
+        )!.sId,
+        agentMessageId: feedback.agentMessageId,
+        userId: feedback.userId,
+        thumbDirection: feedback.thumbDirection,
+        content: feedback.content,
+      }) as AgentMessageFeedbackType
+  );
+
+  return new Ok(feedbacksByMessageId);
+}
+
+/**
+ * We create a feedback for a single message.
+ * As user can be null (user from Slack), we also store the user context, as we do for messages.
+ */
+export async function createOrUpdateMessageFeedback(
+  auth: Authenticator,
+  {
+    messageId,
+    conversation,
+    user,
+    thumbDirection,
+    content,
+  }: {
+    messageId: string;
+    conversation: ConversationType | ConversationWithoutContentType;
+    user: UserType;
+    thumbDirection: AgentMessageFeedbackDirection;
+    content?: string;
+  }
+): Promise<boolean | null> {
+  const owner = auth.workspace();
+  if (!owner) {
+    throw new Error("Unexpected `auth` without `workspace`.");
+  }
+
+  const message = await Message.findOne({
+    where: {
+      sId: messageId,
+      conversationId: conversation.id,
+    },
+  });
+
+  if (!message || !message.agentMessageId) {
+    return null;
+  }
+
+  const agentMessage = await AgentMessage.findOne({
+    where: {
+      id: message.agentMessageId,
+    },
+  });
+
+  if (!agentMessage) {
+    return null;
+  }
+
+  let isGlobalAgent = false;
+  let agentConfigurationId = agentMessage.agentConfigurationId;
+  if (
+    Object.values(GLOBAL_AGENTS_SID).includes(
+      agentMessage.agentConfigurationId as GLOBAL_AGENTS_SID
+    )
+  ) {
+    isGlobalAgent = true;
+  }
+
+  if (!isGlobalAgent) {
+    const agentConfiguration = await AgentConfiguration.findOne({
+      where: {
+        sId: agentMessage.agentConfigurationId,
+      },
+    });
+
+    if (!agentConfiguration) {
+      return null;
+    }
+    agentConfigurationId = agentConfiguration.sId;
+  }
+
+  const feedback =
+    await AgentMessageFeedbackResource.fetchByUserAndAgentMessage({
+      user,
+      agentMessage,
+    });
+
+  if (feedback) {
+    const updatedFeedback = await feedback.updateContentAndThumbDirection(
+      content ?? "",
+      thumbDirection
+    );
+
+    return updatedFeedback.isOk();
+  } else {
+    const newFeedback = await AgentMessageFeedbackResource.makeNew({
+      workspaceId: owner.id,
+      agentConfigurationId: agentConfigurationId,
+      agentConfigurationVersion: agentMessage.agentConfigurationVersion,
+      agentMessageId: agentMessage.id,
+      userId: user.id,
+      thumbDirection,
+      content,
+    });
+    return newFeedback !== null;
+  }
+}
+
+/**
+ * The id of a reaction is not exposed on the API so we need to find it from the message id and the user context.
+ * We destroy reactions, no point in soft-deleting them.
+ */
+export async function deleteMessageFeedback(
+  auth: Authenticator,
+  {
+    messageId,
+    conversation,
+    user,
+  }: {
+    messageId: string;
+    conversation: ConversationType | ConversationWithoutContentType;
+    user: UserType;
+  }
+): Promise<boolean | null> {
+  const owner = auth.workspace();
+  if (!owner) {
+    throw new Error("Unexpected `auth` without `workspace`.");
+  }
+
+  const message = await Message.findOne({
+    where: {
+      sId: messageId,
+      conversationId: conversation.id,
+    },
+    attributes: ["agentMessageId"],
+  });
+
+  if (!message || !message.agentMessageId) {
+    return null;
+  }
+
+  const agentMessage = await AgentMessage.findOne({
+    where: {
+      id: message.agentMessageId,
+    },
+  });
+
+  if (!agentMessage) {
+    return null;
+  }
+
+  const feedback =
+    await AgentMessageFeedbackResource.fetchByUserAndAgentMessage({
+      user,
+      agentMessage,
+    });
+
+  if (!feedback) {
+    return null;
+  }
+
+  const deletedFeedback = await feedback.delete(auth);
+
+  return deletedFeedback.isOk();
+}

--- a/front/lib/api/assistant/feedback.ts
+++ b/front/lib/api/assistant/feedback.ts
@@ -11,10 +11,7 @@ import { canAccessConversation } from "@app/lib/api/assistant/conversation";
 import type { AgentMessageFeedbackDirection } from "@app/lib/api/assistant/conversation/feedbacks";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
-import {
-  AgentMessage,
-  AgentMessageFeedback,
-} from "@app/lib/models/assistant/conversation";
+import { AgentMessage } from "@app/lib/models/assistant/conversation";
 import { Message } from "@app/lib/models/assistant/conversation";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
 

--- a/front/lib/api/assistant/feedback.ts
+++ b/front/lib/api/assistant/feedback.ts
@@ -64,14 +64,12 @@ export async function getConversationFeedbacksForUser(
     },
   });
 
-  const feedbacks = await AgentMessageFeedback.findAll({
-    where: {
-      userId: user.id,
-      agentMessageId: {
-        [Op.in]: agentMessages.map((m) => m.id),
-      },
-    },
-  });
+  const feedbacks =
+    await AgentMessageFeedbackResource.fetchByUserAndAgentMessages(
+      user,
+      agentMessages
+    );
+
   const feedbacksByMessageId = feedbacks.map(
     (feedback) =>
       ({

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -408,10 +408,10 @@ AgentMessageFeedback.init(
 
 Workspace.hasMany(AgentMessageFeedback, {
   foreignKey: { name: "workspaceId", allowNull: false },
-  onDelete: "CASCADE",
+  onDelete: "RESTRICT",
 });
 AgentMessage.hasMany(AgentMessageFeedback, {
-  onDelete: "CASCADE",
+  onDelete: "RESTRICT",
 });
 User.hasMany(AgentMessageFeedback, {
   onDelete: "SET NULL",

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -15,7 +15,6 @@ import type {
 import { DataTypes, Model } from "sequelize";
 
 import type { AgentMessageFeedbackDirection } from "@app/lib/api/assistant/conversation/feedbacks";
-import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import type { AgentMessageContent } from "@app/lib/models/assistant/agent_message_content";
 import { User } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
@@ -342,7 +341,8 @@ export class AgentMessageFeedback extends Model<
   declare updatedAt: CreationOptional<Date>;
 
   declare workspaceId: ForeignKey<Workspace["id"]>;
-  declare agentConfigurationId: ForeignKey<AgentConfiguration["id"]>;
+  declare agentConfigurationId: string;
+  declare agentConfigurationVersion: number;
   declare agentMessageId: ForeignKey<AgentMessage["id"]>;
   declare userId: ForeignKey<User["id"]>;
 
@@ -370,6 +370,14 @@ AgentMessageFeedback.init(
     workspaceId: {
       type: DataTypes.INTEGER,
       allowNull: false,
+    },
+    agentConfigurationId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    agentConfigurationVersion: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
     },
     thumbDirection: {
       type: DataTypes.STRING,
@@ -401,9 +409,6 @@ AgentMessageFeedback.init(
   }
 );
 
-AgentConfiguration.hasMany(AgentMessageFeedback, {
-  onDelete: "RESTRICT",
-});
 AgentMessage.hasMany(AgentMessageFeedback, {
   onDelete: "RESTRICT",
 });

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -400,6 +400,7 @@ AgentMessageFeedback.init(
       {
         fields: ["agentConfigurationId", "agentMessageId", "userId"],
         unique: true,
+        name: "agent_message_feedbacks_agent_configuration_id_agent_message_id",
       },
     ],
   }

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -367,10 +367,6 @@ AgentMessageFeedback.init(
       allowNull: false,
       defaultValue: DataTypes.NOW,
     },
-    workspaceId: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-    },
     agentConfigurationId: {
       type: DataTypes.STRING,
       allowNull: true,
@@ -409,11 +405,15 @@ AgentMessageFeedback.init(
   }
 );
 
+Workspace.hasMany(AgentMessageFeedback, {
+  foreignKey: { name: "workspaceId", allowNull: false },
+  onDelete: "CASCADE",
+});
 AgentMessage.hasMany(AgentMessageFeedback, {
-  onDelete: "RESTRICT",
+  onDelete: "CASCADE",
 });
 User.hasMany(AgentMessageFeedback, {
-  onDelete: "RESTRICT",
+  onDelete: "SET NULL",
 });
 
 export class Message extends Model<

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -1,7 +1,8 @@
 import type { AgentConfigurationType, Result, UserType } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
-import type { CreationAttributes, Transaction } from "sequelize";
 import type { Attributes, ModelStatic } from "sequelize";
+import type { CreationAttributes, Transaction } from "sequelize";
+import { Op } from "sequelize";
 
 import type { AgentMessageFeedbackDirection } from "@app/lib/api/assistant/conversation/feedbacks";
 import type { Authenticator } from "@app/lib/auth";
@@ -79,6 +80,25 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
     return new AgentMessageFeedbackResource(
       AgentMessageFeedback,
       agentMessageFeedback.get()
+    );
+  }
+
+  static async fetchByUserAndAgentMessages(
+    user: UserType,
+    agentMessages: AgentMessage[]
+  ): Promise<AgentMessageFeedbackResource[]> {
+    const agentMessageFeedback = await AgentMessageFeedback.findAll({
+      where: {
+        userId: user.id,
+        agentMessageId: {
+          [Op.in]: agentMessages.map((m) => m.id),
+        },
+      },
+    });
+
+    return agentMessageFeedback.map(
+      (feedback) =>
+        new AgentMessageFeedbackResource(AgentMessageFeedback, feedback.get())
     );
   }
 

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -9,6 +9,7 @@ import { useCallback, useMemo } from "react";
 import type { Fetcher } from "swr";
 
 import { deleteConversation } from "@app/components/assistant/conversation/lib";
+import type { AgentMessageFeedbackType } from "@app/lib/api/assistant/feedback";
 import type { FetchConversationMessagesResponse } from "@app/lib/api/assistant/messages";
 import { getVisualizationRetryMessage } from "@app/lib/client/visualization";
 import {
@@ -88,6 +89,30 @@ export function useConversationReactions({
     reactions: useMemo(() => (data ? data.reactions : []), [data]),
     isReactionsLoading: !error && !data,
     isReactionsError: error,
+    mutateReactions: mutate,
+  };
+}
+
+export function useConversationFeedbacks({
+  conversationId,
+  workspaceId,
+}: {
+  conversationId: string;
+  workspaceId: string;
+}) {
+  const conversationFeedbacksFetcher: Fetcher<{
+    feedbacks: AgentMessageFeedbackType[];
+  }> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/assistant/conversations/${conversationId}/feedbacks`,
+    conversationFeedbacksFetcher
+  );
+
+  return {
+    feedbacks: useMemo(() => (data ? data.feedbacks : []), [data]),
+    isFeedbacksLoading: !error && !data,
+    isFeedbacksError: error,
     mutateReactions: mutate,
   };
 }

--- a/front/migrations/db/migration_122.sql
+++ b/front/migrations/db/migration_122.sql
@@ -5,3 +5,11 @@ ALTER TABLE "agent_message_feedbacks" ADD COLUMN "agentConfigurationVersion" INT
 
 ALTER TABLE "agent_message_feedbacks" ALTER COLUMN "workspaceId" SET NOT NULL;
 ALTER TABLE "agent_message_feedbacks"  ADD FOREIGN KEY ("workspaceId") REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "agent_message_feedbacks" 
+DROP CONSTRAINT "agent_message_feedbacks_userId_fkey",
+ADD CONSTRAINT "agent_message_feedbacks_userId_fkey" 
+    FOREIGN KEY ("userId") 
+    REFERENCES "users"("id") 
+    ON DELETE SET NULL 
+    ON UPDATE CASCADE;

--- a/front/migrations/db/migration_122.sql
+++ b/front/migrations/db/migration_122.sql
@@ -1,4 +1,7 @@
--- First drop the column
+-- First drop the column,
 ALTER TABLE "agent_message_feedbacks" DROP COLUMN "agentConfigurationId";
 ALTER TABLE "agent_message_feedbacks" ADD COLUMN "agentConfigurationId" VARCHAR(255);
 ALTER TABLE "agent_message_feedbacks" ADD COLUMN "agentConfigurationVersion" INTEGER;
+
+ALTER TABLE "agent_message_feedbacks" ALTER COLUMN "workspaceId" SET NOT NULL;
+ALTER TABLE "agent_message_feedbacks"  ADD FOREIGN KEY ("workspaceId") REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/front/migrations/db/migration_122.sql
+++ b/front/migrations/db/migration_122.sql
@@ -1,0 +1,4 @@
+-- First drop the column
+ALTER TABLE "agent_message_feedbacks" DROP COLUMN "agentConfigurationId";
+ALTER TABLE "agent_message_feedbacks" ADD COLUMN "agentConfigurationId" VARCHAR(255);
+ALTER TABLE "agent_message_feedbacks" ADD COLUMN "agentConfigurationVersion" INTEGER;

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.324",
+        "@dust-tt/sparkle": "^0.2.325",
         "@dust-tt/types": "file:../types",
         "@headlessui/react": "^1.7.7",
         "@heroicons/react": "^2.0.11",
@@ -11487,9 +11487,10 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.324",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.324.tgz",
-      "integrity": "sha512-lzUbYBgGDfcwcWUKLFKdKCoRvNP1xRpA70pzct4pOK7LSWKTbO8X6YbmPeTVXqdOe/pcXyu7dxqCCZ/GuK6yqw==",
+      "version": "0.2.325",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.325.tgz",
+      "integrity": "sha512-XVHdUxw74w7Mkv+P+ptlISD+huMTAqT3IpZ+xe1lK3ZgvqLKgpxH71xzdf75cCspgKh+Wswt5WTIAKgVj3Oirg==",
+      "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.324",
+    "@dust-tt/sparkle": "^0.2.325",
     "@dust-tt/types": "file:../types",
     "@headlessui/react": "^1.7.7",
     "@heroicons/react": "^2.0.11",

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/feedbacks.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/feedbacks.ts
@@ -1,0 +1,68 @@
+import type { WithAPIErrorResponse } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
+import type { AgentMessageFeedbackType } from "@app/lib/api/assistant/feedback";
+import { getConversationFeedbacksForUser } from "@app/lib/api/assistant/feedback";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<{ feedbacks: AgentMessageFeedbackType[] }>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  if (!(typeof req.query.cId === "string")) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `cId` (string) is required.",
+      },
+    });
+  }
+
+  const conversationId = req.query.cId;
+  const conversationRes = await getConversationWithoutContent(
+    auth,
+    conversationId
+  );
+
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
+  }
+
+  const conversation = conversationRes.value;
+
+  switch (req.method) {
+    case "GET":
+      const feedbacksRes = await getConversationFeedbacksForUser(
+        auth,
+        conversation
+      );
+
+      if (feedbacksRes.isErr()) {
+        return apiErrorForConversation(req, res, feedbacksRes.error);
+      }
+
+      const feedbacks = feedbacksRes.value;
+
+      res.status(200).json({ feedbacks });
+      return;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks/index.ts
@@ -64,20 +64,21 @@ async function handler(
   }
 
   const messageId = req.query.mId;
-  const bodyValidation = MessageFeedbackRequestBodySchema.decode(req.body);
-  if (isLeft(bodyValidation)) {
-    const pathError = reporter.formatValidationErrors(bodyValidation.left);
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: `Invalid request body: ${pathError}`,
-      },
-    });
-  }
 
   switch (req.method) {
     case "POST":
+      const bodyValidation = MessageFeedbackRequestBodySchema.decode(req.body);
+      if (isLeft(bodyValidation)) {
+        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${pathError}`,
+          },
+        });
+      }
+
       const created = await createOrUpdateMessageFeedback(auth, {
         messageId,
         conversation,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks/index.ts
@@ -1,0 +1,134 @@
+import type { WithAPIErrorResponse } from "@dust-tt/types";
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
+import type { AgentMessageFeedbackDirection } from "@app/lib/api/assistant/conversation/feedbacks";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
+import {
+  createOrUpdateMessageFeedback,
+  deleteMessageFeedback,
+} from "@app/lib/api/assistant/feedback";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+
+export const MessageFeedbackRequestBodySchema = t.type({
+  thumbDirection: t.string,
+  feedbackContent: t.union([t.string, t.undefined, t.null]),
+});
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<{
+      success: boolean;
+    }>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  const user = auth.getNonNullableUser();
+
+  if (!(typeof req.query.cId === "string")) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `cId` (string) is required.",
+      },
+    });
+  }
+
+  const conversationId = req.query.cId;
+  const conversationRes = await getConversationWithoutContent(
+    auth,
+    conversationId
+  );
+
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
+  }
+
+  const conversation = conversationRes.value;
+
+  if (!(typeof req.query.mId === "string")) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `mId` (string) is required.",
+      },
+    });
+  }
+
+  const messageId = req.query.mId;
+  const bodyValidation = MessageFeedbackRequestBodySchema.decode(req.body);
+  if (isLeft(bodyValidation)) {
+    const pathError = reporter.formatValidationErrors(bodyValidation.left);
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid request body: ${pathError}`,
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST":
+      const created = await createOrUpdateMessageFeedback(auth, {
+        messageId,
+        conversation,
+        user,
+        thumbDirection: bodyValidation.right
+          .thumbDirection as AgentMessageFeedbackDirection,
+        content: bodyValidation.right.feedbackContent || "",
+      });
+
+      if (created) {
+        res.status(200).json({ success: true });
+        return;
+      }
+      return apiError(req, res, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "The message you're trying to give feedback to does not exist.",
+        },
+      });
+
+    case "DELETE":
+      const deleted = await deleteMessageFeedback(auth, {
+        messageId,
+        conversation,
+        user,
+      });
+
+      if (deleted) {
+        res.status(200).json({ success: true });
+      }
+      return apiError(req, res, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "The message you're trying to give feedback to does not exist.",
+        },
+      });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message:
+            "The method passed is not supported, POST or DELETE is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -234,7 +234,7 @@ export async function deleteConversationsActivity({
                   }
 
                   await AgentMessageFeedback.destroy({
-                    where: { agentMessageId: msg.id },
+                    where: { agentMessageId: agentMessage.id },
                     transaction: t,
                   });
 

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -34,6 +34,7 @@ import {
 } from "@app/lib/models/assistant/agent";
 import {
   AgentMessage,
+  AgentMessageFeedback,
   Conversation,
   ConversationParticipant,
   Mention,
@@ -231,6 +232,11 @@ export async function deleteConversationsActivity({
                       transaction: t,
                     });
                   }
+
+                  await AgentMessageFeedback.destroy({
+                    where: { agentMessageId: msg.id },
+                    transaction: t,
+                  });
 
                   // Delete associated actions.
 


### PR DESCRIPTION
# Description
This PR adds a feedback system to agent messages, allowing users to provide thumbs up/down feedback with optional text content. This enables tracking feedback for both global and custom agents, storing the agent configuration version for future analysis 

# Risk

The PR introduces a new database schema migration that adds columns to the agent_message_feedbacks table . Migration must be applied before deploying the code changes.

# Deploy Plan
Apply migration 122 to add agentConfigurationId and agentConfigurationVersion columns
Needs https://github.com/dust-tt/dust/pull/8896 to be merged and sparkle to be published