### PR TITLE
poke delete: delete feature flags before workspace

### DIFF
--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -38,6 +38,7 @@ import {
   AgentUserRelation,
   GlobalAgentSettings,
 } from "@app/lib/models/assistant/agent";
+import { FeatureFlag } from "@app/lib/models/feature_flag";
 import { Subscription } from "@app/lib/models/plan";
 import {
   DustAppSecret,
@@ -532,6 +533,11 @@ export async function deleteWorkspaceActivity({
   });
   await ExtensionConfigurationResource.deleteForWorkspace(auth, {});
   await DustAppSecret.destroy({
+    where: {
+      workspaceId: workspace.id,
+    },
+  });
+  await FeatureFlag.destroy({
     where: {
       workspaceId: workspace.id,
     },


### PR DESCRIPTION
## Description

Make sure to delete FeatureFlags when deleting workpace.

From an audit of workspaces foreign key references should the last one.

For: https://github.com/dust-tt/tasks/issues/1873

## Risk

Low

## Deploy Plan

- deploy `front`