### PR TITLE
slack: stop doubling parents in connectors + set parentId

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -605,7 +605,8 @@ export async function syncNonThreaded(
     documentUrl: sourceUrl,
     timestampMs: updatedAt,
     tags,
-    parents: [documentId, channelId, internalIdFromSlackChannelId(channelId)],
+    parentId: internalIdFromSlackChannelId(channelId),
+    parents: [documentId, internalIdFromSlackChannelId(channelId)],
     upsertContext: {
       sync_type: isBatchSync ? "batch" : "incremental",
     },
@@ -815,7 +816,8 @@ export async function syncThread(
     documentUrl: sourceUrl,
     timestampMs: updatedAt,
     tags,
-    parents: [documentId, channelId, internalIdFromSlackChannelId(channelId)],
+    parentId: internalIdFromSlackChannelId(channelId),
+    parents: [documentId, internalIdFromSlackChannelId(channelId)],
     upsertContext: {
       sync_type: isBatchSync ? "batch" : "incremental",
     },


### PR DESCRIPTION
## Description

For: https://github.com/dust-tt/dust/issues/9069

Slack parents migration:

- stop sending double parents
- start setting parentId

## Risk

Low

## Deploy Plan

- deploy `connectors`