### PR TITLE
[KW search] Read the parents from `data_sources_nodes` instead of `data_sources_documents` or `tables`

### DIFF
--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -1996,7 +1996,7 @@ impl Store for PostgresStore {
 
         let sql = format!(
             "SELECT dsd.id, dsd.created, dsd.document_id, dsd.timestamp, dsd.tags_array, \
-               dsd.parents, dsd.source_url, dsd.hash, dsd.text_size, dsd.chunk_count, \
+               dsn.parents, dsd.source_url, dsd.hash, dsd.text_size, dsd.chunk_count, \
                dsn.title, dsn.mime_type \
                FROM data_sources_documents dsd \
                INNER JOIN data_sources_nodes dsn ON dsn.document=dsd.id \


### PR DESCRIPTION
## Description

- Close [#1844](https://github.com/dust-tt/tasks/issues/1844)
- Parents should be read from the table `data_sources_nodes` intead of `data_sources_documents` or `tables`.
- Columns parents from `data_sources_documents` and `tables` will be cleaned in the future, we will have 1 source of truth.

## Risk

- potentially high but rollbackable.

## Deploy Plan

- Deploy core.
