### PR TITLE
middleware to prevent path traversal attempts

### DIFF
--- a/front/middleware.ts
+++ b/front/middleware.ts
@@ -1,0 +1,16 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+export function middleware(request: NextRequest) {
+  // Detect path traversal attempts
+  const url = request.nextUrl.pathname;
+  if (url.includes("../") || url.includes("..%2F") || url.includes("..%5C")) {
+    return new NextResponse(null, { status: 400 });
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: "/:path*",
+};


### PR DESCRIPTION
## Description

In the context of our CAS assesment for our Google restricted scopes app one learning from the scan was that we didn't explicitly prevent path traversals.

This PR adds a middleware to do just that.

## Risk

Tested locally, will test on edge before merging

## Deploy Plan

- deploy `front`