### PR TITLE
Allow to store and replay messages with context menu

### DIFF
--- a/extension/app/background.ts
+++ b/extension/app/background.ts
@@ -67,7 +67,7 @@ const createContextMenus = async () => {
     chrome.contextMenus.create({
       id: configuration.id,
       title: configuration.description,
-      contexts: ["all"],
+      contexts: configuration.includeSelectionOnly ? ["selection"] : ["all"],
     });
   }
   chrome.contextMenus.create({
@@ -113,6 +113,7 @@ const getActionHandler = (menuItemId: string | number) => {
         const params = JSON.stringify({
           includeContent: conf.includeContent,
           includeCapture: conf.includeCapture,
+          includeSelectionOnly: conf.includeSelectionOnly,
           text: conf.text,
           configurationIds: conf.configurationIds,
         });

--- a/extension/app/background.ts
+++ b/extension/app/background.ts
@@ -20,7 +20,7 @@ import type {
   GetActiveTabBackgroundMessage,
   GetActiveTabBackgroundResponse,
   InputBarStatusMessage,
-  UpdateSavedAssistantConfigurations,
+  UpdateQuickActionConfigurations,
 } from "./src/lib/messages";
 import { generatePKCE } from "./src/lib/utils";
 
@@ -195,7 +195,7 @@ chrome.runtime.onMessage.addListener(
     message:
       | AuthBackgroundMessage
       | GetActiveTabBackgroundMessage
-      | UpdateSavedAssistantConfigurations
+      | UpdateQuickActionConfigurations
       | CaptureMesssage
       | InputBarStatusMessage,
     sender,

--- a/extension/app/src/components/conversation/ConversationViewer.tsx
+++ b/extension/app/src/components/conversation/ConversationViewer.tsx
@@ -150,11 +150,13 @@ export function ConversationViewer({
       {/* Invisible span to detect when the user has scrolled to the top of the list. */}
       {conversation &&
         typedGroupedMessages.map((typedGroup, index) => {
+          const isFirstGroup = index === 0;
           const isLastGroup = index === typedGroupedMessages.length - 1;
           return (
             <MessageGroup
               key={`typed-group-${index}`}
               messages={typedGroup}
+              isFirstMessageGroup={isFirstGroup}
               isLastMessageGroup={isLastGroup}
               conversationId={conversationId}
               hideReactions={true}

--- a/extension/app/src/components/conversation/MessageGroup.tsx
+++ b/extension/app/src/components/conversation/MessageGroup.tsx
@@ -9,6 +9,7 @@ import React, { useEffect, useRef } from "react";
 
 interface MessageGroupProps {
   messages: MessageWithContentFragmentsType[];
+  isFirstMessageGroup: boolean;
   isLastMessageGroup: boolean;
   conversationId: string;
   hideReactions: boolean;
@@ -26,6 +27,7 @@ export const LAST_MESSAGE_GROUP_ID = "last-message-group";
 
 export default function MessageGroup({
   messages,
+  isFirstMessageGroup,
   isLastMessageGroup,
   conversationId,
   hideReactions,
@@ -64,6 +66,9 @@ export default function MessageGroup({
           owner={owner}
           reactions={reactions}
           user={user}
+          isFirstMessage={
+            isFirstMessageGroup && messages.at(0)?.sId === message.sId
+          }
           isLastMessage={
             isLastMessageGroup && messages.at(-1)?.sId === message.sId
           }

--- a/extension/app/src/components/conversation/MessageItem.tsx
+++ b/extension/app/src/components/conversation/MessageItem.tsx
@@ -14,6 +14,7 @@ interface MessageItemProps {
   conversationId: string;
   hideReactions: boolean;
   isInModal: boolean;
+  isFirstMessage: boolean;
   isLastMessage: boolean;
   message: MessageWithContentFragmentsType;
   owner: LightWorkspaceType;
@@ -23,7 +24,13 @@ interface MessageItemProps {
 
 const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
   function MessageItem(
-    { conversationId, isLastMessage, message, owner }: MessageItemProps,
+    {
+      conversationId,
+      isFirstMessage,
+      isLastMessage,
+      message,
+      owner,
+    }: MessageItemProps,
     ref
   ) {
     const { sId, type } = message;
@@ -66,6 +73,7 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
             <UserMessage
               citations={citations}
               conversationId={conversationId}
+              isFirstMessage={isFirstMessage}
               isLastMessage={isLastMessage}
               message={message}
               owner={owner}

--- a/extension/app/src/components/conversation/UserMessage.tsx
+++ b/extension/app/src/components/conversation/UserMessage.tsx
@@ -110,7 +110,7 @@ export function UserMessage({
           variant="outline"
           size="xs"
           icon={enabled ? HeartIcon : HeartStrokeIcon}
-          label="Save to context menu"
+          label={enabled ? "Remove from context menu" : "Save to context menu"}
           onClick={async () => {
             if (enabled) {
               const configurations = savedConfigurations.filter(
@@ -123,11 +123,14 @@ export function UserMessage({
               setSavedConfigurations(configurations);
             } else {
               if (savedConfigurationId) {
+                const text = elRef.current?.innerText || "";
+                const description =
+                  text.length > 30 ? text.substring(0, 30) + "..." : text;
                 const configurations = [
                   ...savedConfigurations,
                   {
                     id: savedConfigurationId,
-                    description: `Ask ${elRef.current?.innerText}`,
+                    description: `Ask : ${description}`,
                     text: message.content,
                     includeContent: message.contenFragments
                       ? message.contenFragments?.some(

--- a/extension/app/src/components/conversation/UserMessage.tsx
+++ b/extension/app/src/components/conversation/UserMessage.tsx
@@ -110,9 +110,7 @@ export function UserMessage({
           variant="outline"
           size="xs"
           icon={enabled ? HeartIcon : HeartStrokeIcon}
-          label={
-            enabled ? "Remove from quick actions" : "Save to quick actions"
-          }
+          label={enabled ? "Remove from Quick Actions" : "Save as Quick Action"}
           onClick={async () => {
             if (enabled) {
               const configurations = savedConfigurations.filter(

--- a/extension/app/src/components/conversation/UserMessage.tsx
+++ b/extension/app/src/components/conversation/UserMessage.tsx
@@ -22,7 +22,7 @@ import {
 } from "@extension/components/markdown/MentionBlock";
 import type { MessageWithContentFragmentsType } from "@extension/lib/conversation";
 import { sendMessage } from "@extension/lib/messages";
-import type { SavedAssistantConfiguration } from "@extension/lib/storage";
+import type { QuickActionConfiguration } from "@extension/lib/storage";
 import { getSavedConfigurations } from "@extension/lib/storage";
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { Components } from "react-markdown";
@@ -57,8 +57,8 @@ export function UserMessage({
   owner,
   size,
 }: UserMessageProps) {
-  const [savedConfigurations, setSavedConfigurations] = useState<
-    SavedAssistantConfiguration[]
+  const [quickActionsConfigurations, setQuickActionsConfigurations] = useState<
+    QuickActionConfiguration[]
   >([]);
   const [savedConfigurationId, setSavedConfigurationId] = useState<
     string | undefined
@@ -84,8 +84,8 @@ export function UserMessage({
   useEffect(() => {
     const loadConfigurations = async () => {
       const saved = await getSavedConfigurations();
-      if (saved.length !== savedConfigurations.length) {
-        setSavedConfigurations(saved);
+      if (saved.length !== quickActionsConfigurations.length) {
+        setQuickActionsConfigurations(saved);
       }
     };
     void loadConfigurations();
@@ -100,7 +100,7 @@ export function UserMessage({
     void getId();
   }, []);
 
-  const enabled = !!savedConfigurations.find(
+  const enabled = !!quickActionsConfigurations.find(
     (c) => c.id === savedConfigurationId
   );
 
@@ -113,21 +113,21 @@ export function UserMessage({
           label={enabled ? "Remove from Quick Actions" : "Save as Quick Action"}
           onClick={async () => {
             if (enabled) {
-              const configurations = savedConfigurations.filter(
+              const configurations = quickActionsConfigurations.filter(
                 (c) => c.id !== savedConfigurationId
               );
               void sendMessage({
                 type: "UPDATE_SAVED_CONFIGURATIONS",
                 configurations,
               });
-              setSavedConfigurations(configurations);
+              setQuickActionsConfigurations(configurations);
             } else {
               if (savedConfigurationId) {
                 const text = elRef.current?.innerText || "";
                 const description =
                   text.length > 30 ? text.substring(0, 30) + "..." : text;
                 const configurations = [
-                  ...savedConfigurations,
+                  ...quickActionsConfigurations,
                   {
                     id: savedConfigurationId,
                     description: `Ask : ${description}`,
@@ -158,7 +158,7 @@ export function UserMessage({
                   type: "UPDATE_SAVED_CONFIGURATIONS",
                   configurations,
                 });
-                setSavedConfigurations(configurations);
+                setQuickActionsConfigurations(configurations);
               }
             }
           }}

--- a/extension/app/src/components/conversation/UserMessage.tsx
+++ b/extension/app/src/components/conversation/UserMessage.tsx
@@ -134,17 +134,26 @@ export function UserMessage({
                     text: message.content,
                     includeContent: message.contenFragments
                       ? message.contenFragments?.some(
-                          (cf) => cf.contentType === "text/plain"
+                          (cf) =>
+                            cf.title.startsWith("[page-content]") ||
+                            cf.title.startsWith("[selection]")
                         )
                       : false,
                     includeCapture: message.contenFragments
-                      ? message.contenFragments?.some(
-                          (cf) => cf.contentType === "image/jpeg"
+                      ? message.contenFragments?.some((cf) =>
+                          cf.title.startsWith("[capture]")
+                        )
+                      : false,
+                    includeSelectionOnly: message.contenFragments
+                      ? message.contenFragments?.some((cf) =>
+                          cf.title.startsWith("[selection]")
                         )
                       : false,
                     configurationIds,
                   },
                 ];
+
+                console.log("Saving configurations", configurations);
                 void sendMessage({
                   type: "UPDATE_SAVED_CONFIGURATIONS",
                   configurations,

--- a/extension/app/src/components/conversation/UserMessage.tsx
+++ b/extension/app/src/components/conversation/UserMessage.tsx
@@ -110,7 +110,9 @@ export function UserMessage({
           variant="outline"
           size="xs"
           icon={enabled ? HeartIcon : HeartStrokeIcon}
-          label={enabled ? "Remove from context menu" : "Save to context menu"}
+          label={
+            enabled ? "Remove from quick actions" : "Save to quick actions"
+          }
           onClick={async () => {
             if (enabled) {
               const configurations = savedConfigurations.filter(

--- a/extension/app/src/components/conversation/UserMessage.tsx
+++ b/extension/app/src/components/conversation/UserMessage.tsx
@@ -24,6 +24,7 @@ import type { MessageWithContentFragmentsType } from "@extension/lib/conversatio
 import { sendMessage } from "@extension/lib/messages";
 import type { QuickActionConfiguration } from "@extension/lib/storage";
 import { getSavedConfigurations } from "@extension/lib/storage";
+import { hashBase36 } from "@extension/lib/utils";
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { Components } from "react-markdown";
 import type { PluggableList } from "react-markdown/lib/react-markdown";
@@ -38,14 +39,6 @@ interface UserMessageProps {
   owner: LightWorkspaceType;
   size: ConversationMessageSizeType;
 }
-
-const hashBase64 = async (str: string) => {
-  const msgBuffer = new TextEncoder().encode(str);
-  const hashBuffer = await crypto.subtle.digest("SHA-256", msgBuffer);
-  return Array.from(new Uint8Array(hashBuffer))
-    .map((b) => b.toString(36))
-    .join("");
-};
 
 export function UserMessage({
   citations,
@@ -93,7 +86,7 @@ export function UserMessage({
 
   useEffect(() => {
     const getId = async () => {
-      const hash = await hashBase64(`${configurationIds}-${message.content}`);
+      const hash = await hashBase36(`${configurationIds}-${message.content}`);
       const id = `ask_dust_${hash}`;
       setSavedConfigurationId(id);
     };

--- a/extension/app/src/hooks/useFileUploaderService.ts
+++ b/extension/app/src/hooks/useFileUploaderService.ts
@@ -326,8 +326,8 @@ export function useFileUploaderService(conversationId?: string) {
 
       const title = findAvailableTitle(
         includeSelectionOnly
-          ? `${tabContent.title} (selection)`
-          : `${tabContent.title}`,
+          ? `[selection] ${tabContent.title}`
+          : `[page-content] ${tabContent.title}`,
         "txt",
         existingTitles
       );
@@ -386,7 +386,11 @@ export function useFileUploaderService(conversationId?: string) {
         (blob) =>
           new File(
             [blob],
-            findAvailableTitle(`${tabContent.title}`, "jpg", existingTitles),
+            findAvailableTitle(
+              `[capture] ${tabContent.title}`,
+              "jpg",
+              existingTitles
+            ),
             {
               type: blob.type,
             }

--- a/extension/app/src/lib/messages.ts
+++ b/extension/app/src/lib/messages.ts
@@ -1,4 +1,4 @@
-import type { SavedAssistantConfiguration } from "@extension/lib/storage";
+import type { QuickActionConfiguration } from "@extension/lib/storage";
 import { saveTokens } from "@extension/lib/storage";
 
 export type Auth0AuthorizeResponse = {
@@ -40,9 +40,9 @@ export type InputBarStatusMessage = {
   available: boolean;
 };
 
-export type UpdateSavedAssistantConfigurations = {
+export type UpdateQuickActionConfigurations = {
   type: "UPDATE_SAVED_CONFIGURATIONS";
-  configurations: SavedAssistantConfiguration[];
+  configurations: QuickActionConfiguration[];
 };
 
 export type CaptureMesssage = {

--- a/extension/app/src/lib/messages.ts
+++ b/extension/app/src/lib/messages.ts
@@ -1,3 +1,4 @@
+import type { SavedAssistantConfiguration } from "@extension/lib/storage";
 import { saveTokens } from "@extension/lib/storage";
 
 export type Auth0AuthorizeResponse = {
@@ -38,6 +39,11 @@ export type InputBarStatusMessage = {
   available: boolean;
 };
 
+export type UpdateSavedAssistantConfigurations = {
+  type: "UPDATE_SAVED_CONFIGURATIONS";
+  configurations: SavedAssistantConfiguration[];
+};
+
 export type CaptureMesssage = {
   type: "CAPTURE";
 };
@@ -60,7 +66,7 @@ export type CaptureFullPageMessage = {
   type: "PAGE_CAPTURE_FULL_PAGE";
 };
 
-const sendMessage = <T, U>(message: T): Promise<U> => {
+export const sendMessage = <T, U>(message: T): Promise<U> => {
   return new Promise((resolve, reject) => {
     chrome.runtime.sendMessage(message, (response: U | undefined) => {
       if (chrome.runtime.lastError) {

--- a/extension/app/src/lib/storage.ts
+++ b/extension/app/src/lib/storage.ts
@@ -209,7 +209,7 @@ export const getFileContentFragmentId = async (
   return result[key] ?? null;
 };
 
-export type SavedAssistantConfiguration = {
+export type QuickActionConfiguration = {
   id: string;
   description: string;
   includeContent: boolean;
@@ -220,15 +220,15 @@ export type SavedAssistantConfiguration = {
 };
 
 export const getSavedConfigurations = async (): Promise<
-  SavedAssistantConfiguration[]
+  QuickActionConfiguration[]
 > => {
   const result = await chrome.storage.local.get(["savedConfigurations"]);
   return result.savedConfigurations ?? [];
 };
 
 export const saveConfigurations = async (
-  configs: SavedAssistantConfiguration[]
-): Promise<SavedAssistantConfiguration[]> => {
+  configs: QuickActionConfiguration[]
+): Promise<QuickActionConfiguration[]> => {
   await chrome.storage.local.set({
     ["savedConfigurations"]: configs,
   });

--- a/extension/app/src/lib/storage.ts
+++ b/extension/app/src/lib/storage.ts
@@ -208,3 +208,28 @@ export const getFileContentFragmentId = async (
   const result = await chrome.storage.local.get([key]);
   return result[key] ?? null;
 };
+
+export type SavedAssistantConfiguration = {
+  id: string;
+  description: string;
+  includeContent: boolean;
+  includeCapture: boolean;
+  text: string;
+  configurationIds: string[];
+};
+
+export const getSavedConfigurations = async (): Promise<
+  SavedAssistantConfiguration[]
+> => {
+  const result = await chrome.storage.local.get(["savedConfigurations"]);
+  return result.savedConfigurations ?? [];
+};
+
+export const saveConfigurations = async (
+  configs: SavedAssistantConfiguration[]
+): Promise<SavedAssistantConfiguration[]> => {
+  await chrome.storage.local.set({
+    ["savedConfigurations"]: configs,
+  });
+  return configs;
+};

--- a/extension/app/src/lib/storage.ts
+++ b/extension/app/src/lib/storage.ts
@@ -214,6 +214,7 @@ export type SavedAssistantConfiguration = {
   description: string;
   includeContent: boolean;
   includeCapture: boolean;
+  includeSelectionOnly: boolean;
   text: string;
   configurationIds: string[];
 };

--- a/extension/app/src/lib/utils.ts
+++ b/extension/app/src/lib/utils.ts
@@ -201,3 +201,11 @@ export function compareAgentsForSort(
   // default: sort alphabetically
   return a.name.localeCompare(b.name, "en", { sensitivity: "base" });
 }
+
+export const hashBase36 = async (str: string) => {
+  const msgBuffer = new TextEncoder().encode(str);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", msgBuffer);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(36))
+    .join("");
+};

--- a/extension/app/src/pages/RunPage.tsx
+++ b/extension/app/src/pages/RunPage.tsx
@@ -27,7 +27,9 @@ export const RunPage = () => {
         dustAPI,
         messageData: {
           input: params.text,
-          mentions: [{ configurationId: params.configurationId }],
+          mentions: params.configurationIds.map((cId: any) => ({
+            configurationId: cId,
+          })),
         },
         contentFragments: files
           ? files.map((cf) => ({


### PR DESCRIPTION
fixes: [#1700](https://github.com/dust-tt/tasks/issues/1700)

## Description

Add an button on first message in a conversation to "save" as predefined conversation. Save these in local storage. Update context menu to recreate a new conversation with same message, including text and/or screenshot.

- Create new convo

  <img width="544" alt="Screenshot 2024-11-25 at 17 34 01" src="https://github.com/user-attachments/assets/a9dd9b3e-40c6-484c-951b-e720fdb173e8">

- In conversation, click on "save " : 

  <img width="522" alt="Screenshot 2024-11-25 at 17 34 24" src="https://github.com/user-attachments/assets/edf0b73f-b121-43f5-a981-b9dc113d3f4b">

- Right click  on any page : 

  <img width="970" alt="Screenshot 2024-11-25 at 17 34 54" src="https://github.com/user-attachments/assets/54c2b636-c972-4a1c-babf-b4bc619a58c1">


## To check

- Using a button in the first message was the easiest way to set-up these configs (and it;s actually quite easy to use), but we may want to do something else ?

- The item name in context menu is the entire user prompt, maybe need to put a limit to the length of the text

- We should change "Save to context menu" to something else, as these predefined configurations could  be displayed in home page of the extension (see "translate" and "summarize" buttons in figma design : 

  <img width="479" alt="Screenshot 2024-11-25 at 17 48 28" src="https://github.com/user-attachments/assets/be5e0579-4bfa-4e57-b768-0f0ac345a5b2">

- Do we want to have these buttons appear on the home page now ? If we have a lot, maybe a drop down would be more efficient ?

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
