### PR TITLE
Upg: move maybeUpsertFileAttachment() in postNewContentFragment() as a fallback

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -66,6 +66,7 @@ import {
   makeAgentMentionsRateLimitKeyForWorkspace,
   makeMessageRateLimitKeyForWorkspace,
 } from "@app/lib/api/assistant/rate_limits";
+import { maybeUpsertFileAttachment } from "@app/lib/api/files/utils";
 import { Authenticator } from "@app/lib/auth";
 import { AgentMessageContent } from "@app/lib/models/assistant/agent_message_content";
 import {
@@ -1756,6 +1757,11 @@ export async function postNewContentFragment(
   if (!canAccessConversation(auth, conversation)) {
     return new Err(new ConversationError("conversation_access_restricted"));
   }
+
+  await maybeUpsertFileAttachment(auth, {
+    contentFragments: [cf],
+    conversation,
+  });
 
   const messageId = generateRandomModelSId();
 

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -21,7 +21,6 @@ import {
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { postUserMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
-import { maybeUpsertFileAttachment } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
@@ -171,11 +170,6 @@ async function handler(
             url: req.url,
           });
         }
-
-        await maybeUpsertFileAttachment(auth, {
-          contentFragments: [resolvedFragment],
-          conversation,
-        });
 
         const { context, ...cf } = resolvedFragment;
         const cfRes = await postNewContentFragment(auth, conversation, cf, {

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -22,7 +22,6 @@ import {
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { postUserMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { maybeUpsertFileAttachment } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 
@@ -87,11 +86,6 @@ async function handler(
       };
 
       if (contentFragments.length > 0) {
-        await maybeUpsertFileAttachment(auth, {
-          contentFragments,
-          conversation,
-        });
-
         const newContentFragmentsRes = await Promise.all(
           contentFragments.map((contentFragment) => {
             return postNewContentFragment(auth, conversation, contentFragment, {


### PR DESCRIPTION
## Description

Make sure that all fragment with fileId have a conversationId metadata and upserted correctly if it wasn't set correctly by the client.

## Risk

None

## Deploy Plan

Deploy `front`