### PR TITLE
[KW-search] Enforce always passing parentId in connectors

### DIFF
--- a/connectors/migrations/20230906_2_slack_fill_parents_field.ts
+++ b/connectors/migrations/20230906_2_slack_fill_parents_field.ts
@@ -76,6 +76,7 @@ async function updateParentsFieldForConnector(connector: ConnectorModel) {
           dataSourceConfig: connector,
           documentId: documentIdAndChannel.documentId,
           parents: [documentIdAndChannel.channelId],
+          parentId: null,
         })
       )
     );

--- a/connectors/migrations/20230906_3_github_fill_parents_field.ts
+++ b/connectors/migrations/20230906_3_github_fill_parents_field.ts
@@ -88,6 +88,7 @@ async function updateDiscussionsParentsFieldForConnector(
             getDiscussionInternalId(document.repoId, document.discussionNumber),
             document.repoId,
           ],
+          parentId: document.repoId,
         });
       })
     );
@@ -118,6 +119,7 @@ async function updateIssuesParentsFieldForConnector(connector: ConnectorModel) {
             getIssueInternalId(document.repoId, document.issueNumber),
             document.repoId,
           ],
+          parentId: document.repoId,
         });
       })
     );

--- a/connectors/migrations/20240102_github_add_issues_discussions_parents.ts
+++ b/connectors/migrations/20240102_github_add_issues_discussions_parents.ts
@@ -48,6 +48,7 @@ async function updateParents(connector: ConnectorModel) {
             dataSourceConfig: connector,
             documentId,
             parents,
+            parentId: `${d.repoId}-discussions`,
           });
           console.log(`Updated discussion ${documentId} with: ${parents}`);
         } else {
@@ -78,6 +79,7 @@ async function updateParents(connector: ConnectorModel) {
             dataSourceConfig: connector,
             documentId,
             parents,
+            parentId: `${i.repoId}-issues`,
           });
           console.log(`Updated issue ${documentId} with: ${parents}`);
         } else {

--- a/connectors/migrations/20240802_table_parents.ts
+++ b/connectors/migrations/20240802_table_parents.ts
@@ -49,6 +49,7 @@ async function updateParents({
         tableId,
         parents,
         dataSourceConfig,
+        parentId: parents[1] || null,
       });
     }
   }

--- a/connectors/migrations/20240828_microsoft_refill_parents_field.ts
+++ b/connectors/migrations/20240828_microsoft_refill_parents_field.ts
@@ -80,6 +80,7 @@ async function updateParentsFieldForConnector(
           dataSourceConfig: dataSourceConfigFromConnector(connector),
           documentId: node.internalId,
           parents,
+          parentId: parents[1] || null,
         });
       },
       { concurrency: 8 }

--- a/connectors/migrations/20241030_fix_notion_parents.ts
+++ b/connectors/migrations/20241030_fix_notion_parents.ts
@@ -155,6 +155,7 @@ async function updateParentsFieldForConnector(
                 dataSourceConfig: dataSourceConfigFromConnector(connector),
                 documentId,
                 parents,
+                parentId: parents[1] || null,
                 retries: 3,
               });
             }
@@ -163,6 +164,7 @@ async function updateParentsFieldForConnector(
                 dataSourceConfig: dataSourceConfigFromConnector(connector),
                 tableId,
                 parents,
+                parentId: parents[1] || null,
                 retries: 3,
               });
             }

--- a/connectors/migrations/20241211_fix_gdrive_parents.ts
+++ b/connectors/migrations/20241211_fix_gdrive_parents.ts
@@ -148,6 +148,7 @@ async function migrate({
                   dataSourceConfig,
                   tableId,
                   parents,
+                  parentId: parents[1] || null,
                 });
               }
             }
@@ -210,6 +211,7 @@ async function migrate({
                 dataSourceConfig,
                 tableId,
                 parents,
+                parentId: parents[1] || null,
               });
             }
           }

