### PR TITLE
Fix: notion stuck trying to operate on a page no longer in our db

### DIFF
--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1354,7 +1354,16 @@ export async function cacheBlockChildren({
     },
   });
 
-  if (notionPageModel?.skipReason) {
+  if (!notionPageModel) {
+    logger.info("Skipping page not found in db.");
+    return {
+      nextCursor: null,
+      blocksWithChildren: [],
+      blocksCount: 0,
+    };
+  }
+
+  if (notionPageModel.skipReason) {
     logger.info(
       { skipReason: notionPageModel.skipReason },
       "Skipping page with skip reason"


### PR DESCRIPTION
## Description

An activity is stuck trying to work on a page that no longer exists in our db.

## Risk

Low

## Deploy Plan

Deploy `connectors`.