### PR TITLE
[connectors] Upsert and backfill Confluence spaces as `data_source_folders`

### DIFF
--- a/connectors/migrations/20241216_backfill_confluence_folders.ts
+++ b/connectors/migrations/20241216_backfill_confluence_folders.ts
@@ -1,0 +1,36 @@
+import { makeScript } from "scripts/helpers";
+
+import { makeSpaceInternalId } from "@connectors/connectors/confluence/lib/internal_ids";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { upsertFolderNode } from "@connectors/lib/data_sources";
+import { ConfluenceSpace } from "@connectors/lib/models/confluence";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+
+makeScript({}, async ({ execute }, logger) => {
+  const connectors = await ConnectorResource.listByType("confluence", {});
+
+  for (const connector of connectors) {
+    const confluenceSpaces = await ConfluenceSpace.findAll({
+      attributes: ["spaceId", "name"],
+      where: { connectorId: connector.id },
+    });
+    const dataSourceConfig = dataSourceConfigFromConnector(connector);
+    if (execute) {
+      for (const space of confluenceSpaces) {
+        await upsertFolderNode({
+          dataSourceConfig,
+          folderId: makeSpaceInternalId(space.spaceId),
+          parents: [makeSpaceInternalId(space.spaceId)],
+          title: space.name,
+        });
+      }
+      logger.info(
+        `Upserted ${confluenceSpaces.length} spaces for connector ${connector.id}`
+      );
+    } else {
+      logger.info(
+        `Found ${confluenceSpaces.length} spaces for connector ${connector.id}`
+      );
+    }
+  }
+});

--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -44,12 +44,7 @@ import {
   BaseConnectorManager,
   ConnectorManagerError,
 } from "@connectors/connectors/interface";
-import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
-import {
-  deleteFolderNode,
-  upsertFolderNode,
-} from "@connectors/lib/data_sources";
 import {
   ConfluenceConfiguration,
   ConfluencePage,
@@ -327,7 +322,6 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
         new Error(`Connector not found with id ${this.connectorId}`)
       );
     }
-    const dataSourceConfig = dataSourceConfigFromConnector(connector);
 
     let spaces: ConfluenceSpaceType[] = [];
     // Fetch Confluence spaces only if the intention is to add new spaces to sync.
@@ -355,8 +349,6 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
           },
         });
 
-        await deleteFolderNode({ dataSourceConfig, folderId: internalId });
-
         removedSpaceIds.push(confluenceId);
       } else if (permission === "read") {
         const confluenceSpace = spaces.find((s) => s.id === confluenceId);
@@ -366,13 +358,6 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
           name: confluenceSpace?.name ?? confluenceId,
           spaceId: confluenceId,
           urlSuffix: confluenceSpace?._links.webui,
-        });
-
-        await upsertFolderNode({
-          dataSourceConfig,
-          folderId: internalId,
-          parents: [internalId],
-          title: confluenceSpace?.name ?? confluenceId,
         });
 
         addedSpaceIds.push(confluenceId);

--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -44,7 +44,12 @@ import {
   BaseConnectorManager,
   ConnectorManagerError,
 } from "@connectors/connectors/interface";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
+import {
+  deleteFolderNode,
+  upsertFolderNode,
+} from "@connectors/lib/data_sources";
 import {
   ConfluenceConfiguration,
   ConfluencePage,
@@ -322,6 +327,7 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
         new Error(`Connector not found with id ${this.connectorId}`)
       );
     }
+    const dataSourceConfig = dataSourceConfigFromConnector(connector);
 
     let spaces: ConfluenceSpaceType[] = [];
     // Fetch Confluence spaces only if the intention is to add new spaces to sync.
@@ -349,6 +355,11 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
           },
         });
 
+        await deleteFolderNode({
+          dataSourceConfig,
+          folderId: makeSpaceInternalId(internalId),
+        });
+
         removedSpaceIds.push(confluenceId);
       } else if (permission === "read") {
         const confluenceSpace = spaces.find((s) => s.id === confluenceId);
@@ -358,6 +369,13 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
           name: confluenceSpace?.name ?? confluenceId,
           spaceId: confluenceId,
           urlSuffix: confluenceSpace?._links.webui,
+        });
+
+        await upsertFolderNode({
+          dataSourceConfig,
+          folderId: makeSpaceInternalId(internalId),
+          parents: [makeSpaceInternalId(internalId)],
+          title: confluenceSpace?.name ?? confluenceId,
         });
 
         addedSpaceIds.push(confluenceId);

--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -355,10 +355,7 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
           },
         });
 
-        await deleteFolderNode({
-          dataSourceConfig,
-          folderId: makeSpaceInternalId(internalId),
-        });
+        await deleteFolderNode({ dataSourceConfig, folderId: internalId });
 
         removedSpaceIds.push(confluenceId);
       } else if (permission === "read") {
@@ -373,8 +370,8 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
 
         await upsertFolderNode({
           dataSourceConfig,
-          folderId: makeSpaceInternalId(internalId),
-          parents: [makeSpaceInternalId(internalId)],
+          folderId: internalId,
+          parents: [internalId],
           title: confluenceSpace?.name ?? confluenceId,
         });
 

--- a/connectors/src/connectors/confluence/temporal/workflows.ts
+++ b/connectors/src/connectors/confluence/temporal/workflows.ts
@@ -37,6 +37,7 @@ const {
   fetchConfluenceUserAccountAndConnectorIdsActivity,
 
   fetchConfluenceConfigurationActivity,
+  confluenceUpsertSpaceFolderActivity,
   getSpaceIdsToSyncActivity,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "30 minutes",
@@ -149,6 +150,12 @@ export async function confluenceSpaceSyncWorkflow(
   if (spaceName === null) {
     return startConfluenceRemoveSpaceWorkflow(wInfo, connectorId, spaceId);
   }
+
+  await confluenceUpsertSpaceFolderActivity({
+    connectorId,
+    spaceId,
+    spaceName,
+  });
 
   // Get the root level pages for the space.
   const rootPageRefs = await confluenceGetRootPageRefsActivity({


### PR DESCRIPTION
## Description

- Closes [#9159](https://github.com/dust-tt/dust/issues/9159);
- Add API calls whenever a Confluence space is upserted/deleted in connectors, which is when permissions are set.
- Add a backfill script to backfill existing Confluence spaces.
- Spaces are the only folders in this connector.
- Tested locally, I get the rows in `data_sources_folders`, I also get the nodes in `data_sources_nodes` with `mime_type` `application/vnd.dust.folder`.

## Risk

- Relatively low, not a lot of user-facing impact as of now and easily rollbackable.

## Deploy Plan

- Stop all Confluence connectors.
- Deploy connectors.
- Resume all Confluence connectors.
- Run migration
