### PR TITLE
feat: support updating snowflake connection details

### DIFF
--- a/connectors/src/api/create_connector.ts
+++ b/connectors/src/api/create_connector.ts
@@ -16,6 +16,7 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
 
 import { createConnector } from "@connectors/connectors";
+import type { CreateConnectorErrorCode } from "@connectors/connectors/interface";
 import type { ConnectorManagerError } from "@connectors/connectors/interface";
 import { errorFromAny } from "@connectors/lib/error";
 import logger from "@connectors/logger/logger";
@@ -60,7 +61,10 @@ const _createConnectorAPIHandler = async (
       configuration,
     } = bodyValidation.right;
 
-    let connectorRes: Result<string, ConnectorManagerError> | null = null;
+    let connectorRes: Result<
+      string,
+      ConnectorManagerError<CreateConnectorErrorCode>
+    > | null = null;
 
     switch (req.params.connector_provider) {
       case "webcrawler": {
@@ -157,14 +161,6 @@ const _createConnectorAPIHandler = async (
             status_code: 400,
             api_error: {
               type: "invalid_request_error",
-              message: connectorRes.error.message,
-            },
-          });
-        case "PERMISSION_REVOKED":
-          return apiError(req, res, {
-            status_code: 403,
-            api_error: {
-              type: "authorization_error",
               message: connectorRes.error.message,
             },
           });

--- a/connectors/src/api/update_connector.ts
+++ b/connectors/src/api/update_connector.ts
@@ -1,5 +1,5 @@
 import type { WithConnectorsAPIErrorReponse } from "@dust-tt/types";
-import { UpdateConnectorRequestBodySchema } from "@dust-tt/types";
+import { assertNever, UpdateConnectorRequestBodySchema } from "@dust-tt/types";
 import type { Request, Response } from "express";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
@@ -63,19 +63,25 @@ const _postConnectorUpdateAPIHandler = async (
   });
 
   if (updateRes.isErr()) {
-    if (updateRes.error.type === "connector_oauth_target_mismatch") {
-      return apiError(req, res, {
-        api_error: updateRes.error,
-        status_code: 401,
-      });
-    } else {
-      return apiError(req, res, {
-        status_code: 500,
-        api_error: {
-          type: "internal_server_error",
-          message: `Could not update the connector: ${updateRes.error.message}`,
-        },
-      });
+    switch (updateRes.error.code) {
+      case "CONNECTOR_OAUTH_TARGET_MISMATCH":
+        return apiError(req, res, {
+          status_code: 401,
+          api_error: {
+            type: "connector_oauth_target_mismatch",
+            message: updateRes.error.message,
+          },
+        });
+      case "INVALID_CONFIGURATION":
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: updateRes.error.message,
+          },
+        });
+      default:
+        assertNever(updateRes.error.code);
     }
   }
 

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -11,7 +11,10 @@ import { ConfluenceConnectorManager } from "@connectors/connectors/confluence";
 import { GithubConnectorManager } from "@connectors/connectors/github";
 import { GoogleDriveConnectorManager } from "@connectors/connectors/google_drive";
 import { IntercomConnectorManager } from "@connectors/connectors/intercom";
-import type { ConnectorManagerError } from "@connectors/connectors/interface";
+import type {
+  ConnectorManagerError,
+  CreateConnectorErrorCode,
+} from "@connectors/connectors/interface";
 import { MicrosoftConnectorManager } from "@connectors/connectors/microsoft";
 import { NotionConnectorManager } from "@connectors/connectors/notion";
 import { SlackConnectorManager } from "@connectors/connectors/slack";
