### PR TITLE
Document Tracker Notification workflow - skeletton + activity logic

### DIFF
--- a/front/lib/models/doc_tracker.ts
+++ b/front/lib/models/doc_tracker.ts
@@ -37,6 +37,10 @@ export class TrackerConfigurationModel extends SoftDeletableModel<TrackerConfigu
   declare workspace: NonAttribute<Workspace>;
   declare space: NonAttribute<SpaceModel>;
   declare user: NonAttribute<UserModel> | null;
+  declare dataSourceConfigurations: NonAttribute<
+    TrackerDataSourceConfigurationModel[]
+  >;
+  declare generations: NonAttribute<TrackerGenerationModel[]>;
 }
 
 TrackerConfigurationModel.init(
@@ -266,6 +270,7 @@ TrackerGenerationModel.init(
 
 TrackerConfigurationModel.hasMany(TrackerGenerationModel, {
   foreignKey: { allowNull: false },
+  as: "generations",
   onDelete: "RESTRICT",
 });
 TrackerGenerationModel.belongsTo(TrackerConfigurationModel, {

--- a/front/lib/resources/resource_with_space.ts
+++ b/front/lib/resources/resource_with_space.ts
@@ -63,6 +63,7 @@ export abstract class ResourceWithSpace<
     } & { model: ModelStaticSoftDeletable<M> },
     auth: Authenticator,
     {
+      attributes,
       includes,
       limit,
       order,
@@ -80,6 +81,7 @@ export abstract class ResourceWithSpace<
     ];
 
     const blobs = await this.model.findAll({
+      attributes,
       where: where as WhereOptions<M>,
       include: includeClauses,
       limit,

--- a/front/lib/resources/tracker_resource.ts
+++ b/front/lib/resources/tracker_resource.ts
@@ -3,6 +3,8 @@ import type {
   Result,
   TrackerConfigurationType,
   TrackerDataSourceConfigurationType,
+  TrackerGenerationToProcess,
+  TrackerIdWorkspaceId,
 } from "@dust-tt/types";
 import { Err, Ok, removeNulls } from "@dust-tt/types";
 import assert from "assert";
@@ -12,7 +14,9 @@ import type { Authenticator } from "@app/lib/auth";
 import {
   TrackerConfigurationModel,
   TrackerDataSourceConfigurationModel,
+  TrackerGenerationModel,
 } from "@app/lib/models/doc_tracker";
+import { Workspace } from "@app/lib/models/workspace";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { ResourceWithSpace } from "@app/lib/resources/resource_with_space";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
@@ -32,6 +36,7 @@ export class TrackerConfigurationResource extends ResourceWithSpace<TrackerConfi
     TrackerConfigurationModel;
 
   readonly dataSourceConfigurations: TrackerDataSourceConfigurationModel[];
+  readonly generations: TrackerGenerationToProcess[];
 
   constructor(
     model: ModelStatic<TrackerConfigurationModel>,
@@ -42,6 +47,7 @@ export class TrackerConfigurationResource extends ResourceWithSpace<TrackerConfi
   ) {
     super(TrackerConfigurationResource.model, blob, space);
     this.dataSourceConfigurations = blob.dataSourceConfigurations;
+    this.generations = [];
   }
 
   static async makeNew(
@@ -219,6 +225,7 @@ export class TrackerConfigurationResource extends ResourceWithSpace<TrackerConfi
     const trackers = await this.baseFetchWithAuthorization(auth, {
       ...options,
       includes: [
+        ...(options?.includes || []),
         {
           model: TrackerDataSourceConfigurationModel,
           as: "dataSourceConfigurations",
@@ -226,9 +233,9 @@ export class TrackerConfigurationResource extends ResourceWithSpace<TrackerConfi
       ],
     });
 
-    // This is what enforces the accessibility to an app.
+    // This is what enforces the accessibility to a Tracker.
     return trackers.filter(
-      (tracker) => auth.isBuilder() || tracker.canRead(auth)
+      (tracker) => auth.isAdmin() || tracker.canRead(auth)
     );
   }
 
@@ -262,6 +269,67 @@ export class TrackerConfigurationResource extends ResourceWithSpace<TrackerConfi
         vaultId: space.id,
       },
     });
+  }
+
+  static async fetchWithGenerationsToConsume(
+    auth: Authenticator,
+    id: ModelId
+  ): Promise<TrackerConfigurationType | null> {
+    const tracker = await this.baseFetch(auth, {
+      where: {
+        id,
+        status: "active",
+      },
+      includes: [
+        {
+          // @ts-expect-error @todo(DOC_TRACKER) Fix to remove the ts-expect-error.
+          model: TrackerGenerationModel,
+          // @ts-expect-error @todo(DOC_TRACKER) Fix to remove the ts-expect-error.
+          as: "generations",
+          where: {
+            consumedAt: null,
+          },
+        },
+      ],
+    });
+
+    return tracker ? tracker[0].toJSON() : null;
+  }
+
+  // Internal method for fetching trackers without any authorization checks.
+  // Not intended for use outside of the Tracker workflow.
+  // Fetches the active trackers that have generations to consume.
+  static async internalFetchActivetrackersToProcessByNotificationWorkflow(): Promise<
+    TrackerIdWorkspaceId[]
+  > {
+    const trackers = await TrackerConfigurationResource.model.findAll({
+      attributes: ["id"],
+      where: {
+        status: "active",
+      },
+      include: [
+        {
+          model: Workspace,
+          attributes: ["sId"],
+        },
+        {
+          model: TrackerGenerationModel,
+          as: "generations",
+          where: {
+            consumedAt: null,
+          },
+        },
+      ],
+    });
+
+    const filteredTrackers = trackers.filter(
+      (tracker) => tracker.generations.length
+    );
+
+    return filteredTrackers.map((tracker) => ({
+      trackerId: tracker.id,
+      workspaceId: tracker.workspace.sId,
+    }));
   }
 
   // Deletion.
@@ -322,7 +390,7 @@ export class TrackerConfigurationResource extends ResourceWithSpace<TrackerConfi
       },
     });
 
