### PR TITLE
[k8s] - fix: remove build timestamp from Docker image bu…

### DIFF
--- a/k8s/cloudbuild_tmp.yaml
+++ b/k8s/cloudbuild_tmp.yaml
@@ -4,7 +4,6 @@ steps:
     script: |
       depot build \
         --project 3vz0lnf16v \
-        --build-timestamp $(date +%s) \
         -t us-central1-docker.pkg.dev/${PROJECT_ID}/dust-images/${_IMAGE_NAME}:${SHORT_SHA} \
         -t us-central1-docker.pkg.dev/${PROJECT_ID}/dust-images/${_IMAGE_NAME}:latest \
         -f ${_DOCKERFILE_PATH} \


### PR DESCRIPTION
## Description

Fix depot build in `cloudbuild_tmp.yaml`

## Risk

None

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
