### PR TITLE
[.github] - refacto: specify deploy region 

### DIFF
--- a/.github/workflows/deploy-alerting-temporal.yml
+++ b/.github/workflows/deploy-alerting-temporal.yml
@@ -44,7 +44,8 @@ jobs:
             --image-name=alerting-temporal \
             --dockerfile-path=./Dockerfile \
             --working-dir=./alerting/temporal/ \
-            --dust-client-facing-url=https://dust.tt
+            --dust-client-facing-url=https://dust.tt \ 
+            --region=us-central1
 
       - name: Generate a token
         id: generate-token

--- a/.github/workflows/deploy-connectors.yml
+++ b/.github/workflows/deploy-connectors.yml
@@ -67,7 +67,8 @@ jobs:
             --image-name=connectors \
             --dockerfile-path=./connectors/Dockerfile \
             --working-dir=./ \
-            --dust-client-facing-url=https://dust.tt
+            --dust-client-facing-url=https://dust.tt \ 
+            --region=us-central1
 
       - name: Generate a token
         id: generate-token

--- a/.github/workflows/deploy-core.yml
+++ b/.github/workflows/deploy-core.yml
@@ -67,7 +67,8 @@ jobs:
             --image-name=core \
             --dockerfile-path=./Dockerfile \
             --working-dir=./core/ \
-            --dust-client-facing-url=https://dust.tt
+            --dust-client-facing-url=https://dust.tt \ 
+            --region=us-central1
 
       - name: Generate a token
         id: generate-token

--- a/.github/workflows/deploy-dante.yml
+++ b/.github/workflows/deploy-dante.yml
@@ -54,7 +54,8 @@ jobs:
             --dockerfile-path=./dante.Dockerfile \
             --working-dir=./ \
             --gcloud-ignore-file=../.gcloudignore-dante \
-            --dust-client-facing-url=https://dust.tt
+            --dust-client-facing-url=https://dust.tt \ 
+            --region=us-central1
           cd ..
 
       - name: Generate a token

--- a/.github/workflows/deploy-front-edge.yml
+++ b/.github/workflows/deploy-front-edge.yml
@@ -3,15 +3,6 @@ name: Deploy Front Edge
 on:
   workflow_dispatch:
     inputs:
-      regions:
-        description: "Regions to deploy to"
-        required: true
-        default: "us-central1"
-        type: choice
-        options:
-          - "us-central1"
-          - "europe-west1"
-          - "us-central1,europe-west1"
       check_deployment_blocked:
         description: "Check #deployment locks or force deploy"
         required: true
@@ -30,12 +21,13 @@ env:
   IMAGE_NAME: front-edge
 
 jobs:
-  notify-start:
+  build-and-deploy:
     runs-on: ubuntu-latest
-    outputs:
-      thread_ts: ${{ steps.build_message.outputs.thread_ts }}
+
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v3
+
       - name: Get short sha
         id: short_sha
         run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
@@ -59,42 +51,20 @@ jobs:
           channel: ${{ secrets.SLACK_CHANNEL_ID }}
           slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
 
-  build:
-    needs: notify-start
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        region: ${{ fromJson(format('[{0}]', join(split(github.event.inputs.regions, ','), ','))) }}
-      fail-fast: true
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Get short sha
-        id: short_sha
-        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: "Authenticate with Google Cloud"
         uses: "google-github-actions/auth@v1"
         with:
           credentials_json: "${{ secrets.GCLOUD_SA_KEY }}"
 
-      - name: Build image for ${{ matrix.region }}
+      - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
           ./k8s/cloud-build.sh \
             --image-name=$IMAGE_NAME \
             --dockerfile-path=./front/Dockerfile \
             --working-dir=./ \
-            --dust-client-facing-url=https://front-edge.dust.tt \
-            --region=${{ matrix.region }}
+            --dust-client-facing-url=https://front-edge.dust.tt
 
