### PR TITLE
API/v1: rely on zod-validation-error

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -123,7 +123,8 @@
         "three": "^0.163.0",
         "tsconfig-paths-webpack-plugin": "^4.1.0",
         "uuid": "^9.0.0",
-        "yargs": "^17.7.2"
+        "yargs": "^17.7.2",
+        "zod-validation-error": "^3.4.0"
       },
       "devDependencies": {
         "@google-cloud/storage": "^7.11.2",
@@ -29755,8 +29756,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.11",
-      "license": "MIT"
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -34831,6 +34833,26 @@
       },
       "optionalDependencies": {
         "commander": "^9.4.1"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-3.4.0.tgz",
+      "integrity": "sha512-ZOPR9SVY6Pb2qqO5XHt+MkkTRxGXb4EVtnjc9JpXUOtUB1T9Ru7mZOT361AN3MsetVe7R0a1KZshJDZdgp9miQ==",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.18.0"
       }
     },
     "node_modules/zustand": {

--- a/front/package.json
+++ b/front/package.json
@@ -136,7 +136,8 @@
     "three": "^0.163.0",
     "tsconfig-paths-webpack-plugin": "^4.1.0",
     "uuid": "^9.0.0",
-    "yargs": "^17.7.2"
+    "yargs": "^17.7.2",
+    "zod-validation-error": "^3.4.0"
   },
   "devDependencies": {
     "@google-cloud/storage": "^7.11.2",

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/search.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/search.ts
@@ -70,7 +70,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body: " + fromError(r.error).toString(),
+            message: fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/search.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/search.ts
@@ -3,6 +3,7 @@ import { DataSourceSearchQuerySchema } from "@dust-tt/client";
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { fromError } from "zod-validation-error";
 
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { handleDataSourceSearch } from "@app/lib/api/data_sources";
@@ -62,15 +63,14 @@ async function handler(
         req.query.tags_not = [req.query.tags_not];
       }
 
-      const r = await DataSourceSearchQuerySchema.safeParse(req.query);
+      const r = DataSourceSearchQuerySchema.safeParse(req.query);
 
       if (r.error) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body.",
-            request_format_errors: r.error.flatten(),
+            message: "Invalid request body: " + fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations/[sId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations/[sId]/index.ts
@@ -2,6 +2,7 @@ import type { GetOrPatchAgentConfigurationResponseType } from "@dust-tt/client";
 import { PatchAgentConfigurationRequestSchema } from "@dust-tt/client";
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
+import {fromError} from "zod-validation-error";
 
 import { getLightAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import { setAgentUserFavorite } from "@app/lib/api/assistant/user_relation";
@@ -145,8 +146,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body.",
-            request_format_errors: r.error.flatten(),
+            message: "Invalid request body: " + fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations/[sId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations/[sId]/index.ts
@@ -2,7 +2,7 @@ import type { GetOrPatchAgentConfigurationResponseType } from "@dust-tt/client";
 import { PatchAgentConfigurationRequestSchema } from "@dust-tt/client";
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
-import {fromError} from "zod-validation-error";
+import { fromError } from "zod-validation-error";
 
 import { getLightAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import { setAgentUserFavorite } from "@app/lib/api/assistant/user_relation";

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations/[sId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations/[sId]/index.ts
@@ -146,7 +146,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body: " + fromError(r.error).toString(),
+            message: fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/cancel.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/cancel.ts
@@ -98,7 +98,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body: " + fromError(r.error).toString(),
+            message: fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/cancel.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/cancel.ts
@@ -2,7 +2,7 @@ import type { CancelMessageGenerationResponseType } from "@dust-tt/client";
 import { CancelMessageGenerationRequestSchema } from "@dust-tt/client";
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
-import {fromError} from "zod-validation-error";
+import { fromError } from "zod-validation-error";
 
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/cancel.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/cancel.ts
@@ -2,6 +2,7 @@ import type { CancelMessageGenerationResponseType } from "@dust-tt/client";
 import { CancelMessageGenerationRequestSchema } from "@dust-tt/client";
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
+import {fromError} from "zod-validation-error";
 
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
@@ -97,8 +98,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body.",
-            request_format_errors: r.error.flatten(),
+            message: "Invalid request body: " + fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -95,7 +95,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body: " + fromError(r.error).toString(),
+            message: fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -3,6 +3,7 @@ import { PublicPostContentFragmentRequestBodySchema } from "@dust-tt/client";
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { isContentFragmentInputWithContentType } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { fromError } from "zod-validation-error";
 
 import {
   getConversation,
@@ -87,12 +88,14 @@ async function handler(
       const r = PublicPostContentFragmentRequestBodySchema.safeParse(req.body);
 
       if (r.error) {
+        const ve = fromError(r.error);
+        console.log(ve.toString());
+
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body.",
-            request_format_errors: r.error.flatten(),
+            message: "Invalid request body: " + fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
@@ -3,7 +3,7 @@ import { PublicPostEditMessagesRequestBodySchema } from "@dust-tt/client";
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { isUserMessageType } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
-import {fromError} from "zod-validation-error";
+import { fromError } from "zod-validation-error";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
@@ -3,6 +3,7 @@ import { PublicPostEditMessagesRequestBodySchema } from "@dust-tt/client";
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { isUserMessageType } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
+import {fromError} from "zod-validation-error";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
@@ -127,8 +128,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body.",
-            request_format_errors: r.error.flatten(),
+            message: "Invalid request body: " + fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
@@ -128,7 +128,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body: " + fromError(r.error).toString(),
+            message: fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -3,6 +3,7 @@ import { PublicPostMessagesRequestBodySchema } from "@dust-tt/client";
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { isEmptyString } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
+import {fromError} from "zod-validation-error";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
@@ -87,8 +88,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body.",
-            request_format_errors: r.error.flatten(),
+            message: "Invalid request body: " + fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -88,7 +88,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body: " + fromError(r.error).toString(),
+            message: fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -3,7 +3,7 @@ import { PublicPostMessagesRequestBodySchema } from "@dust-tt/client";
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { isEmptyString } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
-import {fromError} from "zod-validation-error";
+import { fromError } from "zod-validation-error";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -110,7 +110,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body: " + fromError(r.error).toString(),
+            message: fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -14,6 +14,7 @@ import {
   isEmptyString,
 } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
+import {fromError} from "zod-validation-error";
 
 import {
   createConversation,
@@ -109,8 +110,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body.",
-            request_format_errors: r.error.flatten(),
+            message: "Invalid request body: " + fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -14,7 +14,7 @@ import {
   isEmptyString,
 } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
-import {fromError} from "zod-validation-error";
+import { fromError } from "zod-validation-error";
 
 import {
   createConversation,

--- a/front/pages/api/v1/w/[wId]/data_source_views/search.ts
+++ b/front/pages/api/v1/w/[wId]/data_source_views/search.ts
@@ -37,7 +37,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body: " + fromError(r.error).toString(),
+            message: fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/data_source_views/search.ts
+++ b/front/pages/api/v1/w/[wId]/data_source_views/search.ts
@@ -2,7 +2,7 @@ import type { SearchDataSourceViewsResponseType } from "@dust-tt/client";
 import { SearchDataSourceViewsRequestSchema } from "@dust-tt/client";
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
-import {fromError} from "zod-validation-error";
+import { fromError } from "zod-validation-error";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/v1/w/[wId]/data_source_views/search.ts
+++ b/front/pages/api/v1/w/[wId]/data_source_views/search.ts
@@ -2,6 +2,7 @@ import type { SearchDataSourceViewsResponseType } from "@dust-tt/client";
 import { SearchDataSourceViewsRequestSchema } from "@dust-tt/client";
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
+import {fromError} from "zod-validation-error";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -36,8 +37,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid query parameters.",
-            request_format_errors: r.error.flatten(),
+            message: "Invalid request body: " + fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/files/index.ts
+++ b/front/pages/api/v1/w/[wId]/files/index.ts
@@ -8,7 +8,7 @@ import {
   rateLimiter,
 } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
-import {fromError} from "zod-validation-error";
+import { fromError } from "zod-validation-error";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/v1/w/[wId]/files/index.ts
+++ b/front/pages/api/v1/w/[wId]/files/index.ts
@@ -96,7 +96,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body: " + fromError(r.error).toString(),
+            message: fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/files/index.ts
+++ b/front/pages/api/v1/w/[wId]/files/index.ts
@@ -8,6 +8,7 @@ import {
   rateLimiter,
 } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
+import {fromError} from "zod-validation-error";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -95,8 +96,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body.",
-            request_format_errors: r.error.flatten(),
+            message: "Invalid request body: " + fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/members/validate.ts
+++ b/front/pages/api/v1/w/[wId]/members/validate.ts
@@ -2,6 +2,7 @@ import type { ValidateMemberResponseType } from "@dust-tt/client";
 import { ValidateMemberRequestSchema } from "@dust-tt/client";
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
+import {fromError} from "zod-validation-error";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -25,8 +26,7 @@ async function handler(
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: "Invalid request body.",
-        request_format_errors: r.error.flatten(),
+        message: "Invalid request body: " + fromError(r.error).toString(),
       },
     });
   }

--- a/front/pages/api/v1/w/[wId]/members/validate.ts
+++ b/front/pages/api/v1/w/[wId]/members/validate.ts
@@ -26,7 +26,7 @@ async function handler(
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: "Invalid request body: " + fromError(r.error).toString(),
+        message: fromError(r.error).toString(),
       },
     });
   }

--- a/front/pages/api/v1/w/[wId]/members/validate.ts
+++ b/front/pages/api/v1/w/[wId]/members/validate.ts
@@ -2,7 +2,7 @@ import type { ValidateMemberResponseType } from "@dust-tt/client";
 import { ValidateMemberRequestSchema } from "@dust-tt/client";
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
-import {fromError} from "zod-validation-error";
+import { fromError } from "zod-validation-error";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
@@ -204,7 +204,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body: " + fromError(parsing.error).toString(),
+            message: fromError(parsing.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
@@ -3,6 +3,7 @@ import { PatchDataSourceViewRequestSchema } from "@dust-tt/client";
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
+import {fromError} from "zod-validation-error";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import { handlePatchDataSourceView } from "@app/lib/api/data_source_view";
@@ -203,8 +204,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body.",
-            request_format_errors: parsing.error.flatten(),
+            message: "Invalid request body: " + fromError(parsing.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
@@ -3,7 +3,7 @@ import { PatchDataSourceViewRequestSchema } from "@dust-tt/client";
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
-import {fromError} from "zod-validation-error";
+import { fromError } from "zod-validation-error";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import { handlePatchDataSourceView } from "@app/lib/api/data_source_view";

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/search.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/search.ts
@@ -3,6 +3,7 @@ import { DataSourceSearchQuerySchema } from "@dust-tt/client";
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { fromError } from "zod-validation-error";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import { handleDataSourceSearch } from "@app/lib/api/data_sources";
@@ -185,15 +186,14 @@ async function handler(
         req.query.tags_not = [req.query.tags_not];
       }
 
-      const r = await DataSourceSearchQuerySchema.safeParse(req.query);
+      const r = DataSourceSearchQuerySchema.safeParse(req.query);
 
       if (r.error) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body.",
-            request_format_errors: r.error.flatten(),
+            message: "Invalid request body: " + fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/search.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/search.ts
@@ -193,7 +193,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body: " + fromError(r.error).toString(),
+            message: fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -13,7 +13,7 @@ import {
 } from "@dust-tt/types";
 import { validateUrl } from "@dust-tt/types/src/shared/utils/url_utils";
 import type { NextApiRequest, NextApiResponse } from "next";
-import {fromError} from "zod-validation-error";
+import { fromError } from "zod-validation-error";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import apiConfig from "@app/lib/api/config";

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -379,7 +379,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body: " + fromError(r.error).toString(),
+            message: fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -13,6 +13,7 @@ import {
 } from "@dust-tt/types";
 import { validateUrl } from "@dust-tt/types/src/shared/utils/url_utils";
 import type { NextApiRequest, NextApiResponse } from "next";
+import {fromError} from "zod-validation-error";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import apiConfig from "@app/lib/api/config";
@@ -378,8 +379,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body.",
-            request_format_errors: r.error.flatten(),
+            message: "Invalid request body: " + fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/search.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/search.ts
@@ -222,7 +222,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body: " + fromError(r.error).toString(),
+            message: fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/search.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/search.ts
@@ -3,6 +3,7 @@ import { DataSourceSearchQuerySchema } from "@dust-tt/client";
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { fromError } from "zod-validation-error";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import { handleDataSourceSearch } from "@app/lib/api/data_sources";
@@ -214,15 +215,14 @@ async function handler(
         req.query.tags_not = [req.query.tags_not];
       }
 
-      const r = await DataSourceSearchQuerySchema.safeParse(req.query);
+      const r = DataSourceSearchQuerySchema.safeParse(req.query);
 
       if (r.error) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body.",
-            request_format_errors: r.error.flatten(),
+            message: "Invalid request body: " + fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/parents.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/parents.ts
@@ -95,7 +95,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body: " + fromError(r.error).toString(),
+            message: fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/parents.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/parents.ts
@@ -3,6 +3,7 @@ import { PostTableParentsRequestSchema } from "@dust-tt/client";
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { fromError } from "zod-validation-error";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
@@ -87,15 +88,14 @@ async function handler(
 
   switch (req.method) {
     case "POST":
-      const r = await PostTableParentsRequestSchema.safeParse(req.body);
+      const r = PostTableParentsRequestSchema.safeParse(req.body);
 
       if (r.error) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body.",
-            request_format_errors: r.error.flatten(),
+            message: "Invalid request body: " + fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/rows/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/rows/index.ts
@@ -268,7 +268,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body: " + fromError(r.error).toString(),
+            message: fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/rows/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/rows/index.ts
@@ -7,6 +7,7 @@ import { UpsertTableRowsRequestSchema } from "@dust-tt/client";
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { CoreAPI, isSlugified } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { fromError } from "zod-validation-error";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
@@ -260,15 +261,14 @@ async function handler(
       return res.status(200).json({ rows: rowsList, offset, limit, total });
 
     case "POST":
-      const r = await UpsertTableRowsRequestSchema.safeParse(req.body);
+      const r = UpsertTableRowsRequestSchema.safeParse(req.body);
 
       if (r.error) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body.",
-            request_format_errors: r.error.flatten(),
+            message: "Invalid request body: " + fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.ts
@@ -109,7 +109,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body: " + fromError(r.error).toString(),
+            message: fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.ts
@@ -6,7 +6,7 @@ import { UpsertTableFromCsvRequestSchema } from "@dust-tt/client";
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
-import {fromError} from "zod-validation-error";
+import { fromError } from "zod-validation-error";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import { handleDataSourceTableCSVUpsert } from "@app/lib/api/data_sources";

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.ts
@@ -6,6 +6,7 @@ import { UpsertTableFromCsvRequestSchema } from "@dust-tt/client";
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
+import {fromError} from "zod-validation-error";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import { handleDataSourceTableCSVUpsert } from "@app/lib/api/data_sources";
@@ -108,8 +109,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body.",
-            request_format_errors: r.error.flatten(),
+            message: "Invalid request body: " + fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -6,7 +6,7 @@ import { UpsertDatabaseTableRequestSchema } from "@dust-tt/client";
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
-import {fromError} from "zod-validation-error";
+import { fromError } from "zod-validation-error";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -247,7 +247,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body: " + fromError(r.error).toString(),
+            message: fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -6,6 +6,7 @@ import { UpsertDatabaseTableRequestSchema } from "@dust-tt/client";
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
+import {fromError} from "zod-validation-error";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
@@ -246,8 +247,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body.",
-            request_format_errors: r.error.flatten(),
+            message: "Invalid request body: " + fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/v1/w/[wId]/workspace-usage.ts
@@ -117,7 +117,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body: " + fromError(r.error).toString(),
+            message: fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/v1/w/[wId]/workspace-usage.ts
@@ -7,6 +7,7 @@ import { assertNever } from "@dust-tt/types";
 import { endOfMonth } from "date-fns/endOfMonth";
 import JSZip from "jszip";
 import type { NextApiRequest, NextApiResponse } from "next";
+import {fromError} from "zod-validation-error";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -116,8 +117,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body.",
-            request_format_errors: r.error.flatten(),
+            message: "Invalid request body: " + fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/v1/w/[wId]/workspace-usage.ts
@@ -7,7 +7,7 @@ import { assertNever } from "@dust-tt/types";
 import { endOfMonth } from "date-fns/endOfMonth";
 import JSZip from "jszip";
 import type { NextApiRequest, NextApiResponse } from "next";
-import {fromError} from "zod-validation-error";
+import { fromError } from "zod-validation-error";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/search.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/search.ts
@@ -55,7 +55,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body: " + fromError(r.error).toString(),
+            message: fromError(r.error).toString(),
           },
         });
       }

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/search.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/search.ts
@@ -3,6 +3,7 @@ import { DataSourceSearchQuerySchema } from "@dust-tt/client";
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { fromError } from "zod-validation-error";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { handleDataSourceSearch } from "@app/lib/api/data_sources";
@@ -47,15 +48,14 @@ async function handler(
         req.query.tags_not = [req.query.tags_not];
       }
 
-      const r = await DataSourceSearchQuerySchema.safeParse(req.query);
+      const r = DataSourceSearchQuerySchema.safeParse(req.query);
 
       if (r.error) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body.",
-            request_format_errors: r.error.flatten(),
+            message: "Invalid request body: " + fromError(r.error).toString(),
           },
         });
       }

--- a/types/src/front/lib/error.ts
+++ b/types/src/front/lib/error.ts
@@ -107,7 +107,6 @@ export type APIErrorType =
 export type APIError = {
   type: APIErrorType;
   message: string;
-  request_format_errors?: object;
   data_source_error?: CoreAPIError;
   run_error?: CoreAPIError;
   app_error?: CoreAPIError;


### PR DESCRIPTION
## Description

Previous approach would lead to extremely cryptic errors. This is a step better.

Before
```
{"error":{"type":"invalid_request_error","message":"Invalid request body.","request_format_errors":{"formErrors":[],"fieldErrors":{"message":["Invalid input"]}}}}
```

After:
```
{"error":{"type":"invalid_request_error","message":"Validation error: Required at \"content\", or Expected undefined, received string at \"contentType\"; Required at \"fileId\""}}
```

## Risk

None

## Deploy Plan

- deploy `front`