### PR TITLE
enh: claude-3 global agent instructions

### DIFF
--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -599,7 +599,10 @@ function _getClaude3GlobalAgent({
     versionAuthorId: null,
     name: "claude-3",
     description: CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG.description,
-    instructions: null,
+    instructions:
+      "Only use visualization if it is strictly necessary to visualize " +
+      "data or if it was explicitly requested by the user. " +
+      "Do not use visualization if markdown is sufficient.",
     pictureUrl: "https://dust.tt/static/systemavatar/claude_avatar_full.png",
     status,
     scope: "global",


### PR DESCRIPTION
## Description

`@claude-3` global agent currently has no prompt, but has visualization enabled, meaning that the viz metaprompt ends up being its only prompt.

While I'm not convinced this assistant should have visualization enabled to begin with, if it does we at least need to prompt it to not use it all the time as it currently tends to use it for almost every query including queries that definitely do not benefit from it.

From my tests, this prompt is enough to significantly reduce the likelihood of useless uses.

## Risk

N/A

## Deploy Plan

Deploy `front`