### PR TITLE
Extension default shortcut to open panel

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -15,6 +15,14 @@
   "action": {
     "default_title": "Open Dust side panel"
   },
+  "commands": {
+    "_execute_action": {
+      "suggested_key": {
+        "default": "Ctrl + Right",
+        "mac": "Command + Right"
+      }
+    }
+  },
   "side_panel": {
     "default_path": "main.html"
   },


### PR DESCRIPTION
## Description

Quick win, setting a default shortcut for the extension, that can easily be overwritten (same method as when none is set by default). 
I picked `Ctrl + Right` cause it's free and I kind of think it makes sense since the sidePanel pops up on the right. 

(can't use "Ctrl + D" because it's used by Chrome)

## Risk

/ 

## Deploy Plan

None. 