### PR TITLE
[poke] improve error message on FF failed change

### DIFF
--- a/front/components/poke/features/columns.tsx
+++ b/front/components/poke/features/columns.tsx
@@ -69,18 +69,15 @@ async function toggleFeatureFlag(
       }),
     });
     if (!r.ok) {
-      throw new Error("Failed to disable feature.");
+      const error: { error: { message: string } } = await r.json();
+      throw new Error(error.error.message);
     }
 
     reload();
   } catch (e) {
     sendNotification({
       title: "Error",
-      description: `An error occurred while toggling feature "${feature}": ${JSON.stringify(
-        e,
-        null,
-        2
-      )}`,
+      description: `An error occurred while toggling feature "${feature}": ${e}`,
       type: "error",
     });
   }

--- a/front/components/poke/features/columns.tsx
+++ b/front/components/poke/features/columns.tsx
@@ -71,8 +71,6 @@ async function toggleFeatureFlag(
     if (!r.ok) {
       throw new Error("Failed to disable feature.");
     }
-
-    reload();
   } catch (e) {
     sendNotification({
       title: "Error",
@@ -84,4 +82,5 @@ async function toggleFeatureFlag(
       type: "error",
     });
   }
+  reload();
 }

--- a/front/components/poke/features/columns.tsx
+++ b/front/components/poke/features/columns.tsx
@@ -71,6 +71,8 @@ async function toggleFeatureFlag(
     if (!r.ok) {
       throw new Error("Failed to disable feature.");
     }
+
+    reload();
   } catch (e) {
     sendNotification({
       title: "Error",
@@ -82,5 +84,4 @@ async function toggleFeatureFlag(
       type: "error",
     });
   }
-  reload();
 }


### PR DESCRIPTION
## Description

- Close [#1862](https://github.com/dust-tt/tasks/issues/1862)
- This PR aims at adding the error message in the notification, which was currently always empty, in order to mitigate the impact on UX when getting [this error](https://app.datadoghq.eu/logs?query=%40url%3A%2A%2Ffeatures%20status%3Aerror&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZPz4YBmuAf7BgAAABhBWlB6NFlXcEFBQ29HYThPX3BPUnRRQ0wAAAAkMDE5M2Y0MDMtNDYyNS00ZDAyLWJmZGItNjUzYmU3ODNiMjc2AASj1w&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=7335969944735129240&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1734953868634&to_ts=1734968268634&live=true) (The feature flag already exists.) while seeing the FF disabled in the UI then the user is stuck and can click repeatedly not knowing the FF is actually enabled.

## Risk

- Low.

## Deploy Plan

- Deploy front.
