### PR TITLE
fix: re-enable parentId check

### DIFF
--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -1676,13 +1676,12 @@ async fn data_sources_documents_upsert(
     match &payload.parent_id {
         Some(parent_id) => {
             if payload.parents.get(1) != Some(parent_id) {
-                // TODO(fontanierh): Temporary, as we need to let some jobs go through.
-                // return error_response(
-                //     StatusCode::BAD_REQUEST,
-                //     "invalid_parent_id",
-                //     "Failed to upsert document - parents[1] and parent_id should be equal",
-                //     None,
-                // );
+                return error_response(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_parent_id",
+                    "Failed to upsert document - parents[1] and parent_id should be equal",
+                    None,
+                );
             }
         }
         None => {


### PR DESCRIPTION
## Description

Was temporarily disabled to allow front upsert queue to drain

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
