### PR TITLE
chore(front) - bump sparkles version

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.336",
+        "@dust-tt/sparkle": "0.2.338",
         "@dust-tt/types": "file:../types",
         "@headlessui/react": "^1.7.7",
         "@heroicons/react": "^2.0.11",
@@ -11450,9 +11450,10 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.336",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.336.tgz",
-      "integrity": "sha512-5Un1MxSPPHwvqfaA1w9j8s0tuqOF42LNUAbfNHc+e6xc0Fk/xM2fnPpWAGYE897hZtXmCUs6kUXUNsae5E+0WA==",
+      "version": "0.2.338",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.338.tgz",
+      "integrity": "sha512-1GvC8PPf5EYMqAwkudsHfXUXy01/jhQGYNE67e+ex+X+jhy6ZHb2iABJ59pMwYAsS3i6RCiBjQG9nRy3VCj9pg==",
+      "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.336",
+    "@dust-tt/sparkle": "0.2.338",
     "@dust-tt/types": "file:../types",
     "@headlessui/react": "^1.7.7",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description

- Bump sparkles version to get changes from [#9247](https://github.com/dust-tt/dust/pull/9247).
- Fixes https://github.com/dust-tt/tasks/issues/1773
- In this PR I use exact versions of sparkles rather than ^ as it's more practical for developing, wdyt @JulesBelveze?

Before:
![Image](https://github.com/user-attachments/assets/543d47a6-e249-402e-b501-5d59be52ad01)

After:
<img width="970" alt="Screenshot 2024-12-10 at 1 21 11 PM" src="https://github.com/user-attachments/assets/b21ad8d3-cd7d-4c80-90da-cc8654d5cd19">

## Risk

- Risk of breaking the tooltips or having some unwanted results in the UI.

## Deploy Plan

- Deploy front
