### PR TITLE
[front] Delete group when deleting space

### DIFF
--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -319,9 +319,14 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       },
       transaction,
     });
+
+    // Groups and spaces are currently tied together in a 1-1 way, even though the model allow a n-n relation between them.
+    // When deleting a space, we delete the dangling groups as it won't be available in the UI anymore.
+    // This should be changed when we separate the management of groups and spaces
     await concurrentExecutor(
       this.groups,
       async (group) => {
+        // As the model allows it, ensure the group is not associated with any other space.
         const count = await GroupSpaceModel.count({
           where: {
             groupId: group.id,

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -319,6 +319,19 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       },
       transaction,
     });
+    await Promise.all(
+      this.groups.map(async (group) => {
+        const count = await GroupSpaceModel.count({
+          where: {
+            groupId: group.id,
+          },
+          transaction,
+        });
+        if (count === 0) {
+          await group.delete(auth, { transaction });
+        }
+      })
+    );
 
     await SpaceModel.destroy({
       where: {

--- a/front/migrations/20241218_delete_dangling_groups.ts
+++ b/front/migrations/20241218_delete_dangling_groups.ts
@@ -13,10 +13,6 @@ const cleanDanglingGroups = async (
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
   const allGroups = await GroupResource.listAllWorkspaceGroups(auth);
-  // const allGroups: GroupModel[] = await GroupModel.findAll({
-  //   where: { id: { [Op.gt]: nextId } },
-  //   limit: 1000,
-  // });
 
   for (const group of allGroups) {
     frontSequelize.transaction(async (transaction) => {

--- a/front/migrations/20241218_delete_dangling_groups.ts
+++ b/front/migrations/20241218_delete_dangling_groups.ts
@@ -1,0 +1,42 @@
+import { Authenticator } from "@app/lib/auth";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
+import logger from "@app/logger/logger";
+import { makeScript, runOnAllWorkspaces } from "@app/scripts/helpers";
+import { LightWorkspaceType } from "@dust-tt/types";
+
+const cleanDanglingGroups = async (
+  workspace: LightWorkspaceType,
+  execute: boolean
+) => {
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+  const allGroups = await GroupResource.listAllWorkspaceGroups(auth);
+  // const allGroups: GroupModel[] = await GroupModel.findAll({
+  //   where: { id: { [Op.gt]: nextId } },
+  //   limit: 1000,
+  // });
+
+  for (const group of allGroups) {
+    frontSequelize.transaction(async (transaction) => {
+      const c = await GroupSpaceModel.count({
+        where: { groupId: group.id },
+        transaction,
+      });
+
+      if (c === 0) {
+        logger.info({ groupId: group.id }, "Deleting group");
+        if (execute) {
+          await group.delete(auth, { transaction });
+        }
+      }
+    });
+  }
+};
+
+makeScript({}, async ({ execute }) => {
+  return runOnAllWorkspaces(async (workspace) => {
+    await cleanDanglingGroups(workspace, execute);
+  });
+});


### PR DESCRIPTION
## Description

When deleting a space, the associated group should also be deleted.  
As in theory a space can have multiple groups and groups can have multiple spaces, we ensure the group is not associated with any other space before removing.

backfill script to remove groups that are still there.

## Risk


## Deploy Plan

deploy front
run script to clean dangling groups
