### PR TITLE
Poké: display list of blacklisted domains in the extension

### DIFF
--- a/front/components/poke/workspace/table.tsx
+++ b/front/components/poke/workspace/table.tsx
@@ -1,4 +1,8 @@
-import type { WorkspaceDomain, WorkspaceType } from "@dust-tt/types";
+import type {
+  ExtensionConfigurationType,
+  WorkspaceDomain,
+  WorkspaceType,
+} from "@dust-tt/types";
 
 import {
   PokeTable,
@@ -12,10 +16,12 @@ export function WorkspaceInfoTable({
   owner,
   workspaceVerifiedDomain,
   worspaceCreationDay,
+  extensionConfig,
 }: {
   owner: WorkspaceType;
   workspaceVerifiedDomain: WorkspaceDomain | null;
   worspaceCreationDay: string;
+  extensionConfig: ExtensionConfigurationType | null;
 }) {
   return (
     <div className="flex justify-between gap-3">
@@ -47,6 +53,14 @@ export function WorkspaceInfoTable({
                 {workspaceVerifiedDomain?.domainAutoJoinEnabled ? "✅" : "❌"}
               </PokeTableCell>
               <PokeTableCell>{workspaceVerifiedDomain?.domain}</PokeTableCell>
+            </PokeTableRow>
+            <PokeTableRow>
+              <PokeTableCell>Extension blacklisted domains</PokeTableCell>
+              <PokeTableCell>
+                {extensionConfig?.blacklistedDomains.length
+                  ? extensionConfig.blacklistedDomains.join(", ")
+                  : "None"}
+              </PokeTableCell>
             </PokeTableRow>
           </PokeTableBody>
         </PokeTable>

--- a/front/lib/api/poke/plugins/workspaces/extension_blacklist_domains.ts
+++ b/front/lib/api/poke/plugins/workspaces/extension_blacklist_domains.ts
@@ -2,6 +2,7 @@ import { Err, Ok } from "@dust-tt/types";
 
 import { createPlugin } from "@app/lib/api/poke/types";
 import { updateExtensionConfiguration } from "@app/lib/api/workspace";
+import { isDomain } from "@app/lib/utils";
 
 export const extensionBlacklistDomains = createPlugin(
   {
@@ -14,7 +15,7 @@ export const extensionBlacklistDomains = createPlugin(
         type: "string",
         label: "Blacklisted domains",
         description:
-          "Comma-separated list of domains to blacklist for the extension.",
+          "Comma-separated list of domains to blacklist for the extension. This will override the existing list (if any).",
       },
     },
   },
@@ -51,21 +52,11 @@ function areDomainsValid(domains: string[]): boolean {
     return true; // Empty domains array is valid
   }
 
-  // Regular expression for domain validation
-  // - Starts with alphanumeric or hyphen
-  // - Can contain alphanumeric, hyphens
-  // - Must have at least one dot
-  // - TLD must be at least 2 characters
-  // - Cannot start or end with hyphen
-  // - Cannot have consecutive hyphens
-  const domainRegex =
-    /^(?!-)[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*\.[A-Za-z]{2,}(?!-)$/;
-
   return domains.every((domain) => {
     if (domain.length > 253) {
       return false;
     }
-    if (!domainRegex.test(domain)) {
+    if (!isDomain(domain)) {
       return false;
     }
     const labels = domain.split(".");

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -10,6 +10,7 @@ import {
 } from "@dust-tt/sparkle";
 import type {
   DataSourceType,
+  ExtensionConfigurationType,
   SubscriptionType,
   WhitelistableFeature,
   WorkspaceDomain,
@@ -46,6 +47,7 @@ import { Plan, Subscription } from "@app/lib/models/plan";
 import { FREE_NO_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { renderSubscriptionFromModels } from "@app/lib/plans/renderers";
 import { DustProdActionRegistry } from "@app/lib/registry";
+import { ExtensionConfigurationResource } from "@app/lib/resources/extension";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
   owner: WorkspaceType;
@@ -56,6 +58,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   registry: typeof DustProdActionRegistry;
   workspaceVerifiedDomain: WorkspaceDomain | null;
   worspaceCreationDay: string;
+  extensionConfig: ExtensionConfigurationType | null;
   baseUrl: string;
 }>(async (context, auth) => {
   const owner = auth.workspace();
@@ -93,6 +96,9 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   const workspaceVerifiedDomain = await getWorkspaceVerifiedDomain(owner);
   const worspaceCreationDate = await getWorkspaceCreationDate(owner.sId);
 
+  const extensionConfig =
+    await ExtensionConfigurationResource.fetchForWorkspace(auth);
+
   return {
     props: {
       owner,
@@ -106,6 +112,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
       registry: DustProdActionRegistry,
       workspaceVerifiedDomain,
       worspaceCreationDay: format(worspaceCreationDate, "yyyy-MM-dd"),
+      extensionConfig: extensionConfig?.toJSON() ?? null,
       baseUrl: config.getClientFacingUrl(),
     },
   };
@@ -120,6 +127,7 @@ const WorkspacePage = ({
   registry,
   workspaceVerifiedDomain,
   worspaceCreationDay,
+  extensionConfig,
   baseUrl,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const router = useRouter();
@@ -241,6 +249,7 @@ const WorkspacePage = ({
                   owner={owner}
                   workspaceVerifiedDomain={workspaceVerifiedDomain}
                   worspaceCreationDay={worspaceCreationDay}
+                  extensionConfig={extensionConfig}
                 />
                 <div className="flex flex-grow flex-col gap-4">
                   <PluginList


### PR DESCRIPTION
## Description

Small PR to display the blacklisted domains in the extension if any on poké. 

<img width="684" alt="Screenshot 2024-12-30 at 16 52 39" src="https://github.com/user-attachments/assets/92c11491-1eac-4cdb-9bed-c17d7cc1e580" />

## Risk

/ 

## Deploy Plan

Deploy front.