### PR TITLE
[front] Default parents to [documentId] if not specified

### DIFF
--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -640,7 +640,7 @@ export async function handleDataSourceTableCSVUpsert({
   }
 
   const tableId = params.tableId ?? generateRandomModelSId();
-  const tableParents: string[] = params.parents ?? [];
+  const tableParents: string[] = params.parents ?? [tableId];
 
   const flags = await getFeatureFlags(owner);
 

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -497,15 +497,17 @@ async function handler(
         statsDClient.increment("document_no_self_ref.count", 1, statsDTags);
       }
 
+      const documentId = req.query.documentId as string;
+
       if (r.data.async === true) {
         const enqueueRes = await enqueueUpsertDocument({
           upsertDocument: {
             workspaceId: owner.sId,
             dataSourceId: dataSource.sId,
-            documentId: req.query.documentId as string,
+            documentId,
             tags: r.data.tags || [],
             parentId: r.data.parent_id || null,
-            parents: r.data.parents || [],
+            parents: r.data.parents || [documentId],
             timestamp: r.data.timestamp || null,
             sourceUrl,
             section,
@@ -545,7 +547,7 @@ async function handler(
           documentId: req.query.documentId as string,
           tags: r.data.tags || [],
           parentId: r.data.parent_id || null,
-          parents: r.data.parents || [],
+          parents: r.data.parents || [documentId],
           sourceUrl,
           timestamp: r.data.timestamp || null,
           section,

--- a/front/temporal/upsert_queue/activities.ts
+++ b/front/temporal/upsert_queue/activities.ts
@@ -88,7 +88,7 @@ export async function upsertDocumentActivity(
     documentId: upsertQueueItem.documentId,
     tags: upsertQueueItem.tags || [],
     parentId: upsertQueueItem.parentId || null,
-    parents: upsertQueueItem.parents || [],
+    parents: upsertQueueItem.parents || [upsertQueueItem.documentId],
     sourceUrl: upsertQueueItem.sourceUrl,
     timestamp: upsertQueueItem.timestamp,
     section: upsertQueueItem.section,


### PR DESCRIPTION
## Description

If no parents array is specified, defaults to `[documentId]`. 
Note that if a parentId is passed, the full list of parents will also be required as the default value won't be valid in that case.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
