### PR TITLE
enh(Zendesk) - add the endpoint to the logs

### DIFF
--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -21,6 +21,10 @@ import { ZendeskBrandResource } from "@connectors/resources/zendesk_resources";
 const ZENDESK_RATE_LIMIT_MAX_RETRIES = 5;
 const ZENDESK_RATE_LIMIT_TIMEOUT_SECONDS = 60;
 
+function getEndpointFromZendeskUrl(url: string): string {
+  return url.replace(/^https?:\/\/(.*)\.zendesk\.com(.*)/, "$2");
+}
+
 export function createZendeskClient({
   accessToken,
   subdomain,
@@ -162,15 +166,15 @@ async function fetchFromZendeskWithRetries({
     throw new ZendeskApiError(
       "Error parsing Zendesk API response",
       rawResponse.status,
-      rawResponse
+      { rawResponse, endpoint: getEndpointFromZendeskUrl(url) }
     );
   }
   if (!rawResponse.ok) {
-    throw new ZendeskApiError(
-      "Zendesk API error.",
-      rawResponse.status,
-      response
-    );
+    throw new ZendeskApiError("Zendesk API error.", rawResponse.status, {
+      response,
+      rawResponse,
+      endpoint: getEndpointFromZendeskUrl(url),
+    });
   }
 
   return response;


### PR DESCRIPTION
## Description

- Add the endpoint to the error data to enrich the logs.
- We do not pass the full URL as this exposes the subdomain of the customer (not critical but not necessary here).

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
