### PR TITLE
enh(Zendesk) - add a CLI command to fetch a single ticket

### DIFF
--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -137,7 +137,10 @@ export const zendesk = async ({
         connectorId: connector.id,
         ticketId,
       });
-      return { ticket, isTicketOnDb: ticketOnDb !== null };
+      return {
+        ticket: ticket as { [key: string]: unknown } | null,
+        isTicketOnDb: ticketOnDb !== null,
+      };
     }
   }
 };

--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -2,6 +2,7 @@ import type {
   ZendeskCheckIsAdminResponseType,
   ZendeskCommandType,
   ZendeskCountTicketsResponseType,
+  ZendeskFetchTicketResponseType,
   ZendeskResyncTicketsResponseType,
 } from "@dust-tt/types";
 
@@ -27,6 +28,7 @@ export const zendesk = async ({
   | ZendeskCheckIsAdminResponseType
   | ZendeskCountTicketsResponseType
   | ZendeskResyncTicketsResponseType
+  | ZendeskFetchTicketResponseType
 > => {
   const logger = topLogger.child({ majorCommand: "zendesk", command, args });
 

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -350,6 +350,30 @@ export async function fetchZendeskTickets(
 }
 
 /**
+ * Fetches a single ticket from the Zendesk API.
+ */
+export async function fetchZendeskTicket({
+  accessToken,
+  brandSubdomain,
+  ticketId,
+}: {
+  accessToken: string;
+  brandSubdomain: string;
+  ticketId: number;
+}): Promise<ZendeskFetchedTicket | null> {
+  const url = `https://${brandSubdomain}.zendesk.com/api/v2/tickets/${ticketId}`;
+  try {
+    const response = await fetchFromZendeskWithRetries({ url, accessToken });
+    return response?.ticket ?? null;
+  } catch (e) {
+    if (isZendeskNotFoundError(e)) {
+      return null;
+    }
+    throw e;
+  }
+}
+
+/**
  * Fetches the number of tickets in a Brand from the Zendesk API.
  * Only counts tickets that have been solved, and that were updated within the retention period.
  */

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -298,7 +298,7 @@ export type ZendeskResyncTicketsResponseType = t.TypeOf<
 
 export const ZendeskFetchTicketResponseSchema = t.type({
   ticket: t.union([t.UnknownRecord, t.null]), // Zendesk type, can't be iots'd,
-  isTicketOnDB: t.boolean,
+  isTicketOnDb: t.boolean,
 });
 export type ZendeskFetchTicketResponseType = t.TypeOf<
   typeof ZendeskFetchTicketResponseSchema

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -261,12 +261,14 @@ export const ZendeskCommandSchema = t.type({
     t.literal("check-is-admin"),
     t.literal("count-tickets"),
     t.literal("resync-tickets"),
+    t.literal("fetch-ticket"),
   ]),
   args: t.type({
     connectorId: t.union([t.number, t.undefined]),
     brandId: t.union([t.number, t.undefined]),
     query: t.union([t.string, t.undefined]),
     forceResync: t.union([t.literal("true"), t.undefined]),
+    ticketId: t.union([t.number, t.undefined]),
   }),
 });
 export type ZendeskCommandType = t.TypeOf<typeof ZendeskCommandSchema>;
@@ -292,6 +294,14 @@ export const ZendeskResyncTicketsResponseSchema = t.type({
 });
 export type ZendeskResyncTicketsResponseType = t.TypeOf<
   typeof ZendeskResyncTicketsResponseSchema
+>;
+
+export const ZendeskFetchTicketResponseSchema = t.type({
+  ticket: t.union([t.UnknownRecord, t.null]), // Zendesk type, can't be iots'd,
+  isTicketOnDB: t.boolean,
+});
+export type ZendeskFetchTicketResponseType = t.TypeOf<
+  typeof ZendeskFetchTicketResponseSchema
 >;
 /**
  * </Zendesk>

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -463,6 +463,7 @@ export const AdminResponseSchema = t.union([
   IntercomForceResyncArticlesResponseSchema,
   ZendeskCheckIsAdminResponseSchema,
   ZendeskCountTicketsResponseSchema,
+  ZendeskResyncTicketsResponseSchema,
 ]);
 
 export type AdminResponseType = t.TypeOf<typeof AdminResponseSchema>;

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -464,6 +464,7 @@ export const AdminResponseSchema = t.union([
   ZendeskCheckIsAdminResponseSchema,
   ZendeskCountTicketsResponseSchema,
   ZendeskResyncTicketsResponseSchema,
+  ZendeskFetchTicketResponseSchema,
 ]);
 
 export type AdminResponseType = t.TypeOf<typeof AdminResponseSchema>;


### PR DESCRIPTION
## Description

- Part of the investigation of [#1870](https://github.com/dust-tt/tasks/issues/1870).
- This PR aims at adding a CLI command to fetch a single ticket from Zendesk's API.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.