### PR TITLE
enh(Zendesk) - skip incremental syncs on 404

### DIFF
--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -166,7 +166,11 @@ async function fetchFromZendeskWithRetries({
     throw new ZendeskApiError(
       "Error parsing Zendesk API response",
       rawResponse.status,
-      { rawResponse, endpoint: getEndpointFromZendeskUrl(url) }
+      {
+        rawResponse,
+        endpoint: getEndpointFromZendeskUrl(url),
+        statusText: rawResponse.statusText,
+      }
     );
   }
   if (!rawResponse.ok) {
@@ -174,6 +178,7 @@ async function fetchFromZendeskWithRetries({
       response,
       rawResponse,
       endpoint: getEndpointFromZendeskUrl(url),
+      statusText: rawResponse.statusText,
     });
   }
 

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -279,15 +279,22 @@ export async function fetchRecentlyUpdatedArticles({
   articles: ZendeskFetchedArticle[];
   hasMore: boolean;
   endTime: number;
-}> {
+} | null> {
   // this endpoint retrieves changes in content, not only in metadata despite what is mentioned in the documentation.
   const url = `https://${brandSubdomain}.zendesk.com/api/v2/help_center/incremental/articles.json?start_time=${startTime}`;
-  const response = await fetchFromZendeskWithRetries({ url, accessToken });
-  return {
-    articles: response.articles,
-    hasMore: response.next_page !== null && response.articles.length !== 0,
-    endTime: response.end_time,
-  };
+  try {
+    const response = await fetchFromZendeskWithRetries({ url, accessToken });
+    return {
+      articles: response.articles,
+      hasMore: response.next_page !== null && response.articles.length !== 0,
+      endTime: response.end_time,
+    };
+  } catch (e) {
+    if (isZendeskNotFoundError(e)) {
+      return null;
+    }
+    throw e;
+  }
 }
 
 /**


### PR DESCRIPTION
## Description

- This PR handles 404 errors on the incremental articles endpoint by logging a warn and not updating the timestamp cursor.
- Tickets are also not incrementally synced to prevent re-fetching a growing number of tickets endlessly.
- Ideally, this warn should trigger a monitor (maybe panic log?).
- This PR adds the status text to the Zendesk errors.

## Risk

- Low.

## Deploy Plan

- Stop all Zendesk connectors.
- Deploy connectors.
- Resume all Zendesk connectors.
