### PR TITLE
[Keyword search] Folders: require mimetype

### DIFF
--- a/connectors/migrations/20241211_fix_gdrive_parents.ts
+++ b/connectors/migrations/20241211_fix_gdrive_parents.ts
@@ -125,6 +125,7 @@ async function migrate({
                 parents: newParents,
                 parentId: file.parentId ? getDocumentId(file.parentId) : null,
                 title: file.name,
+                mimeType: "application/vnd.dust.googledrive.folder",
               });
             }
           }

--- a/connectors/migrations/20241216_backfill_confluence_folders.ts
+++ b/connectors/migrations/20241216_backfill_confluence_folders.ts
@@ -27,6 +27,7 @@ makeScript({}, async ({ execute }, logger) => {
             folderId: makeSpaceInternalId(space.spaceId),
             parents: [makeSpaceInternalId(space.spaceId)],
             title: space.name,
+            mimeType: "application/vnd.dust.confluence.space",
           });
         },
         { concurrency: FOLDER_CONCURRENCY }

--- a/connectors/migrations/20241216_backfill_ms_folders.ts
+++ b/connectors/migrations/20241216_backfill_ms_folders.ts
@@ -110,6 +110,7 @@ async function backfillFolder({
               parents,
               parentId: file.parentInternalId,
               title: file.name || "",
+              mimeType: "application/vnd.dust.microsoft.folder",
             });
           }
         }

--- a/connectors/migrations/20241216_backfill_zendesk_folders.ts
+++ b/connectors/migrations/20241216_backfill_zendesk_folders.ts
@@ -34,6 +34,7 @@ makeScript({}, async ({ execute }, logger) => {
             folderId: brandInternalId,
             parents: [brandInternalId],
             title: brand.name,
+            mimeType: "application/vnd.dust.zendesk.brand",
           });
 
           const helpCenterNode = brand.getHelpCenterContentNode(connectorId);
@@ -45,6 +46,7 @@ makeScript({}, async ({ execute }, logger) => {
               helpCenterNode.parentInternalId,
             ],
             title: helpCenterNode.title,
+            mimeType: "application/vnd.dust.zendesk.helpcenter",
           });
 
           const ticketsNode = brand.getTicketsContentNode(connectorId);
@@ -53,6 +55,7 @@ makeScript({}, async ({ execute }, logger) => {
             folderId: ticketsNode.internalId,
             parents: [ticketsNode.internalId, ticketsNode.parentInternalId],
             title: ticketsNode.title,
+            mimeType: "application/vnd.dust.zendesk.tickets",
           });
         },
         { concurrency: FOLDER_CONCURRENCY }
@@ -79,6 +82,7 @@ makeScript({}, async ({ execute }, logger) => {
             folderId: parents[0],
             parents,
             title: category.name,
+            mimeType: "application/vnd.dust.zendesk.category",
           });
         },
         { concurrency: FOLDER_CONCURRENCY }

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -220,6 +220,7 @@ export async function confluenceUpsertSpaceFolderActivity({
     folderId: makeSpaceInternalId(spaceId),
     parents: [makeSpaceInternalId(spaceId)],
     title: spaceName,
+    mimeType: "application/vnd.dust.confluence.space",
   });
 }
 

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -485,6 +485,7 @@ export async function incrementalSync(
           folderId: getDocumentId(driveFile.id),
           parents,
           title: driveFile.name ?? "",
+          mimeType: "application/vnd.dust.googledrive.folder",
         });
 
         await GoogleDriveFiles.upsert({
@@ -828,6 +829,7 @@ export async function markFolderAsVisited(
     folderId: getDocumentId(file.id),
     parents,
     title: file.name ?? "",
+    mimeType: "application/vnd.dust.googledrive.folder",
   });
 
   await GoogleDriveFiles.upsert({

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -193,6 +193,7 @@ export async function getRootNodesToSyncFromResources(
         folderId: createdOrUpdatedResource.internalId,
         parents: [createdOrUpdatedResource.internalId],
         title: createdOrUpdatedResource.name ?? "",
+        mimeType: "application/vnd.dust.microsoft.folder",
       }),
     { concurrency: 5 }
   );
@@ -463,6 +464,7 @@ export async function syncFiles({
         folderId: createdOrUpdatedResource.internalId,
         parents: [createdOrUpdatedResource.internalId, ...parents],
         title: createdOrUpdatedResource.name ?? "",
+        mimeType: "application/vnd.dust.microsoft.folder",
       }),
     { concurrency: 5 }
   );
