### PR TITLE
Restore previous behavior when posting a message

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -173,25 +173,36 @@ export function AssistantInputBar({
     if (!conversationId) {
       setLoading(true);
       setDisableSendButton(true);
-    }
 
-    const r = await onSubmit(
-      text,
-      mentions,
-      fileUploaderService.getFileBlobs().map((cf) => {
-        return {
-          title: cf.filename,
-          fileId: cf.fileId,
-        };
-      })
-    );
+      const r = await onSubmit(
+        text,
+        mentions,
+        fileUploaderService.getFileBlobs().map((cf) => {
+          return {
+            title: cf.filename,
+            fileId: cf.fileId,
+          };
+        })
+      );
 
-    if (!conversationId) {
       setLoading(false);
       setDisableSendButton(false);
-    }
+      if (r.isOk()) {
+        resetEditorText();
+        fileUploaderService.resetUpload();
+      }
+    } else {
+      void onSubmit(
+        text,
+        mentions,
+        fileUploaderService.getFileBlobs().map((cf) => {
+          return {
+            title: cf.filename,
+            fileId: cf.fileId,
+          };
+        })
+      );
 
-    if (r.isOk()) {
       resetEditorText();
       fileUploaderService.resetUpload();
     }


### PR DESCRIPTION
## Description

We want the message to disappear immediately from the input bar as before.

## Risk

Low

## Deploy Plan

Deploy `front`