### PR TITLE
fix: skip doc tracker hook if sync_type not incremental

### DIFF
--- a/front/lib/document_upsert_hooks/hooks/document_tracker/index.ts
+++ b/front/lib/document_upsert_hooks/hooks/document_tracker/index.ts
@@ -13,7 +13,12 @@ export const documentTrackerUpsertHook: DocumentUpsertHook = {
     documentId,
     documentHash,
     dataSourceConnectorProvider,
+    upsertContext,
   }) => {
+    if (upsertContext?.sync_type !== "incremental") {
+      return;
+    }
+
     const owner = auth.workspace();
     if (!owner) {
       return;

--- a/front/temporal/document_tracker/workflows.ts
+++ b/front/temporal/document_tracker/workflows.ts
@@ -15,12 +15,6 @@ export async function runDocumentTrackerWorkflow(
   documentHash: string,
   dataSourceConnectorProvider: ConnectorProvider | null
 ) {
-  void workspaceId;
-  void dataSourceId;
-  void documentId;
-  void documentHash;
-  void dataSourceConnectorProvider;
-
   let signaled = false;
   const debounceMs = (() => {
     if (!dataSourceConnectorProvider) {


### PR DESCRIPTION
## Description

Doc tracker hook should be skipped if `upsertContext.sync_type` is not passed or equal to `"batch"`.

## Risk

N/A

## Deploy Plan

Deploy `front`