### PR TITLE
[front] - fix(assistant_builder): active tab

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -480,7 +480,11 @@ export default function AssistantBuilder({
                     assertNever(screen);
                 }
               })()}
-              <PrevNextButtons screen={screen} setScreen={setScreen} />
+              <PrevNextButtons
+                screen={screen}
+                setScreen={setScreen}
+                setCurrentTab={setCurrentTab}
+              />
             </div>
           }
           buttonsRightPanel={

--- a/front/components/assistant_builder/PrevNextButtons.tsx
+++ b/front/components/assistant_builder/PrevNextButtons.tsx
@@ -3,13 +3,17 @@ import React from "react";
 
 import type { BuilderScreen } from "@app/components/assistant_builder/types";
 
+interface PrevNextButtonsProps {
+  screen: BuilderScreen;
+  setScreen: (screen: BuilderScreen) => void;
+  setCurrentTab: (tab: string) => void;
+}
+
 export function PrevNextButtons({
   screen,
   setScreen,
-}: {
-  screen: BuilderScreen;
-  setScreen: (screen: BuilderScreen) => void;
-}) {
+  setCurrentTab,
+}: PrevNextButtonsProps) {
   return (
     <div className="flex py-6">
       {screen !== "instructions" && (
@@ -18,11 +22,9 @@ export function PrevNextButtons({
           size="md"
           variant="highlight"
           onClick={() => {
-            if (screen === "actions") {
-              setScreen("instructions");
-            } else if (screen === "naming") {
-              setScreen("actions");
-            }
+            const newScreen = screen === "actions" ? "instructions" : "actions";
+            setScreen(newScreen);
+            setCurrentTab(newScreen);
           }}
         />
       )}
@@ -33,11 +35,9 @@ export function PrevNextButtons({
           size="md"
           variant="highlight"
           onClick={() => {
-            if (screen === "instructions") {
-              setScreen("actions");
-            } else if (screen === "actions") {
-              setScreen("naming");
-            }
+            const newScreen = screen === "instructions" ? "actions" : "naming";
+            setScreen(newScreen);
+            setCurrentTab(newScreen);
           }}
         />
       )}


### PR DESCRIPTION
## Description

This PR fixes the assistant builder navigation tab which weren't properly updated when clicking on the `PrevNextButton`.

**References:**
- https://github.com/dust-tt/tasks/issues/1735

## Risk

Low

## Deploy Plan

Deploy `front`