### PR TITLE
Move transcripts and email_trigger to use file for attachments

### DIFF
--- a/front/lib/api/files/tool_output.ts
+++ b/front/lib/api/files/tool_output.ts
@@ -1,7 +1,5 @@
-import { Readable } from "stream";
-import { pipeline } from "stream/promises";
-
 import { isJITActionsEnabled } from "@app/lib/api/assistant/jit_actions";
+import { processAndStoreFile } from "@app/lib/api/files/upload";
 import { processAndUpsertToDataSource } from "@app/lib/api/files/upsert";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -36,26 +34,7 @@ export async function internalCreateToolOutputCsvFile(
     },
   });
 
-  // Write both the "original" and "processed" versions simultaneously
-
-  await Promise.all([
-    pipeline(
-      Readable.from(content),
-      fileResource.getWriteStream({
-        auth,
-        version: "original",
-      })
-    ),
-    pipeline(
-      Readable.from(content),
-      fileResource.getWriteStream({
-        auth,
-        version: "processed",
-      })
-    ),
-  ]);
-
-  await fileResource.markAsReady();
+  await processAndStoreFile(auth, { file: fileResource, reqOrString: content });
 
   // If the tool returned no content, it makes no sense to upsert it to the data source
   if (content && (await isJITActionsEnabled(auth))) {

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -234,7 +234,8 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
       const file = await FileResource.fetchByModelId(this.fileId);
       fileSid = file?.sId ?? null;
 
-      // Note: For CSV files outputted by tools, we have a "snippet" version of the output with the first rows stored in GCP, maybe it's better than our "summary" snippet stored on File.
+      // Note: For CSV files outputted by tools, we have a "snippet" version of the output with the
+      // first rows stored in GCP, maybe it's better than our "summary" snippet stored on File.
       // Need more testing, for now we are using the "summary" snippet.
       snippet = file?.snippet ?? null;
     }

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -1,9 +1,7 @@
 import type { PostContentFragmentResponseType } from "@dust-tt/client";
 import { PublicPostContentFragmentRequestBodySchema } from "@dust-tt/client";
-import type {WithAPIErrorResponse} from "@dust-tt/types";
-import {
-  isContentFragmentInputWithContentType
-} from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
+import { isContentFragmentInputWithContentType } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import {

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -1,6 +1,9 @@
 import type { PostContentFragmentResponseType } from "@dust-tt/client";
 import { PublicPostContentFragmentRequestBodySchema } from "@dust-tt/client";
-import type { WithAPIErrorResponse } from "@dust-tt/types";
+import {
+  isContentFragmentInputWithContentType,
+  type WithAPIErrorResponse,
+} from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
@@ -12,6 +15,7 @@ import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/hel
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
+import logger from "@app/logger/logger";
 
 /**
  * @swagger
@@ -114,6 +118,17 @@ async function handler(
         r.data.contentType = normalizedContentType;
       }
       const { context, ...contentFragment } = r.data;
+
+      if (isContentFragmentInputWithContentType(contentFragment)) {
+        logger.warn(
+          {
+            workspaceId: auth.getNonNullableWorkspace().sId,
+            conversationId: conversation.sId,
+            endpoint: "content_fragment",
+          },
+          "Public API: ContentFragmentInputWithContentType"
+        );
+      }
 
       const contentFragmentRes = await postNewContentFragment(
         auth,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -1,8 +1,8 @@
 import type { PostContentFragmentResponseType } from "@dust-tt/client";
 import { PublicPostContentFragmentRequestBodySchema } from "@dust-tt/client";
+import type {WithAPIErrorResponse} from "@dust-tt/types";
 import {
-  isContentFragmentInputWithContentType,
-  type WithAPIErrorResponse,
+  isContentFragmentInputWithContentType
 } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -14,8 +14,8 @@ import {
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { apiError } from "@app/logger/withlogging";
 import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
 
 /**
  * @swagger

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -8,7 +8,11 @@ import type {
   UserMessageType,
   WithAPIErrorResponse,
 } from "@dust-tt/types";
-import { ConversationError, isEmptyString } from "@dust-tt/types";
+import {
+  ConversationError,
+  isContentFragmentInputWithContentType,
+  isEmptyString,
+} from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
@@ -23,6 +27,7 @@ import { postUserMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import { maybeUpsertFileAttachment } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 
 /**
@@ -177,6 +182,18 @@ async function handler(
         });
 
         const { context, ...cf } = resolvedFragment;
+
+        if (isContentFragmentInputWithContentType(cf)) {
+          logger.warn(
+            {
+              workspaceId: auth.getNonNullableWorkspace().sId,
+              conversationId: conversation.sId,
+              endpoint: "conversation",
+            },
+            "Public API: ContentFragmentInputWithContentType"
+          );
+        }
+
         const cfRes = await postNewContentFragment(auth, conversation, cf, {
           username: context?.username || null,
           fullName: context?.fullName || null,

--- a/front/pages/api/v1/w/[wId]/files/[fileId].ts
+++ b/front/pages/api/v1/w/[wId]/files/[fileId].ts
@@ -99,7 +99,7 @@ async function handler(
     }
 
     case "POST": {
-      const r = await processAndStoreFile(auth, { file, req });
+      const r = await processAndStoreFile(auth, { file, reqOrString: req });
 
       if (r.isErr()) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/files/[fileId].ts
+++ b/front/pages/api/w/[wId]/files/[fileId].ts
@@ -127,7 +127,7 @@ async function handler(
     }
 
     case "POST": {
-      const r = await processAndStoreFile(auth, { file, req });
+      const r = await processAndStoreFile(auth, { file, reqOrString: req });
 
       if (r.isErr()) {
         return apiError(req, res, {


### PR DESCRIPTION
## Description

- Move labs transcripts to creating files for content fragments
- Move email_triggers to creating files for content fragments
- add support for passing a string in `processAndStoreFile`
- Log API/v1 usage of `ContentFragmentInputWithContentType`

## Risk

Only risk is labs transcripts

## Deploy Plan

- deploy `front`