### PR TITLE
[.github] - refacto(front-edge): migrate to artifact registry

### DIFF
--- a/.github/workflows/deploy-front-edge-tmp.yml
+++ b/.github/workflows/deploy-front-edge-tmp.yml
@@ -51,13 +51,13 @@ jobs:
 #          channel: ${{ secrets.SLACK_CHANNEL_ID }}
 #          slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
 
-      - name: Configure gcloud credentials
-        run: gcloud auth configure-docker us-central1-docker.pkg.dev
-
       - name: "Authenticate with Google Cloud"
         uses: "google-github-actions/auth@v1"
         with:
           credentials_json: "${{ secrets.GCLOUD_SA_KEY }}"
+
+      - name: Configure gcloud credentials
+        run: gcloud auth configure-docker us-central1-docker.pkg.dev
 
       - name: Build the image on Cloud Build
         run: |

--- a/.github/workflows/deploy-front-edge-tmp.yml
+++ b/.github/workflows/deploy-front-edge-tmp.yml
@@ -1,0 +1,102 @@
+name: Deploy Front Edge
+
+on:
+  workflow_dispatch:
+    inputs:
+      check_deployment_blocked:
+        description: "Check #deployment locks or force deploy"
+        required: true
+        default: "check"
+        type: choice
+        options:
+          - "check"
+          - "force (dangerous)"
+
+concurrency:
+  group: deploy_front_edge
+  cancel-in-progress: false
+
+env:
+  GCLOUD_PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
+  IMAGE_NAME: front-edge
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Get short sha
+        id: short_sha
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+#      - name: Notify Build And Deploy Start
+#        id: build_message
+#        uses: ./.github/actions/slack-notify
+#        with:
+#          step: "start"
+#          component: "front-edge"
+#          image_tag: ${{ steps.short_sha.outputs.short_sha }}
+#          channel: ${{ secrets.SLACK_CHANNEL_ID }}
+#          slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
+#
+#      - name: Slack Check Deployment Blocked
+#        if: ${{ github.event.inputs.check_deployment_blocked != 'force (dangerous)' }}
+#        id: check_deployment_blocked
+#        uses: ./.github/actions/slack-check-deployment-blocked
+#        with:
+#          component: "front-edge"
+#          channel: ${{ secrets.SLACK_CHANNEL_ID }}
+#          slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
+
+      - name: "Authenticate with Google Cloud"
+        uses: "google-github-actions/auth@v1"
+        with:
+          credentials_json: "${{ secrets.GCLOUD_SA_KEY }}"
+
+      - name: Build the image on Cloud Build
+        run: |
+          chmod +x ./k8s/cloud-build.sh
+          ./k8s/cloud-build_tmp.sh --image-name=$IMAGE_NAME --dockerfile-path=./front/Dockerfile --working-dir=./ --dust-client-facing-url=https://front-edge.dust.tt
+
+#      - name: Generate a token
+#        id: generate-token
+#        uses: actions/create-github-app-token@v1
+#        with:
+#          app-id: ${{ secrets.INFRA_DISPATCH_APP_ID }}
+#          private-key: ${{ secrets.INFRA_DISPATCH_APP_PRIVATE_KEY }}
+#          owner: ${{ github.repository_owner }}
+#          repositories: |
+#            dust-infra
+#
+##      - name: Trigger dust-infra workflow
+#        uses: actions/github-script@v6
+#        with:
+#          github-token: ${{ steps.generate-token.outputs.token }}
+#          script: |
+#            await github.rest.repos.createDispatchEvent({
+#              owner: '${{ github.repository_owner }}',
+#              repo: 'dust-infra',
+#              event_type: 'trigger-component-deploy',
+#              client_payload: {
+#                regions: 'us-central1',
+#                component: 'front-edge',
+#                image_tag: '${{ steps.short_sha.outputs.short_sha }}',
+#                slack_thread_ts: "${{ steps.build_message.outputs.thread_ts }}",
+#                slack_channel: '${{ secrets.SLACK_CHANNEL_ID }}'
+#              }
+#            });
+#
+#      - name: Notify Failure
+#        if: failure()
+#        uses: ./.github/actions/slack-notify
+#        with:
+#          step: "failure"
+#          blocked: ${{ steps.check_deployment_blocked.outputs.blocked }}
+#          component: "front-edge"
+#          image_tag: ${{ steps.short_sha.outputs.short_sha }}
+#          channel: ${{ secrets.SLACK_CHANNEL_ID }}
+#          slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
+#          thread_ts: "${{ steps.build_message.outputs.thread_ts }}"

