### PR TITLE
Add: dropdown to show all assistants used by a datasource and show modal on click

### DIFF
--- a/front/components/spaces/UsedByButton.tsx
+++ b/front/components/spaces/UsedByButton.tsx
@@ -1,0 +1,46 @@
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  RobotIcon,
+  ScrollArea,
+} from "@dust-tt/sparkle";
+import type { DataSourceWithAgentsUsageType } from "@dust-tt/types";
+
+export const UsedByButton = ({
+  usage,
+  onItemClick,
+}: {
+  usage: DataSourceWithAgentsUsageType;
+  onItemClick: (assistantSid: string) => void;
+}) => {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          icon={RobotIcon}
+          variant="ghost"
+          isSelect
+          size="sm"
+          label={`${usage.count}`}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="max-w-[300px]">
+        <ScrollArea className="border-1 max-h-[300px]">
+          {usage.agentNames.map((name) => (
+            <DropdownMenuItem
+              key={`assistant-picker-${name}`}
+              label={name}
+              onClick={(e) => {
+                e.stopPropagation();
+                onItemClick(name);
+              }}
+            />
+          ))}
+        </ScrollArea>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/front/components/spaces/UsedByButton.tsx
+++ b/front/components/spaces/UsedByButton.tsx
@@ -16,19 +16,28 @@ export const UsedByButton = ({
   usage: DataSourceWithAgentsUsageType;
   onItemClick: (assistantSid: string) => void;
 }) => {
-  return (
+  return usage.count === 0 ? (
+    <Button
+      icon={RobotIcon}
+      variant="ghost"
+      isSelect={false}
+      size="sm"
+      label={`${usage.count}`}
+      disabled
+    />
+  ) : (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button
           icon={RobotIcon}
           variant="ghost"
-          isSelect
+          isSelect={true}
           size="sm"
           label={`${usage.count}`}
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent className="max-w-[300px]">
-        <ScrollArea className="border-1 max-h-[300px]">
+        <ScrollArea className="border-1 h-[130px]">
           {usage.agentNames.map((name) => (
             <DropdownMenuItem
               key={`assistant-picker-${name}`}

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -1202,24 +1202,34 @@ async function _createAgentDataSourcesConfigData(
   return agentDataSourcesConfigRows;
 }
 
-export async function agentNameIsAvailable(
+export async function getAgentSIdFromName(
   auth: Authenticator,
-  nameToCheck: string
-) {
-  const owner = auth.workspace();
-  if (!owner) {
-    throw new Error("Unexpected `auth` without `workspace`.");
-  }
+  name: string
+): Promise<string | null> {
+  const owner = auth.getNonNullableWorkspace();
 
   const agent = await AgentConfiguration.findOne({
+    attributes: ["sId"],
     where: {
       workspaceId: owner.id,
-      name: nameToCheck,
+      name,
       status: "active",
     },
   });
 
-  return !agent;
+  if (!agent) {
+    return null;
+  }
+
+  return agent.sId;
+}
+
+export async function agentNameIsAvailable(
+  auth: Authenticator,
+  nameToCheck: string
+) {
+  const sId = await getAgentSIdFromName(auth, nameToCheck);
+  return !sId;
 }
 
 export async function setAgentScope(

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -187,6 +187,31 @@ export function useProgressiveAgentConfigurations({
   };
 }
 
+export function useAgentConfigurationSIdLookup({
+  workspaceId,
+  agentConfigurationName,
+}: {
+  workspaceId: string;
+  agentConfigurationName: string | null;
+}) {
+  const sIdFetcher: Fetcher<{
+    sId: string;
+  }> = fetcher;
+
+  const { data, error } = useSWRWithDefaults(
+    agentConfigurationName
+      ? `/api/w/${workspaceId}/assistant/agent_configurations/lookup?handle=${agentConfigurationName}`
+      : null,
+    sIdFetcher
+  );
+
+  return {
+    sId: data ? data.sId : null,
+    isLoading: !error && !data,
+    isError: error,
+  };
+}
+
 export function useAgentConfiguration({
   workspaceId,
   agentConfigurationId,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/lookup.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/lookup.ts
@@ -1,0 +1,64 @@
+import type { WithAPIErrorResponse } from "@dust-tt/types";
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getAgentSIdFromName } from "@app/lib/api/assistant/configuration";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+
+const GetLookupRequestSchema = t.type({
+  handle: t.string,
+});
+
+type GetLookupResponseBody = {
+  sId: string;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetLookupResponseBody | void>>,
+  auth: Authenticator
+): Promise<void> {
+  switch (req.method) {
+    case "GET":
+      const bodyValidation = GetLookupRequestSchema.decode(req.query);
+
+      if (isLeft(bodyValidation)) {
+        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${pathError}`,
+          },
+        });
+      }
+      const sId = await getAgentSIdFromName(auth, bodyValidation.right.handle);
+      if (!sId) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "agent_configuration_not_found",
+            message: "The Assistant you're trying to access was not found.",
+          },
+        });
+      }
+
+      return res.status(200).json({ sId });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

Allow showing the modal of each used assistants via a dropdown.
Added a lookup endpoint (name => sId) as adding sId to the usage endpoint was much much more involved (and the query is not cheap).

**References:**
- https://github.com/dust-tt/tasks/issues/1602

## Risk

None

## Deploy Plan

Deploy `front`