### PR TITLE
BigInt for the win - Wave #1

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -52,7 +52,6 @@ import {
 } from "@app/lib/models/doc_tracker";
 import { FeatureFlag } from "@app/lib/models/feature_flag";
 import { Plan, Subscription } from "@app/lib/models/plan";
-import { User, UserMetadata } from "@app/lib/models/user";
 import {
   DustAppSecret,
   MembershipInvitation,
@@ -85,6 +84,10 @@ import {
 } from "@app/lib/resources/storage/models/runs";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { TemplateModel } from "@app/lib/resources/storage/models/templates";
+import {
+  UserMetadataModel,
+  UserModel,
+} from "@app/lib/resources/storage/models/user";
 import logger from "@app/logger/logger";
 
 async function main() {
@@ -92,8 +95,8 @@ async function main() {
     service: "front",
     logger: logger,
   });
-  await User.sync({ alter: true });
-  await UserMetadata.sync({ alter: true });
+  await UserModel.sync({ alter: true });
+  await UserMetadataModel.sync({ alter: true });
   await Workspace.sync({ alter: true });
   await WorkspaceHasDomain.sync({ alter: true });
   await MembershipModel.sync({ alter: true });

--- a/front/admin/init_dust_apps.ts
+++ b/front/admin/init_dust_apps.ts
@@ -1,11 +1,10 @@
 import { Authenticator } from "@app/lib/auth";
-import { FeatureFlag } from "@app/lib/models/feature_flag";
-import { User } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
 import { internalSubscribeWorkspaceToFreePlan } from "@app/lib/plans/subscription";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import { UserModel } from "@app/lib/resources/storage/models/user";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 
@@ -51,11 +50,11 @@ async function main() {
     planCode: "FREE_UPGRADED_PLAN",
   });
 
