### PR TITLE
 fix: update SQL query condition in parents migrator to use >= for timestamp comparison

### DIFF
--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -2047,6 +2047,7 @@ export async function renderAndUpsertPageFromCache({
       }),
       // TODO(kw_search) remove legacy
       parents: [...parentIds, ...legacyParentIds],
+      parentId: parentIds.length > 1 ? parentIds[1] : null,
       loggerArgs,
       upsertContext: {
         sync_type: isFullSync ? "batch" : "incremental",
@@ -2603,6 +2604,7 @@ export async function upsertDatabaseStructuredDataFromCache({
         tags: [`title:${databaseName}`, "is_database:true"],
         // TODO(kw_search) remove legacy
         parents: [databaseDocId, ...parentIds, ...legacyParentIds],
+        parentId: parentIds.length > 1 ? parentIds[1] : null,
         loggerArgs,
         upsertContext: {
           sync_type: "batch",

--- a/front/migrations/20241211_parents_migrator.ts
+++ b/front/migrations/20241211_parents_migrator.ts
@@ -34,7 +34,7 @@ type ProviderMigrator = {
   ) => { parents: string[]; parentId: string | null };
 };
 
-const QUERY_BATCH_SIZE = 256;
+const QUERY_BATCH_SIZE = 4096;
 const DOCUMENT_CONCURRENCY = 16;
 const TABLE_CONCURRENCY = 16;
 

--- a/front/migrations/20241211_parents_migrator.ts
+++ b/front/migrations/20241211_parents_migrator.ts
@@ -449,7 +449,7 @@ async function migrateDataSource({
   for (;;) {
     const [coreDocumentRows] = (await corePrimary.query(
       "SELECT id, parents, document_id, timestamp FROM data_sources_documents " +
-        "WHERE data_source = ? AND STATUS = ? AND timestamp > ? " +
+        "WHERE data_source = ? AND STATUS = ? AND timestamp >= ? " +
         "ORDER BY timestamp ASC LIMIT ?",
       {
         replacements: [


### PR DESCRIPTION
## Description

Several docs within a datasource can have the same timestamp, which means some docs aren't migrated.

## Risk

process the same docs more than once 

## Deploy Plan

re-run migration on affected connectors (at least notion)