### PR TITLE
parents migrator: use timestamp index and filter superseded

### DIFF
--- a/front/migrations/20241211_parents_migrator.ts
+++ b/front/migrations/20241211_parents_migrator.ts
@@ -321,19 +321,26 @@ async function migrateDataSource({
   const coreDataSourceId = coreDataSourceRows[0].id;
 
   // For all documents in the data source (can be big).
-  let nextDocumentId = 0;
+  let nextTimestamp = 0;
 
   for (;;) {
     const [coreDocumentRows] = (await corePrimary.query(
-      "SELECT id, parents, document_id FROM data_sources_documents " +
-        "WHERE data_source = ? AND id > ? ORDER BY id ASC LIMIT ?",
+      "SELECT id, parents, document_id, timestamp FROM data_sources_documents " +
+        "WHERE data_source = ? AND STATUS = ? AND timestamp > ? " +
+        "ORDER BY timestamp ASC LIMIT ?",
       {
-        replacements: [coreDataSourceId, nextDocumentId, QUERY_BATCH_SIZE],
+        replacements: [
+          coreDataSourceId,
+          "latest",
+          nextTimestamp,
+          QUERY_BATCH_SIZE,
+        ],
       }
     )) as {
       id: number;
       parents: string[];
       document_id: string;
+      timestamp: number;
     }[][];
 
     if (coreDocumentRows.length === 0) {
@@ -359,14 +366,14 @@ async function migrateDataSource({
         {
           error: e,
           nextDataSourceId: dataSource.id,
-          nextDocumentId,
+          nextTimestamp,
         },
         `ERROR`
       );
       throw e;
     }
 
-    nextDocumentId = coreDocumentRows[coreDocumentRows.length - 1].id;
+    nextTimestamp = coreDocumentRows[coreDocumentRows.length - 1].timestamp;
   }
 
   // For all the tables in the data source (can be big).


### PR DESCRIPTION
## Description

Do not retrieve superseded and use timestamp to paginate leveraging this index:

```
"idx_data_sources_documents_data_source_status_timestamp" btree (data_source, status, "timestamp")
```

## Risk

Low tested in dev

## Deploy Plan

N/A