### PR TITLE
Conversation data source creation clean-up

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -55,6 +55,11 @@ import { runActionStreamed } from "@app/lib/actions/server";
 import { runAgent } from "@app/lib/api/assistant/agent";
 import { signalAgentUsage } from "@app/lib/api/assistant/agent_usage";
 import { getLightAgentConfiguration } from "@app/lib/api/assistant/configuration";
+import {
+  canAccessConversation,
+  getConversationGroupIdsFromModel,
+  getConversationRequestedGroupIdsFromModel,
+} from "@app/lib/api/assistant/conversation/auth";
 import { getContentFragmentBlob } from "@app/lib/api/assistant/conversation/content_fragment";
 import { renderConversationForModel } from "@app/lib/api/assistant/generation";
 import {
@@ -67,7 +72,8 @@ import {
 } from "@app/lib/api/assistant/rate_limits";
 import { maybeUpsertFileAttachment } from "@app/lib/api/files/utils";
 import { getSupportedModelConfig } from "@app/lib/assistant";
-import { Authenticator, getFeatureFlags } from "@app/lib/auth";
+import type { Authenticator} from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { AgentMessageContent } from "@app/lib/models/assistant/agent_message_content";
 import {
   AgentMessage,
@@ -80,7 +86,6 @@ import {
 import { countActiveSeatsInWorkspaceCached } from "@app/lib/plans/usage/seats";
 import { cloneBaseConfig, DustProdActionRegistry } from "@app/lib/registry";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
-import { GroupResource } from "@app/lib/resources/group_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
@@ -405,48 +410,6 @@ export async function getConversation(
     title: conversation.title,
     visibility: conversation.visibility,
     content,
-    // TODO(2024-11-04 flav) `group-id` clean-up.
-    groupIds: getConversationGroupIdsFromModel(owner, conversation),
-    requestedGroupIds: getConversationRequestedGroupIdsFromModel(
-      owner,
-      conversation
-    ),
-  });
-}
-
-export async function getConversationWithoutContent(
-  auth: Authenticator,
-  conversationId: string,
-  includeDeleted?: boolean
-): Promise<Result<ConversationWithoutContentType, ConversationError>> {
-  const owner = auth.workspace();
-  if (!owner) {
-    throw new Error("Unexpected `auth` without `workspace`.");
-  }
-
-  const conversation = await Conversation.findOne({
-    where: {
-      sId: conversationId,
-      workspaceId: owner.id,
-      ...(includeDeleted ? {} : { visibility: { [Op.ne]: "deleted" } }),
-    },
-  });
-
-  if (!conversation) {
-    return new Err(new ConversationError("conversation_not_found"));
-  }
-
-  if (!canAccessConversation(auth, conversation)) {
-    return new Err(new ConversationError("conversation_access_restricted"));
-  }
-
-  return new Ok({
-    id: conversation.id,
-    created: conversation.createdAt.getTime(),
-    sId: conversation.sId,
-    owner,
-    title: conversation.title,
-    visibility: conversation.visibility,
     // TODO(2024-11-04 flav) `group-id` clean-up.
     groupIds: getConversationGroupIdsFromModel(owner, conversation),
     requestedGroupIds: getConversationRequestedGroupIdsFromModel(
@@ -2178,48 +2141,5 @@ export async function updateConversationRequestedGroupIds(
       },
       transaction: t,
     }
-  );
-}
-
-// TODO(2024-11-04 flav) `group-id` clean-up.
-function getConversationGroupIdsFromModel(
-  owner: WorkspaceType,
-  conversation: Conversation
-): string[] {
-  return conversation.groupIds.map((g) =>
-    GroupResource.modelIdToSId({
-      id: g,
-      workspaceId: owner.id,
-    })
-  );
-}
-
-function getConversationRequestedGroupIdsFromModel(
-  owner: WorkspaceType,
-  conversation: Conversation
-): string[][] {
-  return conversation.requestedGroupIds.map((groups) =>
-    groups.map((g) =>
-      GroupResource.modelIdToSId({
-        id: g,
-        workspaceId: owner.id,
-      })
-    )
-  );
-}
-
-export function canAccessConversation(
-  auth: Authenticator,
-  conversation: ConversationWithoutContentType | ConversationType | Conversation
-): boolean {
-  const owner = auth.getNonNullableWorkspace();
-
-  const requestedGroupIds =
-    conversation instanceof Conversation
-      ? getConversationRequestedGroupIdsFromModel(owner, conversation)
-      : conversation.requestedGroupIds;
-
-  return auth.canRead(
-    Authenticator.createResourcePermissionsFromGroupIds(requestedGroupIds)
   );
 }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -72,7 +72,7 @@ import {
 } from "@app/lib/api/assistant/rate_limits";
 import { maybeUpsertFileAttachment } from "@app/lib/api/files/utils";
 import { getSupportedModelConfig } from "@app/lib/assistant";
-import type { Authenticator} from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { AgentMessageContent } from "@app/lib/models/assistant/agent_message_content";
 import {

--- a/front/lib/api/assistant/conversation/auth.ts
+++ b/front/lib/api/assistant/conversation/auth.ts
@@ -1,0 +1,52 @@
+import type {
+  ConversationType,
+  ConversationWithoutContentType,
+  WorkspaceType,
+} from "@dust-tt/types";
+
+import { Authenticator } from "@app/lib/auth";
+import { Conversation } from "@app/lib/models/assistant/conversation";
+import { GroupResource } from "@app/lib/resources/group_resource";
+
+// TODO(2024-11-04 flav) `group-id` clean-up.
+export function getConversationGroupIdsFromModel(
+  owner: WorkspaceType,
+  conversation: Conversation
+): string[] {
+  return conversation.groupIds.map((g) =>
+    GroupResource.modelIdToSId({
+      id: g,
+      workspaceId: owner.id,
+    })
+  );
+}
+
+export function getConversationRequestedGroupIdsFromModel(
+  owner: WorkspaceType,
+  conversation: Conversation
+): string[][] {
+  return conversation.requestedGroupIds.map((groups) =>
+    groups.map((g) =>
+      GroupResource.modelIdToSId({
+        id: g,
+        workspaceId: owner.id,
+      })
+    )
+  );
+}
+
+export function canAccessConversation(
+  auth: Authenticator,
+  conversation: ConversationWithoutContentType | ConversationType | Conversation
+): boolean {
+  const owner = auth.getNonNullableWorkspace();
+
+  const requestedGroupIds =
+    conversation instanceof Conversation
+      ? getConversationRequestedGroupIdsFromModel(owner, conversation)
+      : conversation.requestedGroupIds;
+
+  return auth.canRead(
+    Authenticator.createResourcePermissionsFromGroupIds(requestedGroupIds)
+  );
+}

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -1,4 +1,8 @@
-import type { LightWorkspaceType, ModelId } from "@dust-tt/types";
+import type {
+  ConversationType,
+  LightWorkspaceType,
+  ModelId,
+} from "@dust-tt/types";
 import { removeNulls } from "@dust-tt/types";
 import { chunk } from "lodash";
 

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -1,8 +1,4 @@
-import type {
-  ConversationType,
-  LightWorkspaceType,
-  ModelId,
-} from "@dust-tt/types";
+import type { LightWorkspaceType, ModelId } from "@dust-tt/types";
 import { removeNulls } from "@dust-tt/types";
 import { chunk } from "lodash";
 

--- a/front/lib/api/assistant/conversation/without_content.ts
+++ b/front/lib/api/assistant/conversation/without_content.ts
@@ -1,7 +1,4 @@
-import type {
-  ConversationWithoutContentType,
-  Result,
-} from "@dust-tt/types";
+import type { ConversationWithoutContentType, Result } from "@dust-tt/types";
 import { ConversationError } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 import { Op } from "sequelize";
@@ -12,9 +9,7 @@ import {
   getConversationRequestedGroupIdsFromModel,
 } from "@app/lib/api/assistant/conversation/auth";
 import type { Authenticator } from "@app/lib/auth";
-import {
-  Conversation,
-} from "@app/lib/models/assistant/conversation";
+import { Conversation } from "@app/lib/models/assistant/conversation";
 
 export async function getConversationWithoutContent(
   auth: Authenticator,

--- a/front/lib/api/assistant/conversation/without_content.ts
+++ b/front/lib/api/assistant/conversation/without_content.ts
@@ -1,0 +1,59 @@
+import type {
+  ConversationWithoutContentType,
+  Result,
+} from "@dust-tt/types";
+import { ConversationError } from "@dust-tt/types";
+import { Err, Ok } from "@dust-tt/types";
+import { Op } from "sequelize";
+
+import {
+  canAccessConversation,
+  getConversationGroupIdsFromModel,
+  getConversationRequestedGroupIdsFromModel,
+} from "@app/lib/api/assistant/conversation/auth";
+import type { Authenticator } from "@app/lib/auth";
+import {
+  Conversation,
+} from "@app/lib/models/assistant/conversation";
+
+export async function getConversationWithoutContent(
+  auth: Authenticator,
+  conversationId: string,
+  includeDeleted?: boolean
+): Promise<Result<ConversationWithoutContentType, ConversationError>> {
+  const owner = auth.workspace();
+  if (!owner) {
+    throw new Error("Unexpected `auth` without `workspace`.");
+  }
+
+  const conversation = await Conversation.findOne({
+    where: {
+      sId: conversationId,
+      workspaceId: owner.id,
+      ...(includeDeleted ? {} : { visibility: { [Op.ne]: "deleted" } }),
+    },
+  });
+
+  if (!conversation) {
+    return new Err(new ConversationError("conversation_not_found"));
+  }
+
+  if (!canAccessConversation(auth, conversation)) {
+    return new Err(new ConversationError("conversation_access_restricted"));
+  }
+
+  return new Ok({
+    id: conversation.id,
+    created: conversation.createdAt.getTime(),
+    sId: conversation.sId,
+    owner,
+    title: conversation.title,
+    visibility: conversation.visibility,
+    // TODO(2024-11-04 flav) `group-id` clean-up.
+    groupIds: getConversationGroupIdsFromModel(owner, conversation),
+    requestedGroupIds: getConversationRequestedGroupIdsFromModel(
+      owner,
+      conversation
+    ),
+  });
+}

--- a/front/lib/api/assistant/feedback.ts
+++ b/front/lib/api/assistant/feedback.ts
@@ -7,7 +7,7 @@ import type { UserType } from "@dust-tt/types";
 import { ConversationError, Err, GLOBAL_AGENTS_SID, Ok } from "@dust-tt/types";
 import { Op } from "sequelize";
 
-import { canAccessConversation } from "@app/lib/api/assistant/conversation";
+import { canAccessConversation } from "@app/lib/api/assistant/conversation/auth";
 import type { AgentMessageFeedbackDirection } from "@app/lib/api/assistant/conversation/feedbacks";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";

--- a/front/lib/api/assistant/reaction.ts
+++ b/front/lib/api/assistant/reaction.ts
@@ -8,7 +8,7 @@ import type {
 import type { UserType } from "@dust-tt/types";
 import { ConversationError, Err, Ok } from "@dust-tt/types";
 
-import { canAccessConversation } from "@app/lib/api/assistant/conversation";
+import { canAccessConversation } from "@app/lib/api/assistant/conversation/auth";
 import type { Authenticator } from "@app/lib/auth";
 import {
   Message,

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -5,6 +5,7 @@ import type {
 import type {
   ConnectorProvider,
   ConnectorType,
+  ConversationWithoutContentType,
   CoreAPIDataSource,
   CoreAPIDocument,
   CoreAPIError,
@@ -13,7 +14,6 @@ import type {
   DataSourceType,
   DataSourceWithConnectorDetailsType,
   FrontDataSourceDocumentSectionType,
-  ModelId,
   PlanType,
   Result,
   UpsertTableFromCsvRequestType,
@@ -776,14 +776,14 @@ export async function createDataSourceWithoutProvider(
     space,
     name,
     description,
-    conversationId,
+    conversation,
   }: {
     plan: PlanType;
     owner: WorkspaceType;
     space: SpaceResource;
     name: string;
     description: string | null;
-    conversationId?: ModelId;
+    conversation?: ConversationWithoutContentType;
   }
 ): Promise<
   Result<
@@ -884,7 +884,7 @@ export async function createDataSourceWithoutProvider(
         dustAPIDataSourceId: dustDataSource.value.data_source.data_source_id,
         workspaceId: owner.id,
         assistantDefaultSelected: false,
-        conversationId: conversationId,
+        conversationId: conversation?.id,
       },
       space
     );

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -18,6 +18,7 @@ import { Writable } from "stream";
 import { pipeline } from "stream/promises";
 
 import { runAction } from "@app/lib/actions/server";
+import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation/without_content";
 import { isJITActionsEnabled } from "@app/lib/api/assistant/jit_actions";
 import config from "@app/lib/api/config";
 import {
@@ -27,14 +28,12 @@ import {
 } from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
-import { Conversation } from "@app/lib/models/assistant/conversation";
 import { cloneBaseConfig, DustProdActionRegistry } from "@app/lib/registry";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
-import { getConversationWithoutContent } from "../assistant/conversation";
 
 const ENABLE_LLM_SNIPPETS = false;
 

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -1,6 +1,5 @@
 import type {
   ConnectorProvider,
-  ConversationType,
   ConversationWithoutContentType,
   DataSourceType,
   ModelId,

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -1,5 +1,7 @@
 import type {
   ConnectorProvider,
+  ConversationType,
+  ConversationWithoutContentType,
   DataSourceType,
   ModelId,
   Result,
@@ -262,14 +264,14 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
     return dataSource ?? null;
   }
 
-  static async fetchByConversationId(
+  static async fetchByConversation(
     auth: Authenticator,
-    conversationId: number,
+    conversation: ConversationWithoutContentType,
     options?: FetchDataSourceOptions
   ): Promise<DataSourceResource | null> {
     const [dataSource] = await this.baseFetch(auth, options, {
       where: {
-        conversationId,
+        conversationId: conversation.id,
         workspaceId: auth.getNonNullableWorkspace().id,
       },
     });

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -375,9 +375,9 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     conversation: ConversationType
   ): Promise<DataSourceViewResource | null> {
     // Fetch the data source view associated with the datasource that is associated with the conversation.
-    const dataSource = await DataSourceResource.fetchByConversationId(
+    const dataSource = await DataSourceResource.fetchByConversation(
       auth,
-      conversation.id
+      conversation
     );
     if (!dataSource) {
       return null;

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/cancel.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/cancel.ts
@@ -4,8 +4,8 @@ import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { fromError } from "zod-validation-error";
 
-import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
+import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation/without_content";
 import { cancelMessageGenerationEvent } from "@app/lib/api/assistant/pubsub";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -2,8 +2,8 @@ import type { ConversationEventType } from "@dust-tt/client";
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
+import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation/without_content";
 import { getConversationEvents } from "@app/lib/api/assistant/pubsub";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
@@ -2,11 +2,9 @@ import type { AgentMessageEventType } from "@dust-tt/client";
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import {
-  getConversationMessageType,
-  getConversationWithoutContent,
-} from "@app/lib/api/assistant/conversation";
+import { getConversationMessageType } from "@app/lib/api/assistant/conversation";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
+import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation/without_content";
 import { getMessagesEvents } from "@app/lib/api/assistant/pubsub";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
@@ -4,8 +4,8 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
+import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation/without_content";
 import { cancelMessageGenerationEvent } from "@app/lib/api/assistant/pubsub";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -1,8 +1,8 @@
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
+import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation/without_content";
 import { getConversationEvents } from "@app/lib/api/assistant/pubsub";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/feedbacks.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/feedbacks.ts
@@ -1,8 +1,8 @@
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
+import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation/without_content";
 import type { AgentMessageFeedbackType } from "@app/lib/api/assistant/feedback";
 import { getConversationFeedbacksForUser } from "@app/lib/api/assistant/feedback";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -9,10 +9,10 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
   deleteConversation,
-  getConversationWithoutContent,
   updateConversation,
 } from "@app/lib/api/assistant/conversation";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
+import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation/without_content";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
@@ -1,11 +1,9 @@
 import type { WithAPIErrorResponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import {
-  getConversationMessageType,
-  getConversationWithoutContent,
-} from "@app/lib/api/assistant/conversation";
+import { getConversationMessageType } from "@app/lib/api/assistant/conversation";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
+import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation/without_content";
 import { getMessagesEvents } from "@app/lib/api/assistant/pubsub";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks/index.ts
@@ -4,9 +4,9 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
 import type { AgentMessageFeedbackDirection } from "@app/lib/api/assistant/conversation/feedbacks";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
+import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation/without_content";
 import {
   createOrUpdateMessageFeedback,
   deleteMessageFeedback,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
@@ -4,8 +4,8 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
+import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation/without_content";
 import {
   createMessageReaction,
   deleteMessageReaction,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/participants.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/participants.ts
@@ -5,8 +5,8 @@ import type {
 } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
+import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation/without_content";
 import { fetchConversationParticipants } from "@app/lib/api/assistant/participants";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/reactions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/reactions.ts
@@ -4,8 +4,8 @@ import type {
 } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
+import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation/without_content";
 import { getMessageReactions } from "@app/lib/api/assistant/reaction";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/poke/[wId]/conversations/[cId]/index.tsx
+++ b/front/pages/poke/[wId]/conversations/[cId]/index.tsx
@@ -8,7 +8,7 @@ import { assertNever } from "@dust-tt/types";
 import type { InferGetServerSidePropsType } from "next";
 
 import PokeNavbar from "@app/components/poke/PokeNavbar";
-import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
+import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation/without_content";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { DustProdActionRegistry } from "@app/lib/registry";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";

--- a/front/pages/poke/[wId]/conversations/[cId]/index.tsx
+++ b/front/pages/poke/[wId]/conversations/[cId]/index.tsx
@@ -33,16 +33,16 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
     };
   }
 
-  const conversation = await getConversationWithoutContent(auth, cId);
-  if (conversation.isErr()) {
+  const cRes = await getConversationWithoutContent(auth, cId);
+  if (cRes.isErr()) {
     return {
       notFound: true,
     };
   }
 
-  const conversationDataSource = await DataSourceResource.fetchByConversationId(
+  const conversationDataSource = await DataSourceResource.fetchByConversation(
     auth,
-    conversation.value.id
+    cRes.value
   );
 
   return {


### PR DESCRIPTION
## Description

Clean-up: remove use of ModelId + remove import loop (bulk of the PR)
Prep work to add conversation data source deletion from conversation deletion without having to pass a ModelId around.

## Risk

Low. Tested locally.

## Deploy Plan

- deploy `front`