--- a/connectors/migrations/20241212_restore_gdrive_parents.ts
+++ b/connectors/migrations/20241212_restore_gdrive_parents.ts
@@ -44,6 +44,7 @@ async function processLogFile(
           dataSourceConfig,
           documentId: documentId,
           parents: previousParents,
+          parentId: previousParents[1] || null,
         });
       }
     }

--- a/connectors/migrations/20241216_backfill_confluence_folders.ts
+++ b/connectors/migrations/20241216_backfill_confluence_folders.ts
@@ -26,6 +26,7 @@ makeScript({}, async ({ execute }, logger) => {
             dataSourceConfig,
             folderId: makeSpaceInternalId(space.spaceId),
             parents: [makeSpaceInternalId(space.spaceId)],
+            parentId: null,
             title: space.name,
             mimeType: "application/vnd.dust.confluence.space",
           });

--- a/connectors/migrations/20241216_backfill_zendesk_folders.ts
+++ b/connectors/migrations/20241216_backfill_zendesk_folders.ts
@@ -33,6 +33,7 @@ makeScript({}, async ({ execute }, logger) => {
             dataSourceConfig,
             folderId: brandInternalId,
             parents: [brandInternalId],
+            parentId: null,
             title: brand.name,
             mimeType: "application/vnd.dust.zendesk.brand",
           });
@@ -45,6 +46,7 @@ makeScript({}, async ({ execute }, logger) => {
               helpCenterNode.internalId,
               helpCenterNode.parentInternalId,
             ],
+            parentId: helpCenterNode.parentInternalId,
             title: helpCenterNode.title,
             mimeType: "application/vnd.dust.zendesk.helpcenter",
           });
@@ -54,6 +56,7 @@ makeScript({}, async ({ execute }, logger) => {
             dataSourceConfig,
             folderId: ticketsNode.internalId,
             parents: [ticketsNode.internalId, ticketsNode.parentInternalId],
+            parentId: ticketsNode.parentInternalId,
             title: ticketsNode.title,
             mimeType: "application/vnd.dust.zendesk.tickets",
           });
@@ -81,6 +84,7 @@ makeScript({}, async ({ execute }, logger) => {
             dataSourceConfig: dataSourceConfigFromConnector(connector),
             folderId: parents[0],
             parents,
+            parentId: parents[1],
             title: category.name,
             mimeType: "application/vnd.dust.zendesk.category",
           });

--- a/connectors/migrations/20241218_backfill_webcrawler_folders.ts
+++ b/connectors/migrations/20241218_backfill_webcrawler_folders.ts
@@ -76,11 +76,13 @@ makeScript(
             execute,
           });
           if (execute) {
+            const parents = getParents(folder);
             const result = await upsertDataSourceFolder({
               dataSourceConfig,
               folderId: folder.internalId,
               timestampMs: folder.updatedAt.getTime(),
-              parents: getParents(folder),
+              parents,
+              parentId: parents[1] || null,
               title: folder.url,
               mimeType: "application/vnd.dust.webcrawler.folder",
             });

--- a/connectors/migrations/20241219_backfill_github_folders.ts
+++ b/connectors/migrations/20241219_backfill_github_folders.ts
@@ -42,6 +42,7 @@ async function upsertFoldersForConnector(
         dataSourceConfig,
         folderId: repoInternalId,
         parents: [repoInternalId],
+        parentId: null,
         title: repoName,
         mimeType: "application/vnd.dust.github.repository",
       });
@@ -61,6 +62,7 @@ async function upsertFoldersForConnector(
         dataSourceConfig,
         folderId: issuesInternalId,
         parents: [issuesInternalId, repoInternalId],
+        parentId: repoInternalId,
         title: "Issues",
         mimeType: "application/vnd.dust.github.issues",
       });
@@ -76,6 +78,7 @@ async function upsertFoldersForConnector(
         dataSourceConfig,
         folderId: discussionsInternalId,
         parents: [discussionsInternalId, repoInternalId],
+        parentId: repoInternalId,
         title: "Discussions",
         mimeType: "application/vnd.dust.github.discussions",
       });
