### PR TITLE
fix(webcrawler) - validate the URL passed as documentUrl

### DIFF
--- a/connectors/migrations/20241205_check_confluence_modified_pages.ts
+++ b/connectors/migrations/20241205_check_confluence_modified_pages.ts
@@ -1,4 +1,4 @@
-import { ConfluenceClientError } from "@dust-tt/types/src";
+import { ConfluenceClientError } from "@dust-tt/types";
 import { makeScript } from "scripts/helpers";
 
 import {
@@ -44,7 +44,7 @@ makeScript(
 
     for (const connector of connectors) {
       if (
-        connectorsToInclude.length > 0 ||
+        connectorsToInclude.length > 0 &&
         !connectorsToInclude.includes(connector.id.toString())
       ) {
         continue;


### PR DESCRIPTION
## Description

- Some URL crawler cause issues [https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20[…]z=stream&from_ts=1733487291895&to_ts=1733490891895&live=true](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40dd.service%3Afront-worker&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZOcc6yGX1YCwQAAABhBWk9jYzdMNkFBRGlfLU5DMU1nVE9BQmcAAAAkMDE5MzljNzQtY2UyNC00OTA4LWIzNTgtYTk1MjI5MDU1OTc2AAOe4A&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=6000198897476506285&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1733487291895&to_ts=1733490891895&live=true)
- [https://cloud.temporal.io/namespaces/dust-front-prod.gmnlm/workflows/upsert-queue-doc[…]9f-ed6adbc833bf/6cf6395d-63ad-4404-8648-0e373425d55f/history](https://cloud.temporal.io/namespaces/dust-front-prod.gmnlm/workflows/upsert-queue-document-c39e5f4e39-dts_6VgbxAEXRPtr-5ff8212f-73cd-4fbe-969f-ed6adbc833bf/6cf6395d-63ad-4404-8648-0e373425d55f/history)
- These issues occur when the URL string retrieved contains // past the host.
- This PR aims at ignoring such URLs as soon as detected.

## Risk

Low

## Deploy Plan

- Deploy connectors.
