### PR TITLE
Tracker models: add fields to track data processed by Notif workflow

### DIFF
--- a/front/lib/models/doc_tracker.ts
+++ b/front/lib/models/doc_tracker.ts
@@ -26,6 +26,7 @@ export class TrackerConfigurationModel extends SoftDeletableModel<TrackerConfigu
   declare prompt: string | null;
 
   declare frequency: string | null;
+  declare lastNotifiedAt: Date | null;
 
   declare recipients: string[] | null;
 
@@ -85,6 +86,10 @@ TrackerConfigurationModel.init(
     },
     frequency: {
       type: DataTypes.STRING,
+      allowNull: true,
+    },
+    lastNotifiedAt: {
+      type: DataTypes.DATE,
       allowNull: true,
     },
     recipients: {
@@ -215,6 +220,8 @@ export class TrackerGenerationModel extends SoftDeletableModel<TrackerGeneration
   declare dataSourceId: ForeignKey<DataSourceModel["id"]>;
   declare documentId: string;
 
+  declare consumedAt: Date | null;
+
   declare trackerConfiguration: NonAttribute<TrackerConfigurationModel>;
 }
 
@@ -244,6 +251,10 @@ TrackerGenerationModel.init(
     documentId: {
       type: DataTypes.STRING,
       allowNull: false,
+    },
+    consumedAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
     },
   },
   {

--- a/front/migrations/db/migration_130.sql
+++ b/front/migrations/db/migration_130.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public"."tracker_configurations" ADD COLUMN "lastNotifiedAt" TIMESTAMP WITH TIME ZONE;
+ALTER TABLE "public"."tracker_generations" ADD COLUMN "consumedAt" TIMESTAMP WITH TIME ZONE;


### PR DESCRIPTION
## Description

Add `lastNotifiedAt` on `TrackerConfigurationModel` to log when the last TrackerNotificationWorkflow has processed this tracker.
Add `consumedAt` on `TrackerGenerationModel` to log when a generation object has been processed by the TrackerNotificationWorkflow to issue an email.

## Risk

Model only used by our workspace under a feature flag.

## Deploy Plan

Run migration 130.
Deploy front. 
