### PR TITLE
[front] Enforce unique name for data source

### DIFF
--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -823,6 +823,14 @@ export async function createDataSourceWithoutProvider(
     });
   }
 
+  if (dataSources.some((ds) => ds.name === name)) {
+    return new Err({
+      name: "dust_error",
+      code: "invalid_request_error",
+      message: "Data source with that name already exist.",
+    });
+  }
+
   const dataSourceEmbedder =
     owner.defaultEmbeddingProvider ?? DEFAULT_EMBEDDING_PROVIDER_ID;
   const embedderConfig = EMBEDDING_CONFIGS[dataSourceEmbedder];


### PR DESCRIPTION
## Description

Additional check for datasource name. If name already exist, return 400 (invalid_request_error ) instead of 500.

## Risk

none

## Deploy Plan

deploy front
