### PR TITLE
[front] Fix google migrator 

### DIFF
--- a/front/migrations/20241211_parents_migrator.ts
+++ b/front/migrations/20241211_parents_migrator.ts
@@ -190,10 +190,12 @@ const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
   },
   google_drive: {
     transformer: (nodeId, parents) => {
-      const newParents = parents.map((id) =>
-        id.startsWith("gdrive-") || id.startsWith("google-spreadsheet-")
-          ? id
-          : `gdrive-${id}`
+      const newParents = _.uniq(
+        parents.map((id) =>
+          id.startsWith("gdrive-") || id.startsWith("google-spreadsheet-")
+            ? id
+            : `gdrive-${id}`
+        )
       );
 
       return {


### PR DESCRIPTION
## Description

Some tables that have not been rewritten may have duplicate entries ( [gdrive-xxx , xxx, ...] ) because of the auto addition of id at first position - removing to get a valid parentId
 
## Risk

n/a

## Deploy Plan