-  deploy:
-    needs: [notify-start, build]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Get short sha
-        id: short_sha
-        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Generate a token
         id: generate-token
         uses: actions/create-github-app-token@v1
@@ -104,6 +74,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: |
             dust-infra
+
       - name: Trigger dust-infra workflow
         uses: actions/github-script@v6
         with:
@@ -114,20 +85,22 @@ jobs:
               repo: 'dust-infra',
               event_type: 'trigger-component-deploy',
               client_payload: {
-                regions: '${{ github.event.inputs.regions }}',
+                regions: 'us-central1',
                 component: 'front-edge',
                 image_tag: '${{ steps.short_sha.outputs.short_sha }}',
-                slack_thread_ts: "${{ needs.notify-start.outputs.thread_ts }}",
+                slack_thread_ts: "${{ steps.build_message.outputs.thread_ts }}",
                 slack_channel: '${{ secrets.SLACK_CHANNEL_ID }}'
               }
             });
+
       - name: Notify Failure
         if: failure()
         uses: ./.github/actions/slack-notify
         with:
           step: "failure"
+          blocked: ${{ steps.check_deployment_blocked.outputs.blocked }}
           component: "front-edge"
           image_tag: ${{ steps.short_sha.outputs.short_sha }}
           channel: ${{ secrets.SLACK_CHANNEL_ID }}
           slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
-          thread_ts: "${{ needs.notify-start.outputs.thread_ts }}"
+          thread_ts: "${{ steps.build_message.outputs.thread_ts }}"

--- a/.github/workflows/deploy-front-edge.yml
+++ b/.github/workflows/deploy-front-edge.yml
@@ -3,6 +3,15 @@ name: Deploy Front Edge
 on:
   workflow_dispatch:
     inputs:
+      regions:
+        description: "Regions to deploy to"
+        required: true
+        default: "us-central1"
+        type: choice
+        options:
+          - "us-central1"
+          - "europe-west1"
+          - "us-central1,europe-west1"
       check_deployment_blocked:
         description: "Check #deployment locks or force deploy"
         required: true
@@ -21,13 +30,12 @@ env:
   IMAGE_NAME: front-edge
 
 jobs:
-  build-and-deploy:
+  notify-start:
     runs-on: ubuntu-latest
-
+    outputs:
+      thread_ts: ${{ steps.build_message.outputs.thread_ts }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
+      - uses: actions/checkout@v3
       - name: Get short sha
         id: short_sha
         run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
@@ -51,12 +59,25 @@ jobs:
           channel: ${{ secrets.SLACK_CHANNEL_ID }}
           slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
 
+  build:
+    needs: notify-start
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        region: ${{ fromJson(format('[{0}]', join(split(github.event.inputs.regions, ','), ','))) }}
+      fail-fast: true
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get short sha
+        id: short_sha
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: "Authenticate with Google Cloud"
         uses: "google-github-actions/auth@v1"
         with:
           credentials_json: "${{ secrets.GCLOUD_SA_KEY }}"
 
-      - name: Build the image on Cloud Build
+      - name: Build image for ${{ matrix.region }}
         run: |
           chmod +x ./k8s/cloud-build.sh
           ./k8s/cloud-build.sh \
@@ -64,8 +85,16 @@ jobs:
             --dockerfile-path=./front/Dockerfile \
             --working-dir=./ \
             --dust-client-facing-url=https://front-edge.dust.tt \
-            --region=us-central1
+            --region=${{ matrix.region }}
 
+  deploy:
+    needs: [notify-start, build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get short sha
+        id: short_sha
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Generate a token
         id: generate-token
         uses: actions/create-github-app-token@v1
@@ -86,10 +115,10 @@ jobs:
               repo: 'dust-infra',
               event_type: 'trigger-component-deploy',
               client_payload: {
-                regions: 'us-central1',
+                regions: '${{ github.event.inputs.regions }}',
                 component: 'front-edge',
                 image_tag: '${{ steps.short_sha.outputs.short_sha }}',
-                slack_thread_ts: "${{ steps.build_message.outputs.thread_ts }}",
+                slack_thread_ts: "${{ needs.notify-start.outputs.thread_ts }}",
                 slack_channel: '${{ secrets.SLACK_CHANNEL_ID }}'
               }
             });
