### PR TITLE
[connectors] enh(Zendesk) - add a bit more logs on users.find errors

### DIFF
--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -180,7 +180,7 @@ ${comments
       author = users.find((user) => user.id === comment.author_id);
     } catch (e) {
       logger.warn(
-        { connectorId, e, ...loggerArgs },
+        { connectorId, e, usersType: typeof users, ...loggerArgs },
         "[Zendesk] Error finding the author of a comment."
       );
       author = null;


### PR DESCRIPTION
## Description

- The retrieval of the author of a comment sometimes fails for some unknown reason.
- This PR aims at adding a little more logs to help investigate on the side.

## Risk

None.

## Deploy Plan

- Deploy connectors.