### PR TITLE
[Microsoft] Log scrubbed folders and prevent accidental root deletion

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -1094,6 +1094,14 @@ async function scrubRemovedFolders({
 
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
 
+  logger.info(
+    {
+      connectorId: connector.id,
+      nodes: nodes.map((n) => n.toJSON()),
+    },
+    "Scrubbing removed folders"
+  );
+
   for (const node of nodes) {
     if (node.nodeType === "file") {
       await deleteFile({

--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -417,7 +417,10 @@ export async function deleteFolder({
   );
 
   if (root) {
-    await root.delete();
+    // Roots represent the user selection for synchronization As such, they
+    // should be deleted first, explicitly by users, before deleting the
+    // underlying folder
+    throw new Error("Unexpected: attempt to delete folder with root node");
   }
 
   if (folder) {


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/1765

Deleting a root (user selection for sync) should always be explicit, before deleting the underlying folder

Risks
---
New monitors popping on delete folders activity. This will allow us to fix code paths leading to implicit root deletion

Deploy
---
connectors
