### PR TITLE
feat: replace o1-preview by o1

### DIFF
--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -30,7 +30,7 @@ import {
   MISTRAL_MEDIUM_MODEL_CONFIG,
   MISTRAL_SMALL_MODEL_CONFIG,
   O1_MINI_MODEL_CONFIG,
-  O1_PREVIEW_MODEL_CONFIG,
+  O1_MODEL_CONFIG,
 } from "@dust-tt/types";
 import assert from "assert";
 
@@ -326,16 +326,16 @@ function _getO1PreviewGlobalAgent({
     version: 0,
     versionCreatedAt: null,
     versionAuthorId: null,
-    name: "o1-preview",
-    description: O1_PREVIEW_MODEL_CONFIG.description,
+    name: "o1",
+    description: O1_MODEL_CONFIG.description,
     instructions: null,
     pictureUrl: "https://dust.tt/static/systemavatar/o1_avatar_full.png",
     status,
     scope: "global",
     userFavorite: false,
     model: {
-      providerId: O1_PREVIEW_MODEL_CONFIG.providerId,
-      modelId: O1_PREVIEW_MODEL_CONFIG.modelId,
+      providerId: O1_MODEL_CONFIG.providerId,
+      modelId: O1_MODEL_CONFIG.modelId,
       temperature: 1, // 1 is forced for O1
     },
     actions: [],

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -23,7 +23,7 @@ const ModelLLMIdSchema = FlexibleEnumSchema<
   | "gpt-4o-2024-08-06"
   | "gpt-4o"
   | "gpt-4o-mini"
-  | "o1-preview"
+  | "o1"
   | "o1-mini"
   | "claude-3-opus-20240229"
   | "claude-3-5-sonnet-20240620"

--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -89,7 +89,7 @@ export const GPT_4_TURBO_MODEL_ID = "gpt-4-turbo" as const;
 export const GPT_4O_MODEL_ID = "gpt-4o" as const;
 export const GPT_4O_20240806_MODEL_ID = "gpt-4o-2024-08-06" as const;
 export const GPT_4O_MINI_MODEL_ID = "gpt-4o-mini" as const;
-export const O1_PREVIEW_MODEL_ID = "o1-preview" as const;
+export const O1_MODEL_ID = "o1" as const;
 export const O1_MINI_MODEL_ID = "o1-mini" as const;
 export const CLAUDE_3_OPUS_2024029_MODEL_ID = "claude-3-opus-20240229" as const;
 export const CLAUDE_3_5_SONNET_20240620_MODEL_ID =
@@ -124,7 +124,7 @@ export const MODEL_IDS = [
   GPT_4O_MODEL_ID,
   GPT_4O_20240806_MODEL_ID,
   GPT_4O_MINI_MODEL_ID,
-  O1_PREVIEW_MODEL_ID,
+  O1_MODEL_ID,
   O1_MINI_MODEL_ID,
   CLAUDE_3_OPUS_2024029_MODEL_ID,
   CLAUDE_3_5_SONNET_20240620_MODEL_ID,
@@ -267,11 +267,11 @@ export const GPT_4O_MINI_MODEL_CONFIG: ModelConfigurationType = {
   toolUseMetaPrompt: LEGACY_OPEN_AI_TOOL_USE_META_PROMPT,
   supportsVision: true,
 };
-export const O1_PREVIEW_MODEL_CONFIG: ModelConfigurationType = {
+export const O1_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
-  modelId: O1_PREVIEW_MODEL_ID,
-  displayName: "O1 Preview",
-  contextSize: 128_000,
+  modelId: O1_MODEL_ID,
+  displayName: "O1",
+  contextSize: 200_000,
   recommendedTopK: 32,
   recommendedExhaustiveTopK: 128, // 65_536
   largeModel: true,
@@ -601,7 +601,7 @@ export const SUPPORTED_MODEL_CONFIGS: ModelConfigurationType[] = [
   GPT_4O_MODEL_CONFIG,
   GPT_4O_20240806_MODEL_CONFIG,
   GPT_4O_MINI_MODEL_CONFIG,
-  O1_PREVIEW_MODEL_CONFIG,
+  O1_MODEL_CONFIG,
   O1_MINI_MODEL_CONFIG,
   CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG,
   CLAUDE_3_5_SONNET_20240620_DEPRECATED_MODEL_CONFIG,


### PR DESCRIPTION
## Description

replaces `o1-preview` by `o1`.

`o1-preview` and `o1-mini` do not support `system` messages. `o1` supports the new `developer` messages instead of the `system` messages, so I added support for that.

## Risk

N/A

## Deploy Plan

Deploy core, deploy front