@@ -104,4 +133,4 @@ jobs:
           image_tag: ${{ steps.short_sha.outputs.short_sha }}
           channel: ${{ secrets.SLACK_CHANNEL_ID }}
           slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
-          thread_ts: "${{ steps.build_message.outputs.thread_ts }}"
+          thread_ts: "${{ needs.notify-start.outputs.thread_ts }}"

--- a/.github/workflows/deploy-front-edge.yml
+++ b/.github/workflows/deploy-front-edge.yml
@@ -63,7 +63,8 @@ jobs:
             --image-name=$IMAGE_NAME \
             --dockerfile-path=./front/Dockerfile \
             --working-dir=./ \
-            --dust-client-facing-url=https://front-edge.dust.tt
+            --dust-client-facing-url=https://front-edge.dust.tt \
+            --region=us-central1
 
       - name: Generate a token
         id: generate-token

--- a/.github/workflows/deploy-front-edge.yml
+++ b/.github/workflows/deploy-front-edge.yml
@@ -3,6 +3,15 @@ name: Deploy Front Edge
 on:
   workflow_dispatch:
     inputs:
+      regions:
+        description: "Regions to deploy to"
+        required: true
+        default: "us-central1"
+        type: choice
+        options:
+          - "us-central1"
+          - "europe-west1"
+          - "us-central1,europe-west1"
       check_deployment_blocked:
         description: "Check #deployment locks or force deploy"
         required: true
@@ -21,13 +30,12 @@ env:
   IMAGE_NAME: front-edge
 
 jobs:
-  build-and-deploy:
+  notify-start:
     runs-on: ubuntu-latest
-
+    outputs:
+      thread_ts: ${{ steps.build_message.outputs.thread_ts }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
+      - uses: actions/checkout@v3
       - name: Get short sha
         id: short_sha
         run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
@@ -51,20 +59,42 @@ jobs:
           channel: ${{ secrets.SLACK_CHANNEL_ID }}
           slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
 
+  build:
+    needs: notify-start
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        region: ${{ fromJson(format('[{0}]', join(split(github.event.inputs.regions, ','), ','))) }}
+      fail-fast: true
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get short sha
+        id: short_sha
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: "Authenticate with Google Cloud"
         uses: "google-github-actions/auth@v1"
         with:
           credentials_json: "${{ secrets.GCLOUD_SA_KEY }}"
 
-      - name: Build the image on Cloud Build
+      - name: Build image for ${{ matrix.region }}
         run: |
           chmod +x ./k8s/cloud-build.sh
           ./k8s/cloud-build.sh \
             --image-name=$IMAGE_NAME \
             --dockerfile-path=./front/Dockerfile \
             --working-dir=./ \
-            --dust-client-facing-url=https://front-edge.dust.tt
+            --dust-client-facing-url=https://front-edge.dust.tt \
+            --region=${{ matrix.region }}
 
+  deploy:
+    needs: [notify-start, build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get short sha
+        id: short_sha
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Generate a token
         id: generate-token
         uses: actions/create-github-app-token@v1
@@ -74,7 +104,6 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: |
             dust-infra
-
       - name: Trigger dust-infra workflow
         uses: actions/github-script@v6
         with:
@@ -85,22 +114,20 @@ jobs:
               repo: 'dust-infra',
               event_type: 'trigger-component-deploy',
               client_payload: {
-                regions: 'us-central1',
+                regions: '${{ github.event.inputs.regions }}',
                 component: 'front-edge',
                 image_tag: '${{ steps.short_sha.outputs.short_sha }}',
-                slack_thread_ts: "${{ steps.build_message.outputs.thread_ts }}",
+                slack_thread_ts: "${{ needs.notify-start.outputs.thread_ts }}",
                 slack_channel: '${{ secrets.SLACK_CHANNEL_ID }}'
               }
             });
