### PR TITLE
connector: slack send self as first parent

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -588,7 +588,7 @@ export async function syncNonThreaded(
     documentUrl: sourceUrl,
     timestampMs: updatedAt,
     tags,
-    parents: [channelId],
+    parents: [documentId, channelId],
     upsertContext: {
       sync_type: isBatchSync ? "batch" : "incremental",
     },
@@ -782,7 +782,7 @@ export async function syncThread(
     documentUrl: sourceUrl,
     timestampMs: updatedAt,
     tags,
-    parents: [channelId],
+    parents: [documentId, channelId],
     upsertContext: {
       sync_type: isBatchSync ? "batch" : "incremental",
     },


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/dust/issues/9069

- Start sending self (documentId) as first parent of slack documents

## Risk

Low: no impact on content-nodes API nor retrieval (these additional parents are never used)

## Deploy Plan

- deploy `connectors`