### PR TITLE
fix(doc tracker): skip for batch syncs

### DIFF
--- a/front/lib/document_upsert_hooks/hooks/index.ts
+++ b/front/lib/document_upsert_hooks/hooks/index.ts
@@ -34,6 +34,11 @@ export function runDocumentUpsertHooks(
     return;
   }
 
+  if (params.upsertContext?.sync_type !== "incremental") {
+    // Skip hooks for batch syncs
+    return;
+  }
+
   for (const hook of DOCUMENT_UPSERT_HOOKS) {
     void wakeLock(async () => {
       try {


### PR DESCRIPTION
## Description

We used to skip it and it was lost during refactoring. Running the hooks on batch syncs is very costly

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
