### PR TITLE
SQL/Qdrant parents migrator (transform and clean-up steps)

### DIFF
--- a/front/migrations/20241211_parents_migrator.ts
+++ b/front/migrations/20241211_parents_migrator.ts
@@ -120,7 +120,11 @@ async function migrateDocument({
         : migrator.cleaner(coreDocument.document_id, coreDocument.parents);
   } catch (e) {
     logger.error(
-      `TRANSFORM_ERROR: document_id=${coreDocument.document_id} parents=${coreDocument.parents}`
+      {
+        documentId: coreDocument.document_id,
+        parents: coreDocument.parents,
+      },
+      `TRANSFORM_ERROR`
     );
     throw e;
   }
@@ -138,13 +142,21 @@ async function migrateDocument({
     }
 
     logger.info(
-      `LIVE: document_id=${coreDocument.document_id}` +
-        `\nfrom_parents=${coreDocument.parents.join(", ")}\n  to_parents=${newParents.join(", ")}`
+      {
+        documentId: coreDocument.document_id,
+        fromParents: coreDocument.parents,
+        toParents: newParents,
+      },
+      `LIVE`
     );
   } else {
     logger.info(
-      `DRY: document_id=${coreDocument.document_id}` +
-        `\nfrom_parents=${coreDocument.parents.join(", ")}\n  to_parents=${newParents.join(", ")}`
+      {
+        documentId: coreDocument.document_id,
+        fromParents: coreDocument.parents,
+        toParents: newParents,
+      },
+      `DRY`
     );
   }
 
@@ -176,7 +188,11 @@ async function migrateTable({
         : migrator.cleaner(coreTable.table_id, coreTable.parents);
   } catch (e) {
     logger.error(
-      `TRANSFORM_ERROR: table_id=${coreTable.table_id} parents=${coreTable.parents}`
+      {
+        tableId: coreTable.table_id,
+        parents: coreTable.parents,
+      },
+      `TRANSFORM_ERROR`
     );
     throw e;
   }
@@ -194,13 +210,21 @@ async function migrateTable({
     }
 
     logger.info(
-      `LIVE: table_id=${coreTable.table_id}` +
-        `\nfrom_parents=${coreTable.parents.join(", ")}\n  to_parents=${newParents.join(", ")}`
+      {
+        tableId: coreTable.table_id,
+        fromParents: coreTable.parents,
+        toParents: newParents,
+      },
+      `LIVE`
     );
   } else {
     logger.info(
-      `DRY: table_id=${coreTable.table_id}` +
-        `\nfrom_parents=${coreTable.parents.join(", ")}\n  to_parents=${newParents.join(", ")}`
+      {
+        tableId: coreTable.table_id,
+        fromParents: coreTable.parents,
+        toParents: newParents,
+      },
+      `DRY`
     );
   }
 
@@ -274,7 +298,12 @@ async function migrateDataSource({
       );
     } catch (e) {
       logger.error(
-        `ERROR: error=${e} nextDataSourceId=${dataSource.id} nextDocumentId=${nextDocumentId}`
+        {
+          error: e,
+          nextDataSourceId: dataSource.id,
+          nextDocumentId,
+        },
+        `ERROR`
       );
       throw e;
     }
@@ -318,7 +347,12 @@ async function migrateDataSource({
       );
     } catch (e) {
       logger.error(
-        `ERROR: error=${e} nextDataSourceId=${dataSource.id} nextTableId=${nextTableId}`
+        {
+          error: e,
+          nextDataSourceId: dataSource.id,
+          nextTableId,
+        },
+        `ERROR`
       );
       throw e;
     }
@@ -357,7 +391,7 @@ async function migrateAll({
         execute,
       });
     } else {
-      logger.info("SKIP: dataSourceId=" + dataSource.id);
+      logger.info({ dataSourceId: dataSource.id }, "SKIP");
     }
   }
 }

