### PR TITLE
[parents_migration] Skip documents without parents in Confluence

### DIFF
--- a/front/migrations/20241211_parents_migrator.ts
+++ b/front/migrations/20241211_parents_migrator.ts
@@ -25,7 +25,7 @@ type ProviderMigrator = {
   transformer: (
     nodeId: string,
     parents: string[]
-  ) => { parents: string[]; parentId: string | null } | null; // null here means we skip the document
+  ) => { parents: string[]; parentId: string | null };
   /// returns [nodeId, ...newParents] idempotently
   cleaner: (
     nodeId: string,
@@ -198,7 +198,7 @@ const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
           { nodeId, parents, problem: "Not enough parents" },
           "Invalid Confluence parents"
         );
-        return null;
+        return { parents: [nodeId], parentId: null };
       }
       return {
         parents: [
@@ -248,15 +248,12 @@ async function migrateDocument({
   let newParents = coreDocument.parents;
   let newParentId: string | null = null;
   try {
-    const newData =
+    const { parents, parentId } =
       action === "transform"
         ? migrator.transformer(coreDocument.document_id, coreDocument.parents)
         : migrator.cleaner(coreDocument.document_id, coreDocument.parents);
-    if (newData === null) {
-      return new Ok(undefined);
-    }
-    newParents = newData.parents;
-    newParentId = newData.parentId;
+    newParents = parents;
+    newParentId = parentId;
   } catch (e) {
     logger.error(
       {
@@ -328,15 +325,12 @@ async function migrateTable({
   let newParents = coreTable.parents;
   let newParentId: string | null = null;
   try {
-    const newData =
+    const { parents, parentId } =
       action === "transform"
         ? migrator.transformer(coreTable.table_id, coreTable.parents)
         : migrator.cleaner(coreTable.table_id, coreTable.parents);
-    if (newData === null) {
-      return new Ok(undefined);
-    }
-    newParents = newData.parents;
-    newParentId = newData.parentId;
+    newParents = parents;
+    newParentId = parentId;
   } catch (e) {
     logger.error(
       {


### PR DESCRIPTION
## Description

- Some data_source_documents in Confluence have 0 parent.
- This seems to be some legacy issue.
- Unlike Slack we cannot recover the parents using only the `nodeId`.
- Plan is to not handle them for now (only log), the implement a `sync-page` in Confluence admin CLI and use it to fix the parents of the skipped pages.

## Risk

## Deploy Plan

no deploy.