### PR TITLE
[sparkle] - feat: `Sheet`

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.325",
+  "version": "0.2.326",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.325",
+      "version": "0.2.326",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -13,6 +13,7 @@
         "@emoji-mart/react": "^1.1.1",
         "@headlessui/react": "^1.7.19",
         "@radix-ui/react-checkbox": "^1.1.2",
+        "@radix-ui/react-dialog": "^1.1.2",
         "@radix-ui/react-dropdown-menu": "^2.1.2",
         "@radix-ui/react-label": "^2.1.0",
         "@radix-ui/react-popover": "^1.1.2",
@@ -3783,6 +3784,286 @@
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.2.tgz",
+      "integrity": "sha512-Yj4dZtqa2o+kG61fzB0H2qUvmwBA2oyQroGLyNtBj1beo1khoQ3q1a2AO8rrQYjd8256CO9+N8L9tvsS+bnIyA==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.1",
+        "@radix-ui/react-focus-guards": "1.1.1",
+        "@radix-ui/react-focus-scope": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-portal": "1.1.2",
+        "@radix-ui/react-presence": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-slot": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.6.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.0.tgz",
+      "integrity": "sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA=="
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.0.tgz",
+      "integrity": "sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-context": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.1.tgz",
+      "integrity": "sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.1.tgz",
+      "integrity": "sha512-QSxg29lfr/xcev6kSz7MAlmDnzbP1eI/Dwn3Tp1ip0KT5CUELsxkekFEMVBEoykI3oV39hKT4TKZzBNMbcTZYQ==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-escape-keydown": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.1.tgz",
+      "integrity": "sha512-pSIwfrT1a6sIoDASCSpFwOasEwKTZWDw/iBdtnqKO7v6FeOzYJ7U53cPzYFVR3geGGXgVHaH+CdngrrAzqUGxg==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.0.tgz",
+      "integrity": "sha512-200UD8zylvEyL8Bx+z76RJnASR2gRMuxlgFCPAe/Q/679a/r0eK3MBVYMb7vZODZcffZBdob1EGnky78xmVvcA==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-id": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.0.tgz",
+      "integrity": "sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.2.tgz",
+      "integrity": "sha512-WeDYLGPxJb/5EGBoedyJbT0MpoULmwnIPMJMSldkuiMsBAv7N1cRdsTWZWht9vpPOiN3qyiGAtbK2is47/uMFg==",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.0.tgz",
+      "integrity": "sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
+      "integrity": "sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.1.0.tgz",
+      "integrity": "sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.0.tgz",
+      "integrity": "sha512-L7vwWlR1kTTQ3oh7g1O0CBF3YCyyTj8NmhLR+phShpyA50HCfBFKVJTpshm9PzLiKmehsrQzTYTpX9HvmC9rhw==",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz",
+      "integrity": "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/react-remove-scroll": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.6.0.tgz",
+      "integrity": "sha512-I2U4JVEsQenxDAKaVa3VZ/JeJZe0/2DxPWL8Tj8yLKctQJQiZM52pn/GWFpSp8dftjM3pSAHVJZscAnC/y+ySQ==",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.6",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -98,6 +98,7 @@
     "@emoji-mart/react": "^1.1.1",
     "@headlessui/react": "^1.7.19",
     "@radix-ui/react-checkbox": "^1.1.2",
