### PR TITLE
parents migrator: more resilient slack transformer

### DIFF
--- a/front/migrations/20241211_parents_migrator.ts
+++ b/front/migrations/20241211_parents_migrator.ts
@@ -28,21 +28,24 @@ const QUERY_BATCH_SIZE = 128;
 const DOCUMENT_CONCURRENCY = 8;
 const TABLE_CONCURRENCY = 16;
 
+function slackNodeIdToChannelId(nodeId: string) {
+  const parts = nodeId.split("-");
+  if (parts.length < 3) {
+    throw new Error("Invalid nodeId 1");
+  }
+  if (parts[0] !== "slack") {
+    throw new Error("Invalid nodeId 2");
+  }
+  if (!["messages", "thread"].includes(parts[2])) {
+    throw new Error("Invalid nodeId 3");
+  }
+  return parts[1];
+}
+
 const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
   slack: {
     transformer: (nodeId, parents) => {
-      const parts = nodeId.split("-");
-      if (parts.length < 3) {
-        throw new Error("Invalid nodeId 1");
-      }
-      if (parts[0] !== "slack") {
-        throw new Error("Invalid nodeId 2");
-      }
-      if (!["messages", "thread"].includes(parts[2])) {
-        throw new Error("Invalid nodeId 3");
-      }
-      const channelId = parts[1];
-
+      const channelId = slackNodeIdToChannelId(nodeId);
       switch (parents.length) {
         case 0:
           logger.warn(
@@ -121,17 +124,7 @@ const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
       return [nodeId, channelId, `slack-channel-${channelId}`];
     },
     cleaner: (nodeId, parents) => {
-      const parts = nodeId.split("-");
-      if (parts.length < 3) {
-        throw new Error("Invalid nodeId 1");
-      }
-      if (parts[0] !== "slack") {
-        throw new Error("Invalid nodeId 2");
-      }
-      if (!["messages", "thread"].includes(parts[2])) {
-        throw new Error("Invalid nodeId 3");
-      }
-      const channelId = parts[1];
+      const channelId = slackNodeIdToChannelId(nodeId);
 
       if (parents.length === 2) {
         assert(parents[0] === nodeId, "parents[0] !== nodeId");

--- a/front/migrations/20241211_parents_migrator.ts
+++ b/front/migrations/20241211_parents_migrator.ts
@@ -47,12 +47,6 @@ const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
     transformer: (nodeId, parents) => {
       const channelId = slackNodeIdToChannelId(nodeId);
       switch (parents.length) {
-        case 0:
-          logger.warn(
-            { nodeId, parents, problem: "no parents" },
-            "Invalid slack parents"
-          );
-          break;
         case 1: {
           // Check that parents[0] does not have the prefix (it's the channelId)
           if (parents[0] !== channelId) {
@@ -115,7 +109,7 @@ const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
         }
         default:
           logger.warn(
-            { nodeId, parents, problem: "too many parents" },
+            { nodeId, parents, problem: "invalid parents len" },
             "Invalid slack parents"
           );
           break;

--- a/front/migrations/20241211_parents_migrator.ts
+++ b/front/migrations/20241211_parents_migrator.ts
@@ -133,16 +133,22 @@ const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
       }
       const channelId = parts[1];
 
-      if (parents.length !== 3) {
-        throw new Error("Parents len != 3");
+      if (parents.length === 2) {
+        assert(parents[0] === nodeId, "parents[0] !== nodeId");
+        assert(
+          parents[1] === `slack-channel-${channelId}`,
+          "parents[1] !== slack-channel-channelId"
+        );
+      } else if (parents.length === 3) {
+        assert(parents[0] === nodeId, "parents[0] !== nodeId");
+        assert(parents[1] === channelId, "parents[1] !== channelId");
+        assert(
+          parents[2] === `slack-channel-${channelId}`,
+          "parents[2] !== slack-channel-channelId"
+        );
+      } else {
+        throw new Error("Parents len != 2/3");
       }
-
-      assert(parents[0] === nodeId, "parents[0] !== nodeId");
-      assert(parents[1] === channelId, "parents[1] !== channelId");
-      assert(
-        parents[2] === `slack-channel-${channelId}`,
-        "parents[2] !== slack-channel-channelId"
-      );
 
       return [nodeId, `slack-channel-${channelId}`];
     },


### PR DESCRIPTION
## Description

More resilient migrator that infers all parents from document ID and only warns on mismatch of existing parents

## Risk

High, touchy migration. Tested in dev.

## Deploy Plan

N/A