### PR TITLE
fix(snowflake) - fix snowflake interceptor

### DIFF
--- a/connectors/src/connectors/snowflake/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/snowflake/temporal/cast_known_errors.ts
@@ -8,7 +8,10 @@ import { ExternalOAuthTokenError } from "@connectors/lib/error";
 
 interface SnowflakeExpiredPasswordError extends Error {
   code: number;
-  name: string;
+  name: "OperationFailedError";
+  data: {
+    nextAction: "PWD_CHANGE";
+  };
 }
 
 function isSnowflakeExpiredPasswordError(

--- a/connectors/src/connectors/snowflake/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/snowflake/temporal/cast_known_errors.ts
@@ -15,10 +15,13 @@ function isSnowflakeExpiredPasswordError(
   err: unknown
 ): err is SnowflakeExpiredPasswordError {
   return (
-    typeof err === "object" &&
-    err !== null &&
-    "code" in err &&
-    err.code === 390106 // this is the magic code number for an expired password error, the message says "Specified password has expired.  Password must be changed using the Snowflake web console."
+    err instanceof Error &&
+    err.name === "OperationFailedError" &&
+    "data" in err &&
+    typeof err.data === "object" &&
+    err.data !== null &&
+    "nextAction" in err.data &&
+    err.data.nextAction === "PWD_CHANGE"
   );
 }
 


### PR DESCRIPTION
## Description

- The previous works on the interceptor failed to intercept the password errors observed in https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40dd.service%3Aconnectors-worker&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZOcGvQKVnUzBwAAABhBWk9jR3Z0VUFBQTFZcENCckIzMTFRQUkAAAAkMDE5MzljMWItMDc1ZS00NTE0LWJmM2MtZTIyZjYxOWQxODE5AAAAsw&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=6000198897476506285&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1733487291895&to_ts=1733490891895&live=true
- Weirdly enough, the code 390106 did not match (not sure where it comes from).
- Checked in `snowflake-sdk`'s code for how the error was created and used that.

## Risk

- Low

## Deploy Plan

- Deploy connectors.
