### PR TITLE
[KW search] Upsert and backfill GitHub folders

### DIFF
--- a/connectors/migrations/20241219_backfill_github_folders.ts
+++ b/connectors/migrations/20241219_backfill_github_folders.ts
@@ -1,0 +1,148 @@
+import { makeScript } from "scripts/helpers";
+
+import { getGithubCodeDirectoryParentIds } from "@connectors/connectors/github/lib/hierarchy";
+import {
+  getCodeRootInternalId,
+  getDiscussionsInternalId,
+  getIssuesInternalId,
+  getRepositoryInternalId,
+} from "@connectors/connectors/github/lib/utils";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { concurrentExecutor } from "@connectors/lib/async_utils";
+import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
+import {
+  GithubCodeDirectory,
+  GithubCodeRepository,
+  GithubConnectorState,
+} from "@connectors/lib/models/github";
+import type Logger from "@connectors/logger/logger";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+
+const FOLDER_CONCURRENCY = 10;
+
+async function upsertFoldersForConnector(
+  connector: ConnectorResource,
+  execute: boolean,
+  logger: typeof Logger
+) {
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+  const connectorId = connector.id;
+
+  const repositories = await GithubCodeRepository.findAll({
+    where: { connectorId },
+  });
+
+  for (const repository of repositories) {
+    const { repoId, repoName } = repository;
+    const repoInternalId = getRepositoryInternalId(repoId);
+
+    // folder for the repository
+    if (execute) {
+      await upsertDataSourceFolder({
+        dataSourceConfig,
+        folderId: repoInternalId,
+        parents: [repoInternalId],
+        title: repoName,
+        mimeType: "application/vnd.dust.github.repository",
+      });
+      logger.info(
+        `Upserted repository folder ${repoInternalId} for ${repoName}`
+      );
+    } else {
+      logger.info(
+        `Would upsert repository folder ${repoInternalId} for ${repoName}`
+      );
+    }
+
+    // folder with all the issues
+    const issuesInternalId = getIssuesInternalId(repoId);
+    if (execute) {
+      await upsertDataSourceFolder({
+        dataSourceConfig,
+        folderId: issuesInternalId,
+        parents: [issuesInternalId, repoInternalId],
+        title: "Issues",
+        mimeType: "application/vnd.dust.github.issues",
+      });
+      logger.info(`Upserted issues folder ${issuesInternalId}`);
+    } else {
+      logger.info(`Would upsert issues folder ${issuesInternalId}`);
+    }
+
+    // folder with all the discussions
+    const discussionsInternalId = getDiscussionsInternalId(repoId);
+    if (execute) {
+      await upsertDataSourceFolder({
+        dataSourceConfig,
+        folderId: discussionsInternalId,
+        parents: [discussionsInternalId, repoInternalId],
+        title: "Discussions",
+        mimeType: "application/vnd.dust.github.discussions",
+      });
+      logger.info(`Upserted discussions folder ${discussionsInternalId}`);
+    } else {
+      logger.info(`Would upsert discussions folder ${discussionsInternalId}`);
+    }
+
+    const connectorState = await GithubConnectorState.findOne({
+      where: { connectorId },
+    });
+    if (connectorState?.codeSyncEnabled) {
+      // folder for the code root
+      const codeRootInternalId = getCodeRootInternalId(repoId);
+      if (execute) {
+        await upsertDataSourceFolder({
+          dataSourceConfig,
+          folderId: codeRootInternalId,
+          title: "Code",
+          parents: [codeRootInternalId, repoInternalId],
+          mimeType: "application/vnd.dust.github.code.root",
+        });
+        logger.info(`Upserted code root folder ${codeRootInternalId}`);
+      } else {
+        logger.info(`Would upsert code root folder ${codeRootInternalId}`);
+      }
+
+      const directories = await GithubCodeDirectory.findAll({
+        where: { connectorId },
+      });
+
+      // Upsert directories as folders
+      await concurrentExecutor(
+        directories,
+        async (directory) => {
+          const dirParents = await getGithubCodeDirectoryParentIds(
+            connectorId,
+            directory.internalId,
+            parseInt(repoId, 10)
+          );
+          if (execute) {
+            await upsertDataSourceFolder({
+              dataSourceConfig,
+              folderId: directory.internalId,
+              parents: [directory.internalId, ...dirParents],
+              title: directory.dirName,
+              mimeType: "application/vnd.dust.github.code.directory",
+            });
+            logger.info(
+              `Upserted directory folder ${directory.internalId} for ${directory.dirName}`
+            );
+          } else {
+            logger.info(
+              `Would upsert directory folder ${directory.internalId} for ${directory.dirName}`
+            );
+          }
+        },
+        { concurrency: FOLDER_CONCURRENCY }
+      );
+    }
+  }
+}
+makeScript({}, async ({ execute }, logger) => {
+  const connectors = await ConnectorResource.listByType("zendesk", {});
+
+  for (const connector of connectors) {
+    logger.info(`Upserting folders for connector ${connector.id}`);
+    await upsertFoldersForConnector(connector, execute, logger);
+  }
+});

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -1392,3 +1392,23 @@ export async function githubUpsertDiscussionsFolderActivity({
     mimeType: "application/vnd.dust.github.discussions",
   });
 }
+
+export async function githubUpsertCodeRootFolderActivity({
+  connectorId,
+  repoId,
+}: {
+  connectorId: ModelId;
+  repoId: number;
+}) {
+  const connector = await ConnectorResource.fetchById(connectorId);
+  if (!connector) {
+    throw new Error(`Connector not found. ConnectorId: ${connectorId}`);
+  }
+  await upsertDataSourceFolder({
+    dataSourceConfig: dataSourceConfigFromConnector(connector),
+    folderId: getCodeRootInternalId(repoId),
+    title: "Code",
+    parents: [getCodeRootInternalId(repoId), getRepositoryInternalId(repoId)],
+    mimeType: "application/vnd.dust.github.code.root",
+  });
+}

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -668,7 +668,19 @@ export async function githubRepoGarbageCollectActivity(
     logger
   );
 
-  // deleting the repository folder from data_source_folders (core)
+  // deleting the folders that are tied to a repository from data_source_folders (core)
+  await deleteDataSourceFolder({
+    dataSourceConfig,
+    folderId: getDiscussionsInternalId(repoId),
+  });
+  await deleteDataSourceFolder({
+    dataSourceConfig,
+    folderId: getIssuesInternalId(repoId),
+  });
+  await deleteDataSourceFolder({
+    dataSourceConfig,
+    folderId: getCodeRootInternalId(repoId),
+  });
   await deleteDataSourceFolder({
     dataSourceConfig,
     folderId: getRepositoryInternalId(repoId),


### PR DESCRIPTION
## Description

- Closes [#9157](https://github.com/dust-tt/dust/issues/9157)
- Add data_sources_folders upserts for code root and code directories + deletions in GC.
- Add backfill script.
- Add activities for repository folder, issues and discussions (will be added to the workflow in another PR).

## Risk

- Low

## Deploy Plan

- Deploy connectors
- Follow up in another PR to change workflows
- Backfill will be run after this PR
