### PR TITLE
enh(tracker): reduce gdrive debounce and run upsert hooks in dev

### DIFF
--- a/front/lib/document_upsert_hooks/hooks/index.ts
+++ b/front/lib/document_upsert_hooks/hooks/index.ts
@@ -1,4 +1,5 @@
 import type { ConnectorProvider, UpsertContext } from "@dust-tt/types";
+import { isDevelopment } from "@dust-tt/types";
 
 import type { Authenticator } from "@app/lib/auth";
 import { trackerUpsertHook } from "@app/lib/document_upsert_hooks/hooks/tracker";
@@ -30,7 +31,7 @@ export function runDocumentUpsertHooks(
   params: Parameters<DocumentUpsertHook["fn"]>[0]
 ): void {
   // TODO(document-tracker): remove this once we have a way to enable/disable
-  if (params.auth.workspace()?.sId !== DUST_WORKSPACE) {
+  if (params.auth.workspace()?.sId !== DUST_WORKSPACE && !isDevelopment()) {
     return;
   }
 

--- a/front/temporal/tracker/workflows.ts
+++ b/front/temporal/tracker/workflows.ts
@@ -41,7 +41,7 @@ export async function trackersGenerationWorkflow(
     if (!dataSourceConnectorProvider) {
       return 10000;
     }
-    if (dataSourceConnectorProvider === "notion") {
+    if (["notion", "google_drive"].includes(dataSourceConnectorProvider)) {
       return 600000;
     }
     return 3600000;


### PR DESCRIPTION
## Description

- Debounce a whole hour does not make sense for gdrive
- want to run the trackers locally


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
