### PR TITLE
Move TemplateResource to new sIds

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -496,11 +496,6 @@ async function fetchWorkspaceAgentConfigurationsForView(
       actions.push(...processActionConfigurations);
     }
 
-    let template: TemplateResource | null = null;
-    if (agent.templateId) {
-      template = await TemplateResource.fetchByModelId(agent.templateId);
-    }
-
     const agentConfigurationType: AgentConfigurationType = {
       id: agent.id,
       sId: agent.sId,
@@ -522,7 +517,9 @@ async function fetchWorkspaceAgentConfigurationsForView(
       versionAuthorId: agent.authorId,
       maxStepsPerRun: agent.maxStepsPerRun,
       visualizationEnabled: agent.visualizationEnabled ?? false,
-      templateId: template?.sId ?? null,
+      templateId: agent.templateId
+        ? TemplateResource.modelIdToSId({ id: agent.templateId })
+        : null,
       groupIds: agent.groupIds.map((id) =>
         GroupResource.modelIdToSId({ id, workspaceId: owner.id })
       ),

--- a/front/lib/resources/storage/models/templates.ts
+++ b/front/lib/resources/storage/models/templates.ts
@@ -17,7 +17,6 @@ export class TemplateModel extends BaseModel<TemplateModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare sId: string;
   declare description: string | null;
 
   declare visibility: TemplateVisibility;
@@ -53,10 +52,6 @@ TemplateModel.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
-    },
-    sId: {
-      type: DataTypes.STRING,
-      allowNull: false,
     },
     description: {
       type: DataTypes.TEXT,

--- a/front/lib/resources/storage/models/templates.ts
+++ b/front/lib/resources/storage/models/templates.ts
@@ -118,7 +118,6 @@ TemplateModel.init(
     sequelize: frontSequelize,
     modelName: "template",
     indexes: [
-      { unique: true, fields: ["sId"] },
       {
         fields: ["visibility"],
       },

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -26,7 +26,10 @@ const RESOURCES_PREFIX = {
   data_source: "dts",
   data_source_view: "dsv",
   tracker: "trk",
+  template: "tpl",
 };
+
+export const CROSS_WORKSPACE_RESOURCES_WORKSPACE_ID: ModelId = 0;
 
 const ALL_RESOURCES_PREFIXES = Object.values(RESOURCES_PREFIX);
 

--- a/front/migrations/db/migration_131.sql
+++ b/front/migrations/db/migration_131.sql
@@ -1,0 +1,2 @@
+-- Migration created on Dec 16, 2024
+ALTER TABLE "public"."templates" DROP COLUMN "sId";

--- a/front/pages/api/poke/templates/index.ts
+++ b/front/pages/api/poke/templates/index.ts
@@ -10,7 +10,6 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { USED_MODEL_CONFIGS } from "@app/components/providers/types";
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { TemplateResource } from "@app/lib/resources/template_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { AssistantTemplateListType } from "@app/pages/api/w/[wId]/assistant/builder/templates";
@@ -104,7 +103,6 @@ async function handler(
         presetModelId: model.modelId,
         presetProviderId: model.providerId,
         presetTemperature: body.presetTemperature ?? null,
-        sId: generateRandomModelSId(),
         tags: body.tags,
         visibility: body.visibility,
       });

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -231,8 +231,7 @@ export type LightAgentConfigurationType = {
 };
 
 export type AgentConfigurationType = LightAgentConfigurationType & {
-  // If empty, no actions are performed, otherwise the actions are
-  // performed.
+  // If empty, no actions are performed, otherwise the actions are performed.
   actions: AgentActionConfigurationType[];
 };
 


### PR DESCRIPTION
## Description

See: https://app.datadoghq.eu/notebook/194053/agentconfiguration-optimization?notebookType=legacy

Agent configurations retrieval is extremely slow due to a sequential template retrieval on every agent configurations, just to get the sId. Move TemplateResource to using new sIds and save that call.

## Risk

Break template related operations.
Tested in dev
Will test on edge first

## Deploy Plan

- deploy `front`
- run migration (after deploy)