### PR TITLE
Display the free trial wording on pricing table only from landing

### DIFF
--- a/front/components/plans/PlansTables.tsx
+++ b/front/components/plans/PlansTables.tsx
@@ -221,7 +221,9 @@ export function ProPriceTable({
             <Button
               variant="highlight"
               size={biggerButtonSize}
-              label="Start now, 15 days free"
+              label={
+                display === "landing" ? "Start now, 15 days free" : "Start now"
+              }
               icon={RocketIcon}
               disabled={isProcessing}
               onClick={onClick}
@@ -242,7 +244,9 @@ export function ProPriceTable({
             <Button
               variant="highlight"
               size={biggerButtonSize}
-              label="Start now, 15 days free"
+              label={
+                display === "landing" ? "Start now, 15 days free" : "Start now"
+              }
               icon={RocketIcon}
               disabled={isProcessing}
               onClick={onClick}


### PR DESCRIPTION
## Description

The pricing table should not display "Start now, 15 days free" when displayed from the subscription page since if you're on this page then you already have an active subscription, so you won't have a free trial. 

Note: on the paywall page we do not display this version of the pricing table so this button was not displayed. 

<img width="1627" alt="Screenshot 2024-12-12 at 16 58 49" src="https://github.com/user-attachments/assets/5ae12c75-812e-4f92-a6b9-01a1bd3246c2" />

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
