### PR TITLE
AgentUserRelation: optimize query to use index

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -347,6 +347,7 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
       }
       const relations = await AgentUserRelation.findAll({
         where: {
+          workspaceId: owner.id,
           userId,
           favorite: true,
         },
@@ -614,8 +615,8 @@ export async function getAgentConfigurations<V extends "light" | "full">({
     }),
   ]);
 
-  // Filter out agents that the user does not have access to
-  // user should be in all groups that are in the agent's groupIds
+  // Filter out agents that the user does not have access to user should be in all groups that are
+  // in the agent's groupIds
   const allowedAgentConfigurations = dangerouslySkipPermissionFiltering
     ? allAgentConfigurations
     : allAgentConfigurations

--- a/front/lib/api/assistant/get_favorite_states.ts
+++ b/front/lib/api/assistant/get_favorite_states.ts
@@ -19,6 +19,7 @@ export async function getFavoriteStates(
 
   const relations = await AgentUserRelation.findAll({
     where: {
+      workspaceId: auth.getNonNullableWorkspace().id,
       agentConfiguration: { [Op.in]: configurationIds },
       userId: user.id,
     },

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
@@ -140,18 +140,13 @@ async function handler(
           auth,
           agents: agentConfigurations,
         });
-        agentConfigurations = await Promise.all(
-          agentConfigurations.map(
-            async (
-              agentConfiguration,
-              index
-            ): Promise<LightAgentConfigurationType> => {
-              return {
-                ...agentConfiguration,
-                lastAuthors: recentAuthors[index],
-              };
-            }
-          )
+        agentConfigurations = agentConfigurations.map(
+          (agentConfiguration, index) => {
+            return {
+              ...agentConfiguration,
+              lastAuthors: recentAuthors[index],
+            };
+          }
         );
       }
 

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
@@ -1,8 +1,5 @@
 import type { GetAgentConfigurationsResponseType } from "@dust-tt/client";
-import type {
-  LightAgentConfigurationType,
-  WithAPIErrorResponse,
-} from "@dust-tt/types";
+import type { WithAPIErrorResponse } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";


### PR DESCRIPTION
## Description

Adds workspaceId to queries on AgentUserRelation (better hygiene) + optimizes the use of the indexes we have:

```
    indexes: [
      { fields: ["workspaceId", "userId"] },
      {
        fields: ["workspaceId", "agentConfiguration", "userId"],
        unique: true,
        name: "agent_user_relation_config_workspace_user_idx",
      },
    ],
```

Which are probably unused for now since we're missing workspaceId

## Risk

Low

## Deploy Plan

- deploy `front`