### PR TITLE
[front] - fix(retrieval): allow nullable retrivalActionId on RetrievalDocument

### DIFF
--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -754,6 +754,9 @@ export async function retrievalActionTypesFromAgentMessageIds(
   const documentRowsByActionId = documents.reduce<{
     [id: ModelId]: RetrievalDocumentResource[];
   }>((acc, d) => {
+    if (!d.retrievalActionId){
+      return acc;
+    }
     if (!acc[d.retrievalActionId]) {
       acc[d.retrievalActionId] = [];
     }

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -754,7 +754,7 @@ export async function retrievalActionTypesFromAgentMessageIds(
   const documentRowsByActionId = documents.reduce<{
     [id: ModelId]: RetrievalDocumentResource[];
   }>((acc, d) => {
-    if (!d.retrievalActionId){
+    if (!d.retrievalActionId) {
       return acc;
     }
     if (!acc[d.retrievalActionId]) {

--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -326,11 +326,11 @@ RetrievalDocument.init(
 );
 
 AgentRetrievalAction.hasMany(RetrievalDocument, {
-  foreignKey: { name: "retrievalActionId", allowNull: false },
-  onDelete: "CASCADE",
+  foreignKey: { name: "retrievalActionId", allowNull: true },
+  onDelete: "SET NULL",
 });
 RetrievalDocument.belongsTo(AgentRetrievalAction, {
-  foreignKey: { name: "retrievalActionId", allowNull: false },
+  foreignKey: { name: "retrievalActionId", allowNull: true },
 });
 
 DataSourceViewModel.hasMany(RetrievalDocument, {

--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -270,7 +270,7 @@ export class RetrievalDocument extends Model<
 
   // This is nullable as it has to be set null when data sources are deleted.
   declare dataSourceViewId: ForeignKey<DataSourceViewModel["id"]> | null;
-  declare retrievalActionId: ForeignKey<AgentRetrievalAction["id"]>;
+  declare retrievalActionId: ForeignKey<AgentRetrievalAction["id"]> | null;
 
   declare chunks: NonAttribute<RetrievalDocumentChunk[]>;
   declare dataSourceView: NonAttribute<DataSourceViewModel>;

--- a/front/migrations/db/migration_124.sql
+++ b/front/migrations/db/migration_124.sql
@@ -1,0 +1,11 @@
+-- Drop existing foreign key constraint
+ALTER TABLE retrieval_documents
+DROP CONSTRAINT retrieval_documents_retrievalactionid_fkey;
+
+-- Allow null and add new foreign key with SET NULL
+ALTER TABLE retrieval_documents
+ALTER COLUMN "retrievalActionId" DROP NOT NULL,
+ADD CONSTRAINT retrieval_documents_retrievalActionId_fkey
+  FOREIGN KEY ("retrievalActionId")
+  REFERENCES agent_retrieval_actions(id)
+  ON DELETE SET NULL;

--- a/front/migrations/db/migration_124.sql
+++ b/front/migrations/db/migration_124.sql
@@ -1,11 +1,11 @@
 -- Drop existing foreign key constraint
 ALTER TABLE retrieval_documents
-DROP CONSTRAINT retrieval_documents_retrievalactionid_fkey;
+DROP CONSTRAINT "retrieval_documents_retrievalActionid_fkey";
 
 -- Allow null and add new foreign key with SET NULL
 ALTER TABLE retrieval_documents
 ALTER COLUMN "retrievalActionId" DROP NOT NULL,
-ADD CONSTRAINT retrieval_documents_retrievalActionId_fkey
+ADD CONSTRAINT "retrieval_documents_retrievalActionid_fkey"
   FOREIGN KEY ("retrievalActionId")
   REFERENCES agent_retrieval_actions(id)
   ON DELETE SET NULL;

--- a/front/migrations/db/migration_124.sql
+++ b/front/migrations/db/migration_124.sql
@@ -5,7 +5,7 @@ DROP CONSTRAINT "retrieval_documents_retrievalActionid_fkey";
 -- Allow null and add new foreign key with SET NULL
 ALTER TABLE retrieval_documents
 ALTER COLUMN "retrievalActionId" DROP NOT NULL,
-ADD CONSTRAINT "retrieval_documents_retrievalActionid_fkey"
+ADD CONSTRAINT "retrieval_documents_retrievalActionId_fkey"
   FOREIGN KEY ("retrievalActionId")
   REFERENCES agent_retrieval_actions(id)
   ON DELETE SET NULL;


### PR DESCRIPTION
## Description

Updated the foreign key constraint on RetrievalDocument to allow null values, changing deletion policy to set it null instead of cascading delete.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- Deploy front
- Apply migration
