### PR TITLE
Narrow accepted types in content-based (file-less) content fragments

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -21,7 +21,6 @@ import type {
   MentionType,
   PlanType,
   Result,
-  SupportedContentFragmentType,
   UserMessageContext,
   UserMessageErrorEvent,
   UserMessageNewEvent,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2024,26 +2024,6 @@ async function isMessagesLimitReached({
   };
 }
 
-export function normalizeContentFragmentType({
-  contentType,
-  url,
-}: {
-  contentType: SupportedContentFragmentType;
-  url?: string;
-}): SupportedContentFragmentType {
-  // hack: for users creating content_fragments through our public API
-  if ((contentType as string) === "file_attachment") {
-    logger.info(
-      {
-        url,
-      },
-      "ContentFragment of type 'file_attachment' being created"
-    );
-    return "text/plain";
-  }
-  return contentType;
-}
-
 /**
  *  Update the conversation groupIds based on the mentioned agents. This
  *  function is purely additive, groupIds will never be removed from the

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -6,7 +6,6 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
   getConversation,
-  normalizeContentFragmentType,
   postNewContentFragment,
 } from "@app/lib/api/assistant/conversation";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
@@ -99,7 +98,7 @@ async function handler(
       }
 
       if (r.data.content) {
-        const { content, contentType } = r.data;
+        const { content } = r.data;
         if (content.length === 0 || content.length > 128 * 1024) {
           return apiError(req, res, {
             status_code: 400,
@@ -110,11 +109,6 @@ async function handler(
             },
           });
         }
-        const normalizedContentType = normalizeContentFragmentType({
-          contentType,
-          url: req.url,
-        });
-        r.data.contentType = normalizedContentType;
       }
       const { context, ...contentFragment } = r.data;
 

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -19,7 +19,6 @@ import {
   createConversation,
   getConversation,
   getUserConversations,
-  normalizeContentFragmentType,
   postNewContentFragment,
 } from "@app/lib/api/assistant/conversation";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
@@ -169,13 +168,6 @@ async function handler(
       let newMessage: UserMessageType | null = null;
 
       for (const resolvedFragment of resolvedFragments) {
-        if (resolvedFragment.content) {
-          resolvedFragment.contentType = normalizeContentFragmentType({
-            contentType: resolvedFragment.contentType,
-            url: req.url,
-          });
-        }
-
         const { context, ...cf } = resolvedFragment;
 
         if (isContentFragmentInputWithContentType(cf)) {

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -68,6 +68,7 @@ export type ConnectorsAPIErrorType = z.infer<
   typeof ConnectorsAPIErrorTypeSchema
 >;
 
+// Supported content types that are plain text and can be sent as file-less content fragment.
 export const supportedRawText = {
   "text/comma-separated-values": [".csv"],
   "text/csv": [".csv"],
@@ -78,7 +79,7 @@ export const supportedRawText = {
   "text/vnd.dust.attachment.slack.thread": [".txt"],
 } as const;
 
-// Supported content types for plain text.
+// Supported content types for plain text (after processing).
 export const supportedPlainText = {
   "application/msword": [".doc", ".docx"],
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document": [
@@ -95,9 +96,14 @@ export const supportedImage = {
   "image/png": [".png"],
 } as const;
 
+// Legacy content types still retuned by the API when rendering old messages.
+export const supportedLegacy = {
+  "dust-application/slack": [],
+} as const;
+
 export type PlainTextContentType = keyof typeof supportedPlainText;
-export type RawTextContentType = keyof typeof supportedRawText;
 export type ImageContentType = keyof typeof supportedImage;
+export type LegacyContentType = keyof typeof supportedLegacy;
 
 export const supportedPlainTextContentTypes = Object.keys(
   supportedPlainText
@@ -108,9 +114,6 @@ export const supportedImageContentTypes = Object.keys(
 export const supportedLegacyContentTypes = Object.keys(
   supportedImage
 ) as ImageContentType[];
-export const supportedRawTextContentTypes = Object.keys(
-  supportedRawText
-) as RawTextContentType[];
 
 export type SupportedFileContentType = PlainTextContentType | ImageContentType;
 const supportedUploadableContentType = [
@@ -121,13 +124,16 @@ const supportedUploadableContentType = [
 const SupportedContentFragmentTypeSchema = FlexibleEnumSchema([
   ...(Object.keys(supportedPlainText) as [keyof typeof supportedPlainText]),
   ...(Object.keys(supportedImage) as [keyof typeof supportedImage]),
+  ...(Object.keys(supportedLegacy) as [keyof typeof supportedLegacy]),
 ]);
 
 const SupportedInlinedContentFragmentTypeSchema = FlexibleEnumSchema([
   ...(Object.keys(supportedRawText) as [keyof typeof supportedRawText]),
 ]);
-const SupportedFileContentFragmentTypeSchema =
-  SupportedContentFragmentTypeSchema;
+const SupportedFileContentFragmentTypeSchema = FlexibleEnumSchema([
+  ...(Object.keys(supportedPlainText) as [keyof typeof supportedPlainText]),
+  ...(Object.keys(supportedImage) as [keyof typeof supportedImage]),
+]);
 
 const uniq = <T>(arr: T[]): T[] => Array.from(new Set(arr));
 

--- a/types/src/front/api_handlers/internal/assistant.ts
+++ b/types/src/front/api_handlers/internal/assistant.ts
@@ -1,6 +1,6 @@
 import * as t from "io-ts";
 
-import { getSupportedContentFragmentTypeCodec } from "../../content_fragment";
+import { getSupportedInlinedContentTypeCodec } from "../../content_fragment";
 
 export const InternalPostMessagesRequestBodySchema = t.type({
   content: t.string,
@@ -25,7 +25,7 @@ const ContentFragmentInputWithContentSchema = t.intersection([
   ContentFragmentBaseSchema,
   t.type({
     content: t.string,
-    contentType: getSupportedContentFragmentTypeCodec(),
+    contentType: getSupportedInlinedContentTypeCodec(),
   }),
 ]);
 

--- a/types/src/front/content_fragment.ts
+++ b/types/src/front/content_fragment.ts
@@ -7,6 +7,7 @@ import {
   PlainTextContentType,
   SupportedFileContentType,
   supportedImageContentTypes,
+  supportedInlinedContentType,
   supportedPlainTextContentTypes,
   supportedUploadableContentType,
 } from "./files";
@@ -26,8 +27,8 @@ export const supportedContentFragmentType = [
 export type SupportedContentFragmentType =
   (typeof supportedContentFragmentType)[number];
 
-export function getSupportedContentFragmentTypeCodec(): t.Mixed {
-  const [first, second, ...rest] = supportedContentFragmentType;
+export function getSupportedInlinedContentTypeCodec(): t.Mixed {
+  const [first, second, ...rest] = supportedInlinedContentType;
   return t.union([
     t.literal(first),
     t.literal(second),

--- a/types/src/front/content_fragment.ts
+++ b/types/src/front/content_fragment.ts
@@ -27,7 +27,7 @@ export const supportedContentFragmentType = [
 export type SupportedContentFragmentType =
   (typeof supportedContentFragmentType)[number];
 
-export function getSupportedInlinedContentTypeCodec(): t.Mixed {
+export function getSupportedInlinedContentTypeCodec() {
   const [first, second, ...rest] = supportedInlinedContentType;
   return t.union([
     t.literal(first),

--- a/types/src/front/files.ts
+++ b/types/src/front/files.ts
@@ -72,10 +72,17 @@ const supportedDelimitedText = {
   "text/tsv": [".tsv"],
 } as const;
 
+const supportedRawText = {
+  "text/markdown": [".md", ".markdown"],
+  "text/plain": [".txt"],
+  "text/vnd.dust.attachment.slack.thread": [".txt"],
+};
+
 // Supported content types for plain text.
 const supportedPlainText = {
   // We support all tabular content types as plain text.
   ...supportedDelimitedText,
+  ...supportedRawText,
 
   "application/msword": [".doc", ".docx"],
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document": [
@@ -83,10 +90,6 @@ const supportedPlainText = {
     ".docx",
   ],
   "application/pdf": [".pdf"],
-  "text/markdown": [".md", ".markdown"],
-  "text/plain": [".txt"],
-
-  "text/vnd.dust.attachment.slack.thread": [".txt"],
 } as const;
 
 // Supported content types for images.
@@ -123,16 +126,24 @@ export const supportedImageContentTypes = Object.keys(
 export const supportedDelimitedTextContentTypes = Object.keys(
   supportedDelimitedText
 ) as (keyof typeof supportedDelimitedText)[];
+export const supportedRawTextContentTypes = Object.keys(
+  supportedRawText
+) as (keyof typeof supportedRawText)[];
 
 export const supportedUploadableContentType = [
   ...supportedPlainTextContentTypes,
   ...supportedImageContentTypes,
+];
+export const supportedInlinedContentType = [
+  ...supportedDelimitedTextContentTypes,
+  ...supportedRawTextContentTypes,
 ];
 
 // Infer types from the arrays.
 export type PlainTextContentType = keyof typeof supportedPlainText;
 export type ImageContentType = keyof typeof supportedImage;
 export type DelimitedTextContentType = keyof typeof supportedDelimitedText;
+export type RawTextContentType = keyof typeof supportedRawText;
 
 // Union type for all supported content types.
 export type SupportedFileContentType = PlainTextContentType | ImageContentType;
@@ -142,6 +153,18 @@ export function isSupportedFileContentType(
 ): contentType is SupportedFileContentType {
   return supportedUploadableContentType.includes(
     contentType as SupportedFileContentType
+  );
+}
+
+export type SupportedInlinedContentType =
+  | DelimitedTextContentType
+  | RawTextContentType;
+
+export function isSupportedInlinedContentType(
+  contentType: string
+): contentType is SupportedInlinedContentType {
+  return supportedInlinedContentType.includes(
+    contentType as SupportedInlinedContentType
   );
 }
 

--- a/types/src/front/files.ts
+++ b/types/src/front/files.ts
@@ -72,13 +72,14 @@ const supportedDelimitedText = {
   "text/tsv": [".tsv"],
 } as const;
 
+// Supported content types that are plain text and can be sent as file-less content fragment.
 const supportedRawText = {
   "text/markdown": [".md", ".markdown"],
   "text/plain": [".txt"],
   "text/vnd.dust.attachment.slack.thread": [".txt"],
 };
 
-// Supported content types for plain text.
+// Supported content types for plain text (after processing).
 const supportedPlainText = {
   // We support all tabular content types as plain text.
   ...supportedDelimitedText,


### PR DESCRIPTION
## Description

Narrow the content type that can be used when using the public API content fragments without using a file. Also adds validation for file API content types.

## Risk

Low: public API calls using content fragments

https://app.datadoghq.eu/logs?query=%22Public%20API%3A%20ContentFragmentInputWithContentType%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice%2C%40workspaceId&fromUser=true&graphType=flamegraph&highlight=api.atlassian.com&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=1016602553721981239&storage=hot&stream_sort=desc&view=spans&viz=stream&from_ts=1733415120486&to_ts=1733416020486&live=true

## Deploy Plan

- deploy `front`