### PR TITLE
[parents_migration] Add and backfill Google Drive "Shared with me" folders

### DIFF
--- a/connectors/migrations/20241218_backfill_gdrive_shared_with_me.ts
+++ b/connectors/migrations/20241218_backfill_gdrive_shared_with_me.ts
@@ -2,31 +2,38 @@ import { makeScript } from "scripts/helpers";
 
 import { getSharedWithMeFolderId } from "@connectors/connectors/google_drive/lib/hierarchy";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 
 makeScript({}, async ({ execute }, logger) => {
   const connectors = await ConnectorResource.listByType("google_drive", {});
 
-  for (const connector of connectors) {
-    // this is a strict copy-paste of upsertSharedWithMeFolder, I don't want to export it for a migration script and want the folderId for logging purposes
-    const dataSourceConfig = dataSourceConfigFromConnector(connector);
-    const folderId = getSharedWithMeFolderId(connector);
+  await concurrentExecutor(
+    connectors,
+    async (connector) => {
+      // this is a strict copy-paste of upsertSharedWithMeFolder, I don't want to export it for a migration script and want the folderId for logging purposes
+      const dataSourceConfig = dataSourceConfigFromConnector(connector);
+      const folderId = getSharedWithMeFolderId(connector);
 
-    if (execute) {
-      await upsertDataSourceFolder({
-        dataSourceConfig,
-        folderId,
-        parents: [folderId],
-        parentId: null,
-        title: "Shared with me",
-        mimeType: "application/vnd.dust.googledrive.folder",
-      });
-      logger.info(`Upserted folder ${folderId} for connector ${connector.id}`);
-    } else {
-      logger.info(
-        `Would upsert folder ${folderId} for connector ${connector.id}`
-      );
-    }
-  }
+      if (execute) {
+        await upsertDataSourceFolder({
+          dataSourceConfig,
+          folderId,
+          parents: [folderId],
+          parentId: null,
+          title: "Shared with me",
+          mimeType: "application/vnd.dust.googledrive.folder",
+        });
+        logger.info(
+          `Upserted folder ${folderId} for connector ${connector.id}`
+        );
+      } else {
+        logger.info(
+          `Would upsert folder ${folderId} for connector ${connector.id}`
+        );
+      }
+    },
+    { concurrency: 10 }
+  );
 });

--- a/connectors/migrations/20241218_backfill_gdrive_shared_with_me.ts
+++ b/connectors/migrations/20241218_backfill_gdrive_shared_with_me.ts
@@ -1,0 +1,32 @@
+import { makeScript } from "scripts/helpers";
+
+import { getSharedWithMeFolderId } from "@connectors/connectors/google_drive/lib/hierarchy";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+
+makeScript({}, async ({ execute }, logger) => {
+  const connectors = await ConnectorResource.listByType("google_drive", {});
+
+  for (const connector of connectors) {
+    // this is a strict copy-paste of upsertSharedWithMeFolder, I don't want to export it for a migration script and want the folderId for logging purposes
+    const dataSourceConfig = dataSourceConfigFromConnector(connector);
+    const folderId = getSharedWithMeFolderId(connector);
+
+    if (execute) {
+      await upsertDataSourceFolder({
+        dataSourceConfig,
+        folderId,
+        parents: [folderId],
+        parentId: null,
+        title: "Shared with me",
+        mimeType: "application/vnd.dust.googledrive.folder",
+      });
+      logger.info(`Upserted folder ${folderId} for connector ${connector.id}`);
+    } else {
+      logger.info(
+        `Would upsert folder ${folderId} for connector ${connector.id}`
+      );
+    }
+  }
+});