+    "@radix-ui/react-dialog": "^1.1.2",
     "@radix-ui/react-dropdown-menu": "^2.1.2",
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-popover": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.325",
+  "version": "0.2.326",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Sheet.tsx
+++ b/sparkle/src/components/Sheet.tsx
@@ -1,0 +1,155 @@
+import * as SheetPrimitive from "@radix-ui/react-dialog";
+import { cva } from "class-variance-authority";
+import * as React from "react";
+
+import { Button, ScrollArea } from "@sparkle/components";
+import { XMarkIcon } from "@sparkle/icons";
+import { cn } from "@sparkle/lib/utils";
+
+const Sheet = SheetPrimitive.Root;
+
+const SheetTrigger = SheetPrimitive.Trigger;
+
+const SheetClose = SheetPrimitive.Close;
+
+const SheetPortal = SheetPrimitive.Portal;
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={cn(
+      "s-fixed s-inset-0 s-z-50 s-bg-muted-foreground/75 data-[state=open]:s-animate-in data-[state=closed]:s-animate-out data-[state=closed]:s-fade-out-0 data-[state=open]:s-fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+));
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
+
+const SHEET_SIZES = ["md", "lg", "xl"] as const;
+
+type SheetSizeType = (typeof SHEET_SIZES)[number];
+
+const sizeClasses: Record<SheetSizeType, string> = {
+  md: "sm:s-max-w-md",
+  lg: "sm:s-max-w-xl",
+  xl: "sm:s-max-w-3xl",
+};
+
+const sheetVariants = cva(
+  "s-fixed s-z-50 s-overflow-hidden s-bg-background s-transition s-ease-in-out data-[state=open]:s-animate-in data-[state=closed]:s-animate-out data-[state=closed]:s-duration-300 data-[state=open]:s-duration-500 s-flex s-flex-col s-inset-y-0 s-right-0 s-h-full s-w-full data-[state=closed]:s-slide-out-to-right data-[state=open]:s-slide-in-from-right",
+  {
+    variants: {
+      size: sizeClasses
+    },
+    defaultVariants: {
+      size: "md"
+    }
+  }
+)
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content> {
+  size?: SheetSizeType;
+}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Content>,
+  SheetContentProps
+>(({ className, children, size, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <SheetPrimitive.Content
+      ref={ref}
+      className={cn(sheetVariants({ size }), className)}
+      {...props}
+    >
+      {children}
+    </SheetPrimitive.Content>
+  </SheetPortal>
+));
+SheetContent.displayName = SheetPrimitive.Content.displayName;
+
+const SheetHeader = ({
+  className,
+  children,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "s-z-50 s-flex s-flex-none s-flex-col s-gap-2 s-bg-background s-p-5 s-text-left s-shadow-tale",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SheetPrimitive.Close className="s-absolute s-right-3 s-top-4">
+      <Button icon={XMarkIcon} variant="ghost" size="sm" />
+    </SheetPrimitive.Close>
+  </div>
+);
+SheetHeader.displayName = "SheetHeader";
+
+const SheetContainer = ({ children }: React.HTMLAttributes<HTMLDivElement>) => (
+  <ScrollArea className="s-w-full s-flex-grow">
+    <div className="s-relative s-flex s-flex-col s-gap-2 s-p-5 s-text-left s-text-sm s-text-foreground">
+      {children}
+    </div>
+  </ScrollArea>
+);
+SheetContainer.displayName = "SheetContainer";
+
+const SheetFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "s-flex s-flex-none s-flex-row s-gap-2 s-border-t s-border-border s-px-3 s-py-3",
+      className
+    )}
+    {...props}
+  />
+);
+SheetFooter.displayName = "SheetFooter";
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title
+    ref={ref}
+    className={cn("s-text-lg s-font-semibold s-text-foreground", className)}
+    {...props}
+  />
+));
+SheetTitle.displayName = SheetPrimitive.Title.displayName;
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Description
+    ref={ref}
+    className={cn("s-text-sm s-text-muted-foreground", className)}
+    {...props}
+  />
+));
+SheetDescription.displayName = SheetPrimitive.Description.displayName;
+
+export {
+  Sheet,
+  SheetClose,
+  SheetContainer,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetOverlay,
+  SheetPortal,
+  SheetTitle,
+  SheetTrigger,
+};

--- a/sparkle/src/components/Sheet.tsx
+++ b/sparkle/src/components/Sheet.tsx
@@ -128,12 +128,22 @@ const SheetFooter = ({
     )}
     {...props}
   >
