### PR TITLE
[README.md] - fix: correct typo in 'Fronted Engineer' job listing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Check out our [user guides and developer platform](https://docs.dust.tt)
 ## We're hiring
 
 - [Software Engineer](https://jobs.ashbyhq.com/dust/bad88b68-e2db-47f0-ab42-4d6dd2664e76)
-- [Fronted Engineer](https://jobs.ashbyhq.com/dust/f4b23a43-5d07-4ea3-b291-90db7db5e011)
+- [Frontend Engineer](https://jobs.ashbyhq.com/dust/f4b23a43-5d07-4ea3-b291-90db7db5e011)
 - [Security Engineer](https://jobs.ashbyhq.com/dust/4ef6ceae-4779-4113-a82c-198b4b341ef9)
 
 ## Deployment


### PR DESCRIPTION
## Description

Fixed the typo in the job title 'Fronted Engineer' to 'Frontend Engineer'

## Risk

None

## Deploy Plan

N/A