### PR TITLE
Add: unique index for slack messages, drop old index

### DIFF
--- a/connectors/migrations/db/migration_41.sql
+++ b/connectors/migrations/db/migration_41.sql
@@ -1,0 +1,3 @@
+-- Migration created on Dec 12, 2024
+CREATE UNIQUE INDEX CONCURRENTLY "slack_messages_connector_id_channel_id_document_id" ON "slack_messages" ("connectorId", "channelId", "documentId");
+DROP INDEX IF EXISTS "slack_messages_connector_id_channel_id_message_ts";

--- a/connectors/src/lib/models/slack.ts
+++ b/connectors/src/lib/models/slack.ts
@@ -102,7 +102,7 @@ SlackMessages.init(
     sequelize: sequelizeConnection,
     modelName: "slack_messages",
     indexes: [
-      { fields: ["connectorId", "channelId", "messageTs"], unique: true },
+      { fields: ["connectorId", "channelId", "documentId"], unique: true },
     ],
   }
 );


### PR DESCRIPTION
## Description

Now that the migration is complete, drop old index for slack messages and add new unique index.

## Risk

Low

## Deploy Plan

Apply migration, deploy connectors.