### PR TITLE
Tracker: limit pages & routes to admin only + FF

### DIFF
--- a/front/pages/api/w/[wId]/spaces/[spaceId]/trackers/[tId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/trackers/[tId]/index.ts
@@ -6,6 +6,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { TrackerConfigurationResource } from "@app/lib/resources/tracker_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { GetTrackersResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/trackers";
@@ -16,6 +17,28 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<GetTrackersResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
+  const owner = auth.workspace();
+  if (!owner) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace was not found.",
+      },
+    });
+  }
+
+  const flags = await getFeatureFlags(owner);
+  if (!flags.includes("labs_trackers") || !auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can access Trackers.",
+      },
+    });
+  }
   switch (req.method) {
     case "PATCH":
       if (typeof req.query.tId !== "string") {

--- a/front/pages/w/[wId]/assistant/labs/trackers/[tId]/index.tsx
+++ b/front/pages/w/[wId]/assistant/labs/trackers/[tId]/index.tsx
@@ -14,6 +14,7 @@ import type { InferGetServerSidePropsType } from "next";
 import { TrackerBuilder } from "@app/components/trackers/TrackerBuilder";
 import config from "@app/lib/api/config";
 import { getContentNodesForDataSourceView } from "@app/lib/api/data_source_view";
+import { getFeatureFlags } from "@app/lib/auth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -45,6 +46,13 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     !globalSpace ||
     !trackerId
   ) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const flags = await getFeatureFlags(owner);
+  if (!flags.includes("labs_trackers") && !auth.isAdmin()) {
     return {
       notFound: true,
     };

--- a/front/pages/w/[wId]/assistant/labs/trackers/index.tsx
+++ b/front/pages/w/[wId]/assistant/labs/trackers/index.tsx
@@ -25,6 +25,7 @@ import React, { useMemo } from "react";
 import { AssistantSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import config from "@app/lib/api/config";
+import { getFeatureFlags } from "@app/lib/auth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { useTrackers } from "@app/lib/swr/trackers";
@@ -47,6 +48,13 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
 
   if (!owner || !plan || !subscription || !auth.isUser() || !globalSpace) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const flags = await getFeatureFlags(owner);
+  if (!flags.includes("labs_trackers") || !auth.isAdmin()) {
     return {
       notFound: true,
     };

--- a/front/pages/w/[wId]/assistant/labs/trackers/new.tsx
+++ b/front/pages/w/[wId]/assistant/labs/trackers/new.tsx
@@ -9,6 +9,7 @@ import type { InferGetServerSidePropsType } from "next";
 
 import { TrackerBuilder } from "@app/components/trackers/TrackerBuilder";
 import config from "@app/lib/api/config";
+import { getFeatureFlags } from "@app/lib/auth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -36,6 +37,13 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   const dataSourceViews = await DataSourceViewResource.listBySpaces(auth, [
     globalSpace,
   ]);
+
+  const flags = await getFeatureFlags(owner);
+  if (!flags.includes("labs_trackers") || !auth.isAdmin()) {
+    return {
+      notFound: true,
+    };
+  }
 
   return {
     props: {


### PR DESCRIPTION
## Description

Tracker: limit pages & routes to admin only + FF

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 