### PR TITLE
[front] Fix dd metric names

### DIFF
--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -479,6 +479,7 @@ async function handler(
         `data_source_id:${dataSource.id}`,
         `workspace_id:${owner.sId}`,
         `data_source_name:${dataSource.name}`,
+        `document_id:${req.query.documentId}`,
       ];
       if (!r.data.parents || r.data.parents.length === 0) {
         statsDClient.increment("document_empty_parents.count", 1, statsDTags);

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -481,17 +481,9 @@ async function handler(
         `data_source_name:${dataSource.name}`,
       ];
       if (!r.data.parents || r.data.parents.length === 0) {
-        statsDClient.increment(
-          "document_without_a_parent.count",
-          1,
-          statsDTags
-        );
+        statsDClient.increment("document_empty_parents.count", 1, statsDTags);
       } else if (r.data.parents[0] != req.query.documentId) {
-        statsDClient.increment(
-          "document_without_a_parent.count",
-          1,
-          statsDTags
-        );
+        statsDClient.increment("document_no_self_ref.count", 1, statsDTags);
       }
 
       if (r.data.async === true) {


### PR DESCRIPTION
## Description

- In #9011, two metrics were accidentally logged with the same name, this PRs sets different names to distinguish them.
- This PR also adds the document IDs to help look into each connector that does not pass valid parents.

## Risk

Low.

## Deploy Plan

- Deploy front.