@@ -635,6 +637,7 @@ export async function syncDeltaForRootNodesInDrive({
           folderId: blob.internalId,
           parents: [blob.internalId],
           title: blob.name ?? "",
+          mimeType: "application/vnd.dust.microsoft.folder",
         });
 
         // add parent information to new node resource. for the toplevel folder,

--- a/connectors/src/connectors/zendesk/lib/sync_category.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_category.ts
@@ -105,5 +105,6 @@ export async function syncCategory({
     folderId: parents[0],
     parents,
     title: categoryInDb.name,
+    mimeType: "application/vnd.dust.zendesk.category",
   });
 }

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -133,6 +133,7 @@ export async function syncZendeskBrandActivity({
     folderId: brandInternalId,
     parents: [brandInternalId],
     title: brandInDb.name,
+    mimeType: "application/vnd.dust.zendesk.brand",
   });
 
   // using the content node to get one source of truth regarding the parent relationship
@@ -142,6 +143,7 @@ export async function syncZendeskBrandActivity({
     folderId: helpCenterNode.internalId,
     parents: [helpCenterNode.internalId, helpCenterNode.parentInternalId],
     title: helpCenterNode.title,
+    mimeType: "application/vnd.dust.zendesk.helpcenter",
   });
 
   // using the content node to get one source of truth regarding the parent relationship
@@ -151,6 +153,7 @@ export async function syncZendeskBrandActivity({
     folderId: ticketsNode.internalId,
     parents: [ticketsNode.internalId, ticketsNode.parentInternalId],
     title: ticketsNode.title,
+    mimeType: "application/vnd.dust.zendesk.tickets",
   });
 
   // updating the entry in db
