### PR TITLE
fix(Zendesk) - organize ticket and article internal IDs per brand

### DIFF
--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -412,6 +412,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
           if (permission === "none") {
             const updatedCategory = await forbidSyncZendeskCategory({
               connectorId,
+              brandId,
               categoryId,
             });
             if (updatedCategory) {
@@ -578,6 +579,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     const { connectorId } = this;
 
     const { type, objectIds } = getIdFromInternalId(connectorId, internalId);
+    const { brandId } = objectIds;
     switch (type) {
       case "brand": {
         return new Ok([internalId]);
@@ -587,20 +589,19 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
       case "tickets": {
         return new Ok([
           internalId,
-          getBrandInternalId({ connectorId, brandId: objectIds.brandId }),
+          getBrandInternalId({ connectorId, brandId }),
         ]);
       }
       case "category": {
         const category = await ZendeskCategoryResource.fetchByCategoryId({
           connectorId,
-          categoryId: objectIds.categoryId,
+          ...objectIds,
         });
         if (category) {
           return new Ok(category.getParentInternalIds(connectorId));
         } else {
-          const { brandId, categoryId } = objectIds;
           logger.error(
-            { connectorId, categoryId, brandId },
+            { connectorId, ...objectIds },
             "[Zendesk] Category not found"
           );
           return new Err(new Error("Category not found"));
@@ -609,7 +610,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
       case "article": {
         const article = await ZendeskArticleResource.fetchByArticleId({
           connectorId,
-          articleId: objectIds.articleId,
+          ...objectIds,
         });
         if (article) {
           return new Ok(article.getParentInternalIds(connectorId));
@@ -624,7 +625,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
       case "ticket": {
         const ticket = await ZendeskTicketResource.fetchByTicketId({
           connectorId,
-          ticketId: objectIds.ticketId,
+          ...objectIds,
         });
         if (ticket) {
           return new Ok(ticket.getParentInternalIds(connectorId));

--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -135,6 +135,7 @@ export const zendesk = async ({
       });
       const ticketOnDb = await ZendeskTicketResource.fetchByTicketId({
         connectorId: connector.id,
+        brandId,
         ticketId,
       });
       return {

--- a/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
@@ -142,6 +142,7 @@ export async function allowSyncZendeskCategory({
 }): Promise<ZendeskCategoryResource | null> {
   let category = await ZendeskCategoryResource.fetchByCategoryId({
     connectorId,
+    brandId,
     categoryId,
   });
 
@@ -215,14 +216,17 @@ export async function allowSyncZendeskCategory({
  */
 export async function forbidSyncZendeskCategory({
   connectorId,
+  brandId,
   categoryId,
 }: {
   connectorId: ModelId;
+  brandId: number;
   categoryId: number;
 }): Promise<ZendeskCategoryResource | null> {
   // revoking the permissions for the category
   const category = await ZendeskCategoryResource.fetchByCategoryId({
     connectorId,
+    brandId,
     categoryId,
   });
   if (!category) {

--- a/connectors/src/connectors/zendesk/lib/id_conversions.ts
+++ b/connectors/src/connectors/zendesk/lib/id_conversions.ts
@@ -76,51 +76,43 @@ function _getIdFromInternal(internalId: string, prefix: string): number | null {
     : null;
 }
 
-export type InternalIdType =
-  | "brand"
-  | "help-center"
-  | "tickets"
-  | "article"
-  | "ticket";
-
 export function getIdFromInternalId(
   connectorId: ModelId,
   internalId: string
 ):
-  | { type: InternalIdType; objectId: number }
   | {
-      type: "category";
-      objectId: {
-        categoryId: number;
-        brandId: number;
-      };
-    } {
+      type: "brand" | "help-center" | "tickets";
+      objectIds: { brandId: number };
+    }
+  | { type: "category"; objectIds: { brandId: number; categoryId: number } }
+  | { type: "article"; objectIds: { articleId: number } }
+  | { type: "ticket"; objectIds: { ticketId: number } } {
   let objectId = getBrandIdFromInternalId(connectorId, internalId);
   if (objectId) {
-    return { type: "brand", objectId };
+    return { type: "brand", objectIds: { brandId: objectId } };
   }
   objectId = getBrandIdFromHelpCenterId(connectorId, internalId);
   if (objectId) {
-    return { type: "help-center", objectId };
+    return { type: "help-center", objectIds: { brandId: objectId } };
   }
   objectId = getBrandIdFromTicketsId(connectorId, internalId);
   if (objectId) {
-    return { type: "tickets", objectId };
+    return { type: "tickets", objectIds: { brandId: objectId } };
   }
   const { categoryId, brandId } = getCategoryIdFromInternalId(
     connectorId,
     internalId
   );
   if (categoryId && brandId) {
-    return { type: "category", objectId: { categoryId, brandId } };
+    return { type: "category", objectIds: { categoryId, brandId } };
   }
   objectId = getArticleIdFromInternalId(connectorId, internalId);
   if (objectId) {
-    return { type: "article", objectId };
+    return { type: "article", objectIds: { articleId: objectId } };
   }
   objectId = getTicketIdFromInternalId(connectorId, internalId);
   if (objectId) {
-    return { type: "ticket", objectId };
+    return { type: "ticket", objectIds: { ticketId: objectId } };
   }
   logger.error(
     { connectorId, internalId },

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -297,7 +297,7 @@ export async function retrieveChildrenNodes({
         const articlesInDb =
           await ZendeskArticleResource.fetchByCategoryIdReadOnly({
             connectorId,
-            categoryId: objectIds.categoryId,
+            ...objectIds,
           });
         return articlesInDb.map((article) =>
           article.toContentNode(connectorId)

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -259,12 +259,15 @@ export async function retrieveChildrenNodes({
       isReadPermissionsOnly,
     });
   }
-  const { type, objectId } = getIdFromInternalId(connectorId, parentInternalId);
+  const { type, objectIds } = getIdFromInternalId(
+    connectorId,
+    parentInternalId
+  );
   switch (type) {
     case "brand": {
       return getBrandChildren(zendeskApiClient, {
         connectorId,
-        brandId: objectId,
+        brandId: objectIds.brandId,
         isReadPermissionsOnly,
         parentInternalId,
       });
@@ -272,7 +275,7 @@ export async function retrieveChildrenNodes({
     case "help-center": {
       return getHelpCenterChildren(zendeskApiClient, {
         connectorId,
-        brandId: objectId,
+        brandId: objectIds.brandId,
         isReadPermissionsOnly,
         parentInternalId,
       });
@@ -282,7 +285,7 @@ export async function retrieveChildrenNodes({
       if (isReadPermissionsOnly) {
         const ticketsInDb = await ZendeskTicketResource.fetchByBrandIdReadOnly({
           connectorId,
-          brandId: objectId,
+          brandId: objectIds.brandId,
         });
         return ticketsInDb.map((ticket) => ticket.toContentNode(connectorId));
       }
@@ -294,7 +297,7 @@ export async function retrieveChildrenNodes({
         const articlesInDb =
           await ZendeskArticleResource.fetchByCategoryIdReadOnly({
             connectorId,
-            categoryId: objectId.categoryId,
+            categoryId: objectIds.categoryId,
           });
         return articlesInDb.map((article) =>
           article.toContentNode(connectorId)

--- a/connectors/src/connectors/zendesk/lib/sync_article.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_article.ts
@@ -25,6 +25,7 @@ const turndownService = new TurndownService();
  */
 export async function deleteArticle(
   connectorId: ModelId,
+  brandId: number,
   articleId: number,
   dataSourceConfig: DataSourceConfig,
   loggerArgs: Record<string, string | number | null>
@@ -35,7 +36,7 @@ export async function deleteArticle(
   );
   await deleteDataSourceDocument(
     dataSourceConfig,
-    getArticleInternalId({ connectorId, articleId })
+    getArticleInternalId({ connectorId, brandId, articleId })
   );
   await ZendeskArticleResource.deleteByArticleId({ connectorId, articleId });
 }
@@ -66,6 +67,7 @@ export async function syncArticle({
 }) {
   let articleInDb = await ZendeskArticleResource.fetchByArticleId({
     connectorId,
+    brandId: category.brandId,
     articleId: article.id,
   });
   const updatedAtDate = new Date(article.updated_at);
@@ -148,6 +150,7 @@ export async function syncArticle({
 
     const documentId = getArticleInternalId({
       connectorId,
+      brandId: category.brandId,
       articleId: article.id,
     });
 

--- a/connectors/src/connectors/zendesk/lib/sync_category.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_category.ts
@@ -41,7 +41,11 @@ export async function deleteCategory({
     (article) =>
       deleteDataSourceDocument(
         dataSourceConfig,
-        getArticleInternalId({ connectorId, articleId: article.articleId })
+        getArticleInternalId({
+          connectorId,
+          brandId,
+          articleId: article.articleId,
+        })
       ),
     { concurrency: 10 }
   );

--- a/connectors/src/connectors/zendesk/lib/sync_category.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_category.ts
@@ -75,6 +75,7 @@ export async function syncCategory({
 }): Promise<void> {
   let categoryInDb = await ZendeskCategoryResource.fetchByCategoryId({
     connectorId,
+    brandId,
     categoryId: category.id,
   });
   if (!categoryInDb) {

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -24,11 +24,13 @@ const turndownService = new TurndownService();
  */
 export async function deleteTicket({
   connectorId,
+  brandId,
   ticketId,
   dataSourceConfig,
   loggerArgs,
 }: {
   connectorId: ModelId;
+  brandId: number;
   ticketId: number;
   dataSourceConfig: DataSourceConfig;
   loggerArgs: Record<string, string | number | null>;
@@ -39,10 +41,11 @@ export async function deleteTicket({
   );
   await deleteDataSourceDocument(
     dataSourceConfig,
-    getTicketInternalId({ connectorId, ticketId })
+    getTicketInternalId({ connectorId, brandId, ticketId })
   );
   await ZendeskTicketResource.deleteByTicketId({
     connectorId,
+    brandId,
     ticketId,
   });
 }
@@ -73,6 +76,7 @@ export async function syncTicket({
 }) {
   let ticketInDb = await ZendeskTicketResource.fetchByTicketId({
     connectorId,
+    brandId,
     ticketId: ticket.id,
   });
 
@@ -206,6 +210,7 @@ ${comments
 
     const documentId = getTicketInternalId({
       connectorId,
+      brandId,
       ticketId: ticket.id,
     });
 

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -294,6 +294,7 @@ export async function syncZendeskCategoryActivity({
   }
   const categoryInDb = await ZendeskCategoryResource.fetchByCategoryId({
     connectorId,
+    brandId,
     categoryId,
   });
   if (!categoryInDb) {
@@ -350,12 +351,14 @@ export async function syncZendeskCategoryActivity({
  */
 export async function syncZendeskArticleBatchActivity({
   connectorId,
+  brandId,
   categoryId,
   currentSyncDateMs,
   forceResync,
   url,
 }: {
   connectorId: ModelId;
+  brandId: number;
   categoryId: number;
   currentSyncDateMs: number;
   forceResync: boolean;
@@ -374,6 +377,7 @@ export async function syncZendeskArticleBatchActivity({
   };
   const category = await ZendeskCategoryResource.fetchByCategoryId({
     connectorId,
+    brandId,
     categoryId,
   });
   if (!category) {

--- a/connectors/src/connectors/zendesk/temporal/gc_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/gc_activities.ts
@@ -260,6 +260,7 @@ export async function removeEmptyCategoriesActivity(connectorId: number) {
     async ({ categoryId, brandId }) => {
       const articles = await ZendeskArticleResource.fetchByCategoryIdReadOnly({
         connectorId,
+        brandId,
         categoryId,
       });
       if (articles.length === 0) {
@@ -369,7 +370,7 @@ export async function deleteTicketBatchActivity({
     (ticketId) =>
       deleteDataSourceDocument(
         dataSourceConfig,
-        getTicketInternalId({ connectorId, ticketId })
+        getTicketInternalId({ connectorId, brandId, ticketId })
       ),
     { concurrency: 10 }
   );
@@ -419,7 +420,7 @@ export async function deleteArticleBatchActivity({
     (articleId) =>
       deleteDataSourceDocument(
         dataSourceConfig,
-        getArticleInternalId({ connectorId, articleId })
+        getArticleInternalId({ connectorId, brandId, articleId })
       ),
     { concurrency: 10 }
   );

--- a/connectors/src/connectors/zendesk/temporal/gc_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/gc_activities.ts
@@ -101,30 +101,37 @@ export async function removeOutdatedTicketBatchActivity(
     dataSourceId: dataSourceConfig.dataSourceId,
   };
 
-  const ticketIds = await ZendeskTicketResource.fetchOutdatedTicketIds({
-    connectorId,
-    expirationDate: new Date(
-      Date.now() - configuration.retentionPeriodDays * 24 * 60 * 60 * 1000 // conversion from days to ms
-    ),
-    batchSize: ZENDESK_BATCH_SIZE,
-  });
+  const ticketIdsWithBrandIds =
+    await ZendeskTicketResource.fetchOutdatedTicketIds({
+      connectorId,
+      expirationDate: new Date(
+        Date.now() - configuration.retentionPeriodDays * 24 * 60 * 60 * 1000 // conversion from days to ms
+      ),
+      batchSize: ZENDESK_BATCH_SIZE,
+    });
   logger.info(
-    { ...loggerArgs, ticketCount: ticketIds.length },
+    { ...loggerArgs, ticketCount: ticketIdsWithBrandIds.length },
     "[Zendesk] Removing outdated tickets."
   );
 
-  if (ticketIds.length === 0) {
+  if (ticketIdsWithBrandIds.length === 0) {
     return { hasMore: false };
   }
 
   await concurrentExecutor(
-    ticketIds,
-    (ticketId) =>
-      deleteTicket({ connectorId, ticketId, dataSourceConfig, loggerArgs }),
+    ticketIdsWithBrandIds,
+    ({ brandId, ticketId }) =>
+      deleteTicket({
+        connectorId,
+        brandId,
+        ticketId,
+        dataSourceConfig,
+        loggerArgs,
+      }),
     { concurrency: 10 }
   );
 
-  return { hasMore: ticketIds.length === ZENDESK_BATCH_SIZE }; // true iff there are more tickets to process
+  return { hasMore: ticketIdsWithBrandIds.length === ZENDESK_BATCH_SIZE }; // true iff there are more tickets to process
 }
 
 /**

--- a/connectors/src/connectors/zendesk/temporal/gc_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/gc_activities.ts
@@ -194,6 +194,7 @@ export async function removeMissingArticleBatchActivity({
       if (!article) {
         await deleteArticle(
           connectorId,
+          brandId,
           articleId,
           dataSourceConfig,
           loggerArgs

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -230,6 +230,7 @@ export async function syncZendeskTicketUpdateBatchActivity({
       if (ticket.status === "deleted") {
         return deleteTicket({
           connectorId,
+          brandId,
           ticketId: ticket.id,
           dataSourceConfig,
           loggerArgs,

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -122,6 +122,7 @@ export async function syncZendeskArticleUpdateBatchActivity({
       if (section.category_id) {
         let category = await ZendeskCategoryResource.fetchByCategoryId({
           connectorId,
+          brandId,
           categoryId: section.category_id,
         });
         /// fetching and adding the category to the db if it is newly created, and the Help Center is selected

--- a/connectors/src/connectors/zendesk/temporal/workflows.ts
+++ b/connectors/src/connectors/zendesk/temporal/workflows.ts
@@ -392,6 +392,7 @@ export async function zendeskCategorySyncWorkflow({
     await runZendeskActivityWithPagination((url) =>
       syncZendeskArticleBatchActivity({
         connectorId,
+        brandId,
         categoryId,
         currentSyncDateMs,
         forceResync,
@@ -527,6 +528,7 @@ async function runZendeskBrandHelpCenterSyncActivities({
     await runZendeskActivityWithPagination((url) =>
       syncZendeskArticleBatchActivity({
         connectorId,
+        brandId,
         categoryId,
         currentSyncDateMs,
         forceResync,

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -754,13 +754,16 @@ export class ZendeskTicketResource extends BaseResource<ZendeskTicket> {
     connectorId: number;
     expirationDate: Date;
     batchSize: number;
-  }): Promise<number[]> {
+  }): Promise<{ brandId: number; ticketId: number }[]> {
     const tickets = await ZendeskTicket.findAll({
-      attributes: ["ticketId"],
+      attributes: ["ticketId", "brandId"],
       where: { connectorId, ticketUpdatedAt: { [Op.lt]: expirationDate } },
       limit: batchSize,
     });
-    return tickets.map((ticket) => Number(ticket.get().ticketId));
+    return tickets.map((ticket) => {
+      const { ticketId, brandId } = ticket.get();
+      return { ticketId, brandId };
+    });
   }
 
   static async fetchByTicketId({

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -738,7 +738,7 @@ export class ZendeskTicketResource extends BaseResource<ZendeskTicket> {
     const { brandId, ticketId } = this;
     /// Tickets have two parents: the Tickets and the Brand.
     return [
-      getTicketInternalId({ connectorId, ticketId }),
+      getTicketInternalId({ connectorId, brandId, ticketId }),
       getTicketsInternalId({ connectorId, brandId }),
       getBrandInternalId({ connectorId, brandId }),
     ];
@@ -923,7 +923,7 @@ export class ZendeskArticleResource extends BaseResource<ZendeskArticle> {
     const { brandId, categoryId, articleId } = this;
     return {
       provider: "zendesk",
-      internalId: getArticleInternalId({ connectorId, articleId }),
+      internalId: getArticleInternalId({ connectorId, brandId, articleId }),
       parentInternalId: getCategoryInternalId({
         connectorId,
         brandId,
@@ -943,7 +943,7 @@ export class ZendeskArticleResource extends BaseResource<ZendeskArticle> {
     const { brandId, categoryId, articleId } = this;
     /// Articles have three parents: the Category, the Help Center and the Brand.
     return [
-      getArticleInternalId({ connectorId, articleId }),
+      getArticleInternalId({ connectorId, brandId, articleId }),
       getCategoryInternalId({ connectorId, brandId, categoryId }),
       getHelpCenterInternalId({ connectorId, brandId }),
       getBrandInternalId({ connectorId, brandId }),

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -724,7 +724,7 @@ export class ZendeskTicketResource extends BaseResource<ZendeskTicket> {
     const { brandId, ticketId } = this;
     return {
       provider: "zendesk",
-      internalId: getTicketInternalId({ connectorId, ticketId }),
+      internalId: getTicketInternalId({ connectorId, brandId, ticketId }),
       parentInternalId: getTicketsInternalId({ connectorId, brandId }),
       type: "file",
       title: this.subject,

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -505,13 +505,15 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
 
   static async fetchByCategoryIds({
     connectorId,
+    brandId,
     categoryIds,
   }: {
     connectorId: number;
+    brandId: number;
     categoryIds: number[];
   }): Promise<ZendeskCategoryResource[]> {
     const categories = await ZendeskCategory.findAll({
-      where: { connectorId, categoryId: { [Op.in]: categoryIds } },
+      where: { connectorId, brandId, categoryId: { [Op.in]: categoryIds } },
     });
     return categories.map(
       (category) => category && new this(this.model, category.get())
@@ -783,13 +785,15 @@ export class ZendeskTicketResource extends BaseResource<ZendeskTicket> {
 
   static async fetchByTicketIds({
     connectorId,
+    brandId,
     ticketIds,
   }: {
     connectorId: number;
+    brandId: number;
     ticketIds: number[];
   }): Promise<ZendeskTicketResource[]> {
     const tickets = await ZendeskTicket.findAll({
-      where: { connectorId, ticketId: { [Op.in]: ticketIds } },
+      where: { connectorId, brandId, ticketId: { [Op.in]: ticketIds } },
     });
     return tickets.map((ticket) => new this(this.model, ticket.get()));
   }
@@ -1005,13 +1009,15 @@ export class ZendeskArticleResource extends BaseResource<ZendeskArticle> {
 
   static async fetchByArticleIds({
     connectorId,
+    brandId,
     articleIds,
   }: {
     connectorId: number;
+    brandId: number;
     articleIds: number[];
   }): Promise<ZendeskArticleResource[]> {
     const articles = await ZendeskArticle.findAll({
-      where: { connectorId, articleId: { [Op.in]: articleIds } },
+      where: { connectorId, brandId, articleId: { [Op.in]: articleIds } },
     });
     return articles.map((article) => new this(this.model, article.get()));
   }

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -490,13 +490,15 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategory> {
 
   static async fetchByCategoryId({
     connectorId,
+    brandId,
     categoryId,
   }: {
     connectorId: number;
+    brandId: number;
     categoryId: number;
   }): Promise<ZendeskCategoryResource | null> {
     const category = await ZendeskCategory.findOne({
-      where: { connectorId, categoryId },
+      where: { connectorId, brandId, categoryId },
     });
     return category && new this(this.model, category.get());
   }
@@ -763,13 +765,15 @@ export class ZendeskTicketResource extends BaseResource<ZendeskTicket> {
 
   static async fetchByTicketId({
     connectorId,
+    brandId,
     ticketId,
   }: {
     connectorId: number;
+    brandId: number;
     ticketId: number;
   }): Promise<ZendeskTicketResource | null> {
     const ticket = await ZendeskTicket.findOne({
-      where: { connectorId, ticketId },
+      where: { connectorId, brandId, ticketId },
     });
     return ticket && new this(this.model, ticket.get());
   }
@@ -819,12 +823,14 @@ export class ZendeskTicketResource extends BaseResource<ZendeskTicket> {
 
   static async deleteByTicketId({
     connectorId,
+    brandId,
     ticketId,
   }: {
     connectorId: number;
+    brandId: number;
     ticketId: number;
   }): Promise<void> {
-    await ZendeskTicket.destroy({ where: { connectorId, ticketId } });
+    await ZendeskTicket.destroy({ where: { connectorId, brandId, ticketId } });
   }
 
   static async deleteByTicketIds({
@@ -981,13 +987,15 @@ export class ZendeskArticleResource extends BaseResource<ZendeskArticle> {
 
   static async fetchByArticleId({
     connectorId,
+    brandId,
     articleId,
   }: {
     connectorId: number;
+    brandId: number;
     articleId: number;
   }): Promise<ZendeskArticleResource | null> {
     const article = await ZendeskArticle.findOne({
-      where: { connectorId, articleId },
+      where: { connectorId, brandId, articleId },
     });
     return article && new this(this.model, article.get());
   }
@@ -1020,13 +1028,15 @@ export class ZendeskArticleResource extends BaseResource<ZendeskArticle> {
 
   static async fetchByCategoryIdReadOnly({
     connectorId,
+    brandId,
     categoryId,
   }: {
     connectorId: number;
+    brandId: number;
     categoryId: number;
   }): Promise<ZendeskArticleResource[]> {
     const articles = await ZendeskArticle.findAll({
-      where: { connectorId, categoryId, permission: "read" },
+      where: { connectorId, brandId, categoryId, permission: "read" },
     });
     return articles.map((article) => new this(this.model, article.get()));
   }


### PR DESCRIPTION
## Description

- Close #9691
- Close [#1870](https://github.com/dust-tt/tasks/issues/1870)
- Update all the methods that fetch Zendesk tickets, articles or categories by ID to also filter on the brand ID.
- Add the corresponding indexes.
- Change the internal ID for single tickets and articles to include the brand ID.
  - No migration required in `front`: single tickets and articles are never passed as parents.
  - Migration required in `core`: going to backfill new documents with the new ID (see deploy plan).

## Risk

- Moderate risk of breaking the search on Zendesk data sources, relies on a carefully executed migration plan.

## Deploy Plan

- Run the backfill.
- Run the migration that adds the indexes.
- Stop all Zendesk connectors.
- Deploy connectors.
- Resume all Zendesk connectors.
- Run the cleanup script.
