### PR TITLE
Fix: conversation not found should not trigger a 500

### DIFF
--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -416,7 +416,7 @@ export async function fetchConversationMessages(
   });
 
   if (!conversation) {
-    return new Err(new Error("Conversation not found."));
+    return new Err(new ConversationError("conversation_not_found"));
   }
 
   const { hasMore, messages } = await fetchMessagesForPage(


### PR DESCRIPTION
## Description

Refactor so we return the correct `ConversationError` type that is correctly handled as a 404 instead of a 500 (a large part of our 500 "internal server error").

<img width="1151" alt="image" src="https://github.com/user-attachments/assets/0175ef32-a791-41cb-b757-a0874554d9a5" />

## Risk

Low

## Deploy Plan

Deploy `front`