### PR TITLE
[front] End activity if space not found

### DIFF
--- a/front/temporal/permissions_queue/activities.ts
+++ b/front/temporal/permissions_queue/activities.ts
@@ -32,14 +32,15 @@ export async function updateSpacePermissions({
 
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
+  const logger = mainLogger.child({ spaceId, workspaceId });
+
   const space = await SpaceResource.fetchById(auth, spaceId);
   if (!space) {
-    throw new Error("Space not found.");
+    logger.info("Space not found, cancelling activity.");
+    return;
   }
 
   assert(space.isRegular(), "Cannot update permissions for non-regular space.");
-
-  const logger = mainLogger.child({ spaceId, workspaceId });
 
   // Fetch all regular groups of the space.
   const spaceRegularGroups = space.groups.filter((g) => g.isRegular());


### PR DESCRIPTION
## Description

If space has been removed since the creation of the workflow, the activity should end silently.
This happens regularly with automated tests (change permissions + delete space)

## Risk

none

## Deploy Plan

deploy front
