### PR TITLE
fix: properly retrieve tracker maintained scope

### DIFF
--- a/front/lib/document_upsert_hooks/hooks/tracker/actions/doc_tracker_retrieval.ts
+++ b/front/lib/document_upsert_hooks/hooks/tracker/actions/doc_tracker_retrieval.ts
@@ -13,11 +13,13 @@ export async function callDocTrackerRetrievalAction(
     targetDocumentTokens,
     topK,
     maintainedScope,
+    parentsInMap,
   }: {
     inputText: string;
     targetDocumentTokens: number;
     topK: number;
     maintainedScope: TrackerMaintainedScopeType;
+    parentsInMap: Record<string, string[] | null>;
   }
 ): Promise<t.TypeOf<typeof DocTrackerRetrievalActionValueSchema>> {
   const ownerWorkspace = auth.getNonNullableWorkspace();
@@ -31,11 +33,6 @@ export async function callDocTrackerRetrievalAction(
   ) {
     throw new Error("Duplicate data source ids in maintained scope");
   }
-
-  const parentsInMap = _.mapValues(
-    _.keyBy(maintainedScope, "dataSourceId"),
-    (x) => x.filter?.parents?.in ?? null
-  );
 
   const action = DustProdActionRegistry["doc-tracker-retrieval"];
   const config = cloneBaseConfig(action.config);


### PR DESCRIPTION
## Description

- ds block filtering needs the `core` dsId
- content from retrieval needs to be extracted via chunk.text and not directly on the doc

## Risk

N/A

## Deploy Plan

Front deploy