### PR TITLE
[KW-Search] Fix sql for nodes tables creation

### DIFF
--- a/core/src/stores/migrations/20241125_nodes_table.sql
+++ b/core/src/stores/migrations/20241125_nodes_table.sql
@@ -27,9 +27,9 @@ CREATE TABLE data_sources_nodes (
     FOREIGN KEY("table")          REFERENCES tables(id),
     FOREIGN KEY(folder)         REFERENCES data_sources_folders(id),
     CONSTRAINT data_sources_nodes_document_id_table_id_folder_id_check CHECK (
-        (document IS NOT NULL AND table IS NULL AND folder IS NULL) OR
-        (document IS NULL AND table IS NOT NULL AND folder IS NULL) OR
-        (document IS NULL AND table IS NULL AND folder IS NOT NULL)
+        (document IS NOT NULL AND "table" IS NULL AND folder IS NULL) OR
+        (document IS NULL AND "table" IS NOT NULL AND folder IS NULL) OR
+        (document IS NULL AND "table" IS NULL AND folder IS NOT NULL)
     )
 );
 

--- a/core/src/stores/migrations/20241125_nodes_table.sql
+++ b/core/src/stores/migrations/20241125_nodes_table.sql
@@ -20,11 +20,11 @@ CREATE TABLE data_sources_nodes (
     mime_type                    TEXT NOT NULL,
     parents                      TEXT[] NOT NULL,
     document                     BIGINT,
-    table                        BIGINT,
+    "table"                      BIGINT,
     folder                       BIGINT,
     FOREIGN KEY(data_source)    REFERENCES data_sources(id),
     FOREIGN KEY(document)       REFERENCES data_sources_documents(id),
-    FOREIGN KEY(table)          REFERENCES tables(id),
+    FOREIGN KEY("table")          REFERENCES tables(id),
     FOREIGN KEY(folder)         REFERENCES data_sources_folders(id),
     CONSTRAINT data_sources_nodes_document_id_table_id_folder_id_check CHECK (
         (document IS NOT NULL AND table IS NULL AND folder IS NULL) OR

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -523,9 +523,9 @@ pub const POSTGRES_TABLES: [&'static str; 16] = [
        FOREIGN KEY(\"table\")      REFERENCES tables(id),
        FOREIGN KEY(folder)         REFERENCES data_sources_folders(id),
        CONSTRAINT data_sources_nodes_document_id_table_id_folder_id_check CHECK (
-           (document IS NOT NULL AND table IS NULL AND folder IS NULL) OR
-           (document IS NULL AND table IS NOT NULL AND folder IS NULL) OR
-           (document IS NULL AND table IS NULL AND folder IS NOT NULL)
+           (document IS NOT NULL AND \"table\" IS NULL AND folder IS NULL) OR
+           (document IS NULL AND \"table\" IS NOT NULL AND folder IS NULL) OR
+           (document IS NULL AND \"table\" IS NULL AND folder IS NOT NULL)
         )
     );",
 ];

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -516,11 +516,11 @@ pub const POSTGRES_TABLES: [&'static str; 16] = [
        mime_type                    TEXT NOT NULL,
        parents                      TEXT[] NOT NULL,
        document                     BIGINT,
-       table                        BIGINT,
+       \"table\"                      BIGINT,
        folder                       BIGINT,
        FOREIGN KEY(data_source)    REFERENCES data_sources(id),
        FOREIGN KEY(document)       REFERENCES data_sources_documents(id),
-       FOREIGN KEY(table)          REFERENCES tables(id),
+       FOREIGN KEY(\"table\")      REFERENCES tables(id),
        FOREIGN KEY(folder)         REFERENCES data_sources_folders(id),
        CONSTRAINT data_sources_nodes_document_id_table_id_folder_id_check CHECK (
            (document IS NOT NULL AND table IS NULL AND folder IS NULL) OR


### PR DESCRIPTION
Description
---
Migration did not work because quotes were needed for the reserved keyword 'table'

Although not optimal in general as a column name, here it's the best naming, consistent with data_source / document / folder, and avoiding the clash with table_id (which is a string id)

Risk
---
na

Deploy
---
migration on prodbox
deploy core
