### PR TITLE
Redirect FREE_TEST_PLAN to paywall + allow trial

### DIFF
--- a/front/lib/iam/session.ts
+++ b/front/lib/iam/session.ts
@@ -15,6 +15,7 @@ import {
   fetchUserFromSession,
   maybeUpdateFromExternalUser,
 } from "@app/lib/iam/users";
+import { isOldFreePlan } from "@app/lib/plans/plan_codes";
 import logger from "@app/logger/logger";
 import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
@@ -135,7 +136,8 @@ export function makeGetServerSidePropsRequirementsWrapper<
 
       if (
         requireCanUseProduct &&
-        !auth?.subscription()?.plan.limits.canUseProduct
+        (!auth?.subscription()?.plan.limits.canUseProduct ||
+          isOldFreePlan(auth?.subscription()?.plan.code ?? ""))
       ) {
         if (typeof context.query.wId !== "string") {
           // this should never happen.

--- a/front/lib/iam/session.ts
+++ b/front/lib/iam/session.ts
@@ -15,7 +15,6 @@ import {
   fetchUserFromSession,
   maybeUpdateFromExternalUser,
 } from "@app/lib/iam/users";
-import { isOldFreePlan } from "@app/lib/plans/plan_codes";
 import logger from "@app/logger/logger";
 import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
@@ -136,8 +135,7 @@ export function makeGetServerSidePropsRequirementsWrapper<
 
       if (
         requireCanUseProduct &&
-        (!auth?.subscription()?.plan.limits.canUseProduct ||
-          isOldFreePlan(auth?.subscription()?.plan.code ?? ""))
+        !auth?.subscription()?.plan.limits.canUseProduct
       ) {
         if (typeof context.query.wId !== "string") {
           // this should never happen.

--- a/front/lib/plans/free_plans.ts
+++ b/front/lib/plans/free_plans.ts
@@ -73,7 +73,7 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
     maxDataSourcesDocumentsCount: 10,
     maxDataSourcesDocumentsSizeMb: 2,
     trialPeriodDays: 0,
-    canUseProduct: true,
+    canUseProduct: false,
   },
   {
     code: FREE_UPGRADED_PLAN_CODE,

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -2,16 +2,19 @@ import type {
   BillingPeriod,
   LightWorkspaceType,
   Result,
+  SubscriptionType,
   WorkspaceType,
 } from "@dust-tt/types";
-import type { SubscriptionType } from "@dust-tt/types";
 import { Err, isDevelopment, Ok } from "@dust-tt/types";
 import { Stripe } from "stripe";
 
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { Plan, Subscription } from "@app/lib/models/plan";
-import { PRO_PLAN_SEAT_29_CODE } from "@app/lib/plans/plan_codes";
+import {
+  isOldFreePlan,
+  PRO_PLAN_SEAT_29_CODE,
+} from "@app/lib/plans/plan_codes";
 import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
 import {
   isEnterpriseReportUsage,
@@ -117,7 +120,7 @@ export const createProPlanCheckoutSession = async ({
       workspaceId: owner.id,
     },
   });
-  if (existingSubscription) {
+  if (existingSubscription && !isOldFreePlan(existingSubscription.plan.code)) {
     trialAllowed = false;
   }
 

--- a/front/migrations/20241205_free_test_plan_cant_use_product.sql
+++ b/front/migrations/20241205_free_test_plan_cant_use_product.sql
@@ -1,0 +1,3 @@
+UPDATE plans
+SET "canUseProduct" = false
+WHERE "code" = 'FREE_TEST_PLAN';

--- a/front/pages/w/[wId]/subscribe.tsx
+++ b/front/pages/w/[wId]/subscribe.tsx
@@ -1,5 +1,10 @@
-import { BarHeader, Button, LockIcon, Page } from "@dust-tt/sparkle";
-import { useSendNotification } from "@dust-tt/sparkle";
+import {
+  BarHeader,
+  Button,
+  LockIcon,
+  Page,
+  useSendNotification,
+} from "@dust-tt/sparkle";
 import type { BillingPeriod, WorkspaceType } from "@dust-tt/types";
 import { CreditCardIcon } from "@heroicons/react/20/solid";
 import type { InferGetServerSidePropsType } from "next";
@@ -11,6 +16,7 @@ import { UserMenu } from "@app/components/UserMenu";
 import WorkspacePicker from "@app/components/WorkspacePicker";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { withDefaultUserAuthPaywallWhitelisted } from "@app/lib/iam/session";
+import { isOldFreePlan } from "@app/lib/plans/plan_codes";
 import { useUser } from "@app/lib/swr/user";
 import { useWorkspaceSubscriptions } from "@app/lib/swr/workspaces";
 
@@ -49,9 +55,11 @@ export default function Subscribe({
     React.useState<BillingPeriod>("monthly");
 
   // If you had another subscription before, you will not get the free trial again: we use this to show the correct message.
-  // Current plan is always FREE_NO_PLAN if you're on this paywall.
-  // Since FREE_NO_PLAN is not on the database, we check if there is at least 1 subscription.
-  const hasPreviouSubscription = subscriptions?.length > 0;
+  // Current plan is either FREE_NO_PLAN or FREE_TEST_PLAN if you're on this paywall.
+  //FREE_NO_PLAN is not on the database, checking it comes down to having at least 1 subscription.
+  const hasPreviouSubscription =
+    subscriptions?.length > 0 &&
+    (subscriptions.length > 1 || !isOldFreePlan(subscriptions[0].plan.code)); // FREE_TEST_PLAN did not pay, they should be asked to start instead of resume
 
   const { submit: handleSubscribePlan } = useSubmitFunction(
     async (billingPeriod) => {


### PR DESCRIPTION
## Description

- Close [#1756](https://github.com/dust-tt/tasks/issues/1756).
- Redirect FREE_TEST_PLAN to paywall.
- Allow 14 days of trials for FREE_TEST_PLAN.
- Update the paywall messages for them ("activate" billing instead of "resume")
- Set `canUseProduct` to false for FREE_TEST_PLAN.

Tested by upgrading my workspace to FREE_TEST_PLAN + clear cookies, correctly redirected to the paywall.

## Risk

Low

## Deploy Plan

- Run `20241205_free_test_plan_cant_use_product.sql`.
- Deploy front.
