### PR TITLE
[front] - feat(api): lookup endpoint

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -116,8 +116,8 @@ const config = {
       "DEVELOPMENT_DUST_APPS_VAULT_ID"
     );
   },
-  getLookUpBearerToken: (): string | undefined => {
-    return EnvironmentConfig.getOptionalEnvVariable("LOOKUP_API_BEARER");
+  getRegionResolverSecret: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable("REGION_RESOLVER_SECRET");
   },
   // OAuth
   getOAuthGithubApp: (): string => {

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -116,6 +116,9 @@ const config = {
       "DEVELOPMENT_DUST_APPS_VAULT_ID"
     );
   },
+  getLookUpBearerToken: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable("LOOKUP_API_BEARER");
+  },
   // OAuth
   getOAuthGithubApp: (): string => {
     return EnvironmentConfig.getEnvVariable("OAUTH_GITHUB_APP");

--- a/front/lib/iam/users.ts
+++ b/front/lib/iam/users.ts
@@ -31,7 +31,7 @@ async function fetchUserWithLegacyProvider(
   return user;
 }
 
-async function fetchUserWithAuth0Sub(sub: string) {
+export async function fetchUserWithAuth0Sub(sub: string) {
   const userWithAuth0 = await UserResource.fetchByAuth0Sub(sub);
 
   return userWithAuth0;

--- a/front/lib/iam/workspaces.ts
+++ b/front/lib/iam/workspaces.ts
@@ -66,11 +66,10 @@ export async function createWorkspaceInternal({
   return workspace;
 }
 
-export async function findWorkspaceWithVerifiedDomain(
-  session: SessionWithUser
-): Promise<WorkspaceHasDomain | null> {
-  const { user } = session;
-
+export async function findWorkspaceWithVerifiedDomain(user: {
+  email: string;
+  email_verified: boolean;
+}): Promise<WorkspaceHasDomain | null> {
   if (!user.email_verified) {
     return null;
   }

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -243,8 +243,9 @@ async function handleRegularSignupFlow(
     });
   }
 
-  const workspaceWithVerifiedDomain =
-    await findWorkspaceWithVerifiedDomain(session);
+  const workspaceWithVerifiedDomain = await findWorkspaceWithVerifiedDomain(
+    session.user
+  );
   const { workspace: existingWorkspace } = workspaceWithVerifiedDomain ?? {};
 
   // Verify that the user is allowed to join the specified workspace.

--- a/front/pages/api/lookup.ts
+++ b/front/pages/api/lookup.ts
@@ -84,16 +84,6 @@ async function handler(
     });
   }
   const { resource } = req.query;
-  if (!resource || typeof resource !== "string") {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Missing or invalid resource parameter",
-      },
-    });
-  }
-
   const resourceValidation = ResourceType.decode(resource);
   if (isLeft(resourceValidation)) {
     return apiError(req, res, {

--- a/front/pages/api/lookup.ts
+++ b/front/pages/api/lookup.ts
@@ -74,7 +74,7 @@ async function handler(
     });
   }
 
-  if (bearerTokenRes.value !== config.getLookUpBearerToken()) {
+  if (bearerTokenRes.value !== config.getRegionResolverSecret()) {
     return apiError(req, res, {
       status_code: 401,
       api_error: {

--- a/front/pages/api/lookup.ts
+++ b/front/pages/api/lookup.ts
@@ -169,7 +169,7 @@ async function handleLookupUser(
     workspaceWithVerifiedDomain?.domainAutoJoinEnabled ?? false;
 
   return {
-    isNew: !!user,
+    isNew: !user,
     hasInvite: !!pendingInvite,
     hasAutoJoinWorkspace: canAutoJoin,
     workspaceId:

--- a/front/pages/api/lookup.ts
+++ b/front/pages/api/lookup.ts
@@ -105,7 +105,7 @@ async function handler(
             },
           });
         }
-        response = await handleLookupUser(sessionWithUser);
+        response = await handleLookupUser(bodyValidation.right);
       }
       break;
     case "workspace": {

--- a/front/pages/api/lookup.ts
+++ b/front/pages/api/lookup.ts
@@ -8,15 +8,20 @@ import { getBearerToken } from "@app/lib/auth";
 import { getPendingMembershipInvitationWithWorkspaceForEmail } from "@app/lib/iam/invitations";
 import { fetchUserFromSession } from "@app/lib/iam/users";
 import { findWorkspaceWithVerifiedDomain } from "@app/lib/iam/workspaces";
+import { Workspace } from "@app/lib/models/workspace";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
-
-export type UserLookupResponseBody = {
+export type BaseLookupResponse = {
   isNew: boolean;
+};
+
+export type UserLookupResponse = BaseLookupResponse & {
   hasInvite: boolean;
   hasAutoJoinWorkspace: boolean;
   workspaceId?: string;
 };
+
+export type WorkspaceLookupResponse = BaseLookupResponse;
 
 const ExternalUserCodec = t.type({
   email: t.string,
@@ -29,13 +34,26 @@ const ExternalUserCodec = t.type({
   picture: t.union([t.string, t.undefined]),
 });
 
-const LookupRequestBodySchema = t.type({
+export type LookupResponseBody = UserLookupResponse | WorkspaceLookupResponse;
+
+const UserLookupSchema = t.type({
+  resource: t.literal("user"),
   user: ExternalUserCodec,
 });
 
+const WorkspaceLookupSchema = t.type({
+  resource: t.literal("workspace"),
+  workspace: t.string,
+});
+
+const LookupRequestBodySchema = t.union([
+  UserLookupSchema,
+  WorkspaceLookupSchema,
+]);
+
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<UserLookupResponseBody>>
+  res: NextApiResponse<WithAPIErrorResponse<LookupResponseBody>>
 ): Promise<void> {
   if (req.method !== "POST") {
     return apiError(req, res, {
@@ -68,8 +86,8 @@ async function handler(
     });
   }
 
-  const queryValidation = LookupRequestBodySchema.decode(req.body);
-  if (isLeft(queryValidation)) {
+  const bodyValidation = LookupRequestBodySchema.decode(req.body);
+  if (isLeft(bodyValidation)) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -78,34 +96,61 @@ async function handler(
       },
     });
   }
-  const session = queryValidation.right;
 
+  const body = bodyValidation.right;
+
+  let response: LookupResponseBody | null = null;
+  switch (body.resource) {
+    case "user":
+      {
+        response = await handleLookupUser(body);
+      }
+      break;
+    case "workspace": {
+      response = await handleLookupWorkspace(body);
+    }
+  }
+  res.status(200).json(response);
+  return;
+}
+
+async function handleLookupUser(
+  body: t.TypeOf<typeof UserLookupSchema>
+): Promise<UserLookupResponse> {
   // Check if user exists
-  const user = await fetchUserFromSession(session);
+  const user = await fetchUserFromSession(body);
 
   // Check for pending invitations
   const pendingInvite =
-    await getPendingMembershipInvitationWithWorkspaceForEmail(
-      session.user.email
-    );
+    await getPendingMembershipInvitationWithWorkspaceForEmail(body.user.email);
 
   // Check for workspace with verified domain
   const workspaceWithVerifiedDomain =
-    await findWorkspaceWithVerifiedDomain(session);
+    await findWorkspaceWithVerifiedDomain(body);
 
   // Check auto-join
   const canAutoJoin =
     workspaceWithVerifiedDomain?.domainAutoJoinEnabled ?? false;
 
-  res.status(200).json({
+  return {
     isNew: !!user,
     hasInvite: !!pendingInvite,
     hasAutoJoinWorkspace: canAutoJoin,
     workspaceId:
       pendingInvite?.workspace.sId ||
       (canAutoJoin ? workspaceWithVerifiedDomain?.workspace?.sId : undefined),
+  };
+}
+
+async function handleLookupWorkspace(
+  body: t.TypeOf<typeof WorkspaceLookupSchema>
+): Promise<WorkspaceLookupResponse> {
+  const workspace = await Workspace.findOne({
+    where: { sId: body.workspace },
   });
-  return;
+  return {
+    isNew: !!workspace,
+  };
 }
 
 export default withLogging(handler);

--- a/front/pages/api/lookup.ts
+++ b/front/pages/api/lookup.ts
@@ -1,0 +1,116 @@
+import type { WithAPIErrorResponse } from "@dust-tt/types";
+import { isLeft } from "fp-ts/Either";
+import * as t from "io-ts";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getBearerToken } from "@app/lib/auth";
+import { getPendingMembershipInvitationWithWorkspaceForEmail } from "@app/lib/iam/invitations";
+import { fetchUserFromSession } from "@app/lib/iam/users";
+import { findWorkspaceWithVerifiedDomain } from "@app/lib/iam/workspaces";
+import { apiError, withLogging } from "@app/logger/withlogging";
+
+const { LOOKUP_API_SECRET } = process.env;
+
+if (!LOOKUP_API_SECRET) {
+  throw new Error("LOOKUP_API_SECRET is not defined");
+}
+
+export type UserLookupResponseBody = {
+  isNew: boolean;
+  hasInvite: boolean;
+  hasAutoJoinWorkspace: boolean;
+  workspaceId?: string;
+};
+
+const ExternalUserCodec = t.type({
+  email: t.string,
+  email_verified: t.boolean,
+  name: t.string,
+  nickname: t.string,
+  sub: t.string,
+  family_name: t.union([t.string, t.undefined]),
+  given_name: t.union([t.string, t.undefined]),
+  picture: t.union([t.string, t.undefined]),
+});
+
+const LookupRequestBodySchema = t.type({
+  user: ExternalUserCodec,
+});
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<UserLookupResponseBody>>
+): Promise<void> {
+  if (req.method !== "POST") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "Only POST requests are supported",
+      },
+    });
+  }
+
+  const bearerTokenRes = await getBearerToken(req);
+  if (bearerTokenRes.isErr()) {
+    return apiError(req, res, {
+      status_code: 401,
+      api_error: {
+        type: "not_authenticated",
+        message: "The request does not have valid authentication credentials",
+      },
+    });
+  }
+
+  if (bearerTokenRes.value !== LOOKUP_API_SECRET) {
+    return apiError(req, res, {
+      status_code: 401,
+      api_error: {
+        type: "invalid_basic_authorization_error",
+        message: "Invalid token",
+      },
+    });
+  }
+
+  const queryValidation = LookupRequestBodySchema.decode(req.body);
+  if (isLeft(queryValidation)) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid request body",
+      },
+    });
+  }
+  const session = queryValidation.right;
+
+  // Check if user exists
+  const user = await fetchUserFromSession(session);
+  const isNew = !!user;
+
+  // Check for pending invitations
+  const pendingInvite =
+    await getPendingMembershipInvitationWithWorkspaceForEmail(
+      session.user.email
+    );
+
+  // Check for workspace with verified domain
+  const workspaceWithVerifiedDomain =
+    await findWorkspaceWithVerifiedDomain(session);
+
+  // Check auto-join
+  const canAutoJoin =
+    workspaceWithVerifiedDomain?.domainAutoJoinEnabled ?? false;
+
+  res.status(200).json({
+    isNew,
+    hasInvite: !!pendingInvite,
+    hasAutoJoinWorkspace: canAutoJoin,
+    workspaceId:
+      pendingInvite?.workspace.sId ||
+      (canAutoJoin ? workspaceWithVerifiedDomain?.workspace?.sId : undefined),
+  });
+  return;
+}
+
+export default withLogging(handler);

