### PR TITLE
Remove slack integration in builder for users

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -81,7 +81,6 @@ export default function AssistantBuilder({
   defaultIsEdited,
   baseUrl,
   defaultTemplate,
-  isAdmin,
 }: AssistantBuilderProps) {
   const router = useRouter();
   const sendNotification = useSendNotification();
@@ -426,7 +425,6 @@ export default function AssistantBuilder({
                         initialScope={
                           initialBuilderState?.scope ?? defaultScope
                         }
-                        isAdmin={isAdmin}
                         newScope={builderState.scope}
                         owner={owner}
                         showSlackIntegration={showSlackIntegration}

--- a/front/components/assistant_builder/Sharing.tsx
+++ b/front/components/assistant_builder/Sharing.tsx
@@ -26,7 +26,7 @@ import type {
   LightWorkspaceType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { isBuilder } from "@dust-tt/types";
+import { isAdmin, isBuilder } from "@dust-tt/types";
 import { useState } from "react";
 
 import { assistantUsageMessage } from "@app/components/assistant/Usage";
@@ -109,7 +109,6 @@ interface SharingButtonProps {
   agentConfigurationId: string | null;
   baseUrl: string;
   initialScope: NonGlobalScope;
-  isAdmin: boolean;
   newScope: NonGlobalScope;
   owner: WorkspaceType;
   setNewLinkedSlackChannels: (channels: SlackChannel[]) => void;
@@ -123,7 +122,6 @@ export function SharingButton({
   agentConfigurationId,
   baseUrl,
   initialScope,
-  isAdmin,
   newScope,
   owner,
   setNewLinkedSlackChannels,
@@ -167,7 +165,6 @@ export function SharingButton({
             setNewLinkedSlackChannels(slackChannels);
           }}
           assistantHandle="@Dust"
-          isAdmin={isAdmin}
           show={slackDrawerOpened}
           slackDataSource={slackDataSource}
           onClose={() => setSlackDrawerOpened(false)}
@@ -244,7 +241,7 @@ export function SharingButton({
                       // If not admins, but there are channels selected, prevent from removing.
                       disabled={
                         !slackDataSource ||
-                        (slackChannelSelected.length > 0 && !isAdmin)
+                        (slackChannelSelected.length > 0 && !isAdmin(owner))
                       }
                       onClick={() => {
                         if (slackChannelSelected.length > 0) {

--- a/front/components/assistant_builder/SlackIntegration.tsx
+++ b/front/components/assistant_builder/SlackIntegration.tsx
@@ -10,6 +10,7 @@ import type {
   DataSourceType,
   WorkspaceType,
 } from "@dust-tt/types";
+import { isAdmin } from "@dust-tt/types";
 import { useCallback, useEffect, useState } from "react";
 
 import type { ContentNodeTreeItemStatus } from "@app/components/ContentNodeTree";
@@ -127,7 +128,6 @@ export function SlackIntegration({
 interface SlackAssistantDefaultManagerProps {
   assistantHandle?: string;
   existingSelection: SlackChannel[];
-  isAdmin: boolean;
   onClose: () => void;
   onSave: (channels: SlackChannel[]) => void;
   owner: WorkspaceType;
@@ -138,7 +138,6 @@ interface SlackAssistantDefaultManagerProps {
 export function SlackAssistantDefaultManager({
   assistantHandle,
   existingSelection,
-  isAdmin,
   onClose,
   onSave,
   owner,
@@ -184,7 +183,7 @@ export function SlackAssistantDefaultManager({
                 is mentionned in these channels.
               </div>
 
-              {!isAdmin && (
+              {!isAdmin(owner) && (
                 <ContentMessage
                   size="md"
                   variant="pink"
@@ -198,7 +197,7 @@ export function SlackAssistantDefaultManager({
                 </ContentMessage>
               )}
 
-              {isAdmin && (
+              {isAdmin(owner) && (
                 <SlackIntegration
                   existingSelection={existingSelection}
                   onSelectionChange={handleSelectionChange}

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -353,7 +353,6 @@ export type AssistantBuilderProps = {
   defaultTemplate: FetchAssistantTemplateResponse | null;
   flow: BuilderFlow;
   initialBuilderState: AssistantBuilderInitialState | null;
-  isAdmin: boolean;
   owner: WorkspaceType;
   plan: PlanType;
   subscription: SubscriptionType;

--- a/front/components/assistant_builder/useSlackChannels.tsx
+++ b/front/components/assistant_builder/useSlackChannels.tsx
@@ -65,7 +65,7 @@ export function useSlackChannel({
 
   return {
     slackDataSource,
-    showSlackIntegration: !isPrivateAssistant,
+    showSlackIntegration: !isPrivateAssistant && isBuilder,
     selectedSlackChannels,
     slackChannelsLinkedWithAgent,
     setSelectedSlackChannels,

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -32,7 +32,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   dataSourceViews: DataSourceViewType[];
   dustApps: AppType[];
   flow: BuilderFlow;
-  isAdmin: boolean;
   owner: WorkspaceType;
   plan: PlanType;
   spaces: SpaceType[];
@@ -91,7 +90,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       dataSourceViews: dataSourceViews.map((v) => v.toJSON()),
       dustApps: dustApps.map((a) => a.toJSON()),
       flow,
-      isAdmin: auth.isAdmin(),
       owner,
       plan,
       subscription,
@@ -108,7 +106,6 @@ export default function EditAssistant({
   dataSourceViews,
   dustApps,
   flow,
-  isAdmin,
   owner,
   plan,
   subscription,
@@ -154,7 +151,6 @@ export default function EditAssistant({
         }}
         agentConfigurationId={agentConfiguration.sId}
         baseUrl={baseUrl}
-        isAdmin={isAdmin}
         defaultTemplate={null}
       />
     </AssistantBuilderProvider>

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -40,7 +40,6 @@ function getDuplicateAndTemplateIdFromQuery(query: ParsedUrlQuery) {
 }
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
-  isAdmin: boolean;
   owner: WorkspaceType;
   subscription: SubscriptionType;
   plan: PlanType;
@@ -124,7 +123,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       dataSourceViews: dataSourceViews.map((v) => v.toJSON()),
       dustApps: dustApps.map((a) => a.toJSON()),
       flow,
-      isAdmin: auth.isAdmin(),
       owner,
       plan,
       subscription,
@@ -142,7 +140,6 @@ export default function CreateAssistant({
   dataSourceViews,
   dustApps,
   flow,
-  isAdmin,
   owner,
   plan,
   subscription,
@@ -203,7 +200,6 @@ export default function CreateAssistant({
             : null
         }
         agentConfigurationId={null}
-        isAdmin={isAdmin}
         defaultIsEdited={assistantTemplate !== null}
         baseUrl={baseUrl}
         defaultTemplate={assistantTemplate}


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/1868

- Remove slack integration toggle for users
- Also clean-up code to avoid passing isAdmin alongside owner which holds the information

## Risk

Low

## Deploy Plan

- deploy `front`