### PR TITLE
Code block copy button position is off

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.345",
+  "version": "0.2.346",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.345",
+      "version": "0.2.346",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.345",
+  "version": "0.2.346",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/markdown/ContentBlockWrapper.tsx
+++ b/sparkle/src/components/markdown/ContentBlockWrapper.tsx
@@ -106,7 +106,7 @@ export function ContentBlockWrapper({
         <div className="s-w-full s-table-auto">{children}</div>
       </div>
 
-      <div className="s-absolute s-right-2 s-top-2 s-mx-2 s-flex s-gap-3 s-rounded-xl">
+      <div className="s-absolute s-right-1 s-top-1 s-flex s-gap-1 s-rounded-xl">
         {getContentToDownload && (
           <IconButton
             variant={isDarkMode ? "ghost" : "outline"}


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/1799

### Before: 

<kbd>
<img width="548" alt="Screenshot 2024-12-19 at 16 37 08" src="https://github.com/user-attachments/assets/67d8410d-168b-4a4f-bf8b-8a81f48b472b" />
</kbd>

### After: 
<kbd>
<img width="580" alt="Screenshot 2024-12-19 at 16 36 35" src="https://github.com/user-attachments/assets/1f590478-7149-4d30-ab46-739926f1b7fa" />
</kbd>

## Risk

Can be rolled back

## Deploy Plan

Publish sparkle.
Use new version on front. 
