### PR TITLE
[parents_migrations] add front migration for github

### DIFF
--- a/front/migrations/20241211_parents_front_migrator.ts
+++ b/front/migrations/20241211_parents_front_migrator.ts
@@ -63,32 +63,36 @@ const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
     ),
   microsoft: null,
   github: (parents) => {
-    return parents.map((parent) => {
-      if (/^\d+$/.test(parent)) {
-        return `github-repository-${parent}`;
-      }
-      if (/\d+-issues$/.test(parent)) {
-        const repoId = parseInt(parent.replace(/-issues$/, ""), 10);
-        return `github-issues-${repoId}`;
-      }
-      if (/\d+-discussions$/.test(parent)) {
-        const repoId = parseInt(parent.replace(/-discussions$/, ""), 10);
-        return `github-discussions-${repoId}`;
-      }
-      if (
-        /^github-code-\d+$/.test(parent) ||
-        /^github-code-\d+-dir-[a-f0-9]+$/.test(parent) ||
-        /^github-code-\d+-file-[a-f0-9]+$/.test(parent) ||
-        /^github-discussions-\d+$/.test(parent) ||
-        /^github-discussion-\d+$/.test(parent) ||
-        /^github-issues-\d+$/.test(parent) ||
-        /^github-issue-\d+$/.test(parent) ||
-        /^github-repository-\d+$/.test(parent)
-      ) {
-        return parent;
-      }
-      throw new Error(`Unrecognized parent type: ${parent}`);
-    });
+    return [
+      ...new Set(
+        parents.map((parent) => {
+          if (/^\d+$/.test(parent)) {
+            return `github-repository-${parent}`;
+          }
+          if (/\d+-issues$/.test(parent)) {
+            const repoId = parseInt(parent.replace(/-issues$/, ""), 10);
+            return `github-issues-${repoId}`;
+          }
+          if (/\d+-discussions$/.test(parent)) {
+            const repoId = parseInt(parent.replace(/-discussions$/, ""), 10);
+            return `github-discussions-${repoId}`;
+          }
+          if (
+            /^github-code-\d+$/.test(parent) ||
+            /^github-code-\d+-dir-[a-f0-9]+$/.test(parent) ||
+            /^github-code-\d+-file-[a-f0-9]+$/.test(parent) ||
+            /^github-discussions-\d+$/.test(parent) ||
+            /^github-discussion-\d+$/.test(parent) ||
+            /^github-issues-\d+$/.test(parent) ||
+            /^github-issue-\d+$/.test(parent) ||
+            /^github-repository-\d+$/.test(parent)
+          ) {
+            return parent;
+          }
+          throw new Error(`Unrecognized parent type: ${parent}`);
+        })
+      ),
+    ];
   },
   notion: (parents) => {
     return _.uniq(parents.map((p) => _.last(p.split("notion-"))!)).map(

--- a/front/migrations/20241211_parents_front_migrator.ts
+++ b/front/migrations/20241211_parents_front_migrator.ts
@@ -62,7 +62,33 @@ const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
         : `gdrive-${parent}`
     ),
   microsoft: null,
-  github: null,
+  github: (parents) => {
+    const repoId = parents[parents.length - 1];
+    // case where we are already good
+    if (repoId.startsWith("github-repository")) {
+      return parents;
+    }
+    const nodeId = parents[0];
+    if (nodeId.startsWith("github-issue-")) {
+      return [nodeId, `github-issues-${repoId}`, `github-repository-${repoId}`];
+    }
+    if (nodeId.startsWith("github-discussion-")) {
+      return [
+        nodeId,
+        `github-discussions-${repoId}`,
+        `github-repository-${repoId}`,
+      ];
+    }
+    if (nodeId.startsWith("github-code")) {
+      return [
+        nodeId,
+        ...parents.slice(1, -2).reverse(),
+        `github-code-${repoId}`,
+        `github-repository-${repoId}`,
+      ];
+    }
+    throw new Error(`Unrecognized node type: ${nodeId}`);
+  },
   notion: (parents) => {
     return _.uniq(parents.map((p) => _.last(p.split("notion-"))!)).map(
       (id) => `notion-${id}`


### PR DESCRIPTION
## Description

- Follow up from https://github.com/dust-tt/dust/pull/9440
- This PR adds the parents front migration function for github (data_source_views and agent_data_source_configurations).

## Risk

- High

## Deploy Plan

none, it's a migration script
