### PR TITLE
Dust configuration: Use globalSpace data source views 

### DIFF
--- a/front/pages/w/[wId]/builder/assistants/dust.tsx
+++ b/front/pages/w/[wId]/builder/assistants/dust.tsx
@@ -26,7 +26,6 @@ import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
-import { useDataSources } from "@app/lib/swr/data_sources";
 import { useSpaceDataSourceViews } from "@app/lib/swr/spaces";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
@@ -194,7 +193,7 @@ export default function EditDustAssistant({
             <>
               <Page.SectionHeader
                 title="Availability"
-                description="The Dust assistant requres at least one data source to be enabled."
+                description="The Dust assistant requires at least one data source to be enabled."
               />
 
               <ContextItem
@@ -225,7 +224,7 @@ export default function EditDustAssistant({
             <>
               <Page.SectionHeader
                 title="Data Sources and Connections"
-                description="Configure which connections and data sources will be searched by the Dust assistant."
+                description="Configure which Company Data connections and data sources will be searched by the Dust assistant."
               />
               <>
                 {
@@ -269,14 +268,14 @@ export default function EditDustAssistant({
             <>
               <Page.SectionHeader
                 title="This workspace doesn't currently have any data sources."
-                description="Add connections or data sources to enable the Dust assistant."
+                description="Add Company Data connections or data sources to enable the Dust assistant."
                 action={{
-                  label: "Add connections",
+                  label: "Add data",
                   variant: "primary",
                   icon: PlusIcon,
                   onClick: async () => {
                     await router.push(
-                      `/w/${owner.sId}/builder/data-sources/managed`
+                      `/w/${owner.sId}/spaces/${globalSpace.sId}`
                     );
                   },
                 }}

--- a/front/pages/w/[wId]/builder/assistants/dust.tsx
+++ b/front/pages/w/[wId]/builder/assistants/dust.tsx
@@ -12,6 +12,7 @@ import type {
   APIError,
   DataSourceType,
   LightAgentConfigurationType,
+  SpaceType,
   SubscriptionType,
   WorkspaceType,
 } from "@dust-tt/types";
@@ -23,12 +24,15 @@ import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitl
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import { useDataSources } from "@app/lib/swr/data_sources";
+import { useSpaceDataSourceViews } from "@app/lib/swr/spaces";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
+  globalSpace: SpaceType;
 }>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
@@ -39,10 +43,13 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
+  const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
+
   return {
     props: {
       owner,
       subscription,
+      globalSpace: globalSpace.toJSON(),
     },
   };
 });
@@ -50,6 +57,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
 export default function EditDustAssistant({
   owner,
   subscription,
+  globalSpace,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
   const sendNotification = useSendNotification();
@@ -61,16 +69,33 @@ export default function EditDustAssistant({
     workspaceId: owner.sId,
     agentsGetView: "global",
   });
-  const { dataSources, mutateDataSources } = useDataSources(owner);
 
-  const sortedDatasources = dataSources.sort((a, b) => {
-    if (a.connectorProvider && !b.connectorProvider) {
+  const { spaceDataSourceViews, mutate: mutateDataSourceViews } =
+    useSpaceDataSourceViews({
+      workspaceId: owner.sId,
+      spaceId: globalSpace.sId,
+    });
+
+  const sortedDatasources = spaceDataSourceViews.sort((a, b) => {
+    if (a.dataSource.connectorProvider && !b.dataSource.connectorProvider) {
       return -1;
     }
-    if (!a.connectorProvider && b.connectorProvider) {
+    if (!a.dataSource.connectorProvider && b.dataSource.connectorProvider) {
       return 1;
     }
-    return a.name.localeCompare(b.name);
+    if (
+      a.dataSource.connectorProvider === "webcrawler" &&
+      b.dataSource.connectorProvider !== "webcrawler"
+    ) {
+      return 1;
+    }
+    if (
+      a.dataSource.connectorProvider !== "webcrawler" &&
+      b.dataSource.connectorProvider === "webcrawler"
+    ) {
+      return -1;
+    }
+    return a.dataSource.name.localeCompare(b.dataSource.name);
   });
 
   const dustAgentConfiguration = agentConfigurations?.find(
@@ -139,7 +164,7 @@ export default function EditDustAssistant({
         `Failed to update the Data Source (contact support@dust.tt for assistance) (internal error: type=${err.error.type} message=${err.error.message})`
       );
     }
-    await mutateDataSources();
+    await mutateDataSourceViews();
     await mutateAgentConfigurations();
   };
 
@@ -165,7 +190,7 @@ export default function EditDustAssistant({
       />
       <div className="flex flex-col space-y-8 pb-8 pt-8">
         <div className="flex w-full flex-col gap-4">
-          {!!dataSources.length && (
+          {!!spaceDataSourceViews.length && (
             <>
               <Page.SectionHeader
                 title="Availability"
@@ -195,7 +220,7 @@ export default function EditDustAssistant({
               />
             </>
           )}
-          {dataSources.length &&
+          {spaceDataSourceViews.length &&
           dustAgentConfiguration?.status !== "disabled_by_admin" ? (
             <>
               <Page.SectionHeader
@@ -205,28 +230,30 @@ export default function EditDustAssistant({
               <>
                 {
                   <ContextItem.List>
-                    {sortedDatasources.map((ds) => (
+                    {sortedDatasources.map((dsView) => (
                       <ContextItem
-                        key={ds.id}
-                        title={getDisplayNameForDataSource(ds)}
+                        key={dsView.id}
+                        title={getDisplayNameForDataSource(dsView.dataSource)}
                         visual={
                           <ContextItem.Visual
                             visual={getConnectorProviderLogoWithFallback(
-                              ds.connectorProvider,
+                              dsView.dataSource.connectorProvider,
                               CloudArrowDownIcon
                             )}
                           />
                         }
                         action={
                           <SliderToggle
-                            selected={ds.assistantDefaultSelected}
+                            selected={
+                              dsView.dataSource.assistantDefaultSelected
+                            }
                             onClick={async () => {
                               await updateDatasourceSettings(
                                 {
                                   assistantDefaultSelected:
-                                    !ds.assistantDefaultSelected,
+                                    !dsView.dataSource.assistantDefaultSelected,
                                 },
-                                ds
+                                dsView.dataSource
                               );
                             }}
                           />


### PR DESCRIPTION
## Description

As we execute the dust global agent we filter by data sources that are in the global workspace. This PR applies the same filter for the configuration page.

Next step is to move the boolean associated with this in DB out of data sources and into data source views.

Useful query related: https://metabase.dust.tt/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7Im5hdGl2ZSI6eyJxdWVyeSI6Ii0tIFNFTEVDVCBcImFzc2lzdGFudERlZmF1bHRTZWxlY3RlZFwiLCBcImNvbm5lY3RvclByb3ZpZGVyXCIgRlJPTSBkYXRhX3NvdXJjZXMgV0hFUkUgXCJhc3Npc3RhbnREZWZhdWx0U2VsZWN0ZWRcIiA9IHRydWUgQU5EIFwiY29ubmVjdG9yUHJvdmlkZXJcIiBJUyBOVUxMO1xuXG5TRUxFQ1QgXG4gIGRzLmlkLFxuICBkcy5cImFzc2lzdGFudERlZmF1bHRTZWxlY3RlZFwiLCBcbiAgZHMuXCJjb25uZWN0b3JQcm92aWRlclwiLFxuICBkc3YuaWQgYXMgXCJkYXRhU291cmNlVmlld0lkXCIsXG4gIHYuaWQgYXMgXCJ2YXVsdElkXCIsXG4gIHYua2luZCBhcyBcInZhdWx0S2luZFwiLFxuICBnLmlkIGFzIFwiZ3JvdXBJZFwiLFxuICBnLmtpbmQgYXMgXCJncm91cEtpbmRcIlxuRlJPTSBcbiAgXCJkYXRhX3NvdXJjZXNcIiBkc1xuSk9JTiBcbiAgXCJkYXRhX3NvdXJjZV92aWV3c1wiIGRzdiBPTiBkcy5cImlkXCIgPSBkc3YuXCJkYXRhU291cmNlSWRcIlxuSk9JTiBcbiAgXCJ2YXVsdHNcIiB2IE9OIGRzdi5cInZhdWx0SWRcIiA9IHYuXCJpZFwiXG5KT0lOXG4gIFwiZ3JvdXBfdmF1bHRzXCIgZ3Ygb24gZ3YuXCJ2YXVsdElkXCIgPSB2LlwiaWRcIlxuSk9JTlxuICBcImdyb3Vwc1wiIGcgb24gZy5pZCA9IGd2LlwiZ3JvdXBJZFwiXG5XSEVSRSBcbiAgZHMuXCJhc3Npc3RhbnREZWZhdWx0U2VsZWN0ZWRcIiA9IHRydWUgXG4gIEFORCAoZHMuXCJjb25uZWN0b3JQcm92aWRlclwiIElTIE5VTEwgT1IgZHMuXCJjb25uZWN0b3JQcm92aWRlclwiPSd3ZWJjcmF3bGVyJylcbiAgQU5EIHYua2luZCAhPSAnZ2xvYmFsJzsiLCJ0ZW1wbGF0ZS10YWdzIjp7fX0sInR5cGUiOiJuYXRpdmUiLCJkYXRhYmFzZSI6NH0sImRpc3BsYXkiOiJ0YWJsZSIsInBhcmFtZXRlcnMiOltdLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7fSwidHlwZSI6InF1ZXN0aW9uIn0=

## Risk

Low

## Deploy Plan

- deploy `front`