### PR TITLE
Merge the 2 steps in `agent_data_source_configurations`  migration

### DIFF
--- a/front/migrations/20241211_update_parents_agent_data_source_config.ts
+++ b/front/migrations/20241211_update_parents_agent_data_source_config.ts
@@ -50,11 +50,9 @@ export function getUpdatedConfluenceId(internalId: string): string {
 /// we put null values if no migration is needed
 const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
   slack: (parents) =>
-    _.uniq([
-      ...parents.map(
-        (parent) => `slack-channel-` + _.last(parent.split(`slack-channel-`))!
-      ),
-    ]),
+    parents.map(
+      (parent) => `slack-channel-` + _.last(parent.split(`slack-channel-`))!
+    ),
   google_drive: null,
   microsoft: null,
   github: null,


### PR DESCRIPTION
## Description

- This PR changes the migration for `agent_data_source_configurations` to directly change `oldParentIds => newParentIds`.
- Previously, it did it in 2 passes: double the parents, then remove the old ones.

## Risk

- High, every migrator function should be very idempotent.

## Deploy Plan

no deploy, migration file
