### PR TITLE
[parents_migration] update gdrive internal ID to use the prefixed versions

### DIFF
--- a/connectors/migrations/20240529_clean_gdrive_folders.ts
+++ b/connectors/migrations/20240529_clean_gdrive_folders.ts
@@ -3,7 +3,7 @@ import { QueryTypes } from "sequelize";
 import { getGoogleDriveObject } from "@connectors/connectors/google_drive/lib/google_drive_api";
 import {
   getAuthObject,
-  getDocumentId,
+  getInternalId,
 } from "@connectors/connectors/google_drive/temporal/utils";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import {
@@ -104,7 +104,7 @@ async function main() {
         driveFileId: folderId,
         name: file.name,
         mimeType: file.mimeType,
-        dustFileId: getDocumentId(folderId),
+        dustFileId: getInternalId(folderId),
       });
     }
   }

--- a/connectors/migrations/20241211_fix_gdrive_parents.ts
+++ b/connectors/migrations/20241211_fix_gdrive_parents.ts
@@ -2,7 +2,7 @@ import { concurrentExecutor, getGoogleSheetTableId } from "@dust-tt/types";
 import { makeScript } from "scripts/helpers";
 import { Op } from "sequelize";
 
-import { getDocumentId } from "@connectors/connectors/google_drive/temporal/utils";
+import { getInternalId } from "@connectors/connectors/google_drive/temporal/utils";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import {
   getDataSourceFolder,
@@ -110,7 +110,7 @@ async function migrate({
             dataSourceConfig,
             folderId: internalId,
           });
-          const newParents = parents.map((id) => getDocumentId(id));
+          const newParents = parents.map((id) => getInternalId(id));
           if (!folder || folder.parents.join("/") !== newParents.join("/")) {
             childLogger.info(
               { folderId: file.driveFileId, parents: newParents },
@@ -123,14 +123,14 @@ async function migrate({
                 dataSourceConfig,
                 folderId: file.dustFileId,
                 parents: newParents,
-                parentId: file.parentId ? getDocumentId(file.parentId) : null,
+                parentId: file.parentId ? getInternalId(file.parentId) : null,
                 title: file.name,
               });
             }
           }
         } else if (file.mimeType === "text/csv") {
           const tableId = internalId;
-          parents.unshift(...parents.map((id) => getDocumentId(id)));
+          parents.unshift(...parents.map((id) => getInternalId(id)));
           const table = await getDataSourceTable({ dataSourceConfig, tableId });
           if (table) {
             if (table.parents.join("/") !== parents.join("/")) {
@@ -190,7 +190,7 @@ async function migrate({
           return;
         }
 
-        parents.unshift(...parents.map((id) => getDocumentId(id)));
+        parents.unshift(...parents.map((id) => getInternalId(id)));
         parents.unshift(tableId);
 
         const table = await getDataSourceTable({ dataSourceConfig, tableId });

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -36,20 +36,24 @@ import {
 import {
   driveObjectToDustType,
   getAuthObject,
+  getDocumentId,
   getDriveClient,
+  getDriveId,
 } from "@connectors/connectors/google_drive/temporal/utils";
 import type {
   CreateConnectorErrorCode,
   UpdateConnectorErrorCode,
 } from "@connectors/connectors/interface";
-import { ConnectorManagerError } from "@connectors/connectors/interface";
-import { BaseConnectorManager } from "@connectors/connectors/interface";
+import {
+  BaseConnectorManager,
+  ConnectorManagerError,
+} from "@connectors/connectors/interface";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
-import { GoogleDriveSheet } from "@connectors/lib/models/google_drive";
 import {
   GoogleDriveConfig,
   GoogleDriveFiles,
   GoogleDriveFolders,
+  GoogleDriveSheet,
 } from "@connectors/lib/models/google_drive";
 import { syncSucceeded } from "@connectors/lib/sync_status";
 import { terminateAllWorkflowsForConnectorId } from "@connectors/lib/temporal";
@@ -247,8 +251,9 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
         new Error("Tables view is only supported for read permissions")
       );
     }
+    const parentDriveId = parentInternalId && getDriveId(parentInternalId);
     if (filterPermission === "read") {
-      if (parentInternalId === null) {
+      if (parentDriveId === null) {
         // Return the list of folders explicitly selected by the user.
         const folders = await GoogleDriveFolders.findAll({
           where: {
@@ -273,7 +278,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
         // Return the list of all folders and files synced in a parent folder.
         const where: WhereOptions<InferAttributes<GoogleDriveFiles>> = {
           connectorId: this.connectorId,
-          parentId: parentInternalId,
+          parentId: parentDriveId,
         };
         if (isTablesView) {
           // In tables view, we only show folders, spreadhsheets and sheets.
@@ -291,7 +296,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
           sheets = await GoogleDriveSheet.findAll({
             where: {
               connectorId: this.connectorId,
-              driveFileId: parentInternalId,
+              driveFileId: parentDriveId,
             },
           });
         }
@@ -303,7 +308,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
 
             return {
               provider: c.type,
-              internalId: f.driveFileId,
+              internalId: getDocumentId(f.driveFileId),
               parentInternalId: null,
               type,
               title: f.name || "",
@@ -331,7 +336,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
                   s.driveFileId,
                   s.driveSheetId
                 ),
-                parentInternalId: s.driveFileId,
+                parentInternalId: getDocumentId(s.driveFileId),
                 type: "database" as const,
                 title: s.name || "",
                 dustDocumentId: null,
@@ -376,8 +381,10 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
             }
             return {
               provider: c.type,
-              internalId: driveObject.id,
-              parentInternalId: driveObject.parent,
+              internalId: getDocumentId(driveObject.id),
+              parentInternalId:
+                // note: if the parent is null, the drive object falls at top-level
+                driveObject.parent && getDocumentId(driveObject.parent),
               type: "folder" as const,
               title: driveObject.name,
               sourceUrl: driveObject.webViewLink || null,
@@ -431,7 +438,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
         if (parentInternalId === GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID) {
           gdriveQuery += ` and sharedWithMe=true`;
         } else {
-          gdriveQuery += ` and '${parentInternalId}' in parents`;
+          gdriveQuery += ` and '${parentDriveId}' in parents`;
         }
         do {
           const res: GaxiosResponse<drive_v3.Schema$FileList> =
@@ -468,8 +475,9 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
 
             return {
               provider: c.type,
-              internalId: driveObject.id,
-              parentInternalId: driveObject.parent,
+              internalId: getDocumentId(driveObject.id),
+              parentInternalId:
+                driveObject.parent && getDocumentId(driveObject.parent),
               type: "folder" as const,
               title: driveObject.name,
               sourceUrl: driveObject.webViewLink || null,
@@ -516,7 +524,8 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
 
     const addedFolderIds: string[] = [];
     const removedFolderIds: string[] = [];
-    for (const [id, permission] of Object.entries(permissions)) {
+    for (const [internalId, permission] of Object.entries(permissions)) {
+      const id = getDriveId(internalId);
       if (permission === "none") {
         removedFolderIds.push(id);
         await GoogleDriveFolders.destroy({
@@ -572,9 +581,9 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
     internalIds: string[];
     viewType: ContentNodesViewType;
   }): Promise<Result<ContentNode[], Error>> {
-    const driveFileIds = internalIds.filter(
-      (id) => !isGoogleSheetContentNodeInternalId(id)
-    );
+    const driveFileIds = internalIds
+      .filter((id) => !isGoogleSheetContentNodeInternalId(id))
+      .map(getDriveId);
     const sheetIds = internalIds
       .filter((id) => isGoogleSheetContentNodeInternalId(id))
       .map(getGoogleIdsFromSheetContentNodeInternalId);
@@ -636,7 +645,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
 
         return {
           provider: "google_drive",
-          internalId: f.driveFileId,
+          internalId: getDocumentId(f.driveFileId),
           parentInternalId: null,
           type,
           title: f.name || "",
@@ -680,7 +689,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
         s.driveFileId,
         s.driveSheetId
       ),
-      parentInternalId: s.driveFileId,
+      parentInternalId: getDocumentId(s.driveFileId),
       type: "database",
       title: s.name || "",
       dustDocumentId: null,
@@ -937,7 +946,7 @@ async function getFoldersAsContentNodes({
       const sourceUrl = `https://drive.google.com/drive/folders/${f.folderId}`;
       return {
         provider: "google_drive",
-        internalId: f.folderId,
+        internalId: getDocumentId(f.folderId),
         parentInternalId: null,
         type: "folder",
         title: fd.name || "",

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -36,9 +36,9 @@ import {
 import {
   driveObjectToDustType,
   getAuthObject,
-  getDocumentId,
   getDriveClient,
   getDriveId,
+  getInternalId,
 } from "@connectors/connectors/google_drive/temporal/utils";
 import type {
   CreateConnectorErrorCode,
@@ -308,7 +308,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
 
             return {
               provider: c.type,
-              internalId: getDocumentId(f.driveFileId),
+              internalId: getInternalId(f.driveFileId),
               parentInternalId: null,
               type,
               title: f.name || "",
@@ -336,7 +336,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
                   s.driveFileId,
                   s.driveSheetId
                 ),
-                parentInternalId: getDocumentId(s.driveFileId),
+                parentInternalId: getInternalId(s.driveFileId),
                 type: "database" as const,
                 title: s.name || "",
                 dustDocumentId: null,
@@ -381,10 +381,10 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
             }
             return {
               provider: c.type,
-              internalId: getDocumentId(driveObject.id),
+              internalId: getInternalId(driveObject.id),
               parentInternalId:
                 // note: if the parent is null, the drive object falls at top-level
-                driveObject.parent && getDocumentId(driveObject.parent),
+                driveObject.parent && getInternalId(driveObject.parent),
               type: "folder" as const,
               title: driveObject.name,
               sourceUrl: driveObject.webViewLink || null,
@@ -475,9 +475,9 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
 
             return {
               provider: c.type,
-              internalId: getDocumentId(driveObject.id),
+              internalId: getInternalId(driveObject.id),
               parentInternalId:
-                driveObject.parent && getDocumentId(driveObject.parent),
+                driveObject.parent && getInternalId(driveObject.parent),
               type: "folder" as const,
               title: driveObject.name,
               sourceUrl: driveObject.webViewLink || null,
@@ -645,7 +645,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
 
         return {
           provider: "google_drive",
-          internalId: getDocumentId(f.driveFileId),
+          internalId: getInternalId(f.driveFileId),
           parentInternalId: null,
           type,
           title: f.name || "",
@@ -689,7 +689,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
         s.driveFileId,
         s.driveSheetId
       ),
-      parentInternalId: getDocumentId(s.driveFileId),
+      parentInternalId: getInternalId(s.driveFileId),
       type: "database",
       title: s.name || "",
       dustDocumentId: null,
@@ -946,7 +946,7 @@ async function getFoldersAsContentNodes({
       const sourceUrl = `https://drive.google.com/drive/folders/${f.folderId}`;
       return {
         provider: "google_drive",
-        internalId: getDocumentId(f.folderId),
+        internalId: getInternalId(f.folderId),
         parentInternalId: null,
         type: "folder",
         title: fd.name || "",

--- a/connectors/src/connectors/google_drive/lib.ts
+++ b/connectors/src/connectors/google_drive/lib.ts
@@ -8,6 +8,10 @@ import type { InferAttributes, WhereOptions } from "sequelize";
 
 import { isGoogleDriveSpreadSheetFile } from "@connectors/connectors/google_drive/temporal/mime_types";
 import {
+  getDocumentId,
+  getDriveId,
+} from "@connectors/connectors/google_drive/temporal/utils";
+import {
   GoogleDriveFiles,
   GoogleDriveSheet,
 } from "@connectors/lib/models/google_drive";
@@ -69,15 +73,15 @@ async function _getLocalParents(
     const { googleFileId } = getGoogleIdsFromSheetContentNodeInternalId(
       contentNodeInternalId
     );
-    parentId = googleFileId;
+    parentId = getDocumentId(googleFileId);
   } else {
     const object = await GoogleDriveFiles.findOne({
       where: {
         connectorId,
-        driveFileId: contentNodeInternalId,
+        driveFileId: getDriveId(contentNodeInternalId),
       },
     });
-    parentId = object?.parentId ?? null;
+    parentId = object?.parentId ? getDocumentId(object.parentId) : null;
   }
 
   if (!parentId) {

--- a/connectors/src/connectors/google_drive/lib.ts
+++ b/connectors/src/connectors/google_drive/lib.ts
@@ -8,8 +8,8 @@ import type { InferAttributes, WhereOptions } from "sequelize";
 
 import { isGoogleDriveSpreadSheetFile } from "@connectors/connectors/google_drive/temporal/mime_types";
 import {
-  getDocumentId,
   getDriveId,
+  getInternalId,
 } from "@connectors/connectors/google_drive/temporal/utils";
 import {
   GoogleDriveFiles,
@@ -73,7 +73,7 @@ async function _getLocalParents(
     const { googleFileId } = getGoogleIdsFromSheetContentNodeInternalId(
       contentNodeInternalId
     );
-    parentId = getDocumentId(googleFileId);
+    parentId = getInternalId(googleFileId);
   } else {
     const object = await GoogleDriveFiles.findOne({
       where: {
@@ -81,7 +81,7 @@ async function _getLocalParents(
         driveFileId: getDriveId(contentNodeInternalId),
       },
     });
-    parentId = object?.parentId ? getDocumentId(object.parentId) : null;
+    parentId = object?.parentId ? getInternalId(object.parentId) : null;
   }
 
   if (!parentId) {

--- a/connectors/src/connectors/google_drive/lib/cli.ts
+++ b/connectors/src/connectors/google_drive/lib/cli.ts
@@ -10,8 +10,8 @@ import { launchGoogleDriveIncrementalSyncWorkflow } from "@connectors/connectors
 import { MIME_TYPES_TO_EXPORT } from "@connectors/connectors/google_drive/temporal/mime_types";
 import {
   getAuthObject,
-  getDocumentId,
   getDriveClient,
+  getInternalId,
 } from "@connectors/connectors/google_drive/temporal/utils";
 import { throwOnError } from "@connectors/lib/cli";
 import { GoogleDriveFiles } from "@connectors/lib/models/google_drive";
@@ -162,7 +162,7 @@ export const google_drive = async ({
       } else {
         await GoogleDriveFiles.create({
           driveFileId: args.fileId,
-          dustFileId: getDocumentId(args.fileId),
+          dustFileId: getInternalId(args.fileId),
           name: "unknown",
           mimeType: "unknown",
           connectorId: connector.id,

--- a/connectors/src/connectors/google_drive/lib/permissions.ts
+++ b/connectors/src/connectors/google_drive/lib/permissions.ts
@@ -2,7 +2,7 @@ import {
   isGoogleDriveFolder,
   isGoogleDriveSpreadSheetFile,
 } from "@connectors/connectors/google_drive/temporal/mime_types";
-import { getDocumentId } from "@connectors/connectors/google_drive/temporal/utils";
+import { getInternalId } from "@connectors/connectors/google_drive/temporal/utils";
 import type { GoogleDriveFiles } from "@connectors/lib/models/google_drive";
 
 export function getPermissionViewType(file: GoogleDriveFiles) {
@@ -18,5 +18,5 @@ export function getGoogleDriveEntityDocumentId(file: GoogleDriveFiles) {
     return null;
   }
 
-  return getDocumentId(file.driveFileId);
+  return getInternalId(file.driveFileId);
 }

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -19,8 +19,8 @@ import { deleteSpreadsheet } from "@connectors/connectors/google_drive/temporal/
 import {
   driveObjectToDustType,
   getAuthObject,
-  getDocumentId,
   getDriveClient,
+  getInternalId,
   getMyDriveIdCached,
 } from "@connectors/connectors/google_drive/temporal/utils";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
@@ -478,18 +478,18 @@ export async function incrementalSync(
           startSyncTs
         );
 
-        const parents = parentGoogleIds.map((parent) => getDocumentId(parent));
+        const parents = parentGoogleIds.map((parent) => getInternalId(parent));
 
         await upsertDataSourceFolder({
           dataSourceConfig,
-          folderId: getDocumentId(driveFile.id),
+          folderId: getInternalId(driveFile.id),
           parents,
           title: driveFile.name ?? "",
         });
 
         await GoogleDriveFiles.upsert({
           connectorId: connectorId,
-          dustFileId: getDocumentId(driveFile.id),
+          dustFileId: getInternalId(driveFile.id),
           driveFileId: file.id,
           name: file.name,
           mimeType: file.mimeType,
@@ -821,18 +821,18 @@ export async function markFolderAsVisited(
     startSyncTs
   );
 
-  const parents = parentGoogleIds.map((parent) => getDocumentId(parent));
+  const parents = parentGoogleIds.map((parent) => getInternalId(parent));
 
   await upsertDataSourceFolder({
     dataSourceConfig,
-    folderId: getDocumentId(file.id),
+    folderId: getInternalId(file.id),
     parents,
     title: file.name ?? "",
   });
 
   await GoogleDriveFiles.upsert({
     connectorId: connectorId,
-    dustFileId: getDocumentId(driveFileId),
+    dustFileId: getInternalId(driveFileId),
     driveFileId: file.id,
     name: file.name,
     mimeType: file.mimeType,

--- a/connectors/src/connectors/google_drive/temporal/file.ts
+++ b/connectors/src/connectors/google_drive/temporal/file.ts
@@ -13,8 +13,8 @@ import {
 } from "@connectors/connectors/google_drive/temporal/mime_types";
 import { syncSpreadSheet } from "@connectors/connectors/google_drive/temporal/spreadsheets";
 import {
-  getDocumentId,
   getDriveClient,
+  getInternalId,
 } from "@connectors/connectors/google_drive/temporal/utils";
 import {
   handleCsvFile,
@@ -189,7 +189,7 @@ async function handleFileExport(
       startSyncTs
     );
 
-    const parents = parentGoogleIds.map((parent) => getDocumentId(parent));
+    const parents = parentGoogleIds.map((parent) => getInternalId(parent));
 
     result = await handleCsvFile({
       data: res.data,
@@ -241,7 +241,7 @@ export async function syncOneFile(
         },
       });
 
-      const documentId = getDocumentId(file.id);
+      const documentId = getInternalId(file.id);
       const fileInDb = await GoogleDriveFiles.findOne({
         where: { connectorId, driveFileId: file.id },
       });
@@ -329,7 +329,7 @@ async function syncOneFileTable(
   let skipReason: string | undefined;
   const upsertTimestampMs = undefined;
 
-  const documentId = getDocumentId(file.id);
+  const documentId = getInternalId(file.id);
 
   if (isGoogleDriveSpreadSheetFile(file)) {
     const res = await syncSpreadSheet(
@@ -389,7 +389,7 @@ async function syncOneFileTextDocument(
     csvEnabled: config?.csvEnabled || false,
   });
 
-  const documentId = getDocumentId(file.id);
+  const documentId = getInternalId(file.id);
 
   if (MIME_TYPES_TO_EXPORT[file.mimeType]) {
     documentContent = await handleGoogleDriveExport(
@@ -483,7 +483,7 @@ async function upsertGdriveDocument(
       startSyncTs
     );
 
-    const parents = parentGoogleIds.map((parent) => getDocumentId(parent));
+    const parents = parentGoogleIds.map((parent) => getInternalId(parent));
 
     await upsertDataSourceDocument({
       dataSourceConfig,

--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -12,7 +12,7 @@ import { google } from "googleapis";
 import type { OAuth2Client } from "googleapis-common";
 
 import { getFileParentsMemoized } from "@connectors/connectors/google_drive/lib/hierarchy";
-import { getDocumentId } from "@connectors/connectors/google_drive/temporal/utils";
+import { getInternalId } from "@connectors/connectors/google_drive/temporal/utils";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import {
@@ -497,7 +497,7 @@ export async function syncSpreadSheet(
         startSyncTs
       );
 
-      const parents = parentGoogleIds.map((parent) => getDocumentId(parent));
+      const parents = parentGoogleIds.map((parent) => getInternalId(parent));
 
       const successfulSheetIdImports: number[] = [];
       for (const sheet of sheets) {

--- a/connectors/src/connectors/google_drive/temporal/utils.ts
+++ b/connectors/src/connectors/google_drive/temporal/utils.ts
@@ -9,7 +9,7 @@ import { getOAuthConnectionAccessTokenWithThrow } from "@connectors/lib/oauth";
 import logger from "@connectors/logger/logger";
 import type { GoogleDriveObjectType } from "@connectors/types/google_drive";
 
-export function getDocumentId(driveFileId: string): string {
+export function getInternalId(driveFileId: string): string {
   return `gdrive-${driveFileId}`;
 }
 

--- a/connectors/src/connectors/google_drive/temporal/utils.ts
+++ b/connectors/src/connectors/google_drive/temporal/utils.ts
@@ -13,6 +13,10 @@ export function getDocumentId(driveFileId: string): string {
   return `gdrive-${driveFileId}`;
 }
 
+export function getDriveId(documentId: string): string {
+  return documentId.replace(/^gdrive-/, "");
+}
+
 async function _getMyDriveId(auth_credentials: OAuth2Client) {
   const drive = await getDriveClient(auth_credentials);
   let myDriveRes: GaxiosResponse<drive_v3.Schema$File>;


### PR DESCRIPTION
## Description

- Update the /content-node API to rely on the prefixed versions of the internal ID.
- On several db queries we have a field that contains the prefixed version, I opted to remove the prefix and keep the query on the non-prefixed because we have indexes of the corresponding columns.
- Tested locally: connector setup, add data to global space, create assistant.

## Risk

- Quite high.

## Deploy Plan

- Activate kill switches.
- Deploy connectors.
- Run front migration.
- Desactivate kill switches.
