### PR TITLE
fix(Snowflake) - incorrect choice of interceptor

### DIFF
--- a/connectors/src/connectors/snowflake/temporal/worker.ts
+++ b/connectors/src/connectors/snowflake/temporal/worker.ts
@@ -3,8 +3,8 @@ import { Worker } from "@temporalio/worker";
 import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 
 import * as activities from "@connectors/connectors/snowflake/temporal/activities";
+import { SnowflakeCastKnownErrorsInterceptor } from "@connectors/connectors/snowflake/temporal/cast_known_errors";
 import { QUEUE_NAME } from "@connectors/connectors/snowflake/temporal/config";
-import { ZendeskCastKnownErrorsInterceptor } from "@connectors/connectors/zendesk/temporal/cast_known_errors";
 import * as sync_status from "@connectors/lib/sync_status";
 import {
   getTemporalWorkerConnection,
@@ -29,7 +29,7 @@ export async function runSnowflakeWorker() {
         (ctx: Context) => {
           return new ActivityInboundLogInterceptor(ctx, logger);
         },
-        () => new ZendeskCastKnownErrorsInterceptor(),
+        () => new SnowflakeCastKnownErrorsInterceptor(),
       ],
     },
     bundlerOptions: {


### PR DESCRIPTION
## Description

- In a previous PR `SnowflakeCastKnownErrorsInterceptor` was introduced.
- It was not used in the snowflake worker, instead `ZendeskCastKnownErrorsInterceptor` was used.
- This PR fixes that.

## Risk

Low.

## Deploy Plan

- Deploy connectors.