### PR TITLE
[front] Add KillSwitchModel to init-db

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -75,6 +75,7 @@ import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_me
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import { KeyModel } from "@app/lib/resources/storage/models/keys";
+import { KillSwitchModel } from "@app/lib/resources/storage/models/kill_switches";
 // Labs - Can be removed at all times if a solution is dropped
 import {
   LabsTranscriptsConfigurationModel,
@@ -171,6 +172,7 @@ async function main() {
   await RetrievalDocumentChunk.sync({ alter: true });
 
   await FeatureFlag.sync({ alter: true });
+  await KillSwitchModel.sync({ alter: true });
 
   await ConversationClassification.sync({ alter: true });
 


### PR DESCRIPTION
## Description

- When running an init-db from a clean state we don't get the kill_switches table.
- Migrations on it would most likely not be tracked correctly by `npm run create-db-migration`.
- This PR aims at fixing that.

## Risk

- Should have no impact on prod, only front/admin is affected. 

## Deploy Plan

- Nothing to deploy.
