### PR TITLE
fix(connectors) - pass `parentId` in `upsertDataSourceRemoteTable`

### DIFF
--- a/connectors/src/connectors/snowflake/temporal/activities.ts
+++ b/connectors/src/connectors/snowflake/temporal/activities.ts
@@ -170,6 +170,7 @@ export async function syncSnowflakeConnection(connectorId: ModelId) {
             `${table.databaseName}.${table.schemaName}`,
             table.databaseName,
           ],
+          parentId: `${table.databaseName}.${table.schemaName}`,
           title: table.name,
           mimeType: "application/vnd.snowflake.table",
         });

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -631,6 +631,7 @@ export async function upsertDataSourceRemoteTable({
   remoteDatabaseSecretId,
   loggerArgs,
   parents,
+  parentId,
   title,
   mimeType,
 }: {
@@ -642,6 +643,7 @@ export async function upsertDataSourceRemoteTable({
   remoteDatabaseSecretId: string | null;
   loggerArgs?: Record<string, string | number>;
   parents: string[];
+  parentId: string | null;
   title: string;
   mimeType: string;
 }) {
@@ -666,6 +668,7 @@ export async function upsertDataSourceRemoteTable({
   const dustRequestPayload: UpsertDatabaseTableRequestType = {
     name: tableName,
     parents,
+    parent_id: parentId,
     description: tableDescription,
     table_id: tableId,
     remote_database_table_id: remoteDatabaseTableId,


### PR DESCRIPTION
## Description

- Part of #9365
- The function `upsertDataSourceRemoteTable` in `lib/data_sources.ts` now supports and enforces passing a `parentId`.
- This function was only used in the Snowflake connector, which now passes the `parentId` accordingly.

## Risk

- Low, no user-facing impact.

## Deploy Plan

- Deploy connectors.
