### PR TITLE
[connectors] Add a CLI for Zendesk with a `check-is-admin`

### DIFF
--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -1,0 +1,39 @@
+import type { ZendeskCommandType } from "@dust-tt/types";
+import type { ZendeskCheckIsAdminResponseType } from "@dust-tt/types/src";
+
+import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
+import { fetchZendeskCurrentUser } from "@connectors/connectors/zendesk/lib/zendesk_api";
+import { default as topLogger } from "@connectors/logger/logger";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+
+export const zendesk = async ({
+  command,
+  args,
+}: ZendeskCommandType): Promise<ZendeskCheckIsAdminResponseType> => {
+  const logger = topLogger.child({ majorCommand: "zendesk", command, args });
+
+  const connectorId = args.connectorId ? args.connectorId.toString() : null;
+  const connector = connectorId
+    ? await ConnectorResource.fetchById(connectorId)
+    : null;
+  if (connector && connector.type !== "zendesk") {
+    throw new Error(`Connector ${args.connectorId} is not of type zendesk`);
+  }
+
+  switch (command) {
+    case "check-is-admin": {
+      if (!connector) {
+        throw new Error(`Connector ${connectorId} not found`);
+      }
+      const user = await fetchZendeskCurrentUser(
+        await getZendeskSubdomainAndAccessToken(connector.connectionId)
+      );
+      logger.info({ user }, "User returned by /users/me");
+      return {
+        userActive: user.active,
+        userRole: user.role,
+        userIsAdmin: user.role === "admin" && user.active,
+      };
+    }
+  }
+};

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -6,6 +6,7 @@ import type {
   ZendeskFetchedArticle,
   ZendeskFetchedCategory,
   ZendeskFetchedTicket,
+  ZendeskFetchedUser,
 } from "@connectors/@types/node-zendesk";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import logger from "@connectors/logger/logger";
@@ -348,4 +349,22 @@ export async function fetchZendeskTicketsInBrand({
         },
       }
     : { tickets: [], meta: { has_more: false, after_cursor: "" } };
+}
+
+/**
+ * Fetches the current user through a call to `/users/me`.
+ */
+export async function fetchZendeskCurrentUser({
+  subdomain,
+  accessToken,
+}: {
+  subdomain: string;
+  accessToken: string;
+}): Promise<ZendeskFetchedUser> {
+  const response = await fetch(
+    `https://${subdomain}.zendesk.com/api/v2/users/me`,
+    { headers: { Authorization: `Bearer ${accessToken}` } }
+  );
+  const data = await response.json();
+  return data.user;
 }

--- a/connectors/src/lib/cli.ts
+++ b/connectors/src/lib/cli.ts
@@ -23,6 +23,7 @@ import { microsoft } from "@connectors/connectors/microsoft/lib/cli";
 import { notion } from "@connectors/connectors/notion/lib/cli";
 import { slack } from "@connectors/connectors/slack/lib/cli";
 import { launchCrawlWebsiteSchedulerWorkflow } from "@connectors/connectors/webcrawler/temporal/client";
+import { zendesk } from "@connectors/connectors/zendesk/lib/cli";
 import { getTemporalClient } from "@connectors/lib/temporal";
 import { default as topLogger } from "@connectors/logger/logger";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
@@ -51,6 +52,8 @@ export async function runCommand(adminCommand: AdminCommandType) {
       return intercom(adminCommand);
     case "microsoft":
       return microsoft(adminCommand);
+    case "zendesk":
+      return zendesk(adminCommand);
     default:
       assertNever(adminCommand);
   }

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -267,6 +267,7 @@ export const AdminCommandSchema = t.union([
   SlackCommandSchema,
   TemporalCommandSchema,
   WebcrawlerCommandSchema,
+  ZendeskCommandSchema,
 ]);
 
 export type AdminCommandType = t.TypeOf<typeof AdminCommandSchema>;

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -214,6 +214,30 @@ export type IntercomForceResyncArticlesResponseType = t.TypeOf<
  * </ Intercom>
  */
 
+/**
+ * <Zendesk>
+ */
+export const ZendeskCommandSchema = t.type({
+  majorCommand: t.literal("zendesk"),
+  command: t.literal("check-is-admin"),
+  args: t.type({
+    connectorId: t.union([t.number, t.undefined]),
+  }),
+});
+
+export type ZendeskCommandType = t.TypeOf<typeof ZendeskCommandSchema>;
+export const ZendeskCheckIsAdminResponseSchema = t.type({
+  userRole: t.string,
+  userActive: t.boolean,
+  userIsAdmin: t.boolean,
+});
+export type ZendeskCheckIsAdminResponseType = t.TypeOf<
+  typeof ZendeskCheckIsAdminResponseSchema
+>;
+/**
+ * </Zendesk>
+ */
+
 export const MicrosoftCommandSchema = t.type({
   majorCommand: t.literal("microsoft"),
   command: t.union([


### PR DESCRIPTION
## Description

- Add a CLI for Zendesk.
- Add a command `check-is-admin` in this CLI that takes a `connectorId` and check that the user authenticated is an admin (using the `/users/me` endpoint).

## Risk

Very low.

## Deploy Plan

- Deploy connectors.