### PR TITLE
Update default prompt tool use if visu enabled

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -346,7 +346,10 @@ async function* runMultiActionsAgent(
   }
 
   let fallbackPrompt = "You are a conversational assistant";
-  if (agentConfiguration.actions.length) {
+  if (
+    agentConfiguration.actions.length ||
+    agentConfiguration.visualizationEnabled
+  ) {
     fallbackPrompt += " with access to tool use.";
   } else {
     fallbackPrompt += ".";


### PR DESCRIPTION
## Description

Testing to update the default prompt when agent has visu enable and not other action. 
Testing locally it works well to prevent claude from mentionning the viz prompt when not at all relevant. 


## Risk

Can be rolled back.

## Deploy Plan

Deploying to front edge to test with Ed
Deploying front
