### PR TITLE
fix - Ignore URLs that contain // upon upserting them

### DIFF
--- a/types/src/shared/utils/url_utils.ts
+++ b/types/src/shared/utils/url_utils.ts
@@ -15,5 +15,9 @@ export const validateUrl = (
     return { valid: false, standardized: null };
   }
 
+  if (url.pathname.includes("//")) {
+    return { valid: false, standardized: null };
+  }
+
   return { valid: true, standardized: url.href };
 };


### PR DESCRIPTION
## Description

- This PR affects document upsertion in front-worker by ignoring document whose source URL contain a double slash //.

## Risk

Should be low.

## Deploy Plan

- Deploy front.