### PR TITLE
Include startDate and endDate in feedbacks query

### DIFF
--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -115,7 +115,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
       where: {
         workspaceId: workspace.id,
         createdAt: {
-          [Op.between]: [startDate, endDate],
+          [Op.and]: [{ [Op.gte]: startDate }, { [Op.lte]: endDate }],
         },
       },
     }).then((feedbacks) =>


### PR DESCRIPTION
## Description

- A customer told us feedbacks API behaved differently from the rest because it did not _include_ the endDate day
- So moving to lte/gte instead of between to make sure to include both dates

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
