### PR TITLE
Tracker: display status when editing and allow to deactivate/reactivate a tracker

### DIFF
--- a/front/components/trackers/TrackerBuilder.tsx
+++ b/front/components/trackers/TrackerBuilder.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  Chip,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -8,6 +9,7 @@ import {
   Label,
   Page,
   TextArea,
+  TrashIcon,
   useSendNotification,
 } from "@dust-tt/sparkle";
 import type {
@@ -24,6 +26,8 @@ import {
   CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG,
   TRACKER_FREQUENCIES,
 } from "@dust-tt/types";
+import { capitalize } from "lodash";
+import { LockIcon } from "lucide-react";
 import { useRouter } from "next/router";
 import { useContext, useMemo, useState } from "react";
 
@@ -66,6 +70,7 @@ export const TrackerBuilder = ({
 
   const [tracker, setTracker] = useState<TrackerConfigurationStateType>(
     initialTrackerState ?? {
+      status: "active",
       name: null,
       nameError: null,
       description: null,
@@ -165,6 +170,7 @@ export const TrackerBuilder = ({
     const res = await fetch(route, {
       method,
       body: JSON.stringify({
+        status: tracker.status,
         name: tracker.name,
         description: tracker.description,
         prompt: tracker.prompt,
@@ -338,13 +344,36 @@ export const TrackerBuilder = ({
           <div className="flex flex-grow" />
           <div className="flex flex-shrink-0 gap-2">
             {initialTrackerId && (
-              <Button
-                label={"Delete"}
-                variant="warning"
-                onClick={onDelete}
-                isLoading={isDeleting}
-                disabled={isSubmitting || isDeleting}
-              />
+              <DropdownMenu>
+                <DropdownMenuTrigger>
+                  <Chip
+                    size="sm"
+                    color={tracker.status === "active" ? "emerald" : "warning"}
+                    className="capitalize"
+                    icon={tracker.status === "active" ? undefined : LockIcon}
+                  >
+                    {capitalize(tracker.status)}
+                  </Chip>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent>
+                  <DropdownMenuItem
+                    key={tracker.status}
+                    label={
+                      tracker.status === "active" ? "Deactivate" : "Activate"
+                    }
+                    onClick={() => {
+                      setTracker((t) => ({
+                        ...t,
+                        status:
+                          tracker.status === "active" ? "inactive" : "active",
+                      }));
+                      if (!edited) {
+                        setEdited(true);
+                      }
+                    }}
+                  />
+                </DropdownMenuContent>
+              </DropdownMenu>
             )}
             <AdvancedSettings
               owner={owner}
@@ -371,8 +400,20 @@ export const TrackerBuilder = ({
                 }
               }}
             />
+            {initialTrackerId && (
+              <Button
+                icon={TrashIcon}
+                tooltip="Delete Tracker"
+                variant="outline"
+                onClick={onDelete}
+                isLoading={isDeleting}
+                disabled={isSubmitting || isDeleting}
+              />
+            )}
           </div>
         </div>
+
+        {/* Tracker Settings */}
 
         <div className="flex flex-col gap-8">
           <div>
@@ -400,6 +441,7 @@ export const TrackerBuilder = ({
                 placeholder="Descriptive name."
                 message={tracker.nameError}
                 messageStatus={tracker.nameError ? "error" : undefined}
+                disabled={tracker.status === "inactive"}
               />
             </div>
             <div className="md:col-span-2">
@@ -419,10 +461,13 @@ export const TrackerBuilder = ({
                 placeholder="Brief description of what you're tracking and why."
                 message={tracker.descriptionError}
                 messageStatus={tracker.descriptionError ? "error" : undefined}
+                disabled={tracker.status === "inactive"}
               />
             </div>
           </div>
         </div>
+
+        {/* Notification Settings */}
 
         <div className="flex flex-col gap-8">
           <div>
@@ -447,6 +492,7 @@ export const TrackerBuilder = ({
                       }
                       variant="outline"
                       isSelect
+                      disabled={tracker.status === "inactive"}
                     />
                   </DropdownMenuTrigger>
                   <DropdownMenuContent>
@@ -486,10 +532,14 @@ export const TrackerBuilder = ({
                 }}
                 message={tracker.recipientsError}
                 messageStatus={tracker.recipientsError ? "error" : undefined}
+                disabled={tracker.status === "inactive"}
               />
             </div>
           </div>
         </div>
+
+        {/* DataSource Configurations Settings */}
+
         <div className="flex flex-col gap-8">
           <div>
             <Page.SectionHeader title="Tracker Settings" />
@@ -516,6 +566,7 @@ export const TrackerBuilder = ({
               }}
               error={tracker.promptError}
               showErrorLabel={!!tracker.promptError}
+              disabled={tracker.status === "inactive"}
             />
           </div>
           <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
@@ -528,6 +579,7 @@ export const TrackerBuilder = ({
                     setShowMaintainedDsModal(true);
                   }}
                   className="w-fit"
+                  disabled={tracker.status === "inactive"}
                 />
               </div>
             </div>
@@ -558,6 +610,7 @@ export const TrackerBuilder = ({
                     setShowWatchedDataSourcesModal(true);
                   }}
                   className="w-fit"
+                  disabled={tracker.status === "inactive"}
                 />
               </div>
             </div>

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/trackers/[tId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/trackers/[tId]/index.ts
@@ -108,13 +108,13 @@ async function handler(
       const updatedTrackerRes = await tracker.updateConfig(
         auth,
         {
+          status: body.status,
           name: body.name,
           description: body.description,
           prompt: body.prompt,
           modelId: body.modelId,
           providerId: body.providerId,
           temperature: body.temperature,
-          status: "active",
           frequency: body.frequency,
           recipients: body.recipients,
         },

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/trackers/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/trackers/index.ts
@@ -37,6 +37,7 @@ const TrackerDataSourcesConfigurationBodySchema = t.array(
 );
 
 export const PostTrackersRequestBodySchema = t.type({
+  status: t.union([t.literal("active"), t.literal("inactive")]),
   name: t.string,
   description: t.union([t.string, t.null]),
   prompt: t.union([t.string, t.null]),
@@ -137,7 +138,7 @@ async function handler(
           modelId: body.modelId,
           providerId: body.providerId,
           temperature: body.temperature,
-          status: "active",
+          status: body.status,
           frequency: body.frequency,
           recipients: body.recipients,
         },

--- a/front/pages/w/[wId]/assistant/labs/trackers/[tId]/index.tsx
+++ b/front/pages/w/[wId]/assistant/labs/trackers/[tId]/index.tsx
@@ -126,6 +126,7 @@ const initializeTrackerBuilderState = async (
   );
 
   return {
+    status: trackerToEdit.status,
     name: trackerToEdit.name,
     description: trackerToEdit.description,
     prompt: trackerToEdit.prompt,

--- a/types/src/front/tracker.ts
+++ b/types/src/front/tracker.ts
@@ -3,11 +3,13 @@ import { DataSourceViewSelectionConfigurations } from "./data_source_view";
 import { ModelIdType, ModelProviderIdType } from "./lib/assistant";
 import { SpaceType } from "./space";
 
+type TrackerStatus = "active" | "inactive";
+
 export type TrackerConfigurationType = {
   id: ModelId;
   sId: string;
   name: string;
-  status: "active" | "inactive";
+  status: TrackerStatus;
   description: string | null;
   modelId: ModelIdType;
   providerId: ModelProviderIdType;
@@ -33,6 +35,7 @@ export type TrackerDataSourceConfigurationType = {
 
 export type TrackerConfigurationStateType = {
   name: string | null;
+  status: TrackerStatus;
   nameError: string | null;
   description: string | null;
   descriptionError: string | null;
@@ -50,8 +53,12 @@ export type TrackerConfigurationStateType = {
 };
 
 export const TRACKER_FREQUENCIES = [
-  { label: "Daily", value: "0 17 * * 1-5" },
-  { label: "Weekly", value: "0 17 * * 5" },
+  { label: "Daily (Mon-Fri)", value: "0 17 * * 1-5" },
+  { label: "Weekly on Monday", value: "0 17 * * 1" },
+  { label: "Weekly on Tuesday", value: "0 17 * * 2" },
+  { label: "Weekly on Wednesday", value: "0 17 * * 3" },
+  { label: "Weekly on Thursday", value: "0 17 * * 4" },
+  { label: "Weekly on Friday", value: "0 17 * * 5" },
 ];
 
 export type TrackerIdWorkspaceId = {


### PR DESCRIPTION
## Description

Real review for this one is validating the UI cause code logic is quite straightforward. 
Trying to keep the UI as light as possible so just displaying the chip, but unsure whether users will understand they can click on it. Still I think it's better than adding the chip + another button somewhere or a toggle.

Status is displayed on top (only if we're editing an existing tracker): 
<br />
<kbd>
<img width="845" alt="Screenshot 2024-12-19 at 16 00 25" src="https://github.com/user-attachments/assets/3aaa7efe-5ddc-448f-b119-ab6819a9bf64" />
</kbd>
<br />
Click on the tooltip displays an option to deactivate: 
<br />
<kbd>
<img width="842" alt="Screenshot 2024-12-19 at 16 00 51" src="https://github.com/user-attachments/assets/be7bd2ea-bcbd-47e1-8282-c39e11c2603d" />
</kbd>
<br />
When deactivated, we display it in red with a lock icon and all fields are disabled.
<br />
<kbd>
<img width="843" alt="Screenshot 2024-12-19 at 16 00 36" src="https://github.com/user-attachments/assets/7ee099f3-dcd0-40ee-81a5-e69f9a51e666" />
</kbd>

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
