### PR TITLE
New resources for feedback loop

### DIFF
--- a/front/lib/api/assistant/feedback.ts
+++ b/front/lib/api/assistant/feedback.ts
@@ -9,6 +9,7 @@ import { ConversationError, Err, Ok } from "@dust-tt/types";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import { canAccessConversation } from "@app/lib/api/assistant/conversation/auth";
 import type { AgentMessageFeedbackDirection } from "@app/lib/api/assistant/conversation/feedbacks";
+import type { PaginationParams } from "@app/lib/api/pagination";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
 
@@ -174,16 +175,12 @@ export async function getAgentFeedbacks({
   auth,
   agentConfigurationId,
   withMetadata,
-  filters,
+  paginationParams,
 }: {
   auth: Authenticator;
   withMetadata: boolean;
   agentConfigurationId: string;
-  filters?: {
-    limit?: number;
-    olderThan?: Date;
-    earlierThan?: Date;
-  };
+  paginationParams: PaginationParams;
 }): Promise<
   Result<
     (AgentMessageFeedbackType | AgentMessageFeedbackWithMetadataType)[],
@@ -204,7 +201,7 @@ export async function getAgentFeedbacks({
   const feedbacksRes = await AgentMessageFeedbackResource.fetch({
     workspace: owner,
     agentConfiguration,
-    filters,
+    paginationParams,
     withMetadata,
   });
 

--- a/front/lib/api/assistant/feedback.ts
+++ b/front/lib/api/assistant/feedback.ts
@@ -4,15 +4,11 @@ import type {
   Result,
 } from "@dust-tt/types";
 import type { UserType } from "@dust-tt/types";
-import { ConversationError, Err, GLOBAL_AGENTS_SID, Ok } from "@dust-tt/types";
-import { Op } from "sequelize";
+import { ConversationError, Err, Ok } from "@dust-tt/types";
 
 import { canAccessConversation } from "@app/lib/api/assistant/conversation/auth";
 import type { AgentMessageFeedbackDirection } from "@app/lib/api/assistant/conversation/feedbacks";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentConfiguration } from "@app/lib/models/assistant/agent";
-import { AgentMessage } from "@app/lib/models/assistant/conversation";
-import { Message } from "@app/lib/models/assistant/conversation";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
 
 /**
@@ -41,54 +37,24 @@ export async function getConversationFeedbacksForUser(
     return new Err(new ConversationError("conversation_access_restricted"));
   }
 
-  const messages = await Message.findAll({
-    where: {
-      conversationId: conversation.id,
-      agentMessageId: {
-        [Op.ne]: null,
-      },
-    },
-    attributes: ["sId", "agentMessageId"],
-  });
-
-  const agentMessages = await AgentMessage.findAll({
-    where: {
-      id: {
-        [Op.in]: messages
-          .map((m) => m.agentMessageId)
-          .filter((id): id is number => id !== null),
-      },
-    },
-  });
-
   const feedbacks =
-    await AgentMessageFeedbackResource.fetchByUserAndAgentMessages(
-      user,
-      agentMessages
+    await AgentMessageFeedbackResource.getConversationFeedbacksForUser(
+      auth,
+      conversation
     );
 
-  const feedbacksByMessageId = feedbacks.map(
-    (feedback) =>
-      ({
-        id: feedback.id,
-        messageId: messages.find(
-          (m) => m.agentMessageId === feedback.agentMessageId
-        )!.sId,
-        agentMessageId: feedback.agentMessageId,
-        userId: feedback.userId,
-        thumbDirection: feedback.thumbDirection,
-        content: feedback.content,
-      }) as AgentMessageFeedbackType
-  );
+  if (feedbacks.isErr()) {
+    return new Err(feedbacks.error);
+  }
 
-  return new Ok(feedbacksByMessageId);
+  return new Ok(feedbacks.value);
 }
 
 /**
  * We create a feedback for a single message.
  * As user can be null (user from Slack), we also store the user context, as we do for messages.
  */
-export async function createOrUpdateMessageFeedback(
+export async function upsertMessageFeedback(
   auth: Authenticator,
   {
     messageId,
@@ -96,94 +62,71 @@ export async function createOrUpdateMessageFeedback(
     user,
     thumbDirection,
     content,
+    isConversationShared,
   }: {
     messageId: string;
     conversation: ConversationType | ConversationWithoutContentType;
     user: UserType;
     thumbDirection: AgentMessageFeedbackDirection;
     content?: string;
+    isConversationShared?: boolean;
   }
-): Promise<boolean | null> {
+) {
   const owner = auth.workspace();
   if (!owner) {
-    throw new Error("Unexpected `auth` without `workspace`.");
-  }
-
-  const message = await Message.findOne({
-    where: {
-      sId: messageId,
-      conversationId: conversation.id,
-    },
-  });
-
-  if (!message || !message.agentMessageId) {
-    return null;
-  }
-
-  const agentMessage = await AgentMessage.findOne({
-    where: {
-      id: message.agentMessageId,
-    },
-  });
-
-  if (!agentMessage) {
-    return null;
-  }
-
-  let isGlobalAgent = false;
-  let agentConfigurationId = agentMessage.agentConfigurationId;
-  if (
-    Object.values(GLOBAL_AGENTS_SID).includes(
-      agentMessage.agentConfigurationId as GLOBAL_AGENTS_SID
-    )
-  ) {
-    isGlobalAgent = true;
-  }
-
-  if (!isGlobalAgent) {
-    const agentConfiguration = await AgentConfiguration.findOne({
-      where: {
-        sId: agentMessage.agentConfigurationId,
-      },
+    return new Err({
+      type: "workspace_not_found",
+      message: "The workspace you're trying to access was not found.",
     });
-
-    if (!agentConfiguration) {
-      return null;
-    }
-    agentConfigurationId = agentConfiguration.sId;
   }
-
-  const feedback =
-    await AgentMessageFeedbackResource.fetchByUserAndAgentMessage({
+  const feedbackWithConversationContext =
+    await AgentMessageFeedbackResource.getFeedbackWithConversationContext({
+      auth,
+      messageId,
+      conversation,
       user,
-      agentMessage,
     });
+
+  if (feedbackWithConversationContext.isErr()) {
+    return feedbackWithConversationContext;
+  }
+
+  const { agentMessage, feedback, agentConfiguration, isGlobalAgent } =
+    feedbackWithConversationContext.value;
 
   if (feedback) {
-    const updatedFeedback = await feedback.updateContentAndThumbDirection(
-      content ?? "",
-      thumbDirection
-    );
+    await feedback.updateFields({
+      content: content ?? "",
+      thumbDirection,
+      isConversationShared: false,
+    });
+    return new Ok(undefined);
+  }
 
-    return updatedFeedback.isOk();
-  } else {
-    const newFeedback = await AgentMessageFeedbackResource.makeNew({
-      workspaceId: owner.id,
-      agentConfigurationId: agentConfigurationId,
+  try {
+    await AgentMessageFeedbackResource.makeNew({
+      workspaceId: auth.getNonNullableWorkspace().id,
+      // If the agent is global, we use the agent configuration id from the agent message
+      // Otherwise, we use the agent configuration id from the agent configuration
+      agentConfigurationId: isGlobalAgent
+        ? agentMessage.agentConfigurationId
+        : agentConfiguration.sId,
       agentConfigurationVersion: agentMessage.agentConfigurationVersion,
       agentMessageId: agentMessage.id,
       userId: user.id,
       thumbDirection,
       content,
-      isConversationShared: false,
+      isConversationShared: isConversationShared ?? false,
     });
-    return newFeedback !== null;
+  } catch (e) {
+    return new Err(e as Error);
   }
+  return new Ok(undefined);
 }
 
 /**
- * The id of a reaction is not exposed on the API so we need to find it from the message id and the user context.
- * We destroy reactions, no point in soft-deleting them.
+ * The id of a feedback is not exposed on the API so we need to find it from the message id and the user context.
+ * We destroy feedbacks, no point in soft-deleting them.
  */
 export async function deleteMessageFeedback(
   auth: Authenticator,
@@ -196,45 +139,45 @@ export async function deleteMessageFeedback(
     conversation: ConversationType | ConversationWithoutContentType;
     user: UserType;
   }
-): Promise<boolean | null> {
+) {
   const owner = auth.workspace();
   if (!owner) {
-    throw new Error("Unexpected `auth` without `workspace`.");
+    return new Err({
+      type: "workspace_not_found",
+      message: "The workspace you're trying to access was not found.",
+    });
   }
 
-  const message = await Message.findOne({
-    where: {
-      sId: messageId,
-      conversationId: conversation.id,
-    },
-    attributes: ["agentMessageId"],
-  });
-
-  if (!message || !message.agentMessageId) {
-    return null;
+  if (!canAccessConversation(auth, conversation)) {
+    return new Err({
+      type: "conversation_access_restricted",
+      message: "You don't have access to this conversation.",
+    });
   }
 
-  const agentMessage = await AgentMessage.findOne({
-    where: {
-      id: message.agentMessageId,
-    },
-  });
-
-  if (!agentMessage) {
-    return null;
-  }
-
-  const feedback =
-    await AgentMessageFeedbackResource.fetchByUserAndAgentMessage({
+  const feedbackWithContext =
+    await AgentMessageFeedbackResource.getFeedbackWithConversationContext({
+      auth,
+      messageId,
+      conversation,
       user,
-      agentMessage,
     });
 
-  if (!feedback) {
-    return null;
+  if (feedbackWithContext.isErr()) {
+    return feedbackWithContext;
   }
 
-  const deletedFeedback = await feedback.delete(auth);
+  const { feedback } = feedbackWithContext.value;
 
-  return deletedFeedback.isOk();
+  if (!feedback) {
+    return new Ok(undefined);
+  }
+
+  const deleteRes = await feedback.delete(auth, {});
+
+  if (deleteRes.isErr()) {
+    return deleteRes;
+  }
+
+  return new Ok(undefined);
 }

--- a/front/lib/api/assistant/feedback.ts
+++ b/front/lib/api/assistant/feedback.ts
@@ -190,7 +190,7 @@ export async function deleteMessageFeedback(
   return new Ok(undefined);
 }
 
-export async function fetchAgentFeedbacks({
+export async function getAgentFeedbacks({
   auth,
   agentConfigurationId,
   withMetadata,

--- a/front/lib/api/assistant/feedback.ts
+++ b/front/lib/api/assistant/feedback.ts
@@ -202,7 +202,7 @@ export async function getAgentFeedbacks({
   }
 
   const feedbacksRes = await AgentMessageFeedbackResource.fetch({
-    workspaceId: owner.id,
+    workspace: owner,
     agentConfiguration,
     filters,
     withMetadata,

--- a/front/lib/api/assistant/feedback.ts
+++ b/front/lib/api/assistant/feedback.ts
@@ -229,7 +229,7 @@ export async function getAgentFeedbacks({
   }
 
   const feedbacksRes = await AgentMessageFeedbackResource.fetch({
-    workspaceId: owner.sId,
+    workspaceId: owner.id,
     agentConfiguration,
     filters,
     withMetadata,

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -244,8 +244,8 @@ export class AgentMessage extends BaseModel<AgentMessage> {
   declare agentConfigurationVersion: number;
 
   declare agentMessageContents?: NonAttribute<AgentMessageContent[]>;
-
-  declare message?: NonAttribute<Message>;
+  // This points to the message associated with the agent message
+  declare agentMessage?: NonAttribute<Message>;
   declare feedbacks?: NonAttribute<AgentMessageFeedback[]>;
 }
 
@@ -379,7 +379,9 @@ AgentMessage.hasMany(AgentMessageFeedback, {
 UserModel.hasMany(AgentMessageFeedback, {
   onDelete: "SET NULL",
 });
-AgentMessageFeedback.belongsTo(UserModel);
+AgentMessageFeedback.belongsTo(UserModel, {
+  as: "user",
+});
 AgentMessageFeedback.belongsTo(AgentMessage, {
   as: "agentMessage",
 });
@@ -505,7 +507,7 @@ Message.belongsTo(UserMessage, {
 });
 
 AgentMessage.hasOne(Message, {
-  as: "message",
+  as: "agentMessage",
   foreignKey: { name: "agentMessageId", allowNull: true },
 });
 Message.belongsTo(AgentMessage, {

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -518,7 +518,7 @@ Message.belongsTo(Message, {
   foreignKey: { name: "parentId", allowNull: true },
 });
 ContentFragmentModel.hasOne(Message, {
-  as: "contentFragment",
+  as: "message",
   foreignKey: { name: "contentFragmentId", allowNull: true },
 });
 Message.belongsTo(ContentFragmentModel, {

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -244,8 +244,7 @@ export class AgentMessage extends BaseModel<AgentMessage> {
   declare agentConfigurationVersion: number;
 
   declare agentMessageContents?: NonAttribute<AgentMessageContent[]>;
-  // This points to the message associated with the agent message
-  declare agentMessage?: NonAttribute<Message>;
+  declare message?: NonAttribute<Message>;
   declare feedbacks?: NonAttribute<AgentMessageFeedback[]>;
 }
 
@@ -498,7 +497,7 @@ Message.belongsTo(Conversation, {
 });
 
 UserMessage.hasOne(Message, {
-  as: "userMessage",
+  as: "message",
   foreignKey: { name: "userMessageId", allowNull: true },
 });
 Message.belongsTo(UserMessage, {
@@ -507,7 +506,7 @@ Message.belongsTo(UserMessage, {
 });
 
 AgentMessage.hasOne(Message, {
-  as: "agentMessage",
+  as: "message",
   foreignKey: { name: "agentMessageId", allowNull: true },
 });
 Message.belongsTo(AgentMessage, {

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -382,7 +382,6 @@ UserModel.hasMany(AgentMessageFeedback, {
 AgentMessageFeedback.belongsTo(UserModel);
 AgentMessageFeedback.belongsTo(AgentMessage, {
   as: "agentMessage",
-  foreignKey: { allowNull: false },
 });
 
 export class Message extends BaseModel<Message> {

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -244,6 +244,9 @@ export class AgentMessage extends BaseModel<AgentMessage> {
   declare agentConfigurationVersion: number;
 
   declare agentMessageContents?: NonAttribute<AgentMessageContent[]>;
+
+  declare message?: NonAttribute<Message>;
+  declare feedbacks?: NonAttribute<AgentMessageFeedback[]>;
 }
 
 AgentMessage.init(
@@ -304,6 +307,9 @@ export class AgentMessageFeedback extends BaseModel<AgentMessageFeedback> {
 
   declare thumbDirection: AgentMessageFeedbackDirection;
   declare content: string | null;
+
+  declare agentMessage: NonAttribute<AgentMessage>;
+  declare user: NonAttribute<UserModel>;
 }
 
 AgentMessageFeedback.init(
@@ -367,10 +373,16 @@ Workspace.hasMany(AgentMessageFeedback, {
   onDelete: "RESTRICT",
 });
 AgentMessage.hasMany(AgentMessageFeedback, {
+  as: "feedbacks",
   onDelete: "RESTRICT",
 });
 UserModel.hasMany(AgentMessageFeedback, {
   onDelete: "SET NULL",
+});
+AgentMessageFeedback.belongsTo(UserModel);
+AgentMessageFeedback.belongsTo(AgentMessage, {
+  as: "agentMessage",
+  foreignKey: { allowNull: false },
 });
 
 export class Message extends BaseModel<Message> {
@@ -394,6 +406,8 @@ export class Message extends BaseModel<Message> {
   declare agentMessage?: NonAttribute<AgentMessage>;
   declare contentFragment?: NonAttribute<ContentFragmentModel>;
   declare reactions?: NonAttribute<MessageReaction[]>;
+
+  declare conversation?: NonAttribute<Conversation>;
 }
 
 Message.init(
@@ -492,7 +506,7 @@ Message.belongsTo(UserMessage, {
 });
 
 AgentMessage.hasOne(Message, {
-  as: "agentMessage",
+  as: "message",
   foreignKey: { name: "agentMessageId", allowNull: true },
 });
 Message.belongsTo(AgentMessage, {

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -100,7 +100,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
     agentConfiguration,
     filters,
   }: {
-    workspaceId: string;
+    workspaceId: number;
     withMetadata: boolean;
     agentConfiguration?: AgentConfigurationType;
     filters?: {
@@ -132,9 +132,11 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
     const agentMessageFeedback = await AgentMessageFeedback.findAll({
       where: {
         // Necessary for global models who share ids across workspaces
-        workspaceId,
+        workspaceId: workspaceId.toString(),
         // These clauses are optional
-        agentConfigurationId: agentConfiguration?.id,
+        agentConfigurationId: agentConfiguration?.sId
+          ? agentConfiguration.sId.toString()
+          : undefined,
         ...createdAtClause,
       },
 

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -143,6 +143,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
         },
         {
           model: UserResource.model,
+          as: "user",
           attributes: ["name", "imageUrl", "email"],
         },
       ],
@@ -222,6 +223,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
         },
         {
           model: UserResource.model,
+          as: "user",
           attributes: ["name", "email"],
         },
       ],

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -91,12 +91,12 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
   }
 
   static async fetch({
-    workspaceId,
+    workspace,
     withMetadata,
     agentConfiguration,
     filters,
   }: {
-    workspaceId: number;
+    workspace: WorkspaceType;
     withMetadata: boolean;
     agentConfiguration?: AgentConfigurationType;
     filters?: {
@@ -128,7 +128,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
     const agentMessageFeedback = await AgentMessageFeedback.findAll({
       where: {
         // Necessary for global models who share ids across workspaces
-        workspaceId: workspaceId.toString(),
+        workspaceId: workspace.id,
         // These clauses are optional
         ...(agentConfiguration
           ? {

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -187,7 +187,9 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
             agentMessageId: feedback.agentMessageId,
             userId: feedback.userId,
             thumbDirection: feedback.thumbDirection,
-            content: feedback.content?.replace(/\r?\n/g, "\\n") || null,
+            content: feedback.content
+              ? feedback.content.replace(/\r?\n/g, "\\n")
+              : null,
             isConversationShared: feedback.isConversationShared,
             createdAt: feedback.createdAt,
             agentConfigurationId: feedback.agentConfigurationId,
@@ -198,8 +200,8 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
               conversationId: feedback.isConversationShared
                 ? feedback.agentMessage.message.conversation.sId
                 : null,
-              userName: feedback.user.name || "",
-              userEmail: feedback.user.email || "",
+              userName: feedback.user.name,
+              userEmail: feedback.user.email,
               userImageUrl: feedback.user.imageUrl,
             }),
           };
@@ -210,14 +212,14 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
   static async getConversationFeedbacksForUser(
     auth: Authenticator,
     conversation: ConversationType | ConversationWithoutContentType
-  ): Promise<Result<AgentMessageFeedbackType[], ConversationError>> {
+  ): Promise<Result<AgentMessageFeedbackType[], ConversationError | Error>> {
     const owner = auth.workspace();
     if (!owner) {
-      throw new Error("Unexpected `auth` without `workspace`.");
+      return new Err(new Error("workspace_not_found"));
     }
     const user = auth.user();
     if (!user) {
-      throw new Error("Unexpected `auth` without `user`.");
+      return new Err(new Error("user_not_found"));
     }
 
     const feedbackForMessages = await Message.findAll({

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -134,9 +134,11 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
         // Necessary for global models who share ids across workspaces
         workspaceId: workspaceId.toString(),
         // These clauses are optional
-        agentConfigurationId: agentConfiguration?.sId
-          ? agentConfiguration.sId.toString()
-          : undefined,
+        ...(agentConfiguration
+          ? {
+              agentConfigurationId: agentConfiguration.sId.toString(),
+            }
+          : {}),
         ...createdAtClause,
       },
 

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -66,17 +66,13 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
     auth: Authenticator,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<undefined, Error>> {
-    try {
-      await this.model.destroy({
-        where: {
-          id: this.id,
-        },
-        transaction,
-      });
-      return new Ok(undefined);
-    } catch (err) {
-      return new Err(err as Error);
-    }
+    await this.model.destroy({
+      where: {
+        id: this.id,
+      },
+      transaction,
+    });
+    return new Ok(undefined);
   }
 
   async updateFields(
@@ -217,14 +213,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
     auth: Authenticator,
     conversation: ConversationType | ConversationWithoutContentType
   ): Promise<Result<AgentMessageFeedbackType[], ConversationError | Error>> {
-    const owner = auth.workspace();
-    if (!owner) {
-      return new Err(new Error("workspace_not_found"));
-    }
-    const user = auth.user();
-    if (!user) {
-      return new Err(new Error("user_not_found"));
-    }
+    const user = auth.getNonNullableUser();
 
     const feedbackForMessages = await Message.findAll({
       where: {

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -59,33 +59,6 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
     );
   }
 
-  static async fetchByUserAndAgentMessage({
-    auth,
-    user,
-    agentMessage,
-  }: {
-    auth: Authenticator;
-    user: UserType;
-    agentMessage: AgentMessage;
-  }): Promise<AgentMessageFeedbackResource | null> {
-    const agentMessageFeedback = await AgentMessageFeedback.findOne({
-      where: {
-        userId: user.id,
-        agentMessageId: agentMessage.id,
-        workspaceId: auth.getNonNullableWorkspace().id,
-      },
-    });
-
-    if (!agentMessageFeedback) {
-      return null;
-    }
-
-    return new AgentMessageFeedbackResource(
-      AgentMessageFeedback,
-      agentMessageFeedback.get()
-    );
-  }
-
   async updateFields(
     blob: Partial<
       Pick<

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -1,18 +1,30 @@
 import type {
   AgentConfigurationType,
+  AgentMessageType,
+  ConversationError,
+  ConversationType,
+  ConversationWithoutContentType,
+  MessageType,
   Result,
   UserType,
   WorkspaceType,
 } from "@dust-tt/types";
+import { GLOBAL_AGENTS_SID } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 import type { Attributes, ModelStatic } from "sequelize";
 import type { CreationAttributes, Transaction } from "sequelize";
 import { Op } from "sequelize";
 
-import type { AgentMessageFeedbackDirection } from "@app/lib/api/assistant/conversation/feedbacks";
+import type { AgentMessageFeedbackType } from "@app/lib/api/assistant/feedback";
 import type { Authenticator } from "@app/lib/auth";
-import type { AgentMessage } from "@app/lib/models/assistant/conversation";
-import { AgentMessageFeedback } from "@app/lib/models/assistant/conversation";
+import { AgentConfiguration } from "@app/lib/models/assistant/agent";
+import { AgentMessage } from "@app/lib/models/assistant/conversation";
+import {
+  AgentMessage as AgentMessageModel,
+  AgentMessageFeedback,
+  Conversation,
+  Message,
+} from "@app/lib/models/assistant/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -47,27 +59,12 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
     );
   }
 
-  static async listByAgentConfigurationId({
-    agentConfiguration,
-  }: {
-    agentConfiguration: AgentConfigurationType;
-  }): Promise<AgentMessageFeedbackResource[] | null> {
-    const agentMessageFeedback = await AgentMessageFeedback.findAll({
-      where: {
-        agentConfigurationId: agentConfiguration.sId,
-      },
-      order: [["id", "DESC"]],
-    });
-
-    return agentMessageFeedback.map(
-      (feedback) => new this(this.model, feedback.get())
-    );
-  }
-
   static async fetchByUserAndAgentMessage({
+    auth,
     user,
     agentMessage,
   }: {
+    auth: Authenticator;
     user: UserType;
     agentMessage: AgentMessage;
   }): Promise<AgentMessageFeedbackResource | null> {
@@ -75,6 +72,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
       where: {
         userId: user.id,
         agentMessageId: agentMessage.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
       },
     });
 
@@ -88,24 +86,74 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
     );
   }
 
-  static async fetchByUserAndAgentMessages(
-    user: UserType,
-    agentMessages: AgentMessage[]
-  ): Promise<AgentMessageFeedbackResource[]> {
-    const agentMessageFeedback = await AgentMessageFeedback.findAll({
-      where: {
-        userId: user.id,
-        agentMessageId: {
-          [Op.in]: agentMessages.map((m) => m.id),
-        },
-      },
-    });
-
-    return agentMessageFeedback.map(
-      (feedback) => new this(this.model, feedback.get())
-    );
+  async updateFields(
+    blob: Partial<
+      Pick<
+        AgentMessageFeedback,
+        "content" | "thumbDirection" | "isConversationShared"
+      >
+    >
+  ) {
+    return this.update(blob);
   }
 
+  static async fetchByAgentConfigurationId({
+    auth,
+    agentConfigurationId,
+    pagination,
+  }: {
+    auth: Authenticator;
+    agentConfigurationId: string;
+    pagination: {
+      limit: number;
+      olderThan?: Date;
+    };
+  }): Promise<AgentMessageFeedback[]> {
+    const agentMessageFeedback = await AgentMessageFeedback.findAll({
+      where: {
+        agentConfigurationId,
+        // Necessary for global models who share ids across workspaces
+        workspaceId: auth.getNonNullableWorkspace().id,
+        ...(pagination.olderThan && {
+          createdAt: {
+            [Op.lt]: pagination.olderThan,
+          },
+        }),
+      },
+
+      include: [
+        {
+          model: AgentMessageModel,
+          attributes: ["id"],
+          as: "agentMessage",
+          include: [
+            {
+              model: Message,
+              as: "message",
+              attributes: ["id", "sId"],
+              include: [
+                {
+                  model: Conversation,
+                  as: "conversation",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          model: UserResource.model,
+          attributes: ["name", "imageUrl"],
+        },
+      ],
+      order: [
+        ["agentConfigurationVersion", "DESC"],
+        ["createdAt", "DESC"],
+      ],
+      limit: pagination.limit,
+    });
+
+    return agentMessageFeedback;
+  }
   static async listByWorkspaceAndDateRange({
     workspace,
     startDate,
@@ -129,32 +177,209 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
     return feedbacks;
   }
 
+  static async getConversationFeedbacksForUser(
+    auth: Authenticator,
+    conversation: ConversationType | ConversationWithoutContentType
+  ): Promise<Result<AgentMessageFeedbackType[], ConversationError>> {
+    const owner = auth.workspace();
+    if (!owner) {
+      throw new Error("Unexpected `auth` without `workspace`.");
+    }
+    const user = auth.user();
+    if (!user) {
+      throw new Error("Unexpected `auth` without `user`.");
+    }
+
+    const feedbackForMessages = await Message.findAll({
+      where: {
+        conversationId: conversation.id,
+        agentMessageId: {
+          [Op.ne]: null,
+        },
+      },
+      attributes: ["id", "sId", "agentMessageId"],
+      include: [
+        {
+          model: AgentMessage,
+          as: "agentMessage",
+          include: [
+            {
+              model: AgentMessageFeedbackResource.model,
+              as: "feedbacks",
+              where: {
+                userId: user.id,
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const feedbacksWithMessageId = feedbackForMessages
+      // typeguard needed because of TypeScript limitations
+      .filter(
+        (
+          message
+        ): message is Message & {
+          agentMessage: { feedbacks: AgentMessageFeedbackResource[] };
+        } =>
+          !!message.agentMessage?.feedbacks &&
+          message.agentMessage.feedbacks.length > 0
+      )
+      .map((message) => {
+        // Only one feedback can be associated with a message
+        const feedback = message.agentMessage.feedbacks[0];
+        return {
+          id: feedback.id,
+          messageId: message.sId,
+          agentMessageId: feedback.agentMessageId,
+          userId: feedback.userId,
+          thumbDirection: feedback.thumbDirection,
+          content: feedback.content,
+          isConversationShared: feedback.isConversationShared,
+        } as AgentMessageFeedbackType;
+      });
+
+    return new Ok(feedbacksWithMessageId);
+  }
+
   async fetchUser(): Promise<UserResource | null> {
     const users = await UserResource.fetchByModelIds([this.userId]);
     return users[0] ?? null;
   }
 
-  async updateContentAndThumbDirection(
-    content: string,
-    thumbDirection: AgentMessageFeedbackDirection
-  ): Promise<Result<undefined, Error>> {
-    try {
-      await this.model.update(
+  static async getFeedbackWithConversationContext({
+    auth,
+    messageId,
+    conversation,
+    user,
+  }: {
+    auth: Authenticator;
+    messageId: string;
+    conversation: ConversationType | ConversationWithoutContentType;
+    user: UserType;
+  }): Promise<
+    Result<
+      {
+        message: Pick<MessageType, "id" | "sId">;
+        agentMessage: Pick<AgentMessageType, "id"> & {
+          agentConfigurationId: string;
+          agentConfigurationVersion: number;
+        };
+        feedback: AgentMessageFeedbackResource | null;
+      } & ( // Either the agent is not global and has a configuration
+        | {
+            agentConfiguration: Pick<
+              AgentConfigurationType,
+              "id" | "sId" | "version"
+            >;
+            isGlobalAgent: false;
+          }
+        // Or the agent is global and has no configuration
+        | {
+            agentConfiguration: null;
+            isGlobalAgent: true;
+          }
+      ),
+      Error
+    >
+  > {
+    const message = await Message.findOne({
+      attributes: ["id", "sId"],
+      where: {
+        sId: messageId,
+        conversationId: conversation.id,
+      },
+      include: [
         {
-          content,
-          thumbDirection,
+          model: AgentMessage,
+          as: "agentMessage",
+          attributes: [
+            "id",
+            "sId",
+            "agentConfigurationId",
+            "agentConfigurationVersion",
+          ],
         },
-        {
-          where: {
-            id: this.id,
-          },
-        }
-      );
+      ],
+    });
 
-      return new Ok(undefined);
-    } catch (error) {
-      return new Err(error as Error);
+    if (!message || !message.agentMessageId) {
+      return new Err(
+        new Error("Message not found or not associated with an agent message")
+      );
     }
+
+    if (!message.agentMessage) {
+      return new Err(new Error("Agent message not found"));
+    }
+
+    const agentMessageFeedback = await AgentMessageFeedback.findOne({
+      where: {
+        userId: user.id,
+        agentMessageId: message.agentMessage.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+    const agentMessageFeedbackResource = agentMessageFeedback
+      ? new AgentMessageFeedbackResource(
+          AgentMessageFeedback,
+          agentMessageFeedback.get()
+        )
+      : null;
+
+    const isGlobalAgent = Object.values(GLOBAL_AGENTS_SID).includes(
+      message.agentMessage.agentConfigurationId as GLOBAL_AGENTS_SID
+    );
+
+    if (isGlobalAgent) {
+      return new Ok({
+        message: {
+          id: message.id,
+          sId: message.sId,
+        },
+        agentMessage: {
+          id: message.agentMessage.id,
+          agentConfigurationId: message.agentMessage.agentConfigurationId,
+          agentConfigurationVersion:
+            message.agentMessage.agentConfigurationVersion,
+        },
+        feedback: agentMessageFeedbackResource,
+        agentConfiguration: null,
+        isGlobalAgent: true,
+      });
+    }
+
+    const agentConfiguration = await AgentConfiguration.findOne({
+      where: {
+        sId: message.agentMessage.agentConfigurationId,
+      },
+      attributes: ["id", "sId", "version"],
+    });
+
+    if (!agentConfiguration) {
+      return new Err(new Error("Agent configuration not found"));
+    }
+
+    return new Ok({
+      message: {
+        id: message.id,
+        sId: message.sId,
+      },
+      agentMessage: {
+        id: message.agentMessage.id,
+        agentConfigurationId: message.agentMessage.agentConfigurationId,
+        agentConfigurationVersion:
+          message.agentMessage.agentConfigurationVersion,
+      },
+      feedback: agentMessageFeedbackResource,
+      agentConfiguration: {
+        id: agentConfiguration.id,
+        sId: agentConfiguration.sId,
+        version: agentConfiguration.version,
+      },
+      isGlobalAgent,
+    });
   }
 
   async delete(

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/feedbacks.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/feedbacks.ts
@@ -16,7 +16,7 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  const { aId } = req.query;
+  const { aId, limit } = req.query;
 
   if (typeof aId !== "string") {
     return apiError(req, res, {
@@ -42,13 +42,26 @@ async function handler(
 
   switch (req.method) {
     case "GET":
+      if (
+        limit !== undefined &&
+        (typeof limit !== "string" || isNaN(parseInt(limit)))
+      ) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "The request query is invalid, expects { limit: number }.",
+          },
+        });
+      }
+
       const feedbacksRes = await getAgentFeedbacks({
         auth,
         agentConfigurationId: aId,
         withMetadata: req.query.withMetadata === "true",
         filters: {
           // Limit the number of feedbacks to retrieve.
-          limit: req.query.limit ? parseInt(req.query.limit as string) : 50,
+          limit: limit ? parseInt(limit as string) : 50,
           olderThan: req.query.olderThan
             ? new Date(req.query.olderThan as string)
             : undefined,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/feedbacks.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/feedbacks.ts
@@ -42,19 +42,6 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      if (
-        limit !== undefined &&
-        (typeof limit !== "string" || isNaN(parseInt(limit)))
-      ) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: "The request query is invalid, expects { limit: number }.",
-          },
-        });
-      }
-
       const feedbacksRes = await getAgentFeedbacks({
         auth,
         agentConfigurationId: aId,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/feedbacks.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/feedbacks.ts
@@ -1,0 +1,78 @@
+import type { WithAPIErrorResponse } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
+import type { AgentMessageFeedbackType } from "@app/lib/api/assistant/feedback";
+import { getAgentFeedbacks } from "@app/lib/api/assistant/feedback";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<{ feedbacks: AgentMessageFeedbackType[] }>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  const { aId } = req.query;
+
+  if (typeof aId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `aId` (string) is required.",
+      },
+    });
+  }
+
+  // Make sure the agent configuration is accessible by the user
+  const agentConfiguration = await getAgentConfiguration(auth, aId);
+  if (!agentConfiguration) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "agent_configuration_not_found",
+        message: "The agent configuration was not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const feedbacksRes = await getAgentFeedbacks({
+        auth,
+        agentConfigurationId: aId,
+        withMetadata: req.query.withMetadata === "true",
+        filters: {
+          // Limit the number of feedbacks to retrieve.
+          limit: req.query.limit ? parseInt(req.query.limit as string) : 50,
+          olderThan: req.query.olderThan
+            ? new Date(req.query.olderThan as string)
+            : undefined,
+        },
+      });
+
+      if (feedbacksRes.isErr()) {
+        return apiErrorForConversation(req, res, feedbacksRes.error);
+      }
+
+      const feedbacks = feedbacksRes.value;
+
+      res.status(200).json({ feedbacks });
+      return;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/feedbacks.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/feedbacks.ts
@@ -28,7 +28,7 @@ async function handler(
     });
   }
 
-  // Make sure the agent configuration is accessible by the user
+  // IMPORTANT: make sure the agent configuration is accessible by the user.
   const agentConfiguration = await getAgentConfiguration(auth, aId);
   if (!agentConfiguration) {
     return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks/index.ts
@@ -8,8 +8,8 @@ import type { AgentMessageFeedbackDirection } from "@app/lib/api/assistant/conve
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation/without_content";
 import {
-  createOrUpdateMessageFeedback,
   deleteMessageFeedback,
+  upsertMessageFeedback,
 } from "@app/lib/api/assistant/feedback";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -79,7 +79,7 @@ async function handler(
         });
       }
 
-      const created = await createOrUpdateMessageFeedback(auth, {
+      const created = await upsertMessageFeedback(auth, {
         messageId,
         conversation,
         user,


### PR DESCRIPTION
## Description
Smaller version of https://github.com/dust-tt/dust/pull/9368, only focused on API and resources
-> AgentMessageFeedbackResource handles sequelize basic db operations
-> front/lib.api.assistants/feedback manages extra logic around feedback creation (esp. around configurationID for global models)
-> Added a few non-attributes to model to allow sequelize joins

## Risk
Break feedbacks

## Deploy Plan
Deploy front, no migration needed.
