### PR TITLE
[poke] fix: prevent FK error when deleting workspace

### DIFF
--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -600,6 +600,10 @@ export async function deleteWorkspaceActivity({
     });
     await FileResource.deleteAllForWorkspace(workspace, t);
     await RunResource.deleteAllForWorkspace(workspace, t);
+    await AgentUserRelation.destroy({
+      where: { workspaceId: workspace.id },
+      transaction: t,
+    });
 
     hardDeleteLogger.info({ workspaceId }, "Deleting Workspace");
 


### PR DESCRIPTION
## Description

- Fix [FK errors](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E14%20%40dd.service%3Afront-worker&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZOvdS5Ea6Zl8wAAABhBWk92ZFR0dUFBRGdFTGdjWDhHcE93QWQAAAAkMDE5M2FmN2EtYjlkNi00YzMwLThjYzMtMjdjOWZlNDdjZjUzAAH-kA&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1733815006656&to_ts=1733815906656&live=true) occurring in poke `deleteWorkspaceWorkflow`.
- This PR adds an explicit deletion of every AgentUserRelation for a workspace before deleting said workspace.

## Risk

- Part of an admin action.
- Relative to the deletion of data.

## Deploy Plan

- Deploy front
