### PR TITLE
[extension]  Logout when invalid refresh token, handle concurrent refresh requests

### DIFF
--- a/extension/app/src/hooks/useAuthErrorCheck.ts
+++ b/extension/app/src/hooks/useAuthErrorCheck.ts
@@ -1,11 +1,9 @@
 import { useAuth } from "@extension/components/auth/AuthProvider";
 import { logout, refreshToken } from "@extension/lib/auth";
 import { useEffect } from "react";
-import { useNavigate } from "react-router-dom";
 
 export const useAuthErrorCheck = (error: any, mutate: () => any) => {
-  const { setAuthError, handleLogout } = useAuth();
-  const navigate = useNavigate();
+  const { setAuthError } = useAuth();
   useEffect(() => {
     const handleError = async () => {
       if (error) {
@@ -20,8 +18,7 @@ export const useAuthErrorCheck = (error: any, mutate: () => any) => {
             if (res.isOk()) {
               mutate();
             } else {
-              handleLogout();
-              navigate("/login");
+              void logout();
             }
             break;
           case "user_not_found":

--- a/extension/app/src/hooks/useAuthErrorCheck.ts
+++ b/extension/app/src/hooks/useAuthErrorCheck.ts
@@ -1,9 +1,11 @@
 import { useAuth } from "@extension/components/auth/AuthProvider";
 import { logout, refreshToken } from "@extension/lib/auth";
 import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 
 export const useAuthErrorCheck = (error: any, mutate: () => any) => {
-  const { setAuthError } = useAuth();
+  const { setAuthError, handleLogout } = useAuth();
+  const navigate = useNavigate();
   useEffect(() => {
     const handleError = async () => {
       if (error) {
@@ -14,8 +16,13 @@ export const useAuthErrorCheck = (error: any, mutate: () => any) => {
             void logout();
             break;
           case "expired_oauth_token_error":
-            await refreshToken();
-            mutate();
+            const res = await refreshToken();
+            if (res.isOk()) {
+              mutate();
+            } else {
+              handleLogout();
+              navigate("/login");
+            }
             break;
           case "user_not_found":
             setAuthError(error);

--- a/extension/app/src/lib/auth.ts
+++ b/extension/app/src/lib/auth.ts
@@ -79,11 +79,11 @@ export const logout = async (): Promise<boolean> => {
 // Refresh token sends a message to the background script to call the auth0 refresh token endpoint.
 // It updates the stored tokens with the new access token.
 // If the refresh token is invalid, it will call handleLogout.
-export const refreshToken = async (): Promise<
-  Result<StoredTokens, AuthError>
-> => {
+export const refreshToken = async (
+  tokens?: StoredTokens | null
+): Promise<Result<StoredTokens, AuthError>> => {
   try {
-    const tokens = await getStoredTokens();
+    tokens = tokens ?? (await getStoredTokens());
     if (!tokens) {
       return new Err(new AuthError("not_authenticated", "No tokens found."));
     }
@@ -103,7 +103,7 @@ export const refreshToken = async (): Promise<
 export const getAccessToken = async (): Promise<string | null> => {
   let tokens = await getStoredTokens();
   if (!tokens || !tokens.accessToken || tokens.expiresAt < Date.now()) {
-    const refreshRes = await refreshToken();
+    const refreshRes = await refreshToken(tokens);
     if (refreshRes.isOk()) {
       tokens = refreshRes.value;
     }


### PR DESCRIPTION
## Description

- Logout when invalid refresh token : useAuthErrorCheck to check the result of refresh token and not call mutate (refresh) inconditionnaly
- Better handling of refresh requests : send only one refresh, replies to all waiting requesters
- 
## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

publish extension