### PR TITLE
update agent message icons style and add separator

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -409,7 +409,7 @@ export function AgentMessage({
           <Button
             key="copy-msg-button"
             tooltip="Copy to clipboard"
-            variant="outline"
+            variant="ghost"
             size="xs"
             onClick={() => {
               void navigator.clipboard.writeText(
@@ -417,18 +417,23 @@ export function AgentMessage({
               );
             }}
             icon={ClipboardIcon}
+            className="text-muted-foreground"
           />,
           <Button
             key="retry-msg-button"
             tooltip="Retry"
-            variant="outline"
+            variant="ghost"
             size="xs"
             onClick={() => {
               void retryHandler(agentMessageToRender);
             }}
             icon={ArrowPathIcon}
+            className="text-muted-foreground"
             disabled={isRetryHandlerProcessing || shouldStream}
           />,
+          <div key="separator" className="flex items-center">
+            <div className="h-5 w-px bg-border" />
+          </div>,
           <FeedbackSelector
             key="feedback-selector"
             {...messageFeedback}


### PR DESCRIPTION
## Description
Updating the icon style on agent message + added a separator
<img width="164" alt="image" src="https://github.com/user-attachments/assets/02693cf4-1eca-46f9-935e-aed56bcee061">
I updated the thumbs up/thumbs down component too
Thumbs component PR : https://github.com/dust-tt/dust/pull/9123

## Risk
None

## Deploy Plan

