### PR TITLE
POC Open extension sidepanel on a given convo from web app

### DIFF
--- a/extension/app/src/pages/RunPage.tsx
+++ b/extension/app/src/pages/RunPage.tsx
@@ -16,6 +16,11 @@ export const RunPage = () => {
     const run = async () => {
       const params = JSON.parse(decodeURI(location.search.substr(1)));
 
+      if (params.conversationId) {
+        await navigate(`/conversations/${params.conversationId}`);
+        return;
+      }
+
       const files = await fileUploaderService.uploadContentTab({
         includeContent: params.includeContent,
         includeCapture: params.includeCapture,

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -35,5 +35,8 @@
     "contextMenus"
   ],
   "host_permissions": ["<all_urls>"],
+  "externally_connectable": {
+    "matches": ["http://localhost:3000/*"]
+  },
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu2kn2r/3emY/9AwPzAH0qb1KskhZCqLp4PE3o1PqD1hyLTf9fJ+VC0CPyy3F6bep/6mjVZaN+Ufw7bTn3XFoj3TW+Xg5e/KLg+qUn2pUS973j68IyhyIamydfx90ZZajCU1XwB666+8dFwgB6sy4sGe86WNKu0Be+EDhhVFCFVI2D7CyJjlmQXUXTYDr6U41MsdI1DlDK6jrv6N9IkHKhvq1o06GN0W8CpoPJ554iBHWcw5UYNHi6ySxA+u7OoV58tDkTyVOS9sQ8WGIge3hDmhc2jcUhsJTzkeAS3ijShKVdYC0i+5n5g6SnQ4N7y2xehEYsms0ARqkUkF/QPwmTQIDAQAB"
 }

--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -106,6 +106,25 @@ export function UserMenu({
                 }}
               />
             )}
+            <DropdownMenuItem
+              label="Extension"
+              icon={LightbulbIcon}
+              onClick={() => {
+                if (typeof window !== "undefined" && window.chrome?.runtime) {
+                  chrome.runtime.sendMessage(
+                    "okjldflokifdjecnhbmkdanjjbnmlihg",
+                    {
+                      action: "openSidePanel",
+                      workspaceId: owner.sId,
+                      conversationId: "M1wNSpqgq9",
+                    },
+                    (response) => {
+                      console.log("Message sent:", response);
+                    }
+                  );
+                }
+              }}
+            />
           </>
         )}
 

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -33,6 +33,7 @@
         "@tiptap/pm": "^2.1.13",
         "@tiptap/react": "^2.1.13",
         "@tiptap/starter-kit": "^2.1.13",
+        "@types/chrome": "^0.0.287",
         "@uiw/react-textarea-code-editor": "^3.0.2",
         "auth0": "^4.3.1",
         "blake3": "^2.1.7",
@@ -18354,6 +18355,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/chrome": {
+      "version": "0.0.287",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.287.tgz",
+      "integrity": "sha512-wWhBNPNXZHwycHKNYnexUcpSbrihVZu++0rdp6GEk5ZgAglenLx+RwdEouh6FrHS0XQiOxSd62yaujM1OoQlZQ==",
+      "dependencies": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -18427,6 +18437,19 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/filesystem": {
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.36.tgz",
+      "integrity": "sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==",
+      "dependencies": {
+        "@types/filewriter": "*"
+      }
+    },
+    "node_modules/@types/filewriter": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.33.tgz",
+      "integrity": "sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g=="
+    },
     "node_modules/@types/formidable": {
       "version": "3.4.3",
       "dev": true,
@@ -18460,6 +18483,11 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/har-format": {
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.16.tgz",
+      "integrity": "sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A=="
     },
     "node_modules/@types/hast": {
       "version": "2.3.6",

--- a/front/package.json
+++ b/front/package.json
@@ -46,6 +46,7 @@
     "@tiptap/pm": "^2.1.13",
     "@tiptap/react": "^2.1.13",
     "@tiptap/starter-kit": "^2.1.13",
+    "@types/chrome": "^0.0.287",
     "@uiw/react-textarea-code-editor": "^3.0.2",
     "auth0": "^4.3.1",
     "blake3": "^2.1.7",


### PR DESCRIPTION
## Description

Just POCing the ability to open the extension sidepanel on a given convo from another web app.

Context here: https://dust4ai.slack.com/archives/C0525Q93AEL/p1734631147015489

To move forward, what needs to be done: 
- Build the manifest.json at build time so that the env we want to whitelist can come from a config file. 
- Remove the code from front that is just a test for the POC (adding a link on front to send the message)
- Handle the workspaceIf from message sent, if it does not match the current workspaceId of the session we either want to redirect to the right workspace or just do nothing. 


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
