### PR TITLE
fix: upsert table before upserting datasource node

### DIFF
--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -2912,7 +2912,7 @@ impl Store for PostgresStore {
         let stmt = c
             .prepare(
                 "INSERT INTO data_sources_nodes \
-               (id, data_source, created, node_id, timestamp, title, mime_type, parents, document, table, folder) \
+               (id, data_source, created, node_id, timestamp, title, mime_type, parents, document, \"table\", folder) \
                VALUES (DEFAULT, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10) RETURNING id",
             )
             .await?;
@@ -2960,7 +2960,7 @@ impl Store for PostgresStore {
 
         let stmt = c
             .prepare(
-                "SELECT created, timestamp, title, mime_type, parents, document, table, folder, node_id \
+                "SELECT created, timestamp, title, mime_type, parents, document, \"table\", folder, node_id \
                  FROM data_sources_nodes \
                  WHERE data_source = $1 AND node_id = $2 LIMIT 1",
             )


### PR DESCRIPTION
## Description

- table needs to be upserted first, as the upsert datasource node looks for an existing table 
- the word "table" is reserved and needs quoting
## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
