### PR TITLE
[Connectors] Log set permissions body

### DIFF
--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -370,6 +370,15 @@ export class ConnectorsAPI {
       permission: ConnectorPermission;
     }[];
   }): Promise<ConnectorsAPIResponse<void>> {
+    // Connector permission changes are logged so user actions can be traced
+    this._logger.info(
+      {
+        connectorId,
+        resources,
+      },
+      "Setting connector permissions"
+    );
+
     const res = await this._fetchWithError(
       `${this._url}/connectors/${encodeURIComponent(connectorId)}/permissions`,
       {


### PR DESCRIPTION
Description
---
We often need to investigate what was synced or not; for that, auditing the permissions setting request is important

We log them. Permissions change are not that common, so no spam expected

Risk
---
na

Deploy
---
front
