### PR TITLE
[Keyword search] Updates search index on /parents call

### DIFF
--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -1550,6 +1550,7 @@ async fn data_sources_documents_update_parents(
                 .update_parents(
                     state.store.clone(),
                     state.qdrant_clients.clone(),
+                    state.search_store.clone(),
                     document_id,
                     payload.parents,
                 )
@@ -2536,7 +2537,11 @@ async fn tables_update_parents(
             None,
         ),
         Ok(Some(table)) => match table
-            .update_parents(state.store.clone(), payload.parents.clone())
+            .update_parents(
+                state.store.clone(),
+                state.search_store.clone(),
+                payload.parents.clone(),
+            )
             .await
         {
             Err(e) => error_response(

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -496,10 +496,12 @@ impl DataSource {
             )
             .await?;
 
-        search_store
-            .index_node(Node::from(document.unwrap()))
-            .await?;
-
+        match document {
+            Some(document) => {
+                search_store.index_node(Node::from(document)).await?;
+            }
+            None => (),
+        }
         Ok(())
     }
 

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -469,6 +469,7 @@ impl DataSource {
         &self,
         store: Box<dyn Store + Sync + Send>,
         qdrant_clients: QdrantClients,
+        search_store: Box<dyn SearchStore + Sync + Send>,
         document_id: String,
         parents: Vec<String>,
     ) -> Result<()> {
@@ -485,6 +486,20 @@ impl DataSource {
 
         self.update_document_payload(qdrant_clients, document_id_hash, "parents", parents)
             .await?;
+
+        let document = store
+            .load_data_source_document(
+                &self.project,
+                &self.data_source_id(),
+                &document_id.to_string(),
+                &None,
+            )
+            .await?;
+
+        search_store
+            .index_node(Node::from(document.unwrap()))
+            .await?;
+
         Ok(())
     }
 

--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -222,6 +222,7 @@ impl Table {
     pub async fn update_parents(
         &self,
         store: Box<dyn Store + Sync + Send>,
+        search_store: Box<dyn SearchStore + Sync + Send>,
         parents: Vec<String>,
     ) -> Result<()> {
         store
@@ -232,6 +233,8 @@ impl Table {
                 &parents,
             )
             .await?;
+
+        search_store.index_node(Node::from(self.clone())).await?;
         Ok(())
     }
 }

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -148,7 +148,7 @@ impl SearchStore for ElasticsearchSearchStore {
         let now = utils::now();
         // Note: in elasticsearch, the index API updates the document if it
         // already exists.
-	let response = self
+        let response = self
             .client
             .index(IndexParts::IndexId(NODES_INDEX_NAME, &node.unique_id()))
             .timeout("200ms")

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -146,7 +146,9 @@ impl SearchStore for ElasticsearchSearchStore {
     async fn index_node(&self, node: Node) -> Result<()> {
         // todo(kw-search): fail on error
         let now = utils::now();
-        let response = self
+        // Note: in elasticsearch, the index API updates the document if it
+        // already exists.
+	let response = self
             .client
             .index(IndexParts::IndexId(NODES_INDEX_NAME, &node.unique_id()))
             .timeout("200ms")


### PR DESCRIPTION
Description
---
Fixes #9461

Updates parents for documents / tables in elasticsearch whenever they change

Took the opportunity to look for all /parents call to see if we should update folders' parents too. Parents is called in 3 places by connectors
- once in notion, which does not have folders, so no-op;
- once in confluence, for which folders don't directly move AFAICT, no-op too; (cc @aubin, @flavien for confirmation)
- once in microsoft, changed the logic there.

Note: no /parents endpoint for folders since it's just updating the rows in nodes/folders, we just reuse `upsertDataSourceFolder`

Risks
---
low

Deploy
---
core
connectors
