### PR TITLE
[connectors] log(Confluence) - add logs on retries to check the value

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -145,7 +145,7 @@ const ConfluenceReadOperationRestrictionsCodec = t.type({
 // default number of ms we wait before retrying after a rate limit hit.
 const DEFAULT_RETRY_AFTER_DURATION_MS = 10 * 1000;
 // Number of times we retry when rate limited (429).
-const MAX_RATE_LIMIT_RETRY_COUNT = 5;
+const MAX_RATE_LIMIT_RETRY_COUNT = 10;
 // Space types that we support indexing in Dust.
 export const CONFLUENCE_SUPPORTED_SPACE_TYPES = [
   "global",

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -4,6 +4,7 @@ import * as t from "io-ts";
 
 import { setTimeoutAsync } from "@connectors/lib/async_utils";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
+import logger from "@connectors/logger/logger";
 
 const CatchAllCodec = t.record(t.string, t.unknown); // Catch-all for unknown properties.
 
@@ -241,7 +242,12 @@ export class ConfluenceClient {
       // retry the request after a delay: https://developer.atlassian.com/cloud/confluence/rate-limiting/
       if (response.status === 429) {
         if (retryCount < MAX_RATE_LIMIT_RETRY_COUNT) {
-          await setTimeoutAsync(getRetryAfterDuration(response));
+          const delayMs = getRetryAfterDuration(response);
+          logger.warn(
+            { endpoint, retryCount, delayMs },
+            "[Confluence] Rate limit hit, retrying after delay"
+          );
+          await setTimeoutAsync(delayMs);
           return this.request(endpoint, codec, retryCount + 1);
         } else {
           throw new ConfluenceClientError(

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -244,7 +244,7 @@ export class ConfluenceClient {
         if (retryCount < MAX_RATE_LIMIT_RETRY_COUNT) {
           const delayMs = getRetryAfterDuration(response);
           logger.warn(
-            { endpoint, retryCount, delayMs },
+            { endpoint, retryCount, delayMs, headers: response.headers },
             "[Confluence] Rate limit hit, retrying after delay"
           );
           await setTimeoutAsync(delayMs);


### PR DESCRIPTION
## Description

- Add logs to retries on 429 in Confluence.
- Goal here is to check that we pass correct values of retry-after.
- 🔧 increase MAX_RATE_LIMIT_RETRY_COUNT from 5 to 10

## Risk

Low, only logs.

## Deploy Plan

- Deploy connectors.