### PR TITLE
feat: add reasoning effort to agent config model + support in core

### DIFF
--- a/core/src/blocks/chat.rs
+++ b/core/src/blocks/chat.rs
@@ -290,6 +290,9 @@ impl Block for Chat {
                 if let Some(Value::String(s)) = v.get("response_format") {
                     extras["response_format"] = json!(s.clone());
                 }
+                if let Some(Value::String(s)) = v.get("reasoning_effort") {
+                    extras["reasoning_effort"] = json!(s.clone());
+                }
 
                 match extras.as_object().unwrap().keys().len() {
                     0 => None,

--- a/core/src/blocks/llm.rs
+++ b/core/src/blocks/llm.rs
@@ -406,6 +406,9 @@ impl Block for LLM {
                 if let Some(Value::String(s)) = v.get("response_format") {
                     extras["response_format"] = json!(s.clone());
                 }
+                if let Some(Value::String(s)) = v.get("reasoning_effort") {
+                    extras["reasoning_effort"] = json!(s.clone());
+                }
 
                 match extras.as_object().unwrap().keys().len() {
                     0 => None,

--- a/core/src/providers/azure_openai.rs
+++ b/core/src/providers/azure_openai.rs
@@ -447,8 +447,8 @@ impl LLM for AzureOpenAILLM {
             }
         }
 
-        let (openai_user, response_format) = match &extras {
-            None => (None, None),
+        let (openai_user, response_format, reasoning_effort) = match &extras {
+            None => (None, None, None),
             Some(v) => (
                 match v.get("openai_user") {
                     Some(Value::String(u)) => Some(u.to_string()),
@@ -456,6 +456,10 @@ impl LLM for AzureOpenAILLM {
                 },
                 match v.get("response_format") {
                     Some(Value::String(f)) => Some(f.to_string()),
+                    _ => None,
+                },
+                match v.get("reasoning_effort") {
+                    Some(Value::String(r)) => Some(r.to_string()),
                     _ => None,
                 },
             ),
@@ -501,6 +505,7 @@ impl LLM for AzureOpenAILLM {
                     },
                     response_format,
                     openai_user,
+                    reasoning_effort,
                     event_sender,
                 )
                 .await?
@@ -531,6 +536,7 @@ impl LLM for AzureOpenAILLM {
                         None => 0.0,
                     },
                     response_format,
+                    reasoning_effort,
                     openai_user,
                 )
                 .await?

--- a/core/src/providers/togetherai.rs
+++ b/core/src/providers/togetherai.rs
@@ -195,6 +195,7 @@ impl LLM for TogetherAILLM {
                 },
                 None,
                 None,
+                None,
                 event_sender.clone(),
             )
             .await?
@@ -223,6 +224,7 @@ impl LLM for TogetherAILLM {
                     Some(f) => f,
                     None => 0.0,
                 },
+                None,
                 None,
                 None,
             )

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -1,5 +1,6 @@
 import type {
   AgentConfigurationScope,
+  AgentReasoningEffort,
   AgentStatus,
   GlobalAgentStatus,
   ModelIdType,
@@ -34,6 +35,7 @@ export class AgentConfiguration extends BaseModel<AgentConfiguration> {
   declare providerId: ModelProviderIdType;
   declare modelId: ModelIdType;
   declare temperature: number;
+  declare reasoningEffort: AgentReasoningEffort | null;
 
   declare pictureUrl: string;
 
@@ -106,6 +108,10 @@ AgentConfiguration.init(
       type: DataTypes.FLOAT,
       allowNull: false,
       defaultValue: 0.7,
+    },
+    reasoningEffort: {
+      type: DataTypes.STRING,
+      allowNull: true,
     },
     maxStepsPerRun: {
       type: DataTypes.INTEGER,

--- a/front/migrations/db/migration_136.sql
+++ b/front/migrations/db/migration_136.sql
@@ -1,0 +1,2 @@
+-- Migration created on Dec 23, 2024
+ALTER TABLE "public"."agent_configurations" ADD COLUMN "reasoningEffort" VARCHAR(255);

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -176,10 +176,13 @@ export type AgentUsageType = {
 
 export type AgentRecentAuthors = readonly string[];
 
+export type AgentReasoningEffort = "low" | "medium" | "high";
+
 export type AgentModelConfigurationType = {
   providerId: ModelProviderIdType;
   modelId: ModelIdType;
   temperature: number;
+  reasoningEffort?: AgentReasoningEffort;
 };
 
 export type LightAgentConfigurationType = {
@@ -228,6 +231,8 @@ export type LightAgentConfigurationType = {
   //
   // Example: [[1,2], [3,4]] means (1 OR 2) AND (3 OR 4)
   requestedGroupIds: string[][];
+
+  reasoningEffort?: AgentReasoningEffort;
 };
 
 export type AgentConfigurationType = LightAgentConfigurationType & {


### PR DESCRIPTION
## Description

- add `reasoningEffort` on the `agent_configurations` table (optional)
- add support for `reasoning_effort` config on `core` LLM / Chat blocks for OAI provider (as `extras` config).

## Risk

critical path for pretty much everything + database migration

## Deploy Plan

1. apply DB schema migration (prodbox)
2. deploy `core` (adds support for the config) and deploy `front` (functionally a no-op)