-  const users = await User.findAll();
+  const users = await UserModel.findAll();
   await Promise.all(
     users.map(async (user) =>
       MembershipResource.createMembership({
-        user: new UserResource(User, user.get()),
+        user: new UserResource(UserModel, user.get()),
         workspace: lightWorkspace,
         role: "admin",
       })

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -64,6 +64,7 @@ async function destroyMessageRelatedResources(messageIds: Array<ModelId>) {
   await Mention.destroy({
     where: { messageId: messageIds },
   });
+  // TODO: We should also destroy the parent message
   await Message.destroy({
     where: { id: messageIds },
   });

--- a/front/lib/api/assistant/email_trigger.ts
+++ b/front/lib/api/assistant/email_trigger.ts
@@ -24,7 +24,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { Workspace } from "@app/lib/models/workspace";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { MembershipModel } from "@app/lib/resources/storage/models/membership";
-import type { UserModel } from "@app/lib/resources/storage/models/user";
+import { UserModel } from "@app/lib/resources/storage/models/user";
 import { filterAndSortAgents } from "@app/lib/utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
@@ -106,7 +106,7 @@ export async function userAndWorkspacesFromEmail({
     EmailTriggerError
   >
 > {
-  const user = await User.findOne({
+  const user = await UserModel.findOne({
     where: { email },
   });
 

--- a/front/lib/api/assistant/email_trigger.ts
+++ b/front/lib/api/assistant/email_trigger.ts
@@ -21,17 +21,17 @@ import { postUserMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
 import { sendEmail } from "@app/lib/api/email";
 import { processAndStoreFile } from "@app/lib/api/files/upload";
 import type { Authenticator } from "@app/lib/auth";
-import { User } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { MembershipModel } from "@app/lib/resources/storage/models/membership";
+import type { UserModel } from "@app/lib/resources/storage/models/user";
 import { filterAndSortAgents } from "@app/lib/utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 
 const { PRODUCTION_DUST_WORKSPACE_ID } = process.env;
 
-function renderUserType(user: User): UserType {
+function renderUserType(user: UserModel): UserType {
   return {
     sId: user.sId,
     id: user.id,

--- a/front/lib/api/assistant/participants.ts
+++ b/front/lib/api/assistant/participants.ts
@@ -17,13 +17,13 @@ import {
   Message,
   UserMessage,
 } from "@app/lib/models/assistant/conversation";
-import { User } from "@app/lib/models/user";
+import { UserModel } from "@app/lib/resources/storage/models/user";
 
 async function fetchAllUsersById(
   userIds: ModelId[]
 ): Promise<UserParticipantType[]> {
   const users = (
-    await User.findAll({
+    await UserModel.findAll({
       attributes: ["firstName", "lastName", "imageUrl", "username"],
       where: {
         id: {
@@ -31,7 +31,7 @@ async function fetchAllUsersById(
         },
       },
     })
-  ).filter((u) => u !== null) as User[];
+  ).filter((u) => u !== null) as UserModel[];
 
   return users.map((u) => ({
     fullName: formatUserFullName(u),

--- a/front/lib/api/user.ts
+++ b/front/lib/api/user.ts
@@ -8,8 +8,8 @@ import type {
 import { Err, Ok } from "@dust-tt/types";
 
 import type { Authenticator } from "@app/lib/auth";
-import { UserMetadata } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
+import { UserMetadataModel } from "@app/lib/resources/storage/models/user";
 import { UserResource } from "@app/lib/resources/user_resource";
 import logger from "@app/logger/logger";
 
@@ -57,7 +57,7 @@ export async function getUserMetadata(
   user: UserType,
   key: string
 ): Promise<UserMetadataType | null> {
-  const metadata = await UserMetadata.findOne({
+  const metadata = await UserMetadataModel.findOne({
     where: {
       userId: user.id,
       key,
@@ -84,7 +84,7 @@ export async function setUserMetadata(
   user: UserType,
   update: UserMetadataType
 ): Promise<void> {
-  const metadata = await UserMetadata.findOne({
+  const metadata = await UserMetadataModel.findOne({
     where: {
       userId: user.id,
       key: update.key,
@@ -92,7 +92,7 @@ export async function setUserMetadata(
   });
 
   if (!metadata) {
-    await UserMetadata.create({
+    await UserMetadataModel.create({
       userId: user.id,
       key: update.key,
       value: update.value,

--- a/front/lib/document_tracker.ts
+++ b/front/lib/document_tracker.ts
@@ -3,10 +3,10 @@ import { literal, Op } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
 import { TrackedDocument } from "@app/lib/models/doc_tracker";
-import { User } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { UserModel } from "@app/lib/resources/storage/models/user";
 import logger from "@app/logger/logger";
 
 import config from "./api/config";
@@ -91,7 +91,7 @@ export async function updateTrackedDocuments(
   // find users with matching emails
   const emails = Array.from(allEmails);
   let users = emails.length
-    ? await User.findAll({
+    ? await UserModel.findAll({
         where: literal(`lower(email) IN (:emails)`),
         replacements: {
           emails,
@@ -108,7 +108,7 @@ export async function updateTrackedDocuments(
   );
   users = users.filter((user) => userIdsInWorkspace.has(user.id));
 
-  const userByEmail: Map<string, User> = new Map();
+  const userByEmail: Map<string, UserModel> = new Map();
   for (const user of users) {
     userByEmail.set(user.email.toLowerCase(), user);
   }

--- a/front/lib/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
+++ b/front/lib/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
@@ -17,8 +17,8 @@ import {
   DocumentTrackerChangeSuggestion,
   TrackedDocument,
 } from "@app/lib/models/doc_tracker";
-import { User } from "@app/lib/models/user";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { UserModel } from "@app/lib/resources/storage/models/user";
 import mainLogger from "@app/logger/logger";
 
 import { callDocTrackerRetrievalAction } from "./actions/doc_tracker_retrieval";
@@ -410,7 +410,7 @@ export async function documentTrackerSuggestChangesOnUpsert({
       )
     );
 
-    const users = await User.findAll({
+    const users = await UserModel.findAll({
       where: {
         id: {
           [Op.in]: trackedDocuments.map((td) => td.userId),

--- a/front/lib/iam/users.ts
+++ b/front/lib/iam/users.ts
@@ -3,7 +3,7 @@ import type { UserProviderType } from "@dust-tt/types";
 import { sanitizeString } from "@dust-tt/types";
 
 import type { ExternalUser, SessionWithUser } from "@app/lib/iam/provider";
-import { User } from "@app/lib/models/user";
+import { UserModel } from "@app/lib/resources/storage/models/user";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
@@ -74,7 +74,7 @@ export async function maybeUpdateFromExternalUser(
   externalUser: ExternalUser
 ) {
   if (externalUser.picture && externalUser.picture !== user.imageUrl) {
-    void User.update(
+    void UserModel.update(
       {
         imageUrl: externalUser.picture,
       },

--- a/front/lib/models/assistant/actions/browse.ts
+++ b/front/lib/models/assistant/actions/browse.ts
@@ -1,21 +1,13 @@
 import type { BrowseActionOutputType } from "@dust-tt/types";
-import type {
-  CreationOptional,
-  ForeignKey,
-  InferAttributes,
-  InferCreationAttributes,
-} from "sequelize";
-import { DataTypes, Model } from "sequelize";
+import type { CreationOptional, ForeignKey } from "sequelize";
+import { DataTypes } from "sequelize";
 
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { AgentMessage } from "@app/lib/models/assistant/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { BaseModel } from "@app/lib/resources/storage/wrappers";
 
-export class AgentBrowseConfiguration extends Model<
-  InferAttributes<AgentBrowseConfiguration>,
-  InferCreationAttributes<AgentBrowseConfiguration>
-> {
-  declare id: CreationOptional<number>;
+export class AgentBrowseConfiguration extends BaseModel<AgentBrowseConfiguration> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -29,11 +21,6 @@ export class AgentBrowseConfiguration extends Model<
 
 AgentBrowseConfiguration.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -80,11 +67,7 @@ AgentBrowseConfiguration.belongsTo(AgentConfiguration, {
   foreignKey: { name: "agentConfigurationId", allowNull: false },
 });
 
-export class AgentBrowseAction extends Model<
-  InferAttributes<AgentBrowseAction>,
-  InferCreationAttributes<AgentBrowseAction>
-> {
-  declare id: CreationOptional<number>;
+export class AgentBrowseAction extends BaseModel<AgentBrowseAction> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare runId: string | null;
@@ -102,11 +85,6 @@ export class AgentBrowseAction extends Model<
 }
 AgentBrowseAction.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,

--- a/front/lib/models/assistant/actions/conversation/include_file.ts
+++ b/front/lib/models/assistant/actions/conversation/include_file.ts
@@ -1,22 +1,14 @@
-import type {
-  CreationOptional,
-  ForeignKey,
-  InferAttributes,
-  InferCreationAttributes,
-} from "sequelize";
-import { DataTypes, Model } from "sequelize";
+import type { CreationOptional, ForeignKey } from "sequelize";
+import { DataTypes } from "sequelize";
 
 import { AgentMessage } from "@app/lib/models/assistant/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { BaseModel } from "@app/lib/resources/storage/wrappers";
 
 /**
  * ConversationIncludeFile Action
  */
-export class AgentConversationIncludeFileAction extends Model<
-  InferAttributes<AgentConversationIncludeFileAction>,
-  InferCreationAttributes<AgentConversationIncludeFileAction>
-> {
-  declare id: CreationOptional<number>;
+export class AgentConversationIncludeFileAction extends BaseModel<AgentConversationIncludeFileAction> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -31,11 +23,6 @@ export class AgentConversationIncludeFileAction extends Model<
 }
 AgentConversationIncludeFileAction.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,

--- a/front/lib/models/assistant/actions/data_sources.ts
+++ b/front/lib/models/assistant/actions/data_sources.ts
@@ -1,26 +1,17 @@
-import type {
-  CreationOptional,
-  ForeignKey,
-  InferAttributes,
-  InferCreationAttributes,
-  NonAttribute,
-} from "sequelize";
-import { DataTypes, Model } from "sequelize";
+import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
+import { DataTypes } from "sequelize";
 
 import { AgentProcessConfiguration } from "@app/lib/models/assistant/actions/process";
 import { AgentRetrievalConfiguration } from "@app/lib/models/assistant/actions/retrieval";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
+import { BaseModel } from "@app/lib/resources/storage/wrappers";
 
 /**
  * Configuration of Datasources used for Retrieval Action.
  */
-export class AgentDataSourceConfiguration extends Model<
-  InferAttributes<AgentDataSourceConfiguration>,
-  InferCreationAttributes<AgentDataSourceConfiguration>
-> {
-  declare id: CreationOptional<number>;
+export class AgentDataSourceConfiguration extends BaseModel<AgentDataSourceConfiguration> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -44,11 +35,6 @@ export class AgentDataSourceConfiguration extends Model<
 }
 AgentDataSourceConfiguration.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,

--- a/front/lib/models/assistant/actions/dust_app_run.ts
+++ b/front/lib/models/assistant/actions/dust_app_run.ts
@@ -1,21 +1,13 @@
 import type { DustAppParameters } from "@dust-tt/types";
-import type {
-  CreationOptional,
-  ForeignKey,
-  InferAttributes,
-  InferCreationAttributes,
-} from "sequelize";
-import { DataTypes, Model } from "sequelize";
+import type { CreationOptional, ForeignKey } from "sequelize";
+import { DataTypes } from "sequelize";
 
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { AgentMessage } from "@app/lib/models/assistant/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { BaseModel } from "@app/lib/resources/storage/wrappers";
 
-export class AgentDustAppRunConfiguration extends Model<
-  InferAttributes<AgentDustAppRunConfiguration>,
-  InferCreationAttributes<AgentDustAppRunConfiguration>
-> {
-  declare id: CreationOptional<number>;
+export class AgentDustAppRunConfiguration extends BaseModel<AgentDustAppRunConfiguration> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -29,11 +21,6 @@ export class AgentDustAppRunConfiguration extends Model<
 
 AgentDustAppRunConfiguration.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -83,11 +70,7 @@ AgentDustAppRunConfiguration.belongsTo(AgentConfiguration, {
 /**
  * DustAppRun Action
  */
-export class AgentDustAppRunAction extends Model<
-  InferAttributes<AgentDustAppRunAction>,
-  InferCreationAttributes<AgentDustAppRunAction>
-> {
-  declare id: CreationOptional<number>;
+export class AgentDustAppRunAction extends BaseModel<AgentDustAppRunAction> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare runId: string | null;
@@ -108,11 +91,6 @@ export class AgentDustAppRunAction extends Model<
 }
 AgentDustAppRunAction.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,

--- a/front/lib/models/assistant/actions/process.ts
+++ b/front/lib/models/assistant/actions/process.ts
@@ -3,23 +3,15 @@ import type {
   ProcessSchemaPropertyType,
   TimeframeUnit,
 } from "@dust-tt/types";
-import type {
-  CreationOptional,
-  ForeignKey,
-  InferAttributes,
-  InferCreationAttributes,
-} from "sequelize";
-import { DataTypes, Model } from "sequelize";
+import type { CreationOptional, ForeignKey } from "sequelize";
+import { DataTypes } from "sequelize";
 
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { AgentMessage } from "@app/lib/models/assistant/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { BaseModel } from "@app/lib/resources/storage/wrappers";
 
-export class AgentProcessConfiguration extends Model<
-  InferAttributes<AgentProcessConfiguration>,
-  InferCreationAttributes<AgentProcessConfiguration>
-> {
-  declare id: CreationOptional<number>;
+export class AgentProcessConfiguration extends BaseModel<AgentProcessConfiguration> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -41,11 +33,6 @@ export class AgentProcessConfiguration extends Model<
 
 AgentProcessConfiguration.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -129,11 +116,7 @@ AgentProcessConfiguration.belongsTo(AgentConfiguration, {
 /**
  * Process Action
  */
-export class AgentProcessAction extends Model<
-  InferAttributes<AgentProcessAction>,
-  InferCreationAttributes<AgentProcessAction>
-> {
-  declare id: CreationOptional<number>;
+export class AgentProcessAction extends BaseModel<AgentProcessAction> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare runId: string | null;
@@ -154,11 +137,6 @@ export class AgentProcessAction extends Model<
 }
 AgentProcessAction.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,

--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -1,23 +1,14 @@
 import type { TimeframeUnit } from "@dust-tt/types";
-import type {
-  CreationOptional,
-  ForeignKey,
-  InferAttributes,
-  InferCreationAttributes,
-  NonAttribute,
-} from "sequelize";
-import { DataTypes, Model } from "sequelize";
+import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
+import { DataTypes } from "sequelize";
 
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { AgentMessage } from "@app/lib/models/assistant/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
+import { BaseModel } from "@app/lib/resources/storage/wrappers";
 
-export class AgentRetrievalConfiguration extends Model<
-  InferAttributes<AgentRetrievalConfiguration>,
-  InferCreationAttributes<AgentRetrievalConfiguration>
-> {
-  declare id: CreationOptional<number>;
+export class AgentRetrievalConfiguration extends BaseModel<AgentRetrievalConfiguration> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -38,11 +29,6 @@ export class AgentRetrievalConfiguration extends Model<
 
 AgentRetrievalConfiguration.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -144,11 +130,7 @@ AgentRetrievalConfiguration.belongsTo(AgentConfiguration, {
 /**
  * Retrieval Action
  */
-export class AgentRetrievalAction extends Model<
-  InferAttributes<AgentRetrievalAction>,
-  InferCreationAttributes<AgentRetrievalAction>
-> {
-  declare id: CreationOptional<number>;
+export class AgentRetrievalAction extends BaseModel<AgentRetrievalAction> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare runId: string | null;
@@ -168,11 +150,6 @@ export class AgentRetrievalAction extends Model<
 }
 AgentRetrievalAction.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -253,11 +230,7 @@ AgentMessage.hasMany(AgentRetrievalAction, {
   foreignKey: { name: "agentMessageId", allowNull: false },
 });
 
-export class RetrievalDocument extends Model<
-  InferAttributes<RetrievalDocument>,
-  InferCreationAttributes<RetrievalDocument>
-> {
-  declare id: CreationOptional<number>;
+export class RetrievalDocument extends BaseModel<RetrievalDocument> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -278,11 +251,6 @@ export class RetrievalDocument extends Model<
 
 RetrievalDocument.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -342,11 +310,7 @@ RetrievalDocument.belongsTo(DataSourceViewModel, {
   foreignKey: { allowNull: true },
 });
 
-export class RetrievalDocumentChunk extends Model<
-  InferAttributes<RetrievalDocumentChunk>,
-  InferCreationAttributes<RetrievalDocumentChunk>
-> {
-  declare id: CreationOptional<number>;
+export class RetrievalDocumentChunk extends BaseModel<RetrievalDocumentChunk> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -359,11 +323,6 @@ export class RetrievalDocumentChunk extends Model<
 
 RetrievalDocumentChunk.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,

--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -1,11 +1,5 @@
-import type {
-  CreationOptional,
-  ForeignKey,
-  InferAttributes,
-  InferCreationAttributes,
-  NonAttribute,
-} from "sequelize";
-import { DataTypes, Model } from "sequelize";
+import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
+import { DataTypes } from "sequelize";
 
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { AgentMessage } from "@app/lib/models/assistant/conversation";
@@ -13,12 +7,9 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 import { FileModel } from "@app/lib/resources/storage/models/files";
+import { BaseModel } from "@app/lib/resources/storage/wrappers";
 
-export class AgentTablesQueryConfiguration extends Model<
-  InferAttributes<AgentTablesQueryConfiguration>,
-  InferCreationAttributes<AgentTablesQueryConfiguration>
-> {
-  declare id: CreationOptional<number>;
+export class AgentTablesQueryConfiguration extends BaseModel<AgentTablesQueryConfiguration> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -32,11 +23,6 @@ export class AgentTablesQueryConfiguration extends Model<
 
 AgentTablesQueryConfiguration.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -84,11 +70,7 @@ AgentTablesQueryConfiguration.belongsTo(AgentConfiguration, {
   foreignKey: { name: "agentConfigurationId", allowNull: false },
 });
 
-export class AgentTablesQueryConfigurationTable extends Model<
-  InferAttributes<AgentTablesQueryConfigurationTable>,
-  InferCreationAttributes<AgentTablesQueryConfigurationTable>
-> {
-  declare id: CreationOptional<number>;
+export class AgentTablesQueryConfigurationTable extends BaseModel<AgentTablesQueryConfigurationTable> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -106,11 +88,6 @@ export class AgentTablesQueryConfigurationTable extends Model<
 
 AgentTablesQueryConfigurationTable.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -168,11 +145,7 @@ AgentTablesQueryConfigurationTable.belongsTo(DataSourceViewModel, {
   foreignKey: { allowNull: false },
 });
 
-export class AgentTablesQueryAction extends Model<
-  InferAttributes<AgentTablesQueryAction>,
-  InferCreationAttributes<AgentTablesQueryAction>
-> {
-  declare id: CreationOptional<number>;
+export class AgentTablesQueryAction extends BaseModel<AgentTablesQueryAction> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare runId: string | null;
@@ -196,11 +169,6 @@ export class AgentTablesQueryAction extends Model<
 
 AgentTablesQueryAction.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,

--- a/front/lib/models/assistant/actions/websearch.ts
+++ b/front/lib/models/assistant/actions/websearch.ts
@@ -1,21 +1,13 @@
 import type { WebsearchActionOutputType } from "@dust-tt/types";
-import type {
-  CreationOptional,
-  ForeignKey,
-  InferAttributes,
-  InferCreationAttributes,
-} from "sequelize";
-import { DataTypes, Model } from "sequelize";
+import type { CreationOptional, ForeignKey } from "sequelize";
+import { DataTypes } from "sequelize";
 
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { AgentMessage } from "@app/lib/models/assistant/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { BaseModel } from "@app/lib/resources/storage/wrappers";
 
-export class AgentWebsearchConfiguration extends Model<
-  InferAttributes<AgentWebsearchConfiguration>,
-  InferCreationAttributes<AgentWebsearchConfiguration>
-> {
-  declare id: CreationOptional<number>;
+export class AgentWebsearchConfiguration extends BaseModel<AgentWebsearchConfiguration> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -29,11 +21,6 @@ export class AgentWebsearchConfiguration extends Model<
 
 AgentWebsearchConfiguration.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -80,11 +67,7 @@ AgentWebsearchConfiguration.belongsTo(AgentConfiguration, {
   foreignKey: { name: "agentConfigurationId", allowNull: false },
 });
 
-export class AgentWebsearchAction extends Model<
-  InferAttributes<AgentWebsearchAction>,
-  InferCreationAttributes<AgentWebsearchAction>
-> {
-  declare id: CreationOptional<number>;
+export class AgentWebsearchAction extends BaseModel<AgentWebsearchAction> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare runId: string | null;
@@ -102,11 +85,6 @@ export class AgentWebsearchAction extends Model<
 }
 AgentWebsearchAction.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -5,28 +5,19 @@ import type {
   ModelIdType,
   ModelProviderIdType,
 } from "@dust-tt/types";
-import type {
-  CreationOptional,
-  ForeignKey,
-  InferAttributes,
-  InferCreationAttributes,
-  NonAttribute,
-} from "sequelize";
-import { DataTypes, Model } from "sequelize";
+import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
+import { DataTypes } from "sequelize";
 
-import { User } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { TemplateModel } from "@app/lib/resources/storage/models/templates";
+import { UserModel } from "@app/lib/resources/storage/models/user";
+import { BaseModel } from "@app/lib/resources/storage/wrappers";
 
 /**
  * Agent configuration
  */
-export class AgentConfiguration extends Model<
-  InferAttributes<AgentConfiguration>,
-  InferCreationAttributes<AgentConfiguration>
-> {
-  declare id: CreationOptional<number>;
+export class AgentConfiguration extends BaseModel<AgentConfiguration> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -47,7 +38,7 @@ export class AgentConfiguration extends Model<
   declare pictureUrl: string;
 
   declare workspaceId: ForeignKey<Workspace["id"]>;
-  declare authorId: ForeignKey<User["id"]>;
+  declare authorId: ForeignKey<UserModel["id"]>;
 
   declare maxStepsPerRun: number;
   declare visualizationEnabled: boolean;
@@ -57,16 +48,11 @@ export class AgentConfiguration extends Model<
   declare groupIds: number[];
   declare requestedGroupIds: number[][];
 
-  declare author: NonAttribute<User>;
+  declare author: NonAttribute<UserModel>;
 }
 
 AgentConfiguration.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -186,22 +172,18 @@ AgentConfiguration.belongsTo(Workspace, {
 });
 
 // Agent config <> Author
-User.hasMany(AgentConfiguration, {
+UserModel.hasMany(AgentConfiguration, {
   foreignKey: { name: "authorId", allowNull: false },
   onDelete: "CASCADE",
 });
-AgentConfiguration.belongsTo(User, {
+AgentConfiguration.belongsTo(UserModel, {
   foreignKey: { name: "authorId", allowNull: false },
 });
 
 /**
  * Global Agent settings
  */
-export class GlobalAgentSettings extends Model<
-  InferAttributes<GlobalAgentSettings>,
-  InferCreationAttributes<GlobalAgentSettings>
-> {
-  declare id: CreationOptional<number>;
+export class GlobalAgentSettings extends BaseModel<GlobalAgentSettings> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -212,11 +194,6 @@ export class GlobalAgentSettings extends Model<
 }
 GlobalAgentSettings.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -264,11 +241,7 @@ AgentConfiguration.belongsTo(TemplateModel, {
   foreignKey: { name: "templateId", allowNull: true },
 });
 
-export class AgentUserRelation extends Model<
-  InferAttributes<AgentUserRelation>,
-  InferCreationAttributes<AgentUserRelation>
-> {
-  declare id: CreationOptional<number>;
+export class AgentUserRelation extends BaseModel<AgentUserRelation> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -276,17 +249,12 @@ export class AgentUserRelation extends Model<
 
   declare favorite: boolean;
 
-  declare userId: ForeignKey<User["id"]>;
+  declare userId: ForeignKey<UserModel["id"]>;
   declare workspaceId: ForeignKey<Workspace["id"]>;
 }
 
 AgentUserRelation.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -322,7 +290,7 @@ AgentUserRelation.init(
   }
 );
 
-User.hasMany(AgentUserRelation, {
+UserModel.hasMany(AgentUserRelation, {
   foreignKey: { allowNull: false },
   onDelete: "CASCADE",
 });
@@ -330,7 +298,7 @@ Workspace.hasMany(AgentUserRelation, {
   foreignKey: { allowNull: false },
   onDelete: "CASCADE",
 });
-AgentUserRelation.belongsTo(User, {
+AgentUserRelation.belongsTo(UserModel, {
   foreignKey: { allowNull: false },
 });
 AgentUserRelation.belongsTo(Workspace, {

--- a/front/lib/models/assistant/agent_message_content.ts
+++ b/front/lib/models/assistant/agent_message_content.ts
@@ -1,19 +1,11 @@
-import type {
-  CreationOptional,
-  ForeignKey,
-  InferAttributes,
-  InferCreationAttributes,
-} from "sequelize";
-import { DataTypes, Model } from "sequelize";
+import type { CreationOptional, ForeignKey } from "sequelize";
+import { DataTypes } from "sequelize";
 
 import { AgentMessage } from "@app/lib/models/assistant/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { BaseModel } from "@app/lib/resources/storage/wrappers";
 
-export class AgentMessageContent extends Model<
-  InferAttributes<AgentMessageContent>,
-  InferCreationAttributes<AgentMessageContent>
-> {
-  declare id: CreationOptional<number>;
+export class AgentMessageContent extends BaseModel<AgentMessageContent> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -25,11 +17,6 @@ export class AgentMessageContent extends Model<
 
 AgentMessageContent.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -5,27 +5,18 @@ import type {
   ParticipantActionType,
   UserMessageOrigin,
 } from "@dust-tt/types";
-import type {
-  CreationOptional,
-  ForeignKey,
-  InferAttributes,
-  InferCreationAttributes,
-  NonAttribute,
-} from "sequelize";
-import { DataTypes, Model } from "sequelize";
+import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
+import { DataTypes } from "sequelize";
 
 import type { AgentMessageFeedbackDirection } from "@app/lib/api/assistant/conversation/feedbacks";
 import type { AgentMessageContent } from "@app/lib/models/assistant/agent_message_content";
-import { User } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
+import { UserModel } from "@app/lib/resources/storage/models/user";
+import { BaseModel } from "@app/lib/resources/storage/wrappers";
 
-export class Conversation extends Model<
-  InferAttributes<Conversation>,
-  InferCreationAttributes<Conversation>
-> {
-  declare id: CreationOptional<number>;
+export class Conversation extends BaseModel<Conversation> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -42,11 +33,6 @@ export class Conversation extends Model<
 
 Conversation.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -107,29 +93,20 @@ Conversation.belongsTo(Workspace, {
   foreignKey: { name: "workspaceId", allowNull: false },
 });
 
-export class ConversationParticipant extends Model<
-  InferAttributes<ConversationParticipant>,
-  InferCreationAttributes<ConversationParticipant>
-> {
-  declare id: CreationOptional<number>;
+export class ConversationParticipant extends BaseModel<ConversationParticipant> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
   declare action: ParticipantActionType;
 
   declare conversationId: ForeignKey<Conversation["id"]>;
-  declare userId: ForeignKey<User["id"]>;
+  declare userId: ForeignKey<UserModel["id"]>;
 
   declare conversation?: NonAttribute<Conversation>;
-  declare user?: NonAttribute<User>;
+  declare user?: NonAttribute<UserModel>;
 }
 ConversationParticipant.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -174,19 +151,15 @@ Conversation.hasMany(ConversationParticipant, {
 ConversationParticipant.belongsTo(Conversation, {
   foreignKey: { name: "conversationId", allowNull: false },
 });
-User.hasMany(ConversationParticipant, {
+UserModel.hasMany(ConversationParticipant, {
   foreignKey: { name: "userId", allowNull: false },
   onDelete: "CASCADE",
 });
-ConversationParticipant.belongsTo(User, {
+ConversationParticipant.belongsTo(UserModel, {
   foreignKey: { name: "userId", allowNull: false },
 });
 
-export class UserMessage extends Model<
-  InferAttributes<UserMessage>,
-  InferCreationAttributes<UserMessage>
-> {
-  declare id: CreationOptional<number>;
+export class UserMessage extends BaseModel<UserMessage> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -199,16 +172,11 @@ export class UserMessage extends Model<
   declare userContextProfilePictureUrl: string | null;
   declare userContextOrigin: UserMessageOrigin | null;
 
-  declare userId: ForeignKey<User["id"]> | null;
+  declare userId: ForeignKey<UserModel["id"]> | null;
 }
 
 UserMessage.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -254,18 +222,14 @@ UserMessage.init(
   }
 );
 
-User.hasMany(UserMessage, {
+UserModel.hasMany(UserMessage, {
   foreignKey: { name: "userId", allowNull: true }, // null = message is not associated with a user
 });
-UserMessage.belongsTo(User, {
+UserMessage.belongsTo(UserModel, {
   foreignKey: { name: "userId", allowNull: true },
 });
 
-export class AgentMessage extends Model<
-  InferAttributes<AgentMessage>,
-  InferCreationAttributes<AgentMessage>
-> {
-  declare id: CreationOptional<number>;
+export class AgentMessage extends BaseModel<AgentMessage> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare runIds: string[] | null;
@@ -284,11 +248,6 @@ export class AgentMessage extends Model<
 
 AgentMessage.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -332,11 +291,7 @@ AgentMessage.init(
   }
 );
 
-export class AgentMessageFeedback extends Model<
-  InferAttributes<AgentMessageFeedback>,
-  InferCreationAttributes<AgentMessageFeedback>
-> {
-  declare id: CreationOptional<number>;
+export class AgentMessageFeedback extends BaseModel<AgentMessageFeedback> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -344,7 +299,7 @@ export class AgentMessageFeedback extends Model<
   declare agentConfigurationId: string;
   declare agentConfigurationVersion: number;
   declare agentMessageId: ForeignKey<AgentMessage["id"]>;
-  declare userId: ForeignKey<User["id"]>;
+  declare userId: ForeignKey<UserModel["id"]>;
 
   declare thumbDirection: AgentMessageFeedbackDirection;
   declare content: string | null;
@@ -352,11 +307,6 @@ export class AgentMessageFeedback extends Model<
 
 AgentMessageFeedback.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -413,15 +363,11 @@ Workspace.hasMany(AgentMessageFeedback, {
 AgentMessage.hasMany(AgentMessageFeedback, {
   onDelete: "RESTRICT",
 });
-User.hasMany(AgentMessageFeedback, {
+UserModel.hasMany(AgentMessageFeedback, {
   onDelete: "SET NULL",
 });
 
-export class Message extends Model<
-  InferAttributes<Message>,
-  InferCreationAttributes<Message>
-> {
-  declare id: CreationOptional<number>;
+export class Message extends BaseModel<Message> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -446,11 +392,6 @@ export class Message extends Model<
 
 Message.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -565,18 +506,14 @@ Message.belongsTo(ContentFragmentModel, {
   foreignKey: { name: "contentFragmentId", allowNull: true },
 });
 
-export class MessageReaction extends Model<
-  InferAttributes<MessageReaction>,
-  InferCreationAttributes<MessageReaction>
-> {
-  declare id: CreationOptional<number>;
+export class MessageReaction extends BaseModel<MessageReaction> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
   declare messageId: ForeignKey<Message["id"]>;
 
   // User is nullable so that we can store reactions from a Slackbot message
-  declare userId: ForeignKey<User["id"]> | null;
+  declare userId: ForeignKey<UserModel["id"]> | null;
   declare userContextUsername: string;
   declare userContextFullName: string | null;
 
@@ -585,11 +522,6 @@ export class MessageReaction extends Model<
 
 MessageReaction.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -638,18 +570,14 @@ Message.hasMany(MessageReaction, {
 MessageReaction.belongsTo(Message, {
   foreignKey: { name: "messageId", allowNull: false },
 });
-User.hasMany(MessageReaction, {
+UserModel.hasMany(MessageReaction, {
   foreignKey: { name: "userId", allowNull: true }, // null = mention is from a user using a Slackbot
 });
-MessageReaction.belongsTo(User, {
+MessageReaction.belongsTo(UserModel, {
   foreignKey: { name: "userId", allowNull: true }, // null = mention is not a user using a Slackbot
 });
 
-export class Mention extends Model<
-  InferAttributes<Mention>,
-  InferCreationAttributes<Mention>
-> {
-  declare id: CreationOptional<number>;
+export class Mention extends BaseModel<Mention> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -661,11 +589,6 @@ export class Mention extends Model<
 
 Mention.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,

--- a/front/lib/models/conversation_classification.ts
+++ b/front/lib/models/conversation_classification.ts
@@ -1,20 +1,12 @@
 import type { MESSAGE_CLASS } from "@dust-tt/types";
-import type {
-  CreationOptional,
-  ForeignKey,
-  InferAttributes,
-  InferCreationAttributes,
-} from "sequelize";
-import { DataTypes, Model } from "sequelize";
+import type { CreationOptional, ForeignKey } from "sequelize";
+import { DataTypes } from "sequelize";
 
 import { Conversation } from "@app/lib/models/assistant/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { BaseModel } from "@app/lib/resources/storage/wrappers";
 
-export class ConversationClassification extends Model<
-  InferAttributes<ConversationClassification>,
-  InferCreationAttributes<ConversationClassification>
-> {
-  declare id: CreationOptional<number>;
+export class ConversationClassification extends BaseModel<ConversationClassification> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -25,12 +17,6 @@ export class ConversationClassification extends Model<
 
 ConversationClassification.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
-
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,

--- a/front/lib/models/doc_tracker.ts
+++ b/front/lib/models/doc_tracker.ts
@@ -1,37 +1,24 @@
-import type {
-  CreationOptional,
-  ForeignKey,
-  InferAttributes,
-  InferCreationAttributes,
-} from "sequelize";
-import { DataTypes, Model } from "sequelize";
+import type { CreationOptional, ForeignKey } from "sequelize";
+import { DataTypes } from "sequelize";
 
-import { User } from "@app/lib/models/user";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
+import { UserModel } from "@app/lib/resources/storage/models/user";
+import { BaseModel } from "@app/lib/resources/storage/wrappers";
 
-export class TrackedDocument extends Model<
-  InferAttributes<TrackedDocument>,
-  InferCreationAttributes<TrackedDocument>
-> {
-  declare id: CreationOptional<number>;
+export class TrackedDocument extends BaseModel<TrackedDocument> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
   declare documentId: string;
   declare trackingEnabledAt: Date | null;
 
-  declare userId: ForeignKey<User["id"]>;
+  declare userId: ForeignKey<UserModel["id"]>;
   declare dataSourceId: ForeignKey<DataSourceModel["id"]>;
 }
 
 TrackedDocument.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -66,16 +53,12 @@ DataSourceModel.hasMany(TrackedDocument, {
   foreignKey: { allowNull: false },
   onDelete: "CASCADE",
 });
-User.hasMany(TrackedDocument, {
+UserModel.hasMany(TrackedDocument, {
   foreignKey: { allowNull: false },
   onDelete: "CASCADE",
 });
 
-export class DocumentTrackerChangeSuggestion extends Model<
-  InferAttributes<DocumentTrackerChangeSuggestion>,
-  InferCreationAttributes<DocumentTrackerChangeSuggestion>
-> {
-  declare id: CreationOptional<number>;
+export class DocumentTrackerChangeSuggestion extends BaseModel<DocumentTrackerChangeSuggestion> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -90,15 +73,9 @@ export class DocumentTrackerChangeSuggestion extends Model<
 
 DocumentTrackerChangeSuggestion.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: { type: DataTypes.DATE, allowNull: false },
     updatedAt: { type: DataTypes.DATE, allowNull: false },
     suggestion: { type: DataTypes.TEXT, allowNull: false },
-    //@ts-expect-error TODO remove once propagated
     suggestionTitle: { type: DataTypes.TEXT, allowNull: true },
     reason: { type: DataTypes.TEXT, allowNull: true },
     status: {

--- a/front/lib/models/feature_flag.ts
+++ b/front/lib/models/feature_flag.ts
@@ -1,20 +1,12 @@
 import type { WhitelistableFeature } from "@dust-tt/types";
-import type {
-  CreationOptional,
-  ForeignKey,
-  InferAttributes,
-  InferCreationAttributes,
-} from "sequelize";
-import { DataTypes, Model } from "sequelize";
+import type { CreationOptional, ForeignKey } from "sequelize";
+import { DataTypes } from "sequelize";
 
 import { Workspace } from "@app/lib/models/workspace";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { BaseModel } from "@app/lib/resources/storage/wrappers";
 
-export class FeatureFlag extends Model<
-  InferAttributes<FeatureFlag>,
-  InferCreationAttributes<FeatureFlag>
-> {
-  declare id: CreationOptional<number>;
+export class FeatureFlag extends BaseModel<FeatureFlag> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -25,11 +17,6 @@ export class FeatureFlag extends Model<
 
 FeatureFlag.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,

--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -6,21 +6,16 @@ import { SUBSCRIPTION_STATUSES } from "@dust-tt/types";
 import type {
   CreationOptional,
   ForeignKey,
-  InferAttributes,
-  InferCreationAttributes,
   NonAttribute,
   Transaction,
 } from "sequelize";
-import { DataTypes, Model } from "sequelize";
+import { DataTypes } from "sequelize";
 
 import { Workspace } from "@app/lib/models/workspace";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { BaseModel } from "@app/lib/resources/storage/wrappers";
 
-export class Plan extends Model<
-  InferAttributes<Plan>,
-  InferCreationAttributes<Plan>
-> {
-  declare id: CreationOptional<number>;
+export class Plan extends BaseModel<Plan> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -48,11 +43,6 @@ export class Plan extends Model<
 }
 Plan.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -153,11 +143,7 @@ Plan.init(
   }
 );
 
-export class Subscription extends Model<
-  InferAttributes<Subscription>,
-  InferCreationAttributes<Subscription>
-> {
-  declare id: CreationOptional<number>;
+export class Subscription extends BaseModel<Subscription> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -183,11 +169,6 @@ export class Subscription extends Model<
 }
 Subscription.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,

--- a/front/lib/models/workspace.ts
+++ b/front/lib/models/workspace.ts
@@ -4,27 +4,18 @@ import type {
   WorkspaceSegmentationType,
 } from "@dust-tt/types";
 import { MODEL_PROVIDER_IDS } from "@dust-tt/types";
-import type {
-  CreationOptional,
-  ForeignKey,
-  InferAttributes,
-  InferCreationAttributes,
-  NonAttribute,
-} from "sequelize";
-import { DataTypes, Model } from "sequelize";
+import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
+import { DataTypes } from "sequelize";
 
 import type { Subscription } from "@app/lib/models/plan";
-import { User } from "@app/lib/models/user";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { UserModel } from "@app/lib/resources/storage/models/user";
+import { BaseModel } from "@app/lib/resources/storage/wrappers";
 
 const modelProviders = [...MODEL_PROVIDER_IDS] as string[];
 export type ModelProviderIdType = (typeof MODEL_PROVIDER_IDS)[number];
 
-export class Workspace extends Model<
-  InferAttributes<Workspace>,
-  InferCreationAttributes<Workspace>
-> {
-  declare id: CreationOptional<number>;
+export class Workspace extends BaseModel<Workspace> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -39,11 +30,6 @@ export class Workspace extends Model<
 }
 Workspace.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -101,14 +87,10 @@ Workspace.init(
   }
 );
 
-export class WorkspaceHasDomain extends Model<
-  InferAttributes<WorkspaceHasDomain>,
-  InferCreationAttributes<WorkspaceHasDomain>
-> {
+export class WorkspaceHasDomain extends BaseModel<WorkspaceHasDomain> {
   declare createdAt: CreationOptional<Date>;
   declare domain: string;
   declare domainAutoJoinEnabled: CreationOptional<boolean>;
-  declare id: CreationOptional<number>;
   declare updatedAt: CreationOptional<Date>;
 
   declare workspaceId: ForeignKey<Workspace["id"]>;
@@ -116,11 +98,6 @@ export class WorkspaceHasDomain extends Model<
 }
 WorkspaceHasDomain.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -152,11 +129,7 @@ Workspace.hasMany(WorkspaceHasDomain, {
 });
 WorkspaceHasDomain.belongsTo(Workspace);
 
-export class MembershipInvitation extends Model<
-  InferAttributes<MembershipInvitation>,
-  InferCreationAttributes<MembershipInvitation>
-> {
-  declare id: CreationOptional<number>;
+export class MembershipInvitation extends BaseModel<MembershipInvitation> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -166,17 +139,12 @@ export class MembershipInvitation extends Model<
   declare initialRole: Exclude<RoleType, "none">;
 
   declare workspaceId: ForeignKey<Workspace["id"]>;
-  declare invitedUserId: ForeignKey<User["id"]> | null;
+  declare invitedUserId: ForeignKey<UserModel["id"]> | null;
 
   declare workspace: NonAttribute<Workspace>;
 }
 MembershipInvitation.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -229,32 +197,23 @@ Workspace.hasMany(MembershipInvitation, {
 });
 MembershipInvitation.belongsTo(Workspace);
 
-User.hasMany(MembershipInvitation, {
+UserModel.hasMany(MembershipInvitation, {
   foreignKey: "invitedUserId",
 });
 
-export class DustAppSecret extends Model<
-  InferAttributes<DustAppSecret>,
-  InferCreationAttributes<DustAppSecret>
-> {
-  declare id: CreationOptional<number>;
+export class DustAppSecret extends BaseModel<DustAppSecret> {
   declare createdAt: CreationOptional<Date>;
 
   declare name: string;
   declare hash: string;
 
-  declare userId: ForeignKey<User["id"]>;
+  declare userId: ForeignKey<UserModel["id"]>;
   declare workspaceId: ForeignKey<Workspace["id"]>;
 
-  declare user: NonAttribute<User>;
+  declare user: NonAttribute<UserModel>;
 }
 DustAppSecret.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -280,8 +239,8 @@ Workspace.hasMany(DustAppSecret, {
   onDelete: "CASCADE",
 });
 // We don't want to delete keys when a user gets deleted.
-User.hasMany(DustAppSecret, {
+UserModel.hasMany(DustAppSecret, {
   foreignKey: { allowNull: true },
   onDelete: "SET NULL",
 });
-DustAppSecret.belongsTo(User);
+DustAppSecret.belongsTo(UserModel);

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -468,7 +468,7 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
   }
 
   private makeEditedBy(
-    editedByUser: Attributes<User> | undefined,
+    editedByUser: Attributes<UserModel> | undefined,
     editedAt: Date | undefined
   ) {
     if (!editedByUser || !editedAt) {

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -18,10 +18,10 @@ import { getDataSourceUsage } from "@app/lib/api/agent_data_sources";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
 import { AgentTablesQueryConfigurationTable } from "@app/lib/models/assistant/actions/tables_query";
-import { User } from "@app/lib/models/user";
 import { ResourceWithSpace } from "@app/lib/resources/resource_with_space";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
+import { UserModel } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import {
   getResourceIdFromSId,
@@ -64,13 +64,13 @@ export interface DataSourceResource
 export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
   static model: ModelStatic<DataSourceModel> = DataSourceModel;
 
-  readonly editedByUser?: Attributes<User>;
+  readonly editedByUser?: Attributes<UserModel>;
 
   constructor(
     model: ModelStatic<DataSourceModel>,
     blob: Attributes<DataSourceModel>,
     space: SpaceResource,
-    { editedByUser }: { editedByUser?: Attributes<User> } = {}
+    { editedByUser }: { editedByUser?: Attributes<UserModel> } = {}
   ) {
     super(DataSourceResource.model, blob, space);
 
@@ -109,7 +109,7 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
     if (options?.includeEditedBy) {
       result.includes = [
         {
-          model: User,
+          model: UserModel,
           as: "editedByUser",
           required: false,
         },

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -23,7 +23,6 @@ import type { Authenticator } from "@app/lib/auth";
 import { isFolder, isWebsite } from "@app/lib/data_sources";
 import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
 import { AgentTablesQueryConfigurationTable } from "@app/lib/models/assistant/actions/tables_query";
-import { User } from "@app/lib/models/user";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { ResourceWithSpace } from "@app/lib/resources/resource_with_space";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
@@ -31,6 +30,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import type { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
+import { UserModel } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import {
   getResourceIdFromSId,
@@ -70,13 +70,13 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
   static model: ModelStatic<DataSourceViewModel> = DataSourceViewModel;
 
   private ds?: DataSourceResource;
-  readonly editedByUser?: Attributes<User>;
+  readonly editedByUser?: Attributes<UserModel>;
 
   constructor(
     model: ModelStatic<DataSourceViewModel>,
     blob: Attributes<DataSourceViewModel>,
     space: SpaceResource,
-    { editedByUser }: { editedByUser?: Attributes<User> } = {}
+    { editedByUser }: { editedByUser?: Attributes<UserModel> } = {}
   ) {
     super(DataSourceViewModel, blob, space);
 
@@ -185,7 +185,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     if (options?.includeEditedBy) {
       result.includes = [
         {
-          model: User,
+          model: UserModel,
           as: "editedByUser",
           required: false,
         },
@@ -437,7 +437,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
   }
 
   private makeEditedBy(
-    editedByUser: Attributes<User> | undefined,
+    editedByUser: Attributes<UserModel> | undefined,
     editedAt: Date | undefined
   ) {
     if (!editedByUser || !editedAt) {

--- a/front/lib/resources/key_resource.ts
+++ b/front/lib/resources/key_resource.ts
@@ -15,10 +15,10 @@ import { Op } from "sequelize";
 import { v4 as uuidv4 } from "uuid";
 
 import type { Authenticator } from "@app/lib/auth";
-import { User } from "@app/lib/models/user";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { GroupResource } from "@app/lib/resources/group_resource";
 import { KeyModel } from "@app/lib/resources/storage/models/keys";
+import { UserModel } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 
 export interface KeyAuthType {
@@ -35,7 +35,7 @@ export interface KeyResource extends ReadonlyAttributesType<KeyModel> {}
 export class KeyResource extends BaseResource<KeyModel> {
   static model: ModelStatic<KeyModel> = KeyModel;
 
-  private user?: User;
+  private user?: UserModel;
 
   constructor(model: ModelStatic<KeyModel>, blob: Attributes<KeyModel>) {
     super(KeyModel, blob);
@@ -114,7 +114,7 @@ export class KeyResource extends BaseResource<KeyModel> {
         {
           as: "user",
           attributes: ["firstName", "lastName"],
-          model: User,
+          model: UserModel,
           required: false,
         },
       ],

--- a/front/lib/resources/storage/models/apps.ts
+++ b/front/lib/resources/storage/models/apps.ts
@@ -1,21 +1,17 @@
 import type { AppVisibility, DatasetSchema } from "@dust-tt/types";
-import type {
-  CreationOptional,
-  ForeignKey,
-  InferAttributes,
-  InferCreationAttributes,
-  NonAttribute,
-} from "sequelize";
-import { DataTypes, Model } from "sequelize";
+import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
+import { DataTypes } from "sequelize";
 
 import { Workspace } from "@app/lib/models/workspace";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
-import { SoftDeletableModel } from "@app/lib/resources/storage/wrappers";
+import {
+  BaseModel,
+  SoftDeletableModel,
+} from "@app/lib/resources/storage/wrappers";
 
 // TODO(2024-10-04 flav) Remove visibility from here.
 export class AppModel extends SoftDeletableModel<AppModel> {
-  declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -108,11 +104,7 @@ AppModel.belongsTo(SpaceModel, {
   foreignKey: { allowNull: false, name: "vaultId" },
 });
 
-export class Provider extends Model<
-  InferAttributes<Provider>,
-  InferCreationAttributes<Provider>
-> {
-  declare id: CreationOptional<number>;
+export class Provider extends BaseModel<Provider> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -123,11 +115,6 @@ export class Provider extends Model<
 }
 Provider.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -158,10 +145,7 @@ Workspace.hasMany(Provider, {
   onDelete: "CASCADE",
 });
 
-export class Dataset extends Model<
-  InferAttributes<Dataset>,
-  InferCreationAttributes<Dataset>
-> {
+export class Dataset extends BaseModel<Dataset> {
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
@@ -220,11 +204,7 @@ Workspace.hasMany(Dataset, {
   onDelete: "CASCADE",
 });
 
-export class Clone extends Model<
-  InferAttributes<Clone>,
-  InferCreationAttributes<Clone>
-> {
-  declare id: CreationOptional<number>;
+export class Clone extends BaseModel<Clone> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -233,11 +213,6 @@ export class Clone extends Model<
 }
 Clone.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      primaryKey: true,
-      autoIncrement: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,

--- a/front/lib/resources/storage/models/content_fragment.ts
+++ b/front/lib/resources/storage/models/content_fragment.ts
@@ -2,23 +2,15 @@ import type {
   ContentFragmentVersion,
   SupportedContentFragmentType,
 } from "@dust-tt/types";
-import type {
-  CreationOptional,
-  ForeignKey,
-  InferAttributes,
-  InferCreationAttributes,
-} from "sequelize";
-import { DataTypes, Model } from "sequelize";
+import type { CreationOptional, ForeignKey } from "sequelize";
+import { DataTypes } from "sequelize";
 
-import { User } from "@app/lib/models/user";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { FileModel } from "@app/lib/resources/storage/models/files";
+import { UserModel } from "@app/lib/resources/storage/models/user";
+import { BaseModel } from "@app/lib/resources/storage/wrappers";
 
-export class ContentFragmentModel extends Model<
-  InferAttributes<ContentFragmentModel>,
-  InferCreationAttributes<ContentFragmentModel>
-> {
-  declare id: CreationOptional<number>;
+export class ContentFragmentModel extends BaseModel<ContentFragmentModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -45,11 +37,6 @@ export class ContentFragmentModel extends Model<
 
 ContentFragmentModel.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -109,10 +96,10 @@ ContentFragmentModel.init(
   }
 );
 
-User.hasMany(ContentFragmentModel, {
+UserModel.hasMany(ContentFragmentModel, {
   foreignKey: { name: "userId", allowNull: true }, // null = ContentFragment is not associated with a user
 });
-ContentFragmentModel.belongsTo(User, {
+ContentFragmentModel.belongsTo(UserModel, {
   foreignKey: { name: "userId", allowNull: true },
 });
 

--- a/front/lib/resources/storage/models/content_fragment.ts
+++ b/front/lib/resources/storage/models/content_fragment.ts
@@ -29,7 +29,7 @@ export class ContentFragmentModel extends BaseModel<ContentFragmentModel> {
   declare userContextEmail: string | null;
   declare userContextProfilePictureUrl: string | null;
 
-  declare userId: ForeignKey<User["id"]> | null;
+  declare userId: ForeignKey<UserModel["id"]> | null;
   declare fileId: ForeignKey<FileModel["id"]> | null;
 
   declare version: ContentFragmentVersion;

--- a/front/lib/resources/storage/models/data_source.ts
+++ b/front/lib/resources/storage/models/data_source.ts
@@ -3,10 +3,10 @@ import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 import { DataTypes } from "sequelize";
 
 import { Conversation } from "@app/lib/models/assistant/conversation";
-import { User } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
+import { UserModel } from "@app/lib/resources/storage/models/user";
 import { SoftDeletableModel } from "@app/lib/resources/storage/wrappers";
 
 export class DataSourceModel extends SoftDeletableModel<DataSourceModel> {
@@ -15,7 +15,7 @@ export class DataSourceModel extends SoftDeletableModel<DataSourceModel> {
   declare updatedAt: CreationOptional<Date>;
 
   // Corresponds to the ID of the last user to configure the connection.
-  declare editedByUserId: ForeignKey<User["id"]> | null;
+  declare editedByUserId: ForeignKey<UserModel["id"]> | null;
   declare editedAt: Date;
 
   declare name: string;
@@ -29,7 +29,7 @@ export class DataSourceModel extends SoftDeletableModel<DataSourceModel> {
   declare vaultId: ForeignKey<SpaceModel["id"]>;
   declare conversationId: ForeignKey<Conversation["id"]>;
 
-  declare editedByUser: NonAttribute<User>;
+  declare editedByUser: NonAttribute<UserModel>;
   declare conversation: NonAttribute<Conversation>;
   declare space: NonAttribute<SpaceModel>;
   declare workspace: NonAttribute<Workspace>;
@@ -113,7 +113,7 @@ DataSourceModel.belongsTo(Workspace, {
   foreignKey: { name: "workspaceId", allowNull: false },
 });
 
-DataSourceModel.belongsTo(User, {
+DataSourceModel.belongsTo(UserModel, {
   as: "editedByUser",
   foreignKey: { name: "editedByUserId", allowNull: true },
 });

--- a/front/lib/resources/storage/models/data_source_view.ts
+++ b/front/lib/resources/storage/models/data_source_view.ts
@@ -2,11 +2,11 @@ import type { DataSourceViewKind } from "@dust-tt/types";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import { User } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
+import { UserModel } from "@app/lib/resources/storage/models/user";
 import { SoftDeletableModel } from "@app/lib/resources/storage/wrappers";
 
 export class DataSourceViewModel extends SoftDeletableModel<DataSourceViewModel> {
@@ -15,7 +15,7 @@ export class DataSourceViewModel extends SoftDeletableModel<DataSourceViewModel>
   declare updatedAt: CreationOptional<Date>;
 
   // Corresponds to the ID of the last user to configure the connection.
-  declare editedByUserId: ForeignKey<User["id"]> | null;
+  declare editedByUserId: ForeignKey<UserModel["id"]> | null;
   declare editedAt: Date;
 
   declare kind: DataSourceViewKind;
@@ -26,7 +26,7 @@ export class DataSourceViewModel extends SoftDeletableModel<DataSourceViewModel>
   declare workspaceId: ForeignKey<Workspace["id"]>;
 
   declare dataSourceForView: NonAttribute<DataSourceModel>;
-  declare editedByUser: NonAttribute<User>;
+  declare editedByUser: NonAttribute<UserModel>;
   declare space: NonAttribute<SpaceModel>;
   declare workspace: NonAttribute<Workspace>;
 }
@@ -102,7 +102,7 @@ DataSourceViewModel.belongsTo(DataSourceModel, {
   foreignKey: { name: "dataSourceId", allowNull: false },
 });
 
-DataSourceViewModel.belongsTo(User, {
+DataSourceViewModel.belongsTo(UserModel, {
   as: "editedByUser",
   foreignKey: { name: "editedByUserId", allowNull: true },
 });

--- a/front/lib/resources/storage/models/files.ts
+++ b/front/lib/resources/storage/models/files.ts
@@ -4,24 +4,15 @@ import type {
   FileUseCaseMetadata,
   SupportedFileContentType,
 } from "@dust-tt/types";
-import type {
-  CreationOptional,
-  ForeignKey,
-  InferAttributes,
-  InferCreationAttributes,
-  NonAttribute,
-} from "sequelize";
-import { DataTypes, Model } from "sequelize";
+import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
+import { DataTypes } from "sequelize";
 
-import { User } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { UserModel } from "@app/lib/resources/storage/models/user";
+import { BaseModel } from "@app/lib/resources/storage/wrappers";
 
-export class FileModel extends Model<
-  InferAttributes<FileModel>,
-  InferCreationAttributes<FileModel>
-> {
-  declare id: CreationOptional<number>;
+export class FileModel extends BaseModel<FileModel> {
   declare createdAt: CreationOptional<Date>;
 
   declare contentType: SupportedFileContentType;
@@ -32,18 +23,13 @@ export class FileModel extends Model<
   declare useCaseMetadata: FileUseCaseMetadata | null;
   declare snippet: string | null;
 
-  declare userId: ForeignKey<User["id"]> | null;
+  declare userId: ForeignKey<UserModel["id"]> | null;
   declare workspaceId: ForeignKey<Workspace["id"]>;
 
-  declare user: NonAttribute<User>;
+  declare user: NonAttribute<UserModel>;
 }
 FileModel.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -90,8 +76,8 @@ Workspace.hasMany(FileModel, {
   foreignKey: { allowNull: false },
   onDelete: "RESTRICT",
 });
-User.hasMany(FileModel, {
+UserModel.hasMany(FileModel, {
   foreignKey: { allowNull: true },
   onDelete: "RESTRICT",
 });
-FileModel.belongsTo(User);
+FileModel.belongsTo(UserModel);

--- a/front/lib/resources/storage/models/group_memberships.ts
+++ b/front/lib/resources/storage/models/group_memberships.ts
@@ -1,21 +1,13 @@
-import type {
-  CreationOptional,
-  ForeignKey,
-  InferAttributes,
-  InferCreationAttributes,
-} from "sequelize";
-import { DataTypes, Model } from "sequelize";
+import type { CreationOptional, ForeignKey } from "sequelize";
+import { DataTypes } from "sequelize";
 
-import { User } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
+import { UserModel } from "@app/lib/resources/storage/models/user";
+import { BaseModel } from "@app/lib/resources/storage/wrappers";
 
-export class GroupMembershipModel extends Model<
-  InferAttributes<GroupMembershipModel>,
-  InferCreationAttributes<GroupMembershipModel>
-> {
-  declare id: CreationOptional<number>;
+export class GroupMembershipModel extends BaseModel<GroupMembershipModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -23,16 +15,11 @@ export class GroupMembershipModel extends Model<
   declare endAt: Date | null;
 
   declare groupId: ForeignKey<GroupModel["id"]>;
-  declare userId: ForeignKey<User["id"]>;
+  declare userId: ForeignKey<UserModel["id"]>;
   declare workspaceId: ForeignKey<Workspace["id"]>;
 }
 GroupMembershipModel.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -58,7 +45,7 @@ GroupMembershipModel.init(
     indexes: [{ fields: ["userId", "groupId"] }],
   }
 );
-User.hasMany(GroupMembershipModel, {
+UserModel.hasMany(GroupMembershipModel, {
   foreignKey: { allowNull: false },
   onDelete: "RESTRICT",
 });
@@ -70,6 +57,6 @@ Workspace.hasMany(GroupMembershipModel, {
   foreignKey: { allowNull: false },
   onDelete: "RESTRICT",
 });
-GroupMembershipModel.belongsTo(User);
+GroupMembershipModel.belongsTo(UserModel);
 GroupMembershipModel.belongsTo(GroupModel);
 GroupMembershipModel.belongsTo(Workspace);

--- a/front/lib/resources/storage/models/group_spaces.ts
+++ b/front/lib/resources/storage/models/group_spaces.ts
@@ -1,31 +1,18 @@
-import type {
-  CreationOptional,
-  ForeignKey,
-  InferAttributes,
-  InferCreationAttributes,
-} from "sequelize";
-import { DataTypes, Model } from "sequelize";
+import type { CreationOptional, ForeignKey } from "sequelize";
+import { DataTypes } from "sequelize";
 
 import { frontSequelize } from "@app/lib/resources/storage";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
+import { BaseModel } from "@app/lib/resources/storage/wrappers";
 
-export class GroupSpaceModel extends Model<
-  InferAttributes<GroupSpaceModel>,
-  InferCreationAttributes<GroupSpaceModel>
-> {
-  declare id: CreationOptional<number>;
+export class GroupSpaceModel extends BaseModel<GroupSpaceModel> {
   declare createdAt: CreationOptional<Date>;
   declare groupId: ForeignKey<GroupModel["id"]>;
   declare vaultId: ForeignKey<SpaceModel["id"]>;
 }
 GroupSpaceModel.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,

--- a/front/lib/resources/storage/models/groups.ts
+++ b/front/lib/resources/storage/models/groups.ts
@@ -1,22 +1,13 @@
 import type { GroupKind } from "@dust-tt/types";
 import { isGlobalGroupKind, isSystemGroupKind } from "@dust-tt/types";
-import type {
-  CreationOptional,
-  ForeignKey,
-  InferAttributes,
-  InferCreationAttributes,
-  Transaction,
-} from "sequelize";
-import { DataTypes, Model } from "sequelize";
+import type { CreationOptional, ForeignKey, Transaction } from "sequelize";
+import { DataTypes } from "sequelize";
 
 import { Workspace } from "@app/lib/models/workspace";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { BaseModel } from "@app/lib/resources/storage/wrappers";
 
-export class GroupModel extends Model<
-  InferAttributes<GroupModel>,
-  InferCreationAttributes<GroupModel>
-> {
-  declare id: CreationOptional<number>;
+export class GroupModel extends BaseModel<GroupModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -28,11 +19,6 @@ export class GroupModel extends Model<
 
 GroupModel.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,

--- a/front/lib/resources/storage/models/keys.ts
+++ b/front/lib/resources/storage/models/keys.ts
@@ -1,22 +1,13 @@
-import type {
-  CreationOptional,
-  ForeignKey,
-  InferAttributes,
-  InferCreationAttributes,
-  NonAttribute,
-} from "sequelize";
-import { DataTypes, Model } from "sequelize";
+import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
+import { DataTypes } from "sequelize";
 
-import { User } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
+import { UserModel } from "@app/lib/resources/storage/models/user";
+import { BaseModel } from "@app/lib/resources/storage/wrappers";
 
-export class KeyModel extends Model<
-  InferAttributes<KeyModel>,
-  InferCreationAttributes<KeyModel>
-> {
-  declare id: CreationOptional<number>;
+export class KeyModel extends BaseModel<KeyModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare lastUsedAt: CreationOptional<Date>;
@@ -25,20 +16,15 @@ export class KeyModel extends Model<
   declare status: "active" | "disabled";
   declare isSystem: boolean;
 
-  declare userId: ForeignKey<User["id"]>;
+  declare userId: ForeignKey<UserModel["id"]>;
   declare groupId: ForeignKey<GroupModel["id"]>;
   declare workspaceId: ForeignKey<Workspace["id"]>;
 
   declare name: string | null;
-  declare user: NonAttribute<User>;
+  declare user: NonAttribute<UserModel>;
 }
 KeyModel.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -86,7 +72,7 @@ Workspace.hasMany(KeyModel, {
   onDelete: "CASCADE",
 });
 // We don't want to delete keys when a user gets deleted.
-User.hasMany(KeyModel, {
+UserModel.hasMany(KeyModel, {
   foreignKey: { allowNull: true },
   onDelete: "SET NULL",
 });
@@ -95,4 +81,4 @@ GroupModel.hasMany(KeyModel, {
   onDelete: "RESTRICT",
 });
 
-KeyModel.belongsTo(User);
+KeyModel.belongsTo(UserModel);

--- a/front/lib/resources/storage/models/labs_transcripts.ts
+++ b/front/lib/resources/storage/models/labs_transcripts.ts
@@ -1,24 +1,15 @@
 import type { LabsTranscriptsProviderType } from "@dust-tt/types";
-import type {
-  CreationOptional,
-  ForeignKey,
-  InferAttributes,
-  InferCreationAttributes,
-  NonAttribute,
-} from "sequelize";
-import { DataTypes, Model } from "sequelize";
+import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
+import { DataTypes } from "sequelize";
 
 import type { AgentConfiguration } from "@app/lib/models/assistant/agent";
-import { User } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
+import { UserModel } from "@app/lib/resources/storage/models/user";
+import { BaseModel } from "@app/lib/resources/storage/wrappers";
 
-export class LabsTranscriptsConfigurationModel extends Model<
-  InferAttributes<LabsTranscriptsConfigurationModel>,
-  InferCreationAttributes<LabsTranscriptsConfigurationModel>
-> {
-  declare id: CreationOptional<number>;
+export class LabsTranscriptsConfigurationModel extends BaseModel<LabsTranscriptsConfigurationModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -28,18 +19,13 @@ export class LabsTranscriptsConfigurationModel extends Model<
   declare isActive: boolean;
   declare isDefaultFullStorage: boolean;
 
-  declare userId: ForeignKey<User["id"]>;
+  declare userId: ForeignKey<UserModel["id"]>;
   declare workspaceId: ForeignKey<Workspace["id"]>;
   declare dataSourceViewId: ForeignKey<DataSourceViewModel["id"]> | null;
 }
 
 LabsTranscriptsConfigurationModel.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -83,10 +69,10 @@ LabsTranscriptsConfigurationModel.init(
   }
 );
 
-User.hasMany(LabsTranscriptsConfigurationModel, {
+UserModel.hasMany(LabsTranscriptsConfigurationModel, {
   foreignKey: { name: "userId", allowNull: false },
 });
-LabsTranscriptsConfigurationModel.belongsTo(User, {
+LabsTranscriptsConfigurationModel.belongsTo(UserModel, {
   foreignKey: { name: "userId", allowNull: false },
 });
 
@@ -106,11 +92,7 @@ LabsTranscriptsConfigurationModel.belongsTo(DataSourceViewModel, {
   foreignKey: { name: "dataSourceViewId", allowNull: true },
 });
 
-export class LabsTranscriptsHistoryModel extends Model<
-  InferAttributes<LabsTranscriptsHistoryModel>,
-  InferCreationAttributes<LabsTranscriptsHistoryModel>
-> {
-  declare id: CreationOptional<number>;
+export class LabsTranscriptsHistoryModel extends BaseModel<LabsTranscriptsHistoryModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -126,11 +108,6 @@ export class LabsTranscriptsHistoryModel extends Model<
 
 LabsTranscriptsHistoryModel.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,

--- a/front/lib/resources/storage/models/membership.ts
+++ b/front/lib/resources/storage/models/membership.ts
@@ -1,21 +1,13 @@
 import type { MembershipRoleType } from "@dust-tt/types";
-import type {
-  CreationOptional,
-  ForeignKey,
-  InferAttributes,
-  InferCreationAttributes,
-} from "sequelize";
-import { DataTypes, Model } from "sequelize";
+import type { CreationOptional, ForeignKey } from "sequelize";
+import { DataTypes } from "sequelize";
 
-import { User } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { UserModel } from "@app/lib/resources/storage/models/user";
+import { BaseModel } from "@app/lib/resources/storage/wrappers";
 
-export class MembershipModel extends Model<
-  InferAttributes<MembershipModel>,
-  InferCreationAttributes<MembershipModel>
-> {
-  declare id: CreationOptional<number>;
+export class MembershipModel extends BaseModel<MembershipModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -23,16 +15,11 @@ export class MembershipModel extends Model<
   declare startAt: Date;
   declare endAt: Date | null;
 
-  declare userId: ForeignKey<User["id"]>;
+  declare userId: ForeignKey<UserModel["id"]>;
   declare workspaceId: ForeignKey<Workspace["id"]>;
 }
 MembershipModel.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -66,7 +53,7 @@ MembershipModel.init(
     ],
   }
 );
-User.hasMany(MembershipModel, {
+UserModel.hasMany(MembershipModel, {
   foreignKey: { allowNull: false },
   onDelete: "CASCADE",
 });
@@ -75,4 +62,4 @@ Workspace.hasMany(MembershipModel, {
   onDelete: "CASCADE",
 });
 MembershipModel.belongsTo(Workspace);
-MembershipModel.belongsTo(User);
+MembershipModel.belongsTo(UserModel);

--- a/front/lib/resources/storage/models/runs.ts
+++ b/front/lib/resources/storage/models/runs.ts
@@ -10,12 +10,9 @@ import { DataTypes, Model } from "sequelize";
 import { Workspace } from "@app/lib/models/workspace";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { AppModel } from "@app/lib/resources/storage/models/apps";
+import { BaseModel } from "@app/lib/resources/storage/wrappers";
 
-export class RunModel extends Model<
-  InferAttributes<RunModel>,
-  InferCreationAttributes<RunModel>
-> {
-  declare id: CreationOptional<number>;
+export class RunModel extends BaseModel<RunModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -30,11 +27,6 @@ export class RunModel extends Model<
 
 RunModel.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -77,12 +69,7 @@ Workspace.hasMany(RunModel, {
   onDelete: "CASCADE",
 });
 
-export class RunUsageModel extends Model<
-  InferAttributes<RunUsageModel>,
-  InferCreationAttributes<RunUsageModel>
-> {
-  declare id: CreationOptional<number>;
-
+export class RunUsageModel extends BaseModel<RunUsageModel> {
   declare runId: ForeignKey<RunModel["id"]>;
 
   declare providerId: string; //ModelProviderIdType;
@@ -94,11 +81,6 @@ export class RunUsageModel extends Model<
 
 RunUsageModel.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     providerId: {
       type: DataTypes.STRING,
       allowNull: false,

--- a/front/lib/resources/storage/models/runs.ts
+++ b/front/lib/resources/storage/models/runs.ts
@@ -1,11 +1,5 @@
-import type {
-  CreationOptional,
-  ForeignKey,
-  InferAttributes,
-  InferCreationAttributes,
-  NonAttribute,
-} from "sequelize";
-import { DataTypes, Model } from "sequelize";
+import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
+import { DataTypes } from "sequelize";
 
 import { Workspace } from "@app/lib/models/workspace";
 import { frontSequelize } from "@app/lib/resources/storage";

--- a/front/lib/resources/storage/models/templates.ts
+++ b/front/lib/resources/storage/models/templates.ts
@@ -6,21 +6,14 @@ import type {
   TemplateVisibility,
   TimeframeUnit,
 } from "@dust-tt/types";
-import type {
-  CreationOptional,
-  InferAttributes,
-  InferCreationAttributes,
-} from "sequelize";
-import { DataTypes, Model } from "sequelize";
+import type { CreationOptional } from "sequelize";
+import { DataTypes } from "sequelize";
 
 import type { TemplateActionType } from "@app/components/assistant_builder/types";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { BaseModel } from "@app/lib/resources/storage/wrappers";
 
-export class TemplateModel extends Model<
-  InferAttributes<TemplateModel>,
-  InferCreationAttributes<TemplateModel>
-> {
-  declare id: CreationOptional<number>;
+export class TemplateModel extends BaseModel<TemplateModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -51,11 +44,6 @@ export class TemplateModel extends Model<
 
 TemplateModel.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,

--- a/front/lib/resources/storage/models/user.ts
+++ b/front/lib/resources/storage/models/user.ts
@@ -1,19 +1,11 @@
 import type { UserProviderType } from "@dust-tt/types";
-import type {
-  CreationOptional,
-  ForeignKey,
-  InferAttributes,
-  InferCreationAttributes,
-} from "sequelize";
-import { DataTypes, Model } from "sequelize";
+import type { CreationOptional, ForeignKey } from "sequelize";
+import { DataTypes } from "sequelize";
 
 import { frontSequelize } from "@app/lib/resources/storage";
+import { BaseModel } from "@app/lib/resources/storage/wrappers";
 
-export class User extends Model<
-  InferAttributes<User>,
-  InferCreationAttributes<User>
-> {
-  declare id: CreationOptional<number>;
+export class UserModel extends BaseModel<UserModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -31,13 +23,8 @@ export class User extends Model<
 
   declare isDustSuperUser: CreationOptional<boolean>;
 }
-User.init(
+UserModel.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -108,24 +95,15 @@ User.init(
   }
 );
 
-export class UserMetadata extends Model<
-  InferAttributes<UserMetadata>,
-  InferCreationAttributes<UserMetadata>
-> {
-  declare id: CreationOptional<number>;
+export class UserMetadataModel extends BaseModel<UserMetadataModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare key: string;
   declare value: string;
-  declare userId: ForeignKey<User["id"]>;
+  declare userId: ForeignKey<UserModel["id"]>;
 }
-UserMetadata.init(
+UserMetadataModel.init(
   {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -151,7 +129,7 @@ UserMetadata.init(
     indexes: [{ fields: ["userId", "key"], unique: true }],
   }
 );
-User.hasMany(UserMetadata, {
+UserModel.hasMany(UserMetadataModel, {
   foreignKey: { allowNull: false },
   onDelete: "CASCADE",
 });

--- a/front/lib/resources/types.ts
+++ b/front/lib/resources/types.ts
@@ -6,7 +6,10 @@ import type {
   WhereOptions,
 } from "sequelize";
 
-import type { SoftDeletableModel } from "@app/lib/resources/storage/wrappers";
+import type {
+  BaseModel,
+  SoftDeletableModel,
+} from "@app/lib/resources/storage/wrappers";
 
 export type NonAttributeKeys<M> = {
   [K in keyof M]: M[K] extends NonAttribute<Model<any, any>> ? K : never;
@@ -15,7 +18,7 @@ export type NonAttributeKeys<M> = {
 
 export type InferIncludeType<M> = {
   [K in NonAttributeKeys<M>]: M[K] extends NonAttribute<infer T>
-    ? T extends Model<any, any>
+    ? T extends BaseModel<any>
       ? T
       : never
     : never;

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -10,26 +10,26 @@ import { Op } from "sequelize";
 
 import type { PaginationParams } from "@app/lib/api/pagination";
 import type { Authenticator } from "@app/lib/auth";
-import { User } from "@app/lib/models/user";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { MembershipModel } from "@app/lib/resources/storage/models/membership";
+import { UserModel } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unsafe-declaration-merging
-export interface UserResource extends ReadonlyAttributesType<User> {}
+export interface UserResource extends ReadonlyAttributesType<UserModel> {}
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export class UserResource extends BaseResource<User> {
-  static model: ModelStatic<User> = User;
+export class UserResource extends BaseResource<UserModel> {
+  static model: ModelStatic<UserModel> = UserModel;
 
-  constructor(model: ModelStatic<User>, blob: Attributes<User>) {
-    super(User, blob);
+  constructor(model: ModelStatic<UserModel>, blob: Attributes<UserModel>) {
+    super(UserModel, blob);
   }
 
   static async makeNew(
     blob: Omit<
-      Attributes<User>,
+      Attributes<UserModel>,
       | "id"
       | "createdAt"
       | "updatedAt"
@@ -37,99 +37,99 @@ export class UserResource extends BaseResource<User> {
       | "providerId"
       | "imageUrl"
     > &
-      Partial<Pick<Attributes<User>, "providerId" | "imageUrl">>
+      Partial<Pick<Attributes<UserModel>, "providerId" | "imageUrl">>
   ): Promise<UserResource> {
     const lowerCaseEmail = blob.email?.toLowerCase();
-    const user = await User.create({ ...blob, email: lowerCaseEmail });
-    return new this(User, user.get());
+    const user = await UserModel.create({ ...blob, email: lowerCaseEmail });
+    return new this(UserModel, user.get());
   }
 
   static async fetchByIds(userIds: string[]): Promise<UserResource[]> {
-    const users = await User.findAll({
+    const users = await UserModel.findAll({
       where: {
         sId: userIds,
       },
     });
 
-    return users.map((user) => new UserResource(User, user.get()));
+    return users.map((user) => new UserResource(UserModel, user.get()));
   }
 
   static async fetchByModelIds(ids: ModelId[]): Promise<UserResource[]> {
-    const users = await User.findAll({
+    const users = await UserModel.findAll({
       where: {
         id: ids,
       },
     });
 
-    return users.map((user) => new UserResource(User, user.get()));
+    return users.map((user) => new UserResource(UserModel, user.get()));
   }
 
   static async listByUsername(username: string): Promise<UserResource[]> {
-    const users = await User.findAll({
+    const users = await UserModel.findAll({
       where: {
         username,
       },
     });
 
-    return users.map((user) => new UserResource(User, user.get()));
+    return users.map((user) => new UserResource(UserModel, user.get()));
   }
 
   static async listByEmail(email: string): Promise<UserResource[]> {
-    const users = await User.findAll({
+    const users = await UserModel.findAll({
       where: {
         email,
       },
     });
 
-    return users.map((user) => new UserResource(User, user.get()));
+    return users.map((user) => new UserResource(UserModel, user.get()));
   }
 
   static async fetchById(userId: string): Promise<UserResource | null> {
-    const user = await User.findOne({
+    const user = await UserModel.findOne({
       where: {
         sId: userId,
       },
     });
-    return user ? new UserResource(User, user.get()) : null;
+    return user ? new UserResource(UserModel, user.get()) : null;
   }
 
   static async fetchByAuth0Sub(sub: string): Promise<UserResource | null> {
-    const user = await User.findOne({
+    const user = await UserModel.findOne({
       where: {
         auth0Sub: sub,
       },
     });
-    return user ? new UserResource(User, user.get()) : null;
+    return user ? new UserResource(UserModel, user.get()) : null;
   }
 
   static async fetchByEmail(email: string): Promise<UserResource | null> {
-    const user = await User.findOne({
+    const user = await UserModel.findOne({
       where: {
         email: email.toLowerCase(),
       },
     });
 
-    return user ? new UserResource(User, user.get()) : null;
+    return user ? new UserResource(UserModel, user.get()) : null;
   }
 
   static async fetchByProvider(
     provider: UserProviderType,
     providerId: string
   ): Promise<UserResource | null> {
-    const user = await User.findOne({
+    const user = await UserModel.findOne({
       where: {
         provider,
         providerId,
       },
     });
 
-    return user ? new UserResource(User, user.get()) : null;
+    return user ? new UserResource(UserModel, user.get()) : null;
   }
 
   static async getWorkspaceFirstAdmin(
     workspaceId: number
   ): Promise<UserResource | null> {
-    const user = await User.findOne({
+    const user = await UserModel.findOne({
       include: [
         {
           model: MembershipModel,
@@ -143,7 +143,7 @@ export class UserResource extends BaseResource<User> {
       order: [["createdAt", "ASC"]],
     });
 
-    return user ? new UserResource(User, user.get()) : null;
+    return user ? new UserResource(UserModel, user.get()) : null;
   }
 
   static async listUsersWithEmailPredicat(
@@ -160,7 +160,7 @@ export class UserResource extends BaseResource<User> {
       };
     }
 
-    const { count, rows: users } = await User.findAndCountAll({
+    const { count, rows: users } = await UserModel.findAndCountAll({
       where: userWhereClause,
       include: [
         {
@@ -180,7 +180,7 @@ export class UserResource extends BaseResource<User> {
     });
 
     return {
-      users: users.map((u) => new UserResource(User, u.get())),
+      users: users.map((u) => new UserResource(UserModel, u.get())),
       total: count,
     };
   }

--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -10,11 +10,11 @@ import {
   Message,
   UserMessage,
 } from "@app/lib/models/assistant/conversation";
-import { User } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { UserModel } from "@app/lib/resources/storage/models/user";
 
 export interface WorkspaceUsageQueryResult {
   createdAt: string;
@@ -362,7 +362,7 @@ export async function getBuildersUsageData(
     },
     include: [
       {
-        model: User,
+        model: UserModel,
         as: "user",
         attributes: [],
         required: true,

--- a/front/migrations/20230413_objects_workspaces.ts
+++ b/front/migrations/20230413_objects_workspaces.ts
@@ -1,7 +1,6 @@
 // @ts-expect-error old migration code kept for reference
 
 import { personalWorkspace } from "@app/lib/auth";
-import { User } from "@app/lib/models/user";
 import {
   AppModel,
   Dataset,
@@ -10,6 +9,7 @@ import {
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { KeyModel } from "@app/lib/resources/storage/models/keys";
 import { RunModel } from "@app/lib/resources/storage/models/runs";
+import { UserModel } from "@app/lib/resources/storage/models/user";
 
 async function addWorkspaceToObject(
   object: AppModel | Dataset | Provider | KeyModel | DataSourceModel | RunModel
@@ -20,7 +20,7 @@ async function addWorkspaceToObject(
     return;
   }
 
-  const user = await User.findOne({
+  const user = await UserModel.findOne({
     where: {
       // @ts-expect-error old migration code kept for reference
       id: object.userId,

--- a/front/migrations/20230413_workspaces_memberships.ts
+++ b/front/migrations/20230413_workspaces_memberships.ts
@@ -1,9 +1,9 @@
-import { User } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
 import { MembershipModel } from "@app/lib/resources/storage/models/membership";
+import { UserModel } from "@app/lib/resources/storage/models/user";
 
 async function main() {
-  const users = await User.findAll();
+  const users = await UserModel.findAll();
 
   const chunks = [];
   for (let i = 0; i < users.length; i += 16) {

--- a/front/migrations/20230419_user_providers.ts
+++ b/front/migrations/20230419_user_providers.ts
@@ -1,7 +1,7 @@
-import { User } from "@app/lib/models/user";
+import { UserModel } from "@app/lib/resources/storage/models/user";
 
 async function main() {
-  const users = await User.findAll();
+  const users = await UserModel.findAll();
 
   const chunks = [];
   for (let i = 0; i < users.length; i += 16) {

--- a/front/migrations/20231017_user_first_and_last_name.ts
+++ b/front/migrations/20231017_user_first_and_last_name.ts
@@ -1,8 +1,8 @@
-import { User } from "@app/lib/models/user";
+import { UserModel } from "@app/lib/resources/storage/models/user";
 import { guessFirstAndLastNameFromFullName } from "@app/lib/user";
 
 async function main() {
-  const users: User[] = await User.findAll({
+  const users: UserModel[] = await UserModel.findAll({
     // Was run with this were but then we make first name non nullable and linter is not happy
     // where: {
     //   firstName: {
@@ -22,7 +22,7 @@ async function main() {
     console.log(`Processing chunk ${i}/${chunks.length}...`);
     const chunk = chunks[i];
     await Promise.all(
-      chunk.map((u: User) => {
+      chunk.map((u: UserModel) => {
         return (async () => {
           if (!u.firstName) {
             const { firstName, lastName } = guessFirstAndLastNameFromFullName(

--- a/front/migrations/20231204_author_backfill.ts
+++ b/front/migrations/20231204_author_backfill.ts
@@ -1,6 +1,6 @@
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
-import { User } from "@app/lib/models/user";
 import { MembershipModel } from "@app/lib/resources/storage/models/membership";
+import { UserModel } from "@app/lib/resources/storage/models/user";
 
 async function main() {
   console.log("Starting author backfill");
@@ -33,7 +33,7 @@ async function main() {
 
 async function backfillAuthor(workspaceId: number) {
   // set author as the first admin of the workspace
-  const author = await User.findOne({
+  const author = await UserModel.findOne({
     include: [
       {
         model: MembershipModel,

--- a/front/migrations/20231219_imageUrl_backfill.ts
+++ b/front/migrations/20231219_imageUrl_backfill.ts
@@ -1,7 +1,7 @@
 import { UserMessage } from "@app/lib/models/assistant/conversation";
-import { User } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
 import { MembershipModel } from "@app/lib/resources/storage/models/membership";
+import { UserModel } from "@app/lib/resources/storage/models/user";
 
 async function main() {
   console.log("Starting imageUrl backfill");
@@ -33,7 +33,7 @@ async function main() {
 
 async function backfillImageUrl(workspaceId: number) {
   // get all users from workspace whose imageUrl is null
-  const users = await User.findAll({
+  const users = await UserModel.findAll({
     where: {
       imageUrl: null,
     },

--- a/front/migrations/20240404_backfill_users_and_invitations_sid.ts
+++ b/front/migrations/20240404_backfill_users_and_invitations_sid.ts
@@ -1,18 +1,18 @@
-import { User } from "@app/lib/models/user";
 import { MembershipInvitation } from "@app/lib/models/workspace";
+import { UserModel } from "@app/lib/resources/storage/models/user";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 
 const backfillUsers = async (execute: boolean) => {
-  const users = await User.findAll({
+  const users = await UserModel.findAll({
     // @ts-expect-error sId is marked as required in the model, but we are looking for null values
     where: {
       sId: null,
     },
   });
 
-  const chunks: User[][] = [];
+  const chunks: UserModel[][] = [];
   for (let i = 0; i < users.length; i += 16) {
     chunks.push(users.slice(i, i + 16));
   }

--- a/front/migrations/20240423_backfill_customerio.ts
+++ b/front/migrations/20240423_backfill_customerio.ts
@@ -1,13 +1,13 @@
 import * as _ from "lodash";
 
-import { User } from "@app/lib/models/user";
+import { UserModel } from "@app/lib/resources/storage/models/user";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { CustomerioServerSideTracking } from "@app/lib/tracking/customerio/server";
 import logger from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 
 const backfillCustomerIo = async (execute: boolean) => {
-  const allUserModels = await User.findAll();
+  const allUserModels = await UserModel.findAll();
   const users = allUserModels.map((u) => u);
   const chunks = _.chunk(users, 16);
   for (const [i, c] of chunks.entries()) {

--- a/front/migrations/20240513_backfill_customerio_delete_free_test.ts
+++ b/front/migrations/20240513_backfill_customerio_delete_free_test.ts
@@ -1,11 +1,11 @@
 import { removeNulls } from "@dust-tt/types";
 import * as _ from "lodash";
 
-import { User } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
 import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { subscriptionForWorkspaces } from "@app/lib/plans/subscription";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { UserModel } from "@app/lib/resources/storage/models/user";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { CustomerioServerSideTracking } from "@app/lib/tracking/customerio/server";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
@@ -13,7 +13,7 @@ import logger from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 
 const backfillCustomerIo = async (execute: boolean) => {
-  const allUserModels = await User.findAll();
+  const allUserModels = await UserModel.findAll();
   const users = allUserModels.map((u) => u);
   const chunks = _.chunk(users, 16);
   const deletedWorkspaceSids = new Set<string>();

--- a/front/migrations/db/migration_125.sql
+++ b/front/migrations/db/migration_125.sql
@@ -1,3 +1,17 @@
+\set ON_ERROR_STOP on
+
+-- Check if the safety flag variable exists
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_settings
+        WHERE name = 'i_know_what_i_do'
+    ) THEN
+        RAISE EXCEPTION 'Safety flag not set. Run with: psql -v i_know_what_i_do=true -f convert_to_bigint.sql';
+    END IF;
+END $$;
+
 DO $$
 DECLARE
     r RECORD;

--- a/front/migrations/db/migration_125.sql
+++ b/front/migrations/db/migration_125.sql
@@ -1,0 +1,52 @@
+DO $$
+DECLARE
+    r RECORD;
+BEGIN
+    -- First convert all PKs
+    FOR r IN (
+        SELECT
+            t.table_name,
+            c.column_name
+        FROM information_schema.tables t
+        JOIN information_schema.columns c
+            ON t.table_name = c.table_name
+            AND t.table_schema = c.table_schema
+        JOIN information_schema.key_column_usage k
+            ON c.column_name = k.column_name
+            AND c.table_name = k.table_name
+        WHERE c.data_type = 'integer'
+            AND t.table_schema = 'public'
+            AND EXISTS (
+                SELECT 1
+                FROM information_schema.table_constraints tc
+                WHERE tc.constraint_type = 'PRIMARY KEY'
+                    AND tc.table_name = t.table_name
+                    AND tc.constraint_name = k.constraint_name
+            )
+    ) LOOP
+        RAISE NOTICE 'Converting PK column % in table % to bigint', r.column_name, r.table_name;
+        EXECUTE format('ALTER TABLE %I ALTER COLUMN %I TYPE bigint', r.table_name, r.column_name);
+    END LOOP;
+
+    -- Then convert all FKs
+    FOR r IN (
+        SELECT DISTINCT
+            t.table_name,
+            c.column_name
+        FROM information_schema.tables t
+        JOIN information_schema.columns c
+            ON t.table_name = c.table_name
+            AND t.table_schema = c.table_schema
+        JOIN information_schema.key_column_usage k
+            ON c.column_name = k.column_name
+            AND c.table_name = k.table_name
+        JOIN information_schema.table_constraints tc
+            ON tc.constraint_name = k.constraint_name
+        WHERE c.data_type = 'integer'
+            AND t.table_schema = 'public'
+            AND tc.constraint_type = 'FOREIGN KEY'
+    ) LOOP
+        RAISE NOTICE 'Converting FK column % in table % to bigint', r.column_name, r.table_name;
+        EXECUTE format('ALTER TABLE %I ALTER COLUMN %I TYPE bigint', r.table_name, r.column_name);
+    END LOOP;
+END $$;

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -43,7 +43,6 @@ import {
   UserMessage,
 } from "@app/lib/models/assistant/conversation";
 import { Subscription } from "@app/lib/models/plan";
-import { UserMetadata } from "@app/lib/models/user";
 import { MembershipInvitation, Workspace } from "@app/lib/models/workspace";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
@@ -60,6 +59,7 @@ import {
   LabsTranscriptsConfigurationModel,
   LabsTranscriptsHistoryModel,
 } from "@app/lib/resources/storage/models/labs_transcripts";
+import { UserMetadataModel } from "@app/lib/resources/storage/models/user";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
@@ -533,7 +533,7 @@ export async function deleteMembersActivity({
 
         // If the user we're removing the membership of only has one membership, we delete the user.
         if (membershipsOfUser.length === 1) {
-          await UserMetadata.destroy({
+          await UserMetadataModel.destroy({
             where: {
               userId: user.id,
             },


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR finalizes the migration of primary and foreign keys from integers to BigInt in our front database (see production's script [here](https://github.com/dust-tt/dust/pull/9065).

It introduces:
- A new `BaseModel` class that automatically sets id column as BigInt
- Renaming of `User` model to `UserModel`
- Local migration script for the schema changes

All models in the front database have already been migrated to BigInt. This PR simply re-aligns our codebase with this schema by introducing proper model abstractions and type definitions.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

There are no migrations needed to be run. 

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