--- a/front/pages/api/lookup.ts
+++ b/front/pages/api/lookup.ts
@@ -19,7 +19,7 @@ type WorkspaceLookupResponse = {
 type UserLookupResponse = {
   status: "invited" | "member" | "new";
   workspace: {
-    id?: string;
+    sId?: string;
     autoJoin?: boolean;
   };
 };
@@ -150,7 +150,7 @@ async function handleLookupUser(
     status: user ? "member" : pendingInvite ? "invited" : "new",
     workspace: {
       autoJoin: canAutoJoin,
-      id:
+      sId:
         pendingInvite?.workspace.sId ||
         (canAutoJoin ? workspaceWithVerifiedDomain?.workspace?.sId : undefined),
     },

--- a/front/pages/api/lookup.ts
+++ b/front/pages/api/lookup.ts
@@ -8,7 +8,6 @@ import config from "@app/lib/api/config";
 import { getBearerToken } from "@app/lib/auth";
 import { getPendingMembershipInvitationWithWorkspaceForEmail } from "@app/lib/iam/invitations";
 import { fetchUserWithAuth0Sub } from "@app/lib/iam/users";
-import { findWorkspaceWithVerifiedDomain } from "@app/lib/iam/workspaces";
 import { Workspace } from "@app/lib/models/workspace";
 import { apiError, withLogging } from "@app/logger/withlogging";
 

--- a/front/pages/api/lookup.ts
+++ b/front/pages/api/lookup.ts
@@ -13,7 +13,9 @@ import { Workspace } from "@app/lib/models/workspace";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
 type WorkspaceLookupResponse = {
-  isNew: boolean;
+  workspace: {
+    sId: string;
+  } | null;
 };
 
 type UserLookupResponse = {
@@ -164,7 +166,7 @@ async function handleLookupWorkspace(
     where: { sId: body.workspace },
   });
   return {
-    isNew: !!workspace,
+    workspace: workspace?.sId ? { sId: workspace.sId } : null,
   };
 }
 

--- a/front/pages/api/lookup.ts
+++ b/front/pages/api/lookup.ts
@@ -134,16 +134,13 @@ async function handleLookupUser(
   const user = await fetchUserWithAuth0Sub(userLookup.user.sub);
 
   // Check for pending invitations
-  const pendingInvite =
-    await getPendingMembershipInvitationWithWorkspaceForEmail(
-      userLookup.user.email
-    );
-
-  // Check for workspace with verified domain
-  const workspaceWithVerifiedDomain = await findWorkspaceWithVerifiedDomain({
-    email: userLookup.user.email,
-    email_verified: userLookup.user.email_verified,
-  });
+  const [pendingInvite, workspaceWithVerifiedDomain] = await Promise.all([
+    getPendingMembershipInvitationWithWorkspaceForEmail(userLookup.user.email),
+    findWorkspaceWithVerifiedDomain({
+      email: userLookup.user.email,
+      email_verified: userLookup.user.email_verified,
+    }),
+  ]);
 
   // Check auto-join
   const canAutoJoin =

--- a/front/pages/api/lookup.ts
+++ b/front/pages/api/lookup.ts
@@ -14,17 +14,17 @@ import { findWorkspaceWithVerifiedDomain } from "@app/lib/iam/workspaces";
 import { Workspace } from "@app/lib/models/workspace";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
-export type BaseLookupResponse = {
+type BaseLookupResponse = {
   isNew: boolean;
 };
 
-export type UserLookupResponse = BaseLookupResponse & {
+type UserLookupResponse = BaseLookupResponse & {
   hasInvite: boolean;
   hasAutoJoinWorkspace: boolean;
   workspaceId?: string;
 };
 
-export type WorkspaceLookupResponse = BaseLookupResponse;
+type WorkspaceLookupResponse = BaseLookupResponse;
 
 const ExternalUserCodec = t.type({
   email: t.string,
@@ -37,7 +37,7 @@ const ExternalUserCodec = t.type({
   picture: t.union([t.string, t.undefined]),
 });
 
-export type LookupResponseBody = UserLookupResponse | WorkspaceLookupResponse;
+type LookupResponseBody = UserLookupResponse | WorkspaceLookupResponse;
 
 const UserLookupSchema = t.type({
   user: ExternalUserCodec,


### PR DESCRIPTION
## Description

This PR aims at adding a `/lookup` endpoint to resolve regions. This is part of the multi-region cluster efforts.

Rational: we keep the following authentication and only change the auth0 redirection url (see chart)
Once a user gets authenticated via auth0 we then trigger this `/lookup` endpoint, which will check whether the user already exists.
- If it does we redirect the user to the right cluster.
- f it doesn't we insert a page in which the user needs to select its region. Once selected we redirect it to the right cluster and create a workspace/user.

## Risk

Relatively low, endpoint not used yet but changing a type used in the authentication flow

## Deploy Plan

- Add this new endpoint
- Deploy the new resolver service