### PR TITLE
[connectors] add a CLI command `confluence me`

### DIFF
--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -28,7 +28,11 @@ export type ConnectorsCommandType = t.TypeOf<typeof ConnectorsCommandSchema>;
  */
 export const ConfluenceCommandSchema = t.type({
   majorCommand: t.literal("confluence"),
-  command: t.union([t.literal("upsert-page"), t.literal("upsert-pages")]),
+  command: t.union([
+    t.literal("me"),
+    t.literal("upsert-page"),
+    t.literal("upsert-pages"),
+  ]),
   args: t.type({
     connectorId: t.union([t.number, t.undefined]),
     pageId: t.union([t.string, t.undefined]),
@@ -37,6 +41,14 @@ export const ConfluenceCommandSchema = t.type({
   }),
 });
 export type ConfluenceCommandType = t.TypeOf<typeof ConfluenceCommandSchema>;
+
+export const ConfluenceMeResponseSchema = t.type({
+  me: t.UnknownRecord,
+});
+
+export type ConfluenceMeResponseType = t.TypeOf<
+  typeof ConfluenceMeResponseSchema
+>;
 
 export const ConfluenceUpsertPageResponseSchema = t.type({
   workflowId: t.string,

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -45,7 +45,6 @@ export type ConfluenceCommandType = t.TypeOf<typeof ConfluenceCommandSchema>;
 export const ConfluenceMeResponseSchema = t.type({
   me: t.UnknownRecord,
 });
-
 export type ConfluenceMeResponseType = t.TypeOf<
   typeof ConfluenceMeResponseSchema
 >;

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -436,6 +436,8 @@ export const AdminResponseSchema = t.union([
   AdminSuccessResponseSchema,
   BatchAllResponseSchema,
   CheckFileGenericResponseSchema,
+  ConfluenceMeResponseSchema,
+  ConfluenceUpsertPageResponseSchema,
   GetParentsResponseSchema,
   IntercomCheckConversationResponseSchema,
   IntercomCheckMissingConversationsResponseSchema,


### PR DESCRIPTION
## Description

- This PR adds a command `me` to the Confluence admin CLI that logs information relative to the current user.
- This command will typically be used to check that we can do at least 1 API call (checking whether rate limits are hit).

## Risk

- Very low.

## Deploy Plan

- Deploy connectors.
