### PR TITLE
Add logos to various pages of the landing page

### DIFF
--- a/front/pages/home/solutions/data-analytics.tsx
+++ b/front/pages/home/solutions/data-analytics.tsx
@@ -13,6 +13,7 @@ import {
 } from "@app/components/home/Particles";
 import type { SolutionSectionAssistantBlockProps } from "@app/components/home/SolutionSection";
 import { SolutionSection } from "@app/components/home/SolutionSection";
+import TrustedBy from "@app/components/home/TrustedBy";
 
 export async function getServerSideProps() {
   return {
@@ -53,6 +54,7 @@ export default function DataAnalytics() {
         to={pageSettings.to}
         subtitle={pageSettings.description}
       />
+      <TrustedBy />
       <Grid>
         <SolutionSection
           title={

--- a/front/pages/home/solutions/engineering.tsx
+++ b/front/pages/home/solutions/engineering.tsx
@@ -13,6 +13,7 @@ import {
 } from "@app/components/home/Particles";
 import type { SolutionSectionAssistantBlockProps } from "@app/components/home/SolutionSection";
 import { SolutionSection } from "@app/components/home/SolutionSection";
+import TrustedBy from "@app/components/home/TrustedBy";
 
 export async function getServerSideProps() {
   return {
@@ -59,6 +60,7 @@ export default function Engineering() {
         to={pageSettings.to}
         subtitle={pageSettings.description}
       />
+      <TrustedBy />
       <Grid>
         <SolutionSection
           title={"Improve Code Quality."}

--- a/front/pages/home/solutions/knowledge.tsx
+++ b/front/pages/home/solutions/knowledge.tsx
@@ -13,6 +13,7 @@ import {
 } from "@app/components/home/Particles";
 import type { SolutionSectionAssistantBlockProps } from "@app/components/home/SolutionSection";
 import { SolutionSection } from "@app/components/home/SolutionSection";
+import TrustedBy from "@app/components/home/TrustedBy";
 
 export async function getServerSideProps() {
   return {
@@ -55,6 +56,7 @@ export default function Knowledge() {
         to={pageSettings.to}
         subtitle={pageSettings.description}
       />
+      <TrustedBy />
       <Grid>
         <SolutionSection
           title={

--- a/front/pages/home/solutions/marketing.tsx
+++ b/front/pages/home/solutions/marketing.tsx
@@ -13,6 +13,7 @@ import {
 } from "@app/components/home/Particles";
 import type { SolutionSectionAssistantBlockProps } from "@app/components/home/SolutionSection";
 import { SolutionSection } from "@app/components/home/SolutionSection";
+import TrustedBy from "@app/components/home/TrustedBy";
 
 export async function getServerSideProps() {
   return {
@@ -58,6 +59,7 @@ export default function Marketing() {
         to={pageSettings.to}
         subtitle={pageSettings.description}
       />
+      <TrustedBy />
       <Grid>
         <SolutionSection
           title={

--- a/front/pages/home/solutions/recruiting-people.tsx
+++ b/front/pages/home/solutions/recruiting-people.tsx
@@ -13,6 +13,7 @@ import {
 } from "@app/components/home/Particles";
 import type { SolutionSectionAssistantBlockProps } from "@app/components/home/SolutionSection";
 import { SolutionSection } from "@app/components/home/SolutionSection";
+import TrustedBy from "@app/components/home/TrustedBy";
 
 export async function getServerSideProps() {
   return {
@@ -53,6 +54,7 @@ export default function RecruitingPeople() {
         to={pageSettings.to}
         subtitle={pageSettings.description}
       />
+      <TrustedBy />
       <Grid>
         <SolutionSection
           title="Focus on&nbsp;being a&nbsp;business partner, not&nbsp;a&nbsp;help desk."

--- a/front/pages/home/solutions/sales.tsx
+++ b/front/pages/home/solutions/sales.tsx
@@ -13,6 +13,7 @@ import {
 } from "@app/components/home/Particles";
 import type { SolutionSectionAssistantBlockProps } from "@app/components/home/SolutionSection";
 import { SolutionSection } from "@app/components/home/SolutionSection";
+import TrustedBy from "@app/components/home/TrustedBy";
 
 export async function getServerSideProps() {
   return {
@@ -60,6 +61,7 @@ export default function Sales() {
         to={pageSettings.to}
         subtitle={pageSettings.description}
       />
+      <TrustedBy />
       <Grid>
         <SolutionSection
           title={


### PR DESCRIPTION
## Description

- Close https://github.com/dust-tt/tasks/issues/1859
- Add the customer logos to various pages in `/home/solutions`

Before
<img width="2560" alt="Screenshot 2024-12-23 at 10 50 19 AM" src="https://github.com/user-attachments/assets/d7fcbbba-06c6-4959-9b1f-0a0f21d4ef03" />

After
<img width="2560" alt="Screenshot 2024-12-23 at 10 49 57 AM" src="https://github.com/user-attachments/assets/13abea5b-b54e-428f-9fec-102863b28afe" />


## Risk

-

## Deploy Plan

- Deploy front