### PR TITLE
[connectors] Zendesk GA

### DIFF
--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -187,7 +187,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
   zendesk: {
     name: "Zendesk",
     connectorProvider: "zendesk",
-    status: "rolling_out",
+    status: "built",
     hide: false,
     description:
       "Authorize access to Zendesk for indexing tickets from your support center and articles from your help center.",
@@ -197,7 +197,6 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     logoComponent: ZendeskLogo,
     isNested: true,
     isSearchEnabled: false,
-    rollingOutFlag: "zendesk_connector_feature",
   },
 };
 

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -655,7 +655,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "openai_o1_feature"
   | "openai_o1_mini_feature"
   | "snowflake_connector_feature"
-  | "zendesk_connector_feature"
   | "index_private_slack_channel"
   | "conversations_jit_actions"
 >();

--- a/types/src/shared/feature_flags.ts
+++ b/types/src/shared/feature_flags.ts
@@ -7,7 +7,6 @@ export const WHITELISTABLE_FEATURES = [
   "use_app_for_header_detection",
   "openai_o1_feature",
   "openai_o1_mini_feature",
-  "zendesk_connector_feature",
   "index_private_slack_channel",
   "conversations_jit_actions",
   "labs_trackers",


### PR DESCRIPTION
## Description

- This PR sets Zendesk as `built` instead of `rolling_out` and removes the feature flag.

## Risk

- Tested locally that it doesn't break if you have the FF.
- Tested locally that you can create the connector if you don't have it.

## Deploy Plan

- Deploy front.