### PR TITLE
[connectors] Upsert and backfill Zendesk brands and categories as `data_source_folders`

### DIFF
--- a/connectors/migrations/20241216_backfill_zendesk_folders.ts
+++ b/connectors/migrations/20241216_backfill_zendesk_folders.ts
@@ -1,0 +1,95 @@
+import { makeScript } from "scripts/helpers";
+
+import { getBrandInternalId } from "@connectors/connectors/zendesk/lib/id_conversions";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { concurrentExecutor } from "@connectors/lib/async_utils";
+import { upsertFolderNode } from "@connectors/lib/data_sources";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import {
+  ZendeskBrandResource,
+  ZendeskCategoryResource,
+} from "@connectors/resources/zendesk_resources";
+
+const FOLDER_CONCURRENCY = 10;
+
+makeScript({}, async ({ execute }, logger) => {
+  const connectors = await ConnectorResource.listByType("zendesk", {});
+
+  for (const connector of connectors) {
+    const dataSourceConfig = dataSourceConfigFromConnector(connector);
+    const connectorId = connector.id;
+
+    const brands = await ZendeskBrandResource.fetchByConnector(connector);
+    if (execute) {
+      await concurrentExecutor(
+        brands,
+        async (brand) => {
+          /// same code as in the connector
+          const brandInternalId = getBrandInternalId({
+            connectorId,
+            brandId: brand.brandId,
+          });
+          await upsertFolderNode({
+            dataSourceConfig,
+            folderId: brandInternalId,
+            parents: [brandInternalId],
+            title: brand.name,
+          });
+
+          const helpCenterNode = brand.getHelpCenterContentNode(connectorId);
+          await upsertFolderNode({
+            dataSourceConfig,
+            folderId: helpCenterNode.internalId,
+            parents: [
+              helpCenterNode.internalId,
+              helpCenterNode.parentInternalId,
+            ],
+            title: helpCenterNode.title,
+          });
+
+          const ticketsNode = brand.getTicketsContentNode(connectorId);
+          await upsertFolderNode({
+            dataSourceConfig,
+            folderId: ticketsNode.internalId,
+            parents: [ticketsNode.internalId, ticketsNode.parentInternalId],
+            title: ticketsNode.title,
+          });
+        },
+        { concurrency: FOLDER_CONCURRENCY }
+      );
+      logger.info(
+        `Upserted ${brands.length} spaces for connector ${connector.id}`
+      );
+    } else {
+      logger.info(
+        `Found ${brands.length} spaces for connector ${connector.id}`
+      );
+    }
+
+    const categories =
+      await ZendeskCategoryResource.fetchByConnector(connector);
+    if (execute) {
+      await concurrentExecutor(
+        categories,
+        async (category) => {
+          /// same code as in the connector
+          const parents = category.getParentInternalIds(connectorId);
+          await upsertFolderNode({
+            dataSourceConfig: dataSourceConfigFromConnector(connector),
+            folderId: parents[0],
+            parents,
+            title: category.name,
+          });
+        },
+        { concurrency: FOLDER_CONCURRENCY }
+      );
+      logger.info(
+        `Upserted ${brands.length} spaces for connector ${connector.id}`
+      );
+    } else {
+      logger.info(
+        `Found ${brands.length} spaces for connector ${connector.id}`
+      );
+    }
+  }
+});

--- a/connectors/src/connectors/zendesk/lib/sync_category.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_category.ts
@@ -1,9 +1,15 @@
 import type { ModelId } from "@dust-tt/types";
 
 import type { ZendeskFetchedCategory } from "@connectors/@types/node-zendesk";
