### PR TITLE
fix skip document_tracker

### DIFF
--- a/front/start_worker.ts
+++ b/front/start_worker.ts
@@ -4,7 +4,7 @@ import { hideBin } from "yargs/helpers";
 
 import logger from "@app/logger/logger";
 import { runPokeWorker } from "@app/poke/temporal/worker";
-// import { runDocumentTrackerWorker } from "@app/temporal/document_tracker/worker";
+import { runDocumentTrackerWorker } from "@app/temporal/document_tracker/worker";
 import { runHardDeleteWorker } from "@app/temporal/hard_delete/worker";
 import { runLabsWorker } from "@app/temporal/labs/worker";
 import { runMentionsCountWorker } from "@app/temporal/mentions_count_queue/worker";
@@ -23,7 +23,7 @@ type WorkerName =
   | "mentions_count"
   | "permissions_queue"
   | "poke"
-  // | "document_tracker"
+  | "document_tracker"
   | "production_checks"
   | "scrub_workspace_queue"
   | "update_workspace_usage"
@@ -36,7 +36,7 @@ const workerFunctions: Record<WorkerName, () => Promise<void>> = {
   mentions_count: runMentionsCountWorker,
   permissions_queue: runPermissionsWorker,
   poke: runPokeWorker,
-  // document_tracker: runDocumentTrackerWorker,
+  document_tracker: runDocumentTrackerWorker,
   production_checks: runProductionChecksWorker,
   scrub_workspace_queue: runScrubWorkspaceQueueWorker,
   update_workspace_usage: runUpdateWorkspaceUsageWorker,
@@ -46,6 +46,8 @@ const workerFunctions: Record<WorkerName, () => Promise<void>> = {
 const ALL_WORKERS = Object.keys(workerFunctions);
 
 async function runWorkers(workers: WorkerName[]) {
+  // Disable document_tracker
+  workers = workers.filter((worker) => worker !== "document_tracker");
   for (const worker of workers) {
     workerFunctions[worker]().catch((err) =>
       logger.error({ error: err }, `Error running ${worker} worker.`)


### PR DESCRIPTION
## Description

document_tracker is explicitely passed as argument so commenting it in start_worker leads to an error:
https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22or1g1n-186209%22%0Aresource.labels.location%3D%22us-central1%22%0Aresource.labels.cluster_name%3D%22dust-kube%22%0Aresource.labels.namespace_name%3D%22default%22%0Aresource.labels.pod_name%3D%22front-worker-deployment-5f6c776f89-627rt%22%0Aresource.labels.container_name%3D%22front-worker%22;cursorTimestamp=2024-12-11T21:08:19.280640140Z;duration=PT1H?inv=1&invt=Abj3dw&project=or1g1n-186209

## Risk

N/A

## Deploy Plan

- deploy `connectors`