### PR TITLE
[connectors] update Confluence to use new internalIDs in content nodes and upsertions

### DIFF
--- a/connectors/src/connectors/confluence/lib/hierarchy.ts
+++ b/connectors/src/connectors/confluence/lib/hierarchy.ts
@@ -1,8 +1,8 @@
 import type { ModelId } from "@dust-tt/types";
 
 import {
-  makeConfluenceInternalPageId,
-  makeConfluenceInternalSpaceId,
+  makePageInternalId,
+  makeSpaceInternalId,
 } from "@connectors/connectors/confluence/lib/internal_ids";
 import { ConfluencePage } from "@connectors/lib/models/confluence";
 
@@ -68,9 +68,9 @@ export async function getConfluencePageParentIds(
 
   return [
     // Add the current page.
-    makeConfluenceInternalPageId(page.pageId),
-    ...parentIds.map((p) => makeConfluenceInternalPageId(p)),
+    makePageInternalId(page.pageId),
+    ...parentIds.map((p) => makePageInternalId(p)),
     // Add the space id at the end.
-    makeConfluenceInternalSpaceId(page.spaceId),
+    makeSpaceInternalId(page.spaceId),
   ];
 }

--- a/connectors/src/connectors/confluence/lib/internal_ids.ts
+++ b/connectors/src/connectors/confluence/lib/internal_ids.ts
@@ -1,44 +1,39 @@
-import {
-  makeConfluencePageId,
-  makeConfluenceSpaceId,
-} from "@connectors/connectors/confluence/temporal/utils";
+/**
+Naming conventions:
+- Confluence ID: The ID that Confluence uses to identify a space or page, usually just a number.
+- Internal ID: The ID we use in content nodes and in data_source_documents (both document_id and parents).
+Internal IDs are Confluence IDs with a prefix `confluence-space-` or `confluence-page-`.
+ */
 
 enum ConfluenceInternalIdPrefix {
-  Space = "cspace_",
-  Page = "cpage_",
+  Space = "confluence-space-",
+  Page = "confluence-page",
 }
 
