### PR TITLE
[k8s] - refactor: streamline container build step in Cloud Build config

### DIFF
--- a/k8s/cloudbuild_tmp.yaml
+++ b/k8s/cloudbuild_tmp.yaml
@@ -1,34 +1,31 @@
 steps:
-  - name: ghcr.io/depot/cli:latest
-    args:
-      - build
-      - --project
-      - 3vz0lnf16v
-      - -t
-      - us-central1-docker.pkg.dev/$PROJECT_ID/dust-images/${_IMAGE_NAME}:$SHORT_SHA
-      - -t
-      - us-central1-docker.pkg.dev/$PROJECT_ID/dust-images/${_IMAGE_NAME}:latest
-      - --push
-      - -f
-      - ${_DOCKERFILE_PATH}
-      - --build-arg
-      - COMMIT_HASH=$SHORT_SHA
-      - --build-arg
-      - NEXT_PUBLIC_VIZ_URL=https://viz.dust.tt
-      - --build-arg
-      - NEXT_PUBLIC_GA_TRACKING_ID=G-K9HQ2LE04G
-      - --build-arg
-      - NEXT_PUBLIC_DUST_CLIENT_FACING_URL=${_DUST_CLIENT_FACING_URL}
-      - .
+  - id: 'Build Container Image'
+    name: 'ghcr.io/depot/cli:latest'
+    script: |
+      depot build \
+        --project 3vz0lnf16v \
+        --build-timestamp $(date +%s) \
+        -t us-central1-docker.pkg.dev/${PROJECT_ID}/dust-images/${_IMAGE_NAME}:${SHORT_SHA} \
+        -t us-central1-docker.pkg.dev/${PROJECT_ID}/dust-images/${_IMAGE_NAME}:latest \
+        -f ${_DOCKERFILE_PATH} \
+        --build-arg COMMIT_HASH=${SHORT_SHA} \
+        --build-arg NEXT_PUBLIC_VIZ_URL=https://viz.dust.tt \
+        --build-arg NEXT_PUBLIC_GA_TRACKING_ID=G-K9HQ2LE04G \
+        --build-arg NEXT_PUBLIC_DUST_CLIENT_FACING_URL=${_DUST_CLIENT_FACING_URL} \
+        .
     secretEnv:
       - "DEPOT_TOKEN"
 
 timeout: 600s
+options:
+  automapSubstitutions: true
+  logging: CLOUD_LOGGING_ONLY
 
 availableSecrets:
   secretManager:
     - versionName: projects/$PROJECT_ID/secrets/DEPOT_TOKEN/versions/latest
       env: DEPOT_TOKEN
 
-options:
-  logging: CLOUD_LOGGING_ONLY
+images:
+  - us-central1-docker.pkg.dev/${PROJECT_ID}/dust-images/${_IMAGE_NAME}:${SHORT_SHA}
+  - us-central1-docker.pkg.dev/${PROJECT_ID}/dust-images/${_IMAGE_NAME}:latest


### PR DESCRIPTION
## Description

This PR aims at fixing the wrong creation timestamp used and the fact that two images are being pushed to the Artifact Registry.

Note: it only affects the temporary front-edge build 

## Risk

None

## Deploy Plan

N/A