@@ -324,6 +327,7 @@ export async function syncZendeskCategoryActivity({
     folderId: parents[0],
     parents,
     title: categoryInDb.name,
+    mimeType: "application/vnd.dust.zendesk.category",
   });
 
   // otherwise, we update the category name and lastUpsertedTs

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -148,6 +148,7 @@ export async function syncZendeskArticleUpdateBatchActivity({
               folderId: parents[0],
               parents,
               title: category.name,
+              mimeType: "application/vnd.dust.zendesk.category",
             });
           } else {
             /// ignoring these to proceed with the other articles, but these might have to be checked at some point

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -1229,6 +1229,7 @@ export async function _upsertDataSourceFolder({
   parents,
   parentId = parents[1] ?? null,
   title,
+  mimeType,
 }: {
   dataSourceConfig: DataSourceConfig;
   folderId: string;
@@ -1236,6 +1237,7 @@ export async function _upsertDataSourceFolder({
   parents: string[];
   parentId?: string | null;
   title: string;
+  mimeType: string;
 }) {
   const now = new Date();
 
@@ -1245,7 +1247,8 @@ export async function _upsertDataSourceFolder({
     timestampMs ? timestampMs : now.getTime(),
     title,
     parentId,
-    parents
+    parents,
+    mimeType
   );
 
   if (r.isErr()) {

--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -2839,6 +2839,7 @@ struct FoldersUpsertPayload {
     parent_id: Option<String>,
     parents: Vec<String>,
     title: String,
+    mime_type: String,
 }
 
 async fn folders_upsert(
@@ -2892,6 +2893,7 @@ async fn folders_upsert(
                 timestamp: payload.timestamp.unwrap_or(utils::now()),
                 parents: payload.parents,
                 title: payload.title,
+                mime_type: payload.mime_type,
             },
         )
         .await

--- a/core/src/data_sources/folder.rs
+++ b/core/src/data_sources/folder.rs
@@ -10,10 +10,8 @@ pub struct Folder {
     title: String,
     parent_id: Option<String>,
     parents: Vec<String>,
+    mime_type: String,
 }
-
-/// MIME type used to identify folder objects
-pub const FOLDER_MIMETYPE: &str = "application/vnd.dust.folder";
 
 impl Folder {
     pub fn new(
@@ -23,6 +21,7 @@ impl Folder {
         title: String,
         parent_id: Option<String>,
         parents: Vec<String>,
+        mime_type: String,
     ) -> Self {
         Folder {
             data_source_id,
@@ -31,6 +30,7 @@ impl Folder {
             title,
             parent_id,
             parents,
+            mime_type,
         }
     }
 
@@ -52,6 +52,9 @@ impl Folder {
     pub fn parents(&self) -> &Vec<String> {
         &self.parents
     }
+    pub fn mime_type(&self) -> &str {
+        &self.mime_type
+    }
 }
 
 impl From<Folder> for Node {
@@ -62,7 +65,7 @@ impl From<Folder> for Node {
             NodeType::Folder,
             folder.timestamp,
             &folder.title,
-            FOLDER_MIMETYPE,
+            &folder.mime_type,
             folder.parent_id,
             folder.parents,
         )

--- a/core/src/data_sources/node.rs
+++ b/core/src/data_sources/node.rs
@@ -86,6 +86,7 @@ impl Node {
             self.title,
             self.parent_id,
             self.parents,
+            self.mime_type,
         )
     }
 }

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -76,6 +76,7 @@ pub struct FolderUpsertParams {
     pub timestamp: u64,
     pub title: String,
     pub parents: Vec<String>,
+    pub mime_type: String,
 }
 
 #[async_trait]

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId].ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId].ts
@@ -94,7 +94,13 @@ async function handler(
         });
       }
 
-      const { timestamp, parent_id: parentId, parents, title } = r.data;
+      const {
+        timestamp,
+        parent_id: parentId,
+        parents,
+        title,
+        mime_type,
+      } = r.data;
       if (parentId && parents && parents[1] !== parentId) {
         return apiError(req, res, {
           status_code: 400,
@@ -126,6 +132,7 @@ async function handler(
         parentId: parentId || null,
         parents: parents || [fId],
         title: title,
+        mimeType: mime_type,
       });
 
       if (upsertRes.isErr()) {

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -824,7 +824,8 @@ export class DustAPI {
     timestamp: number,
     title: string,
     parentId: string | null,
-    parents: string[]
+    parents: string[],
+    mimeType: string
   ) {
     return this.request({
       method: "POST",
@@ -836,6 +837,7 @@ export class DustAPI {
         title,
         parent_id: parentId,
         parents,
+        mime_type: mimeType,
       },
     });
   }

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2109,6 +2109,7 @@ export const UpsertDataSourceFolderRequestSchema = z.object({
   parents: z.array(z.string()).nullable().optional(),
   parent_id: z.string().nullable().optional(),
   title: z.string(),
+  mime_type: z.string(),
 });
 export type UpsertDataSourceFolderRequestType = z.infer<
   typeof UpsertDataSourceFolderRequestSchema

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -1537,6 +1537,7 @@ export class CoreAPI {
     parentId,
     parents,
     title,
+    mimeType,
   }: {
     projectId: string;
     dataSourceId: string;
@@ -1545,6 +1546,7 @@ export class CoreAPI {
     parentId: string | null;
     parents: string[];
     title: string;
+    mimeType: string;
   }): Promise<CoreAPIResponse<{ folder: CoreAPIFolder }>> {
     const response = await this._fetchWithError(
       `${this._url}/projects/${projectId}/data_sources/${encodeURIComponent(
@@ -1561,6 +1563,7 @@ export class CoreAPI {
           title,
           parent_id: parentId,
           parents,
+          mime_type: mimeType,
         }),
       }
     );


### PR DESCRIPTION
## Description
Fixes #9464 

Requires mime type to be set for folders.

Follow up task will be to backfill and standardize mimetypes everywhere see [here](https://github.com/dust-tt/dust/issues/9486)

## Risk
low, mostly in deploy plan

## Deploy Plan
In that order, so api calls keep working:
- connectors
- front
- core
