### PR TITLE
[front] Check permission before redirecting to stored space

### DIFF
--- a/front/pages/w/[wId]/spaces/index.tsx
+++ b/front/pages/w/[wId]/spaces/index.tsx
@@ -20,7 +20,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements(
     );
     if (selection.lastSpaceId) {
       const space = await SpaceResource.fetchById(auth, selection.lastSpaceId);
-      if (space) {
+      if (space && space.canList(auth)) {
         return {
           redirect: {
             destination: `/w/${owner.sId}/spaces/${space.sId}`,


### PR DESCRIPTION
## Description

If user permission on space has changed since their last visit, going to /spaces will always redirect them to a 404. Check canList() before redirecting

## Risk

n/a

## Deploy Plan

deploy front
