### PR TITLE
[sparkle] - refactor(Button): stronger typing

### DIFF
--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -118,7 +118,7 @@ type MiniButtonProps = CommonButtonProps & {
   label?: never;
 };
 
-type RegularButtonProps = CommonButtonProps & {
+export type RegularButtonProps = CommonButtonProps & {
   size?: Exclude<ButtonSizeType, "mini">;
   icon?: React.ComponentType;
   label?: string;

--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -46,10 +46,10 @@ const styleVariants: Record<ButtonVariantType, string> = {
 };
 
 const sizeVariants: Record<ButtonSizeType, string> = {
+  mini: "s-h-7 s-p-1.5 s-rounded-lg s-text-sm s-gap-1.5",
   xs: "s-h-7 s-px-2.5 s-rounded-lg s-text-xs s-gap-1.5",
   sm: "s-h-9 s-px-3 s-rounded-xl s-text-sm s-gap-2",
   md: "s-h-12 s-px-4 s-py-2 s-rounded-2xl s-text-base s-gap-2.5",
-  mini: "s-h-7 s-p-1.5 s-rounded-lg s-text-sm s-gap-1.5",
 };
 
 const buttonVariants = cva(
@@ -104,17 +104,27 @@ const MetaButton = React.forwardRef<HTMLButtonElement, MetaButtonProps>(
 );
 MetaButton.displayName = "MetaButton";
 
-export interface ButtonProps
-  extends Omit<MetaButtonProps, "children">,
-    Omit<LinkWrapperProps, "children" | "className"> {
-  label?: string;
+type CommonButtonProps = Omit<MetaButtonProps, "children"> &
+  Omit<LinkWrapperProps, "children"> & {
+    isSelect?: boolean;
+    isLoading?: boolean;
+    isPulsing?: boolean;
+    tooltip?: string;
+  };
+
+type MiniButtonProps = CommonButtonProps & {
+  size: "mini";
+  icon: React.ComponentType;
+  label?: never;
+};
+
+type RegularButtonProps = CommonButtonProps & {
+  size?: Exclude<ButtonSizeType, "mini">;
   icon?: React.ComponentType;
-  isSelect?: boolean;
-  isLoading?: boolean;
-  isPulsing?: boolean;
-  tooltip?: string;
-  size?: ButtonSizeType;
-}
+  label?: string;
+};
+
+export type ButtonProps = MiniButtonProps | RegularButtonProps;
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   (

--- a/sparkle/src/components/EmptyCTA.tsx
+++ b/sparkle/src/components/EmptyCTA.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { Button, ButtonProps } from "@sparkle/components/";
+import { Button, ButtonProps, RegularButtonProps } from "@sparkle/components/";
 import { cn } from "@sparkle/lib/utils";
 
 interface EmptyCTAProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -28,7 +28,7 @@ const EmptyCTA = React.forwardRef<HTMLDivElement, EmptyCTAProps>(
 
 EmptyCTA.displayName = "EmptyCTA";
 
-interface EmptyCTAButtonProps extends ButtonProps {
+interface EmptyCTAButtonProps extends RegularButtonProps {
   icon: React.ComponentType;
   label: string;
 }

--- a/sparkle/src/components/EmptyCTA.tsx
+++ b/sparkle/src/components/EmptyCTA.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { Button, ButtonProps, RegularButtonProps } from "@sparkle/components/";
+import { Button, RegularButtonProps } from "@sparkle/components/";
 import { cn } from "@sparkle/lib/utils";
 
 interface EmptyCTAProps extends React.HTMLAttributes<HTMLDivElement> {

--- a/sparkle/src/components/SplitButton.tsx
+++ b/sparkle/src/components/SplitButton.tsx
@@ -7,19 +7,18 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  RegularButtonProps,
 } from "@sparkle/components/";
 import {
   Button,
   ButtonSizeType,
   ButtonVariantType,
-  MetaButtonProps,
 } from "@sparkle/components/Button";
 import { Separator } from "@sparkle/components/Separator";
 import { ChevronDownIcon } from "@sparkle/icons";
 import { cn } from "@sparkle/lib";
 
-const separatorSizeVariants: Record<ButtonSizeType, string> = {
-  mini: "s-h-3",
+const separatorSizeVariants: Record<Exclude<ButtonSizeType, "mini">, string> = {
   xs: "s-h-3",
   sm: "s-h-5",
   md: "s-h-7",
@@ -41,7 +40,7 @@ interface SplitButtonActionProps {
 }
 
 export interface SplitButtonProps
-  extends Omit<MetaButtonProps, "children" | "onClick"> {
+  extends Omit<RegularButtonProps, "children" | "onClick"> {
   /**
    * List of possible actions, will be displayed in dropdown
    */

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -4,7 +4,7 @@ export { AssistantPreview } from "./AssistantPreview";
 export { Avatar } from "./Avatar";
 export { BarHeader } from "./BarHeader";
 export { Breadcrumbs } from "./Breadcrumbs";
-export type { ButtonProps } from "./Button";
+export type { ButtonProps, RegularButtonProps } from "./Button";
 export { Button } from "./Button";
 export { Card, ComposableCard } from "./Card";
 export type { CardButtonProps } from "./CardButton";

--- a/sparkle/src/stories/Button.stories.tsx
+++ b/sparkle/src/stories/Button.stories.tsx
@@ -63,3 +63,7 @@ export const ExampleButton: Story = {
     isSelect: false,
   },
 };
+
+export const MiniButton: Story = {
+  render: () => <Button size="mini" icon={PlusIcon} />,
+};

--- a/sparkle/src/stories/Button.stories.tsx
+++ b/sparkle/src/stories/Button.stories.tsx
@@ -21,15 +21,22 @@ const meta = {
       control: { type: "select" },
     },
     size: {
-      description: "The size of the button",
+      description:
+        "The size of the button (Note: 'mini' size requires an icon and cannot have a label)",
       options: BUTTON_SIZES,
       control: { type: "select" },
     },
     icon: {
-      description: "Optional icon to display in the button",
+      description: "Icon to display in the button (Required for mini size)",
       options: Object.keys(ICONS),
       mapping: ICONS,
       control: { type: "select" },
+      if: { arg: "size", neq: "mini" },
+    },
+    label: {
+      description: "Button label (Not available for mini size)",
+      control: { type: "text" },
+      if: { arg: "size", neq: "mini" },
     },
     isLoading: {
       description: "Whether the button should display a loading spinner",
@@ -48,7 +55,13 @@ const meta = {
       control: "text",
     },
   },
-} satisfies Meta<React.ComponentProps<typeof Button>>;
+  render: (args) => {
+    if (args.size === "mini" && !args.icon) {
+      args.icon = ICONS.PlusIcon;
+    }
+    return <Button {...args} />;
+  },
+} satisfies Meta<typeof Button>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/sparkle/src/stories/Playground.stories.tsx
+++ b/sparkle/src/stories/Playground.stories.tsx
@@ -39,7 +39,9 @@ export const Demo = () => {
           label="Send"
           variant={"ghost"}
           icon={ArrowUpIcon}
-          splitAction={<Button size="mini" variant={"ghost"} icon={ChevronDownIcon} />}
+          splitAction={
+            <Button size="mini" variant={"ghost"} icon={ChevronDownIcon} />
+          }
         />
       </div>
     </div>


### PR DESCRIPTION
## Description

This PR adds stronger typing for `Button` when `size = "mini"`. In this case we want to make sure that `label` cannot be passed and `icon` is required.

## Risk

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
