### PR TITLE
poke delete: fix agent deletion

### DIFF
--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -10,6 +10,10 @@ import { hardDeleteDataSource } from "@app/lib/api/data_sources";
 import { hardDeleteSpace } from "@app/lib/api/spaces";
 import { areAllSubscriptionsCanceled } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
+import {
+  AgentBrowseAction,
+  AgentBrowseConfiguration,
+} from "@app/lib/models/assistant/actions/browse";
 import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
 import {
   AgentDustAppRunAction,
@@ -219,6 +223,7 @@ export async function deleteAgentsActivity({
         },
         transaction: t,
       });
+
       const dustAppRunConfigurations =
         await AgentDustAppRunConfiguration.findAll({
           where: {
@@ -240,6 +245,7 @@ export async function deleteAgentsActivity({
         },
         transaction: t,
       });
+
       const tablesQueryConfigurations =
         await AgentTablesQueryConfiguration.findAll({
           where: {
@@ -269,6 +275,28 @@ export async function deleteAgentsActivity({
         },
         transaction: t,
       });
+
+      const agentBrowseConfigurations = await AgentBrowseConfiguration.findAll({
+        where: {
+          agentConfigurationId: agent.id,
+        },
+        transaction: t,
+      });
+      await AgentBrowseAction.destroy({
+        where: {
+          browseConfigurationId: {
+            [Op.in]: agentBrowseConfigurations.map((r) => r.sId),
+          },
+        },
+        transaction: t,
+      });
+      await AgentBrowseConfiguration.destroy({
+        where: {
+          agentConfigurationId: agent.id,
+        },
+        transaction: t,
+      });
+
       await AgentUserRelation.destroy({
         where: {
           agentConfiguration: agent.sId,


### PR DESCRIPTION
## Description

For: https://github.com/dust-tt/tasks/issues/1873

poke delete workflow choking at every step, now missing AgentBrowserAction/Configuration delete.

Workflow is here: https://cloud.temporal.io/namespaces/dust-front-prod.gmnlm/workflows/poke-xC04MFuDl2-delete-workspace/17f19a83-c49f-4cc2-9c3d-ab5115fa568e/history

## Risk

Low

## Deploy Plan

- deploy `front`