### PR TITLE
[sparkle] - fix(Sheet): focus handling

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.351",
+  "version": "0.2.352",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.351",
+      "version": "0.2.352",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.351",
+  "version": "0.2.352",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/src/components/Sheet.tsx
+++ b/sparkle/src/components/Sheet.tsx
@@ -1,4 +1,5 @@
 import * as SheetPrimitive from "@radix-ui/react-dialog";
+import { FocusScope } from "@radix-ui/react-focus-scope";
 import { cva } from "class-variance-authority";
 import * as React from "react";
 
@@ -54,21 +55,24 @@ const sheetVariants = cva(
 interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content> {
   size?: SheetSizeType;
+  trapFocusScope?: boolean;
 }
 
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ className, children, size, ...props }, ref) => (
+>(({ className, children, size, trapFocusScope, ...props }, ref) => (
   <SheetPortal>
     <SheetOverlay />
-    <SheetPrimitive.Content
-      ref={ref}
-      className={cn(sheetVariants({ size }), className)}
-      {...props}
-    >
-      {children}
-    </SheetPrimitive.Content>
+    <FocusScope trapped={trapFocusScope}>
+      <SheetPrimitive.Content
+        ref={ref}
+        className={cn(sheetVariants({ size }), className)}
+        {...props}
+      >
+        {children}
+      </SheetPrimitive.Content>
+    </FocusScope>
   </SheetPortal>
 ));
 SheetContent.displayName = SheetPrimitive.Content.displayName;

--- a/sparkle/src/stories/Sheet.stories.tsx
+++ b/sparkle/src/stories/Sheet.stories.tsx
@@ -4,6 +4,10 @@ import React from "react";
 import {
   Avatar,
   Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
   Icon,
   Input,
   Page,
@@ -22,6 +26,7 @@ import {
   CloudArrowLeftRightIcon,
   FolderIcon,
   GlobeAltIcon,
+  MoreIcon,
   PencilSquareIcon,
   RocketIcon,
   StarIcon,
@@ -38,7 +43,6 @@ export function Demo() {
   return (
     <div className="s-flex s-flex-col s-gap-6">
       <SheetDemo />
-
       <ContentDemo />
       <SheetCustom />
     </div>
@@ -97,11 +101,41 @@ export function ContentDemo() {
 }
 
 export function SheetCustom() {
+  const SimpleDropdownDemo = () => {
+    return (
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            icon={MoreIcon}
+            onClick={(event) => {
+              event.currentTarget.focus();
+            }}
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          onCloseAutoFocus={(event) => {
+            event.preventDefault();
+          }}
+        >
+          <DropdownMenuItem label="My Account" />
+          <DropdownMenuItem label="Profile" />
+          <DropdownMenuItem label="Billing" />
+          <DropdownMenuItem label="Team" />
+          <DropdownMenuItem label="Subscription" />
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+  };
+
   return (
     <div>
       <Sheet>
         <SheetTrigger asChild>
-          <Button variant="outline" label="Assistant Demo" />
+          <Button
+            aria-hidden="false"
+            variant="outline"
+            label="Assistant Demo"
+          />
         </SheetTrigger>
         <SheetContent>
           <SheetHeader>
@@ -122,11 +156,12 @@ export function SheetCustom() {
                 <Separator orientation="vertical" />
                 <Button icon={PencilSquareIcon} variant={"outline"} />
                 <Button icon={TrashIcon} variant={"outline"} />
+                <SimpleDropdownDemo />
               </div>
             </div>
           </SheetHeader>
           <SheetContainer>
-            <TextArea disabled isDisplay />
+            <TextArea />
           </SheetContainer>
         </SheetContent>
       </Sheet>


### PR DESCRIPTION
## Description

This PR allows passing an additional parameter to the `SheetContent` component. By default, radix `Dialog` creates a focus trap that keeps focus cycling between elements inside the Dialog. This can conflict with nested interactive components like dropdowns.

## Risk

Low

## Deploy Plan

Publish `sparkle`