### PR TITLE
fix(poke)- add a hard delete on memberships to fix stuck workflows

### DIFF
--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -309,6 +309,16 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     });
   }
 
+  static async deleteAllForWorkspace(
+    workspace: LightWorkspaceType,
+    transaction?: Transaction
+  ) {
+    return this.model.destroy({
+      where: { workspaceId: workspace.id },
+      transaction,
+    });
+  }
+
   /**
    * Caller of this method should call `ServerSideTracking.trackCreateMembership`.
    */

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -606,6 +606,7 @@ export async function deleteWorkspaceActivity({
     });
     await FileResource.deleteAllForWorkspace(workspace, t);
     await RunResource.deleteAllForWorkspace(workspace, t);
+    await MembershipResource.deleteAllForWorkspace(workspace, t);
     await AgentUserRelation.destroy({
       where: { workspaceId: workspace.id },
       transaction: t,


### PR DESCRIPTION
## Description

- We got scrub workflows stuck when retrying the workspace deletion activity: [https://app.datadoghq.eu/logs?query=%40attempt%3A%3E14%20%40dd.service%3Afront-worker[…]z=stream&from_ts=1733854096428&to_ts=1733857696428&live=true](https://app.datadoghq.eu/logs?query=%40attempt%3A%3E14%20%40dd.service%3Afront-worker%20%40workflowName%3AdeleteWorkspaceWorkflow%20%40workflowId%3Apoke-d6b0549a94-%2A&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=6000198897476506285&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1733854096428&to_ts=1733857696428&live=true)
- More context in: https://dust4ai.slack.com/archives/C05F84CFP0E/p1733824748398979
- This PR updates the activity to unblock the workflows, this membership deletion should be handled in the activity `deleteMembersActivity` (which isn't the one being retried).

## Risk

- Should be reverted to test the actual workflow.

## Deploy Plan

- Deploy front.
