### PR TITLE
fix(Zendesk) - fix type of `forceResync` CLI argument

### DIFF
--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -90,7 +90,7 @@ export const zendesk = async ({
         throw new Error(`Connector ${connectorId} not found`);
       }
       const result = await launchZendeskTicketReSyncWorkflow(connector, {
-        forceResync: args.forceResync || false,
+        forceResync: args.forceResync === "true",
       });
       if (result.isErr()) {
         logger.error(

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -228,7 +228,7 @@ export const ZendeskCommandSchema = t.type({
     connectorId: t.union([t.number, t.undefined]),
     brandId: t.union([t.number, t.undefined]),
     query: t.union([t.string, t.undefined]),
-    forceResync: t.boolean,
+    forceResync: t.union([t.literal("true"), t.undefined]),
   }),
 });
 export type ZendeskCommandType = t.TypeOf<typeof ZendeskCommandSchema>;


### PR DESCRIPTION
## Description

- The type of `forceResync` was incorrectly set to t.boolean in the CommandSchema.

## Risk

- CLI

## Deploy Plan

- deploy connectors.