-    return {
+    const tracker: TrackerConfigurationType = {
       id: this.id,
       sId: this.sId,
       name: this.name,
@@ -342,5 +410,18 @@ export class TrackerConfigurationResource extends ResourceWithSpace<TrackerConfi
         .filter((dsc) => dsc.scope === "watched")
         .map(dataSourceToJSON),
     };
+
+    if (this.generations.length) {
+      tracker.generations = this.generations.map((g) => {
+        return {
+          id: g.id,
+          content: g.content,
+          thinking: g.thinking,
+          documentId: g.documentId,
+        };
+      });
+    }
+
+    return tracker;
   }
 }

--- a/front/lib/resources/tracker_resource.ts
+++ b/front/lib/resources/tracker_resource.ts
@@ -299,7 +299,7 @@ export class TrackerConfigurationResource extends ResourceWithSpace<TrackerConfi
   // Internal method for fetching trackers without any authorization checks.
   // Not intended for use outside of the Tracker workflow.
   // Fetches the active trackers that have generations to consume.
-  static async internalFetchActivetrackersToProcessByNotificationWorkflow(): Promise<
+  static async internalFetchAllActiveWithUnconsumedGenerations(): Promise<
     TrackerIdWorkspaceId[]
   > {
     const trackers = await TrackerConfigurationResource.model.findAll({

--- a/front/lib/resources/types.ts
+++ b/front/lib/resources/types.ts
@@ -33,6 +33,7 @@ export type TypedIncludeable<M> = {
 }[NonAttributeKeys<M>];
 
 export type ResourceFindOptions<M extends Model> = {
+  attributes?: FindOptions<M>["attributes"];
   includes?: TypedIncludeable<M>[];
   limit?: number;
   order?: FindOptions<M>["order"];

--- a/front/start_worker.ts
+++ b/front/start_worker.ts
@@ -52,7 +52,10 @@ const ALL_WORKERS = Object.keys(workerFunctions);
 
 async function runWorkers(workers: WorkerName[]) {
   // Disable document_tracker
-  workers = workers.filter((worker) => worker !== "document_tracker");
+  workers = workers.filter(
+    (worker) =>
+      worker !== "document_tracker" && worker !== "tracker_notification"
+  );
   for (const worker of workers) {
     workerFunctions[worker]().catch((err) =>
       logger.error({ error: err }, `Error running ${worker} worker.`)

--- a/front/start_worker.ts
+++ b/front/start_worker.ts
@@ -4,7 +4,10 @@ import { hideBin } from "yargs/helpers";
 
 import logger from "@app/logger/logger";
 import { runPokeWorker } from "@app/poke/temporal/worker";
-import { runDocumentTrackerWorker } from "@app/temporal/document_tracker/worker";
+import {
+  runDocumentTrackerWorker,
+  runTrackerNotificationWorker,
+} from "@app/temporal/document_tracker/worker";
 import { runHardDeleteWorker } from "@app/temporal/hard_delete/worker";
 import { runLabsWorker } from "@app/temporal/labs/worker";
 import { runMentionsCountWorker } from "@app/temporal/mentions_count_queue/worker";
@@ -24,6 +27,7 @@ type WorkerName =
   | "permissions_queue"
   | "poke"
   | "document_tracker"
+  | "tracker_notification"
   | "production_checks"
   | "scrub_workspace_queue"
   | "update_workspace_usage"
@@ -37,6 +41,7 @@ const workerFunctions: Record<WorkerName, () => Promise<void>> = {
   permissions_queue: runPermissionsWorker,
   poke: runPokeWorker,
   document_tracker: runDocumentTrackerWorker,
+  tracker_notification: runTrackerNotificationWorker,
   production_checks: runProductionChecksWorker,
   scrub_workspace_queue: runScrubWorkspaceQueueWorker,
   update_workspace_usage: runUpdateWorkspaceUsageWorker,

--- a/front/temporal/document_tracker/activities.ts
+++ b/front/temporal/document_tracker/activities.ts
@@ -132,7 +132,7 @@ async function getDataSourceDocument({
 export const getTrackerIdsToNotifyActivity = async (): Promise<
   TrackerIdWorkspaceId[]
 > => {
-  return TrackerConfigurationResource.internalFetchActivetrackersToProcessByNotificationWorkflow();
+  return TrackerConfigurationResource.internalFetchAllActiveWithUnconsumedGenerations();
 };
 
 /**

--- a/front/temporal/document_tracker/admin/cli.sh
+++ b/front/temporal/document_tracker/admin/cli.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+npx tsx temporal/document_tracker/admin/cli.ts "$@"

--- a/front/temporal/document_tracker/admin/cli.ts
+++ b/front/temporal/document_tracker/admin/cli.ts
@@ -1,0 +1,50 @@
+import parseArgs from "minimist";
+
+import {
+  launchTrackerNotificationWorkflow,
+  stopTrackerNotificationWorkflow,
+} from "@app/temporal/document_tracker/client";
+
+const main = async () => {
+  const argv = parseArgs(process.argv.slice(2));
+
+  const [command] = argv._;
+
+  console.log(`Running command: ${command}`);
+
+  switch (command) {
+    case "start":
+      await launchTrackerNotificationWorkflow();
+      return;
+    case "stop":
+      await stopTrackerNotificationWorkflow();
+      return;
+    case "notify":
+      const workspaceId = argv.workspaceId;
+      const trackerId = argv.trackerId;
+      if (!workspaceId || !trackerId) {
+        console.error("workspaceId and trackerId are required");
+        return;
+      }
+      await launchTrackerNotificationWorkflow([
+        {
+          workspaceId,
+          trackerId,
+        },
+      ]);
+      return;
+    default:
+      return;
+  }
+};
+
+main()
+  .then(() => {
+    console.error("\x1b[32m%s\x1b[0m", `Done`);
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error("\x1b[31m%s\x1b[0m", `Error: ${err.message}`);
+    console.log(err);
+    process.exit(1);
+  });

--- a/front/temporal/document_tracker/client.ts
+++ b/front/temporal/document_tracker/client.ts
@@ -1,10 +1,18 @@
-import type { ConnectorProvider } from "@dust-tt/types";
+import type { ConnectorProvider, TrackerIdWorkspaceId } from "@dust-tt/types";
+import type { WorkflowHandle } from "@temporalio/client";
 
 import { getTemporalClient } from "@app/lib/temporal";
-import { QUEUE_NAME } from "@app/temporal/document_tracker/config";
+import logger from "@app/logger/logger";
+import {
+  RUN_QUEUE_NAME,
+  TRACKER_NOTIFICATION_QUEUE_NAME,
+} from "@app/temporal/document_tracker/config";
 
-import { newUpsertSignal } from "./signals";
-import { runDocumentTrackerWorkflow } from "./workflows";
+import { newUpsertSignal, notifySignal } from "./signals";
+import {
+  runDocumentTrackerWorkflow,
+  trackersNotificationsWorkflow,
+} from "./workflows";
 
 export async function launchRunDocumentTrackerWorkflow({
   workspaceId,
@@ -29,9 +37,40 @@ export async function launchRunDocumentTrackerWorkflow({
       documentHash,
       dataSourceConnectorProvider,
     ],
-    taskQueue: QUEUE_NAME,
+    taskQueue: RUN_QUEUE_NAME,
     workflowId: `workflow-run-document-tracker-${workspaceId}-${dataSourceId}-${documentId}`,
     signal: newUpsertSignal,
     signalArgs: undefined,
   });
+}
+
+export async function launchTrackerNotificationWorkflow(
+  signaledTrackerIds: TrackerIdWorkspaceId[] = []
+) {
+  const client = await getTemporalClient();
+  await client.workflow.signalWithStart(trackersNotificationsWorkflow, {
+    args: [],
+    taskQueue: TRACKER_NOTIFICATION_QUEUE_NAME,
+    workflowId: "document-tracker-notify-workflow",
+    signal: notifySignal,
+    signalArgs: [signaledTrackerIds],
+    cronSchedule: "0 * * * *", // Every hour.
+  });
+}
+
+export async function stopTrackerNotificationWorkflow() {
+  const client = await getTemporalClient();
+
+  try {
+    const handle: WorkflowHandle<typeof trackersNotificationsWorkflow> =
+      client.workflow.getHandle("document-tracker-notify-workflow");
+    await handle.terminate();
+  } catch (e) {
+    logger.error(
+      {
+        error: e,
+      },
+      "[Tracker] Failed stopping workflow."
+    );
+  }
 }

--- a/front/temporal/document_tracker/config.ts
+++ b/front/temporal/document_tracker/config.ts
@@ -1,2 +1,5 @@
-const QUEUE_VERSION = 1;
-export const QUEUE_NAME = `document-tracker-queue-v${QUEUE_VERSION}`;
+const RUN_QUEUE_VERSION = 1;
+export const RUN_QUEUE_NAME = `document-tracker-queue-v${RUN_QUEUE_VERSION}`;
+
+const TRACKER_NOTIFICATION_QUEUE_VERSION = 1;
+export const TRACKER_NOTIFICATION_QUEUE_NAME = `document-tracker-notify-queue-v${TRACKER_NOTIFICATION_QUEUE_VERSION}`;

--- a/front/temporal/document_tracker/signals.ts
+++ b/front/temporal/document_tracker/signals.ts
@@ -1,3 +1,7 @@
+import type { TrackerIdWorkspaceId } from "@dust-tt/types";
 import { defineSignal } from "@temporalio/workflow";
 
 export const newUpsertSignal = defineSignal<[void]>("new_upsert_signal");
+
+export const notifySignal =
+  defineSignal<[TrackerIdWorkspaceId[]]>("notify_signal");

--- a/front/temporal/document_tracker/worker.ts
+++ b/front/temporal/document_tracker/worker.ts
@@ -5,14 +5,37 @@ import { getTemporalWorkerConnection } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
 import * as activities from "@app/temporal/document_tracker/activities";
-import { QUEUE_NAME } from "@app/temporal/document_tracker/config";
+import {
+  RUN_QUEUE_NAME,
+  TRACKER_NOTIFICATION_QUEUE_NAME,
+} from "@app/temporal/document_tracker/config";
 
 export async function runDocumentTrackerWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
   const worker = await Worker.create({
     workflowsPath: require.resolve("./workflows"),
     activities,
-    taskQueue: QUEUE_NAME,
+    taskQueue: RUN_QUEUE_NAME,
+    connection,
+    namespace,
+    interceptors: {
+      activityInbound: [
+        (ctx: Context) => {
+          return new ActivityInboundLogInterceptor(ctx, logger);
+        },
+      ],
+    },
+  });
+
+  await worker.run();
+}
+
+export async function runTrackerNotificationWorker() {
+  const { connection, namespace } = await getTemporalWorkerConnection();
+  const worker = await Worker.create({
+    workflowsPath: require.resolve("./workflows"),
+    activities,
+    taskQueue: TRACKER_NOTIFICATION_QUEUE_NAME,
     connection,
     namespace,
     interceptors: {

--- a/front/temporal/document_tracker/workflows.ts
+++ b/front/temporal/document_tracker/workflows.ts
@@ -1,11 +1,27 @@
-import type { ConnectorProvider } from "@dust-tt/types";
-import { proxyActivities, setHandler, sleep } from "@temporalio/workflow";
+import type { ConnectorProvider, TrackerIdWorkspaceId } from "@dust-tt/types";
+import {
+  executeChild,
+  proxyActivities,
+  setHandler,
+  sleep,
+  workflowInfo,
+} from "@temporalio/workflow";
 
 import type * as activities from "./activities";
-import { newUpsertSignal } from "./signals";
+import { newUpsertSignal, notifySignal } from "./signals";
 
 const { runDocumentTrackerActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "60 minutes",
+});
+
+const { getTrackerIdsToNotifyActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "5 minutes",
+});
+
+const { processTrackerNotificationWorkflowActivity } = proxyActivities<
+  typeof activities
+>({
+  startToCloseTimeout: "30 minutes",
 });
 
 export async function runDocumentTrackerWorkflow(
@@ -47,4 +63,79 @@ export async function runDocumentTrackerWorkflow(
       dataSourceConnectorProvider
     );
   }
+}
+
+/**
+ * Workflow that periodically checks for trackers to notify.
+ * The workflow is scheduled to run every hour.
+ * It fetches the tracker ids to notify and launches a child workflow for each tracker.
+ */
+export async function trackersNotificationsWorkflow() {
+  const { workflowId, memo } = workflowInfo();
+  const currentSyncMs = new Date().getTime();
+  const uniqueTrackers = new Set<TrackerIdWorkspaceId>();
+
+  // Signal handler. Receives the tracker ids to notify.
+  setHandler(notifySignal, (trackers: TrackerIdWorkspaceId[]) => {
+    trackers.forEach((tracker) => {
+      uniqueTrackers.add(tracker);
+    });
+  });
+
+  // If we got no signal then we're on the scheduled execution: we process all trackers.
+  if (uniqueTrackers.size === 0) {
+    const trackers = await getTrackerIdsToNotifyActivity();
+    trackers.forEach((tracker) => uniqueTrackers.add(tracker));
+  }
+
+  // Async operations allow Temporal's event loop to process signals.
+  // If a signal arrives during an async operation, it will update the set before the next iteration.
+  while (uniqueTrackers.size > 0) {
+    // Create a copy of the set to iterate over, to avoid issues with concurrent modification.
+    const trackersToProcess = new Set(uniqueTrackers);
+
+    for (const tracker of trackersToProcess) {
+      if (!uniqueTrackers.has(tracker)) {
+        continue;
+      }
+
+      const { trackerId, workspaceId } = tracker;
+
+      // Async operation yielding control to the Temporal runtime.
+      await executeChild(processTrackerNotificationWorkflow, {
+        workflowId: `${workflowId}-workspace-${workspaceId}-tracker-${trackerId}`,
+        args: [
+          {
+            workspaceId,
+            trackerId,
+            currentSyncMs,
+          },
+        ],
+        memo,
+      });
+
+      // Remove the processed tracker from the original set after the async operation.
+      uniqueTrackers.delete(tracker);
+    }
+  }
+}
+
+/**
+ * Workflow that processes the notification tracker.
+ * The workflow is launched as a child workflow from the notification workflow.
+ */
+export async function processTrackerNotificationWorkflow({
+  trackerId,
+  workspaceId,
+  currentSyncMs,
+}: {
+  trackerId: number;
+  workspaceId: string;
+  currentSyncMs: number;
+}) {
+  await processTrackerNotificationWorkflowActivity({
+    trackerId,
+    workspaceId,
+    currentSyncMs,
+  });
 }

--- a/types/src/front/tracker.ts
+++ b/types/src/front/tracker.ts
@@ -19,6 +19,7 @@ export type TrackerConfigurationType = {
   space: SpaceType;
   maintainedDataSources: TrackerDataSourceConfigurationType[];
   watchedDataSources: TrackerDataSourceConfigurationType[];
+  generations?: TrackerGenerationToProcess[];
 };
 
 export type TrackerDataSourceConfigurationType = {
@@ -59,3 +60,16 @@ export type TrackerFrequencyType = "daily" | "weekly" | "monthly";
 export const FrequencyCodec = ioTsEnum<
   (typeof TRACKER_FREQUENCY_TYPES)[number]
 >(TRACKER_FREQUENCY_TYPES);
+
+export type TrackerIdWorkspaceId = {
+  trackerId: number;
+  workspaceId: string;
+};
+
+export type TrackerGenerationToProcess = {
+  id: ModelId;
+  content: string;
+  thinking: string | null;
+  documentId: string;
+  // TODO: Add info about the document.
+};


### PR DESCRIPTION
## Description

This PR introduces the new workflow for Tracker Notifications. 
-> All the config for the new workflow
-> A short cli to start/stop the workflow, and signal a specific tracker (convenient for developing phase).
-> The base logic of the workflow. 

I decided to do a single workflow as opposed to running one workflow per tracker, to avoid having to deal with creating/updating/deleting workflows to the tracker creation/update/deletion. This workflow should remain quite simple (gather the list of generations to consume, maybe call a Dust app to get a summary, and send some emails), I think this is the easiest way. 

It's a cron workflow run every hour. The main workflow logic is only about spawning child workflow for each tracker that needs to be processed: this will be all the trackers that needs an update at the specific time chosen in the configuration. If no TrackerGenerations are unconsumed we can send an email saying that there's no update (or just do nothing), and if there are generations, we will process them (as described earlier).

I also added a basic system to signal some specific trackers (from their id/workspace id) that should be convenient mainly to debug.

I think we might want to comment the code that launch the worker before merging and uncomment it when the workflow is completed and ready to be tested. WDYT?

## Risk

Can be rolled back.

## Deploy Plan

Deploy front.
