### PR TITLE
[core] document upserts

### DIFF
--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -2683,10 +2683,12 @@ struct FoldersUpsertPayload {
 }
 
 async fn folders_upsert(
-    Path((_, data_source_id)): Path<(i64, String)>,
+    Path((project_id, data_source_id)): Path<(i64, String)>,
     State(state): State<Arc<APIState>>,
     Json(payload): Json<FoldersUpsertPayload>,
 ) -> (StatusCode, Json<APIResponse>) {
+    let project = project::Project::new_from_id(project_id);
+
     let folder = Folder::new(
         &data_source_id,
         &payload.folder_id.clone(),
@@ -2695,7 +2697,11 @@ async fn folders_upsert(
         payload.parents,
     );
 
-    match state.store.upsert_data_source_folder(&folder).await {
+    match state
+        .store
+        .upsert_data_source_folder(&project, &data_source_id, &folder)
+        .await
+    {
         Err(e) => {
             return error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -1608,6 +1608,8 @@ struct DataSourcesDocumentsUpsertPayload {
     section: Section,
     credentials: run::Credentials,
     light_document_output: Option<bool>,
+    title: Option<String>,
+    mime_type: Option<String>,
 }
 
 async fn data_sources_documents_upsert(
@@ -1646,6 +1648,8 @@ async fn data_sources_documents_upsert(
                         state.store.clone(),
                         state.qdrant_clients.clone(),
                         &payload.document_id,
+                        payload.title,
+                        payload.mime_type,
                         payload.timestamp,
                         &payload.tags,
                         &payload.parents,
@@ -2679,14 +2683,11 @@ struct FoldersUpsertPayload {
 }
 
 async fn folders_upsert(
-    Path((project_id, data_source_id)): Path<(i64, String)>,
+    Path((_, data_source_id)): Path<(i64, String)>,
     State(state): State<Arc<APIState>>,
     Json(payload): Json<FoldersUpsertPayload>,
 ) -> (StatusCode, Json<APIResponse>) {
-    let project = project::Project::new_from_id(project_id);
-
     let folder = Folder::new(
-        &project,
         &data_source_id,
         &payload.folder_id.clone(),
         payload.timestamp.unwrap_or(utils::now()),

--- a/core/src/data_sources/folder.rs
+++ b/core/src/data_sources/folder.rs
@@ -1,12 +1,9 @@
 use serde::{Deserialize, Serialize};
 
-use crate::project::Project;
-
 use super::node::{Node, NodeType};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Folder {
-    project: Project,
     data_source_id: String,
     folder_id: String,
     timestamp: u64,
@@ -19,7 +16,6 @@ pub const FOLDER_MIMETYPE: &str = "application/vnd.dust.folder";
 
 impl Folder {
     pub fn new(
-        project: &Project,
         data_source_id: &str,
         folder_id: &str,
         timestamp: u64,
@@ -27,7 +23,6 @@ impl Folder {
         parents: Vec<String>,
     ) -> Self {
         Folder {
-            project: project.clone(),
             data_source_id: data_source_id.to_string(),
             folder_id: folder_id.to_string(),
             timestamp,
@@ -38,7 +33,6 @@ impl Folder {
 
     pub fn from_node(node: &Node) -> Self {
         Folder::new(
-            node.project(),
             node.data_source_id(),
             node.node_id(),
             node.timestamp(),
@@ -47,9 +41,6 @@ impl Folder {
         )
     }
 
-    pub fn project(&self) -> &Project {
-        &self.project
-    }
     pub fn data_source_id(&self) -> &str {
         &self.data_source_id
     }
@@ -70,7 +61,6 @@ impl Folder {
 impl From<Node> for Folder {
     fn from(node: Node) -> Self {
         Folder::new(
-            node.project(),
             node.data_source_id(),
             node.node_id(),
             node.timestamp(),
@@ -83,7 +73,6 @@ impl From<Node> for Folder {
 impl From<Folder> for Node {
     fn from(folder: Folder) -> Self {
         Node::new(
-            &folder.project,
             &folder.data_source_id,
             &folder.folder_id,
             NodeType::Folder,

--- a/core/src/data_sources/node.rs
+++ b/core/src/data_sources/node.rs
@@ -1,7 +1,5 @@
 use serde::{Deserialize, Serialize};
 
-use crate::project::Project;
-
 #[derive(Debug, Clone, Serialize, PartialEq, Deserialize, Copy)]
 pub enum NodeType {
     Document,
@@ -11,7 +9,6 @@ pub enum NodeType {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Node {
-    project: Project,
     data_source_id: String,
     node_id: String,
     node_type: NodeType,
@@ -23,7 +20,6 @@ pub struct Node {
 
 impl Node {
     pub fn new(
-        project: &Project,
         data_source_id: &str,
         node_id: &str,
         node_type: NodeType,
@@ -33,7 +29,6 @@ impl Node {
         parents: Vec<String>,
     ) -> Self {
         Node {
-            project: project.clone(),
             data_source_id: data_source_id.to_string(),
             node_id: node_id.to_string(),
             node_type,
@@ -44,9 +39,6 @@ impl Node {
         }
     }
 
-    pub fn project(&self) -> &Project {
-        &self.project
-    }
     pub fn data_source_id(&self) -> &str {
         &self.data_source_id
     }

--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -222,7 +222,6 @@ impl Table {
 impl From<Table> for Node {
     fn from(table: Table) -> Node {
         Node::new(
-            &table.project,
             &table.data_source_id,
             &table.table_id,
             NodeType::Table,

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -3026,8 +3026,14 @@ impl Store for PostgresStore {
         Ok(())
     }
 
-    async fn upsert_data_source_folder(&self, folder: &Folder) -> Result<()> {
-        let data_source_id = folder.data_source_id();
+    async fn upsert_data_source_folder(
+        &self,
+        project: &Project,
+        data_source_id: &str,
+        folder: &Folder,
+    ) -> Result<()> {
+        let project_id = project.project_id();
+        let data_source_id = data_source_id.to_string();
 
         let pool = self.pool.clone();
         let mut c = pool.get().await?;
@@ -3038,8 +3044,8 @@ impl Store for PostgresStore {
         let tx = c.transaction().await?;
         let r = tx
             .query(
-                "SELECT id FROM data_sources WHERE data_source_id = $1 LIMIT 1",
-                &[&data_source_id],
+                "SELECT id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
+                &[&project_id, &data_source_id],
             )
             .await?;
         let data_source_row_id: i64 = match r.len() {

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -2019,7 +2019,7 @@ impl Store for PostgresStore {
         };
 
         let stmt = tx
-            .prepare("DELETE FROM data_sources_nodes WHERE data_source = $1 AND node_id = $2 AND folder IS NOT NULL")
+            .prepare("DELETE FROM data_sources_nodes WHERE data_source = $1 AND node_id = $2 AND document IS NOT NULL")
             .await?;
         let _ = tx
             .query(&stmt, &[&data_source_row_id, &document_id])
@@ -2071,7 +2071,7 @@ impl Store for PostgresStore {
 
         if status == "active" {
             let stmt = c
-                .prepare("DELETE FROM data_sources_nodes WHERE data_source = $1 AND node_id = $2 AND folder IS NOT NULL")
+                .prepare("DELETE FROM data_sources_nodes WHERE data_source = $1 AND node_id = $2 AND document IS NOT NULL")
                 .await?;
 
             let _ = c.query(&stmt, &[&data_source_row_id, &document_id]).await?;

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -269,7 +269,12 @@ pub trait Store {
         table_id: &str,
     ) -> Result<()>;
     // Folders
-    async fn upsert_data_source_folder(&self, folder: &Folder) -> Result<()>;
+    async fn upsert_data_source_folder(
+        &self,
+        project: &Project,
+        data_source_id: &str,
+        folder: &Folder,
+    ) -> Result<()>;
     async fn load_data_source_folder(
         &self,
         project: &Project,

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -136,6 +136,8 @@ pub trait Store {
         project: &Project,
         data_source_id: &str,
         document: &Document,
+        title: Option<String>,
+        mime_type: Option<String>,
     ) -> Result<()>;
     async fn update_data_source_document_tags(
         &self,


### PR DESCRIPTION
## Description

Handle data_source_nodes when upserting/delete documents. Title and mimetypes are optional for now. As for tables, we create the node entry only if mimetype and title are passed. Node entry points to the active document - (not superseded/deleted), 

Also added folders deletion when scrubbing data_source, and removed project from Folder object (as it's not store in db or used)

## Risk

Issue when manipulating documents, can be reverted

## Deploy Plan

deploy core
