### PR TITLE
Tracker Builder: create / edit without dsv

### DIFF
--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -418,7 +418,7 @@ function ModelList({ modelConfigs, onClick }: ModelListProps) {
   );
 }
 
-function AdvancedSettings({
+export function AdvancedSettings({
   owner,
   plan,
   generationSettings,

--- a/front/components/trackers/TrackerBuilder.tsx
+++ b/front/components/trackers/TrackerBuilder.tsx
@@ -69,11 +69,9 @@ export const TrackerBuilder = ({
 
   void dataSourceViews; // todo: use this
 
-  const extractEmails = (text: string) =>
-    text
-      .split(/[\n,]+/)
-      .map((e) => e.trim())
-      .filter((e, i, self) => self.indexOf(e) === i);
+  const extractEmails = (text: string): string[] => [
+    ...new Set(text.split(/[\n,]+/).map((e) => e.trim())),
+  ];
 
   const onSubmit = async () => {
     // Validate the form

--- a/front/components/trackers/TrackerBuilder.tsx
+++ b/front/components/trackers/TrackerBuilder.tsx
@@ -1,0 +1,376 @@
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Input,
+  Label,
+  Page,
+  TextArea,
+  useSendNotification,
+} from "@dust-tt/sparkle";
+import type {
+  DataSourceViewType,
+  SpaceType,
+  SubscriptionType,
+  SupportedModel,
+  TrackerConfigurationStateType,
+  TrackerConfigurationType,
+  WorkspaceType,
+} from "@dust-tt/types";
+import {
+  CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG,
+  TRACKER_FREQUENCY_TYPES,
+} from "@dust-tt/types";
+import { useRouter } from "next/router";
+import { useState } from "react";
+
+import { AdvancedSettings } from "@app/components/assistant_builder/InstructionScreen";
+import AppLayout from "@app/components/sparkle/AppLayout";
+import { AppLayoutSimpleSaveCancelTitle } from "@app/components/sparkle/AppLayoutTitle";
+import { isEmailValid } from "@app/lib/utils";
+
+export const TrackerBuilder = ({
+  owner,
+  subscription,
+  globalSpace,
+  dataSourceViews,
+  trackerToEdit,
+}: {
+  owner: WorkspaceType;
+  subscription: SubscriptionType;
+  globalSpace: SpaceType;
+  dataSourceViews: DataSourceViewType[];
+  trackerToEdit: TrackerConfigurationType | null;
+}) => {
+  const router = useRouter();
+  const sendNotification = useSendNotification();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const [tracker, setTracker] = useState<TrackerConfigurationStateType>({
+    name: trackerToEdit?.name ?? null,
+    nameError: null,
+    description: trackerToEdit?.description ?? null,
+    descriptionError: null,
+    prompt: trackerToEdit?.prompt ?? null,
+    promptError: null,
+    frequency: trackerToEdit?.frequency ?? "daily",
+    frequencyError: null,
+    recipients: trackerToEdit?.recipients?.join(", ") ?? null,
+    recipientsError: null,
+    modelId:
+      trackerToEdit?.modelId ?? CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG.modelId,
+    providerId:
+      trackerToEdit?.providerId ??
+      CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG.providerId,
+    temperature: trackerToEdit?.temperature ?? 0.5,
+  });
+
+  void dataSourceViews; // todo: use this
+
+  const extractEmails = (text: string) =>
+    text
+      .split(/[\n,]+/)
+      .map((e) => e.trim())
+      .filter((e, i, self) => self.indexOf(e) === i);
+
+  const onSubmit = async () => {
+    // Validate the form
+    setIsSubmitting(true);
+    let hasValidationError = false;
+    if (!tracker.name) {
+      setTracker((t) => ({
+        ...t,
+        nameError: "Name is required.",
+      }));
+      hasValidationError = true;
+    }
+    if (!tracker.recipients?.length) {
+      setTracker((t) => ({
+        ...t,
+        recipientsError: "At least one recipient is required.",
+      }));
+      hasValidationError = true;
+    } else {
+      const recipients = extractEmails(tracker.recipients);
+      if (recipients.map(isEmailValid).includes(false)) {
+        setTracker((t) => ({
+          ...t,
+          recipientsError:
+            "Invalid email addresses: " +
+            recipients.filter((e) => !isEmailValid(e)).join(", "),
+        }));
+        hasValidationError = true;
+      }
+    }
+    if (!tracker.prompt) {
+      setTracker((t) => ({
+        ...t,
+        promptError: "Prompt is required.",
+      }));
+      hasValidationError = true;
+    }
+    if (hasValidationError) {
+      setIsSubmitting(false);
+      return;
+    }
+
+    let route = `/api/w/${owner.sId}/spaces/${globalSpace.sId}/trackers`;
+    let method = "POST";
+
+    if (trackerToEdit) {
+      route += `/${trackerToEdit.sId}`;
+      method = "PATCH";
+    }
+
+    const res = await fetch(route, {
+      method,
+      body: JSON.stringify({
+        name: tracker.name,
+        description: tracker.description,
+        prompt: tracker.prompt,
+        modelId: tracker.modelId,
+        providerId: tracker.providerId,
+        temperature: tracker.temperature,
+        frequency: tracker.frequency,
+        recipients: tracker.recipients ? extractEmails(tracker.recipients) : [],
+      }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    // Handle errors.
+    if (!res.ok) {
+      const resJson = await res.json();
+      sendNotification({
+        title: trackerToEdit
+          ? "Failed to update tracker"
+          : "Failed to create tracker",
+        description: resJson.error.message,
+        type: "error",
+      });
+      setIsSubmitting(false);
+      return;
+    }
+
+    sendNotification({
+      title: trackerToEdit ? "Tracker updated" : "Tracker Created",
+      description: trackerToEdit
+        ? "Tracker updated successfully"
+        : "Tracker created successfully.",
+      type: "success",
+    });
+    setIsSubmitting(false);
+    await router.push(`/w/${owner.sId}/assistant/labs/trackers`);
+  };
+
+  return (
+    <AppLayout
+      owner={owner}
+      subscription={subscription}
+      hideSidebar
+      isWideMode
+      pageTitle={trackerToEdit ? "Dust - Edit Tracker" : "Dust - New Tracker"}
+      titleChildren={
+        <AppLayoutSimpleSaveCancelTitle
+          title={trackerToEdit ? "Edit Tracker" : "New Tracker"}
+          onCancel={async () => {
+            await router.push(`/w/${owner.sId}/assistant/labs/trackers`);
+          }}
+          onSave={onSubmit}
+          isSaving={isSubmitting}
+        />
+      }
+    >
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-16 pb-12">
+        <div className="flex">
+          <div className="flex flex-grow" />
+          <div className="flex flex-shrink-0 flex-col justify-end">
+            <AdvancedSettings
+              owner={owner}
+              plan={subscription.plan}
+              generationSettings={{
+                modelSettings: {
+                  modelId: tracker.modelId,
+                  providerId: tracker.providerId,
+                },
+                temperature: tracker.temperature,
+              }}
+              setGenerationSettings={(g: {
+                modelSettings: SupportedModel;
+                temperature: number;
+              }) => {
+                setTracker((t) => ({
+                  ...t,
+                  modelId: g.modelSettings.modelId,
+                  providerId: g.modelSettings.providerId,
+                  temperature: g.temperature,
+                }));
+              }}
+            />
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-6">
+          <div>
+            <Page.SectionHeader title="Naming" />
+            <div className="text-sm font-normal text-element-700">
+              Give your tracker a clear, memorable name and description that
+              will help you and your team identify its purpose.
+            </div>
+          </div>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <div className="md:col-span-1">
+              <Input
+                label="Name"
+                value={tracker.name || ""}
+                onChange={(e) =>
+                  setTracker((t) => ({
+                    ...t,
+                    name: e.target.value,
+                    nameError: null,
+                  }))
+                }
+                placeholder="Descriptive name."
+                message={tracker.nameError}
+                messageStatus={tracker.nameError ? "error" : undefined}
+              />
+            </div>
+            <div className="md:col-span-2">
+              <Input
+                label="Description"
+                value={tracker.description || ""}
+                onChange={(e) =>
+                  setTracker((t) => ({
+                    ...t,
+                    description: e.target.value,
+                    descriptionError: null,
+                  }))
+                }
+                placeholder="Brief description of what you're tracking and why."
+                message={tracker.descriptionError}
+                messageStatus={tracker.descriptionError ? "error" : undefined}
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-6">
+          <div>
+            <Page.SectionHeader title="Notification Settings" />
+            <div className="text-sm font-normal text-element-700">
+              Choose when and who receives update notifications. We'll bundle
+              all tracked changes into organized email summaries delivered on
+              your preferred schedule.
+            </div>
+          </div>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <div className="flex md:col-span-1">
+              <div className="flex flex-col space-y-2">
+                <Label className="mb-1">Notification frequency</Label>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      label={tracker.frequency}
+                      variant="outline"
+                      isSelect
+                    />
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent>
+                    {TRACKER_FREQUENCY_TYPES.map((f) => (
+                      <DropdownMenuItem
+                        key={f}
+                        label={f}
+                        onClick={() => {
+                          setTracker((t) => ({
+                            ...t,
+                            frequency: f,
+                          }));
+                        }}
+                      />
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            </div>
+            <div className="md:col-span-2">
+              <Input
+                label="Recipients"
+                placeholder="Enter email addresses (separate multiple addresses with commas)."
+                value={tracker.recipients}
+                onChange={(e) =>
+                  setTracker((t) => ({
+                    ...t,
+                    recipients: e.target.value,
+                    recipientsError: null,
+                  }))
+                }
+                message={tracker.recipientsError}
+                messageStatus={tracker.recipientsError ? "error" : undefined}
+              />
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-col gap-6">
+          <div>
+            <Page.SectionHeader title="Tracker Settings" />
+            <div className="text-sm font-normal text-element-700">
+              Set up what you want to track and monitor. Tell us what to look
+              for, specify which documents to maintain current versions of, and
+              select which documents to watch for changes.
+            </div>
+          </div>
+          <div className="flex flex-col space-y-2">
+            <Label className="mb-1">Instructions</Label>
+            <TextArea
+              placeholder="Describe what changes or updates you want to track (be as specific as possible)."
+              value={tracker.prompt || ""}
+              onChange={(e) =>
+                setTracker((t) => ({
+                  ...t,
+                  prompt: e.target.value,
+                  promptError: null,
+                }))
+              }
+              error={tracker.promptError}
+              showErrorLabel={!!tracker.promptError}
+            />
+          </div>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <div className="md:col-span-1">
+              <div className="flex flex-col space-y-2">
+                <Label className="mb-1">Documents to maintain</Label>
+                <Button
+                  label="Select Documents"
+                  onClick={() => {
+                    alert("Select Documents");
+                  }}
+                  className="w-fit"
+                />
+              </div>
+            </div>
+            <div className="flex items-end md:col-span-2" />
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <div className="md:col-span-1">
+              <div className="flex flex-col space-y-2">
+                <Label className="mb-1">Documents to watch</Label>
+                <Button
+                  label="Select Documents"
+                  onClick={() => {
+                    alert("Select Documents");
+                  }}
+                  className="w-fit"
+                />
+              </div>
+            </div>
+            <div className="flex items-end md:col-span-2" />
+          </div>
+        </div>
+      </div>
+    </AppLayout>
+  );
+};

--- a/front/pages/w/[wId]/assistant/labs/trackers/[tId]/index.tsx
+++ b/front/pages/w/[wId]/assistant/labs/trackers/[tId]/index.tsx
@@ -1,0 +1,88 @@
+import type {
+  DataSourceViewType,
+  PlanType,
+  SpaceType,
+  SubscriptionType,
+  TrackerConfigurationType,
+  WorkspaceType,
+} from "@dust-tt/types";
+import type { InferGetServerSidePropsType } from "next";
+
+import { TrackerBuilder } from "@app/components/trackers/TrackerBuilder";
+import config from "@app/lib/api/config";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { TrackerConfigurationResource } from "@app/lib/resources/tracker_resource";
+
+export const getServerSideProps = withDefaultUserAuthRequirements<{
+  baseUrl: string;
+  isAdmin: boolean;
+  owner: WorkspaceType;
+  plan: PlanType;
+  subscription: SubscriptionType;
+  globalSpace: SpaceType;
+  dataSourceViews: DataSourceViewType[];
+  trackerToEdit: TrackerConfigurationType;
+}>(async (_context, auth) => {
+  const owner = auth.workspace();
+  const plan = auth.plan();
+  const subscription = auth.subscription();
+  const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
+  const trackerId = _context.params?.tId as string;
+
+  if (
+    !owner ||
+    !plan ||
+    !subscription ||
+    !auth.isUser() ||
+    !globalSpace ||
+    !trackerId
+  ) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const tracker = await TrackerConfigurationResource.fetchById(auth, trackerId);
+  if (!tracker) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const dataSourceViews = await DataSourceViewResource.listBySpaces(auth, [
+    globalSpace,
+  ]);
+
+  return {
+    props: {
+      baseUrl: config.getClientFacingUrl(),
+      dataSourceViews: dataSourceViews.map((v) => v.toJSON()),
+      isAdmin: auth.isAdmin(),
+      owner,
+      plan,
+      subscription,
+      globalSpace: globalSpace.toJSON(),
+      trackerToEdit: tracker.toJSON(),
+    },
+  };
+});
+
+export default function DocumentTracker({
+  owner,
+  subscription,
+  globalSpace,
+  dataSourceViews,
+  trackerToEdit,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  return (
+    <TrackerBuilder
+      owner={owner}
+      subscription={subscription}
+      globalSpace={globalSpace}
+      dataSourceViews={dataSourceViews}
+      trackerToEdit={trackerToEdit}
+    />
+  );
+}

--- a/front/pages/w/[wId]/assistant/labs/trackers/index.tsx
+++ b/front/pages/w/[wId]/assistant/labs/trackers/index.tsx
@@ -18,6 +18,7 @@ import type {
 import type { CellContext } from "@tanstack/react-table";
 import { capitalize } from "lodash";
 import type { InferGetServerSidePropsType } from "next";
+import { useRouter } from "next/router";
 import React, { useMemo } from "react";
 
 import { AssistantSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
@@ -28,7 +29,7 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { useTrackers } from "@app/lib/swr/trackers";
 
 type RowData = TrackerConfigurationType & {
-  onClick: () => void;
+  onClick: () => undefined;
 };
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
@@ -67,7 +68,7 @@ export default function TrackerConfigurations({
   subscription,
   globalSpace,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
-  // const router = useRouter();
+  const router = useRouter();
 
   const [filter, setFilter] = React.useState<string>("");
 
@@ -81,9 +82,12 @@ export default function TrackerConfigurations({
     () =>
       trackers.map((trackerConfiguration) => ({
         ...trackerConfiguration,
-        onClick: () => alert("Not implemented yet"),
+        onClick: () =>
+          void router.push(
+            `/w/${owner.sId}/assistant/labs/trackers/${trackerConfiguration.sId}`
+          ),
       })),
-    [trackers]
+    [trackers, owner, router]
   );
 
   const columns = [
@@ -159,9 +163,8 @@ export default function TrackerConfigurations({
             <Button
               label="New tracker"
               icon={PlusIcon}
-              onClick={
-                () => alert("Not implemented yet")
-                // router.push(`/w/${owner.sId}/assistant/labs/trackers/new`)
+              onClick={() =>
+                router.push(`/w/${owner.sId}/assistant/labs/trackers/new`)
               }
             />
           </div>

--- a/front/pages/w/[wId]/assistant/labs/trackers/new.tsx
+++ b/front/pages/w/[wId]/assistant/labs/trackers/new.tsx
@@ -1,0 +1,68 @@
+import type {
+  DataSourceViewType,
+  PlanType,
+  SpaceType,
+  SubscriptionType,
+  WorkspaceType,
+} from "@dust-tt/types";
+import type { InferGetServerSidePropsType } from "next";
+
+import { TrackerBuilder } from "@app/components/trackers/TrackerBuilder";
+import config from "@app/lib/api/config";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+
+export const getServerSideProps = withDefaultUserAuthRequirements<{
+  baseUrl: string;
+  isAdmin: boolean;
+  owner: WorkspaceType;
+  plan: PlanType;
+  subscription: SubscriptionType;
+  globalSpace: SpaceType;
+  dataSourceViews: DataSourceViewType[];
+}>(async (_context, auth) => {
+  const owner = auth.workspace();
+  const plan = auth.plan();
+  const subscription = auth.subscription();
+  const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
+
+  if (!owner || !plan || !subscription || !auth.isUser() || !globalSpace) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const dataSourceViews = await DataSourceViewResource.listBySpaces(auth, [
+    globalSpace,
+  ]);
+
+  return {
+    props: {
+      baseUrl: config.getClientFacingUrl(),
+      dataSourceViews: dataSourceViews.map((v) => v.toJSON()),
+      isAdmin: auth.isAdmin(),
+      owner,
+      plan,
+      subscription,
+      globalSpace: globalSpace.toJSON(),
+    },
+  };
+});
+
+export default function DocumentTracker({
+  owner,
+  subscription,
+  globalSpace,
+  dataSourceViews,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  return (
+    <TrackerBuilder
+      owner={owner}
+      subscription={subscription}
+      globalSpace={globalSpace}
+      dataSourceViews={dataSourceViews}
+      trackerToEdit={null}
+    />
+  );
+}

--- a/types/src/front/tracker.ts
+++ b/types/src/front/tracker.ts
@@ -1,4 +1,5 @@
 import { ModelId } from "../shared/model_id";
+import { ioTsEnum } from "../shared/utils/iots_utils";
 import { ModelIdType, ModelProviderIdType } from "./lib/assistant";
 import { SpaceType } from "./space";
 
@@ -13,5 +14,33 @@ export type TrackerConfigurationType = {
   temperature: number;
   prompt: string | null;
   frequency: string | null;
+  recipients: string[];
   space: SpaceType;
 };
+
+export type TrackerConfigurationStateType = {
+  name: string | null;
+  nameError: string | null;
+  description: string | null;
+  descriptionError: string | null;
+  prompt: string | null;
+  promptError: string | null;
+  frequency: string;
+  frequencyError: string | null;
+  recipients: string | null;
+  recipientsError: string | null;
+  modelId: ModelIdType;
+  providerId: ModelProviderIdType;
+  temperature: number;
+};
+
+export const TRACKER_FREQUENCY_TYPES: TrackerFrequencyType[] = [
+  "daily",
+  "weekly",
+  "monthly",
+];
+export type TrackerFrequencyType = "daily" | "weekly" | "monthly";
+
+export const FrequencyCodec = ioTsEnum<
+  (typeof TRACKER_FREQUENCY_TYPES)[number]
+>(TRACKER_FREQUENCY_TYPES);


### PR DESCRIPTION
## Description

Form to create and update a tracker configuration -> Since the PR is already quite big to review I am splitting things, this allows to create/update a tracker but without yet setting the documents to maintain/watch. 

This will come in a second PR. 
The model definition is in the advanced settings as in the Assistant Builder, I think it's best if we define ourselves the best default model for this task and keep this form as short as possible. 

There's many things to improve, such as:
- Global design / copy.
- Form validation.
- Header state (if data was modified or not).
- Handling better a user without write rights on Company data. 

I'm trying to get a first version usable asap, so we can first merge this and iterate. 

<img width="1336" alt="Screenshot 2024-12-09 at 17 25 34" src="https://github.com/user-attachments/assets/0400a120-fbeb-462e-8236-723610855be3">

## Risk

Under a feature flag. 

## Deploy Plan

Deploy front. 
