### PR TITLE
[front] - chore(poke): implement delete transcripts activity

### DIFF
--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -624,7 +624,6 @@ export async function deleteTranscriptsActivity({
       where: {
         workspaceId: workspace.id,
       },
-      transaction: t,
     });
 
     await LabsTranscriptsHistoryModel.destroy({

--- a/front/poke/temporal/workflows.ts
+++ b/front/poke/temporal/workflows.ts
@@ -1,6 +1,7 @@
 import { proxyActivities } from "@temporalio/workflow";
 
 import type * as activities from "@app/poke/temporal/activities";
+import { deleteTranscriptsActivity } from "@app/poke/temporal/activities";
 
 // Create a single proxy with all activities
 const activityProxies = proxyActivities<typeof activities>({
@@ -55,5 +56,6 @@ export async function deleteWorkspaceWorkflow({
   await deleteRunOnDustAppsActivity({ workspaceId });
   await deleteMembersActivity({ workspaceId });
   await deleteSpacesActivity({ workspaceId });
+  await deleteTranscriptsActivity({ workspaceId });
   await deleteWorkspaceActivity({ workspaceId });
 }

--- a/front/poke/temporal/workflows.ts
+++ b/front/poke/temporal/workflows.ts
@@ -1,7 +1,6 @@
 import { proxyActivities } from "@temporalio/workflow";
 
 import type * as activities from "@app/poke/temporal/activities";
-import { deleteTranscriptsActivity } from "@app/poke/temporal/activities";
 
 // Create a single proxy with all activities
 const activityProxies = proxyActivities<typeof activities>({
@@ -16,6 +15,7 @@ const {
   deleteRunOnDustAppsActivity,
   deleteSpacesActivity,
   deleteWorkspaceActivity,
+  deleteTranscriptsActivity,
   isWorkflowDeletableActivity,
   scrubDataSourceActivity,
   scrubSpaceActivity,


### PR DESCRIPTION
## Description

This PR adds a new activity to handle the deletion of transcripts configurations and history for a workspace when triggering a workspace deletion from poke

**References:**
- https://github.com/dust-tt/tasks/issues/1750

## Risk

Low

## Deploy Plan

Deploy `front`