### PR TITLE
Relax columns count when uploading csv

### DIFF
--- a/front/lib/api/files/upload.ts
+++ b/front/lib/api/files/upload.ts
@@ -190,6 +190,7 @@ const extractContentAndSchemaFromCSV: ProcessingFunction = async (
         columns: true,
         skip_empty_lines: true,
         trim: true,
+        relax_column_count: true,
       }),
       new CSVColumnAnalyzerTransform(),
       file.getWriteStream({

--- a/front/lib/api/files/upload.ts
+++ b/front/lib/api/files/upload.ts
@@ -301,7 +301,7 @@ const processingPerContentType: ProcessingPerContentType = {
     tool_output: notSupportedError,
   },
   "text/comma-separated-values": {
-    conversation: storeRawText,
+    conversation: extractContentAndSchemaFromCSV,
     folder: storeRawText,
     avatar: notSupportedError,
     tool_output: notSupportedError,


### PR DESCRIPTION
## Description

Relax the column count when uploading csv.
For example, when a CSV is more or less the export of a dashboard made in google sheet.
It seems that the model is able to understand them just as good.

## Risk

Low

## Deploy Plan

Deploy `front`