### PR TITLE
[.github] - feat(workflows): regional build args

### DIFF
--- a/.github/configs/europe-west1.yaml
+++ b/.github/configs/europe-west1.yaml
@@ -1,0 +1,4 @@
+env:
+  NEXT_PUBLIC_VIZ_URL: "https://viz.dust.tt"
+  NEXT_PUBLIC_GA_TRACKING_ID: "G-K9HQ2LE04G"
+  NEXT_PUBLIC_DUST_CLIENT_FACING_URL: "https://eu-front-edge.dust.tt"

--- a/.github/configs/us-central1.yaml
+++ b/.github/configs/us-central1.yaml
@@ -1,0 +1,4 @@
+env:
+  NEXT_PUBLIC_VIZ_URL: "https://viz.dust.tt"
+  NEXT_PUBLIC_GA_TRACKING_ID: "G-K9HQ2LE04G"
+  NEXT_PUBLIC_DUST_CLIENT_FACING_URL: "https://front-edge.dust.tt"

--- a/.github/workflows/deploy-front-edge.yml
+++ b/.github/workflows/deploy-front-edge.yml
@@ -92,12 +92,11 @@ jobs:
 
       - name: Build image for ${{ matrix.region }}
         run: |
-          chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build.sh \
+          chmod +x ./k8s/cloud-build_tmp.sh
+          ./k8s/cloud-build_tmp.sh \
             --image-name=$IMAGE_NAME \
             --dockerfile-path=./front/Dockerfile \
             --working-dir=./ \
-            --dust-client-facing-url=https://front-edge.dust.tt \
             --region=${{ matrix.region }}
 
   deploy:

--- a/k8s/cloud-build_tmp.sh
+++ b/k8s/cloud-build_tmp.sh
@@ -62,8 +62,8 @@ if [ -n "$GCLOUD_IGNORE_FILE" ]; then
     BUILD_CMD+=(--ignore-file="$GCLOUD_IGNORE_FILE")
 fi
 
-# Add substitutions including the config file path
-BUILD_CMD+=(--substitutions="_REGION=$REGION,_IMAGE_NAME=$IMAGE_NAME,_DOCKERFILE_PATH=$DOCKERFILE_PATH,_CONFIG_FILE=$CONFIG_FILE,SHORT_SHA=$(git rev-parse --short HEAD)" .)
+# Add substitutions
+BUILD_CMD+=(--substitutions="_REGION=$REGION,_IMAGE_NAME=$IMAGE_NAME,_DOCKERFILE_PATH=$DOCKERFILE_PATH,SHORT_SHA=$(git rev-parse --short HEAD)" .)
 
 # Execute the build
 "${BUILD_CMD[@]}"

--- a/k8s/cloud-build_tmp.sh
+++ b/k8s/cloud-build_tmp.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+set -e
+
+# Default values
+SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
+WORKING_DIR=""
+IMAGE_NAME=""
+DOCKERFILE_PATH=""
+REGION=""
+GCLOUD_IGNORE_FILE=""
+
+# Parse command-line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --working-dir=*)
+            WORKING_DIR="${1#*=}"
+            shift
+            ;;
+        --image-name=*)
+            IMAGE_NAME="${1#*=}"
+            shift
+            ;;
+        --dockerfile-path=*)
+            DOCKERFILE_PATH="${1#*=}"
+            shift
+            ;;
+        --region=*)
+            REGION="${1#*=}"
+            shift
+            ;;
+        --gcloud-ignore-file=*)
+            GCLOUD_IGNORE_FILE="${1#*=}"
+            shift
+            ;;
+        *)
+            echo "Error: Unknown argument $1"
+            exit 1
+            ;;
+    esac
+done
+
+# Validate required arguments
+if [ -z "$WORKING_DIR" ] || [ -z "$IMAGE_NAME" ] || [ -z "$DOCKERFILE_PATH" ] || [ -z "$REGION" ]; then
+    echo "Error: --working-dir, --image-name, --region and --dockerfile-path are required"
+    exit 1
+fi
+
+# Change to working directory
+cd "$WORKING_DIR"
+
+# Load region-specific config
+CONFIG_FILE=".github/config/${REGION}.yaml"
+if [ ! -f "$CONFIG_FILE" ]; then
+    echo "Error: Config file not found: $CONFIG_FILE"
+    exit 1
+fi
+
+# Prepare the build command
+BUILD_CMD=(gcloud builds submit --quiet --config "${SCRIPT_DIR}/cloudbuild_tmp.yaml")
+
+if [ -n "$GCLOUD_IGNORE_FILE" ]; then
+    BUILD_CMD+=(--ignore-file="$GCLOUD_IGNORE_FILE")
+fi
+
+# Add substitutions including the config file path
+BUILD_CMD+=(--substitutions="_REGION=$REGION,_IMAGE_NAME=$IMAGE_NAME,_DOCKERFILE_PATH=$DOCKERFILE_PATH,_CONFIG_FILE=$CONFIG_FILE,SHORT_SHA=$(git rev-parse --short HEAD)" .)
+
+# Execute the build
+"${BUILD_CMD[@]}"

--- a/k8s/cloudbuild_tmp.yaml
+++ b/k8s/cloudbuild_tmp.yaml
@@ -3,7 +3,7 @@ steps:
     name: 'ghcr.io/depot/cli:latest'
     script: |
       # Extract env variables for build args
-      yq e '.env' ${_CONFIG_FILE} > build-args.env
+      yq e '.env' .github/config/${_REGION}.yaml > build-args.env
       
       depot build \
         --project 3vz0lnf16v \

--- a/k8s/cloudbuild_tmp.yaml
+++ b/k8s/cloudbuild_tmp.yaml
@@ -1,0 +1,30 @@
+steps:
+  - id: 'Build Container Image'
+    name: 'ghcr.io/depot/cli:latest'
+    script: |
+      # Extract env variables for build args
+      yq e '.env' ${_CONFIG_FILE} > build-args.env
+      
+      depot build \
+        --project 3vz0lnf16v \
+        --provenance=false \
+        -t ${_REGION}-docker.pkg.dev/${PROJECT_ID}/dust-images/${_IMAGE_NAME}:${SHORT_SHA} \
+        -t ${_REGION}-docker.pkg.dev/${PROJECT_ID}/dust-images/${_IMAGE_NAME}:latest \
+        -f ${_DOCKERFILE_PATH} \
+        --build-arg COMMIT_HASH=${SHORT_SHA} \
+        --build-arg-file=build-args.env \
+        --push \
+        .
+    secretEnv:
+      - "DEPOT_TOKEN"
+
+timeout: 1200s
+
+availableSecrets:
+  secretManager:
+    - versionName: projects/$PROJECT_ID/secrets/DEPOT_TOKEN/versions/latest
+      env: DEPOT_TOKEN
+
+options:
+  automapSubstitutions: true
+  logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
## Description

This PR implements regional configuration files to support building and deploying to multiple regions. Build arguments are now loaded from region-specific YAML files that contain environment variables used during the Docker image build process.

Note: this is only done for `front-edge` now -> will test it and migrate all deployments to follow the same pattern once working as expected.

**References**
- https://github.com/dust-tt/tasks/issues/1811

## Risk

Breaking front-edge deployment CI

## Deploy Plan
- Test action for `front-edge`
- Migrate all deployment workflows to follow same structure
