### PR TITLE
Conversation deletion: delete conversation include file actions

### DIFF
--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -3,6 +3,7 @@ import { removeNulls } from "@dust-tt/types";
 import { chunk } from "lodash";
 
 import { AgentBrowseAction } from "@app/lib/models/assistant/actions/browse";
+import { AgentConversationIncludeFileAction } from "@app/lib/models/assistant/actions/conversation/include_file";
 import { AgentDustAppRunAction } from "@app/lib/models/assistant/actions/dust_app_run";
 import { AgentProcessAction } from "@app/lib/models/assistant/actions/process";
 import { AgentRetrievalAction } from "@app/lib/models/assistant/actions/retrieval";
@@ -54,6 +55,9 @@ async function destroyActionsRelatedResources(agentMessageIds: Array<ModelId>) {
     where: { agentMessageId: agentMessageIds },
   });
   await AgentBrowseAction.destroy({
+    where: { agentMessageId: agentMessageIds },
+  });
+  await AgentConversationIncludeFileAction.destroy({
     where: { agentMessageId: agentMessageIds },
   });
 }


### PR DESCRIPTION
## Description

When deleting a conversation (workspace srubbing) `AgentConversationIncludeFileAction` were not deleted leading to foreign key constraints errors

https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E14%20%40dd.service%3Afront-worker&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZQMsiflyY86WQAAABhBWlFNc2k1MUFBRHZBeGRxcGpjOTh3Q0QAAAAkMDE5NDBjYjItMzI5Ni00ZTcxLTliOGQtZGY3Yjg1ZGRjMWRhAAAVhg&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1735207025282&to_ts=1735379825282&live=true

## Risk

Low

## Deploy Plan

- deploy `front`