### PR TITLE
slack: double channelId parents with prefixes

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -588,7 +588,7 @@ export async function syncNonThreaded(
     documentUrl: sourceUrl,
     timestampMs: updatedAt,
     tags,
-    parents: [documentId, channelId],
+    parents: [documentId, channelId, `slack-channel-${channelId}`],
     upsertContext: {
       sync_type: isBatchSync ? "batch" : "incremental",
     },
@@ -782,7 +782,7 @@ export async function syncThread(
     documentUrl: sourceUrl,
     timestampMs: updatedAt,
     tags,
-    parents: [documentId, channelId],
+    parents: [documentId, channelId, `slack-channel-${channelId}`],
     upsertContext: {
       sync_type: isBatchSync ? "batch" : "incremental",
     },


### PR DESCRIPTION
## Description

For: #9069 

Start writing both channelId and `slack-channel-${channelId}` in parents in order to migrate to using only the later.

Next steps:
- Migrate parents to have both everywhere
- Update content-nodes API to return the prefixed version
- Migrate assistants to use the prefixed version
- Stop double sending
- Migrate to remove raw channelIds everywhere

## Risk

Low

## Deploy Plan

- deploy `connectors`