### PR TITLE
[connectors] fix(Zendesk) - high volumes

### DIFF
--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -292,7 +292,7 @@ export async function fetchRecentlyUpdatedTickets(
   });
   return {
     tickets: response.tickets,
-    hasMore: !response.end_of_stream,
+    hasMore: !response.end_of_stream && response.tickets.lenght !== 0,
     nextLink: response.after_url,
   };
 }

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -231,7 +231,7 @@ export async function fetchRecentlyUpdatedArticles({
   });
   return {
     articles: response.articles,
-    hasMore: response.next_page !== null || response.articles.length === 0,
+    hasMore: response.next_page !== null && response.articles.length !== 0,
     endTime: response.end_time,
   };
 }

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -294,7 +294,7 @@ export async function fetchRecentlyUpdatedTickets(
     tickets: response.tickets,
     hasMore:
       !response.end_of_stream &&
-      response.tickets.lenght !== 0 &&
+      response.tickets.length !== 0 &&
       response.after_url !== null,
     nextLink: response.after_url,
   };

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -294,8 +294,8 @@ export async function fetchRecentlyUpdatedTickets(
     tickets: response.tickets,
     hasMore:
       !response.end_of_stream &&
-      response.tickets.length !== 0 &&
-      response.after_url !== null,
+      response.after_url !== null &&
+      response.tickets.length !== 0,
     nextLink: response.after_url,
   };
 }

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -292,7 +292,10 @@ export async function fetchRecentlyUpdatedTickets(
   });
   return {
     tickets: response.tickets,
-    hasMore: !response.end_of_stream && response.tickets.lenght !== 0,
+    hasMore:
+      !response.end_of_stream &&
+      response.tickets.lenght !== 0 &&
+      response.after_url !== null,
     nextLink: response.after_url,
   };
 }


### PR DESCRIPTION
## Description

- Close #8969.
- Fix an issue observed in prod and locally where basically all the articles would be resynced at every incremental update.
- The condition to stop the pagination was incorrect.

Response on empty diff:
```
curl "https://$SUBDOMAIN.zendesk.com/api/v2/help_center/incremental/articles.json?start_time=1732725000" -H "Authorization: Bearer $TOKEN" | jq

{
  "count": 0,
  "next_page": null,
  "end_time": 1,
  "articles": []
}
```

## Risk

Low.

## Deploy Plan

- Deploy connectors.