-    {(leftButtonProps || rightButtonProps) && (
-      <SheetClose className={sheetCloseClassName}>
-        {leftButtonProps && <Button {...leftButtonProps} />}
-        {rightButtonProps && <Button {...rightButtonProps} />}
-      </SheetClose>
-    )}
+    {leftButtonProps &&
+      (leftButtonProps.disabled ? (
+        <Button {...leftButtonProps} />
+      ) : (
+        <SheetClose className={sheetCloseClassName}>
+          <Button {...leftButtonProps} />
+        </SheetClose>
+      ))}
+    {rightButtonProps &&
+      (rightButtonProps.disabled ? (
+        <Button {...rightButtonProps} />
+      ) : (
+        <SheetClose className={sheetCloseClassName}>
+          <Button {...rightButtonProps} />
+        </SheetClose>
+      ))}
     {children}
   </div>
 );

--- a/sparkle/src/components/Sheet.tsx
+++ b/sparkle/src/components/Sheet.tsx
@@ -43,13 +43,13 @@ const sheetVariants = cva(
   "s-fixed s-z-50 s-overflow-hidden s-bg-background s-transition s-ease-in-out data-[state=open]:s-animate-in data-[state=closed]:s-animate-out data-[state=closed]:s-duration-300 data-[state=open]:s-duration-500 s-flex s-flex-col s-inset-y-0 s-right-0 s-h-full s-w-full data-[state=closed]:s-slide-out-to-right data-[state=open]:s-slide-in-from-right",
   {
     variants: {
-      size: sizeClasses
+      size: sizeClasses,
     },
     defaultVariants: {
-      size: "md"
-    }
+      size: "md",
+    },
   }
-)
+);
 
 interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content> {
@@ -73,11 +73,16 @@ const SheetContent = React.forwardRef<
 ));
 SheetContent.displayName = SheetPrimitive.Content.displayName;
 
