### PR TITLE
connectors: slack bot use file API for attachments

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -369,7 +369,8 @@ async function answerMessage(
     slackChannel,
     slackThreadTs || slackMessageTs,
     lastSlackChatBotMessage?.messageTs || slackThreadTs || slackMessageTs,
-    connector
+    connector,
+    lastSlackChatBotMessage?.conversationId || null
   );
 
   if (slackUserInfo.is_bot) {
@@ -695,7 +696,8 @@ async function makeContentFragment(
   channelId: string,
   threadTs: string,
   startingAtTs: string | null,
-  connector: ConnectorResource
+  connector: ConnectorResource,
+  conversationId: string | null
 ): Promise<Result<PublicPostContentFragmentRequestBody | null, Error>> {
   let allMessages: MessageElement[] = [];
 
@@ -780,6 +782,11 @@ async function makeContentFragment(
     fileName,
     fileSize: section.length,
     useCase: "conversation",
+    useCaseMetadata: conversationId
+      ? {
+          conversationId,
+        }
+      : undefined,
     fileObject: new File([section], fileName, { type: contentType }),
   });
 

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -780,11 +780,7 @@ async function makeContentFragment(
     fileName,
     fileSize: section.length,
     useCase: "conversation",
-    fileObject: new File(
-      [new Blob([section], { type: contentType })],
-      fileName,
-      { type: contentType }
-    ),
+    fileObject: new File([section], fileName, { type: contentType }),
   });
 
   if (fileRes.isErr()) {

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -772,8 +772,8 @@ async function makeContentFragment(
   // Prepend $url to the content to make it available to the model.
   const section = `$url: ${url}\n${sectionFullText(content)}`;
 
-  const contentType = "dust-application/slack";
-  const fileName = `thread-${channel.channel.name}.txt`;
+  const contentType = "text/plain";
+  const fileName = `slack_thread-${channel.channel.name}.txt`;
 
   const fileRes = await dustAPI.uploadFile({
     contentType,

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -772,7 +772,7 @@ async function makeContentFragment(
   // Prepend $url to the content to make it available to the model.
   const section = `$url: ${url}\n${sectionFullText(content)}`;
 
-  const contentType = "text/plain";
+  const contentType = "dust-application/slack";
   const fileName = `slack_thread-${channel.channel.name}.txt`;
 
   const fileRes = await dustAPI.uploadFile({

--- a/front/lib/api/files/upload.ts
+++ b/front/lib/api/files/upload.ts
@@ -347,6 +347,12 @@ const processingPerContentType: ProcessingPerContentType = {
     avatar: notSupportedError,
     tool_output: notSupportedError,
   },
+  "dust-application/slack": {
+    conversation: storeRawText,
+    folder: storeRawText,
+    avatar: notSupportedError,
+    tool_output: notSupportedError,
+  },
 };
 
 const maybeApplyProcessing: ProcessingFunction = async (

--- a/front/lib/api/files/upload.ts
+++ b/front/lib/api/files/upload.ts
@@ -349,7 +349,8 @@ const processingPerContentType: ProcessingPerContentType = {
   },
   "dust-application/slack": {
     conversation: storeRawText,
-    folder: storeRawText,
+    folder_document: notSupportedError,
+    folder_table: notSupportedError,
     avatar: notSupportedError,
     tool_output: notSupportedError,
   },

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -343,7 +343,8 @@ const processingPerContentType: ProcessingPerContentType = {
   },
   "dust-application/slack": {
     conversation: upsertDocumentToDatasource,
-    folder: notSupportedError,
+    folder_document: notSupportedError,
+    folder_table: notSupportedError,
     avatar: notSupportedError,
     tool_output: notSupportedError,
   },

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -341,6 +341,12 @@ const processingPerContentType: ProcessingPerContentType = {
     avatar: notSupportedError,
     tool_output: notSupportedError,
   },
+  "dust-application/slack": {
+    conversation: upsertDocumentToDatasource,
+    folder: notSupportedError,
+    avatar: notSupportedError,
+    tool_output: notSupportedError,
+  },
 };
 
 const maybeApplyProcessing: ProcessingFunction = async ({

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -171,6 +171,22 @@ export class DustAPI {
     return new Ok(r.value.user);
   }
 
+  async baseHeaders() {
+    const headers: RequestInit["headers"] = {
+      Authorization: `Bearer ${await this.getApiKey()}`,
+    };
+    if (this._credentials.groupIds) {
+      headers[DustGroupIdsHeader] = this._credentials.groupIds.join(",");
+    }
+    if (this._credentials.userEmail) {
+      headers[DustUserEmailHeader] = this._credentials.userEmail;
+    }
+    if (this._credentials.extraHeaders) {
+      Object.assign(headers, this._credentials.extraHeaders);
+    }
+    return headers;
+  }
+
   async request(args: RequestArgsType) {
     // Conveniently clean path from any leading "/" just in case
     args.path = args.path.replace(/^\/+/, "");
@@ -183,19 +199,8 @@ export class DustAPI {
       url += `?${args.query.toString()}`;
     }
 
-    const headers: RequestInit["headers"] = {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${await this.getApiKey()}`,
-    };
-    if (this._credentials.groupIds) {
-      headers[DustGroupIdsHeader] = this._credentials.groupIds.join(",");
-    }
-    if (this._credentials.userEmail) {
-      headers[DustUserEmailHeader] = this._credentials.userEmail;
-    }
-    if (this._credentials.extraHeaders) {
-      Object.assign(headers, this._credentials.extraHeaders);
-    }
+    const headers = await this.baseHeaders();
+    headers["Content-Type"] = "application/json";
 
     const res = await this._fetchWithError(url, {
       method: args.method,
@@ -801,6 +806,7 @@ export class DustAPI {
     fileName,
     fileSize,
     useCase,
+    useCaseMetadata,
     fileObject,
   }: FileUploadUrlRequestType & { fileObject: File }) {
     FileUploadUrlRequestSchema;
@@ -812,6 +818,7 @@ export class DustAPI {
         fileName,
         fileSize,
         useCase,
+        useCaseMetadata,
       },
     });
 
@@ -834,9 +841,7 @@ export class DustAPI {
     try {
       uploadResult = await fetch(file.uploadUrl, {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${await this.getApiKey()}`,
-        },
+        headers: await this.baseHeaders(),
         body: formData,
       });
     } catch (err) {

--- a/types/src/front/content_fragment.ts
+++ b/types/src/front/content_fragment.ts
@@ -20,7 +20,6 @@ export type ContentFragmentContextType = {
 
 export const supportedContentFragmentType = [
   ...supportedUploadableContentType,
-  "dust-application/slack",
 ] as const;
 
 export type SupportedContentFragmentType =

--- a/types/src/front/files.ts
+++ b/types/src/front/files.ts
@@ -85,6 +85,7 @@ const supportedPlainText = {
   "application/pdf": [".pdf"],
   "text/markdown": [".md", ".markdown"],
   "text/plain": [".txt"],
+  "dust-application/slack": [".txt"],
 } as const;
 
 // Supported content types for images.


### PR DESCRIPTION
## Description

Move to using the file API when creating an attachment to upload the slack thread content when interacting with the slack bot.

Code tested locally

## Risk

Breaking the slack bot.

## Deploy Plan

- deploy `front`
- deploy `connectors`