### PR TITLE
parents migration: slack make cleaner more resilient

### DIFF
--- a/front/migrations/20241211_parents_migrator.ts
+++ b/front/migrations/20241211_parents_migrator.ts
@@ -160,8 +160,12 @@ const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
     },
     cleaner: (nodeId, parents) => {
       const channelId = slackNodeIdToChannelId(nodeId);
-
-      if (parents.length === 2) {
+      if (parents.length === 1) {
+        logger.warn(
+          { nodeId, parents, problem: "Not enough parents" },
+          "Invalid slack parents"
+        );
+      } else if (parents.length === 2) {
         assert(parents[0] === nodeId, "parents[0] !== nodeId");
         assert(
           parents[1] === `slack-channel-${channelId}`,
@@ -175,7 +179,7 @@ const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
           "parents[2] !== slack-channel-channelId"
         );
       } else {
-        throw new Error("Parents len != 2/3");
+        throw new Error("Parents len > 2");
       }
 
       return {


### PR DESCRIPTION
## Description

Unexpectedly found a document that still has 1 parent (maybe upsert queue delay?)

https://metabase.dust.tt/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7Im5hdGl2ZSI6eyJxdWVyeSI6IlNFTEVDVCAqIEZST00gZGF0YV9zb3VyY2VzX2RvY3VtZW50cyBXSEVSRSBkYXRhX3NvdXJjZT0xODMgQU5EIGRvY3VtZW50X2lkPSdzbGFjay1DRlpHTERTMTItbWVzc2FnZXMtMjAyMS0wLTQtMjAyMS0wLTExJyIsInRlbXBsYXRlLXRhZ3MiOnt9fSwidHlwZSI6Im5hdGl2ZSIsImRhdGFiYXNlIjozfSwiZGlzcGxheSI6InRhYmxlIiwicGFyYW1ldGVycyI6W10sInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnt9LCJ0eXBlIjoicXVlc3Rpb24ifQ==

Accept them and set their value correclty.

## Risk

N/A

## Deploy Plan

N/A