### PR TITLE
Use psql copy to upsert all rows at once in case of truncate = true

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,18 +8,19 @@
   },
   "eslint.run": "onSave",
   "typescript.preferences.importModuleSpecifier": "non-relative",
-  "github-actions.workflows.pinned.workflows": []
-  ,
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.formatOnSave": true,
-    "[javascript]": {
-      "editor.defaultFormatter": "esbenp.prettier-vscode"
-    },
-    "[typescript]": {
-      "editor.defaultFormatter": "esbenp.prettier-vscode"
-    },
-    "[typescriptreact]": {
-      "editor.defaultFormatter": "esbenp.prettier-vscode"
-    }
-  
+  "github-actions.workflows.pinned.workflows": [],
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[rust]": {
+    "editor.defaultFormatter": "rust-lang.rust-analyzer"
+  }
 }

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -349,6 +349,7 @@ export async function rowsFromCsv({
     CsvParsingError
   >
 > {
+  const now = performance.now();
   const delimiter = await guessDelimiter(csv);
   if (!delimiter) {
     return new Err({
@@ -496,6 +497,16 @@ export async function rowsFromCsv({
 
     rows.push({ row_id: rowId, value: record });
   }
+
+  logger.info(
+    {
+      durationMs: performance.now() - now,
+      nbRows,
+      nbCols: header.length,
+      workspaceId: auth.getNonNullableWorkspace().id,
+    },
+    "Parsing CSV"
+  );
 
   return new Ok({ detectedHeaders: { header, rowIndex }, rows });
 }


### PR DESCRIPTION
## Description

Our upsert are quite slow when there are a [lot of rows](https://app.datadoghq.eu/logs?query=upsert_rows%20@rows_count:%3E50000%20rows%20upsert&agg_m=count&agg_m_source=base&agg_t=count&cols=host,service,@duration,@rows_count&fromUser=true&messageDisplay=inline&storage=hot&stream_sort=time,desc&viz=stream&from_ts=1732547533702&to_ts=1733152333702&live=true) which will become quite visible when we enable JIT for all.

In case of upsert when truncate == true, we can skip almost all steps from psql insert and just use `COPY` which is the recommended way for high performance batch inserts.

I tried on my laptop with big files, I ended up with 11s for 310k rows, however, it's also quite fast on my laptop with the legacy path as the `tables_rows` table is quite empty. I'm curious to see how much we can gain.

## Risk

Relatively low but I'm slightly worried about escaping special characters. I followed the doc and used my own judgement.

## Deploy Plan

Deploy `core` and benchmark via the logs