### PR TITLE
Add: github action to prevent deployment based on channel topic

### DIFF
--- a/.github/actions/slack-check-deployment-blocked/action.yml
+++ b/.github/actions/slack-check-deployment-blocked/action.yml
@@ -1,0 +1,57 @@
+name: 'Slack Check Deployment Blocked'
+description: 'Check the Slack #deployments channel title if deployment should be blocked'
+
+inputs:
+  component:
+    description: 'Component being deployed'
+    required: true
+  channel:
+    description: 'Slack channel'
+    required: true
+  slack_token:
+    description: 'Slack bot token'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get channel info
+      id: slack_channel_info
+      uses: slackapi/slack-github-action@v2.0.0
+      with:
+        method: conversations.info
+        token: ${{ inputs.slack_token }}
+        payload: |
+          channel: ${{ inputs.channel }}
+
+    - name: Get channel topic
+      if: steps.slack_channel_info.outputs.ok == 'true'
+      id: slack_channel_topic
+      shell: bash
+      run: |
+        RESPONSE='${{ steps.slack_channel_info.outputs.response }}'
+        if ! TOPIC=$(echo "$RESPONSE" | jq -r '.channel.topic.value'); then
+          echo "Failed to extract Slack channel topic" >&2
+          exit 0
+        fi
+        echo "topic=$TOPIC" >> $GITHUB_OUTPUT
+
+    - name: Parse channel topic for blocked deployments
+      if: steps.slack_channel_topic.outputs.topic != ''
+      id: parse_channel_topic
+      shell: bash
+      run: |
+        is_blocked() {
+            local raw_component="$1"
+            local component=$(printf '%s' "$raw_component" | sed 's/[][\.*^$/]/\\&/g')
+
+            local status_string="$2"
+            
+            if echo "$status_string" | grep -q ":x:[ ]*${component}[ ]" || echo "$status_string" | grep -q ":x:[ ]*${component}|\$" ; then
+                return 1
+            else
+                return 0
+            fi
+        }
+        is_blocked "${{ inputs.component }}" "${{ steps.slack_channel_topic.outputs.topic }}" && echo "${{ inputs.component}} is blocked based on channel topic" && exit 1
+    

--- a/.github/workflows/deploy-front-edge.yml
+++ b/.github/workflows/deploy-front-edge.yml
@@ -16,6 +16,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Slack Check Deployment Blocked
+        uses: ./.github/actions/slack-check-deployment-blocked
+        with:
+          step: "start"
+          component: "front"
+          channel: ${{ secrets.SLACK_CHANNEL_ID }}
+          slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
+
       - name: Checkout code
         uses: actions/checkout@v3
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,6 @@
     "source.fixAll.eslint": "explicit"
   },
   "eslint.run": "onSave",
-  "typescript.preferences.importModuleSpecifier": "non-relative"
+  "typescript.preferences.importModuleSpecifier": "non-relative",
+  "github-actions.workflows.pinned.workflows": []
 }


### PR DESCRIPTION
## Description

Add a github action to check the #deployment channel topic to see if a deploy is blocked.

## Risk

Low, testing with front-edge.

## Deploy Plan

Try to deploy `front-edge` and expect it to be blocked.