### PR TITLE
API: accept undefined in content fragment creation

### DIFF
--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -134,7 +134,12 @@ async function handler(
         auth,
         conversation,
         contentFragment,
-        context
+        {
+          email: context?.email ?? null,
+          fullName: context?.fullName ?? null,
+          username: context?.username ?? null,
+          profilePictureUrl: context?.profilePictureUrl ?? null,
+        }
       );
 
       if (contentFragmentRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -191,10 +191,10 @@ async function handler(
         }
 
         const cfRes = await postNewContentFragment(auth, conversation, cf, {
-          username: context?.username || null,
-          fullName: context?.fullName || null,
-          email: context?.email || null,
-          profilePictureUrl: context?.profilePictureUrl || null,
+          username: context?.username ?? null,
+          fullName: context?.fullName ?? null,
+          email: context?.email ?? null,
+          profilePictureUrl: context?.profilePictureUrl ?? null,
         });
         if (cfRes.isErr()) {
           return apiError(req, res, {

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -812,10 +812,10 @@ export type LightAgentConfigurationType = z.infer<
 >;
 
 const ContentFragmentContextSchema = z.object({
-  username: z.string().nullable(),
-  fullName: z.string().nullable(),
-  email: z.string().nullable(),
-  profilePictureUrl: z.string().nullable(),
+  username: z.string().optional().nullable(),
+  fullName: z.string().optional().nullable(),
+  email: z.string().optional().nullable(),
+  profilePictureUrl: z.string().optional().nullable(),
 });
 
 const ContentFragmentSchema = z.object({
@@ -1622,11 +1622,11 @@ export type PublicPostEditMessagesRequestBody = z.infer<
 
 export const PublicContentFragmentWithContentSchema = z.object({
   title: z.string(),
-  url: z.string().nullable(),
+  url: z.string().optional().nullable(),
   content: z.string(),
   contentType: SupportedContentFragmentTypeSchema,
   fileId: z.undefined().nullable(),
-  context: ContentFragmentContextSchema.nullable(),
+  context: ContentFragmentContextSchema.optional().nullable(),
   // Undocumented for now -- allows to supersede an existing content fragment.
   supersededContentFragmentId: z.string().optional().nullable(),
 });
@@ -1637,11 +1637,11 @@ export type PublicContentFragmentWithContent = z.infer<
 
 export const PublicContentFragmentWithFileIdSchema = z.object({
   title: z.string(),
-  url: z.string().nullable(),
+  url: z.string().optional().nullable(),
   content: z.undefined().nullable(),
   contentType: z.undefined().nullable(),
   fileId: z.string(),
-  context: ContentFragmentContextSchema.nullable(),
+  context: ContentFragmentContextSchema.optional().nullable(),
   // Undocumented for now -- allows to supersede an existing content fragment.
   supersededContentFragmentId: z.string().optional().nullable(),
 });


### PR DESCRIPTION
## Description

Allow nullable fields (in our internal types) to be skipped when talking to the API.

## Risk

Low: loosening validation + tested locally

## Deploy Plan

- deploy `front`