### PR TITLE
Fix: extension to match latest dust client sdk

### DIFF
--- a/extension/app/src/components/DropzoneContainer.tsx
+++ b/extension/app/src/components/DropzoneContainer.tsx
@@ -2,8 +2,8 @@ import {
   isSupportedFileContentType,
   isSupportedImageContentType,
   isSupportedPlainTextContentType,
-  supportedImage,
-  supportedPlainText,
+  supportedImageFileFormats,
+  supportedOtherFileFormats,
 } from "@dust-tt/client";
 import { DropzoneOverlay, useSendNotification } from "@dust-tt/sparkle";
 import { useFileDrop } from "@extension/components/conversation/FileUploaderContext";
@@ -19,9 +19,10 @@ const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
 const generateFileName = (blob: Blob) => {
   const extensions =
-    (isSupportedImageContentType(blob.type) && supportedImage[blob.type]) ||
+    (isSupportedImageContentType(blob.type) &&
+      supportedImageFileFormats[blob.type]) ||
     (isSupportedPlainTextContentType(blob.type) &&
-      supportedPlainText[blob.type]);
+      supportedOtherFileFormats[blob.type]);
   const extension = extensions ? extensions[0] : "";
   const name = Array(12)
     .fill(null)

--- a/extension/app/src/components/conversation/UserMessage.tsx
+++ b/extension/app/src/components/conversation/UserMessage.tsx
@@ -48,7 +48,7 @@ export function UserMessage({
   return (
     <ConversationMessage
       pictureUrl={message.user?.image || message.context.profilePictureUrl}
-      name={message.context.fullName}
+      name={message.context.fullName ?? null}
       renderName={(name) => <div className="text-base font-medium">{name}</div>}
       type="user"
       citations={citations}

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -69,7 +69,7 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.0.7",
+      "version": "1.0.13",
       "license": "ISC",
       "dependencies": {
         "eventsource-parser": "^1.1.1",

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Client for Dust API",
   "repository": {
     "type": "git",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -79,7 +79,7 @@ export type ConnectorsAPIErrorType = z.infer<
 >;
 
 // Supported content types that are plain text and can be sent as file-less content fragment.
-const supportedOtherFileFormats = {
+export const supportedOtherFileFormats = {
   "application/msword": [".doc", ".docx"],
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document": [
     ".doc",
@@ -104,7 +104,7 @@ const supportedOtherFileFormats = {
 } as const;
 
 // Supported content types for images.
-const supportedImageFileFormats = {
+export const supportedImageFileFormats = {
   "image/jpeg": [".jpg", ".jpeg"],
   "image/png": [".png"],
   "image/gif": [".gif"],
@@ -120,6 +120,11 @@ const supportedOtherContentTypes = Object.keys(
 const supportedImageContentTypes = Object.keys(
   supportedImageFileFormats
 ) as ImageContentType[];
+
+export const supportedFileExtensions = [
+  ...Object.keys(supportedOtherFileFormats),
+  ...Object.keys(supportedImageFileFormats),
+];
 
 export type SupportedFileContentType = OtherContentType | ImageContentType;
 const supportedUploadableContentType = [


### PR DESCRIPTION
## Description

Update extension to match the latest dust client.

## Risk

Low, `npm build` works again.

## Deploy Plan

Push extension to chrome webstore.