### PR TITLE
Fix: slack message filesize

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -801,13 +801,16 @@ async function makeContentFragment(
   const contentType = "text/vnd.dust.attachment.slack.thread";
   const fileName = `slack_thread-${channel.channel.name}-${threadTs}.txt`;
 
+  const blob = new Blob([section]);
+  const fileSize = blob.size;
+
   const fileRes = await dustAPI.uploadFile({
     contentType,
     fileName,
-    fileSize: section.length,
+    fileSize: fileSize,
     useCase: "conversation",
     useCaseMetadata: conversationId ? { conversationId } : undefined,
-    fileObject: new File([section], fileName, { type: contentType }),
+    fileObject: new File([blob], fileName, { type: contentType }),
   });
 
   if (fileRes.isErr()) {

--- a/front/lib/api/files/utils.ts
+++ b/front/lib/api/files/utils.ts
@@ -63,7 +63,8 @@ export const parseUploadRequest = async (
         return new Err({
           name: "dust_error",
           code: "file_too_large",
-          message: "File is too large.",
+          message:
+            "File is too large or the size passed to the File instance in the DB does not match the size of the uploaded file.",
         });
       }
       // entire message: options.allowEmptyFiles is false, file size should be greater than 0


### PR DESCRIPTION
## Description

Calculate the filesize from the blob size, not just by counting characters.
Improve error message to help future debugging.

## Risk

Low

## Deploy Plan

Deploy `front`, Deploy `connectors`