### PR TITLE
enh(snowflake): add a distinction between 2 errors types

### DIFF
--- a/connectors/src/connectors/snowflake/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/snowflake/temporal/cast_known_errors.ts
@@ -27,6 +27,13 @@ interface SnowflakeAccountLockedError extends SnowflakeError {
   };
 }
 
+interface SnowflakeIncorrectCredentialsError extends SnowflakeError {
+  name: "OperationFailedError";
+  data: {
+    nextAction: "RETRY_LOGIN";
+  };
+}
+
 function isSnowflakeError(err: unknown): err is SnowflakeError {
   return (
     err instanceof Error &&
@@ -48,9 +55,22 @@ function isSnowflakeExpiredPasswordError(
 function isSnowflakeAccountLockedError(
   err: unknown
 ): err is SnowflakeAccountLockedError {
-  return isSnowflakeError(err) && err.data.nextAction === "RETRY_LOGIN";
+  return (
+    isSnowflakeError(err) &&
+    err.message.startsWith(
+      "Your user account has been temporarily locked due to too many failed attempts"
+    )
+  );
 }
 
+function isSnowflakeIncorrectCredentialsError(
+  err: unknown
+): err is SnowflakeIncorrectCredentialsError {
+  return (
+    isSnowflakeError(err) &&
+    err.message.startsWith("Incorrect username or password was specified")
+  );
+}
 export class SnowflakeCastKnownErrorsInterceptor
   implements ActivityInboundCallsInterceptor
 {
@@ -63,7 +83,10 @@ export class SnowflakeCastKnownErrorsInterceptor
     } catch (err: unknown) {
       if (
         isSnowflakeExpiredPasswordError(err) ||
-        isSnowflakeAccountLockedError(err)
+        // technically, the one below could be transient;
+        // we add it here to make the user aware that getting locked out of his account blocks the connection
+        isSnowflakeAccountLockedError(err) ||
+        isSnowflakeIncorrectCredentialsError(err)
       ) {
         throw new ExternalOAuthTokenError(err);
       }


### PR DESCRIPTION
## Description

- The "account locked" and the "invalid credentials" errors were not treated separately prior to this PR.
-  This PR adds a comment to explain why the former is not treated as a transient error.

## Risk

Low, limited to the snowflake connector.

## Deploy Plan

- Deploy connectors.