### PR TITLE
Uniformize parent IDs on GDrive documents

### DIFF
--- a/connectors/src/connectors/google_drive/lib.ts
+++ b/connectors/src/connectors/google_drive/lib.ts
@@ -7,6 +7,7 @@ import {
 import type { InferAttributes, WhereOptions } from "sequelize";
 
 import { isGoogleDriveSpreadSheetFile } from "@connectors/connectors/google_drive/temporal/mime_types";
+import { getDocumentId } from "@connectors/connectors/google_drive/temporal/utils";
 import {
   GoogleDriveFiles,
   GoogleDriveSheet,
@@ -77,7 +78,7 @@ async function _getLocalParents(
         driveFileId: contentNodeInternalId,
       },
     });
-    parentId = object?.parentId ?? null;
+    parentId = object?.parentId ? getDocumentId(object?.parentId) : null;
   }
 
   if (!parentId) {

--- a/connectors/src/connectors/google_drive/temporal/file.ts
+++ b/connectors/src/connectors/google_drive/temporal/file.ts
@@ -472,8 +472,8 @@ async function upsertGdriveDocument(
   if (documentLen > 0 && documentLen <= maxDocumentLen) {
     const parents = (
       await getFileParentsMemoized(connectorId, oauth2client, file, startSyncTs)
-    ).map((f) => f.id);
-    parents.push(file.id);
+    ).map((f) => getDocumentId(f.id));
+    parents.push(documentId);
     parents.reverse();
 
     await upsertToDatasource({

--- a/connectors/src/connectors/google_drive/temporal/utils.ts
+++ b/connectors/src/connectors/google_drive/temporal/utils.ts
@@ -1,3 +1,5 @@
+import assert from "node:assert";
+
 import { cacheWithRedis } from "@dust-tt/types";
 import type { drive_v3 } from "googleapis";
 import { google } from "googleapis";
@@ -11,6 +13,12 @@ import type { GoogleDriveObjectType } from "@connectors/types/google_drive";
 
 export function getDocumentId(driveFileId: string): string {
   return `gdrive-${driveFileId}`;
+}
+
+export function documentIdToDriveFileId(documentId: string): string {
+  const prefix = "gdrive-";
+  assert(documentId.startsWith(prefix), "Invalid documentId");
+  return documentId.replace(prefix, "");
 }
 
 async function _getMyDriveId(auth_credentials: OAuth2Client) {

--- a/front/migrations/20241129_fix_gdrive_file_parents.ts
+++ b/front/migrations/20241129_fix_gdrive_file_parents.ts
@@ -1,0 +1,93 @@
+import { CoreAPI } from "@dust-tt/types/src";
+import assert from "assert";
+import _ from "lodash";
+import { QueryTypes } from "sequelize";
+
+import config from "@app/lib/api/config";
+import { getCorePrimaryDbConnection } from "@app/lib/production_checks/utils";
+import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
+import { makeScript } from "@app/scripts/helpers";
+
+const { CORE_DATABASE_URI } = process.env;
+const SELECT_CHUNK_SIZE = 1000;
+const UPDATE_CHUNK_SIZE = 10;
+
+makeScript({}, async ({ execute }, logger) => {
+  assert(CORE_DATABASE_URI, "CORE_DATABASE_URI is required");
+
+  const coreSequelize = getCorePrimaryDbConnection();
+  const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+
+  const frontGoogleDriveDataSources = await DataSourceModel.findAll({
+    where: { connectorProvider: "google_drive" },
+  });
+
+  for (const ds of frontGoogleDriveDataSources) {
+    logger.info(`Processing data source ${ds.id}`);
+
+    let nextId = 0;
+    for (;;) {
+      const query = `
+          SELECT doc.id, doc.document_id, doc.parents
+          FROM data_sources_documents doc
+                   JOIN data_sources ds ON ds.id = doc.data_source
+          WHERE doc.id > :nextId
+            AND ds.data_source_id = :dataSourceId
+            AND ds.project = :projectId
+          ORDER BY doc.id
+          LIMIT :chunkSize;`;
+
+      logger.info(`Running SELECT query for chunk starting from row ${nextId}`);
+      const result: any[] = await coreSequelize.query(query, {
+        replacements: {
+          dataSourceId: ds.dustAPIDataSourceId,
+          projectId: ds.dustAPIProjectId,
+          chunkSize: SELECT_CHUNK_SIZE,
+          nextId,
+        },
+        type: QueryTypes.SELECT,
+      });
+
+      const rowsToUpdate = result.filter(
+        // same condition as what was logged
+        (row) =>
+          !row.parents ||
+          row.parents.length === 0 ||
+          row.parents[0] !== row.document_id
+      );
+
+      // doing smaller chunks to avoid long transactions
+      const chunks = _.chunk(rowsToUpdate, UPDATE_CHUNK_SIZE);
+
+      for (let i = 0; i < chunks.length; i++) {
+        await Promise.all(
+          chunks[i].map(async (row) => {
+            if (execute) {
+              await coreAPI.updateDataSourceDocumentParents({
+                projectId: ds.dustAPIProjectId,
+                dataSourceId: ds.dustAPIDataSourceId,
+                documentId: row.document_id,
+                parents: row.parents.map((p: string) => `gdrive-${p}`),
+              });
+            } else {
+              logger.info(`Would update document ${row.document_id}`);
+            }
+          })
+        );
+      }
+
+      if (result.length == 0) {
+        logger.info(
+          { dataSource: ds.id, nextId },
+          `Finished processing data source.`
+        );
+        break;
+      }
+      nextId = result[result.length - 1].id;
+      logger.info(
+        { dataSource: ds.id, nextId },
+        `Updated a chunk of ${result.length} documents.`
+      );
+    }
+  }
+});

--- a/front/migrations/20241129_fix_gdrive_file_parents.ts
+++ b/front/migrations/20241129_fix_gdrive_file_parents.ts
@@ -1,5 +1,4 @@
 import { CoreAPI } from "@dust-tt/types/src";
-import assert from "assert";
 import _ from "lodash";
 import { QueryTypes } from "sequelize";
 
@@ -8,13 +7,10 @@ import { getCorePrimaryDbConnection } from "@app/lib/production_checks/utils";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { makeScript } from "@app/scripts/helpers";
 
-const { CORE_DATABASE_URI } = process.env;
 const SELECT_CHUNK_SIZE = 1000;
 const UPDATE_CHUNK_SIZE = 10;
 
 makeScript({}, async ({ execute }, logger) => {
-  assert(CORE_DATABASE_URI, "CORE_DATABASE_URI is required");
-
   const coreSequelize = getCorePrimaryDbConnection();
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/1661
- In Gdrive, document IDs start with the prefix `gdrive`, parent IDs do not: the document ID is correctly equal to `parents[0]` but without the prefix.

## Risk

- Migration script that affects all gdrive `data_source_documents`.
- Break some elements in the UI.

## Deploy Plan

- Deploy connectors
- Run backfill script `front/migrations/20241129_fix_gdrive_file_parents.ts`