### PR TITLE
Allowed mimetype and title params for table creation

### DIFF
--- a/front/components/data_source/TableUploadOrEditModal.tsx
+++ b/front/components/data_source/TableUploadOrEditModal.tsx
@@ -186,6 +186,7 @@ export const TableUploadOrEditModal = ({
       doUpdate,
       fileUploaderService,
       useAppForHeaderDetection,
+      tableState.file?.type,
     ]
   );
 

--- a/front/components/data_source/TableUploadOrEditModal.tsx
+++ b/front/components/data_source/TableUploadOrEditModal.tsx
@@ -144,6 +144,8 @@ export const TableUploadOrEditModal = ({
           truncate: true,
           async: false,
           useAppForHeaderDetection,
+          title: table.name,
+          mimeType: tableState.file?.type ?? "text/csv",
         };
         let upsertRes = null;
         if (initialId) {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/index.ts
@@ -198,7 +198,7 @@ async function handler(
 
       return res.status(200).json({
         table: {
-          name: table.name,
+          name: table.title ?? table.name,
           table_id: table.table_id,
           description: table.description,
           schema: table.schema,
@@ -206,7 +206,7 @@ async function handler(
           tags: table.tags,
           parents: table.parents,
           mime_type: table.mime_type,
-          title: table.title,
+          title: table.title ?? table.name,
         },
       });
 

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/index.ts
@@ -53,7 +53,7 @@ import { apiError } from "@app/logger/withlogging";
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/Datasource'
+ *               $ref: '#/components/schemas/Table'
  *       404:
  *         description: The table was not found
  *       405:
@@ -205,6 +205,8 @@ async function handler(
           timestamp: table.timestamp,
           tags: table.tags,
           parents: table.parents,
+          mime_type: table.mime_type,
+          title: table.title,
         },
       });
 

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/index.ts
@@ -198,7 +198,7 @@ async function handler(
 
       return res.status(200).json({
         table: {
-          name: table.title ?? table.name,
+          name: table.name,
           table_id: table.table_id,
           description: table.description,
           schema: table.schema,
@@ -206,7 +206,7 @@ async function handler(
           tags: table.tags,
           parents: table.parents,
           mime_type: table.mime_type,
-          title: table.title ?? table.name,
+          title: table.title,
         },
       });
 

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.ts
@@ -114,7 +114,11 @@ async function handler(
       }
       const upsertRes = await handleDataSourceTableCSVUpsert({
         auth,
-        params: r.data,
+        params: {
+          ...r.data,
+          mimeType: r.data.mimeType ?? "text/csv",
+          title: r.data.title ?? r.data.name,
+        },
         dataSource,
       });
 

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.ts
@@ -116,7 +116,7 @@ async function handler(
         auth,
         params: {
           ...r.data,
-          mimeType: r.data.mimeType ?? "text/csv",
+          mimeType: r.data.mimeType,
           title: r.data.title ?? r.data.name,
         },
         dataSource,

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -354,6 +354,12 @@ async function handler(
         });
       }
 
+      // Enforce that the table is a parent of itself by default.
+      const parentsWithTableId =
+        parents?.includes(tableId) && parents[0] === tableId
+          ? parents
+          : [tableId, ...(parents || []).filter((p) => p !== tableId)];
+
       const upsertRes = await coreAPI.upsertTable({
         projectId: dataSource.dustAPIProjectId,
         dataSourceId: dataSource.dustAPIDataSourceId,
@@ -363,7 +369,7 @@ async function handler(
         timestamp: timestamp ?? null,
         tags: tags || [],
         // Table is a parent of itself by default.
-        parents: parents || [tableId],
+        parents: parentsWithTableId,
         remoteDatabaseTableId: remoteDatabaseTableId ?? null,
         remoteDatabaseSecretId: remoteDatabaseSecretId ?? null,
         title,

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -95,9 +95,6 @@ import { apiError } from "@app/logger/withlogging";
  *               title:
  *                 type: string
  *                 description: Title of the table
- *               mime_type:
- *                 type: string
- *                 description: Mime type of the table
  *               table_id:
  *                 type: string
  *                 description: Unique identifier for the table

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -219,7 +219,7 @@ async function handler(
       return res.status(200).json({
         tables: tables.map((table) => {
           return {
-            name: table.name,
+            name: table.title ?? table.name,
             table_id: table.table_id,
             description: table.description,
             schema: table.schema,
@@ -227,7 +227,7 @@ async function handler(
             tags: table.tags,
             parents: table.parents,
             mime_type: table.mime_type,
-            title: table.title,
+            title: table.title ?? table.name,
           };
         }),
       });
@@ -390,7 +390,7 @@ async function handler(
 
       return res.status(200).json({
         table: {
-          name: table.name,
+          name: table.title ?? table.name,
           table_id: table.table_id,
           description: table.description,
           schema: table.schema,
@@ -398,7 +398,7 @@ async function handler(
           tags: table.tags,
           parents: table.parents,
           mime_type: table.mime_type,
-          title: table.title,
+          title: table.title ?? table.name,
         },
       });
 

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -53,7 +53,7 @@ import { apiError } from "@app/logger/withlogging";
  *             schema:
  *               type: array
  *               items:
- *                 $ref: '#/components/schemas/Datasource'
+ *                 $ref: '#/components/schemas/Table'
  *       400:
  *         description: Invalid request
  *   post:
@@ -226,6 +226,8 @@ async function handler(
             timestamp: table.timestamp,
             tags: table.tags,
             parents: table.parents,
+            mime_type: table.mime_type,
+            title: table.title,
           };
         }),
       });
@@ -353,7 +355,8 @@ async function handler(
         description,
         timestamp: timestamp ?? null,
         tags: tags || [],
-        parents: parents || [],
+        // Table is a parent of itself by default.
+        parents: parents || [tableId],
         remoteDatabaseTableId: remoteDatabaseTableId ?? null,
         remoteDatabaseSecretId: remoteDatabaseSecretId ?? null,
         title,
@@ -394,6 +397,8 @@ async function handler(
           timestamp: table.timestamp,
           tags: table.tags,
           parents: table.parents,
+          mime_type: table.mime_type,
+          title: table.title,
         },
       });
 

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -92,6 +92,13 @@ import { apiError } from "@app/logger/withlogging";
  *               name:
  *                 type: string
  *                 description: Name of the table
+ *                 deprecated: true  # Add this line to mark as deprecated
+ *               title:
+ *                 type: string
+ *                 description: Title of the table
+ *               mime_type:
+ *                 type: string
+ *                 description: Mime type of the table
  *               table_id:
  *                 type: string
  *                 description: Unique identifier for the table

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -92,7 +92,6 @@ import { apiError } from "@app/logger/withlogging";
  *               name:
  *                 type: string
  *                 description: Name of the table
- *                 deprecated: true  # Add this line to mark as deprecated
  *               title:
  *                 type: string
  *                 description: Title of the table
@@ -226,7 +225,7 @@ async function handler(
       return res.status(200).json({
         tables: tables.map((table) => {
           return {
-            name: table.title ?? table.name,
+            name: table.name,
             table_id: table.table_id,
             description: table.description,
             schema: table.schema,
@@ -234,7 +233,7 @@ async function handler(
             tags: table.tags,
             parents: table.parents,
             mime_type: table.mime_type,
-            title: table.title ?? table.name,
+            title: table.title,
           };
         }),
       });
@@ -403,7 +402,7 @@ async function handler(
 
       return res.status(200).json({
         table: {
-          name: table.title ?? table.name,
+          name: table.name,
           table_id: table.table_id,
           description: table.description,
           schema: table.schema,
@@ -411,7 +410,7 @@ async function handler(
           tags: table.tags,
           parents: table.parents,
           mime_type: table.mime_type,
-          title: table.title ?? table.name,
+          title: table.title,
         },
       });
 

--- a/front/pages/api/v1/w/[wId]/swagger_schemas.ts
+++ b/front/pages/api/v1/w/[wId]/swagger_schemas.ts
@@ -414,6 +414,58 @@
  *           type: boolean
  *           description: Whether this datasource is selected by default for assistants
  *           example: true
+ *     Table:
+ *       type: object
+ *       properties:
+ *         name:
+ *           type: string
+ *           description: Name of the table
+ *           example: "roi.csv"
+ *         table_id:
+ *           type: string
+ *           description: Unique identifier for the table
+ *           example: "1234f4567c"
+ *         description:
+ *           type: string
+ *           description: Description of the table
+ *           example: "roi data for Q1"
+ *         schema:
+ *           type: array
+ *           description: Array of column definitions
+ *           items:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 description: Name of the column
+ *                 example: "roi"
+ *               value_type:
+ *                 type: string
+ *                 description: Data type of the column
+ *                 enum: [text, int, float, bool, date]
+ *                 example: "int"
+ *               possible_values:
+ *                 type: array
+ *                 description: Array of possible values for the column (null if unrestricted)
+ *                 items:
+ *                   type: string
+ *                 nullable: true
+ *                 example: ["1", "2", "3"]
+ *         timestamp:
+ *           type: number
+ *           description: Unix timestamp of table creation/modification
+ *           example: 1732810375150
+ *         tags:
+ *           type: array
+ *           description: Array of tags associated with the table
+ *           items:
+ *             type: string
+ *         parents:
+ *           type: array
+ *           description: Array of parent table IDs
+ *           items:
+ *             type: string
+ *           example: ["1234f4567c"]
  *     DatasourceView:
  *       type: object
  *       properties:

--- a/front/pages/api/v1/w/[wId]/swagger_schemas.ts
+++ b/front/pages/api/v1/w/[wId]/swagger_schemas.ts
@@ -420,7 +420,12 @@
  *         name:
  *           type: string
  *           description: Name of the table
- *           example: "roi.csv"
+ *           example: "Roi data"
+ *           deprecated: true
+ *         title:
+ *           type: string
+ *           description: Title of the table
+ *           example: "ROI Data"
  *         table_id:
  *           type: string
  *           description: Unique identifier for the table
@@ -429,6 +434,10 @@
  *           type: string
  *           description: Description of the table
  *           example: "roi data for Q1"
+ *         mime_type:
+ *           type: string
+ *           description: MIME type of the table
+ *           example: "text/csv"
  *         schema:
  *           type: array
  *           description: Array of column definitions

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -2571,7 +2571,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Datasource"
+                  "$ref": "#/components/schemas/Table"
                 }
               }
             }
@@ -3065,7 +3065,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Datasource"
+                    "$ref": "#/components/schemas/Table"
                   }
                 }
               }
@@ -3954,6 +3954,87 @@
             "type": "boolean",
             "description": "Whether this datasource is selected by default for assistants",
             "example": true
+          }
+        }
+      },
+      "Table": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the table",
+            "example": "roi.csv"
+          },
+          "table_id": {
+            "type": "string",
+            "description": "Unique identifier for the table",
+            "example": "1234f4567c"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the table",
+            "example": "roi data for Q1"
+          },
+          "schema": {
+            "type": "array",
+            "description": "Array of column definitions",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Name of the column",
+                  "example": "roi"
+                },
+                "value_type": {
+                  "type": "string",
+                  "description": "Data type of the column",
+                  "enum": [
+                    "text",
+                    "int",
+                    "float",
+                    "bool",
+                    "date"
+                  ],
+                  "example": "int"
+                },
+                "possible_values": {
+                  "type": "array",
+                  "description": "Array of possible values for the column (null if unrestricted)",
+                  "items": {
+                    "type": "string"
+                  },
+                  "nullable": true,
+                  "example": [
+                    "1",
+                    "2",
+                    "3"
+                  ]
+                }
+              }
+            }
+          },
+          "timestamp": {
+            "type": "number",
+            "description": "Unix timestamp of table creation/modification",
+            "example": 1732810375150
+          },
+          "tags": {
+            "type": "array",
+            "description": "Array of tags associated with the table",
+            "items": {
+              "type": "string"
+            }
+          },
+          "parents": {
+            "type": "array",
+            "description": "Array of parent table IDs",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "1234f4567c"
+            ]
           }
         }
       },

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -3125,7 +3125,16 @@
                 "properties": {
                   "name": {
                     "type": "string",
-                    "description": "Name of the table"
+                    "description": "Name of the table",
+                    "deprecated": true
+                  },
+                  "title": {
+                    "type": "string",
+                    "description": "Title of the table"
+                  },
+                  "mime_type": {
+                    "type": "string",
+                    "description": "Mime type of the table"
                   },
                   "table_id": {
                     "type": "string",

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -3963,7 +3963,13 @@
           "name": {
             "type": "string",
             "description": "Name of the table",
-            "example": "roi.csv"
+            "example": "Roi data",
+            "deprecated": true
+          },
+          "title": {
+            "type": "string",
+            "description": "Title of the table",
+            "example": "ROI Data"
           },
           "table_id": {
             "type": "string",
@@ -3974,6 +3980,11 @@
             "type": "string",
             "description": "Description of the table",
             "example": "roi data for Q1"
+          },
+          "mime_type": {
+            "type": "string",
+            "description": "MIME type of the table",
+            "example": "text/csv"
           },
           "schema": {
             "type": "array",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -314,6 +314,8 @@ const CoreAPITablePublicSchema = z.object({
   timestamp: z.number(),
   tags: z.array(z.string()),
   parents: z.array(z.string()),
+  mime_type: z.string(),
+  title: z.string(),
 });
 
 export type CoreAPITablePublic = z.infer<typeof CoreAPITablePublicSchema>;

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -314,8 +314,8 @@ const CoreAPITablePublicSchema = z.object({
   timestamp: z.number(),
   tags: z.array(z.string()),
   parents: z.array(z.string()),
-  mime_type: z.string(),
-  title: z.string(),
+  mime_type: z.string().optional(),
+  title: z.string().optional(),
 });
 
 export type CoreAPITablePublic = z.infer<typeof CoreAPITablePublicSchema>;

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -128,6 +128,8 @@ export type CoreAPITable = {
   parents: string[];
   created: number;
   data_source_id: string;
+  title: string;
+  mime_type: string;
   remote_database_table_id: string | null;
   remote_database_secret_id: string | null;
 };


### PR DESCRIPTION
## Description

- All table objects have mimetype and title
- Post operations allow passing them, but they're not mandatory
- Get operations always return them
- Also fixed an outdated swagger for the /tables endpoints

## Risk
Worst scenario : Break table endpoints

## Deploy Plan
deploy front

## Test
- [ok] Create a table from the modal
- Post to the `front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.ts api` endpoint
- [ok, enforce dust mimeType] Post to the `front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts` endpoint
- Get from the `front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/index.ts` endpoint -> Get the tables created from previous 3 calls [ok for modal]
- [ok ,but todo left in core] Get from the `front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables` endpoint
- Check swagger
