### PR TITLE
[Auth0] Auth0 blacklisting warning and dangerjs

### DIFF
--- a/front/dangerfile.ts
+++ b/front/dangerfile.ts
@@ -2,6 +2,7 @@ import { danger, fail, warn } from "danger";
 
 const migrationAckLabel = "migration-ack";
 const documentationAckLabel = "documentation-ack";
+const auth0UpdateLabelAck = "auth0-update-ack";
 
 const hasLabel = (label: string) => {
   return danger.github.issue.labels.some((l) => l.name === label);
@@ -46,6 +47,29 @@ function checkDeployPlanSection() {
       "Please include a detailed Deploy Plan section in your PR description."
     );
   }
+}
+
+function checkAuth0UpdateLabel() {
+  if (!hasLabel(auth0UpdateLabelAck)) {
+    failAuth0UpdateLabel();
+  } else {
+    warnAuth0UpdateLabel(auth0UpdateLabelAck);
+  }
+}
+
+function failAuth0UpdateLabel() {
+  fail(
+    "`**/lib/utils/blacklisted_email_domains.ts` has been modified. " +
+      `Please add the \`${auth0UpdateLabelAck}\` label to acknowledge that the Auth0 blacklist has been updated.`
+  );
+}
+
+function warnAuth0UpdateLabel(auth0UpdateLabelAck: string) {
+  warn(
+    "`**/lib/utils/blacklisted_email_domains.ts` has been modified and the PR has the `" +
+      auth0UpdateLabelAck +
+      "` label. Don't forget to update the Auth0 blacklist."
+  );
 }
 
 function checkDocumentationLabel() {
@@ -95,6 +119,14 @@ function checkModifiedFiles() {
 
   if (modifiedPublicApiFiles.length > 0) {
     checkDocumentationLabel();
+  }
+
+  const modifiedAuth0Files = danger.git.modified_files.filter((path) => {
+    return path.startsWith("front/lib/utils/blacklisted_email_domains.ts");
+  });
+
+  if (modifiedAuth0Files.length > 0) {
+    checkAuth0UpdateLabel();
   }
 }
 

--- a/front/lib/utils/blacklisted_email_domains.ts
+++ b/front/lib/utils/blacklisted_email_domains.ts
@@ -1,3 +1,6 @@
+// WARNING: only changing this list will have no effect
+// The blacklist should be updated in auth0 too (actions -> triggers -> pre-user-registration)
+// This list is commited here for reference & traceability
 const BLACKLISTED_EMAIL_DOMAINS = new Set([
   "0-mail.com",
   "027168.com",


### PR DESCRIPTION
Description
---
Updating the blacklist on our codebase has no effect. We need to update it on our Auth0 account.

This led to the following [issue](https://dust4ai.slack.com/archives/C050SM8NSPK/p1733749853572889)

This PR adds a warning and requires an ack from dangerJS.

Risk
---
na

Deploy
---
front