### PR TITLE
[Assistant Details] Favorites button correctly disabled while updating

### DIFF
--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -32,10 +32,11 @@ export function AssistantDetails({
 }: AssistantDetailsProps) {
   const [isUpdatingScope, setIsUpdatingScope] = useState(false);
 
-  const { agentConfiguration } = useAgentConfiguration({
-    workspaceId: owner.sId,
-    agentConfigurationId: assistantId,
-  });
+  const { agentConfiguration, isAgentConfigurationValidating } =
+    useAgentConfiguration({
+      workspaceId: owner.sId,
+      agentConfigurationId: assistantId,
+    });
 
   const doUpdateScope = useUpdateAgentScope({
     owner,
@@ -86,6 +87,7 @@ export function AssistantDetails({
         <AssistantDetailsButtonBar
           owner={owner}
           agentConfiguration={agentConfiguration}
+          isAgentConfigurationValidating={isAgentConfigurationValidating}
         />
       )}
 

--- a/front/components/assistant/AssistantDetailsButtonBar.tsx
+++ b/front/components/assistant/AssistantDetailsButtonBar.tsx
@@ -31,10 +31,12 @@ interface AssistantDetailsButtonBarProps {
   canDelete?: boolean;
   isMoreInfoVisible?: boolean;
   showAddRemoveToFavorite?: boolean;
+  isAgentConfigurationValidating: boolean;
 }
 
 export function AssistantDetailsButtonBar({
   agentConfiguration,
+  isAgentConfigurationValidating,
   owner,
 }: AssistantDetailsButtonBarProps) {
   const { user } = useUser();
@@ -118,19 +120,22 @@ export function AssistantDetailsButtonBar({
     // builders can all edit, non-builders can only edit personal/shared assistants
     isBuilder(owner) || !(agentConfiguration.scope === "workspace");
 
+  const isFavoriteDisabled =
+    isAgentConfigurationValidating || isUpdatingFavorite;
+
   return (
     <div className="flex flex-row items-center gap-2 px-1.5">
       <div className="group">
         <Button
           icon={
-            agentConfiguration.userFavorite || isUpdatingFavorite
+            agentConfiguration.userFavorite || isFavoriteDisabled
               ? StarIcon
               : StarStrokeIcon
           }
           size="sm"
           className="group-hover:hidden"
           variant="outline"
-          disabled={isUpdatingFavorite}
+          disabled={isFavoriteDisabled}
           onClick={() => updateUserFavorite(!agentConfiguration.userFavorite)}
         />
 
@@ -139,7 +144,7 @@ export function AssistantDetailsButtonBar({
           size="sm"
           className="hidden group-hover:block"
           variant="outline"
-          disabled={isUpdatingFavorite}
+          disabled={isFavoriteDisabled}
           onClick={() => updateUserFavorite(!agentConfiguration.userFavorite)}
         />
       </div>

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -210,7 +210,7 @@ export function useAgentConfiguration({
     agentConfiguration: AgentConfigurationType;
   }> = fetcher;
 
-  const { data, error, mutate } = useSWRWithDefaults(
+  const { data, error, mutate, isValidating } = useSWRWithDefaults(
     agentConfigurationId
       ? `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}`
       : null,
@@ -222,6 +222,7 @@ export function useAgentConfiguration({
     agentConfiguration: data ? data.agentConfiguration : null,
     isAgentConfigurationLoading: !error && !data,
     isAgentConfigurationError: error,
+    isAgentConfigurationValidating: isValidating,
     mutateAgentConfiguration: mutate,
   };
 }


### PR DESCRIPTION
Description
---
Fixes #8933 (again)

Former code relied only on `isUpdatingUserFavorite` to show the button properly disabled.

There was an issue since the update finishes `before` the mutation of state fully propagates to agents: first, mutate returns stale data while revalidating (swr); the `await` does not mean we wait for full revalidation.
If updating favorites is finished before revalidation has occured, which is quite likely, then the button will show active with a wrong state.

It's only after revalidation has finished that the button should be re-enabled. This is what the fix is doing in this PR.

Risks
---
none

Deploy
---
front