### PR TITLE
Fix admin > workspace page not loading

### DIFF
--- a/front/components/workspace/ProviderManagementModal.tsx
+++ b/front/components/workspace/ProviderManagementModal.tsx
@@ -173,6 +173,9 @@ export function ProviderManagementModal({
             <ContextItem.List>
               {MODEL_PROVIDER_IDS.map((provider) => {
                 const LogoComponent = MODEL_PROVIDER_LOGOS[provider];
+                if (!modelProviders[provider]) {
+                  return null;
+                }
                 return (
                   <ContextItem
                     key={provider}


### PR DESCRIPTION
## Description

The page admin > workspace is broken on prod: components/workspace/ProviderManagementModal.tsx
Looks like it was caused by the introduction of some new models from new model providers. This fixes it. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
