### PR TITLE
restrict `postNewContentFragment` to `ContentFragmentInputWithFileIdType`

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -10,7 +10,6 @@ import type {
   AgentMessageType,
   AgentMessageWithRankType,
   ContentFragmentContextType,
-  ContentFragmentInputType,
   ContentFragmentInputWithFileIdType,
   ContentFragmentType,
   ConversationTitleEvent,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -11,6 +11,7 @@ import type {
   AgentMessageWithRankType,
   ContentFragmentContextType,
   ContentFragmentInputType,
+  ContentFragmentInputWithFileIdType,
   ContentFragmentType,
   ConversationTitleEvent,
   ConversationType,
@@ -1745,7 +1746,7 @@ export async function* retryAgentMessage(
 export async function postNewContentFragment(
   auth: Authenticator,
   conversation: ConversationType,
-  cf: ContentFragmentInputType,
+  cf: ContentFragmentInputWithFileIdType,
   context: ContentFragmentContextType | null
 ): Promise<Result<ContentFragmentType, Error>> {
   const owner = auth.workspace();

--- a/front/lib/api/assistant/email_trigger.ts
+++ b/front/lib/api/assistant/email_trigger.ts
@@ -19,15 +19,15 @@ import {
 } from "@app/lib/api/assistant/conversation";
 import { postUserMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
 import { sendEmail } from "@app/lib/api/email";
-import { processAndStoreFile } from "@app/lib/api/files/upload";
 import type { Authenticator } from "@app/lib/auth";
 import { Workspace } from "@app/lib/models/workspace";
-import { FileResource } from "@app/lib/resources/file_resource";
 import { MembershipModel } from "@app/lib/resources/storage/models/membership";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { filterAndSortAgents } from "@app/lib/utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
+
+import { toFileContentFragment } from "./conversation/content_fragment";
 
 const { PRODUCTION_DUST_WORKSPACE_ID } = process.env;
 
@@ -309,45 +309,30 @@ export async function triggerFromEmail({
   // console.log("REST_OF_THREAD", restOfThread, restOfThread.length);
 
   if (restOfThread.length > 0) {
-    const file = await FileResource.makeNew({
-      contentType: "text/plain",
+    const contentFragmentRes = await toFileContentFragment(auth, {
+      contentFragment: {
+        title: `Email thread: ${email.subject}`,
+        content: restOfThread,
+        contentType: "text/plain",
+        url: null,
+      },
       fileName: `email-${email.subject}.txt`,
-      fileSize: restOfThread.length,
-      userId: user.id,
-      workspaceId: auth.getNonNullableWorkspace().id,
-      useCase: "conversation",
-      useCaseMetadata: null,
     });
-
-    const processRes = await processAndStoreFile(auth, {
-      file,
-      reqOrString: restOfThread,
-    });
-
-    if (processRes.isErr()) {
+    if (contentFragmentRes.isErr()) {
       return new Err({
         type: "message_creation_error",
         message:
           `Error creating file for content fragment: ` +
-          processRes.error.message,
+          contentFragmentRes.error.message,
       });
     }
 
-    await postNewContentFragment(
-      auth,
-      conversation,
-      {
-        title: `Email thread: ${email.subject}`,
-        url: null,
-        fileId: file.sId,
-      },
-      {
-        username: user.username,
-        fullName: user.fullName,
-        email: user.email,
-        profilePictureUrl: user.image,
-      }
-    );
+    await postNewContentFragment(auth, conversation, contentFragmentRes.value, {
+      username: user.username,
+      fullName: user.fullName,
+      email: user.email,
+      profilePictureUrl: user.image,
+    });
 
     const updatedConversationRes = await getConversation(
       auth,

--- a/front/lib/api/assistant/email_trigger.ts
+++ b/front/lib/api/assistant/email_trigger.ts
@@ -316,23 +316,27 @@ export async function triggerFromEmail({
         contentType: "text/plain",
         url: null,
       },
-      fileName: `email-${email.subject}.txt`,
+      fileName: `email-thread.txt`,
     });
     if (cfRes.isErr()) {
       return new Err({
         type: "message_creation_error",
         message:
-          `Error creating file for content fragment: ` +
-          cfRes.error.message,
+          `Error creating file for content fragment: ` + cfRes.error.message,
       });
     }
 
-    const contentFragmentRes = await postNewContentFragment(auth, conversation, cfRes.value, {
-      username: user.username,
-      fullName: user.fullName,
-      email: user.email,
-      profilePictureUrl: user.image,
-    });
+    const contentFragmentRes = await postNewContentFragment(
+      auth,
+      conversation,
+      cfRes.value,
+      {
+        username: user.username,
+        fullName: user.fullName,
+        email: user.email,
+        profilePictureUrl: user.image,
+      }
+    );
     if (contentFragmentRes.isErr()) {
       return new Err({
         type: "message_creation_error",

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -13,7 +13,6 @@ import { toFileContentFragment } from "@app/lib/api/assistant/conversation/conte
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 
 /**

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -9,6 +9,7 @@ import {
   getConversation,
   postNewContentFragment,
 } from "@app/lib/api/assistant/conversation";
+import { toFileContentFragment } from "@app/lib/api/assistant/conversation/content_fragment";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -113,18 +114,19 @@ async function handler(
           });
         }
       }
-      const { context, ...contentFragment } = r.data;
+      const { context, ...rest } = r.data;
+      let contentFragment = rest;
 
+      // If we receive a content fragment that is not file based, we transform it to a file-based
+      // one.
       if (isContentFragmentInputWithContentType(contentFragment)) {
-        logger.warn(
-          {
-            workspaceId: auth.getNonNullableWorkspace().sId,
-            conversationId: conversation.sId,
-            endpoint: "content_fragment",
-            contentType: contentFragment.contentType,
-          },
-          "Public API: ContentFragmentInputWithContentType"
-        );
+        const contentFragmentRes = await toFileContentFragment(auth, {
+          contentFragment,
+        });
+        if (contentFragmentRes.isErr()) {
+          throw new Error(contentFragmentRes.error.message);
+        }
+        contentFragment = contentFragmentRes.value;
       }
 
       const contentFragmentRes = await postNewContentFragment(

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -27,7 +27,6 @@ import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/hel
 import { postUserMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 
 /**

--- a/types/src/front/files.ts
+++ b/types/src/front/files.ts
@@ -191,6 +191,20 @@ export function isSupportedDelimitedTextContentType(
   );
 }
 
+export function extensionsForContentType(
+  contentType: SupportedFileContentType
+): string[] {
+  if (isSupportedPlainTextContentType(contentType)) {
+    return [...supportedPlainText[contentType]];
+  }
+
+  if (isSupportedImageContentType(contentType)) {
+    return [...supportedImage[contentType]];
+  }
+
+  return [];
+}
+
 // Types.
 
 export type FileStatus = "created" | "failed" | "ready";


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/dust/issues/9171

Introduce `toFileContentFragment` that transforms a content-based contentFragment into a file-based one. Use it everywhere we can.

## Risk

Low, tested locally

## Deploy Plan

- deploy `front`