### PR TITLE
[Keyword search] Backfill nodes index with PSQL nodes table 

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -28,6 +28,10 @@ name = "elasticsearch_create_index"
 path = "bin/elasticsearch/create_index.rs"
 
 [[bin]]
+name = "elasticsearch_backfill_index"
+path = "bin/elasticsearch/backfill_index.rs"
+
+[[bin]]
 name = "qdrant_create_collection"
 path = "bin/qdrant/create_collection.rs"
 

--- a/core/bin/elasticsearch/backfill_index.rs
+++ b/core/bin/elasticsearch/backfill_index.rs
@@ -1,0 +1,125 @@
+use clap::Parser;
+use dust::{
+    data_sources::node::Node,
+    search_stores::search_store::ElasticsearchSearchStore,
+    stores::{postgres::PostgresStore, store::Store},
+    utils::{self},
+};
+use elasticsearch::{http::request::JsonBody, indices::IndicesExistsParts, BulkParts};
+use http::StatusCode;
+use serde_json::json;
+use tracing::info;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    #[arg(long, help = "The version of the index")]
+    index_version: u32,
+
+    #[arg(long, help = "Skip confirmation")]
+    skip_confirmation: bool,
+
+    #[arg(long, help = "The cursor to start from")]
+    start_cursor: Option<i64>,
+}
+
+/*
+ * Backfills nodes index in Elasticsearch for core using the postgres table `data_sources_nodes`
+ *
+ * Usage:
+ * cargo run --bin elasticsearch_backfill_nodes_index -- --index-version <version> [--skip-confirmation] [--start-cursor <cursor>]
+ *
+ */
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // parse args and env vars
+    let args = Args::parse();
+    let index_name = "data_sources_nodes";
+    let index_version = args.index_version;
+
+    let url = std::env::var("ELASTICSEARCH_URL").expect("ELASTICSEARCH_URL must be set");
+    let username =
+        std::env::var("ELASTICSEARCH_USERNAME").expect("ELASTICSEARCH_USERNAME must be set");
+    let password =
+        std::env::var("ELASTICSEARCH_PASSWORD").expect("ELASTICSEARCH_PASSWORD must be set");
+
+    let region = std::env::var("DUST_REGION").expect("DUST_REGION must be set");
+
+    // create ES client
+    let search_store = ElasticsearchSearchStore::new(&url, &username, &password).await?;
+
+    let index_fullname = format!("core.{}_{}", index_name, index_version);
+
+    // err if index does not exist
+    let response = search_store
+        .client
+        .indices()
+        .exists(IndicesExistsParts::Index(&[index_fullname.as_str()]))
+        .send()
+        .await?;
+
+    if response.status_code() != StatusCode::OK {
+        return Err(anyhow::anyhow!("Index does not exist").into());
+    }
+
+    if !args.skip_confirmation {
+        println!(
+            "Are you sure you want to backfill the index {} in region {}? (y/N)",
+            index_fullname, region
+        );
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input).unwrap();
+        if input.trim() != "y" {
+            return Err(anyhow::anyhow!("Aborted").into());
+        }
+    }
+
+    let db_uri = std::env::var("CORE_DATABASE_READ_REPLICA_URI")
+        .expect("CORE_DATABASE_READ_REPLICA_URI must be set");
+    let store = PostgresStore::new(&db_uri).await?;
+    // loop on all nodes in postgres using id as cursor, stopping when timestamp
+    // is greater than now
+    let mut next_cursor = args.start_cursor.unwrap_or(0);
+    let batch_size = 1000;
+    let now = utils::now();
+    loop {
+        info!("Processing 1000 nodes, starting at id {}", next_cursor);
+        let (nodes, cursor) =
+            get_node_batch(next_cursor, batch_size, Box::new(store.clone())).await?;
+        if nodes.is_empty() || nodes.first().unwrap().timestamp > now {
+            break;
+        }
+        next_cursor = cursor;
+
+        //
+        let nodes_body: Vec<JsonBody<_>> = nodes
+            .into_iter()
+            .flat_map(|node| {
+                [
+                    json!({"index": {"_id": node.unique_id()}}).into(),
+                    json!(node).into(),
+                ]
+            })
+            .collect();
+        search_store
+            .client
+            .bulk(BulkParts::Index(index_fullname.as_str()))
+            .body(nodes_body)
+            .send()
+            .await?;
+    }
+
+    Ok(())
+}
+
+async fn get_node_batch(
+    next_cursor: i64,
+    batch_size: i64,
+    store: Box<dyn Store + Sync + Send>,
+) -> Result<(Vec<Node>, i64), Box<dyn std::error::Error>> {
+    let nodes = store
+        .list_data_source_nodes(next_cursor, batch_size)
+        .await?;
+    let last_id = nodes.last().unwrap().1;
+    Ok((nodes.into_iter().map(|(node, _)| node).collect(), last_id))
+}

--- a/core/bin/elasticsearch/create_index.rs
+++ b/core/bin/elasticsearch/create_index.rs
@@ -1,25 +1,9 @@
 use std::collections::HashMap;
 
-use clap::{Parser, ValueEnum};
+use clap::Parser;
 use dust::search_stores::search_store::ElasticsearchSearchStore;
 use elasticsearch::indices::{IndicesCreateParts, IndicesDeleteAliasParts, IndicesExistsParts};
 use http::StatusCode;
