### PR TITLE
[Keyword search] Index documents in elasticsearch (1/3)

### DIFF
--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -48,6 +48,7 @@ use dust::{
     providers::provider::{provider, ProviderID},
     run,
     search_filter::{Filterable, SearchFilter},
+    search_stores::search_store::{ElasticsearchSearchStore, SearchStore},
     sqlite_workers::client::{self, HEARTBEAT_INTERVAL_MS},
     stores::{
         postgres,
@@ -70,7 +71,7 @@ struct APIState {
     store: Box<dyn store::Store + Sync + Send>,
     databases_store: Box<dyn databases_store::DatabasesStore + Sync + Send>,
     qdrant_clients: QdrantClients,
-
+    search_store: Box<dyn SearchStore + Sync + Send>,
     run_manager: Arc<Mutex<RunManager>>,
 }
 
@@ -79,11 +80,13 @@ impl APIState {
         store: Box<dyn store::Store + Sync + Send>,
         databases_store: Box<dyn databases_store::DatabasesStore + Sync + Send>,
         qdrant_clients: QdrantClients,
+        search_store: Box<dyn SearchStore + Sync + Send>,
     ) -> Self {
         APIState {
             store,
             qdrant_clients,
             databases_store,
+            search_store,
             run_manager: Arc::new(Mutex::new(RunManager {
                 pending_apps: vec![],
                 pending_runs: vec![],
@@ -1729,6 +1732,7 @@ async fn data_sources_documents_upsert(
                         &payload.source_url,
                         payload.section,
                         true, // preserve system tags
+                        state.search_store.clone(),
                     )
                     .await
                 {
@@ -3372,10 +3376,19 @@ fn main() {
                 Err(_) => Err(anyhow!("DATABASES_STORE_DATABASE_URI not set."))?,
             };
 
+        let url = std::env::var("ELASTICSEARCH_URL").expect("ELASTICSEARCH_URL must be set");
+        let username =
+            std::env::var("ELASTICSEARCH_USERNAME").expect("ELASTICSEARCH_USERNAME must be set");
+        let password =
+            std::env::var("ELASTICSEARCH_PASSWORD").expect("ELASTICSEARCH_PASSWORD must be set");
+
+        let search_store : Box<dyn SearchStore + Sync + Send> = Box::new(ElasticsearchSearchStore::new(&url, &username, &password).await?);
+
         let state = Arc::new(APIState::new(
             store,
             databases_store,
             QdrantClients::build().await?,
+            search_store,
         ));
 
         let router = Router::new()

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -9,6 +9,10 @@ pub mod stores {
     pub mod postgres;
     pub mod store;
 }
+pub mod search_stores {
+    pub mod search_store;
+}
+
 pub mod app;
 pub mod dataset;
 pub mod data_sources {

--- a/core/src/search_stores/indices/data_sources_nodes_1.mappings.json
+++ b/core/src/search_stores/indices/data_sources_nodes_1.mappings.json
@@ -1,26 +1,21 @@
 {
+  "dynamic": "strict",
   "properties": {
-    "dynamic": "strict",
     "data_source_id": {
-      "type": "keyword",
-      "required": true
+      "type": "keyword"
     },
     "timestamp": {
-      "type": "date",
-      "required": true
+      "type": "date"
     },
     "node_type": {
-      "type": "keyword",
-      "required": true
+      "type": "keyword"
     },
     "node_id": {
-      "type": "keyword",
-      "required": true
+      "type": "keyword"
     },
     "title": {
       "type": "text",
       "analyzer": "standard",
-      "required": true,
       "fields": {
         "edge": {
           "type": "text",
@@ -29,16 +24,13 @@
       }
     },
     "parents": {
-      "type": "keyword",
-      "required": true
+      "type": "keyword"
     },
     "parent_id": {
-      "type": "keyword",
-      "required": true
+      "type": "keyword"
     },
     "mime_type": {
-      "type": "keyword",
-      "required": true
+      "type": "keyword"
     }
   }
 }

--- a/core/src/search_stores/indices/data_sources_nodes_1.mappings.json
+++ b/core/src/search_stores/indices/data_sources_nodes_1.mappings.json
@@ -1,20 +1,26 @@
 {
   "properties": {
+    "dynamic": "strict",
     "data_source_id": {
-      "type": "keyword"
+      "type": "keyword",
+      "required": true
     },
     "timestamp": {
-      "type": "date"
+      "type": "date",
+      "required": true
     },
-    "type": {
-      "type": "keyword"
+    "node_type": {
+      "type": "keyword",
+      "required": true
     },
     "node_id": {
-      "type": "keyword"
+      "type": "keyword",
+      "required": true
     },
     "title": {
       "type": "text",
       "analyzer": "standard",
+      "required": true,
       "fields": {
         "edge": {
           "type": "text",
@@ -23,10 +29,16 @@
       }
     },
     "parents": {
-      "type": "keyword"
+      "type": "keyword",
+      "required": true
     },
-    "mimeType": {
-      "type": "keyword"
+    "parent_id": {
+      "type": "keyword",
+      "required": true
+    },
+    "mime_type": {
+      "type": "keyword",
+      "required": true
     }
   }
 }

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -51,6 +51,12 @@ impl SearchStore for ElasticsearchSearchStore {
         // elasticsearch needs to index a Node, not a Document
         let node = Node::from(document.clone());
 
+        // safety for rollout: we only index one time on five
+        // TODO(kw-search): remove this once prod testing is ok
+        if rand::thread_rng().gen_bool(0.8) {
+            return Ok(());
+        }
+
         self.client
             .index(IndexParts::IndexId(NODES_INDEX_NAME, &document.document_id))
             .timeout("200ms")

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -12,7 +12,7 @@ use crate::data_sources::node::{Node, NodeType};
 
 #[async_trait]
 pub trait SearchStore {
-    async fn index_document(&self, document_id: &str, document: &Document) -> Result<()>;
+    async fn index_document(&self, document: &Document) -> Result<()>;
     fn clone_box(&self) -> Box<dyn SearchStore + Sync + Send>;
 }
 
@@ -61,7 +61,7 @@ impl SearchStore for ElasticsearchSearchStore {
         );
 
         self.client
-            .index(IndexParts::IndexId(NODES_INDEX_NAME, document_id))
+            .index(IndexParts::IndexId(NODES_INDEX_NAME, &document.document_id))
             .body(node)
             .send()
             .await?;

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -1,0 +1,63 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use elasticsearch::{
+    auth::Credentials,
+    http::transport::{SingleNodeConnectionPool, TransportBuilder},
+    Elasticsearch, IndexParts,
+};
+use url::Url;
+
+use crate::data_sources::data_source::Document;
+use crate::data_sources::node::{Node, NodeType};
+
+#[async_trait]
+pub trait SearchStore {
+    async fn index_document(&self, document_id: &str, document: &Document) -> Result<()>;
+}
+
+#[derive(Clone)]
+pub struct ElasticsearchSearchStore {
+    pub client: Elasticsearch,
+}
+
+impl ElasticsearchSearchStore {
+    pub async fn new(es_uri: &str, username: &str, password: &str) -> Result<Self> {
+        let credentials = Credentials::Basic(username.to_string(), password.to_string());
+        let u = Url::parse(es_uri)?;
+        let conn_pool = SingleNodeConnectionPool::new(u);
+        let mut transport_builder = TransportBuilder::new(conn_pool);
+        transport_builder = transport_builder
+            .auth(credentials)
+            .disable_proxy()
+            .cert_validation(elasticsearch::cert::CertificateValidation::None);
+        let transport = transport_builder.build()?;
+        let client = Elasticsearch::new(transport);
+        Ok(Self { client })
+    }
+}
+
+const NODES_INDEX_NAME: &str = "core.data_sources_nodes";
+
+#[async_trait]
+impl SearchStore for ElasticsearchSearchStore {
+    async fn index_document(&self, document_id: &str, document: &Document) -> Result<()> {
+        // elasticsearch needs to index a Node, not a Document
+        let node = Node::new(
+            &document.data_source_id,
+            document_id,
+            NodeType::Document,
+            document.timestamp,
+            &document.title,
+            &document.mime_type,
+            document.parent_id.clone(),
+            document.parents.clone(),
+        );
+
+        self.client
+            .index(IndexParts::IndexId(NODES_INDEX_NAME, document_id))
+            .body(node)
+            .send()
+            .await?;
+        Ok(())
+    }
+}

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -62,6 +62,7 @@ impl SearchStore for ElasticsearchSearchStore {
 
         self.client
             .index(IndexParts::IndexId(NODES_INDEX_NAME, &document.document_id))
+            .timeout("200ms")
             .body(node)
             .send()
             .await?;

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -49,16 +49,7 @@ const NODES_INDEX_NAME: &str = "core.data_sources_nodes";
 impl SearchStore for ElasticsearchSearchStore {
     async fn index_document(&self, document: &Document) -> Result<()> {
         // elasticsearch needs to index a Node, not a Document
-        let node = Node::new(
-            &document.data_source_id,
-            &document.document_id,
-            NodeType::Document,
-            document.timestamp,
-            &document.title,
-            &document.mime_type,
-            document.parent_id.clone(),
-            document.parents.clone(),
-        );
+        let node = Node::from(document.clone());
 
         self.client
             .index(IndexParts::IndexId(NODES_INDEX_NAME, &document.document_id))


### PR DESCRIPTION
### Description
Starts indexing documents in our elasticsearch cluster. PR 1 on 3. 

For safety, full document indexation in ES will be done in 3 steps:
1. Only index 20% of the time (probabilistic). On indexation failure, ignore and do not fail upsert => scope of this PR
2. Index all docs => in a following PR if metrics are fine
3. On failure, fail upsert too => in a last PR if metrics are fine

Also, times out if indexation takes too long. It should average at ~10ms. We start with an aggressive timeouting at 200ms, and in PR 3 will move it to 1 second. There will be a monitor on average indexation latency.

#### Follow-up 
Afterwards, tables and folders will follow with the same process.

Test searches will be performed to ensure the performance / results are adequate

Note: backfilling elasticsearch is not part of this work.

### Risks
High. Impact on a core part of our app. Too big a latency on indexation would cause slowdowns in prod.
Mitigation:
- protection 1: index only 20% of the time
- protection 2: on indexation failure, don't abort upsert, just log error
- 2 reviewers
- aggressive timeout on indexation (200ms)
- monitoring, cf deploy plan
- TODO Explain local tests performed

There is still a risk on blocking, high

### Deploy plan
- update index on production cluster
- core
- create monitor + dashboards for indexation latency / failure
- monitor core health metrics 
  - indexation latency
  - indexation failures (at least until we start failing the upsert)
  - total upsert latency
  - upsert failures
- test searches via kibana (es admin console)
- update issue with results
