### PR TITLE
[front] Give access to all groups for system key

### DIFF
--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -121,22 +121,16 @@ export class GroupResource extends BaseResource<GroupModel> {
   static async listWorkspaceGroupsFromKey(
     key: KeyResource
   ): Promise<GroupResource[]> {
-    let whereCondition: WhereOptions<GroupModel> = {
-      workspaceId: key.workspaceId,
-    };
-
-    // If the key is a system key, we also include the global group.
-    if (key.isSystem) {
-      whereCondition = {
-        ...whereCondition,
-      };
-    } else {
-      // If it's not a system key, we only fetch the associated group.
-      whereCondition = {
-        ...whereCondition,
-        id: key.groupId,
-      };
-    }
+    const whereCondition: WhereOptions<GroupModel> = key.isSystem
+      ? // If the key is a system key, we include all groups in the workspace.
+        {
+          workspaceId: key.workspaceId,
+        }
+      : // If it's not a system key, we only fetch the associated group.
+        {
+          workspaceId: key.workspaceId,
+          id: key.groupId,
+        };
 
     const groups = await this.model.findAll({
       where: whereCondition,

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -129,10 +129,6 @@ export class GroupResource extends BaseResource<GroupModel> {
     if (key.isSystem) {
       whereCondition = {
         ...whereCondition,
-        [Op.or]: [
-          { kind: { [Op.in]: ["system", "global"] } },
-          { id: key.groupId },
-        ],
       };
     } else {
       // If it's not a system key, we only fetch the associated group.

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -297,7 +297,7 @@ async function handler(
   if (
     !dataSource ||
     dataSource.space.sId !== spaceId ||
-    (!dataSource.canRead(auth) && !auth.isSystemKey())
+    !dataSource.canRead(auth)
   ) {
     return apiError(req, res, {
       status_code: 404,


### PR DESCRIPTION
## Description

This revert the previous quick fix ( granting document post for system key ) and instead grant all groups access to system key authenticator, not just only system and global groups. This allows system key to be able to read/write documents into any space.

## Risk

## Deploy Plan

deploy front