### PR TITLE
core: log parents[0] / node_id mismatch

### DIFF
--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -1649,7 +1649,7 @@ async fn data_sources_documents_upsert(
             },
             node_type = "document",
             operation = "upsert",
-            "[KWSEARCH] invariant: first parent must be the document itself"
+            "[KWSEARCH] invariant: first parent must be the node itself"
         );
     }
 

--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -25,7 +25,7 @@ use tokio::{
 };
 use tokio_stream::Stream;
 use tower_http::trace::{self, TraceLayer};
-use tracing::{error, info, warn, Level};
+use tracing::{error, info, Level};
 use tracing_bunyan_formatter::{BunyanFormattingLayer, JsonStorageLayer};
 use tracing_subscriber::prelude::*;
 

--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -1488,7 +1488,7 @@ async fn data_sources_documents_update_parents(
             },
             node_type = "document",
             operation = "update_parents",
-            "[KWSEARCH] invariant: first parent must be the node itself"
+            "[KWSEARCH] invariant_first_parent_self"
         );
     }
 
@@ -1649,7 +1649,7 @@ async fn data_sources_documents_upsert(
             },
             node_type = "document",
             operation = "upsert",
-            "[KWSEARCH] invariant: first parent must be the node itself"
+            "[KWSEARCH] invariant_first_parent_self"
         );
     }
 
@@ -2106,7 +2106,7 @@ async fn tables_upsert(
             },
             node_type = "table",
             operation = "upsert",
-            "[KWSEARCH] invariant: first parent must be the node itself"
+            "[KWSEARCH] invariant_first_parent_self"
         );
     }
 
@@ -2357,7 +2357,7 @@ async fn tables_update_parents(
             },
             node_type = "table",
             operation = "update_parents",
-            "[KWSEARCH] invariant: first parent must be the node itself"
+            "[KWSEARCH] invariant_first_parent_self"
         );
     }
 
@@ -2756,7 +2756,7 @@ async fn folders_upsert(
             },
             node_type = "folder",
             operation = "upsert",
-            "[KWSEARCH] invariant: first parent must be the node itself"
+            "[KWSEARCH] invariant_first_parent_self"
         );
     }
 

