### PR TITLE
Trackers: frequency is a cron string

### DIFF
--- a/front/components/trackers/TrackerBuilder.tsx
+++ b/front/components/trackers/TrackerBuilder.tsx
@@ -21,7 +21,7 @@ import type {
 } from "@dust-tt/types";
 import {
   CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG,
-  TRACKER_FREQUENCY_TYPES,
+  TRACKER_FREQUENCIES,
 } from "@dust-tt/types";
 import { useRouter } from "next/router";
 import { useMemo, useState } from "react";
@@ -68,7 +68,7 @@ export const TrackerBuilder = ({
       descriptionError: null,
       prompt: null,
       promptError: null,
-      frequency: "daily",
+      frequency: TRACKER_FREQUENCIES[0].value,
       frequencyError: null,
       recipients: "",
       recipientsError: null,
@@ -379,20 +379,24 @@ export const TrackerBuilder = ({
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
                     <Button
-                      label={tracker.frequency}
+                      label={
+                        TRACKER_FREQUENCIES.find(
+                          (f) => f.value === tracker.frequency
+                        )?.label || "Select Frequency"
+                      }
                       variant="outline"
                       isSelect
                     />
                   </DropdownMenuTrigger>
                   <DropdownMenuContent>
-                    {TRACKER_FREQUENCY_TYPES.map((f) => (
+                    {TRACKER_FREQUENCIES.map(({ label, value }) => (
                       <DropdownMenuItem
-                        key={f}
-                        label={f}
+                        key={label}
+                        label={label}
                         onClick={() => {
                           setTracker((t) => ({
                             ...t,
-                            frequency: f,
+                            frequency: value,
                           }));
                           if (!edited) {
                             setEdited(true);

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -38,6 +38,7 @@
         "blake3": "^2.1.7",
         "class-variance-authority": "^0.7.0",
         "cmdk": "^1.0.0",
+        "cron-parser": "^4.9.0",
         "csv-parse": "^5.5.2",
         "csv-stringify": "^6.4.5",
         "date-fns": "^3.6.0",
@@ -20577,6 +20578,17 @@
     "node_modules/crelt": {
       "version": "1.0.6",
       "license": "MIT"
+    },
+    "node_modules/cron-parser": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
+      "integrity": "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==",
+      "dependencies": {
+        "luxon": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/front/package.json
+++ b/front/package.json
@@ -51,6 +51,7 @@
     "blake3": "^2.1.7",
     "class-variance-authority": "^0.7.0",
     "cmdk": "^1.0.0",
+    "cron-parser": "^4.9.0",
     "csv-parse": "^5.5.2",
     "csv-stringify": "^6.4.5",
     "date-fns": "^3.6.0",

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/trackers/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/trackers/index.ts
@@ -2,11 +2,7 @@ import type {
   TrackerConfigurationType,
   WithAPIErrorResponse,
 } from "@dust-tt/types";
-import {
-  FrequencyCodec,
-  ModelIdCodec,
-  ModelProviderIdCodec,
-} from "@dust-tt/types";
+import { ModelIdCodec, ModelProviderIdCodec } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -46,7 +42,7 @@ export const PostTrackersRequestBodySchema = t.type({
   prompt: t.union([t.string, t.null]),
   modelId: ModelIdCodec,
   providerId: ModelProviderIdCodec,
-  frequency: FrequencyCodec,
+  frequency: t.string,
   temperature: t.number,
   recipients: t.array(t.string),
   maintainedDataSources: TrackerDataSourcesConfigurationBodySchema,

--- a/front/temporal/tracker/activities.ts
+++ b/front/temporal/tracker/activities.ts
@@ -268,10 +268,12 @@ async function getDataSourceDocument({
  * They are the active trackers that have generations to consume.
  * @returns TrackerIdWorkspaceId[]
  */
-export const getTrackerIdsToNotifyActivity = async (): Promise<
-  TrackerIdWorkspaceId[]
-> => {
-  return TrackerConfigurationResource.internalFetchAllActiveWithUnconsumedGenerations();
+export const getTrackerIdsToNotifyActivity = async (
+  currentSyncMs: number
+): Promise<TrackerIdWorkspaceId[]> => {
+  return TrackerConfigurationResource.internalFetchTrackersToNotify(
+    currentSyncMs
+  );
 };
 
 /**

--- a/front/temporal/tracker/admin/cli.sh
+++ b/front/temporal/tracker/admin/cli.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-npx tsx temporal/document_tracker/admin/cli.ts "$@"
+npx tsx temporal/tracker/admin/cli.ts "$@"

--- a/front/temporal/tracker/admin/cli.ts
+++ b/front/temporal/tracker/admin/cli.ts
@@ -1,5 +1,6 @@
 import parseArgs from "minimist";
 
+import { TrackerConfigurationResource } from "@app/lib/resources/tracker_resource";
 import {
   launchTrackerNotificationWorkflow,
   stopTrackerNotificationWorkflow,

--- a/front/temporal/tracker/workflows.ts
+++ b/front/temporal/tracker/workflows.ts
@@ -76,7 +76,7 @@ export async function trackersGenerationWorkflow(
  */
 export async function trackersNotificationsWorkflow() {
   const { workflowId, memo } = workflowInfo();
-  const currentSyncMs = new Date().getTime();
+  const currentRunMs = new Date().getTime();
   const uniqueTrackers = new Set<TrackerIdWorkspaceId>();
 
   // Signal handler. Receives the tracker ids to notify.
@@ -88,7 +88,7 @@ export async function trackersNotificationsWorkflow() {
 
   // If we got no signal then we're on the scheduled execution: we process all trackers.
   if (uniqueTrackers.size === 0) {
-    const trackers = await getTrackerIdsToNotifyActivity(currentSyncMs);
+    const trackers = await getTrackerIdsToNotifyActivity(currentRunMs);
     trackers.forEach((tracker) => uniqueTrackers.add(tracker));
   }
 
@@ -112,7 +112,7 @@ export async function trackersNotificationsWorkflow() {
           {
             workspaceId,
             trackerId,
-            currentSyncMs,
+            currentRunMs,
           },
         ],
         memo,
@@ -131,15 +131,15 @@ export async function trackersNotificationsWorkflow() {
 export async function processTrackerNotificationWorkflow({
   trackerId,
   workspaceId,
-  currentSyncMs,
+  currentRunMs,
 }: {
   trackerId: number;
   workspaceId: string;
-  currentSyncMs: number;
+  currentRunMs: number;
 }) {
   await processTrackerNotificationWorkflowActivity({
     trackerId,
     workspaceId,
-    currentSyncMs,
+    currentRunMs,
   });
 }

--- a/front/temporal/tracker/workflows.ts
+++ b/front/temporal/tracker/workflows.ts
@@ -88,7 +88,7 @@ export async function trackersNotificationsWorkflow() {
 
   // If we got no signal then we're on the scheduled execution: we process all trackers.
   if (uniqueTrackers.size === 0) {
-    const trackers = await getTrackerIdsToNotifyActivity();
+    const trackers = await getTrackerIdsToNotifyActivity(currentSyncMs);
     trackers.forEach((tracker) => uniqueTrackers.add(tracker));
   }
 

--- a/types/src/front/tracker.ts
+++ b/types/src/front/tracker.ts
@@ -1,5 +1,4 @@
 import { ModelId } from "../shared/model_id";
-import { ioTsEnum } from "../shared/utils/iots_utils";
 import { DataSourceViewSelectionConfigurations } from "./data_source_view";
 import { ModelIdType, ModelProviderIdType } from "./lib/assistant";
 import { SpaceType } from "./space";
@@ -50,16 +49,10 @@ export type TrackerConfigurationStateType = {
   watchedDataSources: DataSourceViewSelectionConfigurations;
 };
 
-export const TRACKER_FREQUENCY_TYPES: TrackerFrequencyType[] = [
-  "daily",
-  "weekly",
-  "monthly",
+export const TRACKER_FREQUENCIES = [
+  { label: "Daily", value: "0 17 * * 1-5" },
+  { label: "Weekly", value: "0 17 * * 5" },
 ];
-export type TrackerFrequencyType = "daily" | "weekly" | "monthly";
-
-export const FrequencyCodec = ioTsEnum<
-  (typeof TRACKER_FREQUENCY_TYPES)[number]
->(TRACKER_FREQUENCY_TYPES);
 
 export type TrackerIdWorkspaceId = {
   trackerId: number;


### PR DESCRIPTION
## Description

Expect that the field frequency is a cron string over an enum. 
Change the way we fetch tracker to notify based on this cron string and the last time they were processed. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front; 