### PR TITLE
[parents_migration] Add and backfill Notion "Orphaned Resources" folders

### DIFF
--- a/connectors/migrations/20241218_backfill_notion_unkown.ts
+++ b/connectors/migrations/20241218_backfill_notion_unkown.ts
@@ -1,6 +1,5 @@
 import { makeScript } from "scripts/helpers";
 
-import { getNotionUnknownFolderId } from "@connectors/connectors/notion";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
@@ -14,7 +13,7 @@ makeScript({}, async ({ execute }, logger) => {
     async (connector) => {
       // this is a strict copy-paste of upsertSharedWithMeFolder, I don't want to export it for a migration script and want the folderId for logging purposes
       const dataSourceConfig = dataSourceConfigFromConnector(connector);
-      const folderId = getNotionUnknownFolderId(dataSourceConfig);
+      const folderId = `notion-unknown`;
 
       if (execute) {
         await upsertDataSourceFolder({

--- a/connectors/migrations/20241218_backfill_notion_unkown.ts
+++ b/connectors/migrations/20241218_backfill_notion_unkown.ts
@@ -11,13 +11,10 @@ makeScript({}, async ({ execute }, logger) => {
   await concurrentExecutor(
     connectors,
     async (connector) => {
-      // this is a strict copy-paste of upsertSharedWithMeFolder, I don't want to export it for a migration script and want the folderId for logging purposes
-      const dataSourceConfig = dataSourceConfigFromConnector(connector);
       const folderId = `notion-unknown`;
-
       if (execute) {
         await upsertDataSourceFolder({
-          dataSourceConfig,
+          dataSourceConfig: dataSourceConfigFromConnector(connector),
           folderId,
           parents: [folderId],
           parentId: null,

--- a/connectors/migrations/20241218_backfill_notion_unkown.ts
+++ b/connectors/migrations/20241218_backfill_notion_unkown.ts
@@ -23,7 +23,7 @@ makeScript({}, async ({ execute }, logger) => {
           parents: [folderId],
           parentId: null,
           title: "Orphaned Resources",
-          mimeType: "application/vnd.dust.notion.folder", // TODO: choose what we do here, this doesn't work since mimeType is not supported
+          mimeType: "application/vnd.dust.notion.page",
         });
         logger.info(
           `Upserted folder ${folderId} for connector ${connector.id}`

--- a/connectors/migrations/20241218_backfill_notion_unkown.ts
+++ b/connectors/migrations/20241218_backfill_notion_unkown.ts
@@ -14,7 +14,7 @@ makeScript({}, async ({ execute }, logger) => {
     async (connector) => {
       // this is a strict copy-paste of upsertSharedWithMeFolder, I don't want to export it for a migration script and want the folderId for logging purposes
       const dataSourceConfig = dataSourceConfigFromConnector(connector);
-      const folderId = getNotionUnknownFolderId(connector.id);
+      const folderId = getNotionUnknownFolderId(dataSourceConfig);
 
       if (execute) {
         await upsertDataSourceFolder({

--- a/connectors/migrations/20241218_backfill_notion_unkown.ts
+++ b/connectors/migrations/20241218_backfill_notion_unkown.ts
@@ -1,0 +1,39 @@
+import { makeScript } from "scripts/helpers";
+
+import { getNotionUnknownFolderId } from "@connectors/connectors/notion";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { concurrentExecutor } from "@connectors/lib/async_utils";
+import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+
+makeScript({}, async ({ execute }, logger) => {
+  const connectors = await ConnectorResource.listByType("notion", {});
+
+  await concurrentExecutor(
+    connectors,
+    async (connector) => {
+      // this is a strict copy-paste of upsertSharedWithMeFolder, I don't want to export it for a migration script and want the folderId for logging purposes
+      const dataSourceConfig = dataSourceConfigFromConnector(connector);
+      const folderId = getNotionUnknownFolderId(connector.id);
+
+      if (execute) {
+        await upsertDataSourceFolder({
+          dataSourceConfig,
+          folderId,
+          parents: [folderId],
+          parentId: null,
+          title: "Orphaned Resources",
+          mimeType: "application/vnd.dust.notion.folder", // TODO: choose what we do here, this doesn't work since mimeType is not supported
+        });
+        logger.info(
+          `Upserted folder ${folderId} for connector ${connector.id}`
+        );
+      } else {
+        logger.info(
+          `Would upsert folder ${folderId} for connector ${connector.id}`
+        );
+      }
+    },
+    { concurrency: 10 }
+  );
+});

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -38,7 +38,7 @@ import { getOrphanedCount, getParents, hasChildren } from "./lib/parents";
 const logger = mainLogger.child({ provider: "notion" });
 
 export function getNotionUnknownFolderId(connectorId: number) {
-  return `${nodeIdFromNotionId("unknown")}-${connectorId}`;
+  return `notion-unknown-${connectorId}`;
 }
 
 function nodeIdFromNotionId(notionId: string) {

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -77,7 +77,7 @@ async function upsertNotionUnknownFolder(connector: ConnectorResource) {
     parents: [folderId],
     parentId: null,
     title: "Orphaned Resources",
-    mimeType: "application/vnd.dust.notion.folder", // TODO: choose what we do here, this doesn't work since mimeType is not supported
+    mimeType: "application/vnd.dust.notion.page",
   });
 }
 

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -23,7 +23,10 @@ import {
 } from "@connectors/connectors/notion/temporal/client";
 import { apiConfig } from "@connectors/lib/api/config";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
-import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
+import {
+  deleteDataSourceFolder,
+  upsertDataSourceFolder,
+} from "@connectors/lib/data_sources";
 import {
   NotionConnectorState,
   NotionDatabase,
@@ -297,6 +300,13 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
       );
       return new Err(new Error("Connector not found"));
     }
+
+    // delete the "Orphaned Resources" folder
+    const dataSourceConfig = dataSourceConfigFromConnector(connector);
+    await deleteDataSourceFolder({
+      dataSourceConfig,
+      folderId: getNotionUnknownFolderId(dataSourceConfig),
+    });
 
     const res = await connector.delete();
     if (res.isErr()) {

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -103,7 +103,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
       parents: [folderId],
       parentId: null,
       title: "Orphaned Resources",
-      mimeType: "application/vnd.dust.notion.page",
+      mimeType: "application/vnd.dust.notion.unknown-folder",
     });
 
     try {

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -49,6 +49,9 @@ function nodeIdFromNotionId(notionId: string) {
 }
 
 function notionIdFromNodeId(nodeId: string) {
+  if (nodeId.startsWith("notion-unknown-")) {
+    return "unknown";
+  }
   return _.last(nodeId.split("notion-"))!;
 }
 

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -440,6 +440,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
       logger.error({ connectorId: this.connectorId }, "Connector not found");
       return new Err(new Error("Connector not found"));
     }
+
     const notionId =
       (parentInternalId && notionIdFromNodeId(parentInternalId)) || "workspace";
 

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -23,10 +23,7 @@ import {
 } from "@connectors/connectors/notion/temporal/client";
 import { apiConfig } from "@connectors/lib/api/config";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
-import {
-  deleteDataSourceFolder,
-  upsertDataSourceFolder,
-} from "@connectors/lib/data_sources";
+import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
 import {
   NotionConnectorState,
   NotionDatabase,
@@ -295,12 +292,6 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
       );
       return new Err(new Error("Connector not found"));
     }
-
-    // delete the "Orphaned Resources" folder
-    await deleteDataSourceFolder({
-      dataSourceConfig: dataSourceConfigFromConnector(connector),
-      folderId: nodeIdFromNotionId("unknown"),
-    });
 
     const res = await connector.delete();
     if (res.isErr()) {

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -594,13 +594,14 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
 
     const contentNodes = pageNodes.concat(dbNodes);
 
-    if (notionIds.includes("unknown")) {
+    const notionUnknownFolderId = getNotionUnknownFolderId(this.connectorId);
+    if (notionIds.includes(notionUnknownFolderId)) {
       const orphanedCount = await getOrphanedCount(this.connectorId);
       if (orphanedCount > 0) {
         contentNodes.push({
           provider: "notion",
           // Orphaned resources in the database will have "unknown" as their parentId.
-          internalId: getNotionUnknownFolderId(this.connectorId),
+          internalId: notionUnknownFolderId,
           parentInternalId: null,
           type: "folder",
           title: "Orphaned Resources",

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -68,10 +68,9 @@ async function workspaceIdFromConnectionId(connectionId: string) {
  * Upserts to data_sources_folders (core) a top-level folder for the orphaned resources.
  */
 async function upsertNotionUnknownFolder(connector: ConnectorResource) {
-  const dataSourceConfig = dataSourceConfigFromConnector(connector);
   const folderId = nodeIdFromNotionId("unknown");
   await upsertDataSourceFolder({
-    dataSourceConfig,
+    dataSourceConfig: dataSourceConfigFromConnector(connector),
     folderId,
     parents: [folderId],
     parentId: null,
@@ -298,9 +297,8 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
     }
 
     // delete the "Orphaned Resources" folder
-    const dataSourceConfig = dataSourceConfigFromConnector(connector);
     await deleteDataSourceFolder({
-      dataSourceConfig,
+      dataSourceConfig: dataSourceConfigFromConnector(connector),
       folderId: nodeIdFromNotionId("unknown"),
     });
 

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -48,14 +48,6 @@ function notionIdFromNodeId(nodeId: string) {
   return _.last(nodeId.split("notion-"))!;
 }
 
-function getNotionResourceParentInternalId(
-  resource: NotionPage | NotionDatabase
-): string | null {
-  return !resource.parentId || resource.parentId === "workspace"
-    ? null
-    : nodeIdFromNotionId(resource.parentId);
-}
-
 async function workspaceIdFromConnectionId(connectionId: string) {
   const tokRes = await getOAuthConnectionAccessToken({
     config: apiConfig.getOAuthAPIConfig(),
@@ -475,7 +467,10 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
       return {
         provider: c.type,
         internalId: nodeIdFromNotionId(page.notionPageId),
-        parentInternalId: getNotionResourceParentInternalId(page),
+        parentInternalId:
+          !page.parentId || page.parentId === "workspace"
+            ? null
+            : nodeIdFromNotionId(page.parentId),
         type: "file",
         title: page.title || "",
         sourceUrl: page.notionUrl || null,
@@ -496,7 +491,10 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
       return {
         provider: c.type,
         internalId: nodeIdFromNotionId(db.notionDatabaseId),
-        parentInternalId: getNotionResourceParentInternalId(db),
+        parentInternalId:
+          !db.parentId || db.parentId === "workspace"
+            ? null
+            : nodeIdFromNotionId(db.parentId),
         type: "database",
         title: db.title || "",
         sourceUrl: db.notionUrl || null,
@@ -572,7 +570,10 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
       pages.map(async (page) => ({
         provider: "notion",
         internalId: nodeIdFromNotionId(page.notionPageId),
-        parentInternalId: getNotionResourceParentInternalId(page),
+        parentInternalId:
+          !page.parentId || page.parentId === "workspace"
+            ? null
+            : nodeIdFromNotionId(page.parentId),
         type: "file",
         title: page.title || "",
         sourceUrl: page.notionUrl || null,
@@ -587,7 +588,10 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
     const dbNodes: ContentNode[] = dbs.map((db) => ({
       provider: "notion",
       internalId: nodeIdFromNotionId(db.notionDatabaseId),
-      parentInternalId: getNotionResourceParentInternalId(db),
+      parentInternalId:
+        !db.parentId || db.parentId === "workspace"
+          ? null
+          : nodeIdFromNotionId(db.parentId),
       type: "database",
       title: db.title || "",
       sourceUrl: db.notionUrl || null,

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -541,11 +541,6 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
   }: {
     internalIds: string[];
   }): Promise<Result<ContentNode[], Error>> {
-    const connector = await ConnectorResource.fetchById(this.connectorId);
-    if (!connector) {
-      logger.error({ connectorId: this.connectorId }, "Connector not found");
-      return new Err(new Error("Connector not found"));
-    }
     const notionIds = internalIds.map((id) => notionIdFromNodeId(id));
 
     const [pages, dbs] = await Promise.all([

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -61,21 +61,6 @@ async function workspaceIdFromConnectionId(connectionId: string) {
   );
 }
 
-/**
- * Upserts to data_sources_folders (core) a top-level folder for the orphaned resources.
- */
-async function upsertNotionUnknownFolder(connector: ConnectorResource) {
-  const folderId = nodeIdFromNotionId("unknown");
-  await upsertDataSourceFolder({
-    dataSourceConfig: dataSourceConfigFromConnector(connector),
-    folderId,
-    parents: [folderId],
-    parentId: null,
-    title: "Orphaned Resources",
-    mimeType: "application/vnd.dust.notion.page",
-  });
-}
-
 export class NotionConnectorManager extends BaseConnectorManager<null> {
   static async create({
     dataSourceConfig,
@@ -110,7 +95,16 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
       {}
     );
 
-    await upsertNotionUnknownFolder(connector);
+    // Upserts to data_sources_folders (core) a top-level folder for the orphaned resources.
+    const folderId = nodeIdFromNotionId("unknown");
+    await upsertDataSourceFolder({
+      dataSourceConfig: dataSourceConfigFromConnector(connector),
+      folderId,
+      parents: [folderId],
+      parentId: null,
+      title: "Orphaned Resources",
+      mimeType: "application/vnd.dust.notion.page",
+    });
 
     try {
       await launchNotionSyncWorkflow(connector.id);

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -602,14 +602,13 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
 
     const contentNodes = pageNodes.concat(dbNodes);
 
-    const notionUnknownFolderId = nodeIdFromNotionId("unknown");
-    if (notionIds.includes(notionUnknownFolderId)) {
+    if (notionIds.includes("unknown")) {
       const orphanedCount = await getOrphanedCount(this.connectorId);
       if (orphanedCount > 0) {
         contentNodes.push({
           provider: "notion",
           // Orphaned resources in the database will have "unknown" as their parentId.
-          internalId: notionUnknownFolderId,
+          internalId: nodeIdFromNotionId("unknown"),
           parentInternalId: null,
           type: "folder",
           title: "Orphaned Resources",

--- a/connectors/src/resources/connector/notion.ts
+++ b/connectors/src/resources/connector/notion.ts
@@ -1,9 +1,6 @@
 import type { ModelId } from "@dust-tt/types";
 import type { Transaction } from "sequelize";
 
-import { getNotionUnknownFolderId } from "@connectors/connectors/notion";
-import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
-import { deleteDataSourceFolder } from "@connectors/lib/data_sources";
 import {
   NotionConnectorBlockCacheEntry,
   NotionConnectorPageCacheEntry,
@@ -70,11 +67,6 @@ export class NotionConnectorStrategy
         connectorId: connector.id,
       },
       transaction,
-    });
-    const dataSourceConfig = dataSourceConfigFromConnector(connector);
-    await deleteDataSourceFolder({
-      dataSourceConfig,
-      folderId: getNotionUnknownFolderId(dataSourceConfig),
     });
   }
 

--- a/connectors/src/resources/connector/notion.ts
+++ b/connectors/src/resources/connector/notion.ts
@@ -1,6 +1,9 @@
 import type { ModelId } from "@dust-tt/types";
 import type { Transaction } from "sequelize";
 
+import { getNotionUnknownFolderId } from "@connectors/connectors/notion";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { deleteDataSourceFolder } from "@connectors/lib/data_sources";
 import {
   NotionConnectorBlockCacheEntry,
   NotionConnectorPageCacheEntry,
@@ -67,6 +70,10 @@ export class NotionConnectorStrategy
         connectorId: connector.id,
       },
       transaction,
+    });
+    await deleteDataSourceFolder({
+      dataSourceConfig: dataSourceConfigFromConnector(connector),
+      folderId: getNotionUnknownFolderId(connector.id),
     });
   }
 

--- a/connectors/src/resources/connector/notion.ts
+++ b/connectors/src/resources/connector/notion.ts
@@ -71,9 +71,10 @@ export class NotionConnectorStrategy
       },
       transaction,
     });
+    const dataSourceConfig = dataSourceConfigFromConnector(connector);
     await deleteDataSourceFolder({
-      dataSourceConfig: dataSourceConfigFromConnector(connector),
-      folderId: getNotionUnknownFolderId(connector.id),
+      dataSourceConfig,
+      folderId: getNotionUnknownFolderId(dataSourceConfig),
     });
   }
 


### PR DESCRIPTION
## Description

- Close [#9457](https://github.com/dust-tt/dust/issues/9457)
- Tested by setting the parentId of a bunch of pages and db to "unknown" and checking that we get them as Orphaned resources.

## Risk

- Lower than all the other parents migrations, easily rollbackable.

## Deploy Plan

- Deploy connectors.
- Run migration.
