### PR TITLE
enh: add gin index on tracker_data_source_configurations.parentsIn

### DIFF
--- a/front/lib/models/doc_tracker.ts
+++ b/front/lib/models/doc_tracker.ts
@@ -184,7 +184,14 @@ TrackerDataSourceConfigurationModel.init(
   {
     modelName: "tracker_data_source_configuration",
     sequelize: frontSequelize,
-    indexes: [{ fields: ["trackerConfigurationId"] }],
+    indexes: [
+      { fields: ["trackerConfigurationId"] },
+      {
+        fields: ["parentsIn"],
+        using: "gin",
+        name: "tracker_data_source_configuration_parent_ids_gin_idx",
+      },
+    ],
   }
 );
 

--- a/front/migrations/db/migration_133.sql
+++ b/front/migrations/db/migration_133.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jan 10, 2024
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "tracker_data_source_configuration_parents_in_gin_idx" ON "public"."tracker_data_source_configurations" USING gin("parentsIn");


### PR DESCRIPTION
## Description

We need it for the overlap query (to get trackers to run based on a watched document)

## Risk

Should be fine since the table is empty

## Deploy Plan

Run the migration.
I am a detailed plan lorem ipsum dolor sit amet.
👋 dangerJS