### PR TITLE
Add Confluence API calls monitoring

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -8,6 +8,7 @@ import {
   ProviderWorkflowError,
 } from "@connectors/lib/error";
 import logger from "@connectors/logger/logger";
+import { statsDClient } from "@connectors/logger/withlogging";
 
 const CatchAllCodec = t.record(t.string, t.unknown); // Catch-all for unknown properties.
 
@@ -208,6 +209,11 @@ export class ConfluenceClient {
           signal: AbortSignal.timeout(30000),
         });
       } catch (e) {
+        statsDClient.increment("external.api.calls", 1, [
+          "provider:confluence",
+          "status:error",
+        ]);
+
         if (
           e instanceof DOMException &&
           (e.name === "TimeoutError" || e.name === "AbortError")
@@ -238,6 +244,11 @@ export class ConfluenceClient {
     })();
 
     if (!response.ok) {
+      statsDClient.increment("external.api.calls", 1, [
+        "provider:confluence",
+        "status:error",
+      ]);
+
       // If the token is invalid, the API will return a 403 Forbidden response.
       if (response.status === 403 && response.statusText === "Forbidden") {
         throw new ExternalOAuthTokenError();
@@ -275,6 +286,11 @@ export class ConfluenceClient {
       );
     }
 
+    statsDClient.increment("external.api.calls", 1, [
+      "provider:confluence",
+      "status:success",
+    ]);
+
     const responseBody = await response.json();
     const result = codec.decode(responseBody);
 
@@ -305,6 +321,11 @@ export class ConfluenceClient {
           signal: AbortSignal.timeout(30000),
         });
       } catch (e) {
+        statsDClient.increment("external.api.calls", 1, [
+          "provider:confluence",
+          "status:error",
+        ]);
+
         if (
           e instanceof DOMException &&
           (e.name === "TimeoutError" || e.name === "AbortError")
@@ -335,6 +356,11 @@ export class ConfluenceClient {
     })();
 
     if (!response.ok) {
+      statsDClient.increment("external.api.calls", 1, [
+        "provider:confluence",
+        "status:error",
+      ]);
+
       throw new ConfluenceClientError(
         `Confluence API responded with status: ${response.status}: ${this.apiUrl}${endpoint}`,
         {
@@ -344,6 +370,11 @@ export class ConfluenceClient {
         }
       );
     }
+
+    statsDClient.increment("external.api.calls", 1, [
+      "provider:confluence",
+      "status:success",
+    ]);
 
     if (response.status === 204) {
       return undefined; // Return undefined for 204 No Content.


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See https://github.com/dust-tt/tasks/issues/1874.

We're experiencing rate limit issues with Confluence API but lack visibility into our actual usage patterns. This PR adds instrumentation to track all Confluence API calls, enabling us to:
- Quantify our API consumption
- Identify potential rate limit bottlenecks
- Make data-driven decisions for optimization

## Changes
- Added Datadog metrics tracking for all Confluence API calls using:
  ```javascript
  metrics.increment('external.api.calls', 1, [
    'provider:confluence',
    'status:success|error'
  ]);

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
