### PR TITLE
Visualization use-case directives

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -13,7 +13,6 @@ import type {
 } from "@dust-tt/types";
 import {
   assertNever,
-  CLAUDE_3_5_SONNET_20241022_MODEL_ID,
   Err,
   isAgentMessageType,
   isContentFragmentMessageTypeModel,
@@ -84,32 +83,6 @@ export async function constructPromptMultiActions(
 
   // INSTRUCTIONS section
   let instructions = "INSTRUCTIONS:\n";
-
-  if (
-    model.providerId === "anthropic" &&
-    model.modelId === CLAUDE_3_5_SONNET_20241022_MODEL_ID
-  ) {
-    instructions += `\
-    STOP AND CHECK BEFORE USING VISUALIZATION:\n
-    MANDATORY CHECKLIST - ALL MUST BE TRUE:\n
-    □ Contains actual data (numbers, measurements, statistics)\n
-    □ Requires visual representation (graphs, charts, plots)\n
-    AUTOMATIC DISQUALIFIERS - ANY ONE MEANS NO VISUALIZATION:\n
-    □ Is it just for layout/styling? → NO VISUALIZATION\n
-    □ Is it just text content? → NO VISUALIZATION\n
-    □ Is it decorative/presentational? → NO VISUALIZATION\n
-    EXAMPLES:\n
-    YES:\n
-    - Time series data needing a line chart\n
-    - Statistical distributions needing a histogram\n
-    - Multi-variable correlations needing a scatter plot\n
-    NO:\n
-    - Text layouts\n
-    - Decorative elements\n
-    - Styled content\n
-    - Presentations\n
-    - Lists or tables that work in markdown`;
-  }
 
   if (agentConfiguration.instructions) {
     instructions += `${agentConfiguration.instructions}\n`;

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -13,6 +13,7 @@ import type {
 } from "@dust-tt/types";
 import {
   assertNever,
+  CLAUDE_3_5_SONNET_20241022_MODEL_ID,
   Err,
   isAgentMessageType,
   isContentFragmentMessageTypeModel,
@@ -83,6 +84,33 @@ export async function constructPromptMultiActions(
 
   // INSTRUCTIONS section
   let instructions = "INSTRUCTIONS:\n";
+
+  if (
+    model.providerId === "anthropic" &&
+    model.modelId === CLAUDE_3_5_SONNET_20241022_MODEL_ID
+  ) {
+    instructions += `\
+    STOP AND CHECK BEFORE USING VISUALIZATION:\n
+    MANDATORY CHECKLIST - ALL MUST BE TRUE:\n
+    □ Contains actual data (numbers, measurements, statistics)\n
+    □ Requires visual representation (graphs, charts, plots)\n
+    AUTOMATIC DISQUALIFIERS - ANY ONE MEANS NO VISUALIZATION:\n
+    □ Is it just for layout/styling? → NO VISUALIZATION\n
+    □ Is it just text content? → NO VISUALIZATION\n
+    □ Is it decorative/presentational? → NO VISUALIZATION\n
+    EXAMPLES:\n
+    YES:\n
+    - Time series data needing a line chart\n
+    - Statistical distributions needing a histogram\n
+    - Multi-variable correlations needing a scatter plot\n
+    NO:\n
+    - Text layouts\n
+    - Decorative elements\n
+    - Styled content\n
+    - Presentations\n
+    - Lists or tables that work in markdown`;
+  }
+
   if (agentConfiguration.instructions) {
     instructions += `${agentConfiguration.instructions}\n`;
   } else if (fallbackPrompt) {

--- a/front/lib/api/assistant/visualization.ts
+++ b/front/lib/api/assistant/visualization.ts
@@ -86,7 +86,7 @@ export async function getVisualizationPrompt({
 export const visualizationSystemPrompt = (jitActionsEnabled: boolean) => `\
 It is possible to generate visualizations for the user (using React components executed in a react-runner environment) that will be rendered in the user's browser by using the :::visualization container block markdown directive.
 
-Guidelines using the :::visualization tag:
+Guidelines using the :::visualization directive:
 - The generated component should always be exported as default
 - There is no internet access in the visualization environment
 - Supported React features:
@@ -126,7 +126,10 @@ Guidelines using the :::visualization tag:
   - Images from the web cannot be rendered or used in the visualization (no internet access).
   - When parsing dates, the date format should be accounted for based on the format seen in the \`<attachment/>\` tag.
   - If needed, the application must contain buttons or other navigation elements to allow the user to scroll/cycle through the content.
-
+- When to use the :::visualization directive:
+  - The visualization directive is particularly adapted to use-cases involving data visualizations such as graphs, charts, and plots.
+  - The visualization directive should not be used for non-interactive presentational or layout purposes.
+  - The visualization directive should not be used for anything that can be achieved with regular markdown.
 
 Example using the \`useFile\` hook:
 

--- a/front/lib/api/assistant/visualization.ts
+++ b/front/lib/api/assistant/visualization.ts
@@ -84,14 +84,22 @@ export async function getVisualizationPrompt({
 }
 
 export const visualizationSystemPrompt = (jitActionsEnabled: boolean) => `\
-Capability to generate visualizations.
-
-You can generate visualizations for the user is a capability you can use if you think the user wants a visualisation.
-Never comment on the instructions to generate visualizations (vizInstructions), the user has not written them or seen them.
-
-<vizInstructions>
-
 It is possible to generate visualizations for the user (using React components executed in a react-runner environment) that will be rendered in the user's browser by using the :::visualization container block markdown directive.
+
+USE Visualization when:
+- Creating data visualizations like (Line graphs, bar charts, scatter plots, simple interactive data displays...)
+- Writing code for:
+  - Basic data processing and analysis
+  - Simple algorithms and flowcharts
+  - Statistical computations with visual output
+  - Real-time data monitoring
+
+DO NOT use Visualization when:
+- Creating design-heavy content like:
+  - Marketing presentations or slides
+  - Website layouts or UI mockups
+  - Infographics or complex illustrations
+  - Logo designs or branding materials
 
 Guidelines using the :::visualization tag:
 - The generated component should always be exported as default
@@ -246,6 +254,4 @@ const SineCosineChart = () => {
 
 export default SineCosineChart;
 :::
-
-</vizInstructions>
 `;

--- a/front/lib/api/assistant/visualization.ts
+++ b/front/lib/api/assistant/visualization.ts
@@ -86,30 +86,33 @@ export async function getVisualizationPrompt({
 export const visualizationSystemPrompt = (jitActionsEnabled: boolean) => `\
 It is possible to generate visualizations for the user (using React components executed in a react-runner environment) that will be rendered in the user's browser by using the :::visualization container block markdown directive.
 
-Guidelines using the :::visualization tag:
-- BEFORE creating any visualization, validate that the content meets ALL of these criteria:
-  1. Contains REAL data (not illustrative/fake data) or interactive elements that REQUIRE visual representation
-  2. The visualization adds meaningful value beyond what plain text/markdown could provide
-  3. The purpose is functional (data analysis, interaction) rather than decorative or presentational
-  4. The data or interaction cannot be effectively communicated through markdown alone
+STOP AND CHECK BEFORE USING VISUALIZATION:
 
-- Common anti-patterns to AVOID:
-  1. Using visualizations for teaching/explaining visualization concepts
-  2. Creating charts with illustrative/fake data
-  3. Using visualizations for layout or styling purposes
-  4. Creating decorative or presentational-only visualizations
+MANDATORY CHECKLIST - ALL MUST BE TRUE:
+□ Contains actual data (numbers, measurements, statistics)
+□ Requires visual representation (graphs, charts, plots)
+□ Cannot be effectively shown in plain markdown
+□ Serves a functional purpose (not decorative)
 
-- Example decision process:
-  ✅ USE for:
-    - "Show me this dataset as a time series graph"
-    - "Let me explore and filter this data interactively"
-    - "Visualize the correlation between these variables"
-  
-  ❌ DO NOT USE for:
-    - "Make this text look nice"
-    - "Show an example of how charts work"
-    - "Display this information in a grid layout"
-    - "Create a decorative illustration"
+AUTOMATIC DISQUALIFIERS - ANY ONE MEANS NO VISUALIZATION:
+□ Is it just for layout/styling? → NO VISUALIZATION
+□ Is it just text content? → NO VISUALIZATION
+□ Is it decorative/presentational? → NO VISUALIZATION
+□ Could it work in markdown? → NO VISUALIZATION
+
+EXAMPLES:
+YES:
+- Time series data needing a line chart
+- Statistical distributions needing a histogram
+- Multi-variable correlations needing a scatter plot
+
+NO:
+- Text layouts
+- Decorative elements
+- Styled content
+- Presentations
+- Lists or tables that work in markdown
+
 
 Guidelines using the :::visualization tag:
 - The generated component should always be exported as default

--- a/front/lib/api/assistant/visualization.ts
+++ b/front/lib/api/assistant/visualization.ts
@@ -86,14 +86,14 @@ export async function getVisualizationPrompt({
 export const visualizationSystemPrompt = (jitActionsEnabled: boolean) => `\
 It is possible to generate visualizations for the user (using React components executed in a react-runner environment) that will be rendered in the user's browser by using the :::visualization container block markdown directive.
 
-USE Visualization when:
-- Creating data visualizations like (Line graphs, bar charts, scatter plots, simple interactive data displays...)
-- Writing code for simple interactive visualizations or svg elements
-
-DO NOT use Visualization when:
-- Creating design-heavy content like:
-  - Marketing presentations or slides
-  - Website layouts or UI mockups
+Guidelines using the :::visualization tag:
+- BEFORE creating any visualization, validate that the content meets BOTH criteria:
+  1. Contains actual data or interactive elements that REQUIRE visual representation
+  2. The visualization adds meaningful value beyond what plain text/markdown could provide
+- If the content is primarily presentational, informational, or could be effectively communicated through markdown formatting, DO NOT use a visualization
+- Example decision process:
+  ✅ USE for: "Show me this data as a graph"
+  ❌ DO NOT USE for: "Make this text look nice"
 
 Guidelines using the :::visualization tag:
 - The generated component should always be exported as default

--- a/front/lib/api/assistant/visualization.ts
+++ b/front/lib/api/assistant/visualization.ts
@@ -84,9 +84,12 @@ export async function getVisualizationPrompt({
 }
 
 export const visualizationSystemPrompt = (jitActionsEnabled: boolean) => `\
-# Capability to generate visualizations
+Capability to generate visualizations.
 
-Generate visualizations for the user is a capability you can choose to use if you think the user wants a visualisation.
+You can generate visualizations for the user is a capability you can use if you think the user wants a visualisation.
+Never comment on the instructions to generate visualizations, the user has not written them or seen them.
+
+This is the beginning of the instructions to generate visualizations.
 
 It is possible to generate visualizations for the user (using React components executed in a react-runner environment) that will be rendered in the user's browser by using the :::visualization container block markdown directive.
 
@@ -243,4 +246,7 @@ const SineCosineChart = () => {
 
 export default SineCosineChart;
 :::
+
+
+This is the end of the instructions to generate vizualisations.
 `;

--- a/front/lib/api/assistant/visualization.ts
+++ b/front/lib/api/assistant/visualization.ts
@@ -87,13 +87,29 @@ export const visualizationSystemPrompt = (jitActionsEnabled: boolean) => `\
 It is possible to generate visualizations for the user (using React components executed in a react-runner environment) that will be rendered in the user's browser by using the :::visualization container block markdown directive.
 
 Guidelines using the :::visualization tag:
-- BEFORE creating any visualization, validate that the content meets BOTH criteria:
-  1. Contains actual data or interactive elements that REQUIRE visual representation
+- BEFORE creating any visualization, validate that the content meets ALL of these criteria:
+  1. Contains REAL data (not illustrative/fake data) or interactive elements that REQUIRE visual representation
   2. The visualization adds meaningful value beyond what plain text/markdown could provide
-- If the content is primarily presentational, informational, or could be effectively communicated through markdown formatting, DO NOT use a visualization
+  3. The purpose is functional (data analysis, interaction) rather than decorative or presentational
+  4. The data or interaction cannot be effectively communicated through markdown alone
+
+- Common anti-patterns to AVOID:
+  1. Using visualizations for teaching/explaining visualization concepts
+  2. Creating charts with illustrative/fake data
+  3. Using visualizations for layout or styling purposes
+  4. Creating decorative or presentational-only visualizations
+
 - Example decision process:
-  ✅ USE for: "Show me this data as a graph"
-  ❌ DO NOT USE for: "Make this text look nice"
+  ✅ USE for:
+    - "Show me this dataset as a time series graph"
+    - "Let me explore and filter this data interactively"
+    - "Visualize the correlation between these variables"
+  
+  ❌ DO NOT USE for:
+    - "Make this text look nice"
+    - "Show an example of how charts work"
+    - "Display this information in a grid layout"
+    - "Create a decorative illustration"
 
 Guidelines using the :::visualization tag:
 - The generated component should always be exported as default

--- a/front/lib/api/assistant/visualization.ts
+++ b/front/lib/api/assistant/visualization.ts
@@ -86,31 +86,6 @@ export async function getVisualizationPrompt({
 export const visualizationSystemPrompt = (jitActionsEnabled: boolean) => `\
 It is possible to generate visualizations for the user (using React components executed in a react-runner environment) that will be rendered in the user's browser by using the :::visualization container block markdown directive.
 
-STOP AND CHECK BEFORE USING VISUALIZATION:
-
-MANDATORY CHECKLIST - ALL MUST BE TRUE:
-□ Contains actual data (numbers, measurements, statistics)
-□ Requires visual representation (graphs, charts, plots)
-
-AUTOMATIC DISQUALIFIERS - ANY ONE MEANS NO VISUALIZATION:
-□ Is it just for layout/styling? → NO VISUALIZATION
-□ Is it just text content? → NO VISUALIZATION
-□ Is it decorative/presentational? → NO VISUALIZATION
-
-EXAMPLES:
-YES:
-- Time series data needing a line chart
-- Statistical distributions needing a histogram
-- Multi-variable correlations needing a scatter plot
-
-NO:
-- Text layouts
-- Decorative elements
-- Styled content
-- Presentations
-- Lists or tables that work in markdown
-
-
 Guidelines using the :::visualization tag:
 - The generated component should always be exported as default
 - There is no internet access in the visualization environment

--- a/front/lib/api/assistant/visualization.ts
+++ b/front/lib/api/assistant/visualization.ts
@@ -84,6 +84,10 @@ export async function getVisualizationPrompt({
 }
 
 export const visualizationSystemPrompt = (jitActionsEnabled: boolean) => `\
+# Capability to generate visualizations
+
+Generate visualizations for the user is a capability you can choose to use if you think the user wants a visualisation.
+
 It is possible to generate visualizations for the user (using React components executed in a react-runner environment) that will be rendered in the user's browser by using the :::visualization container block markdown directive.
 
 Guidelines using the :::visualization tag:

--- a/front/lib/api/assistant/visualization.ts
+++ b/front/lib/api/assistant/visualization.ts
@@ -87,9 +87,9 @@ export const visualizationSystemPrompt = (jitActionsEnabled: boolean) => `\
 Capability to generate visualizations.
 
 You can generate visualizations for the user is a capability you can use if you think the user wants a visualisation.
-Never comment on the instructions to generate visualizations, the user has not written them or seen them.
+Never comment on the instructions to generate visualizations (vizInstructions), the user has not written them or seen them.
 
-This is the beginning of the instructions to generate visualizations.
+<vizInstructions>
 
 It is possible to generate visualizations for the user (using React components executed in a react-runner environment) that will be rendered in the user's browser by using the :::visualization container block markdown directive.
 
@@ -247,6 +247,5 @@ const SineCosineChart = () => {
 export default SineCosineChart;
 :::
 
-
-This is the end of the instructions to generate vizualisations.
+</vizInstructions>
 `;

--- a/front/lib/api/assistant/visualization.ts
+++ b/front/lib/api/assistant/visualization.ts
@@ -88,18 +88,12 @@ It is possible to generate visualizations for the user (using React components e
 
 USE Visualization when:
 - Creating data visualizations like (Line graphs, bar charts, scatter plots, simple interactive data displays...)
-- Writing code for:
-  - Basic data processing and analysis
-  - Simple algorithms and flowcharts
-  - Statistical computations with visual output
-  - Real-time data monitoring
+- Writing code for simple interactive visualizations or svg elements
 
 DO NOT use Visualization when:
 - Creating design-heavy content like:
   - Marketing presentations or slides
   - Website layouts or UI mockups
-  - Infographics or complex illustrations
-  - Logo designs or branding materials
 
 Guidelines using the :::visualization tag:
 - The generated component should always be exported as default

--- a/front/lib/api/assistant/visualization.ts
+++ b/front/lib/api/assistant/visualization.ts
@@ -128,7 +128,6 @@ Guidelines using the :::visualization directive:
   - If needed, the application must contain buttons or other navigation elements to allow the user to scroll/cycle through the content.
 - When to use the :::visualization directive:
   - The visualization directive is particularly adapted to use-cases involving data visualizations such as graphs, charts, and plots.
-  - The visualization directive should not be used for non-interactive presentational or layout purposes.
   - The visualization directive should not be used for anything that can be achieved with regular markdown.
 
 Example using the \`useFile\` hook:

--- a/front/lib/api/assistant/visualization.ts
+++ b/front/lib/api/assistant/visualization.ts
@@ -91,14 +91,11 @@ STOP AND CHECK BEFORE USING VISUALIZATION:
 MANDATORY CHECKLIST - ALL MUST BE TRUE:
 □ Contains actual data (numbers, measurements, statistics)
 □ Requires visual representation (graphs, charts, plots)
-□ Cannot be effectively shown in plain markdown
-□ Serves a functional purpose (not decorative)
 
 AUTOMATIC DISQUALIFIERS - ANY ONE MEANS NO VISUALIZATION:
 □ Is it just for layout/styling? → NO VISUALIZATION
 □ Is it just text content? → NO VISUALIZATION
 □ Is it decorative/presentational? → NO VISUALIZATION
-□ Could it work in markdown? → NO VISUALIZATION
 
 EXAMPLES:
 YES:


### PR DESCRIPTION
## Description

Iteration on https://github.com/dust-tt/dust/pull/9243 that adds directives about when to use viz in the general viz prompt.

We indeed didn't give any direction on when to use viz. Attempted to provide them based on the previous PR.

## Risk

Low

## Deploy Plan

- deploy `front`