### PR TITLE
connectors: fix types interacting with API

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -1,6 +1,7 @@
 import type {
   ConversationPublicType,
   PublicPostContentFragmentRequestBody,
+  UserMessageType,
 } from "@dust-tt/client";
 import { DustAPI } from "@dust-tt/client";
 import type {
@@ -9,7 +10,6 @@ import type {
   LightAgentConfigurationType,
   ModelId,
   Result,
-  UserMessageType,
 } from "@dust-tt/types";
 import { Err, Ok, sectionFullText } from "@dust-tt/types";
 import type { WebClient } from "@slack/web-api";

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -2,11 +2,11 @@ import type {
   AgentActionPublicType,
   ConversationPublicType,
   DustAPI,
+  UserMessageType,
 } from "@dust-tt/client";
 import type {
   LightAgentConfigurationType,
   Result,
-  UserMessageType,
 } from "@dust-tt/types";
 import { ACTION_RUNNING_LABELS, assertNever, Err, Ok } from "@dust-tt/types";
 import type { ChatPostMessageResponse, WebClient } from "@slack/web-api";

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -4,10 +4,7 @@ import type {
   DustAPI,
   UserMessageType,
 } from "@dust-tt/client";
-import type {
-  LightAgentConfigurationType,
-  Result,
-} from "@dust-tt/types";
+import type { LightAgentConfigurationType, Result } from "@dust-tt/types";
 import { ACTION_RUNNING_LABELS, assertNever, Err, Ok } from "@dust-tt/types";
 import type { ChatPostMessageResponse, WebClient } from "@slack/web-api";
 import slackifyMarkdown from "slackify-markdown";


### PR DESCRIPTION
## Description

Mismatch between internal UserMessageType and client UserMessageType (some fields are optional on this one vs only nullable on our internal type)

Ideally we create in client response schemas that are != that the input schermas (more loose)

## Risk

N/A

## Deploy Plan

- deploy `connectors` (no impact, types only)