### PR TITLE
[Microsoft] Triple garbage collection speed

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -925,7 +925,7 @@ export async function microsoftGarbageCollectionActivity({
 
   const nodes = await MicrosoftNodeResource.fetchByPaginatedIds({
     connectorId,
-    pageSize: 300,
+    pageSize: 500,
     idCursor,
   });
 

--- a/connectors/src/connectors/microsoft/temporal/workflows.ts
+++ b/connectors/src/connectors/microsoft/temporal/workflows.ts
@@ -197,7 +197,7 @@ export async function microsoftGarbageCollectionWorkflow({
       rootNodeIds,
       startGarbageCollectionTs,
     });
-    await sleep("1 minute");
+    await sleep("30 seconds");
   }
 }
 


### PR DESCRIPTION
Description
---
Garbage collection for microsoft is throttled to avoid hammering the DB.

However, the throttling is a bit too aggressive, the PR increases the GC rate.

Baseline: to scale properly, GC should go through ~1M documents in a day, close to 1000 / minute.

Risks
---
na

Deploy
---
connectors
