### PR TITLE
fix(github) - ignore errors occurring on readFile

### DIFF
--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -1035,7 +1035,10 @@ export async function githubCodeSyncActivity({
             { repoId, fileName: f.fileName, documentId: f.documentId, err: e },
             "[Github] Error reading file"
           );
-          return;
+          if (e instanceof Error && "code" in e && e.code === "ENOENT") {
+            return;
+          }
+          throw e;
         }
         const contentHash = blake3(content).toString("hex");
         const parentInternalId = f.parentInternalId || rootInternalId;

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -1027,7 +1027,16 @@ export async function githubCodeSyncActivity({
       fq.add(async () => {
         Context.current().heartbeat();
         // Read file (files are 1MB at most).
-        const content = await fs.readFile(f.localFilePath);
+        let content;
+        try {
+          content = await fs.readFile(f.localFilePath);
+        } catch (e) {
+          logger.warn(
+            { repoId, fileName: f.fileName, documentId: f.documentId, err: e },
+            "[Github] Error reading file"
+          );
+          return;
+        }
         const contentHash = blake3(content).toString("hex");
         const parentInternalId = f.parentInternalId || rootInternalId;
 


### PR DESCRIPTION
## Description

- Some `readFile` cause [ENOENT errors](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker%20%40activityName%3AgithubCodeSyncActivity&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=6000198897476506285&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1733316946889&to_ts=1733489746889&live=true), which causes [stuck workflows](https://cloud.temporal.io/namespaces/dust-prod.gmnlm/workflows/workflow-github-8714-full-sync-repo-790639101-syncCodeOnly-false/96fe40de-3c88-40f5-8cc0-823a4e380554/history).
- The retry is expensive.
- This PR aims at ignoring these errors.

## Risk

Should be low, at worse we miss too many files and have to resync.

## Deploy Plan

- Deploy connectors.