### PR TITLE
Clean-up ANTHROPIC_TOOL_USE_META_PROMPT

### DIFF
--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -331,10 +331,7 @@ const ANTHROPIC_TOOL_USE_META_PROMPT =
   `After using a tool, think for one short bullet point in \`<thinking>\` tags to evaluate ` +
   `whether the tools results are enough to answer the user's question. ` +
   `The response to the user must be in \`<response>\` tags. ` +
-  `There must be a single \`<response>\` after the tools use (if any). ` +
-  `When answering basic factual questions (like capitals, simple definitions, ` +
-  `or well-known historical dates), provide the answer directly without using the ` +
-  `search tool AND without mentioning it, common knowledge, or your reasoning process.`;
+  `There must be a single \`<response>\` after the tools use (if any).`;
 
 export const CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",


### PR DESCRIPTION
## Description

Context: introduced here: https://github.com/dust-tt/dust/pull/8637 and then made obsolete here: https://github.com/dust-tt/dust/pull/8651 without proper clean-up.

## Risk

N/A

## Deploy Plan

- deploy `front`