### PR TITLE
Redirect FREE_TEST_PLAN to paywall + allow trial

### DIFF
--- a/front/lib/plans/free_plans.ts
+++ b/front/lib/plans/free_plans.ts
@@ -73,7 +73,7 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
     maxDataSourcesDocumentsCount: 10,
     maxDataSourcesDocumentsSizeMb: 2,
     trialPeriodDays: 0,
-    canUseProduct: true,
+    canUseProduct: false,
   },
   {
     code: FREE_UPGRADED_PLAN_CODE,

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -2,16 +2,19 @@ import type {
   BillingPeriod,
   LightWorkspaceType,
   Result,
+  SubscriptionType,
   WorkspaceType,
 } from "@dust-tt/types";
-import type { SubscriptionType } from "@dust-tt/types";
 import { Err, isDevelopment, Ok } from "@dust-tt/types";
 import { Stripe } from "stripe";
 
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { Plan, Subscription } from "@app/lib/models/plan";
-import { PRO_PLAN_SEAT_29_CODE } from "@app/lib/plans/plan_codes";
+import {
+  isOldFreePlan,
+  PRO_PLAN_SEAT_29_CODE,
+} from "@app/lib/plans/plan_codes";
 import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
 import {
   isEnterpriseReportUsage,
@@ -117,7 +120,7 @@ export const createProPlanCheckoutSession = async ({
       workspaceId: owner.id,
     },
   });
-  if (existingSubscription) {
+  if (existingSubscription && !isOldFreePlan(existingSubscription.plan.code)) {
     trialAllowed = false;
   }
 

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -116,9 +116,8 @@ export const createProPlanCheckoutSession = async ({
   // User under the grandfathered free plan are not allowed to have a trial.
   let trialAllowed = true;
   const existingSubscription = await Subscription.findOne({
-    where: {
-      workspaceId: owner.id,
-    },
+    where: { workspaceId: owner.id },
+    include: [Plan],
   });
   if (existingSubscription && !isOldFreePlan(existingSubscription.plan.code)) {
     trialAllowed = false;

--- a/front/migrations/20241205_free_test_plan_cant_use_product.sql
+++ b/front/migrations/20241205_free_test_plan_cant_use_product.sql
@@ -1,0 +1,3 @@
+UPDATE plans
+SET "canUseProduct" = false
+WHERE "code" = 'FREE_TEST_PLAN';

--- a/front/pages/w/[wId]/subscribe.tsx
+++ b/front/pages/w/[wId]/subscribe.tsx
@@ -56,8 +56,8 @@ export default function Subscribe({
 
   // If you had another subscription before, you will not get the free trial again: we use this to show the correct message.
   // Current plan is either FREE_NO_PLAN or FREE_TEST_PLAN if you're on this paywall.
-  //FREE_NO_PLAN is not on the database, checking it comes down to having at least 1 subscription.
-  const hasPreviouSubscription =
+  // FREE_NO_PLAN is not on the database, checking it comes down to having at least 1 subscription.
+  const hasPreviousSubscription =
     subscriptions?.length > 0 &&
     (subscriptions.length > 1 || !isOldFreePlan(subscriptions[0].plan.code)); // FREE_TEST_PLAN did not pay, they should be asked to start instead of resume
 
@@ -133,7 +133,7 @@ export default function Subscribe({
                   icon={CreditCardIcon}
                   title="Setting up your subscription"
                 />
-                {hasPreviouSubscription ? (
+                {hasPreviousSubscription ? (
                   <>
                     <Page.P>
                       <span className="font-bold">
@@ -192,7 +192,7 @@ export default function Subscribe({
                 <Button
                   variant="primary"
                   label={
-                    hasPreviouSubscription
+                    hasPreviousSubscription
                       ? billingPeriod === "monthly"
                         ? "Resume with monthly billing"
                         : "Resume with yearly billing"

--- a/front/pages/w/[wId]/subscribe.tsx
+++ b/front/pages/w/[wId]/subscribe.tsx
@@ -59,7 +59,7 @@ export default function Subscribe({
   // FREE_NO_PLAN is not on the database, checking it comes down to having at least 1 subscription.
   const hasPreviousSubscription =
     subscriptions?.length > 0 &&
-    (subscriptions.length > 1 || !isOldFreePlan(subscriptions[0].plan.code)); // FREE_TEST_PLAN did not pay, they should be asked to start instead of resume
+    (subscriptions.length >= 2 || !isOldFreePlan(subscriptions[0].plan.code)); // FREE_TEST_PLAN did not pay, they should be asked to start instead of resume
 
   const { submit: handleSubscribePlan } = useSubmitFunction(
     async (billingPeriod) => {

--- a/front/pages/w/[wId]/subscribe.tsx
+++ b/front/pages/w/[wId]/subscribe.tsx
@@ -1,5 +1,10 @@
-import { BarHeader, Button, LockIcon, Page } from "@dust-tt/sparkle";
-import { useSendNotification } from "@dust-tt/sparkle";
+import {
+  BarHeader,
+  Button,
+  LockIcon,
+  Page,
+  useSendNotification,
+} from "@dust-tt/sparkle";
 import type { BillingPeriod, WorkspaceType } from "@dust-tt/types";
 import { CreditCardIcon } from "@heroicons/react/20/solid";
 import type { InferGetServerSidePropsType } from "next";
@@ -11,6 +16,7 @@ import { UserMenu } from "@app/components/UserMenu";
 import WorkspacePicker from "@app/components/WorkspacePicker";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { withDefaultUserAuthPaywallWhitelisted } from "@app/lib/iam/session";
+import { isOldFreePlan } from "@app/lib/plans/plan_codes";
 import { useUser } from "@app/lib/swr/user";
 import { useWorkspaceSubscriptions } from "@app/lib/swr/workspaces";
 
@@ -49,9 +55,11 @@ export default function Subscribe({
     React.useState<BillingPeriod>("monthly");
 
   // If you had another subscription before, you will not get the free trial again: we use this to show the correct message.
-  // Current plan is always FREE_NO_PLAN if you're on this paywall.
-  // Since FREE_NO_PLAN is not on the database, we check if there is at least 1 subscription.
-  const hasPreviouSubscription = subscriptions?.length > 0;
+  // Current plan is either FREE_NO_PLAN or FREE_TEST_PLAN if you're on this paywall.
+  //FREE_NO_PLAN is not on the database, checking it comes down to having at least 1 subscription.
+  const hasPreviouSubscription =
+    subscriptions?.length > 0 &&
+    (subscriptions.length > 1 || !isOldFreePlan(subscriptions[0].plan.code)); // FREE_TEST_PLAN did not pay, they should be asked to start instead of resume
 
   const { submit: handleSubscribePlan } = useSubmitFunction(
     async (billingPeriod) => {

--- a/front/pages/w/[wId]/subscribe.tsx
+++ b/front/pages/w/[wId]/subscribe.tsx
@@ -57,9 +57,9 @@ export default function Subscribe({
   // If you had another subscription before, you will not get the free trial again: we use this to show the correct message.
   // Current plan is either FREE_NO_PLAN or FREE_TEST_PLAN if you're on this paywall.
   // FREE_NO_PLAN is not on the database, checking it comes down to having at least 1 subscription.
-  const hasPreviousSubscription =
-    subscriptions?.length > 0 &&
-    (subscriptions.length >= 2 || !isOldFreePlan(subscriptions[0].plan.code)); // FREE_TEST_PLAN did not pay, they should be asked to start instead of resume
+  const noPreviousSubscription =
+    subscriptions.length === 0 ||
+    (subscriptions.length === 1 && isOldFreePlan(subscriptions[0].plan.code)); // FREE_TEST_PLAN did not pay, they should be asked to start instead of resume
 
   const { submit: handleSubscribePlan } = useSubmitFunction(
     async (billingPeriod) => {
@@ -133,7 +133,7 @@ export default function Subscribe({
                   icon={CreditCardIcon}
                   title="Setting up your subscription"
                 />
-                {hasPreviousSubscription ? (
+                {!noPreviousSubscription ? (
                   <>
                     <Page.P>
                       <span className="font-bold">
@@ -192,7 +192,7 @@ export default function Subscribe({
                 <Button
                   variant="primary"
                   label={
-                    hasPreviousSubscription
+                    !noPreviousSubscription
                       ? billingPeriod === "monthly"
                         ? "Resume with monthly billing"
                         : "Resume with yearly billing"


### PR DESCRIPTION
# Description

- Close https://github.com/dust-tt/tasks/issues/1756.
- Redirect FREE_TEST_PLAN to paywall.
- Allow 14 days of trials for FREE_TEST_PLAN.
- Update the paywall messages for them ("activate" billing instead of "resume")
- Set canUseProduct to false for FREE_TEST_PLAN.
- Tested by upgrading my workspace to FREE_TEST_PLAN + clear cookies, correctly redirected to the paywall.

# Risk

Testing procedure:
- Login with unused account.
- Upgrade to FREE_TEST_PLAN using poke.
- Check that we get paywalled, with a free trial.

<img width="897" alt="Screenshot 2024-12-08 at 7 51 56 PM" src="https://github.com/user-attachments/assets/903297af-817f-41aa-bf0d-4abcf4e0c0f3">

- Check that we get a new pro plan subscription upon completing the Stripe checkout flow. (cant go through yet, have to be added on stripe, will do tomorrow)

# Deploy Plan

- Deploy front.