### PR TITLE
[core] add a log on `parents[1] == parentId`

### DIFF
--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -1507,14 +1507,23 @@ async fn data_sources_documents_update_parents(
             }
         }
         None => {
-            info!(
-                data_source_id = data_source_id,
-                node_id = document_id,
-                parents = ?payload.parents,
-                node_type = "document",
-                operation = "update_parents",
-                "[KWSEARCH] invariant_parent_id_not_none"
-            );
+            if payload.parents.len() > 1 {
+                // TODO(aubin) - re-enable this check if the log below does not pop
+                // return error_response(
+                //     StatusCode::BAD_REQUEST,
+                //     "invalid_parent_id",
+                //     "Failed to update document parents - parent_id should not be null if parents[1] is defined",
+                //     None,
+                // );
+                info!(
+                    data_source_id = data_source_id,
+                    node_id = document_id,
+                    parents = ?payload.parents,
+                    node_type = "document",
+                    operation = "update_parents",
+                    "[KWSEARCH] invariant_parent_id_incorrectly_none"
+                );
+            }
         }
     }
 
@@ -1700,14 +1709,23 @@ async fn data_sources_documents_upsert(
             }
         }
         None => {
-            info!(
-                data_source_id = data_source_id,
-                node_id = payload.document_id,
-                parents = ?payload.parents,
-                node_type = "document",
-                operation = "upsert",
-                "[KWSEARCH] invariant_parent_id_not_none"
-            );
+            if payload.parents.len() > 1 {
+                // TODO(aubin) - re-enable this check if the log below does not pop
+                // return error_response(
+                //     StatusCode::BAD_REQUEST,
+                //     "invalid_parent_id",
+                //     "Failed to upsert document - parent_id should not be null if parents[1] is defined",
+                //     None,
+                // );
+                info!(
+                    data_source_id = data_source_id,
+                    node_id = payload.document_id,
+                    parents = ?payload.parents,
+                    node_type = "document",
+                    operation = "upsert",
+                    "[KWSEARCH] invariant_parent_id_incorrectly_none"
+                );
+            }
         }
     }
 
@@ -2182,14 +2200,23 @@ async fn tables_upsert(
             }
         }
         None => {
-            info!(
-                data_source_id = data_source_id,
-                node_id = payload.table_id,
-                parents = ?payload.parents,
-                node_type = "table",
-                operation = "upsert",
-                "[KWSEARCH] invariant_parent_id_not_none"
-            );
+            if payload.parents.len() > 1 {
+                // TODO(aubin) - re-enable this check if the log below does not pop
+                //     return error_response(
+                //         StatusCode::BAD_REQUEST,
+                //         "invalid_parent_id",
+                //         "Failed to upsert table - parent_id should not be null if parents[1] is defined",
+                //         None,
+                //     );
+                info!(
+                    data_source_id = data_source_id,
+                    node_id = payload.table_id,
+                    parents = ?payload.parents,
+                    node_type = "table",
+                    operation = "upsert",
+                    "[KWSEARCH] invariant_parent_id_incorrectly_none"
+                );
+            }
         }
     }
 
@@ -2466,14 +2493,23 @@ async fn tables_update_parents(
             }
         }
         None => {
-            info!(
-                data_source_id = data_source_id,
-                node_id = table_id,
-                parents = ?payload.parents,
-                node_type = "table",
-                operation = "update_parents",
-                "[KWSEARCH] invariant_parent_id_not_none"
-            );
+            if payload.parents.len() > 1 {
+                // TODO(aubin) - re-enable this check if the log below does not pop
+                //     return error_response(
+                //         StatusCode::BAD_REQUEST,
+                //         "invalid_parent_id",
+                //         "Failed to update table parents - parent_id should not be null if parents[1] is defined",
+                //         None,
+                //     );
+                info!(
+                    data_source_id = data_source_id,
+                    node_id = table_id,
+                    parents = ?payload.parents,
+                    node_type = "table",
+                    operation = "update_parents",
+                    "[KWSEARCH] invariant_parent_id_incorrectly_none"
+                );
+            }
         }
     }
 
