### PR TITLE
Doc tracker models

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -49,6 +49,9 @@ import { ConversationClassification } from "@app/lib/models/conversation_classif
 import {
   DocumentTrackerChangeSuggestion,
   TrackedDocument,
+  TrackerDataSouceConfigurationModel,
+  TrackerGenerationModel,
+  TrackerModel,
 } from "@app/lib/models/doc_tracker";
 import { FeatureFlag } from "@app/lib/models/feature_flag";
 import { Plan, Subscription } from "@app/lib/models/plan";
@@ -121,6 +124,10 @@ async function main() {
   await RunUsageModel.sync({ alter: true });
   await TrackedDocument.sync({ alter: true });
   await DocumentTrackerChangeSuggestion.sync({ alter: true });
+
+  await TrackerModel.sync({ alter: true });
+  await TrackerDataSouceConfigurationModel.sync({ alter: true });
+  await TrackerGenerationModel.sync({ alter: true });
 
   await Plan.sync({ alter: true });
   await Subscription.sync({ alter: true });

--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -49,9 +49,9 @@ import { ConversationClassification } from "@app/lib/models/conversation_classif
 import {
   DocumentTrackerChangeSuggestion,
   TrackedDocument,
+  TrackerConfigurationModel,
   TrackerDataSouceConfigurationModel,
   TrackerGenerationModel,
-  TrackerModel,
 } from "@app/lib/models/doc_tracker";
 import { FeatureFlag } from "@app/lib/models/feature_flag";
 import { Plan, Subscription } from "@app/lib/models/plan";
@@ -125,7 +125,7 @@ async function main() {
   await TrackedDocument.sync({ alter: true });
   await DocumentTrackerChangeSuggestion.sync({ alter: true });
 
-  await TrackerModel.sync({ alter: true });
+  await TrackerConfigurationModel.sync({ alter: true });
   await TrackerDataSouceConfigurationModel.sync({ alter: true });
   await TrackerGenerationModel.sync({ alter: true });
 

--- a/front/lib/models/doc_tracker.ts
+++ b/front/lib/models/doc_tracker.ts
@@ -15,7 +15,7 @@ import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_sour
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { SoftDeletableModel } from "@app/lib/resources/storage/wrappers";
 
-export class TrackerModel extends SoftDeletableModel<TrackerModel> {
+export class TrackerConfigurationModel extends SoftDeletableModel<TrackerConfigurationModel> {
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
@@ -41,7 +41,7 @@ export class TrackerModel extends SoftDeletableModel<TrackerModel> {
   declare user: NonAttribute<User> | null;
 }
 
-TrackerModel.init(
+TrackerConfigurationModel.init(
   {
     id: {
       type: DataTypes.INTEGER,
@@ -93,36 +93,36 @@ TrackerModel.init(
     },
   },
   {
-    modelName: "tracker",
+    modelName: "tracker_configuration",
     sequelize: frontSequelize,
     indexes: [{ fields: ["workspaceId"] }],
   }
 );
 
-Workspace.hasMany(TrackerModel, {
+Workspace.hasMany(TrackerConfigurationModel, {
   foreignKey: { allowNull: false },
   onDelete: "RESTRICT",
 });
 
-TrackerModel.belongsTo(Workspace, {
+TrackerConfigurationModel.belongsTo(Workspace, {
   foreignKey: { allowNull: false },
 });
 
-SpaceModel.hasMany(TrackerModel, {
+SpaceModel.hasMany(TrackerConfigurationModel, {
   foreignKey: { allowNull: false },
   onDelete: "RESTRICT",
 });
 
-TrackerModel.belongsTo(SpaceModel, {
+TrackerConfigurationModel.belongsTo(SpaceModel, {
   foreignKey: { allowNull: false },
 });
 
-User.hasMany(TrackerModel, {
+User.hasMany(TrackerConfigurationModel, {
   foreignKey: { allowNull: true },
   onDelete: "RESTRICT",
 });
 
-TrackerModel.belongsTo(User, {
+TrackerConfigurationModel.belongsTo(User, {
   foreignKey: { allowNull: true },
 });
 
@@ -135,12 +135,12 @@ export class TrackerDataSouceConfigurationModel extends SoftDeletableModel<Track
   declare parentsIn: string[] | null;
   declare parentsNotIn: string[] | null;
 
-  declare trackerId: ForeignKey<TrackerModel["id"]>;
+  declare trackerConfigurationId: ForeignKey<TrackerConfigurationModel["id"]>;
 
   declare dataSourceId: ForeignKey<DataSourceModel["id"]>;
   declare dataSourceViewId: ForeignKey<DataSourceViewModel["id"]>;
 
-  declare tracker: NonAttribute<TrackerModel>;
+  declare trackerConfiguration: NonAttribute<TrackerConfigurationModel>;
   declare dataSource: NonAttribute<DataSourceModel>;
   declare dataSourceView: NonAttribute<DataSourceViewModel>;
 }
@@ -181,15 +181,15 @@ TrackerDataSouceConfigurationModel.init(
   {
     modelName: "tracker_data_source_configuration",
     sequelize: frontSequelize,
-    indexes: [{ fields: ["trackerId"] }],
+    indexes: [{ fields: ["trackerConfigurationId"] }],
   }
 );
 
-TrackerModel.hasMany(TrackerDataSouceConfigurationModel, {
+TrackerConfigurationModel.hasMany(TrackerDataSouceConfigurationModel, {
   foreignKey: { allowNull: false },
   onDelete: "RESTRICT",
 });
-TrackerDataSouceConfigurationModel.belongsTo(TrackerModel, {
+TrackerDataSouceConfigurationModel.belongsTo(TrackerConfigurationModel, {
   foreignKey: { allowNull: false },
 });
 
@@ -217,11 +217,11 @@ export class TrackerGenerationModel extends SoftDeletableModel<TrackerGeneration
   declare content: string;
   declare thinking: string | null;
 
-  declare trackerId: ForeignKey<TrackerModel["id"]>;
+  declare trackerConfigurationId: ForeignKey<TrackerConfigurationModel["id"]>;
   declare dataSourceId: ForeignKey<DataSourceModel["id"]>;
   declare documentId: string;
 
-  declare tracker: NonAttribute<TrackerModel>;
+  declare trackerConfiguration: NonAttribute<TrackerConfigurationModel>;
 }
 
 TrackerGenerationModel.init(
@@ -260,15 +260,15 @@ TrackerGenerationModel.init(
   {
     modelName: "tracker_generation",
     sequelize: frontSequelize,
-    indexes: [{ fields: ["trackerId"] }],
+    indexes: [{ fields: ["trackerConfigurationId"] }],
   }
 );
 
-TrackerModel.hasMany(TrackerGenerationModel, {
+TrackerConfigurationModel.hasMany(TrackerGenerationModel, {
   foreignKey: { allowNull: false },
   onDelete: "RESTRICT",
 });
-TrackerGenerationModel.belongsTo(TrackerModel, {
+TrackerGenerationModel.belongsTo(TrackerConfigurationModel, {
   foreignKey: { allowNull: false },
 });
 

--- a/front/lib/models/doc_tracker.ts
+++ b/front/lib/models/doc_tracker.ts
@@ -13,11 +13,9 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
+import { SoftDeletableModel } from "@app/lib/resources/storage/wrappers";
 
-export class TrackerModel extends Model<
-  InferAttributes<TrackerModel>,
-  InferCreationAttributes<TrackerModel>
-> {
+export class TrackerModel extends SoftDeletableModel<TrackerModel> {
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
@@ -59,6 +57,9 @@ TrackerModel.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
+    },
+    deletedAt: {
+      type: DataTypes.DATE,
     },
     status: {
       type: DataTypes.STRING,
@@ -125,10 +126,7 @@ TrackerModel.belongsTo(User, {
   foreignKey: { allowNull: true },
 });
 
-export class TrackerDataSouceConfigurationModel extends Model<
-  InferAttributes<TrackerDataSouceConfigurationModel>,
-  InferCreationAttributes<TrackerDataSouceConfigurationModel>
-> {
+export class TrackerDataSouceConfigurationModel extends SoftDeletableModel<TrackerDataSouceConfigurationModel> {
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
@@ -163,6 +161,9 @@ TrackerDataSouceConfigurationModel.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
+    },
+    deletedAt: {
+      type: DataTypes.DATE,
     },
     scope: {
       type: DataTypes.STRING,
@@ -208,10 +209,7 @@ TrackerDataSouceConfigurationModel.belongsTo(DataSourceViewModel, {
   foreignKey: { allowNull: false },
 });
 
-export class TrackerGenerationModel extends Model<
-  InferAttributes<TrackerGenerationModel>,
-  InferCreationAttributes<TrackerGenerationModel>
-> {
+export class TrackerGenerationModel extends SoftDeletableModel<TrackerGenerationModel> {
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
@@ -242,6 +240,9 @@ TrackerGenerationModel.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
+    },
+    deletedAt: {
+      type: DataTypes.DATE,
     },
     content: {
       type: DataTypes.TEXT,

--- a/front/migrations/db/migration_124.sql
+++ b/front/migrations/db/migration_124.sql
@@ -1,6 +1,6 @@
 -- Migration created on Dec 04, 2024
 
-CREATE TABLE IF NOT EXISTS "trackers" (
+CREATE TABLE IF NOT EXISTS "tracker_configurations" (
     "id" SERIAL,
     "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
     "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS "trackers" (
     PRIMARY KEY ("id")
 );
 
-CREATE INDEX "trackers_workspace_id" ON "trackers" ("workspaceId");
+CREATE INDEX "tracker_configurations_workspace_id" ON "tracker_configurations" ("workspaceId");
 
 CREATE TABLE IF NOT EXISTS "tracker_data_source_configurations" (
     "id" SERIAL,
@@ -28,13 +28,13 @@ CREATE TABLE IF NOT EXISTS "tracker_data_source_configurations" (
     "scope" VARCHAR(255) NOT NULL,
     "parentsIn" VARCHAR(255)[],
     "parentsNotIn" VARCHAR(255)[],
-    "trackerId" INTEGER NOT NULL REFERENCES "trackers" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "trackerConfigurationId" INTEGER NOT NULL REFERENCES "tracker_configurations" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
     "dataSourceId" INTEGER NOT NULL REFERENCES "data_sources" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
     "dataSourceViewId" INTEGER NOT NULL REFERENCES "data_source_views" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
     PRIMARY KEY ("id")
 );
 
-CREATE INDEX "tracker_data_source_configurations_tracker_id" ON "tracker_data_source_configurations" ("trackerId");
+CREATE INDEX "tracker_data_source_configurations_tracker_configuration_id" ON "tracker_data_source_configurations" ("trackerConfigurationId");
 
 CREATE TABLE IF NOT EXISTS "tracker_generations" (
     "id" SERIAL,
@@ -44,9 +44,9 @@ CREATE TABLE IF NOT EXISTS "tracker_generations" (
     "content" TEXT NOT NULL,
     "thinking" TEXT,
     "documentId" VARCHAR(255) NOT NULL,
-    "trackerId" INTEGER NOT NULL REFERENCES "trackers" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "trackerConfigurationId" INTEGER NOT NULL REFERENCES "tracker_configurations" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
     "dataSourceId" INTEGER NOT NULL REFERENCES "data_sources" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
     PRIMARY KEY ("id")
 );
 
-CREATE INDEX "tracker_generations_tracker_id" ON "tracker_generations" ("trackerId");
+CREATE INDEX "tracker_generations_tracker_configuration_id" ON "tracker_generations" ("trackerConfigurationId");

--- a/front/migrations/db/migration_124.sql
+++ b/front/migrations/db/migration_124.sql
@@ -1,7 +1,10 @@
+-- Migration created on Dec 04, 2024
+
 CREATE TABLE IF NOT EXISTS "trackers" (
     "id" SERIAL,
     "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
     "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "deletedAt" TIMESTAMP WITH TIME ZONE,
     "status" VARCHAR(255) NOT NULL DEFAULT 'active',
     "modelId" VARCHAR(255) NOT NULL,
     "providerId" VARCHAR(255) NOT NULL,
@@ -14,12 +17,14 @@ CREATE TABLE IF NOT EXISTS "trackers" (
     "userId" INTEGER REFERENCES "users" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
     PRIMARY KEY ("id")
 );
+
 CREATE INDEX "trackers_workspace_id" ON "trackers" ("workspaceId");
 
 CREATE TABLE IF NOT EXISTS "tracker_data_source_configurations" (
     "id" SERIAL,
     "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
     "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "deletedAt" TIMESTAMP WITH TIME ZONE,
     "scope" VARCHAR(255) NOT NULL,
     "parentsIn" VARCHAR(255)[],
     "parentsNotIn" VARCHAR(255)[],
@@ -28,12 +33,14 @@ CREATE TABLE IF NOT EXISTS "tracker_data_source_configurations" (
     "dataSourceViewId" INTEGER NOT NULL REFERENCES "data_source_views" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
     PRIMARY KEY ("id")
 );
+
 CREATE INDEX "tracker_data_source_configurations_tracker_id" ON "tracker_data_source_configurations" ("trackerId");
 
 CREATE TABLE IF NOT EXISTS "tracker_generations" (
     "id" SERIAL,
     "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
     "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "deletedAt" TIMESTAMP WITH TIME ZONE,
     "content" TEXT NOT NULL,
     "thinking" TEXT,
     "documentId" VARCHAR(255) NOT NULL,
@@ -41,4 +48,5 @@ CREATE TABLE IF NOT EXISTS "tracker_generations" (
     "dataSourceId" INTEGER NOT NULL REFERENCES "data_sources" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
     PRIMARY KEY ("id")
 );
+
 CREATE INDEX "tracker_generations_tracker_id" ON "tracker_generations" ("trackerId");

--- a/front/migrations/db/migration_124.sql
+++ b/front/migrations/db/migration_124.sql
@@ -1,0 +1,44 @@
+CREATE TABLE IF NOT EXISTS "trackers" (
+    "id" SERIAL,
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "status" VARCHAR(255) NOT NULL DEFAULT 'active',
+    "modelId" VARCHAR(255) NOT NULL,
+    "providerId" VARCHAR(255) NOT NULL,
+    "temperature" FLOAT NOT NULL DEFAULT '0.7',
+    "prompt" TEXT,
+    "frequency" VARCHAR(255),
+    "recipients" VARCHAR(255)[],
+    "workspaceId" INTEGER NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "spaceId" INTEGER NOT NULL REFERENCES "vaults" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "userId" INTEGER REFERENCES "users" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    PRIMARY KEY ("id")
+);
+CREATE INDEX "trackers_workspace_id" ON "trackers" ("workspaceId");
+
+CREATE TABLE IF NOT EXISTS "tracker_data_source_configurations" (
+    "id" SERIAL,
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "scope" VARCHAR(255) NOT NULL,
+    "parentsIn" VARCHAR(255)[],
+    "parentsNotIn" VARCHAR(255)[],
+    "trackerId" INTEGER NOT NULL REFERENCES "trackers" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "dataSourceId" INTEGER NOT NULL REFERENCES "data_sources" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "dataSourceViewId" INTEGER NOT NULL REFERENCES "data_source_views" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    PRIMARY KEY ("id")
+);
+CREATE INDEX "tracker_data_source_configurations_tracker_id" ON "tracker_data_source_configurations" ("trackerId");
+
+CREATE TABLE IF NOT EXISTS "tracker_generations" (
+    "id" SERIAL,
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "content" TEXT NOT NULL,
+    "thinking" TEXT,
+    "documentId" VARCHAR(255) NOT NULL,
+    "trackerId" INTEGER NOT NULL REFERENCES "trackers" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "dataSourceId" INTEGER NOT NULL REFERENCES "data_sources" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    PRIMARY KEY ("id")
+);
+CREATE INDEX "tracker_generations_tracker_id" ON "tracker_generations" ("trackerId");


### PR DESCRIPTION
## Description

Creating the new models for Doc Tracker. 
(There was no question of updating the existing models, easier to create new ones and kill the old ones)


Some changes compared to the Design doc, most discussed irl
-> Removing prefix Document to models
-> Added a status to tracker
-> No model for the destination, for now it's just a list of recipient emails allowing to set some google group for example. 
-> Added some missing relation to tracker
-> Renamed Notification to Generation since we might store multiple generations to then generate one notif that will be an email. 

Open question: Do we want to store the full content of the email generated?

## Risk

New models, not called yet. 

## Deploy Plan

- Run migration 124
- Deploy front. 

## Next steps for models

- Create resources
- Update the scrubbing logic to remove those tables when we delete a workspace (cause it's delete restrict not cascade).
