### PR TITLE
fix(sparkles) - allow wrapping tooltip content

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.337",
+  "version": "0.2.338",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.337",
+      "version": "0.2.338",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.337",
+  "version": "0.2.338",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Tooltip.tsx
+++ b/sparkle/src/components/Tooltip.tsx
@@ -20,7 +20,7 @@ const TooltipContent = React.forwardRef<
     ref={ref}
     sideOffset={sideOffset}
     className={classNames(
-      "s-z-50 s-max-w-xs s-overflow-hidden s-rounded-md s-border s-bg-white s-px-3 s-py-1.5 s-text-sm s-shadow-md",
+      "s-z-50 s-max-w-sm s-overflow-hidden s-whitespace-pre-wrap s-break-words s-rounded-md s-border s-bg-white s-px-3 s-py-1.5 s-text-sm s-shadow-md",
       "s-animate-in s-fade-in-0 s-zoom-in-95",
       "data-[state=closed]:s-animate-out data-[state=closed]:s-fade-out-0 data-[state=closed]:s-zoom-out-95 data-[side=bottom]:s-slide-in-from-top-2 data-[side=left]:s-slide-in-from-right-2 data-[side=right]:s-slide-in-from-left-2 data-[side=top]:s-slide-in-from-bottom-2",
       className || ""


### PR DESCRIPTION
## Description

- Fix [#1773](https://github.com/dust-tt/tasks/issues/1773)
- This PR allows TooltipContent to wrap, solving the issue of cropped tooltips.
- The max width of the tooltip is also increased.

After:
<img width="970" alt="Screenshot 2024-12-10 at 1 21 11 PM" src="https://github.com/user-attachments/assets/b21ad8d3-cd7d-4c80-90da-cc8654d5cd19">

## Risk

- Risk of breaking the tooltips or having some unwanted results in the UI.

## Deploy Plan

- Publish a new version of sparkles.
- Bump the version of sparkles in front.
- Deploy front.
