### PR TITLE
Sparkle: Add isLoading state to split button

### DIFF
--- a/extension/app/src/components/input_bar/InputBarContainer.tsx
+++ b/extension/app/src/components/input_bar/InputBarContainer.tsx
@@ -28,6 +28,7 @@ export interface InputBarContainerProps {
   isTabIncluded: boolean;
   setIncludeTab: (includeTab: boolean) => void;
   fileUploaderService: FileUploaderService;
+  isSubmitting: boolean;
 }
 
 export const InputBarContainer = ({

--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.326",
+  "version": "0.2.327",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.326",
+      "version": "0.2.327",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.326",
+  "version": "0.2.327",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/SplitButton.tsx
+++ b/sparkle/src/components/SplitButton.tsx
@@ -34,6 +34,7 @@ interface SplitButtonActionProps {
   tooltip?: string;
   disabled?: boolean;
   onClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+  isLoading?: boolean;
 }
 
 export interface SplitButtonProps
@@ -113,6 +114,7 @@ export const SplitButton = React.forwardRef<
               icon={ChevronDownIcon}
               disabled={disabled}
               className={cn("s-rounded-l-none s-border-l-0", className)}
+              isLoading={actionToUse.isLoading}
             />
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">

--- a/sparkle/src/stories/SplitButton.stories.tsx
+++ b/sparkle/src/stories/SplitButton.stories.tsx
@@ -43,13 +43,17 @@ export const ExampleButton: Story = {
       {
         label: "Second",
         icon: RobotIcon,
-        tooltip: "Second tooltip",
+        tooltip: "Disabled tooltip",
         disabled: true,
       },
       {
         label: "Third",
-        icon: PlusIcon,
         tooltip: "Third tooltip",
+      },
+      {
+        label: "Fourth",
+        tooltip: "Loading tooltip",
+        isLoading: true,
       },
     ],
   },


### PR DESCRIPTION
## Description

Small: just adding the isLoading props on Split Button (it's a prop of button)

<img width="320" alt="Screenshot 2024-11-28 at 13 54 30" src="https://github.com/user-attachments/assets/02b56521-8d82-4349-ad69-1c6c8c663cc6">


<img width="279" alt="Screenshot 2024-11-28 at 13 54 36" src="https://github.com/user-attachments/assets/76aa1c8f-d541-402a-aeab-eb36defa1aa9">




## Risk

Small, this component is used once on the extension and new props is optional. 

## Deploy Plan

Publish sparkle. 