### PR TITLE
scrub/delete workflows: share conversation deletion logic

### DIFF
--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -127,14 +127,14 @@ async function destroyContentFragments(
 }
 
 async function destroyConversationDataSource({
-  workspaceId,
+  workspace,
   conversationId,
 }: {
-  workspaceId: string;
+  workspace: LightWorkspaceType;
   conversationId: string;
 }) {
   // We need an authenticator to interact with the data source resource.
-  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
   const conversation = await getConversationWithoutContent(
     auth,
     conversationId,
@@ -216,7 +216,7 @@ export async function destroyConversation(
   });
 
   await destroyConversationDataSource({
-    workspaceId: workspace.sId,
+    workspace: workspace,
     conversationId: conversation.sId,
   });
 

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -216,7 +216,7 @@ export async function destroyConversation(
   });
 
   await destroyConversationDataSource({
-    workspace: workspace,
+    workspace,
     conversationId: conversation.sId,
   });
 

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -115,11 +115,8 @@ export async function pauseAllConnectors({
   }
 }
 
-async function deleteAllConversations(auth: Authenticator) {
-  const workspace = auth.workspace();
-  if (!workspace) {
-    throw new Error("No workspace found");
-  }
+export async function deleteAllConversations(auth: Authenticator) {
+  const workspace = auth.getNonNullableWorkspace();
   const conversations = await Conversation.findAll({
     where: { workspaceId: workspace.id },
   });


### PR DESCRIPTION
## Description

For https://github.com/dust-tt/tasks/issues/1873 (will need to restart the GDPR delete of the workspace to complete the task)

Share conversation deletion code across delete/scrub activities so that it all uses `destroyConversation`

## Risk

Low

## Deploy Plan

- deploy `front`