### PR TITLE
Trackers basic list view

### DIFF
--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -7,6 +7,7 @@ import {
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuTrigger,
+  EyeIcon,
   Icon,
   LightbulbIcon,
   LogoutIcon,
@@ -90,6 +91,13 @@ export function UserMenu({
                 label="Meeting transcripts"
                 icon={BookOpenIcon}
                 href={`/w/${owner.sId}/assistant/labs/transcripts`}
+              />
+            )}
+            {featureFlags.includes("labs_trackers") && (
+              <DropdownMenuItem
+                label="Trackers"
+                icon={EyeIcon}
+                href={`/w/${owner.sId}/assistant/labs/trackers`}
               />
             )}
           </>

--- a/front/lib/resources/tracker_resource.ts
+++ b/front/lib/resources/tracker_resource.ts
@@ -112,6 +112,17 @@ export class TrackerConfigurationResource extends ResourceWithSpace<TrackerConfi
     return tracker ?? null;
   }
 
+  static async listBySpace(
+    auth: Authenticator,
+    space: SpaceResource
+  ): Promise<TrackerConfigurationResource[]> {
+    return this.baseFetch(auth, {
+      where: {
+        vaultId: space.id,
+      },
+    });
+  }
+
   // Deletion.
 
   protected async hardDelete(

--- a/front/lib/swr/trackers.ts
+++ b/front/lib/swr/trackers.ts
@@ -1,0 +1,33 @@
+import type { LightWorkspaceType, SpaceType } from "@dust-tt/types";
+import { useMemo } from "react";
+import type { Fetcher } from "swr";
+
+import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { GetTrackersResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/trackers";
+
+export function useTrackers({
+  disabled,
+  owner,
+  space,
+}: {
+  disabled?: boolean;
+  owner: LightWorkspaceType;
+  space: SpaceType;
+}) {
+  const trackersFetcher: Fetcher<GetTrackersResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/w/${owner.sId}/spaces/${space.sId}/trackers`,
+    trackersFetcher,
+    {
+      disabled,
+    }
+  );
+
+  return {
+    trackers: useMemo(() => (data ? data.trackers : []), [data]),
+    isTrackersLoading: !error && !data,
+    isTrackersError: !!error,
+    mutateTrackers: mutate,
+  };
+}

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/trackers/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/trackers/index.ts
@@ -1,0 +1,45 @@
+import type {
+  TrackerConfigurationType,
+  WithAPIErrorResponse,
+} from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { TrackerConfigurationResource } from "@app/lib/resources/tracker_resource";
+import { apiError } from "@app/logger/withlogging";
+
+export type GetTrackersResponseBody = {
+  trackers: TrackerConfigurationType[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetTrackersResponseBody>>,
+  auth: Authenticator,
+  space: SpaceResource
+): Promise<void> {
+  switch (req.method) {
+    case "GET":
+      return res.status(200).json({
+        trackers: (
+          await TrackerConfigurationResource.listBySpace(auth, space)
+        ).map((tracker) => tracker.toJSON()),
+      });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(
+  withResourceFetchingFromRoute(handler, "space")
+);

--- a/front/pages/w/[wId]/assistant/labs/trackers/index.tsx
+++ b/front/pages/w/[wId]/assistant/labs/trackers/index.tsx
@@ -1,0 +1,183 @@
+import {
+  Button,
+  Chip,
+  DataTable,
+  EyeIcon,
+  Page,
+  PencilSquareIcon,
+  PlusIcon,
+  SearchInput,
+} from "@dust-tt/sparkle";
+import type {
+  PlanType,
+  SpaceType,
+  SubscriptionType,
+  TrackerConfigurationType,
+  WorkspaceType,
+} from "@dust-tt/types";
+import type { CellContext } from "@tanstack/react-table";
+import { capitalize } from "lodash";
+import type { InferGetServerSidePropsType } from "next";
+import React, { useMemo } from "react";
+
+import { AssistantSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
+import AppLayout from "@app/components/sparkle/AppLayout";
+import config from "@app/lib/api/config";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { useTrackers } from "@app/lib/swr/trackers";
+
+type RowData = TrackerConfigurationType & {
+  onClick: () => void;
+};
+
+export const getServerSideProps = withDefaultUserAuthRequirements<{
+  baseUrl: string;
+  isAdmin: boolean;
+  owner: WorkspaceType;
+  plan: PlanType;
+  subscription: SubscriptionType;
+  globalSpace: SpaceType;
+}>(async (_context, auth) => {
+  const owner = auth.workspace();
+  const plan = auth.plan();
+  const subscription = auth.subscription();
+  const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
+
+  if (!owner || !plan || !subscription || !auth.isUser() || !globalSpace) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      baseUrl: config.getClientFacingUrl(),
+      isAdmin: auth.isAdmin(),
+      owner,
+      plan,
+      subscription,
+      globalSpace: globalSpace.toJSON(),
+    },
+  };
+});
+
+export default function TrackerConfigurations({
+  owner,
+  subscription,
+  globalSpace,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  // const router = useRouter();
+
+  const [filter, setFilter] = React.useState<string>("");
+
+  const { trackers } = useTrackers({
+    disabled: !owner,
+    owner,
+    space: globalSpace,
+  });
+
+  const rows = useMemo(
+    () =>
+      trackers.map((trackerConfiguration) => ({
+        ...trackerConfiguration,
+        onClick: () => alert("Not implemented yet"),
+      })),
+    [trackers]
+  );
+
+  const columns = [
+    {
+      id: "name",
+      header: "Name",
+      accessorKey: "name",
+      cell: (info: CellContext<RowData, string>) => (
+        <DataTable.CellContent>
+          <span>{info.row.original.name}</span>
+        </DataTable.CellContent>
+      ),
+    },
+    {
+      id: "status",
+      header: "Status",
+      accessorKey: "status",
+      cell: (info: CellContext<RowData, string>) => (
+        <DataTable.CellContent>
+          <Chip
+            size="xs"
+            color={info.row.original.status === "active" ? "emerald" : "slate"}
+            className="capitalize"
+          >
+            {capitalize(info.row.original.status)}
+          </Chip>
+        </DataTable.CellContent>
+      ),
+    },
+    {
+      id: "edit",
+      header: "",
+      accessorKey: "id",
+      cell: (info: CellContext<RowData, string>) => (
+        <Button
+          size="sm"
+          variant="outline"
+          icon={PencilSquareIcon}
+          onClick={info.row.original.onClick}
+        />
+      ),
+    },
+  ];
+
+  return (
+    <AppLayout
+      subscription={subscription}
+      owner={owner}
+      pageTitle="Dust - Trackers"
+      navChildren={<AssistantSidebarMenu owner={owner} />}
+    >
+      <Page.Vertical gap="xl" align="stretch">
+        <Page.Header
+          title="Trackers"
+          icon={EyeIcon}
+          description="Document monitoring made simple."
+        />
+        <Page.SectionHeader title="Watch Changes" />
+        <Page.P>
+          Select documents to monitor, define what matters to you, and receive
+          notifications when relevant changes occur. <br />
+          Set up once, stay informed automatically.
+        </Page.P>
+        <Page.SectionHeader title="Your Trackers" />
+        <div className="w-full max-w-4xl overflow-x-auto">
+          <div className="flex flex-row gap-2">
+            <SearchInput
+              name="filter"
+              placeholder="Filter"
+              value={filter}
+              onChange={(e) => setFilter(e)}
+            />
+            <Button
+              label="New tracker"
+              icon={PlusIcon}
+              onClick={
+                () => alert("Not implemented yet")
+                // router.push(`/w/${owner.sId}/assistant/labs/trackers/new`)
+              }
+            />
+          </div>
+
+          <div className="h-8" />
+
+          {rows.length > 0 && (
+            <DataTable
+              data={rows}
+              filter={filter}
+              filterColumn="name"
+              columns={columns}
+            />
+          )}
+        </div>
+      </Page.Vertical>
+    </AppLayout>
+  );
+}


### PR DESCRIPTION
## Description

List view for Trackers on Labs. I suggested IRL putting it on Spaces but this actually is simpler for V1. I'll probably add more infos on the list view but this is good enough first iterating.

Questions: 
- Since we're V1 I decided that the default and only space we can list trackers for is the global one, is it okay?
- With this scope if feature flag allowed any user of the workspace can see the list of trackers, but they won't be able to edit them (builders only?). 

![Screenshot 2024-12-06 at 14 53 14](https://github.com/user-attachments/assets/80142c53-f725-49e2-a9b3-8e328dbe3b3d)

## Risk

Under a feature flag. 

## Deploy Plan

Deploy front. 
