### PR TITLE
slack attachments: use file API

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -339,14 +339,6 @@ async function answerMessage(
     userType: slackUserInfo.is_bot ? "bot" : "user",
   });
 
-  const buildContentFragmentRes = await makeContentFragment(
-    slackClient,
-    slackChannel,
-    slackThreadTs || slackMessageTs,
-    lastSlackChatBotMessage?.messageTs || slackThreadTs || slackMessageTs,
-    connector
-  );
-
   if (!DUST_FRONT_API) {
     throw new Error("DUST_FRONT_API environment variable is not defined");
   }
@@ -374,6 +366,16 @@ async function answerMessage(
       useLocalInDev: false,
       urlOverride: DUST_FRONT_API,
     }
+  );
+
+  const buildContentFragmentRes = await makeContentFragment(
+    slackClient,
+    dustAPI,
+    slackChannel,
+    slackThreadTs || slackMessageTs,
+    lastSlackChatBotMessage?.messageTs || slackThreadTs || slackMessageTs,
+    connector,
+    lastSlackChatBotMessage?.conversationId || null
   );
 
   const agentConfigurationsRes = await dustAPI.getAgentConfigurations();
@@ -690,10 +692,12 @@ export async function getBotEnabled(
 
 async function makeContentFragment(
   slackClient: WebClient,
+  dustAPI: DustAPI,
   channelId: string,
   threadTs: string,
   startingAtTs: string | null,
-  connector: ConnectorResource
+  connector: ConnectorResource,
+  conversationId: string | null
 ): Promise<Result<PublicPostContentFragmentRequestBody | null, Error>> {
   let allMessages: MessageElement[] = [];
 
@@ -770,11 +774,26 @@ async function makeContentFragment(
   // Prepend $url to the content to make it available to the model.
   const section = `$url: ${url}\n${sectionFullText(content)}`;
 
+  const contentType = "text/vnd.dust.attachment.slack.thread";
+  const fileName = `slack_thread-${channel.channel.name}-${threadTs}.txt`;
+
+  const fileRes = await dustAPI.uploadFile({
+    contentType,
+    fileName,
+    fileSize: section.length,
+    useCase: "conversation",
+    useCaseMetadata: conversationId ? { conversationId } : undefined,
+    fileObject: new File([section], fileName, { type: contentType }),
+  });
+
+  if (fileRes.isErr()) {
+    return new Err(new Error(fileRes.error.message));
+  }
+
   return new Ok({
     title: `Thread content from #${channel.channel.name}`,
-    content: section,
     url: url,
-    contentType: "dust-application/slack",
+    fileId: fileRes.value.id,
     context: null,
   });
 }

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -28,6 +28,7 @@ import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 
 const ENABLE_LLM_SNIPPETS = false;
 
@@ -514,7 +515,7 @@ export async function processAndUpsertToDataSource(
       plan: auth.getNonNullablePlan(),
       owner: auth.getNonNullableWorkspace(),
       space: conversationsSpace,
-      name: "Conversation data source",
+      name: generateRandomModelSId("conv"),
       description: "Files uploaded to conversation",
       conversationId: conversation.id,
     });

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -27,7 +27,6 @@ import { cloneBaseConfig, DustProdActionRegistry } from "@app/lib/registry";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
 
 const ENABLE_LLM_SNIPPETS = false;
@@ -209,10 +208,10 @@ const upsertDocumentToDatasource: ProcessingFunction = async ({
   content,
   dataSource,
 }) => {
-  const documentId = file.sId; // Use the file id as the document id to make it easy to track the document back to the file.
-  const sourceUrl = file.getPublicUrl(auth);
+  // Use the file id as the document id to make it easy to track the document back to the file.
+  const documentId = file.sId;
+  const sourceUrl = file.getPrivateUrl(auth);
 
-  // TODO(JIT) note, upsertDocument do not call runPostUpsertHooks (seems used for document tracker)
   const upsertDocumentRes = await upsertDocument({
     name: documentId,
     source_url: sourceUrl,
@@ -509,13 +508,13 @@ export async function processAndUpsertToDataSource(
     const conversationsSpace =
       await SpaceResource.fetchWorkspaceConversationsSpace(auth);
 
-    // IMPORTANT: never use the conversation sID in the name or description, as conversation sIDs are used as secrets to share the conversation within the workspace users.
-    const name = generateRandomModelSId("conv-");
+    // IMPORTANT: never use the conversation sID in the name or description, as conversation sIDs
+    // are used as secrets to share the conversation within the workspace users.
     const r = await createDataSourceWithoutProvider(auth, {
       plan: auth.getNonNullablePlan(),
       owner: auth.getNonNullableWorkspace(),
       space: conversationsSpace,
-      name: name,
+      name: "Conversation data source",
       description: "Files uploaded to conversation",
       conversationId: conversation.id,
     });

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -27,8 +27,8 @@ import { cloneBaseConfig, DustProdActionRegistry } from "@app/lib/registry";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import logger from "@app/logger/logger";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+import logger from "@app/logger/logger";
 
 const ENABLE_LLM_SNIPPETS = false;
 


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/dust/issues/8986

Use file API with slack attachment
Fixes some issues with the upsertion of attachments

## Risk

Fully texted in dev (through slack, with workflows and as user)

## Deploy Plan

- deploy `front`
- deploy `connectors`