--- a/connectors/migrations/20241218_backfill_gdrive_shared_with_me.ts
+++ b/connectors/migrations/20241218_backfill_gdrive_shared_with_me.ts
@@ -14,7 +14,7 @@ makeScript({}, async ({ execute }, logger) => {
     async (connector) => {
       // this is a strict copy-paste of upsertSharedWithMeFolder, I don't want to export it for a migration script and want the folderId for logging purposes
       const dataSourceConfig = dataSourceConfigFromConnector(connector);
-      const folderId = getSharedWithMeFolderId(connector);
+      const folderId = getSharedWithMeFolderId(dataSourceConfig);
 
       if (execute) {
         await upsertDataSourceFolder({

--- a/connectors/migrations/20241218_backfill_gdrive_shared_with_me.ts
+++ b/connectors/migrations/20241218_backfill_gdrive_shared_with_me.ts
@@ -1,6 +1,7 @@
 import { makeScript } from "scripts/helpers";
 
-import { getSharedWithMeFolderId } from "@connectors/connectors/google_drive/lib/hierarchy";
+import { GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID } from "@connectors/connectors/google_drive/lib/consts";
+import { getInternalId } from "@connectors/connectors/google_drive/temporal/utils";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
@@ -12,13 +13,10 @@ makeScript({}, async ({ execute }, logger) => {
   await concurrentExecutor(
     connectors,
     async (connector) => {
-      // this is a strict copy-paste of upsertSharedWithMeFolder, I don't want to export it for a migration script and want the folderId for logging purposes
-      const dataSourceConfig = dataSourceConfigFromConnector(connector);
-      const folderId = getSharedWithMeFolderId(dataSourceConfig);
-
+      const folderId = getInternalId(GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID);
       if (execute) {
         await upsertDataSourceFolder({
-          dataSourceConfig,
+          dataSourceConfig: dataSourceConfigFromConnector(connector),
           folderId,
           parents: [folderId],
           parentId: null,

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -222,6 +222,13 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
       );
     }
 
+    const dataSourceConfig = dataSourceConfigFromConnector(connector);
+    // cleaning up the Shared With Me folder
+    await deleteDataSourceFolder({
+      dataSourceConfig,
+      folderId: getSharedWithMeFolderId(dataSourceConfig),
+    });
+
     // Google revocation requires refresh tokens so would have to happen in `oauth`. But Google
     // Drive does not rely on webhooks anymore so we can just delete the connector.
 
@@ -233,12 +240,6 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
       );
       return res;
     }
-    const dataSourceConfig = dataSourceConfigFromConnector(connector);
-    // cleaning up the Shared With Me folder
-    await deleteDataSourceFolder({
-      dataSourceConfig,
-      folderId: getSharedWithMeFolderId(dataSourceConfig),
-    });
 
     return new Ok(undefined);
   }

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -23,7 +23,6 @@ import {
   getLocalParents,
   isDriveObjectExpandable,
 } from "@connectors/connectors/google_drive/lib";
-import { GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID } from "@connectors/connectors/google_drive/lib/consts";
 import { getGoogleDriveObject } from "@connectors/connectors/google_drive/lib/google_drive_api";
 import { getSharedWithMeFolderId } from "@connectors/connectors/google_drive/lib/hierarchy";
 import {
@@ -414,7 +413,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
         // that are not living in a shared drive.
         nodes.push({
           provider: c.type,
-          internalId: GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID,
+          internalId: getSharedWithMeFolderId(c),
           parentInternalId: null,
           type: "folder" as const,
           preventSelection: true,
@@ -440,7 +439,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
         // The "Shared with me" view requires to look for folders
         // with the flag `sharedWithMe=true`, but there is no need to check for the parents.
         let gdriveQuery = `mimeType='application/vnd.google-apps.folder'`;
-        if (parentInternalId === GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID) {
+        if (parentInternalId === getSharedWithMeFolderId(c)) {
           gdriveQuery += ` and sharedWithMe=true`;
         } else {
           gdriveQuery += ` and '${parentDriveId}' in parents`;

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -233,10 +233,11 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
       );
       return res;
     }
+    const dataSourceConfig = dataSourceConfigFromConnector(connector);
     // cleaning up the Shared With Me folder
     await deleteDataSourceFolder({
-      dataSourceConfig: dataSourceConfigFromConnector(connector),
-      folderId: getSharedWithMeFolderId(connector),
+      dataSourceConfig,
+      folderId: getSharedWithMeFolderId(dataSourceConfig),
     });
 
     return new Ok(undefined);
@@ -419,9 +420,10 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
         );
         // Adding a fake "Shared with me" node, to allow the user to see their shared files
         // that are not living in a shared drive.
+        const dataSourceConfig = dataSourceConfigFromConnector(c);
         nodes.push({
           provider: c.type,
-          internalId: getSharedWithMeFolderId(c),
+          internalId: getSharedWithMeFolderId(dataSourceConfig),
           parentInternalId: null,
           type: "folder" as const,
           preventSelection: true,
@@ -447,7 +449,8 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
         // The "Shared with me" view requires to look for folders
         // with the flag `sharedWithMe=true`, but there is no need to check for the parents.
         let gdriveQuery = `mimeType='application/vnd.google-apps.folder'`;
-        if (parentInternalId === getSharedWithMeFolderId(c)) {
+        const dataSourceConfig = dataSourceConfigFromConnector(c);
+        if (parentInternalId === getSharedWithMeFolderId(dataSourceConfig)) {
           gdriveQuery += ` and sharedWithMe=true`;
         } else {
           gdriveQuery += ` and '${parentDriveId}' in parents`;

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -48,9 +48,7 @@ import {
   BaseConnectorManager,
   ConnectorManagerError,
 } from "@connectors/connectors/interface";
-import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
-import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
 import {
   GoogleDriveConfig,
   GoogleDriveFiles,
@@ -130,17 +128,6 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
       },
       googleDriveConfigurationBlob
     );
-
-    // Upserts to data_sources_folders (core) a top-level folder "Shared with me".
-    const folderId = getInternalId(GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID);
-    await upsertDataSourceFolder({
-      dataSourceConfig: dataSourceConfigFromConnector(connector),
-      folderId,
-      parents: [folderId],
-      parentId: null,
-      title: "Shared with me",
-      mimeType: "application/vnd.dust.googledrive.folder",
-    });
 
     // We mark it artificially as sync succeeded as google drive is created empty.
     await syncSucceeded(connector.id);

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -25,6 +25,7 @@ import {
 } from "@connectors/connectors/google_drive/lib";
 import { GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID } from "@connectors/connectors/google_drive/lib/consts";
 import { getGoogleDriveObject } from "@connectors/connectors/google_drive/lib/google_drive_api";
+import { getSharedWithMeFolderId } from "@connectors/connectors/google_drive/lib/hierarchy";
 import {
   getGoogleDriveEntityDocumentId,
   getPermissionViewType,
@@ -48,7 +49,9 @@ import {
   BaseConnectorManager,
   ConnectorManagerError,
 } from "@connectors/connectors/interface";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
+import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
 import {
   GoogleDriveConfig,
   GoogleDriveFiles,
@@ -128,6 +131,8 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
       },
       googleDriveConfigurationBlob
     );
+
+    await upsertSharedWithMeFolder(connector);
 
     // We mark it artificially as sync succeeded as google drive is created empty.
     await syncSucceeded(connector.id);

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -50,10 +50,7 @@ import {
 } from "@connectors/connectors/interface";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
-import {
-  deleteDataSourceFolder,
-  upsertDataSourceFolder,
-} from "@connectors/lib/data_sources";
+import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
 import {
   GoogleDriveConfig,
   GoogleDriveFiles,
@@ -221,12 +218,6 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
         new Error(`Could not find connector with id ${this.connectorId}`)
       );
     }
-
-    // cleaning up the Shared With Me folder
-    await deleteDataSourceFolder({
-      dataSourceConfig: dataSourceConfigFromConnector(connector),
-      folderId: getInternalId(GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID),
-    });
 
     // Google revocation requires refresh tokens so would have to happen in `oauth`. But Google
     // Drive does not rely on webhooks anymore so we can just delete the connector.

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -979,3 +979,19 @@ function getSourceUrlForGoogleDriveFiles(f: GoogleDriveFiles): string {
 
   return `https://drive.google.com/file/d/${f.driveFileId}/view`;
 }
+
+/**
+ * Upserts to data_sources_folders (core) a top-level folder "Shared with me".
+ */
+async function upsertSharedWithMeFolder(connector: ConnectorResource) {
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+  const folderId = getSharedWithMeFolderId(dataSourceConfig);
+  await upsertDataSourceFolder({
+    dataSourceConfig,
+    folderId,
+    parents: [folderId],
+    parentId: null,
+    title: "Shared with me",
+    mimeType: "application/vnd.dust.googledrive.folder",
+  });
+}

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -131,7 +131,16 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
       googleDriveConfigurationBlob
     );
 
-    await upsertSharedWithMeFolder(connector);
+    // Upserts to data_sources_folders (core) a top-level folder "Shared with me".
+    const folderId = getInternalId(GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID);
+    await upsertDataSourceFolder({
+      dataSourceConfig: dataSourceConfigFromConnector(connector),
+      folderId,
+      parents: [folderId],
+      parentId: null,
+      title: "Shared with me",
+      mimeType: "application/vnd.dust.googledrive.folder",
+    });
 
     // We mark it artificially as sync succeeded as google drive is created empty.
     await syncSucceeded(connector.id);
@@ -981,19 +990,4 @@ function getSourceUrlForGoogleDriveFiles(f: GoogleDriveFiles): string {
   }
 
   return `https://drive.google.com/file/d/${f.driveFileId}/view`;
-}
-
-/**
- * Upserts to data_sources_folders (core) a top-level folder "Shared with me".
- */
-async function upsertSharedWithMeFolder(connector: ConnectorResource) {
-  const folderId = getInternalId(GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID);
-  await upsertDataSourceFolder({
-    dataSourceConfig: dataSourceConfigFromConnector(connector),
-    folderId,
-    parents: [folderId],
-    parentId: null,
-    title: "Shared with me",
-    mimeType: "application/vnd.dust.googledrive.folder",
-  });
 }

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -222,10 +222,9 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
       );
     }
 
-    const dataSourceConfig = dataSourceConfigFromConnector(connector);
     // cleaning up the Shared With Me folder
     await deleteDataSourceFolder({
-      dataSourceConfig,
+      dataSourceConfig: dataSourceConfigFromConnector(connector),
       folderId: getInternalId(GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID),
     });
 

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -50,7 +50,10 @@ import {
 } from "@connectors/connectors/interface";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
-import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
+import {
+  deleteDataSourceFolder,
+  upsertDataSourceFolder,
+} from "@connectors/lib/data_sources";
 import {
   GoogleDriveConfig,
   GoogleDriveFiles,
@@ -230,6 +233,11 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
       );
       return res;
     }
+    // cleaning up the Shared With Me folder
+    await deleteDataSourceFolder({
+      dataSourceConfig: dataSourceConfigFromConnector(connector),
+      folderId: getSharedWithMeFolderId(connector),
+    });
 
     return new Ok(undefined);
   }

--- a/connectors/src/connectors/google_drive/lib/hierarchy.ts
+++ b/connectors/src/connectors/google_drive/lib/hierarchy.ts
@@ -2,15 +2,9 @@ import type { ModelId } from "@dust-tt/types";
 import { cacheWithRedis } from "@dust-tt/types";
 import type { OAuth2Client } from "googleapis-common";
 
-import { GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID } from "@connectors/connectors/google_drive/lib/consts";
 import { getGoogleDriveObject } from "@connectors/connectors/google_drive/lib/google_drive_api";
 import mainLogger from "@connectors/logger/logger";
-import type { DataSourceConfig } from "@connectors/types/data_source_config";
 import type { GoogleDriveObjectType } from "@connectors/types/google_drive";
-
-export function getSharedWithMeFolderId(dataSourceConfig: DataSourceConfig) {
-  return `gdrive-${GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID}-${dataSourceConfig.dataSourceId}`;
-}
 
 // Please consider using the memoized version getFileParentsMemoized instead of this one.
 async function getFileParents(

--- a/connectors/src/connectors/google_drive/lib/hierarchy.ts
+++ b/connectors/src/connectors/google_drive/lib/hierarchy.ts
@@ -5,11 +5,11 @@ import type { OAuth2Client } from "googleapis-common";
 import { GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID } from "@connectors/connectors/google_drive/lib/consts";
 import { getGoogleDriveObject } from "@connectors/connectors/google_drive/lib/google_drive_api";
 import mainLogger from "@connectors/logger/logger";
-import type { ConnectorResource } from "@connectors/resources/connector_resource";
+import type { DataSourceConfig } from "@connectors/types/data_source_config";
 import type { GoogleDriveObjectType } from "@connectors/types/google_drive";
 
-export function getSharedWithMeFolderId(connector: ConnectorResource) {
-  return `gdrive-${GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID}-${connector.id}`;
+export function getSharedWithMeFolderId(dataSourceConfig: DataSourceConfig) {
+  return `gdrive-${GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID}-${dataSourceConfig.dataSourceId}`;
 }
 
 // Please consider using the memoized version getFileParentsMemoized instead of this one.

--- a/connectors/src/connectors/google_drive/lib/hierarchy.ts
+++ b/connectors/src/connectors/google_drive/lib/hierarchy.ts
@@ -2,9 +2,15 @@ import type { ModelId } from "@dust-tt/types";
 import { cacheWithRedis } from "@dust-tt/types";
 import type { OAuth2Client } from "googleapis-common";
 
+import { GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID } from "@connectors/connectors/google_drive/lib/consts";
 import { getGoogleDriveObject } from "@connectors/connectors/google_drive/lib/google_drive_api";
 import mainLogger from "@connectors/logger/logger";
+import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { GoogleDriveObjectType } from "@connectors/types/google_drive";
+
+export function getSharedWithMeFolderId(connector: ConnectorResource) {
+  return `gdrive-${GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID}-${connector.id}`;
+}
 
 // Please consider using the memoized version getFileParentsMemoized instead of this one.
 async function getFileParents(

--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -25,6 +25,7 @@ const {
   garbageCollectorFinished,
   markFolderAsVisited,
   shouldGarbageCollect,
+  upsertSharedWithMeFolder,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "20 minutes",
 });
@@ -103,6 +104,8 @@ export async function googleDriveFullSync({
       }
     }
   });
+
+  await upsertSharedWithMeFolder(connectorId);
 
   // Temp to clean up the running workflows state
   foldersToBrowse = uniq(foldersToBrowse);

--- a/connectors/src/resources/connector/google_drive.ts
+++ b/connectors/src/resources/connector/google_drive.ts
@@ -1,13 +1,14 @@
 import type { ModelId } from "@dust-tt/types";
 import type { Transaction } from "sequelize";
 
+import { getSharedWithMeFolderId } from "@connectors/connectors/google_drive/lib/hierarchy";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { deleteDataSourceFolder } from "@connectors/lib/data_sources";
 import {
   GoogleDriveConfig,
-  GoogleDriveSheet,
-} from "@connectors/lib/models/google_drive";
-import {
   GoogleDriveFiles,
   GoogleDriveFolders,
+  GoogleDriveSheet,
   GoogleDriveSyncToken,
 } from "@connectors/lib/models/google_drive";
 import type {
@@ -70,6 +71,10 @@ export class GoogleDriveConnectorStrategy
         connectorId: connector.id,
       },
       transaction,
+    });
+    await deleteDataSourceFolder({
+      dataSourceConfig: dataSourceConfigFromConnector(connector),
+      folderId: getSharedWithMeFolderId(connector),
     });
   }
 

--- a/connectors/src/resources/connector/google_drive.ts
+++ b/connectors/src/resources/connector/google_drive.ts
@@ -1,9 +1,6 @@
 import type { ModelId } from "@dust-tt/types";
 import type { Transaction } from "sequelize";
 
-import { getSharedWithMeFolderId } from "@connectors/connectors/google_drive/lib/hierarchy";
-import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
-import { deleteDataSourceFolder } from "@connectors/lib/data_sources";
 import {
   GoogleDriveConfig,
   GoogleDriveFiles,
@@ -71,10 +68,6 @@ export class GoogleDriveConnectorStrategy
         connectorId: connector.id,
       },
       transaction,
-    });
-    await deleteDataSourceFolder({
-      dataSourceConfig: dataSourceConfigFromConnector(connector),
-      folderId: getSharedWithMeFolderId(connector),
     });
   }
 


### PR DESCRIPTION
## Description

- Close #9502
- AFAICT we never set `GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID` as a `parentInternalId` but it still works because we return the correct nodes when querying getPermissions with `parent=GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID`.

## Risk

- Lower than all the other parents migrations, easily rollbackable.

## Deploy Plan

- Deploy connectors.
- Run migration.