-export function makeConfluenceInternalSpaceId(confluenceSpaceId: string) {
+export function makeSpaceInternalId(confluenceSpaceId: string) {
   return `${ConfluenceInternalIdPrefix.Space}${confluenceSpaceId}`;
 }
 
-export function makeConfluenceInternalPageId(confluencePageId: string) {
+export function makePageInternalId(confluencePageId: string) {
   return `${ConfluenceInternalIdPrefix.Page}${confluencePageId}`;
 }
 
-export function getIdFromConfluenceInternalId(internalId: string) {
-  const prefixPattern = `^(${ConfluenceInternalIdPrefix.Space}|${ConfluenceInternalIdPrefix.Page})`;
-  return internalId.replace(new RegExp(prefixPattern), "");
+export function getConfluenceIdFromInternalId(internalId: string) {
+  if (isInternalPageId(internalId) || isInternalSpaceId(internalId)) {
+    const prefixPattern = `^(${ConfluenceInternalIdPrefix.Space}|${ConfluenceInternalIdPrefix.Page})`;
+    return internalId.replace(new RegExp(prefixPattern), "");
+  }
+  throw new Error(`Invalid internal ID: ${internalId}`);
 }
 
-export function isConfluenceInternalSpaceId(
+export function isInternalSpaceId(
   internalId: string
 ): internalId is `${ConfluenceInternalIdPrefix.Space}${string}` {
   return internalId.startsWith(ConfluenceInternalIdPrefix.Space);
 }
 
-export function isConfluenceInternalPageId(
+export function isInternalPageId(
   internalId: string
 ): internalId is `${ConfluenceInternalIdPrefix.Page}${string}` {
   return internalId.startsWith(ConfluenceInternalIdPrefix.Page);
-}
-
-export function convertInternalIdToDocumentId(internalId: string): string {
-  if (isConfluenceInternalPageId(internalId)) {
-    return makeConfluencePageId(getIdFromConfluenceInternalId(internalId));
-  }
-  if (isConfluenceInternalSpaceId(internalId)) {
-    return makeConfluenceSpaceId(getIdFromConfluenceInternalId(internalId));
-  }
-  throw new Error(`Invalid internal ID: ${internalId}`);
 }

--- a/connectors/src/connectors/confluence/lib/permissions.ts
+++ b/connectors/src/connectors/confluence/lib/permissions.ts
@@ -10,11 +10,11 @@ import { Op } from "sequelize";
 import { listConfluenceSpaces } from "@connectors/connectors/confluence/lib/confluence_api";
 import type { ConfluenceSpaceType } from "@connectors/connectors/confluence/lib/confluence_client";
 import {
-  getIdFromConfluenceInternalId,
-  isConfluenceInternalPageId,
-  isConfluenceInternalSpaceId,
-  makeConfluenceInternalPageId,
-  makeConfluenceInternalSpaceId,
+  getConfluenceIdFromInternalId,
+  isInternalPageId,
+  isInternalSpaceId,
+  makePageInternalId,
+  makeSpaceInternalId,
 } from "@connectors/connectors/confluence/lib/internal_ids";
 import type { ConfluenceConfiguration } from "@connectors/lib/models/confluence";
 import {
@@ -47,7 +47,7 @@ export function createContentNodeFromSpace(
 
   return {
     provider: "confluence",
-    internalId: makeConfluenceInternalSpaceId(spaceId),
+    internalId: makeSpaceInternalId(spaceId),
     parentInternalId: null,
     type: "folder",
     title: space.name || "Unnamed Space",
@@ -67,11 +67,11 @@ export function createContentNodeFromPage(
 ): ContentNode {
   return {
     provider: "confluence",
-    internalId: makeConfluenceInternalPageId(page.pageId),
+    internalId: makePageInternalId(page.pageId),
     parentInternalId:
       parent.type === "space"
-        ? makeConfluenceInternalSpaceId(parent.id)
-        : makeConfluenceInternalPageId(parent.id),
+        ? makeSpaceInternalId(parent.id)
+        : makePageInternalId(parent.id),
     type: "file",
     title: page.title,
     sourceUrl: `${baseUrl}/wiki${page.externalUrl}`,
@@ -102,7 +102,7 @@ async function getSynchronizedSpaces(
   confluenceConfig: ConfluenceConfiguration,
   parentInternalId: string
 ): Promise<Result<ContentNode[], Error>> {
-  const confluenceId = getIdFromConfluenceInternalId(parentInternalId);
+  const confluenceId = getConfluenceIdFromInternalId(parentInternalId);
 
   const parentSpace = await ConfluenceSpace.findOne({
     attributes: ["id", "spaceId"],
@@ -149,7 +149,7 @@ async function getSynchronizedChildrenPages(
   confluenceConfig: ConfluenceConfiguration,
   parentInternalId: string
 ): Promise<Result<ContentNode[], Error>> {
-  const confluenceId = getIdFromConfluenceInternalId(parentInternalId);
+  const confluenceId = getConfluenceIdFromInternalId(parentInternalId);
 
   const parentPage = await ConfluencePage.findOne({
     attributes: ["id", "pageId"],
@@ -196,7 +196,7 @@ export async function retrieveHierarchyForParent(
   const { id: connectorId } = connector;
 
   if (parentInternalId) {
-    if (isConfluenceInternalSpaceId(parentInternalId)) {
+    if (isInternalSpaceId(parentInternalId)) {
       const resources = await getSynchronizedSpaces(
         connectorId,
         confluenceConfig,
@@ -208,7 +208,7 @@ export async function retrieveHierarchyForParent(
       }
 
       return new Ok(resources.value);
-    } else if (isConfluenceInternalPageId(parentInternalId)) {
+    } else if (isInternalPageId(parentInternalId)) {
       const resources = await getSynchronizedChildrenPages(
         connectorId,
         confluenceConfig,

--- a/connectors/src/connectors/confluence/temporal/client.ts
+++ b/connectors/src/connectors/confluence/temporal/client.ts
@@ -12,7 +12,7 @@ import { spaceUpdatesSignal } from "@connectors/connectors/confluence/temporal/s
 import {
   makeConfluencePersonalDataWorkflowId,
   makeConfluenceRemoveSpacesWorkflowId,
-} from "@connectors/connectors/confluence/temporal/utils";
+} from "@connectors/connectors/confluence/temporal/workflow_ids";
 import {
   confluencePersonalDataReportingWorkflow,
   confluenceRemoveSpacesWorkflow,

--- a/connectors/src/connectors/confluence/temporal/workflow_ids.ts
+++ b/connectors/src/connectors/confluence/temporal/workflow_ids.ts
@@ -29,15 +29,6 @@ export function makeConfluencePersonalDataWorkflowId() {
   return `confluence-personal-data-reporting`;
 }
 
-export function makeConfluencePageId(pageId: string) {
-  // Omit space reference in the ID to accommodate Confluence pages moving between spaces.
-  return `confluence-page-${pageId}`;
-}
-
-export function makeConfluenceSpaceId(spaceId: string) {
-  return `confluence-space-${spaceId}`;
-}
-
 export function makeConfluenceDocumentUrl({
   baseUrl,
   suffix,

--- a/connectors/src/connectors/confluence/temporal/workflows.ts
+++ b/connectors/src/connectors/confluence/temporal/workflows.ts
@@ -17,7 +17,7 @@ import {
   makeConfluenceRemoveSpaceWorkflowIdFromParentId,
   makeConfluenceSpaceSyncWorkflowIdFromParentId,
   makeConfluenceSyncTopLevelChildPagesWorkflowIdFromParentId,
-} from "@connectors/connectors/confluence/temporal/utils";
+} from "@connectors/connectors/confluence/temporal/workflow_ids";
 
 const {
   confluenceGetSpaceNameActivity,


### PR DESCRIPTION
## Description

- This PR aims at moving the Confluence connector to use the new internalIds (the ones with `confluence-page-` or `confluence-space-`) in both the content nodes and the upsertions.
- Tested locally:
  - we get the correct ID in the data_source_view when running this new version.
  - if we create the data_source_view with the old version of connectors then we don't see nodes in the AssistantBuilder.
  - applying the migration script turns the data_source_view we get when running the old version of connectors into the one we get when running the new one.

## Risk

- everything is logged, missteps will be painful but recoverable

## Deploy Plan

- Use the new button to stop (TBD)
- Deploy connectors
- Shortly after run migrations that changes agent configurations