-
       - name: Notify Failure
         if: failure()
         uses: ./.github/actions/slack-notify
         with:
           step: "failure"
-          blocked: ${{ steps.check_deployment_blocked.outputs.blocked }}
           component: "front-edge"
           image_tag: ${{ steps.short_sha.outputs.short_sha }}
           channel: ${{ secrets.SLACK_CHANNEL_ID }}
           slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
-          thread_ts: "${{ steps.build_message.outputs.thread_ts }}"
+          thread_ts: "${{ needs.notify-start.outputs.thread_ts }}"

--- a/.github/workflows/deploy-front-qa.yml
+++ b/.github/workflows/deploy-front-qa.yml
@@ -45,7 +45,8 @@ jobs:
             --image-name=front-qa \
             --dockerfile-path=./front/Dockerfile \
             --working-dir=./ \
-            --dust-client-facing-url=https://front-qa.dust.tt
+            --dust-client-facing-url=https://front-qa.dust.tt \ 
+            --region=us-central1
 
       - name: Generate a token
         id: generate-token

--- a/.github/workflows/deploy-front.yml
+++ b/.github/workflows/deploy-front.yml
@@ -64,7 +64,8 @@ jobs:
             --image-name=front \
             --dockerfile-path=./front/Dockerfile \
             --working-dir=./ \
-            --dust-client-facing-url=https://dust.tt
+            --dust-client-facing-url=https://dust.tt \ 
+            --region=us-central1
 
       - name: Generate a token
         id: generate-token

--- a/.github/workflows/deploy-nginx.yml
+++ b/.github/workflows/deploy-nginx.yml
@@ -51,7 +51,8 @@ jobs:
             --dockerfile-path=./nginx.Dockerfile \
             --working-dir=./ \
             --gcloud-ignore-file=../.gcloudignore-nginx \
-            --dust-client-facing-url=https://dust.tt
+            --dust-client-facing-url=https://dust.tt \ 
+            --region=us-central1
           cd ..
 
       - name: Generate a token

--- a/.github/workflows/deploy-oauth.yml
+++ b/.github/workflows/deploy-oauth.yml
@@ -64,7 +64,8 @@ jobs:
             --image-name=oauth \
             --dockerfile-path=./oauth.Dockerfile \
             --working-dir=./core/ \
-            --dust-client-facing-url=https://dust.tt
+            --dust-client-facing-url=https://dust.tt \ 
+            --region=us-central1
 
       - name: Generate a token
         id: generate-token

--- a/.github/workflows/deploy-prodbox.yml
+++ b/.github/workflows/deploy-prodbox.yml
@@ -3,15 +3,6 @@ name: Deploy Prodbox
 on:
   workflow_dispatch:
     inputs:
-      regions:
-        description: "Regions to deploy to"
-        required: true
-        default: "us-central1"
-        type: choice
-        options:
-          - "us-central1"
-          - "europe-west1"
-          - "us-central1,europe-west1"
       check_deployment_blocked:
         description: "Check #deployment locks or force deploy"
         required: true
@@ -29,24 +20,15 @@ env:
   GCLOUD_PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
 
 jobs:
-  notify-start:
+  build-and-deploy:
     runs-on: ubuntu-latest
-    outputs:
-      thread_ts: ${{ steps.build_message.outputs.thread_ts }}
+
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ssh-key: "${{ secrets.PRODBOX_PRIVATE_DEPLOY_KEY }}"
-
-      - name: Set regions
-        id: set-regions
-        run: |
-          if [ "${{ github.event.inputs.regions }}" = "all" ]; then
-            echo "regions=[\"us-central1\",\"europe-west1\"]" >> $GITHUB_OUTPUT
-          else
-            echo "regions=[\"${{ github.event.inputs.regions }}\"]" >> $GITHUB_OUTPUT
-          fi
 
       - name: Get short sha
         id: short_sha
