### PR TITLE
enh(zendesk-cli) - allow passing a custom query to `count-tickets`

### DIFF
--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -73,6 +73,7 @@ export const zendesk = async ({
         brandSubdomain,
         accessToken,
         retentionPeriodDays,
+        query: args.query || null,
       });
       logger.info(
         { connectorId, brandId, ticketCount, retentionPeriodDays },

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -388,9 +388,10 @@ export async function fetchZendeskTicketCount({
 }: {
   brandSubdomain: string;
   accessToken: string;
-  retentionPeriodDays: number;
-  query?: string | null;
-}): Promise<number> {
+} & (
+  | { retentionPeriodDays?: number; query: string }
+  | { retentionPeriodDays: number; query?: null }
+)): Promise<number> {
   query ||= `type:ticket status:solved updated>${retentionPeriodDays}days`;
   const url = `https://${brandSubdomain}.zendesk.com/api/v2/search/count?query=${encodeURIComponent(query)}`;
   const response = await fetchFromZendeskWithRetries({ url, accessToken });

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -384,15 +384,17 @@ export async function fetchZendeskTicketCount({
   accessToken,
   brandSubdomain,
   retentionPeriodDays,
+  query = null,
 }: {
   brandSubdomain: string;
   accessToken: string;
   retentionPeriodDays: number;
+  query?: string | null;
 }): Promise<number> {
-  const query = `type:ticket status:solved updated>${retentionPeriodDays}days`;
+  query ||= `type:ticket status:solved updated>${retentionPeriodDays}days`;
   const url = `https://${brandSubdomain}.zendesk.com/api/v2/search/count?query=${encodeURIComponent(query)}`;
   const response = await fetchFromZendeskWithRetries({ url, accessToken });
-  return Number(response.count);
+  return parseInt(response.count, 10);
 }
 
 /**

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -223,6 +223,7 @@ export const ZendeskCommandSchema = t.type({
   args: t.type({
     connectorId: t.union([t.number, t.undefined]),
     brandId: t.union([t.number, t.undefined]),
+    query: t.union([t.string, t.undefined]),
   }),
 });
 export type ZendeskCommandType = t.TypeOf<typeof ZendeskCommandSchema>;


### PR DESCRIPTION
## Description

- This PR adds the possibility to customize the query used when counting the tickets in the admin CLI.

## Risk

- Very low, only affects the admin cli.

## Deploy Plan

- Deploy connectors.