### PR TITLE
[KW-search] Indices on parents array

### DIFF
--- a/core/src/stores/migrations/202412011_indices_parents.sql
+++ b/core/src/stores/migrations/202412011_indices_parents.sql
@@ -1,2 +1,0 @@
-CREATE INDEX CONCURRENTLY idx_parents_second ON data_sources_nodes (data_source, (parents[2]));
-CREATE INDEX CONCURRENTLY idx_parents_single ON data_sources_nodes (data_source, (array_length(parents, 1) = 1));

--- a/core/src/stores/migrations/202412011_indices_parents.sql
+++ b/core/src/stores/migrations/202412011_indices_parents.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY idx_parents_second ON data_sources_nodes (data_source, (parents[2]));
+CREATE INDEX CONCURRENTLY idx_parents_single ON data_sources_nodes (data_source, (array_length(parents, 1) = 1));

--- a/core/src/stores/migrations/20241211_indices_parents.sql
+++ b/core/src/stores/migrations/20241211_indices_parents.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY idx_data_sources_nodes_parents_second ON data_sources_nodes (data_source, (parents[2]));
+CREATE INDEX CONCURRENTLY idx_data_sources_nodes_parents_single ON data_sources_nodes (data_source, (array_length(parents, 1) = 1));

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -602,7 +602,7 @@ pub const POSTGRES_TABLES: [&'static str; 16] = [
     );",
 ];
 
-pub const SQL_INDEXES: [&'static str; 33] = [
+pub const SQL_INDEXES: [&'static str; 35] = [
     "CREATE INDEX IF NOT EXISTS
        idx_specifications_project_created ON specifications (project, created);",
     "CREATE INDEX IF NOT EXISTS
@@ -675,6 +675,10 @@ pub const SQL_INDEXES: [&'static str; 33] = [
         idx_data_sources_nodes_table ON data_sources_nodes(\"table\");",
     "CREATE INDEX IF NOT EXISTS
         idx_data_sources_nodes_folder ON data_sources_nodes(folder);",
+    "CREATE INDEX IF NOT EXISTS
+        idx_parents_second ON data_sources_nodes (data_source, (parents[2]));",
+    "CREATE INDEX IF NOT EXISTS
+        idx_parents_single ON data_sources_nodes (data_source, (array_length(parents, 1) = 1));",
 ];
 
 pub const SQL_FUNCTIONS: [&'static str; 2] = [

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -676,9 +676,9 @@ pub const SQL_INDEXES: [&'static str; 35] = [
     "CREATE INDEX IF NOT EXISTS
         idx_data_sources_nodes_folder ON data_sources_nodes(folder);",
     "CREATE INDEX IF NOT EXISTS
-        idx_parents_second ON data_sources_nodes (data_source, (parents[2]));",
+        idx_data_sources_nodes_parents_second ON data_sources_nodes (data_source, (parents[2]));",
     "CREATE INDEX IF NOT EXISTS
-        idx_parents_single ON data_sources_nodes (data_source, (array_length(parents, 1) = 1));",
+        idx_data_sources_nodes_parents_single ON data_sources_nodes (data_source, (array_length(parents, 1) = 1));",
 ];
 
 pub const SQL_FUNCTIONS: [&'static str; 2] = [


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/dust/issues/9251

The PR will be updated with explain analyze queries to show the indices perform as expected. If they do not, they will be rolled back.

Related important context: https://dust4ai.slack.com/archives/C050SM8NSPK/p1733837120557819

Risks
---
Creating indices could slow down production. Mitigated by 1. running at low peak (lunch or evening) 2. using [CONCURRENTLY](https://dust.tt/w/0ec9852c2f/assistant/59NYjdiRr3):

CREATE INDEX CONCURRENTLY is designed to be low-impact:
- Doesn't block writes/reads on the table
- Takes ~2-3x longer than regular CREATE INDEX
- Can be cancelled safely with pg_cancel_backend() or pg_terminate_backend()

Main impact is on disk I/O and some CPU

Two caveats:
- Requires ~2x disk space during creation
- Can't run inside a transaction block

Deploy
---
- run index creation on prodbox
- post explain analyze queries here
- either rollback, or deploy core

