### PR TITLE
[connectors] do not send parentId until parents list is valid

### DIFF
--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -153,7 +153,7 @@ async function _upsertToDatasource({
         title,
         mime_type: mimeType,
         tags: tags?.map((tag) => tag.substring(0, 512)),
-        parent_id: parents[1] ?? null,
+        parent_id: null, // TODO: parents[1] ?? null when we are sure parents[0] == documentId in all cases
         parents,
         light_document_output: true,
         upsert_context: upsertContext,

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -66,7 +66,7 @@ type UpsertToDataSourceParams = {
   timestampMs?: number;
   tags?: string[];
   parents: string[];
-  parentId: string | null;
+  parentId?: string | null;
   loggerArgs?: Record<string, string | number>;
   upsertContext: UpsertContext;
   title: string;
@@ -743,7 +743,7 @@ export async function upsertTableFromCsv({
   loggerArgs?: Record<string, string | number>;
   truncate: boolean;
   parents: string[];
-  parentId: string | null;
+  parentId?: string | null;
   useAppForHeaderDetection?: boolean;
   title: string;
   mimeType: string;
@@ -1146,7 +1146,7 @@ export async function upsertFolderNode({
   folderId: string;
   timestampMs?: number;
   parents: string[];
-  parentId: string | null;
+  parentId?: string | null;
   title: string;
 }) {
   const now = new Date();

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -153,7 +153,7 @@ async function _upsertToDatasource({
         title,
         mime_type: mimeType,
         tags: tags?.map((tag) => tag.substring(0, 512)),
-        parent_id: parents[1] ?? null,
+        parent_id: null,
         parents,
         light_document_output: true,
         upsert_context: upsertContext,
@@ -771,7 +771,7 @@ export async function upsertTableFromCsv({
     `/data_sources/${dataSourceConfig.dataSourceId}/tables/csv`;
   const dustRequestPayload: UpsertTableFromCsvRequestType = {
     name: tableName,
-    parentId: parents[1] ?? null,
+    parentId: null,
     parents,
     description: tableDescription,
     csv: tableCsv,
@@ -1150,7 +1150,7 @@ export async function upsertFolderNode({
     folderId,
     timestampMs ? timestampMs : now.getTime(),
     title,
-    parents[1] ?? null,
+    null,
     parents
   );
 

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -153,7 +153,7 @@ async function _upsertToDatasource({
         title,
         mime_type: mimeType,
         tags: tags?.map((tag) => tag.substring(0, 512)),
-        parent_id: null,
+        parent_id: parents[1] ?? null,
         parents,
         light_document_output: true,
         upsert_context: upsertContext,
@@ -771,7 +771,7 @@ export async function upsertTableFromCsv({
     `/data_sources/${dataSourceConfig.dataSourceId}/tables/csv`;
   const dustRequestPayload: UpsertTableFromCsvRequestType = {
     name: tableName,
-    parentId: null,
+    parentId: null, // TODO: parents[1] ?? null when we are sure parents[0] == tableId in all cases
     parents,
     description: tableDescription,
     csv: tableCsv,
@@ -1150,7 +1150,7 @@ export async function upsertFolderNode({
     folderId,
     timestampMs ? timestampMs : now.getTime(),
     title,
-    null,
+    parents[1] ?? null,
     parents
   );
 

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -66,6 +66,7 @@ type UpsertToDataSourceParams = {
   timestampMs?: number;
   tags?: string[];
   parents: string[];
+  parentId: string | null;
   loggerArgs?: Record<string, string | number>;
   upsertContext: UpsertContext;
   title: string;
@@ -100,6 +101,7 @@ async function _upsertToDatasource({
   title,
   mimeType,
   async,
+  parentId = null,
 }: UpsertToDataSourceParams) {
   return tracer.trace(
     `connectors`,
@@ -153,7 +155,7 @@ async function _upsertToDatasource({
         title,
         mime_type: mimeType,
         tags: tags?.map((tag) => tag.substring(0, 512)),
-        parent_id: null, // TODO: parents[1] ?? null when we are sure parents[0] == documentId in all cases
+        parent_id: parentId,
         parents,
         light_document_output: true,
         upsert_context: upsertContext,
@@ -728,6 +730,7 @@ export async function upsertTableFromCsv({
   loggerArgs,
   truncate,
   parents,
+  parentId = null,
   useAppForHeaderDetection,
   title,
   mimeType,
@@ -740,6 +743,7 @@ export async function upsertTableFromCsv({
   loggerArgs?: Record<string, string | number>;
   truncate: boolean;
   parents: string[];
+  parentId: string | null;
   useAppForHeaderDetection?: boolean;
   title: string;
   mimeType: string;
@@ -771,7 +775,7 @@ export async function upsertTableFromCsv({
     `/data_sources/${dataSourceConfig.dataSourceId}/tables/csv`;
   const dustRequestPayload: UpsertTableFromCsvRequestType = {
     name: tableName,
-    parentId: null, // TODO: parents[1] ?? null when we are sure parents[0] == tableId in all cases
+    parentId,
     parents,
     description: tableDescription,
     csv: tableCsv,
@@ -1135,12 +1139,14 @@ export async function upsertFolderNode({
   folderId,
   timestampMs,
   parents,
+  parentId = parents[1] ?? null,
   title,
 }: {
   dataSourceConfig: DataSourceConfig;
   folderId: string;
   timestampMs?: number;
   parents: string[];
+  parentId: string | null;
   title: string;
 }) {
   const now = new Date();
@@ -1150,7 +1156,7 @@ export async function upsertFolderNode({
     folderId,
     timestampMs ? timestampMs : now.getTime(),
     title,
-    parents[1] ?? null,
+    parentId,
     parents
   );
 


### PR DESCRIPTION
## Description

We tried to send `parents[1]` as parentId, but if the parents list does not have the table id in `parents[0]`, it's automatically added by : https://github.com/dust-tt/dust/blob/3bb882e07c809f60ab5934ecdcc5fe270d7d44e3/front/lib/api/data_sources.ts#L391 and 

https://github.com/dust-tt/dust/blob/3bb882e07c809f60ab5934ecdcc5fe270d7d44e3/front/lib/api/data_sources.ts#L466

shifting the array and making `parents[1]` the grandparent of the node instead of its parent . This leads to an error in core detecting `parentId !== parents[1]`. 

Folder endpoints does not have this issue.

Setting back to null until we clean parents array.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy connectors