### PR TITLE
Adaptation of the feedback process to include isConversationShared

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -95,7 +95,7 @@ export const FeedbackSelectorPopoverContent = ({
 
   return (
     agentLastAuthor && (
-      <div className="mt-4 flex flex-col gap-2">
+      <div className="mb-4 mt-2 flex flex-col gap-2">
         <Page.P variant="secondary">Your feedback goes to:</Page.P>
         <div className="flex flex-row items-center gap-2">
           {agentLastAuthor.image && (

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -96,7 +96,9 @@ export const FeedbackSelectorPopoverContent = ({
   return (
     agentLastAuthor && (
       <div className="mb-4 mt-2 flex flex-col gap-2">
-        <Page.P variant="secondary">Your feedback goes to:</Page.P>
+        <Page.P variant="secondary">
+          Your feedback is publicly available. The last assistant author is:
+        </Page.P>
         <div className="flex flex-row items-center gap-2">
           {agentLastAuthor.image && (
             <img

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -97,7 +97,8 @@ export const FeedbackSelectorPopoverContent = ({
     agentLastAuthor && (
       <div className="mb-4 mt-2 flex flex-col gap-2">
         <Page.P variant="secondary">
-          Your feedback is publicly available. The last assistant author is:
+          Your feedback is publicly available within the workspace. The last
+          assistant author is:
         </Page.P>
         <div className="flex flex-row items-center gap-2">
           {agentLastAuthor.image && (

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -436,7 +436,7 @@ export function AgentMessage({
             className="text-muted-foreground"
             disabled={isRetryHandlerProcessing || shouldStream}
           />,
-          // One can not leave feedback on global agents.
+          // One cannot leave feedback on global agents.
           ...(isGlobalAgent
             ? []
             : [

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -35,6 +35,7 @@ import type {
 } from "@dust-tt/types";
 import {
   assertNever,
+  GLOBAL_AGENTS_SID,
   isRetrievalActionType,
   isWebsearchActionType,
   removeNulls,
@@ -94,19 +95,20 @@ export const FeedbackSelectorPopoverContent = ({
 
   return (
     agentLastAuthor && (
-      <div className="itemcenter mt-4 flex gap-2">
-        {agentLastAuthor?.image && (
-          <img
-            src={agentLastAuthor?.image}
-            alt={agentLastAuthor?.firstName}
-            className="h-8 w-8 rounded-full"
-          />
-        )}
-        <Page.P variant="secondary">
-          Your feedback will be sent to:
-          <br />
-          {agentLastAuthor?.firstName} {agentLastAuthor?.lastName}
-        </Page.P>
+      <div className="mt-4 flex flex-col gap-2">
+        <Page.P variant="secondary">Your feedback goes to:</Page.P>
+        <div className="flex flex-row items-center gap-2">
+          {agentLastAuthor.image && (
+            <img
+              src={agentLastAuthor.image}
+              alt={agentLastAuthor.firstName}
+              className="h-8 w-8 rounded-full"
+            />
+          )}
+          <Page.P variant="primary">
+            {agentLastAuthor.firstName} {agentLastAuthor.lastName}
+          </Page.P>
+        </div>
       </div>
     )
   );
@@ -152,6 +154,12 @@ export function AgentMessage({
   const [activeReferences, setActiveReferences] = useState<
     { index: number; document: MarkdownCitation }[]
   >([]);
+
+  const isGlobalAgent = useMemo(() => {
+    return Object.values(GLOBAL_AGENTS_SID).includes(
+      message.configuration.sId as GLOBAL_AGENTS_SID
+    );
+  }, [message.configuration.sId]);
 
   const shouldStream = (() => {
     if (message.status !== "created") {
@@ -428,14 +436,19 @@ export function AgentMessage({
             className="text-muted-foreground"
             disabled={isRetryHandlerProcessing || shouldStream}
           />,
-          <div key="separator" className="flex items-center">
-            <div className="h-5 w-px bg-border" />
-          </div>,
-          <FeedbackSelector
-            key="feedback-selector"
-            {...messageFeedback}
-            getPopoverInfo={PopoverContent}
-          />,
+          // One can not leave feedback on global agents.
+          ...(isGlobalAgent
+            ? []
+            : [
+                <div key="separator" className="flex items-center">
+                  <div className="h-5 w-px bg-border" />
+                </div>,
+                <FeedbackSelector
+                  key="feedback-selector"
+                  {...messageFeedback}
+                  getPopoverInfo={PopoverContent}
+                />,
+              ]),
         ];
 
   // References logic.

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -97,8 +97,8 @@ export const FeedbackSelectorPopoverContent = ({
     agentLastAuthor && (
       <div className="mb-4 mt-2 flex flex-col gap-2">
         <Page.P variant="secondary">
-          Your feedback is publicly available within the workspace. The last
-          assistant author is:
+          Your feedback is available to editors of the assistant. The last
+          assistant editor is:
         </Page.P>
         <div className="flex flex-row items-center gap-2">
           {agentLastAuthor.image && (

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -56,10 +56,12 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
           thumb,
           isToRemove,
           feedbackContent,
+          isConversationShared,
         }: {
           thumb: string;
           isToRemove: boolean;
-          feedbackContent?: string | null;
+          feedbackContent: string | null;
+          isConversationShared: boolean;
         }) => {
           const res = await fetch(
             `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages/${message.sId}/feedbacks`,
@@ -71,6 +73,7 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
               body: JSON.stringify({
                 thumbDirection: thumb,
                 feedbackContent,
+                isConversationShared,
               }),
             }
           );
@@ -99,6 +102,7 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
         ? {
             thumb: messageFeedback.thumbDirection,
             feedbackContent: messageFeedback.content,
+            isConversationShared: messageFeedback.isConversationShared,
           }
         : null,
       onSubmitThumb,

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -54,19 +54,19 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
       useSubmitFunction(
         async ({
           thumb,
-          isToRemove,
+          shouldRemoveExistingFeedback,
           feedbackContent,
           isConversationShared,
         }: {
           thumb: string;
-          isToRemove: boolean;
+          shouldRemoveExistingFeedback: boolean;
           feedbackContent: string | null;
           isConversationShared: boolean;
         }) => {
           const res = await fetch(
             `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages/${message.sId}/feedbacks`,
             {
-              method: isToRemove ? "DELETE" : "POST",
+              method: shouldRemoveExistingFeedback ? "DELETE" : "POST",
               headers: {
                 "Content-Type": "application/json",
               },
@@ -78,7 +78,7 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
             }
           );
           if (res.ok) {
-            if (feedbackContent && !isToRemove) {
+            if (feedbackContent && !shouldRemoveExistingFeedback) {
               sendNotification({
                 title: "Feedback submitted",
                 description:

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.350",
+        "@dust-tt/sparkle": "^0.2.351-alpha",
         "@dust-tt/types": "file:../types",
         "@headlessui/react": "^1.7.7",
         "@heroicons/react": "^2.0.11",
@@ -11453,9 +11453,10 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.350",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.350.tgz",
-      "integrity": "sha512-yY9sz4r4L2W1YcOeuulsqujE7Lc5R+ZPGgcIvZzGY/z2X+XqfeouexKre+CD7JqY6ZbsQBKgeB+7PmoGEkA/8Q==",
+      "version": "0.2.351-alpha",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.351-alpha.tgz",
+      "integrity": "sha512-iOXfbqDyHKlR6vEUmZChRUia+NHBX0ArdM2M6B7Kcbdl2WWAl2XILHDgf/Av7y95MfVMVBi283OrbDydVvFNKg==",
+      "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.351-alpha",
+        "@dust-tt/sparkle": "^0.2.351",
         "@dust-tt/types": "file:../types",
         "@headlessui/react": "^1.7.7",
         "@heroicons/react": "^2.0.11",
@@ -11453,9 +11453,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.351-alpha",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.351-alpha.tgz",
-      "integrity": "sha512-iOXfbqDyHKlR6vEUmZChRUia+NHBX0ArdM2M6B7Kcbdl2WWAl2XILHDgf/Av7y95MfVMVBi283OrbDydVvFNKg==",
+      "version": "0.2.351",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.351.tgz",
+      "integrity": "sha512-JavoOPirn+5aqnch06wUpyq8/PetbpdBtrgd86mn0SMoJy9Dqx8Vh7eqyvy/GIqPkJHXtiq2hgKxGbNejJCWfQ==",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/front/package.json
+++ b/front/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.351-alpha",
+    "@dust-tt/sparkle": "^0.2.351",
     "@dust-tt/types": "file:../types",
     "@headlessui/react": "^1.7.7",
     "@heroicons/react": "^2.0.11",

--- a/front/package.json
+++ b/front/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.350",
+    "@dust-tt/sparkle": "^0.2.351-alpha",
     "@dust-tt/types": "file:../types",
     "@headlessui/react": "^1.7.7",
     "@heroicons/react": "^2.0.11",

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks/index.ts
@@ -18,6 +18,7 @@ import { apiError } from "@app/logger/withlogging";
 export const MessageFeedbackRequestBodySchema = t.type({
   thumbDirection: t.string,
   feedbackContent: t.union([t.string, t.undefined, t.null]),
+  isConversationShared: t.union([t.boolean, t.undefined]),
 });
 
 async function handler(
@@ -86,6 +87,7 @@ async function handler(
         thumbDirection: bodyValidation.right
           .thumbDirection as AgentMessageFeedbackDirection,
         content: bodyValidation.right.feedbackContent || "",
+        isConversationShared: bodyValidation.right.isConversationShared,
       });
 
       if (created.isErr()) {


### PR DESCRIPTION


## Description
- Builds on top of https://github.com/dust-tt/dust/pull/9670
- Not allowing feedback on global agents to avoid misleading sharing warnings, and because this feedback is not leveraged
- isConversationShared is passed to the endpoints and persisted


https://github.com/user-attachments/assets/3aad6881-090f-4d0f-9ef1-1e55fb45c0b7


<img width="922" alt="Screenshot 2025-01-02 at 14 01 57" src="https://github.com/user-attachments/assets/212ca03d-acc3-4861-a5a5-a88e5d6c959d" />

## Risk
Break feedback

## Deploy Plan
Deploy Front, after spark is published
