### PR TITLE
enh(Zendesk): use the incremental endpoint for full sync

### DIFF
--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -2,8 +2,8 @@ import type {
   ZendeskCheckIsAdminResponseType,
   ZendeskCommandType,
   ZendeskCountTicketsResponseType,
+  ZendeskResyncTicketsResponseType,
 } from "@dust-tt/types";
-import type { ZendeskResyncTicketsResponseType } from "@dust-tt/types/src";
 
 import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
 import {

--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -3,6 +3,7 @@ import type {
   ZendeskCommandType,
   ZendeskCountTicketsResponseType,
 } from "@dust-tt/types";
+import type { ZendeskResyncTicketsResponseType } from "@dust-tt/types/src";
 
 import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
 import {
@@ -10,6 +11,7 @@ import {
   fetchZendeskTicketCount,
   getZendeskBrandSubdomain,
 } from "@connectors/connectors/zendesk/lib/zendesk_api";
+import { launchZendeskTicketReSyncWorkflow } from "@connectors/connectors/zendesk/temporal/client";
 import { default as topLogger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { ZendeskConfigurationResource } from "@connectors/resources/zendesk_resources";
@@ -18,7 +20,9 @@ export const zendesk = async ({
   command,
   args,
 }: ZendeskCommandType): Promise<
-  ZendeskCheckIsAdminResponseType | ZendeskCountTicketsResponseType
+  | ZendeskCheckIsAdminResponseType
+  | ZendeskCountTicketsResponseType
+  | ZendeskResyncTicketsResponseType
 > => {
   const logger = topLogger.child({ majorCommand: "zendesk", command, args });
 
@@ -80,6 +84,22 @@ export const zendesk = async ({
         "Number of valid tickets found for the brand."
       );
       return { ticketCount };
+    }
+    case "resync-tickets": {
+      if (!connector) {
+        throw new Error(`Connector ${connectorId} not found`);
+      }
+      const result = await launchZendeskTicketReSyncWorkflow(connector, {
+        forceResync: args.forceResync || false,
+      });
+      if (result.isErr()) {
+        logger.error(
+          { error: result.error },
+          "Error launching the sync workflow."
+        );
+        throw result.error;
+      }
+      return { success: true };
     }
   }
 };

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -303,7 +303,7 @@ export async function fetchZendeskArticlesInCategory(
 /**
  * Fetches a batch of the recently updated tickets from the Zendesk API using the incremental API endpoint.
  */
-export async function fetchRecentlyUpdatedTickets(
+export async function fetchZendeskTickets(
   accessToken: string,
   {
     brandSubdomain,
@@ -320,7 +320,7 @@ export async function fetchRecentlyUpdatedTickets(
   const response = await fetchFromZendeskWithRetries({
     url:
       url ?? // using the URL if we got one, reconstructing it otherwise
-      `https://${brandSubdomain}.zendesk.com/api/v2/incremental/tickets/cursor.json?start_time=${startTime}`,
+      `https://${brandSubdomain}.zendesk.com/api/v2/incremental/tickets/cursor?start_time=${startTime}`,
     accessToken,
   });
   return {
@@ -330,49 +330,6 @@ export async function fetchRecentlyUpdatedTickets(
       response.after_url !== null &&
       response.tickets.length !== 0,
     nextLink: response.after_url,
-  };
-}
-
-/**
- * Fetches a batch of tickets from the Zendesk API.
- * Only fetches tickets that have been solved, and that were updated within the retention period.
- */
-export async function fetchZendeskTicketsInBrand(
-  accessToken: string,
-  {
-    brandSubdomain,
-    pageSize,
-    retentionPeriodDays,
-    url,
-  }:
-    | {
-        brandSubdomain: string;
-        pageSize: number;
-        retentionPeriodDays: number;
-        url?: never;
-      }
-    | {
-        brandSubdomain?: never;
-        pageSize?: never;
-        retentionPeriodDays?: never;
-        url: string;
-      }
-): Promise<{
-  tickets: ZendeskFetchedTicket[];
-  hasMore: boolean;
-  nextLink: string | null;
-}> {
-  const query = `status:solved updated>${retentionPeriodDays}days`;
-  const response = await fetchFromZendeskWithRetries({
-    url:
-      url ?? // using the URL if we got one, reconstructing it otherwise
-      `https://${brandSubdomain}.zendesk.com/api/v2/search/export.json?filter[type]=ticket&page[size]=${pageSize}&query=${encodeURIComponent(query)}`,
-    accessToken,
-  });
-  return {
-    tickets: response.results,
-    hasMore: response.meta.has_more,
-    nextLink: response.links.next,
   };
 }
 

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -349,6 +349,9 @@ export async function fetchZendeskTicketCount({
   | { retentionPeriodDays?: number; query: string }
   | { retentionPeriodDays: number; query?: null }
 )): Promise<number> {
+  logger.warn(
+    "Ticket count relies on the Search API, which has proved unreliable."
+  );
   query ||= `type:ticket status:solved updated>${retentionPeriodDays}days`;
   const url = `https://${brandSubdomain}.zendesk.com/api/v2/search/count?query=${encodeURIComponent(query)}`;
   const response = await fetchFromZendeskWithRetries({ url, accessToken });

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -10,7 +10,7 @@ import {
   createZendeskClient,
   fetchZendeskArticlesInCategory,
   fetchZendeskCategoriesInBrand,
-  fetchZendeskTicketsInBrand,
+  fetchZendeskTickets,
   getZendeskBrandSubdomain,
 } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import { ZENDESK_BATCH_SIZE } from "@connectors/connectors/zendesk/temporal/config";
@@ -417,15 +417,12 @@ export async function syncZendeskTicketBatchActivity({
     brandId,
   });
 
-  const { tickets, hasMore, nextLink } = await fetchZendeskTicketsInBrand(
+  const startTime =
+    Math.floor(currentSyncDateMs / 1000) -
+    configuration.retentionPeriodDays * 24 * 60 * 60; // days to seconds
+  const { tickets, hasMore, nextLink } = await fetchZendeskTickets(
     accessToken,
-    url
-      ? { url }
-      : {
-          brandSubdomain,
-          pageSize: ZENDESK_BATCH_SIZE,
-          retentionPeriodDays: configuration.retentionPeriodDays,
-        }
+    url ? { url } : { brandSubdomain, startTime }
   );
 
   if (tickets.length === 0) {
@@ -436,8 +433,10 @@ export async function syncZendeskTicketBatchActivity({
     return { hasMore: false, nextLink: "" };
   }
 
+  const solvedTickets = tickets.filter((t) => t.status === "solved");
+
   const comments2d = await concurrentExecutor(
-    tickets,
+    solvedTickets,
     async (ticket) => zendeskApiClient.tickets.getComments(ticket.id),
     { concurrency: 3, onBatchComplete: heartbeat }
   );
@@ -447,7 +446,7 @@ export async function syncZendeskTicketBatchActivity({
   const { result: users } = await zendeskApiClient.users.showMany(userIds);
 
   const res = await concurrentExecutor(
-    _.zip(tickets, comments2d),
+    _.zip(solvedTickets, comments2d),
     async ([ticket, comments]) => {
       if (!ticket || !comments) {
         throw new Error(

--- a/connectors/src/connectors/zendesk/temporal/client.ts
+++ b/connectors/src/connectors/zendesk/temporal/client.ts
@@ -199,3 +199,24 @@ export async function launchZendeskGarbageCollectionWorkflow(
 
   return new Ok(undefined);
 }
+
+/**
+ * Launches a Zendesk workflow that will resync the tickets.
+ *
+ * It recreates the signals necessary to resync every brand whose tickets are selected by the user.
+ */
+export async function launchZendeskTicketReSyncWorkflow(
+  connector: ConnectorResource,
+  { forceResync = false }: { forceResync?: boolean } = {}
+): Promise<Result<string, Error>> {
+  const brandIds = await ZendeskBrandResource.fetchTicketsAllowedBrandIds(
+    connector.id
+  );
+
+  const result = await launchZendeskSyncWorkflow(connector, {
+    brandIds,
+    forceResync,
+  });
+
+  return result.isErr() ? result : new Ok(connector.id.toString());
+}

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -222,7 +222,7 @@ export async function syncZendeskTicketUpdateBatchActivity({
           dataSourceConfig,
           loggerArgs,
         });
-      } else if (ticket.status === "solved") {
+      } else if (["solved", "closed"].includes(ticket.status)) {
         const comments = await zendeskApiClient.tickets.getComments(ticket.id);
         const { result: users } = await zendeskApiClient.users.showMany(
           comments.map((c) => c.author_id)

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -10,7 +10,7 @@ import {
   changeZendeskClientSubdomain,
   createZendeskClient,
   fetchRecentlyUpdatedArticles,
-  fetchRecentlyUpdatedTickets,
+  fetchZendeskTickets,
 } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
@@ -207,7 +207,7 @@ export async function syncZendeskTicketUpdateBatchActivity({
     brandId,
   });
 
-  const { tickets, hasMore, nextLink } = await fetchRecentlyUpdatedTickets(
+  const { tickets, hasMore, nextLink } = await fetchZendeskTickets(
     accessToken,
     url ? { url } : { brandSubdomain, startTime }
   );

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -219,11 +219,16 @@ export type IntercomForceResyncArticlesResponseType = t.TypeOf<
  */
 export const ZendeskCommandSchema = t.type({
   majorCommand: t.literal("zendesk"),
-  command: t.union([t.literal("check-is-admin"), t.literal("count-tickets")]),
+  command: t.union([
+    t.literal("check-is-admin"),
+    t.literal("count-tickets"),
+    t.literal("resync-tickets"),
+  ]),
   args: t.type({
     connectorId: t.union([t.number, t.undefined]),
     brandId: t.union([t.number, t.undefined]),
     query: t.union([t.string, t.undefined]),
+    forceResync: t.boolean,
   }),
 });
 export type ZendeskCommandType = t.TypeOf<typeof ZendeskCommandSchema>;
@@ -242,6 +247,13 @@ export const ZendeskCountTicketsResponseSchema = t.type({
 });
 export type ZendeskCountTicketsResponseType = t.TypeOf<
   typeof ZendeskCountTicketsResponseSchema
+>;
+
+export const ZendeskResyncTicketsResponseSchema = t.type({
+  success: t.literal(true),
+});
+export type ZendeskResyncTicketsResponseType = t.TypeOf<
+  typeof ZendeskResyncTicketsResponseSchema
 >;
 /**
  * </Zendesk>


### PR DESCRIPTION
## Description

- Current state: there is an issue with Zendesk in that
  - we don't get all the tickets in the first full sync.
  - the incremental sync picks up 4 times more tickets in a month that the full sync.
- The Search API seems to be faulty: it contain a `/count` endpoint that returns a count of 3.8M tickets for the past 6 months for one connector, which seems unreasonable.
- This PR uses the incremental endpoint for the full sync, with a start date today - 6months and then filters the solved tickets.
- Since we can assume that most old tickets are solved, fetching all the tickets and filtering does not seem much more costly than using an unreliable endpoint that filters on fetch.
- Using the same endpoint for the full sync and the incremental sync seems very reasonable.
- Additionally, closed tickets are now also synced, [solved tickets are automatically moved to closed](https://support.zendesk.com/hc/en-us/articles/4408887712154-What-is-the-difference-between-a-Solved-ticket-and-a-Closed-ticket) in Zendesk.

## Risk

Low, tested locally.

## Deploy Plan

- Deploy connectors.