+interface SheetHeaderProps extends React.HTMLAttributes<HTMLDivElement> {
+  hideButton?: boolean;
+}
+
 const SheetHeader = ({
   className,
   children,
+  hideButton = false,
   ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
+}: SheetHeaderProps) => (
   <div
     className={cn(
       "s-z-50 s-flex s-flex-none s-flex-col s-gap-2 s-bg-background s-p-5 s-text-left s-shadow-tale",
@@ -86,9 +91,9 @@ const SheetHeader = ({
     {...props}
   >
     {children}
-    <SheetPrimitive.Close className="s-absolute s-right-3 s-top-4">
-      <Button icon={XMarkIcon} variant="ghost" size="sm" />
-    </SheetPrimitive.Close>
+    <SheetClose className="s-absolute s-right-3 s-top-4">
+      {!hideButton && <Button icon={XMarkIcon} variant="ghost" size="sm" />}
+    </SheetClose>
   </div>
 );
 SheetHeader.displayName = "SheetHeader";
@@ -102,17 +107,35 @@ const SheetContainer = ({ children }: React.HTMLAttributes<HTMLDivElement>) => (
 );
 SheetContainer.displayName = "SheetContainer";
 
+interface SheetFooterProps extends React.HTMLAttributes<HTMLDivElement> {
+  leftButtonProps?: React.ComponentProps<typeof Button>;
+  rightButtonProps?: React.ComponentProps<typeof Button>;
+  sheetCloseClassName?: string;
+}
+
 const SheetFooter = ({
   className,
+  children,
+  leftButtonProps,
+  rightButtonProps,
+  sheetCloseClassName,
   ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
+}: SheetFooterProps) => (
   <div
     className={cn(
       "s-flex s-flex-none s-flex-row s-gap-2 s-border-t s-border-border s-px-3 s-py-3",
       className
     )}
     {...props}
-  />
+  >
+    {(leftButtonProps || rightButtonProps) && (
+      <SheetClose className={sheetCloseClassName}>
+        {leftButtonProps && <Button {...leftButtonProps} />}
+        {rightButtonProps && <Button {...rightButtonProps} />}
+      </SheetClose>
+    )}
+    {children}
+  </div>
 );
 SheetFooter.displayName = "SheetFooter";
 

--- a/sparkle/src/components/Sheet.tsx
+++ b/sparkle/src/components/Sheet.tsx
@@ -132,7 +132,7 @@ const SheetFooter = ({
       (leftButtonProps.disabled ? (
         <Button {...leftButtonProps} />
       ) : (
-        <SheetClose className={sheetCloseClassName}>
+        <SheetClose className={sheetCloseClassName} asChild>
           <Button {...leftButtonProps} />
         </SheetClose>
       ))}
@@ -140,7 +140,7 @@ const SheetFooter = ({
       (rightButtonProps.disabled ? (
         <Button {...rightButtonProps} />
       ) : (
-        <SheetClose className={sheetCloseClassName}>
+        <SheetClose className={sheetCloseClassName} asChild>
           <Button {...rightButtonProps} />
         </SheetClose>
       ))}

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -90,6 +90,19 @@ export { RainbowEffect } from "./RainbowEffect";
 export { ScrollArea, ScrollBar } from "./ScrollArea";
 export { SearchInput } from "./SearchInput";
 export { Separator } from "./Separator";
+export {
+  Sheet,
+    SheetClose,
+    SheetContainer,
+    SheetContent,
+    SheetDescription,
+    SheetFooter,
+    SheetHeader,
+    SheetOverlay,
+    SheetPortal,
+    SheetTitle,
+    SheetTrigger,
+} from  "./Sheet";
 export { SliderToggle } from "./SliderToggle";
 export { default as Spinner } from "./Spinner";
 export { SplitButton } from "./SplitButton";

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -92,17 +92,17 @@ export { SearchInput } from "./SearchInput";
 export { Separator } from "./Separator";
 export {
   Sheet,
-    SheetClose,
-    SheetContainer,
-    SheetContent,
-    SheetDescription,
-    SheetFooter,
-    SheetHeader,
-    SheetOverlay,
-    SheetPortal,
-    SheetTitle,
-    SheetTrigger,
-} from  "./Sheet";
+  SheetClose,
+  SheetContainer,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetOverlay,
+  SheetPortal,
+  SheetTitle,
+  SheetTrigger,
+} from "./Sheet";
 export { SliderToggle } from "./SliderToggle";
 export { default as Spinner } from "./Spinner";
 export { SplitButton } from "./SplitButton";

--- a/sparkle/src/stories/Sheet.stories.tsx
+++ b/sparkle/src/stories/Sheet.stories.tsx
@@ -53,7 +53,7 @@ export function SheetDemo() {
           <Button variant="outline" label="Edit demo" />
         </SheetTrigger>
         <SheetContent>
-          <SheetHeader>
+          <SheetHeader hideButton>
             <SheetTitle>About me</SheetTitle>
           </SheetHeader>
           <SheetContainer>
@@ -62,10 +62,11 @@ export function SheetDemo() {
               <Input label="Lastname" placeholder="Doe" />
             </div>
           </SheetContainer>
-          <SheetFooter>
-            <Button type="submit" label="Cancel" variant="outline" />
-            <Button type="submit" label="Save" variant="highlight" />
-          </SheetFooter>
+          <SheetFooter
+            sheetCloseClassName="s-flex s-gap-2"
+            leftButtonProps={{ label: "Cancel", variant: "warning" }}
+            rightButtonProps={{ label: "Save" }}
+          />
         </SheetContent>
       </Sheet>
     </div>

--- a/sparkle/src/stories/Sheet.stories.tsx
+++ b/sparkle/src/stories/Sheet.stories.tsx
@@ -1,0 +1,372 @@
+import type { Meta } from "@storybook/react";
+import React from "react";
+
+import {
+  Avatar,
+  Button,
+  Icon,
+  Input,
+  Page,
+  Separator,
+  Sheet,
+  SheetContainer,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+  TextArea,
+} from "@sparkle/components";
+import {
+  CloudArrowLeftRightIcon,
+  FolderIcon,
+  GlobeAltIcon,
+  PencilSquareIcon,
+  RocketIcon,
+  StarIcon,
+  TrashIcon,
+} from "@sparkle/icons";
+
+const meta = {
+  title: "NewLayouts/Sheet",
+} satisfies Meta;
+
+export default meta;
+
+export function Demo() {
+  return (
+    <div className="s-flex s-flex-col s-gap-6">
+      <SheetDemo />
+
+      <ContentDemo />
+      <SheetCustom />
+    </div>
+  );
+}
+
+export function SheetDemo() {
+  return (
+    <div>
+      <Sheet>
+        <SheetTrigger asChild>
+          <Button variant="outline" label="Edit demo" />
+        </SheetTrigger>
+        <SheetContent>
+          <SheetHeader>
+            <SheetTitle>About me</SheetTitle>
+          </SheetHeader>
+          <SheetContainer>
+            <div className="s-flex s-flex-col s-gap-6">
+              <Input label="Firstname" placeholder="John" />
+              <Input label="Lastname" placeholder="Doe" />
+            </div>
+          </SheetContainer>
+          <SheetFooter>
+            <Button type="submit" label="Cancel" variant="outline" />
+            <Button type="submit" label="Save" variant="highlight" />
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+    </div>
+  );
+}
+
+export function ContentDemo() {
+  return (
+    <div>
+      <Sheet>
+        <SheetTrigger asChild>
+          <Button variant="outline" label="Content demo" />
+        </SheetTrigger>
+        <SheetContent size="xl">
+          <SheetHeader>
+            <Page.Header
+              icon={RocketIcon}
+              title={<>Quick Guide for new members</>}
+            />
+          </SheetHeader>
+          <SheetContainer>
+            <QIG />
+          </SheetContainer>
+        </SheetContent>
+      </Sheet>
+    </div>
+  );
+}
+
+export function SheetCustom() {
+  return (
+    <div>
+      <Sheet>
+        <SheetTrigger asChild>
+          <Button variant="outline" label="Assistant Demo" />
+        </SheetTrigger>
+        <SheetContent>
+          <SheetHeader>
+            <div className="s-flex s-flex-col s-gap-2">
+              <Avatar
+                size="md"
+                name="Aria Doe"
+                visual="https://dust.tt/static/droidavatar/Droid_Lime_3.jpg"
+              />
+              <div className="s-flex s-flex-col s-gap-0">
+                <SheetTitle>@coucou</SheetTitle>
+                <SheetDescription>
+                  The assistant that allways says hello.
+                </SheetDescription>
+              </div>
+              <div className="s-flex s-gap-2">
+                <Button icon={StarIcon} variant={"outline"} />
+                <Separator orientation="vertical" />
+                <Button icon={PencilSquareIcon} variant={"outline"} />
+                <Button icon={TrashIcon} variant={"outline"} />
+              </div>
+            </div>
+          </SheetHeader>
+          <SheetContainer>
+            <TextArea disabled isDisplay />
+          </SheetContainer>
+        </SheetContent>
+      </Sheet>
+    </div>
+  );
+}
+
+const QIG: React.FC = () => (
+  <div className="s-flex s-flex-col s-gap-5">
+    <Page.Horizontal>
+      <Page.Vertical>
+        <Page.H>
+          👩‍🎨🦸‍♀️🥷🧑‍🚀
+          <br /> Why multiple
+          <br /> Assistants?
+        </Page.H>
+
+        <Page.P>
+          The basic assistant is{" "}
+          <span className="font-bold text-success-500">@gpt4</span>. It is a raw
+          model. “Raw” means it does not have particular instructions or access
+          to knowledge.
+        </Page.P>
+        <Page.P>
+          You also have access to assistants that use a raw model (gpt4 for
+          instance), AND give them specific instructions and access to
+          knowledge.{" "}
+          <span className="font-bold">
+            They can answer specific questions, really well.
+          </span>
+        </Page.P>
+        <Page.P>
+          Assistants can be provided by Dust, by your company (Company
+          assistants), by your coworkers (Shared assistants).
+        </Page.P>
+      </Page.Vertical>
+
+      <Page.Vertical>
+        <Page.H>
+          🛠️
+          <br />
+          How to make
+          <br />
+          an Assistant?
+        </Page.H>
+        <Page.P>You can build Assistants!</Page.P>
+        <Page.P>
+          Assistants start with an “instruction”. A simple text, explaining what
+          you want them to do.
+        </Page.P>
+        <Page.P>
+          For instance, <span className="italic">“Act as a doctor”</span>,{" "}
+          <span className="italic">“Summarise this document”</span>,{" "}
+          <span className="italic">“What do you know about X”</span>.
+        </Page.P>
+        <Page.P>
+          You can give them access to knowledge.
+          <br />
+          We call them <span className="font-bold">Data sources.</span>
+        </Page.P>
+        <Page.P>
+          With the right Data source, assistants can answer demands like
+          <span className="italic">
+            “Have we been working with company X”
+          </span>, <span className="italic">“How do we manage expenses”</span>,{" "}
+          <span className="italic">
+            “Write an intro email using the company tone of voice”...
+          </span>
+        </Page.P>
+      </Page.Vertical>
+    </Page.Horizontal>
+
+    <Page.Vertical>
+      <Page.H>
+        📚
+        <br />
+        What are
+        <br />
+        Data sources?
+      </Page.H>
+
+      <Page.P>
+        To augment your assistants with knowledge, you give them data.
+        <br /> Data can come in different ways in Dust.{" "}
+        <span className="font-bold">Here are the three main ways:</span>
+      </Page.P>
+      <Page.Horizontal>
+        <Page.Vertical sizing="grow">
+          <div className="flex items-center gap-2">
+            <Icon visual={CloudArrowLeftRightIcon} />{" "}
+            <Page.H variant="h6">Connections</Page.H>
+          </div>
+          <Page.P>
+            Notion, Slack, Google Drive... Dust can connect to multiple
+            platforms and synchronize your data.
+          </Page.P>
+        </Page.Vertical>
+        <Page.Vertical sizing="grow">
+          <Page.Horizontal>
+            <div className="flex items-center gap-2">
+              <Icon visual={FolderIcon} /> <Page.H variant="h6">Folders</Page.H>
+            </div>
+          </Page.Horizontal>
+          <Page.P>Upload files (text, pdf, csv) directly in Dust.</Page.P>
+        </Page.Vertical>
+        <Page.Vertical sizing="grow">
+          <Page.Horizontal>
+            <div className="flex items-center gap-2">
+              <Icon visual={GlobeAltIcon} />{" "}
+              <Page.H variant="h6">Websites</Page.H>
+            </div>
+          </Page.Horizontal>
+          <Page.P>
+            Any public website can be synced in Dust. Think FAQ, Wikipedia
+            pages, documentation...
+          </Page.P>
+        </Page.Vertical>
+      </Page.Horizontal>
+    </Page.Vertical>
+    <Page.Vertical sizing="grow">
+      <Page.H>
+        👋 <br />
+        Hello <br /> <span className="text-success-500">@mentions</span>
+      </Page.H>
+      <Page.P>
+        In Dust, you won't find just one AI assistant, but multiple ones.
+      </Page.P>
+      <Page.P>
+        You can call any assistant at any time by typing “@” and the name of the
+        assistant.
+      </Page.P>
+    </Page.Vertical>
+    <Page.Horizontal>
+      <Page.Vertical>
+        <Page.H>
+          👩‍🎨🦸‍♀️🥷🧑‍🚀
+          <br /> Why multiple
+          <br /> Assistants?
+        </Page.H>
+
+        <Page.P>
+          The basic assistant is{" "}
+          <span className="font-bold text-success-500">@gpt4</span>. It is a raw
+          model. “Raw” means it does not have particular instructions or access
+          to knowledge.
+        </Page.P>
+        <Page.P>
+          You also have access to assistants that use a raw model (gpt4 for
+          instance), AND give them specific instructions and access to
+          knowledge.{" "}
+          <span className="font-bold">
+            They can answer specific questions, really well.
+          </span>
+        </Page.P>
+        <Page.P>
+          Assistants can be provided by Dust, by your company (Company
+          assistants), by your coworkers (Shared assistants).
+        </Page.P>
+      </Page.Vertical>
+
+      <Page.Vertical>
+        <Page.H>
+          🛠️
+          <br />
+          How to make
+          <br />
+          an Assistant?
+        </Page.H>
+        <Page.P>You can build Assistants!</Page.P>
+        <Page.P>
+          Assistants start with an “instruction”. A simple text, explaining what
+          you want them to do.
+        </Page.P>
+        <Page.P>
+          For instance, <span className="italic">“Act as a doctor”</span>,{" "}
+          <span className="italic">“Summarise this document”</span>,{" "}
+          <span className="italic">“What do you know about X”</span>.
+        </Page.P>
+        <Page.P>
+          You can give them access to knowledge.
+          <br />
+          We call them <span className="font-bold">Data sources.</span>
+        </Page.P>
+        <Page.P>
+          With the right Data source, assistants can answer demands like
+          <span className="italic">
+            “Have we been working with company X”
+          </span>, <span className="italic">“How do we manage expenses”</span>,{" "}
+          <span className="italic">
+            “Write an intro email using the company tone of voice”...
+          </span>
+        </Page.P>
+      </Page.Vertical>
+    </Page.Horizontal>
+
+    <Page.Vertical>
+      <Page.H>
+        📚
+        <br />
+        What are
+        <br />
+        Data sources?
+      </Page.H>
+
+      <Page.P>
+        To augment your assistants with knowledge, you give them data.
+        <br /> Data can come in different ways in Dust.{" "}
+        <span className="font-bold">Here are the three main ways:</span>
+      </Page.P>
+      <Page.Horizontal>
+        <Page.Vertical sizing="grow">
+          <div className="flex items-center gap-2">
+            <Icon visual={CloudArrowLeftRightIcon} />{" "}
+            <Page.H variant="h6">Connections</Page.H>
+          </div>
+          <Page.P>
+            Notion, Slack, Google Drive... Dust can connect to multiple
+            platforms and synchronize your data.
+          </Page.P>
+        </Page.Vertical>
+        <Page.Vertical sizing="grow">
+          <Page.Horizontal>
+            <div className="flex items-center gap-2">
+              <Icon visual={FolderIcon} /> <Page.H variant="h6">Folders</Page.H>
+            </div>
+          </Page.Horizontal>
+          <Page.P>Upload files (text, pdf, csv) directly in Dust.</Page.P>
+        </Page.Vertical>
+        <Page.Vertical sizing="grow">
+          <Page.Horizontal>
+            <div className="flex items-center gap-2">
+              <Icon visual={GlobeAltIcon} />{" "}
+              <Page.H variant="h6">Websites</Page.H>
+            </div>
+          </Page.Horizontal>
+          <Page.P>
+            Any public website can be synced in Dust. Think FAQ, Wikipedia
+            pages, documentation...
+          </Page.P>
+        </Page.Vertical>
+      </Page.Horizontal>
+    </Page.Vertical>
+  </div>
+);

--- a/sparkle/src/stories/Sheet.stories.tsx
+++ b/sparkle/src/stories/Sheet.stories.tsx
@@ -65,7 +65,7 @@ export function SheetDemo() {
           <SheetFooter
             sheetCloseClassName="s-flex s-gap-2"
             leftButtonProps={{ label: "Cancel", variant: "warning" }}
-            rightButtonProps={{ label: "Save" }}
+            rightButtonProps={{ label: "Save", disabled: true }}
           />
         </SheetContent>
       </Sheet>

--- a/sparkle/tailwind.config.js
+++ b/sparkle/tailwind.config.js
@@ -61,6 +61,7 @@ module.exports = {
         xl: "0 20px 25px rgba(15, 23, 42, 0.12)",
         "2xl": "0 25px 50px rgba(15, 23, 42, 0.12)",
         "inner-border": "inset 0px -2px 0px 0px #1E293B",
+        tale: "0px 0px 12px 12px #F6F8FB",
       },
       zIndex: {
         60: "60",


### PR DESCRIPTION
## Description

This PR introduces a new component: `Sheet` from [shadcn](https://ui.shadcn.com/docs/components/sheet) which is intended to replace our current side modals.

## Risk

N/A

## Deploy Plan

- Publish `sparkle`