### PR TITLE
slack: consider missing_scopes as an auth error

### DIFF
--- a/connectors/src/connectors/slack/lib/slack_client.ts
+++ b/connectors/src/connectors/slack/lib/slack_client.ts
@@ -98,7 +98,7 @@ export async function getSlackClient(
           if (slackError.code === ErrorCode.PlatformError) {
             const platformError = e as WebAPIPlatformError;
             if (
-              ["account_inactive", "invalid_auth"].includes(
+              ["account_inactive", "invalid_auth", "missing_scope"].includes(
                 platformError.data.error
               )
             ) {


### PR DESCRIPTION
## Description

Consider `missing_scope` as an `ExternalOAuthTokenError`

For https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40workflowId&event=AwAAAZQmLzmqeUhe0QAAABhBWlFtTHp5NUFBQVNDT3QtTEEyZnVBQUMAAAAkMDE5NDI2MmYtODRlZC00MWI2LWIwZDctZmIwM2QwZGZiYjNkAAAV0Q&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1735723658560&to_ts=1735810058560&live=true

## Risk

Low

## Deploy Plan

- deploy `connectors`