### PR TITLE
Ext: Polish - Better loading state input bar + Desifn feedback

### DIFF
--- a/extension/app/src/components/assistants/AssistantFavorites.tsx
+++ b/extension/app/src/components/assistants/AssistantFavorites.tsx
@@ -40,7 +40,7 @@ export function AssistantFavorites() {
     <div className="h-full w-full pt-2 pb-12">
       <Page.SectionHeader title="Favorites" />
       {hasFavorites ? (
-        <div className="relative grid w-full grid-cols-1 sm:grid-cols-2 gap-2">
+        <div className="relative grid w-full grid-cols-2 gap-2">
           {agentConfigurations.map(
             ({ sId, name, pictureUrl, lastAuthors, description }) => (
               <AssistantPreview

--- a/extension/app/src/components/assistants/AssistantPicker.tsx
+++ b/extension/app/src/components/assistants/AssistantPicker.tsx
@@ -22,12 +22,14 @@ export function AssistantPicker({
   onItemClick,
   pickerButton,
   size = "md",
+  isLoading,
 }: {
   owner: LightWorkspaceType;
   assistants: LightAgentConfigurationType[];
   onItemClick: (assistant: LightAgentConfigurationType) => void;
   pickerButton?: React.ReactNode;
   size?: "xs" | "sm" | "md";
+  isLoading?: boolean;
 }) {
   const [searchText, setSearchText] = useState("");
   const [searchedAssistants, setSearchedAssistants] = useState<
@@ -56,6 +58,7 @@ export function AssistantPicker({
             isSelect
             size={size}
             tooltip="Pick an assistant"
+            disabled={isLoading ?? false}
           />
         )}
       </DropdownMenuTrigger>
@@ -64,7 +67,6 @@ export function AssistantPicker({
           ref={searchbarRef}
           placeholder="Search"
           name="input"
-          size="xs"
           value={searchText}
           onChange={setSearchText}
           onKeyDown={(e) => {

--- a/extension/app/src/components/conversation/AgentMessage.tsx
+++ b/extension/app/src/components/conversation/AgentMessage.tsx
@@ -22,10 +22,7 @@ import {
   isWebsearchActionType,
   removeNulls,
 } from "@dust-tt/client";
-import type {
-  ConversationMessageEmojiSelectorProps,
-  ConversationMessageSizeType,
-} from "@dust-tt/sparkle";
+import type { ConversationMessageSizeType } from "@dust-tt/sparkle";
 import {
   ArrowPathIcon,
   Button,
@@ -109,7 +106,6 @@ interface AgentMessageProps {
   conversationId: string;
   isLastMessage: boolean;
   message: AgentMessagePublicType;
-  messageEmoji?: ConversationMessageEmojiSelectorProps;
   owner: LightWorkspaceType;
   size: ConversationMessageSizeType;
 }
@@ -124,7 +120,6 @@ export function AgentMessage({
   conversationId,
   isLastMessage,
   message,
-  messageEmoji,
   owner,
   size,
 }: AgentMessageProps) {
@@ -500,7 +495,6 @@ export function AgentMessage({
       name={`@${agentConfiguration.name}`}
       buttons={buttons}
       avatarBusy={agentMessageToRender.status === "created"}
-      messageEmoji={messageEmoji}
       renderName={() => {
         return (
           <div className="flex flex-row items-center gap-2">

--- a/extension/app/src/components/conversation/AttachFile.tsx
+++ b/extension/app/src/components/conversation/AttachFile.tsx
@@ -7,11 +7,13 @@ import { useRef } from "react";
 type AttachFileProps = {
   fileUploaderService: FileUploaderService;
   editorService: EditorService;
+  isLoading: boolean;
 };
 
 export const AttachFile = ({
   fileUploaderService,
   editorService,
+  isLoading,
 }: AttachFileProps) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   return (
@@ -38,6 +40,7 @@ export const AttachFile = ({
         onClick={async () => {
           fileInputRef.current?.click();
         }}
+        disabled={isLoading}
       />
     </>
   );

--- a/extension/app/src/components/conversation/AttachFragment.tsx
+++ b/extension/app/src/components/conversation/AttachFragment.tsx
@@ -1,14 +1,16 @@
-import { Button, CameraIcon, DocumentPlusIcon } from "@dust-tt/sparkle";
+import { Button, DocumentPlusIcon, ImageIcon } from "@dust-tt/sparkle";
 import { InputBarContext } from "@extension/components/input_bar/InputBarContext";
 import type { FileUploaderService } from "@extension/hooks/useFileUploaderService";
 import { useContext, useEffect } from "react";
 
 type AttachFragmentProps = {
   fileUploaderService: FileUploaderService;
+  isLoading: boolean;
 };
 
 export const AttachFragment = ({
   fileUploaderService,
+  isLoading,
 }: AttachFragmentProps) => {
   const { attachPageBlinking, setAttachPageBlinking } =
     useContext(InputBarContext);
@@ -38,11 +40,12 @@ export const AttachFragment = ({
               includeCapture: false,
             })
           }
+          disabled={isLoading}
         />
       </div>
       <div className="block sm:hidden">
         <Button
-          icon={CameraIcon}
+          icon={ImageIcon}
           tooltip="Attach page screenshot"
           variant="outline"
           size="sm"
@@ -52,6 +55,7 @@ export const AttachFragment = ({
               includeCapture: true,
             })
           }
+          disabled={isLoading}
         />
       </div>
       <div className="hidden sm:block">
@@ -68,11 +72,12 @@ export const AttachFragment = ({
               includeCapture: false,
             })
           }
+          disabled={isLoading}
         />
       </div>
       <div className="hidden sm:block">
         <Button
-          icon={CameraIcon}
+          icon={ImageIcon}
           label="Add page screenshot"
           tooltip="Attach page screenshot"
           variant="outline"
@@ -83,6 +88,7 @@ export const AttachFragment = ({
               includeCapture: true,
             })
           }
+          disabled={isLoading}
         />
       </div>
     </>

--- a/extension/app/src/components/conversation/MessageItem.tsx
+++ b/extension/app/src/components/conversation/MessageItem.tsx
@@ -32,8 +32,6 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
       return null;
     }
 
-    const messageEmoji = undefined;
-
     switch (type) {
       case "user_message":
         const citations = message.contenFragments
@@ -81,7 +79,6 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
               conversationId={conversationId}
               isLastMessage={isLastMessage}
               message={message}
-              messageEmoji={messageEmoji}
               owner={owner}
               size="compact"
             />

--- a/extension/app/src/components/conversation/UserMessage.tsx
+++ b/extension/app/src/components/conversation/UserMessage.tsx
@@ -1,9 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import type { LightWorkspaceType, UserMessageType } from "@dust-tt/client";
-import type {
-  ConversationMessageEmojiSelectorProps,
-  ConversationMessageSizeType,
-} from "@dust-tt/sparkle";
+import type { ConversationMessageSizeType } from "@dust-tt/sparkle";
 import { ConversationMessage, Markdown } from "@dust-tt/sparkle";
 import { AgentSuggestion } from "@extension/components/conversation/AgentSuggestion";
 import {
@@ -23,7 +20,6 @@ interface UserMessageProps {
   conversationId: string;
   isLastMessage: boolean;
   message: UserMessageType;
-  messageEmoji?: ConversationMessageEmojiSelectorProps;
   owner: LightWorkspaceType;
   size: ConversationMessageSizeType;
 }
@@ -33,7 +29,6 @@ export function UserMessage({
   conversationId,
   isLastMessage,
   message,
-  messageEmoji,
   owner,
   size,
 }: UserMessageProps) {
@@ -54,7 +49,6 @@ export function UserMessage({
     <ConversationMessage
       pictureUrl={message.user?.image || message.context.profilePictureUrl}
       name={message.context.fullName}
-      messageEmoji={messageEmoji}
       renderName={(name) => <div className="text-base font-medium">{name}</div>}
       type="user"
       citations={citations}

--- a/extension/app/src/components/input_bar/InputBar.tsx
+++ b/extension/app/src/components/input_bar/InputBar.tsx
@@ -245,11 +245,9 @@ export function AssistantInputBar({
         <div className="fixed absolute inset-0 z-50 overflow-hidden">
           <div className="fixed flex inset-0 bg-structure-50/80 backdrop-blur-sm transition-opacity" />
           <div className="fixed top-0 left-0 h-full w-full flex flex-col justify-center items-center gap-4">
-            {isCapturing && (
-              <span className="z-50">
-                <Page.Header title="Screen capture in progress..." />
-              </span>
-            )}
+            <span className="z-50">
+              <Page.Header title="Screen capture in progress..." />
+            </span>
             <Spinner size="xl" />
           </div>
         </div>

--- a/extension/app/src/components/input_bar/InputBar.tsx
+++ b/extension/app/src/components/input_bar/InputBar.tsx
@@ -188,7 +188,8 @@ export function AssistantInputBar({
   const handleSubmit: InputBarContainerProps["onEnterKeyDown"] = async (
     isEmpty,
     textAndMentions,
-    resetEditorText
+    resetEditorText,
+    setLoading
   ) => {
     if (isEmpty) {
       return;
@@ -204,7 +205,7 @@ export function AssistantInputBar({
       kind: cf.kind,
     }));
 
-    resetEditorText();
+    setLoading(true);
 
     if (isTabIncluded) {
       const files = await uploadContentTab({
@@ -228,7 +229,9 @@ export function AssistantInputBar({
       }
     }
 
-    onSubmit(text, mentions, newFiles);
+    await onSubmit(text, mentions, newFiles);
+    setLoading(false);
+    resetEditorText();
     resetUpload();
   };
 
@@ -238,7 +241,7 @@ export function AssistantInputBar({
 
   return (
     <div className="flex w-full flex-col">
-      {(isCapturing || isSubmitting) && (
+      {isCapturing && (
         <div className="fixed absolute inset-0 z-50 overflow-hidden">
           <div className="fixed flex inset-0 bg-structure-50/80 backdrop-blur-sm transition-opacity" />
           <div className="fixed top-0 left-0 h-full w-full flex flex-col justify-center items-center gap-4">
@@ -276,7 +279,10 @@ export function AssistantInputBar({
             )}
           >
             <div className="relative flex w-full flex-1 flex-col">
-              <InputBarCitations fileUploaderService={fileUploaderService} />
+              <InputBarCitations
+                fileUploaderService={fileUploaderService}
+                disabled={isSubmitting ?? false}
+              />
 
               <InputBarContainer
                 disableAutoFocus={disableAutoFocus}
@@ -289,6 +295,7 @@ export function AssistantInputBar({
                 isTabIncluded={isTabIncluded}
                 setIncludeTab={setIncludeTab}
                 fileUploaderService={fileUploaderService}
+                isSubmitting={isSubmitting ?? false}
               />
             </div>
           </div>

--- a/extension/app/src/components/input_bar/InputBarCitations.tsx
+++ b/extension/app/src/components/input_bar/InputBarCitations.tsx
@@ -3,10 +3,12 @@ import type { FileUploaderService } from "@extension/hooks/useFileUploaderServic
 
 interface InputBarCitationsProps {
   fileUploaderService: FileUploaderService;
+  disabled: boolean;
 }
 
 export function InputBarCitations({
   fileUploaderService,
+  disabled,
 }: InputBarCitationsProps) {
   const processContentFragments = () => {
     const nodes: React.ReactNode[] = [];
@@ -21,9 +23,13 @@ export function InputBarCitations({
           size="xs"
           type={isImage ? "image" : "document"}
           imgSrc={blob.preview}
-          onClose={() => {
-            fileUploaderService.removeFile(blob.id);
-          }}
+          onClose={
+            disabled
+              ? undefined
+              : () => {
+                  fileUploaderService.removeFile(blob.id);
+                }
+          }
           isLoading={blob.isUploading}
         />
       );
@@ -37,7 +43,7 @@ export function InputBarCitations({
   }
 
   return (
-    <div className="mr-4 flex gap-2 overflow-auto border-b border-structure-300/50 pb-3">
+    <div className="flex gap-2 overflow-auto border-b border-structure-300/50 pb-3">
       {processContentFragments()}
     </div>
   );

--- a/extension/app/src/components/input_bar/InputBarContainer.tsx
+++ b/extension/app/src/components/input_bar/InputBarContainer.tsx
@@ -42,6 +42,7 @@ export const InputBarContainer = ({
   isTabIncluded,
   setIncludeTab,
   fileUploaderService,
+  isSubmitting,
 }: InputBarContainerProps) => {
   const suggestions = usePublicAssistantSuggestions(agentConfigurations);
 
@@ -76,18 +77,27 @@ export const InputBarContainer = ({
 
   const onClick = async () => {
     const jsonContent = editorService.getTextAndMentions();
-    onEnterKeyDown(editorService.isEmpty(), jsonContent, () => {
-      editorService.clearEditor();
-    });
+    onEnterKeyDown(
+      editorService.isEmpty(),
+      jsonContent,
+      () => {
+        editorService.clearEditor();
+      },
+      (loading) => {
+        editorService.setLoading(loading);
+      }
+    );
   };
 
   const SendAction = {
     label: "Send",
     onClick,
+    isLoading: isSubmitting,
   };
   const SendWithContentAction = {
     label: "Add page text + Send",
     onClick,
+    isLoading: isSubmitting,
   };
 
   return (
@@ -108,6 +118,7 @@ export const InputBarContainer = ({
           <AttachFile
             fileUploaderService={fileUploaderService}
             editorService={editorService}
+            isLoading={isSubmitting}
           />
           <AssistantPicker
             owner={owner}
@@ -116,12 +127,16 @@ export const InputBarContainer = ({
               editorService.insertMention({ id: c.sId, label: c.name });
             }}
             assistants={allAssistants}
+            isLoading={isSubmitting}
           />
         </div>
       </div>
 
       <div className="flex items-center justify-end space-x-2 mt-2">
-        <AttachFragment fileUploaderService={fileUploaderService} />
+        <AttachFragment
+          fileUploaderService={fileUploaderService}
+          isLoading={isSubmitting}
+        />
         <SplitButton
           size="sm"
           actions={[SendAction, SendWithContentAction]}
@@ -130,7 +145,7 @@ export const InputBarContainer = ({
           onActionChange={(action) => {
             setIncludeTab(action === SendWithContentAction);
           }}
-          disabled={editorService.isEmpty()}
+          disabled={isSubmitting || editorService.isEmpty()}
         />
       </div>
     </div>

--- a/extension/app/src/components/input_bar/editor/useCustomEditor.tsx
+++ b/extension/app/src/components/input_bar/editor/useCustomEditor.tsx
@@ -144,6 +144,15 @@ const useEditorService = (editor: Editor | null) => {
       clearEditor() {
         return editor?.commands.clearContent();
       },
+
+      setLoading(loading: boolean) {
+        if (loading) {
+          editor?.view.dom.classList.add("loading-text");
+        } else {
+          editor?.view.dom.classList.remove("loading-text");
+        }
+        return editor?.setEditable(!loading);
+      },
     };
   }, [editor]);
 
@@ -156,7 +165,8 @@ export interface CustomEditorProps {
   onEnterKeyDown: (
     isEmpty: boolean,
     textAndMentions: ReturnType<typeof getTextAndMentionsFromNode>,
-    clearEditor: () => void
+    clearEditor: () => void,
+    setLoading: (loading: boolean) => void
   ) => void;
   suggestions: EditorSuggestions;
   disableAutoFocus: boolean;
@@ -227,10 +237,20 @@ const useCustomEditor = ({
             editor.commands.clearContent();
           };
 
+          const setLoading = (loading: boolean) => {
+            if (loading) {
+              editor?.view.dom.classList.add("loading-text");
+            } else {
+              editor?.view.dom.classList.remove("loading-text");
+            }
+            return editor?.setEditable(!loading);
+          };
+
           onEnterKeyDown(
             editor.isEmpty,
             getTextAndMentionsFromNode(editor.getJSON()),
-            clearEditor
+            clearEditor,
+            setLoading
           );
 
           // Return true to indicate that this key event has been handled.

--- a/extension/app/src/css/custom.css
+++ b/extension/app/src/css/custom.css
@@ -23,3 +23,31 @@ body {
     background-color: rgb(243 232 255 / var(--tw-bg-opacity));
   }
 }
+
+.loading-text {
+  background: linear-gradient(90deg, #999999 0%, #000000 50%, #999999 100%);
+  background-size: 200% auto;
+  -webkit-background-clip: text;
+  background-clip: text;
+  animation:
+    initialFade 0.3s ease-out forwards,
+    rainbowLoop 3s linear infinite;
+}
+
+@keyframes initialFade {
+  from {
+    color: currentColor;
+  }
+  to {
+    color: transparent;
+  }
+}
+
+@keyframes rainbowLoop {
+  0% {
+    background-position: 0% center;
+  }
+  100% {
+    background-position: -200% center;
+  }
+}

--- a/extension/app/src/pages/ConversationPage.tsx
+++ b/extension/app/src/pages/ConversationPage.tsx
@@ -49,19 +49,19 @@ export const ConversationPage = ({
               onClick={() => {
                 navigate("/");
               }}
-              size="md"
+              size="sm"
             />
           }
           rightActions={
             <div className="flex flex-row items-right">
-              <ConversationsListButton size="md" />
+              <ConversationsListButton size="sm" />
 
               <Button
                 icon={ExternalLinkIcon}
                 variant="ghost"
                 href={`${process.env.DUST_DOMAIN}/w/${workspace.sId}/assistant/${conversationId}`}
                 target="_blank"
-                size="md"
+                size="sm"
                 tooltip="Open in Dust"
               />
             </div>

--- a/extension/app/src/pages/MainPage.tsx
+++ b/extension/app/src/pages/MainPage.tsx
@@ -62,13 +62,13 @@ export const MainPage = ({
         }
         rightActions={
           <div className="flex flex-row items-right">
-            <ConversationsListButton size="md" />
+            <ConversationsListButton size="sm" />
 
             <DropdownMenu>
               <DropdownMenuTrigger>
-                <div className="px-2">
+                <div>
                   <Avatar
-                    size="md"
+                    size="sm"
                     visual={
                       user.image
                         ? user.image

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.314",
+        "@dust-tt/sparkle": "^0.2.327",
         "@tailwindcss/forms": "^0.5.9",
         "@tiptap/extension-character-count": "^2.9.1",
         "@tiptap/extension-mention": "^2.9.1",
@@ -69,7 +69,7 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "ISC",
       "dependencies": {
         "eventsource-parser": "^1.1.1",
@@ -271,14 +271,15 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.314",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.314.tgz",
-      "integrity": "sha512-1ze+4wXJNoMBYTkeYp9zKW7gQppvz9NKdL6J8XphrTBAqOjq4ZLBSN9rqbIQ3P7DXMCjUb02m6uxZylzvAYNTg==",
+      "version": "0.2.327",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.327.tgz",
+      "integrity": "sha512-Of7gmeEYglC5R3gLp0AfIoePg7HeG1SyHz/QAWdq8tjsmywblU1JpryeIodxvJsiqQW369KNuhMfhdzYmOCQIQ==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
         "@headlessui/react": "^1.7.19",
         "@radix-ui/react-checkbox": "^1.1.2",
+        "@radix-ui/react-dialog": "^1.1.2",
         "@radix-ui/react-dropdown-menu": "^2.1.2",
         "@radix-ui/react-label": "^2.1.0",
         "@radix-ui/react-popover": "^1.1.2",
@@ -1194,6 +1195,41 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.2.tgz",
+      "integrity": "sha512-Yj4dZtqa2o+kG61fzB0H2qUvmwBA2oyQroGLyNtBj1beo1khoQ3q1a2AO8rrQYjd8256CO9+N8L9tvsS+bnIyA==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.1",
+        "@radix-ui/react-focus-guards": "1.1.1",
+        "@radix-ui/react-focus-scope": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-portal": "1.1.2",
+        "@radix-ui/react-presence": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-slot": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.6.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/extension/package.json
+++ b/extension/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.314",
+    "@dust-tt/sparkle": "^0.2.327",
     "@tailwindcss/forms": "^0.5.9",
     "@tiptap/extension-character-count": "^2.9.1",
     "@tiptap/extension-mention": "^2.9.1",


### PR DESCRIPTION
## Description

Some of the diff (emoji related) is not related to the PR directly, was required because I had to bump sparkle. We were not rendering emojis anyway. 

### Rework loading state.

Remove full page loading when we post a convo, replace it by: 
- the split button is disabled with loading state
- the text and fragments stays in input bar but can't be edited, and there's a slight loading animation on the text
- all other buttons in input bar are disabled.

This was introduced on the web version lately to improve the delay caused by JIT datasources.


### Some polish from Alex

- Smaller icons on header
- Always 2 columns for favorites.


## Risk

Extension only.

## Deploy Plan

No deploy needed.