### PR TITLE
Enable JIT for all userrs

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -193,7 +193,7 @@ export async function renderConversationForModel(
     Error
   >
 > {
-  if (!(await isJITActionsEnabled(auth))) {
+  if (!isJITActionsEnabled()) {
     return renderConversationForModelMultiActions({
       conversation,
       model,

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -42,26 +42,14 @@ import {
   getTextRepresentationFromMessages,
 } from "@app/lib/api/assistant/utils";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { renderLightContentFragmentForModel } from "@app/lib/resources/content_fragment_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { tokenCountForTexts } from "@app/lib/tokenization";
 import logger from "@app/logger/logger";
 
-export async function isJITActionsEnabled(
-  auth: Authenticator
-): Promise<boolean> {
-  let use = false;
-
-  // For now we limit the feature flag to development and dust workspace only to not introduce an extraneous DB call
-  // on the critical path of conversations.
-  const flags = await getFeatureFlags(auth.getNonNullableWorkspace());
-  if (flags.includes("conversations_jit_actions")) {
-    use = true;
-  }
-
-  return use;
+export function isJITActionsEnabled(): boolean {
+  return true;
 }
 
 async function getJITActions(
@@ -168,7 +156,7 @@ export async function getEmulatedAndJITActions(
   const emulatedActions: AgentActionType[] = [];
   let jitActions: ActionConfigurationType[] = [];
 
-  if (await isJITActionsEnabled(auth)) {
+  if (isJITActionsEnabled()) {
     const files = listFiles(conversation);
 
     const a = makeConversationListFilesAction({

--- a/front/lib/api/assistant/visualization.ts
+++ b/front/lib/api/assistant/visualization.ts
@@ -21,7 +21,7 @@ export async function getVisualizationPrompt({
 }) {
   // If `jit_conversations_actions` is enabled we rely on the `conversations_list_files` emulated
   // actions to make the list of files available to the agent.
-  if (await isJITActionsEnabled(auth)) {
+  if (isJITActionsEnabled()) {
     return visualizationSystemPrompt(true);
   }
 

--- a/front/lib/api/files/tool_output.ts
+++ b/front/lib/api/files/tool_output.ts
@@ -37,7 +37,7 @@ export async function internalCreateToolOutputCsvFile(
   await processAndStoreFile(auth, { file: fileResource, reqOrString: content });
 
   // If the tool returned no content, it makes no sense to upsert it to the data source
-  if (content && (await isJITActionsEnabled(auth))) {
+  if (content && isJITActionsEnabled()) {
     const r = await processAndUpsertToDataSource(auth, {
       file: fileResource,
       optionalContent: content,

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -435,7 +435,7 @@ export async function processAndUpsertToDataSource(
     }
   >
 > {
-  const jitEnabled = await isJITActionsEnabled(auth);
+  const jitEnabled = isJITActionsEnabled();
 
   if (!jitEnabled || !isUpsertSupported(file)) {
     return new Ok(file);


### PR DESCRIPTION
## Description

Enable JIT for all users.
I kept the `isJITActionsEnabled()` calls for now to make it easier to disable.

## Risk

Medium but we tested a lot with our own workspaces.

## Deploy Plan

Deploy `front`