### PR TITLE
[front] fix(csv) - csv parsing

### DIFF
--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -378,7 +378,7 @@ export async function rowsFromCsv({
       const record = anyRecord as string[];
       for (const [i, h] of header.entries()) {
         try {
-          (valuesByCol[h] as string[]).push(record[i] ?? "");
+          valuesByCol[h].push(record[i].toString() ?? "");
         } catch (e) {
           logger.error(
             // temporary log to fix the valuesByCol[h].push is not a function error

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -376,7 +376,7 @@ export async function rowsFromCsv({
       for (const [i, h] of header.entries()) {
         try {
           valuesByCol[h] ??= [];
-          (valuesByCol[h] as string[]).push(record[i] || "");
+          (valuesByCol[h] as string[]).push(record[i] ?? "");
         } catch (e) {
           logger.error(
             // temporary log to fix the valuesByCol[h].push is not a function error

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -369,7 +369,7 @@ export async function rowsFromCsv({
 
   let i = 0;
   const parser = parse(csv, { delimiter });
-  const valuesByCol: Record<string, string[]> = {};
+  const valuesByCol: Record<string, string[]> = Object.create(null);
   for await (const anyRecord of parser) {
     if (i++ >= rowIndex) {
       const record = anyRecord as string[];

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -369,6 +369,7 @@ export async function rowsFromCsv({
 
   let i = 0;
   const parser = parse(csv, { delimiter });
+  // this differs with = {} in that it prevent errors when header values clash with object properties such as toString, constructor, ..
   const valuesByCol: Record<string, string[]> = Object.create(null);
   for await (const anyRecord of parser) {
     if (i++ >= rowIndex) {

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -378,7 +378,7 @@ export async function rowsFromCsv({
       const record = anyRecord as string[];
       for (const [i, h] of header.entries()) {
         try {
-          valuesByCol[h].push(record[i].toString() ?? "");
+          (valuesByCol[h] as string[]).push(record[i] ?? "");
         } catch (e) {
           logger.error(
             // temporary log to fix the valuesByCol[h].push is not a function error

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -370,14 +370,12 @@ export async function rowsFromCsv({
   let i = 0;
   const parser = parse(csv, { delimiter });
   const valuesByCol: Record<string, string[]> = {};
-  // init arrays for all headers
-  header.forEach((h) => (valuesByCol[h] = []));
-
   for await (const anyRecord of parser) {
     if (i++ >= rowIndex) {
       const record = anyRecord as string[];
       for (const [i, h] of header.entries()) {
         try {
+          valuesByCol[h] ??= [];
           (valuesByCol[h] as string[]).push(record[i] ?? "");
         } catch (e) {
           logger.error(

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -373,11 +373,10 @@ export async function rowsFromCsv({
   const valuesByCol: Record<string, string[]> = Object.create(null);
   for await (const anyRecord of parser) {
     if (i++ >= rowIndex) {
-      const record = anyRecord as string[];
       for (const [i, h] of header.entries()) {
         try {
           valuesByCol[h] ??= [];
-          (valuesByCol[h] as string[]).push(record[i] ?? "");
+          valuesByCol[h].push((anyRecord[i] ?? "").toString());
         } catch (e) {
           logger.error(
             // temporary log to fix the valuesByCol[h].push is not a function error

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -370,12 +370,14 @@ export async function rowsFromCsv({
   let i = 0;
   const parser = parse(csv, { delimiter });
   const valuesByCol: Record<string, string[]> = {};
+  // init arrays for all headers
+  header.forEach((h) => (valuesByCol[h] = []));
+
   for await (const anyRecord of parser) {
     if (i++ >= rowIndex) {
       const record = anyRecord as string[];
       for (const [i, h] of header.entries()) {
         try {
-          valuesByCol[h] ??= [];
           (valuesByCol[h] as string[]).push(record[i] ?? "");
         } catch (e) {
           logger.error(


### PR DESCRIPTION
## Description

- Follow up on logs gathered using https://github.com/dust-tt/dust/pull/9118.
- `values[h]` is a function: [https://app.datadoghq.eu/logs?query=%40dd.env%3Aprod%20%22Error%20parsing%20record%22[…]=stream&from_ts=1733318910000&to_ts=1733318920000&live=false](https://app.datadoghq.eu/logs?query=%40dd.env%3Aprod%20%22Error%20parsing%20record%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZOR26ROwDl6NwAAABhBWk9SMjY1dUFBQUJKMkxSdXl1VWhnQVMAAAAkMDE5MzkxZGItY2Y1Ni00YjA5LTliYmMtZDQyYzQzZmVjOWU5AAAjhQ&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1733318910000&to_ts=1733318920000&live=false)
- Hypothesis here is that header names are stuff like `onString`.
- Also handles falsey values correctly (does not replace them with "" systematically, only deals with `null` and `undefined`).
- More logs [here](https://app.datadoghq.eu/logs?query=%22Error%20uploading%20table%20to%20Dust.%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1733319867925&to_ts=1733319925679&live=false).

`> {}["constructor"]
[Function: Object]`

Tested with:

constructor | toString | 0 | undefined | null | [] | {}
-- | -- | -- | -- | -- | -- | --
0 | 1 | undefined | 2 |   | null |  


## Risk

Low.

## Deploy Plan

- Deploy front.
