### PR TITLE
slack: upsertFolder when syncing channel

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -252,7 +252,7 @@ export async function syncChannel(
       title: `#${channel.name}`,
       parentId: null,
       parents: [internalIdFromSlackChannelId(channelId)],
-      // mimeType: "application/vnd.dust.slack.channel",
+      mimeType: "application/vnd.dust.slack.channel",
     });
   }
 

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -33,6 +33,7 @@ import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_c
 import { cacheGet, cacheSet } from "@connectors/lib/cache";
 import {
   deleteDataSourceDocument,
+  deleteDataSourceFolder,
   renderDocumentTitleAndContent,
   upsertDataSourceDocument,
   upsertDataSourceFolder,
@@ -1187,6 +1188,12 @@ export async function deleteChannel(channelId: string, connectorId: ModelId) {
       },
     });
   } while (slackMessages.length === maxMessages);
+
+  await deleteDataSourceFolder({
+    dataSourceConfig,
+    folderId: internalIdFromSlackChannelId(channelId),
+  });
+
   logger.info(
     { nbDeleted, channelId, connectorId },
     "Deleted documents from datasource while garbage collecting."


### PR DESCRIPTION
## Description

- upsertDataSourceFolder for channels in slack connectors at first loop of syncChannel (which is the moment we insert if needed SlackChannel in connector DB)
- deleteDataSourceFolder when channels are garbage collected

## Risk

N/A (tested locally)

## Deploy Plan

- deploy `connectors`