### PR TITLE
sdk: fix folder implementation

### DIFF
--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -34,6 +34,7 @@ import {
   APIErrorSchema,
   CancelMessageGenerationResponseSchema,
   CreateConversationResponseSchema,
+  DeleteFolderResponseSchema,
   Err,
   FileUploadRequestResponseSchema,
   FileUploadUrlRequestSchema,
@@ -53,6 +54,7 @@ import {
   RunAppResponseSchema,
   SearchDataSourceViewsResponseSchema,
   TokenizeResponseSchema,
+  UpsertFolderResponseSchema,
 } from "./types";
 
 export * from "./types";
@@ -827,7 +829,7 @@ export class DustAPI {
     parents: string[],
     mimeType: string
   ) {
-    return this.request({
+    const res = await this.request({
       method: "POST",
       path: `data_sources/${dataSourceId}/folders/${encodeURIComponent(
         folderId
@@ -840,15 +842,29 @@ export class DustAPI {
         mime_type: mimeType,
       },
     });
+
+    const r = await this._resultFromResponse(UpsertFolderResponseSchema, res);
+    if (r.isErr()) {
+      return r;
+    }
+
+    return new Ok(r.value);
   }
 
   async deleteFolder(dataSourceId: string, folderId: string) {
-    return this.request({
+    const res = await this.request({
       method: "DELETE",
       path: `data_sources/${dataSourceId}/folders/${encodeURIComponent(
         folderId
       )}`,
     });
+
+    const r = await this._resultFromResponse(DeleteFolderResponseSchema, res);
+    if (r.isErr()) {
+      return r;
+    }
+
+    return new Ok(r.value);
   }
 
   async uploadFile({

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2083,7 +2083,7 @@ export const GetFolderResponseSchema = z.object({
 });
 export type GetFolderResponseType = z.infer<typeof GetFolderResponseSchema>;
 
-const DeleteFolderResponseSchema = z.object({
+export const DeleteFolderResponseSchema = z.object({
   folder: z.object({
     folder_id: z.string(),
   }),
@@ -2091,13 +2091,8 @@ const DeleteFolderResponseSchema = z.object({
 export type DeleteFolderResponseType = z.infer<
   typeof DeleteFolderResponseSchema
 >;
-const UpsertFolderResponseSchema = z.object({
-  document: z.union([
-    CoreAPIFolderSchema,
-    z.object({
-      document_id: z.string(),
-    }),
-  ]),
+export const UpsertFolderResponseSchema = z.object({
+  folder: CoreAPIFolderSchema,
   data_source: DataSourceTypeSchema,
 });
 export type UpsertFolderResponseType = z.infer<


### PR DESCRIPTION
## Description

Current SDK implementation would swallow errors (r? @tdraier)
Response type for folder upsert was inaccurate it seems (r? @overmode)

## Risk

Low

## Deploy Plan

- deploy `connectors`