### PR TITLE
[connectors] cleanup(Zendesk) - remove a misleading parameter

### DIFF
--- a/connectors/src/connectors/zendesk/temporal/client.ts
+++ b/connectors/src/connectors/zendesk/temporal/client.ts
@@ -38,14 +38,12 @@ export function getZendeskGarbageCollectionWorkflowId(
 export async function launchZendeskSyncWorkflow(
   connector: ConnectorResource,
   {
-    startFromTs = null,
     brandIds = [],
     ticketsBrandIds = [],
     helpCenterBrandIds = [],
     categoryIds = [],
     forceResync = false,
   }: {
-    startFromTs?: number | null;
     brandIds?: number[];
     ticketsBrandIds?: number[];
     helpCenterBrandIds?: number[];
@@ -53,10 +51,6 @@ export async function launchZendeskSyncWorkflow(
     forceResync?: boolean;
   } = {}
 ): Promise<Result<undefined, Error>> {
-  if (startFromTs) {
-    throw new Error("[Zendesk] startFromTs not implemented yet.");
-  }
-
   const client = await getTemporalClient();
 
   const signals: (ZendeskUpdateSignal | ZendeskCategoryUpdateSignal)[] = [


### PR DESCRIPTION
## Description

- Remove the unused parameter `startFromTs` from `launchZendeskSyncWorkflow`.
- This feature exists but is not handled there, which is misleading because the error says it is not implemented yet. (it is available in the `sync` method of `ZendeskConnectorManager`).

## Risk

None.

## Deploy Plan

- Deploy connectors.
