### PR TITLE
[front] update data sources list after creation

### DIFF
--- a/front/components/spaces/EditSpaceStaticDatasourcesViews.tsx
+++ b/front/components/spaces/EditSpaceStaticDatasourcesViews.tsx
@@ -96,7 +96,6 @@ export function EditSpaceStaticDatasourcesViews({
           onClose={onClose}
           owner={owner}
           space={space}
-          dataSources={dataSources}
           dataSourceView={dataSourceView}
         />
       ) : null}

--- a/front/components/spaces/SpaceWebsiteModal.tsx
+++ b/front/components/spaces/SpaceWebsiteModal.tsx
@@ -22,7 +22,6 @@ import {
 import type {
   APIError,
   CrawlingFrequency,
-  DataSourceType,
   DataSourceViewType,
   DepthOption,
   SpaceType,
@@ -42,14 +41,14 @@ import {
 import { validateUrl } from "@dust-tt/types/src/shared/utils/url_utils";
 import type * as t from "io-ts";
 import { useRouter } from "next/router";
-import React, { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { DeleteStaticDataSourceDialog } from "@app/components/data_source/DeleteStaticDataSourceDialog";
 import { useDataSourceViewConnectorConfiguration } from "@app/lib/swr/data_source_views";
+import { useDataSources } from "@app/lib/swr/data_sources";
 import { useSpaceDataSourceViews } from "@app/lib/swr/spaces";
 import { urlToDataSourceName } from "@app/lib/webcrawler";
 import type { PostDataSourceWithProviderRequestBodySchema } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_sources";
-import { useDataSources } from "@app/lib/swr/data_sources";
 
 const WEBSITE_CAT = "website";
 

--- a/front/components/spaces/SpaceWebsiteModal.tsx
+++ b/front/components/spaces/SpaceWebsiteModal.tsx
@@ -49,11 +49,11 @@ import { useDataSourceViewConnectorConfiguration } from "@app/lib/swr/data_sourc
 import { useSpaceDataSourceViews } from "@app/lib/swr/spaces";
 import { urlToDataSourceName } from "@app/lib/webcrawler";
 import type { PostDataSourceWithProviderRequestBodySchema } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_sources";
+import { useDataSources } from "@app/lib/swr/data_sources";
 
 const WEBSITE_CAT = "website";
 
 interface SpaceWebsiteModalProps {
-  dataSources: DataSourceType[];
   dataSourceView: DataSourceViewType | null;
   isOpen: boolean;
   onClose: () => void;
@@ -64,7 +64,6 @@ interface SpaceWebsiteModalProps {
 // todo(GROUPS_INFRA): current component has been mostly copy pasted from the WebsiteConfiguration existing component
 // this should be refactored to use the new design.
 export default function SpaceWebsiteModal({
-  dataSources,
   dataSourceView,
   isOpen,
   onClose,
@@ -90,6 +89,8 @@ export default function SpaceWebsiteModal({
   const [dataSourceNameError, setDataSourceNameError] = useState<string | null>(
     null
   );
+
+  const { dataSources, mutateDataSources } = useDataSources(owner);
 
   const [maxPages, setMaxPages] = useState<number | null>(
     WEBCRAWLER_DEFAULT_CONFIGURATION.maxPageToCrawl
@@ -185,9 +186,9 @@ export default function SpaceWebsiteModal({
 
   const updateUrl = (url: string) => {
     setDataSourceUrl(url);
-    const validatedUrl = validateUrl(dataSourceUrl);
+    const validatedUrl = validateUrl(url);
     if (validatedUrl.valid && !dataSourceView) {
-      setDataSourceName(urlToDataSourceName(dataSourceUrl));
+      setDataSourceName(urlToDataSourceName(url));
     }
   };
 
@@ -331,6 +332,7 @@ export default function SpaceWebsiteModal({
         description: `The website has been successfully ${action}.`,
       });
       void mutateSpaceDataSourceViews();
+      void mutateDataSources();
       setIsSaving(false);
     } else {
       const err: { error: APIError } = await res.json();

--- a/front/components/spaces/WebsitesHeaderMenu.tsx
+++ b/front/components/spaces/WebsitesHeaderMenu.tsx
@@ -7,7 +7,6 @@ import type {
 import { useState } from "react";
 
 import SpaceWebsiteModal from "@app/components/spaces/SpaceWebsiteModal";
-import { useDataSources } from "@app/lib/swr/data_sources";
 
 type WebsitesHeaderMenuProps = {
   owner: WorkspaceType;
@@ -24,8 +23,6 @@ export const WebsitesHeaderMenu = ({
 }: WebsitesHeaderMenuProps) => {
   const [showEditWebsiteModal, setShowEditWebsiteModal] = useState(false);
 
-  const { dataSources } = useDataSources(owner);
-
   return (
     <>
       <SpaceWebsiteModal
@@ -35,7 +32,6 @@ export const WebsitesHeaderMenu = ({
         }}
         owner={owner}
         space={space}
-        dataSources={dataSources}
         dataSourceView={dataSourceView}
       />
       <Button


### PR DESCRIPTION
## Description

Reload the list of datasources after creating a webcrawler, to avoid allowing 2 creations with the same name.
Moved the useDataSources call directly where it's used
Also fixed the updateUrl to get the last updated value.

related logs https://app.datadoghq.eu/logs?query=%22Unhandled%20API%20Error%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host,service&fromUser=true&link_source=monitor_notif&messageDisplay=inline&storage=hot&stream_sort=desc&viz=stream&from_ts=1734454806000&to_ts=1734455106000&live=false

## Risk

none

## Deploy Plan

deploy front
