### PR TITLE
ConnectorManagerError<RetrievePermissionsErrorCode>

### DIFF
--- a/connectors/src/api/create_connector.ts
+++ b/connectors/src/api/create_connector.ts
@@ -152,9 +152,8 @@ const _createConnectorAPIHandler = async (
     }
 
     if (connectorRes.isErr()) {
-      // Error result means this is an "expected" error, so not
-      // an internal server error.
-      // We return a 4xx status code for expected errors.
+      // Error result means this is an "expected" error, so not an internal server error. We return
+      // a 4xx status code for expected errors.
       switch (connectorRes.error.code) {
         case "INVALID_CONFIGURATION":
           return apiError(req, res, {

--- a/connectors/src/api/get_connector_permissions.ts
+++ b/connectors/src/api/get_connector_permissions.ts
@@ -1,8 +1,9 @@
+import type { ContentNode } from "@dust-tt/types";
 import type {
   ConnectorPermission,
   WithConnectorsAPIErrorReponse,
 } from "@dust-tt/types";
-import type { ContentNode } from "@dust-tt/types";
+import { assertNever } from "@dust-tt/types";
 import type { Request, Response } from "express";
 
 import { getConnectorManager } from "@connectors/connectors";
@@ -86,25 +87,42 @@ const _getConnectorPermissions = async (
   });
 
   if (pRes.isErr()) {
-    if (
-      pRes.error instanceof ProviderWorkflowError &&
-      pRes.error.type === "rate_limit_error"
-    ) {
-      return apiError(req, res, {
-        status_code: 429,
-        api_error: {
-          type: "connector_rate_limit_error",
-          message: pRes.error.message,
-        },
-      });
+    switch (pRes.error.code) {
+      case "INVALID_PARENT_INTERNAL_ID":
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Invalid parentInternalId",
+          },
+        });
+      case "CONNECTOR_NOT_FOUND":
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "connector_not_found",
+            message: "Connector not found",
+          },
+        });
+      case "EXTERNAL_OAUTH_TOKEN_ERROR":
+        return apiError(req, res, {
+          status_code: 401,
+          api_error: {
+            type: "connector_oauth_error",
+            message: pRes.error.message,
+          },
+        });
+      case "RATE_LIMIT_ERROR":
+        return apiError(req, res, {
+          status_code: 429,
+          api_error: {
+            type: "connector_rate_limit_error",
+            message: pRes.error.message,
+          },
+        });
+      default:
+        assertNever(pRes.error.code);
     }
