### PR TITLE
fixed wrong parentId

### DIFF
--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -351,11 +351,6 @@ async function handler(
       }
 
       // Enforce that the table is a parent of itself by default.
-      const parentsWithTableId =
-        parents?.includes(tableId) && parents[0] === tableId
-          ? parents
-          : [tableId, ...(parents || []).filter((p) => p !== tableId)];
-
       const upsertRes = await coreAPI.upsertTable({
         projectId: dataSource.dustAPIProjectId,
         dataSourceId: dataSource.dustAPIDataSourceId,
@@ -365,7 +360,7 @@ async function handler(
         timestamp: timestamp ?? null,
         tags: tags || [],
         // Table is a parent of itself by default.
-        parents: parentsWithTableId,
+        parents: parents || [tableId],
         remoteDatabaseTableId: remoteDatabaseTableId ?? null,
         remoteDatabaseSecretId: remoteDatabaseSecretId ?? null,
         title,


### PR DESCRIPTION
## Description

id for connectors should not be prepended because it has e.g. a 'notion-' prefix which makes it invalid

## Risk
Break public table upload

## Deploy Plan
deploy front
