### PR TITLE
Upg: hide conversations datasource in poke, add button on debug page, show tables in datasource

### DIFF
--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -10,6 +10,7 @@ import type {
   CreationAttributes,
   ModelStatic,
   Transaction,
+  WhereOptions,
 } from "sequelize";
 import { Op } from "sequelize";
 
@@ -333,12 +334,19 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
 
   static async listByWorkspace(
     auth: Authenticator,
-    options?: FetchDataSourceOptions
+    options?: FetchDataSourceOptions,
+    includeConversationDataSources?: boolean
   ): Promise<DataSourceResource[]> {
+    const where: WhereOptions<DataSourceModel> = {
+      workspaceId: auth.getNonNullableWorkspace().id,
+    };
+    if (!includeConversationDataSources) {
+      where["conversationId"] = {
+        [Op.is]: undefined,
+      };
+    }
     return this.baseFetch(auth, options, {
-      where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
-      },
+      where,
     });
   }
 

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -237,7 +237,8 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
 
   static async listByWorkspace(
     auth: Authenticator,
-    fetchDataSourceViewOptions?: FetchDataSourceViewOptions
+    fetchDataSourceViewOptions?: FetchDataSourceViewOptions,
+    includeConversationDataSources?: boolean
   ) {
     const dataSourceViews = await this.baseFetch(
       auth,
@@ -249,7 +250,11 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
       }
     );
 
-    return dataSourceViews.filter((dsv) => dsv.canList(auth));
+    return dataSourceViews.filter(
+      (dsv) =>
+        (!dsv.space.isConversations() || includeConversationDataSources) &&
+        dsv.canList(auth)
+    );
   }
 
   static async listBySpace(

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/tables/index.ts
@@ -1,0 +1,107 @@
+import type { CoreAPITable, WithAPIErrorResponse } from "@dust-tt/types";
+import { CoreAPI } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
+import config from "@app/lib/api/config";
+import { Authenticator, getSession } from "@app/lib/auth";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+
+export type GetTablesResponseBody = {
+  tables: Array<CoreAPITable>;
+  total: number;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetTablesResponseBody>>
+): Promise<void> {
+  const session = await getSession(req, res);
+  const auth = await Authenticator.fromSuperUserSession(
+    session,
+    req.query.wId as string
+  );
+
+  if (!auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "user_not_found",
+        message: "Could not find the user.",
+      },
+    });
+  }
+
+  const { dsId } = req.query;
+  if (typeof dsId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid path parameters.",
+      },
+    });
+  }
+
+  const dataSource = await DataSourceResource.fetchById(auth, dsId);
+  if (!dataSource) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "The data source you requested was not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const limit = req.query.limit ? parseInt(req.query.limit as string) : 10;
+      const offset = req.query.offset
+        ? parseInt(req.query.offset as string)
+        : 0;
+
+      const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+      const tables = await coreAPI.getTables(
+        {
+          projectId: dataSource.dustAPIProjectId,
+          dataSourceId: dataSource.dustAPIDataSourceId,
+        },
+        {
+          limit,
+          offset,
+        }
+      );
+
+      if (tables.isErr()) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "internal_server_error",
+            message:
+              "We encountered an error while fetching the data source tables.",
+            data_source_error: tables.error,
+          },
+        });
+      }
+
+      res.status(200).json({
+        tables: tables.value.tables,
+        total: tables.value.total,
+      });
+      return;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthentication(handler);

--- a/front/poke/swr/index.ts
+++ b/front/poke/swr/index.ts
@@ -10,6 +10,7 @@ import useSWR from "swr";
 import { fetcher } from "@app/lib/swr/swr";
 import type { PokeFetchAssistantTemplateResponse } from "@app/pages/api/poke/templates/[tId]";
 import type { GetDocumentsResponseBody } from "@app/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/documents";
+import type { GetTablesResponseBody } from "@app/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/tables";
 import type { FetchAssistantTemplatesResponse } from "@app/pages/api/w/[wId]/assistant/builder/templates";
 
 export function usePokeAssistantTemplates() {
@@ -95,5 +96,26 @@ export function useDocuments(
     isDocumentsLoading: !error && !data,
     isDocumentsError: error,
     mutateDocuments: mutate,
+  };
+}
+
+export function useTables(
+  owner: LightWorkspaceType,
+  dataSource: DataSourceType,
+  limit: number,
+  offset: number
+) {
+  const tablesFetcher: Fetcher<GetTablesResponseBody> = fetcher;
+  const { data, error, mutate } = useSWR(
+    `/api/poke/workspaces/${owner.sId}/data_sources/${dataSource.sId}/tables?limit=${limit}&offset=${offset}`,
+    tablesFetcher
+  );
+
+  return {
+    tables: useMemo(() => (data ? data.tables : []), [data]),
+    total: data ? data.total : 0,
+    isTablesLoading: !error && !data,
+    isTablesError: error,
+    mutateTables: mutate,
   };
 }


### PR DESCRIPTION
## Description

Was a bit more involved than expected as we didn't show the tables in poke datasource.
I decided to default to NOT showing any conversation related datasources and datasource views when `listByWorkspace()` is called which I believe is a good thing™ (i checked all callers and tested JIT again).

## Risk

Low

## Deploy Plan

Deploy `front`