### PR TITLE
fix(Confluence) - decrease `TEMPORAL_WORKFLOW_MAX_HISTORY_LENGTH`

### DIFF
--- a/connectors/src/connectors/confluence/temporal/workflows.ts
+++ b/connectors/src/connectors/confluence/temporal/workflows.ts
@@ -50,7 +50,7 @@ const {
 // Set a conservative threshold to start a new workflow and
 // avoid exceeding Temporal's max workflow size limit,
 // since a Confluence page can have an unbounded number of pages.
-const TEMPORAL_WORKFLOW_MAX_HISTORY_LENGTH = 10_000;
+const TEMPORAL_WORKFLOW_MAX_HISTORY_LENGTH = 6_000;
 
 export async function confluenceSyncWorkflow({
   connectorId,


### PR DESCRIPTION
## Description

- Fixes [#1874](https://github.com/dust-tt/tasks/issues/1874)
- Decreases `TEMPORAL_WORKFLOW_MAX_HISTORY_LENGTH` to trigger more `continueAsNew`.
- Some activity inputs contains 2496 `ConfluencePageRef`s (`id: string`, `version: number`, `parentId: string` so typically ~30B) so ~75kB in total.
- With the current limit of 10k events we run the risk of hitting the [hard limit of 50MB](https://temporal.io/blog/very-long-running-workflows) on Temporal's Event History.
- Note: if we had access to [historySize](https://typescript.temporal.io/api/interfaces/workflow.WorkflowInfo#historysize) or [continueAsNewSuggested](https://typescript.temporal.io/api/interfaces/workflow.WorkflowInfo#continueasnewsuggested) (Temporal Server 1.20+) we would have a better control over when to `continueAsNew`.

## Risk

- Low

## Deploy Plan

- Stop all Confluence connectors.
- Deploy connectors
- Resume all Confluence connectors.
