### PR TITLE
dataSourceView references indexes

### DIFF
--- a/front/lib/models/assistant/actions/data_sources.ts
+++ b/front/lib/models/assistant/actions/data_sources.ts
@@ -57,18 +57,10 @@ AgentDataSourceConfiguration.init(
   {
     modelName: "agent_data_source_configuration",
     indexes: [
-      {
-        fields: ["retrievalConfigurationId"],
-      },
-      {
-        fields: ["processConfigurationId"],
-      },
-      {
-        fields: ["dataSourceId"],
-      },
-      {
-        fields: ["dataSourceViewId"],
-      },
+      { fields: ["retrievalConfigurationId"] },
+      { fields: ["processConfigurationId"] },
+      { fields: ["dataSourceId"] },
+      { fields: ["dataSourceViewId"] },
     ],
     sequelize: frontSequelize,
     hooks: {

--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -289,7 +289,10 @@ RetrievalDocument.init(
   {
     modelName: "retrieval_document",
     sequelize: frontSequelize,
-    indexes: [{ fields: ["retrievalActionId"] }],
+    indexes: [
+      { fields: ["retrievalActionId"] },
+      { fields: ["dataSourceViewId"] },
+    ],
   }
 );
 

--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -111,6 +111,8 @@ AgentTablesQueryConfigurationTable.init(
         fields: ["dataSourceViewId", "tableId", "tablesQueryConfigurationId"],
         name: "agent_tables_query_configuration_table_unique_dsv",
       },
+      { fields: ["dataSourceId"] },
+      { fields: ["dataSourceViewId"] },
     ],
     sequelize: frontSequelize,
   }

--- a/front/lib/models/doc_tracker.ts
+++ b/front/lib/models/doc_tracker.ts
@@ -197,6 +197,8 @@ TrackerDataSourceConfigurationModel.init(
         using: "gin",
         name: "tracker_data_source_configuration_parent_ids_gin_idx",
       },
+      { fields: ["dataSourceId"] },
+      { fields: ["dataSourceViewId"] },
     ],
   }
 );

--- a/front/lib/resources/storage/models/labs_transcripts.ts
+++ b/front/lib/resources/storage/models/labs_transcripts.ts
@@ -70,6 +70,7 @@ LabsTranscriptsConfigurationModel.init(
     indexes: [
       { fields: ["userId"] },
       { fields: ["userId", "workspaceId"], unique: true },
+      { fields: ["dataSourceViewId"] },
     ],
   }
 );

--- a/front/migrations/db/migration_138.sql
+++ b/front/migrations/db/migration_138.sql
@@ -1,7 +1,7 @@
 -- Migration created on Jan 02, 2025
-CREATE INDEX "tracker_data_source_configurations_data_source_id" ON "tracker_data_source_configurations" ("dataSourceId");
-CREATE INDEX "tracker_data_source_configurations_data_source_view_id" ON "tracker_data_source_configurations" ("dataSourceViewId");
-CREATE INDEX "agent_tables_query_configuration_tables_data_source_id" ON "agent_tables_query_configuration_tables" ("dataSourceId");
-CREATE INDEX "agent_tables_query_configuration_tables_data_source_view_id" ON "agent_tables_query_configuration_tables" ("dataSourceViewId");
-CREATE INDEX "retrieval_documents_data_source_view_id" ON "retrieval_documents" ("dataSourceViewId");
-CREATE INDEX "labs_transcripts_configurations_data_source_view_id" ON "labs_transcripts_configurations" ("dataSourceViewId");
+CREATE INDEX CONCURRENTLY "tracker_data_source_configurations_data_source_id" ON "tracker_data_source_configurations" ("dataSourceId");
+CREATE INDEX CONCURRENTLY "tracker_data_source_configurations_data_source_view_id" ON "tracker_data_source_configurations" ("dataSourceViewId");
+CREATE INDEX CONCURRENTLY "agent_tables_query_configuration_tables_data_source_id" ON "agent_tables_query_configuration_tables" ("dataSourceId");
+CREATE INDEX CONCURRENTLY "agent_tables_query_configuration_tables_data_source_view_id" ON "agent_tables_query_configuration_tables" ("dataSourceViewId");
+CREATE INDEX CONCURRENTLY "retrieval_documents_data_source_view_id" ON "retrieval_documents" ("dataSourceViewId");
+CREATE INDEX CONCURRENTLY "labs_transcripts_configurations_data_source_view_id" ON "labs_transcripts_configurations" ("dataSourceViewId");

--- a/front/migrations/db/migration_138.sql
+++ b/front/migrations/db/migration_138.sql
@@ -1,0 +1,7 @@
+-- Migration created on Jan 02, 2025
+CREATE INDEX "tracker_data_source_configurations_data_source_id" ON "tracker_data_source_configurations" ("dataSourceId");
+CREATE INDEX "tracker_data_source_configurations_data_source_view_id" ON "tracker_data_source_configurations" ("dataSourceViewId");
+CREATE INDEX "agent_tables_query_configuration_tables_data_source_id" ON "agent_tables_query_configuration_tables" ("dataSourceId");
+CREATE INDEX "agent_tables_query_configuration_tables_data_source_view_id" ON "agent_tables_query_configuration_tables" ("dataSourceViewId");
+CREATE INDEX "retrieval_documents_data_source_view_id" ON "retrieval_documents" ("dataSourceViewId");
+CREATE INDEX "labs_transcripts_configurations_data_source_view_id" ON "labs_transcripts_configurations" ("dataSourceViewId");


### PR DESCRIPTION
## Description

For: https://github.com/dust-tt/tasks/issues/1891

Ensure tables referencing dataSourceView have index. Very likely RetrievalDocument is the culprit here when we delete DataSourceView as we need to do a full table scan on RetrievalDocument to make sure we have no reference.

## Risk

Low

## Deploy Plan

- no need to deploy front
- run migration on `prodbox`