### PR TITLE
[connectors] Add a CLI command for Zendesk

### DIFF
--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -1,17 +1,26 @@
 import type {
   ZendeskCheckIsAdminResponseType,
   ZendeskCommandType,
+  ZendeskCountTicketsResponseType,
 } from "@dust-tt/types";
 
 import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
-import { fetchZendeskCurrentUser } from "@connectors/connectors/zendesk/lib/zendesk_api";
+import {
+  changeZendeskClientSubdomain,
+  createZendeskClient,
+  fetchZendeskCurrentUser,
+  fetchZendeskTicketCount,
+} from "@connectors/connectors/zendesk/lib/zendesk_api";
 import { default as topLogger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
+import { ZendeskConfigurationResource } from "@connectors/resources/zendesk_resources";
 
 export const zendesk = async ({
   command,
   args,
-}: ZendeskCommandType): Promise<ZendeskCheckIsAdminResponseType> => {
+}: ZendeskCommandType): Promise<
+  ZendeskCheckIsAdminResponseType | ZendeskCountTicketsResponseType
+> => {
   const logger = topLogger.child({ majorCommand: "zendesk", command, args });
 
   const connectorId = args.connectorId ? args.connectorId.toString() : null;
@@ -36,6 +45,39 @@ export const zendesk = async ({
         userRole: user.role,
         userIsAdmin: user.role === "admin" && user.active,
       };
+    }
+    case "count-tickets": {
+      if (!connector) {
+        throw new Error(`Connector ${connectorId} not found`);
+      }
+      const brandId = args.brandId ? Number(args.brandId) : null;
+      if (!brandId) {
+        throw new Error(`Missing --brandId argument`);
+      }
+      const configuration =
+        await ZendeskConfigurationResource.fetchByConnectorId(connector.id);
+      if (!configuration) {
+        throw new Error(`No configuration found for connector ${connector.id}`);
+      }
+
+      const { accessToken, subdomain } =
+        await getZendeskSubdomainAndAccessToken(connector.connectionId);
+      const zendeskApiClient = createZendeskClient({ subdomain, accessToken });
+      const brandSubdomain = await changeZendeskClientSubdomain(
+        zendeskApiClient,
+        { connectorId: connector.id, brandId }
+      );
+
+      const ticketCount = await fetchZendeskTicketCount({
+        brandSubdomain,
+        accessToken,
+        retentionPeriodDays: configuration.retentionPeriodDays,
+      });
+      logger.info(
+        { connectorId, brandId, ticketCount },
+        "Number of valid tickets found for the brand."
+      );
+      return ticketCount;
     }
   }
 };

