### PR TITLE
[extension] Fix messaging between app and background

### DIFF
--- a/extension/app/page.ts
+++ b/extension/app/page.ts
@@ -212,12 +212,23 @@ declare global {
         body.style.overflowY = originalBodyOverflowYStyle;
       }
       window.scrollTo(originalX, originalY);
+      // Ensure the callback is called at least once when cleaning up.
+      // If it was called already with results, this will be ignored by promise.
+      callback([]);
     }
     const screenshots: Screenshot[] = [];
 
     (function processArrangements() {
       const next = arrangements.shift();
       if (!next) {
+        if (callback) {
+          callback(
+            screenshots.map((screenshot) =>
+              screenshot.canvas.toDataURL("image/jpeg", 0.8)
+            )
+          );
+        }
+
         cleanUp();
         return;
       }
@@ -289,17 +300,7 @@ declare global {
                   image.height * zoomFactor
                 );
               });
-              // send back log data for debugging (but keep it truthy to
-              // indicate success)
-              if (!arrangements.length) {
-                if (callback) {
-                  callback(
-                    screenshots.map((screenshot) =>
-                      screenshot.canvas.toDataURL("image/jpeg", 0.8)
-                    )
-                  );
-                }
-              }
+
               // Move on to capture next arrangement.
               processArrangements();
             };

--- a/extension/app/src/components/PortContext.tsx
+++ b/extension/app/src/components/PortContext.tsx
@@ -6,6 +6,7 @@ export const PortProvider = ({ children }: { children: React.ReactNode }) => {
   const [port, setPort] = useState<chrome.runtime.Port | null>(null);
 
   useEffect(() => {
+    console.log("Connecting to sidepanel");
     const port = chrome.runtime.connect({ name: "sidepanel-connection" });
 
     setPort(port);

--- a/extension/app/src/components/auth/ProtectedRoute.tsx
+++ b/extension/app/src/components/auth/ProtectedRoute.tsx
@@ -6,12 +6,11 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import { useAuth } from "@extension/components/auth/AuthProvider";
-import { PortContext } from "@extension/components/PortContext";
 import type { RouteChangeMesssage } from "@extension/lib/messages";
 import type { StoredUser } from "@extension/lib/storage";
 import { getPendingUpdate } from "@extension/lib/storage";
 import type { ReactNode } from "react";
-import { useContext, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 type ProtectedRouteProps = {
@@ -37,22 +36,19 @@ export const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
   const navigate = useNavigate();
   const [isLatestVersion, setIsLatestVersion] = useState(true);
 
-  const port = useContext(PortContext);
   useEffect(() => {
-    if (port) {
-      const listener = (message: RouteChangeMesssage) => {
-        const { type } = message;
-        if (type === "EXT_ROUTE_CHANGE") {
-          navigate({ pathname: message.pathname, search: message.search });
-          return false;
-        }
-      };
-      port.onMessage.addListener(listener);
-      return () => {
-        port.onMessage.removeListener(listener);
-      };
-    }
-  }, [port, navigate]);
+    const listener = (message: RouteChangeMesssage) => {
+      const { type } = message;
+      if (type === "EXT_ROUTE_CHANGE") {
+        navigate({ pathname: message.pathname, search: message.search });
+        return false;
+      }
+    };
+    chrome.runtime.onMessage.addListener(listener);
+    return () => {
+      chrome.runtime.onMessage.removeListener(listener);
+    };
+  }, [navigate]);
 
   useEffect(() => {
     if (!isAuthenticated || !isUserSetup || !user || !workspace) {

--- a/extension/app/src/components/input_bar/InputBar.tsx
+++ b/extension/app/src/components/input_bar/InputBar.tsx
@@ -12,7 +12,6 @@ import { InputBarCitations } from "@extension/components/input_bar/InputBarCitat
 import type { InputBarContainerProps } from "@extension/components/input_bar/InputBarContainer";
 import { InputBarContainer } from "@extension/components/input_bar/InputBarContainer";
 import { InputBarContext } from "@extension/components/input_bar/InputBarContext";
-import { PortContext } from "@extension/components/PortContext";
 import { useFileUploaderService } from "@extension/hooks/useFileUploaderService";
 import { useDustAPI } from "@extension/lib/dust_api";
 import type { AttachSelectionMessage } from "@extension/lib/messages";
@@ -63,23 +62,21 @@ export function AssistantInputBar({
     getFileBlobs,
     resetUpload,
   } = fileUploaderService;
-  const port = useContext(PortContext);
+
   useEffect(() => {
-    if (port) {
-      void sendInputBarStatus(true);
-      const listener = async (message: AttachSelectionMessage) => {
-        const { type } = message;
-        if (type === "EXT_ATTACH_TAB") {
-          // Handle message
-          void uploadContentTab(message);
-        }
-      };
-      port.onMessage.addListener(listener);
-      return () => {
-        void sendInputBarStatus(false);
-        port.onMessage.removeListener(listener);
-      };
-    }
+    void sendInputBarStatus(true);
+    const listener = async (message: AttachSelectionMessage) => {
+      const { type } = message;
+      if (type === "EXT_ATTACH_TAB") {
+        // Handle message
+        void uploadContentTab(message);
+      }
+    };
+    chrome.runtime.onMessage.addListener(listener);
+    return () => {
+      void sendInputBarStatus(false);
+      chrome.runtime.onMessage.removeListener(listener);
+    };
   }, []);
 
   const { droppedFiles, setDroppedFiles } = useFileDrop();

--- a/extension/app/src/lib/messages.ts
+++ b/extension/app/src/lib/messages.ts
@@ -173,7 +173,7 @@ export const sendGetActiveTabMessage = (params: GetActiveTabOptions) => {
 };
 
 export const sendInputBarStatus = (available: boolean) => {
-  return sendMessage<InputBarStatusMessage, void>({
+  void chrome.runtime.sendMessage({
     type: "INPUT_BAR_STATUS",
     available,
   });


### PR DESCRIPTION
## Description

This fixes messaging by using chrome.runtime instead of long-lived connection. As the background context can be reset when the worker is restarted, don't store anything that should be kept for long in `state`, only transient information that are expected to be reset.
Fixes input_bar_message to not expect a response.
Also minor fixes in screenshot to better handle errors and timeouts

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
