### PR TITLE
[front] Explicitely handle empty files on upload

### DIFF
--- a/front/lib/api/files/upload.ts
+++ b/front/lib/api/files/upload.ts
@@ -14,8 +14,7 @@ import { parse } from "csv-parse";
 import type { IncomingMessage } from "http";
 import sharp from "sharp";
 import type { TransformCallback } from "stream";
-import { Readable } from "stream";
-import { PassThrough, Transform } from "stream";
+import { PassThrough, Readable, Transform } from "stream";
 import { pipeline } from "stream/promises";
 
 import config from "@app/lib/api/config";
@@ -381,7 +380,8 @@ export async function processAndStoreFile(
         | "internal_server_error"
         | "invalid_request_error"
         | "file_too_large"
-        | "file_type_not_supported";
+        | "file_type_not_supported"
+        | "file_is_empty";
     }
   >
 > {

--- a/front/lib/api/files/utils.ts
+++ b/front/lib/api/files/utils.ts
@@ -22,7 +22,8 @@ export const parseUploadRequest = async (
       code:
         | "internal_server_error"
         | "file_too_large"
-        | "file_type_not_supported";
+        | "file_type_not_supported"
+        | "file_is_empty";
     }
   >
 > => {
@@ -63,6 +64,14 @@ export const parseUploadRequest = async (
           name: "dust_error",
           code: "file_too_large",
           message: "File is too large.",
+        });
+      }
+      // entire message: options.allowEmptyFiles is false, file size should be greater than 0
+      if (error.message.startsWith("options.allowEmptyFiles")) {
+        return new Err({
+          name: "dust_error",
+          code: "file_is_empty",
+          message: "File is empty.",
         });
       }
     }

--- a/types/src/front/lib/error.ts
+++ b/types/src/front/lib/error.ts
@@ -91,6 +91,7 @@ export type APIErrorType =
   | "file_not_found"
   | "file_too_large"
   | "file_type_not_supported"
+  | "file_is_empty"
   // Runs:
   | "run_not_found"
   // Spaces:


### PR DESCRIPTION
## Description

- Empty files throw 500 on upload: https://app.datadoghq.eu/logs?query=%22api%20error%22%20%40dd.env%3Aprod%20%40dd.service%3Afront%20%40apiError.status_code%3A%3E499&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZOblxIoXNvrZAAAABhBWk9ibHhLS0FBQ1VjYldMNlNxT0lnQ1QAAAAkMDE5MzliOWQtOWNkNi00ZTY0LTg1MzYtMDhhZDg3M2E2ZTc3AA1MPg&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=paused&sort=time&storage=hot&stream_sort=desc&viz=stream&from_ts=1733481000000&to_ts=1733482200000&live=false
- They are not handled explicitely and throw on `[form.parse](https://github.com/dust-tt/dust/blob/fa0e92b62fc24e505d2d649d7e9c011943223a8c/front/lib/api/files/utils.ts#L47)`.
- This PR aims at explicitely handle them.

<img width="1362" alt="Screenshot 2024-12-06 at 10 15 40 PM" src="https://github.com/user-attachments/assets/a3401eaf-098a-4d66-ac37-8624ab6dbbc2">

## Risk

- Affects front and contains a change in types.

## Deploy Plan

- Deploy front.