--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -1482,10 +1482,7 @@ async fn data_sources_documents_update_parents(
         info!(
             data_source_id = data_source_id,
             node_id = document_id,
-            parents_0 = match payload.parents.get(0) {
-                None => "None",
-                Some(p) => p,
-            },
+            parents = ?payload.parents,
             node_type = "document",
             operation = "update_parents",
             "[KWSEARCH] invariant_first_parent_self"
@@ -1643,10 +1640,7 @@ async fn data_sources_documents_upsert(
         info!(
             data_source_id = data_source_id,
             node_id = payload.document_id,
-            parents_0 = match payload.parents.get(0) {
-                None => "None",
-                Some(p) => p,
-            },
+            parents = ?payload.parents,
             node_type = "document",
             operation = "upsert",
             "[KWSEARCH] invariant_first_parent_self"
@@ -2100,10 +2094,7 @@ async fn tables_upsert(
         info!(
             data_source_id = data_source_id,
             node_id = payload.table_id,
-            parents_0 = match payload.parents.get(0) {
-                None => "None",
-                Some(p) => p,
-            },
+            parents = ?payload.parents,
             node_type = "table",
             operation = "upsert",
             "[KWSEARCH] invariant_first_parent_self"
@@ -2351,10 +2342,7 @@ async fn tables_update_parents(
         info!(
             data_source_id = data_source_id,
             node_id = table_id,
-            parents_0 = match payload.parents.get(0) {
-                None => "None",
-                Some(p) => p,
-            },
+            parents = ?payload.parents,
             node_type = "table",
             operation = "update_parents",
             "[KWSEARCH] invariant_first_parent_self"
@@ -2750,10 +2738,7 @@ async fn folders_upsert(
         info!(
             data_source_id = data_source_id,
             node_id = payload.folder_id,
-            parents_0 = match payload.parents.get(0) {
-                None => "None",
-                Some(p) => p,
-            },
+            parents = ?payload.parents,
             node_type = "folder",
             operation = "upsert",
             "[KWSEARCH] invariant_first_parent_self"

--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -1478,6 +1478,20 @@ async fn data_sources_documents_update_parents(
 ) -> (StatusCode, Json<APIResponse>) {
     let project = project::Project::new_from_id(project_id);
 
+    if payload.parents.get(0) != Some(&document_id) {
+        info!(
+            data_source_id = data_source_id,
+            node_id = document_id,
+            parents_0 = match payload.parents.get(0) {
+                None => "None",
+                Some(p) => p,
+            },
+            node_type = "document",
+            operation = "update_parents",
+            "[KWSEARCH] invariant: first parent must be the node itself"
+        );
+    }
+
     match state
         .store
         .load_data_source(&project, &data_source_id)
@@ -1627,11 +1641,14 @@ async fn data_sources_documents_upsert(
 
     if payload.parents.get(0) != Some(&payload.document_id) {
         info!(
-            document_id = payload.document_id,
+            data_source_id = data_source_id,
+            node_id = payload.document_id,
             parents_0 = match payload.parents.get(0) {
                 None => "None",
                 Some(p) => p,
             },
+            node_type = "document",
+            operation = "upsert",
             "[KWSEARCH] invariant: first parent must be the document itself"
         );
     }
@@ -2079,6 +2096,20 @@ async fn tables_upsert(
 ) -> (StatusCode, Json<APIResponse>) {
     let project = project::Project::new_from_id(project_id);
 
+    if payload.parents.get(0) != Some(&payload.table_id) {
+        info!(
+            data_source_id = data_source_id,
+            node_id = payload.table_id,
+            parents_0 = match payload.parents.get(0) {
+                None => "None",
+                Some(p) => p,
+            },
+            node_type = "table",
+            operation = "upsert",
+            "[KWSEARCH] invariant: first parent must be the node itself"
+        );
+    }
+
     match state
         .store
         .upsert_data_source_table(
@@ -2315,6 +2346,20 @@ async fn tables_update_parents(
     Json(payload): Json<DataSourcesDocumentsUpdateParentsPayload>,
 ) -> (StatusCode, Json<APIResponse>) {
     let project = project::Project::new_from_id(project_id);
+
+    if payload.parents.get(0) != Some(&table_id) {
+        info!(
+            data_source_id = data_source_id,
+            node_id = table_id,
+            parents_0 = match payload.parents.get(0) {
+                None => "None",
+                Some(p) => p,
+            },
+            node_type = "table",
+            operation = "update_parents",
+            "[KWSEARCH] invariant: first parent must be the node itself"
+        );
+    }
 
     match state
         .store
@@ -2700,6 +2745,20 @@ async fn folders_upsert(
     Json(payload): Json<FoldersUpsertPayload>,
 ) -> (StatusCode, Json<APIResponse>) {
     let project = project::Project::new_from_id(project_id);
+
+    if payload.parents.get(0) != Some(&payload.folder_id) {
+        info!(
+            data_source_id = data_source_id,
+            node_id = payload.folder_id,
+            parents_0 = match payload.parents.get(0) {
+                None => "None",
+                Some(p) => p,
+            },
+            node_type = "folder",
+            operation = "upsert",
+            "[KWSEARCH] invariant: first parent must be the node itself"
+        );
+    }
 
     match state
         .store

--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -25,7 +25,7 @@ use tokio::{
 };
 use tokio_stream::Stream;
 use tower_http::trace::{self, TraceLayer};
-use tracing::{error, info, Level};
+use tracing::{error, info, warn, Level};
 use tracing_bunyan_formatter::{BunyanFormattingLayer, JsonStorageLayer};
 use tracing_subscriber::prelude::*;
 
@@ -1624,6 +1624,17 @@ async fn data_sources_documents_upsert(
         Some(v) => v,
         None => false,
     };
+
+    if payload.parents.get(0) != Some(&payload.document_id) {
+        info!(
+            document_id = payload.document_id,
+            parents_0 = match payload.parents.get(0) {
+                None => "None",
+                Some(p) => p,
+            },
+            "[KWSEARCH] invariant: first parent must be the document itself"
+        );
+    }
 
     match state
         .store

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -26,7 +26,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::str::FromStr;
 use tokio_stream::{self as stream};
-use tracing::{error, info, warn};
+use tracing::{error, info};
 use uuid::Uuid;
 
 /// Section is used to represent the structure of document to be taken into account during chunking.

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -627,22 +627,6 @@ impl DataSource {
             ))?;
         }
 
-        if parents.is_empty() {
-            warn!(
-                document_id = document_id,
-                timestamp = ?timestamp,
-                parents = ?parents,
-                "Upserting a document without any parent"
-            );
-        } else if parents[0] != document_id {
-            warn!(
-                document_id = document_id,
-                timestamp = ?timestamp,
-                parents = ?parents,
-                "Upserting a document that is not self-referenced as its parent"
-            );
-        }
-
         let store = store.clone();
 
         let current_system_tags = if preserve_system_tags {


### PR DESCRIPTION
## Description

Introduce logs wherever we update or set parents in core to log when parents[0] and document_id mismatch.

Goal is to bring that log to 0

## Risk

N/A

## Deploy Plan

- deploy `core`