### PR TITLE
fix(Confluence) -  prevent type issue on `pageId`

### DIFF
--- a/connectors/src/connectors/confluence/lib/cli.ts
+++ b/connectors/src/connectors/confluence/lib/cli.ts
@@ -57,7 +57,8 @@ export const confluence = async ({
       if (!args.pageId) {
         throw new Error("Missing --pageId argument");
       }
-      const { connectorId, pageId } = args;
+      const { connectorId } = args;
+      const pageId = args.pageId.toString();
 
       const client = await getTemporalClient();
       const workflow = await client.workflow.start(

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -35,7 +35,7 @@ export const ConfluenceCommandSchema = t.type({
   ]),
   args: t.type({
     connectorId: t.union([t.number, t.undefined]),
-    pageId: t.union([t.string, t.undefined]),
+    pageId: t.union([t.number, t.undefined]),
     file: t.union([t.string, t.undefined]),
     keyInFile: t.union([t.string, t.undefined]),
   }),


### PR DESCRIPTION
## Description

- The confluence CLI command `confluence upsert-page` is current unusable because of a type issue: `Error: Invalid command: Expecting string at 2.args.pageId.0 but instead got: 9....,Expecting undefined at 2.args.pageId.1 but instead got: 9....`.
- This issue comes from the validation we enforce between our types `ConfluenceCommandType` and the values coming from minimist; since the pageId looks like a number it will be parsed as a number by minimist, which then fails the validation.
- This PR fixes this issue by vaildating the value as a number and then parsing it as a string: it is a correct validation because the pageIds should look like numbers (we can't pass custom arguments to `parseArgs` just for Confluence).

## Risk

- Very low, at worst the commands do not run.

## Deploy Plan

- Deploy connectors.
