### PR TITLE
[connectors] Rework Zendesk full resync

### DIFF
--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -40,9 +40,8 @@ import {
   stopZendeskWorkflows,
 } from "@connectors/connectors/zendesk/temporal/client";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
-import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
-import { ZendeskTimestampCursors } from "@connectors/lib/models/zendesk";
+import { ZendeskTimestampCursor } from "@connectors/lib/models/zendesk";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import {
@@ -250,7 +249,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
 
     // launching an incremental workflow taking the diff starting from the given timestamp
     if (fromTs) {
-      const cursors = await ZendeskTimestampCursors.findOne({
+      const cursors = await ZendeskTimestampCursor.findOne({
         where: { connectorId },
       });
       if (!cursors) {

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -262,6 +262,8 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         forceResync: true,
       });
       return result.isErr() ? result : new Ok(connector.id.toString());
+    } else {
+      await ZendeskTimestampCursor.destroy({ where: { connectorId } });
     }
 
     // launching a full sync workflow otherwise

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -253,7 +253,9 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         where: { connectorId },
       });
       if (!cursors) {
-        throw new Error("[Zendesk] Timestamp cursor not found.");
+        throw new Error(
+          "[Zendesk] Cannot use fromTs on a connector that has never completed an initial sync."
+        );
       }
       await cursors.update({ timestampCursor: new Date(fromTs) });
       const result = await launchZendeskSyncWorkflow(connector, {

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -258,9 +258,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         );
       }
       await cursors.update({ timestampCursor: new Date(fromTs) });
-      const result = await launchZendeskSyncWorkflow(connector, {
-        forceResync: true,
-      });
+      const result = await launchZendeskSyncWorkflow(connector);
       return result.isErr() ? result : new Ok(connector.id.toString());
     } else {
       await ZendeskTimestampCursor.destroy({ where: { connectorId } });

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -195,7 +195,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
   }
 
   /**
-   * Launches a full re-sync workflow for the connector, launches the garbage collection workflow.
+   * Launches an incremental workflow (sync workflow without signals) and the garbage collection workflow for the connector.
    */
   async resume(): Promise<Result<undefined, Error>> {
     const { connectorId } = this;
@@ -664,7 +664,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
   }
 
   /**
-   * Marks the connector as unpaused in db and launches a full resync workflow.
+   * Marks the connector as unpaused in db and restarts the workflows.
    */
   async unpause(): Promise<Result<undefined, Error>> {
     const { connectorId } = this;

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -185,7 +185,14 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
    * Stops all workflows related to the connector (sync and garbage collection).
    */
   async stop(): Promise<Result<undefined, Error>> {
-    return stopZendeskWorkflows(this.connectorId);
+    const { connectorId } = this;
+    const connector = await ConnectorResource.fetchById(connectorId);
+    if (!connector) {
+      throw new Error(
+        `[Zendesk] Connector not found. ConnectorId: ${connectorId}`
+      );
+    }
+    return stopZendeskWorkflows(connector);
   }
 
   /**

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -159,6 +159,9 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     return new Ok(connector.id.toString());
   }
 
+  /**
+   * Deletes the connector and all its related resources.
+   */
   async clean(): Promise<Result<undefined, Error>> {
     const { connectorId } = this;
     const connector = await ConnectorResource.fetchById(connectorId);

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -177,10 +177,16 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     return result;
   }
 
+  /**
+   * Stops all workflows related to the connector (sync and garbage collection).
+   */
   async stop(): Promise<Result<undefined, Error>> {
     return stopZendeskWorkflows(this.connectorId);
   }
 
+  /**
+   * Launches a full re-sync workflow for the connector, launches the garbage collection workflow.
+   */
   async resume(): Promise<Result<undefined, Error>> {
     const { connectorId } = this;
     const connector = await ConnectorResource.fetchById(connectorId);
@@ -257,6 +263,11 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     }
   }
 
