### PR TITLE
[connectors] enh(Confluence) - add a `retry-after` strategy to handle 429

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -165,7 +165,7 @@ function extractCursorFromLinks(links: { next?: string }): string | null {
 }
 
 function getRetryAfterDuration(response: Response): number {
-  const retryAfter = response.headers.get("Retry-After"); // https://developer.atlassian.com/cloud/confluence/rate-limiting/
+  const retryAfter = response.headers.get("retry-after"); // https://developer.atlassian.com/cloud/confluence/rate-limiting/
   if (retryAfter) {
     const delay = parseInt(retryAfter, 10);
     return !Number.isNaN(delay)

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -141,6 +141,7 @@ const ConfluenceReadOperationRestrictionsCodec = t.type({
   restrictions: RestrictionsCodec,
 });
 
+// Number of times we retry when rate limited (429).
 const MAX_RATE_LIMIT_RETRY_COUNT = 5;
 // Space types that we support indexing in Dust.
 export const CONFLUENCE_SUPPORTED_SPACE_TYPES = [

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -142,6 +142,8 @@ const ConfluenceReadOperationRestrictionsCodec = t.type({
   restrictions: RestrictionsCodec,
 });
 
+// default number of ms we wait before retrying after a rate limit hit.
+const DEFAULT_RETRY_AFTER_DURATION_MS = 10 * 1000;
 // Number of times we retry when rate limited (429).
 const MAX_RATE_LIMIT_RETRY_COUNT = 5;
 // Space types that we support indexing in Dust.
@@ -163,13 +165,14 @@ function extractCursorFromLinks(links: { next?: string }): string | null {
 }
 
 function getRetryAfterDuration(response: Response): number {
-  const defaultValue = 10 * 1000;
   const retryAfter = response.headers.get("Retry-After"); // https://developer.atlassian.com/cloud/confluence/rate-limiting/
   if (retryAfter) {
     const delay = parseInt(retryAfter, 10);
-    return !Number.isNaN(delay) ? delay * 1000 : defaultValue;
+    return !Number.isNaN(delay)
+      ? delay * 1000
+      : DEFAULT_RETRY_AFTER_DURATION_MS;
   }
-  return defaultValue;
+  return DEFAULT_RETRY_AFTER_DURATION_MS;
 }
 
 export class ConfluenceClient {

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -2,6 +2,7 @@ import { ConfluenceClientError } from "@dust-tt/types";
 import { isLeft } from "fp-ts/Either";
 import * as t from "io-ts";
 
+import { setTimeoutAsync } from "@connectors/lib/async_utils";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
 
 const CatchAllCodec = t.record(t.string, t.unknown); // Catch-all for unknown properties.
@@ -237,9 +238,7 @@ export class ConfluenceClient {
       // retry the request after a delay: https://developer.atlassian.com/cloud/confluence/rate-limiting/
       if (response.status === 429) {
         if (retryCount < MAX_RATE_LIMIT_RETRY_COUNT) {
-          await new Promise((resolve) =>
-            setTimeout(resolve, getRetryAfterDuration(response))
-          );
+          await setTimeoutAsync(getRetryAfterDuration(response));
           return this.request(endpoint, codec, retryCount + 1);
         } else {
           throw new ConfluenceClientError(

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -141,7 +141,7 @@ const ConfluenceReadOperationRestrictionsCodec = t.type({
   restrictions: RestrictionsCodec,
 });
 
-const MAX_RETRY_COUNT = 5;
+const MAX_RATE_LIMIT_RETRY_COUNT = 5;
 // Space types that we support indexing in Dust.
 export const CONFLUENCE_SUPPORTED_SPACE_TYPES = [
   "global",
@@ -225,14 +225,14 @@ export class ConfluenceClient {
       }
       // retry the request after a delay: https://developer.atlassian.com/cloud/confluence/rate-limiting/
       if (response.status === 429) {
-        if (retryCount < MAX_RETRY_COUNT) {
+        if (retryCount < MAX_RATE_LIMIT_RETRY_COUNT) {
           const delayMs =
             Number(response.headers?.get("Retry-After") || 10) * 1000;
           await new Promise((resolve) => setTimeout(resolve, delayMs));
           return this.request(endpoint, codec, retryCount + 1);
         } else {
           throw new ConfluenceClientError(
-            `Rate limit hit on confluence API more than ${MAX_RETRY_COUNT} times.`,
+            `Rate limit hit on confluence API more than ${MAX_RATE_LIMIT_RETRY_COUNT} times.`,
             {
               type: "http_response_error",
               status: response.status,

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -88,10 +88,15 @@ export async function getZendeskBrandSubdomain({
  */
 async function handleZendeskRateLimit(response: Response): Promise<boolean> {
   if (response.status === 429) {
-    const retryAfter = Math.max(
-      Number(response.headers.get("Retry-After")) || 1,
-      1
-    );
+    let retryAfter = 1;
+
+    const headerValue = response.headers.get("Retry-After"); // https://developer.zendesk.com/api-reference/introduction/rate-limits/
+    if (headerValue) {
+      const delay = parseInt(headerValue, 10);
+      if (!Number.isNaN(delay)) {
+        retryAfter = Math.max(delay, 1);
+      }
+    }
     if (retryAfter > ZENDESK_RATE_LIMIT_TIMEOUT_SECONDS) {
       logger.info(
         { retryAfter },

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -90,7 +90,7 @@ async function handleZendeskRateLimit(response: Response): Promise<boolean> {
   if (response.status === 429) {
     let retryAfter = 1;
 
-    const headerValue = response.headers.get("Retry-After"); // https://developer.zendesk.com/api-reference/introduction/rate-limits/
+    const headerValue = response.headers.get("retry-after"); // https://developer.zendesk.com/api-reference/introduction/rate-limits/
     if (headerValue) {
       const delay = parseInt(headerValue, 10);
       if (!Number.isNaN(delay)) {

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -10,6 +10,7 @@ import type {
   ZendeskFetchedUser,
 } from "@connectors/@types/node-zendesk";
 import { ZendeskApiError } from "@connectors/connectors/zendesk/lib/errors";
+import { setTimeoutAsync } from "@connectors/lib/async_utils";
 import logger from "@connectors/logger/logger";
 import type { ZendeskCategoryResource } from "@connectors/resources/zendesk_resources";
 import { ZendeskBrandResource } from "@connectors/resources/zendesk_resources";
@@ -104,7 +105,7 @@ async function handleZendeskRateLimit(response: Response): Promise<boolean> {
       { response, retryAfter },
       "[Zendesk] Rate limit hit, waiting before retrying."
     );
-    await new Promise((resolve) => setTimeout(resolve, retryAfter * 1000));
+    await setTimeoutAsync(retryAfter * 1000);
     return true;
   }
   return false;

--- a/connectors/src/lib/async_utils.ts
+++ b/connectors/src/lib/async_utils.ts
@@ -43,3 +43,6 @@ export async function concurrentExecutor<T, V>(
 
   return r;
 }
+
+export const setTimeoutAsync = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));


### PR DESCRIPTION
## Description

- We hit rate limits on Confluence API across various connectors [https://app.datadoghq.eu/logs?query=%22Unhandled%20Activity%20Error%22%20service%3Aco[…]z=stream&from_ts=1695710327855&to_ts=1695724727855&live=true](https://app.datadoghq.eu/logs?query=%22Unhandled%20Activity%20Error%22%20service%3Aconnectors-worker&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1695710327855&to_ts=1695724727855&live=true)
- This PR adds a retry-after strategy based on [values provided by the API](https://developer.atlassian.com/cloud/confluence/rate-limiting/).

## Risk

- Low

## Deploy Plan

- Deploy connectors.
