### PR TITLE
[front] - fix: fetch agent configurations

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -373,7 +373,7 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
             sId: agentsGetView.agentIds.filter((id) => !isGlobalAgentId(id)),
           },
           order: [["version", "DESC"]],
-          ...(agentsGetView.allVersions ? {} : { limit: 1 }),
+          ...(agentsGetView.allVersions ? {} : { status: "active" }),
         });
       }
       assertNever(agentsGetView);


### PR DESCRIPTION
## Description

This PR fixes `fetchWorkspaceAgentConfigurationsWithoutActions` to fetch active agent configurations instead of limiting to 1 single element. This was causing 404 on `https://dust.tt/api/w/[wId]/assistant/conversations/[cId]/participants` when listing participants of a conversation with multiple agents.

The error message was:
```
{"error":{"type":"conversation_not_found","message":"Conversation not found"}}
````

**References:**
- https://dust4ai.slack.com/archives/C05F84CFP0E/p1732368920962319

## Risk

Low

## Deploy Plan

Deploy `front`