@@ -96,6 +99,7 @@ async function upsertFoldersForConnector(
           folderId: codeRootInternalId,
           title: "Code",
           parents: [codeRootInternalId, repoInternalId],
+          parentId: repoInternalId,
           mimeType: "application/vnd.dust.github.code.root",
         });
         logger.info(`Upserted code root folder ${codeRootInternalId}`);
@@ -121,6 +125,7 @@ async function upsertFoldersForConnector(
               dataSourceConfig,
               folderId: directory.internalId,
               parents: [directory.internalId, ...dirParents],
+              parentId: dirParents[0] || null,
               title: directory.dirName,
               mimeType: "application/vnd.dust.github.code.directory",
             });

--- a/connectors/migrations/20241219_backfill_intercom_data_source_folders.ts
+++ b/connectors/migrations/20241219_backfill_intercom_data_source_folders.ts
@@ -34,6 +34,7 @@ async function createFolderNodes(execute: boolean) {
         dataSourceConfig,
         folderId: getTeamsInternalId(connector.id),
         parents: [getTeamsInternalId(connector.id)],
+        parentId: null,
         title: "Conversations",
         mimeType: getDataSourceNodeMimeType("CONVERSATIONS_FOLDER"),
       });
@@ -57,6 +58,7 @@ async function createFolderNodes(execute: boolean) {
             dataSourceConfig,
             folderId: teamInternalId,
             parents: [teamInternalId, getTeamsInternalId(connector.id)],
+            parentId: getTeamsInternalId(connector.id),
             title: team.name,
             mimeType: getDataSourceNodeMimeType("TEAM"),
           });
@@ -95,6 +97,7 @@ async function createFolderNodes(execute: boolean) {
             dataSourceConfig,
             folderId: helpCenterInternalId,
             parents: [helpCenterInternalId],
+            parentId: null,
             title: helpCenter.name,
             mimeType: getDataSourceNodeMimeType("HELP_CENTER"),
           });
@@ -128,6 +131,7 @@ async function createFolderNodes(execute: boolean) {
                 dataSourceConfig,
                 folderId: collectionInternalId,
                 parents: collectionParents,
+                parentId: collectionParents[1] || null,
                 title: collection.name,
                 mimeType: getDataSourceNodeMimeType("COLLECTION"),
               });

