### PR TITLE
Tracker: Improve email content with dataSource info

### DIFF
--- a/front/lib/models/doc_tracker.ts
+++ b/front/lib/models/doc_tracker.ts
@@ -234,6 +234,7 @@ export class TrackerGenerationModel extends SoftDeletableModel<TrackerGeneration
   declare consumedAt: Date | null;
 
   declare trackerConfiguration: NonAttribute<TrackerConfigurationModel>;
+  declare dataSource: NonAttribute<DataSourceModel>;
 }
 
 TrackerGenerationModel.init(
@@ -290,6 +291,7 @@ DataSourceModel.hasMany(TrackerGenerationModel, {
 });
 TrackerGenerationModel.belongsTo(DataSourceModel, {
   foreignKey: { allowNull: false },
+  as: "dataSource",
 });
 
 // TODO(DOC_TRACKER) Delete models below this line

--- a/types/src/front/tracker.ts
+++ b/types/src/front/tracker.ts
@@ -64,5 +64,10 @@ export type TrackerGenerationToProcess = {
   content: string;
   thinking: string | null;
   documentId: string;
-  // TODO: Add info about the document.
+  dataSource: {
+    id: ModelId;
+    name: string;
+    dustAPIProjectId: string;
+    dustAPIDataSourceId: string;
+  };
 };


### PR DESCRIPTION
## Description

Fetch the dataSource associated with a generation, and then in the email call Core to get the dataSource info. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
