### PR TITLE
Ext: centralizing isSubmitting state in InputBar context to use it when uploading a content fragment

### DIFF
--- a/extension/app/src/components/input_bar/InputBarContainer.tsx
+++ b/extension/app/src/components/input_bar/InputBarContainer.tsx
@@ -145,7 +145,11 @@ export const InputBarContainer = ({
           onActionChange={(action) => {
             setIncludeTab(action === SendWithContentAction);
           }}
-          disabled={isSubmitting || editorService.isEmpty()}
+          disabled={
+            isSubmitting ||
+            editorService.isEmpty() ||
+            fileUploaderService.isProcessingFiles
+          }
         />
       </div>
     </div>


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/1728

-> Centralize isSubmitting state in InputBar context
-> Set it when uploading a content fragment so we can't send the convo while fragment was not uploaded yet. 

## Risk

Extension only.

## Deploy Plan

Nothing
