### PR TITLE
fix: start with signaled=true in dt workflow

### DIFF
--- a/front/temporal/document_tracker/workflows.ts
+++ b/front/temporal/document_tracker/workflows.ts
@@ -15,7 +15,8 @@ export async function runDocumentTrackerWorkflow(
   documentHash: string,
   dataSourceConnectorProvider: ConnectorProvider | null
 ) {
-  let signaled = false;
+  let signaled = true;
+
   const debounceMs = (() => {
     if (!dataSourceConnectorProvider) {
       return 10000;
@@ -32,8 +33,8 @@ export async function runDocumentTrackerWorkflow(
 
   while (signaled) {
     signaled = false;
-
     await sleep(debounceMs);
+
     if (signaled) {
       continue;
     }


### PR DESCRIPTION
## Description

Signaled should be true at the beginning of the worfklow, so that we run at least one loop iteration if the document was upserted only once.

## Risk

N/A

## Deploy Plan

Depoy front