### PR TITLE
Add: more textual formats support

### DIFF
--- a/front/hooks/useFileUploaderService.ts
+++ b/front/hooks/useFileUploaderService.ts
@@ -140,7 +140,7 @@ export function useFileUploaderService({
               new FileBlobUploadError(
                 "file_type_not_supported",
                 file,
-                `File "${file.name}" is not supported.`
+                `File "${file.name}" is not supported (${contentType}).`
               )
             )
           );

--- a/front/lib/api/assistant/jit_utils.ts
+++ b/front/lib/api/assistant/jit_utils.ts
@@ -4,7 +4,6 @@ import type {
   SupportedContentFragmentType,
 } from "@dust-tt/types";
 import {
-  assertNever,
   isAgentMessageType,
   isContentFragmentType,
   isSupportedDelimitedTextContentType,
@@ -14,52 +13,21 @@ import {
 function isConversationIncludableFileContentType(
   contentType: SupportedContentFragmentType
 ): boolean {
+  // We allow including everything except images.
   if (isSupportedImageContentType(contentType)) {
     return false;
   }
-  // We allow including everything except images.
-  switch (contentType) {
-    case "application/msword":
-    case "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
-    case "application/pdf":
-    case "text/markdown":
-    case "text/plain":
-    case "dust-application/slack":
-    case "text/vnd.dust.attachment.slack.thread":
-    case "text/comma-separated-values":
-    case "text/csv":
-    case "text/tab-separated-values":
-    case "text/tsv":
-      return true;
-
-    default:
-      assertNever(contentType);
-  }
+  return true;
 }
 
 function isQueryableContentType(
   contentType: SupportedContentFragmentType
 ): boolean {
-  if (isSupportedImageContentType(contentType)) {
-    return false;
-  }
+  // For now we only allow querying tabular files.
   if (isSupportedDelimitedTextContentType(contentType)) {
     return true;
   }
-  // For now we only allow querying tabular files.
-  switch (contentType) {
-    case "application/msword":
-    case "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
-    case "application/pdf":
-    case "text/markdown":
-    case "text/plain":
-    case "dust-application/slack":
-    case "text/vnd.dust.attachment.slack.thread":
-      return false;
-
-    default:
-      assertNever(contentType);
-  }
+  return false;
 }
 
 function isSearchableContentType(
@@ -71,20 +39,8 @@ function isSearchableContentType(
   if (isSupportedDelimitedTextContentType(contentType)) {
     return false;
   }
-  // For now we only allow searching text files.
-  switch (contentType) {
-    case "application/msword":
-    case "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
-    case "application/pdf":
-    case "text/markdown":
-    case "text/plain":
-    case "dust-application/slack":
-    case "text/vnd.dust.attachment.slack.thread":
-      return true;
-
-    default:
-      assertNever(contentType);
-  }
+  // For now we allow searching everything else.
+  return true;
 }
 
 function isListableContentType(

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -9,6 +9,7 @@ import {
   Err,
   getSmallWhitelistedModel,
   isSupportedDelimitedTextContentType,
+  isSupportedImageContentType,
   Ok,
   removeNulls,
   slugify,
@@ -66,37 +67,45 @@ async function generateSnippet(
   const startTime = Date.now();
   const owner = auth.getNonNullableWorkspace();
 
+  if (isSupportedImageContentType(file.contentType)) {
+    return new Err(
+      new Error("Image files are not supported for file snippets.")
+    );
+  }
+
+  if (isSupportedDelimitedTextContentType(file.contentType)) {
+    const format =
+      file.contentType === "text/csv" ||
+      file.contentType === "text/comma-separated-values"
+        ? "csv"
+        : "tsv";
+
+    // Parse only the headers from the CSV file
+    const headers = content.split("\n")[0];
+
+    let snippet = `${format.toUpperCase()} file with headers: ${headers}`;
+    if (snippet.length > 256) {
+      snippet = snippet.slice(0, 242) + "... (truncated)";
+    }
+
+    return new Ok(snippet);
+  }
+
   switch (file.contentType) {
-    case "image/jpeg":
-    case "image/png":
-      return new Err(
-        new Error("Image files are not supported for file snippets.")
-      );
-    case "text/csv":
-    case "text/comma-separated-values":
-    case "text/tsv":
-    case "text/tab-separated-values":
-      const format =
-        file.contentType === "text/csv" ||
-        file.contentType === "text/comma-separated-values"
-          ? "csv"
-          : "tsv";
-
-      // Parse only the headers from the CSV file
-      const headers = content.split("\n")[0];
-
-      let snippet = `${format.toUpperCase()} file with headers: ${headers}`;
-      if (snippet.length > 256) {
-        snippet = snippet.slice(0, 242) + "... (truncated)";
-      }
-
-      return new Ok(snippet);
-    case "text/markdown":
-    case "text/plain":
-    case "text/vnd.dust.attachment.slack.thread":
     case "application/msword":
     case "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
     case "application/pdf":
+    case "text/plain":
+    case "text/markdown":
+    case "text/html":
+    case "text/xml":
+    case "text/calendar":
+    case "text/css":
+    case "text/javascript":
+    case "application/json":
+    case "application/xml":
+    case "application/x-sh":
+    case "text/vnd.dust.attachment.slack.thread":
       if (!ENABLE_LLM_SNIPPETS) {
         // Take the first 256 characters
         if (content.length > 256) {
@@ -214,6 +223,7 @@ async function generateSnippet(
           assertNever(run);
       }
       break;
+
     default:
       assertNever(file.contentType);
   }
@@ -311,6 +321,10 @@ const getProcessingFunction = ({
   contentType: SupportedFileContentType;
   useCase: FileUseCase;
 }): ProcessingFunction | undefined => {
+  if (isSupportedImageContentType(contentType)) {
+    return undefined;
+  }
+
   // Use isSupportedDelimitedTextContentType() everywhere to have a common source of truth
   if (isSupportedDelimitedTextContentType(contentType)) {
     if (
@@ -333,14 +347,17 @@ const getProcessingFunction = ({
     case "text/markdown":
     case "text/plain":
     case "text/vnd.dust.attachment.slack.thread":
+    case "text/html":
+    case "text/xml":
+    case "text/calendar":
+    case "text/css":
+    case "text/javascript":
+    case "application/json":
+    case "application/xml":
+    case "application/x-sh":
       if (useCase === "conversation" || useCase === "tool_output") {
         return upsertDocumentToDatasource;
       }
-      break;
-
-    case "image/jpeg":
-    case "image/png":
-      // We do nothing for images.
       break;
 
     default:

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -74,16 +74,10 @@ async function generateSnippet(
   }
 
   if (isSupportedDelimitedTextContentType(file.contentType)) {
-    const format =
-      file.contentType === "text/csv" ||
-      file.contentType === "text/comma-separated-values"
-        ? "csv"
-        : "tsv";
-
     // Parse only the headers from the CSV file
     const headers = content.split("\n")[0];
 
-    let snippet = `${format.toUpperCase()} file with headers: ${headers}`;
+    let snippet = `${file.contentType} file with headers: ${headers}`;
     if (snippet.length > 256) {
       snippet = snippet.slice(0, 242) + "... (truncated)";
     }

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -77,6 +77,14 @@ export const supportedRawText = {
   "text/tab-separated-values": [".tsv"],
   "text/tsv": [".tsv"],
   "text/vnd.dust.attachment.slack.thread": [".txt"],
+  "text/html": [".html", ".htm", ".xhtml", ".xhtml+xml"],
+  "text/xml": [".xml"],
+  "text/calendar": [".ics"],
+  "text/css": [".css"],
+  "text/javascript": [".js", ".mjs"],
+  "application/json": [".json"],
+  "application/xml": [".xml"],
+  "application/x-sh": [".sh"],
 } as const;
 
 // Supported content types for plain text (after processing).

--- a/types/src/front/files.ts
+++ b/types/src/front/files.ts
@@ -80,6 +80,14 @@ const supportedRawText = {
   "text/markdown": [".md", ".markdown"],
   "text/plain": [".txt"],
   "text/vnd.dust.attachment.slack.thread": [".txt"],
+  "text/html": [".html", ".htm", ".xhtml", ".xhtml+xml"],
+  "text/xml": [".xml"],
+  "text/calendar": [".ics"],
+  "text/css": [".css"],
+  "text/javascript": [".js", ".mjs"],
+  "application/json": [".json"],
+  "application/xml": [".xml"],
+  "application/x-sh": [".sh"],
 };
 
 // Supported content types for plain text (after processing).


### PR DESCRIPTION
## Description

Add support for:

```json
{
  "text/html": [".html", ".htm", ".xhtml", ".xhtml+xml"],
  "text/xml": [".xml"],
  "text/calendar": [".ics"],
  "text/css": [".css"],
  "text/javascript": [".js", ".mjs"],
  "application/json": [".json"],
  "application/xml": [".xml"],
  "application/x-sh": [".sh"],
}
```

(more to come in subsequent PR)

## Risk

Low (tested locally)

## Deploy Plan

Deploy `front`