### PR TITLE
Log empty or invalid parents array for documents

### DIFF
--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -25,7 +25,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::str::FromStr;
 use tokio_stream::{self as stream};
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use uuid::Uuid;
 
 /// Section is used to represent the structure of document to be taken into account during chunking.
@@ -602,6 +602,22 @@ impl DataSource {
                  `tags` contains a string starting with \"{}\"",
                 DATA_SOURCE_DOCUMENT_SYSTEM_TAG_PREFIX
             ))?;
+        }
+
+        if parents.is_empty() {
+            warn!(
+                document_id = document_id,
+                timestamp = ?timestamp,
+                parents = ?parents,
+                "Upserting a document without any parent"
+            );
+        } else if parents[0] != document_id {
+            warn!(
+                document_id = document_id,
+                timestamp = ?timestamp,
+                parents = ?parents,
+                "Upserting a document that is not self-referenced as its parent"
+            );
         }
 
         let store = store.clone();


### PR DESCRIPTION
## Description

- First step of https://github.com/dust-tt/tasks/issues/1661.
- Add logging on empty parents upon upsertion in both `core` and `front`.
- Add logging on `parents[0] != document_id` upon upsertion in both `core` and `front`.
- Related [MB query](https://metabase.dust.tt/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjozLCJ0eXBlIjoibmF0aXZlIiwibmF0aXZlIjp7InF1ZXJ5Ijoic2VsZWN0IFRPX0NIQVIqIGZyb20gZGF0YV9zb3VyY2VzX2RvY3VtZW50cyBXSEVSRSBzdGF0dXMgPSAnbGF0ZXN0JyBBTkQgcGFyZW50cyA9ICd7fScgT1JERVIgQlkgaWQgREVTQyBMSU1JVCAxMDA7IiwidGVtcGxhdGUtdGFncyI6e319fSwiZGlzcGxheSI6InRhYmxlIiwicGFyYW1ldGVycyI6W10sInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnt9fQ==).

## Risk

Low.

## Deploy Plan

- Deploy `core`
- Deploy `front`