### PR TITLE
[connectors] Fix(Zendesk) - users not found

### DIFF
--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -175,7 +175,12 @@ ${metadata}
 Conversation:
 ${comments
   .map((comment) => {
-    const author = users.find((user) => user.id === comment.author_id);
+    let author;
+    try {
+      author = users.find((user) => user.id === comment.author_id);
+    } catch (e) {
+      author = null;
+    }
     return `
 [${new Date(comment.created_at).toISOString()}] ${
       author ? `${author.name} (${author.email})` : "Unknown User"

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -179,6 +179,10 @@ ${comments
     try {
       author = users.find((user) => user.id === comment.author_id);
     } catch (e) {
+      logger.warn(
+        { connectorId, e, ...loggerArgs },
+        "[Zendesk] Error finding the author of a comment."
+      );
       author = null;
     }
     return `

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -427,7 +427,7 @@ export async function syncZendeskTicketBatchActivity({
     return { hasMore: false, nextLink: "" };
   }
 
-  const users = await zendeskApiClient.users.list();
+  const users = (await zendeskApiClient.users.list()) || [];
 
   const res = await concurrentExecutor(
     tickets,


### PR DESCRIPTION
## Description

- Fix issues similar to [these](https://app.datadoghq.eu/logs?query=%40dd.service%3Aconnectors-worker%20%40dd.env%3Aprod%20%40hostname%3Aconnectors-worker-zendesk-deployment-%2A%20status%3Aerror%20%22TypeError%3A%20users.find%20is%20not%20a%20function%20%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=6000198897476506285&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1732567949691&to_ts=1732571549691&live=true).
- The response most likely contains an object with error details instead of an array.
- Since this only occurred once, this will be logged and set aside for now.

## Risk

Low.

## Deploy Plan

- Deploy connectors.