-import { getArticleInternalId } from "@connectors/connectors/zendesk/lib/id_conversions";
+import {
+  getArticleInternalId,
+  getCategoryInternalId,
+} from "@connectors/connectors/zendesk/lib/id_conversions";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
-import { deleteFromDataSource } from "@connectors/lib/data_sources";
+import {
+  deleteFolderNode,
+  deleteFromDataSource,
+} from "@connectors/lib/data_sources";
 import {
   ZendeskArticleResource,
   ZendeskCategoryResource,
@@ -16,13 +22,15 @@ import type { DataSourceConfig } from "@connectors/types/data_source_config";
 export async function deleteCategory({
   connectorId,
   categoryId,
+  brandId,
   dataSourceConfig,
 }: {
   connectorId: number;
   categoryId: number;
+  brandId: number;
   dataSourceConfig: DataSourceConfig;
 }) {
-  /// deleting the articles in the data source
+  // deleting the articles in the data source
   const articles = await ZendeskArticleResource.fetchByCategoryId({
     connectorId,
     categoryId,
@@ -36,11 +44,14 @@ export async function deleteCategory({
       ),
     { concurrency: 10 }
   );
-  /// deleting the articles stored in the db
+  // deleting the articles stored in the db
   await ZendeskArticleResource.deleteByCategoryId({
     connectorId,
     categoryId,
   });
+  // deleting the folder in data_sources_folders (core)
+  const folderId = getCategoryInternalId({ connectorId, brandId, categoryId });
+  await deleteFolderNode({ dataSourceConfig, folderId });
   // deleting the category stored in the db
   await ZendeskCategoryResource.deleteByCategoryId({ connectorId, categoryId });
 }

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -309,6 +309,15 @@ export async function syncZendeskCategoryActivity({
     return { shouldSyncArticles: false };
   }
 
+  // upserting a folder to data_sources_folders (core)
+  const parents = categoryInDb.getParentInternalIds(connectorId);
+  await upsertFolderNode({
+    dataSourceConfig: dataSourceConfigFromConnector(connector),
+    folderId: parents[0],
+    parents,
+    title: categoryInDb.name,
+  });
+
   // otherwise, we update the category name and lastUpsertedTs
   await categoryInDb.update({
     name: fetchedCategory.name || "Category",

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -223,6 +223,7 @@ export async function syncZendeskCategoryBatchActivity({
   if (!connector) {
     throw new Error("[Zendesk] Connector not found.");
   }
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
 
   const { accessToken, subdomain } = await getZendeskSubdomainAndAccessToken(
     connector.connectionId
@@ -241,8 +242,15 @@ export async function syncZendeskCategoryBatchActivity({
 
   await concurrentExecutor(
     categories,
-    async (category) =>
-      syncCategory({ connectorId, brandId, category, currentSyncDateMs }),
+    async (category) => {
+      return syncCategory({
+        connectorId,
+        brandId,
+        category,
+        currentSyncDateMs,
+        dataSourceConfig,
+      });
+    },
     {
       concurrency: 10,
       onBatchComplete: heartbeat,

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -141,7 +141,7 @@ export async function syncZendeskBrandActivity({
     dataSourceConfig,
     folderId: helpCenterNode.internalId,
     parents: [helpCenterNode.internalId, helpCenterNode.parentInternalId],
-    title: brandInDb.name,
+    title: helpCenterNode.title,
   });
 
   // using the content node to get one source of truth regarding the parent relationship
@@ -150,7 +150,7 @@ export async function syncZendeskBrandActivity({
     dataSourceConfig,
     folderId: ticketsNode.internalId,
     parents: [ticketsNode.internalId, ticketsNode.parentInternalId],
-    title: brandInDb.name,
+    title: ticketsNode.title,
   });
 
   // updating the entry in db

--- a/connectors/src/connectors/zendesk/temporal/gc_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/gc_activities.ts
@@ -218,20 +218,20 @@ export async function removeForbiddenCategoriesActivity(
   };
 
   const batchSize = 2; // we process categories 2 by 2 since each of them typically contains ~50 articles
-  const categoryAndBrandIds =
+  const categoryIdsWithBrand =
     await ZendeskCategoryResource.fetchReadForbiddenCategoryIds({
       connectorId,
       batchSize,
     });
   logger.info(
-    { ...loggerArgs, categoryCount: categoryAndBrandIds.length },
+    { ...loggerArgs, categoryCount: categoryIdsWithBrand.length },
     "[Zendesk] Removing categories with no permission."
   );
 
-  for (const ids of categoryAndBrandIds) {
+  for (const ids of categoryIdsWithBrand) {
     await deleteCategory({ connectorId, ...ids, dataSourceConfig });
   }
-  return { hasMore: categoryAndBrandIds.length === batchSize };
+  return { hasMore: categoryIdsWithBrand.length === batchSize };
 }
 
 /**
@@ -251,12 +251,12 @@ export async function removeEmptyCategoriesActivity(connectorId: number) {
     dataSourceId: dataSourceConfig.dataSourceId,
   };
 
-  const categoryAndBrandIds =
+  const categoryIdsWithBrand =
     await ZendeskCategoryResource.fetchIdsForConnector(connectorId);
 
   const categoriesToDelete = new Set<{ categoryId: number; brandId: number }>();
   await concurrentExecutor(
-    categoryAndBrandIds,
+    categoryIdsWithBrand,
     async ({ categoryId, brandId }) => {
       const articles = await ZendeskArticleResource.fetchByCategoryIdReadOnly({
         connectorId,

--- a/connectors/src/connectors/zendesk/temporal/gc_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/gc_activities.ts
@@ -3,7 +3,9 @@ import type { ModelId } from "@dust-tt/types";
 import {
   getArticleInternalId,
   getBrandInternalId,
+  getHelpCenterInternalId,
   getTicketInternalId,
+  getTicketsInternalId,
 } from "@connectors/connectors/zendesk/lib/id_conversions";
 import { deleteArticle } from "@connectors/connectors/zendesk/lib/sync_article";
 import { deleteCategory } from "@connectors/connectors/zendesk/lib/sync_category";
@@ -302,8 +304,18 @@ export async function deleteBrandsWithNoPermissionActivity(
   await concurrentExecutor(
     brands,
     async (brandId) => {
-      const folderId = getBrandInternalId({ connectorId, brandId });
-      await deleteFolderNode({ dataSourceConfig, folderId });
+      await deleteFolderNode({
+        dataSourceConfig,
+        folderId: getBrandInternalId({ connectorId, brandId }),
+      });
+      await deleteFolderNode({
+        dataSourceConfig,
+        folderId: getHelpCenterInternalId({ connectorId, brandId }),
+      });
+      await deleteFolderNode({
+        dataSourceConfig,
+        folderId: getTicketsInternalId({ connectorId, brandId }),
+      });
     },
     { concurrency: 10 }
   );

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -14,6 +14,7 @@ import {
 } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
+import { upsertFolderNode } from "@connectors/lib/data_sources";
 import { ZendeskTimestampCursor } from "@connectors/lib/models/zendesk";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -139,6 +140,14 @@ export async function syncZendeskArticleUpdateBatchActivity({
                 url: fetchedCategory.html_url,
                 description: fetchedCategory.description,
               },
+            });
+            // upserting a folder to data_sources_folders (core)
+            const parents = category.getParentInternalIds(connectorId);
+            await upsertFolderNode({
+              dataSourceConfig,
+              folderId: parents[0],
+              parents,
+              title: category.name,
             });
           } else {
             /// ignoring these to proceed with the other articles, but these might have to be checked at some point

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -24,7 +24,7 @@ import {
   ZendeskTicket,
 } from "@connectors/lib/models/zendesk";
 import { BaseResource } from "@connectors/resources/base_resource";
-import type { ReadonlyAttributesType } from "@connectors/resources/storage/types";
+import type { ReadonlyAttributesType } from "@connectors/resources/storage/types"; // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -278,6 +278,16 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
   }
 
   static async fetchTicketsReadForbiddenBrandIds(
+    connectorId: number
+  ): Promise<number[]> {
+    const brands = await ZendeskBrand.findAll({
+      where: { connectorId, ticketsPermission: "none" },
+      attributes: ["brandId"],
+    });
+    return brands.map((brand) => Number(brand.get().brandId));
+  }
+
+  static async fetchBrandsWithNoPermission(
     connectorId: number
   ): Promise<number[]> {
     const brands = await ZendeskBrand.findAll({

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -609,7 +609,7 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
     };
   }
 
-  getParentInternalIds(connectorId: number): string[] {
+  getParentInternalIds(connectorId: number): [string, string, string] {
     /// Categories have two parents: the Help Center and the Brand.
     const { brandId, categoryId } = this;
     return [
@@ -695,7 +695,7 @@ export class ZendeskTicketResource extends BaseResource<ZendeskTicket> {
     };
   }
 
-  getParentInternalIds(connectorId: number): string[] {
+  getParentInternalIds(connectorId: number): [string, string, string] {
     const { brandId, ticketId } = this;
     /// Tickets have two parents: the Tickets and the Brand.
     return [
@@ -900,7 +900,7 @@ export class ZendeskArticleResource extends BaseResource<ZendeskArticle> {
     };
   }
 
-  getParentInternalIds(connectorId: number): string[] {
+  getParentInternalIds(connectorId: number): [string, string, string, string] {
     const { brandId, categoryId, articleId } = this;
     /// Articles have three parents: the Category, the Help Center and the Brand.
     return [

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -341,7 +341,7 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
   getHelpCenterContentNode(
     connectorId: number,
     { richTitle = false }: { richTitle?: boolean } = {}
-  ): ContentNode {
+  ): ContentNode & { parentInternalId: string } {
     const { brandId } = this;
     return {
       provider: "zendesk",
@@ -363,7 +363,7 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
       expandable = false,
       richTitle = false,
     }: { expandable?: boolean; richTitle?: boolean } = {}
-  ): ContentNode {
+  ): ContentNode & { parentInternalId: string } {
     const { brandId } = this;
     return {
       provider: "zendesk",

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -24,7 +24,8 @@ import {
   ZendeskTicket,
 } from "@connectors/lib/models/zendesk";
 import { BaseResource } from "@connectors/resources/base_resource";
-import type { ReadonlyAttributesType } from "@connectors/resources/storage/types"; // Attributes are marked as read-only to reflect the stateless nature of our Resource.
+import type { ConnectorResource } from "@connectors/resources/connector_resource";
+import type { ReadonlyAttributesType } from "@connectors/resources/storage/types";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -186,6 +187,15 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrand> {
     if (this.ticketsPermission === "read") {
       await this.update({ ticketsPermission: "none" });
     }
+  }
+
+  static async fetchByConnector(
+    connector: ConnectorResource
+  ): Promise<ZendeskBrandResource[]> {
+    const brands = await ZendeskBrand.findAll({
+      where: { connectorId: connector.id },
+    });
+    return brands.map((brand) => new this(this.model, brand.get()));
   }
 
   static async fetchByBrandId({
@@ -454,6 +464,15 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
       const { categoryId, brandId } = category.get();
       return { categoryId, brandId };
     });
+  }
+
+  static async fetchByConnector(
+    connector: ConnectorResource
+  ): Promise<ZendeskCategoryResource[]> {
+    const categories = await ZendeskCategory.findAll({
+      where: { connectorId: connector.id },
+    });
+    return categories.map((category) => new this(this.model, category.get()));
   }
 
   static async fetchIdsForConnector(


### PR DESCRIPTION
## Description

- Closes [#9161](https://github.com/dust-tt/dust/issues/9161);
- Add API calls whenever a Zendesk brand is upserted/deleted in connectors (3 folders per brand bc 1 brand, 1 HC, 1 tickets).
- Same for the categories.
- Add a backfill script to backfill existing Zendesk brands and categories.
- Tested locally, I get the rows in `data_sources_folders`, I also get the nodes in `data_sources_nodes` with `mime_type` `application/vnd.dust.folder`.

## Risk

- Relatively low, not a lot of user-facing impact as of now and easily rollbackable.

## Deploy Plan

- Deploy connectors.
- Run migration