-    return apiError(req, res, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: pRes.error.message,
-      },
-    });
   }
 
   if (includeParents) {

--- a/connectors/src/api/get_connector_permissions.ts
+++ b/connectors/src/api/get_connector_permissions.ts
@@ -108,7 +108,7 @@ const _getConnectorPermissions = async (
         return apiError(req, res, {
           status_code: 401,
           api_error: {
-            type: "connector_oauth_error",
+            type: "connector_authorization_error",
             message: pRes.error.message,
           },
         });

--- a/connectors/src/api/get_connector_permissions.ts
+++ b/connectors/src/api/get_connector_permissions.ts
@@ -8,7 +8,6 @@ import type { Request, Response } from "express";
 
 import { getConnectorManager } from "@connectors/connectors";
 import { augmentContentNodesWithParentIds } from "@connectors/lib/api/content_nodes";
-import { ProviderWorkflowError } from "@connectors/lib/error";
 import logger from "@connectors/logger/logger";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";

--- a/connectors/src/api/get_connector_permissions.ts
+++ b/connectors/src/api/get_connector_permissions.ts
@@ -89,11 +89,12 @@ const _getConnectorPermissions = async (
   if (pRes.isErr()) {
     switch (pRes.error.code) {
       case "INVALID_PARENT_INTERNAL_ID":
+      case "INVALID_FILTER_PERMISSION":
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid parentInternalId",
+            message: pRes.error.message,
           },
         });
       case "CONNECTOR_NOT_FOUND":
@@ -101,7 +102,7 @@ const _getConnectorPermissions = async (
           status_code: 404,
           api_error: {
             type: "connector_not_found",
-            message: "Connector not found",
+            message: pRes.error.message,
           },
         });
       case "EXTERNAL_OAUTH_TOKEN_ERROR":

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -42,6 +42,7 @@ import {
 } from "@connectors/connectors/google_drive/temporal/utils";
 import type {
   CreateConnectorErrorCode,
+  RetrievePermissionsErrorCode,
   UpdateConnectorErrorCode,
 } from "@connectors/connectors/interface";
 import {
@@ -49,6 +50,7 @@ import {
   ConnectorManagerError,
 } from "@connectors/connectors/interface";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
+import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import {
   GoogleDriveConfig,
   GoogleDriveFiles,
@@ -238,278 +240,303 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
     parentInternalId: string | null;
     filterPermission: ConnectorPermission | null;
     viewType: ContentNodesViewType;
-  }): Promise<Result<ContentNode[], Error>> {
+  }): Promise<
+    Result<ContentNode[], ConnectorManagerError<RetrievePermissionsErrorCode>>
+  > {
     const c = await ConnectorResource.fetchById(this.connectorId);
     const isTablesView = viewType === "tables";
     if (!c) {
       logger.error({ connectorId: this.connectorId }, "Connector not found");
-      return new Err(new Error("Connector not found"));
-    }
-    const authCredentials = await getAuthObject(c.connectionId);
-    if (isTablesView && filterPermission !== "read") {
       return new Err(
-        new Error("Tables view is only supported for read permissions")
+        new ConnectorManagerError("CONNECTOR_NOT_FOUND", "Connector not found")
       );
     }
-    const parentDriveId = parentInternalId && getDriveId(parentInternalId);
-    if (filterPermission === "read") {
-      if (parentDriveId === null) {
-        // Return the list of folders explicitly selected by the user.
-        const folders = await GoogleDriveFolders.findAll({
-          where: {
-            connectorId: this.connectorId,
-          },
-        });
+    const authCredentials = await getAuthObject(c.connectionId);
 
-        const folderAsContentNodes = await getFoldersAsContentNodes({
-          authCredentials,
-          folders,
-          viewType,
-        });
+    if (isTablesView && filterPermission !== "read") {
+      return new Err(
+        new ConnectorManagerError(
+          "INVALID_FILTER_PERMISSION",
+          "Tables view is only supported for read permissions"
+        )
+      );
+    }
 
-        const nodes = removeNulls(folderAsContentNodes);
-
-        nodes.sort((a, b) => {
-          return a.title.localeCompare(b.title);
-        });
-
-        return new Ok(nodes);
-      } else {
-        // Return the list of all folders and files synced in a parent folder.
-        const where: WhereOptions<InferAttributes<GoogleDriveFiles>> = {
-          connectorId: this.connectorId,
-          parentId: parentDriveId,
-        };
-        if (isTablesView) {
-          // In tables view, we only show folders, spreadhsheets and sheets.
-          // We filter out folders that only contain Documents.
-          where.mimeType = [
-            "application/vnd.google-apps.folder",
-            "application/vnd.google-apps.spreadsheet",
-          ];
-        }
-        const folderOrFiles = await GoogleDriveFiles.findAll({
-          where,
-        });
-        let sheets: GoogleDriveSheet[] = [];
-        if (isTablesView) {
-          sheets = await GoogleDriveSheet.findAll({
+    try {
+      const parentDriveId = parentInternalId && getDriveId(parentInternalId);
+      if (filterPermission === "read") {
+        if (parentDriveId === null) {
+          // Return the list of folders explicitly selected by the user.
+          const folders = await GoogleDriveFolders.findAll({
             where: {
               connectorId: this.connectorId,
-              driveFileId: parentDriveId,
             },
           });
-        }
 
-        let nodes = await concurrentExecutor(
-          folderOrFiles,
-          async (f): Promise<ContentNode> => {
-            const type = getPermissionViewType(f);
+          const folderAsContentNodes = await getFoldersAsContentNodes({
+            authCredentials,
+            folders,
+            viewType,
+          });
 
-            return {
-              provider: c.type,
-              internalId: getInternalId(f.driveFileId),
-              parentInternalId: null,
-              type,
-              title: f.name || "",
-              dustDocumentId: getGoogleDriveEntityDocumentId(f),
-              lastUpdatedAt: f.lastUpsertedTs?.getTime() || null,
-              sourceUrl: getSourceUrlForGoogleDriveFiles(f),
-              expandable: await isDriveObjectExpandable({
-                objectId: f.driveFileId,
-                mimeType: f.mimeType,
+          const nodes = removeNulls(folderAsContentNodes);
+
+          nodes.sort((a, b) => {
+            return a.title.localeCompare(b.title);
+          });
+
+          return new Ok(nodes);
+        } else {
+          // Return the list of all folders and files synced in a parent folder.
+          const where: WhereOptions<InferAttributes<GoogleDriveFiles>> = {
+            connectorId: this.connectorId,
+            parentId: parentDriveId,
+          };
+          if (isTablesView) {
+            // In tables view, we only show folders, spreadhsheets and sheets.
+            // We filter out folders that only contain Documents.
+            where.mimeType = [
+              "application/vnd.google-apps.folder",
+              "application/vnd.google-apps.spreadsheet",
+            ];
+          }
+          const folderOrFiles = await GoogleDriveFiles.findAll({
+            where,
+          });
+          let sheets: GoogleDriveSheet[] = [];
+          if (isTablesView) {
+            sheets = await GoogleDriveSheet.findAll({
+              where: {
                 connectorId: this.connectorId,
-                viewType,
-              }),
-              permission: "read",
-            };
-          },
-          { concurrency: 4 }
-        );
+                driveFileId: parentDriveId,
+              },
+            });
+          }
 
-        if (sheets.length) {
-          nodes = nodes.concat(
-            sheets.map((s) => {
+          let nodes = await concurrentExecutor(
+            folderOrFiles,
+            async (f): Promise<ContentNode> => {
+              const type = getPermissionViewType(f);
+
               return {
                 provider: c.type,
-                internalId: getGoogleSheetContentNodeInternalId(
-                  s.driveFileId,
-                  s.driveSheetId
-                ),
-                parentInternalId: getInternalId(s.driveFileId),
-                type: "database" as const,
-                title: s.name || "",
-                dustDocumentId: null,
-                lastUpdatedAt: s.updatedAt.getTime() || null,
-                sourceUrl: null,
-                expandable: false,
+                internalId: getInternalId(f.driveFileId),
+                parentInternalId: null,
+                type,
+                title: f.name || "",
+                dustDocumentId: getGoogleDriveEntityDocumentId(f),
+                lastUpdatedAt: f.lastUpsertedTs?.getTime() || null,
+                sourceUrl: getSourceUrlForGoogleDriveFiles(f),
+                expandable: await isDriveObjectExpandable({
+                  objectId: f.driveFileId,
+                  mimeType: f.mimeType,
+                  connectorId: this.connectorId,
+                  viewType,
+                }),
                 permission: "read",
-                dustTableId: getGoogleSheetTableId(
-                  s.driveFileId,
-                  s.driveSheetId
+              };
+            },
+            { concurrency: 4 }
+          );
+
+          if (sheets.length) {
+            nodes = nodes.concat(
+              sheets.map((s) => {
+                return {
+                  provider: c.type,
+                  internalId: getGoogleSheetContentNodeInternalId(
+                    s.driveFileId,
+                    s.driveSheetId
+                  ),
+                  parentInternalId: getInternalId(s.driveFileId),
+                  type: "database" as const,
+                  title: s.name || "",
+                  dustDocumentId: null,
+                  lastUpdatedAt: s.updatedAt.getTime() || null,
+                  sourceUrl: null,
+                  expandable: false,
+                  permission: "read",
+                  dustTableId: getGoogleSheetTableId(
+                    s.driveFileId,
+                    s.driveSheetId
+                  ),
+                };
+              })
+            );
+          }
+
+          // Sorting nodes, folders first then alphabetically.
+          nodes.sort((a, b) => {
+            if (a.type !== b.type) {
+              return a.type === "folder" ? -1 : 1;
+            }
+            return a.title.localeCompare(b.title);
+          });
+
+          return new Ok(nodes);
+        }
+      } else if (filterPermission === null) {
+        if (parentInternalId === null) {
+          // Return the list of remote shared drives.
+          const drives = await getDrives(c.id);
+
+          const nodes: ContentNode[] = await Promise.all(
+            drives.map(async (d): Promise<ContentNode> => {
+              const driveObject = await getGoogleDriveObject(
+                authCredentials,
+                d.id
+              );
+              if (!driveObject) {
+                throw new Error(
+                  `Drive ${d.id} unexpectedly not found (got 404).`
+                );
+              }
+              return {
+                provider: c.type,
+                internalId: getInternalId(driveObject.id),
+                parentInternalId:
+                  // note: if the parent is null, the drive object falls at top-level
+                  driveObject.parent && getInternalId(driveObject.parent),
+                type: "folder" as const,
+                title: driveObject.name,
+                sourceUrl: driveObject.webViewLink || null,
+                dustDocumentId: null,
+                lastUpdatedAt: driveObject.updatedAtMs || null,
+                expandable: await folderHasChildren(
+                  this.connectorId,
+                  driveObject.id
                 ),
+                permission: (await GoogleDriveFolders.findOne({
+                  where: {
+                    connectorId: this.connectorId,
+                    folderId: driveObject.id,
+                  },
+                }))
+                  ? "read"
+                  : "none",
               };
             })
           );
-        }
+          // Adding a fake "Shared with me" node, to allow the user to see their shared files
+          // that are not living in a shared drive.
+          nodes.push({
+            provider: c.type,
+            internalId: getInternalId(GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID),
+            parentInternalId: null,
+            type: "folder" as const,
+            preventSelection: true,
+            title: "Shared with me",
+            sourceUrl: null,
+            dustDocumentId: null,
+            lastUpdatedAt: null,
+            expandable: true,
+            permission: "none",
+          });
 
-        // Sorting nodes, folders first then alphabetically.
-        nodes.sort((a, b) => {
-          if (a.type !== b.type) {
-            return a.type === "folder" ? -1 : 1;
+          nodes.sort((a, b) => {
+            return a.title.localeCompare(b.title);
+          });
+
+          return new Ok(nodes);
+        } else {
+          // Return the list of remote folders inside a parent folder.
+          const drive = await getDriveClient(authCredentials);
+          let nextPageToken: string | undefined = undefined;
+          let remoteFolders: drive_v3.Schema$File[] = [];
+          // Depending on the view the user is requesting, the way of querying changes.
+          // The "Shared with me" view requires to look for folders
+          // with the flag `sharedWithMe=true`, but there is no need to check for the parents.
+          let gdriveQuery = `mimeType='application/vnd.google-apps.folder'`;
+          if (
+            parentInternalId ===
+            getInternalId(GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID)
+          ) {
+            gdriveQuery += ` and sharedWithMe=true`;
+          } else {
+            gdriveQuery += ` and '${parentDriveId}' in parents`;
           }
-          return a.title.localeCompare(b.title);
-        });
+          do {
+            const res: GaxiosResponse<drive_v3.Schema$FileList> =
+              await drive.files.list({
+                corpora: "allDrives",
+                pageSize: 200,
+                includeItemsFromAllDrives: true,
+                supportsAllDrives: true,
+                fields: `nextPageToken, files(${FILE_ATTRIBUTES_TO_FETCH.join(
+                  ", "
+                )})`,
+                q: gdriveQuery,
+                pageToken: nextPageToken,
+              });
 
-        return new Ok(nodes);
-      }
-    } else if (filterPermission === null) {
-      if (parentInternalId === null) {
-        // Return the list of remote shared drives.
-        const drives = await getDrives(c.id);
-
-        const nodes: ContentNode[] = await Promise.all(
-          drives.map(async (d): Promise<ContentNode> => {
-            const driveObject = await getGoogleDriveObject(
-              authCredentials,
-              d.id
-            );
-            if (!driveObject) {
+            if (res.status !== 200) {
               throw new Error(
-                `Drive ${d.id} unexpectedly not found (got 404).`
+                `Error getting files. status_code: ${res.status}. status_text: ${res.statusText}`
               );
             }
-            return {
-              provider: c.type,
-              internalId: getInternalId(driveObject.id),
-              parentInternalId:
-                // note: if the parent is null, the drive object falls at top-level
-                driveObject.parent && getInternalId(driveObject.parent),
-              type: "folder" as const,
-              title: driveObject.name,
-              sourceUrl: driveObject.webViewLink || null,
-              dustDocumentId: null,
-              lastUpdatedAt: driveObject.updatedAtMs || null,
-              expandable: await folderHasChildren(
-                this.connectorId,
-                driveObject.id
-              ),
-              permission: (await GoogleDriveFolders.findOne({
-                where: {
-                  connectorId: this.connectorId,
-                  folderId: driveObject.id,
-                },
-              }))
-                ? "read"
-                : "none",
-            };
-          })
-        );
-        // Adding a fake "Shared with me" node, to allow the user to see their shared files
-        // that are not living in a shared drive.
-        nodes.push({
-          provider: c.type,
-          internalId: getInternalId(GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID),
-          parentInternalId: null,
-          type: "folder" as const,
-          preventSelection: true,
-          title: "Shared with me",
-          sourceUrl: null,
-          dustDocumentId: null,
-          lastUpdatedAt: null,
-          expandable: true,
-          permission: "none",
-        });
+            if (!res.data.files) {
+              throw new Error("Files list is undefined");
+            }
+            remoteFolders = remoteFolders.concat(res.data.files);
+            nextPageToken = res.data.nextPageToken || undefined;
+          } while (nextPageToken);
 
-        nodes.sort((a, b) => {
-          return a.title.localeCompare(b.title);
-        });
+          const nodes: ContentNode[] = await Promise.all(
+            remoteFolders.map(async (rf): Promise<ContentNode> => {
+              const driveObject = await driveObjectToDustType(
+                rf,
+                authCredentials
+              );
 
-        return new Ok(nodes);
-      } else {
-        // Return the list of remote folders inside a parent folder.
-        const drive = await getDriveClient(authCredentials);
-        let nextPageToken: string | undefined = undefined;
-        let remoteFolders: drive_v3.Schema$File[] = [];
-        // Depending on the view the user is requesting, the way of querying changes.
-        // The "Shared with me" view requires to look for folders
-        // with the flag `sharedWithMe=true`, but there is no need to check for the parents.
-        let gdriveQuery = `mimeType='application/vnd.google-apps.folder'`;
-        if (
-          parentInternalId ===
-          getInternalId(GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID)
-        ) {
-          gdriveQuery += ` and sharedWithMe=true`;
-        } else {
-          gdriveQuery += ` and '${parentDriveId}' in parents`;
+              return {
+                provider: c.type,
+                internalId: getInternalId(driveObject.id),
+                parentInternalId:
+                  driveObject.parent && getInternalId(driveObject.parent),
+                type: "folder" as const,
+                title: driveObject.name,
+                sourceUrl: driveObject.webViewLink || null,
+                expandable: await folderHasChildren(
+                  this.connectorId,
+                  driveObject.id
+                ),
+                dustDocumentId: null,
+                lastUpdatedAt: driveObject.updatedAtMs || null,
+                permission: (await GoogleDriveFolders.findOne({
+                  where: {
+                    connectorId: this.connectorId,
+                    folderId: driveObject.id,
+                  },
+                }))
+                  ? "read"
+                  : "none",
+              };
+            })
+          );
+
+          nodes.sort((a, b) => {
+            return a.title.localeCompare(b.title);
+          });
+
+          return new Ok(nodes);
         }
-        do {
-          const res: GaxiosResponse<drive_v3.Schema$FileList> =
-            await drive.files.list({
-              corpora: "allDrives",
-              pageSize: 200,
-              includeItemsFromAllDrives: true,
-              supportsAllDrives: true,
-              fields: `nextPageToken, files(${FILE_ATTRIBUTES_TO_FETCH.join(
-                ", "
-              )})`,
-              q: gdriveQuery,
-              pageToken: nextPageToken,
-            });
-
-          if (res.status !== 200) {
-            throw new Error(
-              `Error getting files. status_code: ${res.status}. status_text: ${res.statusText}`
-            );
-          }
-          if (!res.data.files) {
-            throw new Error("Files list is undefined");
-          }
-          remoteFolders = remoteFolders.concat(res.data.files);
-          nextPageToken = res.data.nextPageToken || undefined;
-        } while (nextPageToken);
-
-        const nodes: ContentNode[] = await Promise.all(
-          remoteFolders.map(async (rf): Promise<ContentNode> => {
-            const driveObject = await driveObjectToDustType(
-              rf,
-              authCredentials
-            );
-
-            return {
-              provider: c.type,
-              internalId: getInternalId(driveObject.id),
-              parentInternalId:
-                driveObject.parent && getInternalId(driveObject.parent),
-              type: "folder" as const,
-              title: driveObject.name,
-              sourceUrl: driveObject.webViewLink || null,
-              expandable: await folderHasChildren(
-                this.connectorId,
-                driveObject.id
-              ),
-              dustDocumentId: null,
-              lastUpdatedAt: driveObject.updatedAtMs || null,
-              permission: (await GoogleDriveFolders.findOne({
-                where: {
-                  connectorId: this.connectorId,
-                  folderId: driveObject.id,
-                },
-              }))
-                ? "read"
-                : "none",
-            };
-          })
+      } else {
+        return new Err(
+          new ConnectorManagerError(
+            "INVALID_FILTER_PERMISSION",
+            `Invalid permission: ${filterPermission}`
+          )
         );
-
-        nodes.sort((a, b) => {
-          return a.title.localeCompare(b.title);
-        });
-
-        return new Ok(nodes);
       }
-    } else {
-      return new Err(new Error(`Invalid permission: ${filterPermission}`));
+    } catch (e) {
+      if (e instanceof ExternalOAuthTokenError) {
+        return new Err(
+          new ConnectorManagerError(
+            "EXTERNAL_OAUTH_TOKEN_ERROR",
+            "Google Drive authorization error, please re-authorize."
+          )
+        );
+      }
     }
   }
 

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -30,6 +30,15 @@ import {
   getPermissionViewType,
 } from "@connectors/connectors/google_drive/lib/permissions";
 import {
+  folderHasChildren,
+  getDrives,
+} from "@connectors/connectors/google_drive/temporal/activities";
+import {
+  launchGoogleDriveFullSyncWorkflow,
+  launchGoogleDriveIncrementalSyncWorkflow,
+  launchGoogleGarbageCollector,
+} from "@connectors/connectors/google_drive/temporal/client";
+import {
   isGoogleDriveFolder,
   isGoogleDriveSpreadSheetFile,
 } from "@connectors/connectors/google_drive/temporal/mime_types";
@@ -63,13 +72,6 @@ import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { DataSourceConfig } from "@connectors/types/data_source_config.js";
 import { FILE_ATTRIBUTES_TO_FETCH } from "@connectors/types/google_drive";
-
-import { folderHasChildren, getDrives } from "./temporal/activities";
-import {
-  launchGoogleDriveFullSyncWorkflow,
-  launchGoogleDriveIncrementalSyncWorkflow,
-  launchGoogleGarbageCollector,
-} from "./temporal/client";
 
 export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
   static async create({
@@ -537,6 +539,8 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
           )
         );
       }
+      // Unanhdled error, throwing to get a 500.
+      throw e;
     }
   }
 

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -36,11 +36,13 @@ import {
 } from "@connectors/connectors/intercom/temporal/client";
 import type {
   CreateConnectorErrorCode,
+  RetrievePermissionsErrorCode,
   UpdateConnectorErrorCode,
 } from "@connectors/connectors/interface";
 import { ConnectorManagerError } from "@connectors/connectors/interface";
 import { BaseConnectorManager } from "@connectors/connectors/interface";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import {
   IntercomArticle,
   IntercomCollection,
@@ -309,14 +311,18 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
     parentInternalId: string | null;
     filterPermission: ConnectorPermission | null;
     viewType: ContentNodesViewType;
-  }): Promise<Result<ContentNode[], Error>> {
+  }): Promise<
+    Result<ContentNode[], ConnectorManagerError<RetrievePermissionsErrorCode>>
+  > {
     const connector = await ConnectorResource.fetchById(this.connectorId);
     if (!connector) {
       logger.error(
         { connectorId: this.connectorId },
         "[Intercom] Connector not found."
       );
-      return new Err(new Error("Connector not found"));
+      return new Err(
+        new ConnectorManagerError("CONNECTOR_NOT_FOUND", "Connector not found")
+      );
     }
 
     if (filterPermission === "read" && parentInternalId === null) {
@@ -343,7 +349,16 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
       const nodes = [...helpCenterNodes, ...convosNodes];
       return new Ok(nodes);
     } catch (e) {
-      return new Err(e as Error);
+      if (e instanceof ExternalOAuthTokenError) {
+        return new Err(
+          new ConnectorManagerError(
+            "EXTERNAL_OAUTH_TOKEN_ERROR",
+            "Authorization erorr, please re-authorize Intercom."
+          )
+        );
+      }
+      // Unanhdled error, throwing to get a 500.
+      throw e;
     }
   }
 

--- a/connectors/src/connectors/interface.ts
+++ b/connectors/src/connectors/interface.ts
@@ -17,6 +17,7 @@ export type UpdateConnectorErrorCode =
 
 export type RetrievePermissionsErrorCode =
   | "INVALID_PARENT_INTERNAL_ID"
+  | "INVALID_FILTER_PERMISSION"
   | "EXTERNAL_OAUTH_TOKEN_ERROR"
   | "CONNECTOR_NOT_FOUND"
   | "RATE_LIMIT_ERROR";

--- a/connectors/src/connectors/interface.ts
+++ b/connectors/src/connectors/interface.ts
@@ -65,7 +65,9 @@ export abstract class BaseConnectorManager<T extends ConnectorConfiguration> {
     parentInternalId: string | null;
     filterPermission: ConnectorPermission | null;
     viewType: ContentNodesViewType;
-  }): Promise<Result<ContentNode[], Error>>;
+  }): Promise<
+    Result<ContentNode[], ConnectorManagerError<RetrievePermissionsErrorCode>>
+  >;
 
   abstract setPermissions(params: {
     permissions: Record<string, ConnectorPermission>;

--- a/connectors/src/connectors/interface.ts
+++ b/connectors/src/connectors/interface.ts
@@ -15,6 +15,11 @@ export type UpdateConnectorErrorCode =
   | "INVALID_CONFIGURATION"
   | "CONNECTOR_OAUTH_TARGET_MISMATCH";
 
+export type RetrievePermissionsErrorCode =
+  | "INVALID_PARENT_INTERNAL_ID"
+  | "EXTERNAL_OAUTH_TOKEN_ERROR"
+  | "CONNECTOR_NOT_FOUND";
+
 export class ConnectorManagerError<T extends string> extends Error {
   code: T;
 

--- a/connectors/src/connectors/interface.ts
+++ b/connectors/src/connectors/interface.ts
@@ -18,7 +18,8 @@ export type UpdateConnectorErrorCode =
 export type RetrievePermissionsErrorCode =
   | "INVALID_PARENT_INTERNAL_ID"
   | "EXTERNAL_OAUTH_TOKEN_ERROR"
-  | "CONNECTOR_NOT_FOUND";
+  | "CONNECTOR_NOT_FOUND"
+  | "RATE_LIMIT_ERROR";
 
 export class ConnectorManagerError<T extends string> extends Error {
   code: T;

--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -9,6 +9,7 @@ import { Client } from "@microsoft/microsoft-graph-client";
 
 import type {
   CreateConnectorErrorCode,
+  RetrievePermissionsErrorCode,
   UpdateConnectorErrorCode,
 } from "@connectors/connectors/interface";
 import { ConnectorManagerError } from "@connectors/connectors/interface";
@@ -46,6 +47,7 @@ import {
   launchMicrosoftIncrementalSyncWorkflow,
 } from "@connectors/connectors/microsoft/temporal/client";
 import { getParents } from "@connectors/connectors/microsoft/temporal/file";
+import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import { getOAuthConnectionAccessTokenWithThrow } from "@connectors/lib/oauth";
 import { syncSucceeded } from "@connectors/lib/sync_status";
 import { terminateAllWorkflowsForConnectorId } from "@connectors/lib/temporal";
@@ -203,11 +205,13 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
     parentInternalId: string | null;
     filterPermission: ConnectorPermission | null;
     viewType: ContentNodesViewType;
-  }): Promise<Result<ContentNode[], Error>> {
+  }): Promise<
+    Result<ContentNode[], ConnectorManagerError<RetrievePermissionsErrorCode>>
+  > {
     const connector = await ConnectorResource.fetchById(this.connectorId);
     if (!connector) {
       return new Err(
-        new Error(`Could not find connector with id ${this.connectorId}`)
+        new ConnectorManagerError("CONNECTOR_NOT_FOUND", "Connector not found")
       );
     }
 
@@ -227,11 +231,19 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
       );
       if (!node) {
         return new Err(
-          new Error(`Could not find node with id ${parentInternalId}`)
+          new ConnectorManagerError(
+            "INVALID_PARENT_INTERNAL_ID",
+            `Could not find node with id ${parentInternalId}`
+          )
         );
       }
-      return retrieveChildrenNodes(node, isTablesView);
+      const nRes = await retrieveChildrenNodes(node, isTablesView);
+      if (nRes.isErr()) {
+        throw nRes.error;
+      }
+      return new Ok(nRes.value);
     }
+
     const client = await getClient(connector.connectionId);
     const nodes = [];
 
@@ -251,84 +263,97 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
 
     const { nodeType } = typeAndPathFromInternalId(parentInternalId);
 
-    switch (nodeType) {
-      case "sites-root": {
-        const sites = await getAllPaginatedEntities((nextLink) =>
-          getSites(client, nextLink)
-        );
-        nodes.push(...sites.map((n) => getSiteAsContentNode(n)));
-        break;
+    try {
+      switch (nodeType) {
+        case "sites-root": {
+          const sites = await getAllPaginatedEntities((nextLink) =>
+            getSites(client, nextLink)
+          );
+          nodes.push(...sites.map((n) => getSiteAsContentNode(n)));
+          break;
+        }
+        case "teams-root": {
+          const teams = await getAllPaginatedEntities((nextLink) =>
+            getTeams(client, nextLink)
+          );
+          nodes.push(...teams.map((n) => getTeamAsContentNode(n)));
+          break;
+        }
+        case "team": {
+          const channels = await getAllPaginatedEntities((nextLink) =>
+            getChannels(client, parentInternalId, nextLink)
+          );
+          nodes.push(
+            ...channels.map((n) => getChannelAsContentNode(n, parentInternalId))
+          );
+          break;
+        }
+        case "site": {
+          const subSites = await getAllPaginatedEntities((nextLink) =>
+            getSubSites(client, parentInternalId, nextLink)
+          );
+          const drives = await getAllPaginatedEntities((nextLink) =>
+            getDrives(client, parentInternalId, nextLink)
+          );
+          nodes.push(
+            ...subSites.map((n) => getSiteAsContentNode(n, parentInternalId)),
+            ...drives.map((n) => getDriveAsContentNode(n, parentInternalId))
+          );
+          break;
+        }
+        case "drive":
+        case "folder": {
+          const filesAndFolders = await getAllPaginatedEntities((nextLink) =>
+            getFilesAndFolders(client, parentInternalId, nextLink)
+          );
+          const folders = filesAndFolders.filter((n) => n.folder);
+          nodes.push(
+            ...folders.map((n) => getFolderAsContentNode(n, parentInternalId))
+          );
+          break;
+        }
+        case "channel":
+        case "file":
+        case "page":
+        case "message":
+        case "worksheet":
+          throw new Error(
+            `Unexpected node type ${nodeType} for retrievePermissions`
+          );
+        default: {
+          assertNever(nodeType);
+        }
       }
-      case "teams-root": {
-        const teams = await getAllPaginatedEntities((nextLink) =>
-          getTeams(client, nextLink)
-        );
-        nodes.push(...teams.map((n) => getTeamAsContentNode(n)));
-        break;
-      }
-      case "team": {
-        const channels = await getAllPaginatedEntities((nextLink) =>
-          getChannels(client, parentInternalId, nextLink)
-        );
-        nodes.push(
-          ...channels.map((n) => getChannelAsContentNode(n, parentInternalId))
-        );
-        break;
-      }
-      case "site": {
-        const subSites = await getAllPaginatedEntities((nextLink) =>
-          getSubSites(client, parentInternalId, nextLink)
-        );
-        const drives = await getAllPaginatedEntities((nextLink) =>
-          getDrives(client, parentInternalId, nextLink)
-        );
-        nodes.push(
-          ...subSites.map((n) => getSiteAsContentNode(n, parentInternalId)),
-          ...drives.map((n) => getDriveAsContentNode(n, parentInternalId))
-        );
-        break;
-      }
-      case "drive":
-      case "folder": {
-        const filesAndFolders = await getAllPaginatedEntities((nextLink) =>
-          getFilesAndFolders(client, parentInternalId, nextLink)
-        );
-        const folders = filesAndFolders.filter((n) => n.folder);
-        nodes.push(
-          ...folders.map((n) => getFolderAsContentNode(n, parentInternalId))
-        );
-        break;
-      }
-      case "channel":
-      case "file":
-      case "page":
-      case "message":
-      case "worksheet":
-        throw new Error(
-          `Unexpected node type ${nodeType} for retrievePermissions`
-        );
-      default: {
-        assertNever(nodeType);
-      }
-    }
 
-    const nodesWithPermissions = nodes.map((res) => {
-      return {
-        ...res,
-        permission: (selectedResources.includes(res.internalId) ||
-        (res.parentInternalId &&
-          selectedResources.includes(res.parentInternalId))
-          ? "read"
-          : "none") as ConnectorPermission,
-      };
-    });
+      const nodesWithPermissions = nodes.map((res) => {
+        return {
+          ...res,
+          permission: (selectedResources.includes(res.internalId) ||
+          (res.parentInternalId &&
+            selectedResources.includes(res.parentInternalId))
+            ? "read"
+            : "none") as ConnectorPermission,
+        };
+      });
 
-    if (filterPermission) {
-      return new Ok(
-        nodesWithPermissions.filter((n) => n.permission === filterPermission)
-      );
+      if (filterPermission) {
+        return new Ok(
+          nodesWithPermissions.filter((n) => n.permission === filterPermission)
+        );
+      }
+      return new Ok(nodesWithPermissions);
+    } catch (e) {
+      if (e instanceof ExternalOAuthTokenError) {
+        return new Err(
+          new ConnectorManagerError(
+            "EXTERNAL_OAUTH_TOKEN_ERROR",
+            "Microsoft authorization error, please re-authorize."
+          )
+        );
+      }
+      // Unanhdled error, throwing to get a 500.
+      throw e;
     }
-    return new Ok(nodesWithPermissions);
   }
 
   async setPermissions({

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -10,6 +10,7 @@ import { v4 as uuidv4 } from "uuid";
 
 import type {
   CreateConnectorErrorCode,
+  RetrievePermissionsErrorCode,
   UpdateConnectorErrorCode,
 } from "@connectors/connectors/interface";
 import {
@@ -419,11 +420,15 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
   }: {
     parentInternalId: string | null;
     viewType: ContentNodesViewType;
-  }): Promise<Result<ContentNode[], Error>> {
+  }): Promise<
+    Result<ContentNode[], ConnectorManagerError<RetrievePermissionsErrorCode>>
+  > {
     const c = await ConnectorResource.fetchById(this.connectorId);
     if (!c) {
       logger.error({ connectorId: this.connectorId }, "Connector not found");
-      return new Err(new Error("Connector not found"));
+      return new Err(
+        new ConnectorManagerError("CONNECTOR_NOT_FOUND", "Connector not found")
+      );
     }
 
     const notionId =

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -433,6 +433,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
           )
         );
       }
+      // Unanhdled error, throwing to get a 500.
       throw e;
     }
   }

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -12,6 +12,7 @@ import PQueue from "p-queue";
 
 import type {
   CreateConnectorErrorCode,
+  RetrievePermissionsErrorCode,
   UpdateConnectorErrorCode,
 } from "@connectors/connectors/interface";
 import { ConnectorManagerError } from "@connectors/connectors/interface";
@@ -281,11 +282,14 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
     parentInternalId: string | null;
     filterPermission: ConnectorPermission | null;
     viewType: ContentNodesViewType;
-  }): Promise<Result<ContentNode[], Error>> {
+  }): Promise<
+    Result<ContentNode[], ConnectorManagerError<RetrievePermissionsErrorCode>>
+  > {
     if (parentInternalId) {
       return new Err(
-        new Error(
-          "Slack connector does not support permission retrieval with `parentInternalId`"
+        new ConnectorManagerError(
+          "INVALID_PARENT_INTERNAL_ID",
+          "Slack connector does not support permission retrieval with non null `parentInternalId`"
         )
       );
     }
@@ -293,7 +297,9 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
     const c = await ConnectorResource.fetchById(this.connectorId);
     if (!c) {
       logger.error({ connectorId: this.connectorId }, "Connector not found");
-      return new Err(new Error("Connector not found"));
+      return new Err(
+        new ConnectorManagerError("CONNECTOR_NOT_FOUND", "Connector not found")
+      );
     }
     const slackConfig = await SlackConfigurationResource.fetchByConnectorId(
       this.connectorId
@@ -303,7 +309,8 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
         { connectorId: this.connectorId },
         "Slack configuration not found"
       );
-      return new Err(new Error("Slack configuration not found"));
+      // This is unexpected let's throw to return a 500.
+      throw new Error("Slack configuration not found");
     }
 
     let permissionToFilter: ConnectorPermission[] = [];
@@ -408,7 +415,10 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
       if (e instanceof ExternalOAuthTokenError) {
         logger.error({ connectorId: this.connectorId }, "Slack token invalid");
         return new Err(
-          new Error("Slack token invalid. Please re-authorize Slack.")
+          new ConnectorManagerError(
+            "EXTERNAL_OAUTH_TOKEN_ERROR",
+            "Slack token invalid, please re-authorize Slack."
+          )
         );
       }
       if (e instanceof ProviderWorkflowError && e.type === "rate_limit_error") {
@@ -416,7 +426,12 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
           { connectorId: this.connectorId, error: e },
           "Slack rate limit when retrieving permissions."
         );
-        return new Err(e);
+        return new Err(
+          new ConnectorManagerError(
+            "RATE_LIMIT_ERROR",
+            `Slack rate limit error when retrieving content nodes.`
+          )
+        );
       }
       throw e;
     }

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -417,7 +417,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
         return new Err(
           new ConnectorManagerError(
             "EXTERNAL_OAUTH_TOKEN_ERROR",
-            "Slack token invalid, please re-authorize Slack."
+            "Slack authorization error, please re-authorize."
           )
         );
       }

