### PR TITLE
confluence: reduce max concurent activities from 16 to 8

### DIFF
--- a/connectors/src/connectors/confluence/temporal/worker.ts
+++ b/connectors/src/connectors/confluence/temporal/worker.ts
@@ -19,7 +19,7 @@ export async function runConfluenceWorker() {
     workflowsPath: require.resolve("./workflows"),
     activities: { ...activities, ...sync_status },
     taskQueue: QUEUE_NAME,
-    maxConcurrentActivityTaskExecutions: 16,
+    maxConcurrentActivityTaskExecutions: 8,
     maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
     connection,
     reuseV8Context: true,


### PR DESCRIPTION
## Description

Reduce confluence concurrency because we hit rate limits hard

## Risk

None

## Deploy Plan

- deploy `connectors`