### PR TITLE
[front] Remove the logic of upserting the `document_id` as `parents[0]` from front

### DIFF
--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -630,14 +630,6 @@ export async function handleDataSourceTableCSVUpsert({
   const tableId = params.tableId ?? generateRandomModelSId();
   const tableParents: string[] = params.parents ?? [];
 
-  // Ensure that the tableId is included in the parents as the first item.
-  // remove it if it's already present and add it as the first item.
-  const indexOfTableId = tableParents.indexOf(tableId);
-  if (indexOfTableId !== -1) {
-    tableParents.splice(indexOfTableId, 1);
-  }
-  tableParents.unshift(tableId);
-
   const flags = await getFeatureFlags(owner);
 
   const useAppForHeaderDetection =

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -382,14 +382,6 @@ export async function upsertDocument({
   const documentId = name;
   const documentParents = parents || [];
 
-  // Ensure that the documentId is included in the parents as the first item.
-  // remove it if it's already present and add it as the first item.
-  const indexOfDocumentId = documentParents.indexOf(documentId);
-  if (indexOfDocumentId !== -1) {
-    documentParents.splice(indexOfDocumentId, 1);
-  }
-  documentParents.unshift(documentId);
-
   // Create document with the Dust internal API.
   const upsertRes = await coreAPI.upsertDataSourceDocument({
     projectId: dataSource.dustAPIProjectId,
@@ -456,14 +448,6 @@ export async function upsertTable({
 }) {
   const nonNullTableId = tableId ?? generateRandomModelSId();
   const tableParents: string[] = parents ?? [];
-
-  // Ensure that the nonNullTableId is included in the parents as the first item.
-  // remove it if it's already present and add it as the first item.
-  const indexOfTableId = tableParents.indexOf(nonNullTableId);
-  if (indexOfTableId !== -1) {
-    tableParents.splice(indexOfTableId, 1);
-  }
-  tableParents.unshift(nonNullTableId);
 
   const flags = await getFeatureFlags(auth.getNonNullableWorkspace());
 

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -382,6 +382,14 @@ export async function upsertDocument({
   const documentId = name;
   const documentParents = parents || [];
 
+  // Ensure that the documentId is included in the parents as the first item.
+  // remove it if it's already present and add it as the first item.
+  const indexOfDocumentId = documentParents.indexOf(documentId);
+  if (indexOfDocumentId !== -1) {
+    documentParents.splice(indexOfDocumentId, 1);
+  }
+  documentParents.unshift(documentId);
+
   // Create document with the Dust internal API.
   const upsertRes = await coreAPI.upsertDataSourceDocument({
     projectId: dataSource.dustAPIProjectId,
@@ -448,6 +456,14 @@ export async function upsertTable({
 }) {
   const nonNullTableId = tableId ?? generateRandomModelSId();
   const tableParents: string[] = parents ?? [];
+
+  // Ensure that the nonNullTableId is included in the parents as the first item.
+  // remove it if it's already present and add it as the first item.
+  const indexOfTableId = tableParents.indexOf(nonNullTableId);
+  if (indexOfTableId !== -1) {
+    tableParents.splice(indexOfTableId, 1);
+  }
+  tableParents.unshift(nonNullTableId);
 
   const flags = await getFeatureFlags(auth.getNonNullableWorkspace());
 


### PR DESCRIPTION
## Description

- This PR removes the logic of upserting the `document_id` as `parents[0]` in front.
- The idea is to leave it up to connectors to set the parents, only doing validation in front (we already have logs/metrics).

## Risk

- anything that breaks here is something to change in connectors.

## Deploy Plan

- Deploy front.
