### PR TITLE
Bump extension: 0.0.3

### DIFF
--- a/extension/app/src/pages/MainPage.tsx
+++ b/extension/app/src/pages/MainPage.tsx
@@ -89,7 +89,11 @@ export const MainPage = ({
           </div>
         }
       />
-
+      <div className="flex items-start justify-between">
+        <div className="fixed bottom-0 right-0 z-10 p-2 text-sm element">
+          <p className="text-sm font-normal text-element-700">⇧⌘E</p>
+        </div>
+      </div>
       <div className="h-full w-full pt-28 max-w-4xl mx-auto flex justify-center">
         <FileDropProvider>
           <DropzoneContainer

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dust",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Get more done, faster, with the power of your assistants at your fingertips.",
   "icons": {
     "16": "images/dust16.png",
@@ -13,13 +13,13 @@
     "service_worker": "background.js"
   },
   "action": {
-    "default_title": "Open Dust side panel"
+    "default_title": "Dust ⇧⌘E"
   },
   "commands": {
     "_execute_action": {
       "suggested_key": {
-        "default": "Ctrl + Right",
-        "mac": "Command + Right"
+        "default": "Ctrl + Shift + E",
+        "mac": "Command + Shift + E"
       }
     }
   },

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@dust-tt/client": "file:../sdks/js",
+        "@dust-tt/client": "^1.0.15",
         "@dust-tt/sparkle": "^0.2.332",
         "@tailwindcss/forms": "^0.5.9",
         "@tiptap/extension-character-count": "^2.9.1",
@@ -65,28 +65,6 @@
         "webpack-ext-reloader": "^1.1.13",
         "webpackbar": "^6.0.1",
         "zip-webpack-plugin": "^4.0.1"
-      }
-    },
-    "../sdks/js": {
-      "name": "@dust-tt/client",
-      "version": "1.0.13",
-      "license": "ISC",
-      "dependencies": {
-        "eventsource-parser": "^1.1.1",
-        "moment-timezone": "^0.5.46",
-        "zod": "^3.23.8"
-      },
-      "devDependencies": {
-        "@tsconfig/recommended": "^1.0.3",
-        "@types/node": "^22.7.5",
-        "@types/uuid": "^9.0.7",
-        "dts-cli": "^2.0.5",
-        "eslint-plugin-simple-import-sort": "^12.1.0",
-        "tslib": "^2.6.2",
-        "typescript": "^5.4.5"
-      },
-      "engines": {
-        "node": ">=20"
       }
     },
     "../types": {
@@ -267,8 +245,17 @@
       }
     },
     "node_modules/@dust-tt/client": {
-      "resolved": "../sdks/js",
-      "link": true
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@dust-tt/client/-/client-1.0.15.tgz",
+      "integrity": "sha512-i9N3BBGzPorLDkTW/PpbeVHNjcJ2FIkU9C0mT9VIOkaJh7yaiM4XOLxev5nA4IOnPzA0qj7QyGvqmJr2+GqDNA==",
+      "dependencies": {
+        "eventsource-parser": "^1.1.1",
+        "moment-timezone": "^0.5.46",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@dust-tt/sparkle": {
       "version": "0.2.332",
@@ -5711,6 +5698,14 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/eventsource-parser": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-1.1.2.tgz",
+      "integrity": "sha512-v0eOBUbiaFojBu2s2NPBfYUoRR9GjcDNvCXVaqEf5vVfpIAh9f8RCo4vXTP8c63QRKCFwoLpMpTdPwwhEKVgzA==",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -8806,6 +8801,17 @@
         "node": "*"
       }
     },
+    "node_modules/moment-timezone": {
+      "version": "0.5.46",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.46.tgz",
+      "integrity": "sha512-ZXm9b36esbe7OmdABqIWJuBBiLLwAjrN7CE+7sYdCCx82Nabt1wHDj8TVseS59QIlfFPbOoiBPm6ca9BioG4hw==",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -8839,9 +8845,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "funding": [
         {
           "type": "github",
@@ -12551,6 +12557,14 @@
       "peerDependencies": {
         "webpack": "^4.0.0 || ^5.0.0",
         "webpack-sources": "*"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
+      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zwitch": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -48,7 +48,7 @@
     "zip-webpack-plugin": "^4.0.1"
   },
   "dependencies": {
-    "@dust-tt/client": "file:../sdks/js",
+    "@dust-tt/client": "^1.0.15",
     "@dust-tt/sparkle": "^0.2.332",
     "@tailwindcss/forms": "^0.5.9",
     "@tiptap/extension-character-count": "^2.9.1",


### PR DESCRIPTION
## Description

Bumping the extension to submit the version 0.0.3.

What's new in this version: 
- Fix authors of assistants in favorites card.
- Bump dust client to fix an issue unrelated to the extension. Load this lib as a proper published lib. 
- Set a new default shortcut (and display it on the UI). 

## Risk

/ 

## Deploy Plan

Merge.
Create a new package, ask a few people to test it internally.
Publish this version to the chrome web store.
