### PR TITLE
enh(sparkles) - forwardRef Chip and Tooltip

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.336",
+  "version": "0.2.337",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.336",
+      "version": "0.2.337",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.336",
+  "version": "0.2.337",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Chip.tsx
+++ b/sparkle/src/components/Chip.tsx
@@ -78,22 +78,18 @@ const chipVariants = cva("s-inline-flex s-box-border s-items-center", {
   },
 });
 
-export function Chip({
-  size,
-  color,
-  label,
-  children,
-  className,
-  isBusy,
-  icon,
-}: ChipProps) {
-  return (
+const Chip = React.forwardRef<HTMLDivElement, ChipProps>(
+  (
+    { size, color, label, children, className, isBusy, icon }: ChipProps,
+    ref
+  ) => (
     <div
       className={cn(
         chipVariants({ size, background: color, text: color }),
         className
       )}
       aria-label={label}
+      ref={ref}
     >
       {icon && <Icon visual={icon} size={size as IconProps["size"]} />}
       {label && (
@@ -107,26 +103,9 @@ export function Chip({
       )}
       {children}
     </div>
-  );
-}
+  )
+);
 
-interface ListChipProps {
-  children: ReactNode;
-  className?: string;
-  isWrapping?: boolean;
-}
+Chip.displayName = "Chip";
 
-Chip.List = function ({ children, className, isWrapping }: ListChipProps) {
-  return (
-    <div className={cn("s-flex", className)}>
-      <div
-        className={cn(
-          "s-flex s-flex-row s-gap-2",
-          isWrapping ? "s-flex-wrap" : ""
-        )}
-      >
-        {children}
-      </div>
-    </div>
-  );
-};
+export { Chip };

--- a/sparkle/src/components/Tooltip.tsx
+++ b/sparkle/src/components/Tooltip.tsx
@@ -36,23 +36,23 @@ interface TooltipProps extends TooltipContentProps {
   triggerAsChild?: boolean;
 }
 
-function Tooltip({
-  trigger,
-  tooltipTriggerAsChild = false,
-  label,
-  ...props
-}: TooltipProps) {
-  return (
+const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(
+  (
+    { trigger, tooltipTriggerAsChild = false, label, ...props }: TooltipProps,
+    ref
+  ) => (
     <TooltipProvider>
       <TooltipRoot>
         <TooltipTrigger asChild={tooltipTriggerAsChild}>
           {trigger}
         </TooltipTrigger>
-        <TooltipContent {...props}>{label}</TooltipContent>
+        <TooltipContent {...props} ref={ref}>
+          {label}
+        </TooltipContent>
       </TooltipRoot>
     </TooltipProvider>
-  );
-}
+  )
+);
 
 TooltipContent.displayName = TooltipPrimitive.Content.displayName;
 


### PR DESCRIPTION
## Description

- This PR aims at turning the `Chip` and the `Tooltip` components into `forwardRef`.
- This change will typically allow using them in the context of an `asChild`.

## Risk

- Should be low, no functional change, at worse some Tooltips will be broken and some console errors will pop up in dev.

## Deploy Plan

- Publish sparkles
- Follow up with another PR in front.
