### PR TITLE
DataSourceView queries rely on index

### DIFF
--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -272,6 +272,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
   ) {
     return this.baseFetch(auth, fetchDataSourceViewOptions, {
       where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
         vaultId: spaces.map((s) => s.id),
       },
     });
@@ -285,6 +286,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
   ) {
     return this.baseFetch(auth, fetchDataSourceViewOptions, {
       where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
         dataSourceId: dataSources.map((ds) => ds.id),
         vaultId: space.id,
       },
@@ -298,6 +300,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
   ) {
     return this.baseFetch(auth, fetchDataSourceViewOptions, {
       where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
         dataSourceId: dataSources.map((ds) => ds.id),
       },
     });

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -270,6 +270,8 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     spaces: SpaceResource[],
     fetchDataSourceViewOptions?: FetchDataSourceViewOptions
   ) {
+    // We inject the auth workspaceId to make sure we rely on the associated index as there is no
+    // cross-workspace data source support at this stage.
     return this.baseFetch(auth, fetchDataSourceViewOptions, {
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
@@ -284,6 +286,8 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     space: SpaceResource,
     fetchDataSourceViewOptions?: FetchDataSourceViewOptions
   ) {
+    // We inject the auth workspaceId to make sure we rely on the associated index as there is no
+    // cross-workspace data source support at this stage.
     return this.baseFetch(auth, fetchDataSourceViewOptions, {
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
@@ -298,6 +302,8 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     dataSources: DataSourceResource[],
     fetchDataSourceViewOptions?: FetchDataSourceViewOptions
   ) {
+    // We inject the auth workspaceId to make sure we rely on the associated index as there is no
+    // cross-workspace data source support at this stage.
     return this.baseFetch(auth, fetchDataSourceViewOptions, {
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,


### PR DESCRIPTION
## Description

These queries are potentially not using the index that were created for them because they were missing the workspaceId

Example trace showing such query in production: https://app.datadoghq.eu/apm/trace/3951446458606851887?graphType=waterfall&panel_tab=flamegraph&shouldShowLegend=true&spanID=3033877436380675206&timeHint=1734366238587.001

Intexes are visible here: https://github.com/dust-tt/dust/blob/main/front/lib/resources/storage/models/data_source_view.ts#L72-L77

## Risk

None

## Deploy Plan

- deploy `front`