### PR TITLE
[sparkle] Add prefetch prop for next/link

### DIFF
--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -199,6 +199,7 @@ const DropdownMenuItem = React.forwardRef<
       asChild,
       replace,
       shallow,
+      prefetch,
       ...props
     },
     ref
@@ -220,6 +221,7 @@ const DropdownMenuItem = React.forwardRef<
           rel={rel}
           replace={replace}
           shallow={shallow}
+          prefetch={prefetch}
         >
           <ItemWithLabelIconAndDescription
             label={label}

--- a/sparkle/src/components/LinkWrapper.tsx
+++ b/sparkle/src/components/LinkWrapper.tsx
@@ -9,12 +9,13 @@ export interface LinkWrapperProps {
   replace?: boolean;
   shallow?: boolean;
   target?: string;
+  prefetch?: boolean;
 }
 
 export const LinkWrapper = React.forwardRef<
   HTMLAnchorElement,
   LinkWrapperProps
->(({ children, href, rel, replace, shallow, target }, ref) => {
+>(({ children, href, rel, replace, shallow, target, prefetch }, ref) => {
   const { components } = React.useContext(SparkleContext);
 
   if (href) {
@@ -26,6 +27,7 @@ export const LinkWrapper = React.forwardRef<
         rel={rel}
         replace={replace}
         shallow={shallow}
+        prefetch={prefetch}
       >
         {children}
       </components.link>

--- a/sparkle/src/context.tsx
+++ b/sparkle/src/context.tsx
@@ -21,6 +21,7 @@ type SparkleLinkProps = {
   shallow?: boolean;
   target?: string;
   rel?: string;
+  prefetch?: boolean;
 };
 
 export type SparkleContextLinkType = ComponentType<


### PR DESCRIPTION
## Description

Allows to pass prefetch to next/link component from MenuItem href

## Risk

none
## Deploy Plan

publish sparkle