### PR TITLE
[core] Skip count query when not needed

### DIFF
--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -1585,6 +1585,7 @@ async fn data_sources_documents_versions_list(
                 None => None,
             },
             &query.latest_hash,
+            true,
         )
         .await
     {
@@ -1787,6 +1788,7 @@ async fn data_sources_documents_list(
             &document_ids,
             limit_offset,
             true, // remove system tags
+            true,
         )
         .await
     {

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -1535,6 +1535,7 @@ impl DataSource {
                 // With top_k documents, we should be guaranteed to have at least top_k chunks, if
                 // we make the assumption that each document has at least one chunk.
                 Some((top_k, 0)),
+                false,
             )
             .await?;
 
@@ -1831,6 +1832,7 @@ impl DataSource {
                 None,
                 &None,
                 &None,
+                false,
             )
             .await?;
 
@@ -1887,6 +1889,7 @@ impl DataSource {
                 None,
                 &None,
                 &None,
+                false,
             )
             .await?;
 

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -182,6 +182,7 @@ pub trait Store {
         filter: &Option<SearchFilter>,
         view_filter: &Option<SearchFilter>,
         limit_offset: Option<(usize, usize)>,
+        include_count: bool,
     ) -> Result<(Vec<String>, usize)>;
     async fn create_data_source_document(
         &self,
@@ -219,6 +220,7 @@ pub trait Store {
         limit_offset: Option<(usize, usize)>,
         view_filter: &Option<SearchFilter>,
         latest_hash: &Option<String>,
+        include_count: bool,
     ) -> Result<(Vec<DocumentVersion>, usize)>;
     async fn list_data_source_documents(
         &self,
@@ -228,6 +230,7 @@ pub trait Store {
         document_ids: &Option<Vec<String>>,
         limit_offset: Option<(usize, usize)>,
         remove_system_tags: bool,
+        include_count: bool,
     ) -> Result<(Vec<Document>, usize)>;
     async fn delete_data_source_document(
         &self,


### PR DESCRIPTION
## Description

This adds a parameter to not do an expensive count query when it's not needed (as in data_source.rs )

## Risk

none

## Deploy Plan

deploy core