### PR TITLE
Do not try to upsert if a tool returned no content

### DIFF
--- a/front/lib/api/files/tool_output.ts
+++ b/front/lib/api/files/tool_output.ts
@@ -57,7 +57,8 @@ export async function internalCreateToolOutputCsvFile(
 
   await fileResource.markAsReady();
 
-  if (await isJITActionsEnabled(auth)) {
+  // If the tool returned no content, it makes no sense to upsert it to the data source
+  if (content && (await isJITActionsEnabled(auth))) {
     const r = await processAndUpsertToDataSource(auth, {
       file: fileResource,
       optionalContent: content,


### PR DESCRIPTION
## Description

Fix the error when the tool outputted nothing (for example, 0 rows via table query).

## Risk

None

## Deploy Plan

Deploy `front`