### PR TITLE
fix: AB parsing of include actions with timeframe

### DIFF
--- a/front/components/assistant_builder/actions/TimeDropdown.tsx
+++ b/front/components/assistant_builder/actions/TimeDropdown.tsx
@@ -11,7 +11,7 @@ import { TIME_FRAME_UNIT_TO_LABEL } from "@app/components/assistant_builder/shar
 import type { AssistantBuilderTimeFrame } from "@app/components/assistant_builder/types";
 
 interface TimeUnitDropdownProps<
-  T extends { timeFrame?: AssistantBuilderTimeFrame },
+  T extends { timeFrame?: AssistantBuilderTimeFrame | null },
 > {
   timeFrame: AssistantBuilderTimeFrame;
   disabled?: boolean;
@@ -20,7 +20,7 @@ interface TimeUnitDropdownProps<
 }
 
 export function TimeUnitDropdown<
-  T extends { timeFrame?: AssistantBuilderTimeFrame },
+  T extends { timeFrame?: AssistantBuilderTimeFrame | null },
 >({ timeFrame, updateAction, onEdit, disabled }: TimeUnitDropdownProps<T>) {
   return (
     <DropdownMenu>

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -119,11 +119,11 @@ async function getRetrievalActionConfiguration(
       ? getDefaultRetrievalSearchActionConfiguration()
       : getDefaultRetrievalExhaustiveActionConfiguration();
   if (
+    "timeFrame" in retrievalConfiguration.configuration &&
     action.relativeTimeFrame !== "auto" &&
-    action.relativeTimeFrame !== "none" &&
-    "timeFrame" in retrievalConfiguration
+    action.relativeTimeFrame !== "none"
   ) {
-    retrievalConfiguration.timeFrame = {
+    retrievalConfiguration.configuration.timeFrame = {
       value: action.relativeTimeFrame.duration,
       unit: action.relativeTimeFrame.unit,
     };

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -75,7 +75,7 @@ export type AssistantBuilderRetrievalConfiguration = {
 };
 
 export type AssistantBuilderRetrievalExhaustiveConfiguration = {
-  timeFrame?: AssistantBuilderTimeFrame;
+  timeFrame?: AssistantBuilderTimeFrame | null;
 } & AssistantBuilderRetrievalConfiguration;
 
 // DustAppRun configuration
@@ -246,6 +246,7 @@ export function getDefaultRetrievalExhaustiveActionConfiguration() {
     type: "RETRIEVAL_EXHAUSTIVE",
     configuration: {
       dataSourceConfigurations: {},
+      timeFrame: null,
     } as AssistantBuilderRetrievalExhaustiveConfiguration,
     name: DEFAULT_RETRIEVAL_NO_QUERY_ACTION_NAME,
     description: "",


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/tasks/issues/1809

The assistant builder doesn't correctly parse exhaustive retrieval (aka include) action configs that have a time frame.
This fixes it

## Risk

N/A

## Deploy Plan

deploy front