### PR TITLE
Replacing stroke icons by solid icons

### DIFF
--- a/extension/app/src/components/conversation/AgentMessage.tsx
+++ b/extension/app/src/components/conversation/AgentMessage.tsx
@@ -23,7 +23,7 @@ import {
   removeNulls,
 } from "@dust-tt/client";
 import type { ConversationMessageSizeType } from "@dust-tt/sparkle";
-import { DocumentTextStrokeIcon } from "@dust-tt/sparkle";
+import { DocumentTextIcon } from "@dust-tt/sparkle";
 import {
   Citation,
   CitationIcons,
@@ -107,7 +107,7 @@ export function makeWebsearchResultsCitation(
     description: result.snippet,
     href: result.link,
     title: result.title,
-    icon: <DocumentTextStrokeIcon />,
+    icon: <DocumentTextIcon />,
   };
 }
 

--- a/extension/app/src/components/markdown/MarkdownCitation.tsx
+++ b/extension/app/src/components/markdown/MarkdownCitation.tsx
@@ -1,9 +1,9 @@
 import {
   ConfluenceLogo,
-  DocumentTextStrokeIcon,
+  DocumentTextIcon,
   DriveLogo,
   GithubLogo,
-  ImageStrokeIcon,
+  ImageIcon,
   IntercomLogo,
   MicrosoftLogo,
   NotionLogo,
@@ -31,7 +31,7 @@ export const citationIconMap: Record<
   (props: SVGProps<SVGSVGElement>) => React.JSX.Element
 > = {
   confluence: ConfluenceLogo,
-  document: DocumentTextStrokeIcon,
+  document: DocumentTextIcon,
   github: GithubLogo,
   google_drive: DriveLogo,
   intercom: IntercomLogo,
@@ -39,7 +39,7 @@ export const citationIconMap: Record<
   zendesk: ZendeskLogo,
   notion: NotionLogo,
   slack: SlackLogo,
-  image: ImageStrokeIcon,
+  image: ImageIcon,
   snowflake: SnowflakeLogo,
 };
 

--- a/front/components/actions/websearch/utils.tsx
+++ b/front/components/actions/websearch/utils.tsx
@@ -1,4 +1,4 @@
-import { DocumentTextStrokeIcon } from "@dust-tt/sparkle";
+import { DocumentTextIcon } from "@dust-tt/sparkle";
 import type { WebsearchActionType, WebsearchResultType } from "@dust-tt/types";
 
 import type { MarkdownCitation } from "@app/components/markdown/MarkdownCitation";
@@ -10,7 +10,7 @@ export function makeWebsearchResultsCitation(
     description: result.snippet,
     href: result.link,
     title: result.title,
-    icon: <DocumentTextStrokeIcon />,
+    icon: <DocumentTextIcon />,
   };
 }
 

--- a/front/components/app/blocks/Block.tsx
+++ b/front/components/app/blocks/Block.tsx
@@ -3,7 +3,7 @@ import {
   ChevronDownIcon,
   ChevronUpIcon,
   Spinner,
-  Square3Stack3DStrokeIcon,
+  Square3Stack3DIcon,
   Tooltip,
   TrashIcon,
 } from "@dust-tt/sparkle";
@@ -142,7 +142,7 @@ export default function Block({
                       handleUseCacheChange(false);
                     }}
                   >
-                    <Square3Stack3DStrokeIcon className="h-4 w-4" />
+                    <Square3Stack3DIcon className="h-4 w-4" />
                   </div>
                 }
               />

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -5,7 +5,7 @@ import {
   ClipboardCheckIcon,
   Dialog,
   IconButton,
-  LinkStrokeIcon,
+  LinkIcon,
   PencilSquareIcon,
   Popover,
   TrashIcon,
@@ -224,9 +224,7 @@ export function ConversationTitle({
                       variant="primary"
                       size="sm"
                       label={copyLinkSuccess ? "Copied!" : "Copy the link"}
-                      icon={
-                        copyLinkSuccess ? ClipboardCheckIcon : LinkStrokeIcon
-                      }
+                      icon={copyLinkSuccess ? ClipboardCheckIcon : LinkIcon}
                       onClick={handleClick}
                     />
                   </div>

--- a/front/components/markdown/MarkdownCitation.tsx
+++ b/front/components/markdown/MarkdownCitation.tsx
@@ -1,9 +1,9 @@
 import {
   ConfluenceLogo,
-  DocumentTextStrokeIcon,
+  DocumentTextIcon,
   DriveLogo,
   GithubLogo,
-  ImageStrokeIcon,
+  ImageIcon,
   IntercomLogo,
   MicrosoftLogo,
   NotionLogo,
@@ -34,7 +34,7 @@ export const citationIconMap: Record<
   (props: SVGProps<SVGSVGElement>) => React.JSX.Element
 > = {
   confluence: ConfluenceLogo,
-  document: DocumentTextStrokeIcon,
+  document: DocumentTextIcon,
   github: GithubLogo,
   google_drive: DriveLogo,
   intercom: IntercomLogo,
@@ -42,7 +42,7 @@ export const citationIconMap: Record<
   zendesk: ZendeskLogo,
   notion: NotionLogo,
   slack: SlackLogo,
-  image: ImageStrokeIcon,
+  image: ImageIcon,
   snowflake: SnowflakeLogo,
 };
 

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -1,7 +1,7 @@
 import {
   Button,
   DataTable,
-  ExclamationCircleStrokeIcon,
+  ExclamationCircleIcon,
   Icon,
   Input,
   Modal,
@@ -219,7 +219,7 @@ export function CreateOrEditSpaceModal({
             />
             {!space && (
               <div className="flex gap-1 text-xs text-element-700">
-                <Icon visual={ExclamationCircleStrokeIcon} size="xs" />
+                <Icon visual={ExclamationCircleIcon} size="xs" />
                 <span>Space name must be unique</span>
               </div>
             )}

--- a/front/components/spaces/SpaceCreateAppModal.tsx
+++ b/front/components/spaces/SpaceCreateAppModal.tsx
@@ -1,5 +1,5 @@
 import {
-  ExclamationCircleStrokeIcon,
+  ExclamationCircleIcon,
   Input,
   Modal,
   Page,
@@ -135,7 +135,7 @@ export const SpaceCreateAppModal = ({
                 messageStatus="error"
               />
               <p className="mt-1 flex items-center gap-1 text-sm text-gray-500">
-                <ExclamationCircleStrokeIcon /> Must be unique and only use
+                <ExclamationCircleIcon /> Must be unique and only use
                 alphanumeric, - or _ characters.
               </p>
             </div>

--- a/front/components/spaces/SpaceWebsiteModal.tsx
+++ b/front/components/spaces/SpaceWebsiteModal.tsx
@@ -6,7 +6,7 @@ import {
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
-  ExclamationCircleStrokeIcon,
+  ExclamationCircleIcon,
   InformationCircleIcon,
   Input,
   Label,
@@ -567,7 +567,7 @@ export default function SpaceWebsiteModal({
                     </Label>
                   ) : (
                     <p className="mt-1 flex items-center gap-1 text-sm text-gray-500">
-                      <ExclamationCircleStrokeIcon />
+                      <ExclamationCircleIcon />
                       Website name cannot be changed.
                     </p>
                   )}


### PR DESCRIPTION
## Description

As part of the Sparkles clean-up we decided to avoid using stroke icons (except for some cases like stars for example).

## Risk
None

## Deploy Plan
Merge PR
