### PR TITLE
Ext: rework buttons in input bar

### DIFF
--- a/extension/app/src/components/conversation/AttachFile.tsx
+++ b/extension/app/src/components/conversation/AttachFile.tsx
@@ -1,0 +1,44 @@
+import { supportedFileExtensions } from "@dust-tt/client";
+import { AttachmentIcon, Button } from "@dust-tt/sparkle";
+import type { EditorService } from "@extension/components/input_bar/editor/useCustomEditor";
+import type { FileUploaderService } from "@extension/hooks/useFileUploaderService";
+import { useRef } from "react";
+
+type AttachFileProps = {
+  fileUploaderService: FileUploaderService;
+  editorService: EditorService;
+};
+
+export const AttachFile = ({
+  fileUploaderService,
+  editorService,
+}: AttachFileProps) => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  return (
+    <>
+      <input
+        accept={supportedFileExtensions.join(",")}
+        onChange={async (e) => {
+          await fileUploaderService.handleFileChange(e);
+          if (fileInputRef.current) {
+            fileInputRef.current.value = "";
+          }
+          editorService.focusEnd();
+        }}
+        ref={fileInputRef}
+        style={{ display: "none" }}
+        type="file"
+        multiple={true}
+      />
+      <Button
+        icon={AttachmentIcon}
+        tooltip="Attach file"
+        variant="ghost"
+        size="xs"
+        onClick={async () => {
+          fileInputRef.current?.click();
+        }}
+      />
+    </>
+  );
+};

--- a/extension/app/src/components/conversation/AttachFragment.tsx
+++ b/extension/app/src/components/conversation/AttachFragment.tsx
@@ -1,23 +1,14 @@
-import { supportedFileExtensions } from "@dust-tt/client";
-import {
-  AttachmentIcon,
-  Button,
-  CameraIcon,
-  DocumentPlusIcon,
-} from "@dust-tt/sparkle";
-import type { EditorService } from "@extension/components/input_bar/editor/useCustomEditor";
+import { Button, CameraIcon, DocumentPlusIcon } from "@dust-tt/sparkle";
 import { InputBarContext } from "@extension/components/input_bar/InputBarContext";
 import type { FileUploaderService } from "@extension/hooks/useFileUploaderService";