--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -77,7 +77,7 @@ export const zendesk = async ({
         { connectorId, brandId, ticketCount },
         "Number of valid tickets found for the brand."
       );
-      return ticketCount;
+      return { ticketCount };
     }
   }
 };

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -379,7 +379,7 @@ export async function fetchZendeskTicketCount({
 }): Promise<number> {
   const query = `type:ticket status:solved updated>${retentionPeriodDays}days`;
   const response = await fetchFromZendeskWithRetries({
-    url: `https://${brandSubdomain}.zendesk.com/api/v2/search/export.json?query=${encodeURIComponent(query)}`,
+    url: `https://${brandSubdomain}.zendesk.com/api/v2/search/count?query=${encodeURIComponent(query)}`,
     accessToken,
   });
 

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -365,6 +365,28 @@ export async function fetchZendeskTicketsInBrand(
 }
 
 /**
+ * Fetches the number of tickets in a Brand from the Zendesk API.
+ * Only counts tickets that have been solved, and that were updated within the retention period.
+ */
+export async function fetchZendeskTicketCount({
+  accessToken,
+  brandSubdomain,
+  retentionPeriodDays,
+}: {
+  brandSubdomain: string;
+  accessToken: string;
+  retentionPeriodDays: number;
+}): Promise<number> {
+  const query = `type:ticket status:solved updated>${retentionPeriodDays}days`;
+  const response = await fetchFromZendeskWithRetries({
+    url: `https://${brandSubdomain}.zendesk.com/api/v2/search/export.json?query=${encodeURIComponent(query)}`,
+    accessToken,
+  });
+
+  return Number(response.count);
+}
+
+/**
  * Fetches the current user through a call to `/users/me`.
  */
 export async function fetchZendeskCurrentUser({

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -236,7 +236,9 @@ export type ZendeskCheckIsAdminResponseType = t.TypeOf<
   typeof ZendeskCheckIsAdminResponseSchema
 >;
 
-export const ZendeskCountTicketsResponseSchema = t.number;
+export const ZendeskCountTicketsResponseSchema = t.type({
+  ticketCount: t.number,
+});
 export type ZendeskCountTicketsResponseType = t.TypeOf<
   typeof ZendeskCountTicketsResponseSchema
 >;

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -396,6 +396,7 @@ export const AdminResponseSchema = t.union([
   TemporalUnprocessedWorkflowsResponseSchema,
   IntercomForceResyncArticlesResponseSchema,
   ZendeskCheckIsAdminResponseSchema,
+  ZendeskCountTicketsResponseSchema,
 ]);
 
 export type AdminResponseType = t.TypeOf<typeof AdminResponseSchema>;

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -219,13 +219,14 @@ export type IntercomForceResyncArticlesResponseType = t.TypeOf<
  */
 export const ZendeskCommandSchema = t.type({
   majorCommand: t.literal("zendesk"),
-  command: t.literal("check-is-admin"),
+  command: t.union([t.literal("check-is-admin"), t.literal("count-tickets")]),
   args: t.type({
     connectorId: t.union([t.number, t.undefined]),
+    brandId: t.union([t.number, t.undefined]),
   }),
 });
-
 export type ZendeskCommandType = t.TypeOf<typeof ZendeskCommandSchema>;
+
 export const ZendeskCheckIsAdminResponseSchema = t.type({
   userRole: t.string,
   userActive: t.boolean,
@@ -233,6 +234,11 @@ export const ZendeskCheckIsAdminResponseSchema = t.type({
 });
 export type ZendeskCheckIsAdminResponseType = t.TypeOf<
   typeof ZendeskCheckIsAdminResponseSchema
+>;
+
+export const ZendeskCountTicketsResponseSchema = t.number;
+export type ZendeskCountTicketsResponseType = t.TypeOf<
+  typeof ZendeskCountTicketsResponseSchema
 >;
 /**
  * </Zendesk>


### PR DESCRIPTION
## Description

- This PR aims at adding a CLI command for Zendesk that counts the tickets in a Brand.
- This command relies on a specific endpoint and retrieves the exact number of tickets that should be retrieved.
- This command will be used to investigate why we have [so few tickets](https://metabase.dust.tt/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoyLCJ0eXBlIjoibmF0aXZlIiwibmF0aXZlIjp7InF1ZXJ5IjoiU0VMRUNUIFwiY29ubmVjdG9ySWRcIiwgXCJicmFuZElkXCIsIENPVU5UKCopIGFzIGNvdW50IEZST00gXCJ6ZW5kZXNrX3RpY2tldHNcIiBHUk9VUCBCWSBcImJyYW5kSWRcIiwgXCJjb25uZWN0b3JJZFwiIE9SREVSIEJZIGNvdW50IERFU0M7XG5TRUxFQ1QgXCJjb25uZWN0b3JJZFwiLCBcImJyYW5kSWRcIiwgQ09VTlQoKikgYXMgY291bnQgRlJPTSBcInplbmRlc2tfYXJ0aWNsZXNcIiBHUk9VUCBCWSBcImJyYW5kSWRcIiwgXCJjb25uZWN0b3JJZFwiIE9SREVSIEJZIGNvdW50IERFU0M7XG5cblNFTEVDVCBDT1VOVCgqKSBGUk9NIFwiemVuZGVza190aWNrZXRzXCI7XG5TRUxFQ1QgQ09VTlQoKikgRlJPTSBcInplbmRlc2tfYXJ0aWNsZXNcIjtcblxuU0VMRUNUICogRlJPTSBcInplbmRlc2tfYnJhbmRzXCI7XG5TRUxFQ1QgKiBGUk9NIFwiY29ubmVjdG9yc1wiIFdIRVJFIFwidHlwZVwiID0gJ3plbmRlc2snO1xuXG5TRUxFQ1QgKiBGUk9NIFwiemVuZGVza190aWNrZXRzXCIgT1JERVIgQlkgXCJ0aWNrZXRVcGRhdGVkQXRcIiBBU0M7XG4iLCJ0ZW1wbGF0ZS10YWdzIjp7fX19LCJkaXNwbGF5IjoidGFibGUiLCJwYXJhbWV0ZXJzIjpbXSwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e30sInR5cGUiOiJxdWVzdGlvbiJ9).
- Tested locally, output same as expected.

## Risk

Very low, GET endpoint, only logs information.

## Deploy Plan

- Deploy connectors.
