### PR TITLE
[KW Search] Migrate parents of `agent_data_source_configurations`

### DIFF
--- a/front/migrations/20241211_update_parents_agent_data_source_config.ts
+++ b/front/migrations/20241211_update_parents_agent_data_source_config.ts
@@ -68,21 +68,36 @@ makeScript({}, async ({ execute }, logger) => {
         }
 
         const { parentsIn, parentsNotIn } = configuration;
+        const newParentsIn = parentsIn && migrator(parentsIn);
+        const newParentsNotIn = parentsNotIn && migrator(parentsNotIn);
 
         if (execute) {
           await configuration.update({
-            parentsIn: parentsIn && migrator(parentsIn),
-            parentsNotIn: parentsNotIn && migrator(parentsNotIn),
+            parentsIn: newParentsIn,
+            parentsNotIn: newParentsNotIn,
           });
+          logger.info(
+            {
+              configurationId: configuration.id,
+              connectorProvider: configuration.dataSource.connectorProvider,
+              fromParentsIn: parentsIn,
+              toParentsIn: newParentsIn,
+              fromParentsNotIn: parentsNotIn,
+              toParentsNotIn: newParentsNotIn,
+            },
+            `LIVE`
+          );
         } else {
           logger.info(
             {
-              parentsIn,
-              newParentsIn: parentsIn && migrator(parentsIn),
-              parentsNotIn,
-              newParentsNotIn: parentsNotIn && migrator(parentsNotIn),
+              configurationId: configuration.id,
+              connectorProvider: configuration.dataSource.connectorProvider,
+              fromParentsIn: parentsIn,
+              toParentsIn: newParentsIn,
+              fromParentsNotIn: parentsNotIn,
+              toParentsNotIn: newParentsNotIn,
             },
-            "Would update agent data source configuration"
+            `DRY`
           );
         }
       },

--- a/front/migrations/20241211_update_parents_agent_data_source_config.ts
+++ b/front/migrations/20241211_update_parents_agent_data_source_config.ts
@@ -27,7 +27,7 @@ export function getIdFromConfluenceInternalId(internalId: string) {
   return internalId.replace(new RegExp(prefixPattern), "");
 }
 
-export function convertInternalIdToDocumentId(internalId: string): string {
+export function getUpdatedConfluenceId(internalId: string): string {
   // case where we already got new IDs
   if (
     internalId.startsWith(ConfluenceNewIdPrefix.Page) ||
@@ -56,7 +56,7 @@ const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
   snowflake: null,
   webcrawler: null,
   zendesk: null, // no migration needed!
-  confluence: (parents) => parents.map(convertInternalIdToDocumentId),
+  confluence: (parents) => parents.map(getUpdatedConfluenceId),
   intercom: null, // no migration needed!
 };
 

--- a/front/migrations/20241211_update_parents_agent_data_source_config.ts
+++ b/front/migrations/20241211_update_parents_agent_data_source_config.ts
@@ -22,7 +22,12 @@ const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
   snowflake: null,
   webcrawler: null,
   zendesk: null,
-  confluence: null,
+  confluence: (parents) =>
+    parents.map((parent) =>
+      parent
+        .replace("cspace_", "confluence-space")
+        .replace("cpace_", "confluence-page")
+    ),
   intercom: null,
 };
 

--- a/front/migrations/20241211_update_parents_agent_data_source_config.ts
+++ b/front/migrations/20241211_update_parents_agent_data_source_config.ts
@@ -1,0 +1,69 @@
+import type { ConnectorProvider } from "@dust-tt/types";
+import assert from "assert";
+
+import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
+import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
+import { makeScript } from "@app/scripts/helpers";
+
+type ProviderMigrator = (parents: string[]) => string[];
+
+const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
+  slack: null,
+  google_drive: null,
+  microsoft: null,
+  github: null,
+  notion: null,
+  snowflake: null,
+  webcrawler: null,
+  zendesk: null,
+  confluence: null,
+  intercom: null,
+};
+makeScript({}, async ({ execute }, logger) => {
+  // pagination + concurrency
+  const agentDataSourceConfigurations =
+    await AgentDataSourceConfiguration.findAll({
+      raw: true,
+      include: [
+        {
+          model: DataSourceModel,
+          as: "dataSource",
+          attributes: [],
+          required: true,
+        },
+      ],
+    });
+
+  for (const agentDataSourceConfiguration of agentDataSourceConfigurations) {
+    assert(
+      agentDataSourceConfiguration.dataSource.connectorProvider,
+      "connectorProvider is required"
+    );
+    const migrator =
+      migrators[agentDataSourceConfiguration.dataSource.connectorProvider];
+    assert(migrator, "No migrator found for the connector provider");
+
+    const { parentsIn, parentsNotIn } = agentDataSourceConfiguration;
+
+    if (execute) {
+      await agentDataSourceConfiguration.update({
+        parentsIn: parentsIn && migrator(parentsIn),
+        parentsNotIn: parentsNotIn && migrator(parentsNotIn),
+      });
+    } else {
+      logger.info(
+        {
+          parentsIn,
+          newParentsIn: parentsIn && migrator(parentsIn),
+          parentsNotIn,
+          newParentsNotIn: parentsNotIn && migrator(parentsNotIn),
+        },
+        "Would update agent data source configuration"
+      );
+    }
+  }
+
+  logger.info(
+    `Finished migrating parents for agent data source configurations.`
+  );
+});

--- a/front/migrations/20241211_update_parents_agent_data_source_config.ts
+++ b/front/migrations/20241211_update_parents_agent_data_source_config.ts
@@ -28,7 +28,7 @@ const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
         .replace("cspace_", "confluence-space")
         .replace("cpace_", "confluence-page")
     ),
-  intercom: null,
+  intercom: null, // no migration needed!
 };
 
 makeScript({}, async ({ execute }, logger) => {

--- a/front/migrations/20241211_update_parents_agent_data_source_config.ts
+++ b/front/migrations/20241211_update_parents_agent_data_source_config.ts
@@ -12,6 +12,7 @@ type ProviderMigrator = (parents: string[]) => string[];
 const AGENT_CONFIGURATION_BATCH_SIZE = 100;
 const UPDATE_CONCURRENCY = 10;
 
+// we put null values if no migration is needed
 const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
   slack: null,
   google_drive: null,
@@ -57,7 +58,9 @@ makeScript({}, async ({ execute }, logger) => {
           "connectorProvider is required"
         );
         const migrator = migrators[configuration.dataSource.connectorProvider];
-        assert(migrator, "No migrator found for the connector provider");
+        if (!migrator) {
+          return; // no migration needed
+        }
 
         const { parentsIn, parentsNotIn } = configuration;
 

--- a/front/migrations/20241211_update_parents_agent_data_source_config.ts
+++ b/front/migrations/20241211_update_parents_agent_data_source_config.ts
@@ -21,7 +21,7 @@ const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
   notion: null,
   snowflake: null,
   webcrawler: null,
-  zendesk: null,
+  zendesk: null, // no migration needed!
   confluence: (parents) =>
     parents.map((parent) =>
       parent


### PR DESCRIPTION
## Description

- This PR introduces a migration script for the column `parentsIn` and `parentsNotIn` of table `agent_data_source_configurations`.
- This work is part of task [#9069](https://github.com/dust-tt/dust/issues/9069).

## Risk

- tricky migration IMO

## Deploy Plan

- Run the migration.
