### PR TITLE
fix(connectors) - add a missing parentId in `updateDescendantsParentsInCore`

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -860,14 +860,16 @@ async function updateDescendantsParentsInCore({
   const files = children.filter((child) => child.nodeType === "file");
   const folders = children.filter((child) => child.nodeType === "folder");
 
+  const parents = await getParents({
+    connectorId: folder.connectorId,
+    internalId: folder.internalId,
+    startSyncTs,
+  });
   await upsertDataSourceFolder({
     dataSourceConfig,
     folderId: folder.internalId,
-    parents: await getParents({
-      connectorId: folder.connectorId,
-      internalId: folder.internalId,
-      startSyncTs,
-    }),
+    parents,
+    parentId: parents[1] || null,
     title: folder.name ?? "",
     mimeType: "application/vnd.dust.microsoft.folder",
   });


### PR DESCRIPTION
## Description

- Fix following up on #9580 (not sure why the lint did not fail there).
- `parentId` was not correctly passed in `updateDescendantsParentsInCore` (`microsoft/temporal/activities.ts`)
- This PR fixes that.

## Risk

- Low.

## Deploy Plan

- Deploy connectors
