### PR TITLE
[connectors] Use links provided by Zendesk API instead of reconstructing URLs

### DIFF
--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -203,7 +203,11 @@ export async function fetchZendeskCategoriesInBrand(
     accessToken,
   });
   return (
-    response || { categories: [], meta: { has_more: false, after_cursor: "" } }
+    response || {
+      categories: [],
+      meta: { has_more: false },
+      links: { next: "" },
+    }
   );
 }
 

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -222,7 +222,7 @@ export async function fetchRecentlyUpdatedArticles({
   startTime: number;
 }): Promise<{
   articles: ZendeskFetchedArticle[];
-  nextLink: string | null;
+  hasMore: boolean;
   endTime: number;
 }> {
   // this endpoint retrieves changes in content, not only in metadata despite what is mentioned in the documentation.
@@ -232,7 +232,7 @@ export async function fetchRecentlyUpdatedArticles({
   });
   return {
     articles: response.articles,
-    nextLink: response.next_page,
+    hasMore: response.next_page !== null || response.articles.length === 0,
     endTime: response.end_time,
   };
 }

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -189,16 +189,8 @@ export async function fetchZendeskCategoriesInBrand(
     pageSize,
     url,
   }:
-    | {
-        brandSubdomain: string;
-        pageSize: number;
-        url?: never;
-      }
-    | {
-        brandSubdomain?: never;
-        pageSize?: never;
-        url: string | null;
-      }
+    | { brandSubdomain: string; pageSize: number; url?: never }
+    | { brandSubdomain?: never; pageSize?: never; url: string }
 ): Promise<{
   categories: ZendeskFetchedCategory[];
   meta: { has_more: boolean };

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -225,7 +225,7 @@ export async function fetchRecentlyUpdatedArticles({
   nextLink: string | null;
   endTime: number;
 }> {
-  // this endpoint retrieves changes in content despite what is mentioned in the documentation.
+  // this endpoint retrieves changes in content, not only in metadata despite what is mentioned in the documentation.
   const response = await fetchFromZendeskWithRetries({
     url: `https://${brandSubdomain}.zendesk.com/api/v2/help_center/incremental/articles.json?start_time=${startTime}`,
     accessToken,

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -325,7 +325,7 @@ export async function fetchZendeskTicketsInBrand(
         url: string;
       }
 ): Promise<{
-  tickets: ZendeskFetchedTicket[];
+  results: ZendeskFetchedTicket[];
   meta: { has_more: boolean };
   links: { next: string | null };
 }> {
@@ -339,7 +339,7 @@ export async function fetchZendeskTicketsInBrand(
   });
 
   return (
-    response || { tickets: [], meta: { has_more: false }, links: { next: "" } }
+    response || { results: [], meta: { has_more: false }, links: { next: "" } }
   );
 }
 

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -211,6 +211,7 @@ export async function fetchZendeskCategoriesInBrand(
 
 /**
  * Fetches a batch of the recently updated articles from the Zendesk API using the incremental API endpoint.
+ * https://developer.zendesk.com/documentation/help_center/help-center-api/understanding-incremental-article-exports/
  */
 export async function fetchRecentlyUpdatedArticles({
   brandSubdomain,

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -193,8 +193,8 @@ export async function fetchZendeskCategoriesInBrand(
     | { brandSubdomain?: never; pageSize?: never; url: string }
 ): Promise<{
   categories: ZendeskFetchedCategory[];
-  meta: { has_more: boolean };
-  links: { next: string | null };
+  hasMore: boolean;
+  nextLink: string | null;
 }> {
   const response = await fetchFromZendeskWithRetries({
     url:
@@ -202,13 +202,11 @@ export async function fetchZendeskCategoriesInBrand(
       `https://${brandSubdomain}.zendesk.com/api/v2/help_center/categories?page[size]=${pageSize}`,
     accessToken,
   });
-  return (
-    response || {
-      categories: [],
-      meta: { has_more: false },
-      links: { next: "" },
-    }
-  );
+  return {
+    categories: response.categories,
+    hasMore: response.meta.has_more,
+    nextLink: response.links.next,
+  };
 }
 
 /**
@@ -224,21 +222,19 @@ export async function fetchRecentlyUpdatedArticles({
   startTime: number;
 }): Promise<{
   articles: ZendeskFetchedArticle[];
-  next_page: string | null;
-  end_time: number;
+  nextLink: string | null;
+  endTime: number;
 }> {
   // this endpoint retrieves changes in content despite what is mentioned in the documentation.
   const response = await fetchFromZendeskWithRetries({
     url: `https://${brandSubdomain}.zendesk.com/api/v2/help_center/incremental/articles.json?start_time=${startTime}`,
     accessToken,
   });
-  return (
-    response || {
-      articles: [],
-      next_page: null,
-      end_time: startTime,
-    }
-  );
+  return {
+    articles: response.articles,
+    nextLink: response.next_page,
+    endTime: response.end_time,
+  };
 }
 
 /**
@@ -256,8 +252,8 @@ export async function fetchZendeskArticlesInCategory(
     | { brandSubdomain?: never; pageSize?: never; url: string }
 ): Promise<{
   articles: ZendeskFetchedArticle[];
-  meta: { has_more: boolean };
-  links: { next: string | null };
+  hasMore: boolean;
+  nextLink: string | null;
 }> {
   const response = await fetchFromZendeskWithRetries({
     url:
@@ -265,9 +261,11 @@ export async function fetchZendeskArticlesInCategory(
       `https://${brandSubdomain}.zendesk.com/api/v2/help_center/categories/${category.categoryId}/articles?page[size]=${pageSize}`,
     accessToken,
   });
-  return (
-    response || { articles: [], meta: { has_more: false }, links: { next: "" } }
-  );
+  return {
+    articles: response.articles,
+    hasMore: response.meta.has_more,
+    nextLink: response.links.next,
+  };
 }
 
 /**
@@ -284,8 +282,8 @@ export async function fetchRecentlyUpdatedTickets(
     | { brandSubdomain?: never; startTime?: never; url: string }
 ): Promise<{
   tickets: ZendeskFetchedTicket[];
-  end_of_stream: boolean;
-  after_url: string | null;
+  hasMore: boolean;
+  nextLink: string | null;
 }> {
   const response = await fetchFromZendeskWithRetries({
     url:
@@ -293,7 +291,11 @@ export async function fetchRecentlyUpdatedTickets(
       `https://${brandSubdomain}.zendesk.com/api/v2/incremental/tickets/cursor.json?start_time=${startTime}`,
     accessToken,
   });
-  return response || { tickets: [], end_of_stream: false, after_url: "" };
+  return {
+    tickets: response.tickets,
+    hasMore: !response.end_of_stream,
+    nextLink: response.after_url,
+  };
 }
 
 /**
@@ -321,9 +323,9 @@ export async function fetchZendeskTicketsInBrand(
         url: string;
       }
 ): Promise<{
-  results: ZendeskFetchedTicket[];
-  meta: { has_more: boolean };
-  links: { next: string | null };
+  tickets: ZendeskFetchedTicket[];
+  hasMore: boolean;
+  nextLink: string | null;
 }> {
   const response = await fetchFromZendeskWithRetries({
     url:
@@ -334,9 +336,11 @@ export async function fetchZendeskTicketsInBrand(
     accessToken,
   });
 
-  return (
-    response || { results: [], meta: { has_more: false }, links: { next: "" } }
-  );
+  return {
+    tickets: response.results,
+    hasMore: response.meta.has_more,
+    nextLink: response.links.next,
+  };
 }
 
 /**

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -398,7 +398,7 @@ export async function syncZendeskTicketBatchActivity({
   });
 
   const {
-    tickets,
+    results,
     meta: { has_more: hasMore },
     links: { next: nextLink },
   } = await fetchZendeskTicketsInBrand(
@@ -412,7 +412,7 @@ export async function syncZendeskTicketBatchActivity({
         }
   );
 
-  if (tickets.length === 0) {
+  if (results.length === 0) {
     logger.info(
       { ...loggerArgs, ticketsSynced: 0 },
       `[Zendesk] No tickets to process in batch - stopping.`
@@ -423,7 +423,7 @@ export async function syncZendeskTicketBatchActivity({
   const users = await zendeskApiClient.users.list();
 
   const res = await concurrentExecutor(
-    tickets,
+    results,
     async (ticket) => {
       const comments = await zendeskApiClient.tickets.getComments(ticket.id);
 

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -179,11 +179,7 @@ export async function syncZendeskCategoryBatchActivity({
     connectorId,
   });
 
-  const {
-    categories,
-    meta: { has_more: hasMore },
-    links: { next: nextLink },
-  } = await fetchZendeskCategoriesInBrand(
+  const { categories, hasMore, nextLink } = await fetchZendeskCategoriesInBrand(
     accessToken,
     url ? { url } : { brandSubdomain, pageSize: ZENDESK_BATCH_SIZE }
   );
@@ -314,11 +310,7 @@ export async function syncZendeskArticleBatchActivity({
     connectorId,
   });
 
-  const {
-    articles,
-    meta: { has_more: hasMore },
-    links: { next: nextLink },
-  } = await fetchZendeskArticlesInCategory(
+  const { articles, hasMore, nextLink } = await fetchZendeskArticlesInCategory(
     category,
     accessToken,
     url ? { url } : { brandSubdomain, pageSize: ZENDESK_BATCH_SIZE }
@@ -397,11 +389,7 @@ export async function syncZendeskTicketBatchActivity({
     brandId,
   });
 
-  const {
-    results,
-    meta: { has_more: hasMore },
-    links: { next: nextLink },
-  } = await fetchZendeskTicketsInBrand(
+  const { tickets, hasMore, nextLink } = await fetchZendeskTicketsInBrand(
     accessToken,
     url
       ? { url }
@@ -412,7 +400,7 @@ export async function syncZendeskTicketBatchActivity({
         }
   );
 
-  if (results.length === 0) {
+  if (tickets.length === 0) {
     logger.info(
       { ...loggerArgs, ticketsSynced: 0 },
       `[Zendesk] No tickets to process in batch - stopping.`
@@ -423,7 +411,7 @@ export async function syncZendeskTicketBatchActivity({
   const users = await zendeskApiClient.users.list();
 
   const res = await concurrentExecutor(
-    results,
+    tickets,
     async (ticket) => {
       const comments = await zendeskApiClient.tickets.getComments(ticket.id);
 

--- a/connectors/src/connectors/zendesk/temporal/config.ts
+++ b/connectors/src/connectors/zendesk/temporal/config.ts
@@ -1,4 +1,4 @@
-export const WORKFLOW_VERSION = 9;
+export const WORKFLOW_VERSION = 10;
 export const QUEUE_NAME = `zendesk-queue-v${WORKFLOW_VERSION}`;
 
 // Batch size used when fetching from Zendesk API or from the database

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -108,7 +108,7 @@ export async function syncZendeskArticleUpdateBatchActivity({
     brandId,
   });
 
-  const { articles, end_time, next_page } = await fetchRecentlyUpdatedArticles({
+  const { articles, endTime, nextLink } = await fetchRecentlyUpdatedArticles({
     brandSubdomain,
     accessToken,
     startTime,
@@ -171,7 +171,7 @@ export async function syncZendeskArticleUpdateBatchActivity({
     },
     { concurrency: 10 }
   );
-  return next_page !== null ? end_time : null;
+  return nextLink !== null ? endTime : null;
 }
 
 /**
@@ -212,11 +212,10 @@ export async function syncZendeskTicketUpdateBatchActivity({
     brandId,
   });
 
-  const { tickets, end_of_stream, after_url } =
-    await fetchRecentlyUpdatedTickets(
-      accessToken,
-      url ? { url } : { brandSubdomain, startTime }
-    );
+  const { tickets, hasMore, nextLink } = await fetchRecentlyUpdatedTickets(
+    accessToken,
+    url ? { url } : { brandSubdomain, startTime }
+  );
 
   await concurrentExecutor(
     tickets,
@@ -248,5 +247,5 @@ export async function syncZendeskTicketUpdateBatchActivity({
     },
     { concurrency: 10 }
   );
-  return { hasMore: !end_of_stream, nextLink: after_url };
+  return { hasMore, nextLink };
 }

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -108,7 +108,7 @@ export async function syncZendeskArticleUpdateBatchActivity({
     brandId,
   });
 
-  const { articles, endTime, nextLink } = await fetchRecentlyUpdatedArticles({
+  const { articles, hasMore, endTime } = await fetchRecentlyUpdatedArticles({
     brandSubdomain,
     accessToken,
     startTime,
@@ -171,7 +171,7 @@ export async function syncZendeskArticleUpdateBatchActivity({
     },
     { concurrency: 10 }
   );
-  return nextLink !== null ? endTime : null;
+  return hasMore ? endTime : null;
 }
 
 /**


### PR DESCRIPTION
## Description

- This PR aims at fixing issues similar to [these](https://app.datadoghq.eu/logs?query=%40dd.service%3Aconnectors-worker%20%40dd.env%3Aprod%20%40hostname%3Aconnectors-worker-zendesk-deployment-587788f749-mblcm%20%40status%3A422&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=6000198897476506285&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1732552298312&to_ts=1732553198312&live=true).
- This is a follow up on https://github.com/dust-tt/dust/pull/8870.
- This PR consists in replacing the use of cursors with manually reconstructed URLs with the links provided by the API, which may or may not fix our issue but is easier to maintain nonetheless.

## Risk

Low.

## Deploy Plan

- Deploy connectors.