@@ -71,24 +53,6 @@ jobs:
           channel: ${{ secrets.SLACK_CHANNEL_ID }}
           slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
 
-  build:
-    needs: notify-start
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        region: ${{ fromJson(format('[{0}]', join(split(github.event.inputs.regions, ','), ','))) }}
-      fail-fast: true
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          ssh-key: "${{ secrets.PRODBOX_PRIVATE_DEPLOY_KEY }}"
-
-      - name: Get short sha
-        id: short_sha
-        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-
       - name: "Authenticate with Google Cloud"
         uses: "google-github-actions/auth@v1"
         with:
@@ -97,7 +61,7 @@ jobs:
       - name: "Set up Cloud SDK"
         uses: "google-github-actions/setup-gcloud@v1"
 
-      - name: Build image for ${{ matrix.region }}
+      - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
           ./k8s/cloud-build.sh \
@@ -105,17 +69,8 @@ jobs:
             --dockerfile-path=./prodbox.Dockerfile \
             --working-dir=./ \
             --gcloud-ignore-file=.gcloudignore-prodbox \
-            --dust-client-facing-url=https://dust.tt \
-            --region=${{ matrix.region }}
-
-  deploy:
-    needs: [notify-start, build]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Get short sha
-        id: short_sha
-        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+            --dust-client-facing-url=https://dust.tt \ 
+            --region=us-central1
 
       - name: Generate a token
         id: generate-token
@@ -137,10 +92,10 @@ jobs:
               repo: 'dust-infra',
               event_type: 'trigger-component-deploy',
               client_payload: {
-                regions: '${{ github.event.inputs.regions }}',
+                regions: 'us-central1',
                 component: 'prodbox',
                 image_tag: '${{ steps.short_sha.outputs.short_sha }}',
-                slack_thread_ts: "${{ needs.notify-start.outputs.thread_ts }}",
+                slack_thread_ts: "${{ steps.build_message.outputs.thread_ts }}",
                 slack_channel: '${{ secrets.SLACK_CHANNEL_ID }}'
               }
             });
@@ -150,8 +105,9 @@ jobs:
         uses: ./.github/actions/slack-notify
         with:
           step: "failure"
+          blocked: ${{ steps.check_deployment_blocked.outputs.blocked }}
           component: "prodbox"
           image_tag: ${{ steps.short_sha.outputs.short_sha }}
           channel: ${{ secrets.SLACK_CHANNEL_ID }}
           slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
-          thread_ts: "${{ needs.notify-start.outputs.thread_ts }}"
+          thread_ts: "${{ steps.build_message.outputs.thread_ts }}"

--- a/.github/workflows/deploy-prodbox.yml
+++ b/.github/workflows/deploy-prodbox.yml
@@ -3,6 +3,15 @@ name: Deploy Prodbox
 on:
   workflow_dispatch:
     inputs:
+      regions:
+        description: "Regions to deploy to"
+        required: true
+        default: "us-central1"
+        type: choice
+        options:
+          - "us-central1"
+          - "europe-west1"
+          - "us-central1,europe-west1"
       check_deployment_blocked:
         description: "Check #deployment locks or force deploy"
         required: true
@@ -20,15 +29,24 @@ env:
   GCLOUD_PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
 
 jobs:
-  build-and-deploy:
+  notify-start:
     runs-on: ubuntu-latest
