### PR TITLE
Fix: run lint on connectors and front if sdk/js changes

### DIFF
--- a/.github/workflows/build-and-lint-connectors.yml
+++ b/.github/workflows/build-and-lint-connectors.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - types/**
+      - sdks/js/**
       - connectors/**
       - .github/workflows/build-and-lint-connectors.yml
 

--- a/.github/workflows/build-and-lint-extension.yml
+++ b/.github/workflows/build-and-lint-extension.yml
@@ -3,7 +3,7 @@ name: Lint & Build (extension)
 on:
   push:
     paths:
-      - types/**
+      - sdks/js/**
       - extension/**
       - .github/workflows/build-and-lint-extension.yml
 

--- a/.github/workflows/build-and-lint-front.yml
+++ b/.github/workflows/build-and-lint-front.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - types/**
+      - sdks/js/**
       - front/**
       - .github/workflows/build-and-lint-front.yml
 


### PR DESCRIPTION
## Description

Make sure that we run lint on connectors when sdk/js changes.
Remove the need to run lint on extension when types changes (no longer a dep).

## Risk

Low

## Deploy Plan

Deploy `front`