### PR TITLE
[Table upsert] Bump max col name length to 1024

### DIFF
--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -27,7 +27,7 @@ import logger from "@app/logger/logger";
 import type { DataSourceResource } from "../resources/data_source_resource";
 
 const MAX_TABLE_COLUMNS = 512;
-const MAX_COLUMN_NAME_LENGTH = 512;
+const MAX_COLUMN_NAME_LENGTH = 1024;
 
 type CsvParsingError = {
   type:


### PR DESCRIPTION
Description
---
Length at 512 contributes a little to bursts of errors, see e.g. [here](https://dust4ai.slack.com/archives/C05F84CFP0E/p1733018600595589)

Name > 512 chars is likely 95% of the time caused by a bad (unparseable) csv

Moving to 1024 chars: the idea is to go from 95% to 99.9% and reduce monitor noise

Risks
---
na

Deploy
---
front