--- a/front/migrations/20241211_parents_migrator.ts
+++ b/front/migrations/20241211_parents_migrator.ts
@@ -35,23 +35,23 @@ const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
         case 0:
           throw new Error("No parents");
         case 1: {
-          // Check that parents[1] does not have the prefix
+          // Check that parents[0] does not have the prefix (it's the channelId)
           assert(!parents[0].startsWith("slack-"));
 
           const channelId = parents[0];
           return [nodeId, channelId, `slack-channel-${channelId}`];
         }
         case 2: {
-          // Check parents[0] (the nodeId)
+          // Check parents[0] is the nodeId
           assert(parents[0] === nodeId, "parents[0] !== nodeId");
-          // Check that parents[1] does not have a prefix
+          // Check that parents[1] does not have a prefix (it's the channelId)
           assert(!parents[1].startsWith("slack-"));
 
           const channelId = parents[1];
           return [nodeId, channelId, `slack-channel-${channelId}`];
         }
         case 3: {
-          // Check parents[0] (the nodeId)
+          // Check parents[0] is the nodeId
           assert(parents[0] === nodeId, "parents[0] !== nodeId");
           // Check parents[2] vs parents[1]
           assert(
@@ -70,7 +70,7 @@ const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
       if (parents.length !== 3) {
         throw new Error("Parents len != 3");
       }
-      // Check parents[0] (the nodeId)
+      // Check parents[0] is the nodeId
       assert(parents[0] === nodeId, "parents[0] !== nodeId");
       // Check parents[2] vs parents[1]
       assert(

--- a/front/migrations/20241211_parents_migrator.ts
+++ b/front/migrations/20241211_parents_migrator.ts
@@ -138,11 +138,13 @@ async function migrateDocument({
     }
 
     logger.info(
-      `LIVE: document_id=${coreDocument.document_id} parents=${newParents}`
+      `LIVE: document_id=${coreDocument.document_id}` +
+        `\nfrom_parents=${coreDocument.parents.join(", ")}\n  to_parents=${newParents.join(", ")}`
     );
   } else {
     logger.info(
-      `DRY: document_id=${coreDocument.document_id} parents=${newParents}`
+      `DRY: document_id=${coreDocument.document_id}` +
+        `\nfrom_parents=${coreDocument.parents.join(", ")}\n  to_parents=${newParents.join(", ")}`
     );
   }
 
@@ -191,9 +193,15 @@ async function migrateTable({
       throw new Error(updateRes.error.message);
     }
 
-    logger.info(`LIVE: table_id=${coreTable.table_id} parents=${newParents}`);
+    logger.info(
+      `LIVE: table_id=${coreTable.table_id}` +
+        `\nfrom_parents=${coreTable.parents.join(", ")}\n  to_parents=${newParents.join(", ")}`
+    );
   } else {
-    logger.info(`DRY: table_id=${coreTable.table_id} parents=${newParents}`);
+    logger.info(
+      `DRY: table_id=${coreTable.table_id}` +
+        `\nfrom_parents=${coreTable.parents.join(", ")}\n  to_parents=${newParents.join(", ")}`
+    );
   }
 
   return new Ok(undefined);
@@ -279,7 +287,7 @@ async function migrateDataSource({
 
   for (;;) {
     const [coreTableRows] = (await corePrimary.query(
-      "SELECT id, parents, table_id FROM data_sources_documents " +
+      "SELECT id, parents, table_id FROM tables " +
         "WHERE data_source = ? AND id > ? ORDER BY id ASC LIMIT ?",
       {
         replacements: [coreDataSourceId, nextTableId, QUERY_BATCH_SIZE],

--- a/front/migrations/20241211_parents_migrator.ts
+++ b/front/migrations/20241211_parents_migrator.ts
@@ -1,0 +1,165 @@
+import type { ConnectorProvider } from "@dust-tt/types";
+import { isConnectorProvider } from "@dust-tt/types";
+import { Sequelize } from "sequelize";
+
+// import { QdrantClient } from "@qdrant/js-client-rest";
+import { Authenticator } from "@app/lib/auth";
+import { getCorePrimaryDbConnection } from "@app/lib/production_checks/utils";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
+import { makeScript, runOnAllWorkspaces } from "@app/scripts/helpers";
+import assert from "assert";
+
+const { QDRANT_CLUSTER_0_URL, QDRANT_CLUSTER_0_API_KEY } = process.env;
+
+const client = new QdrantClient({
+  url: QDRANT_URL,
+  apiKey: QDRANT_API_KEY,
+});
+
+type MigratorAction = "transform" | "clean";
+
+const isMigratorAction = (action: string): action is MigratorAction => {
+  return ["transform", "clean"].includes(action);
+};
+
+type ProviderMigrator = {
+  transformer: (parents: string[]) => string[];
+  cleaner: (parents: string[]) => string[];
+};
+
+const DOCUMENT_QUERY_BATCH_SIZE = 128;
+const DOCUMENT_CONCURRENCY = 8;
+
+async function migrateDataSource({
+  provider,
+  dataSource,
+  execute,
+}: {
+  provider: ConnectorProvider;
+  dataSource: DataSourceModel;
+  execute: boolean;
+}) {
+  const corePrimary = getCorePrimaryDbConnection();
+
+  // Retrieve the core data source.
+  const [coreDataSourceRows] = (await corePrimary.query(
+    `SELECT id, data_source_id FROM data_sources WHERE project = ? AND data_source_id = ?`,
+    {
+      replacements: [
+        dataSource.dustAPIProjectId,
+        dataSource.dustAPIDataSourceId,
+      ],
+    }
+  )) as { id: number; data_source_id: string }[][];
+
+  assert(
+    coreDataSourceRows.length === 1 &&
+      coreDataSourceRows[0].data_source_id === dataSource.dustAPIDataSourceId,
+    "Core data source mismatch"
+  );
+
+  const coreDataSourceId = coreDataSourceRows[0].id;
+
+  // for all documents in the data source (can be big)
+  let nextId = 0;
+
+  for (;;) {
+    const [coreDocumentRows] = (await corePrimary.query(
+      "SELECT id, parents, document_id, hash FROM data_sources_documents " +
+        "WHERE data_source = ? AND id > ? ORDER BY id ASC LIMIT ?",
+      {
+        replacements: [
+          coreDataSourceRows[0].id,
+          nextId,
+          DOCUMENT_QUERY_BATCH_SIZE,
+        ],
+      }
+    )) as {
+      id: number;
+      parents: string[];
+      document_id: string;
+      hash: string;
+    }[][];
+
+    nextId = coreDocumentRows[coreDocumentRows.length - 1].id;
+
+    if (coreDocumentRows.length === 0) {
+      break;
+    }
+
+    // concurrentExecutor on documents
+  }
+
+  // for all the tables in the data source (can be big)
+}
+
+async function migrateAll({
+  provider,
+  execute,
+}: {
+  provider: ConnectorProvider;
+  execute: boolean;
+}) {
+  // retrieve all data sources for the provider
+  const dataSources = await DataSourceModel.findAll({
+    where: {
+      connectorProvider: provider,
+    },
+  });
+
+  for (const dataSource of dataSources) {
+    await migrateDataSource({ provider, dataSource, execute });
+  }
+}
+
+const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
+  slack: {
+    transformer: (parents) => {
+      return parents;
+    },
+    cleaner: (parents) => {
+      return parents;
+    },
+  },
+  google_drive: null,
+  microsoft: null,
+  github: null,
+  notion: null,
+  snowflake: null,
+  webcrawler: null,
+  zendesk: null,
+  confluence: null,
+  intercom: null,
+};
+
+makeScript(
+  {
+    provider: {
+      type: "string",
+      required: true,
+    },
+    action: {
+      type: "string",
+      required: true,
+    },
+  },
+  async ({ provider, action, execute }) => {
+    if (!isMigratorAction(action)) {
+      console.error(
+        `Invalid action ${action}, supported actions are "transform" and "clean"`
+      );
+      return;
+    }
+    if (!isConnectorProvider(provider)) {
+      console.error(`Invalid provider ${provider}`);
+      return;
+    }
+    if (!migrators[provider]) {
+      console.error(`No migrator found for provider ${provider}`);
+      return;
+    }
+
+    await migrateAll({ provider, execute });
+  }
+);

--- a/front/migrations/20241211_parents_migrator.ts
+++ b/front/migrations/20241211_parents_migrator.ts
@@ -423,7 +423,8 @@ makeScript(
       console.error(`Invalid provider ${provider}`);
       return;
     }
-    if (!migrators[provider]) {
+    const migrator = migrators[provider];
+    if (!migrator) {
       console.error(`No migrator found for provider ${provider}`);
       return;
     }
@@ -431,7 +432,7 @@ makeScript(
     await migrateAll({
       provider,
       action,
-      migrator: migrators[provider],
+      migrator,
       nextDataSourceId,
       execute,
     });

--- a/front/migrations/20241211_parents_migrator.ts
+++ b/front/migrations/20241211_parents_migrator.ts
@@ -384,6 +384,13 @@ async function migrateAll({
 
   for (const dataSource of dataSources) {
     if (dataSource.id >= nextDataSourceId) {
+      logger.info(
+        {
+          dataSourceId: dataSource.id,
+          connectorProvider: dataSource.connectorProvider,
+        },
+        "MIGRATING"
+      );
       await migrateDataSource({
         migrator,
         action,


### PR DESCRIPTION
## Description

Migrates parents per provider using custom migrators code.

- find all data sources
- for reach (sequentially)
  - iterate on batches of documents from core
  - for each (concurrently)
    - update parents using CoreAPI

## Risk

Quite high risk as it's a tricky migration

Run in dev + checked that assistant are still working locally

## Deploy Plan

- N/A (migration)