### PR TITLE
Public API & SDK get_agent_config fetches with authors + use in extension

### DIFF
--- a/extension/app/src/components/assistants/AssistantFavorites.tsx
+++ b/extension/app/src/components/assistants/AssistantFavorites.tsx
@@ -8,7 +8,7 @@ export function AssistantFavorites() {
     agentConfigurations,
     isAgentConfigurationsLoading,
     isAgentConfigurationsError,
-  } = usePublicAgentConfigurations("favorites");
+  } = usePublicAgentConfigurations("favorites", ["authors"]);
 
   const { setSelectedAssistant } = useContext(InputBarContext);
 

--- a/extension/app/src/components/assistants/usePublicAgentConfigurations.ts
+++ b/extension/app/src/components/assistants/usePublicAgentConfigurations.ts
@@ -4,12 +4,13 @@ import { useSWRWithDefaults } from "@extension/lib/swr";
 import { useMemo } from "react";
 
 export function usePublicAgentConfigurations(
-  view?: AgentConfigurationViewType
+  view?: AgentConfigurationViewType,
+  includes: "authors"[] = []
 ) {
   const dustAPI = useDustAPI();
 
   const agentConfigurationsFetcher = async () => {
-    const res = await dustAPI.getAgentConfigurations(view);
+    const res = await dustAPI.getAgentConfigurations(view, includes);
     if (res.isOk()) {
       return res.value;
     }

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -495,9 +495,26 @@ export class DustAPI {
     return new Ok(r.value.data_sources);
   }
 
-  async getAgentConfigurations(view?: AgentConfigurationViewType) {
-    const path = view
-      ? `assistant/agent_configurations?view=${view}`
+  async getAgentConfigurations(
+    view?: AgentConfigurationViewType,
+    includes: "authors"[] = []
+  ) {
+    // Function to generate query parameters.
+    function getQueryString() {
+      const params = new URLSearchParams();
+      if (typeof view === "string") {
+        params.append("view", view);
+      }
+      if (includes.includes("authors")) {
+        params.append("withAuthors", "true");
+      }
+
+      return params.toString();
+    }
+
+    const queryString = view || includes.length > 0 ? getQueryString() : null;
+    const path = queryString
+      ? `assistant/agent_configurations?${queryString}`
       : "assistant/agent_configurations";
 
     const res = await this.request({


### PR DESCRIPTION
## Description

- Public API: adds query params `withAuthors` to also fetch authors when fetching agents configs, if set to true.
- SDK: Adds `includes` params in `getAgentConfigurations` method.
- Extension: sends the new includes param on the query to fetch Assistant favorites so we can display the authors. 

On the private api includes can be `authors` + `usage`, since `usage` is not used yet I decided to not add it already. It's easier to add it when needed over removing it if we want to. 

<img width="626" alt="Screenshot 2024-12-02 at 16 49 06" src="https://github.com/user-attachments/assets/d2d0a80e-a44f-4aef-895f-09de5fb2b56a">


Fixes: https://github.com/dust-tt/tasks/issues/1727

## Risk

Can be rolled back. 
The new param is optional in the SDK and in API call so should be safe.

## Deploy Plan

- Deploy front. 