@@ -2887,14 +2923,23 @@ async fn folders_upsert(
             }
         }
         None => {
-            info!(
-                data_source_id = data_source_id,
-                node_id = payload.folder_id,
-                parents = ?payload.parents,
-                node_type = "folder",
-                operation = "upsert",
-                "[KWSEARCH] invariant_parent_id_not_none"
-            );
+            if payload.parents.len() > 1 {
+                // TODO(aubin) - re-enable this check if the log below does not pop
+                //     return error_response(
+                //         StatusCode::BAD_REQUEST,
+                //         "invalid_parent_id",
+                //         "Failed to upsert folder - parent_id should not be null if parents[1] is defined",
+                //         None,
+                //     );
+                info!(
+                    data_source_id = data_source_id,
+                    node_id = payload.folder_id,
+                    parents = ?payload.parents,
+                    node_type = "folder",
+                    operation = "upsert",
+                    "[KWSEARCH] invariant_parent_id_incorrectly_none"
+                );
+            }
         }
     }
 

--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -1508,7 +1508,7 @@ async fn data_sources_documents_update_parents(
         }
         None => {
             if payload.parents.len() > 1 {
-                // TODO(aubin) - re-enable this check if the log below does not pop
+                // TODO(aubin) - re-enable this check when the log below does not pop
                 // return error_response(
                 //     StatusCode::BAD_REQUEST,
                 //     "invalid_parent_id",
@@ -1710,7 +1710,7 @@ async fn data_sources_documents_upsert(
         }
         None => {
             if payload.parents.len() > 1 {
-                // TODO(aubin) - re-enable this check if the log below does not pop
+                // TODO(aubin) - re-enable this check when the log below does not pop
                 // return error_response(
                 //     StatusCode::BAD_REQUEST,
                 //     "invalid_parent_id",
@@ -2201,7 +2201,7 @@ async fn tables_upsert(
         }
         None => {
             if payload.parents.len() > 1 {
-                // TODO(aubin) - re-enable this check if the log below does not pop
+                // TODO(aubin) - re-enable this check when the log below does not pop
                 //     return error_response(
                 //         StatusCode::BAD_REQUEST,
                 //         "invalid_parent_id",
@@ -2494,7 +2494,7 @@ async fn tables_update_parents(
         }
         None => {
             if payload.parents.len() > 1 {
-                // TODO(aubin) - re-enable this check if the log below does not pop
+                // TODO(aubin) - re-enable this check when the log below does not pop
                 //     return error_response(
                 //         StatusCode::BAD_REQUEST,
                 //         "invalid_parent_id",
@@ -2924,7 +2924,7 @@ async fn folders_upsert(
         }
         None => {
             if payload.parents.len() > 1 {
-                // TODO(aubin) - re-enable this check if the log below does not pop
+                // TODO(aubin) - re-enable this check when the log below does not pop
                 //     return error_response(
                 //         StatusCode::BAD_REQUEST,
                 //         "invalid_parent_id",

--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -1681,6 +1681,15 @@ async fn data_sources_documents_upsert(
     match &payload.parent_id {
         Some(parent_id) => {
             if payload.parents.get(1) != Some(parent_id) {
+                info!(
+                    data_source_id = data_source_id,
+                    node_id = payload.document_id,
+                    parent_id = parent_id,
+                    parents = ?payload.parents,
+                    node_type = "document",
+                    operation = "upsert",
+                    "[KWSEARCH] invariant_parent_id_equal_parent_1"
+                );
                 // TODO(fontanierh): Temporary, as we need to let some jobs go through.
                 // return error_response(
                 //     StatusCode::BAD_REQUEST,


### PR DESCRIPTION
## Description

- Closes half of #9365 (will do core in an upcoming PR).
- Close #9380.
- Adds a log in core on document/table upsert/parent update when `parents[1] !== parentId`.
- Adds a log in core on document/table upsert/parent update when `parentId == null && parents[1] !== undefined`.
- Already enforced if non null for tables/folders upserts and document parents updates, logged if null.
- Plan is to check that this log does not pop up and uncomment the validation code below.

## Risk

- ~none

## Deploy Plan

- Deploy core.
