### PR TITLE
[.github] - refactor(configs): transition config to .env

### DIFF
--- a/.github/configs/.env.europe-west1
+++ b/.github/configs/.env.europe-west1
@@ -1,0 +1,3 @@
+NEXT_PUBLIC_VIZ_URL="https://eu-viz.dust.tt"
+NEXT_PUBLIC_GA_TRACKING_ID="G-K9HQ2LE04G"
+NEXT_PUBLIC_DUST_CLIENT_FACING_URL="https://eu-front-edge.dust.tt"

--- a/.github/configs/.env.us-central1
+++ b/.github/configs/.env.us-central1
@@ -1,0 +1,3 @@
+NEXT_PUBLIC_VIZ_URL="https://viz.dust.tt"
+NEXT_PUBLIC_GA_TRACKING_ID="G-K9HQ2LE04G"
+NEXT_PUBLIC_DUST_CLIENT_FACING_URL="https://front-edge.dust.tt"

--- a/.github/configs/europe-west1.yaml
+++ b/.github/configs/europe-west1.yaml
@@ -1,4 +1,0 @@
-env:
-  NEXT_PUBLIC_VIZ_URL: "https://eu-viz.dust.tt"
-  NEXT_PUBLIC_GA_TRACKING_ID: "G-K9HQ2LE04G"
-  NEXT_PUBLIC_DUST_CLIENT_FACING_URL: "https://eu-front-edge.dust.tt"

--- a/.github/configs/us-central1.yaml
+++ b/.github/configs/us-central1.yaml
@@ -1,4 +1,0 @@
-env:
-  NEXT_PUBLIC_VIZ_URL: "https://viz.dust.tt"
-  NEXT_PUBLIC_GA_TRACKING_ID: "G-K9HQ2LE04G"
-  NEXT_PUBLIC_DUST_CLIENT_FACING_URL: "https://front-edge.dust.tt"

--- a/k8s/cloudbuild_tmp.yaml
+++ b/k8s/cloudbuild_tmp.yaml
@@ -1,18 +1,6 @@
 steps:
-  - id: 'Prepare Build Args'
-    name: 'mikefarah/yq'
-    script: |
-      #!/usr/bin/env sh
-      yq '.env' -o=props '.github/configs/${_REGION}.yaml' > /workspace/build-args.txt
-    volumes:
-      - name: 'build-args'
-        path: '/build-args'
-
   - id: 'Build Container Image'
     name: 'ghcr.io/depot/cli:latest'
-    volumes:
-      - name: 'build-args'
-        path: '/build-args'
     script: |
       #!/usr/bin/env bash
 
@@ -24,7 +12,7 @@ steps:
           value=$(echo "$value" | xargs)
           build_args+=("--build-arg" "${key}=${value}")
         fi
-      done < /workspace/build-args.txt
+      done < .github/configs/.env.${_REGION}
       
       echo "BUILD ARGUMENTS:"
       echo ${build_args[@]}


### PR DESCRIPTION
## Description

This PR aims at storing the region dependant build args into `.env.*` files instead of `.yaml` files such that variables can directly be loaded without the need for `yq`

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
