### PR TITLE
[landing-page] Update text color for readability

### DIFF
--- a/front/components/home/ContentBlocks.tsx
+++ b/front/components/home/ContentBlocks.tsx
@@ -270,7 +270,7 @@ export const CarousselContentBlock = ({
       <H3 className="text-slate-800">{"Dust for " + title}</H3>
       <div className="flex flex-col gap-2">
         <H2 className="max-w-[600px] text-white">{subtitle}</H2>
-        <P size="md" className="max-w-[720px] text-muted-foreground">
+        <P size="md" className="max-w-[720px] text-slate-700">
           {description}
         </P>
       </div>

--- a/front/components/home/ContentComponents.tsx
+++ b/front/components/home/ContentComponents.tsx
@@ -98,7 +98,7 @@ const pClasses = {
   xxs: "font-objektiv text-xs text-muted-foreground md:text-sm leading-relaxed",
   xs: "font-objektiv text-sm text-slate-400 md:text-base leading-relaxed",
   sm: "font-objektiv text-base text-slate-400 md:text-lg leading-relaxed",
-  md: "font-objektiv text-lg md:text-lg text-slate-700 lg:text-xl leading-relaxed",
+  md: "font-objektiv text-lg md:text-lg text-slate-300 lg:text-xl leading-relaxed",
   lg: "font-objektiv text-lg md:text-xl text-slate-300 lg:text-2xl drop-shadow leading-relaxed",
 };
 

--- a/front/components/home/ContentComponents.tsx
+++ b/front/components/home/ContentComponents.tsx
@@ -127,7 +127,7 @@ export const P = ({
 }: PProps) => {
   if (dotCSS) {
     return (
-      <div className={classNames(className, "flex gap-2 lg:gap-3")}>
+      <div className={classNames("flex gap-2 lg:gap-3", className)}>
         <Icon
           visual={shapeClasses[shape]}
           className={classNames("mt-0.5 shrink-0", dotCSS)}
@@ -137,7 +137,7 @@ export const P = ({
       </div>
     );
   } else {
-    return <p className={classNames(className, pClasses[size])}>{children}</p>;
+    return <p className={classNames(pClasses[size], className)}>{children}</p>;
   }
 };
 


### PR DESCRIPTION
## Description

- Fix https://github.com/dust-tt/tasks/issues/1855
- Follow up on https://github.com/dust-tt/dust/pull/9601

Before:
<img width="2560" alt="Screenshot 2024-12-23 at 12 00 46 PM" src="https://github.com/user-attachments/assets/76506c10-0675-4d6e-9f57-25004f3f68a8" />

After:
<img width="2560" alt="Screenshot 2024-12-23 at 12 01 04 PM" src="https://github.com/user-attachments/assets/3d20d19f-6fe7-44fb-bc68-5a5a590e1c4d" />

## Risk

- UI changes

## Deploy Plan

- Deploy front