### PR TITLE
Enforce self-referencing parents for Intercom conversations

### DIFF
--- a/connectors/src/connectors/intercom/temporal/sync_conversation.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_conversation.ts
@@ -21,13 +21,14 @@ import {
   renderMarkdownSection,
   upsertToDatasource,
 } from "@connectors/lib/data_sources";
-import { IntercomTeam } from "@connectors/lib/models/intercom";
 import {
   IntercomConversation,
+  IntercomTeam,
   IntercomWorkspace,
 } from "@connectors/lib/models/intercom";
 import logger from "@connectors/logger/logger";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
+
 const turndownService = new TurndownService();
 
 export async function deleteTeamAndConversations({
@@ -295,7 +296,10 @@ export async function syncConversation({
     datasourceTags.push(`tag:${tag.name}`);
   });
 
-  const parents = [];
+  // parents in the Core datasource map the internal ids that are used in the permission system
+  // they self reference the document id
+  const documentId = getConversationInternalId(connectorId, conversation.id);
+  const parents = [documentId];
   if (conversationTeamId) {
     parents.push(getTeamInternalId(connectorId, conversationTeamId));
   }
@@ -303,7 +307,7 @@ export async function syncConversation({
 
   await upsertToDatasource({
     dataSourceConfig,
-    documentId: getConversationInternalId(connectorId, conversation.id),
+    documentId,
     documentContent: renderedPage,
     documentUrl: conversationUrl,
     timestampMs: updatedAtDate.getTime(),

--- a/front/migrations/20241129_fix_intercom_conversation_parents.ts
+++ b/front/migrations/20241129_fix_intercom_conversation_parents.ts
@@ -32,7 +32,7 @@ makeScript({}, async ({ execute }, logger) => {
           SET parents = array_prepend(document_id, parents)
               ${queryWhere};`;
 
-      console.log(`Running the following query on core: ${query}`);
+      logger.info(`Running the following query on core: ${query}`);
       await coreSequelize.query(query, {
         replacements: {
           dataSourceId: ds.dustAPIDataSourceId,
@@ -45,7 +45,7 @@ makeScript({}, async ({ execute }, logger) => {
           FROM data_sources_documents
                    ${queryWhere};`;
 
-      console.log(`Running the following query on core: ${query}`);
+      logger.info(`Running the following query on core: ${query}`);
       const results = await coreSequelize.query(query, {
         replacements: {
           dataSourceId: ds.dustAPIDataSourceId,
@@ -54,8 +54,8 @@ makeScript({}, async ({ execute }, logger) => {
         type: QueryTypes.SELECT,
       });
 
-      console.log(`Would update ${results.length} documents`);
-      console.log("Sample of affected rows:", results.slice(0, 5));
+      logger.info(`Would update ${results.length} documents`);
+      logger.info("Sample of affected rows:", results.slice(0, 5));
     }
   }
 });

--- a/front/migrations/20241129_fix_intercom_conversation_parents.ts
+++ b/front/migrations/20241129_fix_intercom_conversation_parents.ts
@@ -1,0 +1,48 @@
+import { Sequelize } from "sequelize";
+
+// To be run from connectors with `CORE_DATABASE_URI`
+const { CORE_DATABASE_URI, LIVE = false } = process.env;
+
+async function main() {
+  const core_sequelize = new Sequelize(CORE_DATABASE_URI as string, {
+    logging: false,
+  });
+
+  if (LIVE) {
+    const query = `
+    UPDATE data_sources_documents 
+    SET parents = array_prepend(document_id, parents) 
+    WHERE document_id <> ALL(parents)
+    AND EXISTS (
+      SELECT 1 FROM data_sources 
+      WHERE data_sources.id = data_sources_documents.data_source 
+      AND data_sources."connectorProvider" = 'intercom'
+    );`;
+
+    await core_sequelize.query(query);
+  } else {
+    const query = `
+    SELECT document_id, parents
+    FROM data_sources_documents 
+    WHERE document_id <> ALL(parents)
+    AND EXISTS (
+      SELECT 1 FROM data_sources 
+      WHERE data_sources.id = data_sources_documents.data_source 
+      AND data_sources."connectorProvider" = 'intercom'
+    );`;
+
+    const [results] = await core_sequelize.query(query);
+    console.log(`Would update ${results.length} documents`);
+    console.log("Sample of affected rows:", results.slice(0, 5));
+  }
+}
+
+main()
+  .then(() => {
+    console.log("Done");
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/front/migrations/20241129_fix_intercom_conversation_parents.ts
+++ b/front/migrations/20241129_fix_intercom_conversation_parents.ts
@@ -1,9 +1,10 @@
 import { CoreAPI } from "@dust-tt/types";
 import assert from "assert";
 import _ from "lodash";
-import { QueryTypes, Sequelize } from "sequelize";
+import { QueryTypes } from "sequelize";
 
 import config from "@app/lib/api/config";
+import { getCorePrimaryDbConnection } from "@app/lib/production_checks/utils";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { makeScript } from "@app/scripts/helpers";
 
@@ -14,9 +15,7 @@ const UPDATE_CHUNK_SIZE = 10;
 makeScript({}, async ({ execute }, logger) => {
   assert(CORE_DATABASE_URI, "CORE_DATABASE_URI is required");
 
-  const coreSequelize = new Sequelize(CORE_DATABASE_URI as string, {
-    logging: false,
-  });
+  const coreSequelize = getCorePrimaryDbConnection();
 
   const frontIntercomDataSources = await DataSourceModel.findAll({
     where: { connectorProvider: "intercom" },

--- a/front/migrations/20241129_fix_intercom_conversation_parents.ts
+++ b/front/migrations/20241129_fix_intercom_conversation_parents.ts
@@ -18,6 +18,7 @@ async function main() {
       WHERE data_sources.id = data_sources_documents.data_source 
       AND data_sources."connectorProvider" = 'intercom'
     );`;
+    console.log(`Running the following query on core: ${query}`);
 
     await core_sequelize.query(query);
   } else {
@@ -30,6 +31,7 @@ async function main() {
       WHERE data_sources.id = data_sources_documents.data_source 
       AND data_sources."connectorProvider" = 'intercom'
     );`;
+    console.log(`Running the following query on core: ${query}`);
 
     const [results] = await core_sequelize.query(query);
     console.log(`Would update ${results.length} documents`);

--- a/front/migrations/20241129_fix_intercom_conversation_parents.ts
+++ b/front/migrations/20241129_fix_intercom_conversation_parents.ts
@@ -1,4 +1,4 @@
-import { Sequelize } from "sequelize";
+import { QueryTypes, Sequelize } from "sequelize";
 
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { makeScript } from "@app/scripts/helpers";
@@ -17,30 +17,43 @@ makeScript({}, async ({ execute }, logger) => {
   for (const ds of frontIntercomDataSources) {
     logger.info(`Processing data source ${ds.id}`);
 
-    const queryWhere = `WHERE document_id <> ALL(parents)
-    AND EXISTS (
-      SELECT 1 FROM data_sources
-      WHERE data_sources.id = data_sources_documents.data_source
-      AND data_sources.data_source_id = ${ds.dustAPIDataSourceId}
-      AND data_sources.project = ${ds.dustAPIProjectId}
-    )`;
+    const queryWhere = `
+      WHERE document_id <> ALL(parents)
+      AND EXISTS (
+        SELECT 1 FROM data_sources
+        WHERE data_sources.id = data_sources_documents.data_source
+        AND data_sources.data_source_id = :dataSourceId
+        AND data_sources.project = :projectId
+      )`;
 
     if (execute) {
       const query = `
-    UPDATE data_sources_documents 
-    SET parents = array_prepend(document_id, parents) 
-    ${queryWhere};`;
-      console.log(`Running the following query on core: ${query}`);
+          UPDATE data_sources_documents
+          SET parents = array_prepend(document_id, parents)
+              ${queryWhere};`;
 
-      await coreSequelize.query(query);
+      console.log(`Running the following query on core: ${query}`);
+      await coreSequelize.query(query, {
+        replacements: {
+          dataSourceId: ds.dustAPIDataSourceId,
+          projectId: ds.dustAPIProjectId,
+        },
+      });
     } else {
       const query = `
-    SELECT document_id, parents
-    FROM data_sources_documents 
-    ${queryWhere};`;
-      console.log(`Running the following query on core: ${query}`);
+          SELECT document_id, parents
+          FROM data_sources_documents
+                   ${queryWhere};`;
 
-      const [results] = await coreSequelize.query(query);
+      console.log(`Running the following query on core: ${query}`);
+      const results = await coreSequelize.query(query, {
+        replacements: {
+          dataSourceId: ds.dustAPIDataSourceId,
+          projectId: ds.dustAPIProjectId,
+        },
+        type: QueryTypes.SELECT,
+      });
+
       console.log(`Would update ${results.length} documents`);
       console.log("Sample of affected rows:", results.slice(0, 5));
     }

--- a/front/migrations/20241129_fix_intercom_conversation_parents.ts
+++ b/front/migrations/20241129_fix_intercom_conversation_parents.ts
@@ -4,6 +4,7 @@ import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { makeScript } from "@app/scripts/helpers";
 
 const { CORE_DATABASE_URI } = process.env;
+const CHUNK_SIZE = 1000;
 
 makeScript({}, async ({ execute }, logger) => {
   const coreSequelize = new Sequelize(CORE_DATABASE_URI as string, {
@@ -17,45 +18,65 @@ makeScript({}, async ({ execute }, logger) => {
   for (const ds of frontIntercomDataSources) {
     logger.info(`Processing data source ${ds.id}`);
 
-    const queryWhere = `
-      WHERE document_id <> ALL(parents)
-      AND EXISTS (
-        SELECT 1 FROM data_sources
-        WHERE data_sources.id = data_sources_documents.data_source
-        AND data_sources.data_source_id = :dataSourceId
-        AND data_sources.project = :projectId
-      )`;
+    let processedCount = 0;
+    let affectedRowCount = 0;
+    do {
+      const whereCondition = `
+        document_id <> ALL(parents)
+        AND EXISTS (
+          SELECT 1 FROM data_sources
+          WHERE data_sources.id = data_sources_documents.data_source
+          AND data_sources.data_source_id = :dataSourceId
+          AND data_sources.project = :projectId
+        )`;
 
-    if (execute) {
-      const query = `
+      if (execute) {
+        const query = `
           UPDATE data_sources_documents
           SET parents = array_prepend(document_id, parents)
-              ${queryWhere};`;
+          WHERE ${whereCondition}
+          LIMIT :chunkSize;`;
 
-      logger.info(`Running the following query on core: ${query}`);
-      await coreSequelize.query(query, {
-        replacements: {
-          dataSourceId: ds.dustAPIDataSourceId,
-          projectId: ds.dustAPIProjectId,
-        },
-      });
-    } else {
-      const query = `
+        logger.info(`Running update query for chunk: ${query}`);
+        const result = await coreSequelize.query(query, {
+          replacements: {
+            dataSourceId: ds.dustAPIDataSourceId,
+            projectId: ds.dustAPIProjectId,
+            chunkSize: CHUNK_SIZE,
+          },
+          type: QueryTypes.UPDATE,
+        });
+
+        affectedRowCount = result[1];
+        logger.info(`Updated ${processedCount} documents so far`);
+      } else {
+        const query = `
           SELECT document_id, parents
           FROM data_sources_documents
-                   ${queryWhere};`;
+          WHERE ${whereCondition}
+          LIMIT :chunkSize;`;
 
-      logger.info(`Running the following query on core: ${query}`);
-      const results = await coreSequelize.query(query, {
-        replacements: {
-          dataSourceId: ds.dustAPIDataSourceId,
-          projectId: ds.dustAPIProjectId,
-        },
-        type: QueryTypes.SELECT,
-      });
+        logger.info(`Running select query for chunk: ${query}`);
+        const results = await coreSequelize.query(query, {
+          replacements: {
+            dataSourceId: ds.dustAPIDataSourceId,
+            projectId: ds.dustAPIProjectId,
+            chunkSize: CHUNK_SIZE,
+          },
+          type: QueryTypes.SELECT,
+        });
 
-      logger.info(`Would update ${results.length} documents`);
-      logger.info("Sample of affected rows:", results.slice(0, 5));
-    }
+        affectedRowCount = results.length;
+        logger.info(`Would update ${processedCount} documents so far`);
+        if (affectedRowCount >= 1) {
+          logger.info("Sample of affected row:", results[0]);
+        }
+      }
+      processedCount += affectedRowCount;
+    } while (affectedRowCount > 0);
+
+    logger.info(
+      `Finished processing data source ${ds.id} - ${processedCount} documents total`
+    );
   }
 });

--- a/front/migrations/20241129_fix_intercom_conversation_parents.ts
+++ b/front/migrations/20241129_fix_intercom_conversation_parents.ts
@@ -28,15 +28,13 @@ makeScript({}, async ({ execute }, logger) => {
     let nextId = 0;
     for (;;) {
       const query = `
-          SELECT id, document_id, parents
-          FROM data_sources_documents
-          WHERE id > :nextId
-            AND EXISTS (SELECT 1
-                        FROM data_sources
-                        WHERE data_sources.id = data_sources_documents.data_source
-                          AND data_sources.data_source_id = :dataSourceId
-                          AND data_sources.project = :projectId)
-          ORDER BY id
+          SELECT doc.id, doc.document_id, doc.parents
+          FROM data_sources_documents doc
+                   JOIN data_sources ds ON ds.id = doc.data_source
+          WHERE doc.id > :nextId
+            AND ds.data_source_id = :dataSourceId
+            AND ds.project = :projectId
+          ORDER BY doc.id
           LIMIT :chunkSize;`;
 
       logger.info(`Running SELECT query for chunk: ${query}`);


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/1661
- Change the parents field passed when upserting an Intercom conversation to datasources to add the document ID as the first element.
- Add a backfilling script for existing documents.

## Risk

- Corrupt data in core if backfill script incorrect.
- Break some elements in the UI.

## Deploy Plan

In this order:
- Deploy connectors.
- Run backfill script.