### PR TITLE
Enforce parent validity when upserting to datasources

### DIFF
--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -605,19 +605,23 @@ impl DataSource {
         }
 
         if parents.is_empty() {
-            warn!(
+            let msg = "Upserting a document without any parent";
+            error!(
                 document_id = document_id,
                 timestamp = ?timestamp,
                 parents = ?parents,
-                "Upserting a document without any parent"
+                msg
             );
+            return Err(anyhow!(msg));
         } else if parents[0] != document_id {
-            warn!(
+            let msg = "Upserting a document that is not self-referenced as its parent";
+            error!(
                 document_id = document_id,
                 timestamp = ?timestamp,
                 parents = ?parents,
-                "Upserting a document that is not self-referenced as its parent"
+                msg
             );
+            return Err(anyhow!(msg));
         }
 
         let store = store.clone();


### PR DESCRIPTION
## Description

- Closes [#1661](https://github.com/dust-tt/tasks/issues/1661).
- Enforce parents non empty + with first element is a self reference.

## Risk

⚠️ Won't be merged before all the affected connectors are fixed and backfilled, would break them otherwise.

## Deploy Plan

- Deploy core.
- Deploy front.
