### PR TITLE
[KW search] Double parents for GitHub documents

### DIFF
--- a/connectors/migrations/20230906_3_github_fill_parents_field.ts
+++ b/connectors/migrations/20230906_3_github_fill_parents_field.ts
@@ -2,9 +2,9 @@ import { existsSync, readFileSync, writeFileSync } from "fs";
 import { Op } from "sequelize";
 
 import {
-  getDiscussionDocumentId,
-  getIssueDocumentId,
-} from "@connectors/connectors/github/temporal/activities";
+  getDiscussionInternalId,
+  getIssueInternalId,
+} from "@connectors/connectors/github/lib/utils";
 import { updateDocumentParentsField } from "@connectors/lib/data_sources";
 import { GithubDiscussion, GithubIssue } from "@connectors/lib/models/github";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
@@ -77,7 +77,7 @@ async function updateDiscussionsParentsFieldForConnector(
     // update parents field for each document of the chunk, in parallel
     await Promise.all(
       chunk.map(async (document) => {
-        const docId = getDiscussionDocumentId(
+        const docId = getDiscussionInternalId(
           document.repoId,
           document.discussionNumber
         );
@@ -85,7 +85,7 @@ async function updateDiscussionsParentsFieldForConnector(
           dataSourceConfig: connector,
           documentId: docId,
           parents: [
-            getDiscussionDocumentId(document.repoId, document.discussionNumber),
+            getDiscussionInternalId(document.repoId, document.discussionNumber),
             document.repoId,
           ],
         });
@@ -110,12 +110,12 @@ async function updateIssuesParentsFieldForConnector(connector: ConnectorModel) {
     // update parents field for each document of the chunk, in parallel
     await Promise.all(
       chunk.map(async (document) => {
-        const docId = getIssueDocumentId(document.repoId, document.issueNumber);
+        const docId = getIssueInternalId(document.repoId, document.issueNumber);
         await updateDocumentParentsField({
           dataSourceConfig: connector,
           documentId: docId,
           parents: [
-            getIssueDocumentId(document.repoId, document.issueNumber),
+            getIssueInternalId(document.repoId, document.issueNumber),
             document.repoId,
           ],
         });

--- a/connectors/migrations/20230906_3_github_fill_parents_field.ts
+++ b/connectors/migrations/20230906_3_github_fill_parents_field.ts
@@ -2,8 +2,8 @@ import { existsSync, readFileSync, writeFileSync } from "fs";
 import { Op } from "sequelize";
 
 import {
-  getDiscussionDocumentId,
-  getIssueDocumentId,
+  getDiscussionNodeId,
+  getIssueNodeId,
 } from "@connectors/connectors/github/lib/utils";
 import { updateDocumentParentsField } from "@connectors/lib/data_sources";
 import { GithubDiscussion, GithubIssue } from "@connectors/lib/models/github";
@@ -77,7 +77,7 @@ async function updateDiscussionsParentsFieldForConnector(
     // update parents field for each document of the chunk, in parallel
     await Promise.all(
       chunk.map(async (document) => {
-        const docId = getDiscussionDocumentId(
+        const docId = getDiscussionNodeId(
           document.repoId,
           document.discussionNumber
         );
@@ -85,7 +85,7 @@ async function updateDiscussionsParentsFieldForConnector(
           dataSourceConfig: connector,
           documentId: docId,
           parents: [
-            getDiscussionDocumentId(document.repoId, document.discussionNumber),
+            getDiscussionNodeId(document.repoId, document.discussionNumber),
             document.repoId,
           ],
         });
@@ -110,12 +110,12 @@ async function updateIssuesParentsFieldForConnector(connector: ConnectorModel) {
     // update parents field for each document of the chunk, in parallel
     await Promise.all(
       chunk.map(async (document) => {
-        const docId = getIssueDocumentId(document.repoId, document.issueNumber);
+        const docId = getIssueNodeId(document.repoId, document.issueNumber);
         await updateDocumentParentsField({
           dataSourceConfig: connector,
           documentId: docId,
           parents: [
-            getIssueDocumentId(document.repoId, document.issueNumber),
+            getIssueNodeId(document.repoId, document.issueNumber),
             document.repoId,
           ],
         });

--- a/connectors/migrations/20230906_3_github_fill_parents_field.ts
+++ b/connectors/migrations/20230906_3_github_fill_parents_field.ts
@@ -2,8 +2,8 @@ import { existsSync, readFileSync, writeFileSync } from "fs";
 import { Op } from "sequelize";
 
 import {
-  getDiscussionInternalId,
-  getIssueInternalId,
+  getDiscussionDocumentId,
+  getIssueDocumentId,
 } from "@connectors/connectors/github/lib/utils";
 import { updateDocumentParentsField } from "@connectors/lib/data_sources";
 import { GithubDiscussion, GithubIssue } from "@connectors/lib/models/github";
@@ -77,7 +77,7 @@ async function updateDiscussionsParentsFieldForConnector(
     // update parents field for each document of the chunk, in parallel
     await Promise.all(
       chunk.map(async (document) => {
-        const docId = getDiscussionInternalId(
+        const docId = getDiscussionDocumentId(
           document.repoId,
           document.discussionNumber
         );
@@ -85,7 +85,7 @@ async function updateDiscussionsParentsFieldForConnector(
           dataSourceConfig: connector,
           documentId: docId,
           parents: [
-            getDiscussionInternalId(document.repoId, document.discussionNumber),
+            getDiscussionDocumentId(document.repoId, document.discussionNumber),
             document.repoId,
           ],
         });
@@ -110,12 +110,12 @@ async function updateIssuesParentsFieldForConnector(connector: ConnectorModel) {
     // update parents field for each document of the chunk, in parallel
     await Promise.all(
       chunk.map(async (document) => {
-        const docId = getIssueInternalId(document.repoId, document.issueNumber);
+        const docId = getIssueDocumentId(document.repoId, document.issueNumber);
         await updateDocumentParentsField({
           dataSourceConfig: connector,
           documentId: docId,
           parents: [
-            getIssueInternalId(document.repoId, document.issueNumber),
+            getIssueDocumentId(document.repoId, document.issueNumber),
             document.repoId,
           ],
         });

--- a/connectors/migrations/20240102_github_add_issues_discussions_parents.ts
+++ b/connectors/migrations/20240102_github_add_issues_discussions_parents.ts
@@ -1,6 +1,6 @@
 import {
-  getDiscussionDocumentId,
-  getIssueDocumentId,
+  getDiscussionNodeId,
+  getIssueNodeId,
 } from "@connectors/connectors/github/lib/utils";
 import { updateDocumentParentsField } from "@connectors/lib/data_sources";
 import { GithubDiscussion, GithubIssue } from "@connectors/lib/models/github";
@@ -38,10 +38,7 @@ async function updateParents(connector: ConnectorModel) {
   for (const chunk of discussionChunks) {
     await Promise.all(
       chunk.map(async (d) => {
-        const documentId = getDiscussionDocumentId(
-          d.repoId,
-          d.discussionNumber
-        );
+        const documentId = getDiscussionNodeId(d.repoId, d.discussionNumber);
         const parents = [documentId, `${d.repoId}-discussions`, d.repoId];
         if (LIVE) {
           await updateDocumentParentsField({
@@ -71,7 +68,7 @@ async function updateParents(connector: ConnectorModel) {
   for (const chunk of issueChunks) {
     await Promise.all(
       chunk.map(async (i) => {
-        const documentId = getIssueDocumentId(i.repoId, i.issueNumber);
+        const documentId = getIssueNodeId(i.repoId, i.issueNumber);
         const parents = [documentId, `${i.repoId}-issues`, i.repoId];
         if (LIVE) {
           await updateDocumentParentsField({

--- a/connectors/migrations/20240102_github_add_issues_discussions_parents.ts
+++ b/connectors/migrations/20240102_github_add_issues_discussions_parents.ts
@@ -1,7 +1,7 @@
 import {
-  getDiscussionDocumentId,
-  getIssueDocumentId,
-} from "@connectors/connectors/github/temporal/activities";
+  getDiscussionInternalId,
+  getIssueInternalId,
+} from "@connectors/connectors/github/lib/utils";
 import { updateDocumentParentsField } from "@connectors/lib/data_sources";
 import { GithubDiscussion, GithubIssue } from "@connectors/lib/models/github";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
@@ -38,7 +38,7 @@ async function updateParents(connector: ConnectorModel) {
   for (const chunk of discussionChunks) {
     await Promise.all(
       chunk.map(async (d) => {
-        const documentId = getDiscussionDocumentId(
+        const documentId = getDiscussionInternalId(
           d.repoId,
           d.discussionNumber
         );
@@ -71,7 +71,7 @@ async function updateParents(connector: ConnectorModel) {
   for (const chunk of issueChunks) {
     await Promise.all(
       chunk.map(async (i) => {
-        const documentId = getIssueDocumentId(i.repoId, i.issueNumber);
+        const documentId = getIssueInternalId(i.repoId, i.issueNumber);
         const parents = [documentId, `${i.repoId}-issues`, i.repoId];
         if (LIVE) {
           await updateDocumentParentsField({

--- a/connectors/migrations/20240102_github_add_issues_discussions_parents.ts
+++ b/connectors/migrations/20240102_github_add_issues_discussions_parents.ts
@@ -1,6 +1,6 @@
 import {
-  getDiscussionInternalId,
-  getIssueInternalId,
+  getDiscussionDocumentId,
+  getIssueDocumentId,
 } from "@connectors/connectors/github/lib/utils";
 import { updateDocumentParentsField } from "@connectors/lib/data_sources";
 import { GithubDiscussion, GithubIssue } from "@connectors/lib/models/github";
@@ -38,7 +38,7 @@ async function updateParents(connector: ConnectorModel) {
   for (const chunk of discussionChunks) {
     await Promise.all(
       chunk.map(async (d) => {
-        const documentId = getDiscussionInternalId(
+        const documentId = getDiscussionDocumentId(
           d.repoId,
           d.discussionNumber
         );
@@ -71,7 +71,7 @@ async function updateParents(connector: ConnectorModel) {
   for (const chunk of issueChunks) {
     await Promise.all(
       chunk.map(async (i) => {
-        const documentId = getIssueInternalId(i.repoId, i.issueNumber);
+        const documentId = getIssueDocumentId(i.repoId, i.issueNumber);
         const parents = [documentId, `${i.repoId}-issues`, i.repoId];
         if (LIVE) {
           await updateDocumentParentsField({

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -1,5 +1,9 @@
-import type { ContentNode, Result } from "@dust-tt/types";
-import type { ConnectorPermission, ContentNodesViewType } from "@dust-tt/types";
+import type {
+  ConnectorPermission,
+  ContentNode,
+  ContentNodesViewType,
+  Result,
+} from "@dust-tt/types";
 import { assertNever, Err, Ok } from "@dust-tt/types";
 
 import type { GithubRepo } from "@connectors/connectors/github/lib/github_api";
@@ -9,14 +13,16 @@ import {
   installationIdFromConnectionId,
 } from "@connectors/connectors/github/lib/github_api";
 import { getGithubCodeOrDirectoryParentIds } from "@connectors/connectors/github/lib/hierarchy";
-import { matchGithubInternalIdType } from "@connectors/connectors/github/lib/utils";
+import { matchGithubNodeIdType } from "@connectors/connectors/github/lib/utils";
 import { launchGithubFullSyncWorkflow } from "@connectors/connectors/github/temporal/client";
 import type {
   CreateConnectorErrorCode,
   UpdateConnectorErrorCode,
 } from "@connectors/connectors/interface";
-import { ConnectorManagerError } from "@connectors/connectors/interface";
-import { BaseConnectorManager } from "@connectors/connectors/interface";
+import {
+  BaseConnectorManager,
+  ConnectorManagerError,
+} from "@connectors/connectors/interface";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import {
   GithubCodeDirectory,
@@ -467,7 +473,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
 
     // We loop on all the internalIds we receive to know what is the related data type
     internalIds.forEach((internalId) => {
-      const { type, repoId } = matchGithubInternalIdType(internalId);
+      const { type, repoId } = matchGithubNodeIdType(internalId);
       allReposIdsToFetch.add(repoId);
 
       switch (type) {

--- a/connectors/src/connectors/github/lib/github_api.ts
+++ b/connectors/src/connectors/github/lib/github_api.ts
@@ -30,8 +30,8 @@ import {
   GetRepoDiscussionsPayloadSchema,
 } from "@connectors/connectors/github/lib/github_graphql";
 import {
-  getCodeDirInternalId,
-  getCodeFileDocumentId,
+  getCodeDirNodeId,
+  getCodeFileNodeId,
 } from "@connectors/connectors/github/lib/utils";
 import { apiConfig } from "@connectors/lib/api/config";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
@@ -851,7 +851,7 @@ export async function processRepository({
 
       const parents = [];
       for (let i = 0; i < path.length; i++) {
-        const pathInternalId = getCodeDirInternalId(
+        const pathInternalId = getCodeDirNodeId(
           repoId,
           path.slice(0, i + 1).join("/")
         );
@@ -862,7 +862,7 @@ export async function processRepository({
         });
       }
 
-      const documentId = getCodeFileDocumentId(
+      const documentId = getCodeFileNodeId(
         repoId,
         `${path.join("/")}/${fileName}`
       );

--- a/connectors/src/connectors/github/lib/github_api.ts
+++ b/connectors/src/connectors/github/lib/github_api.ts
@@ -881,6 +881,7 @@ export async function processRepository({
         sizeBytes: size,
         documentId,
         parentInternalId,
+        /// reversing the parents here since the convention is bottom to top
         parents: [documentId, ...parents.map((p) => p.internalId).reverse()],
         localFilePath: file,
       });

--- a/connectors/src/connectors/github/lib/github_api.ts
+++ b/connectors/src/connectors/github/lib/github_api.ts
@@ -881,7 +881,7 @@ export async function processRepository({
         sizeBytes: size,
         documentId,
         parentInternalId,
-        parents: [documentId, ...parents.map((p) => p.internalId)],
+        parents: [documentId, ...parents.map((p) => p.internalId).reverse()],
         localFilePath: file,
       });
 

--- a/connectors/src/connectors/github/lib/github_api.ts
+++ b/connectors/src/connectors/github/lib/github_api.ts
@@ -883,7 +883,6 @@ export async function processRepository({
         sizeBytes: size,
         documentId,
         parentInternalId,
-        /// reversing the parents here since the convention is bottom to top
         parents: [documentId, ...parents.map((p) => p.internalId)],
         localFilePath: file,
       });

--- a/connectors/src/connectors/github/lib/github_api.ts
+++ b/connectors/src/connectors/github/lib/github_api.ts
@@ -31,7 +31,7 @@ import {
 } from "@connectors/connectors/github/lib/github_graphql";
 import {
   getCodeDirInternalId,
-  getCodeFileInternalId,
+  getCodeFileDocumentId,
 } from "@connectors/connectors/github/lib/utils";
 import { apiConfig } from "@connectors/lib/api/config";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
@@ -862,7 +862,7 @@ export async function processRepository({
         });
       }
 
-      const documentId = getCodeFileInternalId(
+      const documentId = getCodeFileDocumentId(
         repoId,
         `${path.join("/")}/${fileName}`
       );

--- a/connectors/src/connectors/github/lib/utils.ts
+++ b/connectors/src/connectors/github/lib/utils.ts
@@ -76,7 +76,7 @@ export function getIssuesInternalId(repoId: string | number): string {
   return `github-issues-${repoId}`;
 }
 
-export function getIssueInternalId(
+export function getIssueDocumentId(
   repoId: string | number,
   issueNumber: number
 ): string {
@@ -87,7 +87,7 @@ export function getDiscussionsInternalId(repoId: string | number): string {
   return `github-discussions-${repoId}`;
 }
 
-export function getDiscussionInternalId(
+export function getDiscussionDocumentId(
   repoId: string | number,
   discussionNumber: number
 ): string {
@@ -108,7 +108,7 @@ export function getCodeDirInternalId(
     .substring(0, 16)}`;
 }
 
-export function getCodeFileInternalId(
+export function getCodeFileDocumentId(
   repoId: string | number,
   codePath: string
 ): string {

--- a/connectors/src/connectors/github/lib/utils.ts
+++ b/connectors/src/connectors/github/lib/utils.ts
@@ -1,3 +1,5 @@
+import { hash as blake3 } from "blake3/esm/node/hash-fn";
+
 export const GITHUB_CONTENT_NODE_TYPES = [
   "REPO_FULL",
   "REPO_ISSUES",
@@ -64,4 +66,55 @@ export function matchGithubInternalIdType(internalId: string): {
     };
   }
   throw new Error(`Invalid Github internal id: ${internalId}`);
+}
+
+export function getRepositoryInternalId(repoId: string | number): string {
+  return `github-repository-${repoId}`;
+}
+
+export function getIssuesInternalId(repoId: string | number): string {
+  return `github-issues-${repoId}`;
+}
+
+export function getIssueInternalId(
+  repoId: string | number,
+  issueNumber: number
+): string {
+  return `github-issue-${repoId}-${issueNumber}`;
+}
+
+export function getDiscussionsInternalId(repoId: string | number): string {
+  return `github-discussions-${repoId}`;
+}
+
+export function getDiscussionInternalId(
+  repoId: string | number,
+  discussionNumber: number
+): string {
+  return `github-discussion-${repoId}-${discussionNumber}`;
+}
+
+export function getCodeRootInternalId(repoId: string | number): string {
+  return `github-code-${repoId}`;
+}
+
+export function getCodeDirInternalId(
+  repoId: string | number,
+  codePath: string
+): string {
+  const p = `github-code-${repoId}-dir-${codePath}`;
+  return `github-code-${repoId}-dir-${blake3(p)
+    .toString("hex")
+    .substring(0, 16)}`;
+}
+
+export function getCodeFileInternalId(
+  repoId: string | number,
+  codePath: string
+): string {
+  return `github-code-${repoId}-file-${blake3(
+    `github-code-${repoId}-file-${codePath}`
+  )
+    .toString("hex")
+    .substring(0, 16)}`;
 }

--- a/connectors/src/connectors/github/lib/utils.ts
+++ b/connectors/src/connectors/github/lib/utils.ts
@@ -13,7 +13,7 @@ export type GithubContentNodeType = (typeof GITHUB_CONTENT_NODE_TYPES)[number];
 /**
  * Gets the type of the Github content node from its internal id.
  */
-export function matchGithubInternalIdType(internalId: string): {
+export function matchGithubNodeIdType(internalId: string): {
   type: GithubContentNodeType;
   repoId: number;
 } {
@@ -68,37 +68,37 @@ export function matchGithubInternalIdType(internalId: string): {
   throw new Error(`Invalid Github internal id: ${internalId}`);
 }
 
-export function getRepositoryInternalId(repoId: string | number): string {
+export function getRepositoryNodeId(repoId: string | number): string {
   return `github-repository-${repoId}`;
 }
 
-export function getIssuesInternalId(repoId: string | number): string {
+export function getIssuesNodeId(repoId: string | number): string {
   return `github-issues-${repoId}`;
 }
 
-export function getIssueDocumentId(
+export function getIssueNodeId(
   repoId: string | number,
   issueNumber: number
 ): string {
   return `github-issue-${repoId}-${issueNumber}`;
 }
 
-export function getDiscussionsInternalId(repoId: string | number): string {
+export function getDiscussionsNodeId(repoId: string | number): string {
   return `github-discussions-${repoId}`;
 }
 
-export function getDiscussionDocumentId(
+export function getDiscussionNodeId(
   repoId: string | number,
   discussionNumber: number
 ): string {
   return `github-discussion-${repoId}-${discussionNumber}`;
 }
 
-export function getCodeRootInternalId(repoId: string | number): string {
+export function getCodeRootNodeId(repoId: string | number): string {
   return `github-code-${repoId}`;
 }
 
-export function getCodeDirInternalId(
+export function getCodeDirNodeId(
   repoId: string | number,
   codePath: string
 ): string {
@@ -108,7 +108,7 @@ export function getCodeDirInternalId(
     .substring(0, 16)}`;
 }
 
-export function getCodeFileDocumentId(
+export function getCodeFileNodeId(
   repoId: string | number,
   codePath: string
 ): string {

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -22,6 +22,14 @@ import {
   getReposPage,
   processRepository,
 } from "@connectors/connectors/github/lib/github_api";
+import {
+  getCodeRootInternalId,
+  getDiscussionInternalId,
+  getDiscussionsInternalId,
+  getIssueInternalId,
+  getIssuesInternalId,
+  getRepositoryInternalId,
+} from "@connectors/connectors/github/lib/utils";
 import { QUEUE_NAME } from "@connectors/connectors/github/temporal/config";
 import { newWebhookSignal } from "@connectors/connectors/github/temporal/signals";
 import { getCodeSyncWorkflowId } from "@connectors/connectors/github/temporal/utils";
@@ -265,7 +273,7 @@ export async function githubUpsertIssueActivity(
     content: renderedIssue,
   } = renderedIssueResult;
 
-  const documentId = getIssueDocumentId(repoId.toString(), issueNumber);
+  const documentId = getIssueInternalId(repoId.toString(), issueNumber);
   const issueAuthor = renderGithubUser(issue.creator);
   const tags = [
     `title:${issue.title}`,
@@ -291,7 +299,15 @@ export async function githubUpsertIssueActivity(
     // Therefore as a special case we use getIssueDocumentId() to get a parent string
     // The repo id from github is globally unique so used as-is, as per
     // convention to use the external id string.
-    parents: [documentId, `${repoId}-issues`, repoId.toString()],
+    parents: [
+      documentId,
+      // TODO(2024-12-17 aubin): remove the old parent IDs below
+      `${repoId}-issues`,
+      repoId.toString(),
+      // new parent IDs
+      getIssuesInternalId(repoId),
+      getRepositoryInternalId(repoId),
+    ],
     loggerArgs: logger.bindings(),
     upsertContext: {
       sync_type: isBatchSync ? "batch" : "incremental",
@@ -454,7 +470,7 @@ export async function githubUpsertDiscussionActivity(
     logger
   );
 
-  const documentId = getDiscussionDocumentId(
+  const documentId = getDiscussionInternalId(
     repoId.toString(),
     discussionNumber
   );
@@ -477,7 +493,15 @@ export async function githubUpsertDiscussionActivity(
     // as a special case we use getDiscussionDocumentId() to get a parent string
     // The repo id from github is globally unique so used as-is, as per
     // convention to use the external id string.
-    parents: [documentId, `${repoId}-discussions`, repoId.toString()],
+    parents: [
+      documentId,
+      // TODO(2024-12-17 aubin): remove the old parent IDs below
+      `${repoId}-discussions`,
+      repoId.toString(),
+      // new parent IDs
+      getDiscussionsInternalId(repoId),
+      getRepositoryInternalId(repoId),
+    ],
     loggerArgs: logger.bindings(),
     upsertContext: {
       sync_type: isBatchSync ? "batch" : "incremental",
@@ -690,7 +714,7 @@ async function deleteIssue(
     );
   }
 
-  const documentId = getIssueDocumentId(repoId.toString(), issueNumber);
+  const documentId = getIssueInternalId(repoId.toString(), issueNumber);
   logger.info({ documentId }, "Deleting GitHub issue from Dust data source.");
   await deleteFromDataSource(dataSourceConfig, documentId, logger.bindings());
 
@@ -723,7 +747,7 @@ async function deleteDiscussion(
     logger.warn("Discussion not found in DB");
   }
 
-  const documentId = getDiscussionDocumentId(
+  const documentId = getDiscussionInternalId(
     repoId.toString(),
     discussionNumber
   );
@@ -751,20 +775,6 @@ function renderGithubUser(user: GithubUser | null): string {
     return `@${user.login}`;
   }
   return `@${user.id}`;
-}
-
-export function getIssueDocumentId(
-  repoId: string,
-  issueNumber: number
-): string {
-  return `github-issue-${repoId}-${issueNumber}`;
-}
-
-export function getDiscussionDocumentId(
-  repoId: string,
-  discussionNumber: number
-): string {
-  return `github-discussion-${repoId}-${discussionNumber}`;
 }
 
 export function formatCodeContentForUpsert(
@@ -1018,7 +1028,7 @@ export async function githubCodeSyncActivity({
     // incoherent state (files that moved will appear twice before final cleanup). This seems fine
     // given that syncing stallness is already considered an incident.
 
-    const rootInternalId = `github-code-${repoId}`;
+    const rootInternalId = getCodeRootInternalId(repoId);
     const updatedDirectories: { [key: string]: boolean } = {};
     let repoUpdatedAt: Date | null = null;
 
@@ -1104,7 +1114,16 @@ export async function githubCodeSyncActivity({
             documentUrl: f.sourceUrl,
             timestampMs: codeSyncStartedAt.getTime(),
             tags,
-            parents: [...f.parents, rootInternalId, repoId.toString()],
+            parents: [
+              // TODO(2024-12-17 aubin): remove the old parent IDs below
+              ...f.parents,
+              rootInternalId,
+              repoId.toString(),
+              // new parent IDs
+              ...f.parents.slice(1).reverse(),
+              rootInternalId,
+              getRepositoryInternalId(repoId),
+            ],
             loggerArgs: logger.bindings(),
             upsertContext: {
               sync_type: isBatchSync ? "batch" : "incremental",

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -24,9 +24,9 @@ import {
 } from "@connectors/connectors/github/lib/github_api";
 import {
   getCodeRootInternalId,
-  getDiscussionInternalId,
+  getDiscussionDocumentId,
   getDiscussionsInternalId,
-  getIssueInternalId,
+  getIssueDocumentId,
   getIssuesInternalId,
   getRepositoryInternalId,
 } from "@connectors/connectors/github/lib/utils";
@@ -273,7 +273,7 @@ export async function githubUpsertIssueActivity(
     content: renderedIssue,
   } = renderedIssueResult;
 
-  const documentId = getIssueInternalId(repoId.toString(), issueNumber);
+  const documentId = getIssueDocumentId(repoId.toString(), issueNumber);
   const issueAuthor = renderGithubUser(issue.creator);
   const tags = [
     `title:${issue.title}`,
@@ -470,7 +470,7 @@ export async function githubUpsertDiscussionActivity(
     logger
   );
 
-  const documentId = getDiscussionInternalId(
+  const documentId = getDiscussionDocumentId(
     repoId.toString(),
     discussionNumber
   );
@@ -714,7 +714,7 @@ async function deleteIssue(
     );
   }
 
-  const documentId = getIssueInternalId(repoId.toString(), issueNumber);
+  const documentId = getIssueDocumentId(repoId.toString(), issueNumber);
   logger.info({ documentId }, "Deleting GitHub issue from Dust data source.");
   await deleteFromDataSource(dataSourceConfig, documentId, logger.bindings());
 
@@ -747,7 +747,7 @@ async function deleteDiscussion(
     logger.warn("Discussion not found in DB");
   }
 
-  const documentId = getDiscussionInternalId(
+  const documentId = getDiscussionDocumentId(
     repoId.toString(),
     discussionNumber
   );

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -23,12 +23,12 @@ import {
   processRepository,
 } from "@connectors/connectors/github/lib/github_api";
 import {
-  getCodeRootInternalId,
-  getDiscussionDocumentId,
-  getDiscussionsInternalId,
-  getIssueDocumentId,
-  getIssuesInternalId,
-  getRepositoryInternalId,
+  getCodeRootNodeId,
+  getDiscussionNodeId,
+  getDiscussionsNodeId,
+  getIssueNodeId,
+  getIssuesNodeId,
+  getRepositoryNodeId,
 } from "@connectors/connectors/github/lib/utils";
 import { QUEUE_NAME } from "@connectors/connectors/github/temporal/config";
 import { newWebhookSignal } from "@connectors/connectors/github/temporal/signals";
@@ -273,7 +273,7 @@ export async function githubUpsertIssueActivity(
     content: renderedIssue,
   } = renderedIssueResult;
 
-  const documentId = getIssueDocumentId(repoId.toString(), issueNumber);
+  const documentId = getIssueNodeId(repoId.toString(), issueNumber);
   const issueAuthor = renderGithubUser(issue.creator);
   const tags = [
     `title:${issue.title}`,
@@ -305,8 +305,8 @@ export async function githubUpsertIssueActivity(
       `${repoId}-issues`,
       repoId.toString(),
       // new parent IDs
-      getIssuesInternalId(repoId),
-      getRepositoryInternalId(repoId),
+      getIssuesNodeId(repoId),
+      getRepositoryNodeId(repoId),
     ],
     loggerArgs: logger.bindings(),
     upsertContext: {
@@ -470,10 +470,7 @@ export async function githubUpsertDiscussionActivity(
     logger
   );
 
-  const documentId = getDiscussionDocumentId(
-    repoId.toString(),
-    discussionNumber
-  );
+  const documentId = getDiscussionNodeId(repoId.toString(), discussionNumber);
   const tags = [
     `title:${discussion.title}`,
     `author:${discussion.author ? discussion.author.login : "unknown"}`,
@@ -499,8 +496,8 @@ export async function githubUpsertDiscussionActivity(
       `${repoId}-discussions`,
       repoId.toString(),
       // new parent IDs
-      getDiscussionsInternalId(repoId),
-      getRepositoryInternalId(repoId),
+      getDiscussionsNodeId(repoId),
+      getRepositoryNodeId(repoId),
     ],
     loggerArgs: logger.bindings(),
     upsertContext: {
@@ -714,7 +711,7 @@ async function deleteIssue(
     );
   }
 
-  const documentId = getIssueDocumentId(repoId.toString(), issueNumber);
+  const documentId = getIssueNodeId(repoId.toString(), issueNumber);
   logger.info({ documentId }, "Deleting GitHub issue from Dust data source.");
   await deleteFromDataSource(dataSourceConfig, documentId, logger.bindings());
 
@@ -747,10 +744,7 @@ async function deleteDiscussion(
     logger.warn("Discussion not found in DB");
   }
 
-  const documentId = getDiscussionDocumentId(
-    repoId.toString(),
-    discussionNumber
-  );
+  const documentId = getDiscussionNodeId(repoId.toString(), discussionNumber);
   logger.info(
     { documentId },
     "Deleting GitHub discussion from Dust data source."
@@ -1028,7 +1022,7 @@ export async function githubCodeSyncActivity({
     // incoherent state (files that moved will appear twice before final cleanup). This seems fine
     // given that syncing stallness is already considered an incident.
 
-    const rootInternalId = getCodeRootInternalId(repoId);
+    const rootInternalId = getCodeRootNodeId(repoId);
     const updatedDirectories: { [key: string]: boolean } = {};
     let repoUpdatedAt: Date | null = null;
 
@@ -1122,7 +1116,7 @@ export async function githubCodeSyncActivity({
               // new parent IDs
               ...f.parents.slice(1).reverse(),
               rootInternalId,
-              getRepositoryInternalId(repoId),
+              getRepositoryNodeId(repoId),
             ],
             loggerArgs: logger.bindings(),
             upsertContext: {

--- a/front/migrations/20241211_parents_migrator.ts
+++ b/front/migrations/20241211_parents_migrator.ts
@@ -260,8 +260,7 @@ const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
         return { parents, parentId: parents[1] };
       }
       const lastParent = parents[parents.length - 1];
-      // case where we are already good
-      if (!lastParent.startsWith("github-repository")) {
+      if (!lastParent.startsWith("github-repository-")) {
         logger.warn(
           { nodeId, parents, problem: "Not enough parents" },
           "Github parents[-1] !== github-repository-xxx"
@@ -271,7 +270,7 @@ const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
       const repoId = lastParent.replace("github-repository-", "");
       assert(/^\d+$/.test(repoId), `Invalid repoId: ${repoId}`);
 
-      if (nodeId.startsWith("github-code")) {
+      if (nodeId.startsWith("github-code-")) {
         const parentsDir = parents.filter((p) => p.includes("-dir-"));
 
         assert(

--- a/front/migrations/20241211_parents_migrator.ts
+++ b/front/migrations/20241211_parents_migrator.ts
@@ -192,6 +192,13 @@ const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
   microsoft: null,
   github: {
     transformer: (nodeId, parents) => {
+      if (nodeId !== parents[0]) {
+        logger.warn(
+          { nodeId, parents, problem: "Not enough parents" },
+          "Github nodeId !== parents[0]"
+        );
+        return { parents, parentId: parents[1] };
+      }
       const repoId = parents[parents.length - 1];
       // case where we are already good
       if (repoId.startsWith("github-repository")) {

--- a/front/migrations/20241211_parents_migrator.ts
+++ b/front/migrations/20241211_parents_migrator.ts
@@ -202,6 +202,7 @@ const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
           { nodeId, parents, problem: "Not enough parents" },
           "Invalid Github parents"
         );
+        return { parents, parentId: parents[1] };
       }
       assert(/^\d+$/.test(repoId), `Invalid repoId: ${repoId}`);
 

--- a/front/migrations/20241211_parents_migrator.ts
+++ b/front/migrations/20241211_parents_migrator.ts
@@ -241,8 +241,11 @@ const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
         // github-code-${repoId}-file-xxx, github-code-${repoId}-dir-xxx, ..., github-code-${repoId}, ${repoId}
         return {
           parents: [
-            ...parents,
-            ...parents.slice(1, -2).reverse(),
+            nodeId,
+            /// putting the code directories here in reverse
+            ...parents
+              .filter((p) => /^github-code-\d+-dir-[a-f0-9]+$/.test(p)) // same regex as in connectors/github/lib/utils.ts
+              .reverse(),
             `github-code-${repoId}`,
             `github-repository-${repoId}`,
           ],

--- a/front/migrations/20241211_parents_migrator.ts
+++ b/front/migrations/20241211_parents_migrator.ts
@@ -274,29 +274,15 @@ const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
       assert(/^\d+$/.test(repoId), `Invalid repoId: ${repoId}`);
 
       if (nodeId.startsWith("github-code-")) {
-        const parentsDir = parents.filter((p) => p.includes("-dir-"));
-
         assert(
-          parentsDir.length % 2 === 0,
-          `Odd number of parents: ${parentsDir.join(", ")}`
-        );
-
-        // making sure that we got the parents in reverse
-        for (let i = 0; i < Math.floor(parents.length / 2); i++) {
-          assert(
-            parentsDir[i] === parentsDir[parentsDir.length - 1 - i],
-            `parentsDir[${i}] !== parentsDir[${parentsDir.length - 1 - i}]: ${parentsDir.join(", ")}`
-          );
-        }
-        assert(
-          nodeId.startsWith(`github-code-${repoId}-file-`),
+          /^github-code-\d+-file-[a-f0-9]+$/.test(nodeId),
           `Github invalid nodeId: ${nodeId}`
         );
 
         return {
           parents: [
             nodeId,
-            ...parentsDir.slice(parentsDir.length / 2, parentsDir.length), // taking only the part that is in reverse
+            ...parents.filter((p) => /^github-code-\d+-dir-[a-f0-9]+$/.test(p)), // same regex as in connectors/github/lib/utils.ts
             `github-code-${repoId}`,
             `github-repository-${repoId}`,
           ],

--- a/front/migrations/20241211_parents_migrator.ts
+++ b/front/migrations/20241211_parents_migrator.ts
@@ -203,6 +203,7 @@ const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
           "Invalid Github parents"
         );
       }
+      assert(/^\d+$/.test(repoId), `Invalid repoId: ${repoId}`);
 
       if (nodeId.startsWith("github-issue-")) {
         return {


### PR DESCRIPTION
## Description

- Close [#1785](https://github.com/dust-tt/tasks/issues/1785) (not part of the initial card but good to do it now as it breaks other things in the UI).
- Reverse the order of the directories listed in the parents of a Github code file.
- Update the existing migration script for backfilling.
- This one is very tricky: since we only get a substring of the hash of the directory name, there is no way to tell whether the parents are in order only by looking at them (cannot do it idempotently).
- Since we need to do these steps, we decided to do the parent name uniformization (add prefixes) altogether.
- This PR therefore doubles the parents in connector and backfills with the transform.

## Risk

- Limited scope: only the order of the parents is affected.

## Deploy Plan

- Deploy connectors.
- Run the transform.
