### PR TITLE
[Keyword search] Globally unique id as elasticsearch index

### DIFF
--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -3057,7 +3057,10 @@ async fn folders_delete(
             .store
             .delete_data_source_folder(&project, &data_source_id, &folder_id)
             .await?;
-        state.search_store.delete_node(folder_id).await?;
+        state
+            .search_store
+            .delete_node(&data_source_id, &folder_id)
+            .await?;
         Ok(())
     }
     .await;

--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -3049,17 +3049,21 @@ async fn folders_delete(
     let project = project::Project::new_from_id(project_id);
 
     let result = async {
-        state
+        let folder = match state
             .store
             .load_data_source_folder(&project, &data_source_id, &folder_id)
-            .await?;
+            .await?
+        {
+            Some(folder) => folder,
+            None => return Ok(()),
+        };
         state
             .store
             .delete_data_source_folder(&project, &data_source_id, &folder_id)
             .await?;
         state
             .search_store
-            .delete_node(&data_source_id, &folder_id)
+            .delete_node(&folder.data_source_internal_id(), &folder_id)
             .await?;
         Ok(())
     }

--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -35,6 +35,7 @@ use dust::{
     blocks::block::BlockType,
     data_sources::{
         data_source::{self, Section},
+        node::Node,
         qdrant::QdrantClients,
     },
     databases::{
@@ -2204,7 +2205,11 @@ async fn tables_upsert(
         )
         .await
     {
-        Ok(table) => match state.search_store.index_table(table.clone()).await {
+        Ok(table) => match state
+            .search_store
+            .index_node(Node::from(table.clone()))
+            .await
+        {
             Ok(_) => (
                 StatusCode::OK,
                 Json(APIResponse {
@@ -2910,7 +2915,11 @@ async fn folders_upsert(
             "Failed to upsert folder",
             Some(e),
         ),
-        Ok(folder) => match state.search_store.index_folder(folder.clone()).await {
+        Ok(folder) => match state
+            .search_store
+            .index_node(Node::from(folder.clone()))
+            .await
+        {
             Ok(_) => (
                 StatusCode::OK,
                 Json(APIResponse {
@@ -3061,10 +3070,7 @@ async fn folders_delete(
             .store
             .delete_data_source_folder(&project, &data_source_id, &folder_id)
             .await?;
-        state
-            .search_store
-            .delete_node(&folder.data_source_internal_id(), &folder_id)
-            .await?;
+        state.search_store.delete_node(Node::from(folder)).await?;
         Ok(())
     }
     .await;

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -142,6 +142,7 @@ pub struct Chunk {
 #[derive(Debug, Serialize, Clone)]
 pub struct Document {
     pub data_source_id: String,
+    pub data_source_internal_id: String,
     pub created: u64,
     pub document_id: String,
     pub timestamp: u64,
@@ -163,6 +164,7 @@ pub struct Document {
 impl Document {
     pub fn new(
         data_source_id: &str,
+        data_source_internal_id: &str,
         document_id: &str,
         timestamp: u64,
         title: &str,
@@ -176,6 +178,7 @@ impl Document {
     ) -> Result<Self> {
         Ok(Document {
             data_source_id: data_source_id.to_string(),
+            data_source_internal_id: data_source_internal_id.to_string(),
             created: utils::now(),
             document_id: document_id.to_string(),
             timestamp,
@@ -220,6 +223,7 @@ impl From<Document> for Node {
     fn from(document: Document) -> Node {
         Node::new(
             &document.data_source_id,
+            &document.data_source_internal_id,
             &document.document_id,
             NodeType::Document,
             document.timestamp,
@@ -692,6 +696,7 @@ impl DataSource {
 
         let document = Document::new(
             &self.data_source_id,
+            &self.internal_id,
             document_id,
             timestamp,
             title.as_deref().unwrap_or(document_id),
@@ -1749,7 +1754,7 @@ impl DataSource {
 
         // Delete document from search index.
         search_store
-            .delete_node(&self.data_source_id, document_id)
+            .delete_node(&self.internal_id, document_id)
             .await?;
 
         // We also scrub it directly. We used to scrub async but now that we store a GCS version

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -1748,7 +1748,9 @@ impl DataSource {
             .await?;
 
         // Delete document from search index.
-        search_store.delete_node(document_id.to_string()).await?;
+        search_store
+            .delete_node(&self.data_source_id, document_id)
+            .await?;
 
         // We also scrub it directly. We used to scrub async but now that we store a GCS version
         // for each data_source_documents entry we can scrub directly at the time of delete.

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -75,7 +75,7 @@ pub struct Chunk {
     pub expanded_offsets: Vec<usize>,
 }
 
-/// Document is used as a data-strucutre for insertion into the SQL store (no
+/// Document is used as a data-structure for insertion into the SQL store (no
 /// chunks, they are directly inserted in the vector search db). It is also used
 /// as a result from search (only the retrieved chunks are provided in the
 /// result). `hash` covers both the original document id and text and the

--- a/core/src/data_sources/folder.rs
+++ b/core/src/data_sources/folder.rs
@@ -40,6 +40,9 @@ impl Folder {
     pub fn data_source_id(&self) -> &str {
         &self.data_source_id
     }
+    pub fn data_source_internal_id(&self) -> &str {
+        &self.data_source_internal_id
+    }
     pub fn timestamp(&self) -> u64 {
         self.timestamp
     }

--- a/core/src/data_sources/folder.rs
+++ b/core/src/data_sources/folder.rs
@@ -5,6 +5,7 @@ use super::node::{Node, NodeType};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Folder {
     data_source_id: String,
+    data_source_internal_id: String,
     folder_id: String,
     timestamp: u64,
     title: String,
@@ -16,6 +17,7 @@ pub struct Folder {
 impl Folder {
     pub fn new(
         data_source_id: String,
+        data_source_internal_id: String,
         folder_id: String,
         timestamp: u64,
         title: String,
@@ -25,6 +27,7 @@ impl Folder {
     ) -> Self {
         Folder {
             data_source_id,
+            data_source_internal_id,
             folder_id,
             timestamp,
             title,
@@ -61,6 +64,7 @@ impl From<Folder> for Node {
     fn from(folder: Folder) -> Node {
         Node::new(
             &folder.data_source_id,
+            &folder.data_source_internal_id,
             &folder.folder_id,
             NodeType::Folder,
             folder.timestamp,

--- a/core/src/data_sources/node.rs
+++ b/core/src/data_sources/node.rs
@@ -23,6 +23,7 @@ impl fmt::Display for NodeType {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Node {
     pub data_source_id: String,
+    pub data_source_internal_id: String,
     pub node_id: String,
     pub node_type: NodeType,
     pub timestamp: u64,
@@ -35,6 +36,7 @@ pub struct Node {
 impl Node {
     pub fn new(
         data_source_id: &str,
+        data_source_internal_id: &str,
         node_id: &str,
         node_type: NodeType,
         timestamp: u64,
@@ -45,6 +47,7 @@ impl Node {
     ) -> Self {
         Node {
             data_source_id: data_source_id.to_string(),
+            data_source_internal_id: data_source_internal_id.to_string(),
             node_id: node_id.to_string(),
             node_type,
             timestamp,
@@ -57,6 +60,9 @@ impl Node {
 
     pub fn data_source_id(&self) -> &str {
         &self.data_source_id
+    }
+    pub fn data_source_internal_id(&self) -> &str {
+        &self.data_source_internal_id
     }
     pub fn timestamp(&self) -> u64 {
         self.timestamp
@@ -81,6 +87,7 @@ impl Node {
     pub fn into_folder(self) -> Folder {
         Folder::new(
             self.data_source_id,
+            self.data_source_internal_id,
             self.node_id,
             self.timestamp,
             self.title,
@@ -90,15 +97,14 @@ impl Node {
         )
     }
 
-    // globally unique id for the node
-    // used for elasticsearch
+    // Computes a globally unique id for the node.
     pub fn unique_id(&self) -> String {
-        globally_unique_id(&self.data_source_id, &self.node_id)
+        globally_unique_id(&self.data_source_internal_id, &self.node_id)
     }
 }
 
-pub fn globally_unique_id(data_source_id: &str, node_id: &str) -> String {
-    format!("{}__{}", data_source_id, node_id)
+pub fn globally_unique_id(data_source_internal_id: &str, node_id: &str) -> String {
+    format!("{}__{}", data_source_internal_id, node_id)
 }
 
 impl From<serde_json::Value> for Node {

--- a/core/src/data_sources/node.rs
+++ b/core/src/data_sources/node.rs
@@ -98,7 +98,7 @@ impl Node {
 }
 
 pub fn globally_unique_id(data_source_id: &str, node_id: &str) -> String {
-    format!("{}-{}", data_source_id, node_id)
+    format!("{}__{}", data_source_id, node_id)
 }
 
 impl From<serde_json::Value> for Node {

--- a/core/src/data_sources/node.rs
+++ b/core/src/data_sources/node.rs
@@ -99,12 +99,8 @@ impl Node {
 
     // Computes a globally unique id for the node.
     pub fn unique_id(&self) -> String {
-        globally_unique_id(&self.data_source_internal_id, &self.node_id)
+        format!("{}__{}", self.data_source_internal_id, self.node_id)
     }
-}
-
-pub fn globally_unique_id(data_source_internal_id: &str, node_id: &str) -> String {
-    format!("{}__{}", data_source_internal_id, node_id)
 }
 
 impl From<serde_json::Value> for Node {

--- a/core/src/data_sources/node.rs
+++ b/core/src/data_sources/node.rs
@@ -89,6 +89,12 @@ impl Node {
             self.mime_type,
         )
     }
+
+    // globally unique id for the node
+    // used for elasticsearch
+    pub fn globally_unique_id(&self) -> String {
+        format!("{}-{}", self.data_source_id, self.node_id)
+    }
 }
 
 impl From<serde_json::Value> for Node {

--- a/core/src/data_sources/node.rs
+++ b/core/src/data_sources/node.rs
@@ -92,9 +92,13 @@ impl Node {
 
     // globally unique id for the node
     // used for elasticsearch
-    pub fn globally_unique_id(&self) -> String {
-        format!("{}-{}", self.data_source_id, self.node_id)
+    pub fn unique_id(&self) -> String {
+        globally_unique_id(&self.data_source_id, &self.node_id)
     }
+}
+
+pub fn globally_unique_id(data_source_id: &str, node_id: &str) -> String {
+    format!("{}-{}", data_source_id, node_id)
 }
 
 impl From<serde_json::Value> for Node {

--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -211,7 +211,7 @@ impl Table {
         // Delete the table node from the search index.
         if let Some(search_store) = search_store {
             search_store
-                .delete_node(self.table_id().to_string())
+                .delete_node(&self.data_source_id, self.table_id())
                 .await?;
         }
 

--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -52,6 +52,7 @@ pub fn get_table_type_for_tables(tables: Vec<&Table>) -> Result<TableType> {
 pub struct Table {
     project: Project,
     data_source_id: String,
+    data_source_internal_id: String,
     created: u64,
 
     table_id: String,
@@ -75,6 +76,7 @@ impl Table {
     pub fn new(
         project: Project,
         data_source_id: String,
+        data_source_internal_id: String,
         created: u64,
         table_id: String,
         name: String,
@@ -93,6 +95,7 @@ impl Table {
         Table {
             project,
             data_source_id,
+            data_source_internal_id,
             created,
             table_id,
             name,
@@ -211,7 +214,7 @@ impl Table {
         // Delete the table node from the search index.
         if let Some(search_store) = search_store {
             search_store
-                .delete_node(&self.data_source_id, self.table_id())
+                .delete_node(&self.data_source_internal_id, self.table_id())
                 .await?;
         }
 
@@ -239,6 +242,7 @@ impl From<Table> for Node {
     fn from(table: Table) -> Node {
         Node::new(
             &table.data_source_id,
+            &table.data_source_internal_id,
             &table.table_id,
             NodeType::Table,
             table.timestamp,
@@ -583,6 +587,7 @@ mod tests {
         let table = Table::new(
             Project::new_from_id(42),
             "data_source_id".to_string(),
+            "data_source_internal_id".to_string(),
             utils::now(),
             "table_id".to_string(),
             "test_dbml".to_string(),

--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -213,9 +213,7 @@ impl Table {
 
         // Delete the table node from the search index.
         if let Some(search_store) = search_store {
-            search_store
-                .delete_node(&self.data_source_internal_id, self.table_id())
-                .await?;
+            search_store.delete_node(Node::from(self.clone())).await?;
         }
 
         Ok(())

--- a/core/src/search_stores/indices/data_sources_nodes_2.mappings.json
+++ b/core/src/search_stores/indices/data_sources_nodes_2.mappings.json
@@ -1,0 +1,39 @@
+{
+  "dynamic": "strict",
+  "properties": {
+    "data_source_id": {
+      "type": "keyword"
+    },
+    "data_source_internal_id": {
+      "type": "keyword"
+    },
+    "timestamp": {
+      "type": "date"
+    },
+    "node_type": {
+      "type": "keyword"
+    },
+    "node_id": {
+      "type": "keyword"
+    },
+    "title": {
+      "type": "text",
+      "analyzer": "standard",
+      "fields": {
+        "edge": {
+          "type": "text",
+          "analyzer": "edge_analyzer"
+        }
+      }
+    },
+    "parents": {
+      "type": "keyword"
+    },
+    "parent_id": {
+      "type": "keyword"
+    },
+    "mime_type": {
+      "type": "keyword"
+    }
+  }
+}

--- a/core/src/search_stores/indices/data_sources_nodes_2.settings.local.json
+++ b/core/src/search_stores/indices/data_sources_nodes_2.settings.local.json
@@ -1,0 +1,36 @@
+{
+  "number_of_shards": 1,
+  "number_of_replicas": 0,
+  "refresh_interval": "30s",
+  "analysis": {
+    "analyzer": {
+      "icu_analyzer": {
+        "type": "custom",
+        "tokenizer": "icu_tokenizer",
+        "filter": [
+          "icu_folding",
+          "lowercase",
+          "asciifolding",
+          "preserve_word_delimiter"
+        ]
+      },
+      "edge_analyzer": {
+        "type": "custom",
+        "tokenizer": "icu_tokenizer",
+        "filter": ["lowercase", "edge_ngram_filter"]
+      }
+    },
+    "filter": {
+      "preserve_word_delimiter": {
+        "type": "word_delimiter",
+        "split_on_numerics": false,
+        "split_on_case_change": false
+      },
+      "edge_ngram_filter": {
+        "type": "edge_ngram",
+        "min_gram": 2,
+        "max_gram": 20
+      }
+    }
+  }
+}

--- a/core/src/search_stores/indices/data_sources_nodes_2.settings.us-central-1.json
+++ b/core/src/search_stores/indices/data_sources_nodes_2.settings.us-central-1.json
@@ -1,0 +1,36 @@
+{
+  "number_of_shards": 2,
+  "number_of_replicas": 1,
+  "refresh_interval": "30s",
+  "analysis": {
+    "analyzer": {
+      "icu_analyzer": {
+        "type": "custom",
+        "tokenizer": "icu_tokenizer",
+        "filter": [
+          "icu_folding",
+          "lowercase",
+          "asciifolding",
+          "preserve_word_delimiter"
+        ]
+      },
+      "edge_analyzer": {
+        "type": "custom",
+        "tokenizer": "icu_tokenizer",
+        "filter": ["lowercase", "edge_ngram_filter"]
+      }
+    },
+    "filter": {
+      "preserve_word_delimiter": {
+        "type": "word_delimiter",
+        "split_on_numerics": false,
+        "split_on_case_change": false
+      },
+      "edge_ngram_filter": {
+        "type": "edge_ngram",
+        "min_gram": 2,
+        "max_gram": 20
+      }
+    }
+  }
+}

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -44,7 +44,7 @@ pub trait SearchStore {
     async fn index_table(&self, table: Table) -> Result<()>;
     async fn index_folder(&self, folder: Folder) -> Result<()>;
 
-    async fn delete_node(&self, data_source_id: &str, node_id: &str) -> Result<()>;
+    async fn delete_node(&self, data_source_internal_id: &str, node_id: &str) -> Result<()>;
     async fn delete_data_source_nodes(&self, data_source_id: &str) -> Result<()>;
 
     fn clone_box(&self) -> Box<dyn SearchStore + Sync + Send>;
@@ -198,11 +198,11 @@ impl SearchStore for ElasticsearchSearchStore {
         self.index_node(node).await
     }
 
-    async fn delete_node(&self, data_source_id: &str, node_id: &str) -> Result<()> {
+    async fn delete_node(&self, data_source_internal_id: &str, node_id: &str) -> Result<()> {
         self.client
             .delete(DeleteParts::IndexId(
                 NODES_INDEX_NAME,
-                &globally_unique_id(data_source_id, node_id),
+                &globally_unique_id(data_source_internal_id, node_id),
             ))
             .send()
             .await?;

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -152,7 +152,10 @@ impl SearchStore for ElasticsearchSearchStore {
         let now = utils::now();
         match self
             .client
-            .index(IndexParts::IndexId(NODES_INDEX_NAME, &node.node_id))
+            .index(IndexParts::IndexId(
+                NODES_INDEX_NAME,
+                &node.globally_unique_id(),
+            ))
             .timeout("200ms")
             .body(node.clone())
             .send()

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -1307,14 +1307,14 @@ impl Store for PostgresStore {
 
         let r = c
             .query(
-                "SELECT id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
+                "SELECT id, data_source_internal_id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
                 &[&project_id, &data_source_id],
             )
             .await?;
 
-        let data_source_row_id: i64 = match r.len() {
+        let (data_source_row_id, data_source_internal_id): (i64, String) = match r.len() {
             0 => Err(anyhow!("Unknown DataSource: {}", data_source_id))?,
-            1 => r[0].get(0),
+            1 => (r[0].get(0), r[0].get(1)),
             _ => unreachable!(),
         };
 
@@ -1393,6 +1393,7 @@ impl Store for PostgresStore {
                 node_mime_type,
             )) => Ok(Some(Document {
                 data_source_id: data_source_id.clone(),
+                data_source_internal_id: data_source_internal_id.clone(),
                 created: created as u64,
                 timestamp: timestamp as u64,
                 title: node_title.unwrap_or(document_id.clone()),
@@ -1829,14 +1830,14 @@ impl Store for PostgresStore {
 
         let r = c
             .query(
-                "SELECT id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
+                "SELECT id, data_source_internal_id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
                 &[&project_id, &data_source_id],
             )
             .await?;
 
-        let data_source_row_id: i64 = match r.len() {
+        let (data_source_row_id, data_source_internal_id): (i64, String) = match r.len() {
             0 => Err(anyhow!("Unknown DataSource: {}", data_source_id))?,
-            1 => r[0].get(0),
+            1 => (r[0].get(0), r[0].get(1)),
             _ => unreachable!(),
         };
 
@@ -1890,6 +1891,7 @@ impl Store for PostgresStore {
 
         let document = Document {
             data_source_id,
+            data_source_internal_id: data_source_internal_id.to_string(),
             title,
             mime_type,
             created: created as u64,
@@ -1945,14 +1947,14 @@ impl Store for PostgresStore {
 
         let r = c
             .query(
-                "SELECT id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
+                "SELECT id, data_source_internal_id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
                 &[&project_id, &data_source_id],
             )
             .await?;
 
-        let data_source_row_id: i64 = match r.len() {
+        let (data_source_row_id, data_source_internal_id): (i64, String) = match r.len() {
             0 => Err(anyhow!("Unknown DataSource: {}", data_source_id))?,
-            1 => r[0].get(0),
+            1 => (r[0].get(0), r[0].get(1)),
             _ => unreachable!(),
         };
 
@@ -2048,6 +2050,7 @@ impl Store for PostgresStore {
 
                 Ok(Document {
                     data_source_id: data_source_id.clone(),
+                    data_source_internal_id: data_source_internal_id.clone(),
                     created: created as u64,
                     timestamp: timestamp as u64,
                     title: node_title.unwrap_or(document_id.clone()),
@@ -2599,13 +2602,13 @@ impl Store for PostgresStore {
         let tx = c.transaction().await?;
         let r = tx
             .query(
-                "SELECT id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
+                "SELECT id, data_source_internal_id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
                 &[&project_id, &data_source_id],
             )
             .await?;
-        let data_source_row_id: i64 = match r.len() {
+        let (data_source_row_id, data_source_internal_id): (i64, String) = match r.len() {
             0 => Err(anyhow!("Unknown DataSource: {}", data_source_id))?,
-            1 => r[0].get(0),
+            1 => (r[0].get(0), r[0].get(1)),
             _ => unreachable!(),
         };
 
@@ -2664,6 +2667,7 @@ impl Store for PostgresStore {
         let table = Table::new(
             project,
             data_source_id,
+            data_source_internal_id,
             table_created,
             upsert_params.table_id,
             upsert_params.name,
@@ -2853,13 +2857,13 @@ impl Store for PostgresStore {
         // Get the data source row id.
         let stmt = c
             .prepare(
-                "SELECT id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
+                "SELECT id, data_source_internal_id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
             )
             .await?;
         let r = c.query(&stmt, &[&project_id, &data_source_id]).await?;
-        let data_source_row_id: i64 = match r.len() {
+        let (data_source_row_id, data_source_internal_id): (i64, String) = match r.len() {
             0 => Err(anyhow!("Unknown DataSource: {}", data_source_id))?,
-            1 => r[0].get(0),
+            1 => (r[0].get(0), r[0].get(1)),
             _ => unreachable!(),
         };
 
@@ -2938,6 +2942,7 @@ impl Store for PostgresStore {
                 Ok(Some(Table::new(
                     project.clone(),
                     data_source_id.clone(),
+                    data_source_internal_id.clone(),
                     created as u64,
                     table_id,
                     name,
@@ -2974,14 +2979,14 @@ impl Store for PostgresStore {
         // get the data source row id
         let r = c
             .query(
-                "SELECT id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
+                "SELECT id, data_source_internal_id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
                 &[&project_id, &data_source_id],
             )
             .await?;
 
-        let data_source_row_id: i64 = match r.len() {
+        let (data_source_row_id, data_source_internal_id): (i64, String) = match r.len() {
             0 => Err(anyhow!("Unknown DataSource: {}", data_source_id))?,
-            1 => r[0].get(0),
+            1 => (r[0].get(0), r[0].get(1)),
             _ => unreachable!(),
         };
 
@@ -3080,6 +3085,7 @@ impl Store for PostgresStore {
                 Ok(Table::new(
                     project.clone(),
                     data_source_id.clone(),
+                    data_source_internal_id.clone(),
                     created as u64,
                     table_id,
                     name,
@@ -3181,13 +3187,14 @@ impl Store for PostgresStore {
         let tx = c.transaction().await?;
         let r = tx
             .query(
-                "SELECT id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
+                "SELECT id, data_source_internal_id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
                 &[&project_id, &data_source_id],
             )
             .await?;
-        let data_source_row_id: i64 = match r.len() {
+
+        let (data_source_row_id, data_source_internal_id): (i64, String) = match r.len() {
             0 => Err(anyhow!("Unknown DataSource: {}", data_source_id))?,
-            1 => r[0].get(0),
+            1 => (r[0].get(0), r[0].get(1)),
             _ => unreachable!(),
         };
 
@@ -3218,6 +3225,7 @@ impl Store for PostgresStore {
 
         let folder = Folder::new(
             data_source_id,
+            data_source_internal_id,
             upsert_params.folder_id,
             created as u64,
             upsert_params.title,
@@ -3299,14 +3307,14 @@ impl Store for PostgresStore {
         // get the data source row id
         let r = c
             .query(
-                "SELECT id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
+                "SELECT id, data_source_internal_id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
                 &[&project_id, &data_source_id],
             )
             .await?;
 
-        let data_source_row_id: i64 = match r.len() {
+        let (data_source_row_id, data_source_internal_id): (i64, String) = match r.len() {
             0 => Err(anyhow!("Unknown DataSource: {}", data_source_id))?,
-            1 => r[0].get(0),
+            1 => (r[0].get(0), r[0].get(1)),
             _ => unreachable!(),
         };
 
@@ -3395,6 +3403,7 @@ impl Store for PostgresStore {
 
                 Ok(Folder::new(
                     data_source_id.clone(),
+                    data_source_internal_id.clone(),
                     node_id,
                     timestamp as u64,
                     title,
@@ -3460,14 +3469,14 @@ impl Store for PostgresStore {
 
         let r = c
             .query(
-                "SELECT id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
+                "SELECT id, data_source_internal_id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
                 &[&project_id, &data_source_id],
             )
             .await?;
 
-        let data_source_row_id: i64 = match r.len() {
+        let (data_source_row_id, data_source_internal_id): (i64, String) = match r.len() {
             0 => Err(anyhow!("Unknown DataSource: {}", data_source_id))?,
-            1 => r[0].get(0),
+            1 => (r[0].get(0), r[0].get(1)),
             _ => unreachable!(),
         };
 
@@ -3500,6 +3509,7 @@ impl Store for PostgresStore {
                 Ok(Some((
                     Node::new(
                         &data_source_id,
+                        &data_source_internal_id,
                         &node_id,
                         node_type,
                         timestamp as u64,

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -1307,7 +1307,7 @@ impl Store for PostgresStore {
 
         let r = c
             .query(
-                "SELECT id, data_source_internal_id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
+                "select id, internal_id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
                 &[&project_id, &data_source_id],
             )
             .await?;
@@ -1830,7 +1830,7 @@ impl Store for PostgresStore {
 
         let r = c
             .query(
-                "SELECT id, data_source_internal_id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
+                "select id, internal_id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
                 &[&project_id, &data_source_id],
             )
             .await?;
@@ -1947,7 +1947,7 @@ impl Store for PostgresStore {
 
         let r = c
             .query(
-                "SELECT id, data_source_internal_id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
+                "select id, internal_id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
                 &[&project_id, &data_source_id],
             )
             .await?;
@@ -2602,7 +2602,7 @@ impl Store for PostgresStore {
         let tx = c.transaction().await?;
         let r = tx
             .query(
-                "SELECT id, data_source_internal_id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
+                "select id, internal_id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
                 &[&project_id, &data_source_id],
             )
             .await?;
@@ -2857,7 +2857,7 @@ impl Store for PostgresStore {
         // Get the data source row id.
         let stmt = c
             .prepare(
-                "SELECT id, data_source_internal_id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
+                "select id, internal_id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
             )
             .await?;
         let r = c.query(&stmt, &[&project_id, &data_source_id]).await?;
@@ -2979,7 +2979,7 @@ impl Store for PostgresStore {
         // get the data source row id
         let r = c
             .query(
-                "SELECT id, data_source_internal_id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
+                "select id, internal_id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
                 &[&project_id, &data_source_id],
             )
             .await?;
@@ -3187,7 +3187,7 @@ impl Store for PostgresStore {
         let tx = c.transaction().await?;
         let r = tx
             .query(
-                "SELECT id, data_source_internal_id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
+                "select id, internal_id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
                 &[&project_id, &data_source_id],
             )
             .await?;
@@ -3307,7 +3307,7 @@ impl Store for PostgresStore {
         // get the data source row id
         let r = c
             .query(
-                "SELECT id, data_source_internal_id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
+                "select id, internal_id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
                 &[&project_id, &data_source_id],
             )
             .await?;
@@ -3469,7 +3469,7 @@ impl Store for PostgresStore {
 
         let r = c
             .query(
-                "SELECT id, data_source_internal_id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
+                "select id, internal_id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
                 &[&project_id, &data_source_id],
             )
             .await?;


### PR DESCRIPTION
Description
---
Node id is not globally unique, since if e.g. the same notion is plugged on two workspaces, the same page will have the same node id in both workspaces

This PR relies on data sources' internal ids and as such adds them to Nodes/Folders/Documents/Tables

Also updates the elasticsearch mapping for data_source_nodes with `data_source_internal_id`

Fixes #9527

Risks
---
none, index is not used yet and we'll backfill ES from scratch when all data source folders are already backfilled too

Deploy
---
deploy core
create new index
