### PR TITLE
Flav/saml sso

### DIFF
--- a/front/components/workspace/connection.tsx
+++ b/front/components/workspace/connection.tsx
@@ -127,8 +127,8 @@ export function EnterpriseConnectionDetails({
         owner={owner}
       />
       <Page.P variant="secondary">
-        Easily integrate Okta or Microsoft Entra ID to enable Single Sign-On
-        (SSO) for your team.
+        Easily integrate SAML, Okta or Microsoft Entra ID to enable Single
+        Sign-On (SSO) for your team.
       </Page.P>
       <div className="flex w-full flex-col items-start gap-3">
         {enterpriseConnection ? (
@@ -521,11 +521,13 @@ function CreateSAMLEnterpriseConnectionModal({
       strategy: "samlp",
     });
 
-  const { audienceUri, callbackUrl, samlAcsUrl } = strategyDetails;
+  const { audienceUri, samlAcsUrl } = strategyDetails;
 
   const handleCertUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    if (!file) return;
+    if (!file) {
+      return;
+    }
 
     const reader = new FileReader();
     reader.onload = async (e) => {
@@ -544,7 +546,7 @@ function CreateSAMLEnterpriseConnectionModal({
         Discover how to set up SAML SSO – Read Our{" "}
         <a
           className="font-bold underline decoration-2"
-          href="https://docs.dust.tt/docs/microsoft-entra-sso"
+          href="https://docs.dust.tt/docs/saml-sso"
           target="_blank"
         >
           Documentation

--- a/front/components/workspace/connection.tsx
+++ b/front/components/workspace/connection.tsx
@@ -31,7 +31,11 @@ import {
   useFeatureFlags,
   useWorkspaceEnterpriseConnection,
 } from "@app/lib/swr/workspaces";
-import type { PostCreateEnterpriseConnectionRequestBodySchemaType } from "@app/pages/api/w/[wId]/enterprise-connection";
+import type {
+  IdpSpecificConnectionTypeDetails,
+  PostCreateEnterpriseConnectionRequestBodySchemaType,
+  SAMLConnectionTypeDetails,
+} from "@app/pages/api/w/[wId]/enterprise-connection";
 
 interface EnterpriseConnectionDetailsProps {
   owner: WorkspaceType;
@@ -41,8 +45,11 @@ interface EnterpriseConnectionDetailsProps {
 }
 
 export interface EnterpriseConnectionStrategyDetails {
+  audienceUri: string;
   callbackUrl: string;
+  // SAML Specific.
   initiateLoginUrl: string;
+  samlSignInUrl: string;
 }
 
 export function EnterpriseConnectionDetails({
@@ -235,7 +242,7 @@ function CreateOktaEnterpriseConnectionModal({
   strategyDetails: EnterpriseConnectionStrategyDetails;
 }) {
   const [enterpriseConnectionDetails, setEnterpriseConnectionDetails] =
-    useState<Partial<PostCreateEnterpriseConnectionRequestBodySchemaType>>({
+    useState<Partial<IdpSpecificConnectionTypeDetails>>({
       strategy: "okta",
     });
 
@@ -375,7 +382,7 @@ function CreateWAADEnterpriseConnectionModal({
   strategyDetails: EnterpriseConnectionStrategyDetails;
 }) {
   const [enterpriseConnectionDetails, setEnterpriseConnectionDetails] =
-    useState<Partial<PostCreateEnterpriseConnectionRequestBodySchemaType>>({
+    useState<Partial<IdpSpecificConnectionTypeDetails>>({
       strategy: "waad",
     });
 
@@ -498,6 +505,124 @@ function CreateWAADEnterpriseConnectionModal({
   );
 }
 
+function CreateSAMLEnterpriseConnectionModal({
+  createEnterpriseConnection,
+  onConnectionCreated,
+  strategyDetails,
+}: {
+  createEnterpriseConnection: (
+    enterpriseConnection: PostCreateEnterpriseConnectionRequestBodySchemaType
+  ) => Promise<void>;
+  onConnectionCreated: () => void;
+  strategyDetails: EnterpriseConnectionStrategyDetails;
+}) {
+  const [enterpriseConnectionDetails, setEnterpriseConnectionDetails] =
+    useState<Partial<SAMLConnectionTypeDetails>>({
+      strategy: "samlp",
+    });
+
+  const { audienceUri, callbackUrl, samlSignInUrl } = strategyDetails;
+
+  const handleCertUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = async (e) => {
+      const base64Cert = (e.target?.result as string).split(",")[1];
+      setEnterpriseConnectionDetails({
+        ...enterpriseConnectionDetails,
+        x509SignInCertificate: base64Cert,
+      });
+    };
+    reader.readAsDataURL(file);
+  };
+
+  return (
+    <>
+      <div>
+        Discover how to set up SAML SSO – Read Our{" "}
+        <a
+          className="font-bold underline decoration-2"
+          href="https://docs.dust.tt/docs/microsoft-entra-sso"
+          target="_blank"
+        >
+          Documentation
+        </a>
+        .
+      </div>
+      <Page.Layout direction="vertical">
+        <div>
+          Assertion Consumer Service URL:
+          <Input
+            name="Assertion Consumer Service URL"
+            placeholder="Assertion Consumer Service URL"
+            value={samlSignInUrl}
+            disabled
+            className="max-w-sm"
+          />
+        </div>
+        <div>
+          Audience URI (SP Entity ID):
+          <Input
+            name="Audience URI"
+            placeholder="Audience URI"
+            value={audienceUri}
+            disabled
+            className="max-w-sm"
+          />
+        </div>
+        <Page.Separator />
+        <div>
+          Sign In URL:
+          <Input
+            name="Sign In URL"
+            placeholder="https://<okta_tenant_name>.okta.com/app/..."
+            value={enterpriseConnectionDetails.signInUrl ?? ""}
+            onChange={(e) =>
+              setEnterpriseConnectionDetails({
+                ...enterpriseConnectionDetails,
+                signInUrl: e.target.value,
+              })
+            }
+            className="max-w-sm"
+          />
+        </div>
+        <div>
+          IdP Certificate:
+          <Input
+            type="file"
+            accept=".pem,.crt,.cer,.cert"
+            onChange={handleCertUpload}
+            className="max-w-sm"
+          />
+        </div>
+        <Page.Separator />
+        <div className="flex items-start">
+          <Button
+            variant="warning"
+            size="sm"
+            disabled={
+              !(
+                enterpriseConnectionDetails.signInUrl &&
+                enterpriseConnectionDetails.x509SignInCertificate
+              )
+            }
+            icon={LockIcon}
+            label="Create SAML Configuration"
+            onClick={async () => {
+              await createEnterpriseConnection(
+                enterpriseConnectionDetails as PostCreateEnterpriseConnectionRequestBodySchemaType
+              );
+              onConnectionCreated();
+            }}
+          />
+        </div>
+      </Page.Layout>
+    </>
+  );
+}
+
 function StrategyModalContent({
   onConnectionCreated,
   owner,
@@ -559,7 +684,13 @@ function StrategyModalContent({
       );
 
     case "samlp":
-      return <>Not implemented</>;
+      return (
+        <CreateSAMLEnterpriseConnectionModal
+          createEnterpriseConnection={createEnterpriseConnection}
+          onConnectionCreated={onConnectionCreated}
+          strategyDetails={strategyDetails}
+        />
+      );
 
     default:
       assertNever(strategy);
@@ -595,8 +726,8 @@ function CreateEnterpriseConnectionModal({
         {selectedStrategy === null && (
           <div className="flex flex-col gap-4">
             <Page.P variant="secondary">
-              Dust supports Single Sign On (SSO) with Okta and Microsoft Entra
-              Id. Choose the SSO provider you'd like to integrate.
+              Dust supports Single Sign On (SSO) with Okta, Microsoft Entra Id
+              and SAML. Choose the SSO provider you'd like to integrate.
             </Page.P>
             <RadioGroup
               value={selectedStrategy ?? ""}
@@ -608,13 +739,22 @@ function CreateEnterpriseConnectionModal({
               className="flex-col gap-2"
             >
               <RadioGroupChoice
+                value="samlp"
+                label={
+                  <Label className="pl-1">
+                    SAML{" "}
+                    <span className="text-sm text-gray-600">(preferred)</span>
+                  </Label>
+                }
+              />
+              <RadioGroupChoice
                 value="okta"
                 label={<Label className="pl-1">Okta SSO</Label>}
-              ></RadioGroupChoice>
+              />
               <RadioGroupChoice
                 value="waad"
                 label={<Label className="pl-1">Microsoft Entra Id</Label>}
-              ></RadioGroupChoice>
+              />
             </RadioGroup>
           </div>
         )}

--- a/front/components/workspace/connection.tsx
+++ b/front/components/workspace/connection.tsx
@@ -45,11 +45,11 @@ interface EnterpriseConnectionDetailsProps {
 }
 
 export interface EnterpriseConnectionStrategyDetails {
-  audienceUri: string;
   callbackUrl: string;
-  // SAML Specific.
   initiateLoginUrl: string;
-  samlSignInUrl: string;
+  // SAML Specific.
+  audienceUri: string;
+  samlAcsUrl: string;
 }
 
 export function EnterpriseConnectionDetails({
@@ -521,7 +521,7 @@ function CreateSAMLEnterpriseConnectionModal({
       strategy: "samlp",
     });
 
-  const { audienceUri, callbackUrl, samlSignInUrl } = strategyDetails;
+  const { audienceUri, callbackUrl, samlAcsUrl } = strategyDetails;
 
   const handleCertUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -557,7 +557,7 @@ function CreateSAMLEnterpriseConnectionModal({
           <Input
             name="Assertion Consumer Service URL"
             placeholder="Assertion Consumer Service URL"
-            value={samlSignInUrl}
+            value={samlAcsUrl}
             disabled
             className="max-w-sm"
           />

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -11,6 +11,9 @@ const config = {
   getAuth0TenantUrl: (): string => {
     return EnvironmentConfig.getEnvVariable("AUTH0_TENANT_DOMAIN_URL");
   },
+  getAuth0AudienceUri: (): string => {
+    return EnvironmentConfig.getEnvVariable("AUTH0_AUDIENCE_URI");
+  },
   getDustApiAudience: (): string => {
     return EnvironmentConfig.getEnvVariable("DUST_API_AUDIENCE");
   },

--- a/front/lib/api/enterprise_connection.ts
+++ b/front/lib/api/enterprise_connection.ts
@@ -1,10 +1,17 @@
-import type { SupportedEnterpriseConnectionStrategies } from "@dust-tt/types";
+import type {
+  LightWorkspaceType,
+  SupportedEnterpriseConnectionStrategies,
+} from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
 import type { Connection } from "auth0";
 
 import { getAuth0ManagemementClient } from "@app/lib/api/auth0";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
+import {
+  IdpSpecificConnectionTypeDetails,
+  SAMLConnectionTypeDetails,
+} from "@app/pages/api/w/[wId]/enterprise-connection";
 
 function makeEnterpriseConnectionName(workspaceId: string) {
   return `workspace-${workspaceId}`;
@@ -14,6 +21,14 @@ export function makeEnterpriseConnectionInitiateLoginUrl(workspaceId: string) {
   return `${config.getClientFacingUrl()}/api/auth/login?connection=${makeEnterpriseConnectionName(
     workspaceId
   )}`;
+}
+
+export function makeAudienceUri(owner: LightWorkspaceType) {
+  return `${config.getAuth0AudienceUri()}:${makeEnterpriseConnectionName(owner.sId)}`;
+}
+
+export function makeSamlSignInUrl(owner: LightWorkspaceType) {
+  return `https://${config.getAuth0TenantUrl()}/login/callback?connection=${makeEnterpriseConnectionName(owner.sId)}`;
 }
 
 export async function getEnterpriseConnectionForWorkspace(auth: Authenticator) {
@@ -28,12 +43,9 @@ export async function getEnterpriseConnectionForWorkspace(auth: Authenticator) {
   return connections.data.find((c) => c.name === expectedConnectionName);
 }
 
-interface EnterpriseConnectionDetails {
-  clientId: string;
-  clientSecret: string;
-  domain: string;
-  strategy: SupportedEnterpriseConnectionStrategies;
-}
+type EnterpriseConnectionDetails =
+  | IdpSpecificConnectionTypeDetails
+  | SAMLConnectionTypeDetails;
 
 export async function createEnterpriseConnection(
   auth: Authenticator,
@@ -95,9 +107,13 @@ function getCreateConnectionPayloadFromConnectionDetails(
       };
 
     case "samlp":
-      throw new Error("SAML connections creation is not supported.");
+      return {
+        strategy: connectionDetails.strategy,
+        signingCert: connectionDetails.x509SignInCertificate,
+        signInEndpoint: connectionDetails.signInUrl,
+      };
 
     default:
-      assertNever(connectionDetails.strategy);
+      assertNever(connectionDetails);
   }
 }

--- a/front/lib/api/enterprise_connection.ts
+++ b/front/lib/api/enterprise_connection.ts
@@ -27,7 +27,7 @@ export function makeAudienceUri(owner: LightWorkspaceType) {
   return `${config.getAuth0AudienceUri()}:${makeEnterpriseConnectionName(owner.sId)}`;
 }
 
-export function makeSamlSignInUrl(owner: LightWorkspaceType) {
+export function makeSamlAcsUrl(owner: LightWorkspaceType) {
   return `https://${config.getAuth0TenantUrl()}/login/callback?connection=${makeEnterpriseConnectionName(owner.sId)}`;
 }
 

--- a/front/lib/api/enterprise_connection.ts
+++ b/front/lib/api/enterprise_connection.ts
@@ -1,14 +1,11 @@
-import type {
-  LightWorkspaceType,
-  SupportedEnterpriseConnectionStrategies,
-} from "@dust-tt/types";
+import type { LightWorkspaceType } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
 import type { Connection } from "auth0";
 
 import { getAuth0ManagemementClient } from "@app/lib/api/auth0";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
-import {
+import type {
   IdpSpecificConnectionTypeDetails,
   SAMLConnectionTypeDetails,
 } from "@app/pages/api/w/[wId]/enterprise-connection";

--- a/front/pages/api/w/[wId]/enterprise-connection.ts
+++ b/front/pages/api/w/[wId]/enterprise-connection.ts
@@ -23,17 +23,36 @@ export type GetEnterpriseConnectionResponseBody = {
   connection: WorkspaceEnterpriseConnection;
 };
 
-const PostCreateEnterpriseConnectionRequestBodySchema = t.type({
+const PostCreateEnterpriseIdpSpecificConnectionRequestBodySchema = t.type({
   clientId: t.string,
   clientSecret: t.string,
   domain: t.string,
-  // SAML creation is not supported yet.
   strategy: t.union([t.literal("okta"), t.literal("waad")]),
 });
 
-export type PostCreateEnterpriseConnectionRequestBodySchemaType = t.TypeOf<
-  typeof PostCreateEnterpriseConnectionRequestBodySchema
+export type IdpSpecificConnectionTypeDetails = t.TypeOf<
+  typeof PostCreateEnterpriseIdpSpecificConnectionRequestBodySchema
 >;
+
+const PostCreateSAMLEnterpriseConnectionRequestBodySchema = t.type({
+  // Base-64 encoded certificate.
+  x509SignInCertificate: t.string,
+  signInUrl: t.string,
+  strategy: t.literal("samlp"),
+});
+
+const PostCreateEnterpriseConnectionRequestBodySchema = t.union([
+  PostCreateEnterpriseIdpSpecificConnectionRequestBodySchema,
+  PostCreateSAMLEnterpriseConnectionRequestBodySchema,
+]);
+
+export type SAMLConnectionTypeDetails = t.TypeOf<
+  typeof PostCreateSAMLEnterpriseConnectionRequestBodySchema
+>;
+
+export type PostCreateEnterpriseConnectionRequestBodySchemaType =
+  | IdpSpecificConnectionTypeDetails
+  | SAMLConnectionTypeDetails;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -33,7 +33,7 @@ import config from "@app/lib/api/config";
 import {
   makeAudienceUri,
   makeEnterpriseConnectionInitiateLoginUrl,
-  makeSamlSignInUrl,
+  makeSamlAcsUrl,
 } from "@app/lib/api/enterprise_connection";
 import {
   checkWorkspaceSeatAvailabilityUsingAuth,
@@ -74,7 +74,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       initiateLoginUrl: makeEnterpriseConnectionInitiateLoginUrl(owner.sId),
       // SAML specific.
       audienceUri: makeAudienceUri(owner),
-      samlSignInUrl: makeSamlSignInUrl(owner),
+      samlAcsUrl: makeSamlAcsUrl(owner),
     };
 
   const perSeatPricing = await getPerSeatSubscriptionPricing(subscription);

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -30,7 +30,11 @@ import AppLayout from "@app/components/sparkle/AppLayout";
 import type { EnterpriseConnectionStrategyDetails } from "@app/components/workspace/connection";
 import { EnterpriseConnectionDetails } from "@app/components/workspace/connection";
 import config from "@app/lib/api/config";
-import { makeEnterpriseConnectionInitiateLoginUrl } from "@app/lib/api/enterprise_connection";
+import {
+  makeAudienceUri,
+  makeEnterpriseConnectionInitiateLoginUrl,
+  makeSamlSignInUrl,
+} from "@app/lib/api/enterprise_connection";
 import {
   checkWorkspaceSeatAvailabilityUsingAuth,
   getWorkspaceVerifiedDomain,
@@ -68,6 +72,9 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     {
       callbackUrl: config.getAuth0TenantUrl(),
       initiateLoginUrl: makeEnterpriseConnectionInitiateLoginUrl(owner.sId),
+      // SAML specific.
+      audienceUri: makeAudienceUri(owner),
+      samlSignInUrl: makeSamlSignInUrl(owner),
     };
 
   const perSeatPricing = await getPerSeatSubscriptionPricing(subscription);


### PR DESCRIPTION
# SAML SSO Implementation

## Overview
This PR implements generic SAML SSO support in Dust, expanding our authentication capabilities beyond our existing Okta and Microsoft Entra ID integrations. This standardized approach allows us to support any SAML-compliant Identity Provider, making our platform more flexible and future-proof.

## Key Changes
- Implemented SAML SSO configuration interface in the admin dashboard
- Added backend infrastructure for SAML authentication flow
- Integrated X.509 certificate handling for secure SAML assertions
- Created provider-agnostic SAML connection management

## Documentation
Complete SAML integration documentation is available [[here](https://dash.readme.com/project/dust-tt/v1.0/docs/saml-sso)].

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [x] Add missing `AUTH0_AUDIENCE_URI` secret

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