--- a/.github/workflows/deploy-front-edge-tmp.yml
+++ b/.github/workflows/deploy-front-edge-tmp.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Build the image on Cloud Build
         run: |
-          chmod +x ./k8s/cloud-build.sh
+          chmod +x ./k8s/cloud-build_tmp.sh
           ./k8s/cloud-build_tmp.sh \
             --image-name=$IMAGE_NAME \
             --dockerfile-path=./front/Dockerfile \

--- a/.github/workflows/deploy-front-edge-tmp.yml
+++ b/.github/workflows/deploy-front-edge-tmp.yml
@@ -51,6 +51,9 @@ jobs:
 #          channel: ${{ secrets.SLACK_CHANNEL_ID }}
 #          slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
 
+      - name: Configure gcloud credentials
+        run: gcloud auth configure-docker us-central1-docker.pkg.dev
+
       - name: "Authenticate with Google Cloud"
         uses: "google-github-actions/auth@v1"
         with:
@@ -59,7 +62,11 @@ jobs:
       - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build_tmp.sh --image-name=$IMAGE_NAME --dockerfile-path=./front/Dockerfile --working-dir=./ --dust-client-facing-url=https://front-edge.dust.tt
+          ./k8s/cloud-build_tmp.sh \
+            --image-name=$IMAGE_NAME \
+            --dockerfile-path=./front/Dockerfile \
+            --working-dir=./ \
+            --dust-client-facing-url=https://front-edge.dust.tt
 
 #      - name: Generate a token
 #        id: generate-token

--- a/.github/workflows/list-tags.yaml
+++ b/.github/workflows/list-tags.yaml
@@ -1,0 +1,51 @@
+name: List Image Tags
+
+on:
+  workflow_dispatch:
+    inputs:
+      regions:
+        description: "Comma-separated list of regions to deploy"
+        type: choice
+        options:
+          - "us-central1"
+        default: "us-central1"
+        required: true
+      component:
+        description: "Component to deploy"
+        type: choice
+        options:
+          - alerting-temporal
+          - connectors
+          - core
+          - front
+          - front-edge
+          - front-qa
+          - metabase
+          - oauth
+          - prodbox
+          - viz
+        required: true
+
+env:
+  GCLOUD_PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
+
+jobs:
+  list-tags:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Authenticate with Google Cloud"
+        uses: "google-github-actions/auth@v1"
+        with:
+          credentials_json: "${{ secrets.GCLOUD_SA_KEY }}"
+
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v1"
+
+      - name: List available tags
+        run: |
+          echo "Latest tags for ${{ inputs.component }} in ${{ inputs.regions }}:"
+          echo "-------------------------------------------"
+          gcloud container images list-tags ${{ inputs.regions }}-docker.pkg.dev/${{ env.GCLOUD_PROJECT_ID }}/dust-images/${{ inputs.component }} \
+            --limit=10 \
+            --sort-by=~timestamp \
+            --format="table(timestamp.date('%Y-%m-%d %H:%M:%S'),tags[0])"

--- a/.github/workflows/revert-front-edge.yml
+++ b/.github/workflows/revert-front-edge.yml
@@ -1,13 +1,10 @@
 name: Revert Front Edge
 
-on:
-  workflow_dispatch:
-
 env:
   GCLOUD_PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
 
 jobs:
-  rollback-deployment:
+  revert-deployment:
     runs-on: ubuntu-latest
 
     steps:
