### PR TITLE
Various fixes to poke workspace delete

### DIFF
--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -115,7 +115,7 @@ export class RunResource extends BaseResource<RunModel> {
         runId: {
           [Op.in]: Sequelize.literal(
             // Sequelize prevents other safer constructs due to typing with the destroy method.
-            // `appId` cannot cannot be user provided + assert above.
+            // `appId` cannot be user provided + assert above.
             `(SELECT id FROM runs WHERE appId = '${appId}')`
           ),
         },

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -6,6 +6,7 @@ import type {
   Result,
 } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
+import assert from "assert";
 import type {
   Attributes,
   CreationAttributes,
@@ -24,7 +25,6 @@ import {
 } from "@app/lib/resources/storage/models/runs";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { getRunExecutionsDeletionCutoffDate } from "@app/temporal/hard_delete/utils";
-import assert from "assert";
 
 type RunResourceWithApp = RunResource & { app: AppModel };
 

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -24,6 +24,7 @@ import {
 } from "@app/lib/resources/storage/models/runs";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { getRunExecutionsDeletionCutoffDate } from "@app/temporal/hard_delete/utils";
+import assert from "assert";
 
 type RunResourceWithApp = RunResource & { app: AppModel };
 
@@ -108,12 +109,13 @@ export class RunResource extends BaseResource<RunModel> {
   }
 
   static async deleteAllByAppId(appId: ModelId, transaction?: Transaction) {
+    assert(typeof appId === "number");
     await RunUsageModel.destroy({
       where: {
         runId: {
           [Op.in]: Sequelize.literal(
             // Sequelize prevents other safer constructs due to typing with the destroy method.
-            // `appId` cannot cannot be user provided.
+            // `appId` cannot cannot be user provided + assert above.
             `(SELECT id FROM runs WHERE appId = '${appId}')`
           ),
         },
@@ -133,12 +135,13 @@ export class RunResource extends BaseResource<RunModel> {
     workspace: LightWorkspaceType,
     transaction?: Transaction
   ) {
+    assert(typeof workspace.id === "number");
     await RunUsageModel.destroy({
       where: {
         runId: {
           [Op.in]: Sequelize.literal(
             // Sequelize prevents other safer constructs due to typing with the destroy method.
-            // `workspace.id` cannot cannot be user provided.
+            // `workspace.id` cannot cannot be user provided + assert above.
             `(SELECT id FROM runs WHERE workspaceId = '${workspace.id}')`
           ),
         },

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -40,6 +40,7 @@ import {
 } from "@app/lib/models/assistant/agent";
 import { Subscription } from "@app/lib/models/plan";
 import {
+  DustAppSecret,
   MembershipInvitation,
   Workspace,
   WorkspaceHasDomain,
@@ -527,6 +528,11 @@ export async function deleteSpacesActivity({
   });
 
   for (const space of spaces) {
+    const res = await space.delete(auth, { hardDelete: false });
+    if (res.isErr()) {
+      throw res.error;
+    }
+
     await scrubSpaceActivity({
       spaceId: space.sId,
       workspaceId,
@@ -561,6 +567,12 @@ export async function deleteWorkspaceActivity({
       transaction: t,
     });
     await ExtensionConfigurationResource.deleteForWorkspace(auth, {
+      transaction: t,
+    });
+    await DustAppSecret.destroy({
+      where: {
+        workspaceId: workspace.id,
+      },
       transaction: t,
     });
 

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -53,7 +53,6 @@ import { KeyResource } from "@app/lib/resources/key_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { frontSequelize } from "@app/lib/resources/storage";
 import { Provider } from "@app/lib/resources/storage/models/apps";
 import {
   LabsTranscriptsConfigurationModel,
@@ -202,164 +201,139 @@ export async function deleteAgentsActivity({
     },
   });
 
-  await frontSequelize.transaction(async (t) => {
-    await GlobalAgentSettings.destroy({
-      where: {
-        workspaceId: workspace.id,
-      },
-      transaction: t,
-    });
-    for (const agent of agents) {
-      const retrievalConfigurations = await AgentRetrievalConfiguration.findAll(
-        {
-          where: {
-            agentConfigurationId: agent.id,
-          },
-          transaction: t,
-        }
-      );
-      await AgentDataSourceConfiguration.destroy({
-        where: {
-          retrievalConfigurationId: {
-            [Op.in]: retrievalConfigurations.map((r) => r.id),
-          },
-        },
-        transaction: t,
-      });
-      await AgentRetrievalConfiguration.destroy({
-        where: {
-          agentConfigurationId: agent.id,
-        },
-        transaction: t,
-      });
-
-      const dustAppRunConfigurations =
-        await AgentDustAppRunConfiguration.findAll({
-          where: {
-            agentConfigurationId: agent.id,
-          },
-          transaction: t,
-        });
-      await AgentDustAppRunAction.destroy({
-        where: {
-          dustAppRunConfigurationId: {
-            [Op.in]: dustAppRunConfigurations.map((r) => r.sId),
-          },
-        },
-        transaction: t,
-      });
-      await AgentDustAppRunConfiguration.destroy({
-        where: {
-          agentConfigurationId: agent.id,
-        },
-        transaction: t,
-      });
-
-      const tablesQueryConfigurations =
-        await AgentTablesQueryConfiguration.findAll({
-          where: {
-            agentConfigurationId: agent.id,
-          },
-          transaction: t,
-        });
-      await AgentTablesQueryAction.destroy({
-        where: {
-          tablesQueryConfigurationId: {
-            [Op.in]: tablesQueryConfigurations.map((r) => r.sId),
-          },
-        },
-        transaction: t,
-      });
-      await AgentTablesQueryConfigurationTable.destroy({
-        where: {
-          tablesQueryConfigurationId: {
-            [Op.in]: tablesQueryConfigurations.map((r) => r.id),
-          },
-        },
-        transaction: t,
-      });
-      await AgentTablesQueryConfiguration.destroy({
-        where: {
-          agentConfigurationId: agent.id,
-        },
-        transaction: t,
-      });
-
-      const agentBrowseConfigurations = await AgentBrowseConfiguration.findAll({
-        where: {
-          agentConfigurationId: agent.id,
-        },
-        transaction: t,
-      });
-      await AgentBrowseAction.destroy({
-        where: {
-          browseConfigurationId: {
-            [Op.in]: agentBrowseConfigurations.map((r) => r.sId),
-          },
-        },
-        transaction: t,
-      });
-      await AgentBrowseConfiguration.destroy({
-        where: {
-          agentConfigurationId: agent.id,
-        },
-        transaction: t,
-      });
-
-      const agentWebsearchConfigurations =
-        await AgentWebsearchConfiguration.findAll({
-          where: {
-            agentConfigurationId: agent.id,
-          },
-          transaction: t,
-        });
-      await AgentWebsearchAction.destroy({
-        where: {
-          websearchConfigurationId: {
-            [Op.in]: agentWebsearchConfigurations.map((r) => r.sId),
-          },
-        },
-        transaction: t,
-      });
-      await AgentWebsearchConfiguration.destroy({
-        where: {
-          agentConfigurationId: agent.id,
-        },
-        transaction: t,
-      });
-
-      const agentProcessConfigurations =
-        await AgentProcessConfiguration.findAll({
-          where: {
-            agentConfigurationId: agent.id,
-          },
-          transaction: t,
-        });
-      await AgentProcessAction.destroy({
-        where: {
-          processConfigurationId: {
-            [Op.in]: agentProcessConfigurations.map((r) => r.sId),
-          },
-        },
-        transaction: t,
-      });
-      await AgentProcessConfiguration.destroy({
-        where: {
-          agentConfigurationId: agent.id,
-        },
-        transaction: t,
-      });
-
-      await AgentUserRelation.destroy({
-        where: {
-          agentConfiguration: agent.sId,
-        },
-        transaction: t,
-      });
-      hardDeleteLogger.info({ agentId: agent.sId }, "Deleting agent");
-      await agent.destroy({ transaction: t });
-    }
+  await GlobalAgentSettings.destroy({
+    where: {
+      workspaceId: workspace.id,
+    },
   });
+  for (const agent of agents) {
+    const retrievalConfigurations = await AgentRetrievalConfiguration.findAll({
+      where: {
+        agentConfigurationId: agent.id,
+      },
+    });
+    await AgentDataSourceConfiguration.destroy({
+      where: {
+        retrievalConfigurationId: {
+          [Op.in]: retrievalConfigurations.map((r) => r.id),
+        },
+      },
+    });
+    await AgentRetrievalConfiguration.destroy({
+      where: {
+        agentConfigurationId: agent.id,
+      },
+    });
+
+    const dustAppRunConfigurations = await AgentDustAppRunConfiguration.findAll(
+      {
+        where: {
+          agentConfigurationId: agent.id,
+        },
+      }
+    );
+    await AgentDustAppRunAction.destroy({
+      where: {
+        dustAppRunConfigurationId: {
+          [Op.in]: dustAppRunConfigurations.map((r) => r.sId),
+        },
+      },
+    });
+    await AgentDustAppRunConfiguration.destroy({
+      where: {
+        agentConfigurationId: agent.id,
+      },
+    });
+
+    const tablesQueryConfigurations =
+      await AgentTablesQueryConfiguration.findAll({
+        where: {
+          agentConfigurationId: agent.id,
+        },
+      });
+    await AgentTablesQueryAction.destroy({
+      where: {
+        tablesQueryConfigurationId: {
+          [Op.in]: tablesQueryConfigurations.map((r) => r.sId),
+        },
+      },
+    });
+    await AgentTablesQueryConfigurationTable.destroy({
+      where: {
+        tablesQueryConfigurationId: {
+          [Op.in]: tablesQueryConfigurations.map((r) => r.id),
+        },
+      },
+    });
+    await AgentTablesQueryConfiguration.destroy({
+      where: {
+        agentConfigurationId: agent.id,
+      },
+    });
+
+    const agentBrowseConfigurations = await AgentBrowseConfiguration.findAll({
+      where: {
+        agentConfigurationId: agent.id,
+      },
+    });
+    await AgentBrowseAction.destroy({
+      where: {
+        browseConfigurationId: {
+          [Op.in]: agentBrowseConfigurations.map((r) => r.sId),
+        },
+      },
+    });
+    await AgentBrowseConfiguration.destroy({
+      where: {
+        agentConfigurationId: agent.id,
+      },
+    });
+
+    const agentWebsearchConfigurations =
+      await AgentWebsearchConfiguration.findAll({
+        where: {
+          agentConfigurationId: agent.id,
+        },
+      });
+    await AgentWebsearchAction.destroy({
+      where: {
+        websearchConfigurationId: {
+          [Op.in]: agentWebsearchConfigurations.map((r) => r.sId),
+        },
+      },
+    });
+    await AgentWebsearchConfiguration.destroy({
+      where: {
+        agentConfigurationId: agent.id,
+      },
+    });
+
+    const agentProcessConfigurations = await AgentProcessConfiguration.findAll({
+      where: {
+        agentConfigurationId: agent.id,
+      },
+    });
+    await AgentProcessAction.destroy({
+      where: {
+        processConfigurationId: {
+          [Op.in]: agentProcessConfigurations.map((r) => r.sId),
+        },
+      },
+    });
+    await AgentProcessConfiguration.destroy({
+      where: {
+        agentConfigurationId: agent.id,
+      },
+    });
+
+    await AgentUserRelation.destroy({
+      where: {
+        agentConfiguration: agent.sId,
+      },
+    });
+    hardDeleteLogger.info({ agentId: agent.sId }, "Deleting agent");
+    await agent.destroy();
+  }
 }
 
 export async function deleteAppsActivity({
@@ -379,15 +353,12 @@ export async function deleteAppsActivity({
     }
   }
 
-  await frontSequelize.transaction(async (t) => {
-    await KeyResource.deleteAllForWorkspace(workspace, t);
+  await KeyResource.deleteAllForWorkspace(workspace);
 
-    await Provider.destroy({
-      where: {
-        workspaceId: workspace.id,
-      },
-      transaction: t,
-    });
+  await Provider.destroy({
+    where: {
+      workspaceId: workspace.id,
+    },
   });
 }
 
@@ -462,59 +433,54 @@ export async function deleteMembersActivity({
     throw new Error("Could not find the workspace.");
   }
 
-  await frontSequelize.transaction(async (t) => {
-    await MembershipInvitation.destroy({
-      where: {
-        workspaceId: workspace.id,
-      },
-      transaction: t,
-    });
+  await MembershipInvitation.destroy({
+    where: {
+      workspaceId: workspace.id,
+    },
+  });
 
-    const { memberships } = await MembershipResource.getMembershipsForWorkspace(
-      { workspace, transaction: t }
-    );
+  const { memberships } = await MembershipResource.getMembershipsForWorkspace({
+    workspace,
+  });
 
-    for (const membership of memberships) {
-      const user = await UserResource.fetchByModelId(membership.userId, t);
-      if (user) {
-        const { memberships: membershipsOfUser } =
-          await MembershipResource.getLatestMemberships({
-            users: [user],
-            transaction: t,
-          });
+  for (const membership of memberships) {
+    const user = await UserResource.fetchByModelId(membership.userId);
+    if (user) {
+      const { memberships: membershipsOfUser } =
+        await MembershipResource.getLatestMemberships({
+          users: [user],
+        });
 
-        // If the user we're removing the membership of only has one membership, we delete the user.
-        if (membershipsOfUser.length === 1) {
-          await UserMetadataModel.destroy({
-            where: {
-              userId: user.id,
-            },
-            transaction: t,
-          });
-          hardDeleteLogger.info(
-            {
-              membershipId: membership.id,
-              userId: user.sId,
-            },
-            "Deleting Membership and user"
-          );
-
-          // Delete the user's files.
-          await FileResource.deleteAllForUser(user.toJSON(), t);
-          await membership.delete(auth, { transaction: t });
-          await user.delete(auth, { transaction: t });
-        }
-      } else {
+      // If the user we're removing the membership of only has one membership, we delete the user.
+      if (membershipsOfUser.length === 1) {
+        await UserMetadataModel.destroy({
+          where: {
+            userId: user.id,
+          },
+        });
         hardDeleteLogger.info(
           {
             membershipId: membership.id,
+            userId: user.sId,
           },
-          "Deleting Membership"
+          "Deleting Membership and user"
         );
-        await membership.delete(auth, { transaction: t });
+
+        // Delete the user's files.
+        await FileResource.deleteAllForUser(user.toJSON());
+        await membership.delete(auth, {});
+        await user.delete(auth, {});
       }
+    } else {
+      hardDeleteLogger.info(
+        {
+          membershipId: membership.id,
+        },
+        "Deleting Membership"
+      );
+      await membership.delete(auth, {});
     }
-  });
+  }
 }
 
 export async function deleteSpacesActivity({
@@ -548,42 +514,33 @@ export async function deleteWorkspaceActivity({
   const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
   const workspace = auth.getNonNullableWorkspace();
 
-  await frontSequelize.transaction(async (t) => {
-    await Subscription.destroy({
-      where: {
-        workspaceId: workspace.id,
-      },
-      transaction: t,
-    });
-    await FileResource.deleteAllForWorkspace(workspace, t);
-    await RunResource.deleteAllForWorkspace(workspace, t);
-    await MembershipResource.deleteAllForWorkspace(workspace, t);
-    await WorkspaceHasDomain.destroy({
-      where: { workspaceId: workspace.id },
-      transaction: t,
-    });
-    await AgentUserRelation.destroy({
-      where: { workspaceId: workspace.id },
-      transaction: t,
-    });
-    await ExtensionConfigurationResource.deleteForWorkspace(auth, {
-      transaction: t,
-    });
-    await DustAppSecret.destroy({
-      where: {
-        workspaceId: workspace.id,
-      },
-      transaction: t,
-    });
+  await Subscription.destroy({
+    where: {
+      workspaceId: workspace.id,
+    },
+  });
+  await FileResource.deleteAllForWorkspace(workspace);
+  await RunResource.deleteAllForWorkspace(workspace);
+  await MembershipResource.deleteAllForWorkspace(workspace);
+  await WorkspaceHasDomain.destroy({
+    where: { workspaceId: workspace.id },
+  });
+  await AgentUserRelation.destroy({
+    where: { workspaceId: workspace.id },
+  });
+  await ExtensionConfigurationResource.deleteForWorkspace(auth, {});
+  await DustAppSecret.destroy({
+    where: {
+      workspaceId: workspace.id,
+    },
+  });
 
-    hardDeleteLogger.info({ workspaceId }, "Deleting Workspace");
+  hardDeleteLogger.info({ workspaceId }, "Deleting Workspace");
 
-    await Workspace.destroy({
-      where: {
-        id: workspace.id,
-      },
-      transaction: t,
-    });
+  await Workspace.destroy({
+    where: {
+      id: workspace.id,
+    },
   });
 }
 
@@ -595,27 +552,23 @@ export async function deleteTranscriptsActivity({
   const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
   const workspace = auth.getNonNullableWorkspace();
 
-  await frontSequelize.transaction(async (t) => {
-    const configs = await LabsTranscriptsConfigurationModel.findAll({
-      where: {
-        workspaceId: workspace.id,
-      },
-    });
+  const configs = await LabsTranscriptsConfigurationModel.findAll({
+    where: {
+      workspaceId: workspace.id,
+    },
+  });
 
-    await LabsTranscriptsHistoryModel.destroy({
-      where: {
-        configurationId: {
-          [Op.in]: configs.map((c) => c.id),
-        },
+  await LabsTranscriptsHistoryModel.destroy({
+    where: {
+      configurationId: {
+        [Op.in]: configs.map((c) => c.id),
       },
-      transaction: t,
-    });
+    },
+  });
 
-    await LabsTranscriptsConfigurationModel.destroy({
-      where: {
-        workspaceId: workspace.id,
-      },
-      transaction: t,
-    });
+  await LabsTranscriptsConfigurationModel.destroy({
+    where: {
+      workspaceId: workspace.id,
+    },
   });
 }

--- a/front/poke/temporal/workflows.ts
+++ b/front/poke/temporal/workflows.ts
@@ -53,8 +53,8 @@ export async function deleteWorkspaceWorkflow({
   }
   await deleteConversationsActivity({ workspaceId });
   await deleteAgentsActivity({ workspaceId });
-  await deleteAppsActivity({ workspaceId });
   await deleteRunOnDustAppsActivity({ workspaceId });
+  await deleteAppsActivity({ workspaceId });
   await deleteTrackersActivity({ workspaceId });
   await deleteMembersActivity({ workspaceId });
   await deleteSpacesActivity({ workspaceId });


### PR DESCRIPTION
## Description

- Delete RunUsages before deleting Runs
- Reorder deletion of core runs vs apps (hence project deletion)
- Adds removal of DustAppSecret
- Pre-soft delete Spaces before running the deletion activity (otherwise refused by isDeletable)

Successfully run to completion in dev but might still be missing a few things since I have no guarantee I created all models.

## Risk

High-ish given the unsafety of the SQL construct imposed by sequelize hence asking for 4 eyes review

## Deploy Plan

- deploy `front`