### PR TITLE
fix: slack connector getParents should return parents for threads

### DIFF
--- a/connectors/migrations/20241218_backfill_slack_folders.ts
+++ b/connectors/migrations/20241218_backfill_slack_folders.ts
@@ -1,7 +1,7 @@
 import { makeScript } from "scripts/helpers";
 import { Op } from "sequelize";
 
-import { internalIdFromSlackChannelId } from "@connectors/connectors/slack/lib/utils";
+import { slackChannelInternalIdFromSlackChannelId } from "@connectors/connectors/slack/lib/utils";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
@@ -30,7 +30,7 @@ makeScript({}, async ({ execute }, logger) => {
       await concurrentExecutor(
         channels,
         async (channel) => {
-          const internalId = internalIdFromSlackChannelId(
+          const internalId = slackChannelInternalIdFromSlackChannelId(
             channel.slackChannelId
           );
           await upsertDataSourceFolder({

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -645,7 +645,10 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
     }
     // This in theory shouldn't happen
     else {
-      logger.warn({ internalId }, "Unknown internal ID for Slack connector");
+      logger.error(
+        { internalId, panic: true },
+        "Unknown internal ID for Slack connector"
+      );
       return new Ok([internalId]);
     }
   }

--- a/connectors/src/connectors/slack/lib/utils.ts
+++ b/connectors/src/connectors/slack/lib/utils.ts
@@ -51,10 +51,81 @@ export const timeAgoFrom = (millisSinceEpoch: number) => {
   return seconds + "s";
 };
 
-export function internalIdFromSlackChannelId(channel: string) {
+export type SlackChannelInternalId = string;
+export type SlackThreadInternalId = string;
+export type SlackNonThreadedMessagesInternalId = string;
+
+export function isSlackChannelInternalId(
+  internalId: string
+): internalId is SlackChannelInternalId {
+  return internalId.startsWith("slack-channel-");
+}
+
+export function isSlackThreadInternalId(
+  internalId: string
+): internalId is SlackThreadInternalId {
+  return internalId.startsWith("slack-") && internalId.includes("-thread-");
+}
+
+export function isSlackNonThreadedMessagesInternalId(
+  internalId: string
+): internalId is SlackNonThreadedMessagesInternalId {
+  return internalId.startsWith("slack-") && internalId.includes("-messages-");
+}
+
+export function slackChannelInternalIdFromSlackChannelId(
+  channel: string
+): SlackChannelInternalId {
   return `slack-channel-${_.last(channel.split("slack-channel-"))!}`;
 }
 
-export function slackChannelIdFromInternalId(nodeId: string) {
+export function slackChannelIdFromInternalId(nodeId: SlackChannelInternalId) {
   return _.last(nodeId.split("slack-channel-"))!;
+}
+
+export type SlackThreadIdentifier = {
+  channelId: string;
+  threadTs: string;
+};
+
+export function slackThreadInternalIdFromSlackThreadIdentifier({
+  channelId,
+  threadTs,
+}: SlackThreadIdentifier): SlackThreadInternalId {
+  return `slack-${channelId}-thread-${threadTs}`;
+}
+
+export function slackThreadIdentifierFromSlackThreadInternalId(
+  internalId: SlackThreadInternalId
+): SlackThreadIdentifier {
+  const parts = internalId.split("-thread-");
+  const channelId = _.last(parts[0]!.split("slack-"))!;
+  const threadTs = parts[1];
+  return {
+    channelId,
+    threadTs: threadTs!,
+  };
+}
+
+export type SlackNonThreadedMessagesIdentifier = {
+  channelId: string;
+  startDate: Date;
+  endDate: Date;
+};
+
+export function slackNonThreadedMessagesInternalIdFromSlackNonThreadedMessagesIdentifier({
+  channelId,
+  startDate,
+  endDate,
+}: SlackNonThreadedMessagesIdentifier): SlackNonThreadedMessagesInternalId {
+  const startDateStr = `${startDate.getFullYear()}-${startDate.getMonth()}-${startDate.getDate()}`;
+  const endDateStr = `${endDate.getFullYear()}-${endDate.getMonth()}-${endDate.getDate()}`;
+  return `slack-${channelId}-messages-${startDateStr}-${endDateStr}`;
+}
+
+export function slackChannelIdFromSlackNonThreadedMessagesInternalId(
+  internalId: SlackNonThreadedMessagesInternalId
+): string {
+  const parts = internalId.split("-messages-");
+  return _.last(parts[0]!.split("slack-"))!;
 }


### PR DESCRIPTION
## Description

`getContentNodeParents` in the slack connector only works for channel Internal IDs. That was OK until now, since the only use case was the data source selection tree in assistant builder & vaults, and that interface doesn't display threads.

But now we also need this API for the tracker, and we need it to work for all slack content nodes 

## Risk

Critical path of slack connector

## Deploy Plan

deploy connectors