### PR TITLE
remove dust-api definitively

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,10 +10,6 @@ name = "core-api"
 path = "bin/core_api.rs"
 
 [[bin]]
-name = "dust-api"
-path = "bin/core_api.rs"
-
-[[bin]]
 name = "oauth"
 path = "bin/oauth.rs"
 

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN cargo build --release --bin core-api --bin dust-api --bin sqlite-worker
+RUN cargo build --release --bin core-api --bin sqlite-worker
 
 EXPOSE 3001
 


### PR DESCRIPTION
## Description

Follow-up to https://github.com/dust-tt/dust/pull/8970

## Risk

N/A

```
Now using node v20.13.0 (npm v10.5.2)
spolu@spolu-box ~ $ k8s_ssh core
root@core-deployment-865569bcc6-9zpn5:/app# ps -ef
UID          PID    PPID  C STIME TTY          TIME CMD
root           1       0 25 10:06 ?        00:08:54 target/release/core-api
```

## Deploy Plan

- deploy `core`