### PR TITLE
Public API/SDK update for /me route to handle extension blacklisted domains.

### DIFF
--- a/extension/app/src/lib/auth.ts
+++ b/extension/app/src/lib/auth.ts
@@ -117,7 +117,10 @@ const fetchMe = async (
   token: string
 ): Promise<Result<{ user: UserTypeWithWorkspaces }, AuthError>> => {
   const response = await fetch(`${process.env.DUST_DOMAIN}/api/v1/me`, {
-    headers: { Authorization: `Bearer ${token}` },
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "X-Request-Origin": "extension",
+    },
   });
   const me = await response.json();
   if (!response.ok) {

--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -428,7 +428,11 @@ export function withAuth0TokenAuthentication<T>(
         });
       }
 
-      const userWithWorkspaces = await getUserWithWorkspaces(user);
+      const isFromExtension = req.headers["x-request-origin"] === "extension";
+      const userWithWorkspaces = await getUserWithWorkspaces(
+        user,
+        isFromExtension
+      );
 
       return handler(req, res, userWithWorkspaces);
     }

--- a/front/lib/api/user.ts
+++ b/front/lib/api/user.ts
@@ -1,6 +1,5 @@
 import type {
   Result,
-  RoleType,
   UserMetadataType,
   UserType,
   UserTypeWithWorkspaces,
@@ -9,6 +8,7 @@ import { Err, Ok } from "@dust-tt/types";
 
 import type { Authenticator } from "@app/lib/auth";
 import { Workspace } from "@app/lib/models/workspace";
+import { ExtensionConfigurationResource } from "@app/lib/resources/extension";
 import { UserMetadataModel } from "@app/lib/resources/storage/models/user";
 import { UserResource } from "@app/lib/resources/user_resource";
 import logger from "@app/logger/logger";
@@ -140,41 +140,39 @@ export async function fetchRevokedWorkspace(
 }
 
 export async function getUserWithWorkspaces(
-  user: UserResource
+  user: UserResource,
+  populateExtensionConfig = false
 ): Promise<UserTypeWithWorkspaces> {
   const { memberships } = await MembershipResource.getActiveMemberships({
     users: [user],
   });
+  const workspaceIds = memberships.map((m) => m.workspaceId);
   const workspaces = await Workspace.findAll({
     where: {
-      id: memberships.map((m) => m.workspaceId),
+      id: workspaceIds,
     },
   });
+
+  const configs = populateExtensionConfig
+    ? await ExtensionConfigurationResource.internalFetchForWorkspaces(
+        workspaceIds
+      )
+    : [];
 
   return {
     ...user.toJSON(),
     workspaces: workspaces.map((w) => {
-      const m = memberships.find((m) => m.workspaceId === w.id);
-      let role = "none" as RoleType;
-      if (m) {
-        switch (m.role) {
-          case "admin":
-          case "builder":
-          case "user":
-            role = m.role;
-            break;
-          default:
-            role = "none";
-        }
-      }
       return {
         id: w.id,
         sId: w.sId,
         name: w.name,
-        role,
+        role: memberships.find((m) => m.workspaceId === w.id)?.role ?? "none",
         segmentation: w.segmentation || null,
         whiteListedProviders: w.whiteListedProviders,
         defaultEmbeddingProvider: w.defaultEmbeddingProvider,
+        extensionBlacklistedDomains:
+          configs.find((c) => c.workspaceId === w.id)?.blacklistedDomains ??
+          undefined,
       };
     }),
   };

--- a/front/lib/api/user.ts
+++ b/front/lib/api/user.ts
@@ -140,9 +140,9 @@ export async function fetchRevokedWorkspace(
   return new Ok(workspace);
 }
 
-export async function getUserWithWorkspaces<T extends boolean = false>(
+export async function getUserWithWorkspaces<T extends boolean>(
   user: UserResource,
-  populateExtensionConfig: T
+  populateExtensionConfig: T = false as T
 ): Promise<
   T extends true ? UserTypeWithExtensionWorkspaces : UserTypeWithWorkspaces
 > {

--- a/front/lib/api/user.ts
+++ b/front/lib/api/user.ts
@@ -140,9 +140,9 @@ export async function fetchRevokedWorkspace(
   return new Ok(workspace);
 }
 
-export async function getUserWithWorkspaces<T extends boolean>(
+export async function getUserWithWorkspaces<T extends boolean = false>(
   user: UserResource,
-  populateExtensionConfig: T = false as T
+  populateExtensionConfig: T
 ): Promise<
   T extends true ? UserTypeWithExtensionWorkspaces : UserTypeWithWorkspaces
 > {

--- a/front/lib/resources/extension.ts
+++ b/front/lib/resources/extension.ts
@@ -115,6 +115,20 @@ export class ExtensionConfigurationResource extends BaseResource<ExtensionConfig
     return config ? new this(ExtensionConfigurationModel, config.get()) : null;
   }
 
+  static async internalFetchForWorkspaces(
+    workspaceIds: ModelId[]
+  ): Promise<ExtensionConfigurationResource[]> {
+    const configs = await this.model.findAll({
+      where: {
+        workspaceId: workspaceIds,
+      },
+    });
+
+    return configs.map(
+      (config) => new this(ExtensionConfigurationModel, config.get())
+    );
+  }
+
   async updateBlacklistedDomains(
     auth: Authenticator,
     {

--- a/sdks/js/package-lock.json
+++ b/sdks/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/client",
-      "version": "1.0.16",
+      "version": "1.0.17",
       "license": "ISC",
       "dependencies": {
         "eventsource-parser": "^1.1.1",

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "Client for Dust API",
   "repository": {
     "type": "git",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -691,6 +691,7 @@ export type LightWorkspaceType = z.infer<typeof LightWorkspaceSchema>;
 
 const WorkspaceSchema = LightWorkspaceSchema.extend({
   ssoEnforced: z.boolean().optional(),
+  extensionBlacklistedDomains: z.array(z.string()).optional(),
 });
 
 const UserProviderSchema = FlexibleEnumSchema<
@@ -2199,7 +2200,7 @@ export type FileUploadedRequestResponseType = z.infer<
 >;
 
 export const MeResponseSchema = z.object({
-  user: UserSchema.and(z.object({ workspaces: LightWorkspaceSchema.array() })),
+  user: UserSchema.and(z.object({ workspaces: WorkspaceSchema.array() })),
 });
 
 export type MeResponseType = z.infer<typeof MeResponseSchema>;

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -691,7 +691,10 @@ export type LightWorkspaceType = z.infer<typeof LightWorkspaceSchema>;
 
 const WorkspaceSchema = LightWorkspaceSchema.extend({
   ssoEnforced: z.boolean().optional(),
-  extensionBlacklistedDomains: z.array(z.string()).optional(),
+});
+
+const ExtensionWorkspaceSchema = WorkspaceSchema.extend({
+  blacklistedDomains: z.array(z.string()).nullable(),
 });
 
 const UserProviderSchema = FlexibleEnumSchema<
@@ -2200,7 +2203,11 @@ export type FileUploadedRequestResponseType = z.infer<
 >;
 
 export const MeResponseSchema = z.object({
-  user: UserSchema.and(z.object({ workspaces: WorkspaceSchema.array() })),
+  user: UserSchema.and(
+    z.object({
+      workspaces: WorkspaceSchema.array().or(ExtensionWorkspaceSchema.array()),
+    })
+  ),
 });
 
 export type MeResponseType = z.infer<typeof MeResponseSchema>;

--- a/types/src/front/user.ts
+++ b/types/src/front/user.ts
@@ -44,7 +44,10 @@ export type LightWorkspaceType = {
 
 export type WorkspaceType = LightWorkspaceType & {
   ssoEnforced?: boolean;
-  extensionBlacklistedDomains?: string[];
+};
+
+export type ExtensionWorkspaceType = WorkspaceType & {
+  blacklistedDomains: string[] | null;
 };
 
 export type UserProviderType =
@@ -71,6 +74,10 @@ export type UserType = {
 
 export type UserTypeWithWorkspaces = UserType & {
   workspaces: WorkspaceType[];
+};
+
+export type UserTypeWithExtensionWorkspaces = UserType & {
+  workspaces: ExtensionWorkspaceType[];
 };
 
 export type UserMetadataType = {

--- a/types/src/front/user.ts
+++ b/types/src/front/user.ts
@@ -44,6 +44,7 @@ export type LightWorkspaceType = {
 
 export type WorkspaceType = LightWorkspaceType & {
   ssoEnforced?: boolean;
+  extensionBlacklistedDomains?: string[];
 };
 
 export type UserProviderType =
@@ -69,7 +70,7 @@ export type UserType = {
 };
 
 export type UserTypeWithWorkspaces = UserType & {
-  workspaces: LightWorkspaceType[];
+  workspaces: WorkspaceType[];
 };
 
 export type UserMetadataType = {


### PR DESCRIPTION
## Description

Changes on Front: 
- `WorkspaceType` can take an `extensionBlacklistedDomains` string array. 
- `UserTypeWithWorkspace` returns an attached `WorkspaceType` instead of `LightWorkspaceType`.
- `/me` route accepts a header `"X-Request-Origin"`, if set to extension it will populate `extensionBlacklistedDomains` in the response. 

Changes on Node SDK: 
- Schema update for `MeResponseSchema` and `WorkspaceSchema` to match the changes made on front API.
- Bump version. 


## Risk

Should be safe as I'm only adding an optional attribute to an existing type. 

## Deploy Plan

- Deploy front. 
- Publish a new version of the SDK.


## Next

=> Then I can use the updated SDK on the extension to disable the share buttons if the current domain is from a blacklisted domain. 
