### PR TITLE
[connectors] - fix(slack): assistant slack integration

### DIFF
--- a/connectors/src/api/slack_channels_linked_with_agent.ts
+++ b/connectors/src/api/slack_channels_linked_with_agent.ts
@@ -6,11 +6,11 @@ import * as reporter from "io-ts-reporters";
 import { Op } from "sequelize";
 
 import { joinChannel } from "@connectors/connectors/slack/lib/channels";
+import { slackChannelIdFromInternalId } from "@connectors/connectors/slack/lib/utils";
 import { getChannels } from "@connectors/connectors/slack/temporal/activities";
 import { SlackChannel } from "@connectors/lib/models/slack";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 import { sequelizeConnection } from "@connectors/resources/storage";
-import { slackChannelIdFromInternalId } from "@connectors/connectors/slack/lib/utils";
 
 const PatchSlackChannelsLinkedWithAgentReqBodySchema = t.type({
   agent_configuration_id: t.string,

--- a/connectors/src/api/slack_channels_linked_with_agent.ts
+++ b/connectors/src/api/slack_channels_linked_with_agent.ts
@@ -14,7 +14,7 @@ import { sequelizeConnection } from "@connectors/resources/storage";
 
 const PatchSlackChannelsLinkedWithAgentReqBodySchema = t.type({
   agent_configuration_id: t.string,
-  slack_channel_ids: t.array(t.string),
+  slack_channel_internal_ids: t.array(t.string),
   connector_id: t.string,
 });
 
@@ -52,7 +52,7 @@ const _patchSlackChannelsLinkedWithAgentHandler = async (
   const {
     connector_id: connectorId,
     agent_configuration_id: agentConfigurationId,
-    slack_channel_ids: slackChannelInternalIds,
+    slack_channel_internal_ids: slackChannelInternalIds,
   } = bodyValidation.right;
 
   const slackChannelIds = slackChannelInternalIds.map((s) =>

--- a/connectors/src/api/slack_channels_linked_with_agent.ts
+++ b/connectors/src/api/slack_channels_linked_with_agent.ts
@@ -10,6 +10,7 @@ import { getChannels } from "@connectors/connectors/slack/temporal/activities";
 import { SlackChannel } from "@connectors/lib/models/slack";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 import { sequelizeConnection } from "@connectors/resources/storage";
+import { slackChannelIdFromInternalId } from "@connectors/connectors/slack/lib/utils";
 
 const PatchSlackChannelsLinkedWithAgentReqBodySchema = t.type({
   agent_configuration_id: t.string,
@@ -51,9 +52,12 @@ const _patchSlackChannelsLinkedWithAgentHandler = async (
   const {
     connector_id: connectorId,
     agent_configuration_id: agentConfigurationId,
-    slack_channel_ids: slackChannelIds,
+    slack_channel_ids: slackChannelInternalIds,
   } = bodyValidation.right;
 
+  const slackChannelIds = slackChannelInternalIds.map((s) =>
+    slackChannelIdFromInternalId(s)
+  );
   const slackChannels = await SlackChannel.findAll({
     where: {
       slackChannelId: slackChannelIds,

--- a/front/components/assistant_builder/submitAssistantBuilderForm.ts
+++ b/front/components/assistant_builder/submitAssistantBuilderForm.ts
@@ -272,7 +272,7 @@ export async function submitAssistantBuilderForm({
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          slack_channel_ids: selectedSlackChannels.map(
+          slack_channel_internal_ids: selectedSlackChannels.map(
             ({ slackChannelId }) => slackChannelId
           ),
         }),

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
@@ -18,7 +18,7 @@ export type PatchLinkedSlackChannelsResponseBody = {
 };
 
 export const PatchLinkedSlackChannelsRequestBodySchema = t.type({
-  slack_channel_ids: t.array(t.string),
+  slack_channel_internal_ids: t.array(t.string),
 });
 
 async function handler(
@@ -101,7 +101,7 @@ async function handler(
       const connectorsApiRes = await connectorsAPI.linkSlackChannelsWithAgent({
         connectorId: connectorId.toString(),
         agentConfigurationId: agentConfiguration.sId,
-        slackChannelIds: bodyValidation.right.slack_channel_ids,
+        slackChannelInternalIds: bodyValidation.right.slack_channel_internal_ids,
       });
 
       if (connectorsApiRes.isErr()) {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
@@ -101,7 +101,8 @@ async function handler(
       const connectorsApiRes = await connectorsAPI.linkSlackChannelsWithAgent({
         connectorId: connectorId.toString(),
         agentConfigurationId: agentConfiguration.sId,
-        slackChannelInternalIds: bodyValidation.right.slack_channel_internal_ids,
+        slackChannelInternalIds:
+          bodyValidation.right.slack_channel_internal_ids,
       });
 
       if (connectorsApiRes.isErr()) {

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -566,11 +566,11 @@ export class ConnectorsAPI {
 
   async linkSlackChannelsWithAgent({
     connectorId,
-    slackChannelIds,
+    slackChannelInternalIds,
     agentConfigurationId,
   }: {
     connectorId: string;
-    slackChannelIds: string[];
+    slackChannelInternalIds: string[];
     agentConfigurationId: string;
   }): Promise<ConnectorsAPIResponse<{ success: true }>> {
     const res = await this._fetchWithError(
@@ -581,7 +581,7 @@ export class ConnectorsAPI {
         body: JSON.stringify({
           connector_id: connectorId,
           agent_configuration_id: agentConfigurationId,
-          slack_channel_ids: slackChannelIds,
+          slack_channel_internal_ids: slackChannelInternalIds,
         }),
       }
     );


### PR DESCRIPTION
## Description

This PR transform Slack internal channel IDs to public Slack Channel IDs before querying.

**References:**
- https://github.com/dust-tt/tasks/issues/1834

## Risk

Low

## Deploy Plan

- Deploy `connectors`
- Deploy `front`