### PR TITLE
Fix typeguard websearch public sdk

### DIFF
--- a/sdks/js/package-lock.json
+++ b/sdks/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/client",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "ISC",
       "dependencies": {
         "eventsource-parser": "^1.1.1",

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Client for Dust API",
   "repository": {
     "type": "git",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2169,7 +2169,7 @@ export function isRetrievalActionType(
 export function isWebsearchActionType(
   action: AgentActionPublicType
 ): action is WebsearchActionPublicType {
-  return action.type === "retrieval_action";
+  return action.type === "websearch_action";
 }
 
 export function isTablesQueryActionType(


### PR DESCRIPTION
## Description

Websearch citations are never rendered due to a copy/paste mistake on the SDK typeguards
Fix from https://github.com/dust-tt/dust/pull/8470


## Risk

Not risky.

## Deploy Plan

Deploy client. 

