### PR TITLE
[landing-page] Update Blog section thumbnails

### DIFF
--- a/front/components/home/content/Product/BlogSection.tsx
+++ b/front/components/home/content/Product/BlogSection.tsx
@@ -73,7 +73,7 @@ export function BlogSection({
                 href="https://blog.dust.tt/integrating-ai-workflows-alan/"
               >
                 <img
-                  src="https://blog.dust.tt/content/images/size/w2000/2024/07/blog_alan.png"
+                  src="https://blog.dust.tt/content/images/size/w2000/2024/12/alan_dust_customer_story_.png"
                   alt="Blog Image"
                 />
               </BlogBlock>
@@ -85,7 +85,7 @@ export function BlogSection({
                 href="https://blog.dust.tt/pennylane-dust-customer-support-journey/"
               >
                 <img
-                  src="https://blog.dust.tt/content/images/size/w2000/2024/07/blog_penny.png"
+                  src="https://blog.dust.tt/content/images/size/w2000/2024/12/pennylane_dust_customer_story.png"
                   alt="Blog Image"
                 />
               </BlogBlock>


### PR DESCRIPTION
## Description

- Close [#1861](https://github.com/dust-tt/tasks/issues/1861)
- Update 2 thumbnails in the Carousel within the Blog section.

Before:

<img width="2560" alt="Screenshot 2024-12-23 at 2 39 24 PM" src="https://github.com/user-attachments/assets/2e85d24e-f03e-4012-b854-8cbaf81cc3c1" />

After:

<img width="2560" alt="Screenshot 2024-12-23 at 2 38 46 PM" src="https://github.com/user-attachments/assets/3fac02fc-a54b-471e-bcb7-08dac051be79" />

## Risk

- UI changes

## Deploy Plan

- Deploy front
