### PR TITLE
fix(Confluence) - handle 404 on `getPageReadRestrictions`

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_api.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_api.ts
@@ -102,6 +102,10 @@ export async function pageHasReadRestrictions(
 ) {
   const pageReadRestrictions = await client.getPageReadRestrictions(pageId);
 
+  if (pageReadRestrictions === null) {
+    return null; // Page not found, we let the caller choose how to handle this.
+  }
+
   const hasGroupReadPermissions =
     pageReadRestrictions.restrictions.group.results.length > 0;
   const hasUserReadPermissions =

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -550,10 +550,17 @@ export class ConfluenceClient {
   }
 
   async getPageReadRestrictions(pageId: string) {
-    return this.request(
-      `${this.legacyRestApiBaseUrl}/content/${pageId}/restriction/byOperation/read`,
-      ConfluenceReadOperationRestrictionsCodec
-    );
+    try {
+      return await this.request(
+        `${this.legacyRestApiBaseUrl}/content/${pageId}/restriction/byOperation/read`,
+        ConfluenceReadOperationRestrictionsCodec
+      );
+    } catch (err) {
+      if (err instanceof ConfluenceClientError && err.status === 404) {
+        return null;
+      }
+      throw err;
+    }
   }
 
   async getUserAccount() {


### PR DESCRIPTION
## Description

- This PR aims at adding error handling on 404 errors from Confluence API on the endpoint called in `getPageReadRestrictions`.
- Handling these has become necessary in the context of the new CLI commands `confluence upsert-pages` and `confluence upsert-page`, which have a different workflow than the full workflow (these errors pop up as [unhandled activity errors](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40dd.service%3Aconnectors-worker&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZPLuqCp0t1AkgAAABhBWlBMdXFlY0FBQTRlQnlqQWJwUnl3REsAAAAkMDE5M2NiYmEtYzlhYS00OGMyLThlM2MtMDJhOTA0MzE0ODlkAAAAdg&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=6000198897476506285&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1734286579276&to_ts=1734290179276&live=true)).
- These errors are handled by letting the workflow go on and check that the page indeed exists in a direct API call.

## Risk

- Low

## Deploy Plan

- Deploy connectors.
