### PR TITLE
[connectors] refactor(Zendesk) - remove a few deps to node-zendesk

### DIFF
--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -6,10 +6,9 @@ import type {
 
 import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
 import {
-  changeZendeskClientSubdomain,
-  createZendeskClient,
   fetchZendeskCurrentUser,
   fetchZendeskTicketCount,
+  getZendeskBrandSubdomain,
 } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import { default as topLogger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -62,11 +61,12 @@ export const zendesk = async ({
 
       const { accessToken, subdomain } =
         await getZendeskSubdomainAndAccessToken(connector.connectionId);
-      const zendeskApiClient = createZendeskClient({ subdomain, accessToken });
-      const brandSubdomain = await changeZendeskClientSubdomain(
-        zendeskApiClient,
-        { connectorId: connector.id, brandId }
-      );
+      const brandSubdomain = await getZendeskBrandSubdomain({
+        connectorId: connector.id,
+        brandId,
+        subdomain,
+        accessToken,
+      });
 
       const ticketCount = await fetchZendeskTicketCount({
         brandSubdomain,

--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -58,6 +58,7 @@ export const zendesk = async ({
       if (!configuration) {
         throw new Error(`No configuration found for connector ${connector.id}`);
       }
+      const { retentionPeriodDays } = configuration;
 
       const { accessToken, subdomain } =
         await getZendeskSubdomainAndAccessToken(connector.connectionId);
@@ -71,10 +72,10 @@ export const zendesk = async ({
       const ticketCount = await fetchZendeskTicketCount({
         brandSubdomain,
         accessToken,
-        retentionPeriodDays: configuration.retentionPeriodDays,
+        retentionPeriodDays,
       });
       logger.info(
-        { connectorId, brandId, ticketCount },
+        { connectorId, brandId, ticketCount, retentionPeriodDays },
         "Number of valid tickets found for the brand."
       );
       return { ticketCount };

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -189,10 +189,8 @@ export async function fetchZendeskArticle({
   accessToken: string;
   articleId: number;
 }): Promise<ZendeskFetchedArticle | null> {
-  const response = await fetchFromZendeskWithRetries({
-    url: `https://${brandSubdomain}.zendesk.com/api/v2/help_center/articles/${articleId}`,
-    accessToken,
-  });
+  const url = `https://${brandSubdomain}.zendesk.com/api/v2/help_center/articles/${articleId}`;
+  const response = await fetchFromZendeskWithRetries({ url, accessToken });
   return response.article ?? null;
 }
 
@@ -244,10 +242,8 @@ export async function fetchRecentlyUpdatedArticles({
   endTime: number;
 }> {
   // this endpoint retrieves changes in content, not only in metadata despite what is mentioned in the documentation.
-  const response = await fetchFromZendeskWithRetries({
-    url: `https://${brandSubdomain}.zendesk.com/api/v2/help_center/incremental/articles.json?start_time=${startTime}`,
-    accessToken,
-  });
+  const url = `https://${brandSubdomain}.zendesk.com/api/v2/help_center/incremental/articles.json?start_time=${startTime}`;
+  const response = await fetchFromZendeskWithRetries({ url, accessToken });
   return {
     articles: response.articles,
     hasMore: response.next_page !== null && response.articles.length !== 0,
@@ -348,15 +344,13 @@ export async function fetchZendeskTicketsInBrand(
   hasMore: boolean;
   nextLink: string | null;
 }> {
+  const query = `status:solved updated>${retentionPeriodDays}days`;
   const response = await fetchFromZendeskWithRetries({
     url:
       url ?? // using the URL if we got one, reconstructing it otherwise
-      `https://${brandSubdomain}.zendesk.com/api/v2/search/export.json?filter[type]=ticket&page[size]=${pageSize}&query=${encodeURIComponent(
-        `status:solved updated>${retentionPeriodDays}days`
-      )}`,
+      `https://${brandSubdomain}.zendesk.com/api/v2/search/export.json?filter[type]=ticket&page[size]=${pageSize}&query=${encodeURIComponent(query)}`,
     accessToken,
   });
-
   return {
     tickets: response.results,
     hasMore: response.meta.has_more,
@@ -378,11 +372,8 @@ export async function fetchZendeskTicketCount({
   retentionPeriodDays: number;
 }): Promise<number> {
   const query = `type:ticket status:solved updated>${retentionPeriodDays}days`;
-  const response = await fetchFromZendeskWithRetries({
-    url: `https://${brandSubdomain}.zendesk.com/api/v2/search/count?query=${encodeURIComponent(query)}`,
-    accessToken,
-  });
-
+  const url = `https://${brandSubdomain}.zendesk.com/api/v2/search/count?query=${encodeURIComponent(query)}`;
+  const response = await fetchFromZendeskWithRetries({ url, accessToken });
   return Number(response.count);
 }
 
@@ -396,10 +387,7 @@ export async function fetchZendeskCurrentUser({
   subdomain: string;
   accessToken: string;
 }): Promise<ZendeskFetchedUser> {
-  const response = await fetch(
-    `https://${subdomain}.zendesk.com/api/v2/users/me`,
-    { headers: { Authorization: `Bearer ${accessToken}` } }
-  );
-  const data = await response.json();
-  return data.user;
+  const url = `https://${subdomain}.zendesk.com/api/v2/users/me`;
+  const response = await fetchFromZendeskWithRetries({ url, accessToken });
+  return response.user;
 }

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -4,6 +4,7 @@ import { createClient } from "node-zendesk";
 
 import type {
   ZendeskFetchedArticle,
+  ZendeskFetchedBrand,
   ZendeskFetchedCategory,
   ZendeskFetchedTicket,
   ZendeskFetchedUser,
@@ -175,6 +176,23 @@ async function fetchFromZendeskWithRetries({
   }
 
   return response;
+}
+
+/**
+ * Fetches a single brand from the Zendesk API.
+ */
+export async function fetchZendeskBrand({
+  subdomain,
+  accessToken,
+  brandId,
+}: {
+  subdomain: string;
+  accessToken: string;
+  brandId: number;
+}): Promise<ZendeskFetchedBrand | null> {
+  const url = `https://${subdomain}.zendesk.com/api/v2/brands/${brandId}`;
+  const response = await fetchFromZendeskWithRetries({ url, accessToken });
+  return response.brand ?? null;
 }
 
 /**

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -44,39 +44,19 @@ export async function changeZendeskClientSubdomain(
   client: Client,
   { connectorId, brandId }: { connectorId: ModelId; brandId: number }
 ): Promise<string> {
-  const brandInDbSubdomain = await getZendeskBrandInDbSubdomain({
+  const brandInDb = await ZendeskBrandResource.fetchByBrandId({
     connectorId,
     brandId,
   });
-  if (brandInDbSubdomain) {
-    client.config.subdomain = brandInDbSubdomain;
-    return brandInDbSubdomain;
+  if (brandInDb) {
+    client.config.subdomain = brandInDb.subdomain;
+    return brandInDb.subdomain;
   }
   const {
     result: { brand },
   } = await client.brand.show(brandId);
   client.config.subdomain = brand.subdomain;
   return brand.subdomain;
-}
-
-/**
- * Retrieves a brand's subdomain from the database if it exists, fetches it from the Zendesk API otherwise.
- */
-async function getZendeskBrandInDbSubdomain({
-  connectorId,
-  brandId,
-}: {
-  connectorId: ModelId;
-  brandId: number;
-}): Promise<string | null> {
-  const brandInDb = await ZendeskBrandResource.fetchByBrandId({
-    connectorId,
-    brandId,
-  });
-  if (brandInDb) {
-    return brandInDb.subdomain;
-  }
-  return null;
 }
 
 /**
@@ -93,14 +73,13 @@ export async function getZendeskBrandSubdomain({
   subdomain: string;
   accessToken: string;
 }): Promise<string> {
-  const brandInDbSubdomain = await getZendeskBrandInDbSubdomain({
+  const brandInDb = await ZendeskBrandResource.fetchByBrandId({
     connectorId,
     brandId,
   });
-  if (brandInDbSubdomain) {
-    return brandInDbSubdomain;
+  if (brandInDb) {
+    return brandInDb.subdomain;
   }
-
   const brand = await fetchZendeskBrand({ subdomain, accessToken, brandId });
   if (!brand) {
     throw new Error(`Brand ${brandId} not found in Zendesk.`);

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -11,6 +11,7 @@ import {
   fetchZendeskArticlesInCategory,
   fetchZendeskCategoriesInBrand,
   fetchZendeskTicketsInBrand,
+  getZendeskBrandSubdomain,
 } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import { ZENDESK_BATCH_SIZE } from "@connectors/connectors/zendesk/temporal/config";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
@@ -195,10 +196,11 @@ export async function syncZendeskCategoryBatchActivity({
   const { accessToken, subdomain } = await getZendeskSubdomainAndAccessToken(
     connector.connectionId
   );
-  const zendeskApiClient = createZendeskClient({ accessToken, subdomain });
-  const brandSubdomain = await changeZendeskClientSubdomain(zendeskApiClient, {
+  const brandSubdomain = await getZendeskBrandSubdomain({
     brandId,
     connectorId,
+    accessToken,
+    subdomain,
   });
 
   const { categories, hasMore, nextLink } = await fetchZendeskCategoriesInBrand(

--- a/connectors/src/connectors/zendesk/temporal/gc_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/gc_activities.ts
@@ -9,9 +9,8 @@ import { deleteCategory } from "@connectors/connectors/zendesk/lib/sync_category
 import { deleteTicket } from "@connectors/connectors/zendesk/lib/sync_ticket";
 import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
 import {
-  changeZendeskClientSubdomain,
-  createZendeskClient,
   fetchZendeskArticle,
+  getZendeskBrandSubdomain,
 } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import { getZendeskGarbageCollectionWorkflowId } from "@connectors/connectors/zendesk/temporal/client";
 import { ZENDESK_BATCH_SIZE } from "@connectors/connectors/zendesk/temporal/config";
@@ -162,10 +161,11 @@ export async function removeMissingArticleBatchActivity({
   const { subdomain, accessToken } = await getZendeskSubdomainAndAccessToken(
     connector.connectionId
   );
-  const zendeskApiClient = createZendeskClient({ subdomain, accessToken });
-  const brandSubdomain = await changeZendeskClientSubdomain(zendeskApiClient, {
+  const brandSubdomain = await getZendeskBrandSubdomain({
     connectorId,
     brandId,
+    accessToken,
+    subdomain,
   });
 
   // not deleting in batch for now, assuming we won't have that many articles to delete at once


### PR DESCRIPTION
## Description

- This PR removes the dependency to the lib `node-zendesk` when used to only retrieve a brand subdomain.
- It also adds the retention period to the logs of the command `count-tickets`.

## Risk

Low.

## Deploy Plan

- Deploy connectors.