@@ -22,17 +19,63 @@ jobs:
       - name: "Set up Cloud SDK"
         uses: "google-github-actions/setup-gcloud@v1"
 
-      - name: Install gke-gcloud-auth-plugin
+      - name: Get previous image tags
+        id: get_tags
         run: |
-          gcloud components install gke-gcloud-auth-plugin
+          # List the last 10 image tags, sorting by timestamp
+          TAGS=$(gcloud container images list-tags us-central1-docker.pkg.dev/${{ env.GCLOUD_PROJECT_ID }}/dust-images/front-edge \
+            --limit=10 \
+            --sort-by=~timestamp \
+            --format="value(tags[0])")
+          echo "Available tags:"
+          echo "$TAGS"
+          echo "tags=$(echo $TAGS | tr '\n' ',')" >> $GITHUB_OUTPUT
 
-      - name: Setup kubectl
-        run: |
-          gcloud container clusters get-credentials dust-kube --region us-central1
 
-      - name: Rollback the deployment
-        run: |
-          kubectl rollout undo deployment/front-edge-deployment
+      - name: Choose image tag
+        uses: actions/github-script@v6
+        id: choose_tag
+        with:
+          result-encoding: string
+          script: |
+            const choices = ${{ steps.get_tags.outputs.choices }}
+            return await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'revert-front-edge.yml',
+              ref: 'main',
+              inputs: {
+                image_tag: {
+                  description: 'Choose image tag to revert to',
+                  type: 'choice',
+                  options: choices
+                }
+              }
+            })
 
-      - name: Wait for rollback to complete
-        run: kubectl rollout status deployment/front-edge-deployment --timeout=10m
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.INFRA_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.INFRA_DISPATCH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            dust-infra
+
+      - name: Trigger dust-infra workflow
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: '${{ github.repository_owner }}',
+              repo: 'dust-infra',
+              event_type: 'trigger-component-deploy',
+              client_payload: {
+                regions: 'us-central1',
+                component: 'front-edge',
+                image_tag: '${{ fromJSON(steps.get_tags.outputs.choices)[0] }}',
+                slack_channel: '${{ secrets.SLACK_CHANNEL_ID }}'
+              }
+            });

--- a/.github/workflows/revert-front-edge.yml
+++ b/.github/workflows/revert-front-edge.yml
@@ -1,10 +1,13 @@
 name: Revert Front Edge
 
+on:
+  workflow_dispatch:
+
 env:
   GCLOUD_PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
 
 jobs:
-  revert-deployment:
+  rollback-deployment:
     runs-on: ubuntu-latest
 
     steps:
@@ -19,63 +22,17 @@ jobs:
       - name: "Set up Cloud SDK"
         uses: "google-github-actions/setup-gcloud@v1"
 
-      - name: Get previous image tags
-        id: get_tags
+      - name: Install gke-gcloud-auth-plugin
         run: |
-          # List the last 10 image tags, sorting by timestamp
-          TAGS=$(gcloud container images list-tags us-central1-docker.pkg.dev/${{ env.GCLOUD_PROJECT_ID }}/dust-images/front-edge \
-            --limit=10 \
-            --sort-by=~timestamp \
-            --format="value(tags[0])")
-          echo "Available tags:"
-          echo "$TAGS"
-          echo "tags=$(echo $TAGS | tr '\n' ',')" >> $GITHUB_OUTPUT
+          gcloud components install gke-gcloud-auth-plugin
 
+      - name: Setup kubectl
+        run: |
+          gcloud container clusters get-credentials dust-kube --region us-central1
 
-      - name: Choose image tag
-        uses: actions/github-script@v6
-        id: choose_tag
-        with:
-          result-encoding: string
-          script: |
-            const choices = ${{ steps.get_tags.outputs.choices }}
-            return await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'revert-front-edge.yml',
-              ref: 'main',
-              inputs: {
-                image_tag: {
-                  description: 'Choose image tag to revert to',
-                  type: 'choice',
-                  options: choices
-                }
-              }
-            })
+      - name: Rollback the deployment
+        run: |
+          kubectl rollout undo deployment/front-edge-deployment
 
