### PR TITLE
Changed info on analytics card

### DIFF
--- a/front/components/workspace/Analytics.tsx
+++ b/front/components/workspace/Analytics.tsx
@@ -34,15 +34,12 @@ export function QuickInsights({ owner }: QuickInsightsProps) {
             className="w-full"
           />
           <Card
-            title="Active users"
-            subtitle="Daily Active Users"
+            title="Daily Active Users"
+            subtitle="Average on 7 days"
             content={
               <div className="flex flex-col gap-1">
                 <div className="text-lg font-semibold text-element-900">
                   {analytics.averageWeeklyDailyActiveUsers.count}
-                </div>
-                <div className="text-sm text-element-700">
-                  Average on 7 days
                 </div>
               </div>
             }


### PR DESCRIPTION
## Description

Changed the order of information on the cards following Jules' suggestion (DAU card).
From this : 
<img width="760" alt="image" src="https://github.com/user-attachments/assets/b7f49ed7-6bcf-434c-ac7c-49bb634898a2">
To this : 
<img width="428" alt="image" src="https://github.com/user-attachments/assets/e6308a8c-319e-40f2-997e-272629f66ce4">


## Risk

None, It's a minor change
