### PR TITLE
enh: refactor store.rs (more consistent, fewer clones)

### DIFF
--- a/core/src/blocks/database_schema.rs
+++ b/core/src/blocks/database_schema.rs
@@ -163,7 +163,7 @@ pub async fn load_tables_from_identifiers(
             let (project, data_source_name) = project_and_data_source_by_data_source_view
                 .get(&(*workspace_id, *data_source_or_view_id))
                 .expect("Unreachable: missing project.");
-            store.load_table(&project, &data_source_name, &table_id)
+            store.load_data_source_table(&project, &data_source_name, &table_id)
         },
     ))
     .await?)

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -9,7 +9,7 @@ use crate::providers::embedder::{EmbedderRequest, EmbedderVector};
 use crate::providers::provider::ProviderID;
 use crate::run::Credentials;
 use crate::search_filter::{Filterable, SearchFilter};
-use crate::stores::store::Store;
+use crate::stores::store::{Store, UpsertDocument};
 use crate::utils;
 use anyhow::{anyhow, Result};
 use futures::future::try_join_all;
@@ -725,20 +725,42 @@ impl DataSource {
             .await?;
         }
 
+        // Store upsert does not save the text and token count.
+        // These fields don't actually exist in the SQL table.
+        // Because of this, we have to manually construct the UpsertDocument, and save
+        // owned values for text and token count so we can return them.
+        // TODO(@fontanierh): use a different type for "DocumentWithTextAndTokenCount"
+        let doc_text = main_collection_document.text;
+        let doc_token_count = main_collection_document.token_count;
+        let sql_upsert_params = UpsertDocument {
+            document_id: main_collection_document.document_id,
+            timestamp: main_collection_document.timestamp,
+            tags: main_collection_document.tags,
+            parents: main_collection_document.parents,
+            source_url: main_collection_document.source_url,
+            hash: main_collection_document.hash,
+            text_size: main_collection_document.text_size,
+            chunk_count: main_collection_document.chunk_count,
+            chunks: main_collection_document.chunks,
+        };
+
         // Upsert document (SQL).
-        store
+        let mut doc = store
             .upsert_data_source_document(
                 &self.project,
-                &self.data_source_id,
-                &main_collection_document,
+                self.data_source_id.clone(),
+                sql_upsert_params,
             )
             .await?;
+
+        doc.text = doc_text;
+        doc.token_count = doc_token_count;
 
         // Clean-up old superseded versions.
         self.scrub_document_superseded_versions(store, &document_id)
             .await?;
 
