### PR TITLE
[Sparkle] Allow any reactnode description for page header

### DIFF
--- a/sparkle/src/components/Page.tsx
+++ b/sparkle/src/components/Page.tsx
@@ -33,7 +33,7 @@ export function Page({ children, variant = "normal" }: PageProps) {
 
 interface PageHeaderProps {
   title: React.ReactNode;
-  description?: string;
+  description?: React.ReactNode;
   icon?: ComponentType<{ className?: string }>;
 }
 


### PR DESCRIPTION
Description
---
Before, only string was allowed
Pre-requisite for https://github.com/dust-tt/tasks/issues/1736

Risk
---
na

Deploy
---
publish sparkle
