### PR TITLE
Display Dust App name in error messages

### DIFF
--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -333,7 +333,7 @@ export class DustAppRunConfigurationServerRunner extends BaseActionConfiguration
         messageId: agentMessage.sId,
         error: {
           code: "dust_app_run_error",
-          message: `Error running Dust app: ${runRes.error.message}`,
+          message: `Dust App ${app.name}: ${runRes.error.message}`,
         },
       };
       return;


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/1816

Before:
<br>
<kbd>
<img width="555" alt="Screenshot 2024-12-19 at 18 10 02" src="https://github.com/user-attachments/assets/5fc174e1-ddcf-4107-8e36-e9dbc0278bb7" />
</kbd>
<br>
After: 
<br>
<kbd>
<img width="542" alt="Screenshot 2024-12-19 at 18 09 38" src="https://github.com/user-attachments/assets/b3484f01-0c97-48ba-be59-f3073ccbaff2" />
</kbd>

## Risk

/ 

## Deploy Plan

Deploy front.