+  /**
+   * Updates the permissions stored in db,
+   * then launches a sync workflow with the signals
+   * corresponding to the resources that were modified to reflect the changes.
+   */
   async setPermissions({
     permissions,
   }: {
@@ -415,6 +426,9 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     return new Ok(undefined);
   }
 
+  /**
+   * Retrieves a batch of content nodes given their internal IDs.
+   */
   async retrieveBatchContentNodes({
     internalIds,
   }: {
@@ -605,6 +619,9 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     throw new Error("Method not implemented.");
   }
 
+  /**
+   * Marks the connector as paused in db and stops all workflows.
+   */
   async pause(): Promise<Result<undefined, Error>> {
     const { connectorId } = this;
     const connector = await ConnectorResource.fetchById(connectorId);
@@ -616,6 +633,9 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     return this.stop();
   }
 
+  /**
+   * Marks the connector as unpaused in db and launches a full resync workflow.
+   */
   async unpause(): Promise<Result<undefined, Error>> {
     const { connectorId } = this;
     const connector = await ConnectorResource.fetchById(connectorId);

--- a/connectors/src/connectors/zendesk/temporal/client.ts
+++ b/connectors/src/connectors/zendesk/temporal/client.ts
@@ -16,9 +16,14 @@ import {
   zendeskGarbageCollectionWorkflow,
   zendeskSyncWorkflow,
 } from "@connectors/connectors/zendesk/temporal/workflows";
+import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { getTemporalClient } from "@connectors/lib/temporal";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
+import {
+  ZendeskBrandResource,
+  ZendeskCategoryResource,
+} from "@connectors/resources/zendesk_resources";
 
 export function getZendeskSyncWorkflowId(connectorId: ModelId): string {
   return `zendesk-sync-${connectorId}`;
@@ -139,6 +144,46 @@ export async function stopZendeskWorkflows(
     }
   }
   return new Ok(undefined);
+}
+
+/**
+ * Launches a Zendesk workflow that will sync everything that was selected by the user in the UI.
+ *
+ * It recreates the signals necessary to resync every resource selected by the user,
+ * which are all the brands and all the categories whose Help Center is not selected as a whole.
+ */
+export async function launchZendeskFullSyncWorkflow(
+  connector: ConnectorResource,
+  { forceResync = false }: { forceResync?: boolean } = {}
+): Promise<Result<string, Error>> {
+  const brandIds = await ZendeskBrandResource.fetchAllBrandIds(connector.id);
+  const noReadHelpCenterBrandIds =
+    await ZendeskBrandResource.fetchHelpCenterReadForbiddenBrandIds(
+      connector.id
+    );
+  // syncing individual categories syncs for ones where the Help Center is not selected as a whole
+  const categoryIds = (
+    await concurrentExecutor(
+      noReadHelpCenterBrandIds,
+      async (brandId) => {
+        const categoryIds =
+          await ZendeskCategoryResource.fetchReadOnlyCategoryIdsByBrandId({
+            connectorId: connector.id,
+            brandId,
+          });
+        return categoryIds.map((categoryId) => ({ categoryId, brandId }));
+      },
+      { concurrency: 10 }
+    )
+  ).flat();
+
+  const result = await launchZendeskSyncWorkflow(connector, {
+    brandIds,
+    categoryIds,
+    forceResync,
+  });
+
+  return result.isErr() ? result : new Ok(connector.id.toString());
 }
 
 export async function launchZendeskGarbageCollectionWorkflow(

--- a/connectors/src/connectors/zendesk/temporal/client.ts
+++ b/connectors/src/connectors/zendesk/temporal/client.ts
@@ -19,7 +19,7 @@ import {
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { getTemporalClient } from "@connectors/lib/temporal";
 import logger from "@connectors/logger/logger";
-import { ConnectorResource } from "@connectors/resources/connector_resource";
+import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import {
   ZendeskBrandResource,
   ZendeskCategoryResource,
@@ -111,18 +111,13 @@ export async function launchZendeskSyncWorkflow(
 }
 
 export async function stopZendeskWorkflows(
-  connectorId: ModelId
+  connector: ConnectorResource
 ): Promise<Result<undefined, Error>> {
   const client = await getTemporalClient();
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    throw new Error(
-      `[Zendesk] Connector not found. ConnectorId: ${connectorId}`
-    );
-  }
+
   const workflowIds = [
-    getZendeskSyncWorkflowId(connectorId),
-    getZendeskGarbageCollectionWorkflowId(connectorId),
+    getZendeskSyncWorkflowId(connector.id),
+    getZendeskGarbageCollectionWorkflowId(connector.id),
   ];
   for (const workflowId of workflowIds) {
     try {


### PR DESCRIPTION
## Description

- Disable `forceResync` when unpausing/resuming the connector.
- Implement `fromTs` when using `SYNC` (poke plugin): it will sync all the diff captured starting from this date.
- Refactor `stopZendeskWorkflows` to take a rich type in input instead of an ID.
- Add a lot of descriptions.

## Risk

Low.

## Deploy Plan

- Deploy connectors