### PR TITLE
rename progressiveAgentConfigurations to unifiedAgentConfigurations

### DIFF
--- a/front/components/assistant/conversation/AssistantBrowserContainer.tsx
+++ b/front/components/assistant/conversation/AssistantBrowserContainer.tsx
@@ -6,7 +6,7 @@ import type {
 import { useCallback } from "react";
 
 import { AssistantBrowser } from "@app/components/assistant/AssistantBrowser";
-import { useProgressiveAgentConfigurations } from "@app/lib/swr/assistants";
+import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import { classNames } from "@app/lib/utils";
 
 interface AssistantBrowserContainerProps {
@@ -22,7 +22,8 @@ export function AssistantBrowserContainer({
   isBuilder,
   setAssistantToMention,
 }: AssistantBrowserContainerProps) {
-  const { agentConfigurations, isLoading } = useProgressiveAgentConfigurations({
+  // We use this specific hook because this component is involved in the new conversation page.
+  const { agentConfigurations, isLoading } = useUnifiedAgentConfigurations({
     workspaceId: owner.sId,
   });
 

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -18,7 +18,7 @@ import InputBarContainer, {
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
 import type { DustError } from "@app/lib/error";
-import { useProgressiveAgentConfigurations } from "@app/lib/swr/assistants";
+import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import { useConversation } from "@app/lib/swr/conversations";
 import { classNames } from "@app/lib/utils";
 
@@ -82,8 +82,9 @@ export function AssistantInputBar({
     options: { disabled: true }, // We just want to get the mutation function
   });
 
+  // We use this specific hook because this component is involved in the new conversation page.
   const { agentConfigurations: baseAgentConfigurations } =
-    useProgressiveAgentConfigurations({
+    useUnifiedAgentConfigurations({
       workspaceId: owner.sId,
     });
 

--- a/front/components/assistant/conversation/input_bar/editor/useAssistantSuggestions.ts
+++ b/front/components/assistant/conversation/input_bar/editor/useAssistantSuggestions.ts
@@ -5,7 +5,7 @@ import type {
 import { compareAgentsForSort } from "@dust-tt/types";
 import { useMemo } from "react";
 
-import { useProgressiveAgentConfigurations } from "@app/lib/swr/assistants";
+import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 
 function makeEditorSuggestions(
   agentConfigurations: LightAgentConfigurationType[]
@@ -25,7 +25,8 @@ const useAssistantSuggestions = (
   inListAgentConfigurations: LightAgentConfigurationType[],
   owner: WorkspaceType
 ) => {
-  const { agentConfigurations } = useProgressiveAgentConfigurations({
+  // We use this specific hook because this component is involved in the new conversation page.
+  const { agentConfigurations } = useUnifiedAgentConfigurations({
     workspaceId: owner.sId,
   });
 

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -142,25 +142,16 @@ export function useAgentConfigurations({
   };
 }
 
-export function useProgressiveAgentConfigurations({
+// This is the call that is required for the new conversation page to load all views on that page.
+// All elements that are involved in that page should rely on it to avoid concurrent calls to
+// getAgentConfigurations at the initial page load.
+export function useUnifiedAgentConfigurations({
   workspaceId,
   disabled,
 }: {
   workspaceId: string;
   disabled?: boolean;
 }) {
-  // const {
-  //   agentConfigurations: initialAgentConfigurations,
-  //   isAgentConfigurationsLoading: isInitialAgentConfigurationsLoading,
-  // } = useAgentConfigurations({
-  //   workspaceId,
-  //   agentsGetView: "list",
-  //   limit: 24,
-  //   includes: ["usage"],
-  //   disabled,
-  //   revalidate: false,
-  // });
-
   const {
     agentConfigurations: agentConfigurationsWithAuthors,
     isAgentConfigurationsLoading: isAgentConfigurationsWithAuthorsLoading,
@@ -172,13 +163,6 @@ export function useProgressiveAgentConfigurations({
     includes: ["authors", "usage"],
     disabled,
   });
-
-  // const isLoading =
-  //   isInitialAgentConfigurationsLoading ||
-  //   isAgentConfigurationsWithAuthorsLoading;
-  // const agentConfigurations = isAgentConfigurationsWithAuthorsLoading
-  //   ? initialAgentConfigurations
-  //   : agentConfigurationsWithAuthors;
 
   return {
     agentConfigurations: agentConfigurationsWithAuthors,
@@ -419,11 +403,10 @@ export function useUpdateAgentScope({
       agentConfigurationId,
       disabled: true,
     });
-  const { mutate: mutateAgentConfigurations } =
-    useProgressiveAgentConfigurations({
-      workspaceId: owner.sId,
-      disabled: true,
-    });
+  const { mutate: mutateAgentConfigurations } = useUnifiedAgentConfigurations({
+    workspaceId: owner.sId,
+    disabled: true,
+  });
 
   const doUpdate = useCallback(
     async (scope: Exclude<AgentConfigurationScope, "global">) => {
@@ -500,11 +483,10 @@ export function useUpdateUserFavorite({
       agentConfigurationId,
       disabled: true,
     });
-  const { mutate: mutateAgentConfigurations } =
-    useProgressiveAgentConfigurations({
-      workspaceId: owner.sId,
-      disabled: true,
-    });
+  const { mutate: mutateAgentConfigurations } = useUnifiedAgentConfigurations({
+    workspaceId: owner.sId,
+    disabled: true,
+  });
 
   const [isUpdatingFavorite, setIsUpdatingFavorite] = useState(false);
 


### PR DESCRIPTION
## Description

- Rename of `useProgressiveAgentConfigurations` to `useUnifiedAgentConfigurations` with comments

Progressive was not useful and was removed this week to reduce calls to getAgentConfigurations at page load (which were all slowish)

## Risk

N/A rename

## Deploy Plan

- deploy `front`