### PR TITLE
enh(doc tracker) don't debounce if no trackers to run

### DIFF
--- a/front/temporal/tracker/config.ts
+++ b/front/temporal/tracker/config.ts
@@ -1,4 +1,4 @@
-const RUN_QUEUE_VERSION = 1;
+const RUN_QUEUE_VERSION = 2;
 export const RUN_QUEUE_NAME = `document-tracker-queue-v${RUN_QUEUE_VERSION}`;
 
 const TRACKER_NOTIFICATION_QUEUE_VERSION = 1;


### PR DESCRIPTION
## Description

- added a new activity that returns a true if there are trackers to run (so we don't start a debounce loop if the document isn't watched)
- moved getDebounceMs to an activity so we can freely change that code without changing the workflow (changing the workflow for doc tracker is very annoying because we can't easily restart the workflow)

## Risk

We're now double-fetching the trackers to run (once for the "should run", and once when we actually run). I think it's fine (and better than storing the list of tracker in temporal, as we want them fresh when we run anyway).

## Deploy Plan

Will need to kill all current trackers first