### PR TITLE
[landing-page] Add Blog sections with custom colors

### DIFF
--- a/front/components/home/content/Product/BlogSection.tsx
+++ b/front/components/home/content/Product/BlogSection.tsx
@@ -10,14 +10,22 @@ import {
 import { BlogBlock } from "@app/components/home/ContentBlocks";
 import { Grid, H2, P } from "@app/components/home/ContentComponents";
 
-export function BlogSection() {
+interface BlogSectionProps {
+  headerColorFrom?: string;
+  headerColorTo?: string;
+}
+
+export function BlogSection({
+  headerColorFrom = "from-green-200",
+  headerColorTo = "to-emerald-400",
+}: BlogSectionProps) {
   return (
     <Grid gap="gap-8">
       <div className="col-span-12">
         <Carousel className="w-full">
           <div className="mb-6 flex items-end justify-between">
             <div>
-              <H2 from="from-green-200" to="to-emerald-400">
+              <H2 from={headerColorFrom} to={headerColorTo}>
                 Dust in Action:
                 <br />
                 Customer Stories

--- a/front/pages/home/solutions/data-analytics.tsx
+++ b/front/pages/home/solutions/data-analytics.tsx
@@ -1,5 +1,7 @@
 import type { ReactElement } from "react";
+import React from "react";
 
+import { BlogSection } from "@app/components/home/content/Product/BlogSection";
 import {
   CarousselContentBlock,
   HeaderContentBlock,
@@ -144,6 +146,10 @@ export default function DataAnalytics() {
           ]}
         />
       </Grid>
+      <BlogSection
+        headerColorFrom="from-amber-200"
+        headerColorTo="to-amber-500"
+      />
     </>
   );
 }

--- a/front/pages/home/solutions/engineering.tsx
+++ b/front/pages/home/solutions/engineering.tsx
@@ -1,5 +1,7 @@
 import type { ReactElement } from "react";
+import React from "react";
 
+import { BlogSection } from "@app/components/home/content/Product/BlogSection";
 import {
   CarousselContentBlock,
   HeaderContentBlock,
@@ -162,6 +164,10 @@ export default function Engineering() {
           ]}
         />
       </Grid>
+      <BlogSection
+        headerColorFrom="from-emerald-200"
+        headerColorTo="to-emerald-500"
+      />
     </>
   );
 }

--- a/front/pages/home/solutions/knowledge.tsx
+++ b/front/pages/home/solutions/knowledge.tsx
@@ -1,5 +1,7 @@
 import type { ReactElement } from "react";
+import React from "react";
 
+import { BlogSection } from "@app/components/home/content/Product/BlogSection";
 import {
   CarousselContentBlock,
   HeaderContentBlock,
@@ -142,6 +144,10 @@ export default function Knowledge() {
           ]}
         />
       </Grid>
+      <BlogSection
+        headerColorFrom="gradient from-sky-200"
+        headerColorTo="to-sky-500"
+      />
     </>
   );
 }

--- a/front/pages/home/solutions/marketing.tsx
+++ b/front/pages/home/solutions/marketing.tsx
@@ -160,7 +160,7 @@ export default function Marketing() {
       </Grid>
       <BlogSection
         headerColorFrom="from-pink-200"
-        headerColorTo="from-pink-500"
+        headerColorTo="from-pink-300"
       />
     </>
   );

--- a/front/pages/home/solutions/marketing.tsx
+++ b/front/pages/home/solutions/marketing.tsx
@@ -1,5 +1,7 @@
 import type { ReactElement } from "react";
+import React from "react";
 
+import { BlogSection } from "@app/components/home/content/Product/BlogSection";
 import {
   CarousselContentBlock,
   HeaderContentBlock,
@@ -156,6 +158,10 @@ export default function Marketing() {
           ]}
         />
       </Grid>
+      <BlogSection
+        headerColorFrom="from-pink-200"
+        headerColorTo="from-pink-500"
+      />
     </>
   );
 }

--- a/front/pages/home/solutions/recruiting-people.tsx
+++ b/front/pages/home/solutions/recruiting-people.tsx
@@ -1,5 +1,7 @@
 import type { ReactElement } from "react";
+import React from "react";
 
+import { BlogSection } from "@app/components/home/content/Product/BlogSection";
 import {
   CarousselContentBlock,
   HeaderContentBlock,
@@ -180,6 +182,10 @@ export default function RecruitingPeople() {
           ]}
         />
       </Grid>
+      <BlogSection
+        headerColorFrom="from-amber-200"
+        headerColorTo="to-amber-500"
+      />
     </>
   );
 }

--- a/front/pages/home/solutions/sales.tsx
+++ b/front/pages/home/solutions/sales.tsx
@@ -1,5 +1,7 @@
 import type { ReactElement } from "react";
+import React from "react";
 
+import { BlogSection } from "@app/components/home/content/Product/BlogSection";
 import {
   CarousselContentBlock,
   HeaderContentBlock,
@@ -160,6 +162,10 @@ export default function Sales() {
           ]}
         />
       </Grid>
+      <BlogSection
+        headerColorFrom="from-emerald-200"
+        headerColorTo="to-emerald-500"
+      />
     </>
   );
 }


### PR DESCRIPTION
## Description

- Close [#1860](https://github.com/dust-tt/tasks/issues/1860)
- Add Blog sections to various pages of `/home/solutions`, each having custom colors.

<img width="2560" alt="Screenshot 2024-12-23 at 12 34 19 PM" src="https://github.com/user-attachments/assets/9f63bdd4-a416-4417-b39d-0fcc13622e0b" />
<img width="2560" alt="Screenshot 2024-12-23 at 12 34 38 PM" src="https://github.com/user-attachments/assets/8cd098ce-3511-4901-96d6-a4a50c335914" />

+ other pages

## Risk

- UI changes

## Deploy Plan

- Deploy front
