### PR TITLE
enh(zendesk): reduce batch size and add heartbeat

### DIFF
--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -18,6 +18,7 @@ import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import { ZendeskTimestampCursor } from "@connectors/lib/models/zendesk";
 import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
+import { heartbeat } from "@connectors/lib/temporal";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import {
@@ -199,6 +200,7 @@ export async function syncZendeskCategoryBatchActivity({
       syncCategory({ connectorId, brandId, category, currentSyncDateMs }),
     {
       concurrency: 10,
+      onBatchComplete: heartbeat,
     }
   );
 
@@ -361,7 +363,10 @@ export async function syncZendeskArticleBatchActivity({
         loggerArgs,
         forceResync,
       }),
-    { concurrency: 10 }
+    {
+      concurrency: 10,
+      onBatchComplete: heartbeat,
+    }
   );
   return { hasMore, nextLink };
 }
@@ -446,7 +451,10 @@ export async function syncZendeskTicketBatchActivity({
         users,
       });
     },
-    { concurrency: 10 }
+    {
+      concurrency: 10,
+      onBatchComplete: heartbeat,
+    }
   );
 
   logger.info(

--- a/connectors/src/connectors/zendesk/temporal/config.ts
+++ b/connectors/src/connectors/zendesk/temporal/config.ts
@@ -3,4 +3,4 @@ export const QUEUE_NAME = `zendesk-queue-v${WORKFLOW_VERSION}`;
 
 // Batch size used when fetching from Zendesk API or from the database
 // 100 is the maximum value allowed for most endpoints in Zendesk: https://developer.zendesk.com/api-reference/introduction/pagination/
-export const ZENDESK_BATCH_SIZE = 50;
+export const ZENDESK_BATCH_SIZE = 30;


### PR DESCRIPTION
## Description

We're seeing some time outs on `syncZendeskTicketBatchActivity`

While this is definitely not expected and intriguing, we likely want to reduce batch size a bit and ensure the activities are heartbeating to avoid zombie activities.

Added to concurrent executor a way to run an async callback every $concurrency activities.

## Risk

critical path of connectors as it touches the `concurrentExecutor`

## Deploy Plan

Deploy connectors