### PR TITLE
cleanup(GitHub) - remove all the v2 from the workflow names

### DIFF
--- a/connectors/src/connectors/github/temporal/client.ts
+++ b/connectors/src/connectors/github/temporal/client.ts
@@ -23,11 +23,11 @@ import {
   githubCodeSyncWorkflow,
   githubDiscussionGarbageCollectWorkflow,
   githubDiscussionSyncWorkflow,
-  githubFullSyncWorkflowV2,
+  githubFullSyncWorkflow,
   githubIssueGarbageCollectWorkflow,
   githubIssueSyncWorkflow,
   githubRepoGarbageCollectWorkflow,
-  githubReposSyncWorkflowV2,
+  githubReposSyncWorkflow,
 } from "@connectors/connectors/github/temporal/workflows";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { getTemporalClient } from "@connectors/lib/temporal";
@@ -68,7 +68,7 @@ export async function launchGithubFullSyncWorkflow({
     return;
   }
 
-  await client.workflow.start(githubFullSyncWorkflowV2, {
+  await client.workflow.start(githubFullSyncWorkflow, {
     args: [dataSourceConfig, connectorId, syncCodeOnly, forceCodeResync],
     taskQueue: QUEUE_NAME,
     workflowId: getFullSyncWorkflowId(connectorId),
@@ -87,7 +87,7 @@ export async function getGithubFullSyncWorkflow(connectorId: ModelId): Promise<{
 } | null> {
   const client = await getTemporalClient();
 
-  const handle: WorkflowHandle<typeof githubFullSyncWorkflowV2> =
+  const handle: WorkflowHandle<typeof githubFullSyncWorkflow> =
     client.workflow.getHandle(getFullSyncWorkflowId(connectorId));
 
   try {
@@ -116,7 +116,7 @@ export async function launchGithubReposSyncWorkflow(
   }
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
 
-  await client.workflow.start(githubReposSyncWorkflowV2, {
+  await client.workflow.start(githubReposSyncWorkflow, {
     args: [dataSourceConfig, connectorId, orgLogin, repos],
     taskQueue: QUEUE_NAME,
     workflowId: getReposSyncWorkflowId(connectorId),

--- a/connectors/src/connectors/github/temporal/workflows.ts
+++ b/connectors/src/connectors/github/temporal/workflows.ts
@@ -63,9 +63,8 @@ const MAX_CONCURRENT_ISSUE_SYNC_ACTIVITIES_PER_WORKFLOW = 8;
 
 /**
  * This workflow is used to fetch and sync all the repositories of a GitHub connector.
- * It's called v2 because we had to add it when there was already a workflow without the v2 to avoid non-deterministic errors.
  */
-export async function githubFullSyncWorkflowV2(
+export async function githubFullSyncWorkflow(
   dataSourceConfig: DataSourceConfig,
   connectorId: ModelId,
   // Used to re-trigger a code-only full-sync after code syncing is enabled/disabled.
@@ -95,7 +94,7 @@ export async function githubFullSyncWorkflowV2(
       const childWorkflowId = `${fullSyncWorkflowId}-repo-${repo.id}-syncCodeOnly-${syncCodeOnly}`;
       promises.push(
         queue.add(() =>
-          executeChild(githubRepoSyncWorkflowV2, {
+          executeChild(githubRepoSyncWorkflow, {
             workflowId: childWorkflowId,
             searchAttributes: {
               connectorId: [connectorId],
@@ -127,9 +126,8 @@ export async function githubFullSyncWorkflowV2(
 
 /**
  * This workflow is used to sync the given repositories of a GitHub connector.
- * It's called v2 because we had to add it when there was already a workflow without the v2 to avoid non-deterministic errors.
  */
-export async function githubReposSyncWorkflowV2(
+export async function githubReposSyncWorkflow(
   dataSourceConfig: DataSourceConfig,
   connectorId: ModelId,
   orgLogin: string,
@@ -143,7 +141,7 @@ export async function githubReposSyncWorkflowV2(
     const childWorkflowId = `${reposSyncWorkflowId}-repo-${repo.id}`;
     promises.push(
       queue.add(() =>
-        executeChild(githubRepoSyncWorkflowV2, {
+        executeChild(githubRepoSyncWorkflow, {
           workflowId: childWorkflowId,
           searchAttributes: {
             connectorId: [connectorId],
@@ -172,9 +170,8 @@ export async function githubReposSyncWorkflowV2(
 
 /**
  * This workflow is used to sync all the issues of a GitHub connector.
- * It's called v2 because we had to add it when there was already a workflow without the v2 to avoid non-deterministic errors.
  */
-export async function githubRepoIssuesSyncWorkflowV2({
+export async function githubRepoIssuesSyncWorkflow({
   dataSourceConfig,
   connectorId,
   repoName,
@@ -233,9 +230,8 @@ export async function githubRepoIssuesSyncWorkflowV2({
 
 /**
  * This workflow is used to sync all the discussions of a GitHub connector.
- * It's called v2 because we had to add it when there was already a workflow without the v2 to avoid non-deterministic errors.
  */
-export async function githubRepoDiscussionsSyncWorkflowV2({
+export async function githubRepoDiscussionsSyncWorkflow({
   dataSourceConfig,
   connectorId,
   repoName,
@@ -291,9 +287,8 @@ export async function githubRepoDiscussionsSyncWorkflowV2({
 
 /**
  * This workflow is used to sync all the issues, discussions and code of a GitHub connector.
- * It's called v2 because we had to add it when there was already a workflow without the v2 to avoid non-deterministic errors.
  */
-export async function githubRepoSyncWorkflowV2({
+export async function githubRepoSyncWorkflow({
   dataSourceConfig,
   connectorId,
   repoName,
@@ -324,27 +319,24 @@ export async function githubRepoSyncWorkflowV2({
           : getReposSyncWorkflowId(connectorId)
       }-repo-${repoId}-issues-page-${pageNumber}`;
 
-      const shouldContinue = await executeChild(
-        githubRepoIssuesSyncWorkflowV2,
-        {
-          workflowId: childWorkflowId,
-          searchAttributes: {
-            connectorId: [connectorId],
+      const shouldContinue = await executeChild(githubRepoIssuesSyncWorkflow, {
+        workflowId: childWorkflowId,
+        searchAttributes: {
+          connectorId: [connectorId],
+        },
+        args: [
+          {
+            dataSourceConfig,
+            connectorId,
+            repoName,
+            repoId,
+            repoLogin,
+            pageNumber,
           },
-          args: [
-            {
-              dataSourceConfig,
-              connectorId,
-              repoName,
-              repoId,
-              repoLogin,
-              pageNumber,
-            },
-          ],
-          parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE,
-          memo: workflowInfo().memo,
-        }
-      );
+        ],
+        parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE,
+        memo: workflowInfo().memo,
+      });
 
       if (!shouldContinue) {
         break;
@@ -361,7 +353,7 @@ export async function githubRepoSyncWorkflowV2({
           : getReposSyncWorkflowId(connectorId)
       }-repo-${repoId}-issues-page-${cursorIteration}`;
 
-      nextCursor = await executeChild(githubRepoDiscussionsSyncWorkflowV2, {
+      nextCursor = await executeChild(githubRepoDiscussionsSyncWorkflow, {
         workflowId: childWorkflowId,
         searchAttributes: {
           connectorId: [connectorId],


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/9623 and https://github.com/dust-tt/dust/pull/9562
- The workflow names contain `v2` as a result of the operation underwent in https://github.com/dust-tt/dust/pull/9562 to change workflow code without causing non-deterministic errors.
- No affected workflow currently running in https://cloud.temporal.io/namespaces/dust-prod.gmnlm/workflows?query=%60WorkflowId%60+STARTS_WITH+%22workflow-github%22

## Risk

- could cause non-deterministic errors if a modified workflow is running.

## Deploy Plan

- Deploy connectors.
