### PR TITLE
[front] fix(csv) - handle values by col errors

### DIFF
--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -374,12 +374,8 @@ export async function rowsFromCsv({
     if (i++ >= rowIndex) {
       const record = anyRecord as string[];
       for (const [i, h] of header.entries()) {
-        const col = record[i] || "";
-        if (!valuesByCol[h]) {
-          valuesByCol[h] = [col];
-        } else {
-          (valuesByCol[h] as string[]).push(col);
-        }
+        valuesByCol[h] ??= [];
+        (valuesByCol[h] as string[]).push(record[i] || "");
       }
     }
   }

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -374,8 +374,17 @@ export async function rowsFromCsv({
     if (i++ >= rowIndex) {
       const record = anyRecord as string[];
       for (const [i, h] of header.entries()) {
-        valuesByCol[h] ??= [];
-        (valuesByCol[h] as string[]).push(record[i] || "");
+        try {
+          valuesByCol[h] ??= [];
+          (valuesByCol[h] as string[]).push(record[i] || "");
+        } catch (e) {
+          logger.error(
+            // temporary log to fix the valuesByCol[h].push is not a function error
+            { typeOf: typeof valuesByCol[h] },
+            "Error parsing record"
+          );
+          throw e;
+        }
       }
     }
   }


### PR DESCRIPTION
## Description

- Add logging to errors [`TypeError: valuesByCol[h].push is not a function`](https://app.datadoghq.eu/logs?query=%22Unhandled%20API%20Error%22%20status%3Aerror%20%40dd.env%3Aprod%20%22TypeError%3A%20valuesByCol%5Bh%5D.push%20is%20not%20a%20function%20%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1714135514324&to_ts=1714136414324&live=true).
- These errors most likely come from some malformed csv input, but should still be handled on our end IMO.

## Risk

Low.

## Deploy Plan

- Deploy front.