--- a/connectors/src/connectors/confluence/lib/hierarchy.ts
+++ b/connectors/src/connectors/confluence/lib/hierarchy.ts
@@ -41,7 +41,7 @@ export async function getConfluencePageParentIds(
   connectorId: ModelId,
   page: RawConfluencePage,
   cachedHierarchy?: Record<string, string | null>
-) {
+): Promise<[string, ...string[], string]> {
   const pageIdToParentIdMap =
     cachedHierarchy ?? (await getSpaceHierarchy(connectorId, page.spaceId));
 

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -219,6 +219,7 @@ export async function confluenceUpsertSpaceFolderActivity({
     dataSourceConfig: dataSourceConfigFromConnector(connector),
     folderId: makeSpaceInternalId(spaceId),
     parents: [makeSpaceInternalId(spaceId)],
+    parentId: null,
     title: spaceName,
     mimeType: "application/vnd.dust.confluence.space",
   });
@@ -252,7 +253,7 @@ export async function markPageHasVisited({
 interface ConfluenceUpsertPageInput {
   page: NonNullable<Awaited<ReturnType<ConfluenceClient["getPageById"]>>>;
   spaceName: string;
-  parents: string[];
+  parents: [string, ...string[], string];
   confluenceConfig: ConfluenceConfiguration;
   syncType?: UpsertDataSourceDocumentParams["upsertContext"]["sync_type"];
   dataSourceConfig: DataSourceConfig;

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -512,6 +512,7 @@ export async function incrementalSync(
           dataSourceConfig,
           folderId: getInternalId(driveFile.id),
           parents,
+          parentId: parents[1] || null,
           title: driveFile.name ?? "",
           mimeType: "application/vnd.dust.googledrive.folder",
         });
@@ -856,6 +857,7 @@ export async function markFolderAsVisited(
     dataSourceConfig,
     folderId: getInternalId(file.id),
     parents,
+    parentId: parents[1] || null,
     title: file.name ?? "",
     mimeType: "application/vnd.dust.googledrive.folder",
   });

--- a/connectors/src/connectors/google_drive/temporal/file.ts
+++ b/connectors/src/connectors/google_drive/temporal/file.ts
@@ -492,6 +492,7 @@ async function upsertGdriveDocument(
       timestampMs: file.updatedAtMs,
       tags,
       parents,
+      parentId: parents[1] || null,
       upsertContext: {
         sync_type: isBatchSync ? "batch" : "incremental",
       },

--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -83,6 +83,7 @@ async function upsertGdriveTable(
     },
     truncate: true,
     parents: [tableId, ...parents],
+    parentId: parents[0] || null,
     useAppForHeaderDetection: true,
     title: `${spreadsheet.title} - ${title}`,
     mimeType: "application/vnd.google-apps.spreadsheet",

--- a/connectors/src/connectors/intercom/lib/utils.ts
+++ b/connectors/src/connectors/intercom/lib/utils.ts
@@ -149,7 +149,7 @@ export async function getParentIdsForArticle({
   connectorId: number;
   parentCollectionId: string;
   helpCenterId: string;
-}) {
+}): Promise<[string, string, ...string[], string]> {
   // Get collection parents
   const collectionParents = await getParentIdsForCollection({
     connectorId,
@@ -168,11 +168,8 @@ export async function getParentIdsForCollection({
   connectorId: number;
   collectionId: string;
   helpCenterId: string;
-}) {
-  // Initialize the internal IDs array with the collection ID.
-  const parentIds = [
-    getHelpCenterCollectionInternalId(connectorId, collectionId),
-  ];
+}): Promise<[string, ...string[], string]> {
+  const parentIds = [];
 
   // Fetch and add any parent collection Ids.
   let currentParentId = collectionId;
@@ -196,8 +193,10 @@ export async function getParentIdsForCollection({
     );
   }
 
-  // Add the help center internal ID.
-  parentIds.push(getHelpCenterInternalId(connectorId, helpCenterId));
-
-  return parentIds;
+  // Add the collection ID and the help center internal ID.
+  return [
+    getHelpCenterCollectionInternalId(connectorId, collectionId),
+    ...parentIds,
+    getHelpCenterInternalId(connectorId, helpCenterId),
+  ];
 }

--- a/connectors/src/connectors/intercom/temporal/activities.ts
+++ b/connectors/src/connectors/intercom/temporal/activities.ts
@@ -31,13 +31,11 @@ import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_c
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
 import {
-  IntercomConversation,
-  IntercomWorkspace,
-} from "@connectors/lib/models/intercom";
-import {
   IntercomCollection,
+  IntercomConversation,
   IntercomHelpCenter,
   IntercomTeam,
+  IntercomWorkspace,
 } from "@connectors/lib/models/intercom";
 import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
 import logger from "@connectors/logger/logger";
@@ -177,6 +175,7 @@ export async function syncHelpCenterOnlyActivity({
     folderId: helpCenterInternalId,
     title: helpCenterOnIntercom.display_name || "Help Center",
     parents: [helpCenterInternalId],
+    parentId: null,
     mimeType: getDataSourceNodeMimeType("HELP_CENTER"),
   });
 
@@ -509,6 +508,7 @@ export async function syncTeamOnlyActivity({
     folderId: teamInternalId,
     title: teamOnIntercom.name,
     parents: [teamInternalId, getTeamsInternalId(connectorId)],
+    parentId: getTeamsInternalId(connectorId),
     mimeType: getDataSourceNodeMimeType("TEAM"),
   });
 
@@ -743,6 +743,7 @@ export async function upsertIntercomTeamsFolderActivity({
     folderId: getTeamsInternalId(connectorId),
     title: "Conversations",
     parents: [getTeamsInternalId(connectorId)],
+    parentId: null,
     mimeType: getDataSourceNodeMimeType("CONVERSATIONS_FOLDER"),
   });
 }

--- a/connectors/src/connectors/intercom/temporal/sync_conversation.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_conversation.ts
@@ -306,11 +306,13 @@ export async function syncConversation({
   // parents in the Core datasource map the internal ids that are used in the permission system
   // they self reference the document id
   const documentId = getConversationInternalId(connectorId, conversation.id);
-  const parents = [documentId];
-  if (conversationTeamId) {
-    parents.push(getTeamInternalId(connectorId, conversationTeamId));
-  }
-  parents.push(getTeamsInternalId(connectorId));
+  const parents: [string, ...string[], string] = [
+    documentId,
+    ...(conversationTeamId
+      ? [getTeamInternalId(connectorId, conversationTeamId)]
+      : []),
+    getTeamsInternalId(connectorId),
+  ];
 
   await upsertDataSourceDocument({
     dataSourceConfig,
@@ -320,6 +322,7 @@ export async function syncConversation({
     timestampMs: updatedAtDate.getTime(),
     tags: datasourceTags,
     parents,
+    parentId: parents[1],
     loggerArgs: {
       ...loggerArgs,
       conversationId: conversation.id,

--- a/connectors/src/connectors/intercom/temporal/sync_help_center.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_help_center.ts
@@ -228,7 +228,7 @@ export async function upsertCollectionWithChildren({
     folderId: internalCollectionId,
     title: collection.name,
     parents: collectionParents,
-    parentId: collectionParents.length > 2 ? collectionParents[1] : null,
+    parentId: collectionParents[1],
     mimeType: getDataSourceNodeMimeType("COLLECTION"),
   });
 
@@ -420,6 +420,7 @@ export async function upsertArticle({
         `updatedAt:${updatedAtDate.getTime()}`,
       ],
       parents,
+      parentId: parents[1],
       loggerArgs: {
         ...loggerArgs,
         articleId: article.id,

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -465,7 +465,7 @@ export async function syncFiles({
         )
     );
 
-  const parents = await getParents({
+  const parentsOfParent = await getParents({
     connectorId: parent.connectorId,
     internalId: parent.internalId,
     startSyncTs,
@@ -477,8 +477,8 @@ export async function syncFiles({
       upsertDataSourceFolder({
         dataSourceConfig,
         folderId: createdOrUpdatedResource.internalId,
-        parents: [createdOrUpdatedResource.internalId, ...parents],
-        parentId: parents[0],
+        parents: [createdOrUpdatedResource.internalId, ...parentsOfParent],
+        parentId: parentsOfParent[0],
         title: createdOrUpdatedResource.name ?? "",
         mimeType: "application/vnd.dust.microsoft.folder",
       }),

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -893,6 +893,7 @@ async function updateParentsField({
     dataSourceConfig,
     documentId: file.internalId,
     parents,
+    parentId: parents[1] || null,
   });
 }
 

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -206,6 +206,7 @@ export async function getRootNodesToSyncFromResources(
         dataSourceConfig,
         folderId: createdOrUpdatedResource.internalId,
         parents: [createdOrUpdatedResource.internalId],
+        parentId: null,
         title: createdOrUpdatedResource.name ?? "",
         mimeType: "application/vnd.dust.microsoft.folder",
       }),
@@ -477,6 +478,7 @@ export async function syncFiles({
         dataSourceConfig,
         folderId: createdOrUpdatedResource.internalId,
         parents: [createdOrUpdatedResource.internalId, ...parents],
+        parentId: parents[0],
         title: createdOrUpdatedResource.name ?? "",
         mimeType: "application/vnd.dust.microsoft.folder",
       }),
@@ -650,6 +652,7 @@ export async function syncDeltaForRootNodesInDrive({
           dataSourceConfig,
           folderId: blob.internalId,
           parents: [blob.internalId],
+          parentId: null,
           title: blob.name ?? "",
           mimeType: "application/vnd.dust.microsoft.folder",
         });

--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -306,6 +306,7 @@ export async function syncOneFile({
           timestampMs: upsertTimestampMs,
           tags,
           parents,
+          parentId: parents[1] || null,
           upsertContext: {
             sync_type: isBatchSync ? "batch" : "incremental",
           },
@@ -352,7 +353,7 @@ export async function getParents({
   connectorId: ModelId;
   internalId: string;
   startSyncTs: number;
-}): Promise<string[]> {
+}): Promise<[string, ...string[]]> {
   const parentInternalId = await getParentId(
     connectorId,
     internalId,

--- a/connectors/src/connectors/microsoft/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/microsoft/temporal/spreadsheets.ts
@@ -70,7 +70,7 @@ async function upsertMSTable(
   internalId: string,
   spreadsheet: microsoftgraph.DriveItem,
   worksheet: microsoftgraph.WorkbookWorksheet,
-  parents: string[],
+  parents: [string, string, ...string[]],
   rows: string[][],
   loggerArgs: object
 ) {
@@ -99,6 +99,7 @@ async function upsertMSTable(
     },
     truncate: true,
     parents,
+    parentId: parents[1],
     useAppForHeaderDetection: true,
     title: `${spreadsheet.name} - ${worksheet.name}`,
     mimeType:
@@ -183,7 +184,7 @@ async function processSheet({
 
   // Assuming the first line as headers, at least one additional data line is required.
   if (rows.length > 1) {
-    const parents = [
+    const parents: [string, string, ...string[]] = [
       worksheetInternalId,
       ...(await getParents({
         connectorId: connector.id,

--- a/connectors/src/connectors/notion/lib/parents.ts
+++ b/connectors/src/connectors/notion/lib/parents.ts
@@ -176,6 +176,7 @@ export async function updateAllParentsFields(
           dataSourceConfig: dataSourceConfigFromConnector(connector),
           documentId: `notion-${pageId}`,
           parents,
+          parentId: parents[1] || null,
         });
         if (onProgress) {
           await onProgress();

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1,5 +1,9 @@
-import type { CoreAPIDataSourceDocumentSection, ModelId } from "@dust-tt/types";
-import type { PageObjectProperties, ParsedNotionBlock } from "@dust-tt/types";
+import type {
+  CoreAPIDataSourceDocumentSection,
+  ModelId,
+  PageObjectProperties,
+  ParsedNotionBlock,
+} from "@dust-tt/types";
 import { assertNever, getNotionDatabaseTableId, slugify } from "@dust-tt/types";
 import { isFullBlock, isFullPage, isNotionClientError } from "@notionhq/client";
 import type { PageObjectResponse } from "@notionhq/client/build/src/api-endpoints";
@@ -1818,6 +1822,7 @@ export async function renderAndUpsertPageFromCache({
               // We only update the rowId of for the page without truncating the rest of the table (incremental sync).
               truncate: false,
               parents: parents,
+              parentId: parents[1] || null,
               title: parentDb.title ?? "Untitled Notion Database",
               mimeType: "application/vnd.dust.notion.database",
             }),
@@ -2037,7 +2042,7 @@ export async function renderAndUpsertPageFromCache({
         parsedProperties,
       }),
       parents: parentIds,
-      parentId: parentIds.length > 1 ? parentIds[1] : null,
+      parentId: parentIds[1] || null,
       loggerArgs,
       upsertContext: {
         sync_type: isFullSync ? "batch" : "incremental",
@@ -2538,6 +2543,7 @@ export async function upsertDatabaseStructuredDataFromCache({
         // We overwrite the whole table since we just fetched all child pages.
         truncate: true,
         parents: parentIds,
+        parentId: parentIds[1] || null,
         title: dbModel.title ?? "Untitled Notion Database",
         mimeType: "application/vnd.dust.notion.database",
       }),

--- a/connectors/src/connectors/shared/file.ts
+++ b/connectors/src/connectors/shared/file.ts
@@ -10,9 +10,10 @@ import {
   isTextExtractionSupportedContentType,
   Ok,
   pagePrefixesPerMimeType,
+  parseAndStringifyCsv,
+  slugify,
   TextExtraction,
 } from "@dust-tt/types";
-import { parseAndStringifyCsv, slugify } from "@dust-tt/types";
 
 import { apiConfig } from "@connectors/lib/api/config";
 import { upsertDataSourceTableFromCsv } from "@connectors/lib/data_sources";
@@ -78,6 +79,7 @@ export async function handleCsvFile({
       },
       truncate: true,
       parents,
+      parentId: parents[1] || null,
       title: fileName,
       mimeType: "text/csv",
     });

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -279,15 +279,16 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
             lastSeenAt: new Date(),
           });
 
+          // parent folder ids of the page are in hierarchy order from the
+          // page to the root so for the current folder, its parents start at
+          // index+1 (including itself as first parent) and end at the root
+          const parents = parentFolderIds.slice(index + 1);
           await upsertDataSourceFolder({
             dataSourceConfig,
             folderId: webCrawlerFolder.internalId,
             timestampMs: webCrawlerFolder.updatedAt.getTime(),
-
-            // parent folder ids of the page are in hierarchy order from the
-            // page to the root so for the current folder, its parents start at
-            // index+1 (including itself as first parent) and end at the root
-            parents: parentFolderIds.slice(index + 1),
+            parents,
+            parentId: parents[1] || null,
             title: folder,
             mimeType: "application/vnd.dust.webcrawler.folder",
           });
@@ -363,6 +364,7 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
               timestampMs: new Date().getTime(),
               tags: [`title:${stripNullBytes(pageTitle)}`],
               parents: parentFolderIds,
+              parentId: parentFolderIds[1] || null,
               upsertContext: {
                 sync_type: "batch",
               },

--- a/connectors/src/connectors/zendesk/lib/sync_article.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_article.ts
@@ -151,6 +151,7 @@ export async function syncArticle({
       articleId: article.id,
     });
 
+    const parents = articleInDb.getParentInternalIds(connectorId);
     await upsertDataSourceDocument({
       dataSourceConfig,
       documentId,
@@ -162,7 +163,8 @@ export async function syncArticle({
         `createdAt:${createdAt.getTime()}`,
         `updatedAt:${updatedAt.getTime()}`,
       ],
-      parents: articleInDb.getParentInternalIds(connectorId),
+      parents,
+      parentId: parents[1],
       loggerArgs: { ...loggerArgs, articleId: article.id },
       upsertContext: { sync_type: "batch" },
       title: article.title,

--- a/connectors/src/connectors/zendesk/lib/sync_category.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_category.ts
@@ -104,6 +104,7 @@ export async function syncCategory({
     dataSourceConfig,
     folderId: parents[0],
     parents,
+    parentId: parents[1],
     title: categoryInDb.name,
     mimeType: "application/vnd.dust.zendesk.category",
   });

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -209,6 +209,7 @@ ${comments
       ticketId: ticket.id,
     });
 
+    const parents = ticketInDb.getParentInternalIds(connectorId);
     await upsertDataSourceDocument({
       dataSourceConfig,
       documentId,
@@ -221,7 +222,8 @@ ${comments
         `updatedAt:${updatedAtDate.getTime()}`,
         `createdAt:${createdAtDate.getTime()}`,
       ],
-      parents: ticketInDb.getParentInternalIds(connectorId),
+      parents,
+      parentId: parents[1],
       loggerArgs: { ...loggerArgs, ticketId: ticket.id },
       upsertContext: { sync_type: "batch" },
       title: ticket.subject,

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -132,6 +132,7 @@ export async function syncZendeskBrandActivity({
     dataSourceConfig,
     folderId: brandInternalId,
     parents: [brandInternalId],
+    parentId: null,
     title: brandInDb.name,
     mimeType: "application/vnd.dust.zendesk.brand",
   });
@@ -142,6 +143,7 @@ export async function syncZendeskBrandActivity({
     dataSourceConfig,
     folderId: helpCenterNode.internalId,
     parents: [helpCenterNode.internalId, helpCenterNode.parentInternalId],
+    parentId: helpCenterNode.parentInternalId,
     title: helpCenterNode.title,
     mimeType: "application/vnd.dust.zendesk.helpcenter",
   });
@@ -152,6 +154,7 @@ export async function syncZendeskBrandActivity({
     dataSourceConfig,
     folderId: ticketsNode.internalId,
     parents: [ticketsNode.internalId, ticketsNode.parentInternalId],
+    parentId: ticketsNode.parentInternalId,
     title: ticketsNode.title,
     mimeType: "application/vnd.dust.zendesk.tickets",
   });
@@ -326,6 +329,7 @@ export async function syncZendeskCategoryActivity({
     dataSourceConfig: dataSourceConfigFromConnector(connector),
     folderId: parents[0],
     parents,
+    parentId: parents[1],
     title: categoryInDb.name,
     mimeType: "application/vnd.dust.zendesk.category",
   });

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -147,6 +147,7 @@ export async function syncZendeskArticleUpdateBatchActivity({
               dataSourceConfig,
               folderId: parents[0],
               parents,
+              parentId: parents[1],
               title: category.name,
               mimeType: "application/vnd.dust.zendesk.category",
             });

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -331,7 +331,7 @@ async function _updateDataSourceDocumentParents({
   dataSourceConfig: DataSourceConfig;
   documentId: string;
   parents: string[];
-  parentId?: string | null;
+  parentId: string | null;
   loggerArgs?: Record<string, string | number>;
 }) {
   return _updateDocumentOrTableParentsField({
@@ -352,6 +352,7 @@ async function _updateDataSourceTableParents({
   dataSourceConfig: DataSourceConfig;
   tableId: string;
   parents: string[];
+  parentId: string | null;
   loggerArgs?: Record<string, string | number>;
 }) {
   return _updateDocumentOrTableParentsField({
@@ -365,14 +366,14 @@ async function _updateDocumentOrTableParentsField({
   dataSourceConfig,
   id,
   parents,
-  parentId = null,
+  parentId,
   loggerArgs = {},
   tableOrDocument,
 }: {
   dataSourceConfig: DataSourceConfig;
   id: string;
   parents: string[];
-  parentId?: string | null;
+  parentId: string | null;
   loggerArgs?: Record<string, string | number>;
   tableOrDocument: "document" | "table";
 }) {

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -71,7 +71,7 @@ export type UpsertDataSourceDocumentParams = {
   timestampMs?: number;
   tags?: string[];
   parents: string[];
-  parentId?: string | null;
+  parentId: string | null;
   loggerArgs?: Record<string, string | number>;
   upsertContext: UpsertContext;
   title: string;
@@ -108,7 +108,7 @@ async function _upsertDataSourceDocument({
   title,
   mimeType,
   async,
-  parentId = null,
+  parentId,
 }: UpsertDataSourceDocumentParams) {
   return tracer.trace(
     `connectors`,
@@ -1229,7 +1229,7 @@ export async function _upsertDataSourceFolder({
   folderId,
   timestampMs,
   parents,
-  parentId = parents[1] ?? null,
+  parentId,
   title,
   mimeType,
 }: {
@@ -1237,7 +1237,7 @@ export async function _upsertDataSourceFolder({
   folderId: string;
   timestampMs?: number;
   parents: string[];
-  parentId?: string | null;
+  parentId: string | null;
   title: string;
   mimeType: string;
 }) {

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -778,7 +778,7 @@ export async function upsertDataSourceTableFromCsv({
   loggerArgs,
   truncate,
   parents,
-  parentId = null,
+  parentId,
   useAppForHeaderDetection,
   title,
   mimeType,
@@ -791,7 +791,7 @@ export async function upsertDataSourceTableFromCsv({
   loggerArgs?: Record<string, string | number>;
   truncate: boolean;
   parents: string[];
-  parentId?: string | null;
+  parentId: string | null;
   useAppForHeaderDetection?: boolean;
   title: string;
   mimeType: string;


### PR DESCRIPTION
## Description

- Closes half of #9365 (will do core in an upcoming PR).
- Pass `parentId` at every location where they were missing.
- Make `parentId` mandatory on the interface from connectors to api/v1.
- Improve types for the parents when applicable (e.g. add tuples when possible explicitely).
- I updated the migration scripts to please the linter.

## Risk

- Should be at the typing level, if it builds no behavior change is expected.

## Deploy Plan

- Deploy connectors.
