### PR TITLE
[connectors] Rethrow snowflake password errors as ExternalOauthErrors

### DIFF
--- a/connectors/src/connectors/snowflake/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/snowflake/temporal/cast_known_errors.ts
@@ -1,0 +1,39 @@
+import type {
+  ActivityExecuteInput,
+  ActivityInboundCallsInterceptor,
+  Next,
+} from "@temporalio/worker";
+
+import { ExternalOAuthTokenError } from "@connectors/lib/error";
+
+interface SnowflakeApiError extends Error {
+  code: number;
+  name: string;
+}
+
+function isExpiredPasswordError(err: unknown): err is SnowflakeApiError {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    err.code === 390106
+  );
+}
+
+export class SnowflakeCastKnownErrorsInterceptor
+  implements ActivityInboundCallsInterceptor
+{
+  async execute(
+    input: ActivityExecuteInput,
+    next: Next<ActivityInboundCallsInterceptor, "execute">
+  ): Promise<unknown> {
+    try {
+      return await next(input);
+    } catch (err: unknown) {
+      if (isExpiredPasswordError(err)) {
+        throw new ExternalOAuthTokenError(err);
+      }
+      throw err;
+    }
+  }
+}

--- a/connectors/src/connectors/snowflake/temporal/worker.ts
+++ b/connectors/src/connectors/snowflake/temporal/worker.ts
@@ -4,6 +4,7 @@ import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 
 import * as activities from "@connectors/connectors/snowflake/temporal/activities";
 import { QUEUE_NAME } from "@connectors/connectors/snowflake/temporal/config";
+import { ZendeskCastKnownErrorsInterceptor } from "@connectors/connectors/zendesk/temporal/cast_known_errors";
 import * as sync_status from "@connectors/lib/sync_status";
 import {
   getTemporalWorkerConnection,
@@ -28,6 +29,7 @@ export async function runSnowflakeWorker() {
         (ctx: Context) => {
           return new ActivityInboundLogInterceptor(ctx, logger);
         },
+        () => new ZendeskCastKnownErrorsInterceptor(),
       ],
     },
     bundlerOptions: {


### PR DESCRIPTION
## Description

- Add `cast_known_errors` to snowflake.
- Rethrow `Error: Specified password has expired.  Password must be changed using the Snowflake web console.` errors as `ExternalOauthErrors`.
- https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40dd.service%3Aconnectors-worker%20%40error.name%3AOperationFailedError&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=6000198897476506285&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1733404066695&to_ts=1733418466695&live=true

## Risk

Low.

## Deploy Plan

- Deploy connectors.