@@ -91,7 +94,9 @@ export function createConnector({
         connectionId: string;
         configuration: SlackConfiguration;
       };
-    }): Promise<Result<string, ConnectorManagerError>> {
+    }): Promise<
+  Result<string, ConnectorManagerError<CreateConnectorErrorCode>>
+> {
   switch (connectorProvider) {
     case "confluence":
       return ConfluenceConnectorManager.create(params);

--- a/connectors/src/connectors/interface.ts
+++ b/connectors/src/connectors/interface.ts
@@ -1,6 +1,5 @@
 import type {
   ConnectorPermission,
-  ConnectorsAPIError,
   ContentNode,
   ContentNodesViewType,
   ModelId,
@@ -10,12 +9,16 @@ import type { ConnectorConfiguration } from "@dust-tt/types";
 
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
-type ConnectorManagerErrorCode = "INVALID_CONFIGURATION" | "PERMISSION_REVOKED";
+export type CreateConnectorErrorCode = "INVALID_CONFIGURATION";
 
-export class ConnectorManagerError extends Error {
-  code: ConnectorManagerErrorCode;
+export type UpdateConnectorErrorCode =
+  | "INVALID_CONFIGURATION"
+  | "CONNECTOR_OAUTH_TARGET_MISMATCH";
 
-  constructor(code: ConnectorManagerErrorCode, message: string) {
+export class ConnectorManagerError<T extends string> extends Error {
+  code: T;
+
+  constructor(code: T, message: string) {
     super(message);
     this.name = "ConnectorManagerError";
     this.code = code;
@@ -34,13 +37,13 @@ export abstract class BaseConnectorManager<T extends ConnectorConfiguration> {
     dataSourceConfig: DataSourceConfig;
     connectionId: string;
     configuration: ConnectorConfiguration;
-  }): Promise<Result<string, ConnectorManagerError>> {
+  }): Promise<Result<string, ConnectorManagerError<CreateConnectorErrorCode>>> {
     throw new Error("Method not implemented.");
   }
 
   abstract update(params: {
     connectionId?: string | null;
-  }): Promise<Result<string, ConnectorsAPIError>>;
+  }): Promise<Result<string, ConnectorManagerError<UpdateConnectorErrorCode>>>;
 
   abstract clean(params: { force: boolean }): Promise<Result<undefined, Error>>;
 

--- a/connectors/src/connectors/snowflake/index.ts
+++ b/connectors/src/connectors/snowflake/index.ts
@@ -1,12 +1,15 @@
 import type {
   ConnectorPermission,
-  ConnectorsAPIError,
   ContentNode,
   ContentNodesViewType,
   Result,
 } from "@dust-tt/types";
 import { assertNever, Err, Ok } from "@dust-tt/types";
 
+import type {
+  CreateConnectorErrorCode,
+  UpdateConnectorErrorCode,
+} from "@connectors/connectors/interface";
 import { ConnectorManagerError } from "@connectors/connectors/interface";
 import { BaseConnectorManager } from "@connectors/connectors/interface";
 import {
@@ -17,6 +20,7 @@ import {
   getContentNodeParents,
   saveNodesFromPermissions,
 } from "@connectors/connectors/snowflake/lib/permissions";
+import type { TestConnectionError } from "@connectors/connectors/snowflake/lib/snowflake_api";
 import { testConnection } from "@connectors/connectors/snowflake/lib/snowflake_api";
 import {
   getConnector,
@@ -37,6 +41,21 @@ const logger = mainLogger.child({
   connector: "snowflake",
 });
 
+function handleTestConnectionError(
+  e: TestConnectionError
+): "INVALID_CONFIGURATION" {
+  switch (e.code) {
+    case "INVALID_CREDENTIALS":
+    case "NOT_READONLY":
+    case "NO_TABLES":
+      return "INVALID_CONFIGURATION";
+    case "UNKNOWN":
+      throw e;
+    default:
+      assertNever(e.code);
+  }
+}
+
 export class SnowflakeConnectorManager extends BaseConnectorManager<null> {
   static async create({
     dataSourceConfig,
@@ -44,7 +63,7 @@ export class SnowflakeConnectorManager extends BaseConnectorManager<null> {
   }: {
     dataSourceConfig: DataSourceConfig;
     connectionId: string;
-  }): Promise<Result<string, ConnectorManagerError>> {
+  }): Promise<Result<string, ConnectorManagerError<CreateConnectorErrorCode>>> {
     const credentialsRes = await getCredentials({
       credentialsId: connectionId,
       logger,
@@ -57,21 +76,12 @@ export class SnowflakeConnectorManager extends BaseConnectorManager<null> {
     // Then we test the connection is successful.
     const connectionRes = await testConnection({ credentials });
     if (connectionRes.isErr()) {
-      switch (connectionRes.error.code) {
-        case "INVALID_CREDENTIALS":
-        case "NOT_READONLY":
-        case "NO_TABLES":
-          return new Err(
-            new ConnectorManagerError(
-              "INVALID_CONFIGURATION",
-              connectionRes.error.message
-            )
-          );
-        case "UNKNOWN":
-          throw connectionRes.error;
-        default:
-          assertNever(connectionRes.error.code);
-      }
+      return new Err(
+        new ConnectorManagerError(
+          handleTestConnectionError(connectionRes.error),
+          connectionRes.error.message
+        )
+      );
     }
 
     // We can create the connector.
@@ -99,9 +109,40 @@ export class SnowflakeConnectorManager extends BaseConnectorManager<null> {
     connectionId,
   }: {
     connectionId?: string | null;
-  }): Promise<Result<string, ConnectorsAPIError>> {
-    logger.info({ connectionId }, "To be implemented");
-    throw new Error("Method update not implemented.");
+  }): Promise<Result<string, ConnectorManagerError<UpdateConnectorErrorCode>>> {
+    const c = await ConnectorResource.fetchById(this.connectorId);
+    if (!c) {
+      logger.error({ connectorId: this.connectorId }, "Connector not found");
+      throw new Error(`Connector ${this.connectorId} not found`);
+    }
+
+    if (!connectionId) {
+      return new Ok(c.id.toString());
+    }
+
+    const newCredentialsRes = await getCredentials({
+      credentialsId: connectionId,
+      logger,
+    });
+    if (newCredentialsRes.isErr()) {
+      throw newCredentialsRes.error;
+    }
+
+    const newCredentials = newCredentialsRes.value.credentials;
+
+    const connectionRes = await testConnection({ credentials: newCredentials });
+    if (connectionRes.isErr()) {
+      return new Err(
+        new ConnectorManagerError(
+          handleTestConnectionError(connectionRes.error),
+          connectionRes.error.message
+        )
+      );
+    }
+
+    await c.update({ connectionId });
+
+    return new Ok(c.id.toString());
   }
 
   async clean(): Promise<Result<undefined, Error>> {

--- a/connectors/src/connectors/snowflake/index.ts
+++ b/connectors/src/connectors/snowflake/index.ts
@@ -141,6 +141,7 @@ export class SnowflakeConnectorManager extends BaseConnectorManager<null> {
     }
 
     await c.update({ connectionId });
+    await launchSnowflakeSyncWorkflow(c.id);
 
     return new Ok(c.id.toString());
   }

--- a/connectors/src/connectors/snowflake/lib/snowflake_api.ts
+++ b/connectors/src/connectors/snowflake/lib/snowflake_api.ts
@@ -48,7 +48,7 @@ type TestConnectionErrorCode =
   | "NO_TABLES"
   | "UNKNOWN";
 
-class TestConnectionError extends Error {
+export class TestConnectionError extends Error {
   code: TestConnectionErrorCode;
 
   constructor(code: TestConnectionErrorCode, message: string) {

--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -1,6 +1,5 @@
 import type {
   ConnectorPermission,
-  ConnectorsAPIError,
   ContentNode,
   ContentNodesViewType,
   Result,
@@ -15,6 +14,12 @@ import {
   WebCrawlerHeaderRedactedValue,
 } from "@dust-tt/types";
 
+import type {
+  ConnectorManagerError,
+  CreateConnectorErrorCode,
+  UpdateConnectorErrorCode,
+} from "@connectors/connectors/interface";
+import { BaseConnectorManager } from "@connectors/connectors/interface";
 import {
   getDisplayNameForFolder,
   getDisplayNameForPage,
@@ -30,8 +35,6 @@ import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { WebCrawlerConfigurationResource } from "@connectors/resources/webcrawler_resource";
 import type { DataSourceConfig } from "@connectors/types/data_source_config.js";
 
-import type { ConnectorManagerError } from "../interface";
-import { BaseConnectorManager } from "../interface";
 import {
   launchCrawlWebsiteWorkflow,
   stopCrawlWebsiteWorkflow,
@@ -45,7 +48,7 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
     dataSourceConfig: DataSourceConfig;
     connectionId: string;
     configuration: WebCrawlerConfigurationType;
-  }): Promise<Result<string, ConnectorManagerError>> {
+  }): Promise<Result<string, ConnectorManagerError<CreateConnectorErrorCode>>> {
     if (!configuration) {
       throw new Error("Configuration is required");
     }
@@ -464,7 +467,9 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
     return new Ok(undefined);
   }
 
-  async update(): Promise<Result<string, ConnectorsAPIError>> {
+  async update(): Promise<
+    Result<string, ConnectorManagerError<UpdateConnectorErrorCode>>
+  > {
     throw new Error("Method not implemented.");
   }
 

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -260,6 +260,14 @@ function DataSourceEditionModal({
 
   const connectorConfiguration = CONNECTOR_CONFIGURATIONS[connectorProvider];
 
+  if (dataSource.connectorProvider === "snowflake") {
+    return (
+      <DataSourceManagementModal isOpen={isOpen} onClose={onClose}>
+        Edit Snowflake
+      </DataSourceManagementModal>
+    );
+  }
+
   return (
     <DataSourceManagementModal isOpen={isOpen} onClose={onClose}>
       <>
@@ -747,21 +755,24 @@ export function ConnectorPermissionsModal({
         variant="side-md"
       >
         <div className="mx-auto mt-4 flex w-full max-w-4xl grow flex-col gap-4">
-          <div className="flex">
-            {isOAuthProvider(connector.type) && (
-              <Button
-                className="ml-auto justify-self-end"
-                label="Edit permissions"
-                variant="outline"
-                icon={LockIcon}
-                onClick={() => {
-                  setModalToShow("edition");
-                }}
-              />
-            )}
+          <div className="flex flex-row justify-end gap-2">
+            {isOAuthProvider(connector.type) ||
+              (connector.type === "snowflake" && (
+                <Button
+                  label={
+                    connector.type !== "snowflake"
+                      ? "Edit permissions"
+                      : "Edit connection"
+                  }
+                  variant="outline"
+                  icon={LockIcon}
+                  onClick={() => {
+                    setModalToShow("edition");
+                  }}
+                />
+              ))}
             {MANAGED_DS_DELETABLE.includes(connector.type) && (
               <Button
-                className="ml-auto justify-self-end"
                 label="Delete connection"
                 variant="warning"
                 icon={TrashIcon}

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -37,6 +37,7 @@ import { useSWRConfig } from "swr";
 
 import type { ConfirmDataType } from "@app/components/Confirm";
 import { ConfirmContext } from "@app/components/Confirm";
+import { CreateOrUpdateConnectionSnowflakeModal } from "@app/components/data_source/CreateOrUpdateConnectionSnowflakeModal";
 import { RequestDataSourceModal } from "@app/components/data_source/RequestDataSourceModal";
 import { setupConnection } from "@app/components/spaces/AddConnectionMenu";
 import { ConnectorDataUpdatedModal } from "@app/components/spaces/ConnectorDataUpdatedModal";
@@ -816,22 +817,41 @@ export function ConnectorPermissionsModal({
           />
         </div>
       </Modal>
-      <DataSourceEditionModal
-        isOpen={modalToShow === "edition"}
-        onClose={() => closeModal(false)}
-        dataSource={dataSource}
-        owner={owner}
-        onEditPermissionsClick={async (extraConfig: Record<string, string>) => {
-          await handleUpdatePermissions(
-            connector,
-            dataSource,
-            owner,
-            extraConfig,
-            sendNotification
-          );
-          closeModal(false);
-        }}
-      />
+      {/* Snowflake is not oauth-based and has its own config form */}
+      {connector.type === "snowflake" ? (
+        <CreateOrUpdateConnectionSnowflakeModal
+          owner={owner}
+          connectorProviderConfiguration={
+            CONNECTOR_CONFIGURATIONS[connector.type]
+          }
+          isOpen={modalToShow === "edition"}
+          onClose={() => closeModal(false)}
+          dataSourceToUpdate={dataSource}
+          onSuccess={() => {
+            setModalToShow("selection");
+          }}
+        />
+      ) : (
+        <DataSourceEditionModal
+          isOpen={modalToShow === "edition"}
+          onClose={() => closeModal(false)}
+          dataSource={dataSource}
+          owner={owner}
+          onEditPermissionsClick={async (
+            extraConfig: Record<string, string>
+          ) => {
+            await handleUpdatePermissions(
+              connector,
+              dataSource,
+              owner,
+              extraConfig,
+              sendNotification
+            );
+            closeModal(false);
+          }}
+        />
+      )}
+
       <DataSourceDeletionModal
         isOpen={modalToShow === "deletion"}
         onClose={() => closeModal(false)}

--- a/front/components/spaces/AddConnectionMenu.tsx
+++ b/front/components/spaces/AddConnectionMenu.tsx
@@ -24,7 +24,7 @@ import { useRouter } from "next/router";
 import { useState } from "react";
 
 import { CreateConnectionConfirmationModal } from "@app/components/data_source/CreateConnectionConfirmationModal";
-import { CreateConnectionSnowflakeModal } from "@app/components/data_source/CreateConnectionSnowflakeModal";
+import { CreateOrUpdateConnectionSnowflakeModal } from "@app/components/data_source/CreateOrUpdateConnectionSnowflakeModal";
 import {
   CONNECTOR_CONFIGURATIONS,
   getConnectorProviderLogoWithFallback,
@@ -288,7 +288,7 @@ export const AddConnectionMenu = ({
         </Dialog>
 
         {connectorProvider === "snowflake" ? (
-          <CreateConnectionSnowflakeModal
+          <CreateOrUpdateConnectionSnowflakeModal
             owner={owner}
             connectorProviderConfiguration={
               CONNECTOR_CONFIGURATIONS[connectorProvider]
@@ -300,7 +300,7 @@ export const AddConnectionMenu = ({
                 integration: prev.integration,
               }))
             }
-            onSubmit={(
+            createDatasource={(
               args: Omit<
                 Parameters<typeof handleCredentialProviderManagedDataSource>[0],
                 "suffix"
@@ -311,7 +311,7 @@ export const AddConnectionMenu = ({
                 suffix: integration?.setupWithSuffix ?? null,
               })
             }
-            onCreated={onCreated}
+            onSuccess={onCreated}
           />
         ) : (
           connectorProvider && (


### PR DESCRIPTION
## Description

Allow updating a snowflake connection (previously one could only delete it).
fixes https://github.com/dust-tt/tasks/issues/1774

Also stop return `ConnectorsAPIError` directly from connector manager. Use exceptions for internal errors. Use proper error types (with narrow types) for expected errors.

## Risk

Critical path for connectors updates and creates

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