-      - name: Generate a token
-        id: generate-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.INFRA_DISPATCH_APP_ID }}
-          private-key: ${{ secrets.INFRA_DISPATCH_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: |
-            dust-infra
-
-      - name: Trigger dust-infra workflow
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ steps.generate-token.outputs.token }}
-          script: |
-            await github.rest.repos.createDispatchEvent({
-              owner: '${{ github.repository_owner }}',
-              repo: 'dust-infra',
-              event_type: 'trigger-component-deploy',
-              client_payload: {
-                regions: 'us-central1',
-                component: 'front-edge',
-                image_tag: '${{ fromJSON(steps.get_tags.outputs.choices)[0] }}',
-                slack_channel: '${{ secrets.SLACK_CHANNEL_ID }}'
-              }
-            });
+      - name: Wait for rollback to complete
+        run: kubectl rollout status deployment/front-edge-deployment --timeout=10m

--- a/.github/workflows/revert-front-edge.yml
+++ b/.github/workflows/revert-front-edge.yml
@@ -1,7 +1,12 @@
-name: Revert Front Edge
+name: Deploy Front Edge
 
 on:
   workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "The image tag/SHA to deploy"
+        type: string
+        required: true
 
 env:
   GCLOUD_PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
@@ -14,25 +19,61 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Get short sha
+        id: short_sha
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Notify Build And Deploy Start
+        id: build_message
+        uses: ./.github/actions/slack-notify
+        with:
+          step: "start"
+          component: "Revert front-edge"
+          image_tag: ${{ steps.short_sha.outputs.short_sha }}
+          channel: ${{ secrets.SLACK_CHANNEL_ID }}
+          slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
+
       - name: "Authenticate with Google Cloud"
         uses: "google-github-actions/auth@v1"
         with:
           credentials_json: "${{ secrets.GCLOUD_SA_KEY }}"
 
-      - name: "Set up Cloud SDK"
-        uses: "google-github-actions/setup-gcloud@v1"
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.INFRA_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.INFRA_DISPATCH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            dust-infra
 
-      - name: Install gke-gcloud-auth-plugin
-        run: |
-          gcloud components install gke-gcloud-auth-plugin
+      - name: Trigger dust-infra workflow
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: '${{ github.repository_owner }}',
+              repo: 'dust-infra',
+              event_type: 'trigger-component-deploy',
+              client_payload: {
+                regions: 'us-central1',
+                component: 'front-edge',
+                image_tag: '${{ steps.short_sha.outputs.short_sha }}',
+                slack_thread_ts: "${{ steps.build_message.outputs.thread_ts }}",
+                slack_channel: '${{ secrets.SLACK_CHANNEL_ID }}'
+              }
+            });
 
-      - name: Setup kubectl
-        run: |
-          gcloud container clusters get-credentials dust-kube --region us-central1
-
-      - name: Rollback the deployment
-        run: |
-          kubectl rollout undo deployment/front-edge-deployment
-
-      - name: Wait for rollback to complete
-        run: kubectl rollout status deployment/front-edge-deployment --timeout=10m
+      - name: Notify Failure
+        if: failure()
+        uses: ./.github/actions/slack-notify
+        with:
+          step: "failure"
+          blocked: ${{ steps.check_deployment_blocked.outputs.blocked }}
+          component: "Revert front-edge"
+          image_tag: ${{ steps.short_sha.outputs.short_sha }}
+          channel: ${{ secrets.SLACK_CHANNEL_ID }}
+          slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          thread_ts: "${{ steps.build_message.outputs.thread_ts }}"

