### PR TITLE
[front] restore access for webcrawler

### DIFF
--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -297,7 +297,7 @@ async function handler(
   if (
     !dataSource ||
     dataSource.space.sId !== spaceId ||
-    !dataSource.canRead(auth)
+    (!dataSource.canRead(auth) && !auth.isSystemKey())
   ) {
     return apiError(req, res, {
       status_code: 404,


### PR DESCRIPTION
## Description

Webcrawler is using system key, but system key cannot read custom vaults (only access system/global).

## Risk


## Deploy Plan

deploy front