-import { useContext, useEffect, useRef } from "react";
+import { useContext, useEffect } from "react";
 
 type AttachFragmentProps = {
   fileUploaderService: FileUploaderService;
-  editorService: EditorService;
 };
 
 export const AttachFragment = ({
   fileUploaderService,
-  editorService,
 }: AttachFragmentProps) => {
   const { attachPageBlinking, setAttachPageBlinking } =
     useContext(InputBarContext);
@@ -32,57 +23,68 @@ export const AttachFragment = ({
     return () => clearTimeout(timer);
   }, [attachPageBlinking]);
 
-  const fileInputRef = useRef<HTMLInputElement>(null);
   return (
     <>
-      <input
-        accept={supportedFileExtensions.join(",")}
-        onChange={async (e) => {
-          await fileUploaderService.handleFileChange(e);
-          if (fileInputRef.current) {
-            fileInputRef.current.value = "";
+      <div className="block sm:hidden">
+        <Button
+          icon={DocumentPlusIcon}
+          tooltip="Extract text from page and attach"
+          variant="outline"
+          size="sm"
+          className={attachPageBlinking ? "animate-[bgblink_200ms_3]" : ""}
+          onClick={() =>
+            fileUploaderService.uploadContentTab({
+              includeContent: true,
+              includeCapture: false,
+            })
           }
-          editorService.focusEnd();
-        }}
-        ref={fileInputRef}
-        style={{ display: "none" }}
-        type="file"
-        multiple={true}
-      />
-      <Button
-        icon={AttachmentIcon}
-        tooltip="Attach file"
-        variant="ghost"
-        size="xs"
-        onClick={async () => {
-          fileInputRef.current?.click();
-        }}
-      />
-      <Button
-        icon={DocumentPlusIcon}
-        tooltip="Attach tab content"
-        variant="ghost"
-        size="xs"
-        className={attachPageBlinking ? "animate-[bgblink_200ms_3]" : ""}
-        onClick={() =>
-          fileUploaderService.uploadContentTab({
-            includeContent: true,
-            includeCapture: false,
-          })
-        }
-      />
-      <Button
-        icon={CameraIcon}
-        tooltip="Attach tab screenshot"
-        variant="ghost"
-        size="xs"
-        onClick={() =>
-          fileUploaderService.uploadContentTab({
-            includeContent: false,
-            includeCapture: true,
-          })
-        }
-      />
+        />
+      </div>
+      <div className="block sm:hidden">
+        <Button
+          icon={CameraIcon}
+          tooltip="Take page screenshot and attach"
+          variant="outline"
+          size="sm"
+          onClick={() =>
+            fileUploaderService.uploadContentTab({
+              includeContent: false,
+              includeCapture: true,
+            })
+          }
+        />
+      </div>
+      <div className="hidden sm:block">
+        <Button
+          icon={DocumentPlusIcon}
+          label="Add page text"
+          tooltip="Extract text from page and attach"
+          variant="outline"
+          size="sm"
+          className={attachPageBlinking ? "animate-[bgblink_200ms_3]" : ""}
+          onClick={() =>
+            fileUploaderService.uploadContentTab({
+              includeContent: true,
+              includeCapture: false,
+            })
+          }
+        />
+      </div>
+      <div className="hidden sm:block">
+        <Button
+          icon={CameraIcon}
+          label="Add page screenshot"
+          tooltip="Take page screenshot and attach"
+          variant="outline"
+          size="sm"
+          onClick={() =>
+            fileUploaderService.uploadContentTab({
+              includeContent: false,
+              includeCapture: true,
+            })
+          }
+        />
+      </div>
     </>
   );
 };

--- a/extension/app/src/components/input_bar/InputBar.tsx
+++ b/extension/app/src/components/input_bar/InputBar.tsx
@@ -268,7 +268,7 @@ export function AssistantInputBar({
         <div className="flex w-full flex-1 flex-col items-end self-stretch">
           <div
             className={classNames(
-              "relative flex w-full flex-1 flex-col items-stretch gap-0 self-stretch pl-4",
+              "relative flex w-full flex-1 flex-col items-stretch gap-0 self-stretch p-2",
               "border-struture-200 border-t bg-white/90 backdrop-blur focus-within:border-structure-300",
               "transition-all",
               "rounded-2xl border-b border-l border-r border-element-500 focus-within:border-action-300 focus-within:shadow-md focus-within:ring-1",

--- a/extension/app/src/components/input_bar/InputBarContainer.tsx
+++ b/extension/app/src/components/input_bar/InputBarContainer.tsx
@@ -5,6 +5,7 @@ import type {
 } from "@dust-tt/client";
 import { SplitButton } from "@dust-tt/sparkle";
 import { AssistantPicker } from "@extension/components/assistants/AssistantPicker";
+import { AttachFile } from "@extension/components/conversation/AttachFile";
 import { AttachFragment } from "@extension/components/conversation/AttachFragment";
 import type { CustomEditorProps } from "@extension/components/input_bar/editor/useCustomEditor";
 import useCustomEditor from "@extension/components/input_bar/editor/useCustomEditor";
@@ -84,29 +85,26 @@ export const InputBarContainer = ({
     onClick,
   };
   const SendWithContentAction = {
-    label: "Send with tab content",
+    label: "Add page text + Send",
     onClick,
   };
 
   return (
-    <div
-      id="InputBarContainer"
-      className="relative flex flex-1 flex-col sm:flex-row"
-    >
-      <EditorContent
-        editor={editor}
-        className={classNames(
-          contentEditableClasses,
-          "scrollbar-hide",
-          "overflow-y-auto",
-          "min-h-32",
-          "max-h-96"
-        )}
-      />
-
-      <div className="flex  flex-wrap flex-row items-end justify-between gap-2 self-stretch pb-2 pr-2 sm:flex-col sm:border-0">
-        <div className="flex py-2 space-x-1">
-          <AttachFragment
+    <div id="InputBarContainer" className="relative flex flex-col w-full">
+      <div className="flex space-x-2">
+        <EditorContent
+          editor={editor}
+          className={classNames(
+            contentEditableClasses,
+            "scrollbar-hide",
+            "overflow-y-auto",
+            "min-h-32",
+            "max-h-96",
+            "flex-1"
+          )}
+        />
+        <div className="flex items-start">
+          <AttachFile
             fileUploaderService={fileUploaderService}
             editorService={editorService}
           />
@@ -119,6 +117,10 @@ export const InputBarContainer = ({
             assistants={allAssistants}
           />
         </div>
+      </div>
+
+      <div className="flex items-center justify-end space-x-1 mt-2">
+        <AttachFragment fileUploaderService={fileUploaderService} />
         <SplitButton
           size="sm"
           actions={[SendAction, SendWithContentAction]}


### PR DESCRIPTION
## Description

Rework of the input bar button to clarify what's new with the extension as opposed to the input bar on web version that user know.

### Small
<img width="443" alt="Screenshot 2024-11-26 at 16 50 33" src="https://github.com/user-attachments/assets/8d82455b-f630-4391-8281-85a8fa0f433f">


### Bigger
<img width="696" alt="Screenshot 2024-11-26 at 16 50 42" src="https://github.com/user-attachments/assets/8ffde890-5436-40a1-ae72-dbf466fed6ea">


## Risk

Extension only

## Deploy Plan

Nothing. 