### PR TITLE
[front] log(csv) - log column names that causes errors in parsing

### DIFF
--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -380,7 +380,7 @@ export async function rowsFromCsv({
         } catch (e) {
           logger.error(
             // temporary log to fix the valuesByCol[h].push is not a function error
-            { typeOf: typeof valuesByCol[h] },
+            { typeOf: typeof valuesByCol[h], columnName: h },
             "Error parsing record"
           );
           throw e;


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/9118
- [https://app.datadoghq.eu/logs?query=%40dd.env%3Aprod%20%22Error%20parsing%20record%22[…]=stream&from_ts=1733318910000&to_ts=1733318920000&live=false](https://app.datadoghq.eu/logs?query=%40dd.env%3Aprod%20%22Error%20parsing%20record%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZOR26ROwDl6NwAAABhBWk9SMjY1dUFBQUJKMkxSdXl1VWhnQVMAAAAkMDE5MzkxZGItY2Y1Ni00YjA5LTliYmMtZDQyYzQzZmVjOWU5AAAjhQ&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1733318910000&to_ts=1733318920000&live=false)

## Risk

Low, only logs.

## Deploy Plan

- Deploy front
