### PR TITLE
[extension] Reduce maximum capture size for better readability

### DIFF
--- a/extension/app/page.ts
+++ b/extension/app/page.ts
@@ -34,8 +34,8 @@ declare global {
 }
 (function () {
   const CAPTURE_DELAY = 150;
-  const MAX_PRIMARY_DIMENSION = 15000,
-    MAX_SECONDARY_DIMENSION = 4000,
+  const MAX_PRIMARY_DIMENSION = 5000,
+    MAX_SECONDARY_DIMENSION = 3000,
     MAX_AREA = MAX_PRIMARY_DIMENSION * MAX_SECONDARY_DIMENSION;
 
   if (!window.hasScreenCapturePage) {


### PR DESCRIPTION
## Description

Reduce maximum capture size. This make the picture (and the snippet) more readable by models. If screenshot exceed this, multiple files are created. 

## Risk

none

## Deploy Plan

publish extension