### PR TITLE
Refactor: simplify mime types and use a common source of truth everywhere

### DIFF
--- a/front/components/data_source/TableUploadOrEditModal.tsx
+++ b/front/components/data_source/TableUploadOrEditModal.tsx
@@ -16,8 +16,8 @@ import type {
   WorkspaceType,
 } from "@dust-tt/types";
 import {
-  BIG_FILE_SIZE,
   Err,
+  isBigFileSize,
   isSlugified,
   MAX_FILE_SIZES,
   maxFileSizeToHumanReadable,
@@ -237,7 +237,7 @@ export const TableUploadOrEditModal = ({
         name:
           prev.name.length > 0 ? prev.name : stripTableName(selectedFile.name),
       }));
-      setIsBigFile(selectedFile.size > BIG_FILE_SIZE);
+      setIsBigFile(isBigFileSize(selectedFile.size));
     } catch (error) {
       sendNotification({
         type: "error",

--- a/front/hooks/useFileUploaderService.ts
+++ b/front/hooks/useFileUploaderService.ts
@@ -1,7 +1,5 @@
 import { useSendNotification } from "@dust-tt/sparkle";
 import type {
-  FileUploadedRequestResponseBody,
-  FileUploadRequestResponseBody,
   FileUseCase,
   FileUseCaseMetadata,
   LightWorkspaceType,
@@ -19,6 +17,8 @@ import {
 import { useState } from "react";
 
 import { getMimeTypeFromFile } from "@app/lib/file";
+import type { FileUploadRequestResponseBody } from "@app/pages/api/w/[wId]/files";
+import type { FileUploadedRequestResponseBody } from "@app/pages/api/w/[wId]/files/[fileId]";
 
 export interface FileBlob {
   contentType: SupportedFileContentType;

--- a/front/lib/api/assistant/jit_utils.ts
+++ b/front/lib/api/assistant/jit_utils.ts
@@ -90,10 +90,7 @@ function isSearchableContentType(
 function isListableContentType(
   contentType: SupportedContentFragmentType
 ): boolean {
-  // We allow listing all content-types that are not images. Note that
-  // `isSupportedPlainTextContentType` is not enough because it is limited to uploadable (as in from
-  // the conversation) content types which does not cover all non image content types that we
-  // support in the API such as `dust-application/slack`.
+  // We allow listing all content-types that are not images.
   return !isSupportedImageContentType(contentType);
 }
 

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -6,9 +6,10 @@ import type {
   ModelConfigurationType,
   ModelId,
   Result,
+  SupportedContentFragmentType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { Err, isSupportedImageContentFragmentType, Ok } from "@dust-tt/types";
+import { Err, isSupportedImageContentType, Ok } from "@dust-tt/types";
 import type {
   Attributes,
   CreationAttributes,
@@ -359,7 +360,7 @@ export async function renderFromFileId(
     textBytes,
     contentFragmentVersion,
   }: {
-    contentType: string;
+    contentType: SupportedContentFragmentType;
     excludeImages: boolean;
     fileId: string;
     forceFullCSVInclude: boolean;
@@ -369,7 +370,7 @@ export async function renderFromFileId(
     contentFragmentVersion: ContentFragmentVersion;
   }
 ): Promise<Result<ContentFragmentMessageTypeModel, Error>> {
-  if (isSupportedImageContentFragmentType(contentType)) {
+  if (isSupportedImageContentType(contentType)) {
     if (excludeImages || !model.supportsVision) {
       return new Ok({
         role: "content_fragment",
@@ -449,7 +450,7 @@ export async function renderLightContentFragmentForModel(
 ): Promise<ContentFragmentMessageTypeModel> {
   const { contentType, fileId, title, contentFragmentVersion } = message;
 
-  if (fileId && isSupportedImageContentFragmentType(contentType)) {
+  if (fileId && isSupportedImageContentType(contentType)) {
     if (excludeImages || !model.supportsVision) {
       return {
         role: "content_fragment",

--- a/front/pages/api/v1/w/[wId]/files/index.ts
+++ b/front/pages/api/v1/w/[wId]/files/index.ts
@@ -2,7 +2,6 @@ import type { FileUploadRequestResponseType } from "@dust-tt/client";
 import { FileUploadUrlRequestSchema } from "@dust-tt/client";
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import {
-  ensureContentTypeForUseCase,
   ensureFileSize,
   isSupportedFileContentType,
   rateLimiter,
@@ -11,6 +10,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { fromError } from "zod-validation-error";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import { isUploadSupported } from "@app/lib/api/files/upload";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
@@ -131,7 +131,7 @@ async function handler(
         });
       }
 
-      if (!ensureContentTypeForUseCase(contentType, useCase)) {
+      if (!isUploadSupported({ contentType, useCase })) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {

--- a/front/pages/api/w/[wId]/files/[fileId].ts
+++ b/front/pages/api/w/[wId]/files/[fileId].ts
@@ -1,7 +1,5 @@
-import type {
-  FileUploadedRequestResponseBody,
-  WithAPIErrorResponse,
-} from "@dust-tt/types";
+import type { FileType } from "@dust-tt/client";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
@@ -12,6 +10,10 @@ import type { FileVersion } from "@app/lib/resources/file_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
+
+export interface FileUploadedRequestResponseBody {
+  file: FileType;
+}
 
 export const config = {
   api: {

--- a/types/src/front/content_fragment.ts
+++ b/types/src/front/content_fragment.ts
@@ -3,8 +3,6 @@ import * as t from "io-ts";
 import { ModelId } from "../shared/model_id";
 import { MessageType, MessageVisibility } from "./assistant/conversation";
 import {
-  ImageContentType,
-  supportedImageContentTypes,
   supportedInlinedContentType,
   supportedUploadableContentType,
 } from "./files";
@@ -63,8 +61,4 @@ export function isContentFragmentType(
   arg: MessageType
 ): arg is ContentFragmentType {
   return arg.type === "content_fragment";
-}
-
-export function isSupportedImageContentFragmentType(format: string) {
-  return supportedImageContentTypes.includes(format as ImageContentType);
 }


### PR DESCRIPTION
## Description

Before adding support for new file types I wanted to clean up the way we defined and used mimeTypes.

## Risk

Potentially break file uploads but relatively low (tested locally).

## Deploy Plan

Deploy `front`