### PR TITLE
Fix: when 404 on a Gdrive spreadsheet, just continue

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -458,6 +458,17 @@ export async function syncSpreadSheet(
               // Allow to locally retry the API call.
               continue;
             }
+          } else if (
+            err instanceof Error &&
+            "code" in err &&
+            err.code === 404
+          ) {
+            localLogger.info(
+              "[Spreadsheet] Consistently getting 404 Not Found from Google Sheets, skipping further processing."
+            );
+            return {
+              isSupported: false,
+            };
           }
 
           throw err;


### PR DESCRIPTION
## Description

Skip 404 on gsheet doc (but allow retrying later).

## Risk

Low

## Deploy Plan

Deploy `connectors`