--- a/connectors/src/connectors/snowflake/lib/utils.ts
+++ b/connectors/src/connectors/snowflake/lib/utils.ts
@@ -80,12 +80,15 @@ export const getConnectorAndCredentials = async ({
       connector: ConnectorResource;
       credentials: ConnectionCredentials;
     },
-    Error
+    { code: "connector_not_found" | "invalid_credentials"; error: Error }
   >
 > => {
   const connectorRes = await getConnector({ connectorId, logger });
   if (connectorRes.isErr()) {
-    return connectorRes;
+    return new Err({
+      code: "connector_not_found",
+      error: connectorRes.error,
+    });
   }
   const connector = connectorRes.value.connector;
 
@@ -96,7 +99,10 @@ export const getConnectorAndCredentials = async ({
   });
   if (credentialsRes.isErr()) {
     logger.error({ connectorId }, "Failed to retrieve credentials");
-    return new Err(Error("Failed to retrieve credentials"));
+    return new Err({
+      code: "invalid_credentials",
+      error: Error("Failed to retrieve credentials"),
+    });
   }
   // Narrow the type of credentials to just the username/password variant
   const credentials = credentialsRes.value.credential.content;

--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -15,10 +15,11 @@ import {
 } from "@dust-tt/types";
 
 import type {
-  ConnectorManagerError,
   CreateConnectorErrorCode,
+  RetrievePermissionsErrorCode,
   UpdateConnectorErrorCode,
 } from "@connectors/connectors/interface";
+import { ConnectorManagerError } from "@connectors/connectors/interface";
 import { BaseConnectorManager } from "@connectors/connectors/interface";
 import {
   getDisplayNameForFolder,
@@ -130,17 +131,21 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
     parentInternalId: string | null;
     filterPermission: ConnectorPermission | null;
     viewType: ContentNodesViewType;
-  }): Promise<Result<ContentNode[], Error>> {
+  }): Promise<
+    Result<ContentNode[], ConnectorManagerError<RetrievePermissionsErrorCode>>
+  > {
     const connector = await ConnectorResource.fetchById(this.connectorId);
     if (!connector) {
-      return new Err(new Error("Connector not found"));
+      return new Err(
+        new ConnectorManagerError("CONNECTOR_NOT_FOUND", "Connector not found")
+      );
     }
 
     const webCrawlerConfig =
       await WebCrawlerConfigurationResource.fetchByConnectorId(connector.id);
 
     if (!webCrawlerConfig) {
-      return new Err(new Error("Webcrawler configuration not found"));
+      throw new Error("Webcrawler configuration not found");
     }
     let parentUrl: string | null = null;
     if (parentInternalId) {

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -302,15 +302,27 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
       );
     }
 
