### PR TITLE
Fix support for `dust-application/slack` content fragment

### DIFF
--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -140,7 +140,7 @@ export function listFiles(
 
     if (
       isContentFragmentType(m) &&
-      !isListableContentType(m.contentType) &&
+      isListableContentType(m.contentType) &&
       m.contentFragmentVersion === "latest"
     ) {
       if (m.fileId) {

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -23,7 +23,6 @@ import {
   isContentFragmentMessageTypeModel,
   isContentFragmentType,
   isSupportedImageContentType,
-  isSupportedPlainTextContentType,
   isUserMessageType,
   Ok,
   removeNulls,

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -123,7 +123,7 @@ function isSearchableContentType(
 function isListableContentType(
   contentType: SupportedContentFragmentType
 ): boolean {
-  // We allow listing all content-types that are not images. Not that
+  // We allow listing all content-types that are not images. Note that
   // `isSupportedPlainTextContentType` is not enough because it is limited to uploadable (as in from
   // the conversation) content types which does not cover all non image content types that we
   // support in the API such as `dust-application/slack`.

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -121,6 +121,16 @@ function isSearchableContentType(
   }
 }
 
+function isListableContentType(
+  contentType: SupportedContentFragmentType
+): boolean {
+  // We allow listing all content-types that are not images. Not that
+  // `isSupportedPlainTextContentType` is not enough because it is limited to uploadable (as in from
+  // the conversation) content types which does not cover all non image content types that we
+  // support in the API such as `dust-application/slack`.
+  return !isSupportedImageContentType(contentType);
+}
+
 export function listFiles(
   conversation: ConversationType
 ): ConversationFileType[] {
@@ -130,7 +140,7 @@ export function listFiles(
 
     if (
       isContentFragmentType(m) &&
-      isSupportedPlainTextContentType(m.contentType) &&
+      !isListableContentType(m.contentType) &&
       m.contentFragmentVersion === "latest"
     ) {
       if (m.fileId) {


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/dust/issues/8986

Comment explains the PR. Not tested will optimistically test in production.

## Risk

N/A. Behind flag.

## Deploy Plan

- deploy `front`