### PR TITLE
enh(co-ed): generate viz-id & pass it to md directive

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -67,8 +67,10 @@ import {
   mentionDirective,
 } from "@app/components/markdown/MentionBlock";
 import {
+  getInteractiveDocumentPlugin,
   getVisualizationPlugin,
-  sanitizeVisualizationContent,
+  interactiveDocumentDirective,
+  sanitizeContent,
   visualizationDirective,
 } from "@app/components/markdown/VisualizationBlock";
 import { useEventSource } from "@app/hooks/useEventSource";
@@ -456,6 +458,12 @@ export function AgentMessage({
         conversationId,
         message.sId
       ),
+      doc: getInteractiveDocumentPlugin(
+        owner,
+        agentConfiguration.sId,
+        conversationId,
+        message.sId
+      ),
       sup: CiteBlock,
       mention: MentionBlock,
     }),
@@ -463,7 +471,12 @@ export function AgentMessage({
   );
 
   const additionalMarkdownPlugins: PluggableList = useMemo(
-    () => [mentionDirective, getCiteDirective(), visualizationDirective],
+    () => [
+      mentionDirective,
+      getCiteDirective(),
+      visualizationDirective,
+      interactiveDocumentDirective,
+    ],
     []
   );
 
@@ -582,7 +595,7 @@ export function AgentMessage({
                 }}
               >
                 <Markdown
-                  content={sanitizeVisualizationContent(agentMessage.content)}
+                  content={sanitizeContent(agentMessage.content)}
                   isStreaming={
                     streaming && lastTokenClassification === "tokens"
                   }

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -651,6 +651,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema([
   "zendesk_connector_feature",
   "index_private_slack_channel",
   "conversations_jit_actions",
+  "co_edition",
 ]);
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;

--- a/types/src/shared/feature_flags.ts
+++ b/types/src/shared/feature_flags.ts
@@ -10,6 +10,7 @@ export const WHITELISTABLE_FEATURES = [
   "zendesk_connector_feature",
   "index_private_slack_channel",
   "conversations_jit_actions",
+  "co_edition",
 ] as const;
 export type WhitelistableFeature = (typeof WHITELISTABLE_FEATURES)[number];
 export function isWhitelistableFeature(


### PR DESCRIPTION
## Description

- make the model generate a "viz-id" for every viz it generates
- this viz-id is extracted from the markdown plugin and passed to `VisualizationBlock`
- right now this is not doing anything (we ignore the ID)

## Risk

This affects production code and is on the critical path for viz, but it's mostly a no-op (a useless ID is being generated)

## Deploy Plan

N/A