### PR TITLE
github - add new workflows with the folders upsert

### DIFF
--- a/connectors/migrations/20241219_backfill_github_folders.ts
+++ b/connectors/migrations/20241219_backfill_github_folders.ts
@@ -139,7 +139,7 @@ async function upsertFoldersForConnector(
   }
 }
 makeScript({}, async ({ execute }, logger) => {
-  const connectors = await ConnectorResource.listByType("zendesk", {});
+  const connectors = await ConnectorResource.listByType("github", {});
 
   for (const connector of connectors) {
     logger.info(`Upserting folders for connector ${connector.id}`);

--- a/connectors/src/connectors/github/temporal/client.ts
+++ b/connectors/src/connectors/github/temporal/client.ts
@@ -23,11 +23,11 @@ import {
   githubCodeSyncWorkflow,
   githubDiscussionGarbageCollectWorkflow,
   githubDiscussionSyncWorkflow,
-  githubFullSyncWorkflow,
   githubIssueGarbageCollectWorkflow,
   githubIssueSyncWorkflow,
   githubRepoGarbageCollectWorkflow,
-  githubReposSyncWorkflow,
+  githubSyncAllReposWorkflow,
+  githubSyncReposWorkflow,
 } from "@connectors/connectors/github/temporal/workflows";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { getTemporalClient } from "@connectors/lib/temporal";
@@ -68,7 +68,7 @@ export async function launchGithubFullSyncWorkflow({
     return;
   }
 
-  await client.workflow.start(githubFullSyncWorkflow, {
+  await client.workflow.start(githubSyncAllReposWorkflow, {
     args: [dataSourceConfig, connectorId, syncCodeOnly, forceCodeResync],
     taskQueue: QUEUE_NAME,
     workflowId: getFullSyncWorkflowId(connectorId),
@@ -87,7 +87,7 @@ export async function getGithubFullSyncWorkflow(connectorId: ModelId): Promise<{
 } | null> {
   const client = await getTemporalClient();
 
-  const handle: WorkflowHandle<typeof githubFullSyncWorkflow> =
+  const handle: WorkflowHandle<typeof githubSyncAllReposWorkflow> =
     client.workflow.getHandle(getFullSyncWorkflowId(connectorId));
 
   try {
@@ -116,7 +116,7 @@ export async function launchGithubReposSyncWorkflow(
   }
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
 
-  await client.workflow.start(githubReposSyncWorkflow, {
+  await client.workflow.start(githubSyncReposWorkflow, {
     args: [dataSourceConfig, connectorId, orgLogin, repos],
     taskQueue: QUEUE_NAME,
     workflowId: getReposSyncWorkflowId(connectorId),

--- a/connectors/src/connectors/github/temporal/client.ts
+++ b/connectors/src/connectors/github/temporal/client.ts
@@ -23,11 +23,11 @@ import {
   githubCodeSyncWorkflow,
   githubDiscussionGarbageCollectWorkflow,
   githubDiscussionSyncWorkflow,
+  githubFullSyncWorkflowV2,
   githubIssueGarbageCollectWorkflow,
   githubIssueSyncWorkflow,
   githubRepoGarbageCollectWorkflow,
-  githubSyncAllReposWorkflow,
-  githubSyncReposWorkflow,
+  githubReposSyncWorkflowV2,
 } from "@connectors/connectors/github/temporal/workflows";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { getTemporalClient } from "@connectors/lib/temporal";
@@ -68,7 +68,7 @@ export async function launchGithubFullSyncWorkflow({
     return;
   }
 
-  await client.workflow.start(githubSyncAllReposWorkflow, {
+  await client.workflow.start(githubFullSyncWorkflowV2, {
     args: [dataSourceConfig, connectorId, syncCodeOnly, forceCodeResync],
     taskQueue: QUEUE_NAME,
     workflowId: getFullSyncWorkflowId(connectorId),
@@ -87,7 +87,7 @@ export async function getGithubFullSyncWorkflow(connectorId: ModelId): Promise<{
 } | null> {
   const client = await getTemporalClient();
 
-  const handle: WorkflowHandle<typeof githubSyncAllReposWorkflow> =
+  const handle: WorkflowHandle<typeof githubFullSyncWorkflowV2> =
     client.workflow.getHandle(getFullSyncWorkflowId(connectorId));
 
   try {
@@ -116,7 +116,7 @@ export async function launchGithubReposSyncWorkflow(
   }
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
 
-  await client.workflow.start(githubSyncReposWorkflow, {
+  await client.workflow.start(githubReposSyncWorkflowV2, {
     args: [dataSourceConfig, connectorId, orgLogin, repos],
     taskQueue: QUEUE_NAME,
     workflowId: getReposSyncWorkflowId(connectorId),

--- a/connectors/src/connectors/github/temporal/workflows.ts
+++ b/connectors/src/connectors/github/temporal/workflows.ts
@@ -29,6 +29,9 @@ const {
   githubGetRepoDiscussionsResultPageActivity,
   githubIssueGarbageCollectActivity,
   githubDiscussionGarbageCollectActivity,
+  githubUpsertDiscussionsFolderActivity,
+  githubUpsertIssuesFolderActivity,
+  githubUpsertRepositoryFolderActivity,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "5 minute",
 });
@@ -58,6 +61,10 @@ const { githubCodeSyncActivity } = proxyActivities<typeof activities>({
 const MAX_CONCURRENT_REPO_SYNC_WORKFLOWS = 3;
 const MAX_CONCURRENT_ISSUE_SYNC_ACTIVITIES_PER_WORKFLOW = 8;
 
+/**
+ * Duplicate of the one belows apart from the child workflow (githubSyncRepoWorkflow vs githubRepoSyncWorkflow).
+ * Kept for backwards compatibility (to avoid non-deterministic errors).
+ */
 export async function githubFullSyncWorkflow(
   dataSourceConfig: DataSourceConfig,
   connectorId: ModelId,
@@ -118,6 +125,70 @@ export async function githubFullSyncWorkflow(
   await githubSaveSuccessSyncActivity(dataSourceConfig);
 }
 
+export async function githubSyncAllReposWorkflow(
+  dataSourceConfig: DataSourceConfig,
+  connectorId: ModelId,
+  // Used to re-trigger a code-only full-sync after code syncing is enabled/disabled.
+  syncCodeOnly: boolean,
+  forceCodeResync = false
+) {
+  await githubSaveStartSyncActivity(dataSourceConfig);
+
+  const queue = new PQueue({ concurrency: MAX_CONCURRENT_REPO_SYNC_WORKFLOWS });
+  const promises: Promise<void>[] = [];
+
+  let pageNumber = 1; // 1-indexed
+
+  for (;;) {
+    const resultsPage = await githubGetReposResultPageActivity(
+      connectorId,
+      pageNumber,
+      { syncCodeOnly: syncCodeOnly.toString() }
+    );
+    if (!resultsPage.length) {
+      break;
+    }
+    pageNumber += 1;
+
+    for (const repo of resultsPage) {
+      const fullSyncWorkflowId = getFullSyncWorkflowId(connectorId);
+      const childWorkflowId = `${fullSyncWorkflowId}-repo-${repo.id}-syncCodeOnly-${syncCodeOnly}`;
+      promises.push(
+        queue.add(() =>
+          executeChild(githubSyncRepoWorkflow, {
+            workflowId: childWorkflowId,
+            searchAttributes: {
+              connectorId: [connectorId],
+            },
+            args: [
+              {
+                dataSourceConfig,
+                connectorId,
+                repoName: repo.name,
+                repoId: repo.id,
+                repoLogin: repo.login,
+                syncCodeOnly,
+                isFullSync: true,
+                forceCodeResync,
+              },
+            ],
+            parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE,
+            memo: workflowInfo().memo,
+          })
+        )
+      );
+    }
+  }
+
+  await Promise.all(promises);
+
+  await githubSaveSuccessSyncActivity(dataSourceConfig);
+}
+
+/**
+ * Duplicate of the one belows apart from the child workflow (githubSyncRepoWorkflow vs githubRepoSyncWorkflow).
+ * Kept for backwards compatibility (to avoid non-deterministic errors).
+ */
 export async function githubReposSyncWorkflow(
   dataSourceConfig: DataSourceConfig,
   connectorId: ModelId,
@@ -159,6 +230,51 @@ export async function githubReposSyncWorkflow(
   await githubSaveSuccessSyncActivity(dataSourceConfig);
 }
 
+export async function githubSyncReposWorkflow(
+  dataSourceConfig: DataSourceConfig,
+  connectorId: ModelId,
+  orgLogin: string,
+  repos: { name: string; id: number }[]
+) {
+  const queue = new PQueue({ concurrency: MAX_CONCURRENT_REPO_SYNC_WORKFLOWS });
+  const promises: Promise<void>[] = [];
+
+  for (const repo of repos) {
+    const reposSyncWorkflowId = getReposSyncWorkflowId(connectorId);
+    const childWorkflowId = `${reposSyncWorkflowId}-repo-${repo.id}`;
+    promises.push(
+      queue.add(() =>
+        executeChild(githubSyncRepoWorkflow, {
+          workflowId: childWorkflowId,
+          searchAttributes: {
+            connectorId: [connectorId],
+          },
+          args: [
+            {
+              dataSourceConfig,
+              connectorId,
+              repoName: repo.name,
+              repoId: repo.id,
+              repoLogin: orgLogin,
+              syncCodeOnly: false,
+              isFullSync: false,
+            },
+          ],
+          parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE,
+          memo: workflowInfo().memo,
+        })
+      )
+    );
+  }
+
+  await Promise.all(promises);
+  await githubSaveSuccessSyncActivity(dataSourceConfig);
+}
+
+/**
+ * Duplicate of the one belows apart from the missing activity githubUpsertIssuesFolderActivity.
+ * Kept for backwards compatibility (to avoid non-deterministic errors).
+ */
 export async function githubRepoIssuesSyncWorkflow({
   dataSourceConfig,
   connectorId,
@@ -213,6 +329,67 @@ export async function githubRepoIssuesSyncWorkflow({
   return true;
 }
 
+export async function githubSyncRepoIssuesWorkflow({
+  dataSourceConfig,
+  connectorId,
+  repoName,
+  repoId,
+  repoLogin,
+  pageNumber,
+}: {
+  dataSourceConfig: DataSourceConfig;
+  connectorId: ModelId;
+  repoName: string;
+  repoId: number;
+  repoLogin: string;
+  pageNumber: number;
+}): Promise<boolean> {
+  // upserting the folder with all the issues
+  await githubUpsertIssuesFolderActivity({ connectorId, repoId });
+
+  const queue = new PQueue({
+    concurrency: MAX_CONCURRENT_ISSUE_SYNC_ACTIVITIES_PER_WORKFLOW,
+  });
+  const promises: Promise<void>[] = [];
+
+  const resultsPage = await githubGetRepoIssuesResultPageActivity(
+    connectorId,
+    repoName,
+    repoLogin,
+    pageNumber,
+    { repoId }
+  );
+
+  if (!resultsPage.length) {
+    return false;
+  }
+
+  for (const issueNumber of resultsPage) {
+    promises.push(
+      queue.add(() =>
+        githubUpsertIssueActivity(
+          connectorId,
+          repoName,
+          repoId,
+          repoLogin,
+          issueNumber,
+          dataSourceConfig,
+          {},
+          true // isBatchSync
+        )
+      )
+    );
+  }
+
+  await Promise.all(promises);
+
+  return true;
+}
+
+/**
+ * Duplicate of the one belows apart from the missing activity githubUpsertDiscussionsFolderActivity.
+ * Kept for backwards compatibility (to avoid non-deterministic errors).
+ */
 export async function githubRepoDiscussionsSyncWorkflow({
   dataSourceConfig,
   connectorId,
@@ -264,6 +441,65 @@ export async function githubRepoDiscussionsSyncWorkflow({
   return cursor;
 }
 
+export async function githubSyncRepoDiscussionsWorkflow({
+  dataSourceConfig,
+  connectorId,
+  repoName,
+  repoId,
+  repoLogin,
+  nextCursor,
+}: {
+  dataSourceConfig: DataSourceConfig;
+  connectorId: ModelId;
+  repoName: string;
+  repoId: number;
+  repoLogin: string;
+  nextCursor: string | null;
+}): Promise<string | null> {
+  // upserting the folder with all the discussions
+  await githubUpsertDiscussionsFolderActivity({ connectorId, repoId });
+
+  const queue = new PQueue({
+    concurrency: MAX_CONCURRENT_ISSUE_SYNC_ACTIVITIES_PER_WORKFLOW,
+  });
+  const promises: Promise<void>[] = [];
+
+  const { cursor, discussionNumbers } =
+    await githubGetRepoDiscussionsResultPageActivity(
+      connectorId,
+      repoName,
+      repoLogin,
+      nextCursor,
+      { repoId }
+    );
+
+  for (const discussionNumber of discussionNumbers) {
+    promises.push(
+      queue.add(() =>
+        githubUpsertDiscussionActivity(
+          connectorId,
+          repoName,
+          repoId,
+          repoLogin,
+          discussionNumber,
+          dataSourceConfig,
+          {},
+          true // isBatchSync
+        )
+      )
+    );
+  }
+
+  await Promise.all(promises);
+
+  return cursor;
+}
+
+/**
+ * Duplicate of the one belows apart from the missing activity githubUpsertRepositoryFolderActivity and the fact
+ * that this one calls the old workflows githubRepoIssuesSyncWorkflow and githubRepoDiscussionsSyncWorkflow.
+ * Kept for backwards compatibility (to avoid non-deterministic errors).
+ */
 export async function githubRepoSyncWorkflow({
   dataSourceConfig,
   connectorId,
@@ -327,6 +563,110 @@ export async function githubRepoSyncWorkflow({
       }-repo-${repoId}-issues-page-${cursorIteration}`;
 
       nextCursor = await executeChild(githubRepoDiscussionsSyncWorkflow, {
+        workflowId: childWorkflowId,
+        searchAttributes: {
+          connectorId: [connectorId],
+        },
+        args: [
+          {
+            dataSourceConfig,
+            connectorId,
+            repoName,
+            repoId,
+            repoLogin,
+            nextCursor,
+          },
+        ],
+        parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE,
+        memo: workflowInfo().memo,
+      });
+
+      if (!nextCursor) {
+        break;
+      }
+      cursorIteration += 1;
+    }
+  }
+
+  // Start code syncing activity.
+  await githubCodeSyncActivity({
+    dataSourceConfig,
+    connectorId,
+    repoLogin,
+    repoName,
+    repoId,
+    loggerArgs: { syncCodeOnly: syncCodeOnly ? "true" : "false" },
+    isBatchSync: true,
+    forceResync: forceCodeResync,
+  });
+}
+
+export async function githubSyncRepoWorkflow({
+  dataSourceConfig,
+  connectorId,
+  repoName,
+  repoId,
+  repoLogin,
+  syncCodeOnly,
+  isFullSync,
+  forceCodeResync = false,
+}: {
+  dataSourceConfig: DataSourceConfig;
+  connectorId: ModelId;
+  repoName: string;
+  repoId: number;
+  repoLogin: string;
+  syncCodeOnly: boolean;
+  isFullSync: boolean;
+  forceCodeResync?: boolean;
+}) {
+  // upserting the root folder for the repository
+  await githubUpsertRepositoryFolderActivity({ connectorId, repoId, repoName });
+
+  if (!syncCodeOnly) {
+    let pageNumber = 1; // 1-indexed
+    for (;;) {
+      const childWorkflowId = `${
+        isFullSync
+          ? getFullSyncWorkflowId(connectorId)
+          : getReposSyncWorkflowId(connectorId)
+      }-repo-${repoId}-issues-page-${pageNumber}`;
+
+      const shouldContinue = await executeChild(githubSyncRepoIssuesWorkflow, {
+        workflowId: childWorkflowId,
+        searchAttributes: {
+          connectorId: [connectorId],
+        },
+        args: [
+          {
+            dataSourceConfig,
+            connectorId,
+            repoName,
+            repoId,
+            repoLogin,
+            pageNumber,
+          },
+        ],
+        parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE,
+        memo: workflowInfo().memo,
+      });
+
+      if (!shouldContinue) {
+        break;
+      }
+      pageNumber += 1;
+    }
+
+    let nextCursor: string | null = null;
+    let cursorIteration = 0;
+    for (;;) {
+      const childWorkflowId = `${
+        isFullSync
+          ? getFullSyncWorkflowId(connectorId)
+          : getReposSyncWorkflowId(connectorId)
+      }-repo-${repoId}-issues-page-${cursorIteration}`;
+
+      nextCursor = await executeChild(githubSyncRepoDiscussionsWorkflow, {
         workflowId: childWorkflowId,
         searchAttributes: {
           connectorId: [connectorId],

--- a/connectors/src/connectors/github/temporal/workflows.ts
+++ b/connectors/src/connectors/github/temporal/workflows.ts
@@ -125,6 +125,10 @@ export async function githubFullSyncWorkflow(
   await githubSaveSuccessSyncActivity(dataSourceConfig);
 }
 
+/**
+ * This workflow is used to fetch and sync all the repositories of a GitHub connector.
+ * It's called v2 because we had to add it when there was already a workflow without the v2 to avoid non-deterministic errors.
+ */
 export async function githubFullSyncWorkflowV2(
   dataSourceConfig: DataSourceConfig,
   connectorId: ModelId,
@@ -230,6 +234,10 @@ export async function githubReposSyncWorkflow(
   await githubSaveSuccessSyncActivity(dataSourceConfig);
 }
 
+/**
+ * This workflow is used to sync the given repositories of a GitHub connector.
+ * It's called v2 because we had to add it when there was already a workflow without the v2 to avoid non-deterministic errors.
+ */
 export async function githubReposSyncWorkflowV2(
   dataSourceConfig: DataSourceConfig,
   connectorId: ModelId,
@@ -329,6 +337,10 @@ export async function githubRepoIssuesSyncWorkflow({
   return true;
 }
 
+/**
+ * This workflow is used to sync all the issues of a GitHub connector.
+ * It's called v2 because we had to add it when there was already a workflow without the v2 to avoid non-deterministic errors.
+ */
 export async function githubRepoIssuesSyncWorkflowV2({
   dataSourceConfig,
   connectorId,
@@ -441,6 +453,10 @@ export async function githubRepoDiscussionsSyncWorkflow({
   return cursor;
 }
 
+/**
+ * This workflow is used to sync all the discussions of a GitHub connector.
+ * It's called v2 because we had to add it when there was already a workflow without the v2 to avoid non-deterministic errors.
+ */
 export async function githubRepoDiscussionsSyncWorkflowV2({
   dataSourceConfig,
   connectorId,
@@ -601,6 +617,10 @@ export async function githubRepoSyncWorkflow({
   });
 }
 
+/**
+ * This workflow is used to sync all the issues, discussions and code of a GitHub connector.
+ * It's called v2 because we had to add it when there was already a workflow without the v2 to avoid non-deterministic errors.
+ */
 export async function githubRepoSyncWorkflowV2({
   dataSourceConfig,
   connectorId,


### PR DESCRIPTION
## Description

- In the context of [#9157](https://github.com/dust-tt/dust/issues/9157), the work was split between the PR #9556 that updated existing activities and this one that performs workflow-level changes.
- This PR aims at adding the folders upserts for the issues, the discussions, the code root and the repository root in the workflows.
- To avoid non-deterministic errors we will proceed in the following steps:
  - This PR adds new workflows without changing the existing ones and updates the client to only launch the new workflows.
  - When the long-running tasks on old workflows will all be done, we will safely remove them then.
- Workflow setup (`old`/`new`):
  - `githubFullSyncWorkflow`/`githubSyncAllReposWorkflow` fetches the repositories and spawns `githubRepoSyncWorkflow`/`githubSyncRepoWorkflow`.
  - `githubRepoSyncWorkflow`/`githubSyncRepoWorkflow` spawns `githubRepoIssuesSyncWorkflow`/`githubSyncRepoIssuesWorkflow` and `githubRepoDiscussionsSyncWorkflow`/`githubSyncRepoDiscussionsWorkflow` and then runs `githubCodeSyncActivity`.
  - `githubCodeSyncActivity` upserts the "Code" folder itself (this activity has the same level of responsibility than the 2 workflows for the discussions and issues).
  - `githubSyncRepoIssuesWorkflow` runs the activity to upsert the "Issues" folder (only diff with `githubRepoIssuesSyncWorkflow`).
  - `githubSyncRepoDiscussionsWorkflow` runs the activity to upsert the "Discussions" folder (only diff with `githubRepoDiscussionsSyncWorkflow`).
  - The other workflows are unaffected, these are the ones that run on webhooks or daily.

## Risk

- Will need to be handled safely to avoid crashing the workflows and possibly missing webhooks.

## Deploy Plan

- Deploy connectors.
- Run the migration `20241219_backfill_github_folders`.
- Check up on the old workflows (on Monday)
