### PR TITLE
[poke] fix: prevent FK error when deleting workspace

### DIFF
--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -354,16 +354,6 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     });
   }
 
-  static async deleteAllForWorkspace(
-    workspace: LightWorkspaceType,
-    transaction?: Transaction
-  ) {
-    return this.model.destroy({
-      where: { workspaceId: workspace.id },
-      transaction,
-    });
-  }
-
   /**
    * Caller of this method should call `ServerSideTracking.trackCreateMembership`.
    */

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -54,6 +54,51 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     super(MembershipModel, blob);
   }
 
+  static async getMembershipsForWorkspace({
+    workspace,
+    transaction,
+    paginationParams,
+  }: {
+    workspace: LightWorkspaceType;
+    transaction?: Transaction;
+    paginationParams?: PaginationParams;
+  }): Promise<MembershipsWithTotal> {
+    const orderedResourcesFromModels = (resources: MembershipModel[]) =>
+      resources
+        .sort((a, b) => a.startAt.getTime() - b.startAt.getTime())
+        .map(
+          (resource) => new MembershipResource(MembershipModel, resource.get())
+        );
+
+    const whereClause: WhereOptions<InferAttributes<MembershipModel>> = {
+      workspaceId: workspace.id,
+    };
+
+    const findOptions: FindOptions<InferAttributes<MembershipModel>> = {
+      where: { workspaceId: workspace.id },
+      transaction,
+    };
+
+    if (paginationParams) {
+      const { limit, orderColumn, orderDirection, lastValue } =
+        paginationParams;
+
+      if (lastValue) {
+        const op = orderDirection === "desc" ? Op.lt : Op.gt;
+        whereClause[orderColumn as any] = { [op]: lastValue };
+      }
+
+      findOptions.order = [
+        [orderColumn, orderDirection === "desc" ? "DESC" : "ASC"],
+      ];
+      findOptions.limit = limit;
+    }
+
+    const { rows, count } = await MembershipModel.findAndCountAll(findOptions);
+
+    return { memberships: orderedResourcesFromModels(rows), total: count };
+  }
+
   static async getActiveMemberships({
     users,
     workspace,

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -309,6 +309,16 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     });
   }
 
+  static async deleteAllForWorkspace(
+    workspace: LightWorkspaceType,
+    transaction?: Transaction
+  ) {
+    return this.model.destroy({
+      where: { workspaceId: workspace.id },
+      transaction,
+    });
+  }
+
   /**
    * Caller of this method should call `ServerSideTracking.trackCreateMembership`.
    */

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -75,7 +75,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     };
 
     const findOptions: FindOptions<InferAttributes<MembershipModel>> = {
-      where: { workspaceId: workspace.id },
+      where: whereClause,
       transaction,
     };
 

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -517,10 +517,9 @@ export async function deleteMembersActivity({
       transaction: t,
     });
 
-    const { memberships } = await MembershipResource.getLatestMemberships({
-      workspace,
-      transaction: t,
-    });
+    const { memberships } = await MembershipResource.getMembershipsForWorkspace(
+      { workspace, transaction: t }
+    );
 
     for (const membership of memberships) {
       const user = await UserResource.fetchByModelId(membership.userId, t);

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -599,7 +599,6 @@ export async function deleteWorkspaceActivity({
     });
     await FileResource.deleteAllForWorkspace(workspace, t);
     await RunResource.deleteAllForWorkspace(workspace, t);
-    await MembershipResource.deleteAllForWorkspace(workspace, t);
     await AgentUserRelation.destroy({
       where: { workspaceId: workspace.id },
       transaction: t,

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -600,6 +600,7 @@ export async function deleteWorkspaceActivity({
     });
     await FileResource.deleteAllForWorkspace(workspace, t);
     await RunResource.deleteAllForWorkspace(workspace, t);
+    await MembershipResource.deleteAllForWorkspace(workspace, t);
     await AgentUserRelation.destroy({
       where: { workspaceId: workspace.id },
       transaction: t,


### PR DESCRIPTION
## Description

- Fix [FK errors](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Afront-worker&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=6000198897476506285&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1733819687993&to_ts=1733834087993&live=true) occurring in poke `deleteWorkspaceWorkflow` (`ForeignKeyConstraintError: update or delete on table "workspaces" violates foreign key constraint "memberships_workspaceId_fkey" on table "memberships"`).
- This PR adds an explicit deletion of every Membership for a workspace when deleting its members.

## Risk

- Part of an admin action.
- Relative to the deletion of data.

## Deploy Plan

- Deploy front
