### PR TITLE
[parents_migration] Add and backfill Google Drive "Shared with me" folders

### DIFF
--- a/connectors/migrations/20241218_backfill_gdrive_shared_with_me.ts
+++ b/connectors/migrations/20241218_backfill_gdrive_shared_with_me.ts
@@ -1,0 +1,37 @@
+import { makeScript } from "scripts/helpers";
+
+import { GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID } from "@connectors/connectors/google_drive/lib/consts";
+import { getInternalId } from "@connectors/connectors/google_drive/temporal/utils";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { concurrentExecutor } from "@connectors/lib/async_utils";
+import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+
+makeScript({}, async ({ execute }, logger) => {
+  const connectors = await ConnectorResource.listByType("google_drive", {});
+
+  await concurrentExecutor(
+    connectors,
+    async (connector) => {
+      const folderId = getInternalId(GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID);
+      if (execute) {
+        await upsertDataSourceFolder({
+          dataSourceConfig: dataSourceConfigFromConnector(connector),
+          folderId,
+          parents: [folderId],
+          parentId: null,
+          title: "Shared with me",
+          mimeType: "application/vnd.dust.googledrive.folder",
+        });
+        logger.info(
+          `Upserted folder ${folderId} for connector ${connector.id}`
+        );
+      } else {
+        logger.info(
+          `Would upsert folder ${folderId} for connector ${connector.id}`
+        );
+      }
+    },
+    { concurrency: 10 }
+  );
+});

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -409,7 +409,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
         // that are not living in a shared drive.
         nodes.push({
           provider: c.type,
-          internalId: GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID,
+          internalId: getInternalId(GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID),
           parentInternalId: null,
           type: "folder" as const,
           preventSelection: true,
@@ -435,7 +435,10 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
         // The "Shared with me" view requires to look for folders
         // with the flag `sharedWithMe=true`, but there is no need to check for the parents.
         let gdriveQuery = `mimeType='application/vnd.google-apps.folder'`;
-        if (parentInternalId === GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID) {
+        if (
+          parentInternalId ===
+          getInternalId(GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID)
+        ) {
           gdriveQuery += ` and sharedWithMe=true`;
         } else {
           gdriveQuery += ` and '${parentDriveId}' in parents`;

--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -25,6 +25,7 @@ const {
   garbageCollectorFinished,
   markFolderAsVisited,
   shouldGarbageCollect,
+  upsertSharedWithMeFolder,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "20 minutes",
 });
@@ -103,6 +104,8 @@ export async function googleDriveFullSync({
       }
     }
   });
+
+  await upsertSharedWithMeFolder(connectorId);
 
   // Temp to clean up the running workflows state
   foldersToBrowse = uniq(foldersToBrowse);

--- a/connectors/src/lib/cli.ts
+++ b/connectors/src/lib/cli.ts
@@ -271,6 +271,7 @@ export const batch = async ({
         "intercom",
         "confluence",
         "github",
+        "google_drive",
         "snowflake",
         "zendesk",
       ];

--- a/connectors/src/resources/connector/google_drive.ts
+++ b/connectors/src/resources/connector/google_drive.ts
@@ -3,11 +3,9 @@ import type { Transaction } from "sequelize";
 
 import {
   GoogleDriveConfig,
-  GoogleDriveSheet,
-} from "@connectors/lib/models/google_drive";
-import {
   GoogleDriveFiles,
   GoogleDriveFolders,
+  GoogleDriveSheet,
   GoogleDriveSyncToken,
 } from "@connectors/lib/models/google_drive";
 import type {


### PR DESCRIPTION
## Description

- revert revert #9507
- Close #9502
- AFAICT we never set `GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID` as a `parentInternalId` but it still works because we return the correct nodes when querying getPermissions with `parent=GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID`.

## Risk

- Lower than all the other parents migrations, easily rollbackable.

## Deploy Plan

- `./admin/cli.sh batch stop-all --provider google_drive`
- Deploy connectors
- List out every long-running workflow (these are the fullSync for Google Drive)
- `./admin/cli.sh google_drive restart-all-incremental-sync-workflows`
- Restart the fullSyncs that were stopped by the first command (manual operation)
- Run migration.

Temporal runbook: https://www.notion.so/dust-tt/Runbook-Temporal-e065e5ccd53443c1a57118d08c7a19f9#16128599d941807eb9cae977027e67b0
