### PR TITLE
enh(zendesk): skip incremental update on empty initial sync

### DIFF
--- a/connectors/migrations/db/migration_39.sql
+++ b/connectors/migrations/db/migration_39.sql
@@ -1,0 +1,11 @@
+DELETE FROM
+    "zendesk_timestamp_cursors"
+WHERE
+    "timestampCursor" IS NULL;
+
+ALTER TABLE
+    "zendesk_timestamp_cursors"
+ALTER COLUMN
+    "timestampCursor"
+SET
+    NOT NULL;

--- a/connectors/src/admin/db.ts
+++ b/connectors/src/admin/db.ts
@@ -67,7 +67,7 @@ import {
   ZendeskCategory,
   ZendeskConfiguration,
   ZendeskTicket,
-  ZendeskTimestampCursors,
+  ZendeskTimestampCursor,
 } from "@connectors/lib/models/zendesk";
 import logger from "@connectors/logger/logger";
 import { sequelizeConnection } from "@connectors/resources/storage";
@@ -121,7 +121,7 @@ async function main(): Promise<void> {
   await RemoteDatabaseModel.sync({ alter: true });
   await RemoteSchemaModel.sync({ alter: true });
   await RemoteTableModel.sync({ alter: true });
-  await ZendeskTimestampCursors.sync({ alter: true });
+  await ZendeskTimestampCursor.sync({ alter: true });
   await ZendeskConfiguration.sync({ alter: true });
   await ZendeskBrand.sync({ alter: true });
   await ZendeskCategory.sync({ alter: true });

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -14,7 +14,7 @@ import {
 import { ZENDESK_BATCH_SIZE } from "@connectors/connectors/zendesk/temporal/config";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
-import { ZendeskTimestampCursors } from "@connectors/lib/models/zendesk";
+import { ZendeskTimestampCursor } from "@connectors/lib/models/zendesk";
 import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -29,7 +29,7 @@ import {
  */
 export async function zendeskConnectorStartSync(
   connectorId: ModelId
-): Promise<{ isInitialSync: boolean }> {
+): Promise<{ cursor: Date | null }> {
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
     throw new Error("[Zendesk] Connector not found.");
@@ -38,8 +38,11 @@ export async function zendeskConnectorStartSync(
   if (res.isErr()) {
     throw res.error;
   }
+  const cursor = await ZendeskTimestampCursor.findOne({
+    where: { connectorId },
+  });
 
-  return { isInitialSync: !connector.lastSyncSuccessfulTime };
+  return { cursor: cursor?.timestampCursor ?? null };
 }
 
 /**
@@ -55,11 +58,11 @@ export async function saveZendeskConnectorSuccessSync(
   }
 
   // initializing the timestamp cursor if it does not exist (first sync, not incremental)
-  const cursors = await ZendeskTimestampCursors.findOne({
+  const cursors = await ZendeskTimestampCursor.findOne({
     where: { connectorId },
   });
   if (!cursors) {
-    await ZendeskTimestampCursors.create({
+    await ZendeskTimestampCursor.create({
       connectorId,
       timestampCursor: new Date(currentSyncDateMs),
     });

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -27,7 +27,9 @@ import {
 /**
  * This activity is responsible for updating the lastSyncStartTime of the connector to now.
  */
-export async function saveZendeskConnectorStartSync(connectorId: ModelId) {
+export async function zendeskConnectorStartSync(
+  connectorId: ModelId
+): Promise<{ isInitialSync: boolean }> {
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
     throw new Error("[Zendesk] Connector not found.");
@@ -36,6 +38,8 @@ export async function saveZendeskConnectorStartSync(connectorId: ModelId) {
   if (res.isErr()) {
     throw res.error;
   }
+
+  return { isInitialSync: !connector.lastSyncSuccessfulTime };
 }
 
 /**

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -27,15 +27,12 @@ import {
  */
 export async function getZendeskTimestampCursorActivity(
   connectorId: ModelId
-): Promise<Date | null> {
-  let cursors = await ZendeskTimestampCursors.findOne({
+): Promise<Date> {
+  const cursors = await ZendeskTimestampCursors.findOne({
     where: { connectorId },
   });
   if (!cursors) {
-    cursors = await ZendeskTimestampCursors.create({
-      connectorId,
-      timestampCursor: null, // start date of the last successful sync, null for now since we do not know it will succeed
-    });
+    throw new Error("[Zendesk] Timestamp cursor not found.");
   }
   // we get a StartTimeTooRecent error before 1 minute
   const minAgo = Date.now() - 60 * 1000; // 1 minute ago

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -14,7 +14,7 @@ import {
 } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
-import { ZendeskTimestampCursors } from "@connectors/lib/models/zendesk";
+import { ZendeskTimestampCursor } from "@connectors/lib/models/zendesk";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import {
@@ -28,7 +28,7 @@ import {
 export async function getZendeskTimestampCursorActivity(
   connectorId: ModelId
 ): Promise<Date> {
-  const cursors = await ZendeskTimestampCursors.findOne({
+  const cursors = await ZendeskTimestampCursor.findOne({
     where: { connectorId },
   });
   if (!cursors) {
@@ -36,9 +36,7 @@ export async function getZendeskTimestampCursorActivity(
   }
   // we get a StartTimeTooRecent error before 1 minute
   const minAgo = Date.now() - 60 * 1000; // 1 minute ago
-  return cursors.timestampCursor
-    ? new Date(Math.min(cursors.timestampCursor.getTime(), minAgo))
-    : new Date(minAgo);
+  return new Date(Math.min(cursors.timestampCursor.getTime(), minAgo));
 }
 
 /**
@@ -51,7 +49,7 @@ export async function setZendeskTimestampCursorActivity({
   connectorId: ModelId;
   currentSyncDateMs: number;
 }) {
-  const cursors = await ZendeskTimestampCursors.findOne({
+  const cursors = await ZendeskTimestampCursor.findOne({
     where: { connectorId },
   });
   if (!cursors) {

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -71,7 +71,8 @@ export async function zendeskSyncWorkflow({
 }: {
   connectorId: ModelId;
 }) {
-  const { isInitialSync } = await zendeskConnectorStartSync(connectorId);
+  const { cursor } = await zendeskConnectorStartSync(connectorId);
+  const isInitialSync = !cursor;
 
   const brandIds = new Set<number>();
   const brandSignals: ZendeskUpdateSignal[] = [];

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -8,7 +8,6 @@ import {
 } from "@temporalio/workflow";
 
 import type * as activities from "@connectors/connectors/zendesk/temporal/activities";
-import { zendeskConnectorStartSync } from "@connectors/connectors/zendesk/temporal/activities";
 import type * as gc_activities from "@connectors/connectors/zendesk/temporal/gc_activities";
 import type * as incremental_activities from "@connectors/connectors/zendesk/temporal/incremental_activities";
 import type {
@@ -53,6 +52,7 @@ const {
 });
 
 const {
+  zendeskConnectorStartSync,
   saveZendeskConnectorSuccessSync,
   getZendeskHelpCenterReadAllowedBrandIdsActivity,
   getZendeskTicketsAllowedBrandIdsActivity,

--- a/connectors/src/lib/models/zendesk.ts
+++ b/connectors/src/lib/models/zendesk.ts
@@ -15,20 +15,21 @@ function throwOnUnsafeInteger(value: number | null) {
   }
 }
 
-export class ZendeskTimestampCursors extends Model<
-  InferAttributes<ZendeskTimestampCursors>,
-  InferCreationAttributes<ZendeskTimestampCursors>
+export class ZendeskTimestampCursor extends Model<
+  InferAttributes<ZendeskTimestampCursor>,
+  InferCreationAttributes<ZendeskTimestampCursor>
 > {
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare timestampCursor: Date | null; // start date of the last successful sync, null if never successfully synced
+  // start date of the last successful sync
+  declare timestampCursor: Date;
 
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
 }
 
-ZendeskTimestampCursors.init(
+ZendeskTimestampCursor.init(
   {
     id: {
       type: DataTypes.INTEGER,
@@ -47,8 +48,7 @@ ZendeskTimestampCursors.init(
     },
     timestampCursor: {
       type: DataTypes.DATE,
-      allowNull: true,
-      defaultValue: null,
+      allowNull: false,
     },
   },
   {
@@ -57,11 +57,11 @@ ZendeskTimestampCursors.init(
     indexes: [{ fields: ["connectorId"], unique: true }],
   }
 );
-ConnectorModel.hasMany(ZendeskTimestampCursors, {
+ConnectorModel.hasMany(ZendeskTimestampCursor, {
   foreignKey: { allowNull: false },
   onDelete: "RESTRICT",
 });
-ZendeskTimestampCursors.belongsTo(ConnectorModel);
+ZendeskTimestampCursor.belongsTo(ConnectorModel);
 
 export class ZendeskConfiguration extends Model<
   InferAttributes<ZendeskConfiguration>,

--- a/connectors/src/resources/connector/zendesk.ts
+++ b/connectors/src/resources/connector/zendesk.ts
@@ -2,7 +2,7 @@ import type { ModelId } from "@dust-tt/types";
 import type { Transaction } from "sequelize";
 
 import type { ZendeskConfiguration } from "@connectors/lib/models/zendesk";
-import { ZendeskTimestampCursors } from "@connectors/lib/models/zendesk";
+import { ZendeskTimestampCursor } from "@connectors/lib/models/zendesk";
 import type {
   ConnectorProviderConfigurationType,
   ConnectorProviderModelResourceMapping,
@@ -45,7 +45,7 @@ export class ZendeskConnectorStrategy
       transaction
     );
     await ZendeskBrandResource.deleteByConnectorId(connector.id, transaction);
-    await ZendeskTimestampCursors.destroy({
+    await ZendeskTimestampCursor.destroy({
       where: { connectorId: connector.id },
       transaction,
     });


### PR DESCRIPTION
## Description

- `saveZendeskConnectorStartSync` now returns whether the connector has already successfully  synced (and therefore is renamed `zendeskConnectorStartSync`)
- the `incrementalSync` is being skipped if `isInitialSync` is true, even if the admin selected nothing to sync
- a null cursor in the incremental sync is now considered to be an error (technically should be an unreachable code path)


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- deploy
- batch restart zendesk connectors (workflow code not compatible)
- run migration