### PR TITLE
[.github] - fix: correct trailing whitespace in workflow files

### DIFF
--- a/.github/workflows/deploy-alerting-temporal.yml
+++ b/.github/workflows/deploy-alerting-temporal.yml
@@ -44,7 +44,7 @@ jobs:
             --image-name=alerting-temporal \
             --dockerfile-path=./Dockerfile \
             --working-dir=./alerting/temporal/ \
-            --dust-client-facing-url=https://dust.tt \ 
+            --dust-client-facing-url=https://dust.tt \
             --region=us-central1
 
       - name: Generate a token

--- a/.github/workflows/deploy-connectors.yml
+++ b/.github/workflows/deploy-connectors.yml
@@ -67,7 +67,7 @@ jobs:
             --image-name=connectors \
             --dockerfile-path=./connectors/Dockerfile \
             --working-dir=./ \
-            --dust-client-facing-url=https://dust.tt \ 
+            --dust-client-facing-url=https://dust.tt \
             --region=us-central1
 
       - name: Generate a token

--- a/.github/workflows/deploy-core.yml
+++ b/.github/workflows/deploy-core.yml
@@ -67,7 +67,7 @@ jobs:
             --image-name=core \
             --dockerfile-path=./Dockerfile \
             --working-dir=./core/ \
-            --dust-client-facing-url=https://dust.tt \ 
+            --dust-client-facing-url=https://dust.tt \
             --region=us-central1
 
       - name: Generate a token

--- a/.github/workflows/deploy-dante.yml
+++ b/.github/workflows/deploy-dante.yml
@@ -54,7 +54,7 @@ jobs:
             --dockerfile-path=./dante.Dockerfile \
             --working-dir=./ \
             --gcloud-ignore-file=../.gcloudignore-dante \
-            --dust-client-facing-url=https://dust.tt \ 
+            --dust-client-facing-url=https://dust.tt \
             --region=us-central1
           cd ..
 

--- a/.github/workflows/deploy-front-qa.yml
+++ b/.github/workflows/deploy-front-qa.yml
@@ -45,7 +45,7 @@ jobs:
             --image-name=front-qa \
             --dockerfile-path=./front/Dockerfile \
             --working-dir=./ \
-            --dust-client-facing-url=https://front-qa.dust.tt \ 
+            --dust-client-facing-url=https://front-qa.dust.tt \
             --region=us-central1
 
       - name: Generate a token

--- a/.github/workflows/deploy-front.yml
+++ b/.github/workflows/deploy-front.yml
@@ -64,7 +64,7 @@ jobs:
             --image-name=front \
             --dockerfile-path=./front/Dockerfile \
             --working-dir=./ \
-            --dust-client-facing-url=https://dust.tt \ 
+            --dust-client-facing-url=https://dust.tt \
             --region=us-central1
 
       - name: Generate a token

--- a/.github/workflows/deploy-nginx.yml
+++ b/.github/workflows/deploy-nginx.yml
@@ -51,7 +51,7 @@ jobs:
             --dockerfile-path=./nginx.Dockerfile \
             --working-dir=./ \
             --gcloud-ignore-file=../.gcloudignore-nginx \
-            --dust-client-facing-url=https://dust.tt \ 
+            --dust-client-facing-url=https://dust.tt \
             --region=us-central1
           cd ..
 

--- a/.github/workflows/deploy-oauth.yml
+++ b/.github/workflows/deploy-oauth.yml
@@ -64,7 +64,7 @@ jobs:
             --image-name=oauth \
             --dockerfile-path=./oauth.Dockerfile \
             --working-dir=./core/ \
-            --dust-client-facing-url=https://dust.tt \ 
+            --dust-client-facing-url=https://dust.tt \
             --region=us-central1
 
       - name: Generate a token

--- a/.github/workflows/deploy-prodbox.yml
+++ b/.github/workflows/deploy-prodbox.yml
@@ -69,7 +69,7 @@ jobs:
             --dockerfile-path=./prodbox.Dockerfile \
             --working-dir=./ \
             --gcloud-ignore-file=.gcloudignore-prodbox \
-            --dust-client-facing-url=https://dust.tt \ 
+            --dust-client-facing-url=https://dust.tt \
             --region=us-central1
 
       - name: Generate a token

--- a/.github/workflows/deploy-viz.yml
+++ b/.github/workflows/deploy-viz.yml
@@ -67,7 +67,7 @@ jobs:
             --image-name=viz \
             --dockerfile-path=./viz/Dockerfile \
             --working-dir=./ \
-            --dust-client-facing-url=https://dust.tt \ 
+            --dust-client-facing-url=https://dust.tt \
             --region=us-central1
 
       - name: Generate a token


### PR DESCRIPTION
## Description

This PR removes trailing whitespace in various GitHub workflow YAML files

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