-
+    outputs:
+      thread_ts: ${{ steps.build_message.outputs.thread_ts }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ssh-key: "${{ secrets.PRODBOX_PRIVATE_DEPLOY_KEY }}"
+
+      - name: Set regions
+        id: set-regions
+        run: |
+          if [ "${{ github.event.inputs.regions }}" = "all" ]; then
+            echo "regions=[\"us-central1\",\"europe-west1\"]" >> $GITHUB_OUTPUT
+          else
+            echo "regions=[\"${{ github.event.inputs.regions }}\"]" >> $GITHUB_OUTPUT
+          fi
 
       - name: Get short sha
         id: short_sha
@@ -53,6 +71,24 @@ jobs:
           channel: ${{ secrets.SLACK_CHANNEL_ID }}
           slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
 
+  build:
+    needs: notify-start
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        region: ${{ fromJson(format('[{0}]', join(split(github.event.inputs.regions, ','), ','))) }}
+      fail-fast: true
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ssh-key: "${{ secrets.PRODBOX_PRIVATE_DEPLOY_KEY }}"
+
+      - name: Get short sha
+        id: short_sha
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
       - name: "Authenticate with Google Cloud"
         uses: "google-github-actions/auth@v1"
         with:
@@ -61,7 +97,7 @@ jobs:
       - name: "Set up Cloud SDK"
         uses: "google-github-actions/setup-gcloud@v1"
 
-      - name: Build the image on Cloud Build
+      - name: Build image for ${{ matrix.region }}
         run: |
           chmod +x ./k8s/cloud-build.sh
           ./k8s/cloud-build.sh \
@@ -69,8 +105,17 @@ jobs:
             --dockerfile-path=./prodbox.Dockerfile \
             --working-dir=./ \
             --gcloud-ignore-file=.gcloudignore-prodbox \
-            --dust-client-facing-url=https://dust.tt \ 
-            --region=us-central1
+            --dust-client-facing-url=https://dust.tt \
+            --region=${{ matrix.region }}
+
+  deploy:
+    needs: [notify-start, build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get short sha
+        id: short_sha
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Generate a token
         id: generate-token
@@ -92,10 +137,10 @@ jobs:
               repo: 'dust-infra',
               event_type: 'trigger-component-deploy',
               client_payload: {
-                regions: 'us-central1',
+                regions: '${{ github.event.inputs.regions }}',
                 component: 'prodbox',
                 image_tag: '${{ steps.short_sha.outputs.short_sha }}',
-                slack_thread_ts: "${{ steps.build_message.outputs.thread_ts }}",
+                slack_thread_ts: "${{ needs.notify-start.outputs.thread_ts }}",
                 slack_channel: '${{ secrets.SLACK_CHANNEL_ID }}'
               }
             });
@@ -105,9 +150,8 @@ jobs:
         uses: ./.github/actions/slack-notify
         with:
           step: "failure"
-          blocked: ${{ steps.check_deployment_blocked.outputs.blocked }}
           component: "prodbox"
           image_tag: ${{ steps.short_sha.outputs.short_sha }}
           channel: ${{ secrets.SLACK_CHANNEL_ID }}
           slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
-          thread_ts: "${{ steps.build_message.outputs.thread_ts }}"
+          thread_ts: "${{ needs.notify-start.outputs.thread_ts }}"

--- a/.github/workflows/deploy-prodbox.yml
+++ b/.github/workflows/deploy-prodbox.yml
@@ -69,7 +69,8 @@ jobs:
             --dockerfile-path=./prodbox.Dockerfile \
             --working-dir=./ \
             --gcloud-ignore-file=.gcloudignore-prodbox \
-            --dust-client-facing-url=https://dust.tt
+            --dust-client-facing-url=https://dust.tt \ 
+            --region=us-central1
 
       - name: Generate a token
         id: generate-token

--- a/.github/workflows/deploy-viz.yml
+++ b/.github/workflows/deploy-viz.yml
@@ -67,7 +67,8 @@ jobs:
             --image-name=viz \
             --dockerfile-path=./viz/Dockerfile \
             --working-dir=./ \
-            --dust-client-facing-url=https://dust.tt
+            --dust-client-facing-url=https://dust.tt \ 
+            --region=us-central1
 
       - name: Generate a token
         id: generate-token