-
-#[derive(Parser, Debug, Clone, ValueEnum)]
-enum Region {
-    Local,
-    #[clap(name = "us-central-1")]
-    UsCentral1,
-}
-
-impl std::fmt::Display for Region {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Region::Local => write!(f, "local"),
-            Region::UsCentral1 => write!(f, "us-central-1"),
-        }
-    }
-}
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -3535,7 +3535,7 @@ impl Store for PostgresStore {
 
         let stmt = c
             .prepare(
-                "SELECT dsn.timestamp, dsn.title, dsn.mime_type, dsn.parents, dsn.node_id, dsn.document, dsn.\"table\", dsn.folder, ds.data_source_id \
+                "SELECT dsn.timestamp, dsn.title, dsn.mime_type, dsn.parents, dsn.node_id, dsn.document, dsn.\"table\", dsn.folder, ds.data_source_id, ds.internal_id \
                    FROM data_sources_nodes dsn JOIN data_sources ds ON dsn.data_source = ds.id \
                    WHERE dsn.id > $1 ORDER BY dsn.id ASC LIMIT $2",
             )
@@ -3554,6 +3554,7 @@ impl Store for PostgresStore {
                 let table_row_id = row.get::<_, Option<i64>>(6);
                 let folder_row_id = row.get::<_, Option<i64>>(7);
                 let data_source_id: String = row.get::<_, String>(8);
+                let data_source_internal_id: String = row.get::<_, String>(9);
                 let (node_type, row_id) = match (document_row_id, table_row_id, folder_row_id) {
                     (Some(id), None, None) => (NodeType::Document, id),
                     (None, Some(id), None) => (NodeType::Table, id),
@@ -3563,6 +3564,7 @@ impl Store for PostgresStore {
                 (
                     Node::new(
                         &data_source_id,
+                        &data_source_internal_id,
                         &node_id,
                         node_type,
                         timestamp as u64,

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -3529,20 +3529,20 @@ impl Store for PostgresStore {
         &self,
         id_cursor: i64,
         batch_size: i64,
-    ) -> Result<Vec<(Node, i64)>> {
+    ) -> Result<Vec<(Node, i64, i64)>> {
         let pool = self.pool.clone();
         let c = pool.get().await?;
 
         let stmt = c
             .prepare(
-                "SELECT dsn.timestamp, dsn.title, dsn.mime_type, dsn.parents, dsn.node_id, dsn.document, dsn.\"table\", dsn.folder, ds.data_source_id, ds.internal_id \
+                "SELECT dsn.timestamp, dsn.title, dsn.mime_type, dsn.parents, dsn.node_id, dsn.document, dsn.\"table\", dsn.folder, ds.data_source_id, ds.internal_id, dsn.id \
                    FROM data_sources_nodes dsn JOIN data_sources ds ON dsn.data_source = ds.id \
                    WHERE dsn.id > $1 ORDER BY dsn.id ASC LIMIT $2",
             )
             .await?;
         let rows = c.query(&stmt, &[&id_cursor, &batch_size]).await?;
 
-        let nodes: Vec<(Node, i64)> = rows
+        let nodes: Vec<(Node, i64, i64)> = rows
             .iter()
             .map(|row| {
                 let timestamp: i64 = row.get::<_, i64>(0);
@@ -3555,12 +3555,14 @@ impl Store for PostgresStore {
                 let folder_row_id = row.get::<_, Option<i64>>(7);
                 let data_source_id: String = row.get::<_, String>(8);
                 let data_source_internal_id: String = row.get::<_, String>(9);
-                let (node_type, row_id) = match (document_row_id, table_row_id, folder_row_id) {
-                    (Some(id), None, None) => (NodeType::Document, id),
-                    (None, Some(id), None) => (NodeType::Table, id),
-                    (None, None, Some(id)) => (NodeType::Folder, id),
-                    _ => unreachable!(),
-                };
+                let (node_type, element_row_id) =
+                    match (document_row_id, table_row_id, folder_row_id) {
+                        (Some(id), None, None) => (NodeType::Document, id),
+                        (None, Some(id), None) => (NodeType::Table, id),
+                        (None, None, Some(id)) => (NodeType::Folder, id),
+                        _ => unreachable!(),
+                    };
+                let row_id = row.get::<_, i64>(10);
                 (
                     Node::new(
                         &data_source_id,
@@ -3574,6 +3576,7 @@ impl Store for PostgresStore {
                         parents,
                     ),
                     row_id,
+                    element_row_id,
                 )
             })
             .collect::<Vec<_>>();

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -347,6 +347,12 @@ pub trait Store {
         data_source_id: &str,
         node_id: &str,
     ) -> Result<Option<(Node, i64)>>;
+    async fn list_data_source_nodes(
+        &self,
+        id_cursor: i64,
+        batch_size: i64,
+    ) -> Result<Vec<(Node, i64)>>;
+
     // LLM Cache
     async fn llm_cache_get(
         &self,

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -347,11 +347,12 @@ pub trait Store {
         data_source_id: &str,
         node_id: &str,
     ) -> Result<Option<(Node, i64)>>;
+    // returns a list of (node, row_id, element_row_id)
     async fn list_data_source_nodes(
         &self,
         id_cursor: i64,
         batch_size: i64,
-    ) -> Result<Vec<(Node, i64)>>;
+    ) -> Result<Vec<(Node, i64, i64)>>;
 
     // LLM Cache
     async fn llm_cache_get(


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/dust/issues/8765

Note: also fixes `us-central-1` to `us-central1`

Risks
---
We use the read replica so all should be fine
Batch upserts should be quite fast too

Deploy
---
core
