### PR TITLE
Rename core `dust-api` into `core-api`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,15 +7,15 @@
         {
             "type": "lldb",
             "request": "launch",
-            "name": "Debug dust-api",
+            "name": "Debug core-api",
             "cargo": {
                 "args": [
                     "build",
-                    "--bin=dust-api",
+                    "--bin=core-api",
                     "--manifest-path=${workspaceFolder}/core/Cargo.toml"
                 ],
                 "filter": {
-                    "name": "dust-api",
+                    "name": "core-api",
                     "kind": "bin"
                 }
             },

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -6,8 +6,12 @@ edition = "2021"
 # SERVICES
 
 [[bin]]
+name = "core-api"
+path = "bin/core_api.rs"
+
+[[bin]]
 name = "dust-api"
-path = "bin/dust_api.rs"
+path = "bin/core_api.rs"
 
 [[bin]]
 name = "oauth"

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -6,9 +6,9 @@ WORKDIR /app
 
 COPY . .
 
-RUN cargo build --release --bin dust-api --bin sqlite-worker
+RUN cargo build --release --bin core-api --bin sqlite-worker
 
 EXPOSE 3001
 
 # Set a default command, it will start the API service if no command is provided
-CMD ["cargo", "run", "--release", "--bin", "dust-api"]
+CMD ["cargo", "run", "--release", "--bin", "core-api"]

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN cargo build --release --bin core-api --bin sqlite-worker
+RUN cargo build --release --bin core-api --bin dust-api --bin sqlite-worker
 
 EXPOSE 3001
 

--- a/core/admin/dev.sh
+++ b/core/admin/dev.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-cargo run --bin dust-api
+cargo run --bin core-api

--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -10,7 +10,7 @@ use axum::{
     routing::{delete, get, patch, post},
     Router,
 };
-use futures::future::{try_join, try_join_all};
+use futures::future::try_join_all;
 use hyper::http::StatusCode;
 use parking_lot::Mutex;
 use serde_json::{json, Value};

--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -3148,8 +3148,6 @@ fn main() {
 
     let rt = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(32)
-        //.thread_name("dust-api-server")
-        //.thread_stack_size(32 * 1024 * 1024)
         .enable_all()
         .build()
         .unwrap();

--- a/k8s/dust-kube/deployments/core-deployment.yaml
+++ b/k8s/dust-kube/deployments/core-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
         - name: web
           image: gcr.io/or1g1n-186209/core-image:latest
-          command: ["cargo", "run", "--release", "--bin", "dust-api"]
+          command: ["cargo", "run", "--release", "--bin", "core-api"]
           imagePullPolicy: Always
           ports:
             - containerPort: 3001


### PR DESCRIPTION
## Description

We keep both binaries names + build around as we need a 2 step change with dust-infra

## Risk

Large: if bootup fails. Hence why we keep both binaries for now

## Deploy Plan

- deploy `core` (deploying should still use the old binary since the deploy is dust-infra driven)
- update dust-infra https://github.com/dust-tt/dust-infra/pull/85
- deploy `core` (check that the deploy runs core-api now)
- remove all references to dust-api
- deploy `core`