-    const nodes = await retrieveChildrenNodes({
-      connector,
-      parentInternalId,
-      filterPermission,
-      viewType: "documents",
-    });
-
-    nodes.sort((a, b) => a.title.localeCompare(b.title));
-    return new Ok(nodes);
+    try {
+      const nodes = await retrieveChildrenNodes({
+        connector,
+        parentInternalId,
+        filterPermission,
+        viewType: "documents",
+      });
+      nodes.sort((a, b) => a.title.localeCompare(b.title));
+      return new Ok(nodes);
+    } catch (e) {
+      if (e instanceof ExternalOAuthTokenError) {
+        return new Err(
+          new ConnectorManagerError(
+            "EXTERNAL_OAUTH_TOKEN_ERROR",
+            "Authorization erorr, please re-authorize Zendesk."
+          )
+        );
+      }
+      // Unanhdled error, throwing to get a 500.
+      throw e;
+    }
   }
 
   /**

--- a/connectors/src/connectors/zendesk/lib/permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/permissions.ts
@@ -19,8 +19,7 @@ import {
   changeZendeskClientSubdomain,
   createZendeskClient,
 } from "@connectors/connectors/zendesk/lib/zendesk_api";
-import logger from "@connectors/logger/logger";
-import { ConnectorResource } from "@connectors/resources/connector_resource";
+import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import {
   ZendeskArticleResource,
   ZendeskBrandResource,

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -109,7 +109,12 @@ async function getContentNodesForManagedDataSourceView(
     });
 
     if (connectorsRes.isErr()) {
-      if (connectorsRes.error.type === "connector_rate_limit_error") {
+      if (
+        [
+          "connector_rate_limit_error",
+          "connector_authorization_error",
+        ].includes(connectorsRes.error.type)
+      ) {
         return new Err(new Error(connectorsRes.error.message));
       }
       return new Err(

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions/index.ts
@@ -282,6 +282,18 @@ export async function getManagedDataSourcePermissionsHandler(
         },
       });
     }
+    if (permissionsRes.error.type === "connector_authorization_error") {
+      return apiError(req, res, {
+        status_code: 401,
+        api_error: {
+          type: "data_source_auth_error",
+          message:
+            "Authorization error while retrieving the data source permissions.",
+        },
+      });
+    }
+    // Other error codes are invalid requests from front to connectors or 500s which should be
+    // treated as 500.
     return apiError(req, res, {
       status_code: 500,
       api_error: {

--- a/types/src/connectors/api.ts
+++ b/types/src/connectors/api.ts
@@ -13,6 +13,7 @@ export type ConnectorsAPIErrorType =
   | "connector_update_unauthorized"
   | "connector_oauth_target_mismatch"
   | "connector_oauth_error"
+  | "connector_authorization_error"
   | "slack_channel_not_found"
   | "connector_rate_limit_error"
   | "slack_configuration_not_found"


### PR DESCRIPTION
## Description

Adds support for `ConnectorManagerError<RetrievePermissionsErrorCode>` in `ConnectorManager.retrievePermissions` so that we can return proper error codes from connectors and properly react to a selection of them in front.

Fixes: https://github.com/dust-tt/tasks/issues/1878

## Risk

Low

## Deploy Plan

- deploy `connectors`
- deploy `front`