### PR TITLE
[k8s] - fix: increase timeout cloudbuild operations

### DIFF
--- a/k8s/cloudbuild.yaml
+++ b/k8s/cloudbuild.yaml
@@ -17,7 +17,7 @@ steps:
     secretEnv:
       - "DEPOT_TOKEN"
 
-timeout: 600s
+timeout: 1200s
 
 availableSecrets:
   secretManager:


### PR DESCRIPTION
## Description

This PR increases the timeout from 10 minutes to 20 minutes to accommodate longer build processes (especially prodbox)

## Risk

None

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
