### PR TITLE
FileUpload / Slack preparation work

### DIFF
--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -106,6 +106,7 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
               );
               const citationType: CitationType = [
                 "dust-application/slack",
+                "text/vnd.dust.attachment.slack.thread",
               ].includes(contentFragment.contentType)
                 ? "slack"
                 : "document";

--- a/front/lib/api/assistant/actions/conversation/include_file.ts
+++ b/front/lib/api/assistant/actions/conversation/include_file.ts
@@ -53,6 +53,7 @@ export function isConversationIncludableFileContentType(
     case "text/markdown":
     case "text/plain":
     case "dust-application/slack":
+    case "text/vnd.dust.attachment.slack.thread":
     case "text/comma-separated-values":
     case "text/csv":
       return true;

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -82,6 +82,7 @@ function isQueryableContentType(
     case "text/markdown":
     case "text/plain":
     case "dust-application/slack":
+    case "text/vnd.dust.attachment.slack.thread":
     case "text/tab-separated-values":
     case "text/tsv":
       return false;
@@ -108,6 +109,7 @@ function isSearchableContentType(
     case "text/markdown":
     case "text/plain":
     case "dust-application/slack":
+    case "text/vnd.dust.attachment.slack.thread":
     case "text/tab-separated-values":
     case "text/tsv":
       return true;

--- a/front/lib/api/files/upload.ts
+++ b/front/lib/api/files/upload.ts
@@ -354,6 +354,13 @@ const processingPerContentType: ProcessingPerContentType = {
     avatar: notSupportedError,
     tool_output: notSupportedError,
   },
+  "text/vnd.dust.attachment.slack.thread": {
+    conversation: storeRawText,
+    folder_document: notSupportedError,
+    folder_table: notSupportedError,
+    avatar: notSupportedError,
+    tool_output: notSupportedError,
+  },
 };
 
 const maybeApplyProcessing: ProcessingFunction = async (

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -357,6 +357,13 @@ const processingPerContentType: ProcessingPerContentType = {
     avatar: notSupportedError,
     tool_output: notSupportedError,
   },
+  "text/vnd.dust.attachment.slack.thread": {
+    conversation: upsertDocumentToDatasource,
+    folder_document: notSupportedError,
+    folder_table: notSupportedError,
+    avatar: notSupportedError,
+    tool_output: notSupportedError,
+  },
 };
 
 const maybeApplyProcessing: ProcessingFunction = async ({

--- a/front/pages/api/v1/w/[wId]/files/index.ts
+++ b/front/pages/api/v1/w/[wId]/files/index.ts
@@ -84,7 +84,7 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<FileUploadRequestResponseType>>,
   auth: Authenticator
 ): Promise<void> {
-  const user = auth.getNonNullableUser();
+  const user = auth.user();
   const owner = auth.getNonNullableWorkspace();
 
   switch (req.method) {
@@ -154,7 +154,7 @@ async function handler(
         contentType,
         fileName,
         fileSize,
-        userId: user.id,
+        userId: user?.id ?? null,
         workspaceId: owner.id,
         useCase,
         useCaseMetadata: useCaseMetadata,

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -82,6 +82,7 @@ export const supportedPlainText = {
   "text/plain": [".txt"],
   "text/tab-separated-values": [".tsv"],
   "text/tsv": [".tsv"],
+  "text/vnd.dust.attachment.slack.thread": [".txt"],
 } as const;
 
 // Supported content types for images.

--- a/types/src/front/files.ts
+++ b/types/src/front/files.ts
@@ -85,6 +85,8 @@ const supportedPlainText = {
   "application/pdf": [".pdf"],
   "text/markdown": [".md", ".markdown"],
   "text/plain": [".txt"],
+
+  "text/vnd.dust.attachment.slack.thread": [".txt"],
 } as const;
 
 // Supported content types for images.


### PR DESCRIPTION
## Description

- Makes user nullable on api/v1 file upload (data model already accepts null)
- Introduce new content type `text/vnd.dust.attachment.slack.thread` for file upload related slack attachments, goal is to eventually deprecate `dust-application/slack` after potentially migrating it
- Add proper headers in the DustAPI.uploadFile implementation

Reintroduce the non problematic parts of the reverted PR here: https://github.com/dust-tt/dust/pull/9048

Rationale for the content-type name: https://dust.tt/w/0ec9852c2f/assistant/5xssoffqVn

## Risk

Low: no impact on existing systems

## Deploy Plan

- deploy `front`