### PR TITLE
fix(core): temporarily disable parent ID check when upserting dsdocs (and enforce in upsert queue)

### DIFF
--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -1676,12 +1676,13 @@ async fn data_sources_documents_upsert(
     match &payload.parent_id {
         Some(parent_id) => {
             if payload.parents.get(1) != Some(parent_id) {
-                return error_response(
-                    StatusCode::BAD_REQUEST,
-                    "invalid_parent_id",
-                    "Failed to upsert document - parents[1] and parent_id should be equal",
-                    None,
-                );
+                // TODO(fontanierh): Temporary, as we need to let some jobs go through.
+                // return error_response(
+                //     StatusCode::BAD_REQUEST,
+                //     "invalid_parent_id",
+                //     "Failed to upsert document - parents[1] and parent_id should be equal",
+                //     None,
+                // );
             }
         }
         None => {

--- a/front/lib/upsert_queue.ts
+++ b/front/lib/upsert_queue.ts
@@ -84,6 +84,15 @@ export async function enqueueUpsertDocument({
     "[UpsertQueue] Enqueueing document"
   );
 
+  if (
+    upsertDocument.parentId &&
+    upsertDocument.parents?.[1] !== upsertDocument.parentId
+  ) {
+    throw new Error(
+      "Invalid parent id: parents[1] and parentId should be equal"
+    );
+  }
+
   return enqueueUpsert({
     upsertItem: upsertDocument,
     upsertQueueId,
@@ -108,6 +117,15 @@ export async function enqueueUpsertTable({
     },
     "[UpsertQueue] Enqueueing table"
   );
+
+  if (
+    upsertTable.tableParentId &&
+    upsertTable.tableParents?.[1] !== upsertTable.tableParentId
+  ) {
+    throw new Error(
+      "Invalid parent id: parents[1] and tableParentId should be equal"
+    );
+  }
 
   return enqueueUpsert({
     upsertItem: upsertTable,

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -485,6 +485,17 @@ async function handler(
         });
       }
 
+      if (r.data.parent_id && r.data.parents?.[1] !== r.data.parent_id) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "Invalid parent id: parents[1] and parent_id should be equal",
+          },
+        });
+      }
+
       const statsDTags = [
         `data_source_id:${dataSource.id}`,
         `workspace_id:${owner.sId}`,

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -373,6 +373,17 @@ async function handler(
         });
       }
 
+      if (parentId && parents?.[1] !== parentId) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "Invalid parent id: parents[1] and parent_id should be equal",
+          },
+        });
+      }
+
       // Enforce that the table is a parent of itself by default.
       const upsertRes = await coreAPI.upsertTable({
         projectId: dataSource.dustAPIProjectId,


### PR DESCRIPTION
## Description

- temporarily disable checking that parentId == parents[1] in core
- add checks to enforce this before enqueuing for upserts in front

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
