### PR TITLE
Agent configurations: 1 query instead of 3 at new conversation page loading

### DIFF
--- a/front/components/assistant/conversation/AssistantBrowserContainer.tsx
+++ b/front/components/assistant/conversation/AssistantBrowserContainer.tsx
@@ -39,16 +39,16 @@ export function AssistantBrowserContainer({
       }
       const scrollDistance = scrollContainerElement.getBoundingClientRect().top;
 
-      // If the input bar is already in view, set the mention directly. We leave
-      // a little margin, -2 instead of 0, since the autoscroll below can
-      // sometimes scroll a bit over 0, to -0.3 or -0.5, in which case if there
-      // is a clic on a visible assistant we still want this condition to
-      // trigger.
+      // If the input bar is already in view, set the mention directly. We leave a little margin, -2
+      // instead of 0, since the autoscroll below can sometimes scroll a bit over 0, to -0.3 or
+      // -0.5, in which case if there is a clic on a visible assistant we still want this condition
+      // to trigger.
       if (scrollDistance > -2) {
         return onAgentConfigurationClick(agent.sId);
       }
 
-      // Otherwise, scroll to the input bar and set the ref (mention will be set via intersection observer).
+      // Otherwise, scroll to the input bar and set the ref (mention will be set via intersection
+      // observer).
       scrollContainerElement.scrollIntoView({ behavior: "smooth" });
 
       setAssistantToMention(agent);

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -18,10 +18,7 @@ import InputBarContainer, {
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
 import type { DustError } from "@app/lib/error";
-import {
-  useAgentConfigurations,
-  useProgressiveAgentConfigurations,
-} from "@app/lib/swr/assistants";
+import { useProgressiveAgentConfigurations } from "@app/lib/swr/assistants";
 import { useConversation } from "@app/lib/swr/conversations";
 import { classNames } from "@app/lib/utils";
 

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -18,7 +18,10 @@ import InputBarContainer, {
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
 import type { DustError } from "@app/lib/error";
-import { useAgentConfigurations } from "@app/lib/swr/assistants";
+import {
+  useAgentConfigurations,
+  useProgressiveAgentConfigurations,
+} from "@app/lib/swr/assistants";
 import { useConversation } from "@app/lib/swr/conversations";
 import { classNames } from "@app/lib/utils";
 
@@ -83,9 +86,8 @@ export function AssistantInputBar({
   });
 
   const { agentConfigurations: baseAgentConfigurations } =
-    useAgentConfigurations({
+    useProgressiveAgentConfigurations({
       workspaceId: owner.sId,
-      agentsGetView: "list",
     });
 
   // Files upload.

--- a/front/components/assistant/conversation/input_bar/editor/useAssistantSuggestions.ts
+++ b/front/components/assistant/conversation/input_bar/editor/useAssistantSuggestions.ts
@@ -5,7 +5,7 @@ import type {
 import { compareAgentsForSort } from "@dust-tt/types";
 import { useMemo } from "react";
 
-import { useAgentConfigurations } from "@app/lib/swr/assistants";
+import { useProgressiveAgentConfigurations } from "@app/lib/swr/assistants";
 
 function makeEditorSuggestions(
   agentConfigurations: LightAgentConfigurationType[]
@@ -25,9 +25,8 @@ const useAssistantSuggestions = (
   inListAgentConfigurations: LightAgentConfigurationType[],
   owner: WorkspaceType
 ) => {
-  const { agentConfigurations } = useAgentConfigurations({
+  const { agentConfigurations } = useProgressiveAgentConfigurations({
     workspaceId: owner.sId,
-    agentsGetView: "list",
   });
 
   // `useMemo` will ensure that suggestions is only recalculated

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -149,17 +149,17 @@ export function useProgressiveAgentConfigurations({
   workspaceId: string;
   disabled?: boolean;
 }) {
-  const {
-    agentConfigurations: initialAgentConfigurations,
-    isAgentConfigurationsLoading: isInitialAgentConfigurationsLoading,
-  } = useAgentConfigurations({
-    workspaceId,
-    agentsGetView: "list",
-    limit: 24,
-    includes: ["usage"],
-    disabled,
-    revalidate: false,
-  });
+  // const {
+  //   agentConfigurations: initialAgentConfigurations,
+  //   isAgentConfigurationsLoading: isInitialAgentConfigurationsLoading,
+  // } = useAgentConfigurations({
+  //   workspaceId,
+  //   agentsGetView: "list",
+  //   limit: 24,
+  //   includes: ["usage"],
+  //   disabled,
+  //   revalidate: false,
+  // });
 
   const {
     agentConfigurations: agentConfigurationsWithAuthors,
@@ -173,16 +173,16 @@ export function useProgressiveAgentConfigurations({
     disabled,
   });
 
-  const isLoading =
-    isInitialAgentConfigurationsLoading ||
-    isAgentConfigurationsWithAuthorsLoading;
-  const agentConfigurations = isAgentConfigurationsWithAuthorsLoading
-    ? initialAgentConfigurations
-    : agentConfigurationsWithAuthors;
+  // const isLoading =
+  //   isInitialAgentConfigurationsLoading ||
+  //   isAgentConfigurationsWithAuthorsLoading;
+  // const agentConfigurations = isAgentConfigurationsWithAuthorsLoading
+  //   ? initialAgentConfigurations
+  //   : agentConfigurationsWithAuthors;
 
   return {
-    agentConfigurations,
-    isLoading,
+    agentConfigurations: agentConfigurationsWithAuthors,
+    isLoading: isAgentConfigurationsWithAuthorsLoading,
     mutate,
     mutateRegardlessOfQueryParams,
   };


### PR DESCRIPTION
## Description

`useProgressiveAgentConfigurations` was introduced here https://github.com/dust-tt/dust/pull/5766 to speed up loading of agent configurations but in practice the 24 limit no author and the full query are ~~ the same speed in production leading to issuing 2 queries (racing for one another) vs 1 (some holes in the trace flamegraph hints that they are possibly actually racing for resources).

Example trace: https://app.datadoghq.eu/apm/trace/7641219214343951883?graphType=waterfall&panel_tab=flamegraph&shouldShowLegend=true&spanID=7641219214343951883&timeHint=1734365131447.001

Rely on `useProgressiveAgentConfigurations` for all queries from the new conversation page instead of having one with authors and one without it which saves one extra query when loading the new conversation page.

Full context and details here: https://app.datadoghq.eu/notebook/194053/agentconfiguration-optimization?notebookType=legacy&range=86400000&start=1734278426418&live=true

If experimentation is concluent I'll rename `useProgressiveAgentConfigurations` as `useNewConversationPageAgentConfigurations` maybe

## Risk

Low, correctness is ensured, it's more an experimentation in vivo to reduce load and possibly speed up agent configurations retrieval

## Deploy Plan

- deploy `front`