### PR TITLE
Dust client: export WorkspaceType & LightWorkspaceType

### DIFF
--- a/sdks/js/package-lock.json
+++ b/sdks/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/client",
-      "version": "1.0.17",
+      "version": "1.0.18",
       "license": "ISC",
       "dependencies": {
         "eventsource-parser": "^1.1.1",

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "Client for Dust API",
   "repository": {
     "type": "git",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -688,6 +688,8 @@ const LightWorkspaceSchema = z.object({
 });
 
 export type LightWorkspaceType = z.infer<typeof LightWorkspaceSchema>;
+export type WorkspaceType = z.infer<typeof WorkspaceSchema>;
+export type ExtensionWorkspaceType = z.infer<typeof ExtensionWorkspaceSchema>;
 
 const WorkspaceSchema = LightWorkspaceSchema.extend({
   ssoEnforced: z.boolean().optional(),


### PR DESCRIPTION
## Description

Bumping the node SDK to export missing types needed in the extension. 

## Risk

/ 

## Deploy Plan

Publish Dust client. 