--- a/k8s/cloud-build.sh
+++ b/k8s/cloud-build.sh
@@ -10,6 +10,7 @@ GCLOUD_IGNORE_FILE=""
 IMAGE_NAME=""
 DOCKERFILE_PATH=""
 DUST_CLIENT_FACING_URL=""
+REGION=""
 
 # parse command-line arguments
 while [[ $# -gt 0 ]]; do
@@ -34,6 +35,10 @@ while [[ $# -gt 0 ]]; do
       DUST_CLIENT_FACING_URL="${1#*=}"
       shift
       ;;
+    --region=*)
+      REGION="${1#*=}"
+      shift
+      ;;
     *)
       echo "unknown argument: $1"
       exit 1
@@ -42,8 +47,8 @@ while [[ $# -gt 0 ]]; do
 done
 
 # check required arguments
-if [ -z "$WORKING_DIR" ] || [ -z "$IMAGE_NAME" ] || [ -z "$DOCKERFILE_PATH" ]; then
-  echo "error: --working-dir, --image-name, and --dockerfile-path are required"
+if [ -z "$WORKING_DIR" ] || [ -z "$IMAGE_NAME" ] || [ -z "$DOCKERFILE_PATH" ] || [ -z "$REGION" ]; then
+  echo "error: --working-dir, --image-name, --region and --dockerfile-path are required"
   exit 1
 fi
 
@@ -54,13 +59,13 @@ cd "$WORKING_DIR"
 echo "current working directory is $(pwd)"
 
 # prepare substitutions
-SUBSTITUTIONS="SHORT_SHA=$(git rev-parse --short HEAD),_IMAGE_NAME=$IMAGE_NAME,_DOCKERFILE_PATH=$DOCKERFILE_PATH"
+SUBSTITUTIONS="SHORT_SHA=$(git rev-parse --short HEAD),_IMAGE_NAME=$IMAGE_NAME,_DOCKERFILE_PATH=$DOCKERFILE_PATH,_REGION=$REGION"
 if [ -n "$DUST_CLIENT_FACING_URL" ]; then
     SUBSTITUTIONS="$SUBSTITUTIONS,_DUST_CLIENT_FACING_URL=$DUST_CLIENT_FACING_URL"
 fi
 
 # prepare the gcloud command
-GCLOUD_CMD=(gcloud builds submit --quiet --config "${SCRIPT_DIR}/cloudbuild.yaml")
+GCLOUD_CMD=(gcloud builds submit --quiet --config "${SCRIPT_DIR}/cloudbuild.yaml" --region="$REGION")
 
 # add ignore file argument if specified
 if [ -n "$GCLOUD_IGNORE_FILE" ]; then

--- a/k8s/cloudbuild.yaml
+++ b/k8s/cloudbuild.yaml
@@ -5,8 +5,8 @@ steps:
       depot build \
         --project 3vz0lnf16v \
         --provenance=false \
-        -t us-central1-docker.pkg.dev/${PROJECT_ID}/dust-images/${_IMAGE_NAME}:${SHORT_SHA} \
-        -t us-central1-docker.pkg.dev/${PROJECT_ID}/dust-images/${_IMAGE_NAME}:latest \
+        -t ${_REGION}-docker.pkg.dev/${PROJECT_ID}/dust-images/${_IMAGE_NAME}:${SHORT_SHA} \
+        -t ${_REGION}-docker.pkg.dev/${PROJECT_ID}/dust-images/${_IMAGE_NAME}:latest \
         -f ${_DOCKERFILE_PATH} \
         --build-arg COMMIT_HASH=${SHORT_SHA} \
         --build-arg NEXT_PUBLIC_VIZ_URL=https://viz.dust.tt \


### PR DESCRIPTION
## Description

This PR aims at passing the region of the Artifact Registry repository in which to push the image. It also modifies the `deploy-prodbox` workflow to support multi-region deployment.

Note: the multi-region deployment is experimental and needs to be merged on main to be tested. Once fully working for prodbox I will migrate the other deployments to follow the same logic.

## Risk

Breaking deployment workflow

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
