### PR TITLE
Remove requirement for user to create/edit data sources.

### DIFF
--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -345,8 +345,7 @@ export async function handlePatchDataSourceView(
     });
   }
 
-  if (auth.user()) {
-    await dataSourceView.setEditedBy(auth);
-  }
+  await dataSourceView.setEditedBy(auth);
+
   return new Ok(dataSourceView);
 }

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -849,7 +849,7 @@ export async function createDataSourceWithoutProvider(
   try {
     // Asynchronous tracking without awaiting, handled safely
     void ServerSideTracking.trackDataSourceCreated({
-      user: auth.getNonNullableUser(),
+      user: auth.user() ?? undefined,
       workspace: owner,
       dataSource: dataSourceView.dataSource.toJSON(),
     });

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -110,6 +110,7 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
         {
           model: User,
           as: "editedByUser",
+          required: false,
         },
       ];
     }

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -88,7 +88,7 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
     const dataSource = await DataSourceModel.create(
       {
         ...blob,
-        editedByUserId: auth.getNonNullableUser().id,
+        editedByUserId: auth.user()?.id ?? null,
         editedAt: new Date(),
         vaultId: space.id,
       },
@@ -453,7 +453,7 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
 
   async setEditedBy(auth: Authenticator) {
     await this.update({
-      editedByUserId: auth.getNonNullableUser().id,
+      editedByUserId: auth.user()?.id ?? null,
       editedAt: new Date(),
     });
   }

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -98,7 +98,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     const dataSourceView = await DataSourceViewResource.model.create(
       {
         ...blob,
-        editedByUserId: auth.getNonNullableUser().id,
+        editedByUserId: auth.user()?.id ?? null,
         editedAt: new Date(),
         vaultId: space.id,
       },
@@ -425,7 +425,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
 
   async setEditedBy(auth: Authenticator) {
     await this.update({
-      editedByUserId: auth.getNonNullableUser().id,
+      editedByUserId: auth.user()?.id ?? null,
       editedAt: new Date(),
     });
   }

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -187,6 +187,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
         {
           model: User,
           as: "editedByUser",
+          required: false,
         },
       ];
     }

--- a/front/lib/resources/storage/models/data_source.ts
+++ b/front/lib/resources/storage/models/data_source.ts
@@ -15,7 +15,7 @@ export class DataSourceModel extends SoftDeletableModel<DataSourceModel> {
   declare updatedAt: CreationOptional<Date>;
 
   // Corresponds to the ID of the last user to configure the connection.
-  declare editedByUserId: ForeignKey<User["id"]>;
+  declare editedByUserId: ForeignKey<User["id"]> | null;
   declare editedAt: Date;
 
   declare name: string;
@@ -115,7 +115,7 @@ DataSourceModel.belongsTo(Workspace, {
 
 DataSourceModel.belongsTo(User, {
   as: "editedByUser",
-  foreignKey: { name: "editedByUserId", allowNull: false },
+  foreignKey: { name: "editedByUserId", allowNull: true },
 });
 
 DataSourceModel.belongsTo(SpaceModel, {

--- a/front/lib/resources/storage/models/data_source_view.ts
+++ b/front/lib/resources/storage/models/data_source_view.ts
@@ -15,7 +15,7 @@ export class DataSourceViewModel extends SoftDeletableModel<DataSourceViewModel>
   declare updatedAt: CreationOptional<Date>;
 
   // Corresponds to the ID of the last user to configure the connection.
-  declare editedByUserId: ForeignKey<User["id"]>;
+  declare editedByUserId: ForeignKey<User["id"]> | null;
   declare editedAt: Date;
 
   declare kind: DataSourceViewKind;
@@ -104,5 +104,5 @@ DataSourceViewModel.belongsTo(DataSourceModel, {
 
 DataSourceViewModel.belongsTo(User, {
   as: "editedByUser",
-  foreignKey: { name: "editedByUserId", allowNull: false },
+  foreignKey: { name: "editedByUserId", allowNull: true },
 });

--- a/front/lib/resources/types.ts
+++ b/front/lib/resources/types.ts
@@ -25,6 +25,7 @@ export type TypedIncludeable<M> = {
   [K in NonAttributeKeys<M>]: {
     model: ModelStatic<InferIncludeType<M>[K]>;
     as: K;
+    required?: boolean;
   };
 }[NonAttributeKeys<M>];
 

--- a/front/migrations/20240912_backfill_editedbyuser_id.ts
+++ b/front/migrations/20240912_backfill_editedbyuser_id.ts
@@ -8,7 +8,6 @@ import { makeScript } from "@app/scripts/helpers";
 
 makeScript({}, async ({ execute }, logger) => {
   const dataSources: DataSourceModel[] = await DataSourceModel.findAll({
-    // @ts-expect-error Model has been updated, editedByUserId is not nullable.
     where: {
       editedByUserId: {
         [Op.is]: null,

--- a/front/migrations/db/migration_123.sql
+++ b/front/migrations/db/migration_123.sql
@@ -1,0 +1,3 @@
+-- Migration created on Dec 02, 2024
+ALTER TABLE "data_sources"  ADD FOREIGN KEY ("editedByUserId") REFERENCES "users" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "data_source_views"  ADD FOREIGN KEY ("editedByUserId") REFERENCES "users" ("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/front/migrations/db/migration_123.sql
+++ b/front/migrations/db/migration_123.sql
@@ -1,3 +1,3 @@
 -- Migration created on Dec 02, 2024
-ALTER TABLE "data_sources"  ADD FOREIGN KEY ("editedByUserId") REFERENCES "users" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
-ALTER TABLE "data_source_views"  ADD FOREIGN KEY ("editedByUserId") REFERENCES "users" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "data_sources" ALTER COLUMN "editedByUserId" SET NOT NULL;
+ALTER TABLE "data_sources_views" ALTER COLUMN "editedByUserId" SET NOT NULL;


### PR DESCRIPTION
## Description

Conversation JIT data sources opens the requirement to create data sources from our public API (as part of attachment interactions with the Conversation). These request are generally attributed to a key, not a user. We therefore have to allow null editedByUser values in data_sources and data_source_views.

Also audited all uses of getNonNullableUser() to make sure they don't interfere with any API/v1 code pathes. Caugh the `trackDataSourceCreated` one, I don't believe there is any other.

r? @flvndvd 
cc @Fraggle 

## Risk

Low: tested in dev.

## Deploy Plan

- run migration
- deploy `front`