### PR TITLE
fix(snowflake) - match types in the interface SnowflakeError with snowflake-sdk's

### DIFF
--- a/connectors/src/connectors/snowflake/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/snowflake/temporal/cast_known_errors.ts
@@ -7,7 +7,6 @@ import type {
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
 
 interface SnowflakeError extends Error {
-  code: number;
   name: string;
   data: {
     nextAction: string;
@@ -31,10 +30,7 @@ interface SnowflakeAccountLockedError extends SnowflakeError {
 function isSnowflakeError(err: unknown): err is SnowflakeError {
   return (
     err instanceof Error &&
-    "code" in err &&
-    typeof err.code === "number" &&
     "name" in err &&
-    typeof err.name === "string" &&
     "data" in err &&
     typeof err.data === "object" &&
     err.data !== null &&


### PR DESCRIPTION
## Description

- The current interface is too restrictive compared to the one in `snowflake-sdk`, where the `code` is actually optional.
```
export interface SnowflakeError extends Error {
        code?: ErrorCode,
        sqlState?: string,
        data?: Record<string, any>,
        response?: Record<string, any>,
        responseBody?: string,
        cause?: Error,
        isFatal?: boolean,
        externalize?: () => SnowflakeErrorExternal | undefined,
    }
```
- This PR matches the types.

## Risk

Low.

## Deploy Plan

- Deploy connectors.
