### PR TITLE
fix(Zendesk) - improve error handling

### DIFF
--- a/connectors/src/connectors/zendesk/lib/errors.ts
+++ b/connectors/src/connectors/zendesk/lib/errors.ts
@@ -46,6 +46,15 @@ export function isZendeskExpiredCursorError(
   );
 }
 
+/**
+ * Catches 404 errors that were already caught in fetchFromZendeskWithRetries and rethrown as ZendeskApiErrors.
+ * The idea is that we only try/catch the part where we call the API, without wrapping any of our code and from then
+ * only certain functions can actually handle 404 by returning a null.
+ */
+export function isZendeskNotFoundError(err: unknown): boolean {
+  return err instanceof ZendeskApiError && err.status === 404;
+}
+
 export function isNodeZendeskEpipeError(err: unknown): err is NodeZendeskError {
   return (
     typeof err === "object" &&


### PR DESCRIPTION
## Description

- Some 404 errors were hidden and not correctly bubbled up in `fetchFromZendeskWithRetries`, which should never be the place where we handle any kind of error whatsoever.
- This PR proposes to let `fetchFromZendeskWithRetries` only rethrow errors, and from then handle accordingly in each function. For instance we can design a function that checks whether an article exist by fetching and catching 404 only.
- From then we will be able to investigate https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZPke_Y-HVya5wAAABhBWlBrZV94LUFBRDBRU0lqdzNaTklBQUIAAAAkMDE5M2U0N2UtYWIxYi00NzY5LWE1M2QtM2VjYjhjZTM5MjFkAAAYHA&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=6000198897476506285&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1734704698707&to_ts=1734705598707&live=true

## Risk

- Low

## Deploy Plan

- Deploy connectors.