### PR TITLE
[connectors] Throw ExternalOAuth errors on Zendesk 403 errors

### DIFF
--- a/connectors/src/connectors/zendesk/lib/errors.ts
+++ b/connectors/src/connectors/zendesk/lib/errors.ts
@@ -1,0 +1,19 @@
+/**
+ * Errors returned by the library node-zendesk.
+ * Check out https://github.com/blakmatrix/node-zendesk/blob/fa069d927bd418ee2058bb7bb913f9414e395110/src/clients/helpers.js#L262
+ */
+interface NodeZendeskError extends Error {
+  statusCode: number;
+  result: string | null;
+}
+
+export function isNodeZendeskForbiddenError(
+  err: unknown
+): err is NodeZendeskError {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "statusCode" in err &&
+    err.statusCode === 403
+  );
+}

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -9,6 +9,7 @@ import type {
   ZendeskFetchedTicket,
   ZendeskFetchedUser,
 } from "@connectors/@types/node-zendesk";
+import { isNodeZendeskForbiddenError } from "@connectors/connectors/zendesk/lib/errors";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import logger from "@connectors/logger/logger";
 import type { ZendeskCategoryResource } from "@connectors/resources/zendesk_resources";
@@ -380,14 +381,13 @@ export async function fetchArticleMetadata(
       article.author_id
     );
     return { section, user };
-  } catch (e: unknown) {
+  } catch (e) {
     logger.error(
       { articleId: article.id, error: e },
       "[Zendesk] Error fetching article metadata"
     );
-    // @ts-expect-error check out https://github.com/blakmatrix/node-zendesk/blob/fa069d927bd418ee2058bb7bb913f9414e395110/src/clients/helpers.js#L262
-    if (e.statusCode === 403) {
-      throw new ExternalOAuthTokenError();
+    if (isNodeZendeskForbiddenError(e)) {
+      throw new ExternalOAuthTokenError(e);
     }
     throw e;
   }

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -148,6 +148,8 @@ async function fetchFromZendeskWithRetries({
         `[Zendesk] Zendesk API 404 error on: ${getEndpointFromUrl(url)}`
       );
       return null;
+    } else if (rawResponse.status === 403) {
+      throw new ExternalOAuthTokenError();
     }
     logger.error(
       { rawResponse, status: rawResponse.status, text: rawResponse.text },

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -382,7 +382,7 @@ export async function fetchArticleMetadata(
     return { section, user };
   } catch (e: unknown) {
     logger.error(
-      { article, error: e },
+      { articleId: article.id, error: e },
       "[Zendesk] Error fetching article metadata"
     );
     // @ts-expect-error check out https://github.com/blakmatrix/node-zendesk/blob/fa069d927bd418ee2058bb7bb913f9414e395110/src/clients/helpers.js#L262

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -1,5 +1,6 @@
 import type { ModelId } from "@dust-tt/types";
 
+import { isNodeZendeskForbiddenError } from "@connectors/connectors/zendesk/lib/errors";
 import { syncArticle } from "@connectors/connectors/zendesk/lib/sync_article";
 import { syncCategory } from "@connectors/connectors/zendesk/lib/sync_category";
 import { syncTicket } from "@connectors/connectors/zendesk/lib/sync_ticket";
@@ -354,10 +355,9 @@ export async function syncZendeskArticleBatchActivity({
         }),
       { concurrency: 10 }
     );
-  } catch (e: unknown) {
-    // @ts-expect-error check out https://github.com/blakmatrix/node-zendesk/blob/fa069d927bd418ee2058bb7bb913f9414e395110/src/clients/helpers.js#L262
-    if (e.statusCode === 403) {
-      throw new ExternalOAuthTokenError();
+  } catch (e) {
+    if (isNodeZendeskForbiddenError(e)) {
+      throw new ExternalOAuthTokenError(e);
     }
     throw e;
   }

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -9,6 +9,7 @@ import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendes
 import {
   changeZendeskClientSubdomain,
   createZendeskClient,
+  fetchArticleMetadata,
   fetchRecentlyUpdatedArticles,
   fetchRecentlyUpdatedTickets,
 } from "@connectors/connectors/zendesk/lib/zendesk_api";
@@ -112,10 +113,9 @@ export async function syncZendeskArticleUpdateBatchActivity({
   await concurrentExecutor(
     articles,
     async (article) => {
-      const { result: section } =
-        await zendeskApiClient.helpcenter.sections.show(article.section_id);
-      const { result: user } = await zendeskApiClient.users.show(
-        article.author_id
+      const { section, user } = await fetchArticleMetadata(
+        zendeskApiClient,
+        article
       );
 
       if (section.category_id) {


### PR DESCRIPTION
## Description

- This PR aims at replacing unhandled activities errors due to 403 errors in the API (either in `node-zendesk` or in our fetches) with `ExternalOAuthError` thrown.
- This PR does not fix the fact that we need an admin to go through the authentication flow.

## Risk

Low.

## Deploy Plan

- Deploy connectors.