### PR TITLE
Add confluence to parents migration script

### DIFF
--- a/front/migrations/20241211_parents_migrator.ts
+++ b/front/migrations/20241211_parents_migrator.ts
@@ -175,7 +175,7 @@ const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
   confluence: {
     transformer: (nodeId, parents) => {
       return [
-        ...new Set([...parents, ...parents.map(convertConfluenceOldIdToNewId)]),
+        ...new Set([...parents.map(convertConfluenceOldIdToNewId), ...parents]),
       ];
     },
     cleaner: (nodeId, parents) => {

--- a/front/migrations/20241211_parents_migrator.ts
+++ b/front/migrations/20241211_parents_migrator.ts
@@ -39,8 +39,11 @@ enum ConfluenceNewIdPrefix {
 }
 
 function getIdFromConfluenceInternalId(internalId: string) {
-  const prefixPattern = `^(${ConfluenceOldIdPrefix.Space}|${ConfluenceOldIdPrefix.Page})`;
-  return internalId.replace(new RegExp(prefixPattern), "");
+  const oldPrefixPattern = `^(${ConfluenceOldIdPrefix.Space}|${ConfluenceOldIdPrefix.Page})`;
+  const newPrefixPattern = `^(${ConfluenceNewIdPrefix.Space}|${ConfluenceNewIdPrefix.Page})`;
+  return internalId
+    .replace(new RegExp(oldPrefixPattern), "")
+    .replace(new RegExp(newPrefixPattern), ""); // we can have chained old-new prefixes on the initial upsert (huge regression introduced a month ago)
 }
 
 function convertConfluenceOldIdToNewId(internalId: string): string {

--- a/front/migrations/20241211_parents_migrator.ts
+++ b/front/migrations/20241211_parents_migrator.ts
@@ -50,7 +50,7 @@ function convertConfluenceOldIdToNewId(internalId: string): string {
   if (internalId.startsWith(ConfluenceOldIdPrefix.Space)) {
     return `${ConfluenceNewIdPrefix.Space}${getIdFromConfluenceInternalId(internalId)}`;
   }
-  throw new Error(`Invalid internal ID: ${internalId}`);
+  return internalId;
 }
 
 function slackNodeIdToChannelId(nodeId: string) {
@@ -174,31 +174,9 @@ const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
   zendesk: null,
   confluence: {
     transformer: (nodeId, parents) => {
-      // case where we got old IDs exclusively: we add the new IDs to them
-      if (
-        parents.every(
-          (parent) =>
-            parent.startsWith(ConfluenceOldIdPrefix.Page) ||
-            parent.startsWith(ConfluenceOldIdPrefix.Space)
-        )
-      ) {
-        return [...parents, ...parents.map(convertConfluenceOldIdToNewId)];
-      }
-      // checking that we got a mix of old and new IDs, with the old ones matching the new ones
-      for (const parent of parents) {
-        if (
-          parent.startsWith(ConfluenceOldIdPrefix.Page) ||
-          parent.startsWith(ConfluenceOldIdPrefix.Space)
-        ) {
-          assert(parents.includes(convertConfluenceOldIdToNewId(parent)));
-        } else {
-          assert(
-            parent.startsWith(ConfluenceNewIdPrefix.Page) ||
-              parent.startsWith(ConfluenceNewIdPrefix.Space)
-          );
-        }
-      }
-      return parents;
+      return [
+        ...new Set([...parents, ...parents.map(convertConfluenceOldIdToNewId)]),
+      ];
     },
     cleaner: (nodeId, parents) => {
       // we just remove the old IDs


### PR DESCRIPTION
## Description

- Same thing as in #9277 but for Confluence.
- The transformer doubles the ID with some additional checks.
- The cleaner removes every old ID.

## Risk

- Quite high, should def be run in dev to check that agent still work.

## Deploy Plan

n/a
