### PR TITLE
[k8s] - fix: correct writing file path in cloudbuild configuration

### DIFF
--- a/k8s/cloudbuild_tmp.yaml
+++ b/k8s/cloudbuild_tmp.yaml
@@ -3,7 +3,7 @@ steps:
     name: 'mikefarah/yq'
     script: |
       #!/usr/bin/env sh
-      yq '.env' -o=props '.github/configs/${_REGION}.yaml' > /build-args/build-args.txt
+      yq '.env' -o=props '.github/configs/${_REGION}.yaml' > /workspace/build-args.txt
     volumes:
       - name: 'build-args'
         path: '/build-args'
@@ -24,7 +24,7 @@ steps:
           value=$(echo "$value" | xargs)
           build_args+=("--build-arg" "${key}=${value}")
         fi
-      done < /build-args/build-args.txt
+      done < /workspace/build-args.txt
       
       echo "BUILD ARGUMENTS:"
       echo ${build_args[@]}


### PR DESCRIPTION
## Description

This PR changes the output file path for YQ command to use the /workspace directory instead of a non-persistent /build-args path, following [GCP docs](https://cloud.google.com/build/docs/configuring-builds/pass-data-between-steps)

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
