### PR TITLE
Document endpoints expecting mimeType and title

### DIFF
--- a/front/components/data_source/DocumentUploadOrEditModal.tsx
+++ b/front/components/data_source/DocumentUploadOrEditModal.tsx
@@ -51,6 +51,7 @@ interface Document {
   text: string;
   tags: string[];
   sourceUrl: string;
+  mimeType: string | null;
 }
 export interface DocumentUploadOrEditModalProps {
   contentNode?: LightContentNode;
@@ -78,6 +79,7 @@ export const DocumentUploadOrEditModal = ({
     text: "",
     tags: [],
     sourceUrl: "",
+    mimeType: null,
   });
   const fileUploaderService = useFileUploaderService({
     owner,
@@ -135,6 +137,8 @@ export const DocumentUploadOrEditModal = ({
       setIsUpsertingDocument(true);
       const body = {
         name: initialId ?? document.name,
+        title: initialId ?? document.name,
+        mime_type: document.mimeType ?? "text/plain",
         timestamp: null,
         parents: [initialId ?? document.name],
         section: { prefix: null, content: document.text, sections: [] },
@@ -162,6 +166,7 @@ export const DocumentUploadOrEditModal = ({
           text: "",
           tags: [],
           sourceUrl: "",
+          mimeType: null,
         });
         setEditionStatus({
           content: false,
@@ -224,6 +229,7 @@ export const DocumentUploadOrEditModal = ({
         setDocumentState((prev) => ({
           ...prev,
           name: prev.name.length > 0 ? prev.name : selectedFile.name,
+          mimeType: selectedFile.type,
           sourceUrl:
             prev.sourceUrl.length > 0
               ? prev.sourceUrl
@@ -248,6 +254,7 @@ export const DocumentUploadOrEditModal = ({
         text: "",
         tags: [],
         sourceUrl: "",
+        mimeType: null,
       });
     } else if (document && isCoreAPIDocumentType(document)) {
       setDocumentState((prev) => ({
@@ -256,6 +263,7 @@ export const DocumentUploadOrEditModal = ({
         text: document.text ?? "",
         tags: document.tags,
         sourceUrl: document.source_url ?? "",
+        mimeType: document.mime_type,
       }));
     }
   }, [initialId, document]);

--- a/front/components/data_source/DocumentUploadOrEditModal.tsx
+++ b/front/components/data_source/DocumentUploadOrEditModal.tsx
@@ -138,7 +138,7 @@ export const DocumentUploadOrEditModal = ({
       const body = {
         name: initialId ?? document.name,
         title: initialId ?? document.name,
-        mime_type: document.mimeType ?? "text/plain",
+        mime_type: document.mimeType,
         timestamp: null,
         parents: [initialId ?? document.name],
         section: { prefix: null, content: document.text, sections: [] },

--- a/front/lib/upsert_queue.ts
+++ b/front/lib/upsert_queue.ts
@@ -27,17 +27,23 @@ import type { DataSourceResource } from "./resources/data_source_resource";
 
 const { DUST_UPSERT_QUEUE_BUCKET, SERVICE_ACCOUNT } = process.env;
 
-export const EnqueueUpsertDocument = t.type({
-  workspaceId: t.string,
-  dataSourceId: t.string,
-  documentId: t.string,
-  tags: t.union([t.array(t.string), t.null]),
-  parents: t.union([t.array(t.string), t.null]),
-  sourceUrl: t.union([t.string, t.null]),
-  timestamp: t.union([t.number, t.null]),
-  section: FrontDataSourceDocumentSection,
-  upsertContext: t.union([UpsertContextSchema, t.null]),
-});
+export const EnqueueUpsertDocument = t.intersection([
+  t.type({
+    workspaceId: t.string,
+    dataSourceId: t.string,
+    documentId: t.string,
+    tags: t.union([t.array(t.string), t.null]),
+    parents: t.union([t.array(t.string), t.null]),
+    sourceUrl: t.union([t.string, t.null]),
+    timestamp: t.union([t.number, t.null]),
+    section: FrontDataSourceDocumentSection,
+    upsertContext: t.union([UpsertContextSchema, t.null]),
+  }),
+  t.partial({
+    title: t.string,
+    mimeType: t.string,
+  }),
+]);
 
 const DetectedHeaders = t.type({
   header: t.array(t.string),

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -545,8 +545,8 @@ async function handler(
           section,
           credentials,
           lightDocumentOutput: r.data.light_document_output === true,
-          title: r.data.title || null,
-          mimeType: r.data.mime_type || null,
+          title: r.data.title,
+          mimeType: r.data.mime_type,
         });
 
         if (upsertRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -130,6 +130,12 @@ export const config = {
  *           schema:
  *             type: object
  *             properties:
+ *               title:
+ *                 type: string
+ *                 description: The title of the document to upsert.
+ *               mime_type:
+ *                 type: string
+ *                 description: The MIME type of the document to upsert.
  *               text:
  *                 type: string
  *                 description: The text content of the document to upsert.
@@ -499,6 +505,8 @@ async function handler(
             sourceUrl,
             section,
             upsertContext: r.data.upsert_context || null,
+            title: r.data.title || null,
+            mime_type: r.data.mime_type || null,
           },
         });
         if (enqueueRes.isErr()) {
@@ -537,6 +545,8 @@ async function handler(
           section,
           credentials,
           lightDocumentOutput: r.data.light_document_output === true,
+          title: r.data.title || null,
+          mimeType: r.data.mime_type || null,
         });
 
         if (upsertRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -505,8 +505,8 @@ async function handler(
             sourceUrl,
             section,
             upsertContext: r.data.upsert_context || null,
-            title: r.data.title || null,
-            mime_type: r.data.mime_type || null,
+            title: r.data.title ?? undefined,
+            mime_type: r.data.mime_type ?? undefined,
           },
         });
         if (enqueueRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -506,7 +506,7 @@ async function handler(
             section,
             upsertContext: r.data.upsert_context || null,
             title: r.data.title ?? undefined,
-            mime_type: r.data.mime_type ?? undefined,
+            mimeType: r.data.mime_type ?? undefined,
           },
         });
         if (enqueueRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/swagger_schemas.ts
+++ b/front/pages/api/v1/w/[wId]/swagger_schemas.ts
@@ -515,6 +515,14 @@
  *         document_id:
  *           type: string
  *           example: "2c4a6e8d0f"
+ *         title:
+ *           type: string
+ *           description: Title of the document
+ *           example: "Customer Support FAQ"
+ *         mime_type:
+ *           type: string
+ *           description: MIME type of the table
+ *           example: "text/md"
  *         timestamp:
  *           type: number
  *           example: 1625097600

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -1960,6 +1960,14 @@
               "schema": {
                 "type": "object",
                 "properties": {
+                  "title": {
+                    "type": "string",
+                    "description": "The title of the document to upsert."
+                  },
+                  "mime_type": {
+                    "type": "string",
+                    "description": "The MIME type of the document to upsert."
+                  },
                   "text": {
                     "type": "string",
                     "description": "The text content of the document to upsert."
@@ -4100,6 +4108,16 @@
           "document_id": {
             "type": "string",
             "example": "2c4a6e8d0f"
+          },
+          "title": {
+            "type": "string",
+            "description": "Title of the document",
+            "example": "Customer Support FAQ"
+          },
+          "mime_type": {
+            "type": "string",
+            "description": "MIME type of the table",
+            "example": "text/md"
           },
           "timestamp": {
             "type": "number",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1855,6 +1855,8 @@ export const PostDataSourceDocumentRequestSchema = z.object({
   section: FrontDataSourceDocumentSectionSchema.nullable().optional(),
   light_document_output: z.boolean().optional(),
   async: z.boolean().nullable().optional(),
+  mime_type: z.string().nullable().optional(),
+  title: z.string().nullable().optional(),
 });
 
 const GetDocumentResponseSchema = z.object({

--- a/types/src/core/data_source.ts
+++ b/types/src/core/data_source.ts
@@ -61,6 +61,8 @@ export type CoreAPIDocument = {
     vector?: number[] | null;
     score?: number | null;
   }[];
+  title: string | null;
+  mime_type: string | null;
   text?: string | null;
 };
 

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -842,8 +842,8 @@ export class CoreAPI {
     section: CoreAPIDataSourceDocumentSection;
     credentials: CredentialsType;
     lightDocumentOutput?: boolean;
-    title: string | null;
-    mimeType: string | null;
+    title?: string | null;
+    mimeType?: string | null;
   }): Promise<
     CoreAPIResponse<{
       document:
@@ -872,8 +872,8 @@ export class CoreAPI {
           source_url: sourceUrl,
           credentials,
           light_document_output: lightDocumentOutput,
-          title: title,
-          mime_type: mimeType,
+          title: title ?? null,
+          mime_type: mimeType ?? null,
         }),
       }
     );

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -829,6 +829,8 @@ export class CoreAPI {
     section,
     credentials,
     lightDocumentOutput = false,
+    title,
+    mimeType,
   }: {
     projectId: string;
     dataSourceId: string;
@@ -840,6 +842,8 @@ export class CoreAPI {
     section: CoreAPIDataSourceDocumentSection;
     credentials: CredentialsType;
     lightDocumentOutput?: boolean;
+    title: string | null;
+    mimeType: string | null;
   }): Promise<
     CoreAPIResponse<{
       document:
@@ -868,6 +872,8 @@ export class CoreAPI {
           source_url: sourceUrl,
           credentials,
           light_document_output: lightDocumentOutput,
+          title: title,
+          mime_type: mimeType,
         }),
       }
     );


### PR DESCRIPTION
## Description

- Update document type to contain title and mimeType fields
- Modify GET endpoints to return them
- Modify POST endpoints to expect them
- Modify document upload modal to also pass these values

## Risk

Break document-related endpoints and document modal

## Deploy Plan
Deploy when Core model already has documents
