### PR TITLE
[poke] fix: prevent FK error when deleting workspace

### DIFF
--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -118,6 +118,16 @@ export class RunResource extends BaseResource<RunModel> {
     });
   }
 
+  static async deleteAllForWorkspace(
+    workspace: LightWorkspaceType,
+    transaction?: Transaction
+  ) {
+    return this.model.destroy({
+      where: { workspaceId: workspace.id },
+      transaction,
+    });
+  }
+
   async delete(
     auth: Authenticator,
     { transaction }: { transaction?: Transaction } = {}

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -599,6 +599,7 @@ export async function deleteWorkspaceActivity({
       transaction: t,
     });
     await FileResource.deleteAllForWorkspace(workspace, t);
+    await RunResource.deleteAllForWorkspace(workspace, t);
 
     hardDeleteLogger.info({ workspaceId }, "Deleting Workspace");
 


### PR DESCRIPTION
## Description

- Fix [FK errors](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E14%20%40dd.service%3Afront-worker&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZOr_ttwiGmx1QAAABhBWk9yX3VpekFBREstZHM1bFB4Tmt3QU4AAAAkMDE5M2FiZmUtZmI4NC00NWNkLWIwYTYtNGViM2IyYTEzMTI3AAD_uw&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1733757324542&to_ts=1733758224542&live=true) occurring in poke `deleteWorkspaceWorkflow`.
- This PR adds an explicit deletion of every Run for a workspace before deleting said workspace.

## Risk

- Part of an admin action.
- Relative to the deletion of data.

## Deploy Plan

- Deploy front
