### PR TITLE
fix(csv-parse) - allow passing csv with inconsistent number of columns

### DIFF
--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -368,7 +368,7 @@ export async function rowsFromCsv({
   const { header, rowIndex } = headerRes.value;
 
   let i = 0;
-  const parser = parse(csv, { delimiter });
+  const parser = parse(csv, { delimiter, relaxColumnCount: true }); // we allow rows with != col count https://csv.js.org/parse/options/relax_column_count/
   // this differs with = {} in that it prevent errors when header values clash with object properties such as toString, constructor, ..
   const valuesByCol: Record<string, string[]> = Object.create(null);
   for await (const anyRecord of parser) {


### PR DESCRIPTION
## Description

- We get errors when upserting [certain tables](https://app.datadoghq.eu/logs?query=%22Unhandled%20API%20Error%22%20status%3Aerror%20%40dd.env%3Aprod&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZOcS2HjrRW3vwAAABhBWk9jUzNDb0FBQVhkaFNtUHIzdF9BQWMAAAAkMDE5MzljNGItOTBlNC00Njg3LWExZWEtZjc1MDMwY2ZjMjE4AAAY4g&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1714135514324&to_ts=1714136414324&live=true).
- The errors is raised when using `csv-parse`: `CSV_RECORD_INCONSISTENT_FIELDS_LENGTH`.
- It comes from a csv with inconsistent number of rows.

## Risk

## Deploy Plan

- Deploy front.