### PR TITLE
ActionsDetails: finer grained action state

### DIFF
--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -12,7 +12,7 @@ import { getActionSpecification } from "@app/components/actions/types";
 import { AgentMessageActionsDrawer } from "@app/components/assistant/conversation/actions/AgentMessageActionsDrawer";
 import type { AgentStateClassification } from "@app/components/assistant/conversation/AgentMessage";
 import { classNames } from "@app/lib/utils";
-import Me from "@app/pages/api/v1/me";
+
 interface AgentMessageActionsProps {
   agentMessage: AgentMessageType;
   lastAgentStateClassification: AgentStateClassification;
@@ -85,6 +85,8 @@ function ActionDetails({
   onClick: () => void;
   size: ConversationMessageSizeType;
 }) {
+  // We memoize the spinner as otherwise its state gets resetted on each token emission (despite
+  // memoization of label in the parent component).
   const MemoizedSpinner = useMemo(
     () => <Spinner variant="dark" size="xs" />,
     []

--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -5,46 +5,51 @@ import type {
   AgentMessageType,
   LightWorkspaceType,
 } from "@dust-tt/types";
+import { assertNever } from "@dust-tt/types";
 import { useEffect, useMemo, useState } from "react";
 
 import { getActionSpecification } from "@app/components/actions/types";
 import { AgentMessageActionsDrawer } from "@app/components/assistant/conversation/actions/AgentMessageActionsDrawer";
+import type { AgentStateClassification } from "@app/components/assistant/conversation/AgentMessage";
 import { classNames } from "@app/lib/utils";
 interface AgentMessageActionsProps {
   agentMessage: AgentMessageType;
+  lastAgentStateClassification: AgentStateClassification;
   size?: ConversationMessageSizeType;
   owner: LightWorkspaceType;
 }
 
 export function AgentMessageActions({
   agentMessage,
+  lastAgentStateClassification,
   owner,
   size = "normal",
 }: AgentMessageActionsProps) {
   const [chipLabel, setChipLabel] = useState<string | undefined>("Thinking");
   const [isActionDrawerOpened, setIsActionDrawerOpened] = useState(false);
 
-  // We're thinking or acting if the message status is still "created" and we don't have content
-  // yet. Despite our work on chain of thoughts events, it's still possible for content to be
-  // emitted before actions in which case we will think we're not thinking or acting until an action
-  // gets emitted in which case the content will get requalified as chain of thoughts and this will
-  // switch back to true.
+  useEffect(() => {
+    switch (lastAgentStateClassification) {
+      case "thinking":
+        setChipLabel("Thinking");
+        break;
+      case "acting":
+        if (agentMessage.actions.length > 0) {
+          setChipLabel(renderActionName(agentMessage.actions));
+        }
+        break;
+      case "done":
+        setChipLabel(undefined);
+        break;
+      default:
+        assertNever(lastAgentStateClassification);
+    }
+  }, [lastAgentStateClassification, agentMessage.actions]);
+
   const isThinkingOrActing = useMemo(
     () => agentMessage.status === "created",
     [agentMessage.status]
   );
-
-  useEffect(() => {
-    if (isThinkingOrActing) {
-      if (agentMessage.actions.length === 0) {
-        setChipLabel("Thinking");
-      } else {
-        setChipLabel(renderActionName(agentMessage.actions));
-      }
-    } else {
-      setChipLabel(undefined);
-    }
-  }, [isThinkingOrActing, agentMessage.actions]);
 
   return (
     <div className="flex flex-col items-start gap-y-4">
@@ -52,7 +57,7 @@ export function AgentMessageActions({
         actions={agentMessage.actions}
         isOpened={isActionDrawerOpened}
         onClose={() => setIsActionDrawerOpened(false)}
-        isStreaming={isThinkingOrActing || agentMessage.actions.length === 0}
+        isActing={lastAgentStateClassification === "acting"}
         owner={owner}
       />
       <ActionDetails
@@ -84,7 +89,7 @@ function ActionDetails({
   }
 
   return label ? (
-    <div key={label} className="animate-fadeIn duration-1000 fade-out">
+    <div key={label}>
       <Chip size="sm" color="slate" isBusy>
         <div
           className={classNames(
@@ -94,7 +99,7 @@ function ActionDetails({
           onClick={hasActions ? onClick : undefined}
         >
           <Spinner variant="dark" size="xs" />
-          {label}
+          <div>{label}</div>
         </div>
       </Chip>
     </div>

--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -107,7 +107,13 @@ function ActionDetails({
           onClick={hasActions ? onClick : undefined}
         >
           {MemoizedSpinner}
-          {label}
+          {label === "Thinking" ? (
+            <span>{label}</span>
+          ) : (
+            <>
+              Thinking <span className="text-regular">{label}</span>
+            </>
+          )}
         </div>
       </Chip>
     </div>

--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -12,6 +12,7 @@ import { getActionSpecification } from "@app/components/actions/types";
 import { AgentMessageActionsDrawer } from "@app/components/assistant/conversation/actions/AgentMessageActionsDrawer";
 import type { AgentStateClassification } from "@app/components/assistant/conversation/AgentMessage";
 import { classNames } from "@app/lib/utils";
+import Me from "@app/pages/api/v1/me";
 interface AgentMessageActionsProps {
   agentMessage: AgentMessageType;
   lastAgentStateClassification: AgentStateClassification;
@@ -84,6 +85,11 @@ function ActionDetails({
   onClick: () => void;
   size: ConversationMessageSizeType;
 }) {
+  const MemoizedSpinner = useMemo(
+    () => <Spinner variant="dark" size="xs" />,
+    []
+  );
+
   if (!label && (!isActionStepDone || !hasActions)) {
     return null;
   }
@@ -98,7 +104,7 @@ function ActionDetails({
           )}
           onClick={hasActions ? onClick : undefined}
         >
-          <Spinner variant="dark" size="xs" />
+          {MemoizedSpinner}
           {label}
         </div>
       </Chip>

--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -99,7 +99,7 @@ function ActionDetails({
           onClick={hasActions ? onClick : undefined}
         >
           <Spinner variant="dark" size="xs" />
-          <div>{label}</div>
+          {label}
         </div>
       </Chip>
     </div>

--- a/front/components/assistant/conversation/actions/AgentMessageActionsDrawer.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActionsDrawer.tsx
@@ -6,7 +6,7 @@ import { getActionSpecification } from "@app/components/actions/types";
 interface AgentMessageActionsDrawerProps {
   actions: AgentActionType[];
   isOpened: boolean;
-  isStreaming: boolean;
+  isActing: boolean;
   onClose: () => void;
   owner: LightWorkspaceType;
 }
@@ -14,7 +14,7 @@ interface AgentMessageActionsDrawerProps {
 export function AgentMessageActionsDrawer({
   actions,
   isOpened,
-  isStreaming,
+  isActing,
   onClose,
   owner,
 }: AgentMessageActionsDrawerProps) {
@@ -71,7 +71,7 @@ export function AgentMessageActionsDrawer({
                 </div>
               );
             })}
-            {isStreaming && (
+            {isActing && (
               <div className="flex justify-center">
                 <Spinner variant="color" />
               </div>


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/dust/issues/8924

Computes a finer grained Action details state, only showing the action name when the action is actually being executed. This makes one realize that actions are run FAST which overall creates a slightly weird experience.

Also fix the spinner state being resetted whenever tokens are emitted when the model is generating text.

Potential next-steps:
- to find an animation that makes the transition smoother between chip status changes

https://github.com/user-attachments/assets/c9bd4d26-c7a8-4668-94ca-a98d7c6711dc

(video does not include the fix to the spinner during generation, but the code does)

## Risk

Low

## Deploy Plan

- deploy `front`