### PR TITLE
poke delete: fix websearch action/config

### DIFF
--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -26,6 +26,10 @@ import {
   AgentTablesQueryConfigurationTable,
 } from "@app/lib/models/assistant/actions/tables_query";
 import {
+  AgentWebsearchAction,
+  AgentWebsearchConfiguration,
+} from "@app/lib/models/assistant/actions/websearch";
+import {
   AgentConfiguration,
   AgentUserRelation,
   GlobalAgentSettings,
@@ -291,6 +295,28 @@ export async function deleteAgentsActivity({
         transaction: t,
       });
       await AgentBrowseConfiguration.destroy({
+        where: {
+          agentConfigurationId: agent.id,
+        },
+        transaction: t,
+      });
+
+      const agentWebsearchConfigurations =
+        await AgentWebsearchConfiguration.findAll({
+          where: {
+            agentConfigurationId: agent.id,
+          },
+          transaction: t,
+        });
+      await AgentWebsearchAction.destroy({
+        where: {
+          websearchConfigurationId: {
+            [Op.in]: agentWebsearchConfigurations.map((r) => r.sId),
+          },
+        },
+        transaction: t,
+      });
+      await AgentWebsearchConfiguration.destroy({
         where: {
           agentConfigurationId: agent.id,
         },


### PR DESCRIPTION
## Description

For https://github.com/dust-tt/tasks/issues/1873

Only the 4th PR attempting to fix that workflow. This ones deletes Websearch action /config before agent config.

## Risk

Low

## Deploy Plan

- deploy `front`