### PR TITLE
[connectors] Remove the `gdrive-` prefix from gdrive document IDs

### DIFF
--- a/connectors/migrations/20231109_incident_gdrive_non_deleted_files.ts
+++ b/connectors/migrations/20231109_incident_gdrive_non_deleted_files.ts
@@ -36,7 +36,7 @@ async function main() {
 
     const fileHash = files.reduce(
       (acc, f) => {
-        acc[f.dustFileId] = f.id;
+        acc[f.driveFileId] = f.id;
         return acc;
       },
       {} as { [key: string]: number }

--- a/connectors/migrations/20240529_clean_gdrive_folders.ts
+++ b/connectors/migrations/20240529_clean_gdrive_folders.ts
@@ -1,10 +1,7 @@
 import { QueryTypes } from "sequelize";
 
 import { getGoogleDriveObject } from "@connectors/connectors/google_drive/lib/google_drive_api";
-import {
-  getAuthObject,
-  getDocumentId,
-} from "@connectors/connectors/google_drive/temporal/utils";
+import { getAuthObject } from "@connectors/connectors/google_drive/temporal/utils";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import {
   GoogleDriveFiles,
@@ -104,7 +101,6 @@ async function main() {
         driveFileId: folderId,
         name: file.name,
         mimeType: file.mimeType,
-        dustFileId: getDocumentId(folderId),
       });
     }
   }

--- a/connectors/migrations/20240802_table_parents.ts
+++ b/connectors/migrations/20240802_table_parents.ts
@@ -4,6 +4,7 @@ import { Op } from "sequelize";
 import { v4 as uuidv4 } from "uuid";
 
 import { getLocalParents as getGoogleParents } from "@connectors/connectors/google_drive/lib";
+import { getTableId } from "@connectors/connectors/google_drive/temporal/utils";
 import { getParents as getMicrosoftParents } from "@connectors/connectors/microsoft/temporal/file";
 import { getParents as getNotionParents } from "@connectors/connectors/notion/lib/parents";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
@@ -86,14 +87,14 @@ export async function googleTables(
     },
   });
   for (const file of csvFiles) {
-    const { driveFileId, dustFileId, connectorId } = file;
+    const { driveFileId, connectorId } = file;
 
     const dataSourceConfig = dataSourceConfigFromConnector(connector);
 
     const parents = await getGoogleParents(connectorId, driveFileId, memo);
     await updateParents({
       dataSourceConfig,
-      tableId: dustFileId,
+      tableId: getTableId(driveFileId),
       parents,
       execute,
       logger,

--- a/connectors/migrations/db/migration_40.sql
+++ b/connectors/migrations/db/migration_40.sql
@@ -1,0 +1,2 @@
+-- Migration created on Dec 03, 2024
+ALTER TABLE "public"."google_drive_files" DROP COLUMN "dustFileId";

--- a/connectors/src/connectors/google_drive/lib/cli.ts
+++ b/connectors/src/connectors/google_drive/lib/cli.ts
@@ -10,7 +10,6 @@ import { launchGoogleDriveIncrementalSyncWorkflow } from "@connectors/connectors
 import { MIME_TYPES_TO_EXPORT } from "@connectors/connectors/google_drive/temporal/mime_types";
 import {
   getAuthObject,
-  getDocumentId,
   getDriveClient,
 } from "@connectors/connectors/google_drive/temporal/utils";
 import { throwOnError } from "@connectors/lib/cli";
@@ -162,7 +161,6 @@ export const google_drive = async ({
       } else {
         await GoogleDriveFiles.create({
           driveFileId: args.fileId,
-          dustFileId: getDocumentId(args.fileId),
           name: "unknown",
           mimeType: "unknown",
           connectorId: connector.id,

--- a/connectors/src/connectors/google_drive/lib/permissions.ts
+++ b/connectors/src/connectors/google_drive/lib/permissions.ts
@@ -2,7 +2,6 @@ import {
   isGoogleDriveFolder,
   isGoogleDriveSpreadSheetFile,
 } from "@connectors/connectors/google_drive/temporal/mime_types";
-import { getDocumentId } from "@connectors/connectors/google_drive/temporal/utils";
 import type { GoogleDriveFiles } from "@connectors/lib/models/google_drive";
 
 export function getPermissionViewType(file: GoogleDriveFiles) {
@@ -18,5 +17,5 @@ export function getGoogleDriveEntityDocumentId(file: GoogleDriveFiles) {
     return null;
   }
 
-  return getDocumentId(file.driveFileId);
+  return file.driveFileId;
 }

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -1,8 +1,7 @@
 import type { ModelId } from "@dust-tt/types";
 import { uuid4 } from "@temporalio/workflow";
 import type { drive_v3 } from "googleapis";
-import type { GaxiosResponse } from "googleapis-common";
-import type { OAuth2Client } from "googleapis-common";
+import type { GaxiosResponse, OAuth2Client } from "googleapis-common";
 import { GaxiosError } from "googleapis-common";
 import StatsD from "hot-shots";
 import PQueue from "p-queue";
@@ -20,7 +19,6 @@ import { deleteSpreadsheet } from "@connectors/connectors/google_drive/temporal/
 import {
   driveObjectToDustType,
   getAuthObject,
-  getDocumentId,
   getDriveClient,
   getMyDriveIdCached,
 } from "@connectors/connectors/google_drive/temporal/utils";
@@ -470,7 +468,6 @@ export async function incrementalSync(
       if (driveFile.mimeType === "application/vnd.google-apps.folder") {
         await GoogleDriveFiles.upsert({
           connectorId: connectorId,
-          dustFileId: getDocumentId(driveFile.id),
           driveFileId: file.id,
           name: file.name,
           mimeType: file.mimeType,
@@ -747,7 +744,7 @@ export async function deleteFile(googleDriveFile: GoogleDriveFiles) {
     googleDriveFile.mimeType !== "application/vnd.google-apps.folder"
   ) {
     const dataSourceConfig = dataSourceConfigFromConnector(connector);
-    await deleteFromDataSource(dataSourceConfig, googleDriveFile.dustFileId);
+    await deleteFromDataSource(dataSourceConfig, googleDriveFile.driveFileId);
   }
   const folder = await GoogleDriveFolders.findOne({
     where: {
@@ -786,7 +783,6 @@ export async function markFolderAsVisited(
 
   await GoogleDriveFiles.upsert({
     connectorId: connectorId,
-    dustFileId: getDocumentId(driveFileId),
     driveFileId: file.id,
     name: file.name,
     mimeType: file.mimeType,

--- a/connectors/src/connectors/google_drive/temporal/file.ts
+++ b/connectors/src/connectors/google_drive/temporal/file.ts
@@ -13,8 +13,8 @@ import {
 } from "@connectors/connectors/google_drive/temporal/mime_types";
 import { syncSpreadSheet } from "@connectors/connectors/google_drive/temporal/spreadsheets";
 import {
-  getDocumentId,
   getDriveClient,
+  getTableId,
 } from "@connectors/connectors/google_drive/temporal/utils";
 import {
   handleCsvFile,
@@ -187,7 +187,7 @@ async function handleFileExport(
 
     result = await handleCsvFile({
       data: res.data,
-      tableId: getDocumentId(file.id),
+      tableId: getTableId(file.id),
       fileName: file.name || "",
       maxDocumentLen,
       localLogger,

--- a/connectors/src/connectors/google_drive/temporal/utils.ts
+++ b/connectors/src/connectors/google_drive/temporal/utils.ts
@@ -9,7 +9,7 @@ import { getOAuthConnectionAccessTokenWithThrow } from "@connectors/lib/oauth";
 import logger from "@connectors/logger/logger";
 import type { GoogleDriveObjectType } from "@connectors/types/google_drive";
 
-export function getDocumentId(driveFileId: string): string {
+export function getTableId(driveFileId: string): string {
   return `gdrive-${driveFileId}`;
 }
 

--- a/connectors/src/lib/models/google_drive.ts
+++ b/connectors/src/lib/models/google_drive.ts
@@ -123,7 +123,6 @@ export class GoogleDriveFiles extends Model<
   declare lastUpsertedTs: Date | null;
   declare skipReason: string | null;
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
-  declare dustFileId: string;
   declare driveFileId: string;
   declare name: string;
   declare mimeType: string;
@@ -160,10 +159,6 @@ GoogleDriveFiles.init(
     },
     connectorId: {
       type: DataTypes.INTEGER,
-      allowNull: false,
-    },
-    dustFileId: {
-      type: DataTypes.STRING,
       allowNull: false,
     },
     driveFileId: {


### PR DESCRIPTION
## Description

- This PR aims at removing the prefix `gdrive-` in upserted document IDs.
- This change makes the column `dustFileId` of `google_drive_files` obsolete.
- Part of https://github.com/dust-tt/dust/issues/9069
- No change for the tables (to followup).

## Risk

- Migration easily (but ~slowly) revertable since `dustFileId` is `gdrive-${driveFileId}`.
- At worst, it duplicates documents.

## Deploy Plan

- Merge https://github.com/dust-tt/dust/pull/9079 first.
- Run migration.
- Deploy connectors.
