### PR TITLE
enh: send tracker email to all recipients at once

### DIFF
--- a/front/lib/api/assistant/email_trigger.ts
+++ b/front/lib/api/assistant/email_trigger.ts
@@ -506,5 +506,5 @@ export async function replyToEmail({
     html,
   };
 
-  await sendEmail(email.envelope.from, msg);
+  await sendEmail([email.envelope.from], msg);
 }

--- a/front/lib/api/email.ts
+++ b/front/lib/api/email.ts
@@ -22,7 +22,7 @@ export function getSgMailClient(): any {
 
 export async function sendGithubDeletionEmail(email: string): Promise<void> {
   await sendEmailWithTemplate({
-    to: email,
+    to: [email],
     from: {
       name: "Dust team",
       email: "support@dust.help",
@@ -49,7 +49,7 @@ export async function sendCancelSubscriptionEmail(
   const formattedDate = date.toLocaleDateString("en-US", options);
 
   await sendEmailWithTemplate({
-    to: email,
+    to: [email],
     from: {
       name: "Dust team",
       email: "support@dust.help",
@@ -73,7 +73,7 @@ export async function sendReactivateSubscriptionEmail(
   email: string
 ): Promise<void> {
   await sendEmailWithTemplate({
-    to: email,
+    to: [email],
     from: {
       name: "Dust team",
       email: "support@dust.help",
@@ -91,7 +91,7 @@ export async function sendAdminSubscriptionPaymentFailedEmail(
   customerPortailUrl: string | null
 ): Promise<void> {
   await sendEmailWithTemplate({
-    to: email,
+    to: [email],
     from: {
       name: "Dust team",
       email: "support@dust.help",
@@ -118,7 +118,7 @@ export async function sendAdminDataDeletionEmail({
   isLast: boolean;
 }): Promise<void> {
   await sendEmailWithTemplate({
-    to: email,
+    to: [email],
     from: {
       name: "Dust team",
       email: "support@dust.help",
@@ -139,7 +139,7 @@ export async function sendProactiveTrialCancelledEmail(
   email: string
 ): Promise<void> {
   await sendEmailWithTemplate({
-    to: email,
+    to: [email],
     from: {
       name: "Gabriel Hubert",
       email: "gabriel@dust.tt",
@@ -158,14 +158,14 @@ export async function sendProactiveTrialCancelledEmail(
 }
 
 // Avoid using this function directly, use sendEmailWithTemplate instead.
-export async function sendEmail(email: string, message: any) {
-  const msg = { ...message, to: email };
+export async function sendEmail(to: string[], message: any) {
+  const msg = { ...message, to };
 
   // In dev we want to make sure we don't send emails to real users.
   // We prevent sending an email if it's not to a @dust.tt address.
-  if (isDevelopment() && !email.endsWith("@dust.tt")) {
+  if (isDevelopment() && !to.every((email) => email.endsWith("@dust.tt"))) {
     logger.error(
-      { email, subject: message.subject },
+      { emails: to, subject: message.subject },
       "Prevented sending email in development mode to an external email."
     );
     return;
@@ -173,17 +173,17 @@ export async function sendEmail(email: string, message: any) {
 
   try {
     await getSgMailClient().send(msg);
-    logger.info({ email, subject: message.subject }, "Sending email");
+    logger.info({ emails: to, subject: message.subject }, "Sending email");
   } catch (error) {
     logger.error(
-      { error, email, subject: message.subject },
+      { error, emails: to, subject: message.subject },
       "Error sending email."
     );
   }
 }
 
 interface sendEmailWithTemplateParams {
-  to: string;
+  to: string[];
   from: {
     email: string;
     name: string;
@@ -219,7 +219,7 @@ export async function sendEmailWithTemplate({
     logger.error(
       {
         error: e,
-        to,
+        emails: to,
         subject,
       },
       "Error sending email."

--- a/front/lib/api/tracker.ts
+++ b/front/lib/api/tracker.ts
@@ -82,27 +82,27 @@ const sendTrackerEmail = async ({
     throw new Error("No recipients found for tracker");
   }
 
-  const sendEmail =
-    generations.length > 0
-      ? _sendTrackerWithGenerationEmail
-      : _sendTrackerDefaultEmail;
-
-  await Promise.all(
-    Array.from(recipients).map((recipient) =>
-      sendEmail({ name, recipient, generations, localLogger })
-    )
-  );
+  if (generations.length) {
+    await _sendTrackerWithGenerationEmails({
+      name,
+      recipients,
+      generations,
+      localLogger,
+    });
+  } else {
+    await _sendTrackerDefaultEmails({ name, recipients });
+  }
 };
 
-const _sendTrackerDefaultEmail = async ({
+const _sendTrackerDefaultEmails = async ({
   name,
-  recipient,
+  recipients,
 }: {
   name: string;
-  recipient: string;
+  recipients: string[];
 }): Promise<void> => {
   await sendEmailWithTemplate({
-    to: recipient,
+    to: recipients,
     from: {
       name: TRACKER_FROM_NAME,
       email: TRACKER_FROM_EMAIL,
@@ -115,14 +115,14 @@ const _sendTrackerDefaultEmail = async ({
   });
 };
 
-const _sendTrackerWithGenerationEmail = async ({
+const _sendTrackerWithGenerationEmails = async ({
   name,
-  recipient,
+  recipients,
   generations,
   localLogger,
 }: {
   name: string;
-  recipient: string;
+  recipients: string[];
   generations: TrackerGenerationToProcess[];
   localLogger: Logger;
 }): Promise<void> => {
@@ -193,7 +193,7 @@ ${generationBody.join("<br />")}
 `;
 
   await sendEmailWithTemplate({
-    to: recipient,
+    to: recipients,
     from: {
       name: TRACKER_FROM_NAME,
       email: TRACKER_FROM_EMAIL,

--- a/front/mailing/20231117-cancel-email.ts
+++ b/front/mailing/20231117-cancel-email.ts
@@ -37,7 +37,7 @@ export async function sendCancelSubscriptionEmail(
       <p>Please reply to this email if you have any questions.
       <p>The Dust team</p>`,
   };
-  return sendEmail(email, cancelMessage);
+  return sendEmail([email], cancelMessage);
 }
 
 void main().then(() => {

--- a/front/mailing/20231206-update-route.ts
+++ b/front/mailing/20231206-update-route.ts
@@ -68,7 +68,7 @@ Best speed,
 -stan
 `,
   };
-  return sendEmail(email, cancelMessage);
+  return sendEmail([email], cancelMessage);
 }
 
 void main().then(() => {

--- a/front/mailing/20240105-sunset-xp1.ts
+++ b/front/mailing/20240105-sunset-xp1.ts
@@ -42,7 +42,7 @@ Best speed,
 [0] all your data (usage statistics and account information) will be deleted.
 `,
   };
-  await sendEmail(email, message);
+  await sendEmail([email], message);
 }
 
 // void main().then(() => {

--- a/front/migrations/20241101_workspace_keys_incident.ts
+++ b/front/migrations/20241101_workspace_keys_incident.ts
@@ -43,7 +43,9 @@ const sendIncidentEmailToAdmins = async (
   const adminEmails = admins.map((u) => u.email);
 
   return Promise.all(
-    adminEmails.map((email) => sendEmailWithTemplate({ ...message, to: email }))
+    adminEmails.map((email) =>
+      sendEmailWithTemplate({ ...message, to: [email] })
+    )
   );
 };
 


### PR DESCRIPTION
## Description

- avoid constructing the email several times
- have all tracker recipients in the same thread (so you can reply all)

## Risk

Critical path for email

## Deploy Plan

Deploy front