### PR TITLE
[connectors] Spread Confluence workflows every 2 hours

### DIFF
--- a/connectors/src/connectors/confluence/temporal/client.ts
+++ b/connectors/src/connectors/confluence/temporal/client.ts
@@ -51,6 +51,7 @@ export async function launchConfluenceSyncWorkflow(
   const workflowId = makeConfluenceSyncWorkflowId(connector.id);
 
   const minute = connector.id % 60; // Spread workflows across the hour.
+  const oddOrEvenHour = connector.id % 120 >= 60 ? 1 : 0; // Spread workflows on even or odd hours.
 
   // When the workflow is inactive, we omit passing spaceIds as they are only used to signal modifications within a currently active full sync workflow.
   try {
@@ -70,7 +71,7 @@ export async function launchConfluenceSyncWorkflow(
       memo: {
         connectorId,
       },
-      cronSchedule: `${minute} * * * *`, // Every hour at minute `minute`.
+      cronSchedule: `${minute} ${oddOrEvenHour}/2 * * *`, // Every 2 hours at minute `minute`.
     });
   } catch (err) {
     return new Err(err as Error);


### PR DESCRIPTION
## Description

- We are hitting rate limits quite often on Confluence.
- The Confluence sync workflows currently run every hour.
- This PR aims at running them every 2 hours.
- This PR will be follows up with optimizations on the workflows in themselves.

## Risk

- Low

## Deploy Plan

- Stop all Confluence workflows
- Deploy connectors
- Resume all Confluence workflows
