### PR TITLE
feat: excl dsconfig if doc is out of view & add fetchMaintanedScope

### DIFF
--- a/front/temporal/tracker/activities.ts
+++ b/front/temporal/tracker/activities.ts
@@ -84,11 +84,10 @@ export async function trackersGenerationActivity(
   }
 
   const trackers =
-    await TrackerConfigurationResource.fetchAllWatchedForDocument(
-      auth,
+    await TrackerConfigurationResource.fetchAllWatchedForDocument(auth, {
       dataSourceId,
-      docParentIds
-    );
+      parentIds: docParentIds,
+    });
 
   if (!trackers.length) {
     localLogger.info("No active trackers found for document.");


### PR DESCRIPTION
## Description

`fetchAllWatchedForDocument` should not return tracker resources if the watched scope's view doesn't include the doc.
This is done in-memory by fetching the view (including the parentsIn) and ensuring there is overlap between the doc's parentsIn and the view's parentsIn.

added `fetchMaintainedScope`  that is not yet used 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
