### PR TITLE
[connectors] Include isolated Categories in Zendesk article incremental sync

### DIFF
--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -6,7 +6,7 @@ import type {
   ModelStatic,
   Transaction,
 } from "sequelize";
-import { Op } from "sequelize";
+import { col, fn, Op } from "sequelize";
 
 import {
   getArticleInternalId,
@@ -496,6 +496,16 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
       attributes: ["categoryId"],
     });
     return categories.map((category) => category.get().categoryId);
+  }
+
+  static async fetchBrandIdsOfReadOnlyCategories(
+    connectorId: number
+  ): Promise<number[]> {
+    const categories = await ZendeskCategory.findAll({
+      where: { connectorId, permission: "read" },
+      attributes: [[fn("DISTINCT", col("brandId")), "brandId"]],
+    });
+    return categories.map((category) => category.get().brandId);
   }
 
   static async fetchByBrandIdReadOnly({


### PR DESCRIPTION
## Description

This PR fixes an edge case of the article incremental sync.
- Previous behavior: article incremental sync run on brands whose Help Center is selected as a whole.
- Problem: if a user selects single categories, these won't be kept up-to-date.
- Fix: run the incremental sync on brands where at least one category is selected too (overkill but no incremental endpoint for Categories, a permission check is done when syncing the article).

## Risk

Low.

## Deploy Plan

- Deploy connectors.