### PR TITLE
2nd layer of auth in prompt history endpoint

### DIFF
--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/history/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/history/index.ts
@@ -26,11 +26,8 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  if (
-    !req.query.aId ||
-    typeof req.query.aId !== "string" ||
-    req.query.aId.length === 0
-  ) {
+  const { aId } = req.query;
+  if (typeof aId !== "string") {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -41,7 +38,7 @@ async function handler(
   }
 
   // Check that user has access to this assistant
-  const assistant = await getAgentConfiguration(auth, req.query.aId as string);
+  const assistant = await getAgentConfiguration(auth, aId);
   if (
     !assistant ||
     (assistant.scope === "private" &&
@@ -82,7 +79,7 @@ async function handler(
       const agentConfigurations = await getAgentConfigurations({
         auth,
         agentsGetView: {
-          agentIds: [req.query.aId as string],
+          agentIds: [aId],
           allVersions: true,
         },
         variant: "light",

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/history/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/history/index.ts
@@ -7,7 +7,10 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
+import {
+  getAgentConfiguration,
+  getAgentConfigurations,
+} from "@app/lib/api/assistant/configuration";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
@@ -23,6 +26,36 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
+  if (
+    !req.query.aId ||
+    typeof req.query.aId !== "string" ||
+    req.query.aId.length === 0
+  ) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid Assistant ID provided.",
+      },
+    });
+  }
+
+  // Check that user has access to this assistant
+  const assistant = await getAgentConfiguration(auth, req.query.aId as string);
+  if (
+    !assistant ||
+    (assistant.scope === "private" &&
+      assistant.versionAuthorId !== auth.user()?.id)
+  ) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "agent_configuration_not_found",
+        message: "The Assistant you're trying to access was not found.",
+      },
+    });
+  }
+
   switch (req.method) {
     case "GET":
       // extract the limit from the query parameters


### PR DESCRIPTION
## Description
Adding api-level auth check to follow the defense-in-depth principle.
Note: The endpoint was already secure thanks to getAgentConfigurations auth check.

## Risk
Break prompt history -> Not likely, tested locally

## Deploy Plan
Deploy Front
