### PR TITLE
[connectors] Add a CLI command `confluence upsert-page`

### DIFF
--- a/connectors/src/connectors/confluence/lib/cli.ts
+++ b/connectors/src/connectors/confluence/lib/cli.ts
@@ -15,6 +15,7 @@ import {
   confluenceGetSpaceNameActivity,
   fetchConfluenceConfigurationActivity,
   getConfluenceClient,
+  upsertConfluencePageInDb,
   upsertConfluencePageToDataSource,
 } from "@connectors/connectors/confluence/temporal/activities";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
@@ -88,6 +89,7 @@ export const confluence = async ({
         workspaceId: dataSourceConfig.workspaceId,
       };
       const localLogger = logger.child(loggerArgs);
+      const visitedAtMs = new Date().getTime();
 
       const pageInDb = await ConfluencePage.findOne({
         attributes: ["parentId", "skipReason"],
@@ -134,6 +136,7 @@ export const confluence = async ({
         dataSourceConfig,
         loggerArgs
       );
+      await upsertConfluencePageInDb(connector.id, page, visitedAtMs);
       return { success: true };
     }
     case "upsert-pages": {
@@ -184,6 +187,7 @@ export const confluence = async ({
       );
 
       const cachedSpaces: Record<string, cachedSpace> = {};
+      const visitedAtMs = new Date().getTime();
 
       for (const pageId of pageIds) {
         const loggerArgs = {
@@ -232,6 +236,7 @@ export const confluence = async ({
           dataSourceConfig,
           loggerArgs
         );
+        await upsertConfluencePageInDb(connector.id, page, visitedAtMs);
       }
       return { success: true };
     }

--- a/connectors/src/connectors/confluence/lib/cli.ts
+++ b/connectors/src/connectors/confluence/lib/cli.ts
@@ -4,7 +4,14 @@ import type {
   ConfluenceUpsertPageResponseType,
 } from "@dust-tt/types";
 
+import {
+  fetchConfluenceConfigurationActivity,
+  getConfluenceClient,
+  upsertConfluencePageToDataSource,
+} from "@connectors/connectors/confluence/temporal/activities";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { default as topLogger } from "@connectors/logger/logger";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
 
 export const confluence = async ({
   command,
@@ -21,6 +28,51 @@ export const confluence = async ({
       if (!args.pageId) {
         throw new Error("Missing --pageId argument");
       }
+      const connectorId = args.connectorId;
+      const pageId = args.pageId;
+
+      const connector = await ConnectorResource.fetchById(connectorId);
+      if (!connector) {
+        throw new Error("Connector not found.");
+      }
+      const dataSourceConfig = dataSourceConfigFromConnector(connector);
+      const confluenceConfig =
+        await fetchConfluenceConfigurationActivity(connectorId);
+
+      const loggerArgs = {
+        connectorId,
+        dataSourceId: dataSourceConfig.dataSourceId,
+        pageId,
+        workspaceId: dataSourceConfig.workspaceId,
+      };
+      const localLogger = logger.child(loggerArgs);
+
+      const client = await getConfluenceClient(
+        { cloudId: confluenceConfig?.cloudId },
+        connector
+      );
+
+      const page = await client.getPageById(pageId);
+      if (!page) {
+        localLogger.info("Confluence page not found.");
+        return false;
+      }
+      const space = await client.getSpaceById(page.spaceId);
+      if (!space) {
+        localLogger.info("Confluence space not found.");
+        return false;
+      }
+
+      localLogger.info("Upserting Confluence page.");
+      await upsertConfluencePageToDataSource(
+        page,
+        space.name,
+        confluenceConfig,
+        "batch",
+        dataSourceConfig,
+        loggerArgs
+      );
+
       break;
     }
 

--- a/connectors/src/connectors/confluence/lib/cli.ts
+++ b/connectors/src/connectors/confluence/lib/cli.ts
@@ -1,0 +1,30 @@
+import type {
+  AdminSuccessResponseType,
+  ConfluenceCommandType,
+  ConfluenceUpsertPageResponseType,
+} from "@dust-tt/types";
+
+import { default as topLogger } from "@connectors/logger/logger";
+
+export const confluence = async ({
+  command,
+  args,
+}: ConfluenceCommandType): Promise<
+  AdminSuccessResponseType | ConfluenceUpsertPageResponseType
+> => {
+  const logger = topLogger.child({ majorCommand: "confluence", command, args });
+  switch (command) {
+    case "upsert-page": {
+      if (!args.connectorId) {
+        throw new Error("Missing --connectorId argument");
+      }
+      if (!args.pageId) {
+        throw new Error("Missing --pageId argument");
+      }
+      break;
+    }
+
+    default:
+      throw new Error("Unknown Confluence command: " + command);
+  }
+};

--- a/connectors/src/connectors/confluence/lib/cli.ts
+++ b/connectors/src/connectors/confluence/lib/cli.ts
@@ -2,13 +2,17 @@ import type {
   AdminSuccessResponseType,
   ConfluenceCommandType,
   ConfluenceUpsertPageResponseType,
+  ModelId,
 } from "@dust-tt/types";
+import assert from "assert";
+import fs from "fs/promises";
 
 import {
   getConfluencePageParentIds,
   getSpaceHierarchy,
 } from "@connectors/connectors/confluence/lib/hierarchy";
 import {
+  confluenceGetSpaceNameActivity,
   fetchConfluenceConfigurationActivity,
   getConfluenceClient,
   upsertConfluencePageToDataSource,
@@ -17,6 +21,39 @@ import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_c
 import { ConfluencePage } from "@connectors/lib/models/confluence";
 import { default as topLogger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
+
+interface cachedSpace {
+  spaceName: string | null;
+  spaceHierarchy: Record<string, string | null>;
+}
+
+async function cacheSpace(
+  cachedSpaces: Record<string, cachedSpace>,
+  {
+    confluenceCloudId,
+    connectorId,
+    spaceId,
+  }: {
+    confluenceCloudId: string;
+    connectorId: ModelId;
+    spaceId: string;
+  }
+): Promise<cachedSpace> {
+  const cachedSpace = cachedSpaces[spaceId];
+  if (cachedSpace) {
+    return cachedSpace;
+  }
+  const spaceName = await confluenceGetSpaceNameActivity({
+    spaceId,
+    confluenceCloudId,
+    connectorId,
+  });
+  const spaceHierarchy = spaceName
+    ? await getSpaceHierarchy(connectorId, spaceId)
+    : {}; // not fetching if we couldn't get the space from Confluence API anyway
+  cachedSpaces[spaceId] = { spaceName, spaceHierarchy };
+  return { spaceName, spaceHierarchy };
+}
 
 export const confluence = async ({
   command,
@@ -97,6 +134,105 @@ export const confluence = async ({
         dataSourceConfig,
         loggerArgs
       );
+      return { success: true };
+    }
+    case "upsert-pages": {
+      if (!args.connectorId) {
+        throw new Error("Missing --connectorId argument");
+      }
+      if (!args.file) {
+        throw new Error("Missing --file argument");
+      }
+      if (!args.keyInFile) {
+        throw new Error("Missing --keyInFile argument");
+      }
+      const connectorId = args.connectorId;
+      const file = args.file;
+      const keyInFile = args.keyInFile;
+
+      // parsing the JSON file
+      const fileContent = await fs.readFile(file, "utf-8");
+      const jsonArray = JSON.parse(fileContent);
+      assert(Array.isArray(jsonArray), "The file content is not an array.");
+
+      const pageIds = jsonArray.map((entry) => {
+        assert(
+          keyInFile in entry,
+          `Key "${keyInFile}" not found in entry ${JSON.stringify(entry)}`
+        );
+        return entry[keyInFile];
+      });
+
+      // fetching the pages in DB
+      const pagesInDb = Object.fromEntries(
+        (
+          await ConfluencePage.findAll({
+            attributes: ["pageId", "skipReason"],
+            where: { connectorId, pageId: pageIds },
+          })
+        ).map((page) => [page.pageId, page])
+      );
+
+      const connector = await ConnectorResource.fetchById(connectorId);
+      assert(connector !== null, "Connector not found.");
+      const dataSourceConfig = dataSourceConfigFromConnector(connector);
+      const confluenceConfig =
+        await fetchConfluenceConfigurationActivity(connectorId);
+      const client = await getConfluenceClient(
+        { cloudId: confluenceConfig?.cloudId },
+        connector
+      );
+
+      const cachedSpaces: Record<string, cachedSpace> = {};
+
+      for (const pageId of pageIds) {
+        const loggerArgs = {
+          connectorId,
+          dataSourceId: dataSourceConfig.dataSourceId,
+          pageId,
+          workspaceId: dataSourceConfig.workspaceId,
+        };
+        const localLogger = logger.child(loggerArgs);
+
+        const pageInDb = pagesInDb[pageId];
+        if (pageInDb && pageInDb.skipReason !== null) {
+          localLogger.info("Confluence page skipped.");
+          continue;
+        }
+
+        const page = await client.getPageById(pageId);
+        if (!page) {
+          localLogger.info("Confluence page not found.");
+          continue;
+        }
+        // fetching the space if not already cached
+        const { spaceName, spaceHierarchy } = await cacheSpace(cachedSpaces, {
+          connectorId,
+          confluenceCloudId: confluenceConfig?.cloudId,
+          spaceId: page.spaceId,
+        });
+        if (!spaceName) {
+          localLogger.info("Confluence space not found.");
+          continue;
+        }
+
+        const parentIds = await getConfluencePageParentIds(
+          connectorId,
+          { pageId: page.id, parentId: page.parentId, spaceId: page.spaceId },
+          spaceHierarchy
+        );
+
+        localLogger.info("Upserting Confluence page.");
+        await upsertConfluencePageToDataSource(
+          page,
+          spaceName,
+          parentIds,
+          confluenceConfig,
+          "batch",
+          dataSourceConfig,
+          loggerArgs
+        );
+      }
       return { success: true };
     }
 

--- a/connectors/src/connectors/confluence/lib/cli.ts
+++ b/connectors/src/connectors/confluence/lib/cli.ts
@@ -55,12 +55,12 @@ export const confluence = async ({
       const page = await client.getPageById(pageId);
       if (!page) {
         localLogger.info("Confluence page not found.");
-        return false;
+        return { success: false };
       }
       const space = await client.getSpaceById(page.spaceId);
       if (!space) {
         localLogger.info("Confluence space not found.");
-        return false;
+        return { success: false };
       }
 
       localLogger.info("Upserting Confluence page.");
@@ -72,8 +72,7 @@ export const confluence = async ({
         dataSourceConfig,
         loggerArgs
       );
-
-      break;
+      return { success: true };
     }
 
     default:

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -423,7 +423,6 @@ export async function confluenceCheckAndUpsertPageActivity({
   }
 
   localLogger.info("Upserting Confluence page.");
-
   await upsertConfluencePageToDataSource({
     page,
     spaceName,
@@ -436,7 +435,6 @@ export async function confluenceCheckAndUpsertPageActivity({
   });
 
   localLogger.info("Upserting Confluence page in DB.");
-
   await upsertConfluencePageInDb(connector.id, page, visitedAtMs);
 
   return true;
@@ -537,6 +535,7 @@ export async function confluenceUpsertPageWithFullParentsActivity({
     loggerArgs,
   });
 
+  localLogger.info("Upserting Confluence page in DB.");
   await upsertConfluencePageInDb(connector.id, page, visitedAtMs);
 
   return true;

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -93,7 +93,7 @@ export async function getConfluenceClient(
 ) {
   const { cloudId, connectorId } = config;
 
-  // Ensure connector is fetched if not directly provided.
+  // Ensure the connector is fetched if not directly provided.
   const effectiveConnector =
     connector ??
     (connectorId ? await fetchConfluenceConnector(connectorId) : undefined);
@@ -334,7 +334,8 @@ interface ConfluenceCheckAndUpsertPageActivityInput {
 
 /**
  * Upsert a Confluence page without its full parents.
- * Operates greedily by stopping if the page is restricted or if there is a version match (unless the page was moved, in this case we have to upsert because the parents have changed).
+ * Operates greedily by stopping if the page is restricted or if there is a version match
+ * (unless the page was moved, in this case, we have to upsert because the parents have changed).
  */
 export async function confluenceCheckAndUpsertPageActivity({
   connectorId,
@@ -392,15 +393,15 @@ export async function confluenceCheckAndUpsertPageActivity({
     return false;
   }
 
-  // Check version.
+  // Check the version.
   const isSameVersion =
     pageAlreadyInDb && pageAlreadyInDb.version === pageRef.version;
 
-  // Check if page was moved. Version is not bumped when a page is moved.
+  // Check whether the page was moved (the version is not bumped when a page is moved).
   const pageWasMoved =
     pageAlreadyInDb && pageAlreadyInDb.parentId !== pageRef.parentId;
 
-  // Only index in DB if the page does not exis, has been moved or  we want to upsert.
+  // Only index in DB if the page does not exist, has been moved, or we want to upsert.
   if (isSameVersion && !forceUpsert && !pageWasMoved) {
     // Simply record that we visited the page.
     await markPageHasVisited({
@@ -891,7 +892,7 @@ export async function confluenceGetReportPersonalActionActivity(
         "Error while reporting Confluence account."
       );
 
-      // If token has been revoked, return false.
+      // If the token has been revoked, return false.
       if (err instanceof ExternalOAuthTokenError) {
         return false;
       }

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -222,7 +222,7 @@ export async function markPageHasVisited({
   );
 }
 
-export async function upsertConfluencePageToDataSource(
+async function upsertConfluencePageToDataSource(
   page: NonNullable<Awaited<ReturnType<ConfluenceClient["getPageById"]>>>,
   spaceName: string,
   parents: string[],
@@ -296,7 +296,7 @@ export async function upsertConfluencePageToDataSource(
   }
 }
 
-export async function upsertConfluencePageInDb(
+async function upsertConfluencePageInDb(
   connectorId: ModelId,
   page: ConfluencePageWithBodyType,
   visitedAtMs: number
@@ -446,7 +446,10 @@ export async function confluenceUpsertPageWithFullParentsActivity({
   connectorId: ModelId;
   pageId: string;
   cachedSpaceNames?: Record<string, string>;
-  cachedSpaceHierarchies?: Record<string, Record<string, string | null>>;
+  cachedSpaceHierarchies?: Record<
+    string,
+    Awaited<ReturnType<typeof getSpaceHierarchy>>
+  >;
 }): Promise<boolean> {
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -44,7 +44,6 @@ import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
 import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
-import assert from "assert";
 
 /**
  * This type represents the ID that should be passed as parentId to a content node to hide it from the UI.

--- a/connectors/src/connectors/confluence/temporal/workflows.ts
+++ b/connectors/src/connectors/confluence/temporal/workflows.ts
@@ -10,7 +10,6 @@ import {
 
 import type { ConfluencePageRef } from "@connectors/connectors/confluence/lib/confluence_api";
 import type * as activities from "@connectors/connectors/confluence/temporal/activities";
-import { confluenceUpsertPageWithFullParentsActivity } from "@connectors/connectors/confluence/temporal/activities";
 import type { SpaceUpdatesSignal } from "@connectors/connectors/confluence/temporal/signals";
 import { spaceUpdatesSignal } from "@connectors/connectors/confluence/temporal/signals";
 import {
@@ -32,6 +31,7 @@ const {
   confluenceGetActiveChildPageRefsActivity,
   confluenceGetRootPageRefsActivity,
   fetchConfluenceSpaceIdsForConnectorActivity,
+  confluenceUpsertPageWithFullParentsActivity,
 
   confluenceGetReportPersonalActionActivity,
   fetchConfluenceUserAccountAndConnectorIdsActivity,

--- a/connectors/src/connectors/confluence/temporal/workflows.ts
+++ b/connectors/src/connectors/confluence/temporal/workflows.ts
@@ -10,6 +10,7 @@ import {
 
 import type { ConfluencePageRef } from "@connectors/connectors/confluence/lib/confluence_api";
 import type * as activities from "@connectors/connectors/confluence/temporal/activities";
+import { confluenceUpsertPageWithFullParentsActivity } from "@connectors/connectors/confluence/temporal/activities";
 import type { SpaceUpdatesSignal } from "@connectors/connectors/confluence/temporal/signals";
 import { spaceUpdatesSignal } from "@connectors/connectors/confluence/temporal/signals";
 import {
@@ -410,5 +411,41 @@ export async function confluencePersonalDataReportingWorkflow() {
 
       // TODO(2024-01-23 flav) Implement logic to remove row in the Connector table and stop all workflows.
     }
+  }
+}
+
+export async function confluenceUpsertPageWithFullParentsWorkflow({
+  connectorId,
+  pageId,
+}: {
+  connectorId: ModelId;
+  pageId: string;
+}) {
+  await confluenceUpsertPageWithFullParentsActivity({
+    connectorId,
+    pageId,
+  });
+}
+
+export async function confluenceUpsertPagesWithFullParentsWorkflow({
+  connectorId,
+  pageIds,
+}: {
+  connectorId: ModelId;
+  pageIds: string[];
+}) {
+  const cachedSpaceNames: Record<string, string> = {};
+  const cachedSpaceHierarchies: Record<
+    string,
+    Record<string, string | null>
+  > = {};
+
+  for (const pageId of pageIds) {
+    await confluenceUpsertPageWithFullParentsActivity({
+      connectorId,
+      pageId,
+      cachedSpaceNames,
+      cachedSpaceHierarchies,
+    });
   }
 }

--- a/connectors/src/lib/cli.ts
+++ b/connectors/src/lib/cli.ts
@@ -16,6 +16,7 @@ import PQueue from "p-queue";
 import readline from "readline";
 
 import { getConnectorManager } from "@connectors/connectors";
+import { confluence } from "@connectors/connectors/confluence/lib/cli";
 import { github } from "@connectors/connectors/github/lib/cli";
 import { google_drive } from "@connectors/connectors/google_drive/lib/cli";
 import { intercom } from "@connectors/connectors/intercom/lib/cli";
@@ -34,6 +35,8 @@ export async function runCommand(adminCommand: AdminCommandType) {
   switch (adminCommand.majorCommand) {
     case "connectors":
       return connectors(adminCommand);
+    case "confluence":
+      return confluence(adminCommand);
     case "batch":
       return batch(adminCommand);
     case "notion":

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -63,7 +63,7 @@ type UpsertContext = {
   sync_type: "batch" | "incremental";
 };
 
-type UpsertToDataSourceParams = {
+export type UpsertToDataSourceParams = {
   dataSourceConfig: DataSourceConfig;
   documentId: string;
   documentContent: CoreAPIDataSourceDocumentSection;

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -31,7 +31,7 @@ export const ConfluenceCommandSchema = t.type({
   command: t.literal("upsert-page"),
   args: t.type({
     connectorId: t.union([t.number, t.undefined]),
-    pageId: t.union([t.number, t.undefined]),
+    pageId: t.union([t.string, t.undefined]),
   }),
 });
 export type ConfluenceCommandType = t.TypeOf<typeof ConfluenceCommandSchema>;

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -23,6 +23,27 @@ export const ConnectorsCommandSchema = t.type({
 
 export type ConnectorsCommandType = t.TypeOf<typeof ConnectorsCommandSchema>;
 
+/**
+ * <Confluence>
+ */
+export const ConfluenceCommandSchema = t.type({
+  majorCommand: t.literal("confluence"),
+  command: t.literal("upsert-page"),
+  args: t.type({
+    connectorId: t.union([t.number, t.undefined]),
+    pageId: t.union([t.number, t.undefined]),
+  }),
+});
+export type ConfluenceCommandType = t.TypeOf<typeof ConfluenceCommandSchema>;
+
+export const ConfluenceUpsertPageResponseSchema = t.type({});
+export type ConfluenceUpsertPageResponseType = t.TypeOf<
+  typeof ConfluenceUpsertPageResponseSchema
+>;
+/**
+ * </Confluence>
+ */
+
 export const GithubCommandSchema = t.type({
   majorCommand: t.literal("github"),
   command: t.union([
@@ -280,6 +301,7 @@ export type MicrosoftCommandType = t.TypeOf<typeof MicrosoftCommandSchema>;
 export const AdminCommandSchema = t.union([
   BatchCommandSchema,
   ConnectorsCommandSchema,
+  ConfluenceCommandSchema,
   GithubCommandSchema,
   GoogleDriveCommandSchema,
   IntercomCommandSchema,

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -39,7 +39,7 @@ export const ConfluenceCommandSchema = t.type({
 export type ConfluenceCommandType = t.TypeOf<typeof ConfluenceCommandSchema>;
 
 export const ConfluenceUpsertPageResponseSchema = t.type({
-  success: t.union([t.literal(true), t.literal(false)]),
+  success: t.boolean,
 });
 export type ConfluenceUpsertPageResponseType = t.TypeOf<
   typeof ConfluenceUpsertPageResponseSchema

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -39,7 +39,8 @@ export const ConfluenceCommandSchema = t.type({
 export type ConfluenceCommandType = t.TypeOf<typeof ConfluenceCommandSchema>;
 
 export const ConfluenceUpsertPageResponseSchema = t.type({
-  success: t.boolean,
+  workflowId: t.string,
+  workflowUrl: t.union([t.string, t.undefined]),
 });
 export type ConfluenceUpsertPageResponseType = t.TypeOf<
   typeof ConfluenceUpsertPageResponseSchema

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -36,7 +36,9 @@ export const ConfluenceCommandSchema = t.type({
 });
 export type ConfluenceCommandType = t.TypeOf<typeof ConfluenceCommandSchema>;
 
-export const ConfluenceUpsertPageResponseSchema = t.type({});
+export const ConfluenceUpsertPageResponseSchema = t.type({
+  success: t.union([t.literal(true), t.literal(false)]),
+});
 export type ConfluenceUpsertPageResponseType = t.TypeOf<
   typeof ConfluenceUpsertPageResponseSchema
 >;

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -28,10 +28,12 @@ export type ConnectorsCommandType = t.TypeOf<typeof ConnectorsCommandSchema>;
  */
 export const ConfluenceCommandSchema = t.type({
   majorCommand: t.literal("confluence"),
-  command: t.literal("upsert-page"),
+  command: t.union([t.literal("upsert-page"), t.literal("upsert-pages")]),
   args: t.type({
     connectorId: t.union([t.number, t.undefined]),
     pageId: t.union([t.string, t.undefined]),
+    file: t.union([t.string, t.undefined]),
+    keyInFile: t.union([t.string, t.undefined]),
   }),
 });
 export type ConfluenceCommandType = t.TypeOf<typeof ConfluenceCommandSchema>;


### PR DESCRIPTION
## Description

- This PR adds two CLI commands: `confluence upsert-page` and `confluence upsert-pages` that upsert pages given their IDs.
- The upsertion correctly fills the parents.

## Risk

- Low, since we control the input the can pinpoint very precisely the data affected.

## Deploy Plan

- Deploy connectors.