### PR TITLE
[connectors] Fix(zendesk) - Invalid time value

### DIFF
--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -177,7 +177,7 @@ ${comments
   .map((comment) => {
     const author = users.find((user) => user.id === comment.author_id);
     return `
-[${new Date(comment.created_at).toISOString()}] ${
+[${new Date(Number(comment?.created_at)).toISOString()}] ${
       author ? `${author.name} (${author.email})` : "Unknown User"
     }:
 ${comment.body}`;


### PR DESCRIPTION
## Description

- Fix issues to [these](https://app.datadoghq.eu/logs?query=%40dd.service%3Aconnectors-worker%20%40dd.env%3Aprod%20%40hostname%3Aconnectors-worker-zendesk-deployment-%2A%20%22RangeError%3A%20Invalid%20time%20value%20%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=6000198897476506285&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1732567949691&to_ts=1732571549691&live=true).
- These issues come from a missing conversion.

## Risk

Low.

## Deploy Plan

- Deploy connectors.