### PR TITLE
Changing pricing page and adding request demo button

### DIFF
--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -102,7 +102,7 @@ export default function LandingLayout({
             <Button
               variant="highlight"
               size="sm"
-              label="Request demo"
+              label="Request a demo"
               href="https://forms.gle/dGaQ1AZuDCbXY1ft9"
               target="_blank"
             />

--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -98,7 +98,14 @@ export default function LandingLayout({
             <LogoHorizontalColorLogo className="h-[24px] w-[96px]" />
           </div>
           <MainNavigation />
-          <div className="flex flex-grow justify-end">
+          <div className="flex flex-grow justify-end gap-4">
+            <Button
+              variant="highlight"
+              size="sm"
+              label="Request demo"
+              href="https://forms.gle/dGaQ1AZuDCbXY1ft9"
+              target="_blank"
+            />
             <Button
               variant="highlight"
               size="sm"

--- a/front/components/plans/PlansTables.tsx
+++ b/front/components/plans/PlansTables.tsx
@@ -121,19 +121,6 @@ export function ProPriceTable({
       display: ["landing", "subscribe"],
     },
     {
-      label: (
-        <>
-          Unlimited messages (
-          <Hoverable onClick={() => setIsFairUseModalOpened(true)}>
-            Fair use limits apply*
-          </Hoverable>
-          )
-        </>
-      ),
-      variant: "check",
-      display: ["landing", "subscribe"],
-    },
-    {
       label: "Connections (GitHub, Google Drive, Notion, Slack, ...)",
       variant: "check",
       display: ["landing", "subscribe"],
@@ -147,6 +134,19 @@ export function ProPriceTable({
       label: "Privacy and Data Security (SOC2, Zero Data Retention)",
       variant: "check",
       display: ["landing"],
+    },
+    {
+      label: (
+        <>
+          Unlimited messages (
+          <Hoverable onClick={() => setIsFairUseModalOpened(true)}>
+            Fair use limits apply*
+          </Hoverable>
+          )
+        </>
+      ),
+      variant: "check",
+      display: ["landing", "subscribe"],
     },
     {
       label: "Fixed price on programmatic usage (API, GSheet, Zapier)",

--- a/front/components/plans/PlansTables.tsx
+++ b/front/components/plans/PlansTables.tsx
@@ -73,12 +73,17 @@ const ENTERPRISE_PLAN_ITEMS: PriceTableItem[] = [
   {
     label: "(soon) User provisioning",
     variant: "check",
-    display: ["landing", "subscribe"],
+    display: ["landing"],
   },
   {
     label: "(soon) EU data hosting",
     variant: "check",
-    display: ["landing", "subscribe"],
+    display: ["landing"],
+  },
+  {
+    label: "(soon) Salesforce Connection",
+    variant: "check",
+    display: ["landing"],
   }
 ];
 

--- a/front/components/plans/PlansTables.tsx
+++ b/front/components/plans/PlansTables.tsx
@@ -84,7 +84,7 @@ const ENTERPRISE_PLAN_ITEMS: PriceTableItem[] = [
     label: "(soon) Salesforce Connection",
     variant: "check",
     display: ["landing"],
-  }
+  },
 ];
 
 export function ProPriceTable({

--- a/front/components/plans/PlansTables.tsx
+++ b/front/components/plans/PlansTables.tsx
@@ -31,72 +31,53 @@ type PriceTableItem = {
 
 const ENTERPRISE_PLAN_ITEMS: PriceTableItem[] = [
   {
-    label: "From 100 users",
+    label: "Everything in Pro, plus:",
     variant: "check",
     display: ["landing", "subscribe"],
   },
   {
-    label: "Multiple workspaces",
+    label: "Multiple restricted spaces",
     variant: "check",
     display: ["landing", "subscribe"],
   },
   {
-    label: "Privacy and Data Security",
+    label: "Custom programmatic usage (API, Google Sheet, Zapier)",
     variant: "check",
     display: ["landing", "subscribe"],
   },
   {
-    label: "Advanced models (GPT-4, Claude…)",
+    label: "Larger storage and file size limits",
     variant: "check",
     display: ["landing", "subscribe"],
   },
-  {
-    label: "Unlimited custom assistants",
-    variant: "check",
-    display: ["landing", "subscribe"],
-  },
-  {
-    label: "Unlimited messages",
-    variant: "check",
-    display: ["landing", "subscribe"],
-  },
-  {
-    label: "Custom programmatic usage (API)",
-    variant: "check",
-    display: ["landing", "subscribe"],
-  },
-  {
-    label: "Unlimited data sources",
-    variant: "check",
-    display: ["landing", "subscribe"],
-  },
-  {
-    label: "Connections (GitHub, Google Drive, Notion, Slack, ...)",
-    variant: "check",
-    display: ["landing", "subscribe"],
-  },
+
   {
     label: "Single Sign-On (SSO)",
     variant: "check",
     display: ["landing", "subscribe"],
   },
   {
-    label: "Dust Slackbot",
+    label: "Flexible payment options (SEPA, Credit Card)",
     variant: "check",
     display: ["landing", "subscribe"],
   },
   {
-    label: "Assistants can execute actions",
+    label: "Priority access to new features",
     variant: "check",
     display: ["landing", "subscribe"],
   },
   {
-    label: "Unlimited spaces",
+    label: "Enhanced support & dedicated account management",
     variant: "check",
     display: ["landing", "subscribe"],
   },
   {
-    label: "Dedicated account support",
+    label: "(soon) User provisioning",
+    variant: "check",
+    display: ["landing", "subscribe"],
+  },
+  {
+    label: "(soon) EU data hosting",
     variant: "check",
     display: ["landing", "subscribe"],
   },
@@ -126,22 +107,17 @@ export function ProPriceTable({
       display: ["landing", "subscribe"],
     },
     {
-      label: "One workspace",
-      variant: "dash",
-      display: ["landing"],
-    },
-    {
-      label: "Privacy and Data Security",
-      variant: "check",
-      display: ["landing"],
-    },
-    {
       label: "Advanced models (GPT-4, Claude…)",
       variant: "check",
       display: ["landing", "subscribe"],
     },
     {
-      label: "Unlimited custom assistants",
+      label: "Custom assistants which can execute actions",
+      variant: "check",
+      display: ["landing", "subscribe"],
+    },
+    {
+      label: "Custom actions (Dust Apps)",
       variant: "check",
       display: ["landing", "subscribe"],
     },
@@ -159,37 +135,33 @@ export function ProPriceTable({
       display: ["landing", "subscribe"],
     },
     {
-      label: "Limited Programmatic usage (API)",
-      variant: "dash",
-      display: ["landing", "subscribe"],
-    },
-    {
-      label: "Up to 1Gb/user of data sources",
-      variant: "check",
-      display: ["landing", "subscribe"],
-    },
-    {
       label: "Connections (GitHub, Google Drive, Notion, Slack, ...)",
       variant: "check",
       display: ["landing", "subscribe"],
     },
     {
-      label: "Google & GitHub Authentication",
+      label: "Native integrations (Zendesk, Slack, Chrome Extension)",
+      variant: "check",
+      display: ["landing", "subscribe"],
+    },
+    {
+      label: "Privacy and Data Security (SOC2, Zero Data Retention)",
+      variant: "check",
+      display: ["landing"],
+    },
+    {
+      label: "Up to 1Gb/user of data sources",
+      variant: "dash",
+      display: ["landing", "subscribe"],
+    },
+
+    {
+      label: "Limited Programmatic usage (API, Google Sheet, Zapier)",
       variant: "dash",
       display: ["landing", "subscribe"],
     },
     {
-      label: "Dust Slackbot",
-      variant: "check",
-      display: ["landing", "subscribe"],
-    },
-    {
-      label: "Assistants can execute actions",
-      variant: "check",
-      display: ["landing", "subscribe"],
-    },
-    {
-      label: "One space",
+      label: "One restricted space",
       variant: "dash",
       display: ["landing"],
     },
@@ -239,20 +211,6 @@ export function ProPriceTable({
             />
           )
         )}
-        {onClick && (!plan || plan.code !== PRO_PLAN_SEAT_29_CODE) && (
-          <PriceTable.ActionContainer>
-            <Button
-              variant="highlight"
-              size={biggerButtonSize}
-              label={
-                display === "landing" ? "Start now, 15 days free" : "Start now"
-              }
-              icon={RocketIcon}
-              disabled={isProcessing}
-              onClick={onClick}
-            />
-          </PriceTable.ActionContainer>
-        )}
       </PriceTable>
     </>
   );
@@ -268,13 +226,19 @@ function EnterprisePriceTable({
 }) {
   const biggerButtonSize = size === "xs" ? "sm" : "md";
   return (
-    <PriceTable title="Enterprise" price="Custom" size={size} magnified={false}>
+    <PriceTable
+      title="Enterprise"
+      price="Custom"
+      size={size}
+      priceLabel=" 100+ users, pay-per-use"
+      magnified={false}
+    >
       <PriceTable.ActionContainer position="top">
         {onClick && (
           <Button
             variant="highlight"
             size={biggerButtonSize}
-            label="Contact us"
+            label="Contact sales"
             disabled={isProcessing}
             onClick={onClick}
           />
@@ -287,17 +251,6 @@ function EnterprisePriceTable({
           variant={item.variant}
         />
       ))}
-      <PriceTable.ActionContainer>
-        {onClick && (
-          <Button
-            variant="highlight"
-            size={biggerButtonSize}
-            label="Contact us"
-            disabled={isProcessing}
-            onClick={onClick}
-          />
-        )}
-      </PriceTable.ActionContainer>
     </PriceTable>
   );
 }

--- a/front/components/plans/PlansTables.tsx
+++ b/front/components/plans/PlansTables.tsx
@@ -156,7 +156,7 @@ export function ProPriceTable({
     },
 
     {
-      label: "Limited Programmatic usage (API, Google Sheet, Zapier)",
+      label: "Limited programmatic usage (API, Google Sheet, Zapier)",
       variant: "dash",
       display: ["landing", "subscribe"],
     },

--- a/front/components/plans/PlansTables.tsx
+++ b/front/components/plans/PlansTables.tsx
@@ -36,12 +36,7 @@ const ENTERPRISE_PLAN_ITEMS: PriceTableItem[] = [
     display: ["landing", "subscribe"],
   },
   {
-    label: "Multiple restricted spaces",
-    variant: "check",
-    display: ["landing", "subscribe"],
-  },
-  {
-    label: "Custom programmatic usage (API, Google Sheet, Zapier)",
+    label: "Multiple private spaces",
     variant: "check",
     display: ["landing", "subscribe"],
   },
@@ -50,9 +45,13 @@ const ENTERPRISE_PLAN_ITEMS: PriceTableItem[] = [
     variant: "check",
     display: ["landing", "subscribe"],
   },
-
   {
-    label: "Single Sign-On (SSO)",
+    label: "Custom price on programmatic usage (API, GSheet, Zapier)",
+    variant: "check",
+    display: ["landing", "subscribe"],
+  },
+  {
+    label: "Single Sign-On (SSO) (Okta, Entra ID, Jumpcloud)",
     variant: "check",
     display: ["landing", "subscribe"],
   },
@@ -62,12 +61,12 @@ const ENTERPRISE_PLAN_ITEMS: PriceTableItem[] = [
     display: ["landing", "subscribe"],
   },
   {
-    label: "Priority access to new features",
+    label: "Priority support & dedicated account management",
     variant: "check",
     display: ["landing", "subscribe"],
   },
   {
-    label: "Enhanced support & dedicated account management",
+    label: "Priority access to new features",
     variant: "check",
     display: ["landing", "subscribe"],
   },
@@ -80,7 +79,7 @@ const ENTERPRISE_PLAN_ITEMS: PriceTableItem[] = [
     label: "(soon) EU data hosting",
     variant: "check",
     display: ["landing", "subscribe"],
-  },
+  }
 ];
 
 export function ProPriceTable({
@@ -150,18 +149,17 @@ export function ProPriceTable({
       display: ["landing"],
     },
     {
+      label: "Fixed price on programmatic usage (API, GSheet, Zapier)",
+      variant: "dash",
+      display: ["landing", "subscribe"],
+    },
+    {
       label: "Up to 1Gb/user of data sources",
       variant: "dash",
       display: ["landing", "subscribe"],
     },
-
     {
-      label: "Limited programmatic usage (API, Google Sheet, Zapier)",
-      variant: "dash",
-      display: ["landing", "subscribe"],
-    },
-    {
-      label: "One restricted space",
+      label: "One private space",
       variant: "dash",
       display: ["landing"],
     },
@@ -184,7 +182,7 @@ export function ProPriceTable({
         title="Pro"
         price={price}
         color="emerald"
-        priceLabel="/ month / user, excl. tax"
+        priceLabel="/ month / user, excl. tax."
         size={size}
         magnified={false}
       >
@@ -230,7 +228,7 @@ function EnterprisePriceTable({
       title="Enterprise"
       price="Custom"
       size={size}
-      priceLabel=" 100+ users, pay-per-use"
+      priceLabel=" pay-per-use, 100+ users"
       magnified={false}
     >
       <PriceTable.ActionContainer position="top">


### PR DESCRIPTION
## Description

Goal is to simplify "access to demo" on our website and better show difference between plans on our pricing page.

### Pricing Page
<img width="863" alt="image" src="https://github.com/user-attachments/assets/f48b3a68-b124-49b5-992b-6f0a330cd21a" />

### Request Demo Button on top menu (links to the intro call form)
![image](https://github.com/user-attachments/assets/f0298cbf-0f14-40e4-96c5-b618b50a9dc7)


## Risk
* overloading ourselves with non-qualified leads (e.g. pro plans) ?
