### PR TITLE
[front] - fix(participants): status condition in where clause

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -371,9 +371,9 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
             workspaceId: owner.id,
             ...(agentPrefix ? { name: { [Op.iLike]: `${agentPrefix}%` } } : {}),
             sId: agentsGetView.agentIds.filter((id) => !isGlobalAgentId(id)),
+            ...(agentsGetView.allVersions ? {} : { status: "active" }),
           },
           order: [["version", "DESC"]],
-          ...(agentsGetView.allVersions ? {} : { status: "active" }),
         });
       }
       assertNever(agentsGetView);


### PR DESCRIPTION
## Description

This PR adjusts the query logic to filter by active status unless `allVersions` is specified. The previous query was broken as the "status" filter was rendered outside of the where clause.

**References:**
- https://github.com/dust-tt/dust/issues/8891

## Risk

Low

## Deploy Plan

Deploy `front`