### PR TITLE
[parents_migration] Migrate github connector to new IDs in content nodes

### DIFF
--- a/connectors/migrations/20230906_3_github_fill_parents_field.ts
+++ b/connectors/migrations/20230906_3_github_fill_parents_field.ts
@@ -2,8 +2,8 @@ import { existsSync, readFileSync, writeFileSync } from "fs";
 import { Op } from "sequelize";
 
 import {
-  getDiscussionNodeId,
-  getIssueNodeId,
+  getDiscussionInternalId,
+  getIssueInternalId,
 } from "@connectors/connectors/github/lib/utils";
 import { updateDocumentParentsField } from "@connectors/lib/data_sources";
 import { GithubDiscussion, GithubIssue } from "@connectors/lib/models/github";
@@ -77,7 +77,7 @@ async function updateDiscussionsParentsFieldForConnector(
     // update parents field for each document of the chunk, in parallel
     await Promise.all(
       chunk.map(async (document) => {
-        const docId = getDiscussionNodeId(
+        const docId = getDiscussionInternalId(
           document.repoId,
           document.discussionNumber
         );
@@ -85,7 +85,7 @@ async function updateDiscussionsParentsFieldForConnector(
           dataSourceConfig: connector,
           documentId: docId,
           parents: [
-            getDiscussionNodeId(document.repoId, document.discussionNumber),
+            getDiscussionInternalId(document.repoId, document.discussionNumber),
             document.repoId,
           ],
         });
@@ -110,12 +110,12 @@ async function updateIssuesParentsFieldForConnector(connector: ConnectorModel) {
     // update parents field for each document of the chunk, in parallel
     await Promise.all(
       chunk.map(async (document) => {
-        const docId = getIssueNodeId(document.repoId, document.issueNumber);
+        const docId = getIssueInternalId(document.repoId, document.issueNumber);
         await updateDocumentParentsField({
           dataSourceConfig: connector,
           documentId: docId,
           parents: [
-            getIssueNodeId(document.repoId, document.issueNumber),
+            getIssueInternalId(document.repoId, document.issueNumber),
             document.repoId,
           ],
         });

--- a/connectors/migrations/20240102_github_add_issues_discussions_parents.ts
+++ b/connectors/migrations/20240102_github_add_issues_discussions_parents.ts
@@ -1,6 +1,6 @@
 import {
-  getDiscussionNodeId,
-  getIssueNodeId,
+  getDiscussionInternalId,
+  getIssueInternalId,
 } from "@connectors/connectors/github/lib/utils";
 import { updateDocumentParentsField } from "@connectors/lib/data_sources";
 import { GithubDiscussion, GithubIssue } from "@connectors/lib/models/github";
@@ -38,7 +38,10 @@ async function updateParents(connector: ConnectorModel) {
   for (const chunk of discussionChunks) {
     await Promise.all(
       chunk.map(async (d) => {
-        const documentId = getDiscussionNodeId(d.repoId, d.discussionNumber);
+        const documentId = getDiscussionInternalId(
+          d.repoId,
+          d.discussionNumber
+        );
         const parents = [documentId, `${d.repoId}-discussions`, d.repoId];
         if (LIVE) {
           await updateDocumentParentsField({
@@ -68,7 +71,7 @@ async function updateParents(connector: ConnectorModel) {
   for (const chunk of issueChunks) {
     await Promise.all(
       chunk.map(async (i) => {
-        const documentId = getIssueNodeId(i.repoId, i.issueNumber);
+        const documentId = getIssueInternalId(i.repoId, i.issueNumber);
         const parents = [documentId, `${i.repoId}-issues`, i.repoId];
         if (LIVE) {
           await updateDocumentParentsField({

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -297,33 +297,27 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         case "REPO_FULL": {
           const [latestDiscussion, latestIssue, repoRes, codeRepo] =
             await Promise.all([
-              (async () => {
-                return GithubDiscussion.findOne({
-                  where: {
-                    connectorId: c.id,
-                    repoId: repoId.toString(),
-                  },
-                  order: [["updatedAt", "DESC"]],
-                });
-              })(),
-              (async () => {
-                return GithubIssue.findOne({
-                  where: {
-                    connectorId: c.id,
-                    repoId: repoId.toString(),
-                  },
-                  order: [["updatedAt", "DESC"]],
-                });
-              })(),
+              GithubDiscussion.findOne({
+                where: {
+                  connectorId: c.id,
+                  repoId: repoId.toString(),
+                },
+                order: [["updatedAt", "DESC"]],
+              }),
+              GithubIssue.findOne({
+                where: {
+                  connectorId: c.id,
+                  repoId: repoId.toString(),
+                },
+                order: [["updatedAt", "DESC"]],
+              }),
               getRepo(connectionId, repoId),
-              (async () => {
-                return GithubCodeRepository.findOne({
-                  where: {
-                    connectorId: c.id,
-                    repoId: repoId.toString(),
-                  },
-                });
-              })(),
+              GithubCodeRepository.findOne({
+                where: {
+                  connectorId: c.id,
+                  repoId: repoId.toString(),
+                },
+              }),
             ]);
 
           if (repoRes.isErr()) {

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -17,11 +17,11 @@ import {
   getGithubCodeFileParentIds,
 } from "@connectors/connectors/github/lib/hierarchy";
 import {
-  getCodeRootNodeId,
-  getDiscussionsNodeId,
-  getIssuesNodeId,
-  getRepositoryNodeId,
-  matchGithubNodeIdType,
+  getCodeRootInternalId,
+  getDiscussionsInternalId,
+  getIssuesInternalId,
+  getRepositoryInternalId,
+  matchGithubInternalIdType,
 } from "@connectors/connectors/github/lib/utils";
 import { launchGithubFullSyncWorkflow } from "@connectors/connectors/github/temporal/client";
 import type {
@@ -272,7 +272,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         nodes = nodes.concat(
           page.map((repo) => ({
             provider: c.type,
-            internalId: getRepositoryNodeId(repo.id),
+            internalId: getRepositoryInternalId(repo.id),
             parentInternalId: null,
             type: "folder",
             title: repo.name,
@@ -291,7 +291,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
 
       return new Ok(nodes);
     } else {
-      const { type, repoId } = matchGithubNodeIdType(parentInternalId);
+      const { type, repoId } = matchGithubInternalIdType(parentInternalId);
       if (isNaN(repoId)) {
         return new Err(new Error(`Invalid repoId: ${parentInternalId}`));
       }
@@ -334,7 +334,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
           if (latestIssue) {
             nodes.push({
               provider: c.type,
-              internalId: getIssuesNodeId(repoId),
+              internalId: getIssuesInternalId(repoId),
               parentInternalId,
               type: "database",
               title: "Issues",
@@ -349,7 +349,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
           if (latestDiscussion) {
             nodes.push({
               provider: c.type,
-              internalId: getDiscussionsNodeId(repoId),
+              internalId: getDiscussionsInternalId(repoId),
               parentInternalId,
               type: "channel",
               title: "Discussions",
@@ -364,7 +364,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
           if (codeRepo) {
             nodes.push({
               provider: c.type,
-              internalId: getCodeRootNodeId(repoId),
+              internalId: getCodeRootInternalId(repoId),
               parentInternalId,
               type: "folder",
               title: "Code",
@@ -478,7 +478,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
 
     // We loop on all the internalIds we receive to know what is the related data type
     internalIds.forEach((internalId) => {
-      const { type, repoId } = matchGithubNodeIdType(internalId);
+      const { type, repoId } = matchGithubInternalIdType(internalId);
       allReposIdsToFetch.add(repoId);
 
       switch (type) {
@@ -552,7 +552,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
       }
       nodes.push({
         provider: c.type,
-        internalId: getRepositoryNodeId(repoId),
+        internalId: getRepositoryInternalId(repoId),
         parentInternalId: null,
         type: "folder",
         title: repo.name,
@@ -573,8 +573,8 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
       }
       nodes.push({
         provider: c.type,
-        internalId: getIssuesNodeId(repoId),
-        parentInternalId: getRepositoryNodeId(repoId),
+        internalId: getIssuesInternalId(repoId),
+        parentInternalId: getRepositoryInternalId(repoId),
         type: "database",
         title: "Issues",
         titleWithParentsContext: `[${repo.name}] Issues`,
@@ -592,8 +592,8 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
       }
       nodes.push({
         provider: c.type,
-        internalId: getDiscussionsNodeId(repoId),
-        parentInternalId: getRepositoryNodeId(repoId),
+        internalId: getDiscussionsInternalId(repoId),
+        parentInternalId: getRepositoryInternalId(repoId),
         type: "channel",
         title: "Discussions",
         titleWithParentsContext: `[${repo.name}] Discussions`,
@@ -610,8 +610,8 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
       const repo = uniqueRepos[parseInt(codeRepo.repoId)];
       nodes.push({
         provider: c.type,
-        internalId: getCodeRootNodeId(codeRepo.repoId),
-        parentInternalId: getRepositoryNodeId(codeRepo.repoId),
+        internalId: getCodeRootInternalId(codeRepo.repoId),
+        parentInternalId: getRepositoryInternalId(codeRepo.repoId),
         type: "folder",
         title: "Code",
         titleWithParentsContext: repo ? `[${repo.name}] Code` : "Code",
@@ -679,7 +679,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
       );
     }
 
-    const { type, repoId } = matchGithubNodeIdType(internalId);
+    const { type, repoId } = matchGithubInternalIdType(internalId);
 
     switch (type) {
       case "REPO_FULL": {
@@ -687,10 +687,10 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
       }
       case "REPO_ISSUES":
       case "REPO_DISCUSSIONS": {
-        return new Ok([internalId, getRepositoryNodeId(repoId)]);
+        return new Ok([internalId, getRepositoryInternalId(repoId)]);
       }
       case "REPO_CODE": {
-        return new Ok([internalId, getRepositoryNodeId(repoId)]);
+        return new Ok([internalId, getRepositoryInternalId(repoId)]);
       }
       case "REPO_CODE_DIR": {
         const parents = await getGithubCodeDirectoryParentIds(

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -13,7 +13,13 @@ import {
   installationIdFromConnectionId,
 } from "@connectors/connectors/github/lib/github_api";
 import { getGithubCodeOrDirectoryParentIds } from "@connectors/connectors/github/lib/hierarchy";
-import { matchGithubNodeIdType } from "@connectors/connectors/github/lib/utils";
+import {
+  getCodeRootNodeId,
+  getDiscussionsNodeId,
+  getIssuesNodeId,
+  getRepositoryNodeId,
+  matchGithubNodeIdType,
+} from "@connectors/connectors/github/lib/utils";
 import { launchGithubFullSyncWorkflow } from "@connectors/connectors/github/temporal/client";
 import type {
   CreateConnectorErrorCode,
@@ -547,7 +553,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
       }
       nodes.push({
         provider: c.type,
-        internalId: repoId.toString(),
+        internalId: getRepositoryNodeId(repoId),
         parentInternalId: null,
         type: "folder",
         title: repo.name,
@@ -568,8 +574,8 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
       }
       nodes.push({
         provider: c.type,
-        internalId: `${repoId}-issues`,
-        parentInternalId: repoId.toString(),
+        internalId: getIssuesNodeId(repoId),
+        parentInternalId: getRepositoryNodeId(repoId),
         type: "database",
         title: "Issues",
         titleWithParentsContext: `[${repo.name}] Issues`,
@@ -587,8 +593,8 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
       }
       nodes.push({
         provider: c.type,
-        internalId: `${repoId}-discussions`,
-        parentInternalId: repoId.toString(),
+        internalId: getDiscussionsNodeId(repoId),
+        parentInternalId: getRepositoryNodeId(repoId),
         type: "channel",
         title: "Discussions",
         titleWithParentsContext: `[${repo.name}] Discussions`,
@@ -605,8 +611,8 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
       const repo = uniqueRepos[parseInt(codeRepo.repoId)];
       nodes.push({
         provider: c.type,
-        internalId: `github-code-${codeRepo.repoId}`,
-        parentInternalId: codeRepo.repoId,
+        internalId: getCodeRootNodeId(codeRepo.repoId),
+        parentInternalId: getRepositoryNodeId(codeRepo.repoId),
         type: "folder",
         title: "Code",
         titleWithParentsContext: repo ? `[${repo.name}] Code` : "Code",

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -673,8 +673,6 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
     internalId: string;
     memoizationKey?: string;
   }): Promise<Result<string[], Error>> {
-    const baseParents: string[] = [internalId];
-
     const connector = await ConnectorResource.fetchById(this.connectorId);
     if (!connector) {
       return new Err(
@@ -686,14 +684,14 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
 
     switch (type) {
       case "REPO_FULL": {
-        return new Ok(baseParents);
+        return new Ok([internalId]);
       }
       case "REPO_ISSUES":
       case "REPO_DISCUSSIONS": {
-        return new Ok([...baseParents, getRepositoryNodeId(repoId)]);
+        return new Ok([internalId, getRepositoryNodeId(repoId)]);
       }
       case "REPO_CODE": {
-        return new Ok([...baseParents, getRepositoryNodeId(repoId)]);
+        return new Ok([internalId, getRepositoryNodeId(repoId)]);
       }
       case "REPO_CODE_DIR":
       case "REPO_CODE_FILE": {
@@ -702,7 +700,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
           internalId,
           repoId
         );
-        return new Ok([...baseParents, ...parents]);
+        return new Ok([internalId, ...parents]);
       }
       default: {
         assertNever(type);

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -289,12 +289,12 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
       return new Ok(nodes);
     } else {
       const { type, repoId } = matchGithubNodeIdType(parentInternalId);
+      if (isNaN(repoId)) {
+        return new Err(new Error(`Invalid repoId: ${parentInternalId}`));
+      }
+
       switch (type) {
         case "REPO_FULL": {
-          if (isNaN(repoId)) {
-            return new Err(new Error(`Invalid repoId: ${parentInternalId}`));
-          }
-
           const [latestDiscussion, latestIssue, repoRes, codeRepo] =
             await Promise.all([
               (async () => {

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -17,6 +17,7 @@ import {
   getCodeRootNodeId,
   getDiscussionsNodeId,
   getIssuesNodeId,
+  getRepositoryIdFromNodeId,
   getRepositoryNodeId,
   matchGithubNodeIdType,
 } from "@connectors/connectors/github/lib/utils";
@@ -269,7 +270,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         nodes = nodes.concat(
           page.map((repo) => ({
             provider: c.type,
-            internalId: repo.id.toString(),
+            internalId: getRepositoryNodeId(repo.id),
             parentInternalId: null,
             type: "folder",
             title: repo.name,
@@ -352,7 +353,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         // If parentInternalId is set and does not start with `github-code` it means that it is
         // supposed to be the repoId. We support issues and discussions and also want to add the code
         // repo resource if it exists (code sync enabled).
-        const repoId = parseInt(parentInternalId, 10);
+        const repoId = getRepositoryIdFromNodeId(parentInternalId);
         if (isNaN(repoId)) {
           return new Err(new Error(`Invalid repoId: ${parentInternalId}`));
         }
@@ -401,7 +402,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         if (latestIssue) {
           nodes.push({
             provider: c.type,
-            internalId: `${repoId}-issues`,
+            internalId: getIssuesNodeId(repoId),
             parentInternalId,
             type: "database",
             title: "Issues",
@@ -416,7 +417,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         if (latestDiscussion) {
           nodes.push({
             provider: c.type,
-            internalId: `${repoId}-discussions`,
+            internalId: getDiscussionsNodeId(repoId),
             parentInternalId,
             type: "channel",
             title: "Discussions",
@@ -431,7 +432,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         if (codeRepo) {
           nodes.push({
             provider: c.type,
-            internalId: `github-code-${repoId}`,
+            internalId: getCodeRootNodeId(repoId),
             parentInternalId,
             type: "folder",
             title: "Code",

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -12,7 +12,10 @@ import {
   getReposPage,
   installationIdFromConnectionId,
 } from "@connectors/connectors/github/lib/github_api";
-import { getGithubCodeOrDirectoryParentIds } from "@connectors/connectors/github/lib/hierarchy";
+import {
+  getGithubCodeDirectoryParentIds,
+  getGithubCodeFileParentIds,
+} from "@connectors/connectors/github/lib/hierarchy";
 import {
   getCodeRootNodeId,
   getDiscussionsNodeId,
@@ -693,9 +696,16 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
       case "REPO_CODE": {
         return new Ok([internalId, getRepositoryNodeId(repoId)]);
       }
-      case "REPO_CODE_DIR":
+      case "REPO_CODE_DIR": {
+        const parents = await getGithubCodeDirectoryParentIds(
+          connector.id,
+          internalId,
+          repoId
+        );
+        return new Ok([internalId, ...parents]);
+      }
       case "REPO_CODE_FILE": {
-        const parents = await getGithubCodeOrDirectoryParentIds(
+        const parents = await getGithubCodeFileParentIds(
           connector.id,
           internalId,
           repoId

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -381,22 +381,18 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         case "REPO_CODE":
         case "REPO_CODE_DIR": {
           const [files, directories] = await Promise.all([
-            (async () => {
-              return GithubCodeFile.findAll({
-                where: {
-                  connectorId: c.id,
-                  parentInternalId,
-                },
-              });
-            })(),
-            (async () => {
-              return GithubCodeDirectory.findAll({
-                where: {
-                  connectorId: c.id,
-                  parentInternalId,
-                },
-              });
-            })(),
+            GithubCodeFile.findAll({
+              where: {
+                connectorId: c.id,
+                parentInternalId,
+              },
+            }),
+            GithubCodeDirectory.findAll({
+              where: {
+                connectorId: c.id,
+                parentInternalId,
+              },
+            }),
           ]);
 
           files.sort((a, b) => {

--- a/connectors/src/connectors/github/lib/github_api.ts
+++ b/connectors/src/connectors/github/lib/github_api.ts
@@ -883,7 +883,8 @@ export async function processRepository({
         sizeBytes: size,
         documentId,
         parentInternalId,
-        parents: [documentId, ...parents.map((p) => p.internalId)],
+        /// we reverse the parents here since the convention is bottom to top
+        parents: [documentId, ...parents.map((p) => p.internalId).reverse()],
         localFilePath: file,
       });
 

--- a/connectors/src/connectors/github/lib/github_api.ts
+++ b/connectors/src/connectors/github/lib/github_api.ts
@@ -30,8 +30,8 @@ import {
   GetRepoDiscussionsPayloadSchema,
 } from "@connectors/connectors/github/lib/github_graphql";
 import {
-  getCodeDirNodeId,
-  getCodeFileNodeId,
+  getCodeDirInternalId,
+  getCodeFileInternalId,
 } from "@connectors/connectors/github/lib/utils";
 import { apiConfig } from "@connectors/lib/api/config";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
@@ -851,7 +851,7 @@ export async function processRepository({
 
       const parents = [];
       for (let i = 0; i < path.length; i++) {
-        const pathInternalId = getCodeDirNodeId(
+        const pathInternalId = getCodeDirInternalId(
           repoId,
           path.slice(0, i + 1).join("/")
         );
@@ -862,7 +862,7 @@ export async function processRepository({
         });
       }
 
-      const documentId = getCodeFileNodeId(
+      const documentId = getCodeFileInternalId(
         repoId,
         `${path.join("/")}/${fileName}`
       );

--- a/connectors/src/connectors/github/lib/hierarchy.ts
+++ b/connectors/src/connectors/github/lib/hierarchy.ts
@@ -25,7 +25,7 @@ export async function getGithubCodeDirectoryParentIds(
     return [];
   }
 
-  if (directory.parentInternalId.startsWith(`github-code-${repoId}-dir`)) {
+  if (/^github-code-\d+-dir-[a-f0-9]+$/.test(directory.parentInternalId)) {
     // Pull the directory.
     const parents = await getGithubCodeDirectoryParentIds(
       connectorId,
@@ -33,8 +33,8 @@ export async function getGithubCodeDirectoryParentIds(
       repoId
     );
     return [directory.parentInternalId, ...parents];
-  } else if (directory.parentInternalId === `github-code-${repoId}`) {
-    return [`github-code-${repoId}`, `${repoId}`];
+  } else if (directory.parentInternalId === getCodeRootNodeId(repoId)) {
+    return [directory.parentInternalId, getRepositoryNodeId(repoId)];
   }
   return [];
 }
@@ -55,7 +55,7 @@ export async function getGithubCodeFileParentIds(
     return [];
   }
 
-  if (file.parentInternalId.startsWith(`github-code-${repoId}-dir`)) {
+  if (/^github-code-\d+-dir-[a-f0-9]+$/.test(file.parentInternalId)) {
     // Pull the directory.
     const parents = await getGithubCodeDirectoryParentIds(
       connectorId,
@@ -63,8 +63,8 @@ export async function getGithubCodeFileParentIds(
       repoId
     );
     return [file.parentInternalId, ...parents];
-  } else if (file.parentInternalId === `github-code-${repoId}`) {
-    return [`${repoId}`, `github-code-${repoId}`];
+  } else if (file.parentInternalId === getCodeRootNodeId(repoId)) {
+    return [file.parentInternalId, getRepositoryNodeId(repoId)];
   }
   return [];
 }

--- a/connectors/src/connectors/github/lib/hierarchy.ts
+++ b/connectors/src/connectors/github/lib/hierarchy.ts
@@ -1,8 +1,8 @@
 import type { ModelId } from "@dust-tt/types";
 
 import {
-  getCodeRootNodeId,
-  getRepositoryNodeId,
+  getCodeRootInternalId,
+  getRepositoryInternalId,
   isGithubCodeDirId,
 } from "@connectors/connectors/github/lib/utils";
 import {
@@ -34,8 +34,8 @@ export async function getGithubCodeDirectoryParentIds(
       repoId
     );
     return [directory.parentInternalId, ...parents];
-  } else if (directory.parentInternalId === getCodeRootNodeId(repoId)) {
-    return [directory.parentInternalId, getRepositoryNodeId(repoId)];
+  } else if (directory.parentInternalId === getCodeRootInternalId(repoId)) {
+    return [directory.parentInternalId, getRepositoryInternalId(repoId)];
   }
   return [];
 }
@@ -64,8 +64,8 @@ export async function getGithubCodeFileParentIds(
       repoId
     );
     return [file.parentInternalId, ...parents];
-  } else if (file.parentInternalId === getCodeRootNodeId(repoId)) {
-    return [file.parentInternalId, getRepositoryNodeId(repoId)];
+  } else if (file.parentInternalId === getCodeRootInternalId(repoId)) {
+    return [file.parentInternalId, getRepositoryInternalId(repoId)];
   }
   return [];
 }

--- a/connectors/src/connectors/github/lib/hierarchy.ts
+++ b/connectors/src/connectors/github/lib/hierarchy.ts
@@ -3,6 +3,7 @@ import type { ModelId } from "@dust-tt/types";
 import {
   getCodeRootNodeId,
   getRepositoryNodeId,
+  isGithubCodeDirId,
 } from "@connectors/connectors/github/lib/utils";
 import {
   GithubCodeDirectory,
@@ -25,7 +26,7 @@ export async function getGithubCodeDirectoryParentIds(
     return [];
   }
 
-  if (/^github-code-\d+-dir-[a-f0-9]+$/.test(directory.parentInternalId)) {
+  if (isGithubCodeDirId(directory.parentInternalId)) {
     // Pull the directory.
     const parents = await getGithubCodeDirectoryParentIds(
       connectorId,
@@ -55,7 +56,7 @@ export async function getGithubCodeFileParentIds(
     return [];
   }
 
-  if (/^github-code-\d+-dir-[a-f0-9]+$/.test(file.parentInternalId)) {
+  if (isGithubCodeDirId(file.parentInternalId)) {
     // Pull the directory.
     const parents = await getGithubCodeDirectoryParentIds(
       connectorId,

--- a/connectors/src/connectors/github/lib/hierarchy.ts
+++ b/connectors/src/connectors/github/lib/hierarchy.ts
@@ -1,25 +1,15 @@
 import type { ModelId } from "@dust-tt/types";
 
 import {
+  getCodeRootNodeId,
+  getRepositoryNodeId,
+} from "@connectors/connectors/github/lib/utils";
+import {
   GithubCodeDirectory,
   GithubCodeFile,
 } from "@connectors/lib/models/github";
 
-export async function getGithubCodeOrDirectoryParentIds(
-  connectorId: ModelId,
-  internalId: string,
-  repoId: number
-): Promise<string[]> {
-  if (internalId.startsWith(`github-code-${repoId}-dir`)) {
-    return getGithubCodeDirectoryParentIds(connectorId, internalId, repoId);
-  }
-  if (internalId.startsWith(`github-code-${repoId}-file`)) {
-    return getGithubCodeFileParentIds(connectorId, internalId, repoId);
-  }
-  return [];
-}
-
-async function getGithubCodeDirectoryParentIds(
+export async function getGithubCodeDirectoryParentIds(
   connectorId: ModelId,
   internalId: string,
   repoId: number
@@ -49,7 +39,7 @@ async function getGithubCodeDirectoryParentIds(
   return [];
 }
 
-async function getGithubCodeFileParentIds(
+export async function getGithubCodeFileParentIds(
   connectorId: ModelId,
   internalId: string,
   repoId: number

--- a/connectors/src/connectors/github/lib/utils.ts
+++ b/connectors/src/connectors/github/lib/utils.ts
@@ -17,25 +17,25 @@ export function matchGithubNodeIdType(internalId: string): {
   type: GithubContentNodeType;
   repoId: number;
 } {
-  // Full repo is selected, format = "12345678"
-  if (/^\d+$/.test(internalId)) {
+  // Full repo is selected, format = "github-repository-12345678"
+  if (/^github-repository-\d+$/.test(internalId)) {
     return {
       type: "REPO_FULL",
-      repoId: parseInt(internalId, 10),
+      repoId: parseInt(internalId.replace(/^github-repository-/, ""), 10),
     };
   }
-  // All issues from repo are selected, format = "12345678-issues"
-  if (/\d+-issues$/.test(internalId)) {
+  // All issues from repo are selected, format = "github-issues-12345678"
+  if (/^github-issues-\d+$/.test(internalId)) {
     return {
       type: "REPO_ISSUES",
-      repoId: parseInt(internalId.replace(/-issues$/, ""), 10),
+      repoId: parseInt(internalId.replace(/^github-issues-/, ""), 10),
     };
   }
-  // All discussions from repo are selected, format = "12345678-discussions"
-  if (/\d+-discussions$/.test(internalId)) {
+  // All discussions from repo are selected, format = "github-discussions-12345678"
+  if (/^github-discussions-\d+$/.test(internalId)) {
     return {
       type: "REPO_DISCUSSIONS",
-      repoId: parseInt(internalId.replace(/-discussions$/, ""), 10),
+      repoId: parseInt(internalId.replace(/^github-discussions-/, ""), 10),
     };
   }
   // All code from repo is selected, format = "github-code-12345678"

--- a/connectors/src/connectors/github/lib/utils.ts
+++ b/connectors/src/connectors/github/lib/utils.ts
@@ -10,10 +10,6 @@ export const GITHUB_CONTENT_NODE_TYPES = [
 ] as const;
 export type GithubContentNodeType = (typeof GITHUB_CONTENT_NODE_TYPES)[number];
 
-export function getRepositoryIdFromNodeId(internalId: string): number {
-  return parseInt(internalId.replace(/^github-repository-/, ""), 10);
-}
-
 /**
  * Gets the type of the Github content node from its internal id.
  */
@@ -25,7 +21,7 @@ export function matchGithubNodeIdType(internalId: string): {
   if (/^github-repository-\d+$/.test(internalId)) {
     return {
       type: "REPO_FULL",
-      repoId: getRepositoryIdFromNodeId(internalId),
+      repoId: parseInt(internalId.replace(/^github-repository-/, ""), 10),
     };
   }
   // All issues from repo are selected, format = "github-issues-12345678"

--- a/connectors/src/connectors/github/lib/utils.ts
+++ b/connectors/src/connectors/github/lib/utils.ts
@@ -22,7 +22,7 @@ export function isGithubCodeFileId(internalId: string): boolean {
 /**
  * Gets the type of the Github content node from its internal id.
  */
-export function matchGithubNodeIdType(internalId: string): {
+export function matchGithubInternalIdType(internalId: string): {
   type: GithubContentNodeType;
   repoId: number;
 } {
@@ -77,37 +77,37 @@ export function matchGithubNodeIdType(internalId: string): {
   throw new Error(`Invalid Github internal id: ${internalId}`);
 }
 
-export function getRepositoryNodeId(repoId: string | number): string {
+export function getRepositoryInternalId(repoId: string | number): string {
   return `github-repository-${repoId}`;
 }
 
-export function getIssuesNodeId(repoId: string | number): string {
+export function getIssuesInternalId(repoId: string | number): string {
   return `github-issues-${repoId}`;
 }
 
-export function getIssueNodeId(
+export function getIssueInternalId(
   repoId: string | number,
   issueNumber: number
 ): string {
   return `github-issue-${repoId}-${issueNumber}`;
 }
 
-export function getDiscussionsNodeId(repoId: string | number): string {
+export function getDiscussionsInternalId(repoId: string | number): string {
   return `github-discussions-${repoId}`;
 }
 
-export function getDiscussionNodeId(
+export function getDiscussionInternalId(
   repoId: string | number,
   discussionNumber: number
 ): string {
   return `github-discussion-${repoId}-${discussionNumber}`;
 }
 
-export function getCodeRootNodeId(repoId: string | number): string {
+export function getCodeRootInternalId(repoId: string | number): string {
   return `github-code-${repoId}`;
 }
 
-export function getCodeDirNodeId(
+export function getCodeDirInternalId(
   repoId: string | number,
   codePath: string
 ): string {
@@ -117,7 +117,7 @@ export function getCodeDirNodeId(
     .substring(0, 16)}`;
 }
 
-export function getCodeFileNodeId(
+export function getCodeFileInternalId(
   repoId: string | number,
   codePath: string
 ): string {

--- a/connectors/src/connectors/github/lib/utils.ts
+++ b/connectors/src/connectors/github/lib/utils.ts
@@ -8,7 +8,16 @@ export const GITHUB_CONTENT_NODE_TYPES = [
   "REPO_CODE_DIR",
   "REPO_CODE_FILE",
 ] as const;
+
 export type GithubContentNodeType = (typeof GITHUB_CONTENT_NODE_TYPES)[number];
+
+export function isGithubCodeDirId(internalId: string): boolean {
+  return /^github-code-\d+-dir-[a-f0-9]+$/.test(internalId);
+}
+
+export function isGithubCodeFileId(internalId: string): boolean {
+  return /^github-code-\d+-file-[a-f0-9]+$/.test(internalId);
+}
 
 /**
  * Gets the type of the Github content node from its internal id.
@@ -46,7 +55,7 @@ export function matchGithubNodeIdType(internalId: string): {
     };
   }
   // A code directory is selected, format = "github-code-12345678-dir-s0Up1n0u"
-  if (/^github-code-\d+-dir-[a-f0-9]+$/.test(internalId)) {
+  if (isGithubCodeDirId(internalId)) {
     return {
       type: "REPO_CODE_DIR",
       repoId: parseInt(
@@ -56,7 +65,7 @@ export function matchGithubNodeIdType(internalId: string): {
     };
   }
   // A code file is selected, format = "github-code-12345678-file-s0Up1n0u"
-  if (/^github-code-\d+-file-[a-f0-9]+$/.test(internalId)) {
+  if (isGithubCodeFileId(internalId)) {
     return {
       type: "REPO_CODE_FILE",
       repoId: parseInt(

--- a/connectors/src/connectors/github/lib/utils.ts
+++ b/connectors/src/connectors/github/lib/utils.ts
@@ -10,6 +10,10 @@ export const GITHUB_CONTENT_NODE_TYPES = [
 ] as const;
 export type GithubContentNodeType = (typeof GITHUB_CONTENT_NODE_TYPES)[number];
 
+export function getRepositoryIdFromNodeId(internalId: string): number {
+  return parseInt(internalId.replace(/^github-repository-/, ""), 10);
+}
+
 /**
  * Gets the type of the Github content node from its internal id.
  */
@@ -21,7 +25,7 @@ export function matchGithubNodeIdType(internalId: string): {
   if (/^github-repository-\d+$/.test(internalId)) {
     return {
       type: "REPO_FULL",
-      repoId: parseInt(internalId.replace(/^github-repository-/, ""), 10),
+      repoId: getRepositoryIdFromNodeId(internalId),
     };
   }
   // All issues from repo are selected, format = "github-issues-12345678"

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -293,21 +293,7 @@ export async function githubUpsertIssueActivity(
     documentUrl: issue.url,
     timestampMs: updatedAtTimestamp,
     tags: tags,
-    // The convention for parents is to use the external id string; it is ok for
-    // repos, but not practical for issues since the external id is the
-    // issue number, which is not guaranteed unique in the workspace.
-    // Therefore as a special case we use getIssueDocumentId() to get a parent string
-    // The repo id from github is globally unique so used as-is, as per
-    // convention to use the external id string.
-    parents: [
-      documentId,
-      // TODO(2024-12-17 aubin): remove the old parent IDs below
-      `${repoId}-issues`,
-      repoId.toString(),
-      // new parent IDs
-      getIssuesNodeId(repoId),
-      getRepositoryNodeId(repoId),
-    ],
+    parents: [documentId, getIssuesNodeId(repoId), getRepositoryNodeId(repoId)],
     loggerArgs: logger.bindings(),
     upsertContext: {
       sync_type: isBatchSync ? "batch" : "incremental",
@@ -484,18 +470,8 @@ export async function githubUpsertDiscussionActivity(
     documentUrl: discussion.url,
     timestampMs: new Date(discussion.createdAt).getTime(),
     tags,
-    // The convention for parents is to use the external id string; it is ok for
-    // repos, but not practical for discussions since the external id is the
-    // issue number, which is not guaranteed unique in the workspace. Therefore
-    // as a special case we use getDiscussionDocumentId() to get a parent string
-    // The repo id from github is globally unique so used as-is, as per
-    // convention to use the external id string.
     parents: [
       documentId,
-      // TODO(2024-12-17 aubin): remove the old parent IDs below
-      `${repoId}-discussions`,
-      repoId.toString(),
-      // new parent IDs
       getDiscussionsNodeId(repoId),
       getRepositoryNodeId(repoId),
     ],

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -1085,12 +1085,7 @@ export async function githubCodeSyncActivity({
             timestampMs: codeSyncStartedAt.getTime(),
             tags,
             parents: [
-              // TODO(2024-12-17 aubin): remove the old parent IDs below
               ...f.parents,
-              rootInternalId,
-              repoId.toString(),
-              // new parent IDs
-              ...f.parents.slice(1).reverse(),
               rootInternalId,
               getRepositoryNodeId(repoId),
             ],

--- a/front/migrations/20241211_parents_migrator.ts
+++ b/front/migrations/20241211_parents_migrator.ts
@@ -306,11 +306,20 @@ const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
         assert(isGithubCodeFileId(nodeId), `Github invalid nodeId: ${nodeId}`);
 
         let dirParents = parents.filter(isGithubCodeDirId);
+        const setDirParents = new Set(dirParents);
         /// case where we sent the [nodeId, dir3, dir2, dir1, dir1, dir2, dir3, code, repo] and we want to keep only [nodeId, dir1, dir2, dir3, code, repo]
-        if (dirParents.length !== new Set(dirParents).size) {
+        if (dirParents.length !== setDirParents.size) {
           dirParents = dirParents.slice(
             dirParents.length / 2,
             dirParents.length
+          );
+          assert(
+            dirParents.every((p) => setDirParents.has(p)),
+            "dirParent not in set"
+          );
+          assert(
+            setDirParents.size === dirParents.length,
+            "an element from the set is missing"
           );
         }
         return {

--- a/front/migrations/20241211_parents_migrator.ts
+++ b/front/migrations/20241211_parents_migrator.ts
@@ -302,14 +302,24 @@ const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
           `Github invalid nodeId: ${nodeId}`
         );
 
+        let dirParents = parents.filter(
+          (p) => /^github-code-\d+-dir-[a-f0-9]+$/.test(p) // same regex as in connectors/github/lib/utils.ts
+        );
+        /// case where we sent the [nodeId, dir3, dir2, dir1, dir1, dir2, dir3, code, repo] and we want to keep only [nodeId, dir1, dir2, dir3, code, repo]
+        if (dirParents.length !== new Set(dirParents).size) {
+          dirParents = dirParents.slice(
+            dirParents.length / 2,
+            dirParents.length
+          );
+        }
         return {
           parents: [
             nodeId,
-            ...parents.filter((p) => /^github-code-\d+-dir-[a-f0-9]+$/.test(p)), // same regex as in connectors/github/lib/utils.ts
+            ...dirParents,
             `github-code-${repoId}`,
             `github-repository-${repoId}`,
           ],
-          parentId: parents[1],
+          parentId: dirParents[0],
         };
       }
 

--- a/front/migrations/20241211_parents_migrator.ts
+++ b/front/migrations/20241211_parents_migrator.ts
@@ -80,6 +80,14 @@ function slackNodeIdToChannelId(nodeId: string) {
   return parts[1];
 }
 
+export function isGithubCodeDirId(internalId: string): boolean {
+  return /^github-code-\d+-dir-[a-f0-9]+$/.test(internalId);
+}
+
+export function isGithubCodeFileId(internalId: string): boolean {
+  return /^github-code-\d+-file-[a-f0-9]+$/.test(internalId);
+}
+
 const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
   slack: {
     transformer: (nodeId, parents) => {
@@ -266,9 +274,7 @@ const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
         const newParents = [
           nodeId,
           /// putting the code directories here in reverse
-          ...parents
-            .filter((p) => /^github-code-\d+-dir-[a-f0-9]+$/.test(p)) // same regex as in connectors/github/lib/utils.ts
-            .reverse(),
+          ...parents.filter(isGithubCodeDirId).reverse(),
           repoId.toString(),
           `github-code-${repoId}`,
           `github-repository-${repoId}`,
@@ -297,14 +303,9 @@ const migrators: Record<ConnectorProvider, ProviderMigrator | null> = {
       assert(/^\d+$/.test(repoId), `Invalid repoId: ${repoId}`);
 
       if (nodeId.startsWith("github-code-")) {
-        assert(
-          /^github-code-\d+-file-[a-f0-9]+$/.test(nodeId),
-          `Github invalid nodeId: ${nodeId}`
-        );
+        assert(isGithubCodeFileId(nodeId), `Github invalid nodeId: ${nodeId}`);
 
-        let dirParents = parents.filter(
-          (p) => /^github-code-\d+-dir-[a-f0-9]+$/.test(p) // same regex as in connectors/github/lib/utils.ts
-        );
+        let dirParents = parents.filter(isGithubCodeDirId);
         /// case where we sent the [nodeId, dir3, dir2, dir1, dir1, dir2, dir3, code, repo] and we want to keep only [nodeId, dir1, dir2, dir3, code, repo]
         if (dirParents.length !== new Set(dirParents).size) {
           dirParents = dirParents.slice(


### PR DESCRIPTION
## Description

- Follow up on #9440
- This PR changes the IDs in the content nodes in Github connector to use the new IDs (the ones with prefixes) and stop sending x2 parents.
- Tested:
  - With this branch's connectors: add connector, add data to global space, create agent with search
  - With main's connectors: add connector, add data to global space, restart connectors with this branch, check that we can't create an agent, run parents_front migration, check that we can create an agent

## Risk

- high, could break permissions setting, AssistantBuilder and various other things.

## Deploy Plan

- Deploy connectors.
- Run parents_front_migration.
