### PR TITLE
[Keyword search] Index tables and folders in elasticsearch

### DIFF
--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -2896,23 +2896,29 @@ async fn folders_upsert(
         )
         .await
     {
-        Err(e) => {
-            return error_response(
+        Err(e) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "internal_server_error",
+            "Failed to upsert folder",
+            Some(e),
+        ),
+        Ok(folder) => match state.search_store.index_folder(&folder).await {
+            Ok(_) => (
+                StatusCode::OK,
+                Json(APIResponse {
+                    error: None,
+                    response: Some(json!({
+                        "folder": folder
+                    })),
+                }),
+            ),
+            Err(e) => error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "internal_server_error",
-                "Failed to upsert folder",
+                "Failed to index folder",
                 Some(e),
-            )
-        }
-        Ok(folder) => (
-            StatusCode::OK,
-            Json(APIResponse {
-                error: None,
-                response: Some(json!({
-                    "folder": folder
-                })),
-            }),
-        ),
+            ),
+        },
     }
 }
 

--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -2202,7 +2202,7 @@ async fn tables_upsert(
         )
         .await
     {
-        Ok(table) => match state.search_store.index_table(&table).await {
+        Ok(table) => match state.search_store.index_table(table.clone()).await {
             Ok(_) => (
                 StatusCode::OK,
                 Json(APIResponse {
@@ -2902,7 +2902,7 @@ async fn folders_upsert(
             "Failed to upsert folder",
             Some(e),
         ),
-        Ok(folder) => match state.search_store.index_folder(&folder).await {
+        Ok(folder) => match state.search_store.index_folder(folder.clone()).await {
             Ok(_) => (
                 StatusCode::OK,
                 Json(APIResponse {

--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -3077,6 +3077,7 @@ async fn folders_delete(
 }
 
 #[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 struct NodesSearchPayload {
     query: String,
     filter: Vec<DatasourceViewFilter>,

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -761,7 +761,7 @@ impl DataSource {
             .await?;
 
         // Upsert document in search index.
-        search_store.index_document(&document).await?;
+        search_store.index_document(document.clone()).await?;
 
         // Clean-up old superseded versions.
         self.scrub_document_superseded_versions(store, &document_id)

--- a/core/src/data_sources/folder.rs
+++ b/core/src/data_sources/folder.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use super::node::{Node, NodeType};
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Folder {
     data_source_id: String,
@@ -49,5 +51,20 @@ impl Folder {
     }
     pub fn parents(&self) -> &Vec<String> {
         &self.parents
+    }
+}
+
+impl From<Folder> for Node {
+    fn from(folder: Folder) -> Node {
+        Node::new(
+            &folder.data_source_id,
+            &folder.folder_id,
+            NodeType::Folder,
+            folder.timestamp,
+            &folder.title,
+            FOLDER_MIMETYPE,
+            folder.parent_id,
+            folder.parents,
+        )
     }
 }

--- a/core/src/data_sources/node.rs
+++ b/core/src/data_sources/node.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 use super::folder::Folder;
 
@@ -9,16 +10,26 @@ pub enum NodeType {
     Folder,
 }
 
+impl fmt::Display for NodeType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            NodeType::Document => write!(f, "Document"),
+            NodeType::Table => write!(f, "Table"),
+            NodeType::Folder => write!(f, "Folder"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Node {
-    data_source_id: String,
-    node_id: String,
-    node_type: NodeType,
-    timestamp: u64,
-    title: String,
-    mime_type: String,
-    parent_id: Option<String>,
-    parents: Vec<String>,
+    pub data_source_id: String,
+    pub node_id: String,
+    pub node_type: NodeType,
+    pub timestamp: u64,
+    pub title: String,
+    pub mime_type: String,
+    pub parent_id: Option<String>,
+    pub parents: Vec<String>,
 }
 
 impl Node {

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -8,8 +8,11 @@ use elasticsearch::{
 use serde_json::json;
 use url::Url;
 
-use crate::{data_sources::data_source::Document, utils};
 use crate::{data_sources::node::Node, databases::table::Table};
+use crate::{
+    data_sources::{data_source::Document, folder::Folder},
+    utils,
+};
 use tracing::{error, info};
 
 #[derive(serde::Deserialize)]

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -8,8 +8,8 @@ use elasticsearch::{
 use serde_json::json;
 use url::Url;
 
-use crate::data_sources::node::Node;
 use crate::{data_sources::data_source::Document, utils};
+use crate::{data_sources::node::Node, databases::table::Table};
 use tracing::{error, info};
 
 #[derive(serde::Deserialize)]
@@ -33,6 +33,8 @@ pub trait SearchStore {
         options: Option<NodesSearchOptions>,
     ) -> Result<Vec<Node>>;
     async fn index_document(&self, document: &Document) -> Result<()>;
+    async fn index_table(&self, table: &Table) -> Result<()>;
+    async fn index_folder(&self, folder: &Folder) -> Result<()>;
     async fn index_node(&self, node: Node) -> Result<()>;
     fn clone_box(&self) -> Box<dyn SearchStore + Sync + Send>;
 }
@@ -79,6 +81,16 @@ const NODES_INDEX_NAME: &str = "core.data_sources_nodes";
 impl SearchStore for ElasticsearchSearchStore {
     async fn index_document(&self, document: &Document) -> Result<()> {
         let node = Node::from(document.clone());
+        self.index_node(node).await
+    }
+
+    async fn index_table(&self, table: &Table) -> Result<()> {
+        let node = Node::from(table.clone());
+        self.index_node(node).await
+    }
+
+    async fn index_folder(&self, folder: &Folder) -> Result<()> {
+        let node = Node::from(folder.clone());
         self.index_node(node).await
     }
 

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -35,9 +35,9 @@ pub trait SearchStore {
         filter: Vec<DatasourceViewFilter>,
         options: Option<NodesSearchOptions>,
     ) -> Result<Vec<Node>>;
-    async fn index_document(&self, document: &Document) -> Result<()>;
-    async fn index_table(&self, table: &Table) -> Result<()>;
-    async fn index_folder(&self, folder: &Folder) -> Result<()>;
+    async fn index_document(&self, document: Document) -> Result<()>;
+    async fn index_table(&self, table: Table) -> Result<()>;
+    async fn index_folder(&self, folder: Folder) -> Result<()>;
     async fn index_node(&self, node: Node) -> Result<()>;
     fn clone_box(&self) -> Box<dyn SearchStore + Sync + Send>;
 }
@@ -82,18 +82,18 @@ const NODES_INDEX_NAME: &str = "core.data_sources_nodes";
 
 #[async_trait]
 impl SearchStore for ElasticsearchSearchStore {
-    async fn index_document(&self, document: &Document) -> Result<()> {
-        let node = Node::from(document.clone());
+    async fn index_document(&self, document: Document) -> Result<()> {
+        let node = Node::from(document);
         self.index_node(node).await
     }
 
-    async fn index_table(&self, table: &Table) -> Result<()> {
-        let node = Node::from(table.clone());
+    async fn index_table(&self, table: Table) -> Result<()> {
+        let node = Node::from(table);
         self.index_node(node).await
     }
 
-    async fn index_folder(&self, folder: &Folder) -> Result<()> {
-        let node = Node::from(folder.clone());
+    async fn index_folder(&self, folder: Folder) -> Result<()> {
+        let node = Node::from(folder);
         self.index_node(node).await
     }
 

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -124,12 +124,14 @@ impl SearchStore for ElasticsearchSearchStore {
         // First, collect all datasource_ids and their corresponding view_filters
         let mut filter_conditions = Vec::new();
         for f in filter {
+            let mut must_clause = Vec::new();
+            must_clause.push(json!({ "term": { "data_source_id": f.data_source_id } }));
+            if !f.view_filter.is_empty() {
+                must_clause.push(json!({ "terms": { "parents": f.view_filter } }));
+            }
             filter_conditions.push(json!({
                 "bool": {
-                    "must": [
-                        { "term": { "data_source_id": f.data_source_id } },
-                        { "terms": { "parents": f.view_filter } }
-                    ]
+                    "must": must_clause
                 }
             }));
         }


### PR DESCRIPTION
## Description
Fixes #9391 and #9392 

As for previous deploy of #9384 , we currently ignore indexation failures rather than failing the upsert.

Also fixed search query for search_nodes so an empty view_filter searches across all the data source

## Risk
Raising indexation load. Pretty robust since 100% of documents are already indexed and no issue yet, volume should be lower there

Dashboard 
## Deploy Plan
core
monitor [elasticsearch dashboard](https://app.datadoghq.eu/dashboard/ss3-x6k-9kr?fromUser=false&refresh_mode=sliding&from_ts=1734440507236&to_ts=1734454907236&live=true)