-        Ok(main_collection_document)
+        Ok(doc)
     }
 
     async fn upsert_for_embedder(
@@ -1954,7 +1976,7 @@ impl DataSource {
 
         // Delete tables (concurrently).
         let (tables, total) = store
-            .list_tables(&self.project, &self.data_source_id, &None, &None, None)
+            .list_data_source_tables(&self.project, &self.data_source_id, &None, &None, None)
             .await?;
         try_join_all(
             tables

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -732,7 +732,7 @@ impl DataSource {
         // TODO(@fontanierh): use a different type for "DocumentWithTextAndTokenCount"
         let doc_text = main_collection_document.text;
         let doc_token_count = main_collection_document.token_count;
-        let sql_upsert_params = UpsertDocument {
+        let params = UpsertDocument {
             document_id: main_collection_document.document_id,
             timestamp: main_collection_document.timestamp,
             tags: main_collection_document.tags,
@@ -746,11 +746,7 @@ impl DataSource {
 
         // Upsert document (SQL).
         let mut doc = store
-            .upsert_data_source_document(
-                &self.project,
-                self.data_source_id.clone(),
-                sql_upsert_params,
-            )
+            .upsert_data_source_document(&self.project, self.data_source_id.clone(), params)
             .await?;
 
         doc.text = doc_text;

--- a/core/src/data_sources/folder.rs
+++ b/core/src/data_sources/folder.rs
@@ -2,8 +2,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::project::Project;
 
-use super::node::{Node, NodeType};
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Folder {
     project: Project,
@@ -19,32 +17,21 @@ pub const FOLDER_MIMETYPE: &str = "application/vnd.dust.folder";
 
 impl Folder {
     pub fn new(
-        project: &Project,
-        data_source_id: &str,
-        folder_id: &str,
+        project: Project,
+        data_source_id: String,
+        folder_id: String,
         timestamp: u64,
-        title: &str,
+        title: String,
         parents: Vec<String>,
     ) -> Self {
         Folder {
-            project: project.clone(),
-            data_source_id: data_source_id.to_string(),
-            folder_id: folder_id.to_string(),
+            project: project,
+            data_source_id: data_source_id,
+            folder_id: folder_id,
             timestamp,
-            title: title.to_string(),
+            title: title,
             parents,
         }
-    }
-
-    pub fn from_node(node: &Node) -> Self {
-        Folder::new(
-            node.project(),
-            node.data_source_id(),
-            node.node_id(),
-            node.timestamp(),
-            node.title(),
-            node.parents().clone(),
-        )
     }
 
     pub fn project(&self) -> &Project {
@@ -64,33 +51,5 @@ impl Folder {
     }
     pub fn parents(&self) -> &Vec<String> {
         &self.parents
-    }
-}
-
-impl From<Node> for Folder {
-    fn from(node: Node) -> Self {
-        Folder::new(
-            node.project(),
-            node.data_source_id(),
-            node.node_id(),
-            node.timestamp(),
-            node.title(),
-            node.parents().clone(),
-        )
-    }
-}
-
-impl From<Folder> for Node {
-    fn from(folder: Folder) -> Self {
-        Node::new(
-            &folder.project,
-            &folder.data_source_id,
-            &folder.folder_id,
-            NodeType::Folder,
-            folder.timestamp,
-            &folder.title,
-            FOLDER_MIMETYPE,
-            folder.parents.clone(),
-        )
     }
 }

--- a/core/src/data_sources/node.rs
+++ b/core/src/data_sources/node.rs
@@ -2,6 +2,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::project::Project;
 
+use super::folder::Folder;
+
 #[derive(Debug, Clone, Serialize, PartialEq, Deserialize, Copy)]
 pub enum NodeType {
     Document,
@@ -67,5 +69,17 @@ impl Node {
     }
     pub fn parents(&self) -> &Vec<String> {
         &self.parents
+    }
+
+    // Consumes self into a Folder.
+    pub fn into_folder(self) -> Folder {
+        Folder::new(
+            self.project,
+            self.data_source_id,
+            self.node_id,
+            self.timestamp,
+            self.title,
+            self.parents,
+        )
     }
 }

--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -71,35 +71,35 @@ pub struct Table {
 
 impl Table {
     pub fn new(
-        project: &Project,
-        data_source_id: &str,
+        project: Project,
+        data_source_id: String,
         created: u64,
-        table_id: &str,
-        name: &str,
-        description: &str,
+        table_id: String,
+        name: String,
+        description: String,
         timestamp: u64,
-        title: &str,
-        mime_type: &str,
+        title: String,
+        mime_type: String,
         tags: Vec<String>,
         parents: Vec<String>,
-        schema: &Option<TableSchema>,
+        schema: Option<TableSchema>,
         schema_stale_at: Option<u64>,
         remote_database_table_id: Option<String>,
         remote_database_secret_id: Option<String>,
     ) -> Self {
         Table {
-            project: project.clone(),
-            data_source_id: data_source_id.to_string(),
+            project: project,
+            data_source_id: data_source_id,
             created,
-            table_id: table_id.to_string(),
-            name: name.to_string(),
-            description: description.to_string(),
+            table_id: table_id,
+            name: name,
+            description: description,
             timestamp,
             tags,
-            title: title.to_string(),
-            mime_type: mime_type.to_string(),
+            title: title,
+            mime_type: mime_type,
             parents,
-            schema: schema.clone(),
+            schema: schema,
             schema_stale_at,
             remote_database_table_id,
             remote_database_secret_id,
@@ -196,7 +196,7 @@ impl Table {
         }
 
         store
-            .delete_table(&self.project, &self.data_source_id, &self.table_id)
+            .delete_data_source_table(&self.project, &self.data_source_id, &self.table_id)
             .await?;
 
         Ok(())
@@ -208,7 +208,7 @@ impl Table {
         parents: Vec<String>,
     ) -> Result<()> {
         store
-            .update_table_parents(
+            .update_data_source_table_parents(
                 &self.project,
                 &self.data_source_id,
                 &&self.table_id,
@@ -325,7 +325,7 @@ impl LocalTable {
 
         now = utils::now();
         store
-            .update_table_schema(
+            .update_data_source_table_schema(
                 &self.table.project,
                 &self.table.data_source_id,
                 &self.table.table_id,
@@ -348,7 +348,7 @@ impl LocalTable {
             // This is why we invalidate the schema when doing incremental updates, and next time
             // the schema is requested, it will be recomputed from all the rows.
             store
-                .invalidate_table_schema(
+                .invalidate_data_source_table_schema(
                     &self.table.project,
                     &self.table.data_source_id,
                     &self.table.table_id,
@@ -447,7 +447,7 @@ impl LocalTable {
                 let schema = self.compute_schema(databases_store).await?;
 
                 store
-                    .update_table_schema(
+                    .update_data_source_table_schema(
                         &self.table.project,
                         &self.table.data_source_id,
                         &self.table.table_id,
@@ -565,18 +565,18 @@ mod tests {
 
         let schema = TableSchema::from_rows_async(rows).await?;
         let table = Table::new(
-            &Project::new_from_id(42),
-            "data_source_id",
+            Project::new_from_id(42),
+            "data_source_id".to_string(),
             utils::now(),
-            "table_id",
-            "test_dbml",
-            "Test records for DBML rendering",
+            "table_id".to_string(),
+            "test_dbml".to_string(),
+            "Test records for DBML rendering".to_string(),
             utils::now(),
-            "test_dbml",
-            "text/plain",
+            "test_dbml".to_string(),
+            "text/plain".to_string(),
             vec![],
             vec![],
-            &Some(schema),
+            Some(schema),
             None,
             None,
             None,

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -39,9 +39,20 @@ use crate::{
     utils,
 };
 
+use super::store::{UpsertDocument, UpsertFolder, UpsertTable};
+
 #[derive(Clone)]
 pub struct PostgresStore {
     pool: Pool<PostgresConnectionManager<NoTls>>,
+}
+
+pub struct UpsertNode<'a> {
+    pub node_id: &'a str,
+    pub node_type: &'a NodeType,
+    pub timestamp: u64,
+    pub title: &'a str,
+    pub mime_type: &'a str,
+    pub parents: &'a Vec<String>,
 }
 
 impl PostgresStore {
@@ -133,14 +144,14 @@ impl PostgresStore {
 
     async fn upsert_data_source_node(
         &self,
-        node: &Node,
+        params: UpsertNode<'_>,
         data_source_row_id: i64,
         row_id: i64,
         tx: &Transaction<'_>,
     ) -> Result<()> {
         let created = utils::now();
 
-        let (document_row_id, table_row_id, folder_row_id) = match node.node_type() {
+        let (document_row_id, table_row_id, folder_row_id) = match params.node_type {
             NodeType::Document => (Some(row_id), None, None),
             NodeType::Table => (None, Some(row_id), None),
             NodeType::Folder => (None, None, Some(row_id)),
@@ -164,11 +175,11 @@ impl PostgresStore {
                 &[
                     &data_source_row_id,
                     &(created as i64),
-                    &node.node_id(),
-                    &(node.timestamp() as i64),
-                    &node.title(),
-                    &node.mime_type(),
-                    &node.parents(),
+                    &params.node_id,
+                    &(params.timestamp as i64),
+                    &params.title,
+                    &params.mime_type,
+                    &params.parents,
                     &document_row_id,
                     &table_row_id,
                     &folder_row_id,
@@ -1730,20 +1741,12 @@ impl Store for PostgresStore {
     async fn upsert_data_source_document(
         &self,
         project: &Project,
-        data_source_id: &str,
-        document: &Document,
-    ) -> Result<()> {
+        data_source_id: String,
+        params: UpsertDocument,
+    ) -> Result<Document> {
+        let document_created = utils::now();
+
         let project_id = project.project_id();
-        let data_source_id = data_source_id.to_string();
-        let document_id = document.document_id.clone();
-        let document_created = document.created;
-        let document_timestamp = document.timestamp;
-        let document_tags = document.tags.clone();
-        let document_parents = document.parents.clone();
-        let document_source_url = document.source_url.clone();
-        let document_hash = document.hash.clone();
-        let document_text_size = document.text_size;
-        let document_chunk_count = document.chunks.len() as u64;
 
         let pool = self.pool.clone();
         let mut c = pool.get().await?;
@@ -1770,7 +1773,7 @@ impl Store for PostgresStore {
             )
             .await?;
         let _ = tx
-            .query(&stmt, &[&data_source_row_id, &document_id])
+            .query(&stmt, &[&data_source_row_id, &params.document_id])
             .await?;
 
         let stmt = tx
@@ -1778,31 +1781,50 @@ impl Store for PostgresStore {
                 "INSERT INTO data_sources_documents \
                    (id, data_source, created, document_id, timestamp, tags_array, parents, \
                     source_url, hash, text_size, chunk_count, status) \
-                   VALUES (DEFAULT, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) RETURNING id",
+                   VALUES (DEFAULT, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) RETURNING id, created, token_count",
             )
             .await?;
 
-        tx.query_one(
-            &stmt,
-            &[
-                &data_source_row_id,
-                &(document_created as i64),
-                &document_id,
-                &(document_timestamp as i64),
-                &document_tags,
-                &document_parents,
-                &document_source_url,
-                &document_hash,
-                &(document_text_size as i64),
-                &(document_chunk_count as i64),
-                &"latest",
-            ],
-        )
-        .await?;
+        let r = tx
+            .query_one(
+                &stmt,
+                &[
+                    &data_source_row_id,
+                    &(document_created as i64),
+                    &params.document_id,
+                    &(params.timestamp as i64),
+                    &params.tags,
+                    &params.parents,
+                    &params.source_url,
+                    &params.hash,
+                    &(params.text_size as i64),
+                    &(params.chunk_count as i64),
+                    &"latest",
+                ],
+            )
+            .await?;
+
+        let _id: i64 = r.get(0);
+        let created: i64 = r.get(1);
+        let token_count: Option<i64> = r.get(2);
 
         tx.commit().await?;
 
-        Ok(())
+        Ok(Document {
+            data_source_id,
+            created: created as u64,
+            document_id: params.document_id,
+            timestamp: params.timestamp,
+            tags: params.tags,
+            parents: params.parents,
+            source_url: params.source_url,
+            hash: params.hash,
+            text_size: params.text_size,
+            chunk_count: params.chunk_count as usize,
+            chunks: vec![],
+            text: None,
+            token_count: token_count.map(|t| t as usize),
+        })
     }
 
     async fn list_data_source_documents(
@@ -2381,35 +2403,15 @@ impl Store for PostgresStore {
             .collect::<Vec<_>>())
     }
 
-    async fn upsert_table(
+    async fn upsert_data_source_table(
         &self,
-        project: &Project,
-        data_source_id: &str,
-        table_id: &str,
-        name: &str,
-        description: &str,
-        timestamp: u64,
-        tags: &Vec<String>,
-        parents: &Vec<String>,
-        remote_database_table_id: Option<String>,
-        remote_database_secret_id: Option<String>,
-        title: Option<String>,
-        mime_type: Option<String>,
+        project: Project,
+        data_source_id: String,
+        params: UpsertTable,
     ) -> Result<Table> {
         let project_id = project.project_id();
-        let data_source_id = data_source_id.to_string();
 
         let table_created = utils::now();
-        let table_id = table_id.to_string();
-        let table_name = name.to_string();
-        let table_description = description.to_string();
-        let table_timestamp = timestamp;
-        let table_tags = tags.clone();
-        let table_parents = parents.clone();
-        let table_remote_database_table_id = remote_database_table_id.clone();
-        let table_remote_database_secret_id = remote_database_secret_id.clone();
-        let table_title = title.clone();
-        let table_mime_type = mime_type.clone();
 
         let pool = self.pool.clone();
         let mut c = pool.get().await?;
@@ -2437,52 +2439,77 @@ impl Store for PostgresStore {
                        SET name = EXCLUDED.name, description = EXCLUDED.description, \
                        timestamp = EXCLUDED.timestamp, tags_array = EXCLUDED.tags_array, parents = EXCLUDED.parents, \
                          remote_database_table_id = EXCLUDED.remote_database_table_id, remote_database_secret_id = EXCLUDED.remote_database_secret_id \
-                       RETURNING id",
+                       RETURNING id, created, schema, schema_stale_at",
                 )
                 .await?;
 
-        let table_row_id = tx
+        let table_row = tx
             .query_one(
                 &stmt,
                 &[
                     &data_source_row_id,
                     &(table_created as i64),
-                    &table_id,
-                    &table_name,
-                    &table_description,
-                    &(table_timestamp as i64),
-                    &table_tags,
-                    &table_parents,
-                    &table_remote_database_table_id,
-                    &table_remote_database_secret_id,
+                    &params.table_id,
+                    &params.name,
+                    &params.description,
+                    &(params.timestamp as i64),
+                    &params.tags,
+                    &params.parents,
+                    &params.remote_database_table_id,
+                    &params.remote_database_secret_id,
                 ],
             )
-            .await?
-            .get(0);
+            .await?;
+
+        let table_row_id = table_row.get::<usize, i64>(0);
+        let table_created = table_row.get::<usize, i64>(1) as u64;
+        let raw_schema = table_row.get::<usize, Option<String>>(2);
+        let table_schema_stale_at = table_row.get::<usize, Option<i64>>(3);
+
+        let parsed_schema: Option<TableSchema> = match raw_schema {
+            None => None,
+            Some(schema) => {
+                if schema.is_empty() {
+                    None
+                } else {
+                    Some(serde_json::from_str(&schema)?)
+                }
+            }
+        };
+
+        let should_upsert_node = params.title.is_some() && params.mime_type.is_some();
+        let title = params.title.unwrap_or(params.name.clone());
 
         let table = Table::new(
             project,
-            &data_source_id,
+            data_source_id,
             table_created,
-            &table_id,
-            &table_name,
-            &table_description,
-            table_timestamp,
-            &table_title.unwrap_or(table_name.clone()),
-            &table_mime_type.unwrap_or("text/csv".to_string()),
-            table_tags,
-            table_parents,
-            &None,
-            None,
-            table_remote_database_table_id,
-            table_remote_database_secret_id,
+            params.table_id,
+            params.name,
+            params.description,
+            params.timestamp,
+            title,
+            params.mime_type.unwrap_or("text/csv".to_string()),
+            params.tags,
+            params.parents,
+            parsed_schema,
+            table_schema_stale_at.map(|t| t as u64),
+            params.remote_database_table_id,
+            params.remote_database_secret_id,
         );
 
         // TODO(KW_SEARCH_INFRA): make title/mime_type not optional.
         // Upsert the data source node if title and mime_type are present. Otherwise, we skip the upsert.
-        if let (Some(_), Some(_)) = (title, mime_type) {
+        if should_upsert_node {
             self.upsert_data_source_node(
-                &table.clone().into(),
+                UpsertNode {
+                    node_id: table.table_id(),
+                    node_type: &NodeType::Table,
+                    timestamp: table.timestamp(),
+                    title: table.title(),
+                    mime_type: table.mime_type(),
+                    parents: table.parents(),
+                },
                 data_source_row_id,
                 table_row_id,
                 &tx,
@@ -2494,7 +2521,7 @@ impl Store for PostgresStore {
         Ok(table)
     }
 
-    async fn update_table_schema(
+    async fn update_data_source_table_schema(
         &self,
         project: &Project,
         data_source_id: &str,
@@ -2541,7 +2568,7 @@ impl Store for PostgresStore {
         Ok(())
     }
 
-    async fn update_table_parents(
+    async fn update_data_source_table_parents(
         &self,
         project: &Project,
         data_source_id: &str,
@@ -2589,7 +2616,7 @@ impl Store for PostgresStore {
         Ok(())
     }
 
-    async fn invalidate_table_schema(
+    async fn invalidate_data_source_table_schema(
         &self,
         project: &Project,
         data_source_id: &str,
@@ -2629,7 +2656,7 @@ impl Store for PostgresStore {
         Ok(())
     }
 
-    async fn load_table(
+    async fn load_data_source_table(
         &self,
         project: &Project,
         data_source_id: &str,
@@ -2721,19 +2748,23 @@ impl Store for PostgresStore {
                         }
                     }
                 };
+
+                // TODO(KW_SEARCH_INFRA) use title
+                let title = name.clone();
+
                 Ok(Some(Table::new(
-                    project,
-                    &data_source_id,
+                    project.clone(),
+                    data_source_id.clone(),
                     created as u64,
-                    &table_id,
-                    &name,
-                    &description,
+                    table_id,
+                    name,
+                    description,
                     timestamp as u64,
-                    &name,      // TODO(KW_SEARCH_INFRA) use title
-                    "text/csv", // TODO(KW_SEARCH_INFRA) use mimetype
+                    title,
+                    "text/csv".to_string(), // TODO(KW_SEARCH_INFRA) use mimetype
                     tags,
                     parents,
-                    &parsed_schema,
+                    parsed_schema,
                     schema_stale_at.map(|t| t as u64),
                     remote_database_table_id,
                     remote_database_secret_id,
@@ -2742,7 +2773,7 @@ impl Store for PostgresStore {
         }
     }
 
-    async fn list_tables(
+    async fn list_data_source_tables(
         &self,
         project: &Project,
         data_source_id: &str,
@@ -2852,19 +2883,22 @@ impl Store for PostgresStore {
                     }
                 };
 
+                // TODO(KW_SEARCH_INFRA) use title
+                let title = name.clone();
+
                 Ok(Table::new(
-                    project,
-                    &data_source_id,
+                    project.clone(),
+                    data_source_id.clone(),
                     created as u64,
-                    &table_id,
-                    &name,
-                    &description,
+                    table_id,
+                    name,
+                    description,
                     timestamp as u64,
-                    &name,      // TODO(KW_SEARCH_INFRA) use title
-                    "text/csv", // TODO(KW_SEARCH_INFRA)use mimetype
+                    title,
+                    "text/csv".to_string(), // TODO(KW_SEARCH_INFRA)use mimetype
                     tags,
                     parents,
-                    &parsed_schema,
+                    parsed_schema,
                     schema_stale_at.map(|t| t as u64),
                     remote_database_table_id,
                     remote_database_secret_id,
@@ -2893,7 +2927,7 @@ impl Store for PostgresStore {
         Ok((tables, total))
     }
 
-    async fn delete_table(
+    async fn delete_data_source_table(
         &self,
         project: &Project,
         data_source_id: &str,
@@ -2934,8 +2968,13 @@ impl Store for PostgresStore {
         Ok(())
     }
 
-    async fn upsert_data_source_folder(&self, folder: &Folder) -> Result<()> {
-        let data_source_id = folder.data_source_id();
+    async fn upsert_data_source_folder(
+        &self,
+        project: Project,
+        data_source_id: String,
+        params: UpsertFolder,
+    ) -> Result<Folder> {
+        let project_id = project.project_id();
 
         let pool = self.pool.clone();
         let mut c = pool.get().await?;
@@ -2947,7 +2986,7 @@ impl Store for PostgresStore {
         let r = tx
             .query(
                 "SELECT id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
-                &[&folder.project().project_id(), &data_source_id],
+                &[&project_id, &data_source_id],
             )
             .await?;
         let data_source_row_id: i64 = match r.len() {
@@ -2963,20 +3002,38 @@ impl Store for PostgresStore {
                        VALUES (DEFAULT, $1, $2, $3) \
                        ON CONFLICT (folder_id, data_source)  DO UPDATE \
                        SET folder_id = data_sources_folders.folder_id \
-                       RETURNING id",
+                       RETURNING id, created",
             )
             .await?;
 
-        let folder_row_id = tx
+        let r = tx
             .query_one(
                 &stmt,
-                &[&data_source_row_id, &(created as i64), &folder.folder_id()],
+                &[&data_source_row_id, &(created as i64), &params.folder_id],
             )
-            .await?
-            .get(0);
+            .await?;
+
+        let folder_row_id: i64 = r.get(0);
+        let created: i64 = r.get(1);
+
+        let folder = Folder::new(
+            project,
+            data_source_id,
+            params.folder_id,
+            created as u64,
+            params.title,
+            params.parents,
+        );
 
         self.upsert_data_source_node(
-            &folder.clone().into(),
+            UpsertNode {
+                node_id: folder.folder_id(),
+                node_type: &NodeType::Folder,
+                timestamp: folder.timestamp(),
+                title: folder.title(),
+                mime_type: "text/csv",
+                parents: folder.parents(),
+            },
             data_source_row_id,
             folder_row_id,
             &tx,
@@ -2984,7 +3041,7 @@ impl Store for PostgresStore {
         .await?;
         tx.commit().await?;
 
-        Ok(())
+        Ok(folder)
     }
 
     async fn load_data_source_folder(
@@ -3016,7 +3073,7 @@ impl Store for PostgresStore {
 
                 match row.len() {
                     0 => Ok(None),
-                    1 => Ok(Some(node.into())),
+                    1 => Ok(Some(node.into_folder())),
                     _ => unreachable!(),
                 }
             }

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -3196,11 +3196,11 @@ impl Store for PostgresStore {
                 let parents: Vec<String> = r.get(3);
 
                 Ok(Folder::new(
-                    project,
-                    &data_source_id,
-                    &node_id,
+                    project.clone(),
+                    data_source_id.clone(),
+                    node_id,
                     timestamp as u64,
-                    &title,
+                    title,
                     parents,
                 ))
             })


### PR DESCRIPTION
## Description


- rename the tables-related methods from `*_table[s]` into `*_data_source_table[s]` for consistency with other datasource-related resources
- refactor the upsert methods such that:
     - They take as input an owned object of a specific params type instead of the full output object, removing the need to pass fields that are not meant to be upserted
     - They return the full object we get from `load_*` methods (with latest DB state)
     - They always take owned values when they need to consume the values (eg to create the returned object). This removes some unecesary clones (eg, create ref to data_source_id and project, only to have it be cloned in the method while you are dropping the original one in the caller)
- refactor the private methods to upsert data source nodes, so it doesn't require cloning the full object (introduce `UpsertNode` struct which only holds refs)


Had to remove the From<Folder> -> Node and From<Node> -> Folder, as this meant we had to clone the node/folder. Instead, we now have an `into_folder()` method on `Node`, which consumes the node, removing the need for a clone.

There's one last thing I want to do, introduce a new type `DocumentWithTextAndTokenCount` (or something like that), as `text` and `token_count` are only populated in one specific code path, and we have no way to know when at compile time, which is a bit unsatisfying and causes a weird pattern in one place in data_source.rs. Will do that separately.

## Risk

Risky

## Deploy Plan

Deploy code