### PR TITLE
connectors[slack]: update content-nodes to use new itnernalIds

### DIFF
--- a/connectors/src/connectors/slack/lib/utils.ts
+++ b/connectors/src/connectors/slack/lib/utils.ts
@@ -1,3 +1,5 @@
+import _ from "lodash";
+
 export function getWeekStart(date: Date): Date {
   const dateCopy = new Date(date);
 
@@ -48,3 +50,11 @@ export const timeAgoFrom = (millisSinceEpoch: number) => {
   }
   return seconds + "s";
 };
+
+export function internalIdFromSlackChannelId(channel: string) {
+  return `slack-channel-${_.last(channel.split("slack-channel-"))!}`;
+}
+
+export function slackChannelIdFromInternalId(nodeId: string) {
+  return _.last(nodeId.split("slack-channel-"))!;
+}

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -42,7 +42,7 @@ import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
-import { getWeekEnd, getWeekStart } from "../lib/utils";
+import { getWeekEnd, getWeekStart, internalIdFromSlackChannelId } from "../lib/utils";
 
 const logger = mainLogger.child({ provider: "slack" });
 
@@ -588,7 +588,7 @@ export async function syncNonThreaded(
     documentUrl: sourceUrl,
     timestampMs: updatedAt,
     tags,
-    parents: [documentId, channelId, `slack-channel-${channelId}`],
+    parents: [documentId, channelId, internalIdFromSlackChannelId(channelId)],
     upsertContext: {
       sync_type: isBatchSync ? "batch" : "incremental",
     },
@@ -782,7 +782,7 @@ export async function syncThread(
     documentUrl: sourceUrl,
     timestampMs: updatedAt,
     tags,
-    parents: [documentId, channelId, `slack-channel-${channelId}`],
+    parents: [documentId, channelId, internalIdFromSlackChannelId(channelId)],
     upsertContext: {
       sync_type: isBatchSync ? "batch" : "incremental",
     },

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -24,6 +24,11 @@ import {
 import { isSlackWebAPIPlatformError } from "@connectors/connectors/slack/lib/errors";
 import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
 import { getRepliesFromThread } from "@connectors/connectors/slack/lib/thread";
+import {
+  getWeekEnd,
+  getWeekStart,
+  internalIdFromSlackChannelId,
+} from "@connectors/connectors/slack/lib/utils";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { cacheGet, cacheSet } from "@connectors/lib/cache";
 import {
@@ -41,8 +46,6 @@ import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
-
-import { getWeekEnd, getWeekStart, internalIdFromSlackChannelId } from "../lib/utils";
 
 const logger = mainLogger.child({ provider: "slack" });
 


### PR DESCRIPTION
## Description

Move connectors to use the new internalIds

Updates:
- retrievePermissions
- setPermissions
- retrieveBatchContentNodes
- retrieveContentNodeParents

## Risk

Break knowledge and assistant builder for slack

## Deploy Plan

- deploy `connectors` 
- shortly after run migrations that changes agent configurations