### PR TITLE
[k8s] - fix: enable image pushing in Cloud Build configuration

### DIFF
--- a/k8s/cloudbuild_tmp.yaml
+++ b/k8s/cloudbuild_tmp.yaml
@@ -11,6 +11,7 @@ steps:
         --build-arg NEXT_PUBLIC_VIZ_URL=https://viz.dust.tt \
         --build-arg NEXT_PUBLIC_GA_TRACKING_ID=G-K9HQ2LE04G \
         --build-arg NEXT_PUBLIC_DUST_CLIENT_FACING_URL=${_DUST_CLIENT_FACING_URL} \
+        --push \
         .
     secretEnv:
       - "DEPOT_TOKEN"


### PR DESCRIPTION
## Description

Add the `--push` argument to the docker build step to enable pushing the built image to a container registry

## Risk

None

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
