### PR TITLE
[connectors] fix(Zendesk) - correctly return `null` on Zendesk 404 errors

### DIFF
--- a/connectors/src/connectors/zendesk/lib/errors.ts
+++ b/connectors/src/connectors/zendesk/lib/errors.ts
@@ -29,6 +29,10 @@ export function isNodeZendeskForbiddenError(
   );
 }
 
+export function isZendeskForbiddenError(err: unknown): err is ZendeskApiError {
+  return err instanceof ZendeskApiError && err.status === 403;
+}
+
 export function isZendeskExpiredCursorError(
   err: unknown
 ): err is ZendeskApiError {
@@ -42,7 +46,7 @@ export function isZendeskExpiredCursorError(
   );
 }
 
-export function isZendeskEpipeError(err: unknown): err is NodeZendeskError {
+export function isNodeZendeskEpipeError(err: unknown): err is NodeZendeskError {
   return (
     typeof err === "object" &&
     err !== null &&

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -159,10 +159,6 @@ async function fetchFromZendeskWithRetries({
     if (rawResponse.status === 404) {
       return null;
     }
-    logger.error(
-      { rawResponse, status: rawResponse.status, text: rawResponse.text },
-      "[Zendesk] Error parsing Zendesk API response"
-    );
     throw new ZendeskApiError(
       "Error parsing Zendesk API response",
       rawResponse.status,

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -17,13 +17,6 @@ import { ZendeskBrandResource } from "@connectors/resources/zendesk_resources";
 const ZENDESK_RATE_LIMIT_MAX_RETRIES = 5;
 const ZENDESK_RATE_LIMIT_TIMEOUT_SECONDS = 60;
 
-/**
- * Retrieves the endpoint part from a URL used to call the Zendesk API.
- */
-function getEndpointFromUrl(url: string): string {
-  return url.split("api/v2")[1] as string;
-}
-
 export function createZendeskClient({
   accessToken,
   subdomain,

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -170,17 +170,18 @@ async function fetchFromZendeskWithRetries({
       { rawResponse, status: rawResponse.status, text: rawResponse.text },
       "[Zendesk] Error parsing Zendesk API response"
     );
-    throw new Error("Error parsing Zendesk API response");
+    throw new ZendeskApiError(
+      "Error parsing Zendesk API response",
+      rawResponse.status,
+      rawResponse
+    );
   }
   if (!rawResponse.ok) {
-    if (response.type === "error.list" && response.errors?.length) {
-      const error = response.errors[0];
-      if (error.code === "unauthorized") {
-        throw new ExternalOAuthTokenError();
-      }
-      if (error.code === "not_found") {
-        return null;
-      }
+    if (rawResponse.status === 403) {
+      throw new ExternalOAuthTokenError();
+    }
+    if (rawResponse.status === 404) {
+      return null;
     }
     throw new ZendeskApiError(
       "Zendesk API error.",

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -10,7 +10,6 @@ import type {
   ZendeskFetchedUser,
 } from "@connectors/@types/node-zendesk";
 import { ZendeskApiError } from "@connectors/connectors/zendesk/lib/errors";
-import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import logger from "@connectors/logger/logger";
 import type { ZendeskCategoryResource } from "@connectors/resources/zendesk_resources";
 import { ZendeskBrandResource } from "@connectors/resources/zendesk_resources";
@@ -163,8 +162,6 @@ async function fetchFromZendeskWithRetries({
         `[Zendesk] Zendesk API 404 error on: ${getEndpointFromUrl(url)}`
       );
       return null;
-    } else if (rawResponse.status === 403) {
-      throw new ExternalOAuthTokenError();
     }
     logger.error(
       { rawResponse, status: rawResponse.status, text: rawResponse.text },
@@ -177,9 +174,6 @@ async function fetchFromZendeskWithRetries({
     );
   }
   if (!rawResponse.ok) {
-    if (rawResponse.status === 403) {
-      throw new ExternalOAuthTokenError();
-    }
     if (rawResponse.status === 404) {
       return null;
     }

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -157,10 +157,6 @@ async function fetchFromZendeskWithRetries({
     response = await rawResponse.json();
   } catch (e) {
     if (rawResponse.status === 404) {
-      logger.error(
-        { rawResponse, text: rawResponse.text },
-        `[Zendesk] Zendesk API 404 error on: ${getEndpointFromUrl(url)}`
-      );
       return null;
     }
     logger.error(

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -193,7 +193,7 @@ export async function fetchZendeskBrand({
 }): Promise<ZendeskFetchedBrand | null> {
   const url = `https://${subdomain}.zendesk.com/api/v2/brands/${brandId}`;
   const response = await fetchFromZendeskWithRetries({ url, accessToken });
-  return response.brand ?? null;
+  return response?.brand ?? null;
 }
 
 /**
@@ -210,7 +210,7 @@ export async function fetchZendeskArticle({
 }): Promise<ZendeskFetchedArticle | null> {
   const url = `https://${brandSubdomain}.zendesk.com/api/v2/help_center/articles/${articleId}`;
   const response = await fetchFromZendeskWithRetries({ url, accessToken });
-  return response.article ?? null;
+  return response?.article ?? null;
 }
 
 /**

--- a/connectors/src/connectors/zendesk/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/zendesk/temporal/cast_known_errors.ts
@@ -5,9 +5,10 @@ import type {
 } from "@temporalio/worker";
 
 import {
+  isNodeZendeskEpipeError,
   isNodeZendeskForbiddenError,
-  isZendeskEpipeError,
   isZendeskExpiredCursorError,
+  isZendeskForbiddenError,
 } from "@connectors/connectors/zendesk/lib/errors";
 import {
   DustConnectorWorkflowError,
@@ -25,7 +26,7 @@ export class ZendeskCastKnownErrorsInterceptor
     try {
       return await next(input);
     } catch (err: unknown) {
-      if (isNodeZendeskForbiddenError(err)) {
+      if (isNodeZendeskForbiddenError(err) || isZendeskForbiddenError(err)) {
         throw new ExternalOAuthTokenError(err);
       } else if (isZendeskExpiredCursorError(err)) {
         throw new DustConnectorWorkflowError(
@@ -33,7 +34,7 @@ export class ZendeskCastKnownErrorsInterceptor
           "unhandled_internal_activity_error",
           err
         );
-      } else if (isZendeskEpipeError(err)) {
+      } else if (isNodeZendeskEpipeError(err)) {
         throw new ProviderWorkflowError(
           "zendesk",
           "EPIPE",


### PR DESCRIPTION
## Description

- The article garbage collection is broken because `fetchZendeskArticle` throws on 404 instead of returning null.
- This issue comes from previous refactoring works around `cast_known_errors`.

## Risk

Very low.

## Deploy Plan

- Deploy connectors.
