### PR TITLE
[poke] fix: prevent FK error when deleting workspace

### DIFF
--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -32,6 +32,7 @@ import {
   AgentUserRelation,
   GlobalAgentSettings,
 } from "@app/lib/models/assistant/agent";
+import { AgentMessageContent } from "@app/lib/models/assistant/agent_message_content";
 import {
   AgentMessage,
   AgentMessageFeedback,
@@ -43,7 +44,11 @@ import {
   UserMessage,
 } from "@app/lib/models/assistant/conversation";
 import { Subscription } from "@app/lib/models/plan";
-import { MembershipInvitation, Workspace } from "@app/lib/models/workspace";
+import {
+  MembershipInvitation,
+  Workspace,
+  WorkspaceHasDomain,
+} from "@app/lib/models/workspace";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
@@ -63,7 +68,6 @@ import { UserMetadataModel } from "@app/lib/resources/storage/models/user";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
-import { AgentMessageContent } from "@app/lib/models/assistant/agent_message_content";
 
 const hardDeleteLogger = logger.child({ activity: "hard-delete" });
 
@@ -606,6 +610,10 @@ export async function deleteWorkspaceActivity({
     await FileResource.deleteAllForWorkspace(workspace, t);
     await RunResource.deleteAllForWorkspace(workspace, t);
     await MembershipResource.deleteAllForWorkspace(workspace, t);
+    await WorkspaceHasDomain.destroy({
+      where: { workspaceId: workspace.id },
+      transaction: t,
+    });
     await AgentUserRelation.destroy({
       where: { workspaceId: workspace.id },
       transaction: t,


### PR DESCRIPTION
## Description

- Similarly to https://github.com/dust-tt/dust/pull/9248, we get a FK error when deleting a workspace.
- This PR adds an explicit delete on the table `workspace_has_domains` `[ForeignKeyConstraintError: update or delete on table "workspaces" violates foreign key constraint "workspace_has_domains_workspaceId_fkey" on table "workspace_has_domains"](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Afront-worker&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZOyEPzqGIRW-AAAABhBWk95RVFlNEFBQjkxLVl2blRZTDVnQUsAAAAkMDE5M2IyMTEtMGQ0Ny00ZWQ4LTg2OWQtY2M2ODQyOTEzZjA0AAAOyg&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=6000198897476506285&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1731920961786&to_ts=1732525761786&live=true)`

## Risk

## Deploy Plan

- Deploy front.