### PR TITLE
Refactor conversations authentication (get and destroy)

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -344,6 +344,10 @@ export async function getConversation(
     return new Err(new ConversationError("conversation_not_found"));
   }
 
+  if (!canAccessConversation(auth, conversation)) {
+    return new Err(new ConversationError("conversation_access_restricted"));
+  }
+
   const messages = await Message.findAll({
     where: {
       conversationId: conversation.id,

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -1,7 +1,4 @@
-import type {
-  ConversationWithoutContentType,
-  ModelId,
-} from "@dust-tt/types";
+import type { ConversationWithoutContentType, ModelId } from "@dust-tt/types";
 import { removeNulls } from "@dust-tt/types";
 import { chunk } from "lodash";
 

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -1,8 +1,12 @@
-import type { LightWorkspaceType, ModelId } from "@dust-tt/types";
+import type {
+  ConversationWithoutContentType,
+  LightWorkspaceType,
+  ModelId,
+} from "@dust-tt/types";
 import { removeNulls } from "@dust-tt/types";
 import { chunk } from "lodash";
 
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { AgentBrowseAction } from "@app/lib/models/assistant/actions/browse";
 import { AgentConversationIncludeFileAction } from "@app/lib/models/assistant/actions/conversation/include_file";
 import { AgentDustAppRunAction } from "@app/lib/models/assistant/actions/dust_app_run";
@@ -11,10 +15,10 @@ import { AgentRetrievalAction } from "@app/lib/models/assistant/actions/retrieva
 import { AgentTablesQueryAction } from "@app/lib/models/assistant/actions/tables_query";
 import { AgentWebsearchAction } from "@app/lib/models/assistant/actions/websearch";
 import { AgentMessageContent } from "@app/lib/models/assistant/agent_message_content";
-import type { Conversation } from "@app/lib/models/assistant/conversation";
 import {
   AgentMessage,
   AgentMessageFeedback,
+  Conversation,
   ConversationParticipant,
   Mention,
   Message,
@@ -126,27 +130,17 @@ async function destroyContentFragments(
   }
 }
 
-async function destroyConversationDataSource({
-  workspace,
-  conversationId,
-}: {
-  workspace: LightWorkspaceType;
-  conversationId: string;
-}) {
-  // We need an authenticator to interact with the data source resource.
-  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-  const conversation = await getConversationWithoutContent(
-    auth,
-    conversationId,
-    true
-  );
-  if (conversation.isErr()) {
-    throw conversation.error;
+async function destroyConversationDataSource(
+  auth: Authenticator,
+  {
+    conversation,
+  }: {
+    conversation: ConversationWithoutContentType;
   }
-
+) {
   const dataSource = await DataSourceResource.fetchByConversation(
     auth,
-    conversation.value
+    conversation
   );
 
   if (dataSource) {
@@ -154,12 +148,26 @@ async function destroyConversationDataSource({
   }
 }
 
-// This belongs to the ConversationResource.
+// This belongs to the ConversationResource. The authenticator is expected to have access to the
+// groups involved in the conversation.
 export async function destroyConversation(
-  workspace: LightWorkspaceType,
-  conversation: Conversation
+  auth: Authenticator,
+  {
+    conversationId,
+  }: {
+    conversationId: string;
+  }
 ) {
-  const { id: conversationId } = conversation;
+  const workspace = auth.getNonNullableWorkspace();
+  const conversationRes = await getConversationWithoutContent(
+    auth,
+    conversationId,
+    true
+  );
+  if (conversationRes.isErr()) {
+    throw conversationRes.error;
+  }
+  const conversation = conversationRes.value;
 
   const messages = await Message.findAll({
     attributes: [
@@ -215,10 +223,12 @@ export async function destroyConversation(
     where: { conversationId: conversationId },
   });
 
-  await destroyConversationDataSource({
-    workspace,
-    conversationId: conversation.sId,
-  });
+  await destroyConversationDataSource(auth, { conversation });
 
-  await conversation.destroy();
+  const c = await Conversation.findOne({
+    where: { id: conversation.id },
+  });
+  if (c) {
+    await c.destroy();
+  }
 }

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -1,6 +1,5 @@
 import type {
   ConversationWithoutContentType,
-  LightWorkspaceType,
   ModelId,
 } from "@dust-tt/types";
 import { removeNulls } from "@dust-tt/types";

--- a/front/lib/api/assistant/conversation/without_content.ts
+++ b/front/lib/api/assistant/conversation/without_content.ts
@@ -16,10 +16,7 @@ export async function getConversationWithoutContent(
   conversationId: string,
   includeDeleted?: boolean
 ): Promise<Result<ConversationWithoutContentType, ConversationError>> {
-  const owner = auth.workspace();
-  if (!owner) {
-    throw new Error("Unexpected `auth` without `workspace`.");
-  }
+  const owner = auth.getNonNullableWorkspace();
 
   const conversation = await Conversation.findOne({
     where: {

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -528,7 +528,7 @@ export class Authenticator {
    * within the workpsace. */
   static async internalAdminForWorkspace(
     workspaceId: string,
-    unsafeRequestAllGroups = false
+    options?: { dangerouslyRequestAllGroups: boolean }
   ): Promise<Authenticator> {
     const workspace = await Workspace.findOne({
       where: {
@@ -541,7 +541,7 @@ export class Authenticator {
 
     const [groups, subscription] = await Promise.all([
       (async () => {
-        if (unsafeRequestAllGroups) {
+        if (options?.dangerouslyRequestAllGroups) {
           return GroupResource.internalFetchAllWorkspaceGroups(workspace.id);
         } else {
           const globalGroup =

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -227,7 +227,7 @@ export class Authenticator {
     if (workspace) {
       [groups, subscription] = await Promise.all([
         user?.isDustSuperUser
-          ? GroupResource.superAdminFetchWorkspaceGroups(user, workspace.id)
+          ? GroupResource.internalFetchAllWorkspaceGroups(workspace.id)
           : [],
         subscriptionForWorkspace(renderLightWorkspaceType({ workspace })),
       ]);
@@ -524,9 +524,11 @@ export class Authenticator {
     });
   }
 
-  /* As above, with role `admin` */
+  /* As above, with role `admin`. Use requestAllGroups with care as it gives access to all groups
+   * within the workpsace. */
   static async internalAdminForWorkspace(
-    workspaceId: string
+    workspaceId: string,
+    unsafeRequestAllGroups = false
   ): Promise<Authenticator> {
     const workspace = await Workspace.findOne({
       where: {
@@ -537,18 +539,23 @@ export class Authenticator {
       throw new Error(`Could not find workspace with sId ${workspaceId}`);
     }
 
-    let globalGroup: GroupResource | null = null;
-    let subscription: SubscriptionType | null = null;
-
-    [globalGroup, subscription] = await Promise.all([
-      GroupResource.internalFetchWorkspaceGlobalGroup(workspace.id),
+    const [groups, subscription] = await Promise.all([
+      (async () => {
+        if (unsafeRequestAllGroups) {
+          return GroupResource.internalFetchAllWorkspaceGroups(workspace.id);
+        } else {
+          const globalGroup =
+            await GroupResource.internalFetchWorkspaceGlobalGroup(workspace.id);
+          return globalGroup ? [globalGroup] : [];
+        }
+      })(),
       subscriptionForWorkspace(renderLightWorkspaceType({ workspace })),
     ]);
 
     return new Authenticator({
       workspace,
       role: "admin",
-      groups: globalGroup ? [globalGroup] : [],
+      groups,
       subscription,
     });
   }

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -101,14 +101,10 @@ export class GroupResource extends BaseResource<GroupModel> {
 
   // Internal fetcher for Authenticator only
 
-  static async superAdminFetchWorkspaceGroups(
-    userResource: UserResource,
+  // Use with care as this gives access to all groups in the workspace.
+  static async internalFetchAllWorkspaceGroups(
     workspaceId: ModelId
   ): Promise<GroupResource[]> {
-    if (!userResource.isDustSuperUser) {
-      throw new Error("User is not a super admin.");
-    }
-
     const groups = await this.model.findAll({
       where: {
         workspaceId,

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -10,39 +10,22 @@ import { hardDeleteDataSource } from "@app/lib/api/data_sources";
 import { hardDeleteSpace } from "@app/lib/api/spaces";
 import { areAllSubscriptionsCanceled } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
-import { AgentBrowseAction } from "@app/lib/models/assistant/actions/browse";
 import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
 import {
   AgentDustAppRunAction,
   AgentDustAppRunConfiguration,
 } from "@app/lib/models/assistant/actions/dust_app_run";
-import { AgentProcessAction } from "@app/lib/models/assistant/actions/process";
-import {
-  AgentRetrievalAction,
-  AgentRetrievalConfiguration,
-} from "@app/lib/models/assistant/actions/retrieval";
+import { AgentRetrievalConfiguration } from "@app/lib/models/assistant/actions/retrieval";
 import {
   AgentTablesQueryAction,
   AgentTablesQueryConfiguration,
   AgentTablesQueryConfigurationTable,
 } from "@app/lib/models/assistant/actions/tables_query";
-import { AgentWebsearchAction } from "@app/lib/models/assistant/actions/websearch";
 import {
   AgentConfiguration,
   AgentUserRelation,
   GlobalAgentSettings,
 } from "@app/lib/models/assistant/agent";
-import { AgentMessageContent } from "@app/lib/models/assistant/agent_message_content";
-import {
-  AgentMessage,
-  AgentMessageFeedback,
-  Conversation,
-  ConversationParticipant,
-  Mention,
-  Message,
-  MessageReaction,
-  UserMessage,
-} from "@app/lib/models/assistant/conversation";
 import { Subscription } from "@app/lib/models/plan";
 import {
   MembershipInvitation,
@@ -50,12 +33,10 @@ import {
   WorkspaceHasDomain,
 } from "@app/lib/models/workspace";
 import { AppResource } from "@app/lib/resources/app_resource";
-import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
-import { RetrievalDocumentResource } from "@app/lib/resources/retrieval_document_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
@@ -183,7 +164,7 @@ export async function deleteConversationsActivity({
 }: {
   workspaceId: string;
 }) {
-  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId, true);
   await deleteAllConversations(auth);
 }
 

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -164,7 +164,9 @@ export async function deleteConversationsActivity({
 }: {
   workspaceId: string;
 }) {
-  const auth = await Authenticator.internalAdminForWorkspace(workspaceId, true);
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId, {
+    dangerouslyRequestAllGroups: true,
+  });
   await deleteAllConversations(auth);
 }
 

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -87,7 +87,7 @@ export async function scrubWorkspaceData({
 }: {
   workspaceId: string;
 }) {
-  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId, true);
   await deleteAllConversations(auth);
   await archiveAssistants(auth);
   await deleteTrackers(auth);
@@ -129,7 +129,7 @@ export async function deleteAllConversations(auth: Authenticator) {
   for (const conversationChunk of conversationChunks) {
     await Promise.all(
       conversationChunk.map(async (c) => {
-        await destroyConversation(workspace, c);
+        await destroyConversation(auth, { conversationId: c.sId });
       })
     );
   }

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -87,7 +87,9 @@ export async function scrubWorkspaceData({
 }: {
   workspaceId: string;
 }) {
-  const auth = await Authenticator.internalAdminForWorkspace(workspaceId, true);
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId, {
+    dangerouslyRequestAllGroups: true,
+  });
   await deleteAllConversations(auth);
   await archiveAssistants(auth);
   await deleteTrackers(auth);


### PR DESCRIPTION
## Description

- Adds `canAccessConversation` check to `getConversation` (this one is risky as defense in depth will keep an eye post deploy, main risk are activities that didn't have the right auth. User flows should be safe)
- Adds a `unsafeRequestAllGroups` argument to `Authenticator.internalAdminForWorkspace`
- Leverages it in `destroyConversation` modifying call sites

## Risk

- Restriction of `getConversation` is a bit risky but much desirable. Tested various obvious flows in dev but hard to predict all API or activity-based flows here. The risk is worth the added protection.

## Deploy Plan

- deploy `front`