--- a/k8s/cloud-build_tmp.sh
+++ b/k8s/cloud-build_tmp.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -e
+set -x
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
+
+# default values
+WORKING_DIR=""
+GCLOUD_IGNORE_FILE=""
+IMAGE_NAME=""
+DOCKERFILE_PATH=""
+DUST_CLIENT_FACING_URL=""
+
+# parse command-line arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --working-dir=*)
+      WORKING_DIR="${1#*=}"
+      shift
+      ;;
+    --gcloud-ignore-file=*)
+      GCLOUD_IGNORE_FILE="${1#*=}"
+      shift
+      ;;
+    --image-name=*)
+      IMAGE_NAME="${1#*=}"
+      shift
+      ;;
+    --dockerfile-path=*)
+      DOCKERFILE_PATH="${1#*=}"
+      shift
+      ;;
+    --dust-client-facing-url=*)
+      DUST_CLIENT_FACING_URL="${1#*=}"
+      shift
+      ;;
+    *)
+      echo "unknown argument: $1"
+      exit 1
+      ;;
+  esac
+done
+
+# check required arguments
+if [ -z "$WORKING_DIR" ] || [ -z "$IMAGE_NAME" ] || [ -z "$DOCKERFILE_PATH" ]; then
+  echo "error: --working-dir, --image-name, and --dockerfile-path are required"
+  exit 1
+fi
+
+if [ -n "$GCLOUD_IGNORE_FILE" ]; then
+    GCLOUD_IGNORE_FILE_ARG="--ignore-file=$GCLOUD_IGNORE_FILE"
+fi
+
+# change the current working directory to the directory in which to build the image
+cd "$WORKING_DIR"
+
+# check the current working directory
+echo "current working directory is $(pwd)"
+
+# prepare substitutions
+SUBSTITUTIONS="SHORT_SHA=$(git rev-parse --short HEAD),_IMAGE_NAME=$IMAGE_NAME,_DOCKERFILE_PATH=$DOCKERFILE_PATH"
+if [ -n "$DUST_CLIENT_FACING_URL" ]; then
+    SUBSTITUTIONS="$SUBSTITUTIONS,_DUST_CLIENT_FACING_URL=$DUST_CLIENT_FACING_URL"
+fi
+
+# start the build and get its id
+echo "starting build..."
+gcloud builds submit \
+  --quiet \
+  --config "${SCRIPT_DIR}/cloudbuild_tmp.yaml" "${GCLOUD_IGNORE_FILE_ARG}" \
+  --substitutions="$SUBSTITUTIONS" .

--- a/k8s/cloudbuild_tmp.yaml
+++ b/k8s/cloudbuild_tmp.yaml
@@ -1,0 +1,34 @@
+steps:
+  - name: ghcr.io/depot/cli:latest
+    args:
+      - build
+      - --project
+      - 3vz0lnf16v
+      - -t
+      - us-central1-docker.pkg.dev/$PROJECT_ID/dust-images/${_IMAGE_NAME}:$SHORT_SHA
+      - -t
+      - us-central1-docker.pkg.dev/$PROJECT_ID/dust-images/${_IMAGE_NAME}:latest
+      - --push
+      - -f
+      - ${_DOCKERFILE_PATH}
+      - --build-arg
+      - COMMIT_HASH=$SHORT_SHA
+      - --build-arg
+      - NEXT_PUBLIC_VIZ_URL=https://viz.dust.tt
+      - --build-arg
+      - NEXT_PUBLIC_GA_TRACKING_ID=G-K9HQ2LE04G
+      - --build-arg
+      - NEXT_PUBLIC_DUST_CLIENT_FACING_URL=${_DUST_CLIENT_FACING_URL}
+      - .
+    secretEnv:
+      - "DEPOT_TOKEN"
+
+timeout: 600s
+
+availableSecrets:
+  secretManager:
+    - versionName: projects/$PROJECT_ID/secrets/DEPOT_TOKEN/versions/latest
+      env: DEPOT_TOKEN
+
+options:
+  logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
## Description

This PR aims at refactoring the way we build the `front-edge` image and the `revert-front-edge` workflow.

This change is introduced for the following reason:
- container registry will be deprecated in favour of artifact registry mid March
- for some reason the creation timestamp of our images on GCR is wrong -> to be able to revert deployment properly we want to list the last n image tags 

## Risk

None: these changes are only building front